### PR TITLE
fix(ci): lock aider adapter-integration job to Python 3.13

### DIFF
--- a/.github/workflows/adapter-contract-drift.yml
+++ b/.github/workflows/adapter-contract-drift.yml
@@ -77,7 +77,9 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          # aider-chat does not yet support Python 3.14; pin the aider
+          # matrix row to 3.13 until upstream lands 3.14 compatibility.
+          python-version: ${{ matrix.adapter == 'aider' && '3.13' || '3.14' }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
aider-chat does not yet support Python 3.14; the adapter-integration job for aider must stay on 3.13 until upstream lands 3.14 compatibility. This unblocks PRs that picked up 3.14 via the python-version matrix bump.

## Summary by Sourcery

CI:
- Adjust the adapter-contract-drift workflow to use Python 3.13 specifically for the aider adapter while retaining Python 3.14 for other matrix entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline configuration to use Python 3.13 for the aider adapter and Python 3.14 for other adapters, ensuring more appropriate testing environments across different adapter types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->