### PR TITLE
fix(ci): soft-fail landing-dispatch on PAT scope error

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -174,22 +174,41 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      # The PAT must have repo scope on sipyourdrink-ltd/bernstein-landing.
-      # When the secret is not set (e.g. on a forked workflow run), skip
-      # silently so a missing PAT does not block the main-branch pipeline.
+      # The PAT must have actions:write scope on sipyourdrink-ltd/bernstein-landing
+      # so the workflow_dispatch endpoint accepts the call. When the secret is
+      # not set (e.g. on a forked workflow run) or the dispatch endpoint
+      # rejects the request, soft-fail with a warning so a missing or
+      # under-scoped PAT does not block the main-branch pipeline.
       - name: Dispatch docs-mirror-sync in bernstein-landing
         env:
           LANDING_REPO_PAT: ${{ secrets.LANDING_REPO_PAT }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
           if [ -z "${LANDING_REPO_PAT}" ]; then
-            echo "LANDING_REPO_PAT is not set; skipping cross-repo dispatch."
+            echo "::warning::LANDING_REPO_PAT is not set; cross-repo sync skipped."
             exit 0
           fi
-          curl --fail-with-body --silent --show-error \
+          http_code=$(curl --silent --show-error --output /tmp/dispatch-body.txt --write-out '%{http_code}' \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${LANDING_REPO_PAT}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/sipyourdrink-ltd/bernstein-landing/actions/workflows/docs-mirror-sync.yml/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"source_sha\":\"${COMMIT_SHA}\"}}"
+            -d "{\"ref\":\"main\",\"inputs\":{\"source_sha\":\"${COMMIT_SHA}\"}}")
+          echo "Dispatch HTTP status: ${http_code}"
+          if [ -s /tmp/dispatch-body.txt ]; then
+            echo "Dispatch response body:"
+            cat /tmp/dispatch-body.txt
+          fi
+          case "${http_code}" in
+            2*)
+              echo "Cross-repo dispatch accepted."
+              ;;
+            403)
+              echo "::warning::PAT lacks workflow:write scope on bernstein-landing; cross-repo sync skipped. Operator action: grant fine-grained PAT actions:write on bernstein-landing."
+              ;;
+            *)
+              echo "::warning::Cross-repo dispatch to bernstein-landing returned HTTP ${http_code}; sync skipped. Operator action: verify LANDING_REPO_PAT fine-grained scopes (actions:write on bernstein-landing) and workflow file path."
+              ;;
+          esac
+          exit 0


### PR DESCRIPTION
## Summary
- Capture the HTTP status from the cross-repo workflow_dispatch call instead of relying on curl --fail-with-body.
- Emit a `::warning::` annotation with an operator-actionable message when the dispatch endpoint returns 403 (PAT scope) or any other non-2xx status.
- Step now always exits 0, so the docs-drift pipeline on main is not blocked by a missing or under-scoped LANDING_REPO_PAT.

## Why
The trigger-landing-mirror job has been failing on main because the configured LANDING_REPO_PAT can read sipyourdrink-ltd/bernstein-landing but lacks actions:write, so the dispatch endpoint returns 403 and the previous curl --fail-with-body propagated the failure into the job. Cross-repo sync is best-effort and should not gate docs-drift on main.

## Operator follow-up
- Reissue LANDING_REPO_PAT as a fine-grained PAT with `actions:write` on sipyourdrink-ltd/bernstein-landing to re-enable the dispatch.

## Test plan
- [ ] On the next push to main, the trigger-landing-mirror job completes successfully and surfaces a warning annotation when the PAT scope is insufficient.
- [ ] When LANDING_REPO_PAT is unset, the step emits the no-PAT warning and exits 0.

## Summary by Sourcery

CI:
- Update the docs-drift workflow dispatch step to always exit successfully while emitting GitHub warnings for missing or insufficient LANDING_REPO_PAT scopes and non-2xx dispatch responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and diagnostics in the documentation synchronization workflow to be more resilient to missing or insufficient configuration permissions, with enhanced troubleshooting information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: 3269419318 reason=Wording reflects the GitHub OAuth scope name (workflow:write) that the operator must request when migrating to a fine-grained PAT; the remediation hint references the fine-grained equivalent (actions:write) intentionally to cover both scope models. -->
