### PR TITLE
chore(ci): widen sonar-scan timeout and document GlitchTip runtime setup

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -21,7 +21,7 @@ jobs:
   scan:
     name: SonarQube scan
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     if: ${{ vars.SONAR_HOST_URL != '' }}
     steps:
       - name: Harden runner
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          fetch-depth: 0  # Sonar needs full history for blame
+          fetch-depth: 0  # Sonar needs full git history for accurate blame
           persist-credentials: false
 
       - name: Set up Python
@@ -41,13 +41,22 @@ jobs:
         with:
           python-version: '3.14'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Sync dev deps
+        timeout-minutes: 15
+        run: uv sync --group dev
+
       - name: Run coverage
+        timeout-minutes: 30
         run: |
-          pip install --quiet uv
-          uv sync --group dev
           uv run pytest --cov=src/bernstein --cov-report=xml --cov-branch tests/unit/ -q || true
 
       - name: SonarQube scan
+        timeout-minutes: 10
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995  # v8.1.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/operations/glitchtip-setup.md
+++ b/docs/operations/glitchtip-setup.md
@@ -1,0 +1,99 @@
+# GlitchTip setup
+
+Audience: operators wiring Bernstein into a GlitchTip (or any
+Sentry-protocol-compatible) error sink and confirming events flow end to
+end.
+
+Companion to [`observability.md`](./observability.md), which documents the
+broader telemetry contract.  This doc focuses on the operator-facing
+mechanics: project provisioning, DSN distribution, runtime export, and
+event verification.
+
+## TL;DR
+
+| Step | Action |
+|------|--------|
+| 1 | Create an organization + project in the GlitchTip UI |
+| 2 | Copy the project DSN (`Settings -> Projects -> <name> -> Client Keys`) |
+| 3 | Store the DSN in the deploy environment (GH secret, systemd unit, container env) |
+| 4 | Export `GLITCHTIP_DSN=<dsn>` into every Bernstein process |
+| 5 | Trigger a controlled error and confirm the issue lands in the UI |
+
+## Env var
+
+The Bernstein CLI reads exactly one env var at startup:
+
+```text
+GLITCHTIP_DSN=https://<public-key>@<host>/<project-id>
+```
+
+Defined in `src/bernstein/cli/main.py::_init_error_telemetry`.  When the
+var is unset or empty, the helper is a no-op and `sentry-sdk` is never
+imported -- minimal installs pay zero overhead.
+
+`SENTRY_DSN` is **not** read.  Bernstein deliberately uses a
+project-specific env var to keep operator-managed error sinks distinct
+from any third-party Sentry wiring an embedded library might do.
+
+## Provisioning a project
+
+1. Log in to the GlitchTip UI (operator-managed admin credentials).
+2. `Organization -> New Project`, pick **Python** as the platform.
+3. Open the project's **Client Keys (DSN)** page and copy the public DSN.
+   Format: `https://<32-hex-public-key>@<host>/<numeric-project-id>`.
+4. Store the DSN as the `GLITCHTIP_DSN` secret in every deploy surface
+   that runs Bernstein:
+
+   * GitHub Actions: `Settings -> Secrets and variables -> Actions ->
+     New repository secret`, name `GLITCHTIP_DSN`.  The
+     `bernstein-deploy.yml` workflow passes it through to the deploy
+     target.
+   * systemd: drop into the unit's `EnvironmentFile=` or via
+     `Environment=GLITCHTIP_DSN=...`.
+   * Container: pass via `--env GLITCHTIP_DSN=...` or compose `env_file`.
+   * Local operator workstation: `export GLITCHTIP_DSN=...` in the
+     shell that runs `bernstein`.
+
+## Verifying events flow
+
+After exporting the DSN, run a controlled capture to confirm ingestion:
+
+```bash
+export GLITCHTIP_DSN='https://<public-key>@<host>/<project-id>'
+python -c "
+import os, bernstein.cli.main  # triggers _init_error_telemetry
+import sentry_sdk
+sentry_sdk.capture_message('bernstein glitchtip smoke', level='info')
+sentry_sdk.flush(timeout=5)
+"
+```
+
+Then open the GlitchTip UI -> Issues for the project.  The
+`bernstein glitchtip smoke` issue should appear within a few seconds.
+
+To verify via the API (auth token from `Profile -> Auth Tokens`):
+
+```bash
+curl -s -H "Authorization: Bearer $GLITCHTIP_API_TOKEN" \
+  https://<host>/api/0/projects/<org-slug>/<project-slug>/issues/ \
+  | jq '.[].title'
+```
+
+## Rotating the DSN
+
+GlitchTip lets the operator add/revoke client keys without re-provisioning
+the project.  To rotate:
+
+1. `Project Settings -> Client Keys -> New Client Key`.
+2. Update `GLITCHTIP_DSN` in every deploy surface listed above.
+3. Restart Bernstein processes so they pick up the new DSN at import time.
+4. Revoke the old key once traffic on it has stopped.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| No events in UI | Env var not exported in the process | Confirm with `printenv GLITCHTIP_DSN` inside the running process namespace |
+| `ImportError` swallowed silently | `sentry-sdk` not installed | Reinstall with the extra: `pip install 'bernstein[observability]'` |
+| `429 Too Many Requests` from sink | Per-project throttle in GlitchTip | Raise `eventThrottleRate` on the project, or bound `before_send` |
+| DSN works locally, not on VPS | Egress firewall blocks the GlitchTip host | Whitelist the sink host in the VPS egress policy |


### PR DESCRIPTION
## Summary

- Raise `sonar-scan.yml` job timeout from 20m to 60m with per-step caps so the `uv sync --group dev` + pytest --cov phase stops getting killed mid-run on the 127-commit history.
- Switch to the pinned `astral-sh/setup-uv@v8.1.0` action with cache enabled so subsequent scans reuse the dev environment.
- Add `docs/operations/glitchtip-setup.md` covering DSN provisioning, the `GLITCHTIP_DSN` env var contract, runtime export across deploy surfaces, smoke verification, rotation, and a small troubleshooting table.

## Why

All 19 prior `sonar-scan.yml` runs cancelled at the 20-minute job-level wall during the coverage step.  The Sonar server at `https://sonar.bernstein.run` therefore shows zero projects.  Widening the budget plus caching dev deps lets the scan complete and surface its result.

The GlitchTip side is operationally green (project + DSN provisioned, smoke event ingested), but operators had no single page documenting how to export the DSN at runtime; `glitchtip-setup.md` closes that gap.

## Test plan

- [ ] CI runs `sonar-scan.yml` on push to main and completes within budget.
- [ ] Project `bernstein` appears at `https://sonar.bernstein.run/api/projects/search?projects=bernstein`.
- [ ] `docs/operations/glitchtip-setup.md` renders cleanly on GitHub.

## Summary by Sourcery

Increase SonarQube CI scan robustness and document GlitchTip runtime integration for operators.

CI:
- Extend the SonarQube scan workflow timeout and introduce per-step time limits to prevent premature cancellation during dependency sync and coverage runs.
- Adopt the pinned astral-sh/setup-uv action with caching to speed up repeated SonarQube scans.

Documentation:
- Add an operator-focused GlitchTip setup guide covering DSN provisioning, GLITCHTIP_DSN usage, runtime export across environments, verification, rotation, and troubleshooting.