### PR TITLE
feat(orchestration): retry-with-continuation when agent exits without commit

### DIFF
--- a/docs/concepts/orchestrator-hardening.md
+++ b/docs/concepts/orchestrator-hardening.md
@@ -99,6 +99,40 @@ silently disables the guard.
 | `bernstein_run_cost_usd` | gauge | Cumulative routed spend for the active run. |
 | `bernstein_run_budget_remaining_usd` | gauge | Remaining headroom before the budget hard-stop. |
 
+### 4. Commit-completion check (retry-with-continuation)
+
+A common failure mode of CLI coding agents is exiting with success
+while the workspace is unchanged: the assistant reports completion but
+no new commit landed. The orchestrator now snapshots HEAD before the
+adapter spawn and compares after the process exits. When the agent
+exited cleanly (exit code 0) but HEAD did not move, the orchestrator
+launches a single continuation retry through the adapter's
+session-resume primitive and appends a corrective nudge:
+
+> You exited successfully but the workspace has no new commit. Either
+> commit your work or explain in plain prose why no commit was needed
+> for this task.
+
+The retry path is gated by the adapter's
+`supports_session_continuation` flag. Adapters that opt in (Claude
+Code today; more to follow) expose a `continuation_args(session_id)`
+method that returns the CLI flags re-entering the prior conversation
+without re-paying the full setup cost. Adapters that have not opted
+in fall through to the normal failure-handling path.
+
+Hard contract:
+
+- Retry is capped at exactly **one** attempt per task. Recursion is
+  not configurable.
+- Retry only fires when both pre-spawn and post-exit SHAs read
+  successfully. An unknown HEAD (no repo, no commits yet) leaves the
+  exit unchanged.
+- The lifecycle event `agent.retry_continuation` fires once per
+  retry launch with `{session_id, reason, attempt}` for downstream
+  observability.
+
+Source: `src/bernstein/core/orchestration/commit_completion.py`.
+
 ## Limitations
 
 - The adaptive concurrency layer reacts to recent task outcomes
@@ -117,5 +151,6 @@ silently disables the guard.
 - Adaptive parallelism: `src/bernstein/core/orchestration/adaptive_parallelism.py`
 - Tick budget: `src/bernstein/core/orchestration/tick_budget.py`
 - Cost guard: `src/bernstein/core/cost/cost_tracker.py`
+- Commit-completion check: `src/bernstein/core/orchestration/commit_completion.py`
 - [Adaptive parallelism](../architecture/adaptive-parallelism.md)
 - [Cost optimisation](../operations/cost-optimization.md)

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -390,6 +390,15 @@ class CLIAdapter(ABC):
     #: ``0`` keeps the column unset.
     rate_limit_target_rpm: int = 0
 
+    #: Subclasses opt into the retry-with-continuation path by setting
+    #: this to ``True`` and implementing :meth:`continuation_args`. The
+    #: orchestrator consults this attribute via
+    #: :func:`bernstein.core.orchestration.commit_completion.adapter_supports_continuation`
+    #: after a "success without commit" exit and only launches a
+    #: continuation retry when the adapter has opted in. Default
+    #: ``False`` so unknown adapters never trigger the retry path.
+    supports_session_continuation: bool = False
+
     def __init__(self) -> None:
         self._resource_limits: ResourceLimits | None = None
         self._rate_limit_meter: RateLimitMeter | None = None
@@ -729,6 +738,25 @@ class CLIAdapter(ABC):
             back to a fresh spawn.
         """
         return None
+
+    def continuation_args(self, _session_id: str) -> list[str]:
+        """Return CLI flags that re-enter the adapter's prior session.
+
+        Adapters that opt into the retry-with-continuation path
+        (``supports_session_continuation = True``) override this method
+        and return the flag list that resumes the previous conversation
+        without paying the full setup cost again. Typical
+        implementations return ``["--resume", session_id]``,
+        ``["--continue"]``, or an equivalent provider-specific switch.
+
+        The default returns an empty list so adapters that have not
+        opted in never accidentally feed corrupt arguments to the
+        continuation spawn.
+
+        Args:
+            _session_id: The adapter session id from the prior launch.
+        """
+        return []
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -116,6 +116,12 @@ class ClaudeCodeAdapter(CLIAdapter):
     # ``rate_limit_error`` types on the messages API.
     rate_limit_provider = "anthropic"
 
+    # Opt into the retry-with-continuation path. Claude Code's CLI
+    # exposes ``--resume <session-id>`` to re-enter a prior conversation
+    # without paying the full setup cost. See
+    # :mod:`bernstein.core.orchestration.commit_completion`.
+    supports_session_continuation = True
+
     # Track Popen objects for reliable is_alive() via poll()
     _procs: ClassVar[dict[int, subprocess.Popen[bytes]]] = {}
     _wrapper_pids: ClassVar[dict[int, int]] = {}  # claude_pid → wrapper_pid
@@ -641,6 +647,17 @@ class ClaudeCodeAdapter(CLIAdapter):
 
     def name(self) -> str:
         return "Claude Code"
+
+    def continuation_args(self, _session_id: str) -> list[str]:
+        """Return the CLI flags that re-enter the most recent Claude session.
+
+        Claude Code exposes ``--continue`` to re-enter the most recent
+        conversation in the current workdir without paying the full
+        setup cost. The orchestrator launches the retry from the same
+        worktree as the original spawn, so ``--continue`` resolves to
+        the correct prior session without explicit id plumbing.
+        """
+        return ["--continue"]
 
     def detect_tier(self) -> ApiTierInfo | None:
         """Detect Claude API tier based on environment and API key type.

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -110,6 +110,15 @@ class LifecycleEvent(StrEnum):
     # ------------------------------------------------------------------
     RATE_LIMIT_HIT = "rate_limit.hit"
 
+    # ------------------------------------------------------------------
+    # Retry-with-continuation (feat/retry-with-continuation).
+    # Fires when the orchestrator detects a "success without commit"
+    # exit and launches a single continuation retry. Payload carries
+    # ``session_id``, ``reason`` (the :class:`RetryDecision.reason`
+    # tag), and ``attempt`` (1-indexed retry counter).
+    # ------------------------------------------------------------------
+    AGENT_RETRY_CONTINUATION = "agent.retry_continuation"
+
 
 #: The cross-CLI standardised event vocabulary introduced by issue #1323.
 #: Pre-existing snake_case events remain supported but are not part of

--- a/src/bernstein/core/orchestration/commit_completion.py
+++ b/src/bernstein/core/orchestration/commit_completion.py
@@ -1,0 +1,347 @@
+"""Commit-completion verification for the agent dispatch loop.
+
+A common failure mode of CLI coding agents is exiting with success while
+leaving the workspace untouched: the assistant claims it finished, but no
+new commit landed. The agent's self-report cannot be trusted as a
+completion signal — the workspace is the ground truth.
+
+This module snapshots the workspace HEAD before launching an adapter and
+compares it after the process exits. If the agent declared success
+(exit code 0) but HEAD has not moved, the orchestrator launches a single
+retry through the adapter's session-continuation primitive with a
+corrective nudge. The recursion is capped at exactly one retry.
+
+The check is intentionally adapter-agnostic: it only depends on the
+adapter exposing two capabilities -- ``supports_session_continuation`` and
+``continuation_args(session_id)`` -- both declared on
+:class:`bernstein.adapters.base.CLIAdapter`. Adapters that do not support
+a session-resume primitive are skipped: a fresh spawn with full prompt
+reinjection would defeat the cost saving that motivates the retry in the
+first place.
+
+Public surface
+--------------
+
+* :class:`CommitCompletionCheck` -- stateless verifier with
+  ``snapshot_before`` and ``verify_after`` methods.
+* :data:`DEFAULT_CONTINUATION_NUDGE` -- the corrective prompt appended on
+  retry.
+* :data:`RETRY_LIMIT` -- the hard cap on continuation retries
+  (``1`` by v1; the cap is non-configurable on purpose).
+* :func:`maybe_retry_continuation` -- convenience helper that ties the
+  snapshot, verification, retry decision, and lifecycle event together.
+
+See ``docs/concepts/orchestrator-hardening.md`` for the operator-facing
+overview.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from bernstein.core.git.git_basic import rev_parse_head
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.adapters.base import CLIAdapter, SpawnResult
+
+logger = logging.getLogger(__name__)
+
+#: Hard cap on continuation retries triggered by a missing commit. The
+#: cap is one by design: a second retry would compound a flaky run and
+#: blow past the "half a full run" cost budget that justifies the
+#: retry path at all.
+RETRY_LIMIT: int = 1
+
+#: Default corrective nudge appended to the continuation prompt. Kept
+#: short on purpose: the adapter already carries the original prompt
+#: through its native session, so we only need to surface the
+#: discrepancy.
+DEFAULT_CONTINUATION_NUDGE: str = (
+    "You exited successfully but the workspace has no new commit. "
+    "Either commit your work or explain in plain prose why no commit "
+    "was needed for this task."
+)
+
+
+class _ContinuationCapableAdapter(Protocol):
+    """Structural type for adapters wired into the retry path.
+
+    Adapters that opt in declare ``supports_session_continuation = True``
+    on the class and implement :meth:`continuation_args` returning the
+    CLI flags the spawn machinery should append for a continuation
+    launch (typically something like ``["--resume", session_id]`` or
+    ``["--continue"]``).
+
+    The protocol is internal documentation only — the orchestrator
+    consumes :class:`bernstein.adapters.base.CLIAdapter` directly.
+    """
+
+    supports_session_continuation: bool
+
+    def continuation_args(self, session_id: str) -> list[str]:
+        """Return adapter-specific CLI flags for a continuation launch."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionVerdict:
+    """Result of comparing the pre-spawn and post-exit HEAD snapshots.
+
+    Attributes:
+        committed: ``True`` if HEAD moved between snapshot and verify.
+        before: HEAD SHA captured by :meth:`CommitCompletionCheck.snapshot_before`.
+        after: HEAD SHA captured by :meth:`CommitCompletionCheck.verify_after`.
+        reason: Short, operator-facing explanation. Empty when the agent
+            committed normally.
+    """
+
+    committed: bool
+    before: str
+    after: str
+    reason: str = ""
+
+    @property
+    def needs_retry(self) -> bool:
+        """``True`` when the agent declared success but HEAD did not move."""
+        return not self.committed
+
+
+class CommitCompletionCheck:
+    """Stateless verifier that turns workspace HEAD into the completion signal.
+
+    Usage::
+
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(worktree)
+        # ... spawn the adapter, wait for exit ...
+        verdict = check.verify_after(worktree, before=before)
+        if verdict.needs_retry:
+            ...  # see ``maybe_retry_continuation``
+
+    The class is intentionally stateless so it can be reused across
+    sessions without re-instantiation. ``snapshot_before`` and
+    ``verify_after`` are pure git reads and never mutate the worktree.
+    """
+
+    def snapshot_before(self, workdir: Path) -> str:
+        """Return the SHA at HEAD inside ``workdir`` prior to spawning.
+
+        Errors are caught and reported as the empty string so a missing
+        HEAD (uninitialised repo, detached worktree, permission glitch)
+        never blocks a spawn. The matching :meth:`verify_after` call
+        also returns the empty string in that case and the verdict
+        defaults to "no retry" -- we cannot make a confident statement
+        about commit movement when the baseline is unknown.
+        """
+        return _safe_rev_parse(workdir)
+
+    def verify_after(self, workdir: Path, *, before: str) -> CompletionVerdict:
+        """Compare current HEAD against the pre-spawn snapshot.
+
+        Args:
+            workdir: Worktree path the adapter was launched into.
+            before: SHA returned by :meth:`snapshot_before`.
+
+        Returns:
+            A :class:`CompletionVerdict`. ``needs_retry`` is ``True``
+            only when both snapshots are valid (non-empty) *and* the
+            second SHA equals the first.
+        """
+        after = _safe_rev_parse(workdir)
+        if not before or not after:
+            return CompletionVerdict(
+                committed=True,  # unknown -> treat as committed, don't retry
+                before=before,
+                after=after,
+                reason="head_unknown" if not before or not after else "",
+            )
+        if before == after:
+            return CompletionVerdict(
+                committed=False,
+                before=before,
+                after=after,
+                reason="head_did_not_move",
+            )
+        return CompletionVerdict(committed=True, before=before, after=after)
+
+
+def _safe_rev_parse(workdir: Path) -> str:
+    """Best-effort HEAD read; never raises.
+
+    Snapshot/verify must not abort an agent spawn. We log at debug
+    level and return an empty string when git is unavailable, the
+    worktree is missing, or the repo has no commits yet.
+    """
+    try:
+        return rev_parse_head(workdir)
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.debug("commit-completion HEAD probe failed in %s: %s", workdir, exc)
+        return ""
+
+
+def adapter_supports_continuation(adapter: CLIAdapter) -> bool:
+    """Return ``True`` if the adapter advertises session continuation.
+
+    Read off the class attribute :attr:`CLIAdapter.supports_session_continuation`.
+    Adapters that have not opted in default to ``False`` -- the retry
+    path is skipped and the agent's "success-without-commit" exit
+    surfaces to the normal failure-handling path.
+    """
+    return bool(getattr(adapter, "supports_session_continuation", False))
+
+
+@dataclass(frozen=True, slots=True)
+class RetryDecision:
+    """Outcome of the retry-decision step.
+
+    Attributes:
+        should_retry: ``True`` when a continuation spawn is warranted.
+        reason: Short tag for tracing. One of ``"committed"``,
+            ``"head_unknown"``, ``"adapter_unsupported"``,
+            ``"non_zero_exit"``, ``"retry_cap_reached"``, or
+            ``"needs_retry"``.
+    """
+
+    should_retry: bool
+    reason: str
+
+
+def decide_retry(
+    *,
+    adapter: CLIAdapter,
+    verdict: CompletionVerdict,
+    exit_code: int,
+    attempts: int,
+) -> RetryDecision:
+    """Decide whether to launch a continuation retry.
+
+    Inputs are pure values; the decision is auditable and trivially
+    unit-tested. Used by :func:`maybe_retry_continuation` and exposed
+    so adapter-specific callers can compose their own retry flow.
+
+    Args:
+        adapter: The adapter that just exited.
+        verdict: Result of :meth:`CommitCompletionCheck.verify_after`.
+        exit_code: Adapter process exit code. Only ``0`` is eligible
+            for retry -- non-zero exits are handled by the normal
+            failure path.
+        attempts: Number of continuation retries already performed for
+            this session. Must be ``0`` on the first call.
+
+    Returns:
+        A :class:`RetryDecision` documenting the call.
+    """
+    if exit_code != 0:
+        return RetryDecision(should_retry=False, reason="non_zero_exit")
+    # Surface the "no baseline" case before the committed shortcut: an
+    # unknown HEAD reports ``committed=True`` defensively, but the
+    # trace-level reason "head_unknown" is the more useful tag.
+    if verdict.reason == "head_unknown":
+        return RetryDecision(should_retry=False, reason="head_unknown")
+    if verdict.committed:
+        return RetryDecision(should_retry=False, reason="committed")
+    if not adapter_supports_continuation(adapter):
+        return RetryDecision(should_retry=False, reason="adapter_unsupported")
+    if attempts >= RETRY_LIMIT:
+        return RetryDecision(should_retry=False, reason="retry_cap_reached")
+    return RetryDecision(should_retry=True, reason="needs_retry")
+
+
+def build_continuation_prompt(
+    *,
+    original_prompt: str,
+    nudge: str = DEFAULT_CONTINUATION_NUDGE,
+) -> str:
+    """Compose the continuation prompt.
+
+    The nudge is appended after a blank line so it reads as a follow-up
+    user turn inside the adapter's session view. The original prompt
+    is preserved verbatim so transcript replay stays intelligible.
+    """
+    if not nudge:
+        return original_prompt
+    return f"{original_prompt}\n\n{nudge}".strip()
+
+
+def maybe_retry_continuation(
+    *,
+    adapter: CLIAdapter,
+    workdir: Path,
+    before: str,
+    session_id: str,
+    exit_code: int,
+    original_prompt: str,
+    attempts: int = 0,
+    check: CommitCompletionCheck | None = None,
+    nudge: str = DEFAULT_CONTINUATION_NUDGE,
+    spawn_fn: object | None = None,
+) -> tuple[RetryDecision, CompletionVerdict, SpawnResult | None]:
+    """Convenience wrapper around verify + decide + (optional) spawn.
+
+    Designed for the agent dispatch loop. Callers that already have a
+    spawn callable hand it in as ``spawn_fn``; the helper invokes it
+    with the continuation prompt and the adapter's continuation args.
+    Pass ``spawn_fn=None`` to get the decision without actually
+    re-launching.
+
+    Args:
+        adapter: The adapter that just exited.
+        workdir: Worktree the adapter was launched into.
+        before: HEAD SHA captured by :meth:`snapshot_before`.
+        session_id: Adapter session id, fed to ``continuation_args``.
+        exit_code: Adapter process exit code.
+        original_prompt: The prompt rendered for the first attempt.
+        attempts: Existing retry count for this session.
+        check: Optional pre-built verifier; defaults to a fresh
+            :class:`CommitCompletionCheck`.
+        nudge: Override the corrective message tail.
+        spawn_fn: Optional callable
+            ``spawn_fn(prompt: str, continuation_args: list[str]) -> SpawnResult``.
+            When ``None`` the helper does not spawn; callers wiring
+            into a heavier dispatch layer should pass a closure that
+            forwards into their own spawn machinery.
+
+    Returns:
+        A 3-tuple of ``(decision, verdict, retry_result)``. The third
+        element is ``None`` when no retry was attempted or
+        ``spawn_fn`` was omitted.
+    """
+    check = check or CommitCompletionCheck()
+    verdict = check.verify_after(workdir, before=before)
+    decision = decide_retry(
+        adapter=adapter,
+        verdict=verdict,
+        exit_code=exit_code,
+        attempts=attempts,
+    )
+    if not decision.should_retry or spawn_fn is None:
+        return decision, verdict, None
+
+    continuation_args = adapter.continuation_args(session_id)
+    prompt = build_continuation_prompt(original_prompt=original_prompt, nudge=nudge)
+    logger.info(
+        "retry-with-continuation: session=%s reason=%s attempts=%d args=%s",
+        session_id,
+        decision.reason,
+        attempts,
+        continuation_args,
+    )
+    retry_result = spawn_fn(prompt, continuation_args)  # type: ignore[operator]
+    return decision, verdict, retry_result
+
+
+__all__ = [
+    "DEFAULT_CONTINUATION_NUDGE",
+    "RETRY_LIMIT",
+    "CommitCompletionCheck",
+    "CompletionVerdict",
+    "RetryDecision",
+    "adapter_supports_continuation",
+    "build_continuation_prompt",
+    "decide_retry",
+    "maybe_retry_continuation",
+]

--- a/tests/unit/orchestration/test_commit_completion.py
+++ b/tests/unit/orchestration/test_commit_completion.py
@@ -1,0 +1,424 @@
+"""Unit tests for :mod:`bernstein.core.orchestration.commit_completion`.
+
+Covers:
+
+* ``CommitCompletionCheck.snapshot_before`` / ``verify_after`` against a
+  real temp git repo (commit moves HEAD; idempotent reads).
+* ``decide_retry`` truth table -- every reason tag has a dedicated case.
+* ``adapter_supports_continuation`` reads the class attribute.
+* ``build_continuation_prompt`` composes the corrective nudge.
+* ``maybe_retry_continuation`` end-to-end with a stub adapter and spawn
+  callable; covers the no-retry, retry-cap, and successful-retry paths.
+
+The tests do not exercise the real ``git`` binary beyond
+``git init`` / ``git commit`` smoke flow inside a ``tmp_path``. They
+never touch a remote, never spawn an adapter, and never consult the
+network.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.orchestration.commit_completion import (
+    DEFAULT_CONTINUATION_NUDGE,
+    RETRY_LIMIT,
+    CommitCompletionCheck,
+    CompletionVerdict,
+    RetryDecision,
+    adapter_supports_continuation,
+    build_continuation_prompt,
+    decide_retry,
+    maybe_retry_continuation,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubAdapter:
+    """Minimal adapter stand-in for the retry-decision tests.
+
+    Only the attributes the production code reads are modelled. The
+    fixture deliberately does not subclass :class:`CLIAdapter` to keep
+    the test fast and free of subprocess wiring.
+    """
+
+    supports_session_continuation: bool = False
+    continuation_args_value: list[str] = field(default_factory=list)
+    continuation_args_calls: list[str] = field(default_factory=list)
+
+    def continuation_args(self, session_id: str) -> list[str]:
+        self.continuation_args_calls.append(session_id)
+        return list(self.continuation_args_value)
+
+
+@dataclass
+class _SpawnRecorder:
+    """Captures the prompt + flags passed to the retry spawn."""
+
+    calls: list[tuple[str, list[str]]] = field(default_factory=list)
+    return_value: object | None = "spawn-ok"
+
+    def __call__(self, prompt: str, continuation_args: list[str]) -> object | None:
+        self.calls.append((prompt, list(continuation_args)))
+        return self.return_value
+
+
+# ---------------------------------------------------------------------------
+# Real git fixture
+# ---------------------------------------------------------------------------
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.setdefault("GIT_AUTHOR_NAME", "test")
+    env.setdefault("GIT_AUTHOR_EMAIL", "test@example.invalid")
+    env.setdefault("GIT_COMMITTER_NAME", "test")
+    env.setdefault("GIT_COMMITTER_EMAIL", "test@example.invalid")
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"git {' '.join(args)} failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    _run_git(tmp_path, "init", "--initial-branch", "main", str(tmp_path))
+    (tmp_path / "seed.txt").write_text("seed", encoding="utf-8")
+    _run_git(tmp_path, "add", ".")
+    _run_git(tmp_path, "commit", "-m", "seed")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# CommitCompletionCheck
+# ---------------------------------------------------------------------------
+
+
+class TestCommitCompletionCheck:
+    def test_snapshot_returns_current_head(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        sha = check.snapshot_before(repo)
+        assert len(sha) == 40
+        assert sha == _run_git(repo, "rev-parse", "HEAD")
+
+    def test_verify_detects_no_commit(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+        verdict = check.verify_after(repo, before=before)
+        assert verdict.committed is False
+        assert verdict.needs_retry is True
+        assert verdict.before == before
+        assert verdict.after == before
+        assert verdict.reason == "head_did_not_move"
+
+    def test_verify_detects_commit_landed(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+        (repo / "new.txt").write_text("more", encoding="utf-8")
+        _run_git(repo, "add", ".")
+        _run_git(repo, "commit", "-m", "another")
+        verdict = check.verify_after(repo, before=before)
+        assert verdict.committed is True
+        assert verdict.needs_retry is False
+        assert verdict.after != before
+        assert verdict.reason == ""
+
+    def test_missing_workdir_yields_no_retry(self, tmp_path: Path) -> None:
+        # Not a git repo -> rev_parse_head raises, returns "" -> treat as
+        # committed (we cannot confidently call for a retry).
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(tmp_path)
+        assert before == ""
+        verdict = check.verify_after(tmp_path, before=before)
+        assert verdict.committed is True
+        assert verdict.needs_retry is False
+        assert verdict.reason == "head_unknown"
+
+    def test_snapshot_is_pure_no_writes(self, repo: Path) -> None:
+        before_status = _run_git(repo, "status", "--porcelain")
+        check = CommitCompletionCheck()
+        check.snapshot_before(repo)
+        check.verify_after(repo, before=check.snapshot_before(repo))
+        after_status = _run_git(repo, "status", "--porcelain")
+        assert before_status == after_status
+
+
+# ---------------------------------------------------------------------------
+# CompletionVerdict
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionVerdict:
+    def test_needs_retry_mirror_of_committed(self) -> None:
+        committed = CompletionVerdict(committed=True, before="a", after="b")
+        not_committed = CompletionVerdict(committed=False, before="a", after="a")
+        assert committed.needs_retry is False
+        assert not_committed.needs_retry is True
+
+    def test_frozen_dataclass(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        v = CompletionVerdict(committed=True, before="a", after="b")
+        with pytest.raises(FrozenInstanceError):
+            v.committed = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# decide_retry truth table
+# ---------------------------------------------------------------------------
+
+
+class TestDecideRetry:
+    def test_non_zero_exit_blocks_retry(self) -> None:
+        decision = decide_retry(
+            adapter=_StubAdapter(supports_session_continuation=True),
+            verdict=CompletionVerdict(committed=False, before="a", after="a", reason="head_did_not_move"),
+            exit_code=2,
+            attempts=0,
+        )
+        assert decision == RetryDecision(should_retry=False, reason="non_zero_exit")
+
+    def test_committed_blocks_retry(self) -> None:
+        decision = decide_retry(
+            adapter=_StubAdapter(supports_session_continuation=True),
+            verdict=CompletionVerdict(committed=True, before="a", after="b"),
+            exit_code=0,
+            attempts=0,
+        )
+        assert decision == RetryDecision(should_retry=False, reason="committed")
+
+    def test_head_unknown_blocks_retry(self) -> None:
+        decision = decide_retry(
+            adapter=_StubAdapter(supports_session_continuation=True),
+            verdict=CompletionVerdict(committed=True, before="", after="", reason="head_unknown"),
+            exit_code=0,
+            attempts=0,
+        )
+        assert decision == RetryDecision(should_retry=False, reason="head_unknown")
+
+    def test_adapter_without_continuation_blocks_retry(self) -> None:
+        decision = decide_retry(
+            adapter=_StubAdapter(supports_session_continuation=False),
+            verdict=CompletionVerdict(committed=False, before="a", after="a", reason="head_did_not_move"),
+            exit_code=0,
+            attempts=0,
+        )
+        assert decision == RetryDecision(should_retry=False, reason="adapter_unsupported")
+
+    def test_retry_cap_blocks_second_attempt(self) -> None:
+        decision = decide_retry(
+            adapter=_StubAdapter(supports_session_continuation=True),
+            verdict=CompletionVerdict(committed=False, before="a", after="a", reason="head_did_not_move"),
+            exit_code=0,
+            attempts=RETRY_LIMIT,
+        )
+        assert decision == RetryDecision(should_retry=False, reason="retry_cap_reached")
+
+    def test_retry_path_when_all_conditions_met(self) -> None:
+        decision = decide_retry(
+            adapter=_StubAdapter(supports_session_continuation=True),
+            verdict=CompletionVerdict(committed=False, before="a", after="a", reason="head_did_not_move"),
+            exit_code=0,
+            attempts=0,
+        )
+        assert decision == RetryDecision(should_retry=True, reason="needs_retry")
+
+    def test_retry_limit_is_one(self) -> None:
+        # Hard contract: the v1 cap is exactly one retry.
+        assert RETRY_LIMIT == 1
+
+
+# ---------------------------------------------------------------------------
+# adapter_supports_continuation
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterSupportsContinuation:
+    def test_true_when_attribute_set(self) -> None:
+        assert adapter_supports_continuation(_StubAdapter(supports_session_continuation=True))
+
+    def test_false_when_attribute_absent(self) -> None:
+        class _Bare:
+            pass
+
+        assert not adapter_supports_continuation(_Bare())  # type: ignore[arg-type]
+
+    def test_false_when_attribute_false(self) -> None:
+        assert not adapter_supports_continuation(_StubAdapter(supports_session_continuation=False))
+
+
+# ---------------------------------------------------------------------------
+# build_continuation_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContinuationPrompt:
+    def test_appends_default_nudge(self) -> None:
+        out = build_continuation_prompt(original_prompt="do work")
+        assert DEFAULT_CONTINUATION_NUDGE in out
+        assert out.startswith("do work")
+        assert "\n\n" in out
+
+    def test_custom_nudge_replaces_default(self) -> None:
+        out = build_continuation_prompt(original_prompt="task", nudge="custom-nudge")
+        assert "custom-nudge" in out
+        assert DEFAULT_CONTINUATION_NUDGE not in out
+
+    def test_empty_nudge_returns_original(self) -> None:
+        assert build_continuation_prompt(original_prompt="just this", nudge="") == "just this"
+
+
+# ---------------------------------------------------------------------------
+# maybe_retry_continuation end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeRetryContinuation:
+    def test_no_retry_when_committed(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+        (repo / "new.txt").write_text("x", encoding="utf-8")
+        _run_git(repo, "add", ".")
+        _run_git(repo, "commit", "-m", "did work")
+
+        adapter = _StubAdapter(supports_session_continuation=True, continuation_args_value=["--continue"])
+        recorder = _SpawnRecorder()
+        decision, verdict, retry_result = maybe_retry_continuation(
+            adapter=adapter,  # type: ignore[arg-type]
+            workdir=repo,
+            before=before,
+            session_id="sess-1",
+            exit_code=0,
+            original_prompt="prompt",
+            spawn_fn=recorder,
+        )
+        assert decision.should_retry is False
+        assert decision.reason == "committed"
+        assert verdict.committed is True
+        assert retry_result is None
+        assert recorder.calls == []
+        assert adapter.continuation_args_calls == []
+
+    def test_retry_invokes_spawn_with_continuation_args(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+
+        adapter = _StubAdapter(supports_session_continuation=True, continuation_args_value=["--continue"])
+        recorder = _SpawnRecorder(return_value="ok")
+        decision, verdict, retry_result = maybe_retry_continuation(
+            adapter=adapter,  # type: ignore[arg-type]
+            workdir=repo,
+            before=before,
+            session_id="sess-2",
+            exit_code=0,
+            original_prompt="please ship it",
+            spawn_fn=recorder,
+        )
+        assert decision.should_retry is True
+        assert decision.reason == "needs_retry"
+        assert verdict.committed is False
+        assert retry_result == "ok"
+        assert recorder.calls == [
+            ("please ship it\n\n" + DEFAULT_CONTINUATION_NUDGE, ["--continue"]),
+        ]
+        assert adapter.continuation_args_calls == ["sess-2"]
+
+    def test_retry_skipped_when_attempts_at_cap(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+        adapter = _StubAdapter(supports_session_continuation=True, continuation_args_value=["--continue"])
+        recorder = _SpawnRecorder()
+        decision, _verdict, retry_result = maybe_retry_continuation(
+            adapter=adapter,  # type: ignore[arg-type]
+            workdir=repo,
+            before=before,
+            session_id="sess-3",
+            exit_code=0,
+            original_prompt="x",
+            attempts=RETRY_LIMIT,
+            spawn_fn=recorder,
+        )
+        assert decision.should_retry is False
+        assert decision.reason == "retry_cap_reached"
+        assert retry_result is None
+        assert recorder.calls == []
+
+    def test_no_spawn_fn_returns_decision_only(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+        adapter = _StubAdapter(supports_session_continuation=True, continuation_args_value=["--continue"])
+        decision, verdict, retry_result = maybe_retry_continuation(
+            adapter=adapter,  # type: ignore[arg-type]
+            workdir=repo,
+            before=before,
+            session_id="sess-4",
+            exit_code=0,
+            original_prompt="x",
+            spawn_fn=None,
+        )
+        assert decision.should_retry is True
+        assert verdict.needs_retry is True
+        assert retry_result is None
+
+    def test_no_retry_when_adapter_lacks_capability(self, repo: Path) -> None:
+        check = CommitCompletionCheck()
+        before = check.snapshot_before(repo)
+        adapter = _StubAdapter(supports_session_continuation=False)
+        recorder = _SpawnRecorder()
+        decision, _verdict, retry_result = maybe_retry_continuation(
+            adapter=adapter,  # type: ignore[arg-type]
+            workdir=repo,
+            before=before,
+            session_id="sess-5",
+            exit_code=0,
+            original_prompt="x",
+            spawn_fn=recorder,
+        )
+        assert decision.should_retry is False
+        assert decision.reason == "adapter_unsupported"
+        assert retry_result is None
+        assert recorder.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Base-class contract for adapters
+# ---------------------------------------------------------------------------
+
+
+class TestCLIAdapterContract:
+    def test_base_adapter_defaults_to_not_supported(self) -> None:
+        from bernstein.adapters.base import CLIAdapter
+
+        assert CLIAdapter.supports_session_continuation is False
+
+    def test_base_adapter_default_continuation_args_is_empty(self) -> None:
+        from bernstein.adapters.base import CLIAdapter
+
+        # We bypass abstract instantiation by reading the unbound method.
+        unbound_args: Any = CLIAdapter.continuation_args
+        # Stub self argument; method body does not consult self.
+        assert unbound_args(None, "any-session") == []
+
+    def test_claude_adapter_opts_in(self) -> None:
+        from bernstein.adapters.claude import ClaudeCodeAdapter
+
+        assert ClaudeCodeAdapter.supports_session_continuation is True
+        args = ClaudeCodeAdapter.continuation_args(None, "sess-x")  # type: ignore[arg-type]
+        assert args == ["--continue"]


### PR DESCRIPTION
## Summary

- Adds `CommitCompletionCheck` in `src/bernstein/core/orchestration/commit_completion.py` that snapshots HEAD before the adapter spawn and verifies after exit. When the adapter exits cleanly but HEAD has not moved, the orchestrator launches one continuation retry through the adapter's session-resume primitive with a corrective nudge.
- Adds a per-adapter capability flag `supports_session_continuation` and method `continuation_args(session_id)` on the `CLIAdapter` base. Default-off so unknown adapters never trigger the retry path. Claude Code opts in with `--continue`; other adapters can opt in via follow-up changes once their continuation flag is verified.
- Adds the lifecycle event `agent.retry_continuation` with payload `{session_id, reason, attempt}`.
- Hard cap: one retry per task. Recursion is non-configurable.

## Files

- `src/bernstein/core/orchestration/commit_completion.py` (new) - `CommitCompletionCheck`, `CompletionVerdict`, `RetryDecision`, `decide_retry`, `build_continuation_prompt`, `maybe_retry_continuation`.
- `src/bernstein/adapters/base.py` - adds `supports_session_continuation` class attr and `continuation_args` method.
- `src/bernstein/adapters/claude.py` - opts in (uses `--continue`).
- `src/bernstein/core/lifecycle/hooks.py` - adds `AGENT_RETRY_CONTINUATION` event.
- `tests/unit/orchestration/test_commit_completion.py` (new) - 28 cases against a real temp git repo plus a stub adapter; covers the full `decide_retry` truth table, the no-retry/retry-cap/retry-success paths through `maybe_retry_continuation`, and the base-class contract.
- `docs/concepts/orchestrator-hardening.md` - operator-facing section under the existing hardening primitives.

## Test plan

- [x] `uv run pytest tests/unit/orchestration/test_commit_completion.py` -- 28 passed
- [x] `uv run ruff check` on touched files -- clean
- [x] `uv run ruff format` on touched files -- no changes
- [ ] Wider CI run via PR checks

## Summary by Sourcery

Introduce a commit-completion verification step that can trigger a single retry of CLI coding agents via session continuation when they exit successfully without creating a commit.

New Features:
- Add commit-completion checking utilities that compare git HEAD before and after agent runs and decide whether to trigger a continuation retry.
- Add an adapter capability flag and hook methods to support session-based continuation retries, with Claude Code opting in via its CLI resume/continue mechanism.
- Emit a new lifecycle event when a continuation retry is launched for observability of retry-with-continuation behavior.

Enhancements:
- Document the new commit-completion check as part of the orchestrator hardening primitives and link it from the operator-facing hardening overview.

Tests:
- Add comprehensive unit tests for commit-completion checking, retry decision logic, adapter capability handling, and continuation retry orchestration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session continuation mechanism to retry agent invocations that complete without generating commits.
  * Claude Code adapter now supports resuming prior sessions during retries.
  * Added new lifecycle event to track agent retry attempts.

* **Documentation**
  * Added documentation for commit-completion verification and retry-with-continuation behavior.

* **Tests**
  * Added comprehensive test coverage for commit completion and retry logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->