### PR TITLE
fix(sandbox): apply Playwright runner review follow-ups

### DIFF
--- a/src/bernstein/cli/commands/sandbox_cmd.py
+++ b/src/bernstein/cli/commands/sandbox_cmd.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -36,6 +37,10 @@ logger = logging.getLogger(__name__)
 
 
 _DEFAULT_OUTPUT_ROOT = Path(".sdd/sandbox")
+# Allowed task_id shape: must be a single safe slug (letters, digits, dot,
+# hyphen, underscore). Rejects path separators and traversal sequences so
+# `_DEFAULT_OUTPUT_ROOT / task_id` cannot escape the sandbox root.
+_TASK_ID_PATTERN = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 
 
 @click.group("sandbox")
@@ -115,6 +120,12 @@ def web_test(
     as_json: bool,
 ) -> None:
     """Run Playwright scenarios and emit a structured self-test block."""
+    if not _TASK_ID_PATTERN.fullmatch(task_id):
+        raise click.BadParameter(
+            "task_id must match [A-Za-z0-9][A-Za-z0-9._-]{0,127}: no path separators or traversal segments allowed.",
+            param_hint="TASK_ID",
+        )
+
     try:
         scenarios = load_scenarios(scenarios_path)
     except (FileNotFoundError, PlaywrightScenarioError) as exc:

--- a/src/bernstein/core/sandbox/playwright_runner.py
+++ b/src/bernstein/core/sandbox/playwright_runner.py
@@ -337,7 +337,10 @@ def load_scenarios(path: Path) -> list[PlaywrightScenario]:
     """
     if not path.is_file():
         raise FileNotFoundError(f"Scenarios file not found: {path}")
-    raw: object = yaml.safe_load(path.read_text(encoding="utf-8"))
+    try:
+        raw: object = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise PlaywrightScenarioError(f"{path}: invalid YAML: {exc}") from exc
     if raw is None:
         raise PlaywrightScenarioError(f"Scenarios file is empty: {path}")
 
@@ -570,7 +573,7 @@ class PlaywrightRunner:
                     scenario_dir=scenario_dir,
                 )
                 result.steps.append(step_result)
-                if step_result.screenshot_path is not None:
+                if step_result.screenshot_path:
                     result.screenshots.append(step_result.screenshot_path)
                 if step_result.status == "failed":
                     all_passed = False
@@ -600,6 +603,13 @@ class PlaywrightRunner:
             status: StepStatus = "passed"
             error: str | None = None
         except Exception as exc:
+            logger.warning(
+                "Playwright step %d (%s) failed: %s",
+                index,
+                step.type,
+                exc,
+                exc_info=True,
+            )
             status = "failed"
             error = f"{type(exc).__name__}: {exc}"
         finally:
@@ -736,14 +746,20 @@ def _wire_capture(page: Any, result: ScenarioResult) -> None:
     page.on("requestfailed", _on_requestfailed)
 
 
-async def _capture_screenshot(page: Any, target: Path) -> str:
-    """Capture a full-page screenshot. Returns the POSIX path on success."""
+async def _capture_screenshot(page: Any, target: Path) -> str | None:
+    """Capture a full-page screenshot.
+
+    Returns:
+        The POSIX path on success, ``None`` when capture failed. ``None`` so
+        callers can distinguish a missing screenshot from a recorded one
+        without treating an empty string as a valid path.
+    """
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
         await page.screenshot(path=str(target), full_page=True)
     except Exception:
         logger.exception("Failed to capture screenshot to %s", target)
-        return ""
+        return None
     return target.as_posix()
 
 

--- a/src/bernstein/core/sandbox/playwright_runner.py
+++ b/src/bernstein/core/sandbox/playwright_runner.py
@@ -44,6 +44,7 @@ only in v1.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import asdict, dataclass, field
@@ -602,6 +603,11 @@ class PlaywrightRunner:
             await self._dispatch_step(page=page, step=step)
             status: StepStatus = "passed"
             error: str | None = None
+        except asyncio.CancelledError:
+            # Cooperative task cancellation must propagate; do not record
+            # the step as a benign "failed" or it masks the cancel signal
+            # and prevents the parent task from cleaning up promptly.
+            raise
         except Exception as exc:
             logger.warning(
                 "Playwright step %d (%s) failed: %s",
@@ -703,6 +709,11 @@ class PlaywrightRunner:
         )
         try:
             return await judge.dual_attempt(prompt)
+        except asyncio.CancelledError:
+            # Cancellation must propagate so the caller can tear down the
+            # judge attempt cleanly; do not swallow it as a generic
+            # judge failure.
+            raise
         except Exception:
             logger.exception("Playwright judge call failed")
             return None
@@ -757,6 +768,10 @@ async def _capture_screenshot(page: Any, target: Path) -> str | None:
     target.parent.mkdir(parents=True, exist_ok=True)
     try:
         await page.screenshot(path=str(target), full_page=True)
+    except asyncio.CancelledError:
+        # Propagate cancellation; a partial screenshot is not worth
+        # masking the cancel.
+        raise
     except Exception:
         logger.exception("Failed to capture screenshot to %s", target)
         return None

--- a/tests/unit/sandbox/test_playwright_runner.py
+++ b/tests/unit/sandbox/test_playwright_runner.py
@@ -226,6 +226,15 @@ def test_load_scenarios_rejects_non_mapping_step(tmp_path: Path) -> None:
         load_scenarios(path)
 
 
+def test_load_scenarios_normalises_yaml_parse_errors(tmp_path: Path) -> None:
+    # Malformed YAML must surface as PlaywrightScenarioError so the CLI's
+    # except clause converts it into a clean ClickException.
+    path = tmp_path / "broken.yaml"
+    path.write_text("scenarios: [name: x\n  steps: -\n", encoding="utf-8")
+    with pytest.raises(PlaywrightScenarioError, match="invalid YAML"):
+        load_scenarios(path)
+
+
 # ---------------------------------------------------------------------------
 # Runner — happy path + capture
 # ---------------------------------------------------------------------------
@@ -485,6 +494,38 @@ async def test_runner_surfaces_unavailable_playwright(
     )
     with pytest.raises(PlaywrightUnavailableError):
         await runner.run([scenario])
+
+
+def test_cli_rejects_unsafe_task_id(tmp_path: Path) -> None:
+    """task_id with path separators or traversal must be rejected upfront."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.sandbox_cmd import sandbox_group
+
+    scenarios = tmp_path / "scenarios.yaml"
+    scenarios.write_text(
+        "- {name: x, steps: [{type: navigate, url: /}]}",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    bad_inputs = ["../escape", "task/with/slash", "..", ""]
+    for bad in bad_inputs:
+        result = runner.invoke(
+            sandbox_group,
+            [
+                "web-test",
+                bad,
+                "--url",
+                "http://localhost:5173",
+                "--scenarios",
+                str(scenarios),
+            ],
+        )
+        assert result.exit_code != 0, f"task_id {bad!r} should be rejected"
+        # Empty string trips Click's "argument required" check before our
+        # regex, but every non-empty bad input must hit BadParameter.
+        if bad:
+            assert "task_id must match" in result.output
 
 
 def test_run_result_self_test_block_includes_failure_details(tmp_path: Path) -> None:

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -224,12 +224,11 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         # Playwright-based self-testing for UI/web agent runs
         "sandbox",
         # Bot-added: drift autofix (regen_contract_drift.py)
-        "trend-scan",
-        # Bot-added: drift autofix (regen_contract_drift.py)
         "issue-to-pr",
         "pipeline",
         "secrets",
         "trackers",
+        "trend-scan",
     }
 )
 


### PR DESCRIPTION
## Summary

Follow-up to #1603 (Playwright sandbox self-test). Applies must-address review feedback that did not land before the squash-merge.

- Reject task_id values containing path separators or traversal segments. `bernstein sandbox web-test ../escape ...` now exits with a Click `BadParameter` before any filesystem write, so `_DEFAULT_OUTPUT_ROOT / task_id` cannot escape `.sdd/sandbox/`.
- Wrap `yaml.safe_load` in `load_scenarios` and rethrow `yaml.YAMLError` as `PlaywrightScenarioError`. The CLI's existing catch block now converts malformed scenario files into a clean `ClickException` instead of an unstructured traceback.
- Add structured logging before the broad `except Exception` in the per-step dispatcher so unexpected runtime errors stay diagnosable.
- `_capture_screenshot` returns `None` (not an empty string) on capture failure, and the runner treats empty paths as absent before appending to `result.screenshots`.

## Test plan

- [x] `pytest tests/unit/sandbox/test_playwright_runner.py` -- 25 cases, all pass. Two new cases cover the YAML-error normalisation path and the unsafe-task_id rejection (traversal, slashes, empty).
- [x] `pytest tests/unit/sandbox/` -- 77 passed, 1 skipped (no regressions in adjacent suites).
- [x] `ruff check` / `ruff format` / `pyright` clean on changed files.
- [x] `lint-imports` -- 3 contracts kept, 0 broken.

<!-- bot-ack: 3268885897 reason=Allowlist entries auto-added by contract-drift-autofix workflow on this PR; README documentation for issue-to-pr, pipeline, secrets, trackers, trend-scan is tracked separately and is out of scope for the playwright-sandbox follow-up. -->
<!-- bot-ack: 3269031170 reason=The TASK_ID validation is internal path-traversal hardening, not a new user-visible feature. The existing CLI accepted a positional task_id argument before this change; the only difference is that unsafe values now fail fast with a clear BadParameter message instead of corrupting the sandbox tree. The error message is self-describing. Public docs for sandbox-web-test will land alongside the README sweep tracked separately. -->

## Summary by Sourcery

Harden the Playwright sandbox CLI and runner against malformed input and improve error handling and observability.

New Features:
- Validate sandbox task_id values against a strict slug pattern to prevent path traversal and invalid IDs before running web tests.

Bug Fixes:
- Normalize YAML parse failures in scenario files into PlaywrightScenarioError so the CLI surfaces them as clean ClickExceptions instead of raw tracebacks.
- Ensure failed screenshot captures return an absent value and are not treated as valid screenshot paths when aggregating run results.

Enhancements:
- Add structured warning logs for unexpected exceptions during Playwright step execution to aid debugging.

Tests:
- Extend Playwright runner unit tests to cover YAML error normalization and rejection of unsafe task_id values in the sandbox CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid YAML in test scenarios now produces clear error messages.
  * The `sandbox web-test` command now validates task IDs to ensure they follow a safe slug format, rejecting unsafe characters and path traversal patterns.

* **Improvements**
  * Enhanced screenshot capture handling to exclude invalid captures.
  * Improved logging for step execution failures with detailed diagnostic information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

