### PR TITLE
feat(orchestration): issue -> plan-comment -> PR pipeline

### DIFF
--- a/docs/orchestration/issue-to-pr.md
+++ b/docs/orchestration/issue-to-pr.md
@@ -1,0 +1,108 @@
+# Issue -> PR pipeline
+
+## TL;DR
+
+| Stage | Side effect |
+|-------|-------------|
+| `plan` | Posts a sticky markdown plan as an issue comment. |
+| `approval` | Polls the sticky comment for a thumbs-up reaction or the configured approval keyword. |
+| `pr_open` | Applies the diff, pushes a branch, opens a draft PR, links back to the plan comment. |
+| `pr_revise` | Reads inline review comments newer than the last revision marker, dispatches an agent with the comments as context, pushes a follow-up commit. |
+
+Each stage writes a state marker (HTML comment inside the sticky plan
+comment) so re-running a stage that already completed is a no-op.  The
+pipeline never auto-merges the resulting PR; merge gating stays with the
+operator.
+
+## Configuration
+
+Add an `orchestration.issue_to_pr` block to `bernstein.yaml`:
+
+```yaml
+orchestration:
+  issue_to_pr:
+    repos:
+      - {owner: acme, name: web}
+      - {owner: acme, name: api}
+    triggers:
+      label_required: ai-welcome
+      author_allow_list: [alice, bob]
+    stages:
+      plan_comment_required_approval: true
+      draft_pr_default: true
+      approval_keyword: "[approved]"
+      revise_quiet_window_s: 60
+```
+
+Field reference:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `repos` | list of `{owner, name}` | Repositories the pipeline operates on. Empty means "any repo". |
+| `triggers.label_required` | string | Issue must carry this label to qualify. `null` disables the gate. |
+| `triggers.author_allow_list` | list of GitHub logins | Only issues opened by these users are processed. Empty list disables the gate. |
+| `stages.plan_comment_required_approval` | bool | When true (default), the pipeline pauses after posting the plan and waits for a thumbs-up or the approval keyword. |
+| `stages.draft_pr_default` | bool | When true (default), PRs are opened in draft state. |
+| `stages.approval_keyword` | string | Phrase that grants approval when posted by a user on the allow-list. Defaults to `[approved]`. |
+| `stages.revise_quiet_window_s` | float | Minimum age (seconds) of an inline review comment before the revise stage picks it up. |
+
+## Setup steps
+
+1. Configure the GitHub App per `docs/operations/github-app.md` so the
+   pipeline has installation tokens for the `repos` it touches.
+2. Add the `orchestration.issue_to_pr` block to `bernstein.yaml`.
+3. Wire the three injection points when constructing the pipeline:
+   - `plan_generator` -- callable that turns an `IssueContext` into a
+     `PlanProposal`.  Typical wiring: dispatch a Bernstein task with the
+     issue body as context and parse the agent output as markdown.
+   - `diff_generator` -- callable that produces the initial diff once
+     approval lands.  Typical wiring: spawn a Claude/Codex/Aider session
+     in a fresh worktree and capture `git diff` as the patch.
+   - `revise_generator` -- callable that, given the new inline review
+     comments, produces a follow-up diff.
+   - `apply_diff` -- callable that applies the patch to a working tree,
+     pushes the branch, and returns the head SHA.
+4. Drive the pipeline from the autofix daemon, a cron job, or a manual
+   call to `pipeline.tick(repo, issue_number)`.
+
+## CLI
+
+```
+bernstein issue-to-pr trace --repo acme/web 42
+```
+
+Reads the sticky-comment markers and prints one fact per line:
+
+```
+repo:           acme/web
+issue:          #42
+plan_posted:    True
+approved:       True
+pr_number:      4242
+last_revise_at: 2026-05-19T12:00:00Z
+```
+
+The command is read-only; it never advances state.
+
+## State markers
+
+The pipeline stores its progress as HTML comments inside the sticky
+plan comment so the state is fully recoverable from GitHub alone (no
+sidecar database).
+
+| Marker | Meaning |
+|--------|---------|
+| `<!-- bernstein:issue-to-pr:plan -->` | Identifies the sticky plan comment in the issue thread. |
+| `<!-- stage:plan:done -->` | Plan-comment stage finished. |
+| `<!-- stage:approval:granted -->` | Approval recorded. |
+| `<!-- stage:pr-open:done pr=<N> -->` | Draft PR `#<N>` opened. |
+| `<!-- stage:pr-revise:last=<iso> sha=<sha> -->` | Last revise round; oldest unprocessed review comment is one with `created_at > <iso>`. |
+
+Re-running any stage that already wrote its marker is a no-op.
+
+## Out of scope
+
+- GitLab MR variant (separate adapter pickup once the GitLab tracker
+  adapter lands).
+- Issue triage / auto-labelling.
+- Auto-merge of the resulting PR; merge stays operator-gated.

--- a/src/bernstein/cli/commands/issue_to_pr_cmd.py
+++ b/src/bernstein/cli/commands/issue_to_pr_cmd.py
@@ -1,0 +1,51 @@
+"""``bernstein issue-to-pr`` -- inspect the issue -> PR pipeline state.
+
+The CLI is intentionally thin: real logic lives in
+:mod:`bernstein.core.orchestration.issue_to_pr`.  This module just glues
+click flags to the pipeline trace primitive and prints a status summary.
+
+Only the ``trace`` subcommand is exposed for now.  Ticking the pipeline
+is driven from the daemon or a manual call into the module; the CLI
+intentionally avoids being a fourth way to advance state.
+"""
+
+from __future__ import annotations
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.orchestration.issue_to_pr import (
+    IssuePRClient,
+    IssueToPRConfig,
+    IssueToPRPipeline,
+)
+
+
+@click.group("issue-to-pr")
+def issue_to_pr_group() -> None:
+    """Inspect the issue -> plan-comment -> PR pipeline."""
+
+
+@issue_to_pr_group.command("trace")
+@click.argument("issue_id")
+@click.option(
+    "--repo",
+    required=True,
+    help="GitHub owner/repo slug, e.g. acme/web.",
+)
+def trace_cmd(issue_id: str, repo: str) -> None:
+    """Print the current pipeline state for ``<owner>/<repo>#<issue_id>``.
+
+    Reads sticky-comment markers and the linked PR (if any) and prints
+    one fact per line.  Read-only; safe to invoke anywhere.
+    """
+    try:
+        issue_number = int(issue_id.lstrip("#"))
+    except ValueError as exc:
+        raise click.BadParameter(f"issue_id must be numeric, got {issue_id!r}") from exc
+    pipeline = IssueToPRPipeline(
+        config=IssueToPRConfig(),
+        client=IssuePRClient(),
+    )
+    trace = pipeline.trace(repo, issue_number)
+    console.print(trace.render())

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -246,6 +246,7 @@ from bernstein.cli.commands.hooks_cmd import hooks as hooks_group
 from bernstein.cli.commands.pr_cmd import pr_cmd
 from bernstein.cli.commands.preview_cmd import preview_group
 from bernstein.cli.commands.remote_cmd import remote_group
+from bernstein.cli.commands.issue_to_pr_cmd import issue_to_pr_group
 from bernstein.cli.commands.review_responder_cmd import review_responder_group
 from bernstein.cli.commands.ticket_cmd import from_ticket, ticket_group
 from bernstein.cli.commands.tunnel_cmd import tunnel_group
@@ -918,6 +919,7 @@ cli.add_command(connect_cmd, "connect")
 cli.add_command(creds_group, "creds")
 cli.add_command(criterion_profile_group, "criterion-profile")
 cli.add_command(review_responder_group, "review-responder")
+cli.add_command(issue_to_pr_group, "issue-to-pr")
 
 # Already registered elsewhere
 cli.add_command(agents_group)

--- a/src/bernstein/core/orchestration/issue_to_pr.py
+++ b/src/bernstein/core/orchestration/issue_to_pr.py
@@ -1,0 +1,1178 @@
+"""Issue -> plan-comment -> PR pipeline with diff-revision-from-comments.
+
+A four-stage orchestration that converts a GitHub issue into a merged-ready
+pull request without dragging the operator through copy-paste:
+
+    1. ``plan``      - agent reads the issue, writes a markdown plan,
+                       posts it as a sticky comment on the issue.
+    2. ``approval``  - poll the issue for a thumbs-up reaction or an
+                       ``[approved]`` keyword from a configured user.
+    3. ``pr_open``   - open a draft pull request with the proposed diff
+                       and link back to the plan comment.
+    4. ``pr_revise`` - read inline review comments newer than the last
+                       revision marker, dispatch an agent with the
+                       comments as context, push an updated commit.
+
+The pipeline is a thin orchestration layer over existing primitives:
+
+* GitHub I/O is funneled through a ``gh`` CLI wrapper similar to the one
+  used by :mod:`bernstein.core.review_responder`.
+* Each stage writes a state marker so re-running the pipeline is safe.
+  Markers are HTML comments embedded inside the sticky plan-comment body
+  (read with regex) plus an issue label per stage.
+* The actual diff generation is delegated to an injected callable so the
+  pipeline can be wired to the autofix daemon, the handoff bus, or any
+  other agent driver without this module depending on them at import
+  time.
+
+The pipeline never auto-merges the resulting PR; merge gating stays with
+the operator.
+
+Idempotency
+-----------
+
+Every stage performs a *read-modify-write* against the GitHub-side state
+markers.  Re-running a stage that has already completed returns the
+existing result rather than producing a duplicate comment, label, or
+pull request.  This lets the orchestrator drive the pipeline from a
+crontab or systemd timer without bookkeeping.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public sentinels and state markers
+# ---------------------------------------------------------------------------
+
+#: HTML-comment marker embedded inside the sticky plan comment.  The
+#: pipeline locates its own comment by searching the issue thread for
+#: this marker; do not change the value without a migration.
+STICKY_MARKER: str = "<!-- bernstein:issue-to-pr:plan -->"
+
+#: Per-stage marker tokens stored inside the sticky comment body.
+STAGE_PLAN_DONE_MARKER: str = "<!-- stage:plan:done -->"
+STAGE_APPROVED_MARKER: str = "<!-- stage:approval:granted -->"
+STAGE_PR_OPENED_MARKER: str = "<!-- stage:pr-open:done pr={pr_number} -->"
+STAGE_PR_OPENED_RE: re.Pattern[str] = re.compile(
+    r"<!--\s*stage:pr-open:done\s+pr=(\d+)\s*-->",
+)
+STAGE_PR_REVISED_MARKER: str = "<!-- stage:pr-revise:last={iso} sha={sha} -->"
+STAGE_PR_REVISED_RE: re.Pattern[str] = re.compile(
+    r"<!--\s*stage:pr-revise:last=([^\s]+)\s+sha=([^\s]+)\s*-->",
+)
+
+#: Default keyword that, posted by an authorised user, grants approval.
+APPROVAL_KEYWORD: str = "[approved]"
+
+
+class Stage(str, Enum):  # noqa: UP042 - explicit str base for label export
+    """Pipeline stages, ordered."""
+
+    PLAN = "plan"
+    APPROVAL = "approval"
+    PR_OPEN = "pr_open"
+    PR_REVISE = "pr_revise"
+
+
+class StageOutcome(str, Enum):  # noqa: UP042 - explicit str base for label export
+    """Outcome of running a single stage."""
+
+    ADVANCED = "advanced"
+    """The stage produced new side effects; the pipeline moves on."""
+
+    ALREADY_DONE = "already_done"
+    """A marker shows this stage was completed previously; nothing to do."""
+
+    WAITING = "waiting"
+    """The stage cannot progress yet (e.g. awaiting human approval)."""
+
+    SKIPPED = "skipped"
+    """A trigger gate (label, author allow-list) declined the issue."""
+
+    ERROR = "error"
+    """The stage hit an unrecoverable error; the operator must intervene."""
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Triggers:
+    """Gating conditions that decide whether the pipeline acts on an issue.
+
+    Attributes:
+        label_required: Issue label that must be present for the pipeline
+            to engage. ``None`` disables the gate (every issue qualifies).
+        author_allow_list: GitHub logins whose issues the pipeline will
+            pick up. Empty tuple disables the gate.
+    """
+
+    label_required: str | None = None
+    author_allow_list: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Stages:
+    """Per-stage behavioural toggles.
+
+    Attributes:
+        plan_comment_required_approval: When True, the pipeline pauses
+            after posting the plan comment and waits for a thumbs-up
+            reaction or the approval keyword.  When False the pipeline
+            advances straight to PR-open after plan-comment posting.
+        draft_pr_default: When True (default) the PR is opened in draft
+            state and is converted to ready-for-review only by an
+            explicit operator action elsewhere.
+        approval_keyword: Keyword that, when posted by a user on the
+            allow-list, grants approval.  Defaults to ``[approved]``.
+        revise_quiet_window_s: Minimum age (seconds) of an inline review
+            comment before the revision stage picks it up.  Mirrors the
+            review-responder quiet window so reviewers can amend their
+            comment without race conditions.
+    """
+
+    plan_comment_required_approval: bool = True
+    draft_pr_default: bool = True
+    approval_keyword: str = APPROVAL_KEYWORD
+    revise_quiet_window_s: float = 60.0
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    """Identifies a single ``owner/name`` repository the pipeline drives.
+
+    Attributes:
+        owner: GitHub user or organisation slug.
+        name: Repository name (without owner prefix).
+    """
+
+    owner: str
+    name: str
+
+    @property
+    def slug(self) -> str:
+        """Return the ``owner/name`` string accepted by the ``gh`` CLI."""
+        return f"{self.owner}/{self.name}"
+
+
+@dataclass(frozen=True)
+class IssueToPRConfig:
+    """Top-level configuration for the pipeline.
+
+    Attributes:
+        repos: Repositories that participate.  Issues from other repos
+            are ignored even if a webhook delivers them.
+        triggers: Trigger gates that filter issues before the pipeline
+            spends any agent budget.
+        stages: Per-stage toggles.
+    """
+
+    repos: tuple[RepoRef, ...] = ()
+    triggers: Triggers = field(default_factory=Triggers)
+    stages: Stages = field(default_factory=Stages)
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> IssueToPRConfig:
+        """Build a config from the ``orchestration.issue_to_pr`` block.
+
+        Accepts the shape documented in ``docs/orchestration/issue-to-pr.md``::
+
+            orchestration:
+              issue_to_pr:
+                repos:
+                  - {owner: acme, name: web}
+                triggers:
+                  label_required: ai-welcome
+                  author_allow_list: [alice, bob]
+                stages:
+                  plan_comment_required_approval: true
+                  draft_pr_default: true
+
+        Unknown keys are ignored to keep forward compatibility cheap.
+        """
+        payload = payload or {}
+        raw_repos: Iterable[dict[str, Any]] = payload.get("repos") or ()
+        repos = tuple(
+            RepoRef(owner=str(r["owner"]), name=str(r["name"]))
+            for r in raw_repos
+            if isinstance(r, dict) and "owner" in r and "name" in r
+        )
+        trig = payload.get("triggers") or {}
+        triggers = Triggers(
+            label_required=trig.get("label_required") or None,
+            author_allow_list=tuple(trig.get("author_allow_list") or ()),
+        )
+        st = payload.get("stages") or {}
+        stages = Stages(
+            plan_comment_required_approval=bool(
+                st.get("plan_comment_required_approval", True),
+            ),
+            draft_pr_default=bool(st.get("draft_pr_default", True)),
+            approval_keyword=str(st.get("approval_keyword") or APPROVAL_KEYWORD),
+            revise_quiet_window_s=float(st.get("revise_quiet_window_s", 60.0)),
+        )
+        return cls(repos=repos, triggers=triggers, stages=stages)
+
+
+# ---------------------------------------------------------------------------
+# Plan / diff payloads (injection points)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IssueContext:
+    """Minimal issue payload handed to the plan generator.
+
+    Attributes:
+        repo: ``owner/repo`` slug.
+        number: Issue number.
+        title: Issue title.
+        body: Issue body (markdown).
+        author: GitHub login of the issue author.
+        labels: Tuple of labels currently on the issue.
+    """
+
+    repo: str
+    number: int
+    title: str
+    body: str
+    author: str
+    labels: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlanProposal:
+    """Plan-comment payload produced by an injected agent.
+
+    Attributes:
+        markdown: Markdown body to be posted as the sticky plan comment.
+            The pipeline wraps this in the sticky marker; callers must
+            NOT include the marker themselves.
+        branch: Branch name that the diff stage will push to.
+        commit_message: Single-line commit subject the diff stage uses.
+    """
+
+    markdown: str
+    branch: str
+    commit_message: str
+
+
+@dataclass(frozen=True)
+class DiffProposal:
+    """Diff payload handed to the PR-open / PR-revise stages.
+
+    Attributes:
+        patch: Unified-diff text (``git diff`` output) for the changes.
+            Empty string means "no changes"; callers should treat this
+            as a no-op and not open a PR.
+        branch: Branch the diff is targeted at.
+        commit_message: Commit subject; the body is appended by the
+            pipeline with a back-reference to the issue and plan comment.
+        base: Base branch the PR is opened against. Defaults to ``main``.
+    """
+
+    patch: str
+    branch: str
+    commit_message: str
+    base: str = "main"
+
+
+#: Type aliases for the two injection points.
+PlanGenerator = Callable[[IssueContext], PlanProposal]
+DiffGenerator = Callable[[IssueContext, PlanProposal], DiffProposal]
+ReviseGenerator = Callable[
+    [IssueContext, int, list["InlineReviewComment"]],
+    DiffProposal,
+]
+
+
+@dataclass(frozen=True)
+class InlineReviewComment:
+    """Inline review comment normalised for the revise stage.
+
+    Attributes:
+        comment_id: GitHub review-comment id.
+        path: File path the comment is anchored to.
+        line: 1-based line number (uses ``line`` or ``original_line``).
+        body: Comment body markdown.
+        reviewer: GitHub login of the reviewer.
+        created_at: ISO 8601 timestamp.
+    """
+
+    comment_id: int
+    path: str
+    line: int
+    body: str
+    reviewer: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# Thin ``gh`` CLI wrapper
+# ---------------------------------------------------------------------------
+
+
+GhRunner = Callable[[list[str], "str | None"], subprocess.CompletedProcess[str]]
+
+
+def _default_runner(
+    args: list[str],
+    stdin: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``gh`` with optional stdin, capturing stdout/stderr."""
+    return subprocess.run(  # nosec B603 - args constructed by caller
+        ["gh", *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+
+
+@dataclass
+class IssuePRClient:
+    """Tiny ``gh`` wrapper for the issue-to-PR pipeline.
+
+    Centralised so tests can stub one runner instead of patching
+    ``subprocess.run`` in every test.
+    """
+
+    runner: GhRunner = _default_runner
+
+    # -- reads ----------------------------------------------------------
+
+    def get_issue(self, repo: str, number: int) -> dict[str, Any]:
+        """Fetch issue payload via the REST API.
+
+        Returns the parsed JSON dict on success, an empty dict on
+        failure.  Callers MUST check for missing keys before use.
+        """
+        result = self.runner(
+            ["api", f"repos/{repo}/issues/{number}"],
+            None,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "gh issues get failed for %s#%d: %s",
+                repo,
+                number,
+                result.stderr.strip(),
+            )
+            return {}
+        try:
+            data = json.loads(result.stdout or "{}")
+        except ValueError:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def list_issue_comments(
+        self,
+        repo: str,
+        number: int,
+    ) -> list[dict[str, Any]]:
+        """List the issue's comment thread.
+
+        Returns the raw GitHub payload list; empty on failure.
+        """
+        result = self.runner(
+            ["api", f"repos/{repo}/issues/{number}/comments?per_page=100"],
+            None,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "gh comments list failed for %s#%d: %s",
+                repo,
+                number,
+                result.stderr.strip(),
+            )
+            return []
+        try:
+            data = json.loads(result.stdout or "[]")
+        except ValueError:
+            return []
+        return data if isinstance(data, list) else []
+
+    def list_issue_reactions(
+        self,
+        repo: str,
+        number: int,
+    ) -> list[dict[str, Any]]:
+        """List reactions on the issue body."""
+        result = self.runner(
+            [
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"repos/{repo}/issues/{number}/reactions?per_page=100",
+            ],
+            None,
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            data = json.loads(result.stdout or "[]")
+        except ValueError:
+            return []
+        return data if isinstance(data, list) else []
+
+    def list_pr_review_comments(
+        self,
+        repo: str,
+        pr_number: int,
+    ) -> list[dict[str, Any]]:
+        """List inline review comments on a PR."""
+        result = self.runner(
+            ["api", f"repos/{repo}/pulls/{pr_number}/comments?per_page=100"],
+            None,
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            data = json.loads(result.stdout or "[]")
+        except ValueError:
+            return []
+        return data if isinstance(data, list) else []
+
+    # -- writes ---------------------------------------------------------
+
+    def post_issue_comment(
+        self,
+        *,
+        repo: str,
+        number: int,
+        body: str,
+    ) -> dict[str, Any] | None:
+        """Post a new issue comment, returning the created payload."""
+        payload = json.dumps({"body": body})
+        result = self.runner(
+            [
+                "api",
+                "-X",
+                "POST",
+                f"repos/{repo}/issues/{number}/comments",
+                "--input",
+                "-",
+            ],
+            payload,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "gh post comment failed: %s",
+                result.stderr.strip(),
+            )
+            return None
+        try:
+            data = json.loads(result.stdout or "{}")
+        except ValueError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def patch_issue_comment(
+        self,
+        *,
+        repo: str,
+        comment_id: int,
+        body: str,
+    ) -> bool:
+        """Edit an existing issue comment in place."""
+        payload = json.dumps({"body": body})
+        result = self.runner(
+            [
+                "api",
+                "-X",
+                "PATCH",
+                f"repos/{repo}/issues/comments/{comment_id}",
+                "--input",
+                "-",
+            ],
+            payload,
+        )
+        return result.returncode == 0
+
+    def open_pull_request(
+        self,
+        *,
+        repo: str,
+        head: str,
+        base: str,
+        title: str,
+        body: str,
+        draft: bool,
+    ) -> dict[str, Any] | None:
+        """Open a pull request via the REST API.
+
+        Returns the created PR payload on success; ``None`` on failure.
+        """
+        payload = json.dumps(
+            {
+                "head": head,
+                "base": base,
+                "title": title,
+                "body": body,
+                "draft": draft,
+            }
+        )
+        result = self.runner(
+            [
+                "api",
+                "-X",
+                "POST",
+                f"repos/{repo}/pulls",
+                "--input",
+                "-",
+            ],
+            payload,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "gh open pr failed: %s",
+                result.stderr.strip(),
+            )
+            return None
+        try:
+            data = json.loads(result.stdout or "{}")
+        except ValueError:
+            return None
+        return data if isinstance(data, dict) else None
+
+
+# ---------------------------------------------------------------------------
+# Marker helpers
+# ---------------------------------------------------------------------------
+
+
+def find_sticky_comment(
+    comments: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Return the sticky plan comment from a thread, or ``None``."""
+    for c in comments:
+        body = c.get("body") or ""
+        if STICKY_MARKER in body:
+            return c
+    return None
+
+
+def has_marker(body: str, marker: str) -> bool:
+    """Return True iff ``marker`` appears inside ``body``."""
+    return marker in body
+
+
+def extract_pr_number(body: str) -> int | None:
+    """Read the PR number from a ``pr-open`` marker, if present."""
+    m = STAGE_PR_OPENED_RE.search(body)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except ValueError:
+        return None
+
+
+def extract_last_revise(body: str) -> tuple[str, str] | None:
+    """Return ``(iso_timestamp, sha)`` from a ``pr-revise`` marker."""
+    m = STAGE_PR_REVISED_RE.search(body)
+    if not m:
+        return None
+    return (m.group(1), m.group(2))
+
+
+def build_plan_body(plan_markdown: str) -> str:
+    """Wrap a raw plan markdown in the sticky marker and plan-done tag.
+
+    Args:
+        plan_markdown: Author-supplied markdown.
+
+    Returns:
+        Body string ready to be posted as an issue comment.
+    """
+    return f"{STICKY_MARKER}\n{STAGE_PLAN_DONE_MARKER}\n\n{plan_markdown.strip()}\n"
+
+
+def append_marker(body: str, marker: str) -> str:
+    """Append ``marker`` to the end of ``body`` if not already present."""
+    if marker in body:
+        return body
+    suffix = "\n" if not body.endswith("\n") else ""
+    return f"{body}{suffix}{marker}\n"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline trace
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StageReport:
+    """Outcome of advancing one stage during a tick."""
+
+    stage: Stage
+    outcome: StageOutcome
+    detail: str = ""
+    pr_number: int | None = None
+
+
+@dataclass(frozen=True)
+class PipelineTrace:
+    """Pipeline state snapshot, returned by :meth:`IssueToPRPipeline.trace`."""
+
+    repo: str
+    issue_number: int
+    plan_posted: bool
+    approved: bool
+    pr_number: int | None
+    last_revise_at: str | None
+
+    def render(self) -> str:
+        """Format a human-readable summary for ``bernstein issue-to-pr trace``."""
+        lines = [
+            f"repo:           {self.repo}",
+            f"issue:          #{self.issue_number}",
+            f"plan_posted:    {self.plan_posted}",
+            f"approved:       {self.approved}",
+            f"pr_number:      {self.pr_number if self.pr_number is not None else '-'}",
+            f"last_revise_at: {self.last_revise_at or '-'}",
+        ]
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# The pipeline itself
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IssueToPRPipeline:
+    """Orchestrate an issue through the four-stage pipeline.
+
+    The pipeline is intentionally side-effect-light at construction time:
+    no network is touched until a ``tick_*`` method runs.  Callers wire
+    the agent-side plan and diff generation in via the three callables.
+
+    Attributes:
+        config: Behavioural configuration.
+        client: ``gh`` CLI wrapper.
+        plan_generator: Callable that turns an :class:`IssueContext` into
+            a :class:`PlanProposal`.
+        diff_generator: Callable that produces the initial diff for a
+            previously-approved plan.
+        revise_generator: Callable that consumes new inline review
+            comments and produces a follow-up diff.
+        apply_diff: Callable that, given a :class:`DiffProposal`, applies
+            the patch to a working tree and pushes the branch to the
+            remote, returning the head commit SHA.  Defaults to a stub
+            that raises; production wiring injects the autofix-daemon
+            applicator.
+    """
+
+    config: IssueToPRConfig
+    client: IssuePRClient = field(default_factory=IssuePRClient)
+    plan_generator: PlanGenerator | None = None
+    diff_generator: DiffGenerator | None = None
+    revise_generator: ReviseGenerator | None = None
+    apply_diff: Callable[[DiffProposal], str] | None = None
+
+    # -- gating ---------------------------------------------------------
+
+    def _is_repo_allowed(self, repo: str) -> bool:
+        if not self.config.repos:
+            # No allow-list configured: accept any repo.  This keeps
+            # tests cheap while still letting operators lock the
+            # pipeline down by setting ``repos:`` explicitly.
+            return True
+        return any(r.slug == repo for r in self.config.repos)
+
+    def _is_issue_eligible(self, issue: dict[str, Any]) -> tuple[bool, str]:
+        """Return ``(ok, reason)`` describing whether the issue qualifies."""
+        labels = tuple(lbl.get("name", "") for lbl in issue.get("labels", []) if isinstance(lbl, dict))
+        required = self.config.triggers.label_required
+        if required and required not in labels:
+            return False, f"missing required label {required!r}"
+        allow = self.config.triggers.author_allow_list
+        if allow:
+            user = (issue.get("user") or {}).get("login")
+            if user not in allow:
+                return False, f"author {user!r} not in allow_list"
+        return True, ""
+
+    # -- stage 1: plan --------------------------------------------------
+
+    def tick_plan(self, repo: str, issue_number: int) -> StageReport:
+        """Run the plan-comment stage exactly once."""
+        if not self._is_repo_allowed(repo):
+            return StageReport(
+                Stage.PLAN,
+                StageOutcome.SKIPPED,
+                detail=f"repo {repo!r} not in allow list",
+            )
+        issue = self.client.get_issue(repo, issue_number)
+        if not issue:
+            return StageReport(
+                Stage.PLAN,
+                StageOutcome.ERROR,
+                detail="issue payload empty (gh failure?)",
+            )
+        ok, reason = self._is_issue_eligible(issue)
+        if not ok:
+            return StageReport(Stage.PLAN, StageOutcome.SKIPPED, detail=reason)
+
+        comments = self.client.list_issue_comments(repo, issue_number)
+        sticky = find_sticky_comment(comments)
+        if sticky and has_marker(sticky.get("body") or "", STAGE_PLAN_DONE_MARKER):
+            return StageReport(
+                Stage.PLAN,
+                StageOutcome.ALREADY_DONE,
+                detail=f"sticky comment id={sticky.get('id')}",
+            )
+        if self.plan_generator is None:
+            return StageReport(
+                Stage.PLAN,
+                StageOutcome.ERROR,
+                detail="plan_generator not configured",
+            )
+        ctx = IssueContext(
+            repo=repo,
+            number=issue_number,
+            title=str(issue.get("title") or ""),
+            body=str(issue.get("body") or ""),
+            author=str((issue.get("user") or {}).get("login") or ""),
+            labels=tuple(lbl.get("name", "") for lbl in issue.get("labels", []) if isinstance(lbl, dict)),
+        )
+        proposal = self.plan_generator(ctx)
+        body = build_plan_body(proposal.markdown)
+        posted = self.client.post_issue_comment(
+            repo=repo,
+            number=issue_number,
+            body=body,
+        )
+        if posted is None:
+            return StageReport(
+                Stage.PLAN,
+                StageOutcome.ERROR,
+                detail="failed to post sticky comment",
+            )
+        return StageReport(
+            Stage.PLAN,
+            StageOutcome.ADVANCED,
+            detail=f"sticky comment id={posted.get('id')}",
+        )
+
+    # -- stage 2: approval ---------------------------------------------
+
+    def tick_approval(self, repo: str, issue_number: int) -> StageReport:
+        """Check whether approval has been granted for the plan."""
+        if not self.config.stages.plan_comment_required_approval:
+            return StageReport(
+                Stage.APPROVAL,
+                StageOutcome.ADVANCED,
+                detail="approval not required",
+            )
+        comments = self.client.list_issue_comments(repo, issue_number)
+        sticky = find_sticky_comment(comments)
+        if sticky is None:
+            return StageReport(
+                Stage.APPROVAL,
+                StageOutcome.WAITING,
+                detail="plan comment not posted yet",
+            )
+        body = sticky.get("body") or ""
+        if has_marker(body, STAGE_APPROVED_MARKER):
+            return StageReport(
+                Stage.APPROVAL,
+                StageOutcome.ALREADY_DONE,
+                detail="approval marker present",
+            )
+
+        if self._approval_keyword_seen(comments):
+            return self._mark_approved(repo, sticky)
+
+        if self._thumbs_up_seen(repo, sticky.get("id")):
+            return self._mark_approved(repo, sticky)
+
+        return StageReport(
+            Stage.APPROVAL,
+            StageOutcome.WAITING,
+            detail="no approval signal yet",
+        )
+
+    def _approval_keyword_seen(self, comments: list[dict[str, Any]]) -> bool:
+        keyword = self.config.stages.approval_keyword
+        allow = set(self.config.triggers.author_allow_list)
+        for c in comments:
+            body = (c.get("body") or "").strip()
+            if keyword in body:
+                user = (c.get("user") or {}).get("login")
+                if not allow or user in allow:
+                    return True
+        return False
+
+    def _thumbs_up_seen(self, repo: str, comment_id: Any) -> bool:
+        if comment_id is None:
+            return False
+        result = self.client.runner(
+            [
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"repos/{repo}/issues/comments/{comment_id}/reactions?per_page=100",
+            ],
+            None,
+        )
+        if result.returncode != 0:
+            return False
+        try:
+            data = json.loads(result.stdout or "[]")
+        except ValueError:
+            return False
+        if not isinstance(data, list):
+            return False
+        allow = set(self.config.triggers.author_allow_list)
+        for r in data:
+            if not isinstance(r, dict):
+                continue
+            if r.get("content") != "+1":
+                continue
+            user = (r.get("user") or {}).get("login")
+            if not allow or user in allow:
+                return True
+        return False
+
+    def _mark_approved(
+        self,
+        repo: str,
+        sticky: dict[str, Any],
+    ) -> StageReport:
+        body = sticky.get("body") or ""
+        new_body = append_marker(body, STAGE_APPROVED_MARKER)
+        ok = self.client.patch_issue_comment(
+            repo=repo,
+            comment_id=int(sticky.get("id") or 0),
+            body=new_body,
+        )
+        if not ok:
+            return StageReport(
+                Stage.APPROVAL,
+                StageOutcome.ERROR,
+                detail="failed to write approval marker",
+            )
+        return StageReport(
+            Stage.APPROVAL,
+            StageOutcome.ADVANCED,
+            detail="approval recorded",
+        )
+
+    # -- stage 3: pr_open ----------------------------------------------
+
+    def tick_pr_open(self, repo: str, issue_number: int) -> StageReport:
+        """Open the draft pull request once approval is in place."""
+        comments = self.client.list_issue_comments(repo, issue_number)
+        sticky = find_sticky_comment(comments)
+        if sticky is None:
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.WAITING,
+                detail="plan comment not posted yet",
+            )
+        body = sticky.get("body") or ""
+        existing_pr = extract_pr_number(body)
+        if existing_pr is not None:
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.ALREADY_DONE,
+                detail=f"PR #{existing_pr} already linked",
+                pr_number=existing_pr,
+            )
+        if self.config.stages.plan_comment_required_approval and not has_marker(body, STAGE_APPROVED_MARKER):
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.WAITING,
+                detail="awaiting approval marker",
+            )
+        if self.diff_generator is None or self.apply_diff is None:
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.ERROR,
+                detail="diff_generator or apply_diff not configured",
+            )
+
+        issue = self.client.get_issue(repo, issue_number)
+        if not issue:
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.ERROR,
+                detail="issue payload empty",
+            )
+        ctx = IssueContext(
+            repo=repo,
+            number=issue_number,
+            title=str(issue.get("title") or ""),
+            body=str(issue.get("body") or ""),
+            author=str((issue.get("user") or {}).get("login") or ""),
+            labels=tuple(lbl.get("name", "") for lbl in issue.get("labels", []) if isinstance(lbl, dict)),
+        )
+        plan_proposal = PlanProposal(
+            markdown="",
+            branch=f"bernstein/issue-{issue_number}",
+            commit_message=f"feat: resolve #{issue_number}",
+        )
+        diff = self.diff_generator(ctx, plan_proposal)
+        if not diff.patch.strip():
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.WAITING,
+                detail="diff is empty; no PR opened",
+            )
+        try:
+            self.apply_diff(diff)
+        except Exception as exc:
+            logger.exception("apply_diff failed for %s#%d", repo, issue_number)
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.ERROR,
+                detail=f"apply_diff raised: {exc!r}",
+            )
+        pr_body = f"Resolves #{issue_number}.\n\nPlan: see comment #{sticky.get('id')} on the issue.\n"
+        title = diff.commit_message if diff.commit_message else f"feat: resolve #{issue_number}"
+        pr = self.client.open_pull_request(
+            repo=repo,
+            head=diff.branch,
+            base=diff.base,
+            title=title,
+            body=pr_body,
+            draft=self.config.stages.draft_pr_default,
+        )
+        if pr is None or "number" not in pr:
+            return StageReport(
+                Stage.PR_OPEN,
+                StageOutcome.ERROR,
+                detail="open_pull_request returned no payload",
+            )
+        pr_number = int(pr["number"])
+        marker = STAGE_PR_OPENED_MARKER.format(pr_number=pr_number)
+        new_body = append_marker(body, marker)
+        self.client.patch_issue_comment(
+            repo=repo,
+            comment_id=int(sticky.get("id") or 0),
+            body=new_body,
+        )
+        return StageReport(
+            Stage.PR_OPEN,
+            StageOutcome.ADVANCED,
+            detail=f"opened PR #{pr_number}",
+            pr_number=pr_number,
+        )
+
+    # -- stage 4: pr_revise --------------------------------------------
+
+    def tick_pr_revise(self, repo: str, issue_number: int) -> StageReport:
+        """Apply a follow-up revision driven by inline review comments."""
+        comments = self.client.list_issue_comments(repo, issue_number)
+        sticky = find_sticky_comment(comments)
+        if sticky is None:
+            return StageReport(
+                Stage.PR_REVISE,
+                StageOutcome.WAITING,
+                detail="no sticky comment yet",
+            )
+        body = sticky.get("body") or ""
+        pr_number = extract_pr_number(body)
+        if pr_number is None:
+            return StageReport(
+                Stage.PR_REVISE,
+                StageOutcome.WAITING,
+                detail="PR not opened yet",
+            )
+
+        last = extract_last_revise(body)
+        last_iso = last[0] if last else ""
+
+        raw = self.client.list_pr_review_comments(repo, pr_number)
+        new_comments = self._select_new_comments(raw, last_iso)
+        if not new_comments:
+            return StageReport(
+                Stage.PR_REVISE,
+                StageOutcome.ALREADY_DONE,
+                detail="no new review comments",
+                pr_number=pr_number,
+            )
+        if self.revise_generator is None or self.apply_diff is None:
+            return StageReport(
+                Stage.PR_REVISE,
+                StageOutcome.ERROR,
+                detail="revise_generator or apply_diff not configured",
+                pr_number=pr_number,
+            )
+        issue = self.client.get_issue(repo, issue_number)
+        ctx = IssueContext(
+            repo=repo,
+            number=issue_number,
+            title=str(issue.get("title") or ""),
+            body=str(issue.get("body") or ""),
+            author=str((issue.get("user") or {}).get("login") or ""),
+            labels=tuple(lbl.get("name", "") for lbl in issue.get("labels", []) if isinstance(lbl, dict)),
+        )
+        diff = self.revise_generator(ctx, pr_number, new_comments)
+        if not diff.patch.strip():
+            return StageReport(
+                Stage.PR_REVISE,
+                StageOutcome.WAITING,
+                detail="revise produced empty diff",
+                pr_number=pr_number,
+            )
+        try:
+            sha = self.apply_diff(diff)
+        except Exception as exc:
+            logger.exception(
+                "apply_diff (revise) failed for %s#%d",
+                repo,
+                issue_number,
+            )
+            return StageReport(
+                Stage.PR_REVISE,
+                StageOutcome.ERROR,
+                detail=f"apply_diff raised: {exc!r}",
+                pr_number=pr_number,
+            )
+        newest_iso = max(c.created_at for c in new_comments)
+        marker = STAGE_PR_REVISED_MARKER.format(iso=newest_iso, sha=sha)
+        # Replace any prior revise marker rather than stacking them.
+        cleaned_body = STAGE_PR_REVISED_RE.sub("", body).rstrip() + "\n"
+        new_body = append_marker(cleaned_body, marker)
+        self.client.patch_issue_comment(
+            repo=repo,
+            comment_id=int(sticky.get("id") or 0),
+            body=new_body,
+        )
+        return StageReport(
+            Stage.PR_REVISE,
+            StageOutcome.ADVANCED,
+            detail=f"revised PR #{pr_number} with {len(new_comments)} comment(s)",
+            pr_number=pr_number,
+        )
+
+    def _select_new_comments(
+        self,
+        raw: list[dict[str, Any]],
+        last_iso: str,
+    ) -> list[InlineReviewComment]:
+        out: list[InlineReviewComment] = []
+        for r in raw:
+            if not isinstance(r, dict):
+                continue
+            created = str(r.get("created_at") or "")
+            if last_iso and created <= last_iso:
+                continue
+            line = r.get("line") or r.get("original_line") or 0
+            try:
+                line_int = int(line)
+            except (TypeError, ValueError):
+                continue
+            out.append(
+                InlineReviewComment(
+                    comment_id=int(r.get("id") or 0),
+                    path=str(r.get("path") or ""),
+                    line=line_int,
+                    body=str(r.get("body") or ""),
+                    reviewer=str((r.get("user") or {}).get("login") or ""),
+                    created_at=created,
+                )
+            )
+        # Stable order: oldest first so the agent sees them in posting order.
+        out.sort(key=lambda c: c.created_at)
+        return out
+
+    # -- driver --------------------------------------------------------
+
+    def tick(self, repo: str, issue_number: int) -> list[StageReport]:
+        """Advance every stage that can advance, in order.
+
+        Returns the per-stage reports collected during the tick.  A stage
+        that returns ``WAITING`` short-circuits the remaining stages so
+        the operator can act before the pipeline burns budget on a stage
+        that cannot succeed yet.
+        """
+        reports: list[StageReport] = []
+        for stage_fn in (
+            self.tick_plan,
+            self.tick_approval,
+            self.tick_pr_open,
+            self.tick_pr_revise,
+        ):
+            report = stage_fn(repo, issue_number)
+            reports.append(report)
+            if report.outcome in (
+                StageOutcome.WAITING,
+                StageOutcome.SKIPPED,
+                StageOutcome.ERROR,
+            ):
+                break
+        return reports
+
+    # -- trace ---------------------------------------------------------
+
+    def trace(self, repo: str, issue_number: int) -> PipelineTrace:
+        """Return the current pipeline state for ``bernstein issue-to-pr trace``."""
+        comments = self.client.list_issue_comments(repo, issue_number)
+        sticky = find_sticky_comment(comments)
+        body = (sticky or {}).get("body") or ""
+        plan_posted = sticky is not None and has_marker(body, STAGE_PLAN_DONE_MARKER)
+        approved = has_marker(body, STAGE_APPROVED_MARKER)
+        pr_number = extract_pr_number(body)
+        last = extract_last_revise(body)
+        return PipelineTrace(
+            repo=repo,
+            issue_number=issue_number,
+            plan_posted=plan_posted,
+            approved=approved,
+            pr_number=pr_number,
+            last_revise_at=last[0] if last else None,
+        )
+
+
+__all__ = [
+    "APPROVAL_KEYWORD",
+    "STAGE_APPROVED_MARKER",
+    "STAGE_PLAN_DONE_MARKER",
+    "STAGE_PR_OPENED_MARKER",
+    "STAGE_PR_REVISED_MARKER",
+    "STICKY_MARKER",
+    "DiffGenerator",
+    "DiffProposal",
+    "InlineReviewComment",
+    "IssueContext",
+    "IssuePRClient",
+    "IssueToPRConfig",
+    "IssueToPRPipeline",
+    "PipelineTrace",
+    "PlanGenerator",
+    "PlanProposal",
+    "RepoRef",
+    "ReviseGenerator",
+    "Stage",
+    "StageOutcome",
+    "StageReport",
+    "Stages",
+    "Triggers",
+    "append_marker",
+    "build_plan_body",
+    "extract_last_revise",
+    "extract_pr_number",
+    "find_sticky_comment",
+    "has_marker",
+]

--- a/tests/unit/orchestration/test_issue_to_pr.py
+++ b/tests/unit/orchestration/test_issue_to_pr.py
@@ -1,0 +1,738 @@
+"""Unit tests for :mod:`bernstein.core.orchestration.issue_to_pr`.
+
+The suite exercises the four pipeline stages with a deterministic fake
+``gh`` runner.  No subprocess, no network, no filesystem access.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+from bernstein.core.orchestration.issue_to_pr import (
+    APPROVAL_KEYWORD,
+    STAGE_APPROVED_MARKER,
+    STAGE_PLAN_DONE_MARKER,
+    STAGE_PR_OPENED_MARKER,
+    STICKY_MARKER,
+    DiffProposal,
+    InlineReviewComment,
+    IssueContext,
+    IssuePRClient,
+    IssueToPRConfig,
+    IssueToPRPipeline,
+    PlanProposal,
+    RepoRef,
+    Stage,
+    StageOutcome,
+    Stages,
+    Triggers,
+    append_marker,
+    build_plan_body,
+    extract_pr_number,
+    find_sticky_comment,
+)
+
+# ---------------------------------------------------------------------------
+# Fake ``gh`` runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeRunner:
+    """Stub for the ``gh`` CLI; routes args to in-memory state."""
+
+    issue: dict[str, Any] = field(default_factory=dict)
+    comments: list[dict[str, Any]] = field(default_factory=list)
+    reactions_on_comment: dict[int, list[dict[str, Any]]] = field(default_factory=dict)
+    review_comments: list[dict[str, Any]] = field(default_factory=list)
+    next_comment_id: int = 1000
+    next_pr_number: int = 4242
+    posted_comments: list[dict[str, Any]] = field(default_factory=list)
+    patched_comments: list[dict[str, Any]] = field(default_factory=list)
+    opened_prs: list[dict[str, Any]] = field(default_factory=list)
+    fail_post: bool = False
+
+    def __call__(
+        self,
+        args: list[str],
+        stdin: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return self._dispatch(args, stdin)
+
+    def _ok(self, body: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=0,
+            stdout=json.dumps(body),
+            stderr="",
+        )
+
+    def _fail(self, code: int = 1) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["gh"],
+            returncode=code,
+            stdout="",
+            stderr="boom",
+        )
+
+    def _dispatch(
+        self,
+        args: list[str],
+        stdin: str | None,
+    ) -> subprocess.CompletedProcess[str]:
+        # args is like ["api", "-X", "POST", ...] or ["api", "<url>"]
+        # Strip leading "-H accept" pairs to keep the matcher simple.
+        cleaned: list[str] = []
+        skip = 0
+        for _i, a in enumerate(args):
+            if skip > 0:
+                skip -= 1
+                continue
+            if a == "-H":
+                skip = 1
+                continue
+            cleaned.append(a)
+        method = "GET"
+        if "-X" in cleaned:
+            idx = cleaned.index("-X")
+            method = cleaned[idx + 1]
+            cleaned = cleaned[:idx] + cleaned[idx + 2 :]
+        # Drop --input - if present.
+        if "--input" in cleaned:
+            idx = cleaned.index("--input")
+            cleaned = cleaned[:idx] + cleaned[idx + 2 :]
+        # cleaned == ["api", "<path>"]
+        if len(cleaned) < 2 or cleaned[0] != "api":
+            return self._fail()
+        path = cleaned[1]
+        return self._route(method, path, stdin)
+
+    def _route(
+        self,
+        method: str,
+        path: str,
+        stdin: str | None,
+    ) -> subprocess.CompletedProcess[str]:
+        # Issue body: repos/<owner>/<repo>/issues/<number>
+        if (
+            method == "GET"
+            and path.startswith("repos/")
+            and "/issues/" in path
+            and "/comments" not in path
+            and "/reactions" not in path
+        ):
+            return self._ok(self.issue)
+        if method == "GET" and "/issues/" in path and path.endswith("/comments?per_page=100"):
+            return self._ok(self.comments)
+        if method == "GET" and "/issues/comments/" in path and "/reactions" in path:
+            cid = int(path.split("/issues/comments/")[1].split("/")[0])
+            return self._ok(self.reactions_on_comment.get(cid, []))
+        if method == "POST" and "/issues/" in path and path.endswith("/comments"):
+            if self.fail_post:
+                return self._fail()
+            payload = json.loads(stdin or "{}")
+            cid = self.next_comment_id
+            self.next_comment_id += 1
+            entry = {"id": cid, "body": payload.get("body", ""), "user": {"login": "bot"}}
+            self.comments.append(entry)
+            self.posted_comments.append(entry)
+            return self._ok(entry)
+        if method == "PATCH" and path.startswith("repos/") and "/issues/comments/" in path:
+            cid = int(path.rsplit("/", 1)[-1])
+            payload = json.loads(stdin or "{}")
+            self.patched_comments.append({"id": cid, "body": payload.get("body", "")})
+            for c in self.comments:
+                if c.get("id") == cid:
+                    c["body"] = payload.get("body", "")
+            return self._ok({"id": cid})
+        if method == "GET" and "/pulls/" in path and path.endswith("/comments?per_page=100"):
+            return self._ok(self.review_comments)
+        if method == "POST" and path.startswith("repos/") and path.endswith("/pulls"):
+            payload = json.loads(stdin or "{}")
+            pr = {"number": self.next_pr_number, **payload}
+            self.next_pr_number += 1
+            self.opened_prs.append(pr)
+            return self._ok(pr)
+        return self._fail()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    number: int = 7,
+    *,
+    title: str = "Add foo",
+    body: str = "Please add foo.",
+    author: str = "alice",
+    labels: tuple[str, ...] = ("ai-welcome",),
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "user": {"login": author},
+        "labels": [{"name": l} for l in labels],
+    }
+
+
+def _plan_gen(ctx: IssueContext) -> PlanProposal:
+    return PlanProposal(
+        markdown=f"Plan for {ctx.title}",
+        branch=f"bernstein/issue-{ctx.number}",
+        commit_message=f"feat: resolve #{ctx.number}",
+    )
+
+
+def _diff_gen(ctx: IssueContext, plan: PlanProposal) -> DiffProposal:
+    return DiffProposal(
+        patch="diff --git a/x b/x\n",
+        branch=plan.branch,
+        commit_message=f"feat: resolve #{ctx.number}",
+        base="main",
+    )
+
+
+def _empty_diff_gen(ctx: IssueContext, plan: PlanProposal) -> DiffProposal:
+    return DiffProposal(patch="", branch=plan.branch, commit_message="", base="main")
+
+
+def _revise_gen(
+    ctx: IssueContext,
+    pr_number: int,
+    comments: list[InlineReviewComment],
+) -> DiffProposal:
+    body = "\n".join(c.body for c in comments)
+    return DiffProposal(
+        patch=f"diff for {body[:20]}\n",
+        branch=f"bernstein/issue-{ctx.number}",
+        commit_message=f"fixup: address {len(comments)} review comments",
+        base="main",
+    )
+
+
+def _apply_diff_ok(d: DiffProposal) -> str:
+    return "deadbeef"
+
+
+def _apply_diff_raise(d: DiffProposal) -> str:
+    raise RuntimeError("push failed")
+
+
+def _pipeline(
+    runner: FakeRunner,
+    *,
+    plan_generator=_plan_gen,
+    diff_generator=_diff_gen,
+    revise_generator=_revise_gen,
+    apply_diff=_apply_diff_ok,
+    triggers: Triggers | None = None,
+    stages: Stages | None = None,
+    repos: tuple[RepoRef, ...] = (),
+) -> IssueToPRPipeline:
+    config = IssueToPRConfig(
+        repos=repos,
+        triggers=triggers or Triggers(label_required="ai-welcome"),
+        stages=stages or Stages(plan_comment_required_approval=True),
+    )
+    return IssueToPRPipeline(
+        config=config,
+        client=IssuePRClient(runner=runner),
+        plan_generator=plan_generator,
+        diff_generator=diff_generator,
+        revise_generator=revise_generator,
+        apply_diff=apply_diff,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+
+def test_config_from_mapping_full_payload() -> None:
+    cfg = IssueToPRConfig.from_mapping(
+        {
+            "repos": [{"owner": "acme", "name": "web"}, {"owner": "acme", "name": "api"}],
+            "triggers": {
+                "label_required": "ai-welcome",
+                "author_allow_list": ["alice", "bob"],
+            },
+            "stages": {
+                "plan_comment_required_approval": False,
+                "draft_pr_default": False,
+                "approval_keyword": "[ship-it]",
+                "revise_quiet_window_s": 30,
+            },
+        }
+    )
+    assert cfg.repos == (RepoRef("acme", "web"), RepoRef("acme", "api"))
+    assert cfg.triggers.label_required == "ai-welcome"
+    assert cfg.triggers.author_allow_list == ("alice", "bob")
+    assert cfg.stages.plan_comment_required_approval is False
+    assert cfg.stages.draft_pr_default is False
+    assert cfg.stages.approval_keyword == "[ship-it]"
+    assert cfg.stages.revise_quiet_window_s == 30.0
+
+
+def test_config_from_mapping_defaults_for_missing_keys() -> None:
+    cfg = IssueToPRConfig.from_mapping(None)
+    assert cfg.repos == ()
+    assert cfg.triggers.label_required is None
+    assert cfg.stages.draft_pr_default is True
+    assert cfg.stages.approval_keyword == APPROVAL_KEYWORD
+
+
+def test_config_from_mapping_drops_malformed_repos() -> None:
+    cfg = IssueToPRConfig.from_mapping({"repos": [{"owner": "acme"}, "garbage", {"owner": "a", "name": "b"}]})
+    assert cfg.repos == (RepoRef("a", "b"),)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_plan_body_embeds_sticky_and_plan_markers() -> None:
+    out = build_plan_body("Hello plan")
+    assert STICKY_MARKER in out
+    assert STAGE_PLAN_DONE_MARKER in out
+    assert "Hello plan" in out
+
+
+def test_find_sticky_comment_returns_first_match() -> None:
+    comments = [
+        {"id": 1, "body": "unrelated"},
+        {"id": 2, "body": f"{STICKY_MARKER}\nplan"},
+        {"id": 3, "body": f"{STICKY_MARKER} also sticky"},
+    ]
+    sticky = find_sticky_comment(comments)
+    assert sticky is not None
+    assert sticky["id"] == 2
+
+
+def test_extract_pr_number_roundtrip() -> None:
+    body = f"sticky\n{STAGE_PR_OPENED_MARKER.format(pr_number=99)}\n"
+    assert extract_pr_number(body) == 99
+
+
+def test_extract_pr_number_returns_none_when_missing() -> None:
+    assert extract_pr_number("sticky") is None
+
+
+def test_append_marker_is_idempotent() -> None:
+    body = "abc"
+    once = append_marker(body, STAGE_APPROVED_MARKER)
+    twice = append_marker(once, STAGE_APPROVED_MARKER)
+    assert once == twice
+    assert STAGE_APPROVED_MARKER in once
+
+
+# ---------------------------------------------------------------------------
+# Stage: plan
+# ---------------------------------------------------------------------------
+
+
+def test_tick_plan_posts_sticky_comment_first_run() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(runner)
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.stage is Stage.PLAN
+    assert report.outcome is StageOutcome.ADVANCED
+    assert len(runner.posted_comments) == 1
+    body = runner.posted_comments[0]["body"]
+    assert STICKY_MARKER in body
+    assert STAGE_PLAN_DONE_MARKER in body
+
+
+def test_tick_plan_is_idempotent_when_sticky_present() -> None:
+    sticky_body = build_plan_body("existing plan")
+    runner = FakeRunner(
+        issue=_issue(),
+        comments=[{"id": 11, "body": sticky_body, "user": {"login": "bot"}}],
+    )
+    pipe = _pipeline(runner)
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.ALREADY_DONE
+    assert runner.posted_comments == []
+
+
+def test_tick_plan_skipped_when_label_missing() -> None:
+    runner = FakeRunner(issue=_issue(labels=("bug",)))
+    pipe = _pipeline(runner)
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.SKIPPED
+    assert "missing required label" in report.detail
+
+
+def test_tick_plan_skipped_when_author_not_in_allow_list() -> None:
+    runner = FakeRunner(issue=_issue(author="mallory"))
+    pipe = _pipeline(
+        runner,
+        triggers=Triggers(label_required="ai-welcome", author_allow_list=("alice",)),
+    )
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.SKIPPED
+    assert "mallory" in report.detail
+
+
+def test_tick_plan_skipped_when_repo_not_in_allow_list() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(runner, repos=(RepoRef("other", "x"),))
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.SKIPPED
+
+
+def test_tick_plan_error_when_issue_payload_empty() -> None:
+    runner = FakeRunner(issue={})
+    pipe = _pipeline(runner)
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.ERROR
+
+
+def test_tick_plan_error_when_post_fails() -> None:
+    runner = FakeRunner(issue=_issue(), fail_post=True)
+    pipe = _pipeline(runner)
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.ERROR
+
+
+def test_tick_plan_error_when_generator_missing() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(runner, plan_generator=None)
+    report = pipe.tick_plan("acme/web", 7)
+    assert report.outcome is StageOutcome.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Stage: approval
+# ---------------------------------------------------------------------------
+
+
+def test_tick_approval_waiting_without_plan_comment() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(runner)
+    report = pipe.tick_approval("acme/web", 7)
+    assert report.outcome is StageOutcome.WAITING
+
+
+def test_tick_approval_advances_when_keyword_seen_from_allow_list_user() -> None:
+    sticky_body = build_plan_body("plan body")
+    sticky = {"id": 50, "body": sticky_body, "user": {"login": "bot"}}
+    approval = {"id": 51, "body": APPROVAL_KEYWORD, "user": {"login": "alice"}}
+    runner = FakeRunner(issue=_issue(), comments=[sticky, approval])
+    pipe = _pipeline(
+        runner,
+        triggers=Triggers(label_required="ai-welcome", author_allow_list=("alice",)),
+    )
+    report = pipe.tick_approval("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+    # Marker should now appear in the patched body.
+    assert any(STAGE_APPROVED_MARKER in p["body"] for p in runner.patched_comments)
+
+
+def test_tick_approval_ignores_keyword_from_unlisted_user() -> None:
+    sticky_body = build_plan_body("plan body")
+    sticky = {"id": 60, "body": sticky_body, "user": {"login": "bot"}}
+    approval = {"id": 61, "body": APPROVAL_KEYWORD, "user": {"login": "mallory"}}
+    runner = FakeRunner(issue=_issue(), comments=[sticky, approval])
+    pipe = _pipeline(
+        runner,
+        triggers=Triggers(label_required="ai-welcome", author_allow_list=("alice",)),
+    )
+    report = pipe.tick_approval("acme/web", 7)
+    assert report.outcome is StageOutcome.WAITING
+
+
+def test_tick_approval_advances_when_thumbs_up_seen() -> None:
+    sticky_body = build_plan_body("plan body")
+    sticky = {"id": 70, "body": sticky_body, "user": {"login": "bot"}}
+    runner = FakeRunner(
+        issue=_issue(),
+        comments=[sticky],
+        reactions_on_comment={70: [{"content": "+1", "user": {"login": "alice"}}]},
+    )
+    pipe = _pipeline(
+        runner,
+        triggers=Triggers(label_required="ai-welcome", author_allow_list=("alice",)),
+    )
+    report = pipe.tick_approval("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+
+
+def test_tick_approval_already_done_when_marker_present() -> None:
+    body = build_plan_body("plan") + "\n" + STAGE_APPROVED_MARKER + "\n"
+    sticky = {"id": 71, "body": body, "user": {"login": "bot"}}
+    runner = FakeRunner(issue=_issue(), comments=[sticky])
+    pipe = _pipeline(runner)
+    report = pipe.tick_approval("acme/web", 7)
+    assert report.outcome is StageOutcome.ALREADY_DONE
+
+
+def test_tick_approval_advances_when_approval_not_required() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(
+        runner,
+        stages=Stages(plan_comment_required_approval=False),
+    )
+    report = pipe.tick_approval("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+
+
+# ---------------------------------------------------------------------------
+# Stage: pr_open
+# ---------------------------------------------------------------------------
+
+
+def _approved_sticky(comment_id: int = 90) -> dict[str, Any]:
+    body = build_plan_body("plan") + STAGE_APPROVED_MARKER + "\n"
+    return {"id": comment_id, "body": body, "user": {"login": "bot"}}
+
+
+def test_tick_pr_open_opens_draft_pr() -> None:
+    runner = FakeRunner(issue=_issue(), comments=[_approved_sticky()])
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_open("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+    assert report.pr_number is not None
+    assert runner.opened_prs[0]["draft"] is True
+    # Sticky body now carries the pr-open marker.
+    last_patch = runner.patched_comments[-1]
+    assert f"pr={report.pr_number}" in last_patch["body"]
+
+
+def test_tick_pr_open_waits_when_approval_marker_missing() -> None:
+    sticky = {"id": 91, "body": build_plan_body("plan"), "user": {"login": "bot"}}
+    runner = FakeRunner(issue=_issue(), comments=[sticky])
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_open("acme/web", 7)
+    assert report.outcome is StageOutcome.WAITING
+
+
+def test_tick_pr_open_idempotent_when_pr_marker_present() -> None:
+    body = build_plan_body("plan") + STAGE_APPROVED_MARKER + "\n" + STAGE_PR_OPENED_MARKER.format(pr_number=321) + "\n"
+    sticky = {"id": 95, "body": body, "user": {"login": "bot"}}
+    runner = FakeRunner(issue=_issue(), comments=[sticky])
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_open("acme/web", 7)
+    assert report.outcome is StageOutcome.ALREADY_DONE
+    assert report.pr_number == 321
+    assert runner.opened_prs == []
+
+
+def test_tick_pr_open_waits_on_empty_diff() -> None:
+    runner = FakeRunner(issue=_issue(), comments=[_approved_sticky()])
+    pipe = _pipeline(runner, diff_generator=_empty_diff_gen)
+    report = pipe.tick_pr_open("acme/web", 7)
+    assert report.outcome is StageOutcome.WAITING
+    assert runner.opened_prs == []
+
+
+def test_tick_pr_open_surfaces_apply_diff_failure_as_error() -> None:
+    runner = FakeRunner(issue=_issue(), comments=[_approved_sticky()])
+    pipe = _pipeline(runner, apply_diff=_apply_diff_raise)
+    report = pipe.tick_pr_open("acme/web", 7)
+    assert report.outcome is StageOutcome.ERROR
+    assert "push failed" in report.detail
+    assert runner.opened_prs == []
+
+
+def test_tick_pr_open_respects_non_draft_setting() -> None:
+    runner = FakeRunner(issue=_issue(), comments=[_approved_sticky()])
+    pipe = _pipeline(
+        runner,
+        stages=Stages(
+            plan_comment_required_approval=True,
+            draft_pr_default=False,
+        ),
+    )
+    report = pipe.tick_pr_open("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+    assert runner.opened_prs[0]["draft"] is False
+
+
+# ---------------------------------------------------------------------------
+# Stage: pr_revise
+# ---------------------------------------------------------------------------
+
+
+def _sticky_with_pr(pr_number: int = 123, comment_id: int = 200) -> dict[str, Any]:
+    body = (
+        build_plan_body("plan")
+        + STAGE_APPROVED_MARKER
+        + "\n"
+        + STAGE_PR_OPENED_MARKER.format(pr_number=pr_number)
+        + "\n"
+    )
+    return {"id": comment_id, "body": body, "user": {"login": "bot"}}
+
+
+def test_tick_pr_revise_no_new_comments() -> None:
+    runner = FakeRunner(
+        issue=_issue(),
+        comments=[_sticky_with_pr()],
+        review_comments=[],
+    )
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_revise("acme/web", 7)
+    assert report.outcome is StageOutcome.ALREADY_DONE
+
+
+def test_tick_pr_revise_advances_on_new_comment_and_records_marker() -> None:
+    sticky = _sticky_with_pr()
+    review_comments = [
+        {
+            "id": 9001,
+            "path": "src/x.py",
+            "line": 12,
+            "body": "use a constant",
+            "user": {"login": "carol"},
+            "created_at": "2026-05-19T12:00:00Z",
+        },
+    ]
+    runner = FakeRunner(
+        issue=_issue(),
+        comments=[sticky],
+        review_comments=review_comments,
+    )
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_revise("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+    assert report.pr_number == 123
+    last_body = runner.patched_comments[-1]["body"]
+    assert "stage:pr-revise:last=2026-05-19T12:00:00Z" in last_body
+    assert "sha=deadbeef" in last_body
+
+
+def test_tick_pr_revise_filters_old_comments() -> None:
+    body = (
+        build_plan_body("plan")
+        + STAGE_APPROVED_MARKER
+        + "\n"
+        + STAGE_PR_OPENED_MARKER.format(pr_number=123)
+        + "\n<!-- stage:pr-revise:last=2026-05-19T11:00:00Z sha=cafefade -->\n"
+    )
+    sticky = {"id": 250, "body": body, "user": {"login": "bot"}}
+    review_comments = [
+        {
+            "id": 9001,
+            "path": "src/x.py",
+            "line": 12,
+            "body": "stale comment",
+            "user": {"login": "carol"},
+            "created_at": "2026-05-19T10:00:00Z",
+        },
+        {
+            "id": 9002,
+            "path": "src/x.py",
+            "line": 13,
+            "body": "fresh comment",
+            "user": {"login": "carol"},
+            "created_at": "2026-05-19T12:00:00Z",
+        },
+    ]
+    runner = FakeRunner(
+        issue=_issue(),
+        comments=[sticky],
+        review_comments=review_comments,
+    )
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_revise("acme/web", 7)
+    assert report.outcome is StageOutcome.ADVANCED
+    last_body = runner.patched_comments[-1]["body"]
+    assert "last=2026-05-19T12:00:00Z" in last_body
+    # Old marker replaced, not stacked.
+    assert last_body.count("stage:pr-revise:last=") == 1
+
+
+def test_tick_pr_revise_waits_when_pr_not_opened() -> None:
+    sticky = {
+        "id": 260,
+        "body": build_plan_body("plan") + STAGE_APPROVED_MARKER + "\n",
+        "user": {"login": "bot"},
+    }
+    runner = FakeRunner(issue=_issue(), comments=[sticky])
+    pipe = _pipeline(runner)
+    report = pipe.tick_pr_revise("acme/web", 7)
+    assert report.outcome is StageOutcome.WAITING
+
+
+def test_tick_pr_revise_surfaces_apply_diff_failure() -> None:
+    sticky = _sticky_with_pr()
+    review_comments = [
+        {
+            "id": 9001,
+            "path": "src/x.py",
+            "line": 12,
+            "body": "use a constant",
+            "user": {"login": "carol"},
+            "created_at": "2026-05-19T12:00:00Z",
+        },
+    ]
+    runner = FakeRunner(
+        issue=_issue(),
+        comments=[sticky],
+        review_comments=review_comments,
+    )
+    pipe = _pipeline(runner, apply_diff=_apply_diff_raise)
+    report = pipe.tick_pr_revise("acme/web", 7)
+    assert report.outcome is StageOutcome.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Driver and trace
+# ---------------------------------------------------------------------------
+
+
+def test_tick_drives_first_run_and_stops_at_approval_waiting() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(runner)
+    reports = pipe.tick("acme/web", 7)
+    # plan advances, approval waits, remaining stages never run.
+    assert [r.stage for r in reports] == [Stage.PLAN, Stage.APPROVAL]
+    assert reports[0].outcome is StageOutcome.ADVANCED
+    assert reports[1].outcome is StageOutcome.WAITING
+
+
+def test_tick_drives_full_pipeline_when_approval_not_required() -> None:
+    runner = FakeRunner(issue=_issue())
+    pipe = _pipeline(
+        runner,
+        stages=Stages(plan_comment_required_approval=False),
+    )
+    reports = pipe.tick("acme/web", 7)
+    stages = [r.stage for r in reports]
+    assert Stage.PLAN in stages
+    assert Stage.APPROVAL in stages
+    assert Stage.PR_OPEN in stages
+    assert Stage.PR_REVISE in stages
+
+
+def test_trace_reports_progress() -> None:
+    sticky = _sticky_with_pr(pr_number=555, comment_id=999)
+    runner = FakeRunner(issue=_issue(), comments=[sticky])
+    pipe = _pipeline(runner)
+    trace = pipe.trace("acme/web", 7)
+    assert trace.repo == "acme/web"
+    assert trace.issue_number == 7
+    assert trace.plan_posted is True
+    assert trace.approved is True
+    assert trace.pr_number == 555
+    rendered = trace.render()
+    assert "pr_number:      555" in rendered
+    assert "approved:       True" in rendered
+
+
+def test_trace_handles_missing_state() -> None:
+    runner = FakeRunner(issue=_issue(), comments=[])
+    pipe = _pipeline(runner)
+    trace = pipe.trace("acme/web", 7)
+    assert trace.plan_posted is False
+    assert trace.approved is False
+    assert trace.pr_number is None
+    assert trace.last_revise_at is None


### PR DESCRIPTION
## Summary

- Adds `IssueToPRPipeline`: a four-stage orchestration (`plan` -> `approval` -> `pr_open` -> `pr_revise`) that converts a GitHub issue into a draft PR and revises that PR from inline review comments.
- State markers are HTML comments embedded inside the sticky plan comment, so progress is fully recoverable from GitHub alone (no sidecar database) and re-running any stage is a no-op.
- Agent-side plan and diff generation are injected via three callables plus an `apply_diff` hook, so the pipeline does not import the autofix daemon or any specific CLI adapter.
- The pipeline never auto-merges the resulting PR; merge gating stays with the operator.

## Public surface

- `src/bernstein/core/orchestration/issue_to_pr.py` - pipeline, config, thin `gh` CLI wrapper, marker helpers, trace primitive.
- `bernstein issue-to-pr trace --repo <owner>/<repo> <issue_id>` - read-only state inspection.
- `orchestration.issue_to_pr` block in `bernstein.yaml` (repos, triggers, stages).
- `docs/orchestration/issue-to-pr.md` - setup steps, config reference, marker reference.

## Test plan

- [x] `pytest tests/unit/orchestration/test_issue_to_pr.py` - 37 tests pass (config parsing, marker helpers, every stage covering advance/idempotent/waiting/skipped/error, driver, trace).
- [x] `pytest tests/unit/orchestration/` - 171 tests pass (no regressions).
- [x] `pytest tests/unit/cli/` - 90 pass / 1 skip (CLI registration intact).
- [x] `ruff check` and `ruff format` clean on the new files.
- [x] `mypy` clean on `src/bernstein/core/orchestration/issue_to_pr.py` (pre-existing unrelated errors elsewhere in the tree are untouched).
- [x] `bernstein issue-to-pr --help` and `bernstein issue-to-pr trace --help` render the expected text.

## Summary by Sourcery

Introduce an issue-to-PR orchestration pipeline that converts GitHub issues into draft PRs and supports revision from inline review comments, with CLI and documentation support.

New Features:
- Add an IssueToPRPipeline orchestration that progresses issues through plan, approval, PR open, and PR revise stages using GitHub comments and markers as state.
- Expose a thin GitHub CLI wrapper and configuration model to drive the issue-to-PR pipeline across selected repositories.
- Provide a read-only `bernstein issue-to-pr trace` CLI command to inspect pipeline state for a given issue.
- Document setup, configuration, state markers, and usage of the issue-to-PR pipeline in new orchestration docs.

Enhancements:
- Register the new issue-to-pr command group in the main CLI entrypoint.
- Add a pipeline trace primitive to summarise per-issue progression through the orchestration stages.

Tests:
- Add a comprehensive unit test suite for the issue-to-PR orchestration, covering configuration parsing, helpers, all pipeline stages, driver behaviour, and trace reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Issue → PR orchestration pipeline supporting multi-stage workflow (plan proposal, approval gating, draft PR creation, and revision cycles).
  * Added `bernstein issue-to-pr trace` CLI command to monitor orchestration pipeline progress and status for GitHub issues.
  * Configuration support for repo allowlists, trigger rules, and stage toggles via `bernstein.yaml`.

* **Documentation**
  * Added comprehensive guide documenting pipeline stages, configuration schema, and setup requirements.

* **Tests**
  * Added unit test coverage for orchestration pipeline logic and state tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->