### PR TITLE
fix(security): close 4 OSSF Scorecard alerts

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,10 +7,19 @@ name: OSSF Scorecard
 #   https://api.securityscorecards.dev/projects/github.com/sipyourdrink-ltd/bernstein/badge
 #
 # Ref: #1273
+#
+# Job split: the scorecard-action webapp publish enforces "scorecard job
+# must only have steps with `uses`" (see
+# https://github.com/ossf/scorecard-action#workflow-restrictions). Any
+# `run:` step in the same job causes publish_results to fail and skip
+# the SARIF upload, leaving stale Code Scanning alerts. We therefore
+# keep the `analysis` job pure-`uses` and do post-processing
+# (suppression filtering, Code Scanning upload) in a downstream job
+# that consumes the uploaded artifact.
 
 on:
   # Scorecard scores rolling repo posture (signed releases, branch protection,
-  # pinned actions, fuzzing, etc.) — designed for weekly tracking, not
+  # pinned actions, fuzzing, etc.) - designed for weekly tracking, not
   # per-commit gating. Triggering on every push-to-main produces noisy
   # "failures" when individual high-severity findings exist (expected during
   # first-time setup). Restricted to schedule + dispatch + branch-protection
@@ -39,6 +48,11 @@ jobs:
       contents: read
       actions: read
     steps:
+      # IMPORTANT: this job must contain ONLY `uses:` steps. Adding any
+      # `run:` step here causes the scorecard webapp publish to reject
+      # results with "scorecard job must only have steps with `uses`",
+      # which in turn skips SARIF upload to Code Scanning and leaves
+      # stale alerts. Post-processing happens in the `upload` job below.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -60,6 +74,25 @@ jobs:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
+
+  upload:
+    name: Filter suppressions and upload to Code Scanning
+    needs: analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download SARIF artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: scorecard-results
 
       - name: Drop suppressed SARIF results
         # No-op for scorecard output today (the action does not emit


### PR DESCRIPTION
## Summary

Closes 4 open OSSF Scorecard alerts whose underlying code has already been fixed on `main` but which remained open because the Scorecard workflow's SARIF upload to Code Scanning was silently broken.

### Root cause

`ossf/scorecard-action` webapp publish enforces "scorecard job must only have steps with `uses`" (see [workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions)). The previous single-job layout in `.github/workflows/scorecard.yml` mixed a `run:` step (`Drop suppressed SARIF results`) with the scorecard `uses:` steps. The webapp rejected results with HTTP 400, failing the `Run analysis` step and skipping the SARIF upload. Consequently, alerts on lines that have since been fixed never closed.

A manually-dispatched re-run on current `main` (`4df9b5a2`) confirms:

- `Pinned-Dependencies` score now 9 (no warnings for `ci.yml:637-638`, `.clusterfuzzlite/build.sh:11`).
- `Token-Permissions` no longer warns on `cifuzz-pr.yml` `security-events: write` (job is now `contents: read`).

### Alerts addressed

| ID | Rule | Path | Resolution |
|----|------|------|------------|
| 416 | PinnedDependenciesID | `.github/workflows/ci.yml:638` | Already fixed in #1515: pipx bootstrap routes through SHA-pinned `astral-sh/setup-uv`. Stale alert will close on next Scorecard run. |
| 415 | PinnedDependenciesID | `.github/workflows/ci.yml:637` | Same as #416. |
| 414 | PinnedDependenciesID | `.clusterfuzzlite/build.sh:11` | Already fixed in #1515: `pip3 install` uses `--require-hashes --requirement .clusterfuzzlite/requirements.txt` with SHA-pinned PyYAML. Stale alert will close on next Scorecard run. |
| 413 | TokenPermissionsID | `.github/workflows/cifuzz-pr.yml:38` | Already fixed in #1515: cifuzz job is `contents: read` only; `security-events: write` removed (output-sarif disabled). Stale alert will close on next Scorecard run. |

### Fix in this PR

Split `scorecard.yml` into two jobs:

- `analysis`: pure `uses:`-only steps (checkout, scorecard-action, upload-artifact). Satisfies the webapp publish restriction.
- `upload`: depends on `analysis`, downloads the SARIF artifact, runs the suppression filter, uploads to Code Scanning.

This restores SARIF ingestion. The next scheduled or manually-dispatched run will close alerts 413-416.

## Test plan

- [ ] Workflow file passes YAML validation locally (done).
- [ ] zizmor reports no findings on the modified file (done, "No findings to report").
- [ ] PR CI green.
- [ ] After merge, dispatch `OSSF Scorecard` workflow; verify both `analysis` and `upload` jobs succeed and SARIF is uploaded to Code Scanning.
- [ ] Verify alerts 413, 414, 415, 416 transition to fixed in the Security tab.

## Summary by Sourcery

CI:
- Refactor the OSSF Scorecard GitHub Actions workflow into a pure-uses analysis job and a downstream upload job that filters SARIF suppressions and uploads results to Code Scanning.