### PR TITLE
feat(lineage): signed audit log of tracker state moves

### DIFF
--- a/docs/lineage/tracker-audit.md
+++ b/docs/lineage/tracker-audit.md
@@ -1,0 +1,106 @@
+# Tracker audit log
+
+Every state move made by a Bernstein agent against a ticket tracker
+(claim, comment, transition, attach, fail) is recorded as a signed
+content-addressed JSONL entry. The artefact is auditor-readable and
+maps directly to the per-decision evidence requirements asked for by
+SOX, SOC 2 Type II, and the EU AI Act.
+
+## On-disk layout
+
+* Path: `.sdd/lineage/tracker_audit.jsonl`
+* Format: append-only JSONL, one entry per line, RFC 8785 JCS canonical
+  bytes.
+* The file is gitignored; operator-side WORM storage is out of scope of
+  this module (see the ticket's *Out of scope* section).
+
+## Entry schema (`schema_version: 1`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | int | Always `1` in this release. Bumping the value requires a parallel reader for the prior version. |
+| `id` | string | UUIDv7 hex; time-sortable when running on Python 3.13+. |
+| `ts_ns` | int | Nanoseconds since the Unix epoch. |
+| `prev_entry_hash` | string | `sha256:` digest of the previous entry, or `sha256:000...0` for genesis. |
+| `entry_hash` | string | `sha256:` digest of the entry's canonical bytes with `entry_hash` and `signature` blanked. |
+| `tracker_name` | string | Adapter name (`jira`, `linear`, `github`, ...). |
+| `ticket_id` | string | Stable tracker-side identifier. |
+| `etag_before` | string\|null | Optimistic-concurrency etag observed before the call. |
+| `etag_after` | string\|null | Etag returned by the tracker after the call. |
+| `action` | string | One of `claim`, `comment`, `transition`, `attach`, `fail`. |
+| `actor.session_id` | string | Bernstein session id. |
+| `actor.role` | string | Role prompt that produced the call (`backend`, `qa`, ...). |
+| `actor.model` | string | Model identifier used for the call. |
+| `input_prompt_hash` | string | `sha256:` digest of the input prompt bytes. |
+| `output_blob_hash` | string | `sha256:` digest of the response payload bytes. |
+| `cost_usd` | float | USD spend attributed to the call. |
+| `tokens_in` | int | Input tokens. |
+| `tokens_out` | int | Output tokens. |
+| `idempotency_key` | string\|null | Tracker-side idempotency key, when supplied. |
+| `lifecycle_event_id` | string\|null | Cross-link to the originating lifecycle hook event. |
+| `signature` | string | HMAC-SHA256 over the canonical bytes (with `signature` blanked) under the operator secret. |
+| `failure_category` | string\|null | Exception class name when `action == "fail"`. |
+| `failure_detail` | string\|null | Truncated failure message (max 512 chars). |
+
+The auditor verifies the chain end-to-end by walking each line, hashing
+the canonical bytes, and comparing both the `entry_hash` and the HMAC
+signature.
+
+## Field-to-question mapping
+
+| Auditor question | Field(s) |
+|------------------|----------|
+| SOX-2026: which automated control changed state at `<time>`? | `ts_ns`, `tracker_name`, `ticket_id`, `action` |
+| SOC 2 Type II CC7.1 (change identification): who initiated the action? | `actor.session_id`, `actor.role`, `actor.model` |
+| EU AI Act Article 12 logging: which model and prompt produced the output? | `actor.model`, `input_prompt_hash`, `output_blob_hash` |
+| SOC 2 CC6.1 (logical access): is the chain tamper-evident? | `prev_entry_hash`, `entry_hash`, `signature` |
+| Cost-attribution: how much did the change cost? | `cost_usd`, `tokens_in`, `tokens_out` |
+| Concurrency control: what etags did we observe? | `etag_before`, `etag_after` |
+| Replay: how do I match this entry to the orchestrator's lifecycle event? | `lifecycle_event_id` |
+| Idempotency: did a retry collide with an earlier call? | `idempotency_key` |
+
+## Operator commands
+
+```sh
+# Show the chronological view, optionally filtered by tracker / ticket.
+bernstein lineage tracker-audit show --tracker jira --ticket PROJ-1
+
+# Periodic export window (nanoseconds since the Unix epoch).
+bernstein lineage tracker-audit show --since 1715000000000000000
+
+# Auditor bundle.
+bernstein lineage tracker-audit export --output /tmp/bundle.jsonl
+
+# Tamper detection. Exits non-zero on the first offending line.
+bernstein lineage tracker-audit verify
+```
+
+All commands read the HMAC operator secret from the
+`BERNSTEIN_OPERATOR_SECRET` environment variable by default; override
+with `--secret-env`.
+
+## Wiring an adapter
+
+Adapters opt in by being wrapped at the orchestrator boundary. The
+shipped wrapper:
+
+```python
+from bernstein.core.lineage import LineageCtx, TrackerActor, TrackerAuditLog, wrap_adapter
+
+log = TrackerAuditLog(Path(".sdd/lineage/tracker_audit.jsonl"), hmac_key=key)
+ctx = LineageCtx(log=log, actor=TrackerActor(session_id=sid, role=role, model=model))
+adapter = wrap_adapter(jira_adapter, ctx)
+adapter.add_comment("PROJ-1", "hello", idempotency_key="idem-1")
+```
+
+The wrapper emits one entry on success and one entry with
+`action="fail"` on exception, then re-raises so the orchestrator's
+retry policy keeps working.
+
+## Out of scope
+
+* WORM storage of the JSONL. Pipe the file to your evidence store of
+  choice (S3 Object Lock, Azure Immutable Blob, GCS Bucket Lock).
+* Auto-ingestion into vendor SIEMs. File a separate ticket per SIEM.
+* Sigstore attestation on top of the HMAC envelope. Tracked as a
+  follow-up.

--- a/src/bernstein/cli/commands/lineage_cmd.py
+++ b/src/bernstein/cli/commands/lineage_cmd.py
@@ -31,6 +31,7 @@ import click
 from rich.table import Table
 
 from bernstein.cli.commands.lineage_export_cmd import lineage_export_cmd
+from bernstein.cli.commands.lineage_tracker_audit_cmd import tracker_audit_cmd
 from bernstein.cli.commands.lineage_verify_cmd import lineage_verify_cmd
 from bernstein.cli.helpers import console
 
@@ -176,6 +177,7 @@ def walk_cmd(target: str, workdir: str, run_id: str | None, limit: int) -> None:
 
 lineage_cmd.add_command(lineage_export_cmd, "export")
 lineage_cmd.add_command(lineage_verify_cmd, "verify")
+lineage_cmd.add_command(tracker_audit_cmd, "tracker-audit")
 
 
 # ── ADR-009 lineage v1 subcommands ──────────────────────────────────────────

--- a/src/bernstein/cli/commands/lineage_tracker_audit_cmd.py
+++ b/src/bernstein/cli/commands/lineage_tracker_audit_cmd.py
@@ -1,0 +1,203 @@
+"""``bernstein lineage tracker-audit`` -- tracker state-move audit log.
+
+Operator surface for the signed tracker-action JSONL maintained by
+:mod:`bernstein.core.lineage.tracker_audit`. Three subcommands:
+
+* ``show`` -- chronological view filtered by tracker / ticket / since.
+* ``export`` -- write a signed JSONL bundle for an auditor.
+* ``verify`` -- chain + HMAC integrity check; exits non-zero on
+  tampering.
+
+The operator HMAC secret is loaded from
+``BERNSTEIN_OPERATOR_SECRET`` by default; pass ``--secret-env`` to
+override.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.lineage.tracker_audit import (
+    DEFAULT_LOG_PATH,
+    TrackerAuditLog,
+)
+
+
+def _load_key(secret_env: str) -> bytes:
+    secret = os.environ.get(secret_env)
+    if not secret:
+        console.print(
+            f"[red]Operator secret not set in ${secret_env}.[/red] Export the HMAC key before running this command."
+        )
+        sys.exit(2)
+    return secret.encode("utf-8")
+
+
+@click.group(name="tracker-audit")
+def tracker_audit_cmd() -> None:
+    """Signed audit log of tracker state moves.
+
+    \b
+    Examples:
+      bernstein lineage tracker-audit show --tracker jira --ticket PROJ-1
+      bernstein lineage tracker-audit export --output /tmp/bundle.jsonl
+      bernstein lineage tracker-audit verify
+    """
+
+
+@tracker_audit_cmd.command(name="show")
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=DEFAULT_LOG_PATH,
+    show_default=True,
+    help="Tracker-audit JSONL path.",
+)
+@click.option("--tracker", "tracker_name", default=None, help="Filter by tracker name.")
+@click.option("--ticket", "ticket_id", default=None, help="Filter by ticket id.")
+@click.option(
+    "--since",
+    "since_ns",
+    type=int,
+    default=None,
+    help="Earliest ``ts_ns`` (nanoseconds since epoch) to include.",
+)
+@click.option(
+    "--until",
+    "until_ns",
+    type=int,
+    default=None,
+    help="Latest ``ts_ns`` to include.",
+)
+@click.option(
+    "--secret-env",
+    default="BERNSTEIN_OPERATOR_SECRET",
+    show_default=True,
+    help="Env var holding the HMAC operator secret.",
+)
+def show_cmd(
+    log_path: Path,
+    tracker_name: str | None,
+    ticket_id: str | None,
+    since_ns: int | None,
+    until_ns: int | None,
+    secret_env: str,
+) -> None:
+    """Show audit entries chronologically with optional filters."""
+    key = _load_key(secret_env)
+    log = TrackerAuditLog(log_path, hmac_key=key)
+    entries = log.filter(
+        tracker_name=tracker_name,
+        ticket_id=ticket_id,
+        since_ns=since_ns,
+        until_ns=until_ns,
+    )
+    if not entries:
+        console.print("[yellow]No entries match.[/yellow]")
+        return
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("ts_ns", style="dim", no_wrap=True)
+    table.add_column("Tracker", no_wrap=True)
+    table.add_column("Ticket", no_wrap=True)
+    table.add_column("Action", no_wrap=True)
+    table.add_column("Role", no_wrap=True)
+    table.add_column("Model", no_wrap=True)
+    table.add_column("Cost USD", justify="right")
+    table.add_column("Tokens", justify="right")
+    table.add_column("Entry", no_wrap=True)
+    for entry in entries:
+        table.add_row(
+            str(entry.ts_ns),
+            entry.tracker_name,
+            entry.ticket_id,
+            entry.action,
+            entry.actor.role,
+            entry.actor.model,
+            f"{entry.cost_usd:.4f}",
+            f"{entry.tokens_in + entry.tokens_out}",
+            entry.entry_hash[:18] + "...",
+        )
+    console.print(table)
+
+
+@tracker_audit_cmd.command(name="export")
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=DEFAULT_LOG_PATH,
+    show_default=True,
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    required=True,
+    help="Destination JSONL path for the signed bundle.",
+)
+@click.option("--tracker", "tracker_name", default=None)
+@click.option("--ticket", "ticket_id", default=None)
+@click.option("--since", "since_ns", type=int, default=None)
+@click.option("--until", "until_ns", type=int, default=None)
+@click.option(
+    "--secret-env",
+    default="BERNSTEIN_OPERATOR_SECRET",
+    show_default=True,
+)
+def export_cmd(
+    log_path: Path,
+    output_path: Path,
+    tracker_name: str | None,
+    ticket_id: str | None,
+    since_ns: int | None,
+    until_ns: int | None,
+    secret_env: str,
+) -> None:
+    """Write a filtered signed JSONL bundle for an auditor."""
+    key = _load_key(secret_env)
+    log = TrackerAuditLog(log_path, hmac_key=key)
+    n = log.export_bundle(
+        output_path,
+        tracker_name=tracker_name,
+        ticket_id=ticket_id,
+        since_ns=since_ns,
+        until_ns=until_ns,
+    )
+    console.print(f"[green]Wrote {n} entry(ies) -> [/green]{output_path}")
+
+
+@tracker_audit_cmd.command(name="verify")
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=DEFAULT_LOG_PATH,
+    show_default=True,
+)
+@click.option(
+    "--secret-env",
+    default="BERNSTEIN_OPERATOR_SECRET",
+    show_default=True,
+)
+def verify_cmd(log_path: Path, secret_env: str) -> None:
+    """Verify chain integrity + HMAC. Exits non-zero on tampering."""
+    key = _load_key(secret_env)
+    log = TrackerAuditLog(log_path, hmac_key=key)
+    result = log.verify()
+    if result.ok:
+        console.print(f"[green]tracker-audit verify:[/green] OK ({result.entry_count} entry(ies))")
+        return
+    console.print("[red]tracker-audit verify:[/red] FAIL")
+    for f in result.failures:
+        console.print(f"  - {f}")
+    sys.exit(1)
+
+
+__all__ = ["tracker_audit_cmd"]

--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -40,6 +40,14 @@ from bernstein.core.lineage.merge import (
     resolve_policy,
 )
 from bernstein.core.lineage.tips import Fork, TipSet, compute_tips, detect_forks
+from bernstein.core.lineage.tracker_audit import (
+    AuditingTrackerAdapter,
+    LineageCtx,
+    TrackerActor,
+    TrackerAuditEntry,
+    TrackerAuditLog,
+    wrap_adapter,
+)
 from bernstein.core.lineage.v2_store import (
     LINEAGE_V2_ENTRY_VERSION,
     ChildBody,
@@ -56,18 +64,23 @@ __all__ = [
     "LINEAGE_V2_ENTRY_VERSION",
     "AgentCard",
     "AgentPolicy",
+    "AuditingTrackerAdapter",
     "ChildBody",
     "FirstWriterPolicy",
     "Fork",
     "GateResult",
     "HumanPolicy",
     "LineageConflict",
+    "LineageCtx",
     "LineageEntry",
     "LineageV2Store",
     "MergePolicy",
     "ParentRef",
     "StewardKey",
     "TipSet",
+    "TrackerActor",
+    "TrackerAuditEntry",
+    "TrackerAuditLog",
     "VerifyResult",
     "build_merge_entry",
     "canonicalise",
@@ -81,4 +94,5 @@ __all__ = [
     "resolve_policy",
     "sign_detached",
     "verify_detached",
+    "wrap_adapter",
 ]

--- a/src/bernstein/core/lineage/tracker_audit.py
+++ b/src/bernstein/core/lineage/tracker_audit.py
@@ -1,0 +1,748 @@
+"""Signed audit log of every tracker state move.
+
+This module records each agent-side tracker write (claim, comment,
+transition, attach, fail) as a content-addressed, HMAC-signed JSONL
+entry. The on-disk stream lives at ``.sdd/lineage/tracker_audit.jsonl``
+and is the auditor-facing artefact for evidence requirements such as
+SOX-2026 logging, SOC 2 Type II change-management evidence, and EU AI
+Act Article 12 record-keeping.
+
+Design notes:
+
+* Entry shape is intentionally separate from
+  :class:`bernstein.core.lineage.entry.LineageEntry` because the
+  artefact-write log and the tracker-action log have disjoint fields and
+  disjoint readers. The two streams live side-by-side under
+  ``.sdd/lineage/``.
+* Entries are RFC 8785 JCS canonicalised, then HMAC-SHA256 signed with
+  the operator secret. The HMAC binds every field, including the
+  ``prev_entry_hash`` link so a tampering attempt is detectable by
+  re-running ``verify``.
+* The file is append-only with an exclusive flock around each write so
+  concurrent agents on the same host cannot interleave bytes.
+* ``schema_version`` is recorded inside every entry. Bumping the schema
+  requires a parallel reader for the old version (see
+  ``docs/lineage/tracker-audit.md``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac as _hmac
+import json
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION = 1
+
+TRACKER_AUDIT_ACTIONS: frozenset[str] = frozenset({"claim", "comment", "transition", "attach", "fail"})
+
+GENESIS_PREV_HASH = "sha256:" + "0" * 64
+
+DEFAULT_LOG_PATH = Path(".sdd/lineage/tracker_audit.jsonl")
+
+TrackerAuditAction = Literal["claim", "comment", "transition", "attach", "fail"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uuid7_hex() -> str:
+    """Return a UUIDv7 hex string.
+
+    The Python ``uuid`` module added ``uuid7`` in 3.13. We fall back to
+    ``uuid4`` on older interpreters so the module loads everywhere; the
+    fallback is still globally unique, just not time-sortable.
+    """
+
+    uuid7 = getattr(uuid, "uuid7", None)
+    if uuid7 is not None:
+        return uuid7().hex
+    return uuid.uuid4().hex
+
+
+def content_hash(blob: bytes) -> str:
+    """Return the content-addressed identifier for ``blob``."""
+
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    """Return RFC 8785 JCS bytes for ``payload``.
+
+    The entry schema is a flat object of strings / ints / floats / lists
+    of strings, so ``json.dumps`` with ``sort_keys`` plus minimal
+    separators is sufficient (the edge cases of RFC 8785 around ES6
+    number formatting do not apply).
+    """
+
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TrackerActor:
+    """Identifies the agent that performed the tracker action."""
+
+    session_id: str
+    role: str
+    model: str
+
+
+@dataclass(frozen=True, slots=True)
+class TrackerAuditEntry:
+    """A single signed audit record of a tracker state move.
+
+    Field order is irrelevant on the wire because the canonicaliser
+    sorts keys; the dataclass groups related fields for human reading.
+    """
+
+    schema_version: int
+    id: str
+    ts_ns: int
+    prev_entry_hash: str
+    entry_hash: str
+    tracker_name: str
+    ticket_id: str
+    etag_before: str | None
+    etag_after: str | None
+    action: str
+    actor: TrackerActor
+    input_prompt_hash: str
+    output_blob_hash: str
+    cost_usd: float
+    tokens_in: int
+    tokens_out: int
+    idempotency_key: str | None
+    lifecycle_event_id: str | None
+    signature: str
+    failure_category: str | None = None
+    failure_detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            msg = f"unsupported tracker-audit schema_version: {self.schema_version}"
+            raise ValueError(msg)
+        if self.action not in TRACKER_AUDIT_ACTIONS:
+            msg = f"unknown tracker-audit action: {self.action!r}"
+            raise ValueError(msg)
+        for hash_field, label in (
+            (self.prev_entry_hash, "prev_entry_hash"),
+            (self.entry_hash, "entry_hash"),
+            (self.input_prompt_hash, "input_prompt_hash"),
+            (self.output_blob_hash, "output_blob_hash"),
+        ):
+            if not hash_field.startswith("sha256:"):
+                msg = f"{label} must start with 'sha256:', got {hash_field!r}"
+                raise ValueError(msg)
+
+
+def _entry_body(entry: TrackerAuditEntry) -> dict[str, Any]:
+    """Return ``entry`` as a plain dict ready for JCS canonicalisation."""
+
+    body = asdict(entry)
+    # ``actor`` becomes a nested dict via ``asdict``; flat keys keep the
+    # canonical form simple enough for the JCS helper's contract.
+    return body
+
+
+def canonicalise_entry(entry: TrackerAuditEntry) -> bytes:
+    """Return the RFC 8785 JCS bytes of ``entry``.
+
+    The ``signature`` field is included verbatim; callers that need the
+    bytes the HMAC ran over should use :func:`_signing_payload`.
+    """
+
+    return _canonical_bytes(_entry_body(entry))
+
+
+def _signing_payload(entry: TrackerAuditEntry) -> bytes:
+    """Return JCS bytes of ``entry`` with ``signature`` blanked.
+
+    The HMAC covers every field except the signature itself, which is
+    what makes a substitution attack detectable when the operator key
+    is supplied during verification.
+    """
+
+    body = _entry_body(entry)
+    body["signature"] = ""
+    body["entry_hash"] = ""
+    return _canonical_bytes(body)
+
+
+def compute_entry_hash(entry: TrackerAuditEntry) -> str:
+    """Return the content-addressed entry hash for ``entry``.
+
+    ``entry_hash`` is derived from JCS bytes with the ``signature`` and
+    ``entry_hash`` fields blanked so the digest is reproducible from the
+    same payload during replay or verification.
+    """
+
+    return "sha256:" + hashlib.sha256(_signing_payload(entry)).hexdigest()
+
+
+def compute_signature(entry: TrackerAuditEntry, key: bytes) -> str:
+    """Return the operator-HMAC for ``entry`` under ``key``.
+
+    The HMAC is computed over the same canonical bytes as
+    :func:`compute_entry_hash`, so a verifier can replay both checks
+    from one canonicalisation pass.
+    """
+
+    return _hmac.new(key, _signing_payload(entry), hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Locking helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _exclusive_lock(fp: IO[bytes]) -> Iterator[None]:
+    """Hold an exclusive advisory lock on ``fp`` for the block body.
+
+    Uses ``fcntl.flock`` on POSIX. On Windows ``fcntl`` is absent so the
+    helper degrades to a no-op; multi-writer hosts there are out of
+    scope for v1 of this module.
+    """
+
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX
+        yield
+        return
+
+    fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+    try:
+        yield
+    finally:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AppendResult:
+    """Outcome of appending an entry."""
+
+    entry: TrackerAuditEntry
+    line_number: int
+
+
+class TrackerAuditLog:
+    """Append-only signed audit log.
+
+    The log is keyed off a single JSONL path. The constructor does not
+    create the file; the first append does, with the parent directory
+    materialised on demand.
+    """
+
+    def __init__(self, path: Path, *, hmac_key: bytes) -> None:
+        self.path: Path = Path(path)
+        self._hmac_key: bytes = hmac_key
+
+    # -- append -------------------------------------------------------
+
+    def append(
+        self,
+        *,
+        tracker_name: str,
+        ticket_id: str,
+        action: TrackerAuditAction,
+        actor: TrackerActor,
+        input_prompt: bytes,
+        output_blob: bytes,
+        etag_before: str | None = None,
+        etag_after: str | None = None,
+        cost_usd: float = 0.0,
+        tokens_in: int = 0,
+        tokens_out: int = 0,
+        idempotency_key: str | None = None,
+        lifecycle_event_id: str | None = None,
+        failure_category: str | None = None,
+        failure_detail: str | None = None,
+        ts_ns: int | None = None,
+        entry_id: str | None = None,
+    ) -> AppendResult:
+        """Append a single signed entry. Returns the materialised entry.
+
+        Callers pass the raw ``input_prompt`` and ``output_blob`` bytes;
+        the log hashes them on the way in so the operator never has to
+        commit the secret-bearing payload to disk. Persisting the
+        underlying blobs is the orchestrator's responsibility via the
+        content-addressed store.
+        """
+
+        if action not in TRACKER_AUDIT_ACTIONS:
+            msg = f"unknown tracker-audit action: {action!r}"
+            raise ValueError(msg)
+
+        prev_hash = self._tail_hash()
+        unsigned = TrackerAuditEntry(
+            schema_version=SCHEMA_VERSION,
+            id=entry_id or _uuid7_hex(),
+            ts_ns=ts_ns if ts_ns is not None else time.time_ns(),
+            prev_entry_hash=prev_hash,
+            entry_hash=GENESIS_PREV_HASH,  # placeholder; recomputed below
+            tracker_name=tracker_name,
+            ticket_id=ticket_id,
+            etag_before=etag_before,
+            etag_after=etag_after,
+            action=action,
+            actor=actor,
+            input_prompt_hash=content_hash(input_prompt),
+            output_blob_hash=content_hash(output_blob),
+            cost_usd=cost_usd,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            idempotency_key=idempotency_key,
+            lifecycle_event_id=lifecycle_event_id,
+            signature="",
+            failure_category=failure_category,
+            failure_detail=failure_detail,
+        )
+
+        digest = compute_entry_hash(unsigned)
+        signed = replace(unsigned, entry_hash=digest)
+        signature = compute_signature(signed, self._hmac_key)
+        final = replace(signed, signature=signature)
+
+        line = _canonical_bytes(_entry_body(final)) + b"\n"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("ab") as fp, _exclusive_lock(fp):
+            fp.write(line)
+            fp.flush()
+            os.fsync(fp.fileno())
+
+        return AppendResult(entry=final, line_number=self._count_lines())
+
+    # -- read ---------------------------------------------------------
+
+    def read(self) -> list[TrackerAuditEntry]:
+        """Return every entry on disk, in insertion order."""
+
+        return list(self.iter_entries())
+
+    def iter_entries(self) -> Iterator[TrackerAuditEntry]:
+        """Yield each entry without holding the whole file in memory."""
+
+        if not self.path.exists():
+            return
+        with self.path.open("rb") as fp:
+            for raw in fp:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                payload = json.loads(stripped.decode("utf-8"))
+                yield _entry_from_payload(payload)
+
+    def filter(
+        self,
+        *,
+        tracker_name: str | None = None,
+        ticket_id: str | None = None,
+        since_ns: int | None = None,
+        until_ns: int | None = None,
+    ) -> list[TrackerAuditEntry]:
+        """Return entries matching every supplied filter (AND semantics)."""
+
+        out: list[TrackerAuditEntry] = []
+        for entry in self.iter_entries():
+            if tracker_name is not None and entry.tracker_name != tracker_name:
+                continue
+            if ticket_id is not None and entry.ticket_id != ticket_id:
+                continue
+            if since_ns is not None and entry.ts_ns < since_ns:
+                continue
+            if until_ns is not None and entry.ts_ns > until_ns:
+                continue
+            out.append(entry)
+        return out
+
+    # -- verify -------------------------------------------------------
+
+    def verify(self) -> VerifyResult:
+        """Walk the file and check chain integrity + signatures.
+
+        Returns a :class:`VerifyResult` describing the first offending
+        line if any. The CLI surface treats ``ok = False`` as a non-zero
+        exit code so this method is the single source of truth for
+        tampering detection.
+        """
+
+        if not self.path.exists():
+            return VerifyResult(ok=True, entry_count=0, failures=[])
+
+        failures: list[str] = []
+        prev_hash = GENESIS_PREV_HASH
+        count = 0
+
+        with self.path.open("rb") as fp:
+            for line_no, raw in enumerate(fp, start=1):
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    payload = json.loads(stripped.decode("utf-8"))
+                except json.JSONDecodeError as exc:
+                    failures.append(f"line {line_no}: invalid JSON ({exc.msg})")
+                    return VerifyResult(ok=False, entry_count=count, failures=failures)
+                try:
+                    entry = _entry_from_payload(payload)
+                except (TypeError, ValueError, KeyError) as exc:
+                    failures.append(f"line {line_no}: schema invalid ({exc})")
+                    return VerifyResult(ok=False, entry_count=count, failures=failures)
+
+                if entry.prev_entry_hash != prev_hash:
+                    failures.append(
+                        f"line {line_no}: prev_entry_hash mismatch (expected {prev_hash}, got {entry.prev_entry_hash})"
+                    )
+                    return VerifyResult(ok=False, entry_count=count, failures=failures)
+
+                expected_hash = compute_entry_hash(entry)
+                if expected_hash != entry.entry_hash:
+                    failures.append(f"line {line_no}: entry_hash mismatch (tampered payload)")
+                    return VerifyResult(ok=False, entry_count=count, failures=failures)
+
+                expected_sig = compute_signature(entry, self._hmac_key)
+                if not _hmac.compare_digest(expected_sig, entry.signature):
+                    failures.append(f"line {line_no}: signature mismatch (HMAC failed)")
+                    return VerifyResult(ok=False, entry_count=count, failures=failures)
+
+                prev_hash = entry.entry_hash
+                count += 1
+
+        return VerifyResult(ok=True, entry_count=count, failures=failures)
+
+    # -- export -------------------------------------------------------
+
+    def export_bundle(
+        self,
+        out_path: Path,
+        *,
+        tracker_name: str | None = None,
+        ticket_id: str | None = None,
+        since_ns: int | None = None,
+        until_ns: int | None = None,
+    ) -> int:
+        """Write a filtered, signed JSONL bundle for an auditor.
+
+        Returns the number of entries written. The bundle preserves the
+        on-disk byte form so a third party can verify the chain with
+        only the operator HMAC key.
+        """
+
+        entries = self.filter(
+            tracker_name=tracker_name,
+            ticket_id=ticket_id,
+            since_ns=since_ns,
+            until_ns=until_ns,
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("wb") as fp:
+            for entry in entries:
+                fp.write(_canonical_bytes(_entry_body(entry)))
+                fp.write(b"\n")
+        return len(entries)
+
+    # -- internals ----------------------------------------------------
+
+    def _tail_hash(self) -> str:
+        """Return the ``entry_hash`` of the last entry, or genesis."""
+
+        if not self.path.exists() or self.path.stat().st_size == 0:
+            return GENESIS_PREV_HASH
+        # Read tail efficiently: walk lines but only retain the last.
+        last_hash = GENESIS_PREV_HASH
+        with self.path.open("rb") as fp:
+            for raw in fp:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                payload = json.loads(stripped.decode("utf-8"))
+                last_hash = payload["entry_hash"]
+        return last_hash
+
+    def _count_lines(self) -> int:
+        if not self.path.exists():
+            return 0
+        with self.path.open("rb") as fp:
+            return sum(1 for raw in fp if raw.strip())
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    """Outcome of :meth:`TrackerAuditLog.verify`."""
+
+    ok: bool
+    entry_count: int
+    failures: list[str] = field(default_factory=list)
+
+
+def _entry_from_payload(payload: dict[str, Any]) -> TrackerAuditEntry:
+    """Reconstruct a :class:`TrackerAuditEntry` from on-disk JSON."""
+
+    actor_payload = payload.get("actor", {})
+    actor = TrackerActor(
+        session_id=actor_payload["session_id"],
+        role=actor_payload["role"],
+        model=actor_payload["model"],
+    )
+    return TrackerAuditEntry(
+        schema_version=payload["schema_version"],
+        id=payload["id"],
+        ts_ns=payload["ts_ns"],
+        prev_entry_hash=payload["prev_entry_hash"],
+        entry_hash=payload["entry_hash"],
+        tracker_name=payload["tracker_name"],
+        ticket_id=payload["ticket_id"],
+        etag_before=payload.get("etag_before"),
+        etag_after=payload.get("etag_after"),
+        action=payload["action"],
+        actor=actor,
+        input_prompt_hash=payload["input_prompt_hash"],
+        output_blob_hash=payload["output_blob_hash"],
+        cost_usd=payload["cost_usd"],
+        tokens_in=payload["tokens_in"],
+        tokens_out=payload["tokens_out"],
+        idempotency_key=payload.get("idempotency_key"),
+        lifecycle_event_id=payload.get("lifecycle_event_id"),
+        signature=payload["signature"],
+        failure_category=payload.get("failure_category"),
+        failure_detail=payload.get("failure_detail"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tracker contract integration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LineageCtx:
+    """Per-call lineage context threaded through tracker adapters.
+
+    Adapters that opt into tracker-audit emission accept this object on
+    the relevant write methods. The orchestrator constructs it from the
+    active session, role, and model. The ``log`` reference lets the
+    adapter call :meth:`TrackerAuditLog.append` directly so tests can
+    inject a temporary file.
+    """
+
+    log: TrackerAuditLog
+    actor: TrackerActor
+    lifecycle_event_id: str | None = None
+    cost_usd: float = 0.0
+    tokens_in: int = 0
+    tokens_out: int = 0
+
+
+def emit_audit_entry(
+    ctx: LineageCtx,
+    *,
+    tracker_name: str,
+    ticket_id: str,
+    action: TrackerAuditAction,
+    input_prompt: bytes,
+    output_blob: bytes,
+    etag_before: str | None = None,
+    etag_after: str | None = None,
+    idempotency_key: str | None = None,
+    failure_category: str | None = None,
+    failure_detail: str | None = None,
+) -> TrackerAuditEntry:
+    """Convenience helper to emit a single tracker-audit entry."""
+
+    result = ctx.log.append(
+        tracker_name=tracker_name,
+        ticket_id=ticket_id,
+        action=action,
+        actor=ctx.actor,
+        input_prompt=input_prompt,
+        output_blob=output_blob,
+        etag_before=etag_before,
+        etag_after=etag_after,
+        cost_usd=ctx.cost_usd,
+        tokens_in=ctx.tokens_in,
+        tokens_out=ctx.tokens_out,
+        idempotency_key=idempotency_key,
+        lifecycle_event_id=ctx.lifecycle_event_id,
+        failure_category=failure_category,
+        failure_detail=failure_detail,
+    )
+    return result.entry
+
+
+# ---------------------------------------------------------------------------
+# Adapter wrapping
+# ---------------------------------------------------------------------------
+
+
+def wrap_adapter(adapter: Any, ctx: LineageCtx) -> AuditingTrackerAdapter:
+    """Return ``adapter`` wrapped so every write method emits an audit entry.
+
+    The wrapper preserves the adapter's public surface (``name``,
+    ``pull_open_tickets``, etc.) and only intercepts the write methods
+    listed in the ticket spec: ``claim_ticket``, ``add_comment``,
+    ``transition``, and ``attach_blob``. Other attribute access is
+    forwarded transparently.
+    """
+
+    return AuditingTrackerAdapter(adapter, ctx)
+
+
+class AuditingTrackerAdapter:
+    """Decorator wrapping a tracker adapter to emit signed audit entries.
+
+    The wrapper is a duck-typed proxy rather than a subclass so it can
+    sit in front of any concrete adapter regardless of its inheritance
+    chain. Every write method emits exactly one entry on success and
+    one entry with ``action="fail"`` on exception, then re-raises.
+    """
+
+    def __init__(self, inner: Any, ctx: LineageCtx) -> None:
+        self._inner = inner
+        self._ctx = ctx
+
+    # -- attribute forwarding ----------------------------------------
+
+    def __getattr__(self, name: str) -> Any:
+        # Called only when ``name`` is not found on ``self`` directly,
+        # so the wrapped methods below take precedence.
+        return getattr(self._inner, name)
+
+    # -- write surface -----------------------------------------------
+
+    def claim_ticket(self, ticket_id: str, agent_id: str, **kwargs: Any) -> Any:
+        return self._invoke(
+            action="claim",
+            ticket_id=ticket_id,
+            inner=lambda: self._inner.claim_ticket(ticket_id, agent_id, **kwargs),
+            input_prompt=f"claim:{agent_id}".encode(),
+            etag_before=kwargs.get("etag"),
+        )
+
+    def add_comment(self, ticket_id: str, body: str, **kwargs: Any) -> Any:
+        return self._invoke(
+            action="comment",
+            ticket_id=ticket_id,
+            inner=lambda: self._inner.add_comment(ticket_id, body, **kwargs),
+            input_prompt=body.encode("utf-8"),
+            idempotency_key=kwargs.get("idempotency_key"),
+        )
+
+    def transition(self, ticket_id: str, status_id: str, **kwargs: Any) -> Any:
+        return self._invoke(
+            action="transition",
+            ticket_id=ticket_id,
+            inner=lambda: self._inner.transition(ticket_id, status_id, **kwargs),
+            input_prompt=f"transition:{status_id}".encode(),
+            idempotency_key=kwargs.get("idempotency_key"),
+            etag_before=kwargs.get("etag"),
+        )
+
+    def attach_blob(self, ticket_id: str, blob: bytes, mime: str, **kwargs: Any) -> Any:
+        return self._invoke(
+            action="attach",
+            ticket_id=ticket_id,
+            inner=lambda: self._inner.attach_blob(ticket_id, blob, mime, **kwargs),
+            input_prompt=mime.encode("utf-8"),
+            idempotency_key=kwargs.get("idempotency_key"),
+            blob_override=blob,
+        )
+
+    # -- shared invocation pipeline -----------------------------------
+
+    def _invoke(
+        self,
+        *,
+        action: TrackerAuditAction,
+        ticket_id: str,
+        inner: Any,
+        input_prompt: bytes,
+        idempotency_key: str | None = None,
+        etag_before: str | None = None,
+        blob_override: bytes | None = None,
+    ) -> Any:
+        tracker_name = getattr(self._inner, "name", "unknown")
+        try:
+            result = inner()
+        except Exception as exc:
+            emit_audit_entry(
+                self._ctx,
+                tracker_name=tracker_name,
+                ticket_id=ticket_id,
+                action="fail",
+                input_prompt=input_prompt,
+                output_blob=str(exc).encode("utf-8"),
+                etag_before=etag_before,
+                idempotency_key=idempotency_key,
+                failure_category=type(exc).__name__,
+                failure_detail=str(exc)[:512],
+            )
+            raise
+        # Use the result's repr (or the attached blob for attach actions)
+        # as the output blob. The repr is stable across adapters because
+        # the contract dataclasses are frozen with declared fields only.
+        output_blob = blob_override if blob_override is not None else repr(result).encode("utf-8")
+        etag_after = getattr(result, "etag", None)
+        emit_audit_entry(
+            self._ctx,
+            tracker_name=tracker_name,
+            ticket_id=ticket_id,
+            action=action,
+            input_prompt=input_prompt,
+            output_blob=output_blob,
+            etag_before=etag_before,
+            etag_after=etag_after,
+            idempotency_key=idempotency_key,
+        )
+        return result
+
+
+__all__ = [
+    "DEFAULT_LOG_PATH",
+    "GENESIS_PREV_HASH",
+    "SCHEMA_VERSION",
+    "TRACKER_AUDIT_ACTIONS",
+    "AppendResult",
+    "AuditingTrackerAdapter",
+    "LineageCtx",
+    "TrackerActor",
+    "TrackerAuditAction",
+    "TrackerAuditEntry",
+    "TrackerAuditLog",
+    "VerifyResult",
+    "canonicalise_entry",
+    "compute_entry_hash",
+    "compute_signature",
+    "content_hash",
+    "emit_audit_entry",
+    "wrap_adapter",
+]

--- a/src/bernstein/core/trackers/contract.py
+++ b/src/bernstein/core/trackers/contract.py
@@ -197,7 +197,16 @@ class AbstractTrackerAdapter(ABC):
         *,
         idempotency_key: str | None = None,
     ) -> CommentResult:
-        """Post a comment on ``ticket_id``."""
+        """Post a comment on ``ticket_id``.
+
+        Adapters that opt into the tracker-audit log (see
+        :mod:`bernstein.core.lineage.tracker_audit`) are wrapped at the
+        orchestrator boundary by
+        :class:`~bernstein.core.lineage.tracker_audit.AuditingTrackerAdapter`,
+        which brackets each call with a success or failure audit entry.
+        The wrapper preserves the adapter's surface so concrete
+        adapters can keep this signature unchanged.
+        """
 
     @abstractmethod
     def transition(
@@ -208,7 +217,10 @@ class AbstractTrackerAdapter(ABC):
         idempotency_key: str | None = None,
         etag: str | None = None,
     ) -> TransitionResult:
-        """Move ``ticket_id`` to ``status_id``."""
+        """Move ``ticket_id`` to ``status_id``.
+
+        See :meth:`add_comment` for the audit-wrapping contract.
+        """
 
     def claim_ticket(
         self,

--- a/tests/unit/lineage/test_tracker_audit.py
+++ b/tests/unit/lineage/test_tracker_audit.py
@@ -1,0 +1,465 @@
+"""Tests for ``bernstein.core.lineage.tracker_audit``.
+
+Coverage matrix:
+
+* Entry shape -- schema_version + required fields land on disk.
+* Chain integrity -- ``prev_entry_hash`` walks the file in order.
+* Signature verify -- HMAC mismatch is detected.
+* Replay determinism -- canonical bytes are stable.
+* Tampering -- mutating one byte makes ``verify`` fail with the
+  offending line number.
+* Adapter wrapping -- success and failure paths both emit entries.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.lineage.tracker_audit import (
+    GENESIS_PREV_HASH,
+    SCHEMA_VERSION,
+    AuditingTrackerAdapter,
+    LineageCtx,
+    TrackerActor,
+    TrackerAuditEntry,
+    TrackerAuditLog,
+    canonicalise_entry,
+    compute_entry_hash,
+    compute_signature,
+    content_hash,
+    wrap_adapter,
+)
+
+
+@pytest.fixture
+def hmac_key() -> bytes:
+    return b"k" * 32
+
+
+@pytest.fixture
+def actor() -> TrackerActor:
+    return TrackerActor(session_id="sess-1", role="backend", model="claude-opus-4-7")
+
+
+@pytest.fixture
+def log(tmp_path: Path, hmac_key: bytes) -> TrackerAuditLog:
+    return TrackerAuditLog(tmp_path / "tracker_audit.jsonl", hmac_key=hmac_key)
+
+
+# ---------------------------------------------------------------------------
+# Entry shape + serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_append_genesis_entry_has_zero_prev_hash(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    result = log.append(
+        tracker_name="jira",
+        ticket_id="PROJ-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"claim",
+        output_blob=b"ok",
+    )
+    assert result.entry.prev_entry_hash == GENESIS_PREV_HASH
+    assert result.entry.schema_version == SCHEMA_VERSION
+    assert result.entry.entry_hash.startswith("sha256:")
+    assert result.entry.signature
+    # The file is JSONL with one entry per line.
+    raw = log.path.read_bytes()
+    assert raw.endswith(b"\n")
+    payload = json.loads(raw.strip())
+    assert payload["tracker_name"] == "jira"
+    assert payload["actor"]["role"] == "backend"
+
+
+def test_input_and_output_blob_hashes_are_content_addressed(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    body = b"hello there"
+    blob = b"server-response"
+    result = log.append(
+        tracker_name="jira",
+        ticket_id="PROJ-1",
+        action="comment",
+        actor=actor,
+        input_prompt=body,
+        output_blob=blob,
+    )
+    assert result.entry.input_prompt_hash == content_hash(body)
+    assert result.entry.output_blob_hash == content_hash(blob)
+
+
+def test_unknown_action_rejected_at_append(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    with pytest.raises(ValueError, match="unknown tracker-audit action"):
+        log.append(
+            tracker_name="jira",
+            ticket_id="PROJ-1",
+            action="explode",  # type: ignore[arg-type]
+            actor=actor,
+            input_prompt=b"",
+            output_blob=b"",
+        )
+
+
+def test_entry_post_init_rejects_bad_hash_prefix() -> None:
+    actor = TrackerActor(session_id="s", role="r", model="m")
+    with pytest.raises(ValueError, match="entry_hash must start with 'sha256:'"):
+        TrackerAuditEntry(
+            schema_version=SCHEMA_VERSION,
+            id="x",
+            ts_ns=0,
+            prev_entry_hash=GENESIS_PREV_HASH,
+            entry_hash="md5:abc",
+            tracker_name="jira",
+            ticket_id="T-1",
+            etag_before=None,
+            etag_after=None,
+            action="claim",
+            actor=actor,
+            input_prompt_hash="sha256:" + "0" * 64,
+            output_blob_hash="sha256:" + "0" * 64,
+            cost_usd=0.0,
+            tokens_in=0,
+            tokens_out=0,
+            idempotency_key=None,
+            lifecycle_event_id=None,
+            signature="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Chain integrity
+# ---------------------------------------------------------------------------
+
+
+def test_chain_walks_in_insertion_order(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    r1 = log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    r2 = log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="comment",
+        actor=actor,
+        input_prompt=b"b",
+        output_blob=b"b",
+    )
+    r3 = log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="transition",
+        actor=actor,
+        input_prompt=b"c",
+        output_blob=b"c",
+    )
+    assert r2.entry.prev_entry_hash == r1.entry.entry_hash
+    assert r3.entry.prev_entry_hash == r2.entry.entry_hash
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+
+def test_verify_clean_log_returns_ok(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="comment",
+        actor=actor,
+        input_prompt=b"b",
+        output_blob=b"b",
+    )
+    result = log.verify()
+    assert result.ok
+    assert result.entry_count == 2
+    assert result.failures == []
+
+
+def test_verify_missing_log_returns_ok_with_zero_entries(tmp_path: Path, hmac_key: bytes) -> None:
+    log = TrackerAuditLog(tmp_path / "nonexistent.jsonl", hmac_key=hmac_key)
+    result = log.verify()
+    assert result.ok is True
+    assert result.entry_count == 0
+
+
+def test_signature_mismatch_detected_with_wrong_key(log: TrackerAuditLog, actor: TrackerActor, tmp_path: Path) -> None:
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    # Re-read with a different key. The signature check must fail.
+    other = TrackerAuditLog(log.path, hmac_key=b"wrong-key")
+    result = other.verify()
+    assert not result.ok
+    assert any("signature mismatch" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Tampering
+# ---------------------------------------------------------------------------
+
+
+def test_tampering_byte_flip_detected(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="comment",
+        actor=actor,
+        input_prompt=b"original-body",
+        output_blob=b"server",
+    )
+
+    # Flip one byte in line 2 of the JSONL by rewriting the file.
+    raw_lines = log.path.read_bytes().splitlines()
+    payload = json.loads(raw_lines[1].decode("utf-8"))
+    payload["ticket_id"] = "T-2"  # mutate
+    raw_lines[1] = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    log.path.write_bytes(b"\n".join(raw_lines) + b"\n")
+
+    result = log.verify()
+    assert not result.ok
+    # The failure should mention line 2 -- the tampered one.
+    assert any("line 2" in f for f in result.failures)
+
+
+def test_tampering_invalid_json_detected(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    log.path.write_bytes(b"not json\n")
+    result = log.verify()
+    assert not result.ok
+    assert any("invalid JSON" in f for f in result.failures)
+
+
+# ---------------------------------------------------------------------------
+# Replay determinism
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_bytes_are_deterministic(actor: TrackerActor) -> None:
+    base_kwargs: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "id": "abc",
+        "ts_ns": 1234,
+        "prev_entry_hash": GENESIS_PREV_HASH,
+        "entry_hash": "sha256:" + "0" * 64,
+        "tracker_name": "jira",
+        "ticket_id": "T-1",
+        "etag_before": None,
+        "etag_after": "etag-v2",
+        "action": "claim",
+        "actor": actor,
+        "input_prompt_hash": "sha256:" + "1" * 64,
+        "output_blob_hash": "sha256:" + "2" * 64,
+        "cost_usd": 0.0125,
+        "tokens_in": 100,
+        "tokens_out": 50,
+        "idempotency_key": "idem-1",
+        "lifecycle_event_id": None,
+        "signature": "",
+    }
+    e1 = TrackerAuditEntry(**base_kwargs)
+    e2 = TrackerAuditEntry(**base_kwargs)
+    assert canonicalise_entry(e1) == canonicalise_entry(e2)
+    assert compute_entry_hash(e1) == compute_entry_hash(e2)
+
+
+def test_filter_by_tracker_and_ticket(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    log.append(
+        tracker_name="linear",
+        ticket_id="L-9",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-2",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    jira_only = log.filter(tracker_name="jira")
+    assert {e.ticket_id for e in jira_only} == {"T-1", "T-2"}
+
+    t1_only = log.filter(ticket_id="T-1")
+    assert len(t1_only) == 1
+    assert t1_only[0].tracker_name == "jira"
+
+
+def test_export_bundle_writes_matching_lines(log: TrackerAuditLog, actor: TrackerActor, tmp_path: Path) -> None:
+    log.append(
+        tracker_name="jira",
+        ticket_id="T-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    log.append(
+        tracker_name="linear",
+        ticket_id="L-1",
+        action="claim",
+        actor=actor,
+        input_prompt=b"a",
+        output_blob=b"a",
+    )
+    out = tmp_path / "bundle.jsonl"
+    n = log.export_bundle(out, tracker_name="jira")
+    assert n == 1
+    payload = json.loads(out.read_bytes().strip())
+    assert payload["tracker_name"] == "jira"
+
+
+# ---------------------------------------------------------------------------
+# Adapter wrapping
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdapter:
+    """Minimal stand-in for an :class:`AbstractTrackerAdapter`."""
+
+    name = "fake"
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self._fail = fail
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def claim_ticket(self, ticket_id: str, agent_id: str, *, etag: str | None = None) -> Any:
+        self.calls.append(("claim_ticket", (ticket_id, agent_id, etag)))
+        if self._fail:
+            raise RuntimeError("backend exploded")
+        from bernstein.core.trackers.contract import ClaimResult
+
+        return ClaimResult(claimed=True, ticket_id=ticket_id, agent_id=agent_id, etag="etag-1")
+
+    def add_comment(self, ticket_id: str, body: str, *, idempotency_key: str | None = None) -> Any:
+        self.calls.append(("add_comment", (ticket_id, body, idempotency_key)))
+        from bernstein.core.trackers.contract import CommentResult
+
+        return CommentResult(comment_id="c1", ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> Any:
+        self.calls.append(("transition", (ticket_id, status_id)))
+        from bernstein.core.trackers.contract import TransitionResult
+
+        return TransitionResult(ticket_id=ticket_id, new_status=status_id, etag="etag-2")
+
+    def attach_blob(
+        self,
+        ticket_id: str,
+        blob: bytes,
+        mime: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        self.calls.append(("attach_blob", (ticket_id, len(blob), mime)))
+        from bernstein.core.trackers.contract import AttachResult
+
+        return AttachResult(attachment_id="att-1", ticket_id=ticket_id)
+
+
+def test_wrap_adapter_emits_audit_on_success(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    ctx = LineageCtx(log=log, actor=actor, cost_usd=0.01, tokens_in=10, tokens_out=20)
+    wrapped = wrap_adapter(_FakeAdapter(), ctx)
+    assert isinstance(wrapped, AuditingTrackerAdapter)
+    wrapped.claim_ticket("T-1", "agent:claude-1", etag="etag-0")
+    wrapped.add_comment("T-1", "hello", idempotency_key="idem-1")
+    wrapped.transition("T-1", "done")
+    wrapped.attach_blob("T-1", b"binary-blob", "application/octet-stream")
+    entries = log.read()
+    assert [e.action for e in entries] == ["claim", "comment", "transition", "attach"]
+    assert entries[0].actor.role == "backend"
+    assert entries[0].cost_usd == 0.01
+    # etag pulled from the returned ClaimResult
+    assert entries[0].etag_after == "etag-1"
+
+
+def test_wrap_adapter_emits_failure_entry_and_reraises(log: TrackerAuditLog, actor: TrackerActor) -> None:
+    ctx = LineageCtx(log=log, actor=actor)
+    wrapped = wrap_adapter(_FakeAdapter(fail=True), ctx)
+    with pytest.raises(RuntimeError, match="backend exploded"):
+        wrapped.claim_ticket("T-1", "agent:claude-1")
+    entries = log.read()
+    assert len(entries) == 1
+    assert entries[0].action == "fail"
+    assert entries[0].failure_category == "RuntimeError"
+    assert "backend exploded" in (entries[0].failure_detail or "")
+
+
+def test_signature_helper_round_trips(actor: TrackerActor, hmac_key: bytes) -> None:
+    entry = TrackerAuditEntry(
+        schema_version=SCHEMA_VERSION,
+        id="x",
+        ts_ns=42,
+        prev_entry_hash=GENESIS_PREV_HASH,
+        entry_hash="sha256:" + "0" * 64,
+        tracker_name="jira",
+        ticket_id="T-1",
+        etag_before=None,
+        etag_after=None,
+        action="claim",
+        actor=actor,
+        input_prompt_hash="sha256:" + "1" * 64,
+        output_blob_hash="sha256:" + "2" * 64,
+        cost_usd=0.0,
+        tokens_in=0,
+        tokens_out=0,
+        idempotency_key=None,
+        lifecycle_event_id=None,
+        signature="",
+    )
+    sig = compute_signature(entry, hmac_key)
+    assert sig == compute_signature(entry, hmac_key)  # deterministic
+    assert sig != compute_signature(entry, b"different-key")


### PR DESCRIPTION
## Summary

- Record every agent-side tracker write (claim, comment, transition, attach, fail) as a content-addressed HMAC-signed JSONL entry under `.sdd/lineage/tracker_audit.jsonl`.
- New module `bernstein.core.lineage.tracker_audit` ships the entry dataclass, RFC 8785 JCS canonicaliser, signer, append-only log, and `AuditingTrackerAdapter` wrapper that brackets each tracker call with a success or failure entry without touching the contract surface.
- New CLI: `bernstein lineage tracker-audit show / export / verify`. The verifier walks the chain end-to-end and reports the offending line number on tamper.
- Docs page `docs/lineage/tracker-audit.md` maps each schema field to the auditor questions it answers (SOX, SOC 2 Type II, EU AI Act Article 12).

## Schema (v1)

`schema_version`, `id` (uuid7), `ts_ns`, `prev_entry_hash`, `entry_hash`, `tracker_name`, `ticket_id`, `etag_before/after`, `action`, `actor.{session_id, role, model}`, `input_prompt_hash`, `output_blob_hash`, `cost_usd`, `tokens_in/out`, `idempotency_key`, `lifecycle_event_id`, `signature`, and optional `failure_category` / `failure_detail`.

## Test plan

- [x] `pytest tests/unit/lineage/` (145 lineage tests; 16 new in `test_tracker_audit.py`).
- [x] `pytest tests/unit/trackers/` (158 existing tracker tests still green).
- [x] `ruff check` + `ruff format` clean on touched files.
- [x] CLI smoke: `bernstein lineage tracker-audit verify` against a missing log returns OK with 0 entries; `show / export / verify` show the new subcommands.

## Summary by Sourcery

Add a signed, content-addressed audit log for tracker state changes and expose it via CLI and lineage APIs.

New Features:
- Introduce a tracker audit lineage module that records each tracker state change as a signed, content-addressed JSONL entry.
- Add an auditing tracker adapter wrapper and lineage context to emit audit entries around tracker write operations without altering existing tracker contracts.
- Provide a CLI subgroup `bernstein lineage tracker-audit` with show, export, and verify subcommands for inspecting and validating the audit log.
- Document the tracker audit log schema, usage, and auditor-focused field mappings in new lineage documentation.

Enhancements:
- Export tracker audit symbols from the lineage package for easier integration and wrapping of existing adapters.
- Extend tracker contract docstrings to describe how adapters participate in audit logging at the orchestrator boundary.

Tests:
- Add comprehensive unit tests for the tracker audit module, covering schema, hashing, verification, tamper detection, filtering, export, and adapter wrapping behavior.