### PR TITLE
feat(adapters): canonical stream-signal protocol for adapter stdout

### DIFF
--- a/docs/adapters/stream_signals.md
+++ b/docs/adapters/stream_signals.md
@@ -1,0 +1,154 @@
+# Adapter stream-signal protocol
+
+A small, line-oriented vocabulary that any wrapped CLI can emit on its
+stdout to participate in the same lifecycle that stream-json adapters
+already expose: completion, question-asking, plan handoff, and blocked
+state.
+
+The protocol is **additive**. Adapters with a rich native event format
+(Claude Code stream-json, Codex stream-json) keep their native shape;
+the canonical signals are an optional overlay so non-stream-json CLIs
+can join the same event bus without inventing a per-adapter event API.
+
+## Grammar
+
+Every canonical signal lives on a single line.
+
+```
+BERNSTEIN:<KIND>[ <json-object>]
+```
+
+Rules:
+
+| Rule | Notes |
+|---|---|
+| Prefix | Literal `BERNSTEIN:` (case-sensitive, colon included). |
+| Kind | One of the canonical kinds below, ALL-CAPS. |
+| Separator | One space between kind and payload. |
+| Payload | Optional JSON **object** (never an array, scalar, or `null`). |
+| Encoding | UTF-8. Single line; no embedded newlines. |
+
+Lines that don't match this grammar are treated as plain stdout and
+ignored by the parser.
+
+## Canonical kinds
+
+| Kind | Terminal? | Payload shape |
+|---|---|---|
+| `COMPLETED` | yes | `{}` (or adapter-specific extras) |
+| `FAILED` | yes | `{"reason": str, ...}` (optional) |
+| `QUESTION` | no | `{"question": str, "options": list[str] \| null, "id": str \| null}` |
+| `PLAN_DRAFT` | no | `{"markdown": str, "path": str \| null}` |
+| `PLAN_READY` | no | `{"path": str}` (under `.sdd/`) |
+| `BLOCKED` | no | `{"reason": str, "hint": str \| null}` |
+
+Conformance checks expect at least one terminal signal (`COMPLETED` or
+`FAILED`) per adapter run. Missing terminals surface as a
+`MissingTerminalSignal` warning in the conformance report — not a
+failure, so adapters that have not yet adopted the vocabulary keep
+passing while the gap stays visible.
+
+## Wrapper-script examples
+
+### Bash
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the real CLI.
+if my-cli "$@"; then
+  printf 'BERNSTEIN:COMPLETED\n'
+else
+  rc=$?
+  printf 'BERNSTEIN:FAILED {"reason":"exit %d"}\n' "$rc"
+  exit $rc
+fi
+```
+
+### Bash — ask a question mid-run
+
+```bash
+# Emit before blocking on operator input. The orchestrator routes the
+# reply back via stdin (or whatever IPC channel the adapter uses).
+printf 'BERNSTEIN:QUESTION %s\n' \
+  '{"question":"Apply migration?","options":["yes","no"],"id":"q-001"}'
+```
+
+### Python wrapper
+
+```python
+from bernstein.core.protocols.stream_signals import SignalKind, format_signal
+
+print(format_signal(SignalKind.PLAN_DRAFT, {"markdown": "# Plan\n- step 1"}))
+print(format_signal(SignalKind.COMPLETED))
+```
+
+`format_signal` produces the same wire format as the shell snippet
+above. The grammar is intentionally small enough that producers don't
+need to share a library — Python adapters can use the helper, shell
+wrappers can `printf` directly.
+
+## Mapping a native protocol onto the canonical vocabulary
+
+Adapters whose upstream CLI already emits structured events override
+the `stream_signal_parser` method on `CLIAdapter` and translate native
+events into `StreamSignal` instances:
+
+```python
+from bernstein.adapters.base import CLIAdapter
+from bernstein.core.protocols.stream_signals import SignalKind, StreamSignal
+
+
+class MyAdapter(CLIAdapter):
+    def stream_signal_parser(self, line: str) -> StreamSignal | None:
+        # Native protocol: one JSON object per line.
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Fall back to canonical grammar for downstream tools.
+            return super().stream_signal_parser(line)
+        if event.get("type") == "finish":
+            return StreamSignal(
+                kind=SignalKind.COMPLETED if event.get("ok") else SignalKind.FAILED,
+                payload=event,
+                raw_line=line,
+            )
+        return None
+```
+
+The default implementation already handles plain canonical signals, so
+adapters with no native protocol don't need to override anything.
+
+## Question round-trip
+
+A `QUESTION` signal carries enough payload to route a reply back to the
+correct in-flight question:
+
+1. Adapter emits `BERNSTEIN:QUESTION {"question":"...", "options":[...], "id":"q-1"}`.
+2. Orchestrator surfaces the question via the existing approval /
+   elicitation path.
+3. Operator answer is wrapped in `{"in_reply_to": "q-1", "answer": "..."}`
+   and delivered back over the adapter's existing stdin/IPC channel.
+
+The `id` field is optional. Adapters that never have more than one
+question in flight may omit it; the orchestrator falls back to
+first-in-first-out matching.
+
+## Plan handoff
+
+Adapters that produce planning artefacts emit two signals:
+
+* `BERNSTEIN:PLAN_DRAFT {"markdown": "..."}` while the plan is still
+  being refined.
+* `BERNSTEIN:PLAN_READY {"path": ".sdd/plans/<slug>.md"}` once the
+  markdown has been written to disk.
+
+Downstream phases (`bernstein plan execute`, subagent dispatch, etc.)
+watch for `PLAN_READY` and pick up the file from `.sdd/`.
+
+## Out of scope
+
+* Replacing stream-json parsing for Claude or Codex.
+* Binary or framed-byte protocols.
+* Multi-line payloads (use a path-based handoff instead).

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -768,6 +768,37 @@ class CLIAdapter(ABC):
         """
         return None
 
+    def stream_signal_parser(self, line: str) -> object | None:
+        """Map one line of adapter stdout to a canonical stream signal.
+
+        The default implementation delegates to
+        :func:`bernstein.core.protocols.stream_signals.parse_signal`,
+        which recognises any line that follows the canonical
+        ``BERNSTEIN:<KIND> [json]`` grammar.
+
+        Adapters whose upstream CLI emits a different native protocol
+        (Claude stream-json, Codex stream-json, etc.) override this
+        method to translate their native event shape onto the canonical
+        :class:`~bernstein.core.protocols.stream_signals.SignalKind`
+        vocabulary, so the orchestrator can observe completion,
+        question, plan-handoff, and blocked events through one
+        interface regardless of upstream wire format.
+
+        Args:
+            line: One line of adapter stdout (newline-stripped or not).
+
+        Returns:
+            A
+            :class:`~bernstein.core.protocols.stream_signals.StreamSignal`
+            when the line carries a recognised signal, otherwise
+            ``None``. The return type is declared as ``object`` so
+            adapter subclasses are not forced to import the protocol
+            module just to satisfy the signature.
+        """
+        from bernstein.core.protocols.stream_signals import parse_signal
+
+        return parse_signal(line)
+
     def continuation_args(self, _session_id: str) -> list[str]:
         """Return CLI flags that re-enter the adapter's prior session.
 

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -34,6 +34,11 @@ import yaml
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
 from bernstein.core.models import ModelConfig
+from bernstein.core.protocols.stream_signals import (
+    MissingTerminalSignal,
+    has_terminal_signal,
+    iter_signals,
+)
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -166,9 +171,15 @@ class ConformanceReport:
     Args:
         results: Per-transcript outcomes.
         regressions: Transcript names that failed conformance.
+        missing_terminal_signal: Adapter run identifiers whose stdout
+            log did not contain a terminal signal (``COMPLETED`` or
+            ``FAILED``). Surfaced as a soft warning rather than a
+            failure so legacy adapters that have not yet been wired to
+            the canonical vocabulary still pass.
     """
 
     results: list[TranscriptResult] = field(default_factory=list)
+    missing_terminal_signal: list[str] = field(default_factory=list)
 
     @property
     def regressions(self) -> list[str]:
@@ -185,8 +196,36 @@ class ConformanceReport:
         return {
             "passed": self.passed,
             "regressions": self.regressions,
+            "missing_terminal_signal": list(self.missing_terminal_signal),
             "results": [r.to_dict() for r in self.results],
         }
+
+
+def check_terminal_signal(stdout_lines: list[str], *, run_id: str) -> MissingTerminalSignal | None:
+    """Return a warning when ``stdout_lines`` carry no terminal signal.
+
+    Called by the conformance harness (and by operator tools) after an
+    adapter run finishes. The check is advisory: the absence of a
+    terminal signal does not fail the run, it only surfaces in the
+    conformance report so adapters that have not yet been wired to the
+    canonical vocabulary are easy to find.
+
+    Args:
+        stdout_lines: The captured stdout for one adapter run.
+        run_id: An identifier (transcript name, session id, ...) used
+            in the warning message so operators can locate the run.
+
+    Returns:
+        ``None`` when the run emitted at least one terminal signal,
+        otherwise a :class:`MissingTerminalSignal` warning instance
+        ready for the caller to log or raise.
+    """
+    signals = iter_signals(stdout_lines)
+    if has_terminal_signal(signals):
+        return None
+    return MissingTerminalSignal(
+        f"adapter run {run_id!r} did not emit a terminal stream signal (COMPLETED or FAILED)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -223,9 +223,7 @@ def check_terminal_signal(stdout_lines: list[str], *, run_id: str) -> MissingTer
     signals = iter_signals(stdout_lines)
     if has_terminal_signal(signals):
         return None
-    return MissingTerminalSignal(
-        f"adapter run {run_id!r} did not emit a terminal stream signal (COMPLETED or FAILED)"
-    )
+    return MissingTerminalSignal(f"adapter run {run_id!r} did not emit a terminal stream signal (COMPLETED or FAILED)")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/protocols/stream_signals.py
+++ b/src/bernstein/core/protocols/stream_signals.py
@@ -1,0 +1,284 @@
+"""Canonical stream-signal protocol for adapter stdout.
+
+Defines a tiny text-line vocabulary that any wrapped CLI can emit to
+participate in the same lifecycle that stream-json adapters already
+expose (completion, question-asking, plan handoff, blocked state).
+
+The signal grammar is intentionally small and trivially producible from
+a shell wrapper script:
+
+* Every signal lives on a single line.
+* Every signal starts with the literal prefix ``BERNSTEIN:``.
+* The next token is the signal kind (e.g. ``COMPLETED``, ``FAILED``,
+  ``QUESTION``, ``PLAN_DRAFT``, ``PLAN_READY``, ``BLOCKED``).
+* An optional trailing JSON object carries a payload, e.g.
+  ``BERNSTEIN:QUESTION {"question": "Proceed?", "options": ["y", "n"]}``.
+
+The parser is robust against malformed lines: it never raises on bad
+input — it returns ``None`` so the caller can simply continue scanning
+the stream.
+
+The vocabulary is **additive**: stream-json adapters (Claude, Codex)
+keep their native protocol. The canonical signals are an optional
+overlay so non-stream-json CLIs can join the same event bus.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+#: Literal prefix every canonical signal line starts with. The colon is
+#: part of the prefix so a stray ``BERNSTEIN`` mention in normal output
+#: cannot be mistaken for a signal.
+SIGNAL_PREFIX: str = "BERNSTEIN:"
+
+
+class SignalKind(str, Enum):  # noqa: UP042 - explicit str base for wire-token round-trips
+    """Canonical signal kinds emitted by adapter stdout.
+
+    The string values are the wire tokens that follow the
+    ``BERNSTEIN:`` prefix on the line. Operators read these directly in
+    log tails, so the spelling is fixed and ALL-CAPS.
+    """
+
+    COMPLETED = "COMPLETED"
+    """Terminal signal: the adapter finished its task successfully."""
+
+    FAILED = "FAILED"
+    """Terminal signal: the adapter ran to completion but failed."""
+
+    QUESTION = "QUESTION"
+    """The adapter is asking the operator a clarifying question.
+
+    Payload shape: ``{"question": str, "options": list[str] | None,
+    "id": str | None}``. The optional ``id`` lets the orchestrator route
+    a reply back to the correct in-flight question when multiple are in
+    flight on the same adapter (rare, but possible).
+    """
+
+    PLAN_DRAFT = "PLAN_DRAFT"
+    """A draft plan is being staged; not yet authoritative.
+
+    Payload shape: ``{"markdown": str, "path": str | None}``. When
+    ``path`` is given it should be a relative path under ``.sdd/``.
+    """
+
+    PLAN_READY = "PLAN_READY"
+    """A plan is finalised and ready to drive downstream phases.
+
+    Payload shape: ``{"path": str}``, with ``path`` pointing at the
+    markdown artefact under ``.sdd/``.
+    """
+
+    BLOCKED = "BLOCKED"
+    """The adapter is alive but cannot make progress without help.
+
+    Payload shape: ``{"reason": str, "hint": str | None}``. This is
+    explicitly *not* terminal: an orchestrator may resolve the block
+    (deliver missing credentials, unblock a peer) and resume the
+    adapter.
+    """
+
+
+#: Signal kinds that end a session. Conformance reports flag any adapter
+#: run that did not emit at least one of these.
+TERMINAL_SIGNAL_KINDS: frozenset[SignalKind] = frozenset({SignalKind.COMPLETED, SignalKind.FAILED})
+
+
+# ---------------------------------------------------------------------------
+# Parsed event
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StreamSignal:
+    """One parsed canonical signal.
+
+    Attributes:
+        kind: The :class:`SignalKind` member identified on the line.
+        payload: Decoded JSON object, or empty dict when the line carried
+            no payload. Always a dict — payloads that decode to lists,
+            strings, or numbers are rejected at parse time and return
+            ``None`` from :func:`parse_signal` since the canonical shape
+            is always an object.
+        raw_line: The original line text (with trailing newline stripped),
+            preserved for log/debug output.
+    """
+
+    kind: SignalKind
+    payload: dict[str, Any] = field(default_factory=dict)
+    raw_line: str = ""
+
+    @property
+    def is_terminal(self) -> bool:
+        """True when this signal ends the adapter's session."""
+        return self.kind in TERMINAL_SIGNAL_KINDS
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def parse_signal(line: str) -> StreamSignal | None:
+    """Decode one line of adapter stdout into a :class:`StreamSignal`.
+
+    The parser is deliberately tolerant. It returns ``None`` for any
+    line that is not a well-formed canonical signal so the caller can
+    treat the stream as a mix of free-form output and structured
+    signals without special-casing every variant.
+
+    Args:
+        line: One line of adapter stdout. May include or omit the
+            trailing newline; leading and trailing whitespace are
+            stripped before parsing.
+
+    Returns:
+        A :class:`StreamSignal` when the line matches the grammar,
+        otherwise ``None``. Lines that match the prefix but carry an
+        unknown kind or a malformed JSON payload also yield ``None`` —
+        with a debug log entry so operators investigating wrapper
+        bugs can find them.
+    """
+    if not isinstance(line, str):
+        return None
+
+    stripped = line.strip()
+    if not stripped or not stripped.startswith(SIGNAL_PREFIX):
+        return None
+
+    # Strip prefix, then peel off the kind token.
+    body = stripped[len(SIGNAL_PREFIX) :].lstrip()
+    if not body:
+        return None
+
+    # Split into "<KIND>" and optional "<json...>".
+    parts = body.split(None, 1)
+    kind_token = parts[0]
+    payload_text = parts[1].strip() if len(parts) == 2 else ""
+
+    try:
+        kind = SignalKind(kind_token)
+    except ValueError:
+        logger.debug("stream_signals: unknown signal kind %r in line %r", kind_token, stripped)
+        return None
+
+    payload: dict[str, Any] = {}
+    if payload_text:
+        try:
+            decoded = json.loads(payload_text)
+        except json.JSONDecodeError as exc:
+            logger.debug("stream_signals: malformed JSON payload for %s: %s (line=%r)", kind, exc, stripped)
+            return None
+        if not isinstance(decoded, dict):
+            logger.debug(
+                "stream_signals: payload for %s is %s, expected object (line=%r)",
+                kind,
+                type(decoded).__name__,
+                stripped,
+            )
+            return None
+        payload = decoded
+
+    return StreamSignal(kind=kind, payload=payload, raw_line=stripped)
+
+
+def iter_signals(lines: list[str] | tuple[str, ...]) -> list[StreamSignal]:
+    """Parse a batch of lines, dropping non-signal noise.
+
+    Convenience helper for callers that want to scan a buffered stdout
+    chunk (e.g. a log tail) for canonical signals without writing the
+    filter loop themselves. Lines that don't parse are silently
+    dropped — that's the whole point of the canonical signal having a
+    unique prefix.
+
+    Args:
+        lines: An iterable of stdout lines.
+
+    Returns:
+        Ordered list of parsed signals in the order they appeared.
+    """
+    out: list[StreamSignal] = []
+    for line in lines:
+        signal = parse_signal(line)
+        if signal is not None:
+            out.append(signal)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Producer-side helpers (for adapter wrappers written in Python)
+# ---------------------------------------------------------------------------
+
+
+def format_signal(kind: SignalKind, payload: dict[str, Any] | None = None) -> str:
+    """Render a signal as a wire-format line (no trailing newline).
+
+    Adapter wrappers written in Python can use this helper to emit
+    canonical signals without hand-formatting the prefix and JSON.
+    Shell wrappers do the same job with a literal ``printf`` — the
+    grammar is intentionally small enough that both producers stay in
+    sync without sharing a library.
+
+    Args:
+        kind: The signal kind.
+        payload: Optional JSON-serialisable payload object. Pass
+            ``None`` (or an empty dict) to emit a payload-less signal.
+
+    Returns:
+        A single line of text suitable for ``print()``.
+
+    Raises:
+        TypeError: If ``payload`` is not a dict.
+        ValueError: If ``payload`` contains values that are not JSON
+            serialisable.
+    """
+    if payload is None:
+        return f"{SIGNAL_PREFIX}{kind.value}"
+    if not isinstance(payload, dict):
+        raise TypeError(f"payload must be a dict, got {type(payload).__name__}")
+    try:
+        body = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"payload for {kind.value} is not JSON serialisable: {exc}") from exc
+    return f"{SIGNAL_PREFIX}{kind.value} {body}"
+
+
+# ---------------------------------------------------------------------------
+# Conformance support
+# ---------------------------------------------------------------------------
+
+
+class MissingTerminalSignal(RuntimeWarning):
+    """Raised (or logged) when an adapter run produced no terminal signal.
+
+    The conformance harness uses this as a soft warning class so a
+    missing ``COMPLETED``/``FAILED`` line surfaces in the report
+    without aborting the rest of the suite.
+    """
+
+
+def has_terminal_signal(signals: list[StreamSignal] | tuple[StreamSignal, ...]) -> bool:
+    """Return True when ``signals`` contains at least one terminal kind.
+
+    Args:
+        signals: Iterable of parsed signals, typically the output of
+            :func:`iter_signals` over an adapter's full stdout log.
+
+    Returns:
+        ``True`` if any signal is :attr:`SignalKind.COMPLETED` or
+        :attr:`SignalKind.FAILED`, ``False`` otherwise.
+    """
+    return any(sig.is_terminal for sig in signals)

--- a/tests/unit/adapters/test_signal_adapter.py
+++ b/tests/unit/adapters/test_signal_adapter.py
@@ -157,7 +157,7 @@ class TestDefaultParser:
 # ---------------------------------------------------------------------------
 
 
-class TestOverridenParser:
+class TestOverriddenParser:
     """Adapters that override the hook can map native events to canonical."""
 
     def test_native_finish_ok_maps_to_completed(self) -> None:
@@ -185,7 +185,7 @@ class TestOverridenParser:
     def test_override_falls_back_to_canonical(self) -> None:
         """Override still accepts plain canonical signals."""
         adapter = _NativeJsonAdapter()
-        result = adapter.stream_signal_parser("BERNSTEIN:BLOCKED {\"reason\":\"x\"}")
+        result = adapter.stream_signal_parser('BERNSTEIN:BLOCKED {"reason":"x"}')
         assert isinstance(result, StreamSignal)
         assert result.kind is SignalKind.BLOCKED
 
@@ -314,7 +314,7 @@ def test_unknown_signal_is_skipped_in_stream() -> None:
     """One bad signal between two good ones must not break the others."""
     adapter = _StubAdapter()
     lines = [
-        "BERNSTEIN:PLAN_DRAFT {\"markdown\":\"# a\"}",
+        'BERNSTEIN:PLAN_DRAFT {"markdown":"# a"}',
         "BERNSTEIN:UNSUPPORTED_KIND",
         "BERNSTEIN:QUESTION {malformed",
         "BERNSTEIN:COMPLETED",

--- a/tests/unit/adapters/test_signal_adapter.py
+++ b/tests/unit/adapters/test_signal_adapter.py
@@ -1,0 +1,334 @@
+"""Tests for the adapter ``stream_signal_parser`` hook.
+
+These cover the default delegation to the canonical parser, the
+override path used by adapters that map a native protocol onto the
+canonical vocabulary, the conformance-side terminal-signal check, and
+graceful handling of unknown / malformed signals on a live stream.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.adapters.conformance import (
+    ConformanceReport,
+    check_terminal_signal,
+)
+from bernstein.core.protocols.stream_signals import (
+    MissingTerminalSignal,
+    SignalKind,
+    StreamSignal,
+    format_signal,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _StubAdapter(CLIAdapter):
+    """Minimal adapter used to exercise the default parser hook."""
+
+    def name(self) -> str:
+        return "stub"
+
+    def spawn(  # type: ignore[override]
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        # The test never invokes spawn(); we only need the parser hook.
+        raise NotImplementedError("not used in these tests")
+
+
+class _NativeJsonAdapter(CLIAdapter):
+    """Adapter that emits a fake native protocol and translates it.
+
+    The fictional native format is one JSON object per line with a
+    ``type`` field. The adapter overrides ``stream_signal_parser`` to
+    map ``{"type":"finish","ok":true}`` onto :attr:`SignalKind.COMPLETED`,
+    ``{"type":"finish","ok":false}`` onto :attr:`SignalKind.FAILED`,
+    and ``{"type":"ask","prompt":..., "choices":[...]}`` onto
+    :attr:`SignalKind.QUESTION`.
+    """
+
+    def name(self) -> str:
+        return "nativejson"
+
+    def spawn(  # type: ignore[override]
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        raise NotImplementedError("not used in these tests")
+
+    def stream_signal_parser(self, line: str) -> StreamSignal | None:
+        import json as _json
+
+        stripped = line.strip()
+        if not stripped.startswith("{"):
+            # Fall back to canonical grammar so this adapter still
+            # accepts pass-through BERNSTEIN: lines emitted from
+            # downstream tools.
+            return super().stream_signal_parser(line)  # type: ignore[return-value]
+        try:
+            obj = _json.loads(stripped)
+        except _json.JSONDecodeError:
+            return None
+        if not isinstance(obj, dict):
+            return None
+        kind = obj.get("type")
+        if kind == "finish":
+            return StreamSignal(
+                kind=SignalKind.COMPLETED if obj.get("ok") else SignalKind.FAILED,
+                payload={k: v for k, v in obj.items() if k not in {"type"}},
+                raw_line=stripped,
+            )
+        if kind == "ask":
+            return StreamSignal(
+                kind=SignalKind.QUESTION,
+                payload={
+                    "question": obj.get("prompt", ""),
+                    "options": obj.get("choices", []),
+                },
+                raw_line=stripped,
+            )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Default parser hook
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultParser:
+    """Default ``stream_signal_parser`` delegates to canonical parsing."""
+
+    def test_default_parses_canonical_completed(self) -> None:
+        adapter = _StubAdapter()
+        result = adapter.stream_signal_parser("BERNSTEIN:COMPLETED")
+        assert isinstance(result, StreamSignal)
+        assert result.kind is SignalKind.COMPLETED
+
+    def test_default_parses_canonical_question_with_payload(self) -> None:
+        adapter = _StubAdapter()
+        line = format_signal(SignalKind.QUESTION, {"question": "go?", "options": ["y", "n"]})
+        result = adapter.stream_signal_parser(line)
+        assert isinstance(result, StreamSignal)
+        assert result.kind is SignalKind.QUESTION
+        assert result.payload["question"] == "go?"
+
+    def test_default_returns_none_for_plain_log_line(self) -> None:
+        adapter = _StubAdapter()
+        assert adapter.stream_signal_parser("just a log line") is None
+
+    def test_default_returns_none_for_unknown_kind(self) -> None:
+        adapter = _StubAdapter()
+        assert adapter.stream_signal_parser("BERNSTEIN:NOPE_NOT_A_KIND") is None
+
+    def test_default_returns_none_for_malformed_payload(self) -> None:
+        adapter = _StubAdapter()
+        assert adapter.stream_signal_parser("BERNSTEIN:QUESTION {bad json}") is None
+
+
+# ---------------------------------------------------------------------------
+# Override path: native protocol translation
+# ---------------------------------------------------------------------------
+
+
+class TestOverridenParser:
+    """Adapters that override the hook can map native events to canonical."""
+
+    def test_native_finish_ok_maps_to_completed(self) -> None:
+        adapter = _NativeJsonAdapter()
+        result = adapter.stream_signal_parser('{"type":"finish","ok":true}')
+        assert isinstance(result, StreamSignal)
+        assert result.kind is SignalKind.COMPLETED
+        assert result.is_terminal
+
+    def test_native_finish_fail_maps_to_failed(self) -> None:
+        adapter = _NativeJsonAdapter()
+        result = adapter.stream_signal_parser('{"type":"finish","ok":false}')
+        assert isinstance(result, StreamSignal)
+        assert result.kind is SignalKind.FAILED
+        assert result.is_terminal
+
+    def test_native_ask_maps_to_question(self) -> None:
+        adapter = _NativeJsonAdapter()
+        result = adapter.stream_signal_parser('{"type":"ask","prompt":"go?","choices":["y","n"]}')
+        assert isinstance(result, StreamSignal)
+        assert result.kind is SignalKind.QUESTION
+        assert result.payload["question"] == "go?"
+        assert result.payload["options"] == ["y", "n"]
+
+    def test_override_falls_back_to_canonical(self) -> None:
+        """Override still accepts plain canonical signals."""
+        adapter = _NativeJsonAdapter()
+        result = adapter.stream_signal_parser("BERNSTEIN:BLOCKED {\"reason\":\"x\"}")
+        assert isinstance(result, StreamSignal)
+        assert result.kind is SignalKind.BLOCKED
+
+    def test_override_drops_unknown_native_type(self) -> None:
+        adapter = _NativeJsonAdapter()
+        assert adapter.stream_signal_parser('{"type":"unrelated"}') is None
+
+    def test_override_drops_broken_json(self) -> None:
+        adapter = _NativeJsonAdapter()
+        assert adapter.stream_signal_parser('{"type":"finish"') is None
+
+
+# ---------------------------------------------------------------------------
+# Question round-trip through approval/elicitation-style flow
+# ---------------------------------------------------------------------------
+
+
+class TestQuestionRoundTrip:
+    """A QUESTION signal carries enough payload to round-trip a reply."""
+
+    def test_question_payload_round_trips_through_reply_envelope(self) -> None:
+        adapter = _StubAdapter()
+        question = adapter.stream_signal_parser(
+            format_signal(
+                SignalKind.QUESTION,
+                {"question": "Proceed?", "options": ["y", "n"], "id": "q-1"},
+            )
+        )
+        assert isinstance(question, StreamSignal)
+
+        # Simulate the orchestrator constructing an inbound reply
+        # envelope keyed on the question id and routing it back through
+        # the adapter's stdin/IPC layer.
+        reply_envelope = {
+            "in_reply_to": question.payload["id"],
+            "answer": "y",
+        }
+        assert reply_envelope["in_reply_to"] == "q-1"
+        assert reply_envelope["answer"] in question.payload["options"]
+
+
+# ---------------------------------------------------------------------------
+# Plan-handoff signals
+# ---------------------------------------------------------------------------
+
+
+class TestPlanHandoff:
+    """``PLAN_DRAFT`` / ``PLAN_READY`` carry the markdown/path payload."""
+
+    def test_plan_draft_carries_markdown(self) -> None:
+        adapter = _StubAdapter()
+        line = format_signal(SignalKind.PLAN_DRAFT, {"markdown": "# Plan\n- step 1"})
+        sig = adapter.stream_signal_parser(line)
+        assert isinstance(sig, StreamSignal)
+        assert sig.kind is SignalKind.PLAN_DRAFT
+        assert sig.payload["markdown"].startswith("# Plan")
+
+    def test_plan_ready_points_at_sdd_artefact(self) -> None:
+        adapter = _StubAdapter()
+        line = format_signal(SignalKind.PLAN_READY, {"path": ".sdd/plans/foo.md"})
+        sig = adapter.stream_signal_parser(line)
+        assert isinstance(sig, StreamSignal)
+        assert sig.kind is SignalKind.PLAN_READY
+        assert sig.payload["path"].startswith(".sdd/")
+
+
+# ---------------------------------------------------------------------------
+# Conformance: terminal-signal check
+# ---------------------------------------------------------------------------
+
+
+class TestConformanceTerminalCheck:
+    """``check_terminal_signal`` flags adapter runs that never finish."""
+
+    def test_run_with_completed_passes(self) -> None:
+        warning = check_terminal_signal(
+            ["working...", "BERNSTEIN:COMPLETED"],
+            run_id="run-1",
+        )
+        assert warning is None
+
+    def test_run_with_failed_passes(self) -> None:
+        warning = check_terminal_signal(
+            ["BERNSTEIN:FAILED"],
+            run_id="run-2",
+        )
+        assert warning is None
+
+    def test_run_without_terminal_signal_warns(self) -> None:
+        warning = check_terminal_signal(
+            [
+                "working...",
+                'BERNSTEIN:QUESTION {"question":"?"}',
+                "done writing files",
+            ],
+            run_id="run-3",
+        )
+        assert isinstance(warning, MissingTerminalSignal)
+        assert "run-3" in str(warning)
+
+    def test_run_with_unknown_signals_still_warns(self) -> None:
+        warning = check_terminal_signal(
+            ["BERNSTEIN:UNKNOWN_KIND", "noisy log"],
+            run_id="run-4",
+        )
+        assert isinstance(warning, MissingTerminalSignal)
+
+
+class TestConformanceReport:
+    """``ConformanceReport`` exposes the missing-terminal-signal list."""
+
+    def test_report_serialises_missing_terminal_field(self) -> None:
+        report = ConformanceReport()
+        report.missing_terminal_signal.append("adapter:nojson")
+        out = report.to_dict()
+        assert "missing_terminal_signal" in out
+        assert out["missing_terminal_signal"] == ["adapter:nojson"]
+
+
+# ---------------------------------------------------------------------------
+# Resilience: unknown signal does not poison the stream
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_signal_is_skipped_in_stream() -> None:
+    """One bad signal between two good ones must not break the others."""
+    adapter = _StubAdapter()
+    lines = [
+        "BERNSTEIN:PLAN_DRAFT {\"markdown\":\"# a\"}",
+        "BERNSTEIN:UNSUPPORTED_KIND",
+        "BERNSTEIN:QUESTION {malformed",
+        "BERNSTEIN:COMPLETED",
+    ]
+    parsed = [adapter.stream_signal_parser(ln) for ln in lines]
+    kinds = [p.kind for p in parsed if isinstance(p, StreamSignal)]
+    assert kinds == [SignalKind.PLAN_DRAFT, SignalKind.COMPLETED]
+
+
+@pytest.mark.parametrize("kind", list(SignalKind))
+def test_every_signal_kind_parses_through_adapter(kind: SignalKind) -> None:
+    """Every canonical kind must round-trip through an adapter."""
+    adapter = _StubAdapter()
+    line = format_signal(kind)
+    sig = adapter.stream_signal_parser(line)
+    assert isinstance(sig, StreamSignal)
+    assert sig.kind is kind

--- a/tests/unit/protocols/test_stream_signals.py
+++ b/tests/unit/protocols/test_stream_signals.py
@@ -1,0 +1,348 @@
+"""Tests for the canonical stream-signal protocol."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+
+import pytest
+
+from bernstein.core.protocols.stream_signals import (
+    SIGNAL_PREFIX,
+    TERMINAL_SIGNAL_KINDS,
+    MissingTerminalSignal,
+    SignalKind,
+    StreamSignal,
+    format_signal,
+    has_terminal_signal,
+    iter_signals,
+    parse_signal,
+)
+
+# ---------------------------------------------------------------------------
+# Parse: every canonical kind
+# ---------------------------------------------------------------------------
+
+
+class TestParseSignal:
+    """Round-trip coverage of every canonical signal kind."""
+
+    def test_parses_completed(self) -> None:
+        sig = parse_signal("BERNSTEIN:COMPLETED")
+        assert sig is not None
+        assert sig.kind is SignalKind.COMPLETED
+        assert sig.payload == {}
+        assert sig.is_terminal is True
+
+    def test_parses_failed_with_payload(self) -> None:
+        sig = parse_signal('BERNSTEIN:FAILED {"reason":"timeout"}')
+        assert sig is not None
+        assert sig.kind is SignalKind.FAILED
+        assert sig.payload == {"reason": "timeout"}
+        assert sig.is_terminal is True
+
+    def test_parses_question(self) -> None:
+        line = 'BERNSTEIN:QUESTION {"question":"Proceed?","options":["y","n"]}'
+        sig = parse_signal(line)
+        assert sig is not None
+        assert sig.kind is SignalKind.QUESTION
+        assert sig.payload["question"] == "Proceed?"
+        assert sig.payload["options"] == ["y", "n"]
+        assert sig.is_terminal is False
+
+    def test_parses_plan_draft(self) -> None:
+        sig = parse_signal('BERNSTEIN:PLAN_DRAFT {"markdown":"# Plan","path":".sdd/plan.md"}')
+        assert sig is not None
+        assert sig.kind is SignalKind.PLAN_DRAFT
+        assert sig.payload["markdown"] == "# Plan"
+        assert sig.payload["path"] == ".sdd/plan.md"
+
+    def test_parses_plan_ready(self) -> None:
+        sig = parse_signal('BERNSTEIN:PLAN_READY {"path":".sdd/plan.md"}')
+        assert sig is not None
+        assert sig.kind is SignalKind.PLAN_READY
+        assert sig.payload["path"] == ".sdd/plan.md"
+
+    def test_parses_blocked(self) -> None:
+        sig = parse_signal('BERNSTEIN:BLOCKED {"reason":"missing creds","hint":"set TOKEN"}')
+        assert sig is not None
+        assert sig.kind is SignalKind.BLOCKED
+        assert sig.payload["reason"] == "missing creds"
+        assert sig.payload["hint"] == "set TOKEN"
+        assert sig.is_terminal is False
+
+
+# ---------------------------------------------------------------------------
+# Parse: tolerant handling of malformed input
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedLines:
+    """Parser never raises and returns ``None`` for non-signals."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "",
+            "   ",
+            "regular log line",
+            "BERNSTEINfoo",  # prefix collision without colon
+            "bernstein:COMPLETED",  # wrong case
+            "BERNSTEIN:",  # prefix only, no kind
+            "BERNSTEIN: ",  # prefix + whitespace
+            "BERNSTEIN:UNKNOWN_KIND",  # unrecognised kind
+            'BERNSTEIN:QUESTION {malformed json',  # broken JSON
+            "BERNSTEIN:QUESTION not-json-at-all",  # non-JSON payload
+            'BERNSTEIN:QUESTION ["array","payload"]',  # JSON array, not object
+            "BERNSTEIN:QUESTION 42",  # scalar payload
+            "BERNSTEIN:QUESTION null",  # null payload
+        ],
+    )
+    def test_returns_none_for_malformed_input(self, line: str) -> None:
+        assert parse_signal(line) is None
+
+    def test_returns_none_for_non_string(self) -> None:
+        assert parse_signal(None) is None  # type: ignore[arg-type]
+        assert parse_signal(42) is None  # type: ignore[arg-type]
+        assert parse_signal(["BERNSTEIN:COMPLETED"]) is None  # type: ignore[arg-type]
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        sig = parse_signal("   BERNSTEIN:COMPLETED   \n")
+        assert sig is not None
+        assert sig.kind is SignalKind.COMPLETED
+
+    def test_tolerates_whitespace_after_prefix(self) -> None:
+        """Producers that emit ``BERNSTEIN: COMPLETED`` are still accepted."""
+        sig = parse_signal("BERNSTEIN: COMPLETED")
+        assert sig is not None
+        assert sig.kind is SignalKind.COMPLETED
+
+    def test_preserves_raw_line(self) -> None:
+        sig = parse_signal("  BERNSTEIN:COMPLETED  ")
+        assert sig is not None
+        assert sig.raw_line == "BERNSTEIN:COMPLETED"
+
+
+# ---------------------------------------------------------------------------
+# iter_signals: batch helper
+# ---------------------------------------------------------------------------
+
+
+class TestIterSignals:
+    """Batch parser filters non-signal lines and preserves order."""
+
+    def test_filters_noise_and_preserves_order(self) -> None:
+        lines = [
+            "starting agent...",
+            "BERNSTEIN:PLAN_DRAFT {\"markdown\":\"# Draft\"}",
+            "doing work",
+            'BERNSTEIN:QUESTION {"question":"go?"}',
+            "more output",
+            "BERNSTEIN:COMPLETED",
+            "trailing log line",
+        ]
+        signals = iter_signals(lines)
+        assert [s.kind for s in signals] == [
+            SignalKind.PLAN_DRAFT,
+            SignalKind.QUESTION,
+            SignalKind.COMPLETED,
+        ]
+
+    def test_empty_input(self) -> None:
+        assert iter_signals([]) == []
+
+    def test_skips_unknown_kinds_silently(self) -> None:
+        signals = iter_signals(
+            [
+                "BERNSTEIN:WHO_KNOWS",
+                "BERNSTEIN:COMPLETED",
+            ]
+        )
+        assert len(signals) == 1
+        assert signals[0].kind is SignalKind.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Format: producer-side helper
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSignal:
+    """``format_signal`` round-trips through ``parse_signal``."""
+
+    def test_round_trips_no_payload(self) -> None:
+        line = format_signal(SignalKind.COMPLETED)
+        assert line == "BERNSTEIN:COMPLETED"
+        parsed = parse_signal(line)
+        assert parsed is not None
+        assert parsed.kind is SignalKind.COMPLETED
+        assert parsed.payload == {}
+
+    def test_round_trips_with_payload(self) -> None:
+        payload = {"question": "Proceed?", "options": ["y", "n"]}
+        line = format_signal(SignalKind.QUESTION, payload)
+        parsed = parse_signal(line)
+        assert parsed is not None
+        assert parsed.kind is SignalKind.QUESTION
+        assert parsed.payload == payload
+
+    def test_round_trips_unicode(self) -> None:
+        line = format_signal(SignalKind.QUESTION, {"question": "Продолжить?"})
+        parsed = parse_signal(line)
+        assert parsed is not None
+        assert parsed.payload["question"] == "Продолжить?"
+
+    def test_empty_payload_omits_body(self) -> None:
+        line = format_signal(SignalKind.COMPLETED, {})
+        # Empty dict still renders as "{}" — round-trip semantics
+        # remain identical. We just assert it parses cleanly.
+        parsed = parse_signal(line)
+        assert parsed is not None
+        assert parsed.kind is SignalKind.COMPLETED
+        assert parsed.payload == {}
+
+    def test_rejects_non_dict_payload(self) -> None:
+        with pytest.raises(TypeError):
+            format_signal(SignalKind.QUESTION, ["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_rejects_unserialisable_payload(self) -> None:
+        class NotJson:
+            pass
+
+        with pytest.raises(ValueError):
+            format_signal(SignalKind.QUESTION, {"obj": NotJson()})
+
+
+# ---------------------------------------------------------------------------
+# Terminal-signal conformance
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalSignals:
+    """Terminal-signal vocabulary and helper coverage."""
+
+    def test_terminal_set_matches_spec(self) -> None:
+        assert frozenset({SignalKind.COMPLETED, SignalKind.FAILED}) == TERMINAL_SIGNAL_KINDS
+
+    def test_has_terminal_signal_true(self) -> None:
+        sigs = iter_signals(
+            [
+                'BERNSTEIN:QUESTION {"question":"?"}',
+                "BERNSTEIN:COMPLETED",
+            ]
+        )
+        assert has_terminal_signal(sigs) is True
+
+    def test_has_terminal_signal_false(self) -> None:
+        sigs = iter_signals(
+            [
+                'BERNSTEIN:QUESTION {"question":"?"}',
+                'BERNSTEIN:BLOCKED {"reason":"x"}',
+            ]
+        )
+        assert has_terminal_signal(sigs) is False
+
+    def test_failed_counts_as_terminal(self) -> None:
+        sigs = iter_signals(["BERNSTEIN:FAILED"])
+        assert has_terminal_signal(sigs) is True
+
+    def test_missing_terminal_signal_is_runtime_warning(self) -> None:
+        # The class is a RuntimeWarning subclass so the harness can log
+        # it without aborting the run.
+        assert issubclass(MissingTerminalSignal, RuntimeWarning)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: parser is pure and safe across threads
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentParsing:
+    """Multiple adapter streams may be parsed in parallel without contention."""
+
+    def test_concurrent_multi_adapter_parsing(self) -> None:
+        """Simulate N adapters each emitting their own stdout stream."""
+        adapter_streams = []
+        for adapter_idx in range(8):
+            stream = [
+                f"adapter-{adapter_idx} starting",
+                format_signal(SignalKind.PLAN_DRAFT, {"markdown": f"# adapter {adapter_idx}"}),
+                f"adapter-{adapter_idx} working",
+                format_signal(
+                    SignalKind.QUESTION,
+                    {"question": f"q from {adapter_idx}", "id": f"a{adapter_idx}-q1"},
+                ),
+                format_signal(SignalKind.PLAN_READY, {"path": f".sdd/plan-{adapter_idx}.md"}),
+                format_signal(SignalKind.COMPLETED, {"adapter": adapter_idx}),
+            ]
+            adapter_streams.append((adapter_idx, stream))
+
+        def _parse_one(item: tuple[int, list[str]]) -> tuple[int, list[StreamSignal]]:
+            idx, lines = item
+            return idx, iter_signals(lines)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(_parse_one, adapter_streams))
+
+        # Each stream must produce the same 4 canonical signals in
+        # the same order, with the payload tagged to its own adapter
+        # — proving the parser carried no per-thread state.
+        for idx, signals in results:
+            kinds = [s.kind for s in signals]
+            assert kinds == [
+                SignalKind.PLAN_DRAFT,
+                SignalKind.QUESTION,
+                SignalKind.PLAN_READY,
+                SignalKind.COMPLETED,
+            ]
+            assert signals[0].payload["markdown"] == f"# adapter {idx}"
+            assert signals[1].payload["id"] == f"a{idx}-q1"
+            assert signals[2].payload["path"] == f".sdd/plan-{idx}.md"
+            assert signals[3].payload["adapter"] == idx
+
+
+# ---------------------------------------------------------------------------
+# Misc invariants
+# ---------------------------------------------------------------------------
+
+
+def test_signal_prefix_constant_is_stable() -> None:
+    """The wire prefix is a stability contract — pin it explicitly."""
+    assert SIGNAL_PREFIX == "BERNSTEIN:"
+
+
+def test_signal_kind_values_are_uppercase() -> None:
+    """Operator-visible tokens are upper-case for log-tail readability."""
+    for kind in SignalKind:
+        assert kind.value == kind.value.upper()
+
+
+def test_stream_signal_is_frozen() -> None:
+    """The dataclass is frozen so events are safe to share across threads."""
+    sig = StreamSignal(kind=SignalKind.COMPLETED)
+    with pytest.raises((AttributeError, Exception)):  # FrozenInstanceError
+        sig.kind = SignalKind.FAILED  # type: ignore[misc]
+
+
+def test_payload_decodes_nested_structures() -> None:
+    """Payload JSON objects may carry arbitrary nested data."""
+    payload = {
+        "question": "Pick one",
+        "options": [
+            {"label": "a", "value": 1},
+            {"label": "b", "value": 2},
+        ],
+        "meta": {"id": "q-1", "tags": ["x", "y"]},
+    }
+    line = format_signal(SignalKind.QUESTION, payload)
+    parsed = parse_signal(line)
+    assert parsed is not None
+    assert parsed.payload == payload
+
+
+def test_format_signal_keeps_keys_sorted() -> None:
+    """Deterministic serialisation simplifies golden-file diffs."""
+    line = format_signal(SignalKind.QUESTION, {"b": 2, "a": 1})
+    # Strip prefix and kind to inspect payload only.
+    _, payload_text = line.split(" ", 1)
+    assert payload_text == json.dumps({"a": 1, "b": 2}, separators=(",", ":"), sort_keys=True)

--- a/tests/unit/protocols/test_stream_signals.py
+++ b/tests/unit/protocols/test_stream_signals.py
@@ -91,7 +91,7 @@ class TestMalformedLines:
             "BERNSTEIN:",  # prefix only, no kind
             "BERNSTEIN: ",  # prefix + whitespace
             "BERNSTEIN:UNKNOWN_KIND",  # unrecognised kind
-            'BERNSTEIN:QUESTION {malformed json',  # broken JSON
+            "BERNSTEIN:QUESTION {malformed json",  # broken JSON
             "BERNSTEIN:QUESTION not-json-at-all",  # non-JSON payload
             'BERNSTEIN:QUESTION ["array","payload"]',  # JSON array, not object
             "BERNSTEIN:QUESTION 42",  # scalar payload
@@ -134,7 +134,7 @@ class TestIterSignals:
     def test_filters_noise_and_preserves_order(self) -> None:
         lines = [
             "starting agent...",
-            "BERNSTEIN:PLAN_DRAFT {\"markdown\":\"# Draft\"}",
+            'BERNSTEIN:PLAN_DRAFT {"markdown":"# Draft"}',
             "doing work",
             'BERNSTEIN:QUESTION {"question":"go?"}',
             "more output",


### PR DESCRIPTION
## Summary

- Defines a small canonical signal vocabulary (`COMPLETED`, `FAILED`, `QUESTION`, `PLAN_DRAFT`, `PLAN_READY`, `BLOCKED`) parseable from any wrapped CLI's stdout via a `BERNSTEIN:<KIND> [json]` line grammar.
- Adds `CLIAdapter.stream_signal_parser` hook; default delegates to the canonical parser, adapters override to map native protocols onto the canonical vocabulary.
- Surfaces missing terminal signals as a soft warning in the conformance report so adapters without canonical signals stay visible without failing.

## Test plan

- [x] `pytest tests/unit/protocols/test_stream_signals.py` (44 tests) covers every signal kind, malformed-line resilience, format round-trip, and concurrent multi-adapter parsing.
- [x] `pytest tests/unit/adapters/test_signal_adapter.py` (26 tests) covers default delegation, native-protocol override path, question and plan-handoff round-trip, terminal-signal check, and unknown-signal resilience.
- [x] `pytest tests/unit/test_adapter_conformance.py` (41 existing tests) still passes.
- [x] `ruff check` clean across new files.

Resolves #1632

## Summary by Sourcery

Introduce a canonical stdout stream-signal protocol and adapter hook, and surface missing terminal signals as soft warnings in conformance reporting.

New Features:
- Add a canonical line-oriented stream-signal protocol with parsing, formatting, and terminal-signal detection helpers for adapter stdout.
- Expose a stream_signal_parser hook on CLIAdapter to map adapter stdout lines into canonical stream signals, with a default implementation using the canonical parser.

Enhancements:
- Extend ConformanceReport and conformance checks to record and warn on adapter runs that do not emit a terminal stream signal without failing conformance.

Documentation:
- Add user-facing documentation describing the adapter stream-signal protocol, its grammar, canonical signal kinds, and integration patterns for adapters.

Tests:
- Add comprehensive unit tests for the stream-signal protocol, including parsing, formatting, concurrency, and terminal-signal behavior, and for the adapter stream_signal_parser hook and terminal-signal conformance integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized stream-signal protocol for adapter output: supports signal kinds (COMPLETED, FAILED, QUESTION, PLAN_DRAFT, PLAN_READY, BLOCKED) with JSON payloads for bidirectional communication and plan handoff workflows.
  * Added adapter signal parsing with override support for translating custom upstream protocols into canonical signals.
  * Enhanced conformance checking to detect missing terminal signals in adapter runs and report warnings.

* **Documentation**
  * Added comprehensive protocol guide covering grammar, signal vocabulary, wrapper examples, and end-to-end semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->