### PR TITLE
chore(ci): retarget python from 3.14 to 3.13

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.13"
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
@@ -149,7 +149,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Run data-freshness check (soft on PR, strict on push to main)
         run: |

--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Run review-bot acknowledgement gate
         env:

--- a/.github/workflows/review-bot-sweep.yml
+++ b/.github/workflows/review-bot-sweep.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - name: Sweep merged PRs and collect missed findings
         id: collect


### PR DESCRIPTION
## Summary

Retargets the python version used by three CI workflows from 3.14 back to 3.13. The 3.14 references were introduced via #1581 (auto-merged before the retarget could be re-applied).

3.14 has known regressions with adapter dependencies; 3.13 is the safer intermediate step. The repository CI matrix already covers 3.13 across the main test jobs.

Files changed:
- `.github/workflows/docs-drift.yml` (two references)
- `.github/workflows/review-bot-ack.yml`
- `.github/workflows/review-bot-sweep.yml`

## Test plan
- [ ] CI green on all required checks
- [ ] docs-drift and review-bot workflows run successfully on 3.13

## Summary by Sourcery

Retarget CI workflows to use Python 3.13 instead of 3.14 for documentation drift checks and review bot jobs.

CI:
- Update docs-drift workflow to run on Python 3.13.
- Update review-bot acknowledgement workflow to run on Python 3.13.
- Update review-bot sweep workflow to run on Python 3.13.