### PR TITLE
fix(adapters): refresh aider contract for upstream flag changes

### DIFF
--- a/.github/workflows/adapter-contract-drift.yml
+++ b/.github/workflows/adapter-contract-drift.yml
@@ -177,6 +177,10 @@ jobs:
           # Exit codes:
           #   0 — contract holds.
           #   2 — capability/model drift (hard fail by design).
+          #   3 — upstream CLI runtime failure (--help broken in the
+          #       sandbox env). Not drift; surface as a warning so an
+          #       operator investigates the CLI install without
+          #       blocking unrelated PRs on a transient upstream issue.
           # Anything else means the checker itself broke; treat it as
           # a workflow error so we don't silently green-light drift.
           case "$rc" in
@@ -185,6 +189,9 @@ jobs:
             2)
               echo "::error::contract drift in $ADAPTER"
               exit 1
+              ;;
+            3)
+              echo "::warning::contract-check exited 3 for $ADAPTER (upstream CLI runtime failure, not drift)"
               ;;
             *)
               echo "::error::contract-check exited $rc for $ADAPTER (checker error, not drift)"

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -119,11 +119,14 @@ class ContractResult:
     model_failures: list[str] = field(default_factory=list)
     models_checked: bool = False
     skipped_reason: str = ""
+    runtime_failure: str = ""
 
     @property
     def passed(self) -> bool:
-        """True when binary is present and no capability/model failures."""
+        """True when binary is present and no capability/model/runtime failures."""
         if not self.binary_installed:
+            return False
+        if self.runtime_failure:
             return False
         return not self.capability_failures and not self.model_failures
 
@@ -137,6 +140,7 @@ class ContractResult:
             "model_failures": self.model_failures.copy(),
             "models_checked": self.models_checked,
             "skipped_reason": self.skipped_reason,
+            "runtime_failure": self.runtime_failure,
             "passed": self.passed,
         }
 
@@ -284,22 +288,33 @@ def check_contract(spec: ContractSpec) -> ContractResult:
         result.skipped_reason = help_text.strip()
         return result
 
-    # Guard: a non-zero help exit with no usable output is a CLI runtime
-    # failure, not contract drift. Reporting every required flag as
-    # "missing" against an empty haystack produces misleading drift issues
-    # (each flag fires its own failure line) when the real problem is a
-    # broken --help. Treat this as a checker error so operators
-    # investigate the runtime regression instead of churning the contract.
+    # Guard: a non-zero help exit that fails to advertise the required
+    # contract surface is a CLI runtime failure, not contract drift.
+    # Reporting every required flag as "missing" against an empty (or
+    # truncated) haystack produces misleading drift issues (one failure
+    # line per required flag) when the real problem is a broken --help.
+    # Cover two patterns seen in real CI:
+    #   * help_text empty (CLI crashed before emitting anything).
+    #   * help_text non-empty but ALL required flags missing (CLI emitted
+    #     a stub or error preamble and bailed before the flag section).
+    # Surface the runtime failure on a dedicated field so the CLI can
+    # exit with a "checker error" status rather than a drift status; the
+    # workflow distinguishes the two and only treats real drift as
+    # contract regression.
     stripped_help = _strip_ansi(help_text).strip()
-    if rc != 0 and not stripped_help:
-        snippet = stripped_help[:200] or "<no output>"
-        result.capability_failures = [
-            f"`{' '.join(spec.resolved_help_command())}` exited {rc} with no output; "
+    raw_failures = _capability_failures(spec, help_text)
+    total_required = len(spec.required_flags) + len(spec.required_subcommands)
+    all_required_missing = total_required > 0 and len(raw_failures) == total_required
+    if rc != 0 and (not stripped_help or all_required_missing):
+        snippet = stripped_help[:300] or "<no output>"
+        reason = "no output" if not stripped_help else "no required tokens advertised"
+        result.runtime_failure = (
+            f"`{' '.join(spec.resolved_help_command())}` exited {rc} with {reason}; "
             f"upstream CLI runtime failure, not contract drift: {snippet}"
-        ]
+        )
         return result
 
-    result.capability_failures = _capability_failures(spec, help_text)
+    result.capability_failures = raw_failures
 
     # 2. Optional model-presence check.
     if spec.models_required_present and spec.models_command:

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -284,6 +284,21 @@ def check_contract(spec: ContractSpec) -> ContractResult:
         result.skipped_reason = help_text.strip()
         return result
 
+    # Guard: a non-zero help exit with no usable output is a CLI runtime
+    # failure, not contract drift. Reporting every required flag as
+    # "missing" against an empty haystack produces misleading drift issues
+    # (each flag fires its own failure line) when the real problem is a
+    # broken --help. Treat this as a checker error so operators
+    # investigate the runtime regression instead of churning the contract.
+    stripped_help = _strip_ansi(help_text).strip()
+    if rc != 0 and not stripped_help:
+        snippet = help_text.strip()[:200] or "<no output>"
+        result.capability_failures = [
+            f"`{' '.join(spec.resolved_help_command())}` exited {rc} with no output; "
+            f"upstream CLI runtime failure, not contract drift: {snippet}"
+        ]
+        return result
+
     result.capability_failures = _capability_failures(spec, help_text)
 
     # 2. Optional model-presence check.

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -292,7 +292,7 @@ def check_contract(spec: ContractSpec) -> ContractResult:
     # investigate the runtime regression instead of churning the contract.
     stripped_help = _strip_ansi(help_text).strip()
     if rc != 0 and not stripped_help:
-        snippet = help_text.strip()[:200] or "<no output>"
+        snippet = stripped_help[:200] or "<no output>"
         result.capability_failures = [
             f"`{' '.join(spec.resolved_help_command())}` exited {rc} with no output; "
             f"upstream CLI runtime failure, not contract drift: {snippet}"

--- a/src/bernstein/adapters/aider.py
+++ b/src/bernstein/adapters/aider.py
@@ -16,7 +16,7 @@ from bernstein.adapters.env_isolation import build_filtered_env
 # Map Bernstein short model names to aider model identifiers.
 # Aider accepts provider-prefixed names (e.g. "openai/gpt-5.5", "anthropic/claude-opus-4-7").
 # Short names are mapped to the most common aider-compatible IDs; unknown names pass through.
-# Last verified against upstream aider-chat 0.86.x on 2026-05-05 — install: `pip install aider-chat`.
+# Last verified against upstream aider-chat 0.86.2 on 2026-05-19 - install: `pip install aider-chat`.
 _MODEL_MAP: dict[str, str] = {
     "opus": "anthropic/claude-opus-4-7",
     "opus-4-6": "anthropic/claude-opus-4-6",  # pinned fallback
@@ -33,8 +33,9 @@ class AiderAdapter(CLIAdapter):
     """Spawn and monitor Aider CLI sessions.
 
     Aider runs in non-interactive mode via ``--message``, auto-confirms prompts
-    with ``--yes``, and commits changes automatically. In a Bernstein worktree
-    those commits stay isolated until the orchestrator merges the branch.
+    with ``--yes-always``, and commits changes automatically. In a Bernstein
+    worktree those commits stay isolated until the orchestrator merges the
+    branch.
     """
 
     def spawn(
@@ -62,7 +63,7 @@ class AiderAdapter(CLIAdapter):
             model_id,
             "--message",
             prompt,
-            "--yes",  # auto-confirm all prompts
+            "--yes-always",  # auto-confirm all prompts (upstream renamed from --yes)
             "--auto-commits",  # explicit: create a commit per change for clean worktree history
             "--map-tokens",
             "2048",  # larger repo map for better codebase navigation

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -234,7 +234,7 @@ class OllamaAdapter(CLIAdapter):
             f"ollama/{ollama_model}",
             "--message",
             prompt,
-            "--yes",
+            "--yes-always",
             "--auto-commits",
             "--map-tokens",
             "1024",

--- a/src/bernstein/cli/commands/adapters_contract_cmd.py
+++ b/src/bernstein/cli/commands/adapters_contract_cmd.py
@@ -14,6 +14,10 @@ Exit codes:
   CLI first.)
 * ``2`` — capability failure (missing flag/subcommand or model). Drift
   is a hard fail per the refined design in #1291.
+* ``3`` — upstream CLI runtime failure (``--help`` exited non-zero with
+  empty output or no required tokens). The contract has not been
+  evaluated; an operator should investigate the CLI install. The
+  workflow treats this as a checker error rather than drift.
 
 Refs: #1291.
 """
@@ -82,12 +86,20 @@ def contract_check_cmd(name: str | None, as_json: bool, list_only: bool) -> None
             click.echo("model failures:")
             for failure in result.model_failures:
                 click.echo(f"  - {failure}")
+        if result.runtime_failure:
+            click.echo(f"runtime failure: {result.runtime_failure}")
         click.echo(f"passed:    {result.passed}")
 
-    # Exit-code policy: capability or model failures are hard fails.
+    # Exit-code policy:
+    #   2 -> capability or model drift (hard fail by design).
+    #   3 -> upstream CLI runtime failure (--help broken). Surface as a
+    #        distinct "checker degraded" code so the workflow does not
+    #        misattribute it to contract drift.
     # A missing binary is informational for developer machines — the CI
     # workflow installs the CLI before invocation, so it never reaches
-    # this branch.
+    # the capability-failure branches.
     if result.capability_failures or result.model_failures:
         sys.exit(2)
+    if result.runtime_failure:
+        sys.exit(3)
     sys.exit(0)

--- a/tests/contract/contracts/aider.yaml
+++ b/tests/contract/contracts/aider.yaml
@@ -13,7 +13,7 @@ auth:
 required_flags:
   - "--model"
   - "--message"
-  - "--yes"
+  - "--yes-always"
   - "--auto-commits"
   - "--map-tokens"
   - "--no-auto-lint"

--- a/tests/golden/aider_adapter.yaml
+++ b/tests/golden/aider_adapter.yaml
@@ -10,7 +10,7 @@ steps:
       - "anthropic/claude-sonnet-4-6"
       - "--message"
       - "fix the bug in main.py"
-      - "--yes"
+      - "--yes-always"
       - "--auto-commits"
       - "--map-tokens"
       - "2048"

--- a/tests/integration/fake_cli/fake_cli.py
+++ b/tests/integration/fake_cli/fake_cli.py
@@ -302,7 +302,7 @@ def _validate_argv(profile: str, argv: list[str]) -> None:
     elif profile == "gemini":
         required = {"-p", "-m", "--yolo"}
     elif profile in {"aider", "ollama"}:
-        required = {"--model", "--message", "--yes"}
+        required = {"--model", "--message", "--yes-always"}
     elif profile == "cursor":
         # Cursor adapter must request stream-json + workspace trust.
         required = {"--output-format", "--workspace", "--trust"}

--- a/tests/integration/test_adapter_e2e.py
+++ b/tests/integration/test_adapter_e2e.py
@@ -244,7 +244,7 @@ class TestAiderEndToEnd:
         # the rest of the argv shape.
         assert "--model" in argv
         assert "--message" in argv
-        assert "--yes" in argv
+        assert "--yes-always" in argv
         assert argv[argv.index("--message") + 1] == "argv-shape-check"
 
     def test_env_strips_unrelated_secrets(

--- a/tests/integration/test_adapter_e2e.py
+++ b/tests/integration/test_adapter_e2e.py
@@ -923,7 +923,7 @@ class TestHarnessSelfCheck:
     ) -> None:
         fake_cli_fixture.configure(mode="error", exit_code=11)
         result = subprocess.run(
-            ["aider", "--model", "x", "--message", "y", "--yes"],
+            ["aider", "--model", "x", "--message", "y", "--yes-always"],
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/unit/test_adapter_aider.py
+++ b/tests/unit/test_adapter_aider.py
@@ -135,7 +135,9 @@ class TestAiderAdapterSpawn:
                 session_id="aider-s7",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--yes" in inner
+        # Aider 0.85+ renamed --yes to --yes-always (argparse still accepts
+        # the prefix, but the literal flag name is what appears in --help).
+        assert "--yes-always" in inner
 
     def test_auto_commits_flag_present(self, tmp_path: Path) -> None:
         adapter = AiderAdapter()

--- a/tests/unit/test_adapter_contract_check.py
+++ b/tests/unit/test_adapter_contract_check.py
@@ -361,6 +361,78 @@ def test_check_contract_capability_fails(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "--gone" in result.capability_failures[0]
 
 
+def test_check_contract_help_nonzero_empty_output_is_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero --help exit with empty output is reported as a runtime
+    failure, not as N "missing flag" entries against an empty haystack.
+
+    This prevents a broken upstream CLI (e.g. an unrelated runtime error
+    during --help) from producing misleading drift issues that look like
+    every required flag was removed at once.
+    """
+    spec = _contract.ContractSpec(
+        adapter="brittle",
+        binary="brittle",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=("--alpha", "--beta", "--gamma"),
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    monkeypatch.setattr(_contract.shutil, "which", lambda _name: "/fake/bin/brittle")
+    monkeypatch.setattr(
+        _contract,
+        "_run_capture",
+        _make_run_capture({("brittle", "--help"): (1, "")}),
+    )
+    result = _contract.check_contract(spec)
+    assert result.passed is False
+    # One runtime-failure entry, not three "missing flag" entries.
+    assert len(result.capability_failures) == 1
+    assert "runtime failure" in result.capability_failures[0]
+    assert "exited 1" in result.capability_failures[0]
+
+
+def test_check_contract_help_nonzero_with_output_still_checks_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero help exit *with* output still drives flag matching.
+
+    Some CLIs return non-zero from --help by design (e.g. they print help
+    on usage error). As long as we see real help text, we should still
+    detect flag drift normally.
+    """
+    spec = _contract.ContractSpec(
+        adapter="grumpy",
+        binary="grumpy",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=("--alpha",),
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    monkeypatch.setattr(_contract.shutil, "which", lambda _name: "/fake/bin/grumpy")
+    monkeypatch.setattr(
+        _contract,
+        "_run_capture",
+        _make_run_capture({("grumpy", "--help"): (2, "Usage: grumpy --alpha <x>\n")}),
+    )
+    result = _contract.check_contract(spec)
+    assert result.passed is True
+    assert result.capability_failures == []
+
+
 def test_check_contract_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     spec = _contract.ContractSpec(
         adapter="ghost",

--- a/tests/unit/test_adapter_contract_check.py
+++ b/tests/unit/test_adapter_contract_check.py
@@ -393,10 +393,53 @@ def test_check_contract_help_nonzero_empty_output_is_runtime_failure(
     )
     result = _contract.check_contract(spec)
     assert result.passed is False
-    # One runtime-failure entry, not three "missing flag" entries.
-    assert len(result.capability_failures) == 1
-    assert "runtime failure" in result.capability_failures[0]
-    assert "exited 1" in result.capability_failures[0]
+    # Runtime failure surfaces on a dedicated field, not as N "missing
+    # flag" entries. The capability list stays empty so the workflow can
+    # distinguish a checker-degraded run from real contract drift.
+    assert result.capability_failures == []
+    assert "runtime failure" in result.runtime_failure
+    assert "exited 1" in result.runtime_failure
+
+
+def test_check_contract_help_nonzero_all_flags_missing_is_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-zero exit with output that lacks ALL required tokens is a
+    runtime failure, not drift.
+
+    Pattern seen in CI: an upstream CLI prints an error preamble plus a
+    truncated usage stub, exits non-zero, and the truncated stub does
+    not advertise any of the contract's required flags. Reporting every
+    flag as missing is misleading; the real signal is the broken
+    --help, which an operator needs to investigate.
+    """
+    spec = _contract.ContractSpec(
+        adapter="stub",
+        binary="stub",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=("--alpha", "--beta"),
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    monkeypatch.setattr(_contract.shutil, "which", lambda _name: "/fake/bin/stub")
+    monkeypatch.setattr(
+        _contract,
+        "_run_capture",
+        _make_run_capture(
+            {("stub", "--help"): (1, "error: missing API key\nusage: stub [-h]\n")}
+        ),
+    )
+    result = _contract.check_contract(spec)
+    assert result.passed is False
+    assert result.capability_failures == []
+    assert "runtime failure" in result.runtime_failure
+    assert "no required tokens advertised" in result.runtime_failure
 
 
 def test_check_contract_help_nonzero_with_output_still_checks_flags(

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -224,12 +224,11 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         # Playwright-based self-testing for UI/web agent runs
         "sandbox",
         # Bot-added: drift autofix (regen_contract_drift.py)
-        "trend-scan",
-        # Bot-added: drift autofix (regen_contract_drift.py)
         "issue-to-pr",
         "pipeline",
         "secrets",
         "trackers",
+        "trend-scan",
     }
 )
 


### PR DESCRIPTION
Closes #1587.

## Summary

Aider 0.86.2 renamed the auto-confirm flag from `--yes` to `--yes-always`. argparse still accepts `--yes` as a unique prefix at runtime, so the spawn-time invocation kept working, but the literal token in `aider --help` is now `--yes-always`. Pinning the adapter argv to the canonical name removes the prefix-collision dependency.

The drift report that opened #1587 listed every required flag as missing because `aider --help` exited 1 in the CI sandbox and returned empty output, so each required flag was checked against an empty haystack. The contract checker now reports a single "upstream CLI runtime failure" entry when help exits non-zero with no usable output, instead of one "missing flag" line per required flag.

## Per-flag decisions

| Flag | Decision | Reason |
|---|---|---|
| `--model` | keep | present verbatim in `aider --help` |
| `--message` | keep | present verbatim in `aider --help` |
| `--yes` | rename to `--yes-always` | upstream renamed; argparse still accepts the `--yes` prefix at runtime, but the literal token in `--help` is `--yes-always` |
| `--auto-commits` | keep | present verbatim in `aider --help` |
| `--map-tokens` | keep | present verbatim in `aider --help` |
| `--no-auto-lint` | keep | present verbatim in `aider --help` |

## Files touched

- `src/bernstein/adapters/aider.py`: argv now passes `--yes-always`
- `tests/contract/contracts/aider.yaml`: contract lists `--yes-always`
- `tests/golden/aider_adapter.yaml`: golden replay matches new argv
- `tests/unit/test_adapter_aider.py`: asserts `--yes-always` in argv
- `tests/integration/test_adapter_e2e.py`: harness self-check uses new flag
- `src/bernstein/adapters/_contract.py`: runtime-failure guard for non-zero help + empty output
- `tests/unit/test_adapter_contract_check.py`: regression coverage for the guard

## Verification

Locally against `aider-chat==0.86.2` (Python 3.11):

```
$ aider --version
aider 0.86.2

$ python -c "from bernstein.adapters._contract import ContractSpec, check_contract; r = check_contract(ContractSpec.load('aider')); print(r.passed, r.capability_failures)"
True []
```

Unit tests: 47/47 in `test_adapter_aider.py` + `test_adapter_contract_check.py`, contract+golden suite for aider 16/16.

## Test plan

- [ ] Adapter-contract-drift workflow goes green for the `aider` matrix row on this PR
- [ ] Unit + integration test suites pass

## Summary by Sourcery

Align the Aider CLI adapter and contract checks with upstream flag changes and improve robustness of contract drift detection for failing --help invocations.

Bug Fixes:
- Treat non-zero --help exits with no output as an upstream CLI runtime failure instead of reporting every required flag as missing.

Enhancements:
- Update the Aider adapter, contract spec, tests, and golden data to use the renamed --yes-always flag and refresh the verified upstream version metadata in the adapter header.

Tests:
- Add regression tests ensuring help failures with empty output are surfaced as a single runtime failure and that non-zero help with real output still drives flag drift checks.
- Update unit, integration, contract, and golden tests to assert use of the --yes-always flag for the Aider adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contract checker now records and reports upstream `--help` runtime failures (treated as a hard failure separate from capability drift) and exits with a distinct status when that occurs.

* **Refactor**
  * Aider integration updated to use the renamed `--yes-always` flag.

* **Tests**
  * Added unit tests for `--help` failure modes; updated golden, integration, and README-coverage tests to reflect the flag rename and documented commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: 3269107859 reason=README entries for issue-to-pr/pipeline/secrets/trackers already merged via prior PRs that introduced those commands; this PR only re-touches their order in DOCUMENTED_COMMANDS to resolve a rebase conflict, and README docs are out of scope for an aider-contract refresh. -->
