### PR TITLE
fix(orchestration): apply tracker_pipeline review follow-ups

### DIFF
--- a/docs/orchestration/tracker-pipeline.md
+++ b/docs/orchestration/tracker-pipeline.md
@@ -195,8 +195,14 @@ pipeline.tick()
 |---------|---------|
 | `bernstein pipeline run --dry-run` | Print resolved pipeline without dispatching. |
 | `bernstein pipeline run` | One non-blocking sweep across configured trackers. |
-| `bernstein pipeline status` | Print open handoffs from the SQLite ledger. |
+| `bernstein pipeline status` | Print live (non-expired) handoffs from the SQLite ledger. |
 | `bernstein pipeline status --as-json` | Machine-readable output for dashboards. |
+
+Per-tracker filtering is not exposed on the CLI yet: the dispatch
+wiring lives in `build_pipeline_from_yaml` plus the tracker adapter
+registry, which the CLI does not yet drive. Construct the pipeline
+programmatically with a single-entry `trackers` mapping until the
+registry wiring ships.
 
 ## What is deliberately out of scope
 

--- a/src/bernstein/cli/commands/pipeline_cmd.py
+++ b/src/bernstein/cli/commands/pipeline_cmd.py
@@ -47,12 +47,6 @@ def pipeline_group() -> None:
 
 @pipeline_group.command("run")
 @click.option(
-    "--tracker",
-    "tracker_name",
-    default=None,
-    help="Restrict the sweep to the named tracker adapter.",
-)
-@click.option(
     "--workflow",
     "workflow_path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
@@ -75,7 +69,6 @@ def pipeline_group() -> None:
 )
 def run_cmd(
     *,
-    tracker_name: str | None,
     workflow_path: Path | None,
     config_path: Path,
     dry_run: bool,
@@ -85,6 +78,13 @@ def run_cmd(
     The command is non-blocking: each invocation walks every
     configured tracker once. Operators schedule recurring invocations
     via systemd, cron, or the existing ``bernstein daemon`` runner.
+
+    A per-tracker filter is not yet exposed here: the dispatch wiring
+    lives in ``build_pipeline_from_yaml`` and the tracker adapter
+    registry, which the CLI does not yet drive. Operators who need to
+    restrict the sweep should construct their pipeline programmatically
+    with a single-entry ``trackers`` mapping until the registry wiring
+    ships.
     """
     raw = _load_pipeline_block(workflow_path or config_path)
     config = PipelineConfig.from_dict(raw)
@@ -94,7 +94,7 @@ def run_cmd(
         )
         return
     if dry_run:
-        _print_config(config, tracker_name)
+        _print_config(config)
         return
     # The wire-up to real adapters lives in
     # ``bernstein.core.orchestration.tracker_pipeline.build_pipeline_from_yaml``.
@@ -106,7 +106,7 @@ def run_cmd(
         "registry and dispatcher via build_pipeline_from_yaml() to enable "
         "live dispatch.[/dim]"
     )
-    _print_config(config, tracker_name)
+    _print_config(config)
 
 
 @pipeline_group.command("status")
@@ -196,7 +196,7 @@ def _load_pipeline_block(path: Path) -> Mapping[str, Any]:
     return pipeline_block
 
 
-def _print_config(config: PipelineConfig, tracker_filter: str | None) -> None:
+def _print_config(config: PipelineConfig) -> None:
     """Render the resolved config as a Rich table."""
     from rich.table import Table
 
@@ -217,45 +217,24 @@ def _print_config(config: PipelineConfig, tracker_filter: str | None) -> None:
     console.print(table)
     console.print(
         f"[dim]claim_lock_ttl_seconds={config.claim_lock_ttl_seconds} "
-        f"per_role_max_in_flight={config.per_role_max_in_flight} "
-        f"tracker_filter={tracker_filter or 'all'}[/dim]"
+        f"per_role_max_in_flight={config.per_role_max_in_flight}[/dim]"
     )
 
 
 def _read_open_handoffs(ledger_path: Path, config: PipelineConfig) -> list[dict[str, Any]]:
-    """Return live ledger rows as dicts ordered (tracker, role, ticket)."""
-    import sqlite3
-    import time as _time
+    """Return live (non-expired) ledger rows ordered (tracker, role, ticket).
 
+    The ledger has a single source of truth for the SQLite schema and
+    PRAGMAs; we route this read through :meth:`ClaimLedger.live_claims`
+    so the status view stays consistent with the runtime claim path,
+    and expired rows are filtered server-side so they do not bleed into
+    operator dashboards.
+    """
     if not ledger_path.exists():
         return []
-    rows: list[dict[str, Any]] = []
-    now = _time.time()
-    # The ledger is a side-effect-free reader here; we open via the
-    # public class so the schema check matches the runtime version.
     ledger = ClaimLedger(ledger_path)
     try:
-        # Use a direct query for tabular output rather than relying on
-        # the per-key public surface.
-        conn = sqlite3.connect(str(ledger_path))
-        try:
-            cursor = conn.execute(
-                "SELECT tracker, ticket_id, role, claimer_id, lease_expires_at, "
-                "stage_attempt FROM claims ORDER BY tracker, role, ticket_id"
-            )
-            for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall():
-                rows.append(
-                    {
-                        "tracker": tracker,
-                        "ticket_id": ticket_id,
-                        "role": role,
-                        "claimer_id": claimer_id,
-                        "stage_attempt": int(attempt),
-                        "lease_seconds_remaining": max(0.0, float(expires) - now),
-                    }
-                )
-        finally:
-            conn.close()
+        rows = ledger.live_claims()
     finally:
         ledger.close()
     # ``config`` is accepted so we can flag unknown roles in the

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -92,6 +92,7 @@ __all__ = [
     "format_success_comment",
     "make_idempotency_key",
     "parse_failure_block",
+    "parse_success_blocks",
 ]
 
 
@@ -411,28 +412,56 @@ def parse_failure_block(comment_body: str) -> dict[str, Any] | None:
         ``role``, ``stage_attempt``, ``idempotency_key``. ``None`` when
         the block is missing.
     """
-    start = comment_body.find(FAILURE_BLOCK_BEGIN)
-    if start < 0:
-        return None
-    after_start = start + len(FAILURE_BLOCK_BEGIN)
-    end = comment_body.find(FAILURE_BLOCK_END, after_start)
-    if end < 0:
-        return None
-    inner = comment_body[after_start:end].strip()
-    if not inner:
-        return None
-    parsed: dict[str, Any] = {}
-    for raw_line in inner.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
+    blocks = _iter_fenced_blocks(comment_body, FAILURE_BLOCK_BEGIN)
+    for parsed in blocks:
+        return parsed
+    return None
+
+
+def parse_success_blocks(comment_body: str) -> list[dict[str, Any]]:
+    """Return every parsed ``bernstein:success`` block in ``comment_body``.
+
+    Used by :class:`TrackerPipeline._stage_is_eligible` to check the
+    prior-role gate via structured fields rather than raw string match,
+    so cosmetic formatting changes around the fence do not silently
+    break the pipeline ordering contract.
+    """
+    return list(_iter_fenced_blocks(comment_body, _SUCCESS_BLOCK_BEGIN))
+
+
+def _iter_fenced_blocks(comment_body: str, begin_marker: str) -> Iterable[dict[str, Any]]:
+    """Yield every ``begin_marker`` ... ``FAILURE_BLOCK_END`` block as a dict.
+
+    The closing fence is the same backtick triplet used by both success
+    and failure blocks. Empty blocks and blocks missing a closing fence
+    are skipped.
+    """
+    start = 0
+    while True:
+        index = comment_body.find(begin_marker, start)
+        if index < 0:
+            return
+        after_start = index + len(begin_marker)
+        end = comment_body.find(FAILURE_BLOCK_END, after_start)
+        if end < 0:
+            return
+        inner = comment_body[after_start:end].strip()
+        start = end + len(FAILURE_BLOCK_END)
+        if not inner:
             continue
-        if ":" not in line:
-            continue
-        key, sep, value = line.partition(":")
-        if not sep:
-            continue
-        parsed[key.strip()] = _decode_yaml_value(value.strip())
-    return parsed or None
+        parsed: dict[str, Any] = {}
+        for raw_line in inner.splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if ":" not in line:
+                continue
+            key, sep, value = line.partition(":")
+            if not sep:
+                continue
+            parsed[key.strip()] = _decode_yaml_value(value.strip())
+        if parsed:
+            yield parsed
 
 
 def _yaml_quote(value: str) -> str:
@@ -669,6 +698,36 @@ class ClaimLedger:
             claimer_id=claimer_id,
             lease_expires_at=expires_at,
         )
+
+    def live_claims(self, *, now: float | None = None) -> list[dict[str, Any]]:
+        """Return live (non-expired) claims as ordered dicts.
+
+        Used by ``bernstein pipeline status`` and tests to render the
+        live in-flight view without re-implementing the schema or
+        opening a separate sqlite connection. ``now`` is overridable so
+        callers can render a deterministic snapshot.
+        """
+        current = float(time.time() if now is None else now)
+        conn = self._connect()
+        cursor = conn.execute(
+            "SELECT tracker, ticket_id, role, claimer_id, lease_expires_at, "
+            "stage_attempt FROM claims WHERE lease_expires_at > ? "
+            "ORDER BY tracker, role, ticket_id",
+            (current,),
+        )
+        rows: list[dict[str, Any]] = []
+        for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall():
+            rows.append(
+                {
+                    "tracker": tracker,
+                    "ticket_id": ticket_id,
+                    "role": role,
+                    "claimer_id": claimer_id,
+                    "stage_attempt": int(attempt),
+                    "lease_seconds_remaining": float(expires) - current,
+                }
+            )
+        return rows
 
     def release(self, *, tracker: str, ticket_id: str, role: str, claimer_id: str) -> bool:
         """Drop the claim if ``claimer_id`` still owns it.
@@ -950,14 +1009,22 @@ class TrackerPipeline:
         ticket: Ticket,
         stage: PipelineStage,
     ) -> bool:
-        """Check the optional prior-role gate."""
-        if not stage.requires_prior_role:
+        """Check the optional prior-role gate via structured parsing.
+
+        Earlier revisions did a raw substring match on the rendered
+        ``role: "<name>"`` line; small formatting changes (quoting
+        style, extra fields, fence spacing) would silently break the
+        gate. We now lift every ``bernstein:success`` block and look up
+        its ``role`` key, so the gate remains stable across cosmetic
+        changes in the comment renderer.
+        """
+        required_role = stage.requires_prior_role
+        if not required_role:
             return True
-        # Inspect ticket body and (if available) recent free-text
-        # comments. The adapter contract does not currently mandate a
-        # ``list_comments``; we degrade to body-only matching when the
-        # adapter does not provide one.
-        prior_marker = f'role: "{stage.requires_prior_role}"'
+        # Inspect ticket body plus recent free-text comments when the
+        # adapter exposes a ``list_comments`` hook. The adapter contract
+        # does not yet mandate one; we degrade to body-only matching
+        # when the adapter does not provide it.
         haystacks: list[str] = [ticket.body or ""]
         list_comments = getattr(adapter, "list_comments", None)
         if callable(list_comments):
@@ -972,7 +1039,11 @@ class TrackerPipeline:
                     ticket.id,
                     exc_info=True,
                 )
-        return any(prior_marker in text and _SUCCESS_BLOCK_BEGIN in text for text in haystacks)
+        for text in haystacks:
+            for block in parse_success_blocks(text):
+                if block.get("role") == required_role:
+                    return True
+        return False
 
     def _process_ticket(
         self,

--- a/tests/unit/orchestration/test_tracker_pipeline.py
+++ b/tests/unit/orchestration/test_tracker_pipeline.py
@@ -41,6 +41,7 @@ from bernstein.core.orchestration.tracker_pipeline import (
     format_success_comment,
     make_idempotency_key,
     parse_failure_block,
+    parse_success_blocks,
     role_names_in_flight,
 )
 from bernstein.core.trackers.contract import (
@@ -284,6 +285,21 @@ class TestFailurePayload:
         assert 'role: "backend"' in block
         assert 'summary: "patch landed"' in block
 
+    def test_parse_success_blocks_returns_each_block(self) -> None:
+        body = (
+            "first handoff\n\n"
+            + format_success_comment(role="architect", stage_attempt=0, idempotency_key="k1", summary="design ready")
+            + "\n\nsecond handoff\n\n"
+            + format_success_comment(role="backend", stage_attempt=0, idempotency_key="k2", summary="patch landed")
+        )
+        blocks = parse_success_blocks(body)
+        assert [b["role"] for b in blocks] == ["architect", "backend"]
+        assert blocks[0]["summary"] == "design ready"
+        assert blocks[0]["idempotency_key"] == "k1"
+
+    def test_parse_success_blocks_handles_no_match(self) -> None:
+        assert parse_success_blocks("only prose, no fenced block") == []
+
 
 # ---------------------------------------------------------------------------
 # Claim ledger
@@ -456,6 +472,32 @@ class TestClaimLedger:
             == -1
         )
 
+    def test_live_claims_excludes_expired_rows(self, tmp_path: Path) -> None:
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="alive",
+            role="backend",
+            claimer_id="A",
+            ttl_seconds=60,
+            per_role_max_in_flight=4,
+            now=1000.0,
+        )
+        ledger.try_claim(
+            tracker="t",
+            ticket_id="stale",
+            role="qa",
+            claimer_id="B",
+            ttl_seconds=1,
+            per_role_max_in_flight=4,
+            now=900.0,
+        )
+        rows = ledger.live_claims(now=1010.0)
+        # Only the 1000.0+60 row is still alive at now=1010.0; the 900+1
+        # claim aged out and must not appear.
+        assert [r["ticket_id"] for r in rows] == ["alive"]
+        assert rows[0]["lease_seconds_remaining"] > 0
+
 
 # ---------------------------------------------------------------------------
 # Pipeline config
@@ -600,6 +642,66 @@ class TestTrackerPipeline:
         adapter = FakeTrackerAdapter(
             name="fake",
             tickets=[_ticket("T-1", status="design-done", body=marker_body)],
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=two_stage_config,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        pipeline.tick()
+        assert any(call[2] == "backend" for call in dispatcher.calls)
+
+    def test_prior_role_gate_uses_structured_block_not_raw_match(
+        self,
+        tmp_path: Path,
+        two_stage_config: PipelineConfig,
+    ) -> None:
+        """Body mentions ``architect`` in prose only - gate must stay closed.
+
+        Earlier revisions did a raw substring scan that matched any
+        occurrence of ``role: "<name>"`` anywhere in the ticket text;
+        this test pins the structured-parse behaviour so prose that
+        happens to contain the literal token does not unlock the gate.
+        """
+        prose_only = 'architect noted that role: "architect" should review later but did not write a success block.\n'
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="design-done", body=prose_only)],
+        )
+        dispatcher = RecordingDispatcher()
+        pipeline = TrackerPipeline(
+            config=two_stage_config,
+            trackers={"fake": adapter},
+            ledger=ledger,
+            dispatcher=dispatcher,
+        )
+        pipeline.tick()
+        assert dispatcher.calls == []
+
+    def test_prior_role_gate_tolerant_of_extra_yaml_fields(
+        self,
+        tmp_path: Path,
+        two_stage_config: PipelineConfig,
+    ) -> None:
+        """Extra YAML fields and quoting variations do not break the gate."""
+        block_body = (
+            "earlier handoff\n\n"
+            + format_success_comment(
+                role="architect",
+                stage_attempt=2,
+                idempotency_key="abc",
+                summary="design approved with notes",
+                prose="prose above the block",
+            )
+            + "\n"
+        )
+        ledger = ClaimLedger(tmp_path / "claims.db")
+        adapter = FakeTrackerAdapter(
+            name="fake",
+            tickets=[_ticket("T-1", status="design-done", body=block_body)],
         )
         dispatcher = RecordingDispatcher()
         pipeline = TrackerPipeline(


### PR DESCRIPTION
## Summary

Applies the must-address review feedback Sourcery left on #1606 (merged):

- Prior-role gate now parses the structured `bernstein:success` block instead of raw-substring matching the rendered `role: "name"` token. Adds a `parse_success_blocks` helper alongside the existing `parse_failure_block` to keep the parser surface symmetric.
- `bernstein pipeline run --tracker` dropped. The flag was accepted but never affected the sweep; documented the programmatic workaround until the tracker adapter registry wiring lands.
- `bernstein pipeline status` filters expired claims at the SQLite layer via a new `ClaimLedger.live_claims` helper. Earlier the view clamped `lease_seconds_remaining` to zero but still showed long-expired rows.
- Status path routes the read through `ClaimLedger` instead of opening its own `sqlite3.connect`, so the PRAGMA and schema setup remains centralised.

Tests:

- `parse_success_blocks` round-trips multi-block bodies.
- Prior-role gate rejects prose-only matches and accepts blocks with extra YAML fields and surrounding prose.
- `ClaimLedger.live_claims` excludes a row that aged out.

## Test plan

- [ ] `uv run --no-sync pytest tests/unit/orchestration/test_tracker_pipeline.py` - 37 cases (was 32).
- [ ] `uv run --no-sync pytest tests/unit/orchestration/` - existing 166-case suite still green.
- [ ] `uv run --no-sync ruff check src/bernstein/core/orchestration/tracker_pipeline.py src/bernstein/cli/commands/pipeline_cmd.py tests/unit/orchestration/test_tracker_pipeline.py` - clean.

## Summary by Sourcery

Refine tracker pipeline orchestration to rely on structured success blocks and centralized ledger access, while simplifying the CLI and updating documentation.

New Features:
- Expose a ClaimLedger.live_claims helper to retrieve non-expired claims in a consistent, ordered format.
- Add parse_success_blocks to extract structured bernstein:success blocks from tracker comments for prior-role gating.

Bug Fixes:
- Ensure the prior-role gate only unlocks when a structured bernstein:success block with the required role is present, avoiding false positives from prose-only matches.
- Filter expired claim rows at the SQLite layer so pipeline status only shows live handoffs.

Enhancements:
- Route status reads through ClaimLedger instead of opening ad-hoc sqlite3 connections, centralizing schema and PRAGMA handling.
- Adjust the prior-role gate to inspect structured success blocks rather than raw string tokens for robustness against formatting changes.
- Remove the unused --tracker option from bernstein pipeline run and clarify the workflow around per-tracker filtering in the CLI help text and docs.

Documentation:
- Clarify that bernstein pipeline status shows live (non-expired) handoffs and document the current lack of per-tracker CLI filtering with the programmatic workaround.

Tests:
- Extend tracker pipeline unit tests to cover success-block parsing, structured prior-role gating behavior, and exclusion of expired rows from live claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated CLI documentation to clarify `bernstein pipeline status` displays live (non-expired) handoffs from the ledger
  - Added notes on per-tracker filtering limitations and programmatic wiring guidance

* **Changes**
  - Removed `--tracker` filter option from `bernstein pipeline run` command
  - Improved role-gate validation logic for structured success blocks in tickets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->