### PR TITLE
fix(review): apply 44 deferred review-bot findings from 2026-05-19 catch-up

### DIFF
--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -39,11 +39,22 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install cyclonedx-bom
-        run: python -m pip install --upgrade "cyclonedx-bom>=4.5"
+      # ``cyclonedx-py environment`` scans the active Python environment.
+      # Build the SBOM from an isolated venv where only the project and its
+      # resolved dependencies are installed so the output reflects
+      # bernstein's dependency graph rather than whatever the runner base
+      # image happens to carry.
+      - name: Prepare isolated SBOM environment
+        run: |
+          python -m venv .venv-sbom
+          . .venv-sbom/bin/activate
+          python -m pip install --upgrade pip "cyclonedx-bom>=4.5"
+          python -m pip install .
 
       - name: Generate CycloneDX SBOM
-        run: cyclonedx-py environment --output-file bernstein.cyclonedx.json
+        run: |
+          . .venv-sbom/bin/activate
+          cyclonedx-py environment --output-file bernstein.cyclonedx.json
 
       - name: Check operator endpoint
         id: gate

--- a/docs/memory/session-memory.md
+++ b/docs/memory/session-memory.md
@@ -95,13 +95,17 @@ prior = load_recent_turns(
 mem.prune(older_than_ns)
 ```
 
-Drops every turn for this instance's `(task_id, session_id)` whose
-`ts_ns` is strictly less than the cutoff. The episodic JSONL file is
-rewritten in place via a sibling temp file plus atomic rename, so a
-crash mid-prune leaves either the old log or the new log intact.
+Prune operates at two different scopes, on purpose:
 
-The semantic index delete is scoped to `task_id` so a parallel task
-sharing the same `.sdd/memory/` root is never touched.
+- Episodic JSONL pruning is scoped to this instance's
+  `(task_id, session_id)` and drops every turn whose `ts_ns` is strictly
+  less than the cutoff. The JSONL file is rewritten in place via a
+  sibling temp file plus atomic rename, so a crash mid-prune leaves
+  either the old log or the new log intact.
+- Semantic index deletion is scoped to `task_id` only, so a parallel
+  task sharing the same `.sdd/memory/` root is never touched and stale
+  embeddings for other sessions of the same task are cleared in one
+  pass.
 
 ## On-disk layout
 

--- a/docs/operations/post-ci-dispatcher.md
+++ b/docs/operations/post-ci-dispatcher.md
@@ -32,7 +32,7 @@ instead of `on: workflow_run:`; the dispatcher owns the upstream event.
 
 ## Sequence
 
-```
+```text
 CI run completes on main
         |
         v

--- a/docs/orchestration/failure-taxonomy.md
+++ b/docs/orchestration/failure-taxonomy.md
@@ -73,7 +73,7 @@ A downstream parser:
 
 1. Searches the comment body for the literal fence
    `` ```bernstein-failure-v1\n ``.
-2. Reads until the next `` \n``` ``.
+2. Reads until the next closing ``` fence appearing on its own line.
 3. Passes the inner text to a YAML 1.1+ `safe_load`.
 4. Validates that the result is a mapping with at least
    `reason_code`, `category`, `transient`, `next_action`,

--- a/docs/review-bot/deferred-2026-05-19.md
+++ b/docs/review-bot/deferred-2026-05-19.md
@@ -1,0 +1,49 @@
+# Deferred review-bot findings - 2026-05-19
+
+Source manifest: [PR #1584](https://github.com/sipyourdrink-ltd/bernstein/pull/1584).
+
+PR #1584 inventoried 48 review-bot findings and landed mechanical fixes
+for 4. The follow-up pass on `fix/bot-findings-triage-2026-05-19` lands
+the remaining mechanical fixes against the 44 still-deferred items.
+
+This file tracks the residual findings that require design judgement or
+ripple beyond a single mechanical edit, so they are not lost.
+
+## Already resolved (no action needed)
+
+The following findings carry CodeRabbit "Addressed in commits ..."
+markers in the source PR threads; the fixes landed in follow-up commits
+on the source branch before merge.
+
+| Source PR | Comment id | File | Note |
+| --- | --- | --- | --- |
+| #1506 | 3266192266 | `.github/workflows/ci.yml` | Resolved on source branch. |
+| #1506 | 3266192303 | `.github/workflows/publish-homebrew.yml` | Resolved on source branch. |
+| #1506 | 3266291497 | `.github/actions/bootstrap/action.yml` | Stale; action is now pinned to `v8.1.0` and the SHA matches the upstream tag. |
+| #1512 | 3266397890 | `.github/workflows/sonar-scan.yml` | Resolved on source branch. |
+| #1514 | 3266403800 | `.github/workflows/sbom-upload.yml` | Current workflow already has a `gate` step that skips upload when `DT_API_URL` / `DT_API_KEY` are empty. |
+| #1561 | 3267193744 | `docs/orchestration/federation.md` | Resolved on source branch. |
+| #1561 | 3267193774 | `src/bernstein/core/orchestration/federation.py` | Resolved on source branch. |
+| #1562 | 3267230727 | `src/bernstein/core/observability/ticket_bundle.py` | Resolved on source branch. |
+| #1562 | 3267230740 | `src/bernstein/core/observability/ticket_bundle.py` | Resolved on source branch. |
+| #1562 | 3267230752 | `src/bernstein/core/observability/ticket_bundle.py` | Resolved on source branch. |
+| #1562 | 3267230778 | `src/bernstein/core/observability/ticket_bundle.py` | Resolved on source branch. |
+| #1562 | 3267230786 | `src/bernstein/core/observability/ticket_bundle.py` | Resolved on source branch. |
+| #1564 | 3267230565 | `src/bernstein/core/observability/trace_store.py` | Resolved on source branch. |
+| #1566 | 3267243727 | `src/bernstein/core/routes/telemetry_webhooks.py` | Resolved on source branch. |
+
+## Still deferred (design judgement required)
+
+| Source PR | Comment id | File | Why deferred |
+| --- | --- | --- | --- |
+| #1573 | 3267705054 | `src/bernstein/core/trackers/builtin/plane_adapter.py` | Adds a new `ui_base_url` field to the frozen `PlaneConfig` dataclass and changes the public config schema. Needs a config-schema decision and operator docs update; not a single-file mechanical edit. |
+| #1561 | 3267193786 | `src/bernstein/core/trackers/contract.py` | Migrating `custom_fields` from `dict` to an immutable `Mapping` (with `MappingProxyType` defaults) ripples through every adapter that reads/writes the field and through serialization helpers; needs a deliberate pass rather than a single-line edit. |
+| #1564 | 3267230535 | `src/bernstein/core/observability/trace_store.py` | Switching `TraceMetadataHints.started_at` / `cost_usd` to `float \| None` changes the dataclass defaults and the truthiness contract for `_build_entry`, `_hints_from_obj`, and the index serializer. Worth doing intentionally, but not a mechanical edit. |
+| #1563 | 3267228585 | `src/bernstein/core/git/snapshot.py` | Replacing direct `.git` path joins with `git rev-parse --path-format=absolute --git-common-dir` to support linked worktrees and gitfile-backed `.git` entries is a small surface change that needs targeted tests on a worktree fixture. |
+| #1563 | 3267228608 | `src/bernstein/core/git/snapshot.py` | Deriving the next stack index from on-disk refs (not from sidecar-filtered `stack_list()`) plus the `stack_clear` ref-vs-sidecar gap is a multi-function rework; defer until the stack semantics are revisited. |
+| #1560 | 3267194671 | `src/bernstein/core/trackers/builtin/github_projects_adapter.py` | `add_comment` advertises project-item-id support that is not wired through; implementing the item-to-content-id cache plus the `raw["content_id"]` fallback is a feature-shaped change, not a one-line fix. |
+| #1560 | 3267194701 | `src/bernstein/core/trackers/builtin/github_projects_adapter.py` | Distinguishing HTTP 403 abuse-detection from authorization failure requires inspecting response body / `Retry-After` headers; the current code treats all 403 as `RateLimited`, which the new regression test now locks in. Refining the classifier needs deliberate design work. |
+| #1560 | 3267194730 | `tests/unit/trackers/test_github_projects_adapter.py` | Replacing `dict[str, Any]` fixture builders with `TypedDict` / frozen dataclasses touches every helper in the file; left as a follow-up clean-up rather than mixing into the catch-up PR. |
+| #1559 | 3267211055 | `src/bernstein/core/memory/session_memory.py` | Making `Turn` frozen and replacing the persistence dict / `read_episodic` return type with a `RecallRecord` shape ripples through the entire memory module and its tests. Heavy lift; defer. |
+| #1559 | 3267211066 | `src/bernstein/core/memory/session_memory.py` | The semantic prune scope (`task_id` only vs `(task_id, session_id)`) is a deliberate design choice in the current code and docs; the bot finding contradicts the documented behaviour. Needs a design decision before changing SQL semantics. |
+| #1507 | 3266178395 | `.github/workflows/auto-heal.yml` | Adding local `actor` / `repository` guards to the reusable workflow requires deciding whether the workflow should be safely callable on its own or remain dispatcher-only. Operator question, not a mechanical edit. |

--- a/docs/trackers/github-projects.md
+++ b/docs/trackers/github-projects.md
@@ -43,9 +43,22 @@ trackers:
 
 ### Personal Access Token
 
-For solo developers and small teams, a fine-grained PAT with
-`read:project`, `repo`, and `write:project` is sufficient. Point the
-adapter at an environment variable holding the token:
+For solo developers and small teams, a fine-grained personal access
+token is sufficient. Fine-grained PATs use granular per-resource
+permissions rather than the classic scope strings, so configure the
+token with:
+
+- Organization permissions: **Projects: Read and write** (required for
+  Projects v2 API access; the project owner must be an organization for
+  fine-grained PATs).
+- Repository permissions: **Issues: Read and write** and
+  **Pull requests: Read and write** for the repositories whose content
+  is linked into the project.
+
+The legacy scope strings `read:project`, `repo`, and `write:project`
+only apply to classic PATs and are not valid fine-grained PAT
+permissions. Point the adapter at an environment variable holding the
+token:
 
 ```yaml
 trackers:

--- a/src/bernstein/cli/commands/bundle_cmd.py
+++ b/src/bernstein/cli/commands/bundle_cmd.py
@@ -73,14 +73,25 @@ def ticket_cmd(
       bernstein bundle ticket jira PROJ-9 --out PROJ-9.tar.gz \\
         --sign-key keys/lineage.pem --sign-kid lineage-2026
     """
-    if sign_key is not None and not sign_kid:
-        raise click.UsageError("--sign-kid is required when --sign-key is used")
+    # Validate signing inputs together before mutating any state on disk.
+    # --sign-key and --sign-kid must be supplied as a pair: a kid without a
+    # key cannot sign, and a key without a kid leaves the JWS header empty.
+    if bool(sign_key) != bool(sign_kid):
+        raise click.UsageError(
+            "--sign-key and --sign-kid must be provided together",
+        )
+
+    priv_pem: str | None = None
+    if sign_key is not None:
+        try:
+            priv_pem = sign_key.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise click.ClickException(f"could not read --sign-key: {exc}") from exc
 
     bundle = TicketBundle(workdir=workdir, tracker=tracker, ticket_id=ticket_id)
     manifest = bundle.assemble(out=out)
 
-    if sign_key is not None and sign_kid:
-        priv_pem = sign_key.read_text(encoding="utf-8")
+    if priv_pem is not None and sign_kid is not None:
         jws_path = bundle.sign(private_key_pem=priv_pem, kid=sign_kid)
         sig_note = f" Signed -> [bold]{jws_path}[/bold]."
     else:

--- a/src/bernstein/cli/commands/git_cmd.py
+++ b/src/bernstein/cli/commands/git_cmd.py
@@ -252,6 +252,11 @@ def stack_clear_cmd(task_id: str, workdir: str) -> None:
 )
 def gc_cmd(days: int, workdir: str) -> None:
     """Garbage-collect snapshots older than --days."""
+    # Negative retention windows would push the cutoff into the future and
+    # delete every snapshot, so reject them up front rather than rely on the
+    # store layer.
+    if days < 0:
+        raise click.BadParameter("--days must be non-negative", param_hint="--days")
     try:
         store = SnapshotStore(Path(workdir))
         deleted = store.gc(older_than_days=days)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -335,13 +335,19 @@ def _init_error_telemetry() -> None:
         return
     from bernstein import __version__
 
-    sentry_sdk.init(
-        dsn=dsn,
-        traces_sample_rate=0.0,
-        profiles_sample_rate=0.0,
-        send_default_pii=False,
-        release=__version__,
-    )
+    # ``sentry_sdk.init`` raises ``BadDsn`` for a malformed DSN. Telemetry
+    # is best-effort: a misconfigured DSN must not crash the CLI on import.
+    try:
+        sentry_sdk.init(
+            dsn=dsn,
+            traces_sample_rate=0.0,
+            profiles_sample_rate=0.0,
+            send_default_pii=False,
+            release=__version__,
+        )
+    except Exception:
+        # Best-effort import-time telemetry init: never crash the CLI.
+        return
 
 
 _init_error_telemetry()

--- a/src/bernstein/core/git/snapshot.py
+++ b/src/bernstein/core/git/snapshot.py
@@ -285,20 +285,23 @@ def _read_metadata(cwd: Path, snapshot_id: str) -> Snapshot | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+        return Snapshot(
+            snapshot_id=str(payload["snapshot_id"]),
+            tree_sha=str(payload["tree_sha"]),
+            ref=str(payload["ref"]),
+            ts_ns=int(payload["ts_ns"]),
+            task_id=payload.get("task_id"),
+            tool_call_id=payload.get("tool_call_id"),
+            agent_id=payload.get("agent_id"),
+            label=str(payload.get("label", "")),
+            parent_snapshot=payload.get("parent_snapshot"),
+        )
+    except (json.JSONDecodeError, OSError, KeyError, TypeError, ValueError) as exc:
+        # Treat schema-invalid sidecars as unreadable so callers degrade to
+        # the ref-backed snapshot instead of propagating KeyError / TypeError
+        # out of list()/get() and breaking the surrounding command.
         logger.warning("could not read snapshot metadata %s: %s", path, exc)
         return None
-    return Snapshot(
-        snapshot_id=str(payload["snapshot_id"]),
-        tree_sha=str(payload["tree_sha"]),
-        ref=str(payload["ref"]),
-        ts_ns=int(payload["ts_ns"]),
-        task_id=payload.get("task_id"),
-        tool_call_id=payload.get("tool_call_id"),
-        agent_id=payload.get("agent_id"),
-        label=str(payload.get("label", "")),
-        parent_snapshot=payload.get("parent_snapshot"),
-    )
 
 
 def _stack_ref(task_id: str, index: int) -> str:
@@ -564,6 +567,11 @@ class SnapshotStore:
         repository's normal maintenance schedule will reclaim the
         orphaned tree objects on the next pass.
         """
+        # Negative retention windows would push the cutoff into the future
+        # and delete every current snapshot. Fail fast instead of silently
+        # interpreting the input as "delete everything".
+        if older_than_days < 0:
+            raise SnapshotError("older_than_days must be non-negative")
         cutoff_ns = time.time_ns() - older_than_days * 86_400 * 1_000_000_000
         deleted: list[str] = []
         for snap in self.list():

--- a/src/bernstein/core/observability/lineage_alert.py
+++ b/src/bernstein/core/observability/lineage_alert.py
@@ -30,7 +30,7 @@ import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
-from bernstein.core.security.url_allowlist import ensure_http_url
+from bernstein.core.security.url_allowlist import UrlSchemeError, ensure_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -171,9 +171,19 @@ def sink_from_config(
     """
     if not enabled or not webhook_url:
         return NullAlertSink()
-    return WebhookAlertSink(
-        webhook_url,
-        headers=headers,
-        timeout_secs=timeout_secs,
-        max_retries=max_retries,
-    )
+    try:
+        return WebhookAlertSink(
+            webhook_url,
+            headers=headers,
+            timeout_secs=timeout_secs,
+            max_retries=max_retries,
+        )
+    except UrlSchemeError as exc:
+        # Maintain the "orchestrator never raises here" contract: log the
+        # invalid scheme and fall back to the no-op sink so a misconfigured
+        # webhook URL does not crash the run.
+        logger.warning(
+            "lineage alert: webhook URL rejected (%s); falling back to NullAlertSink",
+            exc,
+        )
+        return NullAlertSink()

--- a/src/bernstein/core/protocols/mcp/mcp_transport.py
+++ b/src/bernstein/core/protocols/mcp/mcp_transport.py
@@ -17,7 +17,7 @@ import subprocess
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
-from bernstein.core.security.url_allowlist import ensure_http_url
+from bernstein.core.security.url_allowlist import UrlSchemeError, ensure_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -233,8 +233,13 @@ class SseTransport:
 
         # Defence-in-depth: reject non-HTTP(S) schemes early. The network
         # policy below only checks host/port; without this guard a config
-        # like ``file:///etc/passwd`` would pass it through.
-        ensure_http_url(config.url, allow_http=True, source="mcp:sse")
+        # like ``file:///etc/passwd`` would pass it through. Wrap the
+        # scheme check so callers always see a :class:`TransportError`,
+        # matching the documented contract.
+        try:
+            ensure_http_url(config.url, allow_http=True, source="mcp:sse")
+        except UrlSchemeError as exc:
+            raise TransportError(str(exc)) from exc
         policy_from_env().check_url(config.url, source="mcp:sse")
         self._url = config.url
         self._timeout = config.timeout
@@ -303,7 +308,11 @@ class StreamableHttpTransport:
         from bernstein.core.security.network_policy import policy_from_env
 
         # Defence-in-depth scheme check; see :class:`SseTransport.connect`.
-        ensure_http_url(config.url, allow_http=True, source="mcp:streamable_http")
+        # Wrap ``UrlSchemeError`` so callers always see a ``TransportError``.
+        try:
+            ensure_http_url(config.url, allow_http=True, source="mcp:streamable_http")
+        except UrlSchemeError as exc:
+            raise TransportError(str(exc)) from exc
         policy_from_env().check_url(config.url, source="mcp:streamable_http")
         self._url = config.url
         self._timeout = config.timeout

--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -131,13 +131,24 @@ def _resolve_token(config: GitHubProjectsV2Config) -> str:
 
         private_key = ""
         if config.private_key_path:
-            with open(config.private_key_path) as fh:
-                private_key = fh.read()
+            try:
+                with open(config.private_key_path) as fh:
+                    private_key = fh.read()
+            except OSError as exc:
+                # Normalise file IO failures to the adapter's typed error
+                # surface so callers never see raw FileNotFoundError /
+                # PermissionError from the auth path.
+                msg = f"GitHub App private key could not be read: {config.private_key_path}"
+                raise TrackerUnavailable(msg) from exc
         else:
             env_pk = os.environ.get("GITHUB_APP_PRIVATE_KEY", "")
             if env_pk and os.path.isfile(env_pk):
-                with open(env_pk) as fh:
-                    private_key = fh.read()
+                try:
+                    with open(env_pk) as fh:
+                        private_key = fh.read()
+                except OSError as exc:
+                    msg = f"GitHub App private key could not be read: {env_pk}"
+                    raise TrackerUnavailable(msg) from exc
             else:
                 private_key = env_pk
         if not private_key:
@@ -511,6 +522,12 @@ class GitHubProjectsV2Adapter(AbstractTrackerAdapter):
     ) -> Ticket | None:
         content = raw_item.get("content") or {}
         kind = content.get("__typename")
+        # Skip items whose content is null or of an unknown typename. We
+        # only know how to materialise issues, PRs, and draft issues; any
+        # other shape produces tickets with empty title/body/content ids
+        # and pollutes downstream consumers.
+        if kind not in {"Issue", "PullRequest", "DraftIssue"}:
+            return None
         if kind == "DraftIssue" and not include_drafts:
             return None
 

--- a/tests/unit/scripts/test_sarif_drop_suppressed.py
+++ b/tests/unit/scripts/test_sarif_drop_suppressed.py
@@ -17,7 +17,9 @@ import importlib.util
 import json
 import subprocess
 import sys
+from collections.abc import Generator
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
@@ -27,7 +29,7 @@ SCRIPT_PATH = REPO_ROOT / "scripts" / "sarif_drop_suppressed.py"
 
 
 @pytest.fixture
-def sarif_module():
+def sarif_module() -> Generator[ModuleType, None, None]:
     """Load scripts/sarif_drop_suppressed.py as a module."""
     spec = importlib.util.spec_from_file_location("sarif_drop_suppressed_under_test", SCRIPT_PATH)
     assert spec is not None and spec.loader is not None

--- a/tests/unit/test_post_ci_dispatcher_yaml.py
+++ b/tests/unit/test_post_ci_dispatcher_yaml.py
@@ -101,6 +101,10 @@ def test_dispatcher_calls_each_child(dispatcher: dict[str, Any], child: str) -> 
     assert isinstance(uses, str)
     assert uses.endswith(f"{child}.yml"), f"job `{child}` must reuse `{child}.yml`"
     secrets = job.get("secrets")
+    assert child in EXPECTED_CHILD_SECRETS, (
+        f"EXPECTED_CHILD_SECRETS is missing an entry for child job `{child}` "
+        f"(did you forget to update EXPECTED_CHILD_SECRETS when adding `{child}` to CHILDREN?)"
+    )
     expected = EXPECTED_CHILD_SECRETS[child]
     if not expected:
         assert secrets in (None, {}), (

--- a/tests/unit/trackers/test_github_projects_adapter.py
+++ b/tests/unit/trackers/test_github_projects_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
@@ -360,11 +361,15 @@ def test_add_comment_targets_underlying_subject() -> None:
 
     assert result.comment_id == "IC_1"
     assert result.ticket_id == "I_1"
-    # Inspect the captured mutation payload.
+    # Inspect the captured mutation payload. Parse JSON rather than match
+    # raw byte substrings so formatting / key-order changes in the request
+    # serializer do not flap the assertions.
     sent = route.calls[0].request
-    assert b"addComment" in sent.content
-    assert b'"subjectId":"I_1"' in sent.content
-    assert b'"clientMutationId":"k1"' in sent.content
+    payload = json.loads(sent.content.decode("utf-8"))
+    assert "addComment" in payload.get("query", "")
+    variables = payload.get("variables") or {}
+    assert variables.get("subjectId") == "I_1"
+    assert variables.get("clientMutationId") == "k1"
 
 
 # ---------------------------------------------------------------------------
@@ -457,6 +462,31 @@ def test_rate_limit_with_retry_after_header() -> None:
     finally:
         adapter.close()
     assert exc.value.retry_after == 17.0
+
+
+@respx.mock
+def test_abuse_detection_rate_limit_403() -> None:
+    """HTTP 403 abuse-detection responses surface as ``RateLimited``.
+
+    GitHub returns 403 (not 429) for the abuse-detection / secondary
+    rate-limit branch. The adapter must map this to the typed
+    :class:`RateLimited` error so retry orchestration sees the same
+    signal as a 429.
+    """
+    adapter = _make_adapter()
+    respx.post(GITHUB_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            403,
+            json={"message": "You have exceeded a secondary rate limit"},
+            headers={"Retry-After": "23"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 23.0
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

Follow-up pass to PR #1584. That PR inventoried 48 review-bot findings
and landed mechanical fixes for 4; this PR triages the remaining 44.

Source manifest: #1584.

## Counts

| Bucket | Count |
| --- | --- |
| Applied here | 19 |
| Already resolved on source PRs (CodeRabbit "Addressed in commits ...") | 14 |
| Deferred for design judgement | 11 |
| Total triaged in this PR | 44 |

The 14 already-resolved findings and the 11 deferred items are tracked
in `docs/review-bot/deferred-2026-05-19.md` so they are not lost.

## Applied fixes (one line each)

- docs/orchestration/failure-taxonomy.md: clarify the literal closing fence string in step 2 of the consumer contract. (3267682314)
- docs/memory/session-memory.md: prune scope reads as two distinct scopes (episodic = session, semantic = task) instead of one contradictory paragraph. (3267211040)
- docs/operations/post-ci-dispatcher.md: add ``text`` language tag to the sequence-diagram fence so markdownlint MD040 passes. (3266190394)
- docs/trackers/github-projects.md: replace classic PAT scope strings with the fine-grained PAT permission model. (3267194597)
- src/bernstein/cli/commands/bundle_cmd.py: validate sign inputs as a pair and read the private key before assembling the bundle. (3267230670)
- src/bernstein/cli/commands/git_cmd.py: reject negative ``--days`` for ``bernstein git gc`` before constructing SnapshotStore. (3267228578)
- src/bernstein/cli/main.py: wrap ``sentry_sdk.init`` in a best-effort try/except so a malformed ``GLITCHTIP_DSN`` cannot crash the CLI on import. (3266207374)
- src/bernstein/core/git/snapshot.py: treat schema-invalid snapshot sidecars as unreadable metadata (return None and warn) instead of raising KeyError/TypeError/ValueError through ``get()`` / ``list()``. (3267228593)
- src/bernstein/core/git/snapshot.py: reject negative ``older_than_days`` in ``SnapshotStore.gc`` before computing the cutoff. (3267228601)
- src/bernstein/core/observability/lineage_alert.py: catch ``UrlSchemeError`` in ``sink_from_config`` and fall back to ``NullAlertSink``, preserving the "orchestrator never raises here" contract. (3266517982)
- src/bernstein/core/protocols/mcp/mcp_transport.py: wrap ``UrlSchemeError`` from ``ensure_http_url`` as ``TransportError`` in ``SseTransport.connect``. (3266518004)
- src/bernstein/core/protocols/mcp/mcp_transport.py: same wrap in ``StreamableHttpTransport.connect``. (3266518017)
- src/bernstein/core/trackers/builtin/github_projects_adapter.py: catch OSError around GitHub App private-key reads and raise ``TrackerUnavailable``. (3267194655)
- src/bernstein/core/trackers/builtin/github_projects_adapter.py: skip items whose ``content.__typename`` is not Issue/PullRequest/DraftIssue rather than emitting tickets with empty title/body/content-ids. (3267194694)
- tests/unit/scripts/test_sarif_drop_suppressed.py: annotate the ``sarif_module`` fixture return type as ``Generator[ModuleType, None, None]``. (3267028369)
- tests/unit/test_post_ci_dispatcher_yaml.py: explicit assertion message when ``EXPECTED_CHILD_SECRETS`` is missing an entry for a child rather than a bare KeyError. (3266435436)
- tests/unit/trackers/test_github_projects_adapter.py: parse the GraphQL request body as JSON and assert against ``variables`` rather than byte-substring against raw ``request.content``. (3267194733)
- tests/unit/trackers/test_github_projects_adapter.py: add ``test_abuse_detection_rate_limit_403`` regression test covering the HTTP 403 abuse-detection -> ``RateLimited`` mapping. (3267194743)
- .github/workflows/sbom-upload.yml: generate the SBOM from an isolated venv where only the project and its resolved dependencies are installed. (3266207355)

## Deferred

Tracked in `docs/review-bot/deferred-2026-05-19.md`. Each deferred
item has a one-line "why deferred" rationale. The largest buckets:

- Config-schema or frozen-dataclass migrations that ripple through
  multiple files (Plane ui_base_url, trackers/contract custom_fields,
  TraceMetadataHints Optional defaults, Turn frozen + RecallRecord).
- git worktree / linked-worktree git-dir resolution in
  ``core/git/snapshot.py``.
- session_memory semantic prune scope (current code and docs say
  task-scoped is intentional; the bot finding disagrees and needs a
  design decision).
- Reusable-workflow guards in ``auto-heal.yml`` (operator choice
  whether the workflow should be safely callable on its own).

## Test plan

- [x] ``ruff check`` clean on all modified files.
- [x] ``ruff format --check`` clean on all modified files.
- [x] Targeted unit tests on affected modules pass: lineage_alert,
  sarif_drop_suppressed, post_ci_dispatcher, github_projects_adapter,
  cli_snapshots, ticket_bundle, mcp_config, mcp_composition,
  mcp_resource_cache (140+ tests, all green).
- [ ] CI green.

## Summary by Sourcery

Apply a batch of review-bot-driven cleanups and hardening changes across CLI commands, Git snapshot handling, GitHub Projects tracking, MCP transports, observability sinks, documentation, tests, and the SBOM workflow.

Bug Fixes:
- Prevent malformed Sentry DSNs from crashing the CLI by making error-telemetry initialization best-effort.
- Ensure snapshot garbage collection and CLI wrappers reject negative retention periods instead of accidentally deleting all snapshots.
- Treat unreadable or schema-invalid snapshot metadata sidecars as missing so snapshot listing and lookup degrade gracefully instead of raising.
- Normalize GitHub App private-key read failures to a typed TrackerUnavailable error and skip unsupported/empty GitHub project items when materialising tickets.
- Map GitHub abuse-detection HTTP 403 responses to the RateLimited error with an explicit regression test, and make GraphQL mutation tests resilient to payload formatting changes.
- Preserve the non-raising contract for lineage alert sinks and MCP transports by catching UrlSchemeError and converting it to safe fallbacks or TransportError.
- Improve post-CI dispatcher YAML tests to give clearer failures when expected child secret mappings are missing and type-annotate the SARIF fixture for correctness.

Enhancements:
- Clarify the documented pruning semantics for session memory and refine the GitHub Projects tracker documentation to describe fine-grained PAT permissions instead of legacy scopes.
- Clarify orchestration failure-taxonomy fencing rules and mark the post-CI dispatcher sequence diagram as text for better linting.
- Tighten ticket bundle signing UX by validating signing options together, reading the key once, and surfacing read failures as Click exceptions.

Build:
- Change the SBOM GitHub workflow to generate the CycloneDX SBOM from an isolated virtual environment containing only the project and its resolved dependencies.

Documentation:
- Add a tracking document for deferred and already-resolved review-bot findings from the 2026-05-19 catch-up, including rationale for deferred items.

Tests:
- Add a regression test for GitHub Projects abuse-detection 403 responses mapping to RateLimited and make GraphQL payload assertions schema-aware instead of string-based.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for CLI command parameters and telemetry initialization to prevent crashes from invalid inputs.
  * Improved robustness when reading credentials and metadata files with clearer error messages.
  * Added detection and handling of GitHub rate-limit responses during ticket operations.

* **Documentation**
  * Updated authentication guidance for tracker adapters and clarified operational procedures.

* **Tests**
  * Expanded test coverage for rate-limiting and error scenarios.

* **Chores**
  * Optimized SBOM generation workflow with isolated dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->