### PR TITLE
chore(renovate): pin python to <=3.13 until adapter 3.14 compat is confirmed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,22 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Pin python to 3.13 until aider-chat and other adapters confirm 3.14 compatibility.",
+      "matchManagers": [
+        "github-actions",
+        "docker-compose",
+        "dockerfile",
+        "regex"
+      ],
+      "matchPackagePatterns": [
+        "^python$",
+        "actions/python-versions",
+        "actions/setup-python"
+      ],
+      "allowedVersions": "<=3.13"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate has reopened the Python 3.14 bump three times in one day (#1533 retargeted to 3.13, #1581 retargeted to 3.13, #1589 currently open). Each cycle burns CI minutes and shepherd review attention on a change we cannot land yet: `aider-chat` and similar adapter packages fail to install on 3.14 via `pipx`, and other adapter dependencies have not published 3.14 wheels.

This PR adds a `packageRules` entry to `renovate.json` that caps the `python` package (plus `actions/setup-python` and `actions/python-versions`) at `<=3.13` across the `github-actions`, `docker-compose`, `dockerfile`, and `regex` managers. The pin is intentionally temporary; a separate ticket should track lifting it once the adapter ecosystem catches up to 3.14.

## Test plan

- [ ] Confirm Renovate validates the updated config (Mend Renovate config validation check on this PR).
- [ ] After merge, confirm Renovate does not re-open a 3.14 bump on the next scheduled run.
- [ ] Open follow-up ticket to revisit the pin once `aider-chat` ships 3.14 compatibility.

## Summary by Sourcery

Build:
- Update Renovate configuration to cap Python, actions/setup-python, and actions/python-versions dependencies at <=3.13 for relevant managers to prevent 3.14 bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation configuration to constrain Python package versions to 3.13 and earlier until version 3.14 compatibility is confirmed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->