### PR TITLE
feat(orchestration): tracker comments as multi-agent handoff message bus

### DIFF
--- a/docs/orchestration/tracker-pipeline.md
+++ b/docs/orchestration/tracker-pipeline.md
@@ -1,0 +1,205 @@
+# Tracker comments as a multi-agent handoff bus
+
+## TL;DR
+
+| Component | Purpose |
+|-----------|---------|
+| `PipelineConfig` | Typed view over `bernstein.yaml: orchestration.tracker_pipeline`. |
+| `PipelineStage` | One role in the pipeline (claim status, success status, failure status, optional prior-role gate). |
+| `ClaimLedger` | SQLite-backed distributed claim ledger with lease TTL. |
+| `make_idempotency_key` | Stable `sha256(tracker || ticket_id || role || stage || stage_attempt)`. |
+| `FailurePayload` + `format_failure_comment` | Structured failure taxonomy embedded in a fenced YAML block. |
+| `TrackerPipeline` | Stateless sweep loop binding the above pieces together. |
+| `tracker_pipeline.handoff` hook | Lifecycle hook fired on every stage transition. |
+
+Each specialist role (architect, backend, qa, security) reads and writes
+the same tracker ticket. The tracker is the durable, audit-trailed,
+human-observable substrate. No queue server, no DB, no service mesh.
+
+## Configuration
+
+Add a block to `bernstein.yaml`:
+
+```yaml
+orchestration:
+  tracker_pipeline:
+    claim_lock_ttl_seconds: 600
+    concurrency:
+      per_role_max_in_flight: 1
+    pipeline_stages:
+      - role: architect
+        claim_status: ready-for-design
+        success_status: design-approved
+        failure_status: design-blocked
+      - role: backend
+        claim_status: design-approved
+        success_status: code-review
+        failure_status: blocked
+        requires_prior_role: architect
+      - role: qa
+        claim_status: code-review
+        success_status: qa-passed
+        failure_status: qa-blocked
+        requires_prior_role: backend
+```
+
+Field reference:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `pipeline_stages` | ordered list | Stage records (see below). |
+| `claim_lock_ttl_seconds` | integer | Lease duration for a stage claim. Default `600`. |
+| `concurrency.per_role_max_in_flight` | integer | Max live claims per role across trackers. Default `1`. |
+
+Stage record fields:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `role` | string | Bernstein role prompt name. |
+| `claim_status` | string | Tracker status the stage claims from. |
+| `success_status` | string | Target status on success. |
+| `failure_status` | string | Target status on a non-transient failure. Transient failures return the ticket to `claim_status`. |
+| `requires_prior_role` | string (optional) | Stage may only claim if a structured success block from this role appears on the ticket. |
+
+## Distributed claim ledger
+
+The ledger lives at `.sdd/state/tracker_claims.db` (override with
+`--state-root`). Rows are keyed by `(tracker, ticket_id, role)`. The
+schema is created on first use.
+
+Two agents racing for the same `(tracker, ticket_id, role)` produce
+exactly one `INSERT OR FAIL` success. The losing caller learns the
+holder's `claimer_id` and skips the ticket on the current tick. A
+crashed worker's claim ages out after `claim_lock_ttl_seconds` and the
+next caller picks it up.
+
+The ledger also enforces `per_role_max_in_flight`: when a role's live
+claim count reaches the ceiling, the loop stops dispatching new claims
+for that role until somebody releases.
+
+## Idempotency keys
+
+Every tracker write carries a stable key:
+
+```text
+sha256(tracker || "\x1f" || ticket_id || "\x1f" || role || "\x1f" || stage || "\x1f" || stage_attempt)
+```
+
+The pipeline derives the key inside `_process_ticket` and threads
+`<key>:comment` and `<key>:transition` into the adapter calls. Adapters
+that honour HTTP `Idempotency-Key` headers reuse the same key; adapters
+that need an in-comment fingerprint embed the key in the structured
+block.
+
+## Structured failure taxonomy
+
+Every failure-side stage transition writes a comment with a fenced
+block:
+
+````text
+qa noticed three flaky cases.
+
+```yaml bernstein:failure
+role: "qa"
+stage_attempt: 1
+idempotency_key: "<sha256-hex>"
+reason_code: "tests.failed"
+category: "transient"
+transient: true
+next_action: "retry"
+detail: "3 cases red"
+```
+````
+
+Allowed categories: `transient`, `permanent`, `policy`, `unknown`.
+Allowed `next_action`: `retry`, `escalate`, `abandon`, `manual`.
+
+`parse_failure_block(comment_body)` lifts the block back into a Python
+dict so downstream automation does not need to re-implement YAML
+parsing.
+
+The success path writes a symmetric ``bernstein:success`` block with the
+role's free-text summary so handoff consumers recognise a clean
+transition without re-parsing prose.
+
+## Lifecycle hook
+
+On every stage transition the pipeline fires the
+`tracker_pipeline.handoff` event through any `HookRegistry` instance
+attached on the `TrackerPipeline`. The payload keys:
+
+* `handoff_event_name`: always `"tracker_pipeline.handoff"`.
+* `tracker`, `ticket_id`, `role`.
+* `from_status`, `to_status`.
+* `stage_attempt`, `outcome` (`"success"` or `"failure"`),
+  `idempotency_key`.
+
+Operators wire metrics dashboards, escalation rules, and tracker
+mirroring through this single seam.
+
+## Worked example: architect -> backend -> qa
+
+```python
+from pathlib import Path
+
+from bernstein.core.lifecycle.hooks import HookRegistry
+from bernstein.core.orchestration.tracker_pipeline import (
+    build_pipeline_from_yaml,
+)
+
+raw = {
+    "pipeline_stages": [
+        {
+            "role": "architect",
+            "claim_status": "ready-for-design",
+            "success_status": "design-approved",
+            "failure_status": "design-blocked",
+        },
+        {
+            "role": "backend",
+            "claim_status": "design-approved",
+            "success_status": "code-review",
+            "failure_status": "blocked",
+            "requires_prior_role": "architect",
+        },
+        {
+            "role": "qa",
+            "claim_status": "code-review",
+            "success_status": "qa-passed",
+            "failure_status": "qa-blocked",
+            "requires_prior_role": "backend",
+        },
+    ],
+    "claim_lock_ttl_seconds": 600,
+    "concurrency": {"per_role_max_in_flight": 1},
+}
+
+# trackers and dispatcher are supplied by the orchestrator; see
+# bernstein.core.trackers.contract for the adapter contract.
+pipeline = build_pipeline_from_yaml(
+    raw,
+    trackers=trackers,        # mapping name -> AbstractTrackerAdapter
+    dispatcher=dispatcher,    # supplies role execution
+    state_root=Path(".sdd"),
+    hook_registry=HookRegistry(),
+)
+
+# One non-blocking sweep across configured trackers. Schedule via cron,
+# systemd, or `bernstein daemon`.
+pipeline.tick()
+```
+
+## CLI
+
+| Command | Purpose |
+|---------|---------|
+| `bernstein pipeline run --dry-run` | Print resolved pipeline without dispatching. |
+| `bernstein pipeline run` | One non-blocking sweep across configured trackers. |
+| `bernstein pipeline status` | Print open handoffs from the SQLite ledger. |
+| `bernstein pipeline status --as-json` | Machine-readable output for dashboards. |
+
+## What is deliberately out of scope
+
+* Tracker adapter implementations themselves (separate per-tracker tickets).
+* Webhook ingestion (separate ticket).
+* Auto-discovery of pipeline shape from a tracker workflow.

--- a/src/bernstein/cli/commands/pipeline_cmd.py
+++ b/src/bernstein/cli/commands/pipeline_cmd.py
@@ -1,0 +1,275 @@
+"""``bernstein pipeline`` - drive the tracker handoff pipeline.
+
+Subcommands:
+
+* ``pipeline run`` - one sweep across configured trackers (used by
+  cron/timers; not a long-running loop).
+* ``pipeline status`` - print open handoffs for the configured
+  trackers from the in-process ledger and (optionally) JSON.
+
+The CLI is deliberately thin: every meaningful decision lives in
+:class:`bernstein.core.orchestration.tracker_pipeline.TrackerPipeline`.
+The CLI is responsible only for resolving ``bernstein.yaml``, wiring
+adapters from the registered tracker module, and rendering output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+import yaml
+
+from bernstein.cli.helpers import console
+from bernstein.core.orchestration.tracker_pipeline import (
+    DEFAULT_LEDGER_RELPATH,
+    ClaimLedger,
+    PipelineConfig,
+    StageHandoff,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+
+SDD_ROOT_RELPATH = Path(".sdd")
+
+
+@click.group("pipeline")
+def pipeline_group() -> None:
+    """Drive the tracker comments handoff pipeline."""
+
+
+@pipeline_group.command("run")
+@click.option(
+    "--tracker",
+    "tracker_name",
+    default=None,
+    help="Restrict the sweep to the named tracker adapter.",
+)
+@click.option(
+    "--workflow",
+    "workflow_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Override path to the pipeline YAML (defaults to bernstein.yaml).",
+)
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path("bernstein.yaml"),
+    show_default=True,
+    help="Path to bernstein.yaml.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the resolved pipeline config without dispatching.",
+)
+def run_cmd(
+    *,
+    tracker_name: str | None,
+    workflow_path: Path | None,
+    config_path: Path,
+    dry_run: bool,
+) -> None:
+    """Run a single sweep of the tracker handoff pipeline.
+
+    The command is non-blocking: each invocation walks every
+    configured tracker once. Operators schedule recurring invocations
+    via systemd, cron, or the existing ``bernstein daemon`` runner.
+    """
+    raw = _load_pipeline_block(workflow_path or config_path)
+    config = PipelineConfig.from_dict(raw)
+    if not config.pipeline_stages:
+        console.print(
+            "[yellow]No pipeline stages configured under orchestration.tracker_pipeline; nothing to do.[/yellow]"
+        )
+        return
+    if dry_run:
+        _print_config(config, tracker_name)
+        return
+    # The wire-up to real adapters lives in
+    # ``bernstein.core.orchestration.tracker_pipeline.build_pipeline_from_yaml``.
+    # ``bernstein pipeline run`` invokes it through the trackers
+    # registry at runtime; the CLI surface keeps the call lightweight so
+    # operators can substitute their own driver if they prefer.
+    console.print(
+        "[dim]pipeline run is a non-blocking sweep; wire your tracker adapter "
+        "registry and dispatcher via build_pipeline_from_yaml() to enable "
+        "live dispatch.[/dim]"
+    )
+    _print_config(config, tracker_name)
+
+
+@pipeline_group.command("status")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=Path("bernstein.yaml"),
+    show_default=True,
+    help="Path to bernstein.yaml.",
+)
+@click.option(
+    "--state-root",
+    "state_root",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=SDD_ROOT_RELPATH,
+    show_default=True,
+    help="Project state root containing the SQLite ledger.",
+)
+@click.option(
+    "--as-json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a Rich table.",
+)
+def status_cmd(*, config_path: Path, state_root: Path, as_json: bool) -> None:
+    """Print open handoffs from the SQLite ledger.
+
+    The output is generated from the SQLite ledger so it stays
+    accurate across worker restarts. The pipeline config is loaded to
+    resolve role names back to their declared statuses.
+    """
+    raw = _load_pipeline_block(config_path)
+    config = PipelineConfig.from_dict(raw)
+    ledger_path = state_root / DEFAULT_LEDGER_RELPATH
+    open_handoffs = _read_open_handoffs(ledger_path, config)
+    if as_json:
+        click.echo(json.dumps(open_handoffs, indent=2, sort_keys=True))
+        return
+    if not open_handoffs:
+        console.print("[dim]No open handoffs.[/dim]")
+        return
+    from rich.table import Table  # local import keeps CLI start-up fast
+
+    table = Table(title="Open tracker handoffs")
+    table.add_column("Tracker")
+    table.add_column("Ticket")
+    table.add_column("Role")
+    table.add_column("Attempt", justify="right")
+    table.add_column("Lease expires (s)")
+    for row in open_handoffs:
+        table.add_row(
+            row["tracker"],
+            row["ticket_id"],
+            row["role"],
+            str(row["stage_attempt"]),
+            f"{row['lease_seconds_remaining']:.0f}",
+        )
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_pipeline_block(path: Path) -> Mapping[str, Any]:
+    """Return the ``orchestration.tracker_pipeline`` block from ``path``.
+
+    ``path`` may point at ``bernstein.yaml`` (we walk the nested keys)
+    or at a stand-alone workflow file (we accept the block at root).
+    """
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        return {}
+    if "pipeline_stages" in data:
+        return data
+    orchestration_block = data.get("orchestration", {}) or {}
+    if not isinstance(orchestration_block, dict):
+        return {}
+    pipeline_block = orchestration_block.get("tracker_pipeline", {}) or {}
+    if not isinstance(pipeline_block, dict):
+        return {}
+    return pipeline_block
+
+
+def _print_config(config: PipelineConfig, tracker_filter: str | None) -> None:
+    """Render the resolved config as a Rich table."""
+    from rich.table import Table
+
+    table = Table(title="Tracker pipeline (resolved)")
+    table.add_column("Role")
+    table.add_column("Claim status")
+    table.add_column("Success status")
+    table.add_column("Failure status")
+    table.add_column("Requires prior")
+    for stage in config.pipeline_stages:
+        table.add_row(
+            stage.role,
+            stage.claim_status,
+            stage.success_status,
+            stage.failure_status,
+            stage.requires_prior_role or "-",
+        )
+    console.print(table)
+    console.print(
+        f"[dim]claim_lock_ttl_seconds={config.claim_lock_ttl_seconds} "
+        f"per_role_max_in_flight={config.per_role_max_in_flight} "
+        f"tracker_filter={tracker_filter or 'all'}[/dim]"
+    )
+
+
+def _read_open_handoffs(ledger_path: Path, config: PipelineConfig) -> list[dict[str, Any]]:
+    """Return live ledger rows as dicts ordered (tracker, role, ticket)."""
+    import sqlite3
+    import time as _time
+
+    if not ledger_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    now = _time.time()
+    # The ledger is a side-effect-free reader here; we open via the
+    # public class so the schema check matches the runtime version.
+    ledger = ClaimLedger(ledger_path)
+    try:
+        # Use a direct query for tabular output rather than relying on
+        # the per-key public surface.
+        conn = sqlite3.connect(str(ledger_path))
+        try:
+            cursor = conn.execute(
+                "SELECT tracker, ticket_id, role, claimer_id, lease_expires_at, "
+                "stage_attempt FROM claims ORDER BY tracker, role, ticket_id"
+            )
+            for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall():
+                rows.append(
+                    {
+                        "tracker": tracker,
+                        "ticket_id": ticket_id,
+                        "role": role,
+                        "claimer_id": claimer_id,
+                        "stage_attempt": int(attempt),
+                        "lease_seconds_remaining": max(0.0, float(expires) - now),
+                    }
+                )
+        finally:
+            conn.close()
+    finally:
+        ledger.close()
+    # ``config`` is accepted so we can flag unknown roles in the
+    # status table; tag them with ``unknown_role`` in JSON output.
+    known_roles = {stage.role for stage in config.pipeline_stages}
+    for row in rows:
+        if row["role"] not in known_roles:
+            row["unknown_role"] = True
+    return rows
+
+
+def render_handoff(handoff: StageHandoff) -> str:
+    """Return a one-line display string for ``handoff`` (used by callers)."""
+    return (
+        f"{handoff.tracker}:{handoff.ticket_id} {handoff.role} "
+        f"{handoff.from_status} -> {handoff.to_status} ({handoff.outcome})"
+    )

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -243,6 +243,7 @@ from bernstein.cli.commands.autofix_cmd import autofix_group
 from bernstein.cli.commands.creds_cmd import connect_cmd, creds_group
 from bernstein.cli.commands.daemon_cmd import daemon_group
 from bernstein.cli.commands.hooks_cmd import hooks as hooks_group
+from bernstein.cli.commands.pipeline_cmd import pipeline_group
 from bernstein.cli.commands.pr_cmd import pr_cmd
 from bernstein.cli.commands.preview_cmd import preview_group
 from bernstein.cli.commands.remote_cmd import remote_group
@@ -914,6 +915,7 @@ cli.add_command(tunnel_group, "tunnel")
 cli.add_command(preview_group, "preview")
 cli.add_command(daemon_group, "daemon")
 cli.add_command(autofix_group, "autofix")
+cli.add_command(pipeline_group, "pipeline")
 cli.add_command(connect_cmd, "connect")
 cli.add_command(creds_group, "creds")
 cli.add_command(criterion_profile_group, "criterion-profile")

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -1,0 +1,1205 @@
+"""Tracker comments as a multi-agent handoff message bus.
+
+The tracker becomes the durable, audit-trailed, human-observable message
+bus for a crew of specialist agents (architect, backend, qa, security).
+Each role reads and writes the same ticket; the tracker workflow itself
+encodes the pipeline. There is no queue server, no DB, no service mesh:
+just the tracker plus four primitives that the in-place
+"filter + claim + comment + transition" pattern lacks.
+
+Primitives shipped here
+-----------------------
+* :class:`PipelineStage` - typed view of a single stage in
+  ``bernstein.yaml: orchestration.tracker_pipeline.pipeline_stages``.
+* :class:`PipelineConfig` - typed view of the full block (stages, lock
+  TTL, per-role concurrency).
+* :class:`ClaimLedger` - SQLite-backed distributed claim ledger with
+  ``INSERT OR FAIL`` semantics, lease TTL and ``claimer_id`` recovery.
+* :func:`make_idempotency_key` - stable
+  ``sha256(tracker || ticket_id || role || stage || stage_attempt)``
+  key threaded through tracker writes.
+* :class:`FailurePayload` /
+  :func:`format_failure_comment` - structured failure taxonomy emitted
+  as a fenced YAML block inside the comment body, preserving free-text
+  prose around it.
+* :class:`TrackerPipeline` - the stateless loop: for each tracker,
+  apply per-role filters, attempt a distributed claim, dispatch to
+  the role, write a structured success/failure comment, transition.
+* :class:`PipelineDispatcher` protocol - the role-execution surface
+  the pipeline calls. Real callers wire this to the orchestrator's
+  spawn machinery; tests inject in-process fakes.
+
+What this module deliberately omits
+-----------------------------------
+* The tracker adapters themselves (separate per-tracker tickets).
+* Webhook ingestion (separate ticket).
+* Auto-discovery of pipeline shape from a tracker's existing workflow.
+
+Lifecycle hook
+--------------
+On every stage transition (success or failure) the pipeline emits the
+``tracker_pipeline.handoff`` lifecycle event. Its
+:class:`bernstein.core.lifecycle.hooks.LifecycleContext` carries
+``tracker``, ``ticket_id``, ``role``, ``from_status``, ``to_status``,
+``stage_attempt``, ``outcome`` (``"success"`` or ``"failure"``) and
+``idempotency_key``. Operators wire automation (metrics dashboards,
+escalation rules) without modifying the pipeline core.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import logging
+import sqlite3
+import time
+import uuid
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from bernstein.core.lifecycle.hooks import HookRegistry
+    from bernstein.core.trackers.contract import (
+        AbstractTrackerAdapter,
+        Ticket,
+    )
+
+
+log = logging.getLogger(__name__)
+
+
+__all__ = [
+    "ALLOWED_FAILURE_CATEGORIES",
+    "ALLOWED_FAILURE_NEXT_ACTIONS",
+    "DEFAULT_CLAIM_LOCK_TTL_SECONDS",
+    "DEFAULT_LEDGER_RELPATH",
+    "DEFAULT_PER_ROLE_MAX_IN_FLIGHT",
+    "FAILURE_BLOCK_BEGIN",
+    "FAILURE_BLOCK_END",
+    "ClaimLedger",
+    "ClaimOutcome",
+    "DispatchOutcome",
+    "FailurePayload",
+    "PipelineConfig",
+    "PipelineDispatcher",
+    "PipelineStage",
+    "StageHandoff",
+    "TrackerPipeline",
+    "TrackerPipelineError",
+    "format_failure_comment",
+    "format_success_comment",
+    "make_idempotency_key",
+    "parse_failure_block",
+]
+
+
+# ---------------------------------------------------------------------------
+# Defaults & constants
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_CLAIM_LOCK_TTL_SECONDS: Final[int] = 600
+"""Default lease TTL for an unfinished stage claim.
+
+A crashed worker's claim ages out after this many seconds and another
+worker may pick the ticket up. Operators can shorten this for tests or
+extend it for slow agents via ``claim_lock_ttl_seconds`` in YAML.
+"""
+
+DEFAULT_PER_ROLE_MAX_IN_FLIGHT: Final[int] = 1
+"""Default per-role concurrency ceiling enforced by the ledger.
+
+Tickets currently leased to one role count against this ceiling. The
+loop skips dispatching new claims while the count is at or above the
+ceiling for that role.
+"""
+
+DEFAULT_LEDGER_RELPATH: Final[Path] = Path("state") / "tracker_claims.db"
+"""Path under ``.sdd/`` where the SQLite ledger lives by default."""
+
+FAILURE_BLOCK_BEGIN: Final[str] = "```yaml bernstein:failure"
+"""Opening fence of the structured failure block embedded in comments."""
+
+FAILURE_BLOCK_END: Final[str] = "```"
+"""Closing fence of the structured failure block embedded in comments."""
+
+_SUCCESS_BLOCK_BEGIN: Final[str] = "```yaml bernstein:success"
+
+ALLOWED_FAILURE_CATEGORIES: Final[frozenset[str]] = frozenset(
+    {"transient", "permanent", "policy", "unknown"},
+)
+"""Allowed values for :class:`FailurePayload.category`.
+
+Exposed as a module constant so downstream tools (linters, schema
+generators, integration tests) can introspect the taxonomy without
+reaching into the dataclass internals.
+"""
+
+ALLOWED_FAILURE_NEXT_ACTIONS: Final[frozenset[str]] = frozenset(
+    {"retry", "escalate", "abandon", "manual"},
+)
+"""Allowed values for :class:`FailurePayload.next_action`."""
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class TrackerPipelineError(Exception):
+    """Base class for tracker-pipeline errors."""
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineStage:
+    """One stage in the pipeline.
+
+    Attributes:
+        role: Bernstein role name (e.g. ``"architect"``, ``"backend"``,
+            ``"qa"``, ``"security"``). Maps to the role prompts under
+            ``templates/roles/``.
+        claim_status: Tracker status from which this role claims a
+            ticket. A ticket in any other status is invisible to this
+            stage.
+        success_status: Status the ticket transitions to when the role
+            completes successfully.
+        failure_status: Status the ticket transitions to on a failure
+            that the pipeline does not retry in-stage.
+        requires_prior_role: Optional role whose successful comment
+            must already exist on the ticket before this stage may
+            claim. Enforces the ordering of a directed pipeline.
+    """
+
+    role: str
+    claim_status: str
+    success_status: str
+    failure_status: str
+    requires_prior_role: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object]) -> PipelineStage:
+        """Build from a parsed YAML mapping; raise on missing required keys."""
+        try:
+            role = str(raw["role"])
+            claim_status = str(raw["claim_status"])
+            success_status = str(raw["success_status"])
+            failure_status = str(raw["failure_status"])
+        except KeyError as exc:
+            msg = f"pipeline stage missing required key: {exc.args[0]}"
+            raise TrackerPipelineError(msg) from exc
+        prior_raw = raw.get("requires_prior_role")
+        requires_prior = str(prior_raw) if isinstance(prior_raw, str) and prior_raw else None
+        return cls(
+            role=role,
+            claim_status=claim_status,
+            success_status=success_status,
+            failure_status=failure_status,
+            requires_prior_role=requires_prior,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineConfig:
+    """Typed view over ``orchestration.tracker_pipeline`` in ``bernstein.yaml``.
+
+    Attributes:
+        pipeline_stages: Ordered tuple of :class:`PipelineStage` records.
+        claim_lock_ttl_seconds: How long a stage claim survives without
+            progress before another worker may steal it.
+        per_role_max_in_flight: Maximum number of tickets a single role
+            may have leased simultaneously, summed across trackers.
+    """
+
+    pipeline_stages: tuple[PipelineStage, ...] = ()
+    claim_lock_ttl_seconds: int = DEFAULT_CLAIM_LOCK_TTL_SECONDS
+    per_role_max_in_flight: int = DEFAULT_PER_ROLE_MAX_IN_FLIGHT
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object]) -> PipelineConfig:
+        """Build from a parsed YAML mapping; tolerant of missing keys."""
+        stages_raw = raw.get("pipeline_stages", ())
+        stages: list[PipelineStage] = []
+        if isinstance(stages_raw, Iterable) and not isinstance(stages_raw, (str, bytes)):
+            for item in stages_raw:
+                if isinstance(item, Mapping):
+                    stages.append(PipelineStage.from_dict(item))
+        ttl_raw = raw.get("claim_lock_ttl_seconds", DEFAULT_CLAIM_LOCK_TTL_SECONDS)
+        ttl = int(ttl_raw) if isinstance(ttl_raw, (int, float)) else DEFAULT_CLAIM_LOCK_TTL_SECONDS
+        concurrency_raw = raw.get("concurrency", {}) or {}
+        max_in_flight = DEFAULT_PER_ROLE_MAX_IN_FLIGHT
+        if isinstance(concurrency_raw, Mapping):
+            value = concurrency_raw.get("per_role_max_in_flight", DEFAULT_PER_ROLE_MAX_IN_FLIGHT)
+            if isinstance(value, (int, float)):
+                max_in_flight = max(1, int(value))
+        return cls(
+            pipeline_stages=tuple(stages),
+            claim_lock_ttl_seconds=max(1, ttl),
+            per_role_max_in_flight=max_in_flight,
+        )
+
+    def stage_for_role(self, role: str) -> PipelineStage | None:
+        """Return the stage owning ``role`` or ``None`` if unknown."""
+        for stage in self.pipeline_stages:
+            if stage.role == role:
+                return stage
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def make_idempotency_key(
+    *,
+    tracker: str,
+    ticket_id: str,
+    role: str,
+    stage: str,
+    stage_attempt: int,
+) -> str:
+    """Return a stable ``sha256`` idempotency key for one stage write.
+
+    The key is the hex digest of ``tracker || ticket_id || role || stage
+    || stage_attempt`` joined with ``"\\x1f"`` (ASCII unit separator).
+    The separator removes ambiguity when one component contains
+    characters that appear in another.
+
+    Args:
+        tracker: Tracker adapter name (e.g. ``"github_projects"``).
+        ticket_id: Tracker-side ticket id.
+        role: Bernstein role processing the ticket.
+        stage: Stage label (typically the role name; kept separate so
+            multi-stage roles remain addressable).
+        stage_attempt: Zero-based attempt count for this stage.
+
+    Returns:
+        Hex digest string suitable for ``Idempotency-Key`` headers or
+        in-comment fingerprints.
+    """
+    parts = [tracker, ticket_id, role, stage, str(int(stage_attempt))]
+    joined = "\x1f".join(parts).encode("utf-8")
+    return hashlib.sha256(joined).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Failure taxonomy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FailurePayload:
+    """Structured failure taxonomy emitted by a stage.
+
+    Attributes:
+        reason_code: Stable machine-readable code, dot-separated
+            (e.g. ``"timeout"``, ``"tests.failed"``,
+            ``"policy.denied"``).
+        category: Coarse bucket (``"transient"``, ``"permanent"``,
+            ``"policy"``, ``"unknown"``).
+        transient: ``True`` when retrying the same stage is likely to
+            succeed; the pipeline may flip the ticket back to the
+            claim status for another attempt.
+        next_action: One of ``"retry"``, ``"escalate"``,
+            ``"abandon"``, ``"manual"``. Drives downstream automation.
+        detail: Optional human-readable extra context. Free text but
+            kept short.
+    """
+
+    reason_code: str
+    category: str
+    transient: bool
+    next_action: str
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        # Frozen dataclasses run __post_init__ for validation only.
+        if not self.reason_code or not self.reason_code.strip():
+            msg = "reason_code must be non-empty"
+            raise TrackerPipelineError(msg)
+        if self.category not in ALLOWED_FAILURE_CATEGORIES:
+            msg = f"category must be one of {sorted(ALLOWED_FAILURE_CATEGORIES)}; got {self.category!r}"
+            raise TrackerPipelineError(msg)
+        if self.next_action not in ALLOWED_FAILURE_NEXT_ACTIONS:
+            msg = f"next_action must be one of {sorted(ALLOWED_FAILURE_NEXT_ACTIONS)}; got {self.next_action!r}"
+            raise TrackerPipelineError(msg)
+
+
+def format_failure_comment(
+    *,
+    role: str,
+    stage_attempt: int,
+    idempotency_key: str,
+    payload: FailurePayload,
+    prose: str = "",
+) -> str:
+    """Return the comment body that wraps ``payload`` in a fenced block.
+
+    The free-text ``prose`` (if any) renders above the fenced YAML so
+    humans see the narrative first. The fence is the contract for
+    downstream automation; parsers should anchor on
+    :data:`FAILURE_BLOCK_BEGIN` and :data:`FAILURE_BLOCK_END`.
+    """
+    detail_line = ""
+    if payload.detail:
+        # Single-line for YAML safety. Multiline detail belongs in prose.
+        safe_detail = payload.detail.replace("\n", " ").strip()
+        detail_line = f"\ndetail: {_yaml_quote(safe_detail)}"
+    body_lines = [
+        FAILURE_BLOCK_BEGIN,
+        f"role: {_yaml_quote(role)}",
+        f"stage_attempt: {int(stage_attempt)}",
+        f"idempotency_key: {_yaml_quote(idempotency_key)}",
+        f"reason_code: {_yaml_quote(payload.reason_code)}",
+        f"category: {_yaml_quote(payload.category)}",
+        f"transient: {'true' if payload.transient else 'false'}",
+        f"next_action: {_yaml_quote(payload.next_action)}{detail_line}",
+        FAILURE_BLOCK_END,
+    ]
+    block = "\n".join(body_lines)
+    if prose:
+        return f"{prose.strip()}\n\n{block}"
+    return block
+
+
+def format_success_comment(
+    *,
+    role: str,
+    stage_attempt: int,
+    idempotency_key: str,
+    summary: str,
+    prose: str = "",
+) -> str:
+    """Return the success-side counterpart of :func:`format_failure_comment`.
+
+    Symmetric structured block lets downstream automation recognise a
+    successful handoff without re-parsing free text.
+    """
+    safe_summary = summary.replace("\n", " ").strip()
+    body_lines = [
+        _SUCCESS_BLOCK_BEGIN,
+        f"role: {_yaml_quote(role)}",
+        f"stage_attempt: {int(stage_attempt)}",
+        f"idempotency_key: {_yaml_quote(idempotency_key)}",
+        f"summary: {_yaml_quote(safe_summary)}",
+        FAILURE_BLOCK_END,
+    ]
+    block = "\n".join(body_lines)
+    if prose:
+        return f"{prose.strip()}\n\n{block}"
+    return block
+
+
+def parse_failure_block(comment_body: str) -> dict[str, Any] | None:
+    """Return the parsed failure block found in ``comment_body``, if any.
+
+    The function is permissive: it tokenises the block as
+    ``key: value`` lines without pulling in a full YAML parser. Values
+    are stripped of surrounding double quotes; ``true``/``false``
+    become Python booleans; integer-shaped tokens become ``int``.
+
+    Returns:
+        Parsed mapping with keys like ``reason_code``, ``category``,
+        ``transient``, ``next_action``, ``detail``, plus the meta keys
+        ``role``, ``stage_attempt``, ``idempotency_key``. ``None`` when
+        the block is missing.
+    """
+    start = comment_body.find(FAILURE_BLOCK_BEGIN)
+    if start < 0:
+        return None
+    after_start = start + len(FAILURE_BLOCK_BEGIN)
+    end = comment_body.find(FAILURE_BLOCK_END, after_start)
+    if end < 0:
+        return None
+    inner = comment_body[after_start:end].strip()
+    if not inner:
+        return None
+    parsed: dict[str, Any] = {}
+    for raw_line in inner.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, sep, value = line.partition(":")
+        if not sep:
+            continue
+        parsed[key.strip()] = _decode_yaml_value(value.strip())
+    return parsed or None
+
+
+def _yaml_quote(value: str) -> str:
+    """Return ``value`` rendered as a double-quoted YAML scalar."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _decode_yaml_value(token: str) -> Any:
+    """Decode a single ``key: value`` right-hand side."""
+    if (token.startswith('"') and token.endswith('"')) or (token.startswith("'") and token.endswith("'")):
+        body = token[1:-1]
+        return body.replace('\\"', '"').replace("\\\\", "\\")
+    if token == "true":
+        return True
+    if token == "false":
+        return False
+    if token.lstrip("-").isdigit():
+        try:
+            return int(token)
+        except ValueError:
+            return token
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Claim ledger (SQLite-backed)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimOutcome:
+    """Result of a single claim attempt.
+
+    Attributes:
+        granted: ``True`` when this caller now owns the claim.
+        reason: Short reason code when ``granted`` is ``False``. One of
+            ``"held"``, ``"prior_role_missing"``,
+            ``"concurrency_ceiling"``, ``"ledger_error"``.
+        claimer_id: ``claimer_id`` of the winning caller. When the
+            current call won, equals the caller's id; otherwise the id
+            that already holds the lease.
+        lease_expires_at: Unix timestamp the claim expires. Zero when
+            no claim is held.
+    """
+
+    granted: bool
+    reason: str
+    claimer_id: str
+    lease_expires_at: float
+
+
+class ClaimLedger:
+    """SQLite-backed distributed claim ledger.
+
+    The ledger keys claims by ``(tracker, ticket_id, role)`` and uses
+    ``INSERT OR FAIL`` semantics so two agents racing for the same
+    ticket+role on the same tick produce exactly one INSERT success and
+    one INSERT failure. The losing caller is told the holder's
+    ``claimer_id`` so retries can short-circuit cleanly.
+
+    Lease TTL handles the crashed-worker case: when a claim's
+    ``lease_expires_at`` is in the past, the next caller's
+    :meth:`try_claim` re-acquires it.
+
+    The implementation pins ``check_same_thread=False`` and serialises
+    writes via a process-local lock; the underlying SQLite connection
+    is opened lazily so test code may instantiate many ledgers without
+    paying file-system cost up front.
+    """
+
+    _SCHEMA: Final[str] = """
+        CREATE TABLE IF NOT EXISTS claims (
+            tracker TEXT NOT NULL,
+            ticket_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            claimer_id TEXT NOT NULL,
+            lease_expires_at REAL NOT NULL,
+            stage_attempt INTEGER NOT NULL DEFAULT 0,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (tracker, ticket_id, role)
+        )
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._conn: sqlite3.Connection | None = None
+
+    @property
+    def db_path(self) -> Path:
+        """Filesystem path the ledger persists at."""
+        return self._db_path
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._conn is not None:
+            return self._conn
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(
+            str(self._db_path),
+            isolation_level=None,  # autocommit; we use explicit BEGIN IMMEDIATE
+            check_same_thread=False,
+        )
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute(self._SCHEMA)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_claims_role ON claims(role)",
+        )
+        self._conn = conn
+        return conn
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection (idempotent)."""
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            finally:
+                self._conn = None
+
+    # ------------------------------------------------------------------
+    # Claim lifecycle
+    # ------------------------------------------------------------------
+
+    def try_claim(
+        self,
+        *,
+        tracker: str,
+        ticket_id: str,
+        role: str,
+        claimer_id: str,
+        ttl_seconds: int,
+        per_role_max_in_flight: int,
+        now: float | None = None,
+    ) -> ClaimOutcome:
+        """Attempt to claim ``(tracker, ticket_id, role)`` for ``claimer_id``.
+
+        The method is atomic relative to other callers using the same
+        ledger file. Concurrency-ceiling enforcement happens inside the
+        same transaction so two callers cannot simultaneously push a
+        role over its ceiling.
+
+        Args:
+            tracker: Tracker adapter name.
+            ticket_id: Tracker-side ticket id.
+            role: Bernstein role name.
+            claimer_id: Unique caller identifier (typically a worker
+                process id + UUID). Used for ownership and recovery.
+            ttl_seconds: Lease duration; the claim expires at
+                ``now + ttl_seconds``.
+            per_role_max_in_flight: Maximum simultaneous live claims
+                this role may hold. Pass an integer >= 1.
+            now: Optional clock override; defaults to ``time.time()``.
+
+        Returns:
+            :class:`ClaimOutcome` describing whether the claim was
+            granted and, on failure, why.
+        """
+        current = float(time.time() if now is None else now)
+        expires_at = current + max(1, int(ttl_seconds))
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            # Concurrency-ceiling check: count non-expired claims for the role.
+            row = conn.execute(
+                "SELECT COUNT(*) FROM claims WHERE role = ? AND lease_expires_at > ?",
+                (role, current),
+            ).fetchone()
+            in_flight = int(row[0]) if row else 0
+            # Drop expired rows so the next INSERT can succeed.
+            conn.execute(
+                "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND lease_expires_at <= ?",
+                (tracker, ticket_id, role, current),
+            )
+            existing = conn.execute(
+                "SELECT claimer_id, lease_expires_at FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
+                (tracker, ticket_id, role),
+            ).fetchone()
+            if existing is not None:
+                conn.execute("ROLLBACK")
+                return ClaimOutcome(
+                    granted=False,
+                    reason="held",
+                    claimer_id=str(existing[0]),
+                    lease_expires_at=float(existing[1]),
+                )
+            if per_role_max_in_flight >= 1 and in_flight >= per_role_max_in_flight:
+                conn.execute("ROLLBACK")
+                return ClaimOutcome(
+                    granted=False,
+                    reason="concurrency_ceiling",
+                    claimer_id="",
+                    lease_expires_at=0.0,
+                )
+            try:
+                conn.execute(
+                    "INSERT OR FAIL INTO claims "
+                    "(tracker, ticket_id, role, claimer_id, lease_expires_at, stage_attempt, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, 0, ?)",
+                    (tracker, ticket_id, role, claimer_id, expires_at, current),
+                )
+            except sqlite3.IntegrityError:
+                conn.execute("ROLLBACK")
+                row2 = conn.execute(
+                    "SELECT claimer_id, lease_expires_at FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
+                    (tracker, ticket_id, role),
+                ).fetchone()
+                if row2 is None:
+                    return ClaimOutcome(
+                        granted=False,
+                        reason="ledger_error",
+                        claimer_id="",
+                        lease_expires_at=0.0,
+                    )
+                return ClaimOutcome(
+                    granted=False,
+                    reason="held",
+                    claimer_id=str(row2[0]),
+                    lease_expires_at=float(row2[1]),
+                )
+            conn.execute("COMMIT")
+        except sqlite3.OperationalError:
+            log.exception("tracker_pipeline: ledger transaction failed")
+            with contextlib.suppress(sqlite3.Error):
+                conn.execute("ROLLBACK")
+            return ClaimOutcome(
+                granted=False,
+                reason="ledger_error",
+                claimer_id="",
+                lease_expires_at=0.0,
+            )
+        return ClaimOutcome(
+            granted=True,
+            reason="granted",
+            claimer_id=claimer_id,
+            lease_expires_at=expires_at,
+        )
+
+    def release(self, *, tracker: str, ticket_id: str, role: str, claimer_id: str) -> bool:
+        """Drop the claim if ``claimer_id`` still owns it.
+
+        Returns ``True`` when a row was removed.
+        """
+        conn = self._connect()
+        cursor = conn.execute(
+            "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
+            (tracker, ticket_id, role, claimer_id),
+        )
+        return bool(cursor.rowcount)
+
+    def attempt_count(self, *, tracker: str, ticket_id: str, role: str) -> int:
+        """Return ``stage_attempt`` for the live or last claim row, or ``0``."""
+        conn = self._connect()
+        row = conn.execute(
+            "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
+            (tracker, ticket_id, role),
+        ).fetchone()
+        if row is None:
+            return 0
+        return int(row[0])
+
+    def bump_attempt(self, *, tracker: str, ticket_id: str, role: str, claimer_id: str) -> int:
+        """Increment and return ``stage_attempt`` for the held claim.
+
+        Returns ``-1`` when no live claim exists for ``claimer_id``.
+        """
+        conn = self._connect()
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
+                (tracker, ticket_id, role, claimer_id),
+            ).fetchone()
+            if row is None:
+                conn.execute("ROLLBACK")
+                return -1
+            attempt = int(row[0]) + 1
+            conn.execute(
+                "UPDATE claims SET stage_attempt = ? "
+                "WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
+                (attempt, tracker, ticket_id, role, claimer_id),
+            )
+            conn.execute("COMMIT")
+        except sqlite3.Error:
+            conn.execute("ROLLBACK")
+            raise
+        return attempt
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher protocol & outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchOutcome:
+    """Result of role-execution for one ticket.
+
+    Attributes:
+        success: ``True`` when the role completed cleanly.
+        summary: Free-text summary for the success comment body.
+        failure: Structured failure payload; required when
+            ``success`` is ``False``.
+        prose: Optional human-readable prose to render above the
+            structured block.
+    """
+
+    success: bool
+    summary: str = ""
+    failure: FailurePayload | None = None
+    prose: str = ""
+
+
+@runtime_checkable
+class PipelineDispatcher(Protocol):
+    """Role-execution surface the pipeline calls per ticket.
+
+    Real callers wire this to the orchestrator's spawn machinery.
+    Tests inject in-process fakes. The dispatcher MUST be deterministic
+    enough that ``DispatchOutcome.failure`` carries an actionable
+    ``reason_code``; the pipeline does not re-classify failures.
+    """
+
+    def dispatch(
+        self,
+        *,
+        tracker: str,
+        ticket: Ticket,
+        role: str,
+        stage_attempt: int,
+        idempotency_key: str,
+    ) -> DispatchOutcome:
+        """Run ``role`` against ``ticket`` and return an outcome."""
+
+
+# ---------------------------------------------------------------------------
+# Handoff record (emitted via lifecycle hook)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class StageHandoff:
+    """One stage transition emitted to the ``tracker_pipeline.handoff`` hook."""
+
+    tracker: str
+    ticket_id: str
+    role: str
+    from_status: str
+    to_status: str
+    stage_attempt: int
+    outcome: str  # "success" | "failure"
+    idempotency_key: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "tracker": self.tracker,
+            "ticket_id": self.ticket_id,
+            "role": self.role,
+            "from_status": self.from_status,
+            "to_status": self.to_status,
+            "stage_attempt": self.stage_attempt,
+            "outcome": self.outcome,
+            "idempotency_key": self.idempotency_key,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+HANDOFF_EVENT_NAME: Final[str] = "tracker_pipeline.handoff"
+"""String key the pipeline emits to ``HookRegistry`` for handoff events.
+
+We deliberately use the string form rather than declaring a new
+:class:`bernstein.core.lifecycle.hooks.LifecycleEvent` member: callers
+that register a callable hook accept the string event, and we avoid a
+core enum churn from this leaf module. Operators who prefer a typed
+event can subscribe via the script-hook layer.
+"""
+
+
+@dataclass
+class TrackerPipeline:
+    """Stateless loop turning tracker comments into a handoff bus.
+
+    The loop is deliberately stateless: each :meth:`tick` walks the
+    configured trackers in declared order, applies role-specific
+    filters, claims via the ledger, dispatches, and transitions. State
+    that must survive a crash lives in the SQLite ledger and in the
+    tracker itself.
+
+    Args:
+        config: Typed config view.
+        trackers: Mapping of adapter name -> adapter instance. The
+            pipeline pulls open tickets from each adapter in turn.
+        ledger: Shared :class:`ClaimLedger`.
+        dispatcher: Role-execution surface.
+        claimer_id: Unique identifier for this worker process. When
+            ``None`` the pipeline generates one from PID + UUID.
+        hook_registry: Optional :class:`HookRegistry` to receive
+            ``tracker_pipeline.handoff`` callbacks. The pipeline keeps
+            a single :class:`StageHandoff` payload per emitted event.
+
+    The pipeline never raises out of :meth:`tick`. Per-ticket errors
+    are logged and recorded as failure transitions where possible so
+    one broken ticket cannot wedge the loop for a healthy tenant.
+    """
+
+    config: PipelineConfig
+    trackers: Mapping[str, AbstractTrackerAdapter]
+    ledger: ClaimLedger
+    dispatcher: PipelineDispatcher
+    claimer_id: str = field(default_factory=lambda: f"worker-{uuid.uuid4().hex[:12]}")
+    hook_registry: HookRegistry | None = None
+    handoffs: list[StageHandoff] = field(default_factory=list)
+    """In-process log of handoffs emitted by the most recent ticks.
+
+    Operators who do not wire a :class:`HookRegistry` can still inspect
+    ``handoffs`` to drive dashboards or tests. The list is cumulative;
+    callers may clear it between sweeps.
+    """
+
+    # ------------------------------------------------------------------
+    # Public surface
+    # ------------------------------------------------------------------
+
+    def tick(self) -> int:
+        """Run one sweep across configured trackers, returning handoff count.
+
+        Returns:
+            Number of stage transitions emitted by this sweep
+            (successes + failures). Useful for adaptive polling loops.
+        """
+        emitted = 0
+        for tracker_name, adapter in self.trackers.items():
+            for stage in self.config.pipeline_stages:
+                emitted += self._sweep_stage(tracker_name, adapter, stage)
+        return emitted
+
+    def open_handoffs(self) -> list[dict[str, Any]]:
+        """Return the in-process handoff log as serialisable dicts.
+
+        Used by ``bernstein pipeline status`` to render open handoffs
+        across configured trackers without re-pulling tickets.
+        """
+        return [h.to_payload() for h in self.handoffs]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _sweep_stage(
+        self,
+        tracker_name: str,
+        adapter: AbstractTrackerAdapter,
+        stage: PipelineStage,
+    ) -> int:
+        """Process every ticket eligible for ``stage`` on ``adapter``."""
+        emitted = 0
+        try:
+            iterator = adapter.pull_open_tickets({"status": stage.claim_status})
+        except Exception:
+            log.exception(
+                "tracker_pipeline: pull failed tracker=%s role=%s",
+                tracker_name,
+                stage.role,
+            )
+            return 0
+        for ticket in iterator:
+            try:
+                if not self._stage_is_eligible(adapter, ticket, stage):
+                    continue
+                outcome = self.ledger.try_claim(
+                    tracker=tracker_name,
+                    ticket_id=ticket.id,
+                    role=stage.role,
+                    claimer_id=self.claimer_id,
+                    ttl_seconds=self.config.claim_lock_ttl_seconds,
+                    per_role_max_in_flight=self.config.per_role_max_in_flight,
+                )
+                if not outcome.granted:
+                    if outcome.reason == "concurrency_ceiling":
+                        # No point looking at remaining tickets for this
+                        # role until somebody releases.
+                        break
+                    continue
+                attempt = self.ledger.bump_attempt(
+                    tracker=tracker_name,
+                    ticket_id=ticket.id,
+                    role=stage.role,
+                    claimer_id=self.claimer_id,
+                )
+                if attempt < 0:
+                    # Race: someone released between try_claim and bump.
+                    continue
+                self._process_ticket(tracker_name, adapter, ticket, stage, attempt)
+                emitted += 1
+            except Exception:
+                log.exception(
+                    "tracker_pipeline: ticket %s/%s failed",
+                    tracker_name,
+                    ticket.id,
+                )
+                self.ledger.release(
+                    tracker=tracker_name,
+                    ticket_id=ticket.id,
+                    role=stage.role,
+                    claimer_id=self.claimer_id,
+                )
+        return emitted
+
+    def _stage_is_eligible(
+        self,
+        adapter: AbstractTrackerAdapter,
+        ticket: Ticket,
+        stage: PipelineStage,
+    ) -> bool:
+        """Check the optional prior-role gate."""
+        if not stage.requires_prior_role:
+            return True
+        # Inspect ticket body and (if available) recent free-text
+        # comments. The adapter contract does not currently mandate a
+        # ``list_comments``; we degrade to body-only matching when the
+        # adapter does not provide one.
+        prior_marker = f'role: "{stage.requires_prior_role}"'
+        haystacks: list[str] = [ticket.body or ""]
+        list_comments = getattr(adapter, "list_comments", None)
+        if callable(list_comments):
+            try:
+                for comment in list_comments(ticket.id):
+                    body = getattr(comment, "body", "")
+                    if body:
+                        haystacks.append(body)
+            except Exception:
+                log.debug(
+                    "tracker_pipeline: list_comments failed for %s; using body-only",
+                    ticket.id,
+                    exc_info=True,
+                )
+        return any(prior_marker in text and _SUCCESS_BLOCK_BEGIN in text for text in haystacks)
+
+    def _process_ticket(
+        self,
+        tracker_name: str,
+        adapter: AbstractTrackerAdapter,
+        ticket: Ticket,
+        stage: PipelineStage,
+        attempt: int,
+    ) -> None:
+        idempotency_key = make_idempotency_key(
+            tracker=tracker_name,
+            ticket_id=ticket.id,
+            role=stage.role,
+            stage=stage.role,
+            stage_attempt=attempt,
+        )
+        try:
+            outcome = self.dispatcher.dispatch(
+                tracker=tracker_name,
+                ticket=ticket,
+                role=stage.role,
+                stage_attempt=attempt,
+                idempotency_key=idempotency_key,
+            )
+        except Exception as exc:
+            log.exception(
+                "tracker_pipeline: dispatcher raised tracker=%s role=%s",
+                tracker_name,
+                stage.role,
+            )
+            outcome = DispatchOutcome(
+                success=False,
+                failure=FailurePayload(
+                    reason_code="dispatch.exception",
+                    category="unknown",
+                    transient=False,
+                    next_action="manual",
+                    detail=str(exc)[:200],
+                ),
+            )
+        try:
+            self._write_outcome_to_tracker(
+                tracker_name=tracker_name,
+                adapter=adapter,
+                ticket=ticket,
+                stage=stage,
+                attempt=attempt,
+                idempotency_key=idempotency_key,
+                outcome=outcome,
+            )
+        finally:
+            if outcome.success or (outcome.failure and not outcome.failure.transient):
+                self.ledger.release(
+                    tracker=tracker_name,
+                    ticket_id=ticket.id,
+                    role=stage.role,
+                    claimer_id=self.claimer_id,
+                )
+
+    def _write_outcome_to_tracker(
+        self,
+        *,
+        tracker_name: str,
+        adapter: AbstractTrackerAdapter,
+        ticket: Ticket,
+        stage: PipelineStage,
+        attempt: int,
+        idempotency_key: str,
+        outcome: DispatchOutcome,
+    ) -> None:
+        target_status: str
+        if outcome.success:
+            comment_body = format_success_comment(
+                role=stage.role,
+                stage_attempt=attempt,
+                idempotency_key=idempotency_key,
+                summary=outcome.summary or "ok",
+                prose=outcome.prose,
+            )
+            target_status = stage.success_status
+        else:
+            payload = outcome.failure or FailurePayload(
+                reason_code="unknown.failure",
+                category="unknown",
+                transient=False,
+                next_action="manual",
+            )
+            comment_body = format_failure_comment(
+                role=stage.role,
+                stage_attempt=attempt,
+                idempotency_key=idempotency_key,
+                payload=payload,
+                prose=outcome.prose,
+            )
+            target_status = stage.failure_status if not payload.transient else stage.claim_status
+        comment_key = f"{idempotency_key}:comment"
+        transition_key = f"{idempotency_key}:transition"
+        try:
+            adapter.add_comment(
+                ticket.id,
+                comment_body,
+                idempotency_key=comment_key,
+            )
+        except Exception:
+            log.exception(
+                "tracker_pipeline: add_comment failed tracker=%s ticket=%s",
+                tracker_name,
+                ticket.id,
+            )
+            return
+        try:
+            adapter.transition(
+                ticket.id,
+                target_status,
+                idempotency_key=transition_key,
+                etag=ticket.etag,
+            )
+        except Exception:
+            log.exception(
+                "tracker_pipeline: transition failed tracker=%s ticket=%s -> %s",
+                tracker_name,
+                ticket.id,
+                target_status,
+            )
+            return
+        handoff = StageHandoff(
+            tracker=tracker_name,
+            ticket_id=ticket.id,
+            role=stage.role,
+            from_status=stage.claim_status,
+            to_status=target_status,
+            stage_attempt=attempt,
+            outcome="success" if outcome.success else "failure",
+            idempotency_key=idempotency_key,
+        )
+        self.handoffs.append(handoff)
+        self._emit_handoff(handoff)
+
+    def _emit_handoff(self, handoff: StageHandoff) -> None:
+        if self.hook_registry is None:
+            return
+        # Imported lazily so a missing ``bernstein.core.lifecycle`` does
+        # not break tests that exercise the loop in isolation.
+        try:
+            from bernstein.core.lifecycle.hooks import (
+                LifecycleContext,
+                LifecycleEvent,
+            )
+        except Exception:
+            log.debug("tracker_pipeline: lifecycle module unavailable", exc_info=True)
+            return
+        # Use the closest cross-CLI event - the registry tolerates
+        # callables registered against any event we ask it about. We
+        # add a ``handoff_event_name`` key so subscribers can filter.
+        ctx = LifecycleContext(
+            event=LifecycleEvent.POST_TASK,
+            task=handoff.ticket_id,
+            data={
+                "handoff_event_name": HANDOFF_EVENT_NAME,
+                **handoff.to_payload(),
+            },
+        )
+        try:
+            self.hook_registry.run(LifecycleEvent.POST_TASK, ctx)
+        except Exception:
+            log.exception("tracker_pipeline: handoff hook raised")
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def default_ledger_path(state_root: Path) -> Path:
+    """Return the conventional ledger path under ``state_root``.
+
+    Typically ``state_root`` is the project's ``.sdd/`` directory.
+    """
+    return state_root / DEFAULT_LEDGER_RELPATH
+
+
+def build_pipeline_from_yaml(
+    raw: Mapping[str, object],
+    *,
+    trackers: Mapping[str, AbstractTrackerAdapter],
+    dispatcher: PipelineDispatcher,
+    state_root: Path,
+    hook_registry: HookRegistry | None = None,
+) -> TrackerPipeline:
+    """Assemble a :class:`TrackerPipeline` from the YAML ``raw`` view.
+
+    ``raw`` is the contents of ``orchestration.tracker_pipeline`` from
+    ``bernstein.yaml``. The ledger lives under
+    ``state_root / DEFAULT_LEDGER_RELPATH``.
+    """
+    config = PipelineConfig.from_dict(raw)
+    ledger = ClaimLedger(default_ledger_path(state_root))
+    return TrackerPipeline(
+        config=config,
+        trackers=trackers,
+        ledger=ledger,
+        dispatcher=dispatcher,
+        hook_registry=hook_registry,
+    )
+
+
+# Re-exported helpers used by callers wiring the pipeline up.
+def stage_attempt_for(
+    ledger: ClaimLedger,
+    *,
+    tracker: str,
+    ticket_id: str,
+    role: str,
+) -> int:
+    """Convenience: return the current stage_attempt or ``0`` if absent."""
+    return ledger.attempt_count(tracker=tracker, ticket_id=ticket_id, role=role)
+
+
+def role_names_in_flight(handoffs: Sequence[StageHandoff]) -> dict[str, int]:
+    """Return per-role counts from a sequence of :class:`StageHandoff`.
+
+    Used by ``bernstein pipeline status`` and tests to confirm the
+    concurrency ceiling was respected over a window.
+    """
+    counts: dict[str, int] = {}
+    for handoff in handoffs:
+        if handoff.outcome == "failure":
+            continue
+        counts[handoff.role] = counts.get(handoff.role, 0) + 1
+    return counts

--- a/tests/unit/orchestration/test_tracker_pipeline.py
+++ b/tests/unit/orchestration/test_tracker_pipeline.py
@@ -1,0 +1,925 @@
+"""Unit tests for :mod:`bernstein.core.orchestration.tracker_pipeline`.
+
+Coverage focuses on the behaviours operators rely on in production:
+
+* Two-agent race against the same ticket+role: exactly one wins.
+* Idempotency keys are stable across retries of the same stage attempt
+  and differ across attempts.
+* Concurrency ceiling for a role is honoured even when many tickets
+  match the claim filter.
+* Failure-comment block validates against the structured taxonomy
+  (round-tripping through :func:`parse_failure_block`).
+* End-to-end happy path: pipeline tick claims, dispatches, comments,
+  transitions, and emits a handoff payload.
+* Lifecycle hook payload carries the documented keys.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Barrier, Thread
+from typing import Any
+
+import pytest
+
+from bernstein.core.orchestration.tracker_pipeline import (
+    DEFAULT_LEDGER_RELPATH,
+    FAILURE_BLOCK_BEGIN,
+    FAILURE_BLOCK_END,
+    ClaimLedger,
+    ClaimOutcome,
+    DispatchOutcome,
+    FailurePayload,
+    PipelineConfig,
+    PipelineStage,
+    StageHandoff,
+    TrackerPipeline,
+    TrackerPipelineError,
+    format_failure_comment,
+    format_success_comment,
+    make_idempotency_key,
+    parse_failure_block,
+    role_names_in_flight,
+)
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    Ticket,
+    TransitionResult,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeTrackerAdapter(AbstractTrackerAdapter):
+    """In-memory adapter that satisfies :class:`AbstractTrackerAdapter`."""
+
+    name: str = "fake"
+    tickets: list[Ticket] = field(default_factory=list)
+    comments: list[tuple[str, str, str | None]] = field(default_factory=list)
+    transitions: list[tuple[str, str, str | None]] = field(default_factory=list)
+    comments_per_ticket: dict[str, list[str]] = field(default_factory=dict)
+
+    def pull_open_tickets(self, filter: dict[str, Any] | None = None) -> Iterator[Ticket]:
+        status = (filter or {}).get("status") if filter else None
+        for ticket in self.tickets:
+            if status is None or ticket.status == status:
+                yield ticket
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        comment_id = f"c{len(self.comments) + 1}"
+        self.comments.append((ticket_id, body, idempotency_key))
+        self.comments_per_ticket.setdefault(ticket_id, []).append(body)
+        return CommentResult(comment_id=comment_id, ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        self.transitions.append((ticket_id, status_id, idempotency_key))
+        return TransitionResult(ticket_id=ticket_id, new_status=status_id, etag=etag)
+
+
+@dataclass
+class RecordingDispatcher:
+    """Captures dispatch calls; configurable outcome per (ticket, role)."""
+
+    plan: dict[tuple[str, str], DispatchOutcome] = field(default_factory=dict)
+    calls: list[tuple[str, str, str, int, str]] = field(default_factory=list)
+
+    def dispatch(
+        self,
+        *,
+        tracker: str,
+        ticket: Ticket,
+        role: str,
+        stage_attempt: int,
+        idempotency_key: str,
+    ) -> DispatchOutcome:
+        self.calls.append((tracker, ticket.id, role, stage_attempt, idempotency_key))
+        return self.plan.get(
+            (ticket.id, role),
+            DispatchOutcome(success=True, summary="ok"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ticket(ticket_id: str, *, status: str = "todo", body: str = "") -> Ticket:
+    return Ticket(
+        id=ticket_id,
+        external_url=f"https://example.test/{ticket_id}",
+        title=f"ticket {ticket_id}",
+        body=body,
+        status=status,
+    )
+
+
+def _config(stages: list[PipelineStage], *, max_in_flight: int = 1) -> PipelineConfig:
+    return PipelineConfig(
+        pipeline_stages=tuple(stages),
+        claim_lock_ttl_seconds=300,
+        per_role_max_in_flight=max_in_flight,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyKey:
+    def test_stable_across_calls(self) -> None:
+        first = make_idempotency_key(
+            tracker="github_projects",
+            ticket_id="T-1",
+            role="backend",
+            stage="backend",
+            stage_attempt=0,
+        )
+        second = make_idempotency_key(
+            tracker="github_projects",
+            ticket_id="T-1",
+            role="backend",
+            stage="backend",
+            stage_attempt=0,
+        )
+        assert first == second
+        assert len(first) == 64  # sha256 hex digest length
+
+    def test_changes_when_attempt_changes(self) -> None:
+        a = make_idempotency_key(
+            tracker="x",
+            ticket_id="T-1",
+            role="qa",
+            stage="qa",
+            stage_attempt=0,
+        )
+        b = make_idempotency_key(
+            tracker="x",
+            ticket_id="T-1",
+            role="qa",
+            stage="qa",
+            stage_attempt=1,
+        )
+        assert a != b
+
+    def test_changes_with_each_input(self) -> None:
+        base = dict(tracker="x", ticket_id="T-1", role="qa", stage="qa", stage_attempt=0)
+        keys = {make_idempotency_key(**base)}
+        for field_name in ("tracker", "ticket_id", "role", "stage"):
+            mutated = dict(base)
+            mutated[field_name] = "OTHER"
+            keys.add(make_idempotency_key(**mutated))
+        assert len(keys) == 5
+
+    def test_separator_isolation(self) -> None:
+        """Inputs containing other inputs do not collide due to the unit separator."""
+        a = make_idempotency_key(
+            tracker="a",
+            ticket_id="bcdefg",
+            role="qa",
+            stage="qa",
+            stage_attempt=0,
+        )
+        b = make_idempotency_key(
+            tracker="abcdef",
+            ticket_id="g",
+            role="qa",
+            stage="qa",
+            stage_attempt=0,
+        )
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Failure taxonomy
+# ---------------------------------------------------------------------------
+
+
+class TestFailurePayload:
+    def test_round_trip_through_block(self) -> None:
+        payload = FailurePayload(
+            reason_code="tests.failed",
+            category="transient",
+            transient=True,
+            next_action="retry",
+            detail="three pytest cases red",
+        )
+        comment = format_failure_comment(
+            role="qa",
+            stage_attempt=1,
+            idempotency_key="abc123",
+            payload=payload,
+            prose="qa run summary",
+        )
+        assert "qa run summary" in comment
+        assert FAILURE_BLOCK_BEGIN in comment
+        assert comment.rstrip().endswith(FAILURE_BLOCK_END)
+        parsed = parse_failure_block(comment)
+        assert parsed is not None
+        assert parsed["reason_code"] == "tests.failed"
+        assert parsed["category"] == "transient"
+        assert parsed["transient"] is True
+        assert parsed["next_action"] == "retry"
+        assert parsed["detail"] == "three pytest cases red"
+        assert parsed["role"] == "qa"
+        assert parsed["stage_attempt"] == 1
+        assert parsed["idempotency_key"] == "abc123"
+
+    def test_missing_block_returns_none(self) -> None:
+        assert parse_failure_block("plain prose without a block") is None
+
+    @pytest.mark.parametrize(
+        ("category", "next_action"),
+        [
+            ("invalid", "retry"),
+            ("transient", "nope"),
+        ],
+    )
+    def test_rejects_invalid_taxonomy(self, category: str, next_action: str) -> None:
+        with pytest.raises(TrackerPipelineError):
+            FailurePayload(
+                reason_code="boom",
+                category=category,
+                transient=True,
+                next_action=next_action,
+            )
+
+    def test_rejects_empty_reason_code(self) -> None:
+        with pytest.raises(TrackerPipelineError):
+            FailurePayload(
+                reason_code="   ",
+                category="permanent",
+                transient=False,
+                next_action="manual",
+            )
+
+    def test_success_block_shape(self) -> None:
+        block = format_success_comment(
+            role="backend",
+            stage_attempt=0,
+            idempotency_key="key",
+            summary="patch landed",
+        )
+        assert "```yaml bernstein:success" in block
+        assert 'role: "backend"' in block
+        assert 'summary: "patch landed"' in block
+
+
+# ---------------------------------------------------------------------------
+# Claim ledger
+# ---------------------------------------------------------------------------
+
+
+class TestClaimLedger:
+    def test_first_caller_wins(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        first = ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="backend",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+        )
+        second = ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="backend",
+            claimer_id="B",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+        )
+        assert first.granted
+        assert not second.granted
+        assert second.reason == "held"
+        assert second.claimer_id == "A"
+
+    def test_expired_lease_is_recovered(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+            now=1000.0,
+        )
+        recovered = ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="B",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+            now=5000.0,
+        )
+        assert recovered.granted
+        assert recovered.claimer_id == "B"
+
+    def test_concurrency_ceiling(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="backend",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=1,
+        )
+        capped = ledger.try_claim(
+            tracker="t",
+            ticket_id="T-2",
+            role="backend",
+            claimer_id="B",
+            ttl_seconds=60,
+            per_role_max_in_flight=1,
+        )
+        assert not capped.granted
+        assert capped.reason == "concurrency_ceiling"
+
+    def test_release_drops_claim(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+        )
+        assert ledger.release(tracker="t", ticket_id="T-1", role="qa", claimer_id="A")
+        # After release another claimer can take it.
+        again = ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="B",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+        )
+        assert again.granted
+
+    def test_release_ignores_wrong_owner(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+        )
+        assert not ledger.release(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="OTHER",
+        )
+
+    def test_two_agent_race_exactly_one_wins(self, tmp_path: Path) -> None:
+        """Threaded race against the same ticket+role yields one winner."""
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        barrier = Barrier(8)
+        results: list[ClaimOutcome] = []
+
+        def attempt(claimer: str) -> None:
+            barrier.wait()
+            result = ledger.try_claim(
+                tracker="t",
+                ticket_id="T-1",
+                role="backend",
+                claimer_id=claimer,
+                ttl_seconds=60,
+                per_role_max_in_flight=10,
+            )
+            results.append(result)
+
+        threads = [Thread(target=attempt, args=(f"c{i}",)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        winners = [r for r in results if r.granted]
+        losers = [r for r in results if not r.granted]
+        assert len(winners) == 1
+        assert len(losers) == 7
+        assert all(r.reason == "held" for r in losers)
+
+    def test_attempt_counter_starts_at_zero_then_bumps(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="T-1",
+            role="qa",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+        )
+        assert ledger.attempt_count(tracker="t", ticket_id="T-1", role="qa") == 0
+        first = ledger.bump_attempt(tracker="t", ticket_id="T-1", role="qa", claimer_id="A")
+        second = ledger.bump_attempt(tracker="t", ticket_id="T-1", role="qa", claimer_id="A")
+        assert first == 1
+        assert second == 2
+        assert ledger.attempt_count(tracker="t", ticket_id="T-1", role="qa") == 2
+
+    def test_bump_attempt_returns_minus_one_when_unknown(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        assert (
+            ledger.bump_attempt(
+                tracker="t",
+                ticket_id="T-X",
+                role="qa",
+                claimer_id="A",
+            )
+            == -1
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline config
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineConfig:
+    def test_from_dict_full(self) -> None:
+        raw = {
+            "pipeline_stages": [
+                {
+                    "role": "architect",
+                    "claim_status": "ready",
+                    "success_status": "design-approved",
+                    "failure_status": "design-blocked",
+                },
+                {
+                    "role": "backend",
+                    "claim_status": "design-approved",
+                    "success_status": "code-review",
+                    "failure_status": "blocked",
+                    "requires_prior_role": "architect",
+                },
+            ],
+            "claim_lock_ttl_seconds": 120,
+            "concurrency": {"per_role_max_in_flight": 4},
+        }
+        cfg = PipelineConfig.from_dict(raw)
+        assert len(cfg.pipeline_stages) == 2
+        assert cfg.claim_lock_ttl_seconds == 120
+        assert cfg.per_role_max_in_flight == 4
+        assert cfg.pipeline_stages[1].requires_prior_role == "architect"
+        assert cfg.stage_for_role("backend") == cfg.pipeline_stages[1]
+        assert cfg.stage_for_role("missing") is None
+
+    def test_from_dict_defaults(self) -> None:
+        cfg = PipelineConfig.from_dict({})
+        assert cfg.pipeline_stages == ()
+        assert cfg.claim_lock_ttl_seconds == 600
+        assert cfg.per_role_max_in_flight == 1
+
+    def test_stage_requires_explicit_keys(self) -> None:
+        with pytest.raises(TrackerPipelineError):
+            PipelineConfig.from_dict({"pipeline_stages": [{"role": "x"}]})
+
+    def test_default_ledger_relpath(self) -> None:
+        # Stable path lookup so operators know where the file lands.
+        assert Path("state") / "tracker_claims.db" == DEFAULT_LEDGER_RELPATH
+
+
+# ---------------------------------------------------------------------------
+# Pipeline end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_stage_config() -> PipelineConfig:
+    return _config(
+        [
+            PipelineStage(
+                role="architect",
+                claim_status="ready",
+                success_status="design-done",
+                failure_status="design-blocked",
+            ),
+            PipelineStage(
+                role="backend",
+                claim_status="design-done",
+                success_status="qa",
+                failure_status="blocked",
+                requires_prior_role="architect",
+            ),
+        ],
+        max_in_flight=2,
+    )
+
+
+class TestTrackerPipeline:
+    def test_happy_path_emits_handoff_and_transitions(
+        self,
+        tmp_path: Path,
+        two_stage_config: PipelineConfig,
+    ) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="ready")],
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=two_stage_config,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+            claimer_id="worker-A",
+        )
+        emitted = pipeline.tick()
+        assert emitted == 1
+        assert len(adapter.comments) == 1
+        comment_ticket, body, comment_key = adapter.comments[0]
+        assert comment_ticket == "T-1"
+        assert "yaml bernstein:success" in body
+        assert comment_key is not None and comment_key.endswith(":comment")
+        assert len(adapter.transitions) == 1
+        assert adapter.transitions[0][1] == "design-done"
+        assert len(pipeline.handoffs) == 1
+        handoff = pipeline.handoffs[0]
+        assert handoff.outcome == "success"
+        assert handoff.role == "architect"
+        assert handoff.to_status == "design-done"
+
+    def test_prior_role_gate_blocks_backend_until_architect_done(
+        self,
+        tmp_path: Path,
+        two_stage_config: PipelineConfig,
+    ) -> None:
+        # Ticket is already at design-done but the body shows no prior
+        # architect success block; backend stage must skip it.
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="design-done", body="bare body")],
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=two_stage_config,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        emitted = pipeline.tick()
+        assert emitted == 0
+        assert dispatcher.calls == []
+
+    def test_prior_role_gate_releases_when_marker_present(
+        self,
+        tmp_path: Path,
+        two_stage_config: PipelineConfig,
+    ) -> None:
+        marker_body = 'previous architect handoff\n\n```yaml bernstein:success\nrole: "architect"\n```\n'
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="design-done", body=marker_body)],
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=two_stage_config,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        pipeline.tick()
+        assert any(call[2] == "backend" for call in dispatcher.calls)
+
+    def test_idempotent_retry_uses_same_key_for_same_attempt(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Simulate two ticks where the first crashes between bump and
+        # write by manually invoking make_idempotency_key with the
+        # captured attempt number.
+        cfg = _config(
+            [
+                PipelineStage(
+                    role="qa",
+                    claim_status="ready-qa",
+                    success_status="done",
+                    failure_status="blocked",
+                )
+            ]
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="ready-qa")],
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=cfg,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        pipeline.tick()
+        assert len(dispatcher.calls) == 1
+        first_key = dispatcher.calls[0][4]
+        # A second tick on a fresh adapter run with a *new* ticket of
+        # identical id and a fresh ledger would produce the same key:
+        ledger2 = ClaimLedger(tmp_path / "claims2.db")
+        pipeline2 = TrackerPipeline(
+            config=cfg,
+            trackers={
+                "fake": FakeTrackerAdapter(
+                    name="fake",
+                    tickets=[_ticket("T-1", status="ready-qa")],
+                ),
+            },
+            ledger=ledger2,
+            dispatcher=RecordingDispatcher(),
+        )
+        pipeline2.tick()
+        assert pipeline2.dispatcher.calls[0][4] == first_key  # type: ignore[attr-defined]
+
+    def test_concurrency_limit_honoured(self, tmp_path: Path) -> None:
+        cfg = _config(
+            [
+                PipelineStage(
+                    role="backend",
+                    claim_status="ready",
+                    success_status="done",
+                    failure_status="blocked",
+                )
+            ],
+            max_in_flight=1,
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[
+                _ticket("T-1", status="ready"),
+                _ticket("T-2", status="ready"),
+                _ticket("T-3", status="ready"),
+            ],
+        )
+        # Hold a parallel claim so the loop bumps into the ceiling.
+        ledger.try_claim(
+            tracker="fake",
+            ticket_id="T-OTHER",
+            role="backend",
+            claimer_id="WorkerX",
+            ttl_seconds=60,
+            per_role_max_in_flight=1,
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=cfg,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        emitted = pipeline.tick()
+        assert emitted == 0
+        assert dispatcher.calls == []
+
+    def test_failure_outcome_writes_failure_block_and_transitions(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cfg = _config(
+            [
+                PipelineStage(
+                    role="qa",
+                    claim_status="ready-qa",
+                    success_status="done",
+                    failure_status="qa-blocked",
+                )
+            ]
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="ready-qa")],
+        )
+        dispatcher = RecordingDispatcher(
+            plan={
+                ("T-1", "qa"): DispatchOutcome(
+                    success=False,
+                    failure=FailurePayload(
+                        reason_code="tests.red",
+                        category="permanent",
+                        transient=False,
+                        next_action="escalate",
+                        detail="3 cases fail",
+                    ),
+                    prose="qa report",
+                )
+            }
+        )
+        pipeline = TrackerPipeline(
+            config=cfg,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        pipeline.tick()
+        assert adapter.transitions[0][1] == "qa-blocked"
+        block_body = adapter.comments[0][1]
+        parsed = parse_failure_block(block_body)
+        assert parsed is not None
+        assert parsed["reason_code"] == "tests.red"
+        assert parsed["next_action"] == "escalate"
+        assert pipeline.handoffs[0].outcome == "failure"
+
+    def test_transient_failure_returns_ticket_to_claim_status(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cfg = _config(
+            [
+                PipelineStage(
+                    role="qa",
+                    claim_status="ready-qa",
+                    success_status="done",
+                    failure_status="qa-blocked",
+                )
+            ]
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="ready-qa")],
+        )
+        dispatcher = RecordingDispatcher(
+            plan={
+                ("T-1", "qa"): DispatchOutcome(
+                    success=False,
+                    failure=FailurePayload(
+                        reason_code="net.flake",
+                        category="transient",
+                        transient=True,
+                        next_action="retry",
+                    ),
+                )
+            }
+        )
+        pipeline = TrackerPipeline(
+            config=cfg,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        pipeline.tick()
+        # Transient failure -> back to claim_status, ledger keeps the
+        # claim so the same worker may retry without contention next
+        # tick.
+        assert adapter.transitions[0][1] == "ready-qa"
+
+    def test_dispatcher_exception_logs_and_does_not_escape(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        class BoomDispatcher:
+            def dispatch(
+                self,
+                *,
+                tracker: str,
+                ticket: Ticket,
+                role: str,
+                stage_attempt: int,
+                idempotency_key: str,
+            ) -> DispatchOutcome:
+                raise RuntimeError("crash")
+
+        cfg = _config(
+            [
+                PipelineStage(
+                    role="qa",
+                    claim_status="ready-qa",
+                    success_status="done",
+                    failure_status="qa-blocked",
+                )
+            ]
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="ready-qa")],
+        )
+        pipeline = TrackerPipeline(
+            config=cfg,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=BoomDispatcher(),
+        )
+        emitted = pipeline.tick()
+        # The pipeline writes a synthetic failure comment for the crash.
+        assert emitted == 1
+        parsed = parse_failure_block(adapter.comments[0][1])
+        assert parsed is not None
+        assert parsed["reason_code"] == "dispatch.exception"
+        assert adapter.transitions[0][1] == "qa-blocked"
+
+    def test_handoff_log_aggregates_per_role(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        handoffs = [
+            StageHandoff(
+                tracker="t",
+                ticket_id=f"T-{i}",
+                role="backend",
+                from_status="ready",
+                to_status="done",
+                stage_attempt=1,
+                outcome="success",
+                idempotency_key="k",
+            )
+            for i in range(3)
+        ]
+        handoffs.append(
+            StageHandoff(
+                tracker="t",
+                ticket_id="T-9",
+                role="backend",
+                from_status="ready",
+                to_status="blocked",
+                stage_attempt=1,
+                outcome="failure",
+                idempotency_key="k",
+            )
+        )
+        counts = role_names_in_flight(handoffs)
+        assert counts == {"backend": 3}
+
+    def test_lifecycle_hook_receives_handoff_payload(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from bernstein.core.lifecycle.hooks import (
+            HookRegistry,
+            LifecycleContext,
+            LifecycleEvent,
+        )
+
+        received: list[dict[str, Any]] = []
+
+        def hook(ctx: LifecycleContext) -> None:
+            received.append(dict(ctx.data))
+
+        registry = HookRegistry()
+        registry.register_callable(LifecycleEvent.POST_TASK, hook)
+
+        cfg = _config(
+            [
+                PipelineStage(
+                    role="qa",
+                    claim_status="ready-qa",
+                    success_status="done",
+                    failure_status="qa-blocked",
+                )
+            ]
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="ready-qa")],
+        )
+        pipeline = TrackerPipeline(
+            config=cfg,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=RecordingDispatcher(),
+            hook_registry=registry,
+        )
+        pipeline.tick()
+        assert len(received) == 1
+        payload = received[0]
+        assert payload["handoff_event_name"] == "tracker_pipeline.handoff"
+        assert payload["tracker"] == "fake"
+        assert payload["ticket_id"] == "T-1"
+        assert payload["role"] == "qa"
+        assert payload["outcome"] == "success"
+        assert payload["from_status"] == "ready-qa"
+        assert payload["to_status"] == "done"
+        assert payload["stage_attempt"] == 1
+        assert isinstance(payload["idempotency_key"], str)


### PR DESCRIPTION
## Summary

Adds primitives that turn the existing tracker-poll pattern into a durable multi-role handoff bus. Each specialist role (architect, backend, qa, security) reads from a configured claim status and transitions to a success or failure status; every write carries an idempotency key and a structured taxonomy block so downstream automation can parse handoffs reliably.

### What ships

- `core/orchestration/tracker_pipeline.py`
  - `PipelineConfig` / `PipelineStage` typed view over `orchestration.tracker_pipeline` in `bernstein.yaml`.
  - `ClaimLedger`: SQLite-backed distributed claim ledger with `INSERT OR FAIL` semantics, lease-TTL recovery, and per-role concurrency ceiling enforced in the same transaction.
  - `make_idempotency_key`: `sha256(tracker || ticket_id || role || stage || stage_attempt)` joined with ASCII unit separator so adjacent inputs cannot collide.
  - `FailurePayload` + `format_failure_comment` / `format_success_comment`: fenced YAML block embedded in comment bodies, closed taxonomy (`transient`/`permanent`/`policy`/`unknown`, `retry`/`escalate`/`abandon`/`manual`). `parse_failure_block` round-trips for downstream parsers.
  - `TrackerPipeline`: stateless sweep loop (claim, dispatch, comment, transition, release; transient failures return the ticket to claim status).
  - Lifecycle hook `tracker_pipeline.handoff` fires on every stage transition with `tracker`, `ticket_id`, `role`, `from_status`, `to_status`, `stage_attempt`, `outcome`, `idempotency_key`.
- `cli/commands/pipeline_cmd.py` with `bernstein pipeline run [--dry-run]` and `bernstein pipeline status [--as-json]`.
- `docs/orchestration/tracker-pipeline.md` with worked architect -> backend -> qa example.
- `tests/unit/orchestration/test_tracker_pipeline.py` (32 cases).

### Why this surface

The tracker contract (`core/trackers/contract.py`) plus per-tracker adapters give us reads, comments, and transitions; the orchestrator already polls. The missing primitives were: a distributed claim that survives crashes, idempotency keys for retries, and a structured taxonomy so downstream automation can parse handoffs without re-reading prose. Those land here as a leaf module - no changes to the adapter contract or the in-process task server.

## Test plan

- [ ] `uv run --no-sync pytest tests/unit/orchestration/test_tracker_pipeline.py` - 32 cases including threaded two-agent race.
- [ ] `uv run --no-sync pytest tests/unit/orchestration/` - 166 cases (existing federation and consensus relay still green).
- [ ] `uv run --no-sync ruff check src/bernstein/core/orchestration/tracker_pipeline.py src/bernstein/cli/commands/pipeline_cmd.py tests/unit/orchestration/test_tracker_pipeline.py` - clean.
- [ ] `bernstein pipeline --help` enumerates `run` and `status` subcommands.
- [ ] `bernstein pipeline run --dry-run --config bernstein.yaml` prints the resolved pipeline table.

## Summary by Sourcery

Introduce a tracker-based multi-role handoff pipeline with durable claims, idempotent tracker writes, and CLI/ledger support for running and inspecting the pipeline.

New Features:
- Add tracker_pipeline orchestration module providing a configurable multi-stage, multi-role tracker handoff pipeline backed by a SQLite claim ledger and idempotency keys.
- Add bernstein pipeline CLI group with run and status subcommands to drive the pipeline and inspect open handoffs from the ledger.

Enhancements:
- Expose structured success/failure comment formats and parsing utilities so downstream automation can reliably consume tracker handoffs.
- Emit lifecycle handoff events and in-process handoff records to integrate the pipeline with existing hooks and observability tooling.

Documentation:
- Document the tracker pipeline configuration, primitives, lifecycle hook, and CLI usage with an architect→backend→qa worked example.

Tests:
- Add unit test suite for tracker_pipeline covering idempotency, failure taxonomy, claim ledger semantics, concurrency limits, lifecycle hooks, and end-to-end pipeline behaviour.