### PR TITLE
fix(docs): sync agents-md module map for devops package

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -23,6 +23,7 @@ alwaysApply: false
 | `config/`               | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
+| `devops/`               | devops sub-package |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
 | `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |

--- a/.goosehints
+++ b/.goosehints
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `config/`               | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
+| `devops/`               | devops sub-package |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
 | `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `config/`               | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
+| `devops/`               | devops sub-package |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
 | `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `config/`               | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
+| `devops/`               | devops sub-package |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
 | `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `config/`               | Config: seed parsing, config management, settings, feature gates |
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
+| `devops/`               | devops sub-package |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
 | `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |


### PR DESCRIPTION
## Summary

The docs-drift gate on `main` is failing because the `agents-md sync` outputs went stale after the `devops/` sub-package landed. Regenerate the canonical AGENTS.md, CLAUDE.md, CONVENTIONS.md, `.goosehints`, and the cursor module-map rule by running:

```
uv run bernstein agents-md sync
```

## Files touched

- `AGENTS.md`
- `CLAUDE.md`
- `CONVENTIONS.md`
- `.goosehints`
- `.cursor/rules/module-map.mdc`

Each gets one extra row in the module table for `devops/`. No manual edits.

## Why now

Unblocks the `docs-drift` gate on main HEAD so subsequent merges and the next release land green.

## Summary by Sourcery

Sync generated documentation and tooling metadata to include the new devops sub-package in the agents/module maps.

Documentation:
- Add the devops/ sub-package to the module overview tables in AGENTS.md, CLAUDE.md, and CONVENTIONS.md.

Chores:
- Regenerate .goosehints and .cursor/rules/module-map.mdc to reflect the devops/ module and clear docs-drift.