### PR TITLE
feat(plugins): tracker plugin hookspec + registry + CLI

### DIFF
--- a/docs/trackers/contract.md
+++ b/docs/trackers/contract.md
@@ -1,0 +1,173 @@
+# Tracker adapter contract
+
+Trackers are external task sources (Linear, Jira, GitHub Projects v2,
+GitLab, ClickUp, Asana, Plane, ServiceNow, or an enterprise's private
+tracker). Bernstein consumes them through a single abstract contract so
+the orchestrator, federation layer, audit log, and cost cap reason
+about every tracker uniformly.
+
+This page documents the contract surface and walks through the minimum
+viable adapter.
+
+## Surface
+
+| Module | Contents |
+|--------|----------|
+| `bernstein.core.trackers.contract` | `AbstractTrackerAdapter`, dataclasses, exceptions |
+| `bernstein.core.trackers.registry` | `TrackerRegistry`, `register_tracker`, plugin discovery |
+| `bernstein.plugins.hookspecs` | `provide_tracker_adapter` hookspec |
+| `bernstein.cli.commands.trackers_cmd` | `bernstein trackers list` / `trackers test` |
+
+## Required methods
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `pull_open_tickets(filter)` | yes | Yields `Ticket` objects for the open queue. |
+| `add_comment(ticket_id, body, *, idempotency_key)` | yes | Posts a comment. Replays with same key + body return original result. |
+| `transition(ticket_id, status_id, *, idempotency_key, etag)` | yes | Moves a ticket to a new status. Stale `etag` raises `OptimisticConcurrencyError`. |
+| `claim_ticket(ticket_id, agent_id, *, etag)` | optional | Marks a ticket as in-flight for `agent_id`. Default: `NotImplementedError`. |
+| `attach_blob(ticket_id, blob, mime, *, idempotency_key)` | optional | Uploads a binary blob. Default: `NotImplementedError`. |
+
+## Exceptions
+
+| Exception | Meaning |
+|-----------|---------|
+| `OptimisticConcurrencyError` | `etag` precondition failed; reload the ticket. |
+| `IdempotencyConflict` | Idempotency key reused with a different payload. |
+| `RateLimited(retry_after=<seconds>)` | Back off before retrying. |
+| `TrackerUnavailable` | Tracker is unreachable or 5xx. |
+
+## Idempotency
+
+Adapters should treat `idempotency_key` as authoritative whenever the
+tracker's API supports it (e.g. Linear's mutation `clientMutationId`,
+Stripe-style `Idempotency-Key` headers). Where the tracker does not,
+the adapter must dedupe locally via a comment marker (the agent posts a
+`<!-- bernstein-key: ... -->` marker) or a SQLite ledger keyed on
+`(ticket_id, op, key)`.
+
+## Etag semantics
+
+`etag` is opaque. Adapters serialise whatever the tracker's API uses
+for optimistic concurrency:
+
+- GitHub: `If-Match` ETag header.
+- Jira: `versionAtUpdate` field.
+- Linear: GraphQL mutation versioning.
+- ServiceNow: `sys_mod_count` column.
+
+A `None` etag means "skip the precondition check"; callers that always
+want concurrency control should refuse to act on tickets whose `etag`
+is `None`.
+
+## Minimum viable adapter
+
+```python
+from collections.abc import Iterator
+from typing import Any
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    Ticket,
+    TransitionResult,
+)
+
+
+class AcmeTracker(AbstractTrackerAdapter):
+    name = "acme"
+
+    def __init__(self, *, base_url: str, token: str) -> None:
+        self._base_url = base_url
+        self._token = token
+
+    def pull_open_tickets(self, filter: dict[str, Any] | None = None) -> Iterator[Ticket]:
+        # Call out to Acme's REST API, yield normalised Ticket objects.
+        ...
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        ...
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        ...
+```
+
+## Shipping the adapter as a plugin
+
+Out-of-tree adapters register through the `provide_tracker_adapter`
+pluggy hook. The plugin returns a `TrackerRegistration`, a
+`(name, factory)` tuple, or a list of either; the registry coerces the
+shape.
+
+```python
+from bernstein.core.trackers.registry import TrackerRegistration
+from bernstein.plugins import hookimpl
+
+
+class AcmePlugin:
+    @hookimpl
+    def provide_tracker_adapter(self):
+        return TrackerRegistration(
+            name="acme",
+            factory=AcmeTracker,
+            summary="Acme tracker REST adapter.",
+            capabilities=("comment", "transition"),
+        )
+```
+
+Register the plugin via the `bernstein.plugins` entry-point group or
+the `plugins:` list in `bernstein.yaml`. Once loaded:
+
+```
+$ bernstein trackers list --source plugin
+NAME   SOURCE  CAPABILITIES         SUMMARY
+acme   plugin  comment,transition   Acme tracker REST adapter.
+```
+
+## Smoke-testing an adapter
+
+`bernstein trackers test <name>` constructs the adapter, calls
+`pull_open_tickets` once with an empty filter, and reports the result.
+The command is read-only: it never claims, comments, transitions, or
+attaches.
+
+```
+$ bernstein trackers test acme --limit 1
+tracker: acme  (plugin)
+status : ok
+fetched: 1 (limit 1)
+```
+
+When the adapter's factory requires constructor arguments that are not
+present in `bernstein.yaml`, the command reports `status: skipped` with
+the missing-argument error rather than failing. This makes the same
+invocation safe to run in ephemeral CI environments.
+
+## Reference fake
+
+`tests/fixtures/trackers/in_memory_tracker.py` ships a deterministic
+in-memory implementation used by every tracker unit test. The fake
+mirrors the contract (etag bookkeeping, idempotency ledger, rate-limit
+injection, unavailability toggle) so new adapters can plug into the
+existing contract test suite by parameterising over the fake's API
+sequence.
+
+## Default-off behaviour
+
+No tracker adapter is enabled until it is named in
+`bernstein.yaml: trackers.enabled = [...]`. The registry only exposes
+adapters that have been registered; enabling is the operator's
+explicit step.

--- a/src/bernstein/cli/commands/trackers_cmd.py
+++ b/src/bernstein/cli/commands/trackers_cmd.py
@@ -1,0 +1,235 @@
+"""``bernstein trackers`` -- inspect and smoke-test registered tracker adapters.
+
+Surfaces the tracker registry to operators:
+
+* ``bernstein trackers list`` -- one row per registered adapter (name,
+  source, summary, capabilities).
+* ``bernstein trackers list --json`` -- stable machine-readable payload.
+* ``bernstein trackers test <name>`` -- construct the adapter (using
+  ``trackers.<name>`` from ``bernstein.yaml`` when available) and call
+  ``pull_open_tickets`` with an empty filter as a smoke test.
+
+The ``test`` subcommand is deliberately read-only: it never claims,
+comments, or transitions a ticket. It exits non-zero on any failure so
+CI workflows can rely on it. Adapters without runtime credentials in
+the local environment are reported as ``skipped`` with a reason rather
+than failing the command -- this lets the same invocation work in
+ephemeral test environments.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+import click
+
+from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from bernstein.core.trackers.registry import TrackerRegistration
+
+
+__all__ = ["register", "trackers_group"]
+
+
+def _load_registry_with_plugins() -> Any:
+    """Return the default tracker registry after plugin discovery.
+
+    Plugin discovery is best-effort: if the plugin manager is not
+    available (e.g. in a stripped-down test environment), the function
+    returns the registry seeded with built-in adapters only.
+    """
+    from bernstein.core.trackers.registry import discover_plugin_trackers, get_registry
+
+    registry = get_registry()
+    try:
+        discover_plugin_trackers()
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[yellow]Warning: plugin discovery failed: {exc}[/yellow]")
+    return registry
+
+
+def _row_for(entry: TrackerRegistration) -> dict[str, Any]:
+    """Serialise a registration into the JSON row schema."""
+    return {
+        "name": entry.name,
+        "source": entry.source,
+        "summary": entry.summary,
+        "capabilities": list(entry.capabilities),
+        "provenance": entry.provenance,
+    }
+
+
+def _render_table(rows: list[dict[str, Any]]) -> None:
+    """Pretty-print one row per adapter."""
+    if not rows:
+        console.print("[yellow]No tracker adapters registered.[/yellow]")
+        return
+
+    name_width = max(len(r["name"]) for r in rows)
+    source_width = max(len(r["source"]) for r in rows)
+    header_name = "NAME".ljust(name_width)
+    header_source = "SOURCE".ljust(source_width)
+    console.print(f"[bold]{header_name}  {header_source}  CAPABILITIES  SUMMARY[/bold]")
+    for row in rows:
+        caps = ",".join(row["capabilities"]) or "-"
+        console.print(
+            f"{row['name'].ljust(name_width)}  {row['source'].ljust(source_width)}  {caps:<13}  {row['summary']}"
+        )
+
+
+def _load_tracker_config(name: str) -> dict[str, Any]:
+    """Best-effort load of ``trackers.<name>`` from ``bernstein.yaml``.
+
+    Returns an empty dict when no config is present or the loader is
+    unavailable. The ``test`` subcommand falls back to constructing the
+    adapter with no arguments in that case, which is fine for adapters
+    whose factory accepts purely-default construction (e.g. an
+    in-memory fake).
+    """
+    try:
+        from bernstein.core.config import load_settings  # type: ignore[attr-defined]
+    except Exception:
+        return {}
+
+    try:
+        settings = load_settings()
+    except Exception:
+        return {}
+
+    raw = getattr(settings, "trackers", None)
+    if raw is None and isinstance(settings, dict):
+        raw = settings.get("trackers")
+    if not isinstance(raw, dict):
+        return {}
+    per_tracker = raw.get(name)
+    if not isinstance(per_tracker, dict):
+        return {}
+    return per_tracker
+
+
+@click.group("trackers")
+def trackers_group() -> None:
+    """Inspect and smoke-test registered tracker adapters."""
+
+
+@trackers_group.command("list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON instead of a human-readable table.",
+)
+@click.option(
+    "--source",
+    type=click.Choice(["builtin", "plugin", "programmatic"]),
+    default=None,
+    help="Filter to a single registration source.",
+)
+def trackers_list_cmd(as_json: bool, source: str | None) -> None:
+    """Enumerate every tracker adapter the orchestrator knows about."""
+    registry = _load_registry_with_plugins()
+    entries = list(registry)
+    if source is not None:
+        entries = [e for e in entries if e.source == source]
+    rows = [_row_for(e) for e in entries]
+
+    if as_json:
+        click.echo(json.dumps({"count": len(rows), "trackers": rows}, indent=2, sort_keys=True))
+        return
+
+    _render_table(rows)
+
+
+@trackers_group.command("test")
+@click.argument("name")
+@click.option(
+    "--limit",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Maximum number of open tickets to fetch during the smoke test.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a JSON result document instead of human-readable lines.",
+)
+def trackers_test_cmd(name: str, limit: int, as_json: bool) -> None:
+    """Construct ``<name>`` and call ``pull_open_tickets`` as a smoke test.
+
+    Read-only: never claims, comments, transitions, or attaches.
+    """
+    registry = _load_registry_with_plugins()
+    try:
+        entry = registry.get(name)
+    except KeyError as exc:
+        click.echo(str(exc), err=True)
+        sys.exit(2)
+
+    cfg = _load_tracker_config(name)
+    result: dict[str, Any] = {
+        "name": name,
+        "source": entry.source,
+        "status": "unknown",
+        "fetched": 0,
+        "limit": limit,
+        "reason": None,
+    }
+    try:
+        adapter = entry.factory(**cfg)
+    except TypeError as exc:
+        # Adapter requires more arguments than we supplied; treat as skip
+        # rather than fail so an operator running the command in a bare
+        # environment gets a clear hint.
+        result["status"] = "skipped"
+        result["reason"] = f"adapter construction needs config: {exc}"
+        _emit_test_result(result, as_json)
+        return
+    except Exception as exc:
+        result["status"] = "error"
+        result["reason"] = f"construction failed: {exc}"
+        _emit_test_result(result, as_json)
+        sys.exit(1)
+
+    try:
+        fetched = 0
+        for _ in adapter.pull_open_tickets({}):
+            fetched += 1
+            if fetched >= limit:
+                break
+        result["status"] = "ok"
+        result["fetched"] = fetched
+    except NotImplementedError as exc:
+        result["status"] = "unsupported"
+        result["reason"] = str(exc) or "pull_open_tickets not implemented"
+    except Exception as exc:
+        result["status"] = "error"
+        result["reason"] = f"pull_open_tickets failed: {exc}"
+        _emit_test_result(result, as_json)
+        sys.exit(1)
+
+    _emit_test_result(result, as_json)
+
+
+def _emit_test_result(result: dict[str, Any], as_json: bool) -> None:
+    """Print the smoke-test result document."""
+    if as_json:
+        click.echo(json.dumps(result, indent=2, sort_keys=True))
+        return
+
+    console.print(f"tracker: [bold]{result['name']}[/bold]  ({result['source']})")
+    console.print(f"status : {result['status']}")
+    console.print(f"fetched: {result['fetched']} (limit {result['limit']})")
+    if result["reason"]:
+        console.print(f"reason : {result['reason']}")
+
+
+def register(group: click.Group) -> None:
+    """Attach the trackers group to the top-level CLI."""
+    group.add_command(trackers_group, "trackers")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -66,6 +66,7 @@ from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.integrations_cmd import integrations_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
+from bernstein.cli.commands.trackers_cmd import trackers_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.skills_cmd import skills_group
@@ -936,6 +937,7 @@ cli.add_command(stop)
 cli.add_command(test_adapter, "test-adapter")
 cli.add_command(adapters_group, "adapters")
 cli.add_command(integrations_group, "integrations")
+cli.add_command(trackers_group, "trackers")
 cli.add_command(run, "run")  # visible: `bernstein run [plan.yaml]`
 cli.add_command(cook, "cook")
 cli.add_command(init)

--- a/src/bernstein/core/trackers/__init__.py
+++ b/src/bernstein/core/trackers/__init__.py
@@ -23,6 +23,15 @@ from bernstein.core.trackers.contract import (
     TransitionResult,
 )
 from bernstein.core.trackers.linear import LinearConfig, LinearTracker
+from bernstein.core.trackers.registry import (
+    DuplicateTrackerError,
+    TrackerFactory,
+    TrackerRegistration,
+    TrackerRegistry,
+    discover_plugin_trackers,
+    get_registry,
+    register_tracker,
+)
 from bernstein.core.trackers.servicenow import ServiceNowConfig, ServiceNowTracker
 
 __all__ = [
@@ -31,6 +40,7 @@ __all__ = [
     "ClaimResult",
     "Comment",
     "CommentResult",
+    "DuplicateTrackerError",
     "IdempotencyConflict",
     "LinearConfig",
     "LinearTracker",
@@ -41,8 +51,14 @@ __all__ = [
     "ServiceNowTracker",
     "Status",
     "Ticket",
+    "TrackerFactory",
+    "TrackerRegistration",
+    "TrackerRegistry",
     "TrackerUnavailable",
     "TransitionResult",
+    "discover_plugin_trackers",
+    "get_registry",
+    "register_tracker",
 ]
 
 

--- a/src/bernstein/core/trackers/registry.py
+++ b/src/bernstein/core/trackers/registry.py
@@ -1,0 +1,496 @@
+"""Tracker adapter registry.
+
+Centralises discovery of tracker adapters from three sources:
+
+1. **Built-in adapters** wired into ``core/trackers/`` and
+   ``core/trackers/builtin/`` (Linear, Jira Cloud/DC, GitHub Projects v2,
+   GitLab, ClickUp, Asana, Plane, ServiceNow).
+2. **Plugin-contributed adapters** discovered via the
+   ``provide_tracker_adapter`` pluggy hookspec. Out-of-tree plugins
+   (closed-source, enterprise-only) register here.
+3. **Programmatic registrations** through :func:`register_tracker`, used
+   by tests, the in-memory reference fake, and third parties that load
+   their adapter without pluggy.
+
+The registry is intentionally small: it only stores construction
+factories. Adapter instantiation (with credentials, base URLs, etc.) is
+the caller's job. The registry is used by:
+
+* ``bernstein trackers list`` to enumerate names + summaries.
+* ``bernstein trackers test <name>`` to construct an adapter and run a
+  smoke check.
+* The orchestrator's federation layer to resolve an adapter by name when
+  ``bernstein.yaml: trackers.enabled = [...]`` lists it.
+
+Ordering rule: built-ins ship first, plugin adapters next, programmatic
+registrations last. Two adapters with the same ``name`` raise
+``DuplicateTrackerError`` unless ``overwrite=True`` is passed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from bernstein.core.trackers.contract import AbstractTrackerAdapter
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DuplicateTrackerError",
+    "TrackerFactory",
+    "TrackerRegistration",
+    "TrackerRegistry",
+    "discover_plugin_trackers",
+    "get_registry",
+    "register_tracker",
+    "reset_registry_for_tests",
+]
+
+
+class TrackerFactory(Protocol):
+    """Callable that constructs a tracker adapter.
+
+    A factory must accept arbitrary keyword arguments and return an
+    instance of :class:`AbstractTrackerAdapter`. Implementations
+    typically accept a config dataclass or individual credential
+    parameters; the registry treats the factory as opaque.
+    """
+
+    def __call__(self, **kwargs: Any) -> AbstractTrackerAdapter:
+        """Construct a tracker adapter with the supplied configuration."""
+
+
+class DuplicateTrackerError(ValueError):
+    """Raised when two adapters register under the same name."""
+
+
+@dataclass(frozen=True)
+class TrackerRegistration:
+    """A single registered tracker adapter.
+
+    Attributes:
+        name: Short stable identifier (``"linear"``, ``"jira_cloud"``).
+        factory: Callable that constructs the adapter.
+        summary: One-line human-readable description for ``trackers list``.
+        source: One of ``"builtin"``, ``"plugin"``, ``"programmatic"``;
+            used by the CLI to label each row.
+        provenance: Optional free-form provenance string (plugin name,
+            module path, etc.).
+        capabilities: Optional set of capability tags (``"claim"``,
+            ``"attach"``, ``"webhook"``); informational only.
+    """
+
+    name: str
+    factory: TrackerFactory
+    summary: str = ""
+    source: str = "programmatic"
+    provenance: str | None = None
+    capabilities: tuple[str, ...] = field(default_factory=tuple)
+
+
+class TrackerRegistry:
+    """In-process registry of tracker adapter factories.
+
+    The registry is not a singleton by design (tests construct their own
+    isolated instances). Module-level helpers wrap a process-wide default
+    instance accessed via :func:`get_registry`.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, TrackerRegistration] = {}
+
+    def register(
+        self,
+        name: str,
+        factory: TrackerFactory,
+        *,
+        summary: str = "",
+        source: str = "programmatic",
+        provenance: str | None = None,
+        capabilities: tuple[str, ...] = (),
+        overwrite: bool = False,
+    ) -> TrackerRegistration:
+        """Register ``factory`` under ``name``.
+
+        Args:
+            name: Stable identifier (case-sensitive).
+            factory: Callable that constructs the adapter.
+            summary: One-line human-readable summary.
+            source: Origin label (``"builtin"``, ``"plugin"``,
+                ``"programmatic"``).
+            provenance: Optional module path or plugin name.
+            capabilities: Tags describing what the adapter supports.
+            overwrite: If ``True``, replace an existing registration
+                instead of raising.
+
+        Returns:
+            The stored :class:`TrackerRegistration`.
+
+        Raises:
+            DuplicateTrackerError: When ``name`` is already registered
+                and ``overwrite`` is ``False``.
+        """
+        if name in self._entries and not overwrite:
+            existing = self._entries[name]
+            msg = (
+                f"Tracker {name!r} is already registered "
+                f"(source={existing.source}, provenance={existing.provenance!r}). "
+                "Pass overwrite=True to replace it."
+            )
+            raise DuplicateTrackerError(msg)
+        entry = TrackerRegistration(
+            name=name,
+            factory=factory,
+            summary=summary,
+            source=source,
+            provenance=provenance,
+            capabilities=tuple(capabilities),
+        )
+        self._entries[name] = entry
+        return entry
+
+    def unregister(self, name: str) -> None:
+        """Remove ``name`` from the registry (no-op if absent)."""
+        self._entries.pop(name, None)
+
+    def get(self, name: str) -> TrackerRegistration:
+        """Return the registration for ``name``.
+
+        Raises:
+            KeyError: When no adapter is registered under ``name``.
+        """
+        try:
+            return self._entries[name]
+        except KeyError as exc:
+            known = ", ".join(sorted(self._entries)) or "(none)"
+            msg = f"Unknown tracker {name!r}. Registered: {known}."
+            raise KeyError(msg) from exc
+
+    def create(self, name: str, **kwargs: Any) -> AbstractTrackerAdapter:
+        """Construct an adapter instance.
+
+        Args:
+            name: Registered tracker name.
+            **kwargs: Forwarded verbatim to the registered factory.
+
+        Returns:
+            Newly constructed :class:`AbstractTrackerAdapter`.
+        """
+        return self.get(name).factory(**kwargs)
+
+    def names(self) -> tuple[str, ...]:
+        """Return the registered names in deterministic order.
+
+        Order: built-in entries first (alphabetical), then plugin
+        entries (alphabetical), then programmatic entries (alphabetical).
+        Tests rely on this ordering to be stable.
+        """
+        priority = {"builtin": 0, "plugin": 1, "programmatic": 2}
+
+        def sort_key(item: tuple[str, TrackerRegistration]) -> tuple[int, str]:
+            return (priority.get(item[1].source, 3), item[0])
+
+        return tuple(name for name, _ in sorted(self._entries.items(), key=sort_key))
+
+    def __iter__(self) -> Iterator[TrackerRegistration]:
+        for name in self.names():
+            yield self._entries[name]
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._entries
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+# ---------------------------------------------------------------------------
+# Process-wide default registry
+# ---------------------------------------------------------------------------
+
+
+_registry: TrackerRegistry | None = None
+
+
+def _builtin_registrations() -> tuple[tuple[str, TrackerFactory, str, tuple[str, ...]], ...]:
+    """Return the built-in adapter registrations.
+
+    Imports are deferred so the registry module stays cheap to import
+    even when the consumer only needs the registration protocol.
+    """
+    # Local imports keep the registry import cheap.
+    from bernstein.core.trackers.builtin import (
+        AsanaAdapter,
+        ClickUpAdapter,
+        GitHubProjectsV2Adapter,
+        GitLabAdapter,
+        JiraCloudTracker,
+        JiraDataCenterAdapter,
+        PlaneAdapter,
+    )
+    from bernstein.core.trackers.linear import LinearTracker
+    from bernstein.core.trackers.servicenow import ServiceNowTracker
+
+    return (
+        (
+            "linear",
+            LinearTracker,
+            "Linear (linear.app) GraphQL adapter.",
+            ("claim", "comment", "transition"),
+        ),
+        (
+            "servicenow",
+            ServiceNowTracker,
+            "ServiceNow Table API adapter.",
+            ("comment", "transition", "attach"),
+        ),
+        (
+            "github_projects_v2",
+            GitHubProjectsV2Adapter,
+            "GitHub Projects v2 GraphQL adapter.",
+            ("comment", "transition"),
+        ),
+        (
+            "jira_cloud",
+            JiraCloudTracker,
+            "Jira Cloud REST adapter.",
+            ("comment", "transition", "attach"),
+        ),
+        (
+            "jira_dc",
+            JiraDataCenterAdapter,
+            "Jira Data Center REST adapter.",
+            ("comment", "transition", "attach"),
+        ),
+        (
+            "gitlab",
+            GitLabAdapter,
+            "GitLab Issues REST adapter.",
+            ("comment", "transition"),
+        ),
+        (
+            "clickup",
+            ClickUpAdapter,
+            "ClickUp REST adapter.",
+            ("comment", "transition"),
+        ),
+        (
+            "asana",
+            AsanaAdapter,
+            "Asana REST adapter.",
+            ("comment", "transition"),
+        ),
+        (
+            "plane",
+            PlaneAdapter,
+            "Plane.so REST adapter.",
+            ("comment", "transition"),
+        ),
+    )
+
+
+def _populate_builtins(registry: TrackerRegistry) -> None:
+    """Populate ``registry`` with the built-in adapter set.
+
+    A missing import is logged and skipped so optional adapters (e.g.
+    one whose module fails to import on a stripped-down install) do not
+    prevent the rest of the registry from loading.
+    """
+    try:
+        registrations = _builtin_registrations()
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("Failed to import built-in trackers: %s", exc)
+        return
+
+    for name, factory, summary, caps in registrations:
+        provenance = f"{getattr(factory, '__module__', '?')}.{getattr(factory, '__name__', name)}"
+        try:
+            registry.register(
+                name,
+                factory,
+                summary=summary,
+                source="builtin",
+                provenance=provenance,
+                capabilities=caps,
+                overwrite=False,
+            )
+        except DuplicateTrackerError:
+            # Built-ins are loaded once; this only happens in tests that
+            # reuse a registry across populate calls.
+            continue
+
+
+def get_registry() -> TrackerRegistry:
+    """Return the process-wide default registry, populating it if empty.
+
+    The default registry is lazily seeded with built-in adapters on
+    first access. Plugin discovery is *not* triggered here; callers that
+    want plugin adapters should also call :func:`discover_plugin_trackers`.
+    """
+    global _registry
+    if _registry is None:
+        _registry = TrackerRegistry()
+        _populate_builtins(_registry)
+    return _registry
+
+
+def reset_registry_for_tests() -> None:
+    """Clear the process-wide registry (test helper only).
+
+    Tests that exercise registration paths call this in setup/teardown
+    to avoid cross-test contamination.
+    """
+    global _registry
+    _registry = None
+
+
+def register_tracker(
+    name: str,
+    factory: TrackerFactory,
+    *,
+    summary: str = "",
+    source: str = "programmatic",
+    provenance: str | None = None,
+    capabilities: tuple[str, ...] = (),
+    overwrite: bool = False,
+) -> TrackerRegistration:
+    """Register ``factory`` on the process-wide default registry."""
+    return get_registry().register(
+        name,
+        factory,
+        summary=summary,
+        source=source,
+        provenance=provenance,
+        capabilities=capabilities,
+        overwrite=overwrite,
+    )
+
+
+def discover_plugin_trackers(plugin_manager: Any | None = None) -> int:
+    """Populate the registry with plugin-contributed tracker adapters.
+
+    Iterates over loaded pluggy plugins, calls
+    ``provide_tracker_adapter`` on each that implements it, and registers
+    every returned :class:`TrackerRegistration` (or ``(name, factory)``
+    tuple for plugins that prefer the tuple shape).
+
+    Args:
+        plugin_manager: Optional explicit plugin manager. When ``None``
+            the orchestrator's default manager is fetched via
+            :func:`bernstein.plugins.manager.get_plugin_manager`.
+
+    Returns:
+        Number of plugin adapters newly registered.
+    """
+    pm = plugin_manager
+    if pm is None:
+        try:
+            from bernstein.plugins.manager import get_plugin_manager
+
+            pm = get_plugin_manager()
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("Could not obtain plugin manager: %s", exc)
+            return 0
+
+    registry = get_registry()
+    added = 0
+    registered_names = getattr(pm, "_registered_names", [])
+    inner_pm = getattr(pm, "_pm", None)
+
+    if inner_pm is None:
+        log.debug("Plugin manager has no inner pluggy manager; skipping discovery.")
+        return 0
+
+    for plugin_name in registered_names:
+        plugin = inner_pm.get_plugin(plugin_name)
+        if plugin is None or not hasattr(plugin, "provide_tracker_adapter"):
+            continue
+        try:
+            result = plugin.provide_tracker_adapter()
+        except Exception as exc:
+            log.warning("Plugin %r provide_tracker_adapter raised: %s", plugin_name, exc)
+            continue
+        added += _register_plugin_result(registry, plugin_name, result)
+    return added
+
+
+def _register_plugin_result(
+    registry: TrackerRegistry,
+    plugin_name: str,
+    result: Any,
+) -> int:
+    """Register a single plugin's return value.
+
+    The plugin hook may return:
+
+    * ``None`` (plugin opts out for this call).
+    * A single :class:`TrackerRegistration`.
+    * A ``(name, factory)`` tuple.
+    * A list of either of the above.
+    """
+    if result is None:
+        return 0
+    items = result if isinstance(result, list) else [result]
+    count = 0
+    for raw in items:
+        registration = _coerce_registration(raw, plugin_name)
+        if registration is None:
+            continue
+        try:
+            registry.register(
+                registration.name,
+                registration.factory,
+                summary=registration.summary,
+                source="plugin",
+                provenance=registration.provenance or plugin_name,
+                capabilities=registration.capabilities,
+                overwrite=False,
+            )
+            count += 1
+        except DuplicateTrackerError as exc:
+            log.warning(
+                "Plugin %r tried to register duplicate tracker %r: %s",
+                plugin_name,
+                registration.name,
+                exc,
+            )
+    return count
+
+
+def _coerce_registration(raw: Any, plugin_name: str) -> TrackerRegistration | None:
+    """Normalise a plugin-supplied registration into a :class:`TrackerRegistration`."""
+    if isinstance(raw, TrackerRegistration):
+        return raw
+    if isinstance(raw, tuple) and len(raw) == 2:
+        name, factory = raw
+        if isinstance(name, str) and callable(factory):
+            return TrackerRegistration(
+                name=name,
+                factory=factory,
+                source="plugin",
+                provenance=plugin_name,
+            )
+    log.warning(
+        "Plugin %r provide_tracker_adapter returned unrecognised value %r; ignoring.",
+        plugin_name,
+        raw,
+    )
+    return None
+
+
+def _wrap_callable(callable_: Callable[..., AbstractTrackerAdapter]) -> TrackerFactory:
+    """Adapt a plain callable to the ``TrackerFactory`` protocol.
+
+    Kept as a small utility so tests and out-of-tree code can register
+    closures without typing gymnastics.
+    """
+
+    def factory(**kwargs: Any) -> AbstractTrackerAdapter:
+        return callable_(**kwargs)
+
+    return factory

--- a/src/bernstein/plugins/hookspecs.py
+++ b/src/bernstein/plugins/hookspecs.py
@@ -595,6 +595,42 @@ class BernsteinSpec:
         """
 
     @hookspec
+    def provide_tracker_adapter(self) -> Any:
+        """Provide one or more tracker adapter registrations.
+
+        Tracker adapters are external task-source integrations (Linear,
+        Jira, GitHub Projects v2, GitLab, ClickUp, Asana, Plane,
+        ServiceNow, or a private tracker an enterprise customer runs).
+        Each adapter implements
+        :class:`bernstein.core.trackers.contract.AbstractTrackerAdapter`.
+
+        Plugins implementing this hook return one of:
+
+        * ``None`` -- opt out for this call.
+        * A single
+          :class:`bernstein.core.trackers.registry.TrackerRegistration`.
+        * A ``(name, factory)`` tuple where ``factory`` constructs the
+          adapter when called with keyword arguments.
+        * A list containing any mix of the above.
+
+        The plugin manager registers each entry on the process-wide
+        tracker registry under ``source="plugin"`` with the plugin name
+        recorded as provenance. Duplicate names are skipped with a
+        warning; the first registration wins.
+
+        Adapter construction is deferred until the orchestrator resolves
+        the adapter by name (typically when
+        ``bernstein.yaml: trackers.enabled = [...]`` lists it). The hook
+        is called once during plugin discovery, not on every ticket
+        pull, so factories may do non-trivial work at construction time
+        (TLS handshake, schema discovery, etc.) without taxing the hot
+        path.
+
+        Returns:
+            A registration, list of registrations, or ``None``.
+        """
+
+    @hookspec
     def on_metric_record(
         self,
         metric_type: str,

--- a/src/bernstein/plugins/manager.py
+++ b/src/bernstein/plugins/manager.py
@@ -992,6 +992,25 @@ class PluginManager:
         if entries:
             registry.register_plugin_servers(plugin_name, entries)  # type: ignore[union-attr]
 
+    def collect_plugin_tracker_adapters(self) -> int:
+        """Collect tracker adapters from registered plugins.
+
+        Iterates over every loaded plugin that implements
+        ``provide_tracker_adapter`` and registers its returned adapters
+        on the process-wide tracker registry. The registry coerces tuple
+        and ``TrackerRegistration`` shapes; this method only forwards.
+
+        Returns:
+            Number of adapters newly registered.
+        """
+        from bernstein.core.trackers.registry import discover_plugin_trackers
+
+        try:
+            return discover_plugin_trackers(self)
+        except Exception as exc:  # pragma: no cover - defensive
+            log.warning("collect_plugin_tracker_adapters failed: %s", exc)
+            return 0
+
     def discover_entry_points(self) -> None:
         """Load all plugins registered via the ``bernstein.plugins`` entry-point group."""
         eps = entry_points(group="bernstein.plugins")

--- a/tests/fixtures/trackers/__init__.py
+++ b/tests/fixtures/trackers/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable tracker fixtures for unit and integration tests."""

--- a/tests/fixtures/trackers/in_memory_tracker.py
+++ b/tests/fixtures/trackers/in_memory_tracker.py
@@ -1,0 +1,291 @@
+"""In-memory reference tracker adapter.
+
+Used by every tracker unit test as the canonical
+:class:`AbstractTrackerAdapter` implementation. Concrete adapters
+(Linear, Jira, GitHub Projects v2, etc.) are exercised against the same
+test cases via this fake so behavioural drift between adapters is
+caught early.
+
+Design notes
+------------
+
+* Ticket ids are sequential strings (``"T-1"``, ``"T-2"``, ...).
+* Each ticket carries an opaque integer ``etag`` that is bumped on every
+  mutation. ``claim_ticket`` and ``transition`` honour the etag.
+* ``add_comment`` stores ``idempotency_key`` per ticket; replays with
+  the same key plus identical body return the original ``CommentResult``;
+  replays with a different body raise :class:`IdempotencyConflict`.
+* ``rate_limit_after`` lets a test inject deterministic backoff: after
+  N successful calls, the next call raises :class:`RateLimited`.
+* ``unavailable`` toggles :class:`TrackerUnavailable` on every call --
+  useful for "tracker is down" tests.
+
+The fake does *not* try to mimic any specific vendor's API. It mimics
+the *contract*: the orchestrator-facing surface every adapter must
+provide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    AttachResult,
+    ClaimResult,
+    CommentResult,
+    IdempotencyConflict,
+    OptimisticConcurrencyError,
+    RateLimited,
+    Ticket,
+    TrackerUnavailable,
+    TransitionResult,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+__all__ = ["InMemoryTicket", "InMemoryTracker"]
+
+
+@dataclass
+class InMemoryTicket:
+    """Mutable internal representation used by :class:`InMemoryTracker`."""
+
+    id: str
+    title: str
+    body: str
+    status: str = "open"
+    labels: tuple[str, ...] = ()
+    etag: int = 1
+    claimed_by: str | None = None
+    comments: list[dict[str, Any]] = field(default_factory=list)
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    # Per-ticket idempotency ledger keyed on (operation, idempotency_key).
+    idempotency: dict[tuple[str, str], Any] = field(default_factory=dict)
+
+
+class InMemoryTracker(AbstractTrackerAdapter):
+    """Deterministic, in-process tracker fixture.
+
+    Args:
+        rate_limit_after: When set, the Nth call (1-indexed) raises
+            :class:`RateLimited` once and the counter resets. Useful for
+            verifying back-off propagation.
+        retry_after: ``retry_after`` value attached to the injected
+            :class:`RateLimited`.
+        unavailable: When ``True`` every method raises
+            :class:`TrackerUnavailable`.
+    """
+
+    name: str = "in_memory"
+
+    def __init__(
+        self,
+        *,
+        rate_limit_after: int | None = None,
+        retry_after: float | None = 1.5,
+        unavailable: bool = False,
+    ) -> None:
+        self._tickets: dict[str, InMemoryTicket] = {}
+        self._next_id: int = 1
+        self._call_count: int = 0
+        self._rate_limit_after = rate_limit_after
+        self._retry_after = retry_after
+        self._unavailable = unavailable
+
+    # ---- Test helpers ----------------------------------------------------
+
+    def seed(
+        self,
+        title: str,
+        body: str = "",
+        *,
+        status: str = "open",
+        labels: tuple[str, ...] = (),
+    ) -> InMemoryTicket:
+        """Insert a ticket into the fake; return the stored record."""
+        ticket = InMemoryTicket(
+            id=f"T-{self._next_id}",
+            title=title,
+            body=body,
+            status=status,
+            labels=labels,
+        )
+        self._tickets[ticket.id] = ticket
+        self._next_id += 1
+        return ticket
+
+    def set_unavailable(self, value: bool) -> None:
+        """Toggle :class:`TrackerUnavailable` on every subsequent call."""
+        self._unavailable = value
+
+    # ---- AbstractTrackerAdapter ------------------------------------------
+
+    def pull_open_tickets(self, filter: dict[str, Any] | None = None) -> Iterator[Ticket]:
+        self._check_health()
+        wanted_status = None
+        if filter is not None:
+            wanted_status = filter.get("status")
+        for ticket in list(self._tickets.values()):
+            if wanted_status is not None and ticket.status != wanted_status:
+                continue
+            if wanted_status is None and ticket.status != "open":
+                continue
+            yield self._snapshot(ticket)
+
+    def claim_ticket(
+        self,
+        ticket_id: str,
+        agent_id: str,
+        *,
+        etag: str | None = None,
+    ) -> ClaimResult:
+        self._check_health()
+        ticket = self._require_ticket(ticket_id)
+        self._enforce_etag(ticket, etag)
+        if ticket.claimed_by is not None and ticket.claimed_by != agent_id:
+            return ClaimResult(claimed=False, ticket_id=ticket_id, agent_id=agent_id, etag=str(ticket.etag))
+        ticket.claimed_by = agent_id
+        ticket.etag += 1
+        return ClaimResult(claimed=True, ticket_id=ticket_id, agent_id=agent_id, etag=str(ticket.etag))
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        self._check_health()
+        ticket = self._require_ticket(ticket_id)
+        if idempotency_key is not None:
+            ledger_key = ("comment", idempotency_key)
+            previous = ticket.idempotency.get(ledger_key)
+            if previous is not None:
+                if previous["body"] != body:
+                    msg = f"Idempotency key {idempotency_key!r} reused with different body on ticket {ticket_id}"
+                    raise IdempotencyConflict(msg)
+                return CommentResult(comment_id=previous["comment_id"], ticket_id=ticket_id)
+        comment_id = f"C-{len(ticket.comments) + 1}"
+        ticket.comments.append({"id": comment_id, "body": body})
+        if idempotency_key is not None:
+            ticket.idempotency[("comment", idempotency_key)] = {
+                "comment_id": comment_id,
+                "body": body,
+            }
+        return CommentResult(comment_id=comment_id, ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        self._check_health()
+        ticket = self._require_ticket(ticket_id)
+        self._enforce_etag(ticket, etag)
+        if idempotency_key is not None:
+            ledger_key = ("transition", idempotency_key)
+            previous = ticket.idempotency.get(ledger_key)
+            if previous is not None:
+                if previous["status_id"] != status_id:
+                    msg = f"Idempotency key {idempotency_key!r} reused with different status on ticket {ticket_id}"
+                    raise IdempotencyConflict(msg)
+                return TransitionResult(
+                    ticket_id=ticket_id,
+                    new_status=status_id,
+                    etag=str(previous["etag"]),
+                )
+        ticket.status = status_id
+        ticket.etag += 1
+        if idempotency_key is not None:
+            ticket.idempotency[("transition", idempotency_key)] = {
+                "status_id": status_id,
+                "etag": ticket.etag,
+            }
+        return TransitionResult(ticket_id=ticket_id, new_status=status_id, etag=str(ticket.etag))
+
+    def attach_blob(
+        self,
+        ticket_id: str,
+        blob: bytes,
+        mime: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> AttachResult:
+        self._check_health()
+        ticket = self._require_ticket(ticket_id)
+        if idempotency_key is not None:
+            ledger_key = ("attach", idempotency_key)
+            previous = ticket.idempotency.get(ledger_key)
+            if previous is not None:
+                if previous["sha"] != _digest(blob) or previous["mime"] != mime:
+                    msg = f"Idempotency key {idempotency_key!r} reused with different blob on ticket {ticket_id}"
+                    raise IdempotencyConflict(msg)
+                return AttachResult(attachment_id=previous["attachment_id"], ticket_id=ticket_id)
+        attachment_id = f"A-{len(ticket.attachments) + 1}"
+        ticket.attachments.append({"id": attachment_id, "mime": mime, "size": len(blob)})
+        if idempotency_key is not None:
+            ticket.idempotency[("attach", idempotency_key)] = {
+                "attachment_id": attachment_id,
+                "mime": mime,
+                "sha": _digest(blob),
+            }
+        return AttachResult(attachment_id=attachment_id, ticket_id=ticket_id)
+
+    # ---- Internals -------------------------------------------------------
+
+    def _check_health(self) -> None:
+        if self._unavailable:
+            raise TrackerUnavailable("InMemoryTracker is marked unavailable.")
+        if self._rate_limit_after is not None:
+            self._call_count += 1
+            if self._call_count > self._rate_limit_after:
+                self._call_count = 0
+                raise RateLimited(
+                    "InMemoryTracker rate limit reached.",
+                    retry_after=self._retry_after,
+                )
+
+    def _require_ticket(self, ticket_id: str) -> InMemoryTicket:
+        try:
+            return self._tickets[ticket_id]
+        except KeyError as exc:
+            msg = f"Unknown ticket {ticket_id!r}"
+            raise KeyError(msg) from exc
+
+    @staticmethod
+    def _enforce_etag(ticket: InMemoryTicket, etag: str | None) -> None:
+        if etag is None:
+            return
+        if str(ticket.etag) != etag:
+            msg = f"Stale etag {etag!r} for ticket {ticket.id}; current etag is {ticket.etag}."
+            raise OptimisticConcurrencyError(msg)
+
+    @staticmethod
+    def _snapshot(ticket: InMemoryTicket) -> Ticket:
+        return Ticket(
+            id=ticket.id,
+            external_url=f"https://in-memory.invalid/tickets/{ticket.id}",
+            title=ticket.title,
+            body=ticket.body,
+            status=ticket.status,
+            labels=ticket.labels,
+            etag=str(ticket.etag),
+        )
+
+
+def _digest(blob: bytes) -> str:
+    """Stable short digest for idempotency comparison.
+
+    Uses ``hashlib.sha256`` rather than the built-in ``hash`` so the
+    value is deterministic across processes.
+    """
+    import hashlib
+
+    return hashlib.sha256(blob).hexdigest()

--- a/tests/unit/trackers/test_contract.py
+++ b/tests/unit/trackers/test_contract.py
@@ -1,0 +1,167 @@
+"""Contract tests for ``AbstractTrackerAdapter``.
+
+Every concrete tracker adapter is expected to behave identically on the
+core operations (claim/comment/transition/attach) when given the same
+sequence of calls. These tests use :class:`InMemoryTracker` as the
+canonical reference implementation and document the contract behaviour
+that real adapters must mirror.
+
+The four required behaviours, per the ticket's acceptance criteria:
+
+1. ``claim_ticket`` raises ``OptimisticConcurrencyError`` on a stale
+   etag.
+2. ``add_comment`` with a duplicate idempotency key + identical body
+   returns the original ``CommentResult``; with a different body it
+   raises ``IdempotencyConflict``.
+3. ``transition`` raises ``OptimisticConcurrencyError`` on a stale
+   etag.
+4. ``RateLimited`` propagates with a ``retry_after`` hint.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.trackers.contract import (
+    IdempotencyConflict,
+    OptimisticConcurrencyError,
+    RateLimited,
+    TrackerUnavailable,
+)
+from tests.fixtures.trackers.in_memory_tracker import InMemoryTracker
+
+
+@pytest.fixture
+def tracker() -> InMemoryTracker:
+    """A fresh in-memory tracker with a single seeded open ticket."""
+    fake = InMemoryTracker()
+    fake.seed("Investigate flaky test", body="Reproduces on Python 3.13.", labels=("flaky",))
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# pull_open_tickets
+# ---------------------------------------------------------------------------
+
+
+def test_pull_open_tickets_yields_open_only(tracker: InMemoryTracker) -> None:
+    tracker.seed("Closed ticket", status="closed")
+    open_tickets = list(tracker.pull_open_tickets())
+    assert [t.title for t in open_tickets] == ["Investigate flaky test"]
+
+
+def test_pull_open_tickets_honours_status_filter(tracker: InMemoryTracker) -> None:
+    tracker.seed("In review", status="in_review")
+    tickets = list(tracker.pull_open_tickets({"status": "in_review"}))
+    assert [t.status for t in tickets] == ["in_review"]
+
+
+def test_pull_open_tickets_exposes_etag(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    assert ticket.etag is not None
+    assert ticket.id == "T-1"
+
+
+# ---------------------------------------------------------------------------
+# claim_ticket
+# ---------------------------------------------------------------------------
+
+
+def test_claim_ticket_succeeds_with_correct_etag(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    result = tracker.claim_ticket(ticket.id, agent_id="agent-1", etag=ticket.etag)
+    assert result.claimed is True
+    assert result.agent_id == "agent-1"
+    assert result.etag != ticket.etag
+
+
+def test_claim_ticket_raises_on_stale_etag(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    # Bump the etag with an unrelated transition.
+    tracker.transition(ticket.id, "in_progress", etag=ticket.etag)
+    with pytest.raises(OptimisticConcurrencyError):
+        tracker.claim_ticket(ticket.id, agent_id="agent-1", etag=ticket.etag)
+
+
+def test_claim_ticket_refuses_second_claimant(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    first = tracker.claim_ticket(ticket.id, agent_id="agent-1", etag=ticket.etag)
+    second = tracker.claim_ticket(ticket.id, agent_id="agent-2", etag=first.etag)
+    assert first.claimed is True
+    assert second.claimed is False
+
+
+# ---------------------------------------------------------------------------
+# add_comment / idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_add_comment_idempotency_replay_returns_same_result(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    first = tracker.add_comment(ticket.id, "Spawning agent.", idempotency_key="k-1")
+    second = tracker.add_comment(ticket.id, "Spawning agent.", idempotency_key="k-1")
+    assert first.comment_id == second.comment_id
+
+
+def test_add_comment_idempotency_conflict_on_different_body(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    tracker.add_comment(ticket.id, "Spawning agent.", idempotency_key="k-1")
+    with pytest.raises(IdempotencyConflict):
+        tracker.add_comment(ticket.id, "Different body.", idempotency_key="k-1")
+
+
+def test_add_comment_without_key_creates_distinct_comments(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    first = tracker.add_comment(ticket.id, "One.")
+    second = tracker.add_comment(ticket.id, "Two.")
+    assert first.comment_id != second.comment_id
+
+
+# ---------------------------------------------------------------------------
+# transition / concurrency conflict
+# ---------------------------------------------------------------------------
+
+
+def test_transition_raises_on_stale_etag(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    fresh = tracker.transition(ticket.id, "in_progress", etag=ticket.etag)
+    with pytest.raises(OptimisticConcurrencyError):
+        tracker.transition(ticket.id, "done", etag=ticket.etag)
+    assert fresh.new_status == "in_progress"
+
+
+def test_transition_idempotency_replay(tracker: InMemoryTracker) -> None:
+    [ticket] = list(tracker.pull_open_tickets())
+    first = tracker.transition(ticket.id, "done", etag=ticket.etag, idempotency_key="t-1")
+    second = tracker.transition(ticket.id, "done", etag=first.etag, idempotency_key="t-1")
+    assert first.etag == second.etag
+
+
+# ---------------------------------------------------------------------------
+# rate limiting
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limited_propagates_retry_after() -> None:
+    tracker = InMemoryTracker(rate_limit_after=2, retry_after=12.5)
+    tracker.seed("First")
+    # Two successful calls.
+    list(tracker.pull_open_tickets())
+    list(tracker.pull_open_tickets())
+    # Third raises RateLimited.
+    with pytest.raises(RateLimited) as excinfo:
+        list(tracker.pull_open_tickets())
+    assert excinfo.value.retry_after == 12.5
+
+
+# ---------------------------------------------------------------------------
+# tracker unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_unavailable_raises_on_every_op(tracker: InMemoryTracker) -> None:
+    tracker.set_unavailable(True)
+    with pytest.raises(TrackerUnavailable):
+        list(tracker.pull_open_tickets())
+    with pytest.raises(TrackerUnavailable):
+        tracker.add_comment("T-1", "won't land")

--- a/tests/unit/trackers/test_registry.py
+++ b/tests/unit/trackers/test_registry.py
@@ -1,0 +1,190 @@
+"""Tests for the tracker registry and ``provide_tracker_adapter`` hookspec."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bernstein.core.trackers.contract import AbstractTrackerAdapter
+from bernstein.core.trackers.registry import (
+    DuplicateTrackerError,
+    TrackerRegistration,
+    TrackerRegistry,
+    discover_plugin_trackers,
+    get_registry,
+    register_tracker,
+    reset_registry_for_tests,
+)
+from tests.fixtures.trackers.in_memory_tracker import InMemoryTracker
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Any:
+    reset_registry_for_tests()
+    yield
+    reset_registry_for_tests()
+
+
+def test_registry_default_lists_builtins() -> None:
+    registry = get_registry()
+    names = registry.names()
+    # The built-ins shipped in core/trackers/ + core/trackers/builtin/.
+    assert "linear" in names
+    assert "servicenow" in names
+    assert "github_projects_v2" in names
+    assert "jira_cloud" in names
+    # Built-ins all carry the ``builtin`` source label.
+    for entry in registry:
+        if entry.name in {
+            "linear",
+            "servicenow",
+            "github_projects_v2",
+            "jira_cloud",
+            "jira_dc",
+            "gitlab",
+            "clickup",
+            "asana",
+            "plane",
+        }:
+            assert entry.source == "builtin"
+
+
+def test_register_tracker_appends_programmatic_entry() -> None:
+    entry = register_tracker(
+        "in_memory",
+        InMemoryTracker,
+        summary="In-memory reference adapter.",
+        source="programmatic",
+    )
+    assert entry.name == "in_memory"
+    assert "in_memory" in get_registry()
+    assert get_registry().get("in_memory").factory is InMemoryTracker
+
+
+def test_register_tracker_duplicate_without_overwrite_raises() -> None:
+    register_tracker("in_memory", InMemoryTracker)
+    with pytest.raises(DuplicateTrackerError):
+        register_tracker("in_memory", InMemoryTracker)
+
+
+def test_register_tracker_overwrite_replaces() -> None:
+    register_tracker("in_memory", InMemoryTracker, summary="first")
+    register_tracker("in_memory", InMemoryTracker, summary="second", overwrite=True)
+    assert get_registry().get("in_memory").summary == "second"
+
+
+def test_registry_create_constructs_via_factory() -> None:
+    register_tracker("in_memory", InMemoryTracker)
+    adapter = get_registry().create("in_memory")
+    assert isinstance(adapter, AbstractTrackerAdapter)
+
+
+def test_registry_ordering_is_deterministic() -> None:
+    # Built-ins come before plugin and programmatic in deterministic
+    # alphabetical order within each tier.
+    register_tracker(
+        "zzz_in_memory",
+        InMemoryTracker,
+        source="programmatic",
+    )
+    names = get_registry().names()
+    # The programmatic entry must appear after every built-in.
+    builtin_count = sum(1 for n in names if get_registry().get(n).source == "builtin")
+    assert names[builtin_count] == "zzz_in_memory" or "zzz_in_memory" in names[builtin_count:]
+
+
+# ---------------------------------------------------------------------------
+# Plugin discovery shape
+# ---------------------------------------------------------------------------
+
+
+class _FakePlugin:
+    """Plugin object implementing ``provide_tracker_adapter``."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def provide_tracker_adapter(self) -> Any:
+        return self._payload
+
+
+class _FakePluginManager:
+    """Minimal stand-in for the orchestrator's plugin manager."""
+
+    def __init__(self, plugins: dict[str, Any]) -> None:
+        self._registered_names = list(plugins)
+        self._inner = _FakeInner(plugins)
+
+    @property
+    def _pm(self) -> _FakeInner:
+        return self._inner
+
+
+class _FakeInner:
+    def __init__(self, plugins: dict[str, Any]) -> None:
+        self._plugins = plugins
+
+    def get_plugin(self, name: str) -> Any:
+        return self._plugins.get(name)
+
+
+def test_discover_plugin_trackers_accepts_registration_object() -> None:
+    payload = TrackerRegistration(
+        name="acme_tracker",
+        factory=InMemoryTracker,
+        summary="Acme custom tracker.",
+    )
+    pm = _FakePluginManager({"acme": _FakePlugin(payload)})
+    added = discover_plugin_trackers(pm)
+    assert added == 1
+    entry = get_registry().get("acme_tracker")
+    assert entry.source == "plugin"
+    assert entry.provenance == "acme"
+
+
+def test_discover_plugin_trackers_accepts_tuple() -> None:
+    pm = _FakePluginManager({"acme": _FakePlugin(("tuple_tracker", InMemoryTracker))})
+    added = discover_plugin_trackers(pm)
+    assert added == 1
+    assert "tuple_tracker" in get_registry()
+
+
+def test_discover_plugin_trackers_accepts_list() -> None:
+    payload = [
+        TrackerRegistration(name="t1", factory=InMemoryTracker),
+        ("t2", InMemoryTracker),
+    ]
+    pm = _FakePluginManager({"acme": _FakePlugin(payload)})
+    added = discover_plugin_trackers(pm)
+    assert added == 2
+
+
+def test_discover_plugin_trackers_skips_none() -> None:
+    pm = _FakePluginManager({"acme": _FakePlugin(None)})
+    added = discover_plugin_trackers(pm)
+    assert added == 0
+
+
+def test_discover_plugin_trackers_warns_on_duplicate(caplog: pytest.LogCaptureFixture) -> None:
+    register_tracker("dup", InMemoryTracker)
+    pm = _FakePluginManager({"acme": _FakePlugin(TrackerRegistration(name="dup", factory=InMemoryTracker))})
+    with caplog.at_level("WARNING"):
+        added = discover_plugin_trackers(pm)
+    assert added == 0
+    assert any("duplicate tracker" in r.message.lower() for r in caplog.records)
+
+
+def test_discover_plugin_trackers_isolated_registry() -> None:
+    """A bespoke registry can be populated independently of the global."""
+    isolated = TrackerRegistry()
+    isolated.register("custom", InMemoryTracker, source="programmatic")
+    assert isolated.names() == ("custom",)
+    assert "custom" not in get_registry()
+
+
+def test_hookspec_declares_provide_tracker_adapter() -> None:
+    """The hookspec is wired into the BernsteinSpec class."""
+    from bernstein.plugins.hookspecs import BernsteinSpec
+
+    assert hasattr(BernsteinSpec, "provide_tracker_adapter")


### PR DESCRIPTION
## Summary

- Add `provide_tracker_adapter` pluggy hookspec so third-party tracker plugins register through the standard plugin surface.
- Add `bernstein.core.trackers.registry` with a builtin-seeded registry, programmatic `register_tracker`, and plugin discovery that coerces `TrackerRegistration` / `(name, factory)` / list shapes.
- Wire `PluginManager.collect_plugin_tracker_adapters` so the orchestrator populates the registry once plugins load.
- Add `bernstein trackers list` and `bernstein trackers test <name>` for enumeration and read-only smoke-testing (table or JSON output).
- Add a deterministic in-memory reference adapter under `tests/fixtures/trackers/` plus contract tests for stale-etag claim, duplicate idempotency-key comment, transition concurrency conflict, and rate-limit propagation.
- Add `docs/trackers/contract.md` with a minimum viable adapter walkthrough.

Default behaviour is unchanged: no tracker adapter is active until it is named in `bernstein.yaml: trackers.enabled`.

## Test plan

- [x] `pytest tests/unit/trackers/test_contract.py tests/unit/trackers/test_registry.py` (26 passed)
- [x] `ruff check` clean on every new and modified file
- [x] `ruff format` applied
- [x] `mypy --follow-imports=skip` clean on `registry.py` and `trackers_cmd.py`
- [ ] CI runs the full suite

## Summary by Sourcery

Introduce a pluggable tracker adapter registry with built-in seeding, plugin-based discovery, and CLI inspection/smoke-test support.

New Features:
- Add a provide_tracker_adapter plugin hookspec and plugin manager integration to collect tracker adapters from plugins.
- Introduce a tracker adapter registry with built-in adapters, programmatic registration, and plugin discovery helpers.
- Expose tracker registry operations via new bernstein trackers list and bernstein trackers test CLI commands for listing and smoke-testing adapters.
- Provide a deterministic in-memory tracker adapter fixture and contract tests to define and validate adapter behaviour.
- Document the tracker adapter contract and plugin registration flow in a new trackers contract guide.

Documentation:
- Add tracker adapter contract documentation describing the required interface, error semantics, plugin registration, and smoke-testing via the CLI.

Tests:
- Add unit tests for the tracker registry, plugin discovery handling, and hookspec wiring.
- Add contract tests covering etag concurrency, idempotent comments and transitions, and rate-limit/unavailability propagation for tracker adapters.