### PR TITLE
feat(orchestration): single-writer run-state actor with bounded replay buffer

### DIFF
--- a/docs/orchestration/run-actor.md
+++ b/docs/orchestration/run-actor.md
@@ -1,0 +1,154 @@
+# Single-writer run-state actor
+
+`core/orchestration/run_actor.py` funnels every mutation of an
+orchestration session's live state through one actor task. Callers
+enqueue typed events; one writer applies them via a pure reducer and
+appends to a bounded replay buffer. Subscribers read from the buffer
+with a `last_seen_seq` and receive explicit `Gap` markers when they
+have fallen past the window.
+
+## TL;DR
+
+| Concept       | Role |
+|---------------|---|
+| `RunState`    | Frozen dataclass; canonical per-session state. |
+| `Event`       | Typed mutation request; stamped with a monotonic `seq`. |
+| `apply_event` | Pure reducer `(state, event) -> state`. |
+| `RunActor`    | Owns one `RunState`; single-writer async task. |
+| `ReplayBuffer`| Bounded ring of stamped events (default 1024). |
+| `Gap`         | Sentinel `{up_to_seq}` returned when buffer evicted past a subscriber's resume point. |
+
+## Why
+
+Without a single writer, many call sites can race to mutate live run
+state and many subscribers can re-derive it from disk or DB. Under a
+reconnect with a slow consumer, the subscriber can silently observe an
+inconsistent snapshot. A `Gap{up_to_seq}` marker lets a client
+distinguish "I am caught up" from "I missed events between
+`last_seen_seq` and `up_to_seq`; reconcile from a fresh snapshot".
+
+## Event vocabulary
+
+Today's reducer recognises the kinds below. New kinds extend the
+reducer without breaking existing subscribers; unknown kinds advance
+the sequence number and otherwise no-op.
+
+| Kind                  | Mutates                                       |
+|-----------------------|-----------------------------------------------|
+| `session_started`     | `status -> "running"`                         |
+| `task_started`        | `tasks[task_id].status = "running"` + payload |
+| `task_progress`       | `tasks[task_id].status = "running"` + payload |
+| `task_completed`      | `tasks[task_id].status = "done"`              |
+| `task_failed`         | `tasks[task_id].status = "failed"`            |
+| `approval_requested`  | `approvals[approval_id] = "pending"`          |
+| `approval_granted`    | `approvals[approval_id] = "granted"`          |
+| `approval_denied`     | `approvals[approval_id] = "denied"`           |
+| `watchdog_tick`       | only advances `last_seq`                      |
+| `session_ended`       | `status -> "done"` / `"failed"`               |
+
+The reducer is pure and total: it always returns a new frozen
+`RunState` and never mutates its inputs.
+
+## Sequence-number contract
+
+* `seq = 0` means "no events applied".
+* The actor stamps each accepted event with `state.last_seq + 1`
+  before applying.
+* `apply_event` rejects any event whose `seq != state.last_seq + 1`
+  (returns `state` unchanged, logs a warning). The actor never produces
+  such events itself; the check is defensive against direct reducer
+  use.
+* `RunState` is the only object that holds `last_seq`. Subscribers
+  persist it themselves.
+
+## Gap-marker contract
+
+`ReplayBuffer.since(last_seen_seq)` returns one of:
+
+1. **Empty list** — caller is at or past the latest stored seq.
+2. **List of events in `(last_seen_seq, latest_held]`** — caller is
+   inside the buffer window. No `Gap` is produced.
+3. **`[Gap(up_to_seq=oldest_held - 1), ...remaining]`** — caller is
+   below the buffer's oldest stored seq. Exactly one `Gap` precedes
+   the events still in the buffer. `up_to_seq` is the highest seq
+   that has been evicted and can never be replayed.
+
+A subscriber that observes a `Gap` must re-snapshot via
+`RunActor.snapshot()` rather than try to rebuild missed state from
+the truncated stream.
+
+## Usage
+
+```python
+import asyncio
+
+from bernstein.core.orchestration.run_actor import Event, RunActor
+
+
+async def main() -> None:
+    actor = RunActor("sess-42", replay_capacity=1024)
+    await actor.start()
+    try:
+        # Writers: enqueue typed events.
+        await actor.submit_and_wait(
+            Event(kind="session_started", source="bootstrap"),
+        )
+        await actor.submit_and_wait(
+            Event(
+                kind="task_started",
+                payload={"task_id": "T1", "role": "backend"},
+                source="worker",
+            ),
+        )
+
+        # Readers: snapshot returns the frozen state right now.
+        state = actor.snapshot()
+        assert state.tasks["T1"]["status"] == "running"
+
+        # Subscribers: replay strictly after their last-seen seq.
+        items = await actor.since(last_seen_seq=0)
+        for item in items:
+            ...  # Event or Gap
+    finally:
+        await actor.stop()
+```
+
+### Reconnecting subscribers (SSE / websocket)
+
+Clients carry their highest applied seq (typically as the
+`Last-Event-Id` HTTP header). On reconnect:
+
+1. Server calls `await actor.since(last_seen_seq)`.
+2. If item 0 is a `Gap`, the server emits a `gap` event with the
+   payload `{"up_to_seq": gap.up_to_seq}`. The client interprets this
+   as "your local projection is stale; ignore it and treat the next
+   snapshot as ground truth".
+3. The server emits the remaining events.
+4. The server resumes normal incremental delivery from the latest seq.
+
+This means a reconnect-after-eviction is **observable**, not silently
+corrupt.
+
+## Scope
+
+* In-memory only. Persistence is out of scope; pair with the existing
+  WAL if durability is required.
+* One actor per session, one process. Cross-process fan-out is not
+  handled here.
+* Migrating every legacy writer is its own follow-up. The actor lands
+  alongside one critical caller adaptation; the remaining call sites
+  will be moved over incrementally.
+
+## Testing
+
+Unit tests live under `tests/unit/run_actor/`:
+
+* `test_single_writer.py` — concurrent writers see a strictly
+  monotonic seq log; events are applied exactly once.
+* `test_pure_apply.py` — `apply_event` is deterministic and does not
+  mutate its inputs; `fold` reconstructs state from an event log.
+* `test_snapshot_read.py` — `snapshot()` returns a stable frozen view.
+* `test_replay_after_gap.py` — `since()` emits a `Gap` marker when
+  the buffer has evicted past the caller's `last_seen_seq`.
+* `test_evicted_reconnect.py` — a reconnect past the window observes
+  exactly one `Gap` followed by the current snapshot.

--- a/src/bernstein/core/orchestration/approval_gate.py
+++ b/src/bernstein/core/orchestration/approval_gate.py
@@ -130,6 +130,46 @@ def _emit_audit(
         )
 
 
+def _publish_actor_event(
+    *,
+    session_id: str | None,
+    kind: Literal["approval_requested", "approval_granted", "approval_denied"],
+    task_id: str,
+    extras: dict[str, object] | None = None,
+) -> None:
+    """Mirror an approval-gate decision into a registered :class:`RunActor`.
+
+    The bridge is best-effort: if no actor is registered for the given
+    session id (the common case today), this is a silent no-op. The
+    file-driven gate remains the source of truth either way; the actor
+    feed is an opt-in observability channel that runs alongside it.
+    """
+    if not session_id:
+        return
+    try:
+        from bernstein.core.orchestration.run_actor import Event
+        from bernstein.core.orchestration.run_actor_registry import (
+            publish_event_sync,
+        )
+    except Exception:
+        logger.debug("approval gate: actor bridge import failed", exc_info=True)
+        return
+    payload: dict[str, object] = {"approval_id": task_id, "task_id": task_id}
+    if extras:
+        payload.update(extras)
+    try:
+        publish_event_sync(
+            session_id,
+            Event(kind=kind, payload=payload, source="approval_gate"),
+        )
+    except Exception:
+        logger.debug(
+            "approval gate: actor bridge publish failed for %s",
+            task_id,
+            exc_info=True,
+        )
+
+
 def _pending_path(workdir: Path, task_id: str) -> Path:
     """Return the ``<task_id>.pending`` sentinel path."""
     return _approvals_dir(workdir) / f"{task_id}.pending"
@@ -272,6 +312,7 @@ def wait_for_approval(
     now: float | None = None,
     monotonic: object | None = None,
     sleep: object | None = None,
+    session_id: str | None = None,
 ) -> ApprovalOutcome:
     """Block until the operator decides or the TTL fires.
 
@@ -290,6 +331,13 @@ def wait_for_approval(
         workdir: Project root. Defaults to the current working directory.
         audit_log: Optional explicit audit log; defaults to the
             lifecycle-registered singleton.
+        session_id: Optional run-actor session id. When set, the gate
+            mirrors ``approval_requested`` / ``approval_granted`` /
+            ``approval_denied`` events into a :class:`RunActor`
+            registered under that id (see
+            :mod:`bernstein.core.orchestration.run_actor_registry`). The
+            mirror is best-effort and never affects the file-driven
+            decision contract.
         poll_interval_s: Seconds between filesystem checks.
         now: Optional injected wall-clock timestamp (used by
             :func:`write_pending_sentinel` for deterministic ISO strings).
@@ -334,11 +382,23 @@ def wait_for_approval(
                 "default_action": spec.default_action,
             },
         )
+        _publish_actor_event(
+            session_id=session_id,
+            kind="approval_requested",
+            task_id=task_id,
+            extras={"prompt": spec.prompt},
+        )
         _emit_audit(
             audit_log,
             event_type="approval_resolved",
             task_id=task_id,
             details={"outcome": outcome, "decision_source": source},
+        )
+        _publish_actor_event(
+            session_id=session_id,
+            kind="approval_granted" if outcome == "approved" else "approval_denied",
+            task_id=task_id,
+            extras={"decision_source": source},
         )
         _cleanup_pending(root, task_id)
         return outcome
@@ -355,6 +415,12 @@ def wait_for_approval(
             "default_action": spec.default_action,
         },
     )
+    _publish_actor_event(
+        session_id=session_id,
+        kind="approval_requested",
+        task_id=task_id,
+        extras={"prompt": spec.prompt},
+    )
 
     deadline = monotonic_clock() + float(spec.timeout_seconds)  # type: ignore[operator]
     while True:
@@ -366,6 +432,12 @@ def wait_for_approval(
                 event_type="approval_resolved",
                 task_id=task_id,
                 details={"outcome": outcome, "decision_source": source},
+            )
+            _publish_actor_event(
+                session_id=session_id,
+                kind="approval_granted" if outcome == "approved" else "approval_denied",
+                task_id=task_id,
+                extras={"decision_source": source},
             )
             _cleanup_pending(root, task_id)
             return outcome
@@ -392,6 +464,15 @@ def wait_for_approval(
                     "decision_source": "timeout-default",
                     "default_action": spec.default_action,
                     "applied_outcome": outcome,
+                },
+            )
+            _publish_actor_event(
+                session_id=session_id,
+                kind="approval_granted" if outcome == "approved" else "approval_denied",
+                task_id=task_id,
+                extras={
+                    "decision_source": "timeout-default",
+                    "default_action": spec.default_action,
                 },
             )
             _cleanup_pending(root, task_id)

--- a/src/bernstein/core/orchestration/run_actor.py
+++ b/src/bernstein/core/orchestration/run_actor.py
@@ -1,0 +1,505 @@
+"""Single-writer actor that owns canonical run-state per orchestration session.
+
+Background
+==========
+
+Today multiple call sites (worker loop, watchdog, approval gate, lifecycle
+hooks, IPC receivers) mutate the live state of a running orchestration
+session. Subscribers (SSE streams, dashboard projections, replay listeners)
+re-read files or DB rows to project the current state. Under reconnect or a
+slow consumer, subscribers can silently observe inconsistent snapshots
+because there is no single ordering point and no gap signal.
+
+This module introduces the single-writer-actor pattern:
+
+* A :class:`RunActor` owns one :class:`RunState` per session.
+* Mutations are typed :class:`Event` records submitted via an async queue.
+* Exactly one task drains the queue and applies events to the state via
+  the pure :func:`apply_event` reducer.
+* Each event is stamped with a monotonic sequence number.
+* A bounded :class:`ReplayBuffer` keeps the last ``capacity`` events.
+* Subscribers pass a ``last_seen_seq`` and receive either the events since
+  that sequence or a :class:`Gap` marker if the buffer has evicted past
+  that point.
+
+The reducer is pure and synchronous, so applying an event is trivially
+testable and deterministic. The actor task is the only mutator, so
+ordering and exactly-once-apply are guaranteed by construction.
+
+Scope
+=====
+
+In-memory only. Durability (WAL, persistent event store, cross-process
+fan-out) is out of scope and is layered on by other components if needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, replace
+from itertools import count
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Events
+# ---------------------------------------------------------------------------
+
+
+EventKind = Literal[
+    "session_started",
+    "task_started",
+    "task_progress",
+    "task_completed",
+    "task_failed",
+    "approval_requested",
+    "approval_granted",
+    "approval_denied",
+    "watchdog_tick",
+    "session_ended",
+]
+
+
+@dataclass(frozen=True)
+class Event:
+    """A single mutation request applied by the actor.
+
+    Events are immutable. The actor stamps each accepted event with a
+    monotonic ``seq`` (set to ``-1`` by callers and rewritten before
+    apply).
+
+    Attributes:
+        kind: Discriminator naming the mutation.
+        payload: Mutation-specific data (kept generic on purpose so the
+            module does not have to know every caller's domain).
+        seq: Monotonic sequence number assigned by the actor. ``-1`` for
+            unstamped events.
+        source: Free-form caller tag for tracing (``"watchdog"``,
+            ``"worker"``, …).
+    """
+
+    kind: EventKind
+    payload: Mapping[str, Any] = field(default_factory=dict[str, Any])
+    seq: int = -1
+    source: str = ""
+
+
+@dataclass(frozen=True)
+class Gap:
+    """Sentinel emitted to a subscriber that has fallen behind the buffer.
+
+    A ``Gap`` tells the client: "you asked for events after
+    ``up_to_seq``, but the buffer no longer holds them. Treat current
+    state as a fresh snapshot; reconcile from there."
+
+    Attributes:
+        up_to_seq: The greatest sequence number the buffer can no longer
+            serve. A client that re-subscribes should request a snapshot
+            instead of trying to resume from below ``up_to_seq``.
+    """
+
+    up_to_seq: int
+
+
+ReplayItem = Event | Gap
+
+
+# ---------------------------------------------------------------------------
+# State + reducer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunState:
+    """Canonical state of a single orchestration run.
+
+    Kept intentionally generic. Concrete fields the actor cares about
+    today live in ``tasks`` and ``approvals``; richer projections layer
+    on top.
+
+    Attributes:
+        session_id: Stable session identifier owned by the actor.
+        status: ``"pending"`` / ``"running"`` / ``"done"`` / ``"failed"``.
+        tasks: Mapping ``task_id -> task_record`` (each value is a frozen
+            mapping for safety).
+        approvals: Mapping ``approval_id -> "pending" | "granted" |
+            "denied"``.
+        last_seq: Highest sequence number applied so far. ``0`` means no
+            events have been applied yet.
+        meta: Free-form metadata propagated by callers.
+    """
+
+    session_id: str
+    status: Literal["pending", "running", "done", "failed"] = "pending"
+    tasks: Mapping[str, Mapping[str, Any]] = field(default_factory=dict[str, Mapping[str, Any]])
+    approvals: Mapping[str, Literal["pending", "granted", "denied"]] = field(
+        default_factory=dict[str, Literal["pending", "granted", "denied"]]
+    )
+    last_seq: int = 0
+    meta: Mapping[str, Any] = field(default_factory=dict[str, Any])
+
+
+def _merge_task(
+    tasks: Mapping[str, Mapping[str, Any]],
+    task_id: str,
+    patch: Mapping[str, Any],
+) -> Mapping[str, Mapping[str, Any]]:
+    """Return a new tasks mapping with ``task_id`` patched."""
+    new = dict(tasks)
+    base = dict(new.get(task_id, {}))
+    base.update(patch)
+    new[task_id] = base
+    return new
+
+
+def apply_event(state: RunState, event: Event) -> RunState:
+    """Pure reducer mapping ``(state, event)`` to a new state.
+
+    Out-of-order events are rejected: an event whose ``seq`` is not
+    exactly ``state.last_seq + 1`` returns ``state`` unchanged, with a
+    warning logged. The actor never submits out-of-order events itself,
+    so this only fires if a reducer is invoked from outside (e.g. in a
+    property test).
+
+    The reducer is pure: it returns a new :class:`RunState` and does not
+    mutate ``state`` or ``event``.
+
+    Args:
+        state: Current state.
+        event: Event with a stamped ``seq`` (>= 1).
+
+    Returns:
+        New state after applying the event, or ``state`` unchanged if
+        the event is out of order.
+    """
+    if event.seq != state.last_seq + 1:
+        logger.warning(
+            "apply_event: out-of-order seq=%d last_seq=%d kind=%s; dropping",
+            event.seq,
+            state.last_seq,
+            event.kind,
+        )
+        return state
+
+    kind = event.kind
+    payload = event.payload
+
+    if kind == "session_started":
+        return replace(state, status="running", last_seq=event.seq)
+
+    if kind == "session_ended":
+        end_status = payload.get("status", "done")
+        if end_status not in {"done", "failed"}:
+            end_status = "done"
+        return replace(state, status=end_status, last_seq=event.seq)
+
+    if kind in {"task_started", "task_progress", "task_completed", "task_failed"}:
+        task_id = str(payload.get("task_id", ""))
+        if not task_id:
+            return replace(state, last_seq=event.seq)
+        status_map = {
+            "task_started": "running",
+            "task_progress": "running",
+            "task_completed": "done",
+            "task_failed": "failed",
+        }
+        patch: dict[str, Any] = {"status": status_map[kind]}
+        for k, v in payload.items():
+            if k != "task_id":
+                patch[k] = v
+        return replace(
+            state,
+            tasks=_merge_task(state.tasks, task_id, patch),
+            last_seq=event.seq,
+        )
+
+    if kind in {"approval_requested", "approval_granted", "approval_denied"}:
+        approval_id = str(payload.get("approval_id", ""))
+        if not approval_id:
+            return replace(state, last_seq=event.seq)
+        status_map_a: dict[str, Literal["pending", "granted", "denied"]] = {
+            "approval_requested": "pending",
+            "approval_granted": "granted",
+            "approval_denied": "denied",
+        }
+        new_approvals = dict(state.approvals)
+        new_approvals[approval_id] = status_map_a[kind]
+        return replace(state, approvals=new_approvals, last_seq=event.seq)
+
+    if kind == "watchdog_tick":
+        # Pure liveness ping; only advances seq.
+        return replace(state, last_seq=event.seq)
+
+    # Unknown kind: advance seq so we do not block the log, but do not mutate.
+    logger.warning("apply_event: unknown event kind %r; advancing seq only", kind)
+    return replace(state, last_seq=event.seq)
+
+
+# ---------------------------------------------------------------------------
+# Replay buffer
+# ---------------------------------------------------------------------------
+
+
+class ReplayBuffer:
+    """Bounded ring of stamped events with explicit gap semantics.
+
+    The buffer keeps at most ``capacity`` events. When a new event
+    arrives and the buffer is full, the oldest event is evicted and the
+    buffer remembers ``oldest_seq`` so subscribers asking for an
+    evicted range receive a :class:`Gap` marker instead of silently
+    truncated data.
+
+    The buffer is intentionally synchronous and thread-/task-unaware:
+    only the actor's writer task appends to it, and ``since`` is called
+    by subscribers under the actor's lock.
+    """
+
+    def __init__(self, capacity: int = 1024) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be >= 1")
+        self._capacity = capacity
+        self._events: deque[Event] = deque(maxlen=capacity)
+        # Smallest seq that *was ever appended but is no longer stored*.
+        # When 0, nothing has been evicted yet.
+        self._oldest_evicted_seq = 0
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def append(self, event: Event) -> None:
+        """Append a stamped event, evicting the oldest if full."""
+        if len(self._events) == self._capacity and self._events:
+            evicted = self._events[0]
+            self._oldest_evicted_seq = evicted.seq
+        self._events.append(event)
+
+    def since(self, last_seen_seq: int) -> list[ReplayItem]:
+        """Return items with ``seq > last_seen_seq``.
+
+        Semantics:
+
+        * If ``last_seen_seq`` is at or above the latest stored seq, an
+          empty list is returned (the caller is caught up).
+        * If the buffer can serve everything strictly above
+          ``last_seen_seq``, those events are returned in order.
+        * If the buffer has evicted past ``last_seen_seq``, exactly one
+          :class:`Gap` marker is returned, followed by every event the
+          buffer still holds. The ``Gap.up_to_seq`` equals the highest
+          seq that has been evicted, so the client knows nothing
+          ``<= up_to_seq`` can ever be replayed.
+
+        Args:
+            last_seen_seq: The greatest sequence number the subscriber
+                claims to have already applied. ``0`` means the
+                subscriber is fresh.
+
+        Returns:
+            An in-order list of :class:`Event` and at most one
+            :class:`Gap` (always first if present).
+        """
+        if not self._events:
+            # Buffer is empty: nothing to replay, no gap either.
+            return []
+        oldest_held = self._events[0].seq
+        latest_held = self._events[-1].seq
+
+        if last_seen_seq >= latest_held:
+            return []
+
+        if last_seen_seq + 1 < oldest_held:
+            # Subscriber asks for evicted range.
+            gap = Gap(up_to_seq=oldest_held - 1)
+            return [gap, *list(self._events)]
+
+        # All requested events are still held.
+        return [e for e in self._events if e.seq > last_seen_seq]
+
+    def __len__(self) -> int:
+        return len(self._events)
+
+
+# ---------------------------------------------------------------------------
+# Actor
+# ---------------------------------------------------------------------------
+
+
+class RunActor:
+    """Single-writer actor that owns one :class:`RunState`.
+
+    Callers submit events via :meth:`submit` (sync, fire-and-forget) or
+    :meth:`submit_and_wait` (awaits until the event has been applied).
+    Reads go through :meth:`snapshot`, which returns the frozen
+    :class:`RunState` as of "now". Subscribers replay via :meth:`since`.
+
+    The actor must be started with :meth:`start` and stopped with
+    :meth:`stop`; lifecycle is also exposed via the
+    :meth:`run` async context-manager helper.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        replay_capacity: int = 1024,
+        initial_state: RunState | None = None,
+    ) -> None:
+        self._state: RunState = initial_state or RunState(session_id=session_id)
+        if self._state.session_id != session_id:
+            raise ValueError(
+                "initial_state.session_id does not match session_id argument",
+            )
+        self._queue: asyncio.Queue[tuple[Event, asyncio.Future[int] | None]] = asyncio.Queue()
+        self._buffer = ReplayBuffer(capacity=replay_capacity)
+        self._seq_gen = count(1)
+        self._task: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+        self._stopped = asyncio.Event()
+        self._started = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start the writer task. Idempotent."""
+        if self._started:
+            return
+        self._started = True
+        self._task = asyncio.create_task(self._run_loop(), name=f"run-actor-{self._state.session_id}")
+
+    async def stop(self) -> None:
+        """Drain pending events and stop the writer task."""
+        if not self._started or self._task is None:
+            return
+        self._stopped.set()
+        # Submit a no-op so the loop wakes up and observes the flag.
+        await self._queue.put((Event(kind="watchdog_tick", source="stop"), None))
+        await self._task
+        self._task = None
+        self._started = False
+
+    # ------------------------------------------------------------------
+    # Writer loop
+    # ------------------------------------------------------------------
+
+    async def _run_loop(self) -> None:
+        while True:
+            event, fut = await self._queue.get()
+            if self._stopped.is_set() and event.source == "stop":
+                if fut is not None and not fut.done():
+                    fut.set_result(-1)
+                self._queue.task_done()
+                break
+            try:
+                seq = next(self._seq_gen)
+                stamped = Event(
+                    kind=event.kind,
+                    payload=event.payload,
+                    seq=seq,
+                    source=event.source,
+                )
+                async with self._lock:
+                    new_state = apply_event(self._state, stamped)
+                    # The reducer drops out-of-order events; the actor
+                    # never produces them, so this branch is purely
+                    # defensive.
+                    if new_state is self._state:
+                        logger.error(
+                            "RunActor: reducer rejected stamped event seq=%d kind=%s",
+                            seq,
+                            stamped.kind,
+                        )
+                    else:
+                        self._state = new_state
+                        self._buffer.append(stamped)
+                if fut is not None and not fut.done():
+                    fut.set_result(seq)
+            except Exception as exc:
+                logger.exception("RunActor: writer error: %s", exc)
+                if fut is not None and not fut.done():
+                    fut.set_exception(exc)
+            finally:
+                self._queue.task_done()
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    async def submit(self, event: Event) -> None:
+        """Enqueue an event. Returns once the event is queued."""
+        if not self._started:
+            raise RuntimeError("RunActor.submit called before start()")
+        await self._queue.put((event, None))
+
+    async def submit_and_wait(self, event: Event) -> int:
+        """Enqueue an event and await its applied sequence number."""
+        if not self._started:
+            raise RuntimeError("RunActor.submit_and_wait called before start()")
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[int] = loop.create_future()
+        await self._queue.put((event, fut))
+        return await fut
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> RunState:
+        """Return the current state.
+
+        :class:`RunState` is frozen, so the returned value is safe to
+        share across tasks.
+        """
+        return self._state
+
+    async def since(self, last_seen_seq: int) -> list[ReplayItem]:
+        """Return events / gap-markers strictly after ``last_seen_seq``.
+
+        Held under the actor lock to keep the snapshot and replay
+        consistent.
+        """
+        async with self._lock:
+            return self._buffer.since(last_seen_seq)
+
+
+# ---------------------------------------------------------------------------
+# Convenience: stateless reducer over a stream
+# ---------------------------------------------------------------------------
+
+
+def fold(events: Iterable[Event], initial: RunState) -> RunState:
+    """Apply a sequence of events to ``initial`` via :func:`apply_event`.
+
+    Useful for tests and for reconstructing state from a persistent log
+    without spinning up an actor task.
+
+    Args:
+        events: Stamped events in ascending sequence order.
+        initial: Starting state (typically ``RunState(session_id=…)``).
+
+    Returns:
+        Final state after every event has been applied.
+    """
+    state = initial
+    for event in events:
+        state = apply_event(state, event)
+    return state
+
+
+__all__ = [
+    "Event",
+    "EventKind",
+    "Gap",
+    "ReplayBuffer",
+    "ReplayItem",
+    "RunActor",
+    "RunState",
+    "apply_event",
+    "fold",
+]

--- a/src/bernstein/core/orchestration/run_actor_registry.py
+++ b/src/bernstein/core/orchestration/run_actor_registry.py
@@ -1,0 +1,97 @@
+"""Process-local registry of live :class:`RunActor` instances.
+
+Many existing call sites in the orchestration layer are synchronous
+(file-driven CLI helpers, subprocess shims). They cannot directly
+``await`` an actor, but they can publish events into one by id if the
+actor is registered in the current process.
+
+This module exposes a tiny registry plus :func:`publish_event_sync`, a
+fire-and-forget bridge that schedules an event submission on the actor's
+loop. If no actor is registered for the given session id, the call is a
+silent no-op. This makes the bridge safe to drop into legacy writers as
+a parallel emit while the rest of the migration is in flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.orchestration.run_actor import Event, RunActor
+
+logger = logging.getLogger(__name__)
+
+
+_lock = threading.Lock()
+_actors: dict[str, tuple[RunActor, asyncio.AbstractEventLoop]] = {}
+
+
+def register(actor: RunActor, loop: asyncio.AbstractEventLoop | None = None) -> None:
+    """Register ``actor`` so sync writers can publish into it.
+
+    Args:
+        actor: A started :class:`RunActor`.
+        loop: The event loop the actor lives on. Defaults to the
+            currently running loop.
+    """
+    if loop is None:
+        loop = asyncio.get_running_loop()
+    with _lock:
+        _actors[actor.snapshot().session_id] = (actor, loop)
+
+
+def unregister(session_id: str) -> None:
+    """Drop ``session_id`` from the registry. No-op if absent."""
+    with _lock:
+        _actors.pop(session_id, None)
+
+
+def get(session_id: str) -> RunActor | None:
+    """Return the registered actor for ``session_id``, or ``None``."""
+    with _lock:
+        entry = _actors.get(session_id)
+    return entry[0] if entry else None
+
+
+def publish_event_sync(session_id: str, event: Event) -> bool:
+    """Schedule ``event`` on the actor's loop. Returns False if no actor.
+
+    Safe to call from any thread, including outside an asyncio context.
+    Returns immediately; the event is queued on the actor's loop.
+
+    Args:
+        session_id: Target session id.
+        event: Unstamped event to submit.
+
+    Returns:
+        True if an actor was found and the submit was scheduled; False
+        otherwise (the caller's legacy code path is the source of
+        truth in that case).
+    """
+    with _lock:
+        entry = _actors.get(session_id)
+    if entry is None:
+        return False
+    actor, loop = entry
+    try:
+        asyncio.run_coroutine_threadsafe(actor.submit(event), loop)
+        return True
+    except RuntimeError as exc:
+        # Loop is closed.
+        logger.debug(
+            "publish_event_sync: loop closed for session %s: %s",
+            session_id,
+            exc,
+        )
+        return False
+
+
+__all__ = [
+    "get",
+    "publish_event_sync",
+    "register",
+    "unregister",
+]

--- a/tests/unit/run_actor/test_evicted_reconnect.py
+++ b/tests/unit/run_actor/test_evicted_reconnect.py
@@ -1,0 +1,95 @@
+"""Evicted-reconnect contract.
+
+A client that disconnects, then reconnects past the buffer window, must
+observe:
+
+1. Exactly one :class:`Gap` marker.
+2. Followed by the current snapshot (i.e. every event still held).
+
+After consuming the gap, the client uses :meth:`RunActor.snapshot` to
+realign and then resumes incremental reads from the latest seen seq.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.orchestration.run_actor import (
+    Event,
+    Gap,
+    RunActor,
+)
+
+
+@pytest.mark.asyncio
+async def test_evicted_reconnect_observes_gap_then_realigns_via_snapshot() -> None:
+    actor = RunActor("sess-reconnect", replay_capacity=8)
+    await actor.start()
+    try:
+        # Initial run: 5 task_started events.
+        for i in range(5):
+            await actor.submit_and_wait(Event(kind="task_started", payload={"task_id": f"T{i}"}))
+        # Client snapshots and disconnects.
+        first_snap = actor.snapshot()
+        client_last_seen = first_snap.last_seq
+        assert client_last_seen == 5
+
+        # While disconnected: 20 more events. The buffer (capacity 8)
+        # has evicted everything from seq 1..17.
+        for i in range(5, 25):
+            await actor.submit_and_wait(Event(kind="task_progress", payload={"task_id": f"T{i}"}))
+
+        # Client reconnects with its stale last_seen_seq.
+        items = await actor.since(client_last_seen)
+        assert isinstance(items[0], Gap)
+        assert items[0].up_to_seq >= client_last_seen
+        # Exactly one Gap.
+        assert sum(1 for i in items if isinstance(i, Gap)) == 1
+
+        # All non-Gap items are inside the current buffer window.
+        events_after_gap = [i for i in items[1:] if not isinstance(i, Gap)]
+        seqs = [e.seq for e in events_after_gap]
+        assert seqs == sorted(seqs)
+        assert all(s > items[0].up_to_seq for s in seqs)
+
+        # Client realigns via snapshot rather than trying to re-derive
+        # missed state from the truncated stream.
+        snap = actor.snapshot()
+        assert snap.last_seq == 25
+        # Resume from snapshot: subsequent reads return only new items.
+        items_resume = await actor.since(snap.last_seq)
+        assert items_resume == []
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_fresh_subscriber_with_seq_zero_gets_no_gap_when_buffer_fits() -> None:
+    """Edge case: brand-new subscriber, capacity holds entire history."""
+    actor = RunActor("sess-fresh", replay_capacity=64)
+    await actor.start()
+    try:
+        for _ in range(5):
+            await actor.submit_and_wait(Event(kind="watchdog_tick"))
+        items = await actor.since(0)
+        assert all(not isinstance(i, Gap) for i in items)
+        assert [i.seq for i in items] == [1, 2, 3, 4, 5]  # type: ignore[union-attr]
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_fresh_subscriber_with_seq_zero_after_eviction_gets_gap() -> None:
+    """Edge case: brand-new subscriber arrives after eviction."""
+    actor = RunActor("sess-fresh-late", replay_capacity=4)
+    await actor.start()
+    try:
+        for _ in range(20):
+            await actor.submit_and_wait(Event(kind="watchdog_tick"))
+        items = await actor.since(0)
+        assert isinstance(items[0], Gap)
+        # Subsequent items are the current window only.
+        events = items[1:]
+        assert len(events) == 4
+    finally:
+        await actor.stop()

--- a/tests/unit/run_actor/test_pure_apply.py
+++ b/tests/unit/run_actor/test_pure_apply.py
@@ -1,0 +1,61 @@
+"""Purity of :func:`apply_event`.
+
+The reducer must be deterministic and must not mutate inputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from bernstein.core.orchestration.run_actor import (
+    Event,
+    RunState,
+    apply_event,
+    fold,
+)
+
+
+def test_apply_event_does_not_mutate_inputs() -> None:
+    state = RunState(session_id="s")
+    event = Event(kind="session_started", seq=1, source="t")
+    snapshot_before = replace(state)
+    new = apply_event(state, event)
+    assert state == snapshot_before, "input state was mutated"
+    assert new is not state
+    assert new.status == "running"
+    assert new.last_seq == 1
+
+
+def test_apply_event_is_deterministic() -> None:
+    a = RunState(session_id="s")
+    b = RunState(session_id="s")
+    e1 = Event(kind="task_started", payload={"task_id": "T1"}, seq=1)
+    e2 = Event(kind="task_completed", payload={"task_id": "T1"}, seq=2)
+    final_a = apply_event(apply_event(a, e1), e2)
+    final_b = apply_event(apply_event(b, e1), e2)
+    assert final_a == final_b
+    assert final_a.tasks["T1"]["status"] == "done"
+
+
+def test_out_of_order_event_is_rejected() -> None:
+    state = RunState(session_id="s")
+    # seq=2 with last_seq=0 is out of order.
+    e = Event(kind="task_started", payload={"task_id": "T1"}, seq=2)
+    out = apply_event(state, e)
+    assert out == state, "out-of-order event must return state unchanged"
+
+
+def test_fold_reconstructs_from_event_log() -> None:
+    events = [
+        Event(kind="session_started", seq=1),
+        Event(kind="task_started", payload={"task_id": "A"}, seq=2),
+        Event(kind="task_completed", payload={"task_id": "A"}, seq=3),
+        Event(kind="approval_requested", payload={"approval_id": "AP1"}, seq=4),
+        Event(kind="approval_granted", payload={"approval_id": "AP1"}, seq=5),
+        Event(kind="session_ended", payload={"status": "done"}, seq=6),
+    ]
+    final = fold(events, RunState(session_id="s"))
+    assert final.status == "done"
+    assert final.last_seq == 6
+    assert final.tasks["A"]["status"] == "done"
+    assert final.approvals["AP1"] == "granted"

--- a/tests/unit/run_actor/test_replay_after_gap.py
+++ b/tests/unit/run_actor/test_replay_after_gap.py
@@ -1,0 +1,94 @@
+"""Replay after the bounded buffer has evicted events.
+
+A subscriber that requests a range below the buffer's oldest stored
+sequence MUST receive exactly one :class:`Gap` marker followed by every
+event the buffer still holds — never a silently truncated list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.orchestration.run_actor import (
+    Event,
+    Gap,
+    ReplayBuffer,
+    RunActor,
+)
+
+
+def _stamp(events: list[Event]) -> list[Event]:
+    """Assign monotonic seq=1..N for buffer-only tests."""
+    out = []
+    for i, ev in enumerate(events, start=1):
+        out.append(Event(kind=ev.kind, payload=ev.payload, seq=i, source=ev.source))
+    return out
+
+
+def test_buffer_within_capacity_returns_no_gap() -> None:
+    buf = ReplayBuffer(capacity=8)
+    for e in _stamp([Event(kind="watchdog_tick") for _ in range(5)]):
+        buf.append(e)
+
+    items = buf.since(2)
+    assert all(not isinstance(i, Gap) for i in items)
+    assert [i.seq for i in items] == [3, 4, 5]  # type: ignore[union-attr]
+
+
+def test_buffer_evicted_returns_gap_then_remaining_events() -> None:
+    buf = ReplayBuffer(capacity=4)
+    # Append 10; buffer keeps last 4 (seqs 7..10).
+    for e in _stamp([Event(kind="watchdog_tick") for _ in range(10)]):
+        buf.append(e)
+
+    # Subscriber says "I've seen seq=3"; the range 4..6 is evicted.
+    items = buf.since(3)
+    assert len(items) >= 1
+    assert isinstance(items[0], Gap)
+    gap = items[0]
+    # gap.up_to_seq == 6 because oldest held is 7.
+    assert gap.up_to_seq == 6
+    # Remaining items are exactly the events still in the buffer.
+    tail = items[1:]
+    assert [i.seq for i in tail] == [7, 8, 9, 10]  # type: ignore[union-attr]
+
+
+def test_buffer_request_at_or_above_latest_returns_empty() -> None:
+    buf = ReplayBuffer(capacity=4)
+    for e in _stamp([Event(kind="watchdog_tick") for _ in range(4)]):
+        buf.append(e)
+    assert buf.since(4) == []
+    assert buf.since(99) == []
+
+
+def test_buffer_exactly_one_gap_even_with_huge_gap() -> None:
+    buf = ReplayBuffer(capacity=4)
+    for e in _stamp([Event(kind="watchdog_tick") for _ in range(100)]):
+        buf.append(e)
+    items = buf.since(1)
+    gaps = [i for i in items if isinstance(i, Gap)]
+    assert len(gaps) == 1, "exactly one Gap marker even when far behind"
+
+
+@pytest.mark.asyncio
+async def test_actor_replay_after_gap_end_to_end() -> None:
+    actor = RunActor("sess-gap", replay_capacity=4)
+    await actor.start()
+    try:
+        # Submit 10 events; buffer keeps last 4 (seqs 7..10).
+        for i in range(10):
+            await actor.submit_and_wait(Event(kind="watchdog_tick", payload={"i": i}))
+
+        # A subscriber comes back claiming last-seen = 2.
+        items = await actor.since(2)
+        assert isinstance(items[0], Gap)
+        assert items[0].up_to_seq == 6
+        tail = items[1:]
+        assert [i.seq for i in tail] == [7, 8, 9, 10]  # type: ignore[union-attr]
+
+        # And a fresh subscriber (last_seen=8) still inside the window:
+        items_ok = await actor.since(8)
+        assert all(not isinstance(i, Gap) for i in items_ok)
+        assert [i.seq for i in items_ok] == [9, 10]  # type: ignore[union-attr]
+    finally:
+        await actor.stop()

--- a/tests/unit/run_actor/test_single_writer.py
+++ b/tests/unit/run_actor/test_single_writer.py
@@ -1,0 +1,67 @@
+"""Single-writer invariance for :class:`RunActor`.
+
+Concurrent submitters MUST observe a total order: events come out with
+strictly monotonic sequence numbers, and each event is applied exactly
+once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from bernstein.core.orchestration.run_actor import Event, RunActor
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writers_observe_total_order() -> None:
+    """N concurrent writers produce a strictly monotonic seq log."""
+    actor = RunActor("sess-1")
+    await actor.start()
+    try:
+        writers = 16
+        per_writer = 25
+        total = writers * per_writer
+
+        async def writer(writer_id: int) -> list[int]:
+            seqs: list[int] = []
+            for i in range(per_writer):
+                seq = await actor.submit_and_wait(
+                    Event(
+                        kind="task_progress",
+                        payload={"task_id": f"w{writer_id}-t{i}", "step": i},
+                        source=f"writer-{writer_id}",
+                    )
+                )
+                seqs.append(seq)
+            return seqs
+
+        results = await asyncio.gather(*(writer(w) for w in range(writers)))
+        assigned = sorted(seq for run in results for seq in run)
+        assert assigned == list(range(1, total + 1)), "seqs must be 1..N exactly once"
+
+        # No event lost: state should reflect exactly `total` applied events
+        # (each writer writes distinct task_ids).
+        snap = actor.snapshot()
+        assert snap.last_seq == total
+        assert len(snap.tasks) == total
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_sequence_is_monotonic_under_load() -> None:
+    """Even with fire-and-forget submit(), seq is strictly monotonic."""
+    actor = RunActor("sess-monotonic")
+    await actor.start()
+    try:
+        for i in range(200):
+            await actor.submit(Event(kind="watchdog_tick", payload={"i": i}, source="tick"))
+
+        # Quiesce the queue.
+        await actor._queue.join()
+        snap = actor.snapshot()
+        assert snap.last_seq == 200
+    finally:
+        await actor.stop()

--- a/tests/unit/run_actor/test_snapshot_read.py
+++ b/tests/unit/run_actor/test_snapshot_read.py
@@ -1,0 +1,76 @@
+"""Snapshot reads on :class:`RunActor`.
+
+A reader gets a stable, frozen view of state. Mutations submitted after
+the snapshot was taken do not retroactively change the snapshot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import pytest
+
+from bernstein.core.orchestration.run_actor import Event, RunActor
+
+
+@pytest.mark.asyncio
+async def test_snapshot_is_stable_across_subsequent_writes() -> None:
+    actor = RunActor("sess-snap")
+    await actor.start()
+    try:
+        await actor.submit_and_wait(Event(kind="task_started", payload={"task_id": "A"}, source="t"))
+        snap_a = actor.snapshot()
+
+        await actor.submit_and_wait(Event(kind="task_completed", payload={"task_id": "A"}, source="t"))
+        snap_b = actor.snapshot()
+
+        # snap_a is the previous state object and is frozen.
+        assert dataclasses.is_dataclass(snap_a)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            snap_a.last_seq = 99  # type: ignore[misc]
+
+        assert snap_a.tasks["A"]["status"] == "running"
+        assert snap_b.tasks["A"]["status"] == "done"
+        assert snap_a is not snap_b
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_after_no_writes() -> None:
+    actor = RunActor("sess-empty")
+    await actor.start()
+    try:
+        snap = actor.snapshot()
+        assert snap.session_id == "sess-empty"
+        assert snap.last_seq == 0
+        assert snap.status == "pending"
+        assert snap.tasks == {}
+    finally:
+        await actor.stop()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_readers_see_consistent_state() -> None:
+    actor = RunActor("sess-readers")
+    await actor.start()
+    try:
+        for i in range(50):
+            await actor.submit_and_wait(
+                Event(
+                    kind="task_progress",
+                    payload={"task_id": f"T{i}", "step": i},
+                )
+            )
+
+        async def reader() -> int:
+            snap = actor.snapshot()
+            await asyncio.sleep(0)
+            return snap.last_seq
+
+        seqs = await asyncio.gather(*(reader() for _ in range(10)))
+        # All readers see a coherent (post-writes) state.
+        assert all(s == 50 for s in seqs)
+    finally:
+        await actor.stop()


### PR DESCRIPTION
## Summary

- New `core/orchestration/run_actor.py`: `RunActor` owns canonical per-session state; mutations flow as typed `Event`s through one async queue; pure `apply_event(state, event) -> state` reducer applies them with monotonic `seq` numbers.
- New `ReplayBuffer`: bounded ring (default 1024) that returns an explicit `Gap{up_to_seq}` marker when a subscriber asks for an evicted range. Reconnect-after-eviction is observable, not silently corrupt.
- New `run_actor_registry.py`: process-local registry + `publish_event_sync` bridge so synchronous legacy writers can opt into the actor without an asyncio rewrite.
- Approval gate adapted (1 caller): gains an opt-in `session_id` kwarg that mirrors `approval_requested` / `approval_granted` / `approval_denied` into a registered `RunActor`. File-driven decision contract is unchanged.
- Migration of remaining writers (worker subprocess, watchdog, lifecycle hooks, hooks_receiver) and the SSE/websocket `Last-Event-Id` adoption is deferred to a follow-up ticket as the issue notes (L scope).

## Tests

`tests/unit/run_actor/` - 17 cases, all green:

- `test_single_writer.py` - concurrent writers see a strictly monotonic seq log; events applied exactly once.
- `test_pure_apply.py` - `apply_event` is deterministic and non-mutating; `fold` reconstructs state from an event log.
- `test_snapshot_read.py` - frozen snapshots stable across subsequent writes; concurrent readers consistent.
- `test_replay_after_gap.py` - `ReplayBuffer.since(seq)` emits a `Gap` marker when the requested range has been evicted; never silently truncates.
- `test_evicted_reconnect.py` - reconnect past the window observes exactly one `Gap` followed by the current snapshot.

## Docs

`docs/orchestration/run-actor.md` - actor boundary, event vocabulary, seq + gap-marker contracts, reconnect-subscriber recipe.

## Test plan

- [x] `uv run pytest tests/unit/run_actor/ -q` - 17 passed.
- [x] `uv run pytest tests/ -k approval_gate -q` - 84 passed (no regressions from approval-gate edits).
- [x] `uv run ruff check` on new + edited files - clean.
- [x] `uv run ruff format --check` on new + edited files - clean.
- [x] `uv run pyright` on `src/bernstein/core/orchestration/run_actor*.py` - clean (approval_gate has 5 pre-existing pyright errors, untouched by this PR).

Refs #1630.

## Summary by Sourcery

Introduce a single-writer run-state actor with a bounded replay buffer and integrate approval-gate events into the new actor while documenting the model and covering it with focused unit tests.

New Features:
- Add a RunActor abstraction that owns canonical per-session run state and applies typed events via a pure reducer with monotonically increasing sequence numbers.
- Introduce a bounded ReplayBuffer that serves recent events and emits explicit gap markers when a subscriber has fallen behind the retained window.
- Provide a process-local run_actor_registry with a synchronous publish_event_sync bridge so legacy synchronous code paths can emit events into a registered actor.
- Extend the approval gate to optionally mirror approval_requested, approval_granted, and approval_denied decisions into a RunActor based on an opt-in session_id.

Documentation:
- Document the run-state actor design, event vocabulary, sequence and gap contracts, and reconnect patterns for subscribers in a new orchestration/run-actor.md guide.

Tests:
- Add unit tests for the RunActor single-writer guarantees, purity and determinism of the reducer, snapshot consistency, and replay semantics including gap handling and reconnect behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State tracking system for orchestration sessions that records all events with complete audit history and replay capabilities
  * Approval decisions now integrated as trackable events for improved visibility and comprehensive audit trails
  * Enhanced session reconnection with automatic state recovery and synchronization when connections are interrupted

* **Documentation**
  * Added documentation for orchestration events covering event tracking, replay, and reconnection scenarios with usage examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->