### PR TITLE
feat(trackers): webhook ingestion receiver with replay protection

### DIFF
--- a/docs/trackers/webhooks.md
+++ b/docs/trackers/webhooks.md
@@ -1,0 +1,114 @@
+# Tracker webhook ingestion
+
+Bernstein can ingest tracker events via inbound webhooks instead of (or
+alongside) the polling loop. Polling stays the default; webhook
+ingestion is opt-in per adapter via `bernstein.yaml`.
+
+The receiver verifies the per-tracker HMAC signature, deduplicates
+deliveries using a bounded in-memory + on-disk ledger, and produces the
+same normalised `Ticket` objects the polling path emits. The result
+feeds into the orchestrator's existing task queue without code changes
+downstream.
+
+## Why webhooks
+
+Polling intervals between 30 seconds and five minutes cap the time
+between a tracker change and a Bernstein response. Webhooks remove that
+floor and free a portion of the tracker's rate-limit budget that polling
+spent on no-op fetches.
+
+## Configuration
+
+Add a `webhook` block under the tracker entry in `bernstein.yaml`:
+
+```yaml
+trackers:
+  jira_cloud:
+    webhook:
+      enabled: true
+      secret_env: JIRA_CLOUD_WEBHOOK_SECRET
+      public_url_base: https://bernstein.example.com
+```
+
+| Key               | Required | Description |
+|-------------------|----------|-------------|
+| `enabled`         | yes      | When `false`, the route returns 503 so the tracker stops retrying. |
+| `secret_env`      | yes      | Environment variable holding the shared HMAC secret. Resolved at request time so secret rotation does not require a restart. |
+| `public_url_base` | advisory | Reverse-proxy URL operators register with the tracker. Documented here so the operator can paste it into the tracker UI. |
+
+The webhook endpoint is `POST /webhooks/trackers/<adapter_name>` where
+`<adapter_name>` is the short tracker name (`jira_cloud`, `github`,
+`gitlab`, `linear`, `plane`, ...).
+
+## Supported trackers
+
+Built-in handlers ship for:
+
+| Adapter      | Verification header               | Delivery-id header                  |
+|--------------|-----------------------------------|-------------------------------------|
+| `jira_cloud` | `X-Hub-Signature-256` (HMAC-SHA256, `sha256=` prefix) | `X-Atlassian-Webhook-Identifier` |
+| `github`     | `X-Hub-Signature-256` (HMAC-SHA256, `sha256=` prefix) | `X-GitHub-Delivery`              |
+| `gitlab`     | `X-Gitlab-Token` (constant-time compare)              | `X-Gitlab-Event-UUID`            |
+| `linear`     | `Linear-Signature` (HMAC-SHA256, raw hex)             | `Linear-Delivery`                |
+| `plane`      | `X-Plane-Signature` (HMAC-SHA256, raw hex)            | `X-Plane-Delivery`               |
+
+Adapters that ship outside the core package can register handlers by
+calling
+`bernstein.core.trackers.webhook_receiver.register_handler(WebhookHandler(...))`
+during import.
+
+## Replay protection
+
+Each delivery is keyed by the tracker-provided delivery id (header above)
+or, when the tracker omits one, a SHA-256 of the raw body. The receiver
+keeps the last 4096 ids in memory and appends an entry to
+`.sdd/runtime/tracker_webhook_ledger.jsonl` so restarts do not lose
+replay state. Re-delivery returns HTTP 200 with `status: replay` so the
+tracker treats the duplicate as accepted without writing it through
+again.
+
+## Startup-poll recovery
+
+On boot the orchestrator may call
+`bernstein.core.trackers.webhook_receiver.replay_recent_via_poll` to
+catch events that the tracker tried to deliver while Bernstein was
+down. The helper runs a single poll, filters tickets older than the
+caller-supplied `last_processed_ts`, and feeds the rest into the same
+sink the webhook route uses. Adapters that do not populate
+`raw["updated_at"]` simply replay all open tickets, which is the safe
+default.
+
+## Reverse-proxy setup
+
+Most trackers require an HTTPS endpoint. Two patterns work today:
+
+### nginx / caddy
+
+Forward `https://bernstein.example.com/webhooks/trackers/<adapter>` to
+the bernstein server's `POST /webhooks/trackers/<adapter>` route. The
+receiver consumes the raw body, so any proxy that preserves bytes will
+work.
+
+### ngrok / cloudflared
+
+Operators running Bernstein on a laptop can use the existing tunnel
+subsystem. Start the tunnel (`bernstein preview`, or any tunnel
+provider registered under `bernstein.core.tunnels`) and paste the
+resulting public URL plus `/webhooks/trackers/<adapter>` into the
+tracker's webhook configuration UI.
+
+## Verifying a delivery locally
+
+```bash
+curl -sX POST http://localhost:8000/webhooks/trackers/github \
+  -H "x-github-event: issues" \
+  -H "x-github-delivery: $(uuidgen)" \
+  -H "x-hub-signature-256: sha256=$(python -c \
+       'import hmac,hashlib,sys; print(hmac.new(b"shh", sys.stdin.buffer.read(), hashlib.sha256).hexdigest())' \
+       < payload.json)" \
+  --data-binary @payload.json
+```
+
+A 200 response with `status: accepted` confirms verification, parsing,
+and dedup all succeeded. A 401 means the signature did not match; 503
+means the endpoint is disabled or the `secret_env` variable is empty.

--- a/src/bernstein/core/routes/tracker_webhooks.py
+++ b/src/bernstein/core/routes/tracker_webhooks.py
@@ -1,0 +1,125 @@
+"""FastAPI route for tracker webhook ingestion.
+
+Exposes ``POST /webhooks/trackers/<adapter_name>``.  The route delegates
+verification, parsing, and replay-protection to
+:class:`bernstein.core.trackers.webhook_receiver.WebhookReceiver` so the
+HTTP layer stays thin and the business logic stays unit-testable.
+
+Per-adapter configuration is loaded from ``bernstein.yaml`` under
+``trackers.<name>.webhook``:
+
+```yaml
+trackers:
+  jira_cloud:
+    webhook:
+      enabled: true
+      secret_env: JIRA_CLOUD_WEBHOOK_SECRET
+      public_url_base: https://bernstein.example.com
+```
+
+Polling remains the default; the webhook route is opt-in per adapter via
+``enabled: true`` and a configured ``secret_env`` that resolves to a
+non-empty value at request time.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from bernstein.core.trackers.webhook_receiver import (
+    ReceiveResult,
+    WebhookReceiver,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _get_receiver(request: Request) -> WebhookReceiver:
+    """Return the per-app :class:`WebhookReceiver`, constructing on demand.
+
+    The first call wires a default-configured receiver onto
+    ``app.state``.  Subsequent calls reuse the same instance so the
+    in-memory replay ledger stays warm across requests.
+    """
+
+    receiver = getattr(request.app.state, "tracker_webhook_receiver", None)
+    if receiver is None:
+        receiver = WebhookReceiver()
+        request.app.state.tracker_webhook_receiver = receiver
+    return receiver
+
+
+def _status_to_response(result: ReceiveResult) -> JSONResponse:
+    """Translate a :class:`ReceiveResult` into an HTTP response.
+
+    The status mapping is chosen so trackers stop retrying on permanent
+    rejections (4xx) and back off on transient ones (5xx).  ``replay``
+    returns 200 so the tracker treats the delivery as accepted without
+    creating a duplicate ticket downstream.
+    """
+
+    body = {"status": result.status, "delivery_id": result.delivery_id}
+    if result.status == "accepted":
+        return JSONResponse(status_code=200, content=body)
+    if result.status in {"replay", "ignored"}:
+        return JSONResponse(status_code=200, content=body)
+    if result.status == "unknown_adapter":
+        return JSONResponse(status_code=404, content=body)
+    if result.status in {"disabled", "not_configured"}:
+        return JSONResponse(status_code=503, content=body)
+    if result.status in {"bad_signature", "bad_payload"}:
+        return JSONResponse(status_code=401 if result.status == "bad_signature" else 400, content=body)
+    # Default to 500 for unexpected statuses so monitoring catches them.
+    return JSONResponse(status_code=500, content=body)
+
+
+@router.post("/webhooks/trackers/{adapter}", status_code=200)
+async def tracker_webhook(adapter: str, request: Request) -> JSONResponse:
+    """Receive a tracker webhook, verify, dedupe, and enqueue.
+
+    Path parameter:
+        adapter: Short adapter name registered via
+            :func:`bernstein.core.trackers.webhook_receiver.register_handler`.
+
+    The endpoint accepts any JSON object.  All verification and replay
+    decisions are made before the body is enqueued.  When verification
+    succeeds and the delivery is fresh the parsed
+    :class:`~bernstein.core.trackers.webhook_receiver.TrackerEvent` is
+    stashed on ``app.state.tracker_event_queue`` if present so the
+    orchestrator's normal task ingestion can drain it; if no queue is
+    wired we simply log the event.  Either way the tracker receives a
+    200 so it does not retry.
+    """
+
+    receiver = _get_receiver(request)
+    body = await request.body()
+    headers = {k: v for k, v in request.headers.items()}
+
+    result = receiver.receive(adapter, headers, body)
+
+    if result.status == "accepted" and result.event is not None:
+        queue = getattr(request.app.state, "tracker_event_queue", None)
+        if queue is not None:
+            try:
+                queue.put_nowait(result.event)
+            except Exception as exc:  # boundary
+                logger.warning(
+                    "Tracker webhook queue rejected event adapter=%s id=%s: %s",
+                    adapter,
+                    result.delivery_id,
+                    exc,
+                )
+        else:
+            logger.info(
+                "Tracker webhook accepted adapter=%s id=%s ticket=%s",
+                adapter,
+                result.delivery_id,
+                result.event.ticket.id,
+            )
+
+    return _status_to_response(result)

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -905,6 +905,9 @@ def create_app(
     from bernstein.core.routes.telemetry_webhooks import (
         router as telemetry_webhooks_router,
     )
+    from bernstein.core.routes.tracker_webhooks import (
+        router as tracker_webhooks_router,
+    )
     from bernstein.core.routes.webhooks import router as webhooks_router
     from bernstein.core.routes.workspace import router as workspace_router
 
@@ -1261,6 +1264,7 @@ def create_app(
         workspace_router,
         webhooks_router,
         telemetry_webhooks_router,
+        tracker_webhooks_router,
         discord_router,
         slack_router,
         costs_router,

--- a/src/bernstein/core/trackers/webhook_receiver.py
+++ b/src/bernstein/core/trackers/webhook_receiver.py
@@ -1,0 +1,771 @@
+"""Tracker webhook receiver.
+
+Inbound-webhook ingestion mode for tracker adapters. Trackers that
+support webhooks (Jira Cloud, GitHub, GitLab, Linear, Plane, ...) can
+push events to ``POST /webhooks/trackers/<adapter_name>`` which produces
+the same normalised ``Ticket`` objects the polling path emits.
+
+Polling remains the default and stays available; webhook ingestion is
+opt-in per adapter via ``bernstein.yaml: trackers.<name>.webhook``.
+
+Design notes:
+
+* Per-adapter handlers implement two pure functions:
+  ``verify_signature(headers, body, secret) -> bool`` and
+  ``parse_event(headers, payload) -> TrackerEvent | None``.  Both are
+  small and free of orchestrator dependencies so they can be unit-tested
+  without a live server.
+* Replay protection is layered.  In-memory: a bounded ordered-set of
+  recently seen delivery ids.  On-disk: an append-only JSONL ledger that
+  survives restarts.  The receiver checks both layers; a delivery id
+  found in either causes a 200 OK no-op response so trackers do not
+  retry indefinitely.
+* Recovery: ``replay_recent_via_poll`` runs a single poll at startup for
+  events newer than ``last_processed_ts`` so missed deliveries during
+  bernstein downtime are not lost.
+
+The module deliberately exposes small primitives.  The FastAPI route is
+in :mod:`bernstein.core.routes.tracker_webhooks` and is the only place
+that touches the running task store.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from bernstein.core.trackers.contract import RoutingHint, Ticket
+from bernstein.core.webhook_signatures import verify_hmac_sha256
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TrackerEvent:
+    """Normalised inbound tracker event.
+
+    ``ticket`` is the same dataclass produced by the polling path so the
+    orchestrator can feed events into the same downstream queue without
+    branching on transport.
+
+    Attributes:
+        adapter: Short adapter name (``jira_cloud``, ``github``, ...).
+        action: Event action (``created``, ``updated``, ``transitioned``).
+        ticket: Normalised ticket payload.
+        delivery_id: Stable per-delivery identifier used for replay
+            protection.  Falls back to a hash of the raw body when the
+            tracker does not send one.
+        received_ts: Unix seconds the receiver accepted the event.
+    """
+
+    adapter: str
+    action: str
+    ticket: Ticket
+    delivery_id: str
+    received_ts: float = field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# Handler protocol + registry
+# ---------------------------------------------------------------------------
+
+
+VerifyFn = Callable[[dict[str, str], bytes, str], bool]
+ParseFn = Callable[[dict[str, str], dict[str, Any]], "TrackerEvent | None"]
+DeliveryIdFn = Callable[[dict[str, str], bytes], str]
+
+
+@dataclass(frozen=True)
+class WebhookHandler:
+    """Per-adapter webhook handler bundle.
+
+    Each entry is a tiny pure-function trio so adapters can stay in their
+    own modules and unit-test their parsing without spinning up the
+    server.
+    """
+
+    adapter: str
+    verify_signature: VerifyFn
+    parse_event: ParseFn
+    delivery_id: DeliveryIdFn
+
+
+_HANDLERS: dict[str, WebhookHandler] = {}
+
+
+def register_handler(handler: WebhookHandler) -> None:
+    """Register a per-adapter webhook handler.
+
+    Re-registration with the same adapter name overwrites the previous
+    entry; this is useful for tests and for plugin reload.
+    """
+
+    _HANDLERS[handler.adapter] = handler
+
+
+def get_handler(adapter: str) -> WebhookHandler | None:
+    """Return the handler registered for ``adapter`` or ``None``."""
+
+    return _HANDLERS.get(adapter)
+
+
+def list_handlers() -> list[str]:
+    """Return the sorted list of currently registered adapter names."""
+
+    return sorted(_HANDLERS)
+
+
+# ---------------------------------------------------------------------------
+# Replay protection
+# ---------------------------------------------------------------------------
+
+
+class ReplayLedger:
+    """Bounded in-memory + on-disk ledger of seen delivery ids.
+
+    The in-memory layer is an ``OrderedDict`` capped at ``max_entries``;
+    on overflow the oldest delivery id is evicted.  The on-disk layer is
+    an append-only JSONL file that is loaded on construction so restarts
+    keep replay protection.  Writes are best-effort: a disk failure logs
+    a warning and falls back to the in-memory layer rather than rejecting
+    the inbound event (the alternative is losing legitimate webhooks).
+    """
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        max_entries: int = 4096,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._seen: OrderedDict[str, float] = OrderedDict()
+        self._max = max_entries
+        self._path = path
+        self._load_from_disk()
+
+    def _load_from_disk(self) -> None:
+        if self._path is None or not self._path.exists():
+            return
+        try:
+            with self._path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    delivery_id = entry.get("delivery_id")
+                    ts = entry.get("ts")
+                    if not isinstance(delivery_id, str) or not isinstance(ts, (int, float)):
+                        continue
+                    self._seen[delivery_id] = float(ts)
+                    self._seen.move_to_end(delivery_id)
+                    while len(self._seen) > self._max:
+                        self._seen.popitem(last=False)
+        except OSError as exc:
+            logger.warning("ReplayLedger: failed to load %s: %s", self._path, exc)
+
+    def seen(self, delivery_id: str) -> bool:
+        """Return ``True`` when ``delivery_id`` has already been recorded."""
+
+        with self._lock:
+            return delivery_id in self._seen
+
+    def remember(self, delivery_id: str, *, ts: float | None = None) -> bool:
+        """Record ``delivery_id``.  Return ``True`` if it was new.
+
+        The on-disk append is best-effort; failures log a warning but do
+        not raise so a transient disk error does not surface as a 5xx to
+        the tracker.
+        """
+
+        ts_value = float(ts if ts is not None else time.time())
+        with self._lock:
+            if delivery_id in self._seen:
+                # Refresh recency so the LRU keeps active deliveries hot.
+                self._seen.move_to_end(delivery_id)
+                return False
+            self._seen[delivery_id] = ts_value
+            while len(self._seen) > self._max:
+                self._seen.popitem(last=False)
+        if self._path is not None:
+            try:
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+                with self._path.open("a", encoding="utf-8") as fh:
+                    fh.write(json.dumps({"delivery_id": delivery_id, "ts": ts_value}) + "\n")
+            except OSError as exc:
+                logger.warning("ReplayLedger: append failed for %s: %s", self._path, exc)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Receiver
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WebhookConfig:
+    """Per-adapter webhook config loaded from ``bernstein.yaml``.
+
+    Attributes:
+        enabled: Whether the webhook endpoint accepts deliveries for this
+            adapter.  When ``False`` the receiver returns 503 so a tracker
+            stops retrying.
+        secret_env: Environment variable that holds the shared HMAC
+            secret.  The receiver looks the variable up at request time
+            so secret rotation does not require a process restart.
+        public_url_base: Reverse-proxy URL operators wire into the
+            tracker (advisory; consumed by docs, not by the receiver).
+    """
+
+    enabled: bool = False
+    secret_env: str = ""
+    public_url_base: str = ""
+
+
+class WebhookReceiver:
+    """Stateful receiver that turns inbound HTTP requests into ``TrackerEvent``.
+
+    The receiver owns a :class:`ReplayLedger` and a per-adapter
+    :class:`WebhookConfig` map.  Handlers live in the module-level
+    registry so adapter packages can register themselves at import time
+    without holding a reference to a singleton.
+    """
+
+    def __init__(
+        self,
+        *,
+        ledger: ReplayLedger | None = None,
+        configs: dict[str, WebhookConfig] | None = None,
+    ) -> None:
+        self._ledger = ledger or ReplayLedger()
+        self._configs: dict[str, WebhookConfig] = dict(configs or {})
+
+    @property
+    def ledger(self) -> ReplayLedger:
+        return self._ledger
+
+    def configure(self, adapter: str, config: WebhookConfig) -> None:
+        """Register or replace the webhook config for ``adapter``."""
+
+        self._configs[adapter] = config
+
+    def get_config(self, adapter: str) -> WebhookConfig:
+        """Return the webhook config for ``adapter`` (defaults to disabled)."""
+
+        return self._configs.get(adapter, WebhookConfig())
+
+    def receive(
+        self,
+        adapter: str,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> ReceiveResult:
+        """Verify, parse, and replay-check a single inbound delivery.
+
+        Returns a :class:`ReceiveResult`; the caller (FastAPI route)
+        renders the appropriate HTTP status.  This method is sync because
+        verification + parsing are CPU-only; the route is async so it can
+        delegate any I/O elsewhere.
+        """
+
+        handler = get_handler(adapter)
+        if handler is None:
+            return ReceiveResult(status="unknown_adapter")
+
+        config = self.get_config(adapter)
+        if not config.enabled:
+            return ReceiveResult(status="disabled")
+
+        secret = os.environ.get(config.secret_env, "") if config.secret_env else ""
+        if not secret:
+            return ReceiveResult(status="not_configured")
+
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+
+        if not handler.verify_signature(lower_headers, body, secret):
+            return ReceiveResult(status="bad_signature")
+
+        delivery_id = handler.delivery_id(lower_headers, body)
+        if self._ledger.seen(delivery_id):
+            return ReceiveResult(status="replay", delivery_id=delivery_id)
+
+        try:
+            payload = json.loads(body or b"{}")
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return ReceiveResult(status="bad_payload", delivery_id=delivery_id)
+
+        if not isinstance(payload, dict):
+            return ReceiveResult(status="bad_payload", delivery_id=delivery_id)
+
+        try:
+            event = handler.parse_event(lower_headers, payload)
+        except Exception as exc:  # boundary
+            logger.debug("Parser raised for adapter=%s: %s", adapter, exc)
+            return ReceiveResult(status="bad_payload", delivery_id=delivery_id)
+
+        # Record only after successful parse so a flaky parser does not
+        # poison the ledger and silently swallow legitimate retries.
+        self._ledger.remember(delivery_id)
+
+        if event is None:
+            return ReceiveResult(status="ignored", delivery_id=delivery_id)
+
+        # Parsers populate a best-effort delivery_id from header lookups
+        # but the receiver-side derivation is the source of truth.
+        canonical_event = (
+            event
+            if event.delivery_id == delivery_id
+            else TrackerEvent(
+                adapter=event.adapter,
+                action=event.action,
+                ticket=event.ticket,
+                delivery_id=delivery_id,
+                received_ts=event.received_ts,
+            )
+        )
+        return ReceiveResult(status="accepted", delivery_id=delivery_id, event=canonical_event)
+
+
+@dataclass(frozen=True)
+class ReceiveResult:
+    """Outcome of :meth:`WebhookReceiver.receive`."""
+
+    status: str
+    delivery_id: str | None = None
+    event: TrackerEvent | None = None
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers reused by per-adapter handlers
+# ---------------------------------------------------------------------------
+
+
+def _body_hash(body: bytes) -> str:
+    """Stable hash of the body used as a fallback delivery id."""
+
+    return hashlib.sha256(body).hexdigest()
+
+
+def _header(headers: dict[str, str], name: str) -> str:
+    return headers.get(name.lower(), "")
+
+
+# ---------------------------------------------------------------------------
+# Adapter implementations
+# ---------------------------------------------------------------------------
+
+
+# --- Jira Cloud ------------------------------------------------------------
+
+_JIRA_BROWSE_TMPL = "https://{domain}/browse/{key}"
+
+
+def _jira_cloud_verify(headers: dict[str, str], body: bytes, secret: str) -> bool:
+    # Jira Cloud's "Webhook secret" feature posts the secret in the
+    # standard Atlassian ``x-hub-signature`` header (HMAC-SHA256, hex,
+    # ``sha256=`` prefix), matching GitHub's convention.  Atlassian's
+    # docs accept either ``X-Hub-Signature`` or ``X-Atlassian-Webhook-Identifier``
+    # depending on integration kind; we accept both prefixes.
+    signature = _header(headers, "x-hub-signature-256") or _header(headers, "x-hub-signature")
+    if not signature:
+        return False
+    return verify_hmac_sha256(body, signature, secret, prefix="sha256=")
+
+
+def _jira_cloud_delivery_id(headers: dict[str, str], body: bytes) -> str:
+    delivery = _header(headers, "x-atlassian-webhook-identifier")
+    if delivery:
+        return f"jira_cloud:{delivery}"
+    return f"jira_cloud:{_body_hash(body)}"
+
+
+def _jira_cloud_parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEvent | None:
+    issue = payload.get("issue") or {}
+    key = str(issue.get("key") or "")
+    if not key:
+        return None
+    fields = issue.get("fields") or {}
+    status_obj = fields.get("status") or {}
+    status_name = str(status_obj.get("name") or "")
+    labels_raw = fields.get("labels") or []
+    labels = tuple(str(x) for x in labels_raw if x)
+    summary = str(fields.get("summary") or "")
+    description = fields.get("description")
+    # ADF blob (dict) is dropped here; downstream renderers consume the raw
+    # payload from ``ticket.raw`` if they need to surface formatted bodies.
+    body_text = "" if isinstance(description, dict) else str(description or "")
+    # Best-effort browse URL using the issue self link.
+    self_link = str(issue.get("self") or "")
+    domain = ""
+    if "://" in self_link:
+        domain = self_link.split("://", 1)[1].split("/", 1)[0]
+    external_url = _JIRA_BROWSE_TMPL.format(domain=domain, key=key) if domain else ""
+    ticket = Ticket(
+        id=key,
+        external_url=external_url,
+        title=summary,
+        body=body_text,
+        status=status_name,
+        labels=labels,
+        etag=None,
+        raw={"issue_id": str(issue.get("id") or ""), "key": key},
+    )
+    return TrackerEvent(
+        adapter="jira_cloud",
+        action=str(payload.get("webhookEvent") or "updated"),
+        ticket=ticket,
+        delivery_id=_jira_cloud_delivery_id(headers, b""),
+    )
+
+
+# --- GitHub ----------------------------------------------------------------
+
+
+def _github_verify(headers: dict[str, str], body: bytes, secret: str) -> bool:
+    signature = _header(headers, "x-hub-signature-256")
+    if not signature:
+        return False
+    return verify_hmac_sha256(body, signature, secret, prefix="sha256=")
+
+
+def _github_delivery_id(headers: dict[str, str], body: bytes) -> str:
+    delivery = _header(headers, "x-github-delivery")
+    if delivery:
+        return f"github:{delivery}"
+    return f"github:{_body_hash(body)}"
+
+
+def _github_parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEvent | None:
+    event_type = _header(headers, "x-github-event") or "unknown"
+    if event_type not in {"issues", "issue_comment", "pull_request"}:
+        return None
+    issue = payload.get("issue") or payload.get("pull_request") or {}
+    if not issue:
+        return None
+    issue_id = str(issue.get("id") or issue.get("node_id") or "")
+    number = issue.get("number")
+    repo = payload.get("repository") or {}
+    repo_full = str(repo.get("full_name") or "")
+    if number is not None and repo_full:
+        ticket_id = f"{repo_full}#{number}"
+    elif issue_id:
+        ticket_id = issue_id
+    else:
+        return None
+    external_url = str(issue.get("html_url") or "")
+    title = str(issue.get("title") or "")
+    body_text = str(issue.get("body") or "")
+    state = str(issue.get("state") or "")
+    labels_raw = issue.get("labels") or []
+    labels = tuple(str(x.get("name") if isinstance(x, dict) else x) for x in labels_raw if x)
+    ticket = Ticket(
+        id=ticket_id,
+        external_url=external_url,
+        title=title,
+        body=body_text,
+        status=state,
+        labels=labels,
+        raw={"repo": repo_full, "number": number, "issue_id": issue_id},
+    )
+    return TrackerEvent(
+        adapter="github",
+        action=str(payload.get("action") or event_type),
+        ticket=ticket,
+        delivery_id=_github_delivery_id(headers, b""),
+    )
+
+
+# --- GitLab ----------------------------------------------------------------
+
+
+def _gitlab_verify(headers: dict[str, str], body: bytes, secret: str) -> bool:
+    # GitLab posts the secret token verbatim in ``x-gitlab-token``.
+    # constant-time compare to avoid early-exit timing leakage.
+    del body
+    provided = _header(headers, "x-gitlab-token")
+    if not provided or not secret:
+        return False
+    return hmac.compare_digest(provided, secret)
+
+
+def _gitlab_delivery_id(headers: dict[str, str], body: bytes) -> str:
+    delivery = _header(headers, "x-gitlab-event-uuid")
+    if delivery:
+        return f"gitlab:{delivery}"
+    return f"gitlab:{_body_hash(body)}"
+
+
+def _gitlab_parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEvent | None:
+    kind = str(payload.get("object_kind") or "")
+    if kind not in {"issue", "note"}:
+        return None
+    attrs = payload.get("object_attributes") or {}
+    if kind == "note":
+        issue_obj = payload.get("issue") or {}
+        if not issue_obj:
+            return None
+        attrs = {**issue_obj, **{"action": attrs.get("action", "commented")}}
+    iid = attrs.get("iid")
+    project = payload.get("project") or {}
+    project_path = str(project.get("path_with_namespace") or project.get("name") or "")
+    if iid is None or not project_path:
+        return None
+    ticket_id = f"{project_path}#{iid}"
+    external_url = str(attrs.get("url") or "")
+    title = str(attrs.get("title") or "")
+    body_text = str(attrs.get("description") or "")
+    state = str(attrs.get("state") or attrs.get("status") or "")
+    labels_raw = payload.get("labels") or []
+    labels = tuple(str(x.get("title") if isinstance(x, dict) else x) for x in labels_raw if x)
+    ticket = Ticket(
+        id=ticket_id,
+        external_url=external_url,
+        title=title,
+        body=body_text,
+        status=state,
+        labels=labels,
+        raw={"project": project_path, "iid": iid},
+    )
+    return TrackerEvent(
+        adapter="gitlab",
+        action=str(attrs.get("action") or kind),
+        ticket=ticket,
+        delivery_id=_gitlab_delivery_id(headers, b""),
+    )
+
+
+# --- Linear ----------------------------------------------------------------
+
+
+def _linear_verify(headers: dict[str, str], body: bytes, secret: str) -> bool:
+    signature = _header(headers, "linear-signature")
+    if not signature:
+        return False
+    # Linear sends raw hex without prefix.
+    return verify_hmac_sha256(body, signature, secret, prefix="")
+
+
+def _linear_delivery_id(headers: dict[str, str], body: bytes) -> str:
+    # Linear sends ``linear-delivery`` on each event.
+    delivery = _header(headers, "linear-delivery")
+    if delivery:
+        return f"linear:{delivery}"
+    return f"linear:{_body_hash(body)}"
+
+
+def _linear_parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEvent | None:
+    data = payload.get("data") or {}
+    issue_id = str(data.get("id") or "")
+    if not issue_id:
+        return None
+    identifier = str(data.get("identifier") or issue_id)
+    title = str(data.get("title") or "")
+    body_text = str(data.get("description") or "")
+    state_obj = data.get("state") or {}
+    state_name = str(state_obj.get("name") or "")
+    labels_raw = data.get("labels") or []
+    if isinstance(labels_raw, dict):
+        # Linear webhook payloads sometimes wrap labels in ``{"nodes": [...]}``.
+        labels_raw = labels_raw.get("nodes") or []
+    labels = tuple(str(x.get("name") if isinstance(x, dict) else x) for x in labels_raw if x)
+    external_url = str(data.get("url") or "")
+    ticket = Ticket(
+        id=identifier,
+        external_url=external_url,
+        title=title,
+        body=body_text,
+        status=state_name,
+        labels=labels,
+        routing_hint=RoutingHint(),
+        raw={"id": issue_id, "identifier": identifier},
+    )
+    return TrackerEvent(
+        adapter="linear",
+        action=str(payload.get("action") or payload.get("type") or "updated"),
+        ticket=ticket,
+        delivery_id=_linear_delivery_id(headers, b""),
+    )
+
+
+# --- Plane -----------------------------------------------------------------
+
+
+def _plane_verify(headers: dict[str, str], body: bytes, secret: str) -> bool:
+    # Plane's webhook header is ``x-plane-signature`` carrying a hex
+    # HMAC-SHA256 of the raw body.  No prefix.
+    signature = _header(headers, "x-plane-signature")
+    if not signature:
+        return False
+    return verify_hmac_sha256(body, signature, secret, prefix="")
+
+
+def _plane_delivery_id(headers: dict[str, str], body: bytes) -> str:
+    delivery = _header(headers, "x-plane-delivery")
+    if delivery:
+        return f"plane:{delivery}"
+    return f"plane:{_body_hash(body)}"
+
+
+def _plane_parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEvent | None:
+    data = payload.get("data") or payload.get("issue") or {}
+    issue_id = str(data.get("id") or "")
+    if not issue_id:
+        return None
+    sequence_id = data.get("sequence_id")
+    project_id = str(data.get("project") or data.get("project_id") or "")
+    ticket_id = f"{project_id}#{sequence_id}" if project_id and sequence_id is not None else issue_id
+    title = str(data.get("name") or data.get("title") or "")
+    body_text = str(data.get("description_stripped") or data.get("description") or "")
+    state = str(data.get("state") or data.get("state_detail", {}).get("name") or "")
+    labels_raw = data.get("labels") or []
+    labels = tuple(str(x) for x in labels_raw if x)
+    external_url = str(data.get("url") or "")
+    ticket = Ticket(
+        id=ticket_id,
+        external_url=external_url,
+        title=title,
+        body=body_text,
+        status=state,
+        labels=labels,
+        raw={"id": issue_id, "project": project_id, "sequence_id": sequence_id},
+    )
+    return TrackerEvent(
+        adapter="plane",
+        action=str(payload.get("action") or payload.get("event") or "updated"),
+        ticket=ticket,
+        delivery_id=_plane_delivery_id(headers, b""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default handler registration
+# ---------------------------------------------------------------------------
+
+
+def register_builtin_handlers() -> None:
+    """Register the built-in tracker webhook handlers.
+
+    Idempotent — safe to call multiple times.  Adapter implementations
+    that ship outside the core package can register additional handlers
+    via :func:`register_handler` from their own ``__init__`` hooks.
+    """
+
+    register_handler(
+        WebhookHandler(
+            adapter="jira_cloud",
+            verify_signature=_jira_cloud_verify,
+            parse_event=_jira_cloud_parse,
+            delivery_id=_jira_cloud_delivery_id,
+        )
+    )
+    register_handler(
+        WebhookHandler(
+            adapter="github",
+            verify_signature=_github_verify,
+            parse_event=_github_parse,
+            delivery_id=_github_delivery_id,
+        )
+    )
+    register_handler(
+        WebhookHandler(
+            adapter="gitlab",
+            verify_signature=_gitlab_verify,
+            parse_event=_gitlab_parse,
+            delivery_id=_gitlab_delivery_id,
+        )
+    )
+    register_handler(
+        WebhookHandler(
+            adapter="linear",
+            verify_signature=_linear_verify,
+            parse_event=_linear_parse,
+            delivery_id=_linear_delivery_id,
+        )
+    )
+    register_handler(
+        WebhookHandler(
+            adapter="plane",
+            verify_signature=_plane_verify,
+            parse_event=_plane_parse,
+            delivery_id=_plane_delivery_id,
+        )
+    )
+
+
+# Register defaults at import time so the FastAPI route does not need to
+# coordinate ordering with the server bootstrap.
+register_builtin_handlers()
+
+
+# ---------------------------------------------------------------------------
+# Startup-poll recovery
+# ---------------------------------------------------------------------------
+
+
+def replay_recent_via_poll(
+    adapter: Any,
+    *,
+    last_processed_ts: float,
+    sink: Callable[[Ticket], None],
+    now: Callable[[], float] | None = None,
+) -> int:
+    """Poll once and feed any ticket newer than ``last_processed_ts`` to ``sink``.
+
+    Used at process start to catch events that the tracker tried to
+    deliver while bernstein was down.  The tracker adapter's
+    ``pull_open_tickets`` already paginates the upstream API, so we just
+    iterate and filter by an ``updated_at`` claim on the raw payload —
+    adapters that do not populate that field simply replay all open
+    tickets, which is the safe default.
+
+    Returns the number of tickets handed to ``sink``.
+    """
+
+    del now  # reserved for clock injection in tests; currently unused
+    count = 0
+    pull = getattr(adapter, "pull_open_tickets", None)
+    if pull is None:
+        return 0
+    for ticket in pull():
+        raw = getattr(ticket, "raw", None) or {}
+        ts_field = raw.get("updated_at") or raw.get("updatedAt")
+        if isinstance(ts_field, (int, float)) and ts_field <= last_processed_ts:
+            continue
+        sink(ticket)
+        count += 1
+    return count
+
+
+__all__ = [
+    "ReceiveResult",
+    "ReplayLedger",
+    "TrackerEvent",
+    "WebhookConfig",
+    "WebhookHandler",
+    "WebhookReceiver",
+    "get_handler",
+    "list_handlers",
+    "register_builtin_handlers",
+    "register_handler",
+    "replay_recent_via_poll",
+]

--- a/tests/unit/trackers/test_webhook_receiver.py
+++ b/tests/unit/trackers/test_webhook_receiver.py
@@ -1,0 +1,501 @@
+"""Tests for :mod:`bernstein.core.trackers.webhook_receiver`."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.trackers import Ticket
+from bernstein.core.trackers.webhook_receiver import (
+    ReceiveResult,
+    ReplayLedger,
+    TrackerEvent,
+    WebhookConfig,
+    WebhookHandler,
+    WebhookReceiver,
+    get_handler,
+    list_handlers,
+    register_builtin_handlers,
+    register_handler,
+    replay_recent_via_poll,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _hex_sig(secret: str, body: bytes) -> str:
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def _prefixed_sig(secret: str, body: bytes) -> str:
+    return "sha256=" + _hex_sig(secret, body)
+
+
+def _make_receiver(adapter: str, *, secret_env: str = "TEST_WH_SECRET") -> WebhookReceiver:
+    receiver = WebhookReceiver()
+    receiver.configure(adapter, WebhookConfig(enabled=True, secret_env=secret_env))
+    return receiver
+
+
+# ---------------------------------------------------------------------------
+# ReplayLedger
+# ---------------------------------------------------------------------------
+
+
+def test_replay_ledger_dedupes_in_memory() -> None:
+    ledger = ReplayLedger(max_entries=4)
+    assert ledger.remember("a") is True
+    assert ledger.remember("a") is False
+    assert ledger.seen("a") is True
+    assert ledger.seen("b") is False
+
+
+def test_replay_ledger_persists_to_disk(tmp_path: Path) -> None:
+    p = tmp_path / "ledger.jsonl"
+    ledger1 = ReplayLedger(p)
+    ledger1.remember("d-1")
+    ledger1.remember("d-2")
+    # Construct a second ledger pointing at the same file — replay should be
+    # rejected even after a "restart".
+    ledger2 = ReplayLedger(p)
+    assert ledger2.seen("d-1") is True
+    assert ledger2.remember("d-1") is False
+    assert ledger2.remember("d-3") is True
+
+
+def test_replay_ledger_evicts_oldest() -> None:
+    ledger = ReplayLedger(max_entries=2)
+    ledger.remember("x")
+    ledger.remember("y")
+    ledger.remember("z")
+    # ``x`` should have been evicted now that ``z`` is in.
+    assert ledger.seen("x") is False
+    assert ledger.seen("y") is True
+    assert ledger.seen("z") is True
+
+
+def test_replay_ledger_disk_failure_does_not_raise(tmp_path: Path) -> None:
+    # Use a path under a non-writable directory.  We simulate by pointing
+    # at a child of a file (cannot be a directory).
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x", encoding="utf-8")
+    bad_path = blocker / "ledger.jsonl"
+    ledger = ReplayLedger(bad_path)
+    # remember() must not raise even though mkdir + open will fail.
+    assert ledger.remember("only-in-memory") is True
+    assert ledger.seen("only-in-memory") is True
+
+
+# ---------------------------------------------------------------------------
+# Built-in handler registration
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_handlers_registered() -> None:
+    register_builtin_handlers()
+    names = set(list_handlers())
+    assert {"jira_cloud", "github", "gitlab", "linear", "plane"} <= names
+
+
+# ---------------------------------------------------------------------------
+# Receiver - verification & disabled paths
+# ---------------------------------------------------------------------------
+
+
+def test_receive_disabled_returns_disabled() -> None:
+    receiver = WebhookReceiver()
+    # No configure() call — adapter is disabled.
+    result = receiver.receive("github", {}, b"{}")
+    assert result.status == "disabled"
+
+
+def test_receive_unknown_adapter() -> None:
+    receiver = _make_receiver("nope")
+    result = receiver.receive("nope", {}, b"{}")
+    assert result.status == "unknown_adapter"
+
+
+def test_receive_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TEST_WH_SECRET", raising=False)
+    receiver = _make_receiver("github")
+    result = receiver.receive("github", {}, b"{}")
+    assert result.status == "not_configured"
+
+
+def test_receive_bad_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "shh")
+    receiver = _make_receiver("github")
+    result = receiver.receive(
+        "github",
+        {"x-hub-signature-256": "sha256=" + "0" * 64},
+        b"{}",
+    )
+    assert result.status == "bad_signature"
+
+
+# ---------------------------------------------------------------------------
+# GitHub handler
+# ---------------------------------------------------------------------------
+
+
+def _github_payload() -> dict[str, Any]:
+    return {
+        "action": "opened",
+        "issue": {
+            "id": 1,
+            "number": 42,
+            "html_url": "https://github.com/acme/repo/issues/42",
+            "title": "Bug: parser crash",
+            "body": "stack trace",
+            "state": "open",
+            "labels": [{"name": "bug"}, {"name": "p1"}],
+        },
+        "repository": {"full_name": "acme/repo"},
+    }
+
+
+def test_github_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "shh")
+    receiver = _make_receiver("github")
+    body = json.dumps(_github_payload()).encode("utf-8")
+    headers = {
+        "x-hub-signature-256": _prefixed_sig("shh", body),
+        "x-github-event": "issues",
+        "x-github-delivery": "deadbeef-1",
+    }
+    result = receiver.receive("github", headers, body)
+    assert result.status == "accepted"
+    assert result.event is not None
+    assert result.event.adapter == "github"
+    assert result.event.ticket.id == "acme/repo#42"
+    assert result.event.ticket.labels == ("bug", "p1")
+    assert result.event.delivery_id == "github:deadbeef-1"
+
+
+def test_github_replay_dedupes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "shh")
+    receiver = _make_receiver("github")
+    body = json.dumps(_github_payload()).encode("utf-8")
+    headers = {
+        "x-hub-signature-256": _prefixed_sig("shh", body),
+        "x-github-event": "issues",
+        "x-github-delivery": "abc-replay",
+    }
+    first = receiver.receive("github", headers, body)
+    second = receiver.receive("github", headers, body)
+    assert first.status == "accepted"
+    assert second.status == "replay"
+
+
+def test_github_bad_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "shh")
+    receiver = _make_receiver("github")
+    body = b"not json"
+    headers = {
+        "x-hub-signature-256": _prefixed_sig("shh", body),
+        "x-github-event": "issues",
+        "x-github-delivery": "bad-1",
+    }
+    result = receiver.receive("github", headers, body)
+    assert result.status == "bad_payload"
+
+
+def test_github_ignores_unhandled_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "shh")
+    receiver = _make_receiver("github")
+    body = json.dumps({"action": "completed"}).encode("utf-8")
+    headers = {
+        "x-hub-signature-256": _prefixed_sig("shh", body),
+        "x-github-event": "workflow_run",
+        "x-github-delivery": "skip-1",
+    }
+    result = receiver.receive("github", headers, body)
+    assert result.status == "ignored"
+
+
+# ---------------------------------------------------------------------------
+# Jira Cloud handler
+# ---------------------------------------------------------------------------
+
+
+def test_jira_cloud_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "jira-shh")
+    receiver = _make_receiver("jira_cloud")
+    payload = {
+        "webhookEvent": "jira:issue_updated",
+        "issue": {
+            "id": "10042",
+            "key": "ACME-7",
+            "self": "https://acme.atlassian.net/rest/api/3/issue/10042",
+            "fields": {
+                "summary": "Refactor parser",
+                "description": "details",
+                "status": {"name": "In Progress"},
+                "labels": ["backend", "p2"],
+            },
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-hub-signature-256": _prefixed_sig("jira-shh", body),
+        "x-atlassian-webhook-identifier": "jira-1",
+    }
+    result = receiver.receive("jira_cloud", headers, body)
+    assert result.status == "accepted"
+    assert result.event is not None
+    assert result.event.ticket.id == "ACME-7"
+    assert result.event.ticket.external_url.startswith("https://acme.atlassian.net/browse/ACME-7")
+    assert result.event.ticket.status == "In Progress"
+    assert result.event.ticket.labels == ("backend", "p2")
+    assert result.event.delivery_id == "jira_cloud:jira-1"
+
+
+def test_jira_cloud_missing_issue_returns_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "jira-shh")
+    receiver = _make_receiver("jira_cloud")
+    body = json.dumps({"webhookEvent": "noop"}).encode("utf-8")
+    headers = {
+        "x-hub-signature-256": _prefixed_sig("jira-shh", body),
+        "x-atlassian-webhook-identifier": "jira-empty",
+    }
+    result = receiver.receive("jira_cloud", headers, body)
+    assert result.status == "ignored"
+
+
+# ---------------------------------------------------------------------------
+# GitLab handler
+# ---------------------------------------------------------------------------
+
+
+def test_gitlab_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "gl-token")
+    receiver = _make_receiver("gitlab")
+    payload = {
+        "object_kind": "issue",
+        "object_attributes": {
+            "iid": 17,
+            "title": "Race condition",
+            "description": "see logs",
+            "state": "opened",
+            "url": "https://gitlab.example.com/acme/repo/-/issues/17",
+            "action": "open",
+        },
+        "project": {"path_with_namespace": "acme/repo"},
+        "labels": [{"title": "bug"}],
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-gitlab-token": "gl-token",
+        "x-gitlab-event-uuid": "gl-1",
+    }
+    result = receiver.receive("gitlab", headers, body)
+    assert result.status == "accepted"
+    assert result.event is not None
+    assert result.event.ticket.id == "acme/repo#17"
+    assert result.event.ticket.labels == ("bug",)
+    assert result.event.delivery_id == "gitlab:gl-1"
+
+
+def test_gitlab_bad_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "gl-token")
+    receiver = _make_receiver("gitlab")
+    body = json.dumps({"object_kind": "issue"}).encode("utf-8")
+    headers = {"x-gitlab-token": "wrong"}
+    result = receiver.receive("gitlab", headers, body)
+    assert result.status == "bad_signature"
+
+
+# ---------------------------------------------------------------------------
+# Linear handler
+# ---------------------------------------------------------------------------
+
+
+def test_linear_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "ln-secret")
+    receiver = _make_receiver("linear")
+    payload = {
+        "type": "Issue",
+        "action": "update",
+        "data": {
+            "id": "abc-uuid",
+            "identifier": "ENG-12",
+            "title": "Investigate flake",
+            "description": "happens twice a week",
+            "state": {"name": "In Progress"},
+            "url": "https://linear.app/acme/issue/ENG-12",
+            "labels": {"nodes": [{"name": "flake"}]},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "linear-signature": _hex_sig("ln-secret", body),
+        "linear-delivery": "ln-1",
+    }
+    result = receiver.receive("linear", headers, body)
+    assert result.status == "accepted"
+    assert result.event is not None
+    assert result.event.ticket.id == "ENG-12"
+    assert result.event.ticket.labels == ("flake",)
+    assert result.event.delivery_id == "linear:ln-1"
+
+
+# ---------------------------------------------------------------------------
+# Plane handler
+# ---------------------------------------------------------------------------
+
+
+def test_plane_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TEST_WH_SECRET", "plane-secret")
+    receiver = _make_receiver("plane")
+    payload = {
+        "event": "issue.updated",
+        "action": "updated",
+        "data": {
+            "id": "issue-uuid",
+            "sequence_id": 3,
+            "project": "proj-uuid",
+            "name": "Telemetry stuck",
+            "description_stripped": "details",
+            "state": "In Progress",
+            "url": "https://plane.example.com/.../issues/issue-uuid",
+            "labels": ["telemetry"],
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-plane-signature": _hex_sig("plane-secret", body),
+        "x-plane-delivery": "plane-1",
+    }
+    result = receiver.receive("plane", headers, body)
+    assert result.status == "accepted"
+    assert result.event is not None
+    assert result.event.ticket.id == "proj-uuid#3"
+    assert result.event.ticket.status == "In Progress"
+    assert result.event.delivery_id == "plane:plane-1"
+
+
+# ---------------------------------------------------------------------------
+# Custom handler registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_custom_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _verify(headers: dict[str, str], body: bytes, secret: str) -> bool:
+        del body
+        return headers.get("x-test-token") == secret
+
+    def _parse(headers: dict[str, str], payload: dict[str, Any]) -> TrackerEvent | None:
+        del headers
+        if not payload.get("id"):
+            return None
+        return TrackerEvent(
+            adapter="custom",
+            action=str(payload.get("action") or "updated"),
+            ticket=Ticket(
+                id=str(payload["id"]),
+                external_url="",
+                title=str(payload.get("title") or ""),
+                body="",
+                status="open",
+            ),
+            delivery_id="",
+        )
+
+    def _delivery(headers: dict[str, str], body: bytes) -> str:
+        del body
+        return f"custom:{headers.get('x-test-delivery', 'unknown')}"
+
+    register_handler(
+        WebhookHandler(
+            adapter="custom_test_tracker",
+            verify_signature=_verify,
+            parse_event=_parse,
+            delivery_id=_delivery,
+        )
+    )
+    assert get_handler("custom_test_tracker") is not None
+
+    monkeypatch.setenv("CUSTOM_WH", "abc")
+    receiver = _make_receiver("custom_test_tracker", secret_env="CUSTOM_WH")
+    headers = {"x-test-token": "abc", "x-test-delivery": "d-1"}
+    body = json.dumps({"id": "t-1", "action": "created"}).encode("utf-8")
+    result = receiver.receive("custom_test_tracker", headers, body)
+    assert result.status == "accepted"
+    assert result.event is not None
+    assert result.event.delivery_id == "custom:d-1"
+
+
+# ---------------------------------------------------------------------------
+# Startup-poll recovery
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    def __init__(self, tickets: list[Ticket]) -> None:
+        self._tickets = tickets
+
+    def pull_open_tickets(self) -> Any:
+        return iter(self._tickets)
+
+
+def test_replay_recent_via_poll_filters_by_timestamp() -> None:
+    old = Ticket(
+        id="OLD-1",
+        external_url="",
+        title="old",
+        body="",
+        status="open",
+        raw={"updated_at": 100.0},
+    )
+    fresh = Ticket(
+        id="NEW-1",
+        external_url="",
+        title="fresh",
+        body="",
+        status="open",
+        raw={"updated_at": 999.0},
+    )
+    delivered: list[Ticket] = []
+    n = replay_recent_via_poll(
+        _FakeAdapter([old, fresh]),
+        last_processed_ts=500.0,
+        sink=delivered.append,
+    )
+    assert n == 1
+    assert delivered[0].id == "NEW-1"
+
+
+def test_replay_recent_via_poll_no_timestamps_replays_all() -> None:
+    tickets = [
+        Ticket(id="A", external_url="", title="a", body="", status="open"),
+        Ticket(id="B", external_url="", title="b", body="", status="open"),
+    ]
+    delivered: list[Ticket] = []
+    n = replay_recent_via_poll(_FakeAdapter(tickets), last_processed_ts=0.0, sink=delivered.append)
+    assert n == 2
+
+
+def test_replay_recent_via_poll_adapter_without_pull_returns_zero() -> None:
+    class _NoPull:
+        pass
+
+    n = replay_recent_via_poll(_NoPull(), last_processed_ts=0.0, sink=lambda t: None)
+    assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Receive result helper
+# ---------------------------------------------------------------------------
+
+
+def test_receive_result_defaults() -> None:
+    r = ReceiveResult(status="accepted")
+    assert r.delivery_id is None
+    assert r.event is None


### PR DESCRIPTION
## Summary

- New `WebhookReceiver` (`src/bernstein/core/trackers/webhook_receiver.py`) turns inbound tracker webhooks into the same `Ticket` objects the polling path emits. Per-tracker handlers ship for Jira Cloud, GitHub, GitLab, Linear, Plane.
- HMAC-SHA256 (or constant-time token compare for GitLab) verification plus a bounded in-memory + on-disk `ReplayLedger` keyed by tracker-supplied delivery ids.
- FastAPI route `POST /webhooks/trackers/<adapter>` wired into the task server router (also surfaces under `/api/v1/`).
- `replay_recent_via_poll` helper for startup recovery of events the tracker tried to deliver while bernstein was down.
- Polling remains the default; webhook ingestion is opt-in per tracker via `trackers.<name>.webhook` in `bernstein.yaml`.

## Test plan

- [x] `uv run pytest tests/unit/trackers/test_webhook_receiver.py` (24 passed)
- [x] `uv run pytest tests/unit/trackers/` (182 passed, no regressions)
- [x] `uv run pytest tests/unit/test_generic_webhook.py tests/unit/test_gitlab_webhooks.py tests/unit/test_webhook_handler.py tests/unit/test_webhook_route.py tests/unit/test_webhook_signatures.py tests/unit/test_webhook_verify.py` (99 passed)
- [x] `uv run ruff check` on new + modified files - All checks passed
- [x] `uv run ruff format --check` on new + modified files - all formatted
- [x] Manual `create_app` smoke test confirms the new route appears at both `/webhooks/trackers/{adapter}` and `/api/v1/webhooks/trackers/{adapter}`

## Files

- `src/bernstein/core/trackers/webhook_receiver.py` (new)
- `src/bernstein/core/routes/tracker_webhooks.py` (new)
- `src/bernstein/core/server/server_app.py` (router registration)
- `tests/unit/trackers/test_webhook_receiver.py` (new, 24 tests)
- `docs/trackers/webhooks.md` (new)

## Summary by Sourcery

Introduce a tracker webhook ingestion path that normalises inbound events into tickets with replay protection and exposes them via a new FastAPI route.

New Features:
- Add a WebhookReceiver and per-adapter handlers to turn inbound tracker webhooks into normalised Ticket events with HMAC verification and replay protection.
- Expose a POST /webhooks/trackers/{adapter} FastAPI endpoint that validates, deduplicates, and forwards accepted tracker webhook events into the orchestrator queue.
- Document tracker webhook ingestion configuration, supported adapters, and operational guidance in a new trackers/webhooks.md guide.

Enhancements:
- Extend the server application to register the new tracker webhooks router so webhook endpoints are available under the main API.

Tests:
- Add a comprehensive unit test suite for the webhook receiver, replay ledger, handler registration, and startup replay helper.