### PR TITLE
fix(test): repair main-red after merges

### DIFF
--- a/src/bernstein/core/git/git_context.py
+++ b/src/bernstein/core/git/git_context.py
@@ -42,7 +42,7 @@ def _run_git(args: list[str], cwd: Path, *, timeout: int = 10) -> str | None:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     except (subprocess.TimeoutExpired, OSError) as exc:
-        args_str = " ".join(a for a in args)
+        args_str = " ".join(str(a) for a in args)
         logger.debug("git %s failed: %s", args_str, exc)
     return None
 


### PR DESCRIPTION
## Summary

Main branch CI went red on HEAD d1b58539 (run 26112876751). Three unit tests fail on Python 3.12 and 3.13, both ubuntu-latest and macos-latest, with:

    TypeError: sequence item 6: expected str instance, PosixPath found

Originating change: PR #1558 (commit f584180d, "fix(quality): bulk refurb auto-fix across src/"). The FURB155 batch in that PR rewrote `src/bernstein/core/git/git_context.py:_run_git` and dropped the `str()` conversion in the debug-log args formatter:

    args_str = " ".join(str(a) for a in args)   # before
    args_str = " ".join(a for a in args)        # after refurb

The exception handler runs only when `subprocess.run` raises `TimeoutExpired` or `OSError`. Callers in `core/knowledge/knowledge_base.py` (and the existing tests) pass a `pathlib.Path` positionally into a slot that ends up in the git argv list, so the bare join now raises and propagates out of `_run_git` instead of being swallowed by the existing defensive path.

Fix: restore the `str()` conversion. One-line change, no behaviour change beyond reinstating the defensive log formatting.

## Failing tests now passing locally

- tests/unit/test_context.py::TestGitCochangedFiles::test_returns_list
- tests/unit/test_context_builder.py::TestTaskContextBuilder::test_includes_file_summary_for_python_files
- tests/unit/test_failure_reduction.py::TestFileContextDiscovery::test_task_context_includes_file_info

## Test plan

- [x] Reproduce all three failures locally on Python 3.13 with `uv run pytest <path> -x -q`
- [x] Apply fix; rerun the three tests, all pass
- [ ] CI green on this PR before merge

## Summary by Sourcery

Bug Fixes:
- Fix TypeError in git subprocess error logging by converting all arguments to strings before joining.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message robustness for command failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->