### PR TITLE
feat(devops): scheduled upstream-signal sweep with operator rollup

### DIFF
--- a/.github/workflows/trend-scan.yml
+++ b/.github/workflows/trend-scan.yml
@@ -1,0 +1,74 @@
+name: Trend scan
+
+# Scheduled job that ingests upstream dependency-relevant signals into the
+# orchestrator state as a markdown rollup. The rollup is uploaded as a
+# workflow artifact for operator review. No tickets are filed automatically.
+#
+# Default: workflow_dispatch only. Operators opt in to the weekly schedule
+# by uncommenting the cron block below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: "Tier filter (all | 1 | 2 | 3)"
+        required: false
+        default: "all"
+  # schedule:
+  #   - cron: "0 13 * * 1"  # Monday 13:00 UTC
+
+concurrency:
+  group: trend-scan
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  scan:
+    name: Run trend scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install bernstein (editable)
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run trend-scan (offline stub)
+        env:
+          TIER: ${{ github.event.inputs.tier || 'all' }}
+          BERNSTEIN_TREND_SCAN_OFFLINE: "1"
+        run: |
+          set -euo pipefail
+          mkdir -p .sdd/trend-scan
+          bernstein trend-scan run \
+            --tier "${TIER}" \
+            --rollup-dir .sdd/trend-scan \
+            --backlog-dir .sdd/backlog \
+            --offline-stub
+
+      - name: Upload rollup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trend-scan-rollup
+          path: |
+            .sdd/trend-scan/rollup-*.md
+            .sdd/trend-scan/rollup-*.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/devops/trend-scan-automation.md
+++ b/docs/devops/trend-scan-automation.md
@@ -1,0 +1,95 @@
+# Trend scan automation
+
+A scheduled job that ingests upstream dependency-relevant signals into the
+orchestrator backlog directory as a markdown rollup. No tickets are filed
+automatically; the operator reviews the rollup and runs `bernstein backlog
+new` for the rows that warrant a ticket.
+
+## What it does
+
+1. Iterates configured source specs (each with required + boost +
+   negative keywords).
+2. Calls an injected fetcher per source (a subprocess command, or an
+   offline stub for testing).
+3. Scores candidates with a deterministic keyword-overlap function,
+   normalised by document length.
+4. Runs gap analysis against `.sdd/backlog/` and (optionally) a list of
+   recently-closed issue keywords, classifying each row as `new`,
+   `duplicate`, or `recently-closed`.
+5. Writes a markdown rollup plus a sibling JSON file.
+
+## CLI
+
+```
+bernstein trend-scan run \
+  --tier all \
+  --rollup-dir .sdd/trend-scan \
+  --backlog-dir .sdd/backlog
+```
+
+Common flags:
+
+| Flag | Purpose |
+| --- | --- |
+| `--tier` | Restrict to one tier (`all`, `1`, `2`, `3`). |
+| `--output` | Override the rollup file path. |
+| `--sources` | JSON file overriding the default source specs. |
+| `--fetcher-cmd` | External fetcher executable. |
+| `--offline-stub` | Force the no-op fetcher (no network). |
+| `--max-per-source` | Cap candidates surfaced per source (default 5). |
+
+### Source spec format
+
+```json
+[
+  {
+    "name": "python-release-notes",
+    "tier": 1,
+    "keywords": ["python", "release"],
+    "boost_keywords": ["security", "deprecation"],
+    "negative_keywords": ["draft"],
+    "min_score": 0.5
+  }
+]
+```
+
+### Wiring a real fetcher
+
+The CLI does not perform network I/O itself. To feed live data, point
+`--fetcher-cmd` at an executable. It is invoked once per source:
+
+```
+<fetcher-cmd> <source_name> <tier>
+```
+
+The executable must write one JSON object per line on stdout with the
+shape:
+
+```json
+{"title": "...", "url": "...", "ts": "2026-05-19T00:00:00Z", "body": "..."}
+```
+
+Malformed lines are skipped with a warning. Non-zero exit treats the
+source as empty for that run.
+
+## Scheduled workflow
+
+`.github/workflows/trend-scan.yml` runs the CLI on `workflow_dispatch` by
+default. To enable the weekly schedule, uncomment the `schedule:` block in
+that file. The job uploads the rollup as a workflow artifact for operator
+review; it does not commit or open issues.
+
+## Operator workflow
+
+1. Open the latest workflow run, download `trend-scan-rollup`.
+2. Skim the table; ignore `duplicate` and `recently-closed` rows unless
+   context has changed.
+3. For each `new` row that warrants action, run `bernstein backlog new`
+   and paste the relevant URL plus a one-line problem statement.
+
+## Tests
+
+`tests/unit/devops/test_trend_scan.py` covers scoring, filtering, gap
+analysis, the end-to-end `run_scan` entry point, and a CLI smoke test
+using `click.testing.CliRunner`. All tests use the offline stub or
+injected fetchers; nothing in the test suite touches the network.

--- a/src/bernstein/cli/commands/trend_scan_cmd.py
+++ b/src/bernstein/cli/commands/trend_scan_cmd.py
@@ -1,0 +1,238 @@
+"""CLI surface for the scheduled trend-scan job.
+
+``bernstein trend-scan run`` ingests upstream dependency-relevant signals
+into the orchestrator backlog directory as a markdown rollup. No tickets are
+filed automatically.
+
+Network access is opt-in: the default fetcher is the offline stub
+(``--offline-stub`` / ``BERNSTEIN_TREND_SCAN_OFFLINE=1``), which returns an
+empty result set. Operators wire a real fetcher by passing ``--fetcher-cmd``
+that points to an executable returning one JSON item per line on stdout.
+This keeps the CLI testable in CI without leaking outbound HTTP into unit
+tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from bernstein.core.devops.trend_scan import (
+    RawItem,
+    SourceSpec,
+    TrendScanConfig,
+    load_default_sources,
+    run_scan,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = ["trend_scan_group"]
+
+
+def _parse_sources_json(path: Path) -> tuple[SourceSpec, ...]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        msg = "--sources file must contain a JSON array of source specs"
+        raise click.BadParameter(msg)
+    specs: list[SourceSpec] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            msg = "each source spec must be an object"
+            raise click.BadParameter(msg)
+        try:
+            specs.append(
+                SourceSpec(
+                    name=str(entry["name"]),
+                    tier=int(entry["tier"]),  # type: ignore[arg-type]
+                    keywords=tuple(entry.get("keywords", ())),
+                    boost_keywords=tuple(entry.get("boost_keywords", ())),
+                    negative_keywords=tuple(entry.get("negative_keywords", ())),
+                    min_score=float(entry.get("min_score", 0.5)),
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            msg = f"invalid source spec entry: {exc}"
+            raise click.BadParameter(msg) from exc
+    return tuple(specs)
+
+
+def _filter_by_tier(sources: Iterable[SourceSpec], tier: str) -> tuple[SourceSpec, ...]:
+    if tier == "all":
+        return tuple(sources)
+    want = int(tier)
+    return tuple(s for s in sources if s.tier == want)
+
+
+def _stub_fetcher(_spec: SourceSpec) -> Iterable[RawItem]:
+    """Offline stub. Returns no items.
+
+    Used when the operator has not wired an external fetcher. The rollup
+    still gets written (with a "no candidates" body), which is useful for
+    smoke-testing the scheduled workflow.
+    """
+
+    return ()
+
+
+def _make_subprocess_fetcher(fetcher_cmd: str, timeout: float):
+    def _fetch(spec: SourceSpec) -> Iterable[RawItem]:
+        argv = [*shlex.split(fetcher_cmd), spec.name, str(spec.tier)]
+        try:
+            completed = subprocess.run(
+                argv,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            click.echo(f"trend-scan: fetcher timed out for source={spec.name}", err=True)
+            return ()
+        if completed.returncode != 0:
+            click.echo(
+                f"trend-scan: fetcher exit {completed.returncode} for source={spec.name}: "
+                f"{completed.stderr.strip()[:200]}",
+                err=True,
+            )
+            return ()
+        items: list[RawItem] = []
+        for raw_line in completed.stdout.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                click.echo(f"trend-scan: ignoring non-JSON line from source={spec.name}", err=True)
+                continue
+            try:
+                items.append(
+                    RawItem(
+                        title=str(payload["title"]),
+                        url=str(payload.get("url", "")),
+                        ts=str(payload.get("ts", "")),
+                        body=str(payload.get("body", "")),
+                    )
+                )
+            except (KeyError, TypeError):
+                click.echo(f"trend-scan: ignoring malformed item from source={spec.name}", err=True)
+                continue
+        return items
+
+    return _fetch
+
+
+@click.group(name="trend-scan")
+def trend_scan_group() -> None:
+    """Scheduled upstream-signal sweep.
+
+    Produces an operator-reviewable markdown rollup. No tickets are filed
+    automatically; the operator decides which rows become tickets.
+    """
+
+
+@trend_scan_group.command("run")
+@click.option(
+    "--tier",
+    type=click.Choice(["all", "1", "2", "3"]),
+    default="all",
+    show_default=True,
+    help="Which tier(s) to scan.",
+)
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Rollup output path. Defaults to .sdd/trend-scan/rollup-<date>.md.",
+)
+@click.option(
+    "--backlog-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".sdd/backlog"),
+    show_default=True,
+    help="Backlog directory used for gap analysis.",
+)
+@click.option(
+    "--rollup-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".sdd/trend-scan"),
+    show_default=True,
+    help="Directory for rollup files when --output is not set.",
+)
+@click.option(
+    "--sources",
+    "sources_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="JSON file overriding the default source specs.",
+)
+@click.option(
+    "--fetcher-cmd",
+    type=str,
+    default=None,
+    help="Executable that returns one JSON item per line on stdout. "
+    "Invoked as: <cmd> <source_name> <tier>. If unset, the offline stub is used.",
+)
+@click.option(
+    "--fetcher-timeout",
+    type=float,
+    default=30.0,
+    show_default=True,
+    help="Per-source fetcher timeout in seconds.",
+)
+@click.option(
+    "--max-per-source",
+    type=click.IntRange(min=1, max=50),
+    default=5,
+    show_default=True,
+    help="Cap on candidates surfaced per source.",
+)
+@click.option(
+    "--offline-stub/--no-offline-stub",
+    default=False,
+    help="Force the offline stub fetcher (no network).",
+)
+def trend_scan_run(
+    tier: str,
+    output: Path | None,
+    backlog_dir: Path,
+    rollup_dir: Path,
+    sources_path: Path | None,
+    fetcher_cmd: str | None,
+    fetcher_timeout: float,
+    max_per_source: int,
+    offline_stub: bool,
+) -> None:
+    """Run the scan and write the rollup."""
+
+    sources = _parse_sources_json(sources_path) if sources_path is not None else load_default_sources()
+
+    selected = _filter_by_tier(sources, tier)
+    if not selected:
+        click.echo(f"trend-scan: no sources selected for tier={tier}", err=True)
+        sys.exit(2)
+
+    config = TrendScanConfig(
+        sources=selected,
+        backlog_dir=backlog_dir,
+        rollup_dir=rollup_dir,
+        max_candidates_per_source=max_per_source,
+    )
+
+    if offline_stub or os.environ.get("BERNSTEIN_TREND_SCAN_OFFLINE") == "1" or fetcher_cmd is None:
+        fetcher = _stub_fetcher
+    else:
+        fetcher = _make_subprocess_fetcher(fetcher_cmd, fetcher_timeout)
+
+    result = run_scan(config, fetcher=fetcher, output_path=output)
+
+    click.echo(f"trend-scan: wrote rollup with {len(result.candidates)} candidates -> {result.rollup_path}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1096,3 +1096,8 @@ cli.add_command(simulate_cmd, "simulate")
 from bernstein.cli.commands.telemetry_cmd import telemetry_group  # noqa: E402
 
 cli.add_command(telemetry_group, "telemetry")
+
+# Scheduled upstream-signal sweep (operator-reviewable rollup, no auto-filing).
+from bernstein.cli.commands.trend_scan_cmd import trend_scan_group  # noqa: E402
+
+cli.add_command(trend_scan_group, "trend-scan")

--- a/src/bernstein/core/devops/__init__.py
+++ b/src/bernstein/core/devops/__init__.py
@@ -1,0 +1,7 @@
+"""devops sub-package.
+
+Scheduled orchestrator-side hygiene jobs that produce operator-reviewable
+artefacts (no auto-filing). Each module under this package is independently
+importable via its fully-qualified path; this package init intentionally
+exposes no symbols.
+"""

--- a/src/bernstein/core/devops/trend_scan.py
+++ b/src/bernstein/core/devops/trend_scan.py
@@ -1,0 +1,505 @@
+"""Scheduled upstream-signal ingestion for the orchestrator backlog.
+
+This module powers the ``bernstein trend-scan run`` CLI and the optional
+``trend-scan.yml`` GitHub Actions workflow. It ingests upstream
+dependency-relevant signals (release notes, advisories, RFC threads) from a
+configurable set of sources, runs a deterministic keyword + relevance filter,
+gap-checks each candidate against open / recently-closed issues and the
+``.sdd/backlog/`` directory, and writes a markdown rollup for operator
+review.
+
+Design constraints:
+
+* No auto-filing. The output is a rollup file; the operator decides which
+  candidates become tickets via the existing ``bernstein backlog new`` flow.
+* No network calls inside this module. Source fetchers are injected as
+  callables so tests can stub them and so the CLI can wire whatever fetch
+  primitive the operator prefers (``WebFetch``, ``urllib``, a cached HTTP
+  client, etc.).
+* Deterministic ordering. All sort keys are total: ``(score desc, source,
+  url)``. This keeps the rollup diffable week-over-week.
+* No competitor namedrops in source labels or filters - sources are tiered
+  by signal stability (Tier 1 = upstream release feeds, Tier 2 = advisory
+  feeds), not by any commercial classification.
+
+Public surface:
+
+* :class:`Candidate` - normalised result row.
+* :class:`SourceSpec` - per-source filter config.
+* :class:`TrendScanConfig` - top-level configuration.
+* :func:`run_scan` - orchestrator entry point used by the CLI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+__all__ = [
+    "Candidate",
+    "GapStatus",
+    "RawItem",
+    "SourceSpec",
+    "TrendScanConfig",
+    "TrendScanResult",
+    "build_rollup_markdown",
+    "classify_gap",
+    "filter_items",
+    "load_backlog_keywords",
+    "load_default_sources",
+    "run_scan",
+    "score_item",
+]
+
+
+Tier = Literal[1, 2, 3]
+GapStatus = Literal["new", "duplicate", "recently-closed"]
+
+
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_+-]{1,}")
+
+
+def _tokens(text: str) -> list[str]:
+    """Lowercased word tokens. Cheap, deterministic, no external deps."""
+
+    return [match.group(0).lower() for match in _WORD_RE.finditer(text or "")]
+
+
+@dataclass(frozen=True)
+class RawItem:
+    """One un-filtered item produced by a source fetcher."""
+
+    title: str
+    url: str
+    ts: str  # ISO-8601, ``YYYY-MM-DDTHH:MM:SSZ``
+    body: str = ""
+
+    def fingerprint(self) -> str:
+        """Stable id for dedup across runs and across sources.
+
+        Hashes the URL when present (URLs are canonical), falls back to a
+        normalised title hash for sources that only expose a title.
+        """
+
+        key = (self.url or self.title).strip().lower()
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """Configuration for one source feed.
+
+    ``keywords`` is the inclusion list - at least one must match the title or
+    body for the item to be considered. ``boost_keywords`` adds to the
+    relevance score but is not required for inclusion. ``negative_keywords``
+    drops the item outright.
+    """
+
+    name: str
+    tier: Tier
+    keywords: tuple[str, ...]
+    boost_keywords: tuple[str, ...] = ()
+    negative_keywords: tuple[str, ...] = ()
+    min_score: float = 0.5
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One filtered, scored candidate ready for the rollup."""
+
+    source: str
+    tier: Tier
+    title: str
+    url: str
+    ts: str
+    score: float
+    matched_keywords: tuple[str, ...]
+    gap_status: GapStatus = "new"
+    related_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        data["matched_keywords"] = list(self.matched_keywords)
+        data["related_refs"] = list(self.related_refs)
+        return data
+
+
+@dataclass(frozen=True)
+class TrendScanConfig:
+    """Top-level configuration for one scan run."""
+
+    sources: tuple[SourceSpec, ...]
+    backlog_dir: Path
+    closed_lookback_days: int = 60
+    rollup_dir: Path = field(default_factory=lambda: Path(".sdd/trend-scan"))
+    max_candidates_per_source: int = 5
+
+
+@dataclass(frozen=True)
+class TrendScanResult:
+    """What :func:`run_scan` returns."""
+
+    candidates: tuple[Candidate, ...]
+    rollup_path: Path
+    generated_at: str
+
+
+# ---------------------------------------------------------------------------
+# Filtering + scoring
+# ---------------------------------------------------------------------------
+
+
+def score_item(item: RawItem, spec: SourceSpec) -> tuple[float, tuple[str, ...]]:
+    """Return (score, matched_keywords).
+
+    Scoring is intentionally simple and deterministic:
+
+    * +1.0 per distinct ``keywords`` hit
+    * +0.5 per distinct ``boost_keywords`` hit
+    * normalised by ``log2(1 + |title| + |body|)`` so very long pages don't
+      drown the signal
+    """
+
+    text_tokens = set(_tokens(f"{item.title}\n{item.body}"))
+    if not text_tokens:
+        return 0.0, ()
+
+    neg = {kw.lower() for kw in spec.negative_keywords}
+    if neg & text_tokens:
+        return 0.0, ()
+
+    raw_hits = sorted(text_tokens & {kw.lower() for kw in spec.keywords})
+    if not raw_hits:
+        return 0.0, ()
+
+    boost_hits = sorted(text_tokens & {kw.lower() for kw in spec.boost_keywords})
+    raw_score = float(len(raw_hits)) + 0.5 * float(len(boost_hits))
+    length_norm = math.log2(1.0 + len(text_tokens))
+    score = raw_score / max(length_norm, 1.0)
+
+    return round(score, 4), tuple(raw_hits + boost_hits)
+
+
+def filter_items(items: Iterable[RawItem], spec: SourceSpec) -> list[tuple[RawItem, float, tuple[str, ...]]]:
+    """Apply the spec's keyword filter and score the survivors."""
+
+    scored: list[tuple[RawItem, float, tuple[str, ...]]] = []
+    seen_fingerprints: set[str] = set()
+    for item in items:
+        fp = item.fingerprint()
+        if fp in seen_fingerprints:
+            continue
+        seen_fingerprints.add(fp)
+        score, matched = score_item(item, spec)
+        if score < spec.min_score:
+            continue
+        scored.append((item, score, matched))
+
+    scored.sort(key=lambda row: (-row[1], (row[0].url or row[0].title).lower()))
+    return scored
+
+
+# ---------------------------------------------------------------------------
+# Gap analysis
+# ---------------------------------------------------------------------------
+
+
+def load_backlog_keywords(backlog_dir: Path) -> dict[str, set[str]]:
+    """Return ``{relative_path: token_set}`` for every backlog markdown file.
+
+    Used by :func:`classify_gap` to detect ``duplicate`` candidates against
+    existing open / claimed tickets without requiring a network call.
+    """
+
+    tokens_by_path: dict[str, set[str]] = {}
+    if not backlog_dir.exists():
+        return tokens_by_path
+
+    for path in sorted(backlog_dir.rglob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        rel = str(path.relative_to(backlog_dir))
+        tokens_by_path[rel] = set(_tokens(text))
+
+    return tokens_by_path
+
+
+def classify_gap(
+    candidate_tokens: set[str],
+    backlog_tokens: dict[str, set[str]],
+    closed_issue_keywords: Sequence[tuple[str, set[str]]],
+    *,
+    overlap_threshold: int = 4,
+) -> tuple[GapStatus, tuple[str, ...]]:
+    """Classify a candidate as ``new`` / ``duplicate`` / ``recently-closed``.
+
+    The classifier picks the strongest signal:
+
+    * Duplicate against backlog: token overlap >= ``overlap_threshold`` with
+      any backlog file in ``open/`` or ``claimed/``.
+    * Recently-closed: overlap against ``closed_issue_keywords``.
+    * Otherwise ``new``.
+
+    Returns the status plus a tuple of related refs (file paths or issue
+    keys) sorted by descending overlap. Capped at 5 refs so the rollup stays
+    scannable.
+    """
+
+    if not candidate_tokens:
+        return "new", ()
+
+    backlog_hits: list[tuple[int, int, str]] = []
+    for path, tokens in backlog_tokens.items():
+        overlap = len(candidate_tokens & tokens)
+        if overlap >= overlap_threshold:
+            # Active tickets (``open/`` / ``claimed/``) sort ahead of
+            # ``closed/`` so the operator lands on the live ticket first
+            # when both match.
+            active_priority = 0 if path.startswith(("open/", "claimed/")) else 1
+            backlog_hits.append((active_priority, -overlap, path))
+
+    closed_hits: list[tuple[int, str]] = []
+    for ref, tokens in closed_issue_keywords:
+        overlap = len(candidate_tokens & tokens)
+        if overlap >= overlap_threshold:
+            closed_hits.append((overlap, ref))
+
+    if backlog_hits:
+        backlog_hits.sort()
+        refs = tuple(path for _, _, path in backlog_hits[:5])
+        if any(ref.startswith(("open/", "claimed/")) for ref in refs):
+            return "duplicate", refs
+        # Backlog hit but only inside closed/ - treat as recently-closed.
+        return "recently-closed", refs
+
+    if closed_hits:
+        closed_hits.sort(key=lambda row: (-row[0], row[1]))
+        return "recently-closed", tuple(ref for _, ref in closed_hits[:5])
+
+    return "new", ()
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def load_default_sources() -> tuple[SourceSpec, ...]:
+    """A conservative default set of upstream sources.
+
+    Sources are framed by signal type (runtime, packaging, advisories), not
+    by any commercial classification. The operator can override this set via
+    a JSON config file passed to the CLI.
+    """
+
+    return (
+        SourceSpec(
+            name="python-release-notes",
+            tier=1,
+            keywords=("python", "cpython", "release", "security"),
+            boost_keywords=("3.13", "3.14", "deprecation", "removal"),
+        ),
+        SourceSpec(
+            name="pip-release-notes",
+            tier=1,
+            keywords=("pip", "pypa", "resolver", "dependency"),
+            boost_keywords=("breaking", "deprecation"),
+        ),
+        SourceSpec(
+            name="pypi-advisories",
+            tier=2,
+            keywords=("vulnerability", "advisory", "cve", "supply", "chain"),
+            boost_keywords=("python", "pypi", "wheel"),
+        ),
+        SourceSpec(
+            name="github-actions-changelog",
+            tier=2,
+            keywords=("actions", "runner", "deprecation", "security"),
+            boost_keywords=("workflow", "permissions", "oidc"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rollup writer
+# ---------------------------------------------------------------------------
+
+
+def build_rollup_markdown(
+    candidates: Sequence[Candidate],
+    *,
+    generated_at: str,
+    sources: Sequence[SourceSpec],
+) -> str:
+    """Format the candidate list as the rollup markdown.
+
+    The format is intentionally diff-friendly: a single H1, a short
+    preamble, one table grouped by tier, and a per-tier footer with totals.
+    """
+
+    lines: list[str] = []
+    lines.append("# Trend scan rollup")
+    lines.append("")
+    lines.append(f"_Generated: {generated_at}_")
+    lines.append("")
+    lines.append(
+        "Scheduled job that ingests upstream dependency-relevant signals into the "
+        "orchestrator state. No tickets are filed automatically - the operator "
+        "reviews this rollup and runs `bernstein backlog new` for the rows that "
+        "warrant a ticket."
+    )
+    lines.append("")
+    lines.append(f"Sources scanned: {len(sources)}. Candidates surfaced: {len(candidates)}.")
+    lines.append("")
+
+    if not candidates:
+        lines.append("No candidates passed the per-source filters this run.")
+        lines.append("")
+        return "\n".join(lines)
+
+    by_tier: dict[int, list[Candidate]] = {}
+    for cand in candidates:
+        by_tier.setdefault(cand.tier, []).append(cand)
+
+    for tier in sorted(by_tier):
+        lines.append(f"## Tier {tier}")
+        lines.append("")
+        lines.append("| Source | Title | Status | Score | Matched | Refs |")
+        lines.append("| --- | --- | --- | --- | --- | --- |")
+        for cand in by_tier[tier]:
+            title_cell = f"[{_escape(cand.title)}]({cand.url})" if cand.url else _escape(cand.title)
+            matched_cell = ", ".join(cand.matched_keywords) or "-"
+            refs_cell = ", ".join(cand.related_refs) or "-"
+            lines.append(
+                f"| {_escape(cand.source)} | {title_cell} | {cand.gap_status} | "
+                f"{cand.score:.2f} | {_escape(matched_cell)} | {_escape(refs_cell)} |"
+            )
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "_Operator action: review the `new` rows; ignore `duplicate` and `recently-closed` unless context has changed._"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _escape(value: str) -> str:
+    """Escape pipe and backslash for markdown-table-safe cells."""
+
+    return value.replace("\\", "\\\\").replace("|", "\\|")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator entry point
+# ---------------------------------------------------------------------------
+
+
+SourceFetcher = Callable[[SourceSpec], Iterable[RawItem]]
+ClosedIssueLoader = Callable[[int], Sequence[tuple[str, set[str]]]]
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run_scan(
+    config: TrendScanConfig,
+    *,
+    fetcher: SourceFetcher,
+    closed_issue_loader: ClosedIssueLoader | None = None,
+    now_iso: Callable[[], str] = _now_iso,
+    output_path: Path | None = None,
+) -> TrendScanResult:
+    """Run one scan pass and write the rollup.
+
+    Parameters
+    ----------
+    config:
+        Top-level configuration. ``config.sources`` selects which feeds
+        participate in this run.
+    fetcher:
+        Injected callable that returns an iterable of :class:`RawItem` for a
+        given source. The CLI wires this to whatever HTTP primitive the
+        operator prefers; tests pass a deterministic stub.
+    closed_issue_loader:
+        Optional callable that returns ``[(ref, token_set), ...]`` for
+        recently-closed issues. Defaults to an empty list (purely
+        backlog-based gap analysis).
+    now_iso:
+        Override for the timestamp source. Used by tests to keep the rollup
+        deterministic.
+    output_path:
+        Override the rollup destination. Defaults to
+        ``config.rollup_dir / 'rollup-<YYYY-MM-DD>.md'``.
+    """
+
+    generated_at = now_iso()
+    closed_keywords = list((closed_issue_loader or (lambda _: []))(config.closed_lookback_days))
+    backlog_tokens = load_backlog_keywords(config.backlog_dir)
+
+    all_candidates: list[Candidate] = []
+    for spec in config.sources:
+        scored = filter_items(fetcher(spec), spec)
+        per_source = scored[: config.max_candidates_per_source]
+        for item, score, matched in per_source:
+            cand_tokens = set(_tokens(f"{item.title}\n{item.body}"))
+            gap_status, refs = classify_gap(cand_tokens, backlog_tokens, closed_keywords)
+            all_candidates.append(
+                Candidate(
+                    source=spec.name,
+                    tier=spec.tier,
+                    title=item.title,
+                    url=item.url,
+                    ts=item.ts,
+                    score=score,
+                    matched_keywords=matched,
+                    gap_status=gap_status,
+                    related_refs=refs,
+                )
+            )
+
+    all_candidates.sort(key=lambda c: (c.tier, -c.score, c.source, c.url))
+
+    rollup_md = build_rollup_markdown(
+        all_candidates,
+        generated_at=generated_at,
+        sources=config.sources,
+    )
+
+    if output_path is None:
+        day = generated_at[:10]
+        output_path = config.rollup_dir / f"rollup-{day}.md"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rollup_md, encoding="utf-8")
+
+    # Also write a sibling JSON file so downstream tools can diff
+    # structurally instead of via markdown.
+    json_path = output_path.with_suffix(".json")
+    json_path.write_text(
+        json.dumps(
+            {
+                "generated_at": generated_at,
+                "candidates": [c.to_dict() for c in all_candidates],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    return TrendScanResult(
+        candidates=tuple(all_candidates),
+        rollup_path=output_path,
+        generated_at=generated_at,
+    )

--- a/tests/unit/devops/test_trend_scan.py
+++ b/tests/unit/devops/test_trend_scan.py
@@ -1,0 +1,397 @@
+"""Tests for the trend-scan scheduled job.
+
+Coverage:
+
+* score_item: keyword + boost + negative + length normalisation.
+* filter_items: dedup + min_score cutoff + deterministic ordering.
+* classify_gap: backlog duplicate, recently-closed, new.
+* run_scan: end-to-end with a stub fetcher, including rollup file shape.
+* CLI: ``bernstein trend-scan run --offline-stub`` smoke test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.trend_scan_cmd import trend_scan_group
+from bernstein.core.devops.trend_scan import (
+    Candidate,
+    RawItem,
+    SourceSpec,
+    TrendScanConfig,
+    classify_gap,
+    filter_items,
+    load_backlog_keywords,
+    load_default_sources,
+    run_scan,
+    score_item,
+)
+
+
+@pytest.fixture
+def spec() -> SourceSpec:
+    return SourceSpec(
+        name="example",
+        tier=1,
+        keywords=("python", "release"),
+        boost_keywords=("security",),
+        negative_keywords=("spam",),
+        min_score=0.1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# score_item
+# ---------------------------------------------------------------------------
+
+
+def test_score_item_hits_required_keyword(spec: SourceSpec) -> None:
+    item = RawItem(title="Python 3.13 release", url="https://example/1", ts="2026-05-19T00:00:00Z")
+    score, matched = score_item(item, spec)
+    assert score > 0
+    assert "python" in matched
+    assert "release" in matched
+
+
+def test_score_item_misses_when_no_required_keyword(spec: SourceSpec) -> None:
+    item = RawItem(title="Random news", url="https://example/2", ts="2026-05-19T00:00:00Z")
+    score, matched = score_item(item, spec)
+    assert score == 0.0
+    assert matched == ()
+
+
+def test_score_item_negative_keyword_zeroes_score(spec: SourceSpec) -> None:
+    item = RawItem(title="Python release", url="https://example/3", ts="2026-05-19T00:00:00Z", body="spam content")
+    score, _ = score_item(item, spec)
+    assert score == 0.0
+
+
+def test_score_item_boost_keyword_increases_score(spec: SourceSpec) -> None:
+    plain = RawItem(title="Python release notes", url="https://example/4", ts="2026-05-19T00:00:00Z")
+    boosted = RawItem(
+        title="Python release security patch",
+        url="https://example/5",
+        ts="2026-05-19T00:00:00Z",
+    )
+    plain_score, _ = score_item(plain, spec)
+    boosted_score, _ = score_item(boosted, spec)
+    assert boosted_score > plain_score
+
+
+def test_score_item_empty_text_returns_zero(spec: SourceSpec) -> None:
+    item = RawItem(title="", url="", ts="")
+    score, matched = score_item(item, spec)
+    assert score == 0.0
+    assert matched == ()
+
+
+# ---------------------------------------------------------------------------
+# filter_items
+# ---------------------------------------------------------------------------
+
+
+def test_filter_items_drops_below_min_score(spec: SourceSpec) -> None:
+    high = RawItem(title="Python release security", url="https://example/a", ts="2026-05-19T00:00:00Z")
+    low_kw = RawItem(title="Frog photo", url="https://example/b", ts="2026-05-19T00:00:00Z")
+    survivors = filter_items([high, low_kw], spec)
+    urls = [item.url for item, _, _ in survivors]
+    assert "https://example/a" in urls
+    assert "https://example/b" not in urls
+
+
+def test_filter_items_dedups_by_fingerprint(spec: SourceSpec) -> None:
+    one = RawItem(title="Python release", url="https://example/x", ts="2026-05-19T00:00:00Z")
+    dup = RawItem(title="Python release", url="https://example/x", ts="2026-05-19T00:00:00Z")
+    survivors = filter_items([one, dup], spec)
+    assert len(survivors) == 1
+
+
+def test_filter_items_orders_by_score_then_url(spec: SourceSpec) -> None:
+    # Higher: two required + one boost keyword in one short title.
+    higher = RawItem(
+        title="Python release notes security",
+        url="https://example/z",
+        ts="2026-05-19T00:00:00Z",
+    )
+    # Lower: one required keyword only, longer body that depresses the score.
+    lower = RawItem(
+        title="Python news",
+        url="https://example/a",
+        ts="2026-05-19T00:00:00Z",
+        body="unrelated padding word salad longer document content",
+    )
+    survivors = filter_items([lower, higher], spec)
+    assert survivors, "expected at least one survivor"
+    assert survivors[0][0].url == "https://example/z"
+
+
+# ---------------------------------------------------------------------------
+# classify_gap
+# ---------------------------------------------------------------------------
+
+
+def test_classify_gap_marks_duplicate_for_open_backlog(tmp_path: Path) -> None:
+    backlog_tokens = {
+        "open/some-ticket.md": {"python", "release", "patch", "operator", "rollup"},
+    }
+    status, refs = classify_gap(
+        {"python", "release", "patch", "operator", "rollup"},
+        backlog_tokens,
+        [],
+    )
+    assert status == "duplicate"
+    assert refs == ("open/some-ticket.md",)
+
+
+def test_classify_gap_marks_recently_closed_from_closed_issues() -> None:
+    closed = [("ISSUE-123", {"python", "release", "security", "patch", "rollup"})]
+    status, refs = classify_gap(
+        {"python", "release", "security", "patch", "rollup"},
+        {},
+        closed,
+    )
+    assert status == "recently-closed"
+    assert refs == ("ISSUE-123",)
+
+
+def test_classify_gap_new_when_no_overlap() -> None:
+    status, refs = classify_gap({"python", "release"}, {}, [])
+    assert status == "new"
+    assert refs == ()
+
+
+def test_classify_gap_prefers_open_over_closed() -> None:
+    tokens = {"python", "release", "patch", "operator", "rollup"}
+    backlog_tokens = {
+        "open/foo.md": tokens,
+        "closed/old.md": tokens,
+    }
+    closed = [("ISSUE-1", tokens)]
+    status, refs = classify_gap(tokens, backlog_tokens, closed)
+    assert status == "duplicate"
+    assert refs[0].startswith("open/")
+
+
+# ---------------------------------------------------------------------------
+# load_backlog_keywords
+# ---------------------------------------------------------------------------
+
+
+def test_load_backlog_keywords_returns_empty_when_dir_missing(tmp_path: Path) -> None:
+    result = load_backlog_keywords(tmp_path / "does-not-exist")
+    assert result == {}
+
+
+def test_load_backlog_keywords_indexes_markdown(tmp_path: Path) -> None:
+    (tmp_path / "open").mkdir()
+    (tmp_path / "open" / "feat-x.md").write_text("# Feature X\n\nPython release rollup.\n", encoding="utf-8")
+    result = load_backlog_keywords(tmp_path)
+    assert "open/feat-x.md" in result
+    assert "python" in result["open/feat-x.md"]
+
+
+# ---------------------------------------------------------------------------
+# run_scan
+# ---------------------------------------------------------------------------
+
+
+def test_run_scan_writes_rollup_and_json(tmp_path: Path) -> None:
+    sources = (
+        SourceSpec(
+            name="stub-source",
+            tier=1,
+            keywords=("python",),
+            min_score=0.1,
+        ),
+    )
+
+    def fetcher(spec: SourceSpec) -> list[RawItem]:
+        return [
+            RawItem(
+                title="Python 3.13 RC available",
+                url="https://example/py-3.13",
+                ts="2026-05-19T00:00:00Z",
+            ),
+        ]
+
+    config = TrendScanConfig(
+        sources=sources,
+        backlog_dir=tmp_path / "backlog",
+        rollup_dir=tmp_path / "rollup",
+    )
+    result = run_scan(
+        config,
+        fetcher=fetcher,
+        now_iso=lambda: "2026-05-19T12:00:00Z",
+    )
+
+    assert result.rollup_path.exists()
+    md = result.rollup_path.read_text(encoding="utf-8")
+    assert "Trend scan rollup" in md
+    assert "stub-source" in md
+    assert "Python 3.13 RC available" in md
+
+    json_path = result.rollup_path.with_suffix(".json")
+    assert json_path.exists()
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["generated_at"] == "2026-05-19T12:00:00Z"
+    assert payload["candidates"][0]["source"] == "stub-source"
+
+
+def test_run_scan_empty_result_writes_no_candidates_message(tmp_path: Path) -> None:
+    config = TrendScanConfig(
+        sources=load_default_sources(),
+        backlog_dir=tmp_path / "backlog",
+        rollup_dir=tmp_path / "rollup",
+    )
+    result = run_scan(
+        config,
+        fetcher=lambda _spec: [],
+        now_iso=lambda: "2026-05-19T12:00:00Z",
+    )
+    md = result.rollup_path.read_text(encoding="utf-8")
+    assert "No candidates passed" in md
+    assert result.candidates == ()
+
+
+def test_run_scan_marks_duplicate_against_backlog(tmp_path: Path) -> None:
+    backlog = tmp_path / "backlog" / "open"
+    backlog.mkdir(parents=True)
+    (backlog / "py-313-tracking.md").write_text(
+        "# Python 3.13 rollup tracking\n\nrelease security patch operator backlog\n",
+        encoding="utf-8",
+    )
+
+    sources = (
+        SourceSpec(
+            name="stub-source",
+            tier=1,
+            keywords=("python", "release"),
+            boost_keywords=("security", "patch"),
+            min_score=0.1,
+        ),
+    )
+
+    def fetcher(_spec: SourceSpec) -> list[RawItem]:
+        return [
+            RawItem(
+                title="Python 3.13 release notes",
+                url="https://example/py-313",
+                ts="2026-05-19T00:00:00Z",
+                body="security patch operator backlog rollup tracking",
+            ),
+        ]
+
+    config = TrendScanConfig(
+        sources=sources,
+        backlog_dir=tmp_path / "backlog",
+        rollup_dir=tmp_path / "rollup",
+    )
+    result = run_scan(config, fetcher=fetcher, now_iso=lambda: "2026-05-19T12:00:00Z")
+
+    assert len(result.candidates) == 1
+    assert result.candidates[0].gap_status == "duplicate"
+    assert any(ref.startswith("open/") for ref in result.candidates[0].related_refs)
+
+
+def test_run_scan_caps_per_source(tmp_path: Path) -> None:
+    sources = (SourceSpec(name="noisy", tier=1, keywords=("python",), min_score=0.0),)
+
+    def fetcher(_spec: SourceSpec) -> list[RawItem]:
+        return [
+            RawItem(title=f"Python item {i}", url=f"https://example/{i}", ts="2026-05-19T00:00:00Z") for i in range(20)
+        ]
+
+    config = TrendScanConfig(
+        sources=sources,
+        backlog_dir=tmp_path / "backlog",
+        rollup_dir=tmp_path / "rollup",
+        max_candidates_per_source=3,
+    )
+    result = run_scan(config, fetcher=fetcher, now_iso=lambda: "2026-05-19T12:00:00Z")
+    assert len(result.candidates) == 3
+
+
+# ---------------------------------------------------------------------------
+# Candidate.to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_to_dict_lists_collections() -> None:
+    cand = Candidate(
+        source="s",
+        tier=1,
+        title="t",
+        url="u",
+        ts="2026-05-19T00:00:00Z",
+        score=1.0,
+        matched_keywords=("a", "b"),
+        gap_status="new",
+        related_refs=("ref-1",),
+    )
+    data = cand.to_dict()
+    assert data["matched_keywords"] == ["a", "b"]
+    assert data["related_refs"] == ["ref-1"]
+    assert data["gap_status"] == "new"
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_offline_stub_writes_empty_rollup(tmp_path: Path) -> None:
+    runner = CliRunner()
+    rollup_dir = tmp_path / "rollup"
+    backlog_dir = tmp_path / "backlog"
+    backlog_dir.mkdir()
+    result = runner.invoke(
+        trend_scan_group,
+        [
+            "run",
+            "--tier",
+            "all",
+            "--rollup-dir",
+            str(rollup_dir),
+            "--backlog-dir",
+            str(backlog_dir),
+            "--offline-stub",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    files = list(rollup_dir.glob("rollup-*.md"))
+    assert len(files) == 1
+    md = files[0].read_text(encoding="utf-8")
+    assert "No candidates passed" in md
+
+
+def test_cli_unknown_tier_returns_error(tmp_path: Path) -> None:
+    runner = CliRunner()
+    backlog_dir = tmp_path / "backlog"
+    backlog_dir.mkdir()
+    # Build a sources file with only tier 2 sources, then ask for tier 1.
+    sources_path = tmp_path / "sources.json"
+    sources_path.write_text(
+        json.dumps([{"name": "only-2", "tier": 2, "keywords": ["python"]}]),
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        trend_scan_group,
+        [
+            "run",
+            "--tier",
+            "1",
+            "--rollup-dir",
+            str(tmp_path / "rollup"),
+            "--backlog-dir",
+            str(backlog_dir),
+            "--sources",
+            str(sources_path),
+            "--offline-stub",
+        ],
+    )
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary

- Adds `bernstein trend-scan run` CLI plus an opt-in GitHub Actions workflow. The job ingests upstream dependency-relevant signals (release notes, advisories) into a markdown rollup under `.sdd/trend-scan/` for operator review. No tickets are filed automatically; the operator runs `bernstein backlog new` for rows that warrant it.
- Deterministic keyword + boost scoring with length normalisation. Gap analysis classifies each candidate as `new` / `duplicate` / `recently-closed` by token overlap against `.sdd/backlog/` and an optional closed-issue list.
- No network I/O in the module. Source fetchers are injected as callables; the CLI exposes a `--fetcher-cmd` hook and defaults to an offline stub so the scheduled workflow is safe in CI.
- Workflow defaults to `workflow_dispatch` only; the weekly cron line ships commented out.

Closes the open backlog ticket `feat-2026-05-19-trend-scan-automation`.

## Test plan

- [x] `pytest tests/unit/devops/test_trend_scan.py` (21 tests, all green)
- [x] `ruff check` clean on new + touched files
- [x] `bernstein trend-scan run --offline-stub --rollup-dir <tmp>` writes empty rollup and exits 0
- [x] `python -c "from bernstein.cli.main import cli"` confirms the new group registers without breaking the existing CLI
- [ ] Manual `workflow_dispatch` run after merge to confirm the artifact uploads

## Summary by Sourcery

Introduce a scheduled trend-scan facility that ingests upstream dependency signals into markdown rollups for operator review without automatic ticket creation.

New Features:
- Add a devops trend-scan core module that scores upstream signals, performs gap analysis against backlog and recently closed issues, and emits markdown and JSON rollups.
- Expose a `bernstein trend-scan` CLI group with a `run` command supporting offline stubs, external fetcher integration, tier filtering, and configurable source specs.
- Provide a GitHub Actions workflow to run the trend-scan job on demand (and optionally on a schedule) and upload rollup artifacts for review.

Documentation:
- Add operator-facing documentation describing the trend scan automation, CLI usage, source configuration, and scheduled workflow behaviour.

Tests:
- Add unit tests covering trend-scan scoring, filtering, gap classification, backlog indexing, end-to-end scan orchestration, and CLI behaviour including the offline stub and tier selection.

Chores:
- Introduce a `devops` core subpackage to host orchestrator-side hygiene jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `trend-scan` CLI command to generate dependency signal reports with configurable filtering and gap analysis.
  * Added GitHub Actions workflow for automated trend scanning with manual trigger support and optional scheduling.
  * Reports include markdown rollups and JSON snapshots with candidate scoring and classification.

* **Documentation**
  * Added trend scan automation guide covering workflow configuration, usage, and operator workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->