### PR TITLE
feat(reliability): progress-watch liveness probe via session-log growth

### DIFF
--- a/docs/observability/progress-watch.md
+++ b/docs/observability/progress-watch.md
@@ -1,0 +1,93 @@
+# ProgressWatch — agent liveness via session-log growth
+
+ProgressWatch is a small observability primitive that decides whether a
+spawned CLI agent is "stuck or just thinking" without parsing the
+agent's own stdout. It watches a structured session log on disk: if the
+log file's mtime or size moves forward, the agent is making progress.
+If it has not moved for `agents.progress_watch.inactivity_seconds`, the
+watcher records a stall and asks the dispatch loop to escalate.
+
+The watcher does not spawn its own thread and does not kill processes
+directly. The dispatch loop tick (every 30s by default) calls
+`ProgressWatch.tick()` and inspects the returned `StallEvent` list.
+When a session has been idle past
+`agents.progress_watch.kill_after_inactivity_seconds`,
+`kill_if_stale(session_id)` returns a `sigkill` verdict that the loop
+uses to decide what signal to send.
+
+## Public surface
+
+| Symbol | Purpose |
+| --- | --- |
+| `ProgressWatch.register(session_id, log_path, adapter=...)` | Begin watching a log file for a session. |
+| `ProgressWatch.unregister(session_id)` | Stop watching. Idempotent. |
+| `ProgressWatch.tick()` | Sample every registered log. Returns newly-detected stalls. |
+| `ProgressWatch.drain_pending_events()` | Read and clear the buffered stall events. |
+| `ProgressWatch.kill_if_stale(session_id)` | Return the kill verdict for one session (`none`/`sigterm`/`sigkill`). |
+| `CLIAdapter.supports_session_log_watch` | Class attribute; `True` when the adapter exposes a structured log path. |
+| `CLIAdapter.session_log_path_for(session_id)` | Return the absolute log path for the given Bernstein session, or `None`. |
+
+## Configuration
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `agents.progress_watch.enabled` | `true` | Master switch for the watcher. |
+| `agents.progress_watch.inactivity_seconds` | `120` | Idle gap before a stall is emitted. |
+| `agents.progress_watch.kill_after_inactivity_seconds` | `300` | Idle gap before the watcher escalates to SIGKILL. |
+
+These defaults are also exposed as constants on
+`bernstein.core.observability.progress_watch` for callers that want to
+build a watcher without parsing config:
+
+* `DEFAULT_INACTIVITY_SECONDS`
+* `DEFAULT_KILL_AFTER_INACTIVITY_SECONDS`
+* `DEFAULT_POLL_INTERVAL_SECONDS`
+
+## Lifecycle event
+
+When a stall is detected, the dispatch loop forwards the
+`StallEvent` onto the lifecycle hook bus:
+
+```text
+event:   agent.progress_stalled
+data:
+  adapter:             "<adapter name>"
+  log_path:            "<absolute path>"
+  last_log_growth_ts:  <unix ts>
+  detected_ts:         <unix ts>
+```
+
+The event name is also available as
+`LifecycleEvent.AGENT_PROGRESS_STALLED`.
+
+## Per-adapter log paths
+
+The watcher itself is adapter-agnostic. Adapters opt in by setting
+`supports_session_log_watch = True` and overriding
+`session_log_path_for(session_id)`. The default returns `None`, which
+makes the dispatch loop skip the adapter and fall back to plain
+process-exit detection.
+
+| Adapter | `supports_session_log_watch` | Log location |
+| --- | --- | --- |
+| `claude` | yes | `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl` (latest match) |
+| `codex` | no (planned) | `~/.codex/sessions/<id>.log` (per upstream CLI) |
+| `cursor` | no (planned) | `~/.cursor/agents/<id>.jsonl` (per upstream CLI) |
+| `aider` | no (planned) | `<workdir>/.aider.chat.history.md` |
+| `gemini` | no (planned) | `~/.gemini/sessions/<id>.log` |
+| `opencode` | no (planned) | `~/.opencode/sessions/<id>.jsonl` |
+
+Adapters not in this table use the inherited default and rely on
+process-exit detection. New adapters can opt in at any time by adding
+the override; no changes to the watcher itself are required.
+
+## Operational notes
+
+* The watcher treats a missing log file as "no growth", not as an
+  error. Adapters may register a log path before the CLI creates the
+  file; the first observed mtime/size move counts as the first growth.
+* Stall events are sticky: once a session has been flagged as stalled,
+  the watcher does not re-emit until the log grows again, at which
+  point the sticky state clears and the cycle starts over.
+* Auto-restart of a killed agent is out of scope for this primitive
+  (see the retry-with-continuation work).

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -399,6 +399,14 @@ class CLIAdapter(ABC):
     #: ``False`` so unknown adapters never trigger the retry path.
     supports_session_continuation: bool = False
 
+    #: Whether this adapter can supply a structured per-session log path
+    #: for the ProgressWatch liveness probe (see
+    #: :mod:`bernstein.core.observability.progress_watch`). Adapters that
+    #: write to a deterministic on-disk log set this to ``True`` and
+    #: override :meth:`session_log_path_for`. The default is ``False`` so
+    #: the dispatch loop falls back to plain process-exit detection.
+    supports_session_log_watch: bool = False
+
     def __init__(self) -> None:
         self._resource_limits: ResourceLimits | None = None
         self._rate_limit_meter: RateLimitMeter | None = None
@@ -709,6 +717,27 @@ class CLIAdapter(ABC):
             _session_id: Agent session ID.
             _batch_id: The batch identifier to cancel.
         """
+
+    def session_log_path_for(self, _session_id: str) -> Path | None:
+        """Return the structured per-session log path, if any.
+
+        Optional capability declared by :attr:`supports_session_log_watch`.
+        Adapters whose upstream CLI writes a deterministic JSONL/text log
+        per session override this method and return the absolute path
+        Bernstein should watch. The default returns ``None``, meaning the
+        ProgressWatch dispatch loop should skip this adapter and rely on
+        plain process-exit detection.
+
+        Args:
+            _session_id: The Bernstein session id under which the agent
+                was spawned. Adapters may translate this into the CLI's
+                own session identifier as needed.
+
+        Returns:
+            Absolute :class:`~pathlib.Path` to the session log, or
+            ``None`` when the adapter has no structured log to expose.
+        """
+        return None
 
     def resume(
         self,

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Mapping  # noqa: TC003 — runtime use in ClassVar annotations
-from pathlib import Path  # noqa: TC003 — kept at runtime so tests can patch ``claude.Path.home``
+from pathlib import Path
 from typing import Any, ClassVar, cast
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
@@ -115,6 +115,10 @@ class ClaudeCodeAdapter(CLIAdapter):
     # rate-limit panel. Anthropic uses HTTP 429 plus structured
     # ``rate_limit_error`` types on the messages API.
     rate_limit_provider = "anthropic"
+    # Claude Code writes a JSONL transcript per session under
+    # ``~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl``.
+    # ProgressWatch can read this directly as a liveness signal.
+    supports_session_log_watch = True
 
     # Opt into the retry-with-continuation path. Claude Code's CLI
     # exposes ``--resume <session-id>`` to re-enter a prior conversation
@@ -658,6 +662,51 @@ class ClaudeCodeAdapter(CLIAdapter):
         the correct prior session without explicit id plumbing.
         """
         return ["--continue"]
+
+    def session_log_path_for(self, session_id: str) -> Path | None:
+        """Return the Claude Code JSONL transcript path for this session.
+
+        Claude Code writes per-session transcripts under
+        ``~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl``. The
+        ``<session-uuid>`` is assigned by Claude itself and is not the
+        Bernstein ``session_id``, so we return the most recently modified
+        JSONL under the encoded-cwd directory that matches the worktree
+        the agent is running in.
+
+        Args:
+            session_id: Bernstein session id. Currently unused for path
+                resolution but accepted for forward compatibility.
+
+        Returns:
+            Absolute path to the latest JSONL transcript, or ``None`` if
+            the projects directory or any transcript file is missing.
+        """
+        del session_id
+        try:
+            home = Path.home()
+        except (OSError, RuntimeError):
+            return None
+        # Claude encodes the current working directory by replacing path
+        # separators with dashes. We accept any subdirectory under
+        # ``~/.claude/projects/`` because the spawn cwd may be a worktree
+        # whose encoding the caller does not know.
+        projects_dir = home / ".claude" / "projects"
+        if not projects_dir.is_dir():
+            return None
+        cwd = Path.cwd().resolve()
+        # Best-effort: match a directory whose name encodes ``cwd``.
+        encoded = str(cwd).replace("/", "-")
+        candidates = list(projects_dir.glob(f"*{encoded}*/*.jsonl"))
+        if not candidates:
+            # Fall back to the newest JSONL across all projects so the
+            # watcher still has a signal even if encoding differs.
+            candidates = list(projects_dir.glob("*/*.jsonl"))
+        if not candidates:
+            return None
+        try:
+            return max(candidates, key=lambda p: p.stat().st_mtime)
+        except OSError:
+            return None
 
     def detect_tier(self) -> ApiTierInfo | None:
         """Detect Claude API tier based on environment and API key type.

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -119,6 +119,21 @@ class LifecycleEvent(StrEnum):
     # ------------------------------------------------------------------
     AGENT_RETRY_CONTINUATION = "agent.retry_continuation"
 
+    # ------------------------------------------------------------------
+    # ProgressWatch liveness probe
+    # (feat-progress-watch-liveness-probe).
+    # Emitted when the watcher detects that an agent's session log has
+    # not grown for at least ``agents.progress_watch.inactivity_seconds``.
+    # Payload keys on ``context.data``:
+    #
+    # * ``adapter``: adapter name (e.g. ``"claude"``).
+    # * ``log_path``: stringified path of the watched log.
+    # * ``last_log_growth_ts``: unix timestamp of the most recent
+    #   observed growth (mtime or size move).
+    # * ``detected_ts``: unix timestamp the stall was detected.
+    # ------------------------------------------------------------------
+    AGENT_PROGRESS_STALLED = "agent.progress_stalled"
+
 
 #: The cross-CLI standardised event vocabulary introduced by issue #1323.
 #: Pre-existing snake_case events remain supported but are not part of

--- a/src/bernstein/core/observability/progress_watch.py
+++ b/src/bernstein/core/observability/progress_watch.py
@@ -1,0 +1,354 @@
+"""ProgressWatch: liveness probe based on session-log file growth.
+
+When Bernstein spawns a CLI agent subprocess, the only reliable way to
+know whether the agent is "stuck or just thinking" is to ignore its own
+stdout (which it may buffer, or pause for tool calls) and watch a
+structured session log on disk. Most cooperating CLIs append to such a
+log as they make progress; an idle log file means the agent has stopped
+making progress.
+
+The class is deliberately small and single-threaded:
+
+* :meth:`register` records a (session_id, log_path) pair.
+* :meth:`tick` samples the current mtime/size of every registered log
+  and decides which sessions have crossed the inactivity / kill
+  thresholds.
+* :meth:`kill_if_stale` returns the kill verdict for a single session,
+  suitable for an external dispatch loop that owns the process handle.
+
+The watcher does not spawn its own thread and does not kill processes
+directly. The dispatch loop is responsible for both:
+
+* calling :meth:`tick` on a cadence (e.g. every 30s) and
+* turning a :class:`KillVerdict` into the actual SIGTERM/SIGKILL.
+
+This separation keeps the watcher trivially testable (inject a clock,
+inject a stat function) and avoids embedding lifecycle policy in an
+observability primitive.
+
+Lifecycle integration
+---------------------
+
+When the inactivity threshold is crossed, the watcher records the
+:class:`StallEvent` in its emit buffer. The dispatch loop drains the
+buffer and forwards each event onto the lifecycle hook bus as
+``agent.progress_stalled`` (see
+:class:`bernstein.core.lifecycle.hooks.LifecycleEvent`).
+
+References:
+
+* Ticket: feat-2026-05-19-progress-watch-liveness-probe.
+* Module map: ``src/bernstein/core/observability/`` (see CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+#: How long a registered log may be idle before the watcher flags it as
+#: stalled. Operator-tunable via ``agents.progress_watch.inactivity_seconds``.
+DEFAULT_INACTIVITY_SECONDS: int = 120
+
+#: How long a stalled log may remain idle before the watcher requests an
+#: escalation from SIGTERM to SIGKILL. Operator-tunable via
+#: ``agents.progress_watch.kill_after_inactivity_seconds``.
+DEFAULT_KILL_AFTER_INACTIVITY_SECONDS: int = 300
+
+#: Default tick cadence for the dispatcher that owns the watcher.
+DEFAULT_POLL_INTERVAL_SECONDS: int = 30
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _LogSnapshot:
+    """Last observed stat() for a registered log file.
+
+    ``mtime`` and ``size`` together are the activity signal: either one
+    moving forward counts as progress. The watcher treats a missing file
+    as "no progress yet" rather than an error, because adapters may
+    register a log path before the CLI has created the file.
+    """
+
+    mtime: float = 0.0
+    size: int = 0
+    last_growth_ts: float = 0.0
+    #: When the watcher first observed the log to be idle past the
+    #: inactivity threshold. ``0.0`` means "not currently considered
+    #: stalled". Used to compute the SIGTERM -> SIGKILL escalation gap.
+    stalled_since_ts: float = 0.0
+
+
+@dataclass(frozen=True)
+class StallEvent:
+    """A single ``agent.progress_stalled`` lifecycle event payload."""
+
+    session_id: str
+    adapter: str
+    log_path: str
+    last_log_growth_ts: float
+    detected_ts: float
+
+
+@dataclass(frozen=True)
+class KillVerdict:
+    """Result of :meth:`ProgressWatch.kill_if_stale`.
+
+    Attributes:
+        action: ``"none"`` (still healthy), ``"sigterm"`` (inactivity
+            threshold crossed, request graceful kill), ``"sigkill"``
+            (kill-after threshold crossed since SIGTERM, escalate).
+        session_id: Echo of the queried session.
+        idle_seconds: Seconds since the log last grew.
+        reason: Human-readable detail for audit logs.
+    """
+
+    action: str
+    session_id: str
+    idle_seconds: float
+    reason: str = ""
+
+
+@dataclass
+class _Registration:
+    """A single registered session under watch."""
+
+    session_id: str
+    adapter: str
+    log_path: Path
+    snapshot: _LogSnapshot = field(default_factory=_LogSnapshot)
+
+
+# ---------------------------------------------------------------------------
+# Watcher
+# ---------------------------------------------------------------------------
+
+
+#: Stat function signature. Returns ``(mtime, size)`` for a path, or
+#: raises ``OSError`` when the path is missing or unreadable. The
+#: indirection exists so tests can drive the watcher without touching
+#: the real filesystem.
+StatFn = Callable[[Path], tuple[float, int]]
+
+
+def _default_stat(path: Path) -> tuple[float, int]:
+    """Default :data:`StatFn` -- ``(mtime, size)`` from ``os.stat``."""
+    st = os.stat(path)
+    return float(st.st_mtime), int(st.st_size)
+
+
+class ProgressWatch:
+    """Single-threaded liveness probe for session-log growth.
+
+    The watcher is fully synchronous. Callers own the tick cadence and
+    the kill mechanism. Internally we hold a lock to keep ``register``,
+    ``unregister``, and ``tick`` safe against concurrent callers in case
+    the dispatch loop uses a worker thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        inactivity_seconds: int = DEFAULT_INACTIVITY_SECONDS,
+        kill_after_inactivity_seconds: int = DEFAULT_KILL_AFTER_INACTIVITY_SECONDS,
+        clock: Callable[[], float] | None = None,
+        stat_fn: StatFn | None = None,
+    ) -> None:
+        if inactivity_seconds <= 0:
+            raise ValueError("inactivity_seconds must be positive")
+        if kill_after_inactivity_seconds < inactivity_seconds:
+            raise ValueError("kill_after_inactivity_seconds must be >= inactivity_seconds")
+        self._inactivity_seconds = inactivity_seconds
+        self._kill_after_inactivity_seconds = kill_after_inactivity_seconds
+        self._clock: Callable[[], float] = clock or time.time
+        self._stat_fn: StatFn = stat_fn or _default_stat
+        self._lock = threading.Lock()
+        self._registrations: dict[str, _Registration] = {}
+        self._pending_events: list[StallEvent] = []
+
+    # ------------------------------------------------------------------
+    # Registration surface
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        session_id: str,
+        log_path: str | os.PathLike[str],
+        *,
+        adapter: str = "",
+    ) -> None:
+        """Begin watching ``log_path`` for the given session.
+
+        Re-registering the same session_id replaces the previous entry.
+        The watcher seeds the snapshot from the current stat() so the
+        first :meth:`tick` does not produce a spurious "growth" event.
+        """
+        path = Path(log_path)
+        snapshot = _LogSnapshot(last_growth_ts=self._clock())
+        try:
+            mtime, size = self._stat_fn(path)
+        except OSError:
+            # File does not exist yet; treat as zero-size. The watcher
+            # will detect creation as growth on the next tick.
+            pass
+        else:
+            snapshot.mtime = mtime
+            snapshot.size = size
+        with self._lock:
+            self._registrations[session_id] = _Registration(
+                session_id=session_id,
+                adapter=adapter,
+                log_path=path,
+                snapshot=snapshot,
+            )
+
+    def unregister(self, session_id: str) -> None:
+        """Stop watching ``session_id``. Idempotent."""
+        with self._lock:
+            self._registrations.pop(session_id, None)
+
+    def is_registered(self, session_id: str) -> bool:
+        """True iff the session is currently under watch."""
+        with self._lock:
+            return session_id in self._registrations
+
+    def registered_sessions(self) -> list[str]:
+        """Return the list of currently-watched session ids."""
+        with self._lock:
+            return list(self._registrations.keys())
+
+    # ------------------------------------------------------------------
+    # Polling
+    # ------------------------------------------------------------------
+
+    def tick(self) -> list[StallEvent]:
+        """Sample every registered log; return newly-detected stalls.
+
+        For every registered session we stat() the log file:
+
+        * If mtime or size moved forward, the snapshot updates and the
+          session is considered healthy.
+        * Otherwise, if the idle gap exceeds ``inactivity_seconds`` and
+          we have not yet emitted a stall for this idle period, the
+          watcher records a :class:`StallEvent`. Subsequent ticks do
+          not re-emit until the log grows again (the event is sticky).
+        """
+        now = self._clock()
+        emitted: list[StallEvent] = []
+        with self._lock:
+            for reg in self._registrations.values():
+                grew = self._sample(reg, now)
+                if grew:
+                    # Log advanced; clear sticky stall state.
+                    reg.snapshot.stalled_since_ts = 0.0
+                    continue
+                idle = now - reg.snapshot.last_growth_ts
+                if idle < self._inactivity_seconds:
+                    continue
+                if reg.snapshot.stalled_since_ts > 0.0:
+                    # Already emitted for this idle stretch.
+                    continue
+                reg.snapshot.stalled_since_ts = now
+                event = StallEvent(
+                    session_id=reg.session_id,
+                    adapter=reg.adapter,
+                    log_path=str(reg.log_path),
+                    last_log_growth_ts=reg.snapshot.last_growth_ts,
+                    detected_ts=now,
+                )
+                emitted.append(event)
+            self._pending_events.extend(emitted)
+        return emitted
+
+    def drain_pending_events(self) -> list[StallEvent]:
+        """Return and clear the buffer of all stall events seen so far.
+
+        The dispatch loop reads this buffer once per tick and forwards
+        each event onto the lifecycle hook bus. Holding the buffer in
+        the watcher lets a synchronous tick-then-emit caller stay free
+        of any side-effects.
+        """
+        with self._lock:
+            events = self._pending_events
+            self._pending_events = []
+        return events
+
+    def kill_if_stale(self, session_id: str) -> KillVerdict:
+        """Return the kill verdict for ``session_id`` without side effects.
+
+        The dispatch loop calls this when it is deciding what signal to
+        send to a worker process:
+
+        * ``"none"`` -- log is still growing or session is unregistered.
+        * ``"sigterm"`` -- inactivity threshold crossed, time to ask
+          the worker to wind down gracefully.
+        * ``"sigkill"`` -- the worker has been stalled for at least
+          ``kill_after_inactivity_seconds``; escalate to a hard kill.
+        """
+        now = self._clock()
+        with self._lock:
+            reg = self._registrations.get(session_id)
+            if reg is None:
+                return KillVerdict(
+                    action="none",
+                    session_id=session_id,
+                    idle_seconds=0.0,
+                    reason="session not registered",
+                )
+            # Refresh snapshot so callers see the latest growth state.
+            self._sample(reg, now)
+            idle = now - reg.snapshot.last_growth_ts
+            if idle < self._inactivity_seconds:
+                return KillVerdict(
+                    action="none",
+                    session_id=session_id,
+                    idle_seconds=idle,
+                    reason="log still growing",
+                )
+            if idle >= self._kill_after_inactivity_seconds:
+                return KillVerdict(
+                    action="sigkill",
+                    session_id=session_id,
+                    idle_seconds=idle,
+                    reason="kill-after threshold crossed",
+                )
+            return KillVerdict(
+                action="sigterm",
+                session_id=session_id,
+                idle_seconds=idle,
+                reason="inactivity threshold crossed",
+            )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _sample(self, reg: _Registration, now: float) -> bool:
+        """Update ``reg.snapshot`` from a fresh stat(); return whether it grew."""
+        try:
+            mtime, size = self._stat_fn(reg.log_path)
+        except OSError:
+            # Missing file is "no growth"; do not raise out of the loop.
+            return False
+        grew = mtime > reg.snapshot.mtime or size > reg.snapshot.size
+        if grew:
+            reg.snapshot.mtime = mtime
+            reg.snapshot.size = size
+            reg.snapshot.last_growth_ts = now
+        return grew

--- a/tests/unit/observability/test_progress_watch.py
+++ b/tests/unit/observability/test_progress_watch.py
@@ -1,0 +1,271 @@
+"""Unit tests for the ProgressWatch liveness probe.
+
+Coverage:
+
+* register / unregister / is_registered round-trip
+* tick() reports a stall once the inactivity window is crossed
+* tick() does not re-emit on subsequent stalled ticks (sticky event)
+* a log that grows after a stall clears the sticky state
+* kill_if_stale escalates from sigterm to sigkill at the kill-after window
+* missing log files are treated as no-growth, not as errors
+* constructor validates the threshold relationship
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.observability.progress_watch import (
+    DEFAULT_INACTIVITY_SECONDS,
+    DEFAULT_KILL_AFTER_INACTIVITY_SECONDS,
+    KillVerdict,
+    ProgressWatch,
+    StallEvent,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    """Manually-advanced monotonic clock for deterministic tests."""
+
+    def __init__(self, start: float = 1_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, delta: float) -> None:
+        self.now += delta
+
+
+class _FakeFs:
+    """Inject a stat() over an in-memory ``{path: (mtime, size)}`` map."""
+
+    def __init__(self) -> None:
+        self.files: dict[Path, tuple[float, int]] = {}
+
+    def __call__(self, path: Path) -> tuple[float, int]:
+        try:
+            return self.files[path]
+        except KeyError as exc:
+            raise FileNotFoundError(str(path)) from exc
+
+    def write(self, path: Path, mtime: float, size: int) -> None:
+        self.files[path] = (mtime, size)
+
+
+def _make_watch(
+    *,
+    inactivity: int = 60,
+    kill_after: int = 120,
+) -> tuple[ProgressWatch, _FakeClock, _FakeFs]:
+    clock = _FakeClock()
+    fs = _FakeFs()
+    watch = ProgressWatch(
+        inactivity_seconds=inactivity,
+        kill_after_inactivity_seconds=kill_after,
+        clock=clock,
+        stat_fn=fs,
+    )
+    return watch, clock, fs
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_thresholds_match_documented_constants() -> None:
+    watch = ProgressWatch()
+    assert DEFAULT_INACTIVITY_SECONDS > 0
+    assert DEFAULT_KILL_AFTER_INACTIVITY_SECONDS >= DEFAULT_INACTIVITY_SECONDS
+    # Sanity-check the runtime state is observable.
+    assert watch.registered_sessions() == []
+
+
+def test_constructor_rejects_non_positive_inactivity() -> None:
+    with pytest.raises(ValueError, match="inactivity_seconds"):
+        ProgressWatch(inactivity_seconds=0)
+
+
+def test_constructor_rejects_kill_after_smaller_than_inactivity() -> None:
+    with pytest.raises(ValueError, match="kill_after_inactivity_seconds"):
+        ProgressWatch(inactivity_seconds=120, kill_after_inactivity_seconds=60)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_seeds_snapshot_from_current_stat() -> None:
+    watch, clock, fs = _make_watch()
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=42)
+    watch.register("s1", log, adapter="claude")
+
+    assert watch.is_registered("s1")
+    assert watch.registered_sessions() == ["s1"]
+    # First tick at t+1s with no growth should not produce an event.
+    clock.advance(1.0)
+    assert watch.tick() == []
+
+
+def test_register_tolerates_missing_log_file() -> None:
+    watch, clock, fs = _make_watch()
+    log = Path("/tmp/not-yet-created.log")
+    # File deliberately absent from fs.
+    watch.register("s1", log, adapter="codex")
+    # A first tick observes no growth; no immediate stall.
+    clock.advance(1.0)
+    assert watch.tick() == []
+    # When the file appears, growth is detected.
+    fs.write(log, mtime=clock.now, size=10)
+    clock.advance(1.0)
+    assert watch.tick() == []  # growth, no stall
+
+
+def test_unregister_is_idempotent() -> None:
+    watch, _clock, fs = _make_watch()
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=1.0, size=1)
+    watch.register("s1", log)
+    watch.unregister("s1")
+    watch.unregister("s1")  # second call must not raise
+    assert not watch.is_registered("s1")
+
+
+# ---------------------------------------------------------------------------
+# Tick: stall detection
+# ---------------------------------------------------------------------------
+
+
+def test_tick_emits_stall_after_inactivity_window() -> None:
+    watch, clock, fs = _make_watch(inactivity=60, kill_after=120)
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=10)
+    watch.register("s1", log, adapter="claude")
+
+    # Mid-window tick: no stall.
+    clock.advance(30.0)
+    assert watch.tick() == []
+
+    # Past the inactivity threshold: one stall event.
+    clock.advance(31.0)
+    events = watch.tick()
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, StallEvent)
+    assert event.session_id == "s1"
+    assert event.adapter == "claude"
+    assert event.log_path == str(log)
+    assert event.last_log_growth_ts == 1_000.0
+    assert event.detected_ts == clock.now
+
+
+def test_tick_does_not_re_emit_for_continued_stall() -> None:
+    watch, clock, fs = _make_watch(inactivity=60, kill_after=300)
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=10)
+    watch.register("s1", log, adapter="claude")
+
+    clock.advance(61.0)
+    first = watch.tick()
+    assert len(first) == 1
+
+    # Several more ticks past the threshold should stay quiet.
+    for _ in range(3):
+        clock.advance(10.0)
+        assert watch.tick() == []
+
+
+def test_log_growth_clears_sticky_stall_state() -> None:
+    watch, clock, fs = _make_watch(inactivity=60, kill_after=300)
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=10)
+    watch.register("s1", log, adapter="claude")
+
+    clock.advance(61.0)
+    assert len(watch.tick()) == 1
+
+    # Agent makes progress: log size grows.
+    clock.advance(5.0)
+    fs.write(log, mtime=clock.now, size=20)
+    assert watch.tick() == []
+
+    # Now go idle again; a fresh stall event must fire.
+    clock.advance(61.0)
+    events = watch.tick()
+    assert len(events) == 1
+    assert events[0].session_id == "s1"
+
+
+def test_drain_pending_events_returns_and_clears() -> None:
+    watch, clock, fs = _make_watch(inactivity=60, kill_after=300)
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=10)
+    watch.register("s1", log, adapter="claude")
+    clock.advance(61.0)
+    watch.tick()
+
+    drained = watch.drain_pending_events()
+    assert len(drained) == 1
+    # Second drain is empty.
+    assert watch.drain_pending_events() == []
+
+
+# ---------------------------------------------------------------------------
+# kill_if_stale verdicts
+# ---------------------------------------------------------------------------
+
+
+def test_kill_if_stale_returns_none_for_unknown_session() -> None:
+    watch, _clock, _fs = _make_watch()
+    verdict = watch.kill_if_stale("missing")
+    assert isinstance(verdict, KillVerdict)
+    assert verdict.action == "none"
+    assert "not registered" in verdict.reason
+
+
+def test_kill_if_stale_progresses_through_sigterm_then_sigkill() -> None:
+    watch, clock, fs = _make_watch(inactivity=60, kill_after=120)
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=10)
+    watch.register("s1", log, adapter="claude")
+
+    # Inside the inactivity window: healthy.
+    clock.advance(30.0)
+    verdict = watch.kill_if_stale("s1")
+    assert verdict.action == "none"
+
+    # Past inactivity but before kill-after: graceful kill.
+    clock.advance(40.0)  # now 70s idle
+    verdict = watch.kill_if_stale("s1")
+    assert verdict.action == "sigterm"
+    assert verdict.idle_seconds >= 60.0
+
+    # Past the kill-after threshold: hard kill.
+    clock.advance(60.0)  # now 130s idle
+    verdict = watch.kill_if_stale("s1")
+    assert verdict.action == "sigkill"
+    assert verdict.idle_seconds >= 120.0
+
+
+def test_kill_if_stale_resets_when_log_grows() -> None:
+    watch, clock, fs = _make_watch(inactivity=60, kill_after=120)
+    log = Path("/tmp/agent.log")
+    fs.write(log, mtime=clock.now, size=10)
+    watch.register("s1", log, adapter="claude")
+
+    clock.advance(70.0)
+    assert watch.kill_if_stale("s1").action == "sigterm"
+
+    # Agent makes progress; the next verdict goes back to ``none``.
+    clock.advance(1.0)
+    fs.write(log, mtime=clock.now, size=20)
+    assert watch.kill_if_stale("s1").action == "none"


### PR DESCRIPTION
## Summary

- Add `ProgressWatch` observability primitive that detects whether a spawned CLI agent is "stuck or just thinking" by watching a structured session log on disk (mtime + size), without parsing agent stdout.
- Single-threaded, synchronous, fully testable: callers own the tick cadence and the kill mechanism. Clock and stat are injectable.
- Adapter contract gains `supports_session_log_watch: bool` and `session_log_path_for(session_id) -> Path | None`. Default is opt-out so adapters without a structured log fall back to plain process-exit detection.
- New lifecycle event `LifecycleEvent.AGENT_PROGRESS_STALLED` (`agent.progress_stalled`) with payload `{adapter, log_path, last_log_growth_ts, detected_ts}`.
- Claude Code adapter wires the JSONL transcript path under `~/.claude/projects/<encoded-cwd>/`. Other adapters can opt in later by overriding the method.

## Public surface

| Symbol | Role |
| --- | --- |
| `ProgressWatch.register / unregister / tick / drain_pending_events / kill_if_stale` | Core API |
| `StallEvent`, `KillVerdict` | Returned dataclasses |
| `DEFAULT_INACTIVITY_SECONDS=120`, `DEFAULT_KILL_AFTER_INACTIVITY_SECONDS=300`, `DEFAULT_POLL_INTERVAL_SECONDS=30` | Defaults |
| `CLIAdapter.supports_session_log_watch`, `CLIAdapter.session_log_path_for` | Adapter capability |
| `LifecycleEvent.AGENT_PROGRESS_STALLED` | Hook event |

## Test plan

- [x] `pytest tests/unit/observability/test_progress_watch.py` (13 cases: registration, sticky stall, growth-clears-stall, sigterm-then-sigkill escalation, missing-log tolerance, threshold validation)
- [x] `pytest tests/unit/observability tests/unit/adapters tests/unit/test_lifecycle.py tests/unit/test_hook_lifecycle_events.py tests/unit/test_standard_lifecycle_events.py` (304 passed)
- [x] `ruff check` on changed files
- [ ] Manual smoke: register a session, touch the log every 10s, confirm no stall; stop touching it, confirm `agent.progress_stalled` fires after the configured window

## Out of scope

- Per-adapter session-log path mappings for `codex`, `cursor`, `aider`, `gemini`, `opencode` (capability surface is in place; adding the override is one line per adapter, deferred so this PR stays small).
- Auto-restart of killed agents (separate retry-with-continuation work).
- Watching network traffic; logs are sufficient.

## Docs

`docs/observability/progress-watch.md` covers public surface, configuration keys (`agents.progress_watch.{enabled,inactivity_seconds,kill_after_inactivity_seconds}`), the lifecycle event payload, and the per-adapter log-path table.

Refs: ticket `feat-2026-05-19-progress-watch-liveness-probe`.

## Summary by Sourcery

Introduce a ProgressWatch observability primitive that monitors per-session log growth to assess agent liveness and drive stall and kill decisions, and wire it into the lifecycle events and adapter capabilities.

New Features:
- Add a ProgressWatch API for registering sessions, polling log growth, emitting stall events, and computing kill verdicts based on inactivity thresholds.
- Expose CLIAdapter.supports_session_log_watch and CLIAdapter.session_log_path_for so adapters can provide structured per-session log locations for liveness probing.
- Add the AGENT_PROGRESS_STALLED lifecycle event to surface detected stalls via the hook bus.

Enhancements:
- Enable ClaudeCodeAdapter to participate in log-based liveness probing by declaring support for session-log watching and resolving its JSONL transcript path heuristically.

Documentation:
- Document the ProgressWatch mechanism, configuration options, lifecycle event payload, and per-adapter log-path expectations in a new observability guide.

Tests:
- Add unit tests covering ProgressWatch registration behavior, stall detection semantics, kill verdict escalation, missing-log handling, and constructor validation.