### PR TITLE
feat(security): bind approval responses to single-use nonce

### DIFF
--- a/src/bernstein/cli/commands/approval_cmd.py
+++ b/src/bernstein/cli/commands/approval_cmd.py
@@ -103,7 +103,10 @@ def approve_tool_cmd(
 
     console.print(_render(approval))
     decision = ApprovalDecision.ALWAYS if always else ApprovalDecision.ALLOW
-    queue.resolve(approval.id, decision, reason="cli")
+    # The CLI is a human-channel surface: it reads the on-disk record
+    # which carries the nonce, and threads it back so the gate enforces
+    # the single-use binding uniformly across TUI, HTTP, and CLI paths.
+    queue.resolve(approval.id, decision, reason="cli", nonce=approval.nonce)
     if always:
         try:
             target = promote_to_always_allow(approval, workdir=Path(workdir))
@@ -149,7 +152,7 @@ def reject_tool_cmd(
         return
 
     console.print(_render(approval))
-    queue.resolve(approval.id, ApprovalDecision.REJECT, reason="cli")
+    queue.resolve(approval.id, ApprovalDecision.REJECT, reason="cli", nonce=approval.nonce)
     console.print(f"[red]Rejected {approval.id}[/]")
 
 

--- a/src/bernstein/core/approval/__init__.py
+++ b/src/bernstein/core/approval/__init__.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 from bernstein.core.approval.models import (
     ApprovalDecision,
+    ApprovalNonceExpired,
+    ApprovalNonceMismatch,
     ApprovalTimeoutError,
     PendingApproval,
     ResolvedApproval,
@@ -58,6 +60,8 @@ __all__ = [
     "ApprovalDecision",
     "ApprovalGate",
     "ApprovalMode",
+    "ApprovalNonceExpired",
+    "ApprovalNonceMismatch",
     "ApprovalQueue",
     "ApprovalResult",
     "ApprovalTimeoutError",

--- a/src/bernstein/core/approval/models.py
+++ b/src/bernstein/core/approval/models.py
@@ -25,6 +25,27 @@ class ApprovalTimeoutError(RuntimeError):
     """
 
 
+class ApprovalNonceMismatch(RuntimeError):
+    """Raised when an approval reply carries a nonce that does not match.
+
+    The gate mints a 16-byte single-use nonce when a request is queued.
+    The reply must echo the exact nonce; a missing, stale, replayed, or
+    forged nonce raises this error so the gate refuses to resolve. The
+    failure is surfaced as ``409 NONCE_MISMATCH`` over HTTP and
+    ``EAPPRVL_NONCE`` over IPC.
+    """
+
+
+class ApprovalNonceExpired(RuntimeError):
+    """Raised when the nonce belongs to a superseded or expired approval.
+
+    The original approval may have timed out, been replaced by a newer
+    request for the same target, or already been resolved. Replaying the
+    old nonce surfaces this error and the gate refuses to resolve. HTTP
+    callers see ``410 NONCE_EXPIRED``.
+    """
+
+
 class ApprovalDecision(StrEnum):
     """Operator verdict on a pending tool-call approval.
 
@@ -45,6 +66,15 @@ def _new_id() -> str:
     return f"ap-{secrets.token_hex(6)}"
 
 
+#: Length of the single-use nonce minted per approval.
+NONCE_BYTES: int = 16
+
+
+def _new_nonce() -> bytes:
+    """Return a fresh single-use 16-byte nonce."""
+    return secrets.token_bytes(NONCE_BYTES)
+
+
 @dataclass(frozen=True)
 class PendingApproval:
     """A tool call awaiting an operator decision.
@@ -62,6 +92,10 @@ class PendingApproval:
         ttl_seconds: Time-to-live in seconds. After ``created_at +
             ttl_seconds`` the approval is considered expired and the
             default resolver rejects it.
+        nonce: Server-generated single-use 16-byte token. The reply must
+            echo this exact value or the gate refuses to resolve. Never
+            written into adapter-visible state, agent stdin, or any
+            rendered prompt template.
     """
 
     id: str = field(default_factory=_new_id)
@@ -71,6 +105,12 @@ class PendingApproval:
     tool_args: dict[str, Any] = field(default_factory=dict)
     created_at: float = field(default_factory=time.time)
     ttl_seconds: int = 600
+    nonce: bytes = field(default_factory=_new_nonce)
+
+    @property
+    def nonce_hex(self) -> str:
+        """Return the nonce as a lowercase hex string for HTTP/SSE wire use."""
+        return self.nonce.hex()
 
     @property
     def expires_at(self) -> float:
@@ -86,17 +126,42 @@ class PendingApproval:
         current = time.time() if now is None else now
         return current >= self.expires_at
 
-    def to_dict(self) -> dict[str, Any]:
-        """Return a JSON-serialisable representation."""
-        return asdict(self)
+    def to_dict(self, *, include_nonce: bool = True) -> dict[str, Any]:
+        """Return a JSON-serialisable representation.
+
+        Args:
+            include_nonce: When ``False`` the ``nonce`` key is omitted,
+                so it can be used for any surface visible to agent
+                processes, rendered prompts, or third-party adapters.
+                The default ``True`` includes the hex-encoded nonce for
+                on-disk persistence read by the human-channel resolvers.
+        """
+        payload = asdict(self)
+        nonce_bytes = payload.pop("nonce", b"")
+        if include_nonce:
+            payload["nonce"] = nonce_bytes.hex() if isinstance(nonce_bytes, (bytes, bytearray)) else str(nonce_bytes)
+        return payload
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PendingApproval:
         """Build a :class:`PendingApproval` from a JSON-decoded mapping.
 
         Unknown keys are ignored so the on-disk format can grow without
-        breaking older readers.
+        breaking older readers. A missing ``nonce`` field rehydrates with
+        a fresh nonce so legacy on-disk records load (they will still be
+        rejected on resolve because the in-memory minted nonce will not
+        match anything the operator can supply).
         """
+        raw_nonce = data.get("nonce")
+        if isinstance(raw_nonce, (bytes, bytearray)):
+            nonce = bytes(raw_nonce)
+        elif isinstance(raw_nonce, str) and raw_nonce:
+            try:
+                nonce = bytes.fromhex(raw_nonce)
+            except ValueError:
+                nonce = _new_nonce()
+        else:
+            nonce = _new_nonce()
         known = {
             "id": str(data.get("id", _new_id())),
             "session_id": str(data.get("session_id", "")),
@@ -105,6 +170,7 @@ class PendingApproval:
             "tool_args": dict(data.get("tool_args", {}) or {}),
             "created_at": float(data.get("created_at", time.time())),
             "ttl_seconds": int(data.get("ttl_seconds", 600)),
+            "nonce": nonce,
         }
         return cls(**known)
 

--- a/src/bernstein/core/approval/queue.py
+++ b/src/bernstein/core/approval/queue.py
@@ -28,6 +28,8 @@ import yaml
 
 from bernstein.core.approval.models import (
     ApprovalDecision,
+    ApprovalNonceExpired,
+    ApprovalNonceMismatch,
     ApprovalTimeoutError,
     PendingApproval,
     ResolvedApproval,
@@ -49,6 +51,31 @@ _RESOLVED_SUFFIX = ".resolved.json"
 
 #: Filename suffix for pending approval records.
 _PENDING_SUFFIX = ".json"
+
+
+def _coerce_nonce(value: bytes | bytearray | str) -> bytes | None:
+    """Return *value* normalised to raw bytes, or ``None`` if unparseable.
+
+    Accepts raw bytes (already in the right form) or a hex string (the
+    wire form used over HTTP/SSE). Anything else, including the empty
+    string, returns ``None`` so the caller surfaces a nonce mismatch
+    rather than silently accepting the reply.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value) if value else None
+    if isinstance(value, str) and value:
+        try:
+            return bytes.fromhex(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _nonces_equal(a: bytes, b: bytes) -> bool:
+    """Constant-time equality check for two nonce byte-strings."""
+    import hmac
+
+    return hmac.compare_digest(a, b)
 
 
 def _atomic_write(path: Path, payload: str) -> None:
@@ -209,6 +236,7 @@ class ApprovalQueue:
         decision: ApprovalDecision,
         *,
         reason: str = "",
+        nonce: bytes | str | None = None,
     ) -> ResolvedApproval:
         """Record an operator decision for *approval_id*.
 
@@ -221,6 +249,12 @@ class ApprovalQueue:
             approval_id: Id of the pending approval to resolve.
             decision: Operator verdict.
             reason: Optional free-form note included in the sentinel.
+            nonce: Single-use token issued when the approval was queued.
+                Required for any human-channel reply path; only server-
+                internal callers (TTL eviction, sweeper) may omit it.
+                Mismatches raise :class:`ApprovalNonceMismatch`; replays
+                or stale nonces against an already-resolved or expired
+                approval raise :class:`ApprovalNonceExpired`.
 
         Returns:
             The authoritative :class:`ResolvedApproval`.
@@ -228,13 +262,29 @@ class ApprovalQueue:
         Raises:
             KeyError: When *approval_id* has neither a pending entry nor
                 an already-resolved record.
+            ApprovalNonceMismatch: When *nonce* was supplied but does
+                not match the pending approval's nonce.
+            ApprovalNonceExpired: When *nonce* was supplied for an
+                approval that has already been resolved or evicted, so
+                replaying the same nonce twice is rejected.
         """
         with self._lock:
             existing = self._resolved.get(approval_id)
             if existing is not None:
+                # Idempotent for nonce-less internal callers; nonce
+                # replay attempts against an already-resolved approval
+                # are rejected as expired to foreclose stale-button
+                # double-tap on superseded prompts.
+                if nonce is not None:
+                    raise ApprovalNonceExpired(f"Approval {approval_id} is already resolved; nonce replay rejected.")
                 return existing
             if approval_id not in self._pending:
                 raise KeyError(f"Unknown approval id: {approval_id}")
+            pending = self._pending[approval_id]
+            if nonce is not None:
+                supplied = _coerce_nonce(nonce)
+                if supplied is None or not _nonces_equal(supplied, pending.nonce):
+                    raise ApprovalNonceMismatch(f"Approval {approval_id} nonce does not match; refusing to resolve.")
             resolution = ResolvedApproval(approval_id=approval_id, decision=decision, reason=reason)
             self._resolved[approval_id] = resolution
             event = self._events.setdefault(approval_id, asyncio.Event())

--- a/src/bernstein/core/quality/review_pipeline/review_gate.py
+++ b/src/bernstein/core/quality/review_pipeline/review_gate.py
@@ -220,9 +220,7 @@ class ReviewGate:
     verdict_parser: VerdictParser
     model_selection: ModelSelection = ModelSelection.DifferentModelPreferred
     requires_fresh_session: bool = True
-    prompt_template: str = (
-        "## Spec\n\n{spec}\n\n## Diff\n\n{diff}\n\n## Test output\n\n{test_output}\n"
-    )
+    prompt_template: str = "## Spec\n\n{spec}\n\n## Diff\n\n{diff}\n\n## Test output\n\n{test_output}\n"
 
     def __post_init__(self) -> None:
         # ``requires_fresh_session`` is part of the public contract; the
@@ -230,8 +228,7 @@ class ReviewGate:
         # that try to disable it.
         if not self.requires_fresh_session:
             raise FreshContextViolation(
-                "ReviewGate requires fresh-session semantics; "
-                "requires_fresh_session must be True",
+                "ReviewGate requires fresh-session semantics; requires_fresh_session must be True",
             )
 
     # -- model selection ---------------------------------------------------
@@ -260,10 +257,9 @@ class ReviewGate:
                 and no distinct candidate exists.
         """
         if explicit_reviewer is not None:
-            if (
-                self.model_selection is ModelSelection.DifferentModelRequired
-                and _normalised(explicit_reviewer) == _normalised(implementer_model)
-            ):
+            if self.model_selection is ModelSelection.DifferentModelRequired and _normalised(
+                explicit_reviewer
+            ) == _normalised(implementer_model):
                 raise EvalGateConfigError(
                     f"DifferentModelRequired: explicit reviewer "
                     f"{explicit_reviewer!r} matches implementer model "
@@ -271,9 +267,7 @@ class ReviewGate:
                 )
             return explicit_reviewer
 
-        distinct = [
-            c for c in candidates if _normalised(c) != _normalised(implementer_model)
-        ]
+        distinct = [c for c in candidates if _normalised(c) != _normalised(implementer_model)]
 
         if distinct:
             return distinct[0]
@@ -445,9 +439,7 @@ def parse_structured_verdict(
 
     text = raw.strip()
     if text.startswith("```"):
-        text = "\n".join(
-            line for line in text.splitlines() if not line.strip().startswith("```")
-        ).strip()
+        text = "\n".join(line for line in text.splitlines() if not line.strip().startswith("```")).strip()
 
     try:
         data = json.loads(text)
@@ -479,13 +471,9 @@ def parse_structured_verdict(
         state = "fail"
 
     issues_raw = data.get("issues", [])
-    issues: list[str] = (
-        [str(i) for i in issues_raw] if isinstance(issues_raw, list) else []
-    )
+    issues: list[str] = [str(i) for i in issues_raw] if isinstance(issues_raw, list) else []
     questions_raw = data.get("questions", [])
-    questions: list[str] = (
-        [str(q) for q in questions_raw] if isinstance(questions_raw, list) else []
-    )
+    questions: list[str] = [str(q) for q in questions_raw] if isinstance(questions_raw, list) else []
 
     confidence_raw = data.get("confidence", 1.0)
     try:

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -26,7 +26,11 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from bernstein.core.approval.models import ApprovalDecision
+from bernstein.core.approval.models import (
+    ApprovalDecision,
+    ApprovalNonceExpired,
+    ApprovalNonceMismatch,
+)
 from bernstein.core.approval.models import PendingApproval as QueuedApproval
 from bernstein.core.approval.queue import get_default_queue, promote_to_always_allow
 from bernstein.core.sanitize import sanitize_log
@@ -224,7 +228,13 @@ def reject_task(task_id: str, body: ApprovalDecisionRequest) -> dict[str, str]:
 
 
 class QueuedApprovalResponse(BaseModel):
-    """One queued tool-call approval from the op-002 approval queue."""
+    """One queued tool-call approval from the op-002 approval queue.
+
+    The ``nonce`` field is the hex-encoded single-use token the reply
+    must echo. It travels only over the human-channel surface (TUI,
+    dashboard, chat bridge) and never reaches agent stdin or any
+    rendered prompt template.
+    """
 
     id: str
     session_id: str
@@ -233,6 +243,7 @@ class QueuedApprovalResponse(BaseModel):
     tool_args: dict[str, object]
     created_at: float
     ttl_seconds: int
+    nonce: str
 
 
 class QueuedApprovalsResponse(BaseModel):
@@ -242,9 +253,15 @@ class QueuedApprovalsResponse(BaseModel):
 
 
 class ResolveRequest(BaseModel):
-    """Body for ``POST /approvals/{id}/resolve``."""
+    """Body for ``POST /approvals/{id}/resolve``.
+
+    The ``nonce`` is mandatory: the reply must echo the exact hex string
+    issued when the approval was queued. A missing or unparseable value
+    is rejected with ``409 NONCE_MISMATCH``.
+    """
 
     decision: Literal["allow", "reject", "always"]
+    nonce: str
     reason: str = ""
 
 
@@ -258,6 +275,7 @@ def _to_response(approval: QueuedApproval) -> QueuedApprovalResponse:
         tool_args=dict(approval.tool_args),
         created_at=approval.created_at,
         ttl_seconds=approval.ttl_seconds,
+        nonce=approval.nonce_hex,
     )
 
 
@@ -278,21 +296,38 @@ def list_queued_approvals(session_id: str | None = None) -> QueuedApprovalsRespo
     responses={
         400: {"description": "Invalid approval id or decision"},
         404: {"description": "No pending approval with that id"},
+        409: {"description": "NONCE_MISMATCH"},
+        410: {"description": "NONCE_EXPIRED"},
     },
 )
 def resolve_queued_approval(approval_id: str, body: ResolveRequest) -> dict[str, str]:
-    """Resolve a queued approval with ``allow``, ``reject``, or ``always``."""
+    """Resolve a queued approval with ``allow``, ``reject``, or ``always``.
+
+    The request body must echo the ``nonce`` the gate issued when the
+    approval was queued. Mismatches return ``409 NONCE_MISMATCH``; a
+    nonce replayed against an already-resolved or evicted approval
+    returns ``410 NONCE_EXPIRED``.
+    """
     if not re.fullmatch(r"[a-zA-Z0-9_-]+", approval_id):
         raise HTTPException(status_code=400, detail="Invalid approval id format")
     queue = get_default_queue()
     approval = queue.get(approval_id)
     if approval is None:
+        # An already-resolved approval with a supplied nonce is reported
+        # as gone rather than missing so replay attempts are visible.
+        if queue.get_resolution(approval_id) is not None:
+            raise HTTPException(status_code=410, detail="NONCE_EXPIRED")
         raise HTTPException(status_code=404, detail=f"No pending approval {approval_id}")
     try:
         decision = ApprovalDecision(body.decision)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid decision: {body.decision}") from exc
-    resolution = queue.resolve(approval_id, decision, reason=body.reason)
+    try:
+        resolution = queue.resolve(approval_id, decision, reason=body.reason, nonce=body.nonce)
+    except ApprovalNonceMismatch as exc:
+        raise HTTPException(status_code=409, detail="NONCE_MISMATCH") from exc
+    except ApprovalNonceExpired as exc:
+        raise HTTPException(status_code=410, detail="NONCE_EXPIRED") from exc
     if decision is ApprovalDecision.ALWAYS:
         try:
             promote_to_always_allow(approval)
@@ -320,8 +355,9 @@ def approvals_live_fragment(session_id: str | None = None) -> HTMLResponse:
     rows: list[str] = []
     for approval in pending:
         args_json = html.escape(json.dumps(approval.tool_args))
+        nonce_attr = html.escape(approval.nonce_hex)
         rows.append(
-            f'<div class="approval-row" data-id="{html.escape(approval.id)}">'
+            f'<div class="approval-row" data-id="{html.escape(approval.id)}" data-nonce="{nonce_attr}">'
             f'<div class="approval-meta">'
             f'<span class="approval-tool">{html.escape(approval.tool_name)}</span> '
             f'<span class="approval-role">{html.escape(approval.agent_role)}</span> '
@@ -337,10 +373,12 @@ def approvals_live_fragment(session_id: str | None = None) -> HTMLResponse:
     script = (
         "<script>"
         "function resolveApproval(id, decision){"
+        "var el=document.querySelector('[data-id=\"'+id+'\"]');"
+        "var nonce=el?el.getAttribute('data-nonce'):'';"
         "fetch('/approvals/'+encodeURIComponent(id)+'/resolve',"
         "{method:'POST',headers:{'Content-Type':'application/json'},"
-        "body:JSON.stringify({decision:decision})})"
-        ".then(function(){var el=document.querySelector('[data-id=\"'+id+'\"]');if(el)el.remove();});}"
+        "body:JSON.stringify({decision:decision,nonce:nonce})})"
+        ".then(function(r){if(r.ok && el){el.remove();}});}"
         "</script>"
     )
     body = f'<section id="approvals-panel"><h3>Pending approvals</h3>{"".join(rows)}{script}</section>'

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -255,13 +255,15 @@ class QueuedApprovalsResponse(BaseModel):
 class ResolveRequest(BaseModel):
     """Body for ``POST /approvals/{id}/resolve``.
 
-    The ``nonce`` is mandatory: the reply must echo the exact hex string
-    issued when the approval was queued. A missing or unparseable value
-    is rejected with ``409 NONCE_MISMATCH``.
+    The reply must echo the exact ``nonce`` hex string issued when the
+    approval was queued. ``nonce`` defaults to an empty string at the
+    schema layer so a missing field flows through the handler as a
+    nonce mismatch (``409 NONCE_MISMATCH``) rather than a Pydantic 422
+    validation error, matching the documented contract.
     """
 
     decision: Literal["allow", "reject", "always"]
-    nonce: str
+    nonce: str = ""
     reason: str = ""
 
 

--- a/tests/unit/approval/__init__.py
+++ b/tests/unit/approval/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the interactive approval queue (op-002)."""

--- a/tests/unit/approval/test_nonce_binding.py
+++ b/tests/unit/approval/test_nonce_binding.py
@@ -1,0 +1,272 @@
+"""Single-use nonce binding for human-in-the-loop approvals.
+
+Covers the gate's guarantee that an approval reply must echo the
+exact 16-byte nonce minted when the prompt was queued. Mismatches and
+replays are rejected with ``ApprovalNonceMismatch`` / ``ApprovalNonceExpired``
+and never resolve the gate, so superseded prompts cannot be re-tapped
+and the agent cannot forge its own approval.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.approval.models import (
+    NONCE_BYTES,
+    ApprovalDecision,
+    ApprovalNonceExpired,
+    ApprovalNonceMismatch,
+    PendingApproval,
+)
+from bernstein.core.approval.queue import ApprovalQueue
+
+
+def _push(queue: ApprovalQueue, *, tool: str = "shell", ttl: int = 30) -> PendingApproval:
+    """Push a fresh pending approval onto *queue* for the test."""
+    return queue.push(
+        PendingApproval(
+            session_id="S-test",
+            agent_role="backend",
+            tool_name=tool,
+            tool_args={"command": f"echo {tool}"},
+            ttl_seconds=ttl,
+        )
+    )
+
+
+def test_minted_nonce_is_sixteen_random_bytes(tmp_path: Path) -> None:
+    """Every queued approval gets a fresh 16-byte nonce."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    a = _push(queue, tool="a")
+    b = _push(queue, tool="b")
+
+    assert isinstance(a.nonce, bytes)
+    assert len(a.nonce) == NONCE_BYTES == 16
+    assert a.nonce != b.nonce
+    # Hex round-trip is stable for HTTP/SSE wire use.
+    assert bytes.fromhex(a.nonce_hex) == a.nonce
+
+
+def test_valid_nonce_resolves_the_gate(tmp_path: Path) -> None:
+    """Reply that echoes the exact nonce resolves the approval."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    resolution = queue.resolve(
+        approval.id,
+        ApprovalDecision.ALLOW,
+        nonce=approval.nonce,
+        reason="ok",
+    )
+
+    assert resolution.decision is ApprovalDecision.ALLOW
+    assert queue.get(approval.id) is None  # pending entry consumed
+
+
+def test_hex_nonce_string_is_accepted(tmp_path: Path) -> None:
+    """The wire form (hex string) is interchangeable with raw bytes."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    resolution = queue.resolve(
+        approval.id,
+        ApprovalDecision.ALLOW,
+        nonce=approval.nonce_hex,
+    )
+
+    assert resolution.decision is ApprovalDecision.ALLOW
+
+
+def test_missing_nonce_in_reply_is_rejected(tmp_path: Path) -> None:
+    """An empty / unparseable nonce string is rejected as a mismatch.
+
+    A reply path that forgets to thread the nonce is indistinguishable
+    from a forged reply; the gate must refuse to resolve either way.
+    """
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    with pytest.raises(ApprovalNonceMismatch):
+        queue.resolve(approval.id, ApprovalDecision.ALLOW, nonce="")
+
+    # The approval is still pending : no resolution leaked through.
+    assert queue.get(approval.id) is not None
+    assert queue.get_resolution(approval.id) is None
+
+
+def test_forged_nonce_is_rejected(tmp_path: Path) -> None:
+    """A 16-byte string the agent could plausibly generate is rejected."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    forged = b"\x00" * NONCE_BYTES
+    assert forged != approval.nonce
+
+    with pytest.raises(ApprovalNonceMismatch):
+        queue.resolve(approval.id, ApprovalDecision.ALLOW, nonce=forged)
+
+    assert queue.get(approval.id) is not None
+    assert queue.get_resolution(approval.id) is None
+
+
+def test_unparseable_hex_string_is_rejected(tmp_path: Path) -> None:
+    """A nonce that is not a valid hex string is treated as a mismatch."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    with pytest.raises(ApprovalNonceMismatch):
+        queue.resolve(approval.id, ApprovalDecision.ALLOW, nonce="not-hex-zz")
+
+    assert queue.get(approval.id) is not None
+
+
+def test_stale_nonce_after_ttl_is_rejected(tmp_path: Path) -> None:
+    """Replaying a nonce after the approval expired is rejected."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = queue.push(
+        PendingApproval(
+            session_id="S-test",
+            agent_role="backend",
+            tool_name="shell",
+            tool_args={"command": "ls"},
+            ttl_seconds=1,
+        )
+    )
+
+    # Evict using a faked clock : the queue rejects expired entries
+    # with the server-side internal path (no nonce), then the operator
+    # replay must be refused.
+    queue.evict_expired(now=time.time() + 3600)
+    assert queue.get_resolution(approval.id) is not None
+
+    with pytest.raises(ApprovalNonceExpired):
+        queue.resolve(
+            approval.id,
+            ApprovalDecision.ALLOW,
+            nonce=approval.nonce,
+        )
+
+
+def test_replay_of_same_nonce_is_rejected(tmp_path: Path) -> None:
+    """Same nonce played twice : the second attempt is rejected."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    first = queue.resolve(
+        approval.id,
+        ApprovalDecision.ALLOW,
+        nonce=approval.nonce,
+    )
+    assert first.decision is ApprovalDecision.ALLOW
+
+    with pytest.raises(ApprovalNonceExpired):
+        queue.resolve(
+            approval.id,
+            ApprovalDecision.REJECT,
+            nonce=approval.nonce,
+        )
+
+    # The original decision stands : replay cannot flip the verdict.
+    final = queue.get_resolution(approval.id)
+    assert final is not None
+    assert final.decision is ApprovalDecision.ALLOW
+
+
+def test_superseded_approval_invalidates_nonce(tmp_path: Path) -> None:
+    """A new request for the same tool replaces the old approval id.
+
+    The old nonce belongs to the superseded request; replaying it must
+    not resolve the newly-queued approval (different id, different
+    nonce).
+    """
+    queue = ApprovalQueue(base_dir=tmp_path)
+    first = _push(queue)
+    # Operator cancels / agent supersedes the first request and a new
+    # one is queued for the same logical target.
+    queue.evict_expired(now=time.time() + 3600)
+
+    second = _push(queue)
+    assert second.id != first.id
+    assert second.nonce != first.nonce
+
+    # Replaying the first nonce against the second approval is rejected
+    # by id-bound mismatch.
+    with pytest.raises(ApprovalNonceMismatch):
+        queue.resolve(second.id, ApprovalDecision.ALLOW, nonce=first.nonce)
+
+    # The second approval is still pending.
+    assert queue.get(second.id) is not None
+
+
+def test_nonce_persists_to_disk_for_human_channel_resolvers(tmp_path: Path) -> None:
+    """On-disk JSON carries the hex nonce so the CLI/web can read it."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    record_path = tmp_path / f"{approval.id}.json"
+    payload = json.loads(record_path.read_text(encoding="utf-8"))
+    assert payload["nonce"] == approval.nonce_hex
+    assert len(bytes.fromhex(payload["nonce"])) == NONCE_BYTES
+
+
+def test_nonce_not_exposed_via_to_dict_when_excluded() -> None:
+    """``to_dict(include_nonce=False)`` strips the nonce.
+
+    Adapter-facing serialisations (agent stdin, prompt templates) must
+    use this form so the nonce never reaches the agent process.
+    """
+    approval = PendingApproval(
+        session_id="S",
+        agent_role="backend",
+        tool_name="shell",
+        tool_args={"command": "ls"},
+    )
+    public = approval.to_dict(include_nonce=False)
+    assert "nonce" not in public
+    # Sanity: every other field is still there so callers do not lose
+    # context they depend on.
+    for key in ("id", "session_id", "agent_role", "tool_name", "tool_args"):
+        assert key in public
+
+
+def test_wait_for_resolves_normally_when_correct_nonce_is_supplied(tmp_path: Path) -> None:
+    """End-to-end: gate awaits resolution; correct nonce wins."""
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    async def scenario() -> None:
+        async def resolver() -> None:
+            await asyncio.sleep(0.01)
+            queue.resolve(
+                approval.id,
+                ApprovalDecision.ALLOW,
+                nonce=approval.nonce,
+            )
+
+        task = asyncio.create_task(resolver())
+        result = await queue.wait_for(approval.id, timeout_seconds=2.0)
+        await task
+        assert result.decision is ApprovalDecision.ALLOW
+
+    asyncio.run(scenario())
+
+
+def test_resolve_without_nonce_remains_back_compat_for_server_internals(tmp_path: Path) -> None:
+    """Server-internal callers (timeout, evict) may resolve without a nonce.
+
+    Only human-channel reply paths supply a nonce. The TTL-driven
+    eviction path and the wait-for timeout fallback must keep working
+    so the gate does not deadlock when no operator answers.
+    """
+    queue = ApprovalQueue(base_dir=tmp_path)
+    approval = _push(queue)
+
+    # Nonce omitted entirely: this is the back-compat / server-internal
+    # path used by evict_expired and the wait_for timeout fallback.
+    resolution = queue.resolve(approval.id, ApprovalDecision.REJECT, reason="server-internal")
+    assert resolution.decision is ApprovalDecision.REJECT


### PR DESCRIPTION
## Summary

Implements issue #1619: every pending approval gets a 16-byte
server-generated single-use nonce; the human-channel reply must echo
the exact value or the gate refuses to resolve.

- `core/approval/models.py`: `PendingApproval.nonce` (16 random bytes;
  hex on the wire), `nonce_hex` property, `to_dict(include_nonce=False)`
  for adapter-facing serialisations, new `ApprovalNonceMismatch` and
  `ApprovalNonceExpired` errors.
- `core/approval/queue.py`: `resolve()` accepts a nonce and validates
  it in constant time (`hmac.compare_digest`). Mismatches raise
  `ApprovalNonceMismatch`; replays against an already-resolved or
  evicted approval raise `ApprovalNonceExpired`. Server-internal
  callers (TTL evict, `wait_for` timeout fallback) keep the no-nonce
  path so they cannot deadlock.
- `core/routes/approvals.py`: `ResolveRequest` now requires `nonce`;
  HTTP returns `409 NONCE_MISMATCH` / `410 NONCE_EXPIRED`. The live
  fragment HTML threads the nonce through the button handlers via
  `data-nonce` so the dashboard reply path is bound too.
- `cli/commands/approval_cmd.py`: `approve-tool` / `reject-tool`
  read the on-disk record (already nonce-bearing) and thread the
  nonce back through `resolve()`.

## Test plan

- [x] `uv run pytest tests/unit/approval -q` (13 new tests)
- [x] `uv run pytest tests/unit/test_approval_queue.py tests/unit/test_approval_hook.py tests/unit/test_approval_cli.py tests/integration/test_approval_gate.py -q` (37 pre-existing, 0 regressions)
- [x] `uv run ruff check` clean on touched modules
- [x] `uv run ruff format --check` clean on touched modules

New tests cover: valid nonce passes, missing/forged/unparseable nonces
rejected, stale nonce after TTL eviction rejected, replay of same
nonce rejected, superseded approval rejects old nonce, nonce persisted
to disk for human-channel resolvers, `include_nonce=False` strips it
for adapter-facing surfaces, `wait_for` end-to-end with correct nonce,
back-compat no-nonce path for server internals.

Closes #1619.

## Summary by Sourcery

Bind human-channel approval resolutions to a per-approval single-use nonce and expose appropriate errors and HTTP statuses for mismatches and replays.

New Features:
- Issue a server-generated 16-byte single-use nonce for each pending approval and require clients to echo it when resolving approvals.
- Expose nonce values over human-facing approval surfaces (HTTP API responses and dashboard fragment) while keeping them out of adapter-facing serialisations and prompts.

Enhancements:
- Extend the approval queue to validate supplied nonces, reject mismatches and replays, and surface dedicated ApprovalNonceMismatch and ApprovalNonceExpired errors.
- Maintain backwards-compatible nonce-less resolution for server-internal flows such as TTL eviction and timeout fallbacks.

Tests:
- Add unit tests covering nonce issuance, validation, replay and expiry semantics, persistence to disk, exclusion from public serialisations, and end-to-end wait_for behaviour with correct and missing nonces.