### PR TITLE
docs(drift): playbook + drift-check workflow + comprehensive doc refresh

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,160 @@
+name: docs-drift
+
+# Reads the doc inventory in docs/playbooks/docs-drift.md and checks that
+# every source-of-truth file referenced by a doc still exists, that the
+# canonical AGENTS.md / CLAUDE.md / CONVENTIONS.md / .goosehints /
+# .cursor/rules/*.mdc outputs agree with `bernstein agents-md verify`, and
+# that every enumerated doc file is present on disk. On pull requests the
+# report is posted as a non-blocking PR comment so the change can land in
+# the same PR. On pushes to main the gate fails so the drift gets fixed in
+# a follow-up.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "src/bernstein/**"
+      - "scripts/check_docs_drift.py"
+      - "scripts/gen_agents_md.py"
+      - ".github/workflows/docs-drift.yml"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "CONVENTIONS.md"
+      - ".goosehints"
+      - "README.md"
+      - "CONTRIBUTING.md"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "src/bernstein/**"
+      - "scripts/check_docs_drift.py"
+      - "scripts/gen_agents_md.py"
+      - ".github/workflows/docs-drift.yml"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "CONVENTIONS.md"
+      - ".goosehints"
+      - "README.md"
+      - "CONTRIBUTING.md"
+
+concurrency:
+  group: docs-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    name: Run drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install bernstein for agents-md verify
+        run: uv sync --no-dev --frozen
+        continue-on-error: true
+
+      - name: Run docs drift checker
+        id: drift
+        run: |
+          set +e
+          python scripts/check_docs_drift.py > drift-report.md
+          rc=$?
+          echo "report_rc=${rc}" >> "$GITHUB_OUTPUT"
+          # Re-run in JSON form for the clean-flag decision.
+          python scripts/check_docs_drift.py --json > drift-report.json
+          # Extract the top-level "clean" boolean so later steps can branch.
+          clean=$(python -c "import json,sys; print(json.load(open('drift-report.json')).get('clean', False))")
+          echo "clean=${clean}" >> "$GITHUB_OUTPUT"
+          cat drift-report.md
+        shell: bash
+
+      - name: Upload drift report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-drift-report
+          path: |
+            drift-report.md
+            drift-report.json
+          retention-days: 14
+
+      - name: Comment drift report on the pull request
+        if: github.event_name == 'pull_request' && steps.drift.outputs.clean != 'True'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('drift-report.md', 'utf8');
+            const tag = '<!-- docs-drift-report -->';
+            const issue_number = context.payload.pull_request.number;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(tag));
+            const payload = `${tag}\n${body}`;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body: payload,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: payload,
+              });
+            }
+
+      - name: Fail the gate on main-branch drift
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          python scripts/check_docs_drift.py --strict
+
+  trigger-landing-mirror:
+    name: Trigger bernstein-landing docs mirror
+    needs: drift-check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      # The PAT must have repo scope on sipyourdrink-ltd/bernstein-landing.
+      # When the secret is not set (e.g. on a forked workflow run), skip
+      # silently so a missing PAT does not block the main-branch pipeline.
+      - name: Dispatch docs-mirror-sync in bernstein-landing
+        env:
+          LANDING_REPO_PAT: ${{ secrets.LANDING_REPO_PAT }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "${LANDING_REPO_PAT}" ]; then
+            echo "LANDING_REPO_PAT is not set; skipping cross-repo dispatch."
+            exit 0
+          fi
+          curl --fail-with-body --silent --show-error \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${LANDING_REPO_PAT}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/sipyourdrink-ltd/bernstein-landing/actions/workflows/docs-mirror-sync.yml/dispatches \
+            -d "{\"ref\":\"main\",\"inputs\":{\"source_sha\":\"${COMMIT_SHA}\"}}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ When adding a new CLI command, create a new `*_cmd.py` module in `cli/commands/`
 
 ## Supported CLI Adapters
 
-Bernstein ships with 43 adapters (42 named + 1 generic catch-all). Before writing a new adapter, check `src/bernstein/adapters/registry.py` for the full list — a subset is shown here for orientation:
+Bernstein ships with 44 adapters (43 named + 1 generic catch-all). Before writing a new adapter, check `src/bernstein/adapters/registry.py` for the full list — a subset is shown here for orientation:
 
 | Adapter | File | Agent |
 |---------|------|-------|
@@ -206,7 +206,7 @@ Role templates live in `templates/roles/<role-name>/` with three files:
 - `task_prompt.md` — per-task instructions template
 - `config.yaml` — default model and effort
 
-Built-in roles: `manager`, `backend`, `frontend`, `qa`, `security`, `architect`, `devops`, `reviewer`, `docs`, `ml-engineer`, `prompt-engineer`, `retrieval`, `vp`, `analyst`, `resolver`, `visionary`, `ci-fixer`.
+Built-in roles: `adversary`, `analyst`, `architect`, `backend`, `ci-fixer`, `devops`, `docs`, `frontend`, `manager`, `ml-engineer`, `prompt-engineer`, `qa`, `resolver`, `retrieval`, `reviewer`, `security`, `visionary`, `vp`.
 
 Copy an existing role and customize:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 
 ### at a glance
 
-- **44 CLI agent adapters** ship in v1.10.7 — 41 third-party wrappers, 2 leaf-node delegators, plus a generic `--prompt` wrapper. Source of truth: the [supported agents](#supported-agents) table below.
+- **44 CLI agent adapters** ship in v2.2.x — 41 third-party wrappers, 2 leaf-node delegators, plus a generic `--prompt` wrapper. Source of truth: the [supported agents](#supported-agents) table below.
 - **HMAC-SHA256 audit chain** per [RFC 2104](https://datatracker.ietf.org/doc/html/rfc2104), one record per scheduling decision, tamper-evident. Operator guide: [docs/security/audit-log.md](docs/security/audit-log.md).
 - **Bearer-token task server** authenticates the manager and every worker to `POST /tasks` and friends. Per-session zero-trust JWT in `.sdd/runtime/agent_tokens/`, legacy `BERNSTEIN_AUTH_TOKEN` fallback, opt-out via `BERNSTEIN_AUTH_DISABLED=1`. Flow + diagnostics: [docs/security/manager-auth.md](docs/security/manager-auth.md).
 - **Signed agent cards** use detached JWS ([RFC 7515 §A.5](https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.5)) over [RFC 8785 (JCS)](https://datatracker.ietf.org/doc/html/rfc8785) canonicalization, with [Ed25519 / EdDSA](https://datatracker.ietf.org/doc/html/rfc8037) keys. Code: [src/bernstein/core/security/agent_card_signer.py](src/bernstein/core/security/agent_card_signer.py).

--- a/docs/concepts/artifact-lineage.md
+++ b/docs/concepts/artifact-lineage.md
@@ -89,7 +89,7 @@ Each `LineageRecord` carries:
 - No backfill. Historical writes from before the feature was enabled
   have no records.
 - CLI text and HTML/CSV/JSON-LD exporters; no GUI.
-- PII redaction lives in `core/security/pii_gating.py`; lineage
+- PII redaction lives in `core/security/pii_output_gate.py`; lineage
   records inherit whatever redaction the audit log already applies —
   no extra layer.
 

--- a/docs/concepts/spec-as-test.md
+++ b/docs/concepts/spec-as-test.md
@@ -84,5 +84,5 @@ warning.
 
 - Source: `src/bernstein/core/planning/spec_assertions.py`
 - Drain hook: `src/bernstein/core/orchestration/drain.py`
-- Run flag: `src/bernstein/cli/commands/run_cmd.py`
+- Run flag: `src/bernstein/cli/run_cmd.py`
 - PR #1003

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: Bernstein — Open-Source Multi-Agent Orchestration Platform
 description: >-
   Bernstein is the open-source multi-agent orchestrator for AI coding agents.
   Run Claude Code, Codex, Gemini CLI, and the OpenAI Agents SDK in parallel.
-  Deterministic scheduling, 43 adapters, pluggable sandbox backends,
+  Deterministic scheduling, 44 adapters, pluggable sandbox backends,
   cloud artifact storage, progressive skills, zero vendor lock-in.
 tags:
   - orchestration
@@ -74,7 +74,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    42 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
+    44 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**
@@ -99,7 +99,7 @@ Bernstein is built for the forward-deployed engineering pattern:
 parachute onto a client repo and stand up an AI engineering crew in
 minutes. State lives in `.sdd/` — no server to provision. Per-agent
 credential scoping keeps your keys out of the client's environment.
-The 42-adapter spread means the swarm runs on whichever CLI agent
+The 44-adapter spread means the swarm runs on whichever CLI agent
 the client already trusts (Claude Code, Codex, Gemini CLI, Aider,
 and more). Every step is an HMAC-signed audit record, replayable
 for client compliance review.

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -1,0 +1,190 @@
+# Docs drift playbook
+
+This playbook enumerates every documentation file in the bernstein repository,
+points each one at a concrete source of truth in code (or marks it static), and
+records the drift signal that should trigger a refresh.
+
+## Why this exists
+
+Code and docs drift apart over time. This playbook gives future agents
+mechanically discoverable check-points so the gap can be detected and closed
+without re-reading every file. The companion CI workflow at
+`.github/workflows/docs-drift.yml` consumes this file via
+`scripts/check_docs_drift.py` and reports drift on every push to `main` and on
+every pull request.
+
+## How agents pick up drift
+
+Convention: when you change code under `src/bernstein/<package>/`, also update
+the doc rows in the table below that name that package as their source of
+truth. The CI workflow will block merges to `main` on uncorrected drift; on
+pull requests it posts a non-blocking comment so the change can land in the
+same PR.
+
+Drift remediation paths used by the rows below:
+
+| Remediation token | What it runs |
+|-------------------|--------------|
+| `agents-md-sync` | `uv run bernstein agents-md sync` then `uv run bernstein agents-md verify` |
+| `gen-agents-md` | `uv run python scripts/gen_agents_md.py --update` (legacy detailed module map; do not run if `agents-md-sync` is the active source of truth) |
+| `manual-prose` | Re-read the source-of-truth module and adjust the prose by hand; no script generates this content |
+| `manual-cmd` | The doc lists a CLI command surface; re-run `bernstein <cmd> --help` and reconcile |
+| `gen-benchmarks` | `uv run python scripts/generate_benchmark_docs.py` |
+| `static` | No code source; check only repo URL / contact / license updates |
+
+## Doc inventory
+
+### Root (`./`)
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `README.md` | `src/bernstein/cli/main.py`, `src/bernstein/cli/commands/`, `src/bernstein/adapters/registry.py`, `pyproject.toml` (`[project.scripts]`, `[project.optional-dependencies]`) | New top-level command, adapter added or removed, install method changed, optional extra added | `manual-prose` |
+| `AGENTS.md` | `src/bernstein/` package layout (auto-derived); curated content under `.sdd/agents-md/` | New top-level package or module under `src/bernstein/`; any change to the canonical IR | `agents-md-sync` |
+| `CLAUDE.md` | Mirror of canonical IR via `bernstein agents-md sync` | Drift versus AGENTS.md canonical | `agents-md-sync` |
+| `CONVENTIONS.md` | Mirror of canonical IR for Aider via `bernstein agents-md sync` | Drift versus AGENTS.md canonical | `agents-md-sync` |
+| `CODE_OF_CONDUCT.md` | None (Contributor Covenant 2.1 verbatim) | Repo URL change, contact email change | `static` |
+| `CONTRIBUTING.md` | `src/bernstein/adapters/registry.py`, `src/bernstein/adapters/base.py`, `templates/roles/`, `scripts/run_tests.py`, `.importlinter` | New adapter contract method, new role added under `templates/roles/`, change to lint / type-check pipeline | `manual-prose` |
+| `SECURITY.md` | `pyproject.toml` version, security policy contacts | Bounty program changes, scope changes, new in-scope target | `manual-prose` |
+| `CHANGELOG.md` | Release-please managed (`release-please-config.json`, `release-please-manifest.json`) plus hand-curated `## Unreleased` section | New release tag, manual entry needed for behaviour-visible code change | `manual-prose` |
+| `CONTRIBUTORS.md` | None (hand-curated list of named contributors) | New contributor merged a PR | `static` |
+
+### `docs/` top-level
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `docs/index.md` | All docs subdirs (each linked entry must resolve) | Linked page renamed / deleted, getting-started / installation / operations / reference / architecture path moved | `manual-prose` |
+| `docs/adapter-deferred.md` | `src/bernstein/adapters/registry.py` (negative-space: agents NOT integrated) | A previously-deferred agent now has a stable CLI binary | `manual-prose` |
+| `docs/agents-md.md` | `src/bernstein/cli/commands/agents_md_cmd.py`, `src/bernstein/core/knowledge/agents_md_bridge.py`, `src/bernstein/core/knowledge/agents_md_generator.py` | New target format added to the canonical IR, sync command options change | `manual-prose` |
+| `docs/CHANGELOG.md` | Mirror of root `CHANGELOG.md` for mkdocs | Root changelog edited | `manual-prose` |
+| `docs/CODE_REVIEW.md` | `src/bernstein/core/quality/`, `src/bernstein/core/review/`, `src/bernstein/core/review_responder/` | Review pipeline stage added, reviewer-role policy change | `manual-prose` |
+| `docs/competitors.md` | None (memo summarising external projects) | Star-count or feature-table refresh requested | `static` |
+| `docs/ENTERPRISE.md` | `src/bernstein/core/compliance/`, `src/bernstein/core/security/`, audit / lineage / air-gap surface | New regulator mapping, new compliance pack target, audit export schema change | `manual-prose` |
+| `docs/lineage.md` | `src/bernstein/core/lineage/`, `src/bernstein/core/persistence/lineage.py`, `src/bernstein/cli/commands/lineage_cmd.py` | Lineage record schema change, signature algorithm change, new verify CLI subcommand | `manual-prose` |
+| `docs/llm-citation-surface.md` | None (positioning note about how the project surfaces in LLM citations) | External citation pattern audited | `static` |
+| `docs/routine-scenarios.md` | `src/bernstein/core/planning/routine_bridge.py`, `src/bernstein/cli/commands/routine_cmd.py`, `src/bernstein/mcp/routine_tools.py` | Routine <-> Scenario bridge surface change | `manual-prose` |
+| `docs/telemetry.md` | `src/bernstein/core/telemetry/`, `src/bernstein/cli/commands/telemetry_cmd.py` | New telemetry event, opt-out matrix change, retention policy change | `manual-prose` |
+| `docs/use-cases.md` | `src/bernstein/cli/main.py` (command list) plus operator workflow CLIs | New operator workflow command (`autofix`, `review-responder`, `dep-impact`, etc.) | `manual-prose` |
+| `docs/whats-new.md` | Release tags, hand-curated highlights | New release published | `manual-prose` |
+
+### `docs/concepts/`
+
+Each file in this folder pairs a Bernstein architectural concept with a concrete
+module path. The drift signal in every row is "the named source module has
+been moved, renamed, deleted, or its public surface changed."
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `abstracted-code-review.md` | `src/bernstein/core/quality/review_pipeline/abstract_diff.py`, `src/bernstein/core/review_responder/pr_gen.py` | Diff abstraction class renamed, PR-generation signature change | `manual-prose` |
+| `action-cache.md` | `src/bernstein/core/persistence/action_cache.py`, `src/bernstein/core/persistence/fingerprint.py`, `src/bernstein/cli/commands/cache_cmd.py` | Cache record schema change, fingerprint inputs change | `manual-prose` |
+| `agent-mode-profiles.md` | `src/bernstein/core/routing/mode_profile.py`, `src/bernstein/core/agents/spawner_prompt.py` | New mode profile, profile selection input change | `manual-prose` |
+| `artifact-lineage.md` | `src/bernstein/core/persistence/lineage.py`, `src/bernstein/cli/commands/lineage_cmd.py` | Lineage record schema change | `manual-prose` |
+| `ast-aware-chunking.md` | `src/bernstein/core/quality/review_pipeline/ast_chunker.py`, `src/bernstein/core/knowledge/ast_symbol_graph.py` | Chunker public surface change | `manual-prose` |
+| `best-of-n.md` | `src/bernstein/core/orchestration/best_of_n.py`, `src/bernstein/core/orchestration/tick_pipeline.py` | New routing input, tick-pipeline hook change | `manual-prose` |
+| `feature-contract.md` | `src/bernstein/core/planning/feature_contract.py`, `src/bernstein/core/security/audit.py`, `src/bernstein/core/quality/janitor.py` | Feature-contract schema change, audit hook signature change | `manual-prose` |
+| `fingerprint-memoization.md` | `src/bernstein/core/persistence/fingerprint.py` | Memoization key inputs change | `manual-prose` |
+| `jsonl-memory-log.md` | `src/bernstein/core/memory/jsonl_log.py`, `src/bernstein/core/memory/sqlite_store.py`, `src/bernstein/cli/commands/memory_cmd.py` | Event schema change, store backend swap | `manual-prose` |
+| `orchestrator-hardening.md` | `src/bernstein/core/orchestration/orchestrator.py`, `src/bernstein/core/orchestration/adaptive_parallelism.py`, `src/bernstein/core/orchestration/tick_budget.py`, `src/bernstein/core/cost/cost_tracker.py` | New hardening primitive, budget knob added | `manual-prose` |
+| `phase-pipeline.md` | `src/bernstein/core/orchestration/phase_pipeline.py`, `src/bernstein/core/planning/plan_loader.py`, `src/bernstein/core/routing/router.py` | New phase, phase contract change | `manual-prose` |
+| `sandbox-selector.md` | `src/bernstein/core/sandbox/selector.py`, `src/bernstein/core/sandbox/registry.py` | New sandbox backend registered, selector heuristic change | `manual-prose` |
+| `scaffold.md` | `src/bernstein/cli/commands/scaffold_cmd.py`, `src/bernstein/cli/scaffold/templates.py` | New scaffold template, CLI flag change | `manual-prose` |
+| `schema-validation-retry.md` | `src/bernstein/core/tasks/schema_retry.py` | Retry policy change, schema validator change | `manual-prose` |
+| `spec-as-test.md` | `src/bernstein/core/planning/spec_assertions.py`, `src/bernstein/core/orchestration/drain.py`, `src/bernstein/cli/run_cmd.py` | Spec-assertion schema change, drain-hook signature change | `manual-prose` |
+| `swarm-migration.md` | `src/bernstein/core/tasks/swarm_migration.py`, `src/bernstein/cli/commands/migrate_cmd.py` | Migration entry point change, CLI flag change | `manual-prose` |
+| `task-budgets.md` | `src/bernstein/core/cost/budget_countdown.py` | Budget-format function renamed | `manual-prose` |
+| `team-hub.md` | `src/bernstein/core/plugins_core/team_hub_loader.py`, `src/bernstein/core/plugins_core/team_hub_manifest.py` | Manifest schema change | `manual-prose` |
+| `wiki-build.md` | `src/bernstein/cli/commands/wiki_cmd.py`, `src/bernstein/core/knowledge/ast_symbol_graph.py`, `src/bernstein/core/knowledge/wiki_renderer.py` | Wiki-build CLI flag change, renderer output schema change | `manual-prose` |
+
+### `docs/gui/`
+
+Source of truth for this group is `src/bernstein/gui/` (FastAPI + SPA), `web/`
+(Vite + React + Tailwind), and the GUI mount logic.
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `index.md` | `src/bernstein/gui/__init__.py`, `src/bernstein/gui/cli.py`, `web/` | New tab added to the SPA, `gui-meta` route change | `manual-prose` |
+| `install.md` | `src/bernstein/gui/cli.py`, `pyproject.toml` `[project.optional-dependencies]` (`gui` extra) | New runtime dep in `gui` extra, install-time check change | `manual-prose` |
+| `configuration.md` | `src/bernstein/core/security/auth_middleware.py`, `src/bernstein/cli/run_bootstrap.py`, `src/bernstein/adapters/mock.py`, `src/bernstein/core/fleet/` | Auth source change, idle-mode change, fleet wiring change | `manual-prose` |
+| `screens.md` | `web/src/` SPA component tree | New per-task drawer tab, new top-level tab | `manual-prose` |
+| `playground.md` | `src/bernstein/adapters/mock.py`, `src/bernstein/cli/run_bootstrap.py` (`--idle`) | Mock-idle option change | `manual-prose` |
+| `troubleshooting.md` | `src/bernstein/gui/cli.py` (`_check_gui_extras`), static-assets gating | Error-message change in the extras check | `manual-prose` |
+| `mobile.md` | `web/` responsive breakpoints | Layout breakpoint change | `manual-prose` |
+
+### `docs/compare/`
+
+Pre-existing comparison memos. Treated as static for the drift gate; the gate
+only verifies that the linked files exist and that the entry in
+`docs/index.md` (if any) still resolves. Do not rewrite competitor content
+here from a drift-check pass.
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `README.md` | None (index of the comparison memos in this folder) | A memo is renamed or removed | `static` |
+| `bernstein-vs-agentsmesh.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-claude-flow.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-claude-squad.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-conductor.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-crystal.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-dorothy.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-github-agent-hq.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-paperclip.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-parallel-code.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-single-agent.md` | None | Manual refresh by operator | `static` |
+| `bernstein-vs-stoneforge.md` | None | Manual refresh by operator | `static` |
+| `deterministic-vs-llm-orchestration.md` | None | Manual refresh by operator | `static` |
+| `openai-agents.md` | None | Manual refresh by operator | `static` |
+
+### `docs/sdd/`
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `ticket_schema.md` | `.sdd/backlog/` ticket files; ticket consumers under `src/bernstein/core/planning/` | New required ticket field, label taxonomy change | `manual-prose` |
+
+### Benchmarks
+
+| Doc | Source of truth | Drift signal | Remediation |
+|-----|-----------------|--------------|-------------|
+| `docs/benchmarks/BENCHMARKS.md` | `src/bernstein/benchmark/`, `scripts/generate_benchmark_docs.py`, simulation harness inputs | New benchmark added, methodology change | `gen-benchmarks` (regenerate) or `manual-prose` |
+
+## Cross-repo
+
+The public website and several long-form pages live in
+[`sipyourdrink-ltd/bernstein-landing`](https://github.com/sipyourdrink-ltd/bernstein-landing).
+These pages mirror or extend the bernstein docs; when bernstein docs change,
+the landing copy may need a follow-up edit.
+
+| Landing page | Mirrors / extends |
+|--------------|-------------------|
+| `app/cli-quickstart/page.tsx` | `README.md` install + first-run, `docs/getting-started/install.md`, `docs/getting-started/first-run.md` |
+| `app/docs/cli/page.tsx` | `README.md` operator-commands table, `docs/reference/cli/` |
+| `app/why-bernstein/page.tsx` | `README.md` "at a glance" + capabilities, `docs/whats-new.md` |
+| `app/compare/` | `docs/compare/` comparison memos |
+| Blog (`app/blog/`) | Long-form essays that may cite `docs/concepts/` or `docs/architecture/` |
+
+The CI drift gate dispatches a `docs-mirror-sync` workflow in bernstein-landing
+on every push to `main` (only if the `LANDING_REPO_PAT` secret is set). The
+landing-side workflow is responsible for opening its own follow-up PR with the
+mirrored content.
+
+## Adding a new doc
+
+When you add a new file under `docs/` (or a new root-level doc):
+
+1. Add a row to the appropriate table above.
+2. Set the source-of-truth column to a concrete module path under `src/`, or
+   to `static` if there is no code source.
+3. Update `scripts/check_docs_drift.py` only if the new doc needs a custom
+   check beyond "the named source-of-truth file still exists." The default
+   path-existence check covers the common case.
+4. If the new doc is operator-facing, link it from `docs/index.md`.
+
+## Adding a new code module
+
+When you add a new top-level package under `src/bernstein/` or a new module
+that becomes a source of truth for a doc:
+
+1. Run `uv run bernstein agents-md sync` so the canonical AGENTS.md / CLAUDE.md
+   / CONVENTIONS.md / `.goosehints` / `.cursor/rules/*.mdc` pick up the new
+   module entry.
+2. Run `uv run bernstein agents-md verify` to confirm all five outputs agree.
+3. If the new module has a concept-doc-worthy public surface, add a file under
+   `docs/concepts/` and a corresponding row in this playbook.

--- a/scripts/check_docs_drift.py
+++ b/scripts/check_docs_drift.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Docs drift checker.
+
+Walks the doc inventory recorded in ``docs/playbooks/docs-drift.md`` and
+emits a report describing which docs are likely stale relative to their
+source-of-truth files.
+
+Checks performed:
+
+1. Every ``Source of truth`` path referenced in the playbook must exist
+   under the repository root. If it does not, the doc that names it has
+   drifted: either the doc references a moved/renamed module or the
+   playbook itself needs updating.
+2. The canonical AGENTS.md / CLAUDE.md / CONVENTIONS.md / `.goosehints`
+   / `.cursor/rules/*.mdc` outputs must agree with
+   ``bernstein agents-md verify``.
+3. Every doc enumerated in the playbook must exist on disk.
+
+Outputs a Markdown report on stdout. Exits non-zero on drift only when
+called with ``--strict`` (used by the CI gate on pushes to main); for
+pull requests the workflow runs without ``--strict`` so the comment
+posts as advisory.
+
+Usage:
+
+    uv run python scripts/check_docs_drift.py [--strict] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLAYBOOK = REPO_ROOT / "docs" / "playbooks" / "docs-drift.md"
+
+# A markdown table row matches when it has at least 4 pipe-separated
+# columns: doc / source / drift signal / remediation.
+_ROW_RE = re.compile(r"^\|\s*`([^`|]+?)`\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*`([a-z-]+)`\s*\|\s*$")
+# Within the "source of truth" column, repo-relative paths are written as
+# ``backticked`` tokens. Any token that starts with src/, scripts/,
+# templates/, web/, pyproject.toml, .sdd/, .github/, .importlinter,
+# release-please-*, .cursor/, or a docs/ subdir is treated as a path.
+_PATH_RE = re.compile(r"`([^`\s]+)`")
+
+
+@dataclass
+class DocRow:
+    doc: str
+    sources_raw: str
+    drift_signal: str
+    remediation: str
+    section: str = ""
+
+    @property
+    def source_paths(self) -> list[str]:
+        out: list[str] = []
+        for match in _PATH_RE.finditer(self.sources_raw):
+            tok = match.group(1)
+            if tok.endswith(".py") or "/" in tok or tok.endswith(".toml"):
+                out.append(tok.rstrip("/"))
+        return out
+
+
+@dataclass
+class DriftReport:
+    missing_sources: list[tuple[DocRow, str]] = field(default_factory=list)
+    missing_docs: list[DocRow] = field(default_factory=list)
+    agents_md_drift: list[str] = field(default_factory=list)
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.missing_sources and not self.missing_docs and not self.agents_md_drift
+
+
+def parse_playbook(path: Path) -> list[DocRow]:
+    rows: list[DocRow] = []
+    section = ""
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("###"):
+            section = line.lstrip("# ").strip()
+            continue
+        match = _ROW_RE.match(line)
+        if not match:
+            continue
+        doc, src, drift, remediation = match.groups()
+        # Skip the legend table at the top of the playbook (its first
+        # column lists remediation tokens, not real doc paths). The
+        # legend has no real source path, only descriptive prose, so the
+        # row is filtered out by checking the second column for an
+        # explicit "What it runs" header on the surrounding section.
+        if section.lower().startswith("how agents pick"):
+            continue
+        rows.append(
+            DocRow(
+                doc=doc.strip(),
+                sources_raw=src.strip(),
+                drift_signal=drift.strip(),
+                remediation=remediation.strip(),
+                section=section,
+            )
+        )
+    return rows
+
+
+def _doc_path(row: DocRow) -> Path:
+    # Root-level docs are written as bare filenames (README.md, ...).
+    # Everything else is repo-relative (docs/concepts/foo.md).
+    if "/" in row.doc:
+        return REPO_ROOT / row.doc
+    if row.section.lower().startswith("root"):
+        return REPO_ROOT / row.doc
+    # Heuristic fallback: section names like "docs/concepts/" map a
+    # bare filename row to that subdir.
+    if row.section.startswith("`docs/") and row.section.endswith("`"):
+        subdir = row.section.strip("`")
+        return REPO_ROOT / subdir / row.doc
+    return REPO_ROOT / row.doc
+
+
+# Path prefixes that are runtime state (gitignored) or output artefacts;
+# their absence in the working tree is expected and does not indicate drift.
+_RUNTIME_PREFIXES = (".sdd/", ".bernstein/", "dist/", "build/", "node_modules/")
+
+
+def check_sources(rows: list[DocRow]) -> list[tuple[DocRow, str]]:
+    missing: list[tuple[DocRow, str]] = []
+    for row in rows:
+        if row.remediation == "static":
+            continue
+        for src in row.source_paths:
+            if any(src.startswith(prefix) for prefix in _RUNTIME_PREFIXES):
+                continue
+            full = REPO_ROOT / src
+            if not full.exists():
+                missing.append((row, src))
+    return missing
+
+
+def check_docs(rows: list[DocRow]) -> list[DocRow]:
+    missing: list[DocRow] = []
+    for row in rows:
+        path = _doc_path(row)
+        if not path.exists():
+            missing.append(row)
+    return missing
+
+
+def check_agents_md() -> list[str]:
+    """Run ``bernstein agents-md verify`` and report drift lines.
+
+    The check is best-effort. If the CLI is not installed (CI runs
+    without the bernstein package in some matrices) it returns an empty
+    list rather than failing the gate.
+    """
+    try:
+        result = subprocess.run(
+            ["uv", "run", "--quiet", "bernstein", "agents-md", "verify"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if result.returncode == 0:
+        return []
+    lines = [
+        line
+        for line in (result.stdout + result.stderr).splitlines()
+        if "drift" in line.lower() or "out of sync" in line.lower()
+    ]
+    return lines or ["bernstein agents-md verify exited non-zero"]
+
+
+def render_markdown(report: DriftReport) -> str:
+    parts: list[str] = ["# Docs drift report\n"]
+    if report.is_clean:
+        parts.append("No drift detected. Docs are in sync with code.\n")
+        return "".join(parts)
+
+    if report.agents_md_drift:
+        parts.append("## AGENTS.md / CLAUDE.md / CONVENTIONS.md sync drift\n\n")
+        for line in report.agents_md_drift:
+            parts.append(f"- {line}\n")
+        parts.append("\nRun `uv run bernstein agents-md sync` to refresh.\n\n")
+
+    if report.missing_sources:
+        parts.append("## Doc references a missing source-of-truth path\n\n")
+        parts.append("| Doc | Missing source | Remediation |\n")
+        parts.append("|-----|----------------|-------------|\n")
+        for row, src in report.missing_sources:
+            parts.append(f"| `{row.doc}` | `{src}` | `{row.remediation}` |\n")
+        parts.append(
+            "\nEither the doc references a moved or renamed module, or the "
+            "drift playbook needs a row update. Open the doc, check the "
+            "source-of-truth column in `docs/playbooks/docs-drift.md`, and "
+            "fix the stale path.\n\n"
+        )
+
+    if report.missing_docs:
+        parts.append("## Doc enumerated in the playbook is missing on disk\n\n")
+        for row in report.missing_docs:
+            parts.append(f"- `{row.doc}` (section: {row.section})\n")
+        parts.append("\nEither restore the doc or remove the row from `docs/playbooks/docs-drift.md`.\n\n")
+
+    return "".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when drift is detected (used by the main-branch gate).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON summary instead of the Markdown report.",
+    )
+    args = parser.parse_args()
+
+    rows = parse_playbook(PLAYBOOK)
+    if not rows:
+        print("ERROR: could not parse any doc rows from", PLAYBOOK, file=sys.stderr)
+        return 1
+
+    report = DriftReport(
+        missing_sources=check_sources(rows),
+        missing_docs=check_docs(rows),
+        agents_md_drift=check_agents_md(),
+    )
+
+    if args.json:
+        payload = {
+            "clean": report.is_clean,
+            "missing_sources": [{"doc": row.doc, "source": src} for row, src in report.missing_sources],
+            "missing_docs": [row.doc for row in report.missing_docs],
+            "agents_md_drift": report.agents_md_drift,
+            "rows_checked": len(rows),
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(render_markdown(report))
+
+    if args.strict and not report.is_clean:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Comprehensive documentation sync after recent code changes; adds a drift-check CI workflow to keep docs in lockstep with code going forward.

- New playbook at `docs/playbooks/docs-drift.md` enumerating every root-level and `docs/` markdown file (root, `docs/`, `docs/concepts/`, `docs/gui/`, `docs/compare/`, `docs/sdd/`) with a concrete source-of-truth pointer into `src/bernstein/...` or an explicit `static` marker.
- New CI gate at `.github/workflows/docs-drift.yml` plus `scripts/check_docs_drift.py`. Runs on every push to `main` and every PR. On PRs it posts the report as a non-blocking comment (so the change can land in the same PR); on `main` the gate fails so the drift gets fixed in a follow-up. Also dispatches a `docs-mirror-sync` workflow in `sipyourdrink-ltd/bernstein-landing` on main-branch pushes; skips silently when the `LANDING_REPO_PAT` secret is not set.
- Root-doc refresh: `README.md` (adapter-count version anchor moved from v1.10.7 to v2.2.x), `CONTRIBUTING.md` (adapter count 43 -> 44, role list now matches `templates/roles/`). `AGENTS.md` / `CLAUDE.md` / `CONVENTIONS.md` / `.goosehints` / `.cursor/rules/*.mdc` are produced by `bernstein agents-md sync` and verified clean by `bernstein agents-md verify`. `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `CONTRIBUTORS.md` reviewed - no drift.
- `docs/` refresh: 3 files (`docs/index.md` adapter-count fix; `docs/concepts/spec-as-test.md` `run_cmd.py` path corrected to `cli/` not `cli/commands/`; `docs/concepts/artifact-lineage.md` `pii_gating.py` -> `pii_output_gate.py`). Concept docs, GUI docs, and `docs/index.md` cross-checked against current code; the rest had no drift to fix. Per the playbook convention, `docs/compare/` content is left untouched - the gate only verifies the files exist.

## Test plan

- [x] `python3 scripts/check_docs_drift.py --strict` exits 0 in the worktree
- [x] `uv run --quiet bernstein agents-md verify` reports `OK all 13 file(s) in sync`
- [x] `uv run ruff check scripts/check_docs_drift.py` clean
- [x] `uv run ruff format --check scripts/check_docs_drift.py` clean
- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI `docs-drift` job runs green on this PR
- [ ] On a follow-up PR that touches a doc-source-of-truth path, the drift report posts as a PR comment

## Summary by Sourcery

Add a docs drift playbook and automated drift-check workflow, and refresh key documentation to align with current code and adapter counts.

New Features:
- Introduce a docs drift playbook enumerating all major docs with their code sources of truth and remediation guidance.
- Add a Python-based docs drift checker that validates playbook entries, doc existence, and agents metadata sync.
- Set up a docs-drift GitHub Actions workflow that runs on pushes and PRs, posts advisory PR comments, and triggers cross-repo docs mirroring to the landing site.

Enhancements:
- Update README, CONTRIBUTING, and docs index/concept pages to reflect the current adapter count, role list, and correct module paths.