### PR TITLE
refactor: bulk refurb autofix wave 3 (FURB184/123/138 + leftovers)

### DIFF
--- a/src/bernstein/adapters/ci/gitlab_ci.py
+++ b/src/bernstein/adapters/ci/gitlab_ci.py
@@ -77,10 +77,7 @@ def _extract_steps(clean_log: str) -> list[GitLabCIStep]:
         List of ``GitLabCIStep`` objects.
     """
     steps: list[GitLabCIStep] = []
-    positions: list[tuple[str, int]] = []
-
-    for m in _SECTION_START_RE.finditer(clean_log):
-        positions.append((m.group(1), m.end()))
+    positions: list[tuple[str, int]] = [(m.group(1), m.end()) for m in _SECTION_START_RE.finditer(clean_log)]
 
     for i, (name, start_pos) in enumerate(positions):
         end_pos = positions[i + 1][1] if i + 1 < len(positions) else len(clean_log)

--- a/src/bernstein/cli/commands/lineage_export_cmd.py
+++ b/src/bernstein/cli/commands/lineage_export_cmd.py
@@ -151,45 +151,44 @@ def render_jsonld(rows: list[dict[str, Any]], *, run_id: str) -> str:
     model are kept as additionalProperty so a verifier sees the raw
     values without inventing schema.org terms.
     """
-    actions: list[dict[str, Any]] = []
-    for row in rows:
-        actions.append(
-            {
-                "@type": "Action",
-                "actionStatus": "CompletedActionStatus",
-                "startTime": row["timestamp"],
-                "agent": {
-                    "@type": "SoftwareApplication",
-                    "identifier": row["agent_id"],
-                    "applicationSuite": row["model"],
-                },
-                "object": {
-                    "@type": "DigitalDocument",
-                    "identifier": row["output_path"],
-                    "sha256": row["output_sha256"],
-                    "lineStart": row["output_line_start"],
-                    "lineEnd": row["output_line_end"],
-                },
-                "instrument": [
-                    {"@type": "DigitalDocument", "identifier": p, "sha256": s}
-                    for p, s in zip(
-                        row["input_paths"].split("|") if row["input_paths"] else [],
-                        row["input_shas"].split("|") if row["input_shas"] else [],
-                        strict=False,
-                    )
-                ],
-                "additionalProperty": [
-                    {"@type": "PropertyValue", "name": "schema_version", "value": row["schema_version"]},
-                    {"@type": "PropertyValue", "name": "run_id", "value": row["run_id"]},
-                    {"@type": "PropertyValue", "name": "tick_id", "value": row["tick_id"]},
-                    {"@type": "PropertyValue", "name": "prompt_sha", "value": row["prompt_sha"]},
-                    {"@type": "PropertyValue", "name": "cost_usd", "value": row["cost_usd"]},
-                    {"@type": "PropertyValue", "name": "tokens", "value": row["tokens"]},
-                    {"@type": "PropertyValue", "name": "regulatory_class", "value": row["regulatory_class"]},
-                    {"@type": "PropertyValue", "name": "customer_signature", "value": row["customer_signature"]},
-                ],
-            }
-        )
+    actions: list[dict[str, Any]] = [
+        {
+            "@type": "Action",
+            "actionStatus": "CompletedActionStatus",
+            "startTime": row["timestamp"],
+            "agent": {
+                "@type": "SoftwareApplication",
+                "identifier": row["agent_id"],
+                "applicationSuite": row["model"],
+            },
+            "object": {
+                "@type": "DigitalDocument",
+                "identifier": row["output_path"],
+                "sha256": row["output_sha256"],
+                "lineStart": row["output_line_start"],
+                "lineEnd": row["output_line_end"],
+            },
+            "instrument": [
+                {"@type": "DigitalDocument", "identifier": p, "sha256": s}
+                for p, s in zip(
+                    row["input_paths"].split("|") if row["input_paths"] else [],
+                    row["input_shas"].split("|") if row["input_shas"] else [],
+                    strict=False,
+                )
+            ],
+            "additionalProperty": [
+                {"@type": "PropertyValue", "name": "schema_version", "value": row["schema_version"]},
+                {"@type": "PropertyValue", "name": "run_id", "value": row["run_id"]},
+                {"@type": "PropertyValue", "name": "tick_id", "value": row["tick_id"]},
+                {"@type": "PropertyValue", "name": "prompt_sha", "value": row["prompt_sha"]},
+                {"@type": "PropertyValue", "name": "cost_usd", "value": row["cost_usd"]},
+                {"@type": "PropertyValue", "name": "tokens", "value": row["tokens"]},
+                {"@type": "PropertyValue", "name": "regulatory_class", "value": row["regulatory_class"]},
+                {"@type": "PropertyValue", "name": "customer_signature", "value": row["customer_signature"]},
+            ],
+        }
+        for row in rows
+    ]
     doc: dict[str, Any] = {
         "@context": "https://schema.org",
         "@type": "ItemList",

--- a/src/bernstein/cli/commands/manifest_cmd.py
+++ b/src/bernstein/cli/commands/manifest_cmd.py
@@ -180,8 +180,8 @@ def manifest_diff(run_a: str, run_b: str) -> None:
 
     table = Table(show_header=True, header_style="bold")
     table.add_column("Field", style="bold")
-    table.add_column(str(run_a), style="red")
-    table.add_column(str(run_b), style="green")
+    table.add_column(run_a, style="red")
+    table.add_column(run_b, style="green")
 
     for field_name, (va, vb) in sorted(diffs.items()):
         table.add_row(field_name, _format_value(va), _format_value(vb))

--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -641,9 +641,7 @@ def _find_port_pids_unix(port: int) -> list[int]:
         errors="replace",
         timeout=5,
     )
-    pids: list[int] = []
-    for line in result.stdout.strip().splitlines():
-        pids.append(int(line.strip()))
+    pids: list[int] = [int(line.strip()) for line in result.stdout.strip().splitlines()]
     return pids
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -56,19 +56,18 @@ def _build_synthetic_plan(goal: str, team: list[str] | None = None) -> tuple[Any
     from bernstein.core.plan_approval import create_plan
 
     roles = team or ["manager"]
-    tasks: list[Task] = []
-    for i, role in enumerate(roles):
-        tasks.append(
-            Task(
-                id=f"planned-{i + 1}",
-                title=f"[{role}] {goal[:70]}",
-                description=goal,
-                role=role,
-                priority=i + 1,
-                scope=Scope.MEDIUM,
-                complexity=Complexity.MEDIUM,
-            )
+    tasks: list[Task] = [
+        Task(
+            id=f"planned-{i + 1}",
+            title=f"[{role}] {goal[:70]}",
+            description=goal,
+            role=role,
+            priority=i + 1,
+            scope=Scope.MEDIUM,
+            complexity=Complexity.MEDIUM,
         )
+        for i, role in enumerate(roles)
+    ]
     plan = create_plan(goal, tasks)
     return plan, tasks
 

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -803,9 +803,10 @@ def _render_prompt(
     # Specialist agents from agency catalog
     specialist_block = ""
     if agency_catalog and role == "manager":
-        specialists: list[str] = []
-        for agent in sorted(agency_catalog.values(), key=lambda a: a.role):
-            specialists.append(f"- **{agent.name}** ({agent.role}): {agent.description}")
+        specialists: list[str] = [
+            f"- **{agent.name}** ({agent.role}): {agent.description}"
+            for agent in sorted(agency_catalog.values(), key=lambda a: a.role)
+        ]
         if specialists:
             specialist_block = (
                 "\n\n## Available specialist agents (from Agency catalog)\n"

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -637,9 +637,10 @@ def _render_prompt(
     # Specialist agents from agency catalog
     specialist_block = ""
     if agency_catalog and role == "manager":
-        specialists: list[str] = []
-        for agent in sorted(agency_catalog.values(), key=lambda a: a.role):
-            specialists.append(f"- **{agent.name}** ({agent.role}): {agent.description}")
+        specialists: list[str] = [
+            f"- **{agent.name}** ({agent.role}): {agent.description}"
+            for agent in sorted(agency_catalog.values(), key=lambda a: a.role)
+        ]
         if specialists:
             specialist_block = (
                 "\n\n## Available specialist agents (from Agency catalog)\n"

--- a/src/bernstein/core/autofix/telemetry_grounded.py
+++ b/src/bernstein/core/autofix/telemetry_grounded.py
@@ -606,8 +606,8 @@ class RecentJsonlLogRetriever:
         scan_bytes: int = 256 * 1024,
     ) -> None:
         self._log_path = log_path
-        self._max_lines = max(1, int(max_lines))
-        self._scan_bytes = max(1024, int(scan_bytes))
+        self._max_lines = max(1, max_lines)
+        self._scan_bytes = max(1024, scan_bytes)
 
     def retrieve(self, event: TelemetryEvent) -> GroundingContext:
         if not event.fingerprint:

--- a/src/bernstein/core/autofix/telemetry_grounded.py
+++ b/src/bernstein/core/autofix/telemetry_grounded.py
@@ -606,8 +606,8 @@ class RecentJsonlLogRetriever:
         scan_bytes: int = 256 * 1024,
     ) -> None:
         self._log_path = log_path
-        self._max_lines = max(1, max_lines)
-        self._scan_bytes = max(1024, scan_bytes)
+        self._max_lines = max(1, int(max_lines))
+        self._scan_bytes = max(1024, int(scan_bytes))
 
     def retrieve(self, event: TelemetryEvent) -> GroundingContext:
         if not event.fingerprint:

--- a/src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py
@@ -45,9 +45,7 @@ CYCLONEDX_SERIAL_NS = "urn:uuid:bernstein-ai-bom"
 
 def encode_cyclonedx(bom: AIBOM) -> bytes:
     """Return CycloneDX 1.5 (AI/ML extension) JSON bytes."""
-    components: list[dict[str, Any]] = []
-    for model in bom.models:
-        components.append(_model_component(model))
+    components: list[dict[str, Any]] = [_model_component(model) for model in bom.models]
     for prompt in bom.prompts:
         components.append(_prompt_component(prompt))
     for adapter in bom.adapters:

--- a/src/bernstein/core/compliance/ai_bom_encoders/spdx.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/spdx.py
@@ -37,9 +37,7 @@ DATA_LICENSE = "CC0-1.0"
 
 def encode_spdx(bom: AIBOM) -> bytes:
     """Return SPDX 2.3 JSON bytes."""
-    packages: list[dict[str, Any]] = []
-    for model in bom.models:
-        packages.append(_model_package(model))
+    packages: list[dict[str, Any]] = [_model_package(model) for model in bom.models]
     for prompt in bom.prompts:
         packages.append(_prompt_package(prompt))
     for adapter in bom.adapters:

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -619,20 +619,19 @@ class EpsilonGreedyBandit:
 
     def summary(self) -> list[dict[str, Any]]:
         """Return a summary of all arm statistics, sorted by role then cost."""
-        rows: list[dict[str, Any]] = []
-        for arm in sorted(self._arms.values(), key=lambda a: (a.role, _model_cost(a.model))):
-            rows.append(
-                {
-                    "role": arm.role,
-                    "model": arm.model,
-                    "observations": arm.observations,
-                    "success_rate": round(arm.success_rate, 3),
-                    "avg_cost_usd": round(arm.avg_cost_usd, 6),
-                    "avg_latency_s": round(arm.avg_latency_s, 1),
-                    "trusted": arm.observations >= self.min_observations,
-                    "meets_quality": arm.success_rate >= self.quality_threshold,
-                }
-            )
+        rows: list[dict[str, Any]] = [
+            {
+                "role": arm.role,
+                "model": arm.model,
+                "observations": arm.observations,
+                "success_rate": round(arm.success_rate, 3),
+                "avg_cost_usd": round(arm.avg_cost_usd, 6),
+                "avg_latency_s": round(arm.avg_latency_s, 1),
+                "trusted": arm.observations >= self.min_observations,
+                "meets_quality": arm.success_rate >= self.quality_threshold,
+            }
+            for arm in sorted(self._arms.values(), key=lambda a: (a.role, _model_cost(a.model)))
+        ]
         return rows
 
     def get_arm(self, role: str, model: str) -> BanditArm | None:

--- a/src/bernstein/core/cost/ticket_cap.py
+++ b/src/bernstein/core/cost/ticket_cap.py
@@ -321,7 +321,7 @@ class TicketCostCapMeter:
         Args:
             cost_usd: USD delta to add. Non-positive values are ignored.
         """
-        delta = max(0.0, cost_usd)
+        delta = max(0.0, float(cost_usd))
         with self._lock:
             self._spent_usd += delta
             if self._should_halt_locked():

--- a/src/bernstein/core/cost/ticket_cap.py
+++ b/src/bernstein/core/cost/ticket_cap.py
@@ -82,8 +82,8 @@ class CostCapExceeded(RuntimeError):
     ) -> None:
         super().__init__(f"ticket {ticket_id!r} exceeded cost cap: spent=${cost_usd:.4f} cap=${cap_usd:.4f} ({reason})")
         self.ticket_id = ticket_id
-        self.cost_usd = float(cost_usd)
-        self.cap_usd = float(cap_usd)
+        self.cost_usd = cost_usd
+        self.cap_usd = cap_usd
         self.reason = reason
 
 
@@ -321,7 +321,7 @@ class TicketCostCapMeter:
         Args:
             cost_usd: USD delta to add. Non-positive values are ignored.
         """
-        delta = max(0.0, float(cost_usd))
+        delta = max(0.0, cost_usd)
         with self._lock:
             self._spent_usd += delta
             if self._should_halt_locked():

--- a/src/bernstein/core/credential_scoping.py
+++ b/src/bernstein/core/credential_scoping.py
@@ -758,7 +758,7 @@ def resolve_default_policy(
     """
     import os
 
-    source_env = env if env is not None else dict(os.environ)
+    source_env = env if env is not None else os.environ.copy()
     base = Path(workdir) if workdir is not None else Path.cwd()
 
     # 1. Explicit opt-out — short-circuit before any I/O.

--- a/src/bernstein/core/devops/trend_scan.py
+++ b/src/bernstein/core/devops/trend_scan.py
@@ -347,23 +347,24 @@ def build_rollup_markdown(
     """
 
     lines: list[str] = []
-    lines.append("# Trend scan rollup")
-    lines.append("")
-    lines.append(f"_Generated: {generated_at}_")
-    lines.append("")
-    lines.append(
-        "Scheduled job that ingests upstream dependency-relevant signals into the "
-        "orchestrator state. No tickets are filed automatically - the operator "
-        "reviews this rollup and runs `bernstein backlog new` for the rows that "
-        "warrant a ticket."
+    lines.extend(
+        (
+            "# Trend scan rollup",
+            "",
+            f"_Generated: {generated_at}_",
+            "",
+            "Scheduled job that ingests upstream dependency-relevant signals into the "
+            "orchestrator state. No tickets are filed automatically - the operator "
+            "reviews this rollup and runs `bernstein backlog new` for the rows that "
+            "warrant a ticket.",
+            "",
+            f"Sources scanned: {len(sources)}. Candidates surfaced: {len(candidates)}.",
+            "",
+        )
     )
-    lines.append("")
-    lines.append(f"Sources scanned: {len(sources)}. Candidates surfaced: {len(candidates)}.")
-    lines.append("")
 
     if not candidates:
-        lines.append("No candidates passed the per-source filters this run.")
-        lines.append("")
+        lines.extend(("No candidates passed the per-source filters this run.", ""))
         return "\n".join(lines)
 
     by_tier: dict[int, list[Candidate]] = {}
@@ -371,10 +372,14 @@ def build_rollup_markdown(
         by_tier.setdefault(cand.tier, []).append(cand)
 
     for tier in sorted(by_tier):
-        lines.append(f"## Tier {tier}")
-        lines.append("")
-        lines.append("| Source | Title | Status | Score | Matched | Refs |")
-        lines.append("| --- | --- | --- | --- | --- | --- |")
+        lines.extend(
+            (
+                f"## Tier {tier}",
+                "",
+                "| Source | Title | Status | Score | Matched | Refs |",
+                "| --- | --- | --- | --- | --- | --- |",
+            )
+        )
         for cand in by_tier[tier]:
             title_cell = f"[{_escape(cand.title)}]({cand.url})" if cand.url else _escape(cand.title)
             matched_cell = ", ".join(cand.matched_keywords) or "-"
@@ -385,12 +390,15 @@ def build_rollup_markdown(
             )
         lines.append("")
 
-    lines.append("---")
-    lines.append("")
-    lines.append(
-        "_Operator action: review the `new` rows; ignore `duplicate` and `recently-closed` unless context has changed._"
+    lines.extend(
+        (
+            "---",
+            "",
+            "_Operator action: review the `new` rows; ignore `duplicate` and"
+            " `recently-closed` unless context has changed._",
+            "",
+        )
     )
-    lines.append("")
     return "\n".join(lines)
 
 

--- a/src/bernstein/core/fleet/audit.py
+++ b/src/bernstein/core/fleet/audit.py
@@ -129,21 +129,20 @@ def load_recent_entries(project: str, sdd_dir: Path, *, max_entries: int = 500) 
     Returns:
         Parsed entries in chronological order (oldest first).
     """
-    rows: list[AuditEntry] = []
-    for filename, line_no, entry in _iter_recent_entries(sdd_dir / "audit", max_entries):
-        rows.append(
-            AuditEntry(
-                project=project,
-                ts=_coerce_ts(entry),
-                role=str(entry.get("role", "") or ""),
-                adapter=str(entry.get("adapter", "") or ""),
-                outcome=str(entry.get("outcome", entry.get("status", "")) or ""),
-                kind=str(entry.get("kind", entry.get("event", "")) or ""),
-                line_no=line_no,
-                source_file=filename,
-                raw=entry,
-            )
+    rows: list[AuditEntry] = [
+        AuditEntry(
+            project=project,
+            ts=_coerce_ts(entry),
+            role=str(entry.get("role", "") or ""),
+            adapter=str(entry.get("adapter", "") or ""),
+            outcome=str(entry.get("outcome", entry.get("status", "")) or ""),
+            kind=str(entry.get("kind", entry.get("event", "")) or ""),
+            line_no=line_no,
+            source_file=filename,
+            raw=entry,
         )
+        for filename, line_no, entry in _iter_recent_entries(sdd_dir / "audit", max_entries)
+    ]
     return rows
 
 

--- a/src/bernstein/core/fleet/directory_registry.py
+++ b/src/bernstein/core/fleet/directory_registry.py
@@ -262,7 +262,7 @@ class DirectoryRegistry:
         scan = self.scan()
         config = FleetConfig(
             projects=[s.to_project_config() for s in scan.instances],
-            errors=list(scan.errors),
+            errors=scan.errors.copy(),
             source_path=self._root,
         )
         for index, spec in enumerate(scan.disabled):

--- a/src/bernstein/core/git/git_context.py
+++ b/src/bernstein/core/git/git_context.py
@@ -42,7 +42,7 @@ def _run_git(args: list[str], cwd: Path, *, timeout: int = 10) -> str | None:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     except (subprocess.TimeoutExpired, OSError) as exc:
-        args_str = " ".join(str(a) for a in args)
+        args_str = " ".join(a for a in args)
         logger.debug("git %s failed: %s", args_str, exc)
     return None
 

--- a/src/bernstein/core/knowledge/knowledge_base.py
+++ b/src/bernstein/core/knowledge/knowledge_base.py
@@ -253,11 +253,7 @@ class TaskContextBuilder:
         Returns:
             Formatted task context string.
         """
-        sections: list[str] = []
-
-        # Per-file context
-        for fpath in files[:5]:  # Limit to first 5 files
-            sections.append(self.file_context(fpath, max_chars=800))
+        sections: list[str] = [self.file_context(fpath, max_chars=800) for fpath in files[:5]]
 
         # Cross-file info
         all_imports: set[str] = set()

--- a/src/bernstein/core/lineage/audit.py
+++ b/src/bernstein/core/lineage/audit.py
@@ -60,7 +60,7 @@ class LineageMergeAuditRecord:
             "artefact_path": self.artefact_path,
             "policy": self.policy,
             "winner_hash": self.winner_hash,
-            "candidate_hashes": list(self.candidate_hashes),
+            "candidate_hashes": self.candidate_hashes.copy(),
             "parent_hash": self.parent_hash,
             "reason": self.reason,
         }
@@ -134,7 +134,7 @@ def emit_lineage_merge_entry(
         artefact_path=artefact_path,
         policy=policy,
         winner_hash=winner_hash,
-        candidate_hashes=list(candidate_hashes),
+        candidate_hashes=candidate_hashes.copy(),
         parent_hash=parent_hash,
         reason=reason,
     )

--- a/src/bernstein/core/lineage/v2_store.py
+++ b/src/bernstein/core/lineage/v2_store.py
@@ -324,7 +324,7 @@ class LineageV2Store:
             child_run_id=draft.child_run_id,
             seq=draft.seq,
             kind=draft.kind,
-            payload=dict(draft.payload),
+            payload=draft.payload.copy(),
             ts_ns=draft.ts_ns,
             prev_hmac=draft.prev_hmac,
             hmac=h,
@@ -353,7 +353,7 @@ class LineageV2Store:
                 child_run_id=child_body.child_run_id,
                 seq=child_body.seq,
                 kind=child_body.kind,
-                payload=dict(child_body.payload),
+                payload=child_body.payload.copy(),
                 ts_ns=child_body.ts_ns,
                 prev_hmac="",
                 hmac="",
@@ -370,7 +370,7 @@ class LineageV2Store:
                 child_run_id=child_body.child_run_id,
                 seq=child_body.seq,
                 kind=child_body.kind,
-                payload=dict(child_body.payload),
+                payload=child_body.payload.copy(),
                 ts_ns=child_body.ts_ns,
                 prev_hmac=prev_child_hmac,
                 hmac="",
@@ -425,7 +425,7 @@ class LineageV2Store:
                 child_run_id=body.child_run_id,
                 seq=body.seq,
                 kind=body.kind,
-                payload=dict(body.payload),
+                payload=body.payload.copy(),
                 ts_ns=body.ts_ns,
                 prev_hmac=prev,
                 hmac="",
@@ -531,7 +531,7 @@ class LineageV2Store:
                         child_run_id=body.child_run_id,
                         seq=body.seq,
                         kind=body.kind,
-                        payload=dict(body.payload),
+                        payload=body.payload.copy(),
                         ts_ns=body.ts_ns,
                         prev_hmac="",
                         hmac="",
@@ -706,7 +706,7 @@ def is_v2_enabled(env: dict[str, str] | None = None, cfg: dict[str, Any] | None 
 
     Defaults to False (v1 stays the default).
     """
-    e: dict[str, str] = dict(env) if env is not None else dict(os.environ)
+    e: dict[str, str] = dict(env) if env is not None else os.environ.copy()
     flag = e.get("BERNSTEIN_LINEAGE_V2", "").strip().lower()
     if flag in {"1", "true", "yes", "on"}:
         return True

--- a/src/bernstein/core/memory/session_memory.py
+++ b/src/bernstein/core/memory/session_memory.py
@@ -309,7 +309,7 @@ class SessionMemory:
             "ts_ns": turn.ts_ns,
             "task_id": self._task_id,
             "session_id": self._session_id,
-            "tags": list(turn.tags),
+            "tags": turn.tags.copy(),
             "content_hash": chash,
         }
         line = json.dumps(record, ensure_ascii=False, separators=(",", ":"))

--- a/src/bernstein/core/observability/runbooks.py
+++ b/src/bernstein/core/observability/runbooks.py
@@ -164,17 +164,16 @@ class RunbookEngine:
             return _default_runbook_rules()
         try:
             data = json.loads(config_path.read_text())
-            rules: list[RunbookRule] = []
-            for entry in data.get("runbooks", []):
-                rules.append(
-                    RunbookRule(
-                        name=entry["name"],
-                        detect=entry["detect"],
-                        action=entry["action"],
-                        auto_execute=entry.get("auto_execute", False),
-                        max_retries=entry.get("max_retries", 2),
-                    )
+            rules: list[RunbookRule] = [
+                RunbookRule(
+                    name=entry["name"],
+                    detect=entry["detect"],
+                    action=entry["action"],
+                    auto_execute=entry.get("auto_execute", False),
+                    max_retries=entry.get("max_retries", 2),
                 )
+                for entry in data.get("runbooks", [])
+            ]
             return rules
         except (json.JSONDecodeError, KeyError, OSError) as exc:
             logger.warning("Failed to load runbook config: %s", exc)

--- a/src/bernstein/core/observability/slo.py
+++ b/src/bernstein/core/observability/slo.py
@@ -385,18 +385,17 @@ class SLOTracker:
 
     def get_dashboard(self) -> dict[str, object]:
         """Return SLO dashboard data for TUI/web rendering."""
-        slos: list[dict[str, object]] = []
-        for name, target in self.targets.items():
-            slos.append(
-                {
-                    "name": name,
-                    "description": target.description,
-                    "target": target.target,
-                    "current": round(target.current, 4),
-                    "status": target.status.value,
-                    "met": target.met,
-                }
-            )
+        slos: list[dict[str, object]] = [
+            {
+                "name": name,
+                "description": target.description,
+                "target": target.target,
+                "current": round(target.current, 4),
+                "status": target.status.value,
+                "met": target.met,
+            }
+            for name, target in self.targets.items()
+        ]
         return {
             "slos": slos,
             "error_budget": {

--- a/src/bernstein/core/observability/ticket_bundle.py
+++ b/src/bernstein/core/observability/ticket_bundle.py
@@ -146,7 +146,7 @@ class BundleManifest:
             "ticket_id": self.ticket_id,
             "files": [entry.to_dict() for entry in self.files],
             "pr_number": self.pr_number,
-            "commits": list(self.commits),
+            "commits": self.commits.copy(),
         }
 
     def canonical_bytes(self) -> bytes:
@@ -508,16 +508,15 @@ class TicketBundle:
             arc = f"pr/pr_{pr_number if pr_number is not None else 'unknown'}.json"
             entries.append((arc, "pr", pr_bytes))
 
-        manifest_entries: list[ManifestEntry] = []
-        for arcname, section, data in entries:
-            manifest_entries.append(
-                ManifestEntry(
-                    arcname=arcname,
-                    size_bytes=len(data),
-                    sha256=_sha256_bytes(data),
-                    section=section,
-                ),
+        manifest_entries: list[ManifestEntry] = [
+            ManifestEntry(
+                arcname=arcname,
+                size_bytes=len(data),
+                sha256=_sha256_bytes(data),
+                section=section,
             )
+            for arcname, section, data in entries
+        ]
         manifest_entries.sort(key=lambda e: e.arcname)
 
         manifest = BundleManifest(
@@ -528,7 +527,7 @@ class TicketBundle:
             ticket_id=self.ticket_id,
             files=manifest_entries,
             pr_number=pr_number,
-            commits=list(commits),
+            commits=commits.copy(),
         )
 
         out.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/core/orchestration/manager.py
+++ b/src/bernstein/core/orchestration/manager.py
@@ -596,17 +596,15 @@ Be precise and complete. Include all necessary imports, tests, and documentation
             text = text.strip()
 
             changes_data: Any = json.loads(text)
-            changes: list[FileChange] = []
-
-            for item in changes_data:
-                changes.append(
-                    FileChange(
-                        path=item.get("path", ""),
-                        operation=item.get("operation", "modify"),
-                        new_content=item.get("new_content"),
-                        old_content=item.get("old_content"),
-                    )
+            changes: list[FileChange] = [
+                FileChange(
+                    path=item.get("path", ""),
+                    operation=item.get("operation", "modify"),
+                    new_content=item.get("new_content"),
+                    old_content=item.get("old_content"),
                 )
+                for item in changes_data
+            ]
 
             return changes
 

--- a/src/bernstein/core/orchestration/multi_cell.py
+++ b/src/bernstein/core/orchestration/multi_cell.py
@@ -95,26 +95,25 @@ def _fetch_tasks_for_cell(
         params={"status": status, "cell_id": cell_id},
     )
     resp.raise_for_status()
-    tasks: list[Task] = []
-    for raw in resp.json():
-        tasks.append(
-            Task(
-                id=raw["id"],
-                title=raw["title"],
-                description=raw["description"],
-                role=raw["role"],
-                priority=raw.get("priority", 2),
-                scope=Scope(raw.get("scope", "medium")),
-                complexity=Complexity(raw.get("complexity", "medium")),
-                estimated_minutes=raw.get("estimated_minutes", 30),
-                status=TaskStatus(raw.get("status", "open")),
-                depends_on=raw.get("depends_on", []),
-                owned_files=raw.get("owned_files", []),
-                assigned_agent=raw.get("assigned_agent"),
-                result_summary=raw.get("result_summary"),
-                cell_id=raw.get("cell_id"),
-            )
+    tasks: list[Task] = [
+        Task(
+            id=raw["id"],
+            title=raw["title"],
+            description=raw["description"],
+            role=raw["role"],
+            priority=raw.get("priority", 2),
+            scope=Scope(raw.get("scope", "medium")),
+            complexity=Complexity(raw.get("complexity", "medium")),
+            estimated_minutes=raw.get("estimated_minutes", 30),
+            status=TaskStatus(raw.get("status", "open")),
+            depends_on=raw.get("depends_on", []),
+            owned_files=raw.get("owned_files", []),
+            assigned_agent=raw.get("assigned_agent"),
+            result_summary=raw.get("result_summary"),
+            cell_id=raw.get("cell_id"),
         )
+        for raw in resp.json()
+    ]
     return tasks
 
 

--- a/src/bernstein/core/orchestration/multi_criteria_rank.py
+++ b/src/bernstein/core/orchestration/multi_criteria_rank.py
@@ -359,9 +359,7 @@ def _vector_normalise(matrix: list[list[float]]) -> list[list[float]]:
         norms.append(math.sqrt(col_sq))
     out: list[list[float]] = []
     for row in matrix:
-        new_row: list[float] = []
-        for j, v in enumerate(row):
-            new_row.append(v / norms[j] if norms[j] > 0.0 else 0.0)
+        new_row: list[float] = [v / norms[j] if norms[j] > 0.0 else 0.0 for j, v in enumerate(row)]
         out.append(new_row)
     return out
 
@@ -404,18 +402,15 @@ def render_ranking_json(
     the snapshot deterministic across platforms (where the last 1-2
     ULPs of a ``math.sqrt`` may differ).
     """
-    rows: list[dict[str, object]] = []
-    for r in ranked:
-        rows.append(
-            {
-                "key": r.key,
-                "rank": r.rank,
-                "closeness": round(r.closeness, precision),
-                "normalised_scores": {
-                    name: round(r.normalised_scores.get(name, 0.0), precision) for name in profile.names
-                },
-            }
-        )
+    rows: list[dict[str, object]] = [
+        {
+            "key": r.key,
+            "rank": r.rank,
+            "closeness": round(r.closeness, precision),
+            "normalised_scores": {name: round(r.normalised_scores.get(name, 0.0), precision) for name in profile.names},
+        }
+        for r in ranked
+    ]
     winner_key = rows[0]["key"] if rows else None
     return {
         "method": "topsis",

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3714,9 +3714,7 @@ class Orchestrator:
         total_cost = collector.get_total_cost()
         files_modified: int = sum(getattr(m, "files_modified", 0) for m in collector.task_metrics.values())
 
-        task_lines: list[str] = []
-        for task in sorted(done_tasks, key=lambda t: t.title):
-            task_lines.append(f"- [x] {task.title}")
+        task_lines: list[str] = [f"- [x] {task.title}" for task in sorted(done_tasks, key=lambda t: t.title)]
         for task in sorted(failed_tasks, key=lambda t: t.title):
             task_lines.append(f"- [ ] {task.title} *(failed)*")
 

--- a/src/bernstein/core/orchestration/orchestrator_summary.py
+++ b/src/bernstein/core/orchestration/orchestrator_summary.py
@@ -63,9 +63,7 @@ def generate_run_summary(
         completed_tasks=total_completed,
     )
 
-    task_lines: list[str] = []
-    for task in sorted(done_tasks, key=lambda t: t.title):
-        task_lines.append(f"- [x] {task.title}")
+    task_lines: list[str] = [f"- [x] {task.title}" for task in sorted(done_tasks, key=lambda t: t.title)]
     for task in sorted(failed_tasks, key=lambda t: t.title):
         task_lines.append(f"- [ ] {task.title} *(failed)*")
 

--- a/src/bernstein/core/orchestration/phase_schemas.py
+++ b/src/bernstein/core/orchestration/phase_schemas.py
@@ -246,16 +246,15 @@ def validate_phase_output(phase: Phase | str, payload: object) -> list[PhaseSche
         ]
 
     validator = Draft202012Validator(schema)
-    errors: list[PhaseSchemaError] = []
-    for err in sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path)):
-        errors.append(
-            PhaseSchemaError(
-                phase=name,
-                schema_id=schema_id,
-                field_path=_format_path(err),
-                message=err.message,
-            )
+    errors: list[PhaseSchemaError] = [
+        PhaseSchemaError(
+            phase=name,
+            schema_id=schema_id,
+            field_path=_format_path(err),
+            message=err.message,
         )
+        for err in sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
+    ]
     return errors
 
 

--- a/src/bernstein/core/orchestration/run_session.py
+++ b/src/bernstein/core/orchestration/run_session.py
@@ -205,24 +205,23 @@ class RunSession:
         _complexity_map = {c.value: c for c in Complexity}
         _type_map = {t.value: t for t in TaskType}
 
-        result: list[Task] = []
-        for d in self.tasks:
-            result.append(
-                Task(
-                    id=d.get("id", ""),
-                    title=d.get("title", ""),
-                    description=d.get("description", ""),
-                    role=d.get("role", "backend"),
-                    priority=int(d.get("priority", 5)),
-                    scope=_scope_map.get(d.get("scope", "medium"), Scope.MEDIUM),
-                    complexity=_complexity_map.get(d.get("complexity", "medium"), Complexity.MEDIUM),
-                    status=_status_map.get(d.get("status", "open"), TaskStatus.OPEN),
-                    estimated_minutes=int(d.get("estimated_minutes", 30)),
-                    depends_on=d.get("depends_on") or [],
-                    owned_files=d.get("owned_files") or [],
-                    task_type=_type_map.get(d.get("task_type", "standard"), TaskType.STANDARD),
-                )
+        result: list[Task] = [
+            Task(
+                id=d.get("id", ""),
+                title=d.get("title", ""),
+                description=d.get("description", ""),
+                role=d.get("role", "backend"),
+                priority=int(d.get("priority", 5)),
+                scope=_scope_map.get(d.get("scope", "medium"), Scope.MEDIUM),
+                complexity=_complexity_map.get(d.get("complexity", "medium"), Complexity.MEDIUM),
+                status=_status_map.get(d.get("status", "open"), TaskStatus.OPEN),
+                estimated_minutes=int(d.get("estimated_minutes", 30)),
+                depends_on=d.get("depends_on") or [],
+                owned_files=d.get("owned_files") or [],
+                task_type=_type_map.get(d.get("task_type", "standard"), TaskType.STANDARD),
             )
+            for d in self.tasks
+        ]
         return result  # type: ignore[return-value]
 
     # ------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -285,7 +285,7 @@ def make_idempotency_key(
         Hex digest string suitable for ``Idempotency-Key`` headers or
         in-comment fingerprints.
     """
-    parts = [tracker, ticket_id, role, stage, str(stage_attempt)]
+    parts = [tracker, ticket_id, role, stage, str(int(stage_attempt))]
     joined = "\x1f".join(parts).encode("utf-8")
     return hashlib.sha256(joined).hexdigest()
 
@@ -356,7 +356,7 @@ def format_failure_comment(
     body_lines = [
         FAILURE_BLOCK_BEGIN,
         f"role: {_yaml_quote(role)}",
-        f"stage_attempt: {stage_attempt}",
+        f"stage_attempt: {int(stage_attempt)}",
         f"idempotency_key: {_yaml_quote(idempotency_key)}",
         f"reason_code: {_yaml_quote(payload.reason_code)}",
         f"category: {_yaml_quote(payload.category)}",
@@ -387,7 +387,7 @@ def format_success_comment(
     body_lines = [
         _SUCCESS_BLOCK_BEGIN,
         f"role: {_yaml_quote(role)}",
-        f"stage_attempt: {stage_attempt}",
+        f"stage_attempt: {int(stage_attempt)}",
         f"idempotency_key: {_yaml_quote(idempotency_key)}",
         f"summary: {_yaml_quote(safe_summary)}",
         FAILURE_BLOCK_END,

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -285,7 +285,7 @@ def make_idempotency_key(
         Hex digest string suitable for ``Idempotency-Key`` headers or
         in-comment fingerprints.
     """
-    parts = [tracker, ticket_id, role, stage, str(int(stage_attempt))]
+    parts = [tracker, ticket_id, role, stage, str(stage_attempt)]
     joined = "\x1f".join(parts).encode("utf-8")
     return hashlib.sha256(joined).hexdigest()
 
@@ -356,7 +356,7 @@ def format_failure_comment(
     body_lines = [
         FAILURE_BLOCK_BEGIN,
         f"role: {_yaml_quote(role)}",
-        f"stage_attempt: {int(stage_attempt)}",
+        f"stage_attempt: {stage_attempt}",
         f"idempotency_key: {_yaml_quote(idempotency_key)}",
         f"reason_code: {_yaml_quote(payload.reason_code)}",
         f"category: {_yaml_quote(payload.category)}",
@@ -387,7 +387,7 @@ def format_success_comment(
     body_lines = [
         _SUCCESS_BLOCK_BEGIN,
         f"role: {_yaml_quote(role)}",
-        f"stage_attempt: {int(stage_attempt)}",
+        f"stage_attempt: {stage_attempt}",
         f"idempotency_key: {_yaml_quote(idempotency_key)}",
         f"summary: {_yaml_quote(safe_summary)}",
         FAILURE_BLOCK_END,
@@ -620,7 +620,7 @@ class ClaimLedger:
             granted and, on failure, why.
         """
         current = float(time.time() if now is None else now)
-        expires_at = current + max(1, int(ttl_seconds))
+        expires_at = current + max(1, ttl_seconds)
         conn = self._connect()
         try:
             conn.execute("BEGIN IMMEDIATE")
@@ -715,18 +715,17 @@ class ClaimLedger:
             "ORDER BY tracker, role, ticket_id",
             (current,),
         )
-        rows: list[dict[str, Any]] = []
-        for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall():
-            rows.append(
-                {
-                    "tracker": tracker,
-                    "ticket_id": ticket_id,
-                    "role": role,
-                    "claimer_id": claimer_id,
-                    "stage_attempt": int(attempt),
-                    "lease_seconds_remaining": float(expires) - current,
-                }
-            )
+        rows: list[dict[str, Any]] = [
+            {
+                "tracker": tracker,
+                "ticket_id": ticket_id,
+                "role": role,
+                "claimer_id": claimer_id,
+                "stage_attempt": int(attempt),
+                "lease_seconds_remaining": float(expires) - current,
+            }
+            for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall()
+        ]
         return rows
 
     def release(self, *, tracker: str, ticket_id: str, role: str, claimer_id: str) -> bool:

--- a/src/bernstein/core/persistence/lineage.py
+++ b/src/bernstein/core/persistence/lineage.py
@@ -566,9 +566,7 @@ def collect_bundle_records(sdd_dir: Path, *, max_records: int = 500) -> list[dic
     cases generally want the latest activity, not the oldest.
     """
     reader = LineageReader(sdd_dir)
-    records: list[dict[str, Any]] = []
-    for record in reader.iter_records():
-        records.append(record_to_dict(record))
+    records: list[dict[str, Any]] = [record_to_dict(record) for record in reader.iter_records()]
     if len(records) > max_records:
         records = records[-max_records:]
     return records

--- a/src/bernstein/core/persistence/store_postgres.py
+++ b/src/bernstein/core/persistence/store_postgres.py
@@ -748,21 +748,20 @@ class PostgresTaskStore(BaseTaskStore):
                 """,
                 limit,
             )
-        records: list[ArchiveRecord] = []
-        for row in reversed(rows):  # oldest-first
-            records.append(
-                AR(
-                    task_id=row["task_id"],
-                    title=row["title"],
-                    role=row["role"],
-                    status=row["status"],
-                    created_at=row["created_at"],
-                    completed_at=row["completed_at"],
-                    duration_seconds=row["duration_seconds"],
-                    result_summary=row["result_summary"],
-                    cost_usd=row["cost_usd"],
-                )
+        records: list[ArchiveRecord] = [
+            AR(
+                task_id=row["task_id"],
+                title=row["title"],
+                role=row["role"],
+                status=row["status"],
+                created_at=row["created_at"],
+                completed_at=row["completed_at"],
+                duration_seconds=row["duration_seconds"],
+                result_summary=row["result_summary"],
+                cost_usd=row["cost_usd"],
             )
+            for row in reversed(rows)
+        ]
         return records
 
     # -- agent heartbeats ----------------------------------------------------

--- a/src/bernstein/core/planning/workflow.py
+++ b/src/bernstein/core/planning/workflow.py
@@ -92,16 +92,15 @@ class WorkflowDefinition:
         This hash is recorded in run metadata so auditors can verify
         which workflow definition was used for a given run.
         """
-        canonical: list[dict[str, object]] = []
-        for phase in self.phases:
-            canonical.append(
-                {
-                    "name": phase.name,
-                    "allowed_roles": sorted(phase.allowed_roles),
-                    "completion_statuses": sorted(s.value for s in phase.completion_statuses),
-                    "requires_approval": phase.requires_approval,
-                }
-            )
+        canonical: list[dict[str, object]] = [
+            {
+                "name": phase.name,
+                "allowed_roles": sorted(phase.allowed_roles),
+                "completion_statuses": sorted(s.value for s in phase.completion_statuses),
+                "requires_approval": phase.requires_approval,
+            }
+            for phase in self.phases
+        ]
         payload = json.dumps(
             {"name": self.name, "version": self.version, "phases": canonical},
             sort_keys=True,

--- a/src/bernstein/core/protocols/backstage_plugin.py
+++ b/src/bernstein/core/protocols/backstage_plugin.py
@@ -273,9 +273,7 @@ class BackstageExporter:
             msg = "entries must not be empty"
             raise ValueError(msg)
 
-        docs: list[str] = []
-        for entry in entries:
-            docs.append(self.build_entity_yaml(entry.entity, entry.spec, entry.relations))
+        docs: list[str] = [self.build_entity_yaml(entry.entity, entry.spec, entry.relations) for entry in entries]
         return "---\n".join(docs)
 
     def build_entity_yaml(

--- a/src/bernstein/core/protocols/cluster/cluster.py
+++ b/src/bernstein/core/protocols/cluster/cluster.py
@@ -93,20 +93,19 @@ class NodeRegistry:
         if self._persist_path is None:
             return
         try:
-            data: list[dict[str, Any]] = []
-            for node in self._nodes.values():
-                data.append(
-                    {
-                        "id": node.id,
-                        "name": node.name,
-                        "url": node.url,
-                        "max_agents": node.capacity.max_agents,
-                        "supported_models": node.capacity.supported_models,
-                        "registered_at": node.registered_at,
-                        "labels": node.labels,
-                        "cell_ids": node.cell_ids,
-                    }
-                )
+            data: list[dict[str, Any]] = [
+                {
+                    "id": node.id,
+                    "name": node.name,
+                    "url": node.url,
+                    "max_agents": node.capacity.max_agents,
+                    "supported_models": node.capacity.supported_models,
+                    "registered_at": node.registered_at,
+                    "labels": node.labels,
+                    "cell_ids": node.cell_ids,
+                }
+                for node in self._nodes.values()
+            ]
             self._persist_path.parent.mkdir(parents=True, exist_ok=True)
             self._persist_path.write_text(json.dumps(data, indent=2))
         except Exception as exc:

--- a/src/bernstein/core/protocols/mcp_catalog/service.py
+++ b/src/bernstein/core/protocols/mcp_catalog/service.py
@@ -265,9 +265,9 @@ class CatalogService:
     ) -> list[tuple[InstalledEntry, CatalogEntry | None]]:
         """Pair each installed entry with its current catalog entry, if any."""
         catalog = self.browse(force_refresh=force_refresh)
-        out: list[tuple[InstalledEntry, CatalogEntry | None]] = []
-        for installed in self.list_installed():
-            out.append((installed, catalog.find(installed.id)))
+        out: list[tuple[InstalledEntry, CatalogEntry | None]] = [
+            (installed, catalog.find(installed.id)) for installed in self.list_installed()
+        ]
         return out
 
     # ------------------------------------------------------------------

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -96,18 +96,17 @@ class GateRunner:
         format_steps = [s for s in pipeline if s.name == "auto_format"]
         other_steps = [s for s in pipeline if s.name != "auto_format"]
 
-        format_results: list[GateResult] = []
-        for step in format_steps:
-            format_results.append(
-                await self._run_step(
-                    step,
-                    task,
-                    run_dir,
-                    changed_files,
-                    skip_set=skip_set,
-                    bypass_reason=bypass_reason,
-                )
+        format_results: list[GateResult] = [
+            await self._run_step(
+                step,
+                task,
+                run_dir,
+                changed_files,
+                skip_set=skip_set,
+                bypass_reason=bypass_reason,
             )
+            for step in format_steps
+        ]
 
         other_results = list(
             await asyncio.gather(

--- a/src/bernstein/core/review_responder/bundling.py
+++ b/src/bernstein/core/review_responder/bundling.py
@@ -133,16 +133,15 @@ class RoundBundler:
         """
         cap = max(1, self.config.max_comments_per_round)
         chunks: list[list[ReviewComment]] = [bundle.comments[i : i + cap] for i in range(0, len(bundle.comments), cap)]
-        rounds: list[ReviewRound] = []
-        for chunk in chunks:
-            rounds.append(
-                ReviewRound(
-                    round_id=f"rnd-{uuid.uuid4().hex[:12]}",
-                    repo=bundle.repo,
-                    pr_number=bundle.pr_number,
-                    comments=tuple(chunk),
-                    opened_at=bundle.opened_at,
-                    sealed_at=sealed_at,
-                )
+        rounds: list[ReviewRound] = [
+            ReviewRound(
+                round_id=f"rnd-{uuid.uuid4().hex[:12]}",
+                repo=bundle.repo,
+                pr_number=bundle.pr_number,
+                comments=tuple(chunk),
+                opened_at=bundle.opened_at,
+                sealed_at=sealed_at,
             )
+            for chunk in chunks
+        ]
         return rounds

--- a/src/bernstein/core/routes/costs.py
+++ b/src/bernstein/core/routes/costs.py
@@ -495,14 +495,13 @@ def _bucket_usages(
             slot = int(ts // bucket_seconds) * bucket_seconds
             buckets[slot] += float(usage.cost_usd)
 
-    series: list[dict[str, Any]] = []
-    for slot in sorted(buckets):
-        series.append(
-            {
-                "ts": datetime.fromtimestamp(slot, tz=UTC).isoformat(),
-                "usd": round(buckets[slot], 6),
-            }
-        )
+    series: list[dict[str, Any]] = [
+        {
+            "ts": datetime.fromtimestamp(slot, tz=UTC).isoformat(),
+            "usd": round(buckets[slot], 6),
+        }
+        for slot in sorted(buckets)
+    ]
     return series
 
 

--- a/src/bernstein/core/routes/status_dashboard.py
+++ b/src/bernstein/core/routes/status_dashboard.py
@@ -1123,22 +1123,21 @@ def dashboard_data(request: Request) -> JSONResponse:
     merge_queue = _read_merge_queue(request)
 
     # -- Task timeline data for Gantt ----------------------------------------
-    task_timeline: list[dict[str, Any]] = []
-    for t in tasks:
-        task_timeline.append(
-            {
-                "id": t.id,
-                "title": t.title[:50],
-                "role": t.role,
-                "status": t.status.value,
-                "priority": t.priority,
-                "assigned_agent": t.assigned_agent,
-                "created_at": t.created_at,
-                "progress": _task_progress_pct(t),
-                "owned_files": t.owned_files,
-                "depends_on": list(getattr(t, "depends_on", None) or []),
-            }
-        )
+    task_timeline: list[dict[str, Any]] = [
+        {
+            "id": t.id,
+            "title": t.title[:50],
+            "role": t.role,
+            "status": t.status.value,
+            "priority": t.priority,
+            "assigned_agent": t.assigned_agent,
+            "created_at": t.created_at,
+            "progress": _task_progress_pct(t),
+            "owned_files": t.owned_files,
+            "depends_on": list(getattr(t, "depends_on", None) or []),
+        }
+        for t in tasks
+    ]
 
     # -- Agent details with cost + task info ---------------------------------
     live_per_agent: dict[str, float] = live_costs.get("per_agent") or {}

--- a/src/bernstein/core/routes/task_detail.py
+++ b/src/bernstein/core/routes/task_detail.py
@@ -92,15 +92,14 @@ def task_detail(request: Request, task_id: str) -> TaskDetailResponse:
         agent_status = "assigned"
 
     # Build progress entries from task.progress_log (list[dict[str, Any]])
-    progress_entries: list[dict[str, Any]] = []
-    for entry in task.progress_log:
-        progress_entries.append(
-            {
-                "message": str(entry.get("message", "")),
-                "percent": int(entry.get("percent", 0)),
-                "timestamp": float(entry.get("timestamp", 0)),
-            }
-        )
+    progress_entries: list[dict[str, Any]] = [
+        {
+            "message": str(entry.get("message", "")),
+            "percent": int(entry.get("percent", 0)),
+            "timestamp": float(entry.get("timestamp", 0)),
+        }
+        for entry in task.progress_log
+    ]
 
     return TaskDetailResponse(
         task=task_to_response(task),

--- a/src/bernstein/core/routing/bandit_router.py
+++ b/src/bernstein/core/routing/bandit_router.py
@@ -330,9 +330,9 @@ def _sherman_morrison_update(mat_inv: list[list[float]], x: list[float]) -> list
                 recovered[i][j] += x[i] * x[j]
         return _inv(recovered)
 
-    updated: list[list[float]] = []
-    for i, row in enumerate(mat_inv):
-        updated.append([value - (mat_x[i] * mat_x[j]) / denom for j, value in enumerate(row)])
+    updated: list[list[float]] = [
+        [value - (mat_x[i] * mat_x[j]) / denom for j, value in enumerate(row)] for i, row in enumerate(mat_inv)
+    ]
     return updated
 
 

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -764,9 +764,7 @@ class TierAwareRouter:
         tasks: list[Task],
     ) -> list[RoutingDecision]:
         """Route a batch of tasks, returning decisions for each."""
-        decisions: list[RoutingDecision] = []
-        for task in tasks:
-            decisions.append(self.select_provider_for_task(task))
+        decisions: list[RoutingDecision] = [self.select_provider_for_task(task) for task in tasks]
         return decisions
 
     def get_provider_summary(self) -> dict[str, dict[str, Any]]:

--- a/src/bernstein/core/sandbox/playwright_runner.py
+++ b/src/bernstein/core/sandbox/playwright_runner.py
@@ -245,9 +245,9 @@ class ScenarioResult:
             "expectation": self.scenario.expectation,
             "passed": self.passed,
             "steps": [asdict(step) for step in self.steps],
-            "console_messages": list(self.console_messages),
-            "network_errors": list(self.network_errors),
-            "screenshots": list(self.screenshots),
+            "console_messages": self.console_messages.copy(),
+            "network_errors": self.network_errors.copy(),
+            "screenshots": self.screenshots.copy(),
             "output_dir": self.output_dir,
         }
 
@@ -301,13 +301,17 @@ class PlaywrightRunResult:
                 for shot in scenario.screenshots:
                     lines.append(f"  - {shot}")
         if self.judge_verdict is not None:
-            lines.append("")
-            lines.append("### Judge verdict")
-            lines.append(f"verdict: {self.judge_verdict.verdict}")
-            lines.append(f"correctness: {self.judge_verdict.correctness}")
-            lines.append(f"style: {self.judge_verdict.style}")
-            lines.append(f"test_coverage: {self.judge_verdict.test_coverage}")
-            lines.append(f"safety: {self.judge_verdict.safety}")
+            lines.extend(
+                (
+                    "",
+                    "### Judge verdict",
+                    f"verdict: {self.judge_verdict.verdict}",
+                    f"correctness: {self.judge_verdict.correctness}",
+                    f"style: {self.judge_verdict.style}",
+                    f"test_coverage: {self.judge_verdict.test_coverage}",
+                    f"safety: {self.judge_verdict.safety}",
+                )
+            )
             if self.judge_verdict.issues:
                 lines.append("issues:")
                 for issue in self.judge_verdict.issues:

--- a/src/bernstein/core/security/agent_card_keystore.py
+++ b/src/bernstein/core/security/agent_card_keystore.py
@@ -137,7 +137,7 @@ class AgentCardKeystore:
                 touching real wall-clock state.
         """
         self._dir = (key_dir or DEFAULT_KEY_DIR).resolve()
-        self._grace_seconds = max(0, int(grace_seconds))
+        self._grace_seconds = max(0, grace_seconds)
         self._clock = clock or _dt.datetime
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/security/audit_export.py
+++ b/src/bernstein/core/security/audit_export.py
@@ -591,21 +591,20 @@ class WebhookExporter(BaseSIEMExporter):
         Returns:
             List of JSON-serialisable event dicts.
         """
-        events: list[dict[str, Any]] = []
-        for entry in entries:
-            events.append(
-                {
-                    "timestamp": entry.timestamp,
-                    "event_type": entry.event_type,
-                    "actor": entry.actor,
-                    "resource": entry.resource,
-                    "action": entry.action,
-                    "outcome": entry.outcome,
-                    "details": entry.details,
-                    "hmac": entry.hmac,
-                    "source": "bernstein-audit",
-                },
-            )
+        events: list[dict[str, Any]] = [
+            {
+                "timestamp": entry.timestamp,
+                "event_type": entry.event_type,
+                "actor": entry.actor,
+                "resource": entry.resource,
+                "action": entry.action,
+                "outcome": entry.outcome,
+                "details": entry.details,
+                "hmac": entry.hmac,
+                "source": "bernstein-audit",
+            }
+            for entry in entries
+        ]
         return events
 
 
@@ -644,20 +643,19 @@ class FileExporter(BaseSIEMExporter):
         Returns:
             JSON-serialisable event dicts.
         """
-        docs: list[dict[str, Any]] = []
-        for entry in entries:
-            docs.append(
-                {
-                    "timestamp": entry.timestamp,
-                    "event_type": entry.event_type,
-                    "actor": entry.actor,
-                    "resource": entry.resource,
-                    "action": entry.action,
-                    "outcome": entry.outcome,
-                    "details": entry.details,
-                    "hmac": entry.hmac,
-                },
-            )
+        docs: list[dict[str, Any]] = [
+            {
+                "timestamp": entry.timestamp,
+                "event_type": entry.event_type,
+                "actor": entry.actor,
+                "resource": entry.resource,
+                "action": entry.action,
+                "outcome": entry.outcome,
+                "details": entry.details,
+                "hmac": entry.hmac,
+            }
+            for entry in entries
+        ]
         return docs
 
     def flush(self) -> ExportResult:

--- a/src/bernstein/core/security/audit_multitenant.py
+++ b/src/bernstein/core/security/audit_multitenant.py
@@ -325,7 +325,7 @@ def _rebuild_slice_chain(
             "prev_hmac": prev,
         }
         slice_hmac = _compute_event_hmac(key, prev, payload)
-        emitted = dict(payload)
+        emitted = payload.copy()
         emitted["hmac"] = slice_hmac
         rebuilt.append(emitted)
         prev = slice_hmac

--- a/src/bernstein/core/security/auth.py
+++ b/src/bernstein/core/security/auth.py
@@ -956,7 +956,7 @@ class AuthService:
 
     @property
     def group_role_map(self) -> dict[str, AuthRole]:
-        return dict(self._group_role_map)
+        return self._group_role_map.copy()
 
     # -- OIDC --
 

--- a/src/bernstein/core/security/claude_permission_profiles.py
+++ b/src/bernstein/core/security/claude_permission_profiles.py
@@ -143,7 +143,7 @@ class PermissionProfileManager:
         overrides: Per-task permission overrides.
     """
 
-    profiles: dict[str, PermissionProfile] = field(default_factory=lambda: dict(_PROFILES))
+    profiles: dict[str, PermissionProfile] = field(default_factory=lambda: _PROFILES.copy())
     overrides: dict[str, PermissionProfile] = field(default_factory=dict[str, PermissionProfile])
 
     def get_profile(self, role: str) -> PermissionProfile:

--- a/src/bernstein/core/security/claude_tool_result_injection.py
+++ b/src/bernstein/core/security/claude_tool_result_injection.py
@@ -223,7 +223,7 @@ class ToolResultInjector:
         action_required = len(failed_gates) > 0
 
         return InjectionPayload(
-            gate_results=list(self.results),
+            gate_results=self.results.copy(),
             summary=summary,
             action_required=action_required,
             format=fmt,

--- a/src/bernstein/core/security/command_policy.py
+++ b/src/bernstein/core/security/command_policy.py
@@ -178,7 +178,7 @@ def _parse_role_policy(role_name: str, role_cfg: object) -> RoleCommandPolicy | 
                 deny_messages[int(k)] = str(v)
 
     return RoleCommandPolicy(
-        role=str(role_name),
+        role=role_name,
         allow=_parse_string_list(rc.get("allow", [])),
         deny=_parse_string_list(rc.get("deny", [])),
         deny_messages=deny_messages,

--- a/src/bernstein/core/security/command_policy.py
+++ b/src/bernstein/core/security/command_policy.py
@@ -178,7 +178,7 @@ def _parse_role_policy(role_name: str, role_cfg: object) -> RoleCommandPolicy | 
                 deny_messages[int(k)] = str(v)
 
     return RoleCommandPolicy(
-        role=role_name,
+        role=str(role_name),
         allow=_parse_string_list(rc.get("allow", [])),
         deny=_parse_string_list(rc.get("deny", [])),
         deny_messages=deny_messages,

--- a/src/bernstein/core/security/data_residency.py
+++ b/src/bernstein/core/security/data_residency.py
@@ -273,7 +273,7 @@ class DataResidencyController:
             List of attestation records.
         """
         if tenant_id is None:
-            return list(self._attestations)
+            return self._attestations.copy()
         return [a for a in self._attestations if a.tenant_id == tenant_id]
 
     def get_non_compliant(

--- a/src/bernstein/core/security/denial_tracker.py
+++ b/src/bernstein/core/security/denial_tracker.py
@@ -178,7 +178,7 @@ class DenialTracker:
         Returns:
             Dict mapping session IDs to their denial records.
         """
-        return dict(self._sessions)
+        return self._sessions.copy()
 
     def clear_session(self, session_id: str) -> None:
         """Remove tracking data for a session.

--- a/src/bernstein/core/security/dp_telemetry.py
+++ b/src/bernstein/core/security/dp_telemetry.py
@@ -106,7 +106,7 @@ class PrivacyBudgetTracker:
     @property
     def entries(self) -> list[BudgetEntry]:
         """Return the budget expenditure log."""
-        return list(self._entries)
+        return self._entries.copy()
 
     def can_spend(self, epsilon: float) -> bool:
         """Check if spending epsilon would stay within budget.

--- a/src/bernstein/core/security/dual_approval.py
+++ b/src/bernstein/core/security/dual_approval.py
@@ -171,7 +171,7 @@ def evaluate_approval(
 
     return ApprovalStatus(
         request=request,
-        responses=list(responses),
+        responses=responses.copy(),
         is_approved=is_approved,
         is_expired=is_expired,
         is_denied=is_denied,

--- a/src/bernstein/core/security/external_policy_hook.py
+++ b/src/bernstein/core/security/external_policy_hook.py
@@ -349,7 +349,7 @@ class PolicyHookRegistry:
     @property
     def hooks(self) -> list[ExternalPolicyHook]:
         """Return the list of registered hooks."""
-        return list(self._hooks)
+        return self._hooks.copy()
 
     def register(self, hook: ExternalPolicyHook) -> None:
         """Register an external policy hook.

--- a/src/bernstein/core/security/graduated_access.py
+++ b/src/bernstein/core/security/graduated_access.py
@@ -173,7 +173,7 @@ class GraduatedAccessManager:
         policies: dict[TrustLevel, AccessPolicy] | None = None,
     ) -> None:
         self._records: dict[str, AgentTrustRecord] = {}
-        self._policies = policies if policies is not None else dict(_DEFAULT_POLICIES)
+        self._policies = policies if policies is not None else _DEFAULT_POLICIES.copy()
 
     # -- record helpers -----------------------------------------------------
 

--- a/src/bernstein/core/security/hipaa.py
+++ b/src/bernstein/core/security/hipaa.py
@@ -239,7 +239,7 @@ class PHIDetector:
         extra_patterns: list[tuple[PHICategory, re.Pattern[str], str]] | None = None,
     ) -> None:
         self._require_health_context = require_health_context
-        self._patterns = list(_PHI_PATTERNS)
+        self._patterns = _PHI_PATTERNS.copy()
         if extra_patterns:
             self._patterns.extend(extra_patterns)
 

--- a/src/bernstein/core/security/jwt_tokens.py
+++ b/src/bernstein/core/security/jwt_tokens.py
@@ -338,7 +338,7 @@ class TokenRefreshScheduler:
         token = self._manager.create_token(
             session_id=self._session_id,
             user_id=self._user_id,
-            scopes=list(self._scopes),
+            scopes=self._scopes.copy(),
         )
         payload = self._manager.verify_token(token)
         if payload is None:

--- a/src/bernstein/core/security/key_rotation_support.py
+++ b/src/bernstein/core/security/key_rotation_support.py
@@ -187,7 +187,7 @@ class AgentKeyUpdater:
     @property
     def update_log(self) -> list[AgentUpdateResult]:
         """Return the log of update results."""
-        return list(self._update_log)
+        return self._update_log.copy()
 
     def register_agent(self, agent_id: str, env_vars: dict[str, str]) -> None:
         """Register an agent and its environment variables.
@@ -196,7 +196,7 @@ class AgentKeyUpdater:
             agent_id: The agent identifier.
             env_vars: The agent's environment variables.
         """
-        self._agent_env[agent_id] = dict(env_vars)
+        self._agent_env[agent_id] = env_vars.copy()
 
     def unregister_agent(self, agent_id: str) -> None:
         """Remove an agent from the registry.

--- a/src/bernstein/core/security/network_isolation.py
+++ b/src/bernstein/core/security/network_isolation.py
@@ -241,11 +241,9 @@ class NetworkIsolationValidator:
         Returns:
             Aggregate result of all checks.
         """
-        checks: list[IsolationCheck] = []
-
-        # Check allowed endpoints are reachable
-        for endpoint in self._policy.allowed_endpoints:
-            checks.append(self.check_endpoint_reachable(endpoint))
+        checks: list[IsolationCheck] = [
+            self.check_endpoint_reachable(endpoint) for endpoint in self._policy.allowed_endpoints
+        ]
 
         # Check denied endpoints are blocked
         for endpoint in self._policy.denied_endpoints:

--- a/src/bernstein/core/security/permission_graph.py
+++ b/src/bernstein/core/security/permission_graph.py
@@ -279,12 +279,12 @@ class PermissionGraph:
     @property
     def layers(self) -> list[PermissionLayer]:
         """Return the ordered list of layers."""
-        return list(self._layers)
+        return self._layers.copy()
 
     @property
     def audit_log(self) -> list[GraphResult]:
         """Return the full audit log of past evaluations."""
-        return list(self._audit_log)
+        return self._audit_log.copy()
 
     def add_layer(self, layer: PermissionLayer) -> None:
         """Append a layer to the evaluation stack.

--- a/src/bernstein/core/security/permission_policy.py
+++ b/src/bernstein/core/security/permission_policy.py
@@ -300,7 +300,7 @@ def resolve_profile(
         # skeleton named after what the operator asked for so the
         # audit trail shows the typo verbatim.
         logger.warning("Unknown permission profile %r; falling back to deny-all", chosen)
-        base = PermissionProfile(name=str(chosen_norm), default="deny")
+        base = PermissionProfile(name=chosen_norm, default="deny")
 
     overrides = section.get(chosen_norm)
     if isinstance(overrides, dict):
@@ -482,7 +482,7 @@ def _record_denial(
         "actor": call.actor,
     }
     if call.extra:
-        record["extra"] = dict(call.extra)
+        record["extra"] = call.extra.copy()
 
     logger.warning(
         "Permission denial: tool=%s profile=%s reason=%s",

--- a/src/bernstein/core/security/policy_templates.py
+++ b/src/bernstein/core/security/policy_templates.py
@@ -81,7 +81,7 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     Lists and scalars in *override* replace those in *base*.
     Nested dicts are merged recursively.
     """
-    merged: dict[str, Any] = dict(base)
+    merged: dict[str, Any] = base.copy()
     for key, value in override.items():
         if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
             merged[key] = _deep_merge(
@@ -110,7 +110,7 @@ def apply_org_policies(
     Returns:
         New config dict with all policy overrides merged in.
     """
-    result = dict(config)
+    result = config.copy()
     for tpl in templates:
         result = _deep_merge(result, tpl.overrides)
     return result

--- a/src/bernstein/core/security/promptware_detector.py
+++ b/src/bernstein/core/security/promptware_detector.py
@@ -67,7 +67,7 @@ def is_enabled(env: dict[str, str] | None = None) -> bool:
     into a hard guardrail. Truthy values are case-insensitive: ``on``,
     ``1``, ``true``, ``yes``.
     """
-    source = env if env is not None else dict(os.environ)
+    source = env if env is not None else os.environ.copy()
     raw = source.get(ENV_FLAG, "").strip().lower()
     return raw in {"on", "1", "true", "yes"}
 

--- a/src/bernstein/core/security/role_adapter_policy.py
+++ b/src/bernstein/core/security/role_adapter_policy.py
@@ -107,9 +107,9 @@ class RolePolicy:
         normalised: dict[str, tuple[str, ...]] = {}
         for role, allowed in data.items():
             if isinstance(allowed, (list, tuple, set)):
-                normalised[str(role)] = tuple(sorted({str(a) for a in allowed}))
+                normalised[role] = tuple(sorted({str(a) for a in allowed}))
             else:
-                normalised[str(role)] = ()
+                normalised[role] = ()
         return cls(per_role_allowlists=normalised)
 
 

--- a/src/bernstein/core/security/rule_enforcer.py
+++ b/src/bernstein/core/security/rule_enforcer.py
@@ -172,7 +172,7 @@ def load_rules_config(workdir: Path) -> RulesConfig | None:
             logger.warning("Skipping rule with missing/empty id: %r", rule_raw)
             continue
         exclude_raw: object = rule_raw.get("exclude", [])
-        exclude: list[str] = list(cast("list[str]", exclude_raw)) if isinstance(exclude_raw, list) else []
+        exclude: list[str] = cast("list[str]", exclude_raw).copy() if isinstance(exclude_raw, list) else []
         pattern_val: str | None = cast(_CAST_STR_NONE, rule_raw.get("pattern"))
         files_val: str | None = cast(_CAST_STR_NONE, rule_raw.get("files"))
         path_val: str | None = cast(_CAST_STR_NONE, rule_raw.get("path"))

--- a/src/bernstein/core/security/sandbox.py
+++ b/src/bernstein/core/security/sandbox.py
@@ -118,7 +118,7 @@ def _parse_image_config(image_raw: object) -> tuple[str, dict[str, str]]:
                 continue
             if not isinstance(raw_value, str):
                 raise ValueError("sandbox.image adapter entries must be strings")
-            adapter_images[str(raw_key).strip().lower()] = raw_value
+            adapter_images[raw_key.strip().lower()] = raw_value
         return default_raw, adapter_images
     raise ValueError("sandbox.image must be a string or mapping")
 

--- a/src/bernstein/core/security/sandbox.py
+++ b/src/bernstein/core/security/sandbox.py
@@ -116,6 +116,8 @@ def _parse_image_config(image_raw: object) -> tuple[str, dict[str, str]]:
         for raw_key, raw_value in image_map.items():
             if raw_key == "default":
                 continue
+            if not isinstance(raw_key, str):
+                raise ValueError("sandbox.image adapter keys must be strings")
             if not isinstance(raw_value, str):
                 raise ValueError("sandbox.image adapter entries must be strings")
             adapter_images[raw_key.strip().lower()] = raw_value

--- a/src/bernstein/core/security/sandbox_escape_detector.py
+++ b/src/bernstein/core/security/sandbox_escape_detector.py
@@ -155,7 +155,7 @@ class SandboxEscapeDetector:
     @property
     def violations(self) -> list[EscapeViolation]:
         """Return all recorded violations."""
-        return list(self._violations)
+        return self._violations.copy()
 
     def check_filesystem(
         self,

--- a/src/bernstein/core/security/seccomp_profiles.py
+++ b/src/bernstein/core/security/seccomp_profiles.py
@@ -428,9 +428,9 @@ def _build_profile(
 
 # Pre-built profiles keyed by AgentSeccompProfile.
 _PROFILE_SYSCALLS: dict[AgentSeccompProfile, list[str]] = {
-    AgentSeccompProfile.STRICT: list(_SYSCALLS_BASE),
-    AgentSeccompProfile.HTTP_AGENT: list(_SYSCALLS_BASE) + list(_SYSCALLS_NETWORK),
-    AgentSeccompProfile.DEFAULT: list(_SYSCALLS_BASE) + list(_SYSCALLS_NETWORK) + list(_SYSCALLS_SUBPROCESS),
+    AgentSeccompProfile.STRICT: _SYSCALLS_BASE.copy(),
+    AgentSeccompProfile.HTTP_AGENT: _SYSCALLS_BASE.copy() + _SYSCALLS_NETWORK.copy(),
+    AgentSeccompProfile.DEFAULT: _SYSCALLS_BASE.copy() + _SYSCALLS_NETWORK.copy() + _SYSCALLS_SUBPROCESS.copy(),
 }
 
 
@@ -462,7 +462,7 @@ def build_custom_profile(
     Returns:
         Seccomp profile as a JSON-serialisable dict.
     """
-    syscalls = list(_PROFILE_SYSCALLS[base])
+    syscalls = _PROFILE_SYSCALLS[base].copy()
     if extra_syscalls:
         syscalls.extend(extra_syscalls)
     return _build_profile(syscalls, name)

--- a/src/bernstein/core/security/secrets.py
+++ b/src/bernstein/core/security/secrets.py
@@ -458,7 +458,7 @@ def _apply_field_map(raw: dict[str, str], field_map: dict[str, str]) -> dict[str
         Remapped dict.
     """
     if not field_map:
-        return dict(raw)
+        return raw.copy()
 
     result: dict[str, str] = {}
     for secret_field, env_var in field_map.items():

--- a/src/bernstein/core/security/secrets_broker.py
+++ b/src/bernstein/core/security/secrets_broker.py
@@ -767,7 +767,7 @@ class SecretsBroker:
         per_secret = self._config.ttl_overrides.get(secret_name)
         if per_secret is not None:
             return int(per_secret)
-        return int(self._config.ttl_seconds_default)
+        return self._config.ttl_seconds_default
 
     def _emit(self, event: AuditEvent) -> None:
         """Dispatch *event* to the logger and the optional audit sink.

--- a/src/bernstein/core/security/vault/backend_file.py
+++ b/src/bernstein/core/security/vault/backend_file.py
@@ -261,7 +261,7 @@ class FileBackend(CredentialVault):
             stored = _record_to_stored(record)
             out.append(
                 CredentialRecord(
-                    provider_id=str(provider_id),
+                    provider_id=provider_id,
                     account=stored.account,
                     fingerprint=stored.fingerprint,
                     created_at=stored.created_at,

--- a/src/bernstein/core/security/vault_injector.py
+++ b/src/bernstein/core/security/vault_injector.py
@@ -378,7 +378,7 @@ def _apply_env_map(raw: dict[str, str], env_map: dict[str, str]) -> dict[str, st
         Dict mapping env var names to values.
     """
     if not env_map:
-        return dict(raw)
+        return raw.copy()
     result: dict[str, str] = {}
     for field_name, env_var in env_map.items():
         value = raw.get(field_name)

--- a/src/bernstein/core/security/vuln_disclosure.py
+++ b/src/bernstein/core/security/vuln_disclosure.py
@@ -243,7 +243,7 @@ class VulnerabilityDisclosureManager:
     @property
     def reports(self) -> dict[str, VulnReport]:
         """Return a shallow copy of all tracked reports."""
-        return dict(self._reports)
+        return self._reports.copy()
 
     # -- Report submission ---------------------------------------------------
 

--- a/src/bernstein/core/server/api_compat_checker.py
+++ b/src/bernstein/core/server/api_compat_checker.py
@@ -451,17 +451,16 @@ def _breaking_from_deleted_file(rel_path: str, old_source: str) -> list[Breaking
     except SyntaxError:
         return []
 
-    breaks: list[BreakingChange] = []
-    for func_info in _extract_functions(old_tree).values():
-        breaks.append(
-            BreakingChange(
-                file=rel_path,
-                name=func_info.name,
-                change_type=ChangeType.REMOVED_FUNCTION,
-                description=f"Public function '{func_info.name}' removed (file deleted)",
-                line=func_info.line,
-            )
+    breaks: list[BreakingChange] = [
+        BreakingChange(
+            file=rel_path,
+            name=func_info.name,
+            change_type=ChangeType.REMOVED_FUNCTION,
+            description=f"Public function '{func_info.name}' removed (file deleted)",
+            line=func_info.line,
         )
+        for func_info in _extract_functions(old_tree).values()
+    ]
     for cls_info in _extract_classes(old_tree).values():
         breaks.append(
             BreakingChange(

--- a/src/bernstein/core/tasks/lifecycle_diagrams.py
+++ b/src/bernstein/core/tasks/lifecycle_diagrams.py
@@ -127,15 +127,14 @@ def extract_task_lifecycle() -> StateMachine:
     from bernstein.core.tasks.lifecycle import TASK_TRANSITIONS, TERMINAL_TASK_STATUSES
     from bernstein.core.tasks.models import TaskStatus
 
-    states: list[State] = []
-    for ts in TaskStatus:
-        states.append(
-            State(
-                name=ts.value,
-                description=_TASK_STATE_DESCRIPTIONS.get(ts.value, ts.value),
-                is_terminal=ts in TERMINAL_TASK_STATUSES,
-            )
+    states: list[State] = [
+        State(
+            name=ts.value,
+            description=_TASK_STATE_DESCRIPTIONS.get(ts.value, ts.value),
+            is_terminal=ts in TERMINAL_TASK_STATUSES,
         )
+        for ts in TaskStatus
+    ]
 
     transitions: list[Transition] = []
     for from_ts, to_ts in TASK_TRANSITIONS:
@@ -172,15 +171,14 @@ def extract_agent_lifecycle() -> StateMachine:
 
     # Terminal = no outbound transitions.
     sources = {from_s for from_s, _ in AGENT_TRANSITIONS}
-    states: list[State] = []
-    for sn in state_names:
-        states.append(
-            State(
-                name=sn,
-                description=_AGENT_STATE_DESCRIPTIONS.get(sn, sn),
-                is_terminal=sn not in sources,
-            )
+    states: list[State] = [
+        State(
+            name=sn,
+            description=_AGENT_STATE_DESCRIPTIONS.get(sn, sn),
+            is_terminal=sn not in sources,
         )
+        for sn in state_names
+    ]
 
     transitions: list[Transition] = []
     for from_s, to_s in AGENT_TRANSITIONS:

--- a/src/bernstein/core/tokens/auto_distillation.py
+++ b/src/bernstein/core/tokens/auto_distillation.py
@@ -744,18 +744,17 @@ class AutoDistiller:
         """
         self._ensure_loaded()
         s = self.stats()
-        models_info: list[dict[str, Any]] = []
-        for m in self._models.values():
-            models_info.append(
-                {
-                    "model_name": m.model_name,
-                    "key": m.distillation_key,
-                    "active": m.active,
-                    "tasks_routed": m.tasks_routed,
-                    "success_rate": round(m.success_rate, 3),
-                    "avg_cost_usd": round(m.avg_cost_usd, 6),
-                }
-            )
+        models_info: list[dict[str, Any]] = [
+            {
+                "model_name": m.model_name,
+                "key": m.distillation_key,
+                "active": m.active,
+                "tasks_routed": m.tasks_routed,
+                "success_rate": round(m.success_rate, 3),
+                "avg_cost_usd": round(m.avg_cost_usd, 6),
+            }
+            for m in self._models.values()
+        ]
         return {
             "enabled": self._config.enabled,
             "total_examples": s.total_examples,

--- a/src/bernstein/core/trackers/builtin/asana_adapter.py
+++ b/src/bernstein/core/trackers/builtin/asana_adapter.py
@@ -151,7 +151,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/builtin/clickup_adapter.py
+++ b/src/bernstein/core/trackers/builtin/clickup_adapter.py
@@ -147,7 +147,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -175,7 +175,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -175,7 +175,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, min_interval)
+        self._min_interval = max(0.0, float(min_interval))
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/builtin/jira_dc_adapter.py
+++ b/src/bernstein/core/trackers/builtin/jira_dc_adapter.py
@@ -155,7 +155,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/builtin/plane_adapter.py
+++ b/src/bernstein/core/trackers/builtin/plane_adapter.py
@@ -144,7 +144,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/linear.py
+++ b/src/bernstein/core/trackers/linear.py
@@ -138,7 +138,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/trackers/registry.py
+++ b/src/bernstein/core/trackers/registry.py
@@ -150,7 +150,7 @@ class TrackerRegistry:
             summary=summary,
             source=source,
             provenance=provenance,
-            capabilities=tuple(capabilities),
+            capabilities=capabilities,
         )
         self._entries[name] = entry
         return entry

--- a/src/bernstein/core/trackers/registry.py
+++ b/src/bernstein/core/trackers/registry.py
@@ -150,7 +150,7 @@ class TrackerRegistry:
             summary=summary,
             source=source,
             provenance=provenance,
-            capabilities=capabilities,
+            capabilities=tuple(capabilities),
         )
         self._entries[name] = entry
         return entry

--- a/src/bernstein/core/trackers/servicenow.py
+++ b/src/bernstein/core/trackers/servicenow.py
@@ -144,7 +144,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 

--- a/src/bernstein/core/worktrees/classifier.py
+++ b/src/bernstein/core/worktrees/classifier.py
@@ -196,17 +196,16 @@ def classify_worktrees(
     """
     clock = time.time() if now is None else now
     git_paths = _git_worktree_paths(repo_root)
-    rows: list[ClassifiedWorktree] = []
-    for path in iter_worktree_dirs(repo_root):
-        rows.append(
-            _classify_one(
-                path,
-                repo_root=repo_root,
-                git_paths=git_paths,
-                now=clock,
-                stale_trace_age_s=stale_trace_age_s,
-            )
+    rows: list[ClassifiedWorktree] = [
+        _classify_one(
+            path,
+            repo_root=repo_root,
+            git_paths=git_paths,
+            now=clock,
+            stale_trace_age_s=stale_trace_age_s,
         )
+        for path in iter_worktree_dirs(repo_root)
+    ]
     return rows
 
 

--- a/src/bernstein/eval/scenario_generator.py
+++ b/src/bernstein/eval/scenario_generator.py
@@ -553,15 +553,14 @@ def list_scenarios(
     if is_disabled():
         return []
     reg = registry or build_default_registry()
-    out: list[dict[str, Any]] = []
-    for sid, gen in reg.items():
-        out.append(
-            {
-                "id": sid,
-                "severity": gen.severity,
-                "axes": {k: list(v) for k, v in gen.axes.items()},
-            }
-        )
+    out: list[dict[str, Any]] = [
+        {
+            "id": sid,
+            "severity": gen.severity,
+            "axes": {k: list(v) for k, v in gen.axes.items()},
+        }
+        for sid, gen in reg.items()
+    ]
     return out
 
 

--- a/src/bernstein/eval/vcr_fixture.py
+++ b/src/bernstein/eval/vcr_fixture.py
@@ -242,9 +242,7 @@ class VcrFixture:
                 result[k_str] = self.hydrate_value(v)
             return result
         if isinstance(value, list):
-            items: list[Any] = []
-            for item in cast("list[Any]", value):
-                items.append(self.hydrate_value(item))
+            items: list[Any] = [self.hydrate_value(item) for item in cast("list[Any]", value)]
             return items
         return value
 

--- a/src/bernstein/gui/qr.py
+++ b/src/bernstein/gui/qr.py
@@ -115,9 +115,7 @@ def _matrix_to_text(matrix: list[list[bool]]) -> str:
     """
     lines: list[str] = []
     for row in matrix:
-        line_parts: list[str] = []
-        for cell in row:
-            line_parts.append(QR_DARK if cell else QR_LIGHT)
+        line_parts: list[str] = [QR_DARK if cell else QR_LIGHT for cell in row]
         lines.append("".join(line_parts))
     return "\n".join(lines)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -183,7 +183,7 @@ def make_task_batch(
         msg = "count must be >= 1"
         raise ValueError(msg)
 
-    effective_roles = roles or list(_DEFAULT_ROLES)
+    effective_roles = roles or _DEFAULT_ROLES.copy()
     tasks: list[Task] = []
 
     for i in range(count):

--- a/tests/fixtures/mcp_fake_lab.py
+++ b/tests/fixtures/mcp_fake_lab.py
@@ -291,7 +291,7 @@ class McpFakeLab:
     @property
     def requests(self) -> list[httpx.Request]:
         """All HTTP requests captured during this lab session, in order."""
-        return list(self._requests)
+        return self._requests.copy()
 
     def assert_called(self, method: str, path: str) -> None:
         """Assert that at least one request with *method* and *path* was made.

--- a/tests/integration/cluster/conftest.py
+++ b/tests/integration/cluster/conftest.py
@@ -394,7 +394,7 @@ class ClusterHandle:
         if ready_file.exists():
             ready_file.unlink()
         log = self.workdir / f"worker-{name}.log"
-        env = dict(os.environ)
+        env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
         # Workers always traverse the partition proxy.
         script = _worker_script(self.proxied_url, name, self.cluster_secret, ready_file, log)
@@ -473,7 +473,7 @@ class ClusterHandle:
     # ---- teardown ----------------------------------------------------- #
 
     def shutdown(self) -> None:
-        for w in list(self.workers):
+        for w in self.workers.copy():
             _terminate(w.proc)
         self.workers.clear()
         _terminate(self.central_proc)
@@ -497,7 +497,7 @@ def _start_central(
     nodes_json: Path,
 ) -> subprocess.Popen[bytes]:
     """Launch ``uvicorn bernstein.core.server:app`` as a subprocess."""
-    env = dict(os.environ)
+    env = os.environ.copy()
     env["BERNSTEIN_CLUSTER_ENABLED"] = "1"
     env["BERNSTEIN_CLUSTER_AUTH_SECRET"] = secret
     env["BERNSTEIN_AUTH_DISABLED"] = "1"

--- a/tests/integration/cluster/test_real_2node.py
+++ b/tests/integration/cluster/test_real_2node.py
@@ -300,28 +300,27 @@ def test_concurrent_claims_exactly_one_winner(
     from pathlib import Path as _P
 
     worker_script = _P(__file__).parent / "_worker_proc.py"
-    procs: list[subprocess.Popen[bytes]] = []
-    for result_file in (result_a, result_b):
-        procs.append(
-            subprocess.Popen(
-                [
-                    sys.executable,
-                    str(worker_script),
-                    "--server",
-                    handle.central_url,
-                    "--task-id",
-                    task_id,
-                    "--token",
-                    admin_token,
-                    "--result-file",
-                    str(result_file),
-                    "--start-at",
-                    str(start_at),
-                    "--expected-version",
-                    "1",
-                ],
-            )
+    procs: list[subprocess.Popen[bytes]] = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                str(worker_script),
+                "--server",
+                handle.central_url,
+                "--task-id",
+                task_id,
+                "--token",
+                admin_token,
+                "--result-file",
+                str(result_file),
+                "--start-at",
+                str(start_at),
+                "--expected-version",
+                "1",
+            ],
         )
+        for result_file in (result_a, result_b)
+    ]
 
     for p in procs:
         p.wait(timeout=15.0)

--- a/tests/integration/fake_cli/conftest_adapters.py
+++ b/tests/integration/fake_cli/conftest_adapters.py
@@ -115,8 +115,8 @@ class FakeCLIHandle:
         """
         lines: list[str] = [
             f"export BERNSTEIN_FAKE_CLI_MODE={_shell_quote(mode)}",
-            f"export BERNSTEIN_FAKE_CLI_EXIT_CODE={int(exit_code)}",
-            f"export BERNSTEIN_FAKE_CLI_DELAY_S={float(delay_s)}",
+            f"export BERNSTEIN_FAKE_CLI_EXIT_CODE={exit_code}",
+            f"export BERNSTEIN_FAKE_CLI_DELAY_S={delay_s}",
             f"export BERNSTEIN_FAKE_CLI_ARGV_DUMP={_shell_quote(str(self.argv_dump))}",
             f"export BERNSTEIN_FAKE_CLI_ENV_DUMP={_shell_quote(str(self.env_dump))}",
         ]

--- a/tests/integration/fake_cli/fake_cli.py
+++ b/tests/integration/fake_cli/fake_cli.py
@@ -377,7 +377,7 @@ def _maybe_dump_env() -> None:
         return
     try:
         Path(dump_path).write_text(
-            json.dumps(dict(os.environ), sort_keys=True),
+            json.dumps(os.environ.copy(), sort_keys=True),
             encoding="utf-8",
         )
     except OSError as exc:

--- a/tests/integration/test_best_of_n_ranking.py
+++ b/tests/integration/test_best_of_n_ranking.py
@@ -84,7 +84,7 @@ def _runner_for(
         return ids[:n]
 
     def await_results(_ids: list[str]) -> list[CandidateResult]:
-        return list(candidates)
+        return candidates.copy()
 
     return BestOfNRunner(spawner=spawn, awaiter=await_results)
 

--- a/tests/integration/test_bom_cli.py
+++ b/tests/integration/test_bom_cli.py
@@ -289,7 +289,7 @@ class TestRoundTrip:
 
     def test_multi_run_emits_are_independent(self, tmp_path: Path) -> None:
         snap_a = _snapshot()
-        snap_b = dict(snap_a)
+        snap_b = snap_a.copy()
         snap_b["run_id"] = "20260518-test-002"
         a_path = tmp_path / "a.json"
         b_path = tmp_path / "b.json"

--- a/tests/integration/test_claim_next_concurrency.py
+++ b/tests/integration/test_claim_next_concurrency.py
@@ -206,7 +206,7 @@ def _run_claimer_process(
     *,
     role: str | None = None,
 ) -> subprocess.Popen[str]:
-    env = dict(os.environ)
+    env = os.environ.copy()
     env["BACKLOG_PATH"] = str(backlog_path)
     env["CLAIMER_ID"] = claimer_id
     if role is not None:

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -44,7 +44,7 @@ def captured_audit() -> tuple[list[tuple[str, str, dict[str, Any]]], Callable[..
     log: list[tuple[str, str, dict[str, Any]]] = []
 
     def _emit(event_type: str, resource_id: str, details: dict[str, Any]) -> None:
-        log.append((event_type, resource_id, dict(details)))
+        log.append((event_type, resource_id, details.copy()))
 
     return log, _emit
 

--- a/tests/property/test_lineage_v2_properties.py
+++ b/tests/property/test_lineage_v2_properties.py
@@ -78,7 +78,7 @@ def _make_pair(task_id: str, child_run_id: str, ts_ns: int, payload: dict[str, o
         child_run_id=child_run_id,
         seq=0,
         kind="subagent.started",
-        payload=dict(payload),
+        payload=payload.copy(),
         ts_ns=ts_ns,
         prev_hmac="",
         hmac="",
@@ -314,7 +314,7 @@ def test_property_roundtrip(
             child_run_id=run_id,
             seq=0,
             kind="x",
-            payload=dict(payload),
+            payload=payload.copy(),
             ts_ns=ts_ns,
             prev_hmac="",
             hmac="",
@@ -349,8 +349,8 @@ def test_property_child_sha_distinguishes_distinct_seeds(
     seq_a: int,
     seq_b: int,
 ) -> None:
-    sa = compute_child_sha(ChildBody(v=2, task_id="t", child_run_id="r", seq=seq_a, kind="x", payload=dict(a)))
-    sb = compute_child_sha(ChildBody(v=2, task_id="t", child_run_id="r", seq=seq_b, kind="x", payload=dict(b)))
+    sa = compute_child_sha(ChildBody(v=2, task_id="t", child_run_id="r", seq=seq_a, kind="x", payload=a.copy()))
+    sb = compute_child_sha(ChildBody(v=2, task_id="t", child_run_id="r", seq=seq_b, kind="x", payload=b.copy()))
     if (a, seq_a) == (b, seq_b):
         assert sa == sb
     else:
@@ -625,7 +625,7 @@ def test_property_stamp_idempotent(payload: dict[str, object]) -> None:
         child_run_id="r",
         seq=0,
         kind="x",
-        payload=dict(payload),
+        payload=payload.copy(),
         ts_ns=0,
         prev_hmac="",
         hmac="",

--- a/tests/property/test_merkle_seal_properties.py
+++ b/tests/property/test_merkle_seal_properties.py
@@ -110,7 +110,7 @@ def test_leaf_swap_changes_root(pairs: list[tuple[str, str]]) -> None:
     pairs_sorted = sorted(pairs)
     if pairs_sorted[0][1] == pairs_sorted[1][1]:
         pytest.skip("identical leaf hashes — swap is a no-op")
-    swapped = list(pairs_sorted)
+    swapped = pairs_sorted.copy()
     swapped[0], swapped[1] = swapped[1], swapped[0]
     root_a = build_merkle_tree(pairs_sorted).root.hash
     root_b = build_merkle_tree(swapped).root.hash

--- a/tests/property/test_prompt_cache_locality_properties.py
+++ b/tests/property/test_prompt_cache_locality_properties.py
@@ -88,7 +88,7 @@ def test_one_header_change_increments_drift_by_exactly_one(
     snap2 = locality.snapshot(role)
     assert snap2.drift_count == 0, "identical prefix incremented drift"
 
-    altered = dict(header)
+    altered = header.copy()
     altered[extra_key] = extra_val
     prefix2 = build_stable_prefix(header=altered, body=body)
     locality.observe(role=role, prefix=prefix2)

--- a/tests/property/test_topsis_properties.py
+++ b/tests/property/test_topsis_properties.py
@@ -99,7 +99,7 @@ def test_no_nan_propagates_to_normalised_scores(candidates: list[Candidate]) -> 
 def test_permutation_symmetry_of_winner(candidates: list[Candidate], seed: int) -> None:
     """Shuffling the input order must not change the (key, closeness) set."""
     rng = random.Random(seed)
-    shuffled = list(candidates)
+    shuffled = candidates.copy()
     rng.shuffle(shuffled)
     base = {(r.key, round(r.closeness, 9)) for r in rank_candidates(candidates, _PROFILE)}
     shuf = {(r.key, round(r.closeness, 9)) for r in rank_candidates(shuffled, _PROFILE)}
@@ -109,7 +109,7 @@ def test_permutation_symmetry_of_winner(candidates: list[Candidate], seed: int) 
 @given(_candidates_strategy(), st.integers(min_value=0, max_value=10_000))
 def test_winner_key_is_stable_under_shuffle(candidates: list[Candidate], seed: int) -> None:
     rng = random.Random(seed)
-    shuffled = list(candidates)
+    shuffled = candidates.copy()
     rng.shuffle(shuffled)
     w1 = rank_candidates(candidates, _PROFILE)[0].key
     w2 = rank_candidates(shuffled, _PROFILE)[0].key

--- a/tests/unit/autofix/test_review_router.py
+++ b/tests/unit/autofix/test_review_router.py
@@ -93,7 +93,7 @@ class _GhSpy:
     captured: list[list[str]] = field(default_factory=list)
 
     def __call__(self, argv: list[str]) -> str:
-        self.captured.append(list(argv))
+        self.captured.append(argv.copy())
         if not self.payloads:
             raise AssertionError("gh runner called more times than payloads provided")
         item = self.payloads.pop(0)
@@ -446,7 +446,7 @@ def test_resolve_pr_number_falls_back_to_git_config() -> None:
     captured: list[list[str]] = []
 
     def _git_runner(argv: list[str], _workdir: Path | None) -> str:
-        captured.append(list(argv))
+        captured.append(argv.copy())
         return "33\n"
 
     assert (

--- a/tests/unit/compliance/test_ai_bom.py
+++ b/tests/unit/compliance/test_ai_bom.py
@@ -796,7 +796,7 @@ class TestProperties:
     @given(snap=_snapshot())
     def test_input_permutation_invariant(self, snap: dict[str, Any]) -> None:
         assume(snap["run_id"])
-        rev = dict(snap)
+        rev = snap.copy()
         rev["models"] = list(reversed(snap["models"]))
         rev["prompts"] = list(reversed(snap["prompts"]))
         rev["adapters"] = list(reversed(snap["adapters"]))
@@ -817,7 +817,7 @@ class TestProperties:
     def test_content_hash_changes_with_run_id(self, snap: dict[str, Any]) -> None:
         assume(snap["run_id"])
         bom_a = generate_bom(snap)
-        snap_b = dict(snap)
+        snap_b = snap.copy()
         snap_b["run_id"] = snap["run_id"] + "x"
         bom_b = generate_bom(snap_b)
         assert bom_content_hash(bom_a) != bom_content_hash(bom_b)
@@ -837,7 +837,7 @@ class TestProperties:
     @given(snap=_snapshot())
     def test_models_dedup_invariant_on_doubling(self, snap: dict[str, Any]) -> None:
         assume(snap["run_id"])
-        doubled = dict(snap)
+        doubled = snap.copy()
         doubled["models"] = snap["models"] + snap["models"]
         bom_single = generate_bom(snap)
         bom_doubled = generate_bom(doubled)

--- a/tests/unit/eval/test_pentest_scorer.py
+++ b/tests/unit/eval/test_pentest_scorer.py
@@ -123,7 +123,7 @@ def test_paths_match_unrelated_files() -> None:
 
 def test_score_perfect_report() -> None:
     """All ground-truth findings reported with canonical labels."""
-    report = list(_GROUND_TRUTH_10)
+    report = _GROUND_TRUTH_10.copy()
     score = PentestScorer().score(report=report, ground_truth=_GROUND_TRUTH_10)
     assert score.precision == 1.0
     assert score.recall == 1.0
@@ -480,7 +480,7 @@ def test_property_counts_sum_consistent(report: list[Finding], truth: list[Findi
 @given(truth=st.lists(_FINDING_GEN, min_size=1, max_size=10))
 def test_property_perfect_report_recovers_full_score(truth: list[Finding]) -> None:
     """Submitting ground truth itself gives precision = recall = 1."""
-    s = PentestScorer().score(report=list(truth), ground_truth=truth)
+    s = PentestScorer().score(report=truth.copy(), ground_truth=truth)
     assert s.recall == 1.0
     assert s.precision == 1.0
 
@@ -502,7 +502,7 @@ def test_property_adding_correct_finding_does_not_lower_recall(truth: list[Findi
 
     Adding the truth list to the report monotonically increases recall to 1.
     """
-    s = PentestScorer().score(report=extra + list(truth), ground_truth=truth)
+    s = PentestScorer().score(report=extra + truth.copy(), ground_truth=truth)
     assert s.recall == 1.0
 
 
@@ -515,6 +515,6 @@ def test_property_subset_report_recall_monotone(truth: list[Finding]) -> None:
     scorer = PentestScorer()
     prev = 0.0
     for k in range(len(truth) + 1):
-        s = scorer.score(report=list(truth[:k]), ground_truth=truth)
+        s = scorer.score(report=truth[:k].copy(), ground_truth=truth)
         assert s.recall >= prev - 1e-9
         prev = s.recall

--- a/tests/unit/notifications/test_dispatcher.py
+++ b/tests/unit/notifications/test_dispatcher.py
@@ -79,7 +79,7 @@ def _make_dispatcher(
     audit_calls: list[tuple[str, str, str, dict[str, object]]] = []
 
     def _audit_hook(actor: str, rt: str, rid: str, details: dict[str, object]) -> None:
-        audit_calls.append((actor, rt, rid, dict(details)))
+        audit_calls.append((actor, rt, rid, details.copy()))
 
     dispatcher = NotificationDispatcher(
         tmp_path,

--- a/tests/unit/orchestration/test_commit_completion.py
+++ b/tests/unit/orchestration/test_commit_completion.py
@@ -59,7 +59,7 @@ class _StubAdapter:
 
     def continuation_args(self, session_id: str) -> list[str]:
         self.continuation_args_calls.append(session_id)
-        return list(self.continuation_args_value)
+        return self.continuation_args_value.copy()
 
 
 @dataclass
@@ -70,7 +70,7 @@ class _SpawnRecorder:
     return_value: object | None = "spawn-ok"
 
     def __call__(self, prompt: str, continuation_args: list[str]) -> object | None:
-        self.calls.append((prompt, list(continuation_args)))
+        self.calls.append((prompt, continuation_args.copy()))
         return self.return_value
 
 

--- a/tests/unit/orchestration/test_tracker_pipeline.py
+++ b/tests/unit/orchestration/test_tracker_pipeline.py
@@ -187,7 +187,7 @@ class TestIdempotencyKey:
         base = dict(tracker="x", ticket_id="T-1", role="qa", stage="qa", stage_attempt=0)
         keys = {make_idempotency_key(**base)}
         for field_name in ("tracker", "ticket_id", "role", "stage"):
-            mutated = dict(base)
+            mutated = base.copy()
             mutated[field_name] = "OTHER"
             keys.add(make_idempotency_key(**mutated))
         assert len(keys) == 5

--- a/tests/unit/protocols/mcp_catalog/test_fetcher.py
+++ b/tests/unit/protocols/mcp_catalog/test_fetcher.py
@@ -45,7 +45,7 @@ class _FakeTransport:
         self.queue.append(resp)
 
     def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponse:
-        self.calls.append((url, dict(headers)))
+        self.calls.append((url, headers.copy()))
         if not self.queue:
             raise AssertionError(f"unexpected request to {url}")
         return self.queue.pop(0)

--- a/tests/unit/protocols/mcp_catalog/test_service.py
+++ b/tests/unit/protocols/mcp_catalog/test_service.py
@@ -63,7 +63,7 @@ def _good_catalog(version: str = "1.0.0") -> dict[str, Any]:
 
 class _FakeTransport:
     def __init__(self, responses: list[HTTPResponse]) -> None:
-        self._responses = list(responses)
+        self._responses = responses.copy()
 
     def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponse:
         if not self._responses:

--- a/tests/unit/review/test_perspectives.py
+++ b/tests/unit/review/test_perspectives.py
@@ -139,7 +139,7 @@ def _fake_adapter_call(
         prior: list[PerspectiveVerdict],
     ) -> str:
         seen_envelopes[spec.name] = input_text
-        seen_priors[spec.name] = list(prior)
+        seen_priors[spec.name] = prior.copy()
         return f"verdict[{spec.name}/{spec.adapter}]"
 
     return _call

--- a/tests/unit/review_responder/conftest.py
+++ b/tests/unit/review_responder/conftest.py
@@ -102,7 +102,7 @@ def make_round(*comments: ReviewComment, round_id: str = "rnd-test") -> ReviewRo
         round_id=round_id,
         repo=comments[0].repo,
         pr_number=comments[0].pr_number,
-        comments=tuple(comments),
+        comments=comments,
         opened_at=1.0,
         sealed_at=2.0,
     )
@@ -131,7 +131,7 @@ class FakeGhRunner:
         stdin: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         """Record the call and return the canned response."""
-        self.calls.append((list(args), stdin))
+        self.calls.append((args.copy(), stdin))
         joined = " ".join(args)
         for needle, (rc, stdout) in self.responses.items():
             if needle in joined:

--- a/tests/unit/scripts/test_sarif_drop_suppressed.py
+++ b/tests/unit/scripts/test_sarif_drop_suppressed.py
@@ -57,7 +57,7 @@ def _sarif(*results_per_run: list[dict[str, Any]]) -> dict[str, Any]:
         "runs": [
             {
                 "tool": {"driver": {"name": f"tool-{idx}"}},
-                "results": list(results),
+                "results": results.copy(),
             }
             for idx, results in enumerate(results_per_run)
         ],

--- a/tests/unit/security/test_secrets_broker.py
+++ b/tests/unit/security/test_secrets_broker.py
@@ -42,7 +42,7 @@ class _MemoryBackend(SecretsBackend):
     name = "memory"
 
     def __init__(self, secrets: dict[str, str]) -> None:
-        self._secrets = dict(secrets)
+        self._secrets = secrets.copy()
         self.reads: list[str] = []
 
     def read(self, secret_name: str) -> str:

--- a/tests/unit/skills/test_loader.py
+++ b/tests/unit/skills/test_loader.py
@@ -28,7 +28,7 @@ class _InMemorySource(SkillSource):
         return self._label
 
     def iter_skills(self) -> list[SkillArtifact]:
-        return list(self._artifacts)
+        return self._artifacts.copy()
 
 
 def _artifact(name: str, origin: str) -> SkillArtifact:

--- a/tests/unit/skills/test_plugin_source.py
+++ b/tests/unit/skills/test_plugin_source.py
@@ -33,7 +33,7 @@ def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEntryPoi
         group: str | None = None,
     ) -> Iterator[_FakeEntryPoint] | list[_FakeEntryPoint]:
         assert group == PLUGIN_ENTRY_POINT_GROUP
-        return list(eps)
+        return eps.copy()
 
     monkeypatch.setattr(
         "bernstein.core.skills.sources.plugin.entry_points",

--- a/tests/unit/storage/test_s3_sink_unit.py
+++ b/tests/unit/storage/test_s3_sink_unit.py
@@ -45,7 +45,7 @@ class _StubPaginator:
         self._pages = pages
 
     def paginate(self, **_: Any) -> list[dict[str, Any]]:
-        return list(self._pages)
+        return self._pages.copy()
 
 
 class _StubS3Client:
@@ -67,7 +67,7 @@ class _StubS3Client:
             "ETag": '"stub-etag"',
         }
         self.store_meta[key] = meta
-        self.calls.append(("put_object", dict(kwargs)))
+        self.calls.append(("put_object", kwargs.copy()))
         return {}
 
     def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:

--- a/tests/unit/test_adapter_clm.py
+++ b/tests/unit/test_adapter_clm.py
@@ -864,7 +864,7 @@ def test_spawn_passes_clm_namespaced_extras_only(tmp_path: Path) -> None:
     from bernstein.adapters.env_isolation import build_filtered_env as real_build
 
     def _spy(extra_keys: list[str], **kwargs: object) -> dict[str, str]:
-        captured["extra_keys"] = list(extra_keys)
+        captured["extra_keys"] = extra_keys.copy()
         return real_build(extra_keys, **kwargs)
 
     with (

--- a/tests/unit/test_adapter_contract_check.py
+++ b/tests/unit/test_adapter_contract_check.py
@@ -431,9 +431,7 @@ def test_check_contract_help_nonzero_all_flags_missing_is_runtime_failure(
     monkeypatch.setattr(
         _contract,
         "_run_capture",
-        _make_run_capture(
-            {("stub", "--help"): (1, "error: missing API key\nusage: stub [-h]\n")}
-        ),
+        _make_run_capture({("stub", "--help"): (1, "error: missing API key\nusage: stub [-h]\n")}),
     )
     result = _contract.check_contract(spec)
     assert result.passed is False

--- a/tests/unit/test_adapter_plugin_sdk.py
+++ b/tests/unit/test_adapter_plugin_sdk.py
@@ -59,7 +59,7 @@ class _StubPluginAdapter(PluginAdapter):
         return self._healthy
 
     def supported_models(self) -> list[str]:
-        return list(self._models)
+        return self._models.copy()
 
     def spawn(
         self,

--- a/tests/unit/test_commit_provenance.py
+++ b/tests/unit/test_commit_provenance.py
@@ -304,20 +304,19 @@ class TestBuildProvenanceChain:
         assert chain.records[0].agent_id == "a1"
 
     def test_records_sorted_by_timestamp(self, tmp_path: Path) -> None:
-        entries = []
-        for i, ts in enumerate([3.0, 1.0, 2.0]):
-            entries.append(
-                {
-                    "commit_sha": f"{'0' * 39}{i}",
-                    "agent_id": f"a{i}",
-                    "task_id": f"t{i}",
-                    "run_id": _RUN_ID,
-                    "model": "sonnet",
-                    "role": "backend",
-                    "timestamp": ts,
-                    "signature_type": "none",
-                }
-            )
+        entries = [
+            {
+                "commit_sha": f"{'0' * 39}{i}",
+                "agent_id": f"a{i}",
+                "task_id": f"t{i}",
+                "run_id": _RUN_ID,
+                "model": "sonnet",
+                "role": "backend",
+                "timestamp": ts,
+                "signature_type": "none",
+            }
+            for i, ts in enumerate([3.0, 1.0, 2.0])
+        ]
         lines = "\n".join(json.dumps(e) for e in entries) + "\n"
         (tmp_path / "provenance.jsonl").write_text(lines)
         chain = build_provenance_chain(_RUN_ID, tmp_path)

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -290,13 +290,13 @@ class TestCFGEnvVarExpansion:
             assert expand_env_vars("https://${HOST}/api") == "https://example.com/api"
 
     def test_default_fallback(self) -> None:
-        env = dict(os.environ)
+        env = os.environ.copy()
         env.pop("UNSET_VAR", None)
         with patch.dict(os.environ, env, clear=True):
             assert expand_env_vars("${UNSET_VAR:-fallback}") == "fallback"
 
     def test_default_empty_string(self) -> None:
-        env = dict(os.environ)
+        env = os.environ.copy()
         env.pop("UNSET_VAR", None)
         with patch.dict(os.environ, env, clear=True):
             assert expand_env_vars("${UNSET_VAR:-}") == ""
@@ -306,7 +306,7 @@ class TestCFGEnvVarExpansion:
             assert expand_env_vars("${SET_VAR:-default}") == "actual"
 
     def test_unset_no_default_raises(self) -> None:
-        env = dict(os.environ)
+        env = os.environ.copy()
         env.pop("MISSING_VAR", None)
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(EnvExpansionError, match="MISSING_VAR.*not set"):
@@ -397,7 +397,7 @@ class TestCFGConfigMigration:
             _config_schema_mod.CURRENT_CONFIG_VERSION = 2
 
             def migrate_v1_to_v2(data: dict[str, Any]) -> dict[str, Any]:
-                data = dict(data)
+                data = data.copy()
                 if "old_field" in data:
                     data["new_field"] = data.pop("old_field")
                 return data
@@ -562,7 +562,7 @@ class TestLoadAndValidate:
     def test_load_with_env_expansion(self, tmp_path: Path) -> None:
         data = _minimal_config(internal_llm_model="${TEST_MODEL:-fallback-model}")
         p = _write_yaml(tmp_path, data)
-        env = dict(os.environ)
+        env = os.environ.copy()
         env.pop("TEST_MODEL", None)
         with patch.dict(os.environ, env, clear=True):
             cfg = load_and_validate(p)

--- a/tests/unit/test_cost_allocation_tags.py
+++ b/tests/unit/test_cost_allocation_tags.py
@@ -129,7 +129,7 @@ def _aggregate_by_tag(
         for k, v in u.cost_tags.items():
             if tag_key is None or k == tag_key:
                 by_tag[k][v] += u.cost_usd
-    return {k: dict(vals) for k, vals in by_tag.items()}
+    return {k: vals.copy() for k, vals in by_tag.items()}
 
 
 class TestByTagAggregation:

--- a/tests/unit/test_cost_history.py
+++ b/tests/unit/test_cost_history.py
@@ -72,17 +72,16 @@ def test_upsert_replaces_same_date_and_prunes_old_history(tmp_path: Path) -> Non
 def test_compute_trends_detects_upward_spend_shift() -> None:
     """compute_trends marks the trend as up when the current 30-day window is materially higher."""
     today = date.today()
-    snapshots: list[DailyCostSnapshot] = []
-    for days_ago in range(60, 30, -1):
-        snapshots.append(
-            DailyCostSnapshot(
-                date_str=(today - timedelta(days=days_ago)).isoformat(),
-                spent_usd=10.0,
-                budget_usd=0.0,
-                run_count=1,
-                timestamp=0.0,
-            )
+    snapshots: list[DailyCostSnapshot] = [
+        DailyCostSnapshot(
+            date_str=(today - timedelta(days=days_ago)).isoformat(),
+            spent_usd=10.0,
+            budget_usd=0.0,
+            run_count=1,
+            timestamp=0.0,
         )
+        for days_ago in range(60, 30, -1)
+    ]
     for days_ago in range(30, 0, -1):
         snapshots.append(
             DailyCostSnapshot(

--- a/tests/unit/test_cost_preflight_v2.py
+++ b/tests/unit/test_cost_preflight_v2.py
@@ -239,10 +239,7 @@ def test_compute_band_rounds_to_two_decimals(metrics_dir: Path) -> None:
 def test_compute_band_mixed_pair_ignores_other_pairs(metrics_dir: Path) -> None:
     """A file that mixes pairs only consumes records matching the query."""
     history = metrics_dir / "cost.jsonl"
-    records: list[dict[str, object]] = []
-    # Heavy noise for the wrong pair.
-    for _ in range(60):
-        records.append({"role": "qa", "adapter": "codex", "cost_usd": 99.0})
+    records: list[dict[str, object]] = [{"role": "qa", "adapter": "codex", "cost_usd": 99.0} for _ in range(60)]
     # Only three matching records — small history, but still > 0 samples.
     records.extend(
         [

--- a/tests/unit/test_generic_webhook.py
+++ b/tests/unit/test_generic_webhook.py
@@ -180,7 +180,7 @@ async def test_webhook_malformed_timestamp_returns_401(client: AsyncClient, monk
     monkeypatch.setenv("BERNSTEIN_WEBHOOK_SECRET", _WEBHOOK_SECRET)
     body = json.dumps(_WEBHOOK_PAYLOAD).encode()
     # Start from a valid header set, then clobber the timestamp.
-    headers = dict(_signed(body))
+    headers = _signed(body).copy()
     headers["x-bernstein-timestamp"] = "not-a-number"
     resp = await client.post("/webhook", content=body, headers=headers)
     assert resp.status_code == 401
@@ -241,7 +241,7 @@ async def test_webhook_with_wrong_signature_returns_401(client: AsyncClient, mon
     """POST with a wrong HMAC signature must return 401."""
     monkeypatch.setenv("BERNSTEIN_WEBHOOK_SECRET", _WEBHOOK_SECRET)
     body = json.dumps(_WEBHOOK_PAYLOAD).encode()
-    headers = dict(_signed(body))
+    headers = _signed(body).copy()
     headers["x-bernstein-webhook-signature-256"] = "sha256=deadbeef"
     resp = await client.post("/webhook", content=body, headers=headers)
     assert resp.status_code == 401

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -114,7 +114,7 @@ def _stub_bisect_env(
         return GitResult(returncode=0, stdout="", stderr="")
 
     def _fake_run(cmd: list[str], *args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        captured_argv.append(list(cmd))
+        captured_argv.append(cmd.copy())
         # Pretend `git check-ref-format --branch X` passes for non-malicious input.
         if len(cmd) >= 2 and cmd[:2] == ["git", "check-ref-format"]:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")

--- a/tests/unit/test_gitops_integration.py
+++ b/tests/unit/test_gitops_integration.py
@@ -61,7 +61,7 @@ class _FakeClock:
     """Injectable clock for testing wait_for_sync."""
 
     def __init__(self, times: list[float]) -> None:
-        self._times = list(times)
+        self._times = times.copy()
         self._idx = 0
 
     def time(self) -> float:

--- a/tests/unit/test_live_visuals.py
+++ b/tests/unit/test_live_visuals.py
@@ -97,7 +97,7 @@ def test_splash_screen_wrapper_delegates_to_v2(monkeypatch: pytest.MonkeyPatch) 
     calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     def fake_render(*args: object, **kwargs: object) -> None:
-        calls.append((args, dict(kwargs)))
+        calls.append((args, kwargs.copy()))
 
     def fake_resolve(raw: object | None = None) -> VisualConfig:
         return VisualConfig()

--- a/tests/unit/test_log_redact.py
+++ b/tests/unit/test_log_redact.py
@@ -181,7 +181,7 @@ class TestInstall:
     def test_installs_on_root(self) -> None:
         root = logging.getLogger()
         # Remove any existing filter from prior test runs
-        for f in list(root.filters):
+        for f in root.filters.copy():
             if isinstance(f, PiiRedactingFilter):
                 root.removeFilter(f)
         if hasattr(root, "_bernstein_pii_filter"):
@@ -252,7 +252,7 @@ class TestEndToEnd:
 
         # Cleanup
         test_logger.removeHandler(handler)
-        for f in list(test_logger.filters):
+        for f in test_logger.filters.copy():
             if isinstance(f, PiiRedactingFilter):
                 test_logger.removeFilter(f)
         if hasattr(test_logger, "_bernstein_pii_filter"):

--- a/tests/unit/test_mcp_tool_search.py
+++ b/tests/unit/test_mcp_tool_search.py
@@ -36,16 +36,15 @@ def small_catalog() -> ToolCatalog:
 
 @pytest.fixture()
 def large_catalog() -> ToolCatalog:
-    entries: list[ToolEntry] = []
-    for i in range(80):
-        entries.append(
-            _entry(
-                f"server{i}.tool_{i}",
-                "do something useful with the input parameters and return a structured response payload",
-                server=f"server{i}",
-                schema={"a": "string", "b": "number", "c": "boolean", "d": {"nested": "object"}},
-            )
+    entries: list[ToolEntry] = [
+        _entry(
+            f"server{i}.tool_{i}",
+            "do something useful with the input parameters and return a structured response payload",
+            server=f"server{i}",
+            schema={"a": "string", "b": "number", "c": "boolean", "d": {"nested": "object"}},
         )
+        for i in range(80)
+    ]
     return ToolCatalog(entries)
 
 

--- a/tests/unit/test_multi_criteria_rank.py
+++ b/tests/unit/test_multi_criteria_rank.py
@@ -31,7 +31,7 @@ from bernstein.core.orchestration.multi_criteria_rank import (
 
 
 def _cand(key: str, **scores: float) -> Candidate:
-    return Candidate(key=key, scores=dict(scores))
+    return Candidate(key=key, scores=scores.copy())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -5566,18 +5566,17 @@ class TestRunManagerQueueReview:
     ):  # type: ignore[no-untyped-def]
         from bernstein.core.manager import QueueCorrection, QueueReviewResult
 
-        parsed_corrections = []
-        for c in corrections:
-            parsed_corrections.append(
-                QueueCorrection(
-                    action=c["action"],
-                    task_id=c.get("task_id"),
-                    new_role=c.get("new_role"),
-                    new_priority=c.get("new_priority"),
-                    reason=c.get("reason", ""),
-                    new_task=c.get("new_task"),
-                )
+        parsed_corrections = [
+            QueueCorrection(
+                action=c["action"],
+                task_id=c.get("task_id"),
+                new_role=c.get("new_role"),
+                new_priority=c.get("new_priority"),
+                reason=c.get("reason", ""),
+                new_task=c.get("new_task"),
             )
+            for c in corrections
+        ]
         return QueueReviewResult(corrections=parsed_corrections, reasoning=reasoning)
 
     def test_resets_counters_and_sets_last_review_ts(self, tmp_path: Path) -> None:

--- a/tests/unit/test_prompt_cache_locality.py
+++ b/tests/unit/test_prompt_cache_locality.py
@@ -229,7 +229,7 @@ class _RecordingCounter:
         self._last: dict[str, str] = {}
 
     def labels(self, **kwargs: str) -> _RecordingCounter:
-        self._last = dict(kwargs)
+        self._last = kwargs.copy()
         return self
 
     def inc(self, value: float = 1.0) -> None:

--- a/tests/unit/test_refinement_loop.py
+++ b/tests/unit/test_refinement_loop.py
@@ -94,7 +94,7 @@ class _ScriptedCritic:
         score = self.scores[idx] if idx < len(self.scores) else self.scores[-1]
         issues: list[CritiqueIssue] = []
         if self.issues_per_round is not None and idx < len(self.issues_per_round):
-            issues = list(self.issues_per_round[idx])
+            issues = self.issues_per_round[idx].copy()
         veto = round_index in self.veto_rounds
         return Critique(score=score, issues=issues, veto=veto, rationale=f"round-{round_index}")
 
@@ -859,8 +859,8 @@ def test_property_monotone_in_budget(budget: float, per_round_cost: float) -> No
 def test_property_deterministic_with_seed(seed: int, rounds: int) -> None:
     """Two runners with the same seed produce identical reports."""
     scores = [0.1 + 0.1 * i for i in range(rounds)]
-    r1 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
-    r2 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
+    r1 = _runner(critic=_ScriptedCritic(scores=scores.copy()), seed=seed, plateau_window=rounds + 10)
+    r2 = _runner(critic=_ScriptedCritic(scores=scores.copy()), seed=seed, plateau_window=rounds + 10)
     rep1 = r1.run(_task(refinement_rounds=rounds))
     rep2 = r2.run(_task(refinement_rounds=rounds))
     assert rep1.rounds_run == rep2.rounds_run
@@ -1031,8 +1031,8 @@ def test_property_critique_round_trip(score: float, veto: bool, rationale: str) 
 def test_property_seeded_run_report_stable_across_repeat(rounds: int, seed: int) -> None:
     """A seeded runner produces identical reports on repeated invocation."""
     scores = [0.05 * (i + 1) for i in range(rounds)]
-    r1 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
-    r2 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
+    r1 = _runner(critic=_ScriptedCritic(scores=scores.copy()), seed=seed, plateau_window=rounds + 10)
+    r2 = _runner(critic=_ScriptedCritic(scores=scores.copy()), seed=seed, plateau_window=rounds + 10)
     rep1 = r1.run(_task(refinement_rounds=rounds))
     rep2 = r2.run(_task(refinement_rounds=rounds))
     assert rep1.per_round_critique == rep2.per_round_critique

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -768,9 +768,7 @@ class TestSchedulerFairness:
             # Create 3-5 tasks for "overserved" role, 1-2 for "starving"
             n_overserved = rng.randint(3, 5)
             n_starving = rng.randint(1, 2)
-            tasks = []
-            for i in range(n_overserved):
-                tasks.append(_make_task(id=f"T-os-{trial}-{i}", role="backend", priority=2))
+            tasks = [_make_task(id=f"T-os-{trial}-{i}", role="backend", priority=2) for i in range(n_overserved)]
             for i in range(n_starving):
                 tasks.append(_make_task(id=f"T-sv-{trial}-{i}", role="qa", priority=2))
 

--- a/tests/unit/test_review_bot_ack_workflow_yaml.py
+++ b/tests/unit/test_review_bot_ack_workflow_yaml.py
@@ -70,15 +70,11 @@ def test_gate_job_emits_review_bot_ack_check(
 ) -> None:
     jobs = gate_doc.get("jobs")
     assert isinstance(jobs, dict)
-    assert "review-bot-ack" in jobs, (
-        "gate workflow must define a job that produces the "
-        "`review-bot-ack` check name"
-    )
+    assert "review-bot-ack" in jobs, "gate workflow must define a job that produces the `review-bot-ack` check name"
     job = jobs["review-bot-ack"]
     assert isinstance(job, dict)
     assert job.get("name") == "review-bot-ack", (
-        "job `name:` must equal the literal check name "
-        "`review-bot-ack` (branch protection keys on the literal name)"
+        "job `name:` must equal the literal check name `review-bot-ack` (branch protection keys on the literal name)"
     )
 
 

--- a/tests/unit/test_run_export.py
+++ b/tests/unit/test_run_export.py
@@ -386,19 +386,18 @@ def test_export_no_data(tmp_path: Path) -> None:
 def test_size_limit_enforced(tmp_path: Path) -> None:
     """export_run_report raises ValueError when report exceeds 500KB."""
     # Create a mock report and directly call the render function with oversized data
-    large_rows = []
-    for i in range(3000):
-        large_rows.append(
-            _TaskRow(
-                title=f"Very long task title number {i} with extra padding to make it much larger so we exceed the limit",
-                role="backend",
-                status="done",
-                model="test-model",
-                duration_s=60.0,
-                cost_usd=0.01,
-                janitor_passed=True,
-            )
+    large_rows = [
+        _TaskRow(
+            title=f"Very long task title number {i} with extra padding to make it much larger so we exceed the limit",
+            role="backend",
+            status="done",
+            model="test-model",
+            duration_s=60.0,
+            cost_usd=0.01,
+            janitor_passed=True,
         )
+        for i in range(3000)
+    ]
 
     report = _ExportReport(
         goal="",

--- a/tests/unit/test_seccomp_profiles.py
+++ b/tests/unit/test_seccomp_profiles.py
@@ -128,7 +128,7 @@ def test_write_profile_default_dir_is_tmp(monkeypatch: pytest.MonkeyPatch) -> No
     # Check that passing None dest_dir doesn't raise and file ends up somewhere sensible
     out = write_profile(AgentSeccompProfile.STRICT, dest_dir=None)
     assert out.exists()
-    assert str(tempfile.gettempdir()) in str(out)
+    assert tempfile.gettempdir() in str(out)
 
 
 def test_write_custom_profile(tmp_path: Path) -> None:

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -88,7 +88,7 @@ class _FakeSession(SandboxSession):
         stdin: bytes | None = None,
     ) -> ExecResult:
         del cwd, env, timeout, stdin
-        self._exec_calls.append(list(cmd))
+        self._exec_calls.append(cmd.copy())
         if self._exec_blocker is not None:
             await self._exec_blocker.wait()
         return ExecResult(

--- a/tests/unit/test_token_binding.py
+++ b/tests/unit/test_token_binding.py
@@ -159,9 +159,7 @@ class TestTokenRateLimit:
             enforce_run_binding=False,
         )
         claims = {"jti": "token-1", "iat": time.time()}
-        results = []
-        for _ in range(5):
-            results.append(validator.validate(claims))
+        results = [validator.validate(claims) for _ in range(5)]
         # First 3 should succeed, 4th and 5th should fail
         assert results[0].valid
         assert results[1].valid

--- a/tests/unit/test_webhook_route.py
+++ b/tests/unit/test_webhook_route.py
@@ -115,7 +115,7 @@ async def test_generic_webhook_enforces_hmac_only(client: AsyncClient, monkeypat
     )
     assert plaintext.status_code == 401
 
-    wrong_sig = dict(_signed_headers(body))
+    wrong_sig = _signed_headers(body).copy()
     wrong_sig["x-bernstein-webhook-signature-256"] = "sha256=deadbeef"
     rejected = await client.post("/webhook", content=body, headers=wrong_sig)
     assert rejected.status_code == 401

--- a/tests/unit/test_wiki_renderer.py
+++ b/tests/unit/test_wiki_renderer.py
@@ -135,19 +135,18 @@ def test_render_wiki_skips_test_files_from_public_api() -> None:
 
 
 def test_render_wiki_truncates_oversized_packages() -> None:
-    nodes: list[SymbolNode] = []
-    for i in range(20):
-        nodes.append(
-            SymbolNode(
-                id=f"src/pkg/mod.py::fn_{i:02d}",
-                name=f"fn_{i:02d}",
-                kind="function",
-                file="src/pkg/mod.py",
-                line_start=i + 1,
-                line_end=i + 2,
-                signature=f"def fn_{i:02d}() -> None",
-            ),
+    nodes: list[SymbolNode] = [
+        SymbolNode(
+            id=f"src/pkg/mod.py::fn_{i:02d}",
+            name=f"fn_{i:02d}",
+            kind="function",
+            file="src/pkg/mod.py",
+            line_start=i + 1,
+            line_end=i + 2,
+            signature=f"def fn_{i:02d}() -> None",
         )
+        for i in range(20)
+    ]
     graph = _make_graph_with(*nodes)
     output = render_wiki(graph, ["src/pkg/mod.py"], repo_name="big")
 

--- a/tests/unit/trackers/test_jira_cloud_adapter.py
+++ b/tests/unit/trackers/test_jira_cloud_adapter.py
@@ -381,9 +381,7 @@ def test_conflict_raises_optimistic_concurrency() -> None:
 def test_precondition_failed_raises_optimistic_concurrency() -> None:
     adapter = _make_adapter()
     url = f"https://{DOMAIN}/rest/api/3/issue/ACME-1/transitions"
-    respx.post(url).mock(
-        return_value=httpx.Response(412, json={"message": "precondition failed"})
-    )
+    respx.post(url).mock(return_value=httpx.Response(412, json={"message": "precondition failed"}))
     try:
         with pytest.raises(OptimisticConcurrencyError):
             adapter.transition("ACME-1", "41")


### PR DESCRIPTION
## Summary

Mechanical code-quality cleanup of remaining refurb findings across `src/` and `tests/`. Wave 3 of the bulk auto-fix work started in #1558 and continued in #1582.

## Rules auto-fixed (and call-site counts)

| Rule | Description | Sites fixed | Tooling |
|---|---|---|---|
| FURB123 | redundant cast (`dict(x)` -> `x.copy()`, `str(x)` -> `x` when already `str`, `list(x)` -> `x.copy()`) | 147 | custom line-based rewriter that parses refurb's "Replace X with Y" suggestions |
| FURB138 | assign-empty-list + for-append-loop -> list comprehension | 57 | libcst rewriter restricted to single-statement-body pattern, with `ast.parse` round-trip |
| FURB113 | repeated `append` -> `list.extend` (leftovers from wave 2) | 5 | `ruff check --select FURB113 --preview --unsafe-fixes --fix` |

One FURB123 site was reverted manually after ruff caught it: a `bytes(trace_bytes)` call inside an `isinstance(bytearray)` branch where the cast is meaningful (refurb's type narrowing made it look redundant). This is exactly the type-inference edge case the wave 3 plan warned about.

Reformatted by `ruff format` (3 files).

## Rules skipped this round

| Rule | Sites | Reason |
|---|---|---|
| FURB184 | 2440 | fluent-chain rewrite still requires whole-function liveness analysis; same reasoning as wave 2 |
| FURB138 leftovers | 49 | multi-statement loop bodies, guarded branches, or appends with `continue`/`break` |
| FURB108 | 24 | per-site review needed (variable-RHS patterns, idiom check) |
| FURB173 | 2 | per-site review needed |

## Refurb counts (top rules)

| Rule    | Before wave 3 | After wave 3 |
|---------|---------------|--------------|
| FURB123 |           148 |            0 |
| FURB138 |           106 |           49 |
| FURB113 |            31 |           26 |

## Verification

- `uv run ruff check src/ tests/`: clean.
- `uv run ruff format src/ tests/`: no-op on a second pass.
- pytest on 42 changed unit-test files: **1314 passed, 7 skipped, 0 regressions** vs `origin/main`.
- Syntax-check pass on every modified file (`ast.parse` round-trip post-edit).

## Test plan

- [x] `uv run ruff check src/ tests/` clean.
- [x] `uv run ruff format src/ tests/` no-op on a second pass.
- [x] pytest on changed unit-test files passes with no regressions vs `origin/main`.
- [ ] CI green on this PR.

## Summary by Sourcery

Apply automated refurb and style cleanups across core runtime, security, orchestration, routing, CLI, and test code to remove redundant casts, prefer comprehensions and list/dict copies, and simplify collection construction and environment handling.

Enhancements:
- Replace imperative loops that build lists or dicts with comprehensions or list literals in core services, orchestration helpers, lineage, security utilities, routing, and adapters.
- Standardise use of copy() and .copy() for collections and os.environ instead of redundant casts to clarify intent and avoid unnecessary conversions.
- Tighten small numeric and type coercions by removing redundant int()/float() wrapping where arguments are already correctly typed or validated.
- Slightly streamline string building and logging/audit helpers for git, markdown, prompts, and YAML/SPDX/CycloneDX encoders.

Tests:
- Update unit, integration, and property tests to match new collection construction patterns, copying semantics, and environment handling without changing test coverage or behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal code patterns for improved maintainability and consistency across the codebase. These are internal refactoring changes with no impact on user-facing functionality or features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: nit-batch reason=Style/nit suggestions (TypedDict refactors, FURB consistency, dict.copy alignment) deferred to a dedicated typing pass; correctness findings addressed in fixup commit. -->
