### PR TITLE
refactor: bulk refurb autofix wave 4 (FURB184 + leftovers)

### DIFF
--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -260,14 +260,18 @@ class ClaudeCodeAdapter(CLIAdapter):
         base_turns = COST.effort_base_turns.get(effort, 50)
         scope_multiplier = self._SCOPE_MULTIPLIERS.get(task_scope, 1.5)
         max_turns = self.BATCH_MAX_TURNS if batch_mode else int(base_turns * scope_multiplier)
-        claude_effort = ({"max": "max", "high": "high", "medium": "medium", "normal": "medium", "low": "low"}).get(effort, "high")
+        claude_effort = ({"max": "max", "high": "high", "medium": "medium", "normal": "medium", "low": "low"}).get(
+            effort, "high"
+        )
 
         # Choose fallback model: opus-4-7 → opus-4-6 → sonnet → haiku
-        fallback_model = ({
-            "claude-opus-4-7": "claude-opus-4-6",
-            "claude-opus-4-6": "claude-sonnet-4-6",
-            "claude-sonnet-4-6": "claude-haiku-4-5-20251001",
-        }).get(model_id)
+        fallback_model = (
+            {
+                "claude-opus-4-7": "claude-opus-4-6",
+                "claude-opus-4-6": "claude-sonnet-4-6",
+                "claude-sonnet-4-6": "claude-haiku-4-5-20251001",
+            }
+        ).get(model_id)
 
         cmd = [
             "claude",

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -260,16 +260,14 @@ class ClaudeCodeAdapter(CLIAdapter):
         base_turns = COST.effort_base_turns.get(effort, 50)
         scope_multiplier = self._SCOPE_MULTIPLIERS.get(task_scope, 1.5)
         max_turns = self.BATCH_MAX_TURNS if batch_mode else int(base_turns * scope_multiplier)
-        effort_map = {"max": "max", "high": "high", "medium": "medium", "normal": "medium", "low": "low"}
-        claude_effort = effort_map.get(effort, "high")
+        claude_effort = ({"max": "max", "high": "high", "medium": "medium", "normal": "medium", "low": "low"}).get(effort, "high")
 
         # Choose fallback model: opus-4-7 → opus-4-6 → sonnet → haiku
-        _fallback_map = {
+        fallback_model = ({
             "claude-opus-4-7": "claude-opus-4-6",
             "claude-opus-4-6": "claude-sonnet-4-6",
             "claude-sonnet-4-6": "claude-haiku-4-5-20251001",
-        }
-        fallback_model = _fallback_map.get(model_id)
+        }).get(model_id)
 
         cmd = [
             "claude",
@@ -381,8 +379,7 @@ class ClaudeCodeAdapter(CLIAdapter):
                 parent environment is inherited (legacy behaviour).
         """
         log_file = log_path.open("w")
-        stderr_path = log_path.with_suffix(".stderr.log")
-        stderr_file = stderr_path.open("w")
+        stderr_file = log_path.with_suffix(".stderr.log").open("w")
         preexec_fn = self._get_preexec_fn()
         try:
             try:

--- a/src/bernstein/adapters/junie.py
+++ b/src/bernstein/adapters/junie.py
@@ -275,5 +275,4 @@ class JunieAdapter(CLIAdapter):
             provider_value = getattr(provider_obj, "value", str(provider_obj))
             if provider_value:
                 return str(provider_value).lower()
-        env_value = os.environ.get(_JUNIE_PROVIDER_KEY, "")
-        return env_value.lower()
+        return os.environ.get(_JUNIE_PROVIDER_KEY, "").lower()

--- a/src/bernstein/bridges/cloudflare_workflow.py
+++ b/src/bernstein/bridges/cloudflare_workflow.py
@@ -174,8 +174,7 @@ class CloudflareWorkflowBridge(RuntimeBridge):
                 status_code=resp.status_code,
             )
 
-        data = resp.json()
-        result = data.get("result", {})
+        result = resp.json().get("result", {})
         now = time.time()
         return AgentStatus(
             agent_id=request.agent_id,
@@ -218,8 +217,7 @@ class CloudflareWorkflowBridge(RuntimeBridge):
                 status_code=resp.status_code,
             )
 
-        data = resp.json()
-        result = data.get("result", {})
+        result = resp.json().get("result", {})
         step = result.get("current_step", "")
         status_str = result.get("status", "")
         state = self._map_step_to_state(step, status_str)
@@ -355,8 +353,7 @@ class CloudflareWorkflowBridge(RuntimeBridge):
                 status_code=resp.status_code,
             )
 
-        data = resp.json()
-        result = data.get("result", {})
+        result = resp.json().get("result", {})
         step_str = result.get("current_step", "claim")
         status_str = result.get("status", "")
 

--- a/src/bernstein/bridges/openclaw_gateway.py
+++ b/src/bernstein/bridges/openclaw_gateway.py
@@ -170,8 +170,7 @@ class _IdentityStore:
 
     def save_device_token(self, token: str) -> None:
         """Persist a gateway-issued device token."""
-        token_path = self._dir / _DEVICE_TOKEN_FILE
-        token_path.write_text(token.strip(), encoding="utf-8")
+        (self._dir / _DEVICE_TOKEN_FILE).write_text(token.strip(), encoding="utf-8")
 
 
 class OpenClawGatewayClient:
@@ -282,10 +281,7 @@ class OpenClawGatewayClient:
             candidates = payload
         if not isinstance(candidates, list):
             return []
-        result: list[dict[str, Any]] = []
-        for item_raw in cast("list[object]", candidates):
-            if isinstance(item_raw, dict):
-                result.append(cast("dict[str, Any]", item_raw))
+        result = [cast("dict[str, Any]", item_raw) for item_raw in cast("list[object]", candidates) if isinstance(item_raw, dict)]
         return result
 
     async def _connect_websocket(self) -> ClientConnection:
@@ -333,8 +329,7 @@ class OpenClawGatewayClient:
         payload_raw = challenge.get("payload")
         if not isinstance(payload_raw, dict):
             raise BridgeError("OpenClaw connect.challenge payload missing")
-        payload = cast(_CAST_DICT_STR_OBJ, payload_raw)
-        nonce = payload.get("nonce")
+        nonce = cast(_CAST_DICT_STR_OBJ, payload_raw).get("nonce")
         if not isinstance(nonce, str) or not nonce:
             raise BridgeError("OpenClaw connect.challenge nonce missing")
 
@@ -375,10 +370,8 @@ class OpenClawGatewayClient:
                 }
             )
         )
-        response = await self._await_response(websocket, request_id)
-        payload_raw = response.get("payload")
-        payload_dict = cast(_CAST_DICT_STR_OBJ, payload_raw) if isinstance(payload_raw, dict) else {}
-        auth_payload = payload_dict.get("auth")
+        payload_raw = (await self._await_response(websocket, request_id)).get("payload")
+        auth_payload = (cast(_CAST_DICT_STR_OBJ, payload_raw) if isinstance(payload_raw, dict) else {}).get("auth")
         if isinstance(auth_payload, dict):
             auth_dict = cast(_CAST_DICT_STR_OBJ, auth_payload)
             device_token = auth_dict.get("deviceToken")
@@ -390,8 +383,7 @@ class OpenClawGatewayClient:
         request_id = uuid.uuid4().hex
         frame = {"type": "req", "id": request_id, "method": method, "params": params}
         await websocket.send(json.dumps(frame))
-        response = await self._await_response(websocket, request_id)
-        payload = response.get("payload")
+        payload = (await self._await_response(websocket, request_id)).get("payload")
         if not isinstance(payload, dict):
             return {}
         return cast("dict[str, Any]", payload)

--- a/src/bernstein/bridges/openclaw_gateway.py
+++ b/src/bernstein/bridges/openclaw_gateway.py
@@ -281,7 +281,11 @@ class OpenClawGatewayClient:
             candidates = payload
         if not isinstance(candidates, list):
             return []
-        result = [cast("dict[str, Any]", item_raw) for item_raw in cast("list[object]", candidates) if isinstance(item_raw, dict)]
+        result = [
+            cast("dict[str, Any]", item_raw)
+            for item_raw in cast("list[object]", candidates)
+            if isinstance(item_raw, dict)
+        ]
         return result
 
     async def _connect_websocket(self) -> ClientConnection:

--- a/src/bernstein/cli/commands/abandonments_cmd.py
+++ b/src/bernstein/cli/commands/abandonments_cmd.py
@@ -54,8 +54,7 @@ def abandonments_group() -> None:
 @click.option("--json", "json_out", is_flag=True, default=False, help="Emit machine-readable JSON.")
 def list_cmd(workdir: Path, limit: int, json_out: bool) -> None:
     """List the most recent abandonment rows (newest first)."""
-    ledger = _ledger(workdir)
-    rows = ledger.list_recent(limit=limit)
+    rows = _ledger(workdir).list_recent(limit=limit)
     if json_out or is_json():
         print_json([row.to_dict() for row in rows])
         return
@@ -97,8 +96,7 @@ def list_cmd(workdir: Path, limit: int, json_out: bool) -> None:
 @click.option("--json", "json_out", is_flag=True, default=False, help="Emit machine-readable JSON.")
 def stats_cmd(workdir: Path, json_out: bool) -> None:
     """Show abandonment roll-ups by reason / role / adapter."""
-    ledger = _ledger(workdir)
-    stats = ledger.stats()
+    stats = _ledger(workdir).stats()
     if json_out or is_json():
         print_json(stats)
         return

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -104,10 +104,12 @@ def live(interval: float, classic: bool, no_splash: bool) -> None:
 
     print_banner()
 
-    (LiveView(
-        server_url=SERVER_URL,
-        interval=interval,
-    )).run()
+    (
+        LiveView(
+            server_url=SERVER_URL,
+            interval=interval,
+        )
+    ).run()
 
 
 def _load_live_seed_config(seed_path: Path | None) -> Any:

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -104,11 +104,10 @@ def live(interval: float, classic: bool, no_splash: bool) -> None:
 
     print_banner()
 
-    view = LiveView(
+    (LiveView(
         server_url=SERVER_URL,
         interval=interval,
-    )
-    view.run()
+    )).run()
 
 
 def _load_live_seed_config(seed_path: Path | None) -> Any:
@@ -1173,8 +1172,7 @@ def trace_reindex_cmd(ctx: click.Context) -> None:
     from bernstein.core.observability.trace_store import ContentAddressedTraceStore
 
     traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
-    store = ContentAddressedTraceStore(Path(traces_dir))
-    count = store.reindex()
+    count = ContentAddressedTraceStore(Path(traces_dir)).reindex()
     console.print(f"[green]Reindex complete:[/green] {count} entries")
 
 

--- a/src/bernstein/cli/commands/agents_cmd.py
+++ b/src/bernstein/cli/commands/agents_cmd.py
@@ -66,8 +66,7 @@ def _sync_local_definitions(definitions_path: Path, registry_cls: type) -> None:
         console.print(f"  [yellow]Directory does not exist:[/yellow] {definitions_path}")
         console.print(f"  [dim]Create it with: mkdir -p {definitions_path}[/dim]")
         return
-    registry = registry_cls(definitions_dir=definitions_path)
-    loaded = registry.load_definitions()
+    loaded = registry_cls(definitions_dir=definitions_path).load_definitions()
     console.print(f"  [green]✓[/green] Loaded {len(loaded)} agent definition(s)")
     for defn in loaded:
         console.print(f"    [dim]{defn.name}[/dim] v{defn.version} ({defn.role})")
@@ -520,8 +519,7 @@ def agents_match(role: str, task_description: str) -> None:
     t.append("  Priority  ", style="dim")
     t.append(f"{match.priority}\n")
     t.append("  Tools     ", style="dim")
-    t.append(", ".join(match.tools) if match.tools else "—")
-    t.append("\n\n")
+    t.extend((", ".join(match.tools) if match.tools else "—", "\n\n"))
     t.append("  Description\n", style="dim")
     t.append(f"    {match.description[:120]}\n")
 

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -187,8 +187,7 @@ def _verify_hmac_chain() -> bool:
     """Verify HMAC chain and print results. Returns True if valid."""
     from bernstein.core.audit import AuditLog
 
-    audit_log = AuditLog(AUDIT_DIR)
-    hmac_valid, hmac_errors = audit_log.verify()
+    hmac_valid, hmac_errors = AuditLog(AUDIT_DIR).verify()
 
     console.print()
     if hmac_valid:
@@ -234,8 +233,7 @@ def verify_hmac_cmd() -> None:
         console.print(f"[red]Audit directory not found:[/red] {AUDIT_DIR}")
         raise SystemExit(1)
 
-    audit_log = AuditLog(AUDIT_DIR)
-    valid, errors = audit_log.verify()
+    valid, errors = AuditLog(AUDIT_DIR).verify()
 
     console.print()
     if valid:
@@ -1246,8 +1244,7 @@ def query_cmd(event_type: str | None, actor: str | None, since: str | None, limi
         console.print(f"[red]Audit directory not found:[/red] {AUDIT_DIR}")
         raise SystemExit(1)
 
-    audit_log = AuditLog(AUDIT_DIR)
-    events = audit_log.query(event_type=event_type, actor=actor, since=since)
+    events = AuditLog(AUDIT_DIR).query(event_type=event_type, actor=actor, since=since)
     events = events[:limit]
 
     if not events:
@@ -1674,8 +1671,7 @@ def _print_post_archive_verify(audit_dir: Path) -> int:
     """
     from bernstein.core.security.audit import AuditLog
 
-    audit_log = AuditLog(audit_dir)
-    valid, errors = audit_log.verify()
+    valid, errors = AuditLog(audit_dir).verify()
     console.print()
     if valid:
         console.print(

--- a/src/bernstein/cli/commands/autofix_cmd.py
+++ b/src/bernstein/cli/commands/autofix_cmd.py
@@ -533,8 +533,7 @@ def review_cmd(
     # Surface the spawning agent's worktree (if registered) so an
     # operator running ``review --once`` from any directory still
     # sees which workspace the eventual dispatcher will resume.
-    registry = WorktreeRegistry(default_registry_path(workdir))
-    record = registry.lookup(resolved_pr)
+    record = WorktreeRegistry(default_registry_path(workdir)).lookup(resolved_pr)
     if record is not None:
         click.echo(
             f"review_router: PR #{resolved_pr} maps to worktree {record.worktree_path}"
@@ -639,8 +638,7 @@ def review_register_cmd(
 def review_resolve_cmd(pr_number: int, as_json: bool) -> None:
     """Print the registered worktree path for a PR (exit non-zero if missing)."""
     workdir = _resolve_workdir()
-    registry = WorktreeRegistry(default_registry_path(workdir))
-    record = registry.lookup(pr_number)
+    record = WorktreeRegistry(default_registry_path(workdir)).lookup(pr_number)
     if record is None:
         if as_json:
             click.echo(json.dumps({"pr_number": pr_number, "found": False}, sort_keys=True))

--- a/src/bernstein/cli/commands/blast_radius_cmd.py
+++ b/src/bernstein/cli/commands/blast_radius_cmd.py
@@ -151,8 +151,7 @@ def score_cmd(
                 paths.append(stripped)
     diff_text = diff_file.read_text(encoding="utf-8") if diff_file is not None else ""
 
-    scorer = BlastRadiusScorer()
-    report = scorer.score(files=paths, diff_text=diff_text)
+    report = BlastRadiusScorer().score(files=paths, diff_text=diff_text)
     click.echo(_format_report(report, fmt=fmt.lower()))
 
     if save_as is not None:

--- a/src/bernstein/cli/commands/cache_cmd.py
+++ b/src/bernstein/cli/commands/cache_cmd.py
@@ -63,8 +63,7 @@ def cache_group() -> None:
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 def list_cache_entries(workdir: Path, limit: int, as_json: bool) -> None:
     """List cached task-result entries."""
-    mgr = ResponseCacheManager(workdir.resolve())
-    entries = mgr.list_entries()
+    entries = ResponseCacheManager(workdir.resolve()).list_entries()
     if limit > 0:
         entries = entries[:limit]
 
@@ -108,8 +107,7 @@ def list_cache_entries(workdir: Path, limit: int, as_json: bool) -> None:
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 def inspect_cache_entry(task_id: str, workdir: Path, as_json: bool) -> None:
     """Inspect the cached result produced by a specific task."""
-    mgr = ResponseCacheManager(workdir.resolve())
-    entry = mgr.inspect_task(task_id)
+    entry = ResponseCacheManager(workdir.resolve()).inspect_task(task_id)
     if entry is None:
         if as_json:
             click.echo(json.dumps({"error": f"No cache entry found for task {task_id}"}, indent=2))
@@ -154,8 +152,7 @@ def clear_cache_entries(workdir: Path, unverified_only: bool, yes: bool) -> None
     if not yes and not click.confirm(f"Delete {target} from the response cache?"):
         raise SystemExit(1)
 
-    mgr = ResponseCacheManager(workdir.resolve())
-    removed = mgr.clear(unverified_only=unverified_only)
+    removed = ResponseCacheManager(workdir.resolve()).clear(unverified_only=unverified_only)
     console.print(f"[green]Removed {removed} response-cache entr{'y' if removed == 1 else 'ies'}.[/green]")
 
 

--- a/src/bernstein/cli/commands/chat_cmd.py
+++ b/src/bernstein/cli/commands/chat_cmd.py
@@ -104,8 +104,7 @@ def chat_serve(platform: str, token: str | None, allow: str | None) -> None:
 def chat_status() -> None:
     """Print active chat<->session bindings."""
     workdir = _DEFAULT_WORKDIR()
-    store = BindingStore(workdir)
-    entries = store.all()
+    entries = BindingStore(workdir).all()
     if not entries:
         click.echo("chat: no active bindings.")
         return

--- a/src/bernstein/cli/commands/ci_cmd.py
+++ b/src/bernstein/cli/commands/ci_cmd.py
@@ -84,8 +84,7 @@ def ci_fix(run_url: str, token: str | None, server: str) -> None:
     if ctx.file_path:
         console.print(f"  File:  [dim]{ctx.file_path}:{ctx.line_number}[/dim]")
 
-    pipeline = CIAutofixPipeline(server_url=server)
-    task_id = pipeline.create_fix_task(ctx, run_url=run_url)
+    task_id = CIAutofixPipeline(server_url=server).create_fix_task(ctx, run_url=run_url)
 
     if task_id:
         console.print(f"\n[green]Fix task created:[/green] [bold]{task_id}[/bold]")

--- a/src/bernstein/cli/commands/cloud_cmd.py
+++ b/src/bernstein/cli/commands/cloud_cmd.py
@@ -103,8 +103,7 @@ def cloud_run(goal: str, max_agents: int, model: str, budget: float, *, wait: bo
     }
     resp = _cloud_request("POST", _RUNS_PATH, token, json=payload)
     resp.raise_for_status()
-    data = resp.json()
-    run_id = data.get("id", "unknown")
+    run_id = resp.json().get("id", "unknown")
     click.echo(f"Started cloud run: {run_id}")
 
     if wait:

--- a/src/bernstein/cli/commands/compare_cmd.py
+++ b/src/bernstein/cli/commands/compare_cmd.py
@@ -122,8 +122,7 @@ def _parallel_executor_factory(max_workers: int) -> tuple[Executor, ThreadPoolEx
     pool = ThreadPoolExecutor(max_workers=max(1, max_workers), thread_name_prefix="compare")
 
     def _exec(adapter_name: str, task: CompareTaskSpec, worktree: Path) -> AdapterRun:
-        future = pool.submit(_real_adapter_executor, adapter_name, task, worktree)
-        return future.result()
+        return pool.submit(_real_adapter_executor, adapter_name, task, worktree).result()
 
     return _exec, pool
 

--- a/src/bernstein/cli/commands/compliance_cmd.py
+++ b/src/bernstein/cli/commands/compliance_cmd.py
@@ -247,8 +247,7 @@ def disable_framework(framework: str, workdir: Path) -> None:
     """
     fw = ComplianceFramework(framework.lower())
     config_dir = workdir / ".sdd" / "compliance"
-    lib = CompliancePolicyLibrary()
-    lib.disable(fw, config_dir=config_dir)
+    CompliancePolicyLibrary().disable(fw, config_dir=config_dir)
     click.echo(f"Disabled {fw.value} compliance framework.")
 
 
@@ -447,8 +446,7 @@ def export_rego(framework: str, output_dir: Path | None, workdir: Path) -> None:
     """
     fw = ComplianceFramework(framework.lower())
     dest = output_dir or (workdir / ".sdd" / "compliance" / "rego" / fw.value)
-    lib = CompliancePolicyLibrary()
-    paths = lib.export_rego(fw, dest_dir=dest)
+    paths = CompliancePolicyLibrary().export_rego(fw, dest_dir=dest)
     click.echo(f"Exported {len(paths)} Rego policies to: {dest}")
 
 

--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -86,7 +86,7 @@ def _count_task_status(task_records: list[dict[str, Any]]) -> tuple[int, int]:
     done = sum(1 for r in seen.values() if r.get("status") == "done")
     failed = sum(1 for r in seen.values() if r.get("status") == "failed")
     # If status not recorded, fall back to presence of cost as "done"
-    if done == 0 and failed == 0 and seen:
+    if done == failed == 0 and seen:
         done = sum(1 for r in seen.values() if float(r.get("cost_usd", 0) or 0) > 0)
     return done, failed
 

--- a/src/bernstein/cli/commands/creds_cmd.py
+++ b/src/bernstein/cli/commands/creds_cmd.py
@@ -220,8 +220,7 @@ def creds_group() -> None:
 @_backend_options
 def creds_list(backend: BackendChoice | None, passphrase_env: str | None) -> None:
     """List stored credentials. Never prints the secret itself."""
-    vault = _open_vault_or_exit(backend, passphrase_env)
-    records = vault.list()
+    records = _open_vault_or_exit(backend, passphrase_env).list()
     if not records:
         console.print("[yellow]No credentials stored.[/yellow]  Run [bold]bernstein connect <provider>[/bold] first.")
         return

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -559,8 +559,7 @@ def benchmark_simulate(
         baseline_path=bline,
         output_dir=output_dir,
     )
-    bench = ReproducibleBenchmark(tasks=tasks, config=config)
-    run, report = bench.run_and_compare()
+    run, report = ReproducibleBenchmark(tasks=tasks, config=config).run_and_compare()
 
     # --- Summary table ---
     table = Table(title=f"Benchmark simulation (seed={seed})", header_style=_STYLE_BOLD_CYAN, show_lines=False)
@@ -972,8 +971,7 @@ def eval_failures() -> None:
         console.print(_NO_EVAL_RUNS_MSG)
         raise SystemExit(1)
 
-    data = json_mod.loads(run_files[0].read_text(encoding="utf-8"))
-    failures = data.get("failures", [])
+    failures = json_mod.loads(run_files[0].read_text(encoding="utf-8")).get("failures", [])
 
     if not failures:
         console.print("[green]No failures in the most recent run.[/green]")
@@ -1017,8 +1015,7 @@ def eval_sync_incidents(workdir: str, dry_run: bool) -> None:
     from bernstein.eval.incident_synthesizer import IncidentSynthesizer
 
     root = Path(workdir).resolve()
-    synth = IncidentSynthesizer(root)
-    result = synth.sync(dry_run=dry_run)
+    result = IncidentSynthesizer(root).sync(dry_run=dry_run)
 
     if dry_run:
         console.print(f"[bold]Dry run[/bold]: {len(result.created)} case(s) would be created:")

--- a/src/bernstein/cli/commands/evolve_cmd.py
+++ b/src/bernstein/cli/commands/evolve_cmd.py
@@ -271,8 +271,7 @@ def evolve_review(workdir: str) -> None:
 
     root = Path(workdir).resolve()
     decisions_dir = root / ".sdd" / "evolution"
-    gate = ApprovalGate(decisions_dir=decisions_dir)
-    pending = gate.get_pending_decisions()
+    pending = ApprovalGate(decisions_dir=decisions_dir).get_pending_decisions()
 
     if not pending:
         console.print("[dim]No proposals pending review.[/dim]")
@@ -322,8 +321,7 @@ def evolve_approve(proposal_id: str, reviewer: str, workdir: str) -> None:
 
     root = Path(workdir).resolve()
     decisions_dir = root / ".sdd" / "evolution"
-    gate = ApprovalGate(decisions_dir=decisions_dir)
-    decision = gate.approve(proposal_id, reviewer=reviewer)
+    decision = ApprovalGate(decisions_dir=decisions_dir).approve(proposal_id, reviewer=reviewer)
 
     if decision is None:
         console.print(

--- a/src/bernstein/cli/commands/explain_cmd.py
+++ b/src/bernstein/cli/commands/explain_cmd.py
@@ -217,8 +217,7 @@ def explain_cmd(task_id: str, as_json: bool, traces_dir: str) -> None:
     # 2. Load traces
     from bernstein.core.traces import TraceStore
 
-    store = TraceStore(Path(traces_dir))
-    traces = store.read_by_task(task_id)
+    traces = TraceStore(Path(traces_dir)).read_by_task(task_id)
 
     # 3. JSON output
     if as_json:

--- a/src/bernstein/cli/commands/handoff_cmd.py
+++ b/src/bernstein/cli/commands/handoff_cmd.py
@@ -136,8 +136,7 @@ def handoff_status() -> None:
     from bernstein.core.handoff import HandoffTokenStore
 
     workdir = _DEFAULT_WORKDIR()
-    store = HandoffTokenStore(workdir)
-    tokens = store.all()
+    tokens = HandoffTokenStore(workdir).all()
     if not tokens:
         click.echo("handoff: no live tokens.")
         return
@@ -163,8 +162,7 @@ def _render_attach_banner(record: HandoffToken) -> None:
 def _replay_tail(workdir: Path, session_id: str, tail_lines: int) -> None:
     if tail_lines <= 0:
         return
-    buffer = StreamTailBuffer(workdir, session_id)
-    entries = buffer.read(limit=tail_lines)
+    entries = StreamTailBuffer(workdir, session_id).read(limit=tail_lines)
     if not entries:
         click.echo("handoff: no buffered tail to replay.")
         return

--- a/src/bernstein/cli/commands/issue_to_pr_cmd.py
+++ b/src/bernstein/cli/commands/issue_to_pr_cmd.py
@@ -43,8 +43,10 @@ def trace_cmd(issue_id: str, repo: str) -> None:
         issue_number = int(issue_id.lstrip("#"))
     except ValueError as exc:
         raise click.BadParameter(f"issue_id must be numeric, got {issue_id!r}") from exc
-    trace = (IssueToPRPipeline(
-        config=IssueToPRConfig(),
-        client=IssuePRClient(),
-    )).trace(repo, issue_number)
+    trace = (
+        IssueToPRPipeline(
+            config=IssueToPRConfig(),
+            client=IssuePRClient(),
+        )
+    ).trace(repo, issue_number)
     console.print(trace.render())

--- a/src/bernstein/cli/commands/issue_to_pr_cmd.py
+++ b/src/bernstein/cli/commands/issue_to_pr_cmd.py
@@ -43,9 +43,8 @@ def trace_cmd(issue_id: str, repo: str) -> None:
         issue_number = int(issue_id.lstrip("#"))
     except ValueError as exc:
         raise click.BadParameter(f"issue_id must be numeric, got {issue_id!r}") from exc
-    pipeline = IssueToPRPipeline(
+    trace = (IssueToPRPipeline(
         config=IssueToPRConfig(),
         client=IssuePRClient(),
-    )
-    trace = pipeline.trace(repo, issue_number)
+    )).trace(repo, issue_number)
     console.print(trace.render())

--- a/src/bernstein/cli/commands/lineage_cmd.py
+++ b/src/bernstein/cli/commands/lineage_cmd.py
@@ -127,8 +127,7 @@ def walk_cmd(target: str, workdir: str, run_id: str | None, limit: int) -> None:
 
     path, line = _parse_target(target)
 
-    reader = LineageReader(sdd_dir)
-    records = reader.lookup(path, line, run_id=run_id)
+    records = LineageReader(sdd_dir).lookup(path, line, run_id=run_id)
 
     if not records:
         console.print(f"[yellow]No lineage records for[/yellow] {target}")
@@ -681,8 +680,7 @@ def v2_show_cmd(task_id: str, root: Path | None, output_json: bool) -> None:
     """Reconstruct + print the full timeline for ``TASK_ID``."""
     import json as _json
 
-    store = _load_v2_store(root or _default_v2_root())
-    timeline = store.replay(task_id)
+    timeline = _load_v2_store(root or _default_v2_root()).replay(task_id)
     if output_json:
         from dataclasses import asdict
 
@@ -727,8 +725,7 @@ def v2_verify_cmd(root: Path | None, output_json: bool) -> None:
     import json as _json
     import sys
 
-    store = _load_v2_store(root or _default_v2_root())
-    result = store.verify()
+    result = _load_v2_store(root or _default_v2_root()).verify()
     if output_json:
         click.echo(
             _json.dumps(

--- a/src/bernstein/cli/commands/lineage_tracker_audit_cmd.py
+++ b/src/bernstein/cli/commands/lineage_tracker_audit_cmd.py
@@ -92,8 +92,7 @@ def show_cmd(
 ) -> None:
     """Show audit entries chronologically with optional filters."""
     key = _load_key(secret_env)
-    log = TrackerAuditLog(log_path, hmac_key=key)
-    entries = log.filter(
+    entries = TrackerAuditLog(log_path, hmac_key=key).filter(
         tracker_name=tracker_name,
         ticket_id=ticket_id,
         since_ns=since_ns,
@@ -162,8 +161,7 @@ def export_cmd(
 ) -> None:
     """Write a filtered signed JSONL bundle for an auditor."""
     key = _load_key(secret_env)
-    log = TrackerAuditLog(log_path, hmac_key=key)
-    n = log.export_bundle(
+    n = TrackerAuditLog(log_path, hmac_key=key).export_bundle(
         output_path,
         tracker_name=tracker_name,
         ticket_id=ticket_id,
@@ -189,8 +187,7 @@ def export_cmd(
 def verify_cmd(log_path: Path, secret_env: str) -> None:
     """Verify chain integrity + HMAC. Exits non-zero on tampering."""
     key = _load_key(secret_env)
-    log = TrackerAuditLog(log_path, hmac_key=key)
-    result = log.verify()
+    result = TrackerAuditLog(log_path, hmac_key=key).verify()
     if result.ok:
         console.print(f"[green]tracker-audit verify:[/green] OK ({result.entry_count} entry(ies))")
         return

--- a/src/bernstein/cli/commands/mcp_catalog_cmd.py
+++ b/src/bernstein/cli/commands/mcp_catalog_cmd.py
@@ -238,8 +238,7 @@ def search_cmd(query: str, refresh: bool) -> None:
 @click.option("--refresh", is_flag=True, help="Skip the freshness window.")
 def info_cmd(entry_id: str, refresh: bool) -> None:
     """Show full info for a single catalog entry."""
-    service = _build_service()
-    entry = service.info(entry_id, force_refresh=refresh)
+    entry = _build_service().info(entry_id, force_refresh=refresh)
     if entry is None:
         raise click.ClickException(f"Catalog entry {entry_id!r} not found")
     console.print(f"[bold]{entry.id}[/bold] - {entry.name} ({entry.version_pin})")
@@ -375,8 +374,7 @@ def uninstall_cmd(entry_id: str) -> None:
 @catalog_group.command("status")
 def status_cmd() -> None:
     """Show cache + cadence + installed-count for ``mcp catalog``."""
-    service = _build_service()
-    status = service.status()
+    status = _build_service().status()
     console.print("[bold cyan]MCP Catalog Status[/bold cyan]")
     console.print(f"Cache:                {status.cache_path}")
     console.print(f"Last fetch:           {status.last_fetch_at or 'never'}")

--- a/src/bernstein/cli/commands/memory_cmd.py
+++ b/src/bernstein/cli/commands/memory_cmd.py
@@ -143,11 +143,13 @@ def share_fact(key: str, value: str, tag: str, scope: str) -> None:
     db_path = _resolve_db_path()
     db_path.parent.mkdir(parents=True, exist_ok=True)
     store = SQLiteMemoryStore(db_path)
-    fact = (CrossTaskKB(
-        store,
-        run_id=_resolve_run_id(),
-        producer_task_id=_resolve_task_id(),
-    )).publish(
+    fact = (
+        CrossTaskKB(
+            store,
+            run_id=_resolve_run_id(),
+            producer_task_id=_resolve_task_id(),
+        )
+    ).publish(
         tag=tag,
         key=key,
         value=value,

--- a/src/bernstein/cli/commands/memory_cmd.py
+++ b/src/bernstein/cli/commands/memory_cmd.py
@@ -60,8 +60,7 @@ def list_memory(memory_type: str | None, tag: list[str], limit: int) -> None:
         console.print("[dim]No memory database found.[/dim]")
         return
 
-    store = SQLiteMemoryStore(db_path)
-    entries = store.list(type=_coerce_memory_type(memory_type), tags=tag or None, limit=limit)
+    entries = SQLiteMemoryStore(db_path).list(type=_coerce_memory_type(memory_type), tags=tag or None, limit=limit)
 
     if not entries:
         console.print("[dim]No matching memories found.[/dim]")
@@ -103,8 +102,7 @@ def list_memory(memory_type: str | None, tag: list[str], limit: int) -> None:
 def add_memory(content: str, memory_type: str, tag: list[str]) -> None:
     """Add a new persistent memory entry."""
     db_path = Path(_MEMORY_DB_PATH)
-    store = SQLiteMemoryStore(db_path)
-    entry_id = store.add(type=cast("MemoryType", memory_type), content=content, tags=tag.copy())
+    entry_id = SQLiteMemoryStore(db_path).add(type=cast("MemoryType", memory_type), content=content, tags=tag.copy())
     console.print(f"[green]✓[/green] Added memory entry [bold]#{entry_id}[/bold]")
 
 
@@ -145,12 +143,11 @@ def share_fact(key: str, value: str, tag: str, scope: str) -> None:
     db_path = _resolve_db_path()
     db_path.parent.mkdir(parents=True, exist_ok=True)
     store = SQLiteMemoryStore(db_path)
-    facade = CrossTaskKB(
+    fact = (CrossTaskKB(
         store,
         run_id=_resolve_run_id(),
         producer_task_id=_resolve_task_id(),
-    )
-    fact = facade.publish(
+    )).publish(
         tag=tag,
         key=key,
         value=value,

--- a/src/bernstein/cli/commands/plan_archive_cmd.py
+++ b/src/bernstein/cli/commands/plan_archive_cmd.py
@@ -87,8 +87,7 @@ def plan_show(plan_id: str) -> None:
     The id is the filename stem (e.g. ``2026-04-23-strategic-300``).
     Active plans are looked up by their original filename stem.
     """
-    lifecycle = _resolve_lifecycle()
-    found = lifecycle.find(plan_id)
+    found = _resolve_lifecycle().find(plan_id)
     if found is None:
         console.print(f"[red]No plan with id {plan_id!r} found.[/red]")
         raise SystemExit(1)

--- a/src/bernstein/cli/commands/prompts_cmd.py
+++ b/src/bernstein/cli/commands/prompts_cmd.py
@@ -108,8 +108,7 @@ def prompts_show(name: str) -> None:
     """
     from bernstein.core.prompt_versioning import PromptRegistry, VersionMetrics
 
-    registry = PromptRegistry(_sdd_dir())
-    meta = registry.get_meta(name)
+    meta = PromptRegistry(_sdd_dir()).get_meta(name)
 
     if meta is None:
         console.print(f"[red]Prompt [bold]{name}[/bold] not found.[/red]")
@@ -175,8 +174,7 @@ def prompts_compare(name: str, v1: int, v2: int, as_json: bool) -> None:
 
     from bernstein.core.prompt_versioning import PromptRegistry
 
-    registry = PromptRegistry(_sdd_dir())
-    result = registry.compare_versions(name, v1, v2)
+    result = PromptRegistry(_sdd_dir()).compare_versions(name, v1, v2)
 
     if result is None:
         console.print(f"[red]Cannot compare: prompt [bold]{name}[/bold] v{v1}/v{v2} not found.[/red]")

--- a/src/bernstein/cli/commands/recipes_cmd.py
+++ b/src/bernstein/cli/commands/recipes_cmd.py
@@ -374,8 +374,7 @@ def _execute(
 
     from bernstein.core.workflows import NodeStatus, WorkflowRunner
 
-    runner = WorkflowRunner(workdir=Path.cwd())
-    execution = runner.run(workflow, goal=goal)
+    execution = WorkflowRunner(workdir=Path.cwd()).run(workflow, goal=goal)
 
     table = Table(title=f"Run {execution.run_id}")
     table.add_column("Node")

--- a/src/bernstein/cli/commands/report_cmd.py
+++ b/src/bernstein/cli/commands/report_cmd.py
@@ -27,7 +27,7 @@ def report_cmd(run_id: str | None, workdir: str, save: bool) -> None:
     generator = RunReportGenerator(workdir_path, run_id=run_id)
     report = generator.generate()
 
-    if report.run_id == 'unknown' and report.tasks_completed == report.tasks_failed == 0:
+    if report.run_id == "unknown" and report.tasks_completed == report.tasks_failed == 0:
         console.print("[yellow]No run data found.[/yellow] Has a run completed in this project?")
         raise SystemExit(1)
 

--- a/src/bernstein/cli/commands/report_cmd.py
+++ b/src/bernstein/cli/commands/report_cmd.py
@@ -27,7 +27,7 @@ def report_cmd(run_id: str | None, workdir: str, save: bool) -> None:
     generator = RunReportGenerator(workdir_path, run_id=run_id)
     report = generator.generate()
 
-    if report.run_id == "unknown" and report.tasks_completed == 0 and report.tasks_failed == 0:
+    if report.run_id == 'unknown' and report.tasks_completed == report.tasks_failed == 0:
         console.print("[yellow]No run data found.[/yellow] Has a run completed in this project?")
         raise SystemExit(1)
 

--- a/src/bernstein/cli/commands/review_responder_cmd.py
+++ b/src/bernstein/cli/commands/review_responder_cmd.py
@@ -175,11 +175,13 @@ def tick_cmd(repo: str, pr_numbers: tuple[int, ...]) -> None:
     def _capture(comment: ReviewComment) -> None:
         received.append(comment.comment_id)
 
-    n = (PollingListener(
-        repo=repo,
-        pr_numbers=pr_numbers or None,
-        on_comment=_capture,
-    )).tick()
+    n = (
+        PollingListener(
+            repo=repo,
+            pr_numbers=pr_numbers or None,
+            on_comment=_capture,
+        )
+    ).tick()
     console.print(f"[green]review-responder tick[/green] new_comments={n}")
     if received:
         console.print(json.dumps(received))

--- a/src/bernstein/cli/commands/review_responder_cmd.py
+++ b/src/bernstein/cli/commands/review_responder_cmd.py
@@ -175,12 +175,11 @@ def tick_cmd(repo: str, pr_numbers: tuple[int, ...]) -> None:
     def _capture(comment: ReviewComment) -> None:
         received.append(comment.comment_id)
 
-    listener = PollingListener(
+    n = (PollingListener(
         repo=repo,
         pr_numbers=pr_numbers or None,
         on_comment=_capture,
-    )
-    n = listener.tick()
+    )).tick()
     console.print(f"[green]review-responder tick[/green] new_comments={n}")
     if received:
         console.print(json.dumps(received))

--- a/src/bernstein/cli/commands/role_adapter_policy_cmd.py
+++ b/src/bernstein/cli/commands/role_adapter_policy_cmd.py
@@ -53,8 +53,7 @@ def show_policy(policy_file: Path, as_json: bool) -> None:
     An empty allow-list for a role means **all adapters allowed** (the
     back-compat default). A role missing from the map is also unrestricted.
     """
-    policy = load_policy_file(policy_file)
-    payload = policy.to_dict()
+    payload = load_policy_file(policy_file).to_dict()
     if as_json:
         click.echo(json.dumps(payload, indent=2, sort_keys=True))
         return

--- a/src/bernstein/cli/commands/routine_cmd.py
+++ b/src/bernstein/cli/commands/routine_cmd.py
@@ -221,8 +221,7 @@ def routine_bindings(scenarios_dir: Path | None) -> None:
     from rich.table import Table
 
     console = Console()
-    bridge = _make_bridge(scenarios_dir, Path.cwd())
-    bindings = bridge.list_bindings()
+    bindings = _make_bridge(scenarios_dir, Path.cwd()).list_bindings()
     if not bindings:
         console.print("[yellow]No bindings registered.[/yellow]")
         return

--- a/src/bernstein/cli/commands/token_cmd.py
+++ b/src/bernstein/cli/commands/token_cmd.py
@@ -166,8 +166,7 @@ def token_report_cmd(metrics_dir: str, as_json: bool, as_markdown: bool) -> None
         raise SystemExit(1)
 
     workdir = mdir.parent.parent  # .sdd/metrics -> .sdd -> workdir
-    analyzer = TokenUsageAnalyzer(workdir)
-    analysis = analyzer.analyze()
+    analysis = TokenUsageAnalyzer(workdir).analyze()
 
     if not analysis.task_stats:
         if as_json or is_json():

--- a/src/bernstein/cli/commands/triggers_cmd.py
+++ b/src/bernstein/cli/commands/triggers_cmd.py
@@ -40,8 +40,7 @@ def triggers_list() -> None:
         console.print(f"[dim]Create {config_path} to define trigger rules.[/dim]")
         return
 
-    mgr = TriggerManager(sdd_dir)
-    triggers = mgr.list_triggers()
+    triggers = TriggerManager(sdd_dir).list_triggers()
 
     if not triggers:
         console.print("[yellow]No triggers defined in triggers.yaml.[/yellow]")
@@ -89,8 +88,7 @@ def triggers_history(limit: int) -> None:
         console.print("[red]No .sdd/ directory found.[/red]")
         raise SystemExit(1)
 
-    mgr = TriggerManager(sdd_dir)
-    history = mgr.get_fire_history(limit=limit)
+    history = TriggerManager(sdd_dir).get_fire_history(limit=limit)
 
     if not history:
         console.print("[dim]No trigger fire history.[/dim]")

--- a/src/bernstein/cli/commands/tunnel_cmd.py
+++ b/src/bernstein/cli/commands/tunnel_cmd.py
@@ -100,8 +100,7 @@ def start_cmd(port: int, provider: str, name: str | None) -> None:
 @tunnel_group.command("list")
 def list_cmd() -> None:
     """Show every active tunnel."""
-    reg = _build_registry()
-    handles = reg.list_active()
+    handles = _build_registry().list_active()
     if not handles:
         console.print("[dim]No active tunnels.[/dim]")
         return

--- a/src/bernstein/cli/commands/workflow_cmd.py
+++ b/src/bernstein/cli/commands/workflow_cmd.py
@@ -359,8 +359,7 @@ def run_cmd(name_or_path: str, goal: str, dry_run: bool) -> None:
             console.print(f"  [bold]Layer {index}:[/bold] {ids}")
         return
 
-    runner = WorkflowRunner(workdir=Path.cwd())
-    execution = runner.run(spec, goal=goal)
+    execution = WorkflowRunner(workdir=Path.cwd()).run(spec, goal=goal)
 
     table = Table(title=f"Run {execution.run_id}")
     table.add_column("Node")

--- a/src/bernstein/cli/display/image_renderer.py
+++ b/src/bernstein/cli/display/image_renderer.py
@@ -311,9 +311,11 @@ class BrailleRenderer(BaseRenderer):
     def render(self, img: Image.Image, width: int, height: int) -> str:
         pixel_w = width * 2
         pixel_h = height * 4
-        pixels = (img.convert("L")
+        pixels = (
+            img.convert("L")
             .resize((pixel_w, pixel_h), Image.Resampling.LANCZOS)
-            .point(lambda p: 255 if p >= self._THRESHOLD else 0)).load()
+            .point(lambda p: 255 if p >= self._THRESHOLD else 0)
+        ).load()
         if pixels is None:  # pragma: no cover
             return ""
 

--- a/src/bernstein/cli/display/image_renderer.py
+++ b/src/bernstein/cli/display/image_renderer.py
@@ -311,12 +311,9 @@ class BrailleRenderer(BaseRenderer):
     def render(self, img: Image.Image, width: int, height: int) -> str:
         pixel_w = width * 2
         pixel_h = height * 4
-        mono = (
-            img.convert("L")
+        pixels = (img.convert("L")
             .resize((pixel_w, pixel_h), Image.Resampling.LANCZOS)
-            .point(lambda p: 255 if p >= self._THRESHOLD else 0)
-        )
-        pixels = mono.load()
+            .point(lambda p: 255 if p >= self._THRESHOLD else 0)).load()
         if pixels is None:  # pragma: no cover
             return ""
 
@@ -381,8 +378,7 @@ def render_image(
         caps = TerminalCaps.detect()
 
     out: TextIO = file if file is not None else sys.stdout
-    renderer = _make_renderer(caps)
-    output = renderer.render(img, width, height)
+    output = _make_renderer(caps).render(img, width, height)
 
     if synchronized and caps.is_tty:
         out.write("\033[?2026h")  # begin synchronized update

--- a/src/bernstein/cli/display/terminal_caps.py
+++ b/src/bernstein/cli/display/terminal_caps.py
@@ -102,8 +102,7 @@ class TerminalCaps:
         use :func:`detect_capabilities` for a cached, production-safe call.
         """
         term = os.environ.get("TERM", "")
-        term_program = os.environ.get("TERM_PROGRAM", "")
-        term_program_lower = term_program.lower()
+        term_program_lower = os.environ.get("TERM_PROGRAM", "").lower()
         colorterm = os.environ.get("COLORTERM", "").lower()
 
         truecolor = colorterm in ("truecolor", "24bit")

--- a/src/bernstein/cli/doctor/environment_checks.py
+++ b/src/bernstein/cli/doctor/environment_checks.py
@@ -123,10 +123,7 @@ def detect_environments(
     exists = file_exists if file_exists is not None else _default_file_exists
     probe_list = list(probes) if probes is not None else ENVIRONMENT_PROBES
 
-    matches: list[EnvironmentProbe] = []
-    for probe in probe_list:
-        if probe.matches(env_map, exists):
-            matches.append(probe)
+    matches = [probe for probe in probe_list if probe.matches(env_map, exists)]
 
     if len(matches) > 1:
         specific = [p for p in matches if p.label != "Generic CI"]

--- a/src/bernstein/cli/live.py
+++ b/src/bernstein/cli/live.py
@@ -190,11 +190,9 @@ class LiveView:
         tasks_table = _build_tasks_table(tasks)
 
         # Progress + cost
-        progress = TaskProgressBar()
-        progress_text = progress.render(summary)
+        progress_text = TaskProgressBar().render(summary)
 
-        cost_panel = CostBurnPanel()
-        cost_renderable = cost_panel.render(
+        cost_renderable = CostBurnPanel().render(
             total_cost, elapsed, budget_usd=budget_usd, per_model=per_model, per_agent=per_agent
         )
 

--- a/src/bernstein/cli/plan/plan_diff.py
+++ b/src/bernstein/cli/plan/plan_diff.py
@@ -131,8 +131,7 @@ def _extract_deps(plan: dict) -> set[tuple[str, str]]:
     deps: set[tuple[str, str]] = set()
     for stage in plan.get("stages") or []:
         stage_name = str(stage.get("name", ""))
-        for dep in stage.get("depends_on") or []:
-            deps.add((stage_name, str(dep)))
+        deps.update((stage_name, str(dep)) for dep in stage.get("depends_on") or [])
     return deps
 
 

--- a/src/bernstein/cli/plan/plan_display.py
+++ b/src/bernstein/cli/plan/plan_display.py
@@ -355,8 +355,7 @@ class _PlanRenderer:
         )
 
         # Created timestamp
-        created = datetime.datetime.fromtimestamp(plan.created_at, tz=datetime.UTC)
-        created_str = created.strftime("%Y-%m-%d %H:%M UTC")
+        created_str = datetime.datetime.fromtimestamp(plan.created_at, tz=datetime.UTC).strftime("%Y-%m-%d %H:%M UTC")
         self._add(
             _box_row(
                 f"[{C_WHITE}]Created:[/{C_WHITE}] [{C_DIM}]{created_str}[/{C_DIM}]",
@@ -403,8 +402,7 @@ class _PlanRenderer:
 
     def _task_table(self) -> None:
         """Task list inner box with table layout."""
-        plan = self.plan
-        estimates = plan.task_estimates
+        estimates = self.plan.task_estimates
         if not estimates:
             return
 
@@ -527,8 +525,7 @@ def render_plan(
         console = Console()
 
     width = min(console.size.width, 100)
-    renderer = _PlanRenderer(plan, tasks, width)
-    lines = renderer.build()
+    lines = _PlanRenderer(plan, tasks, width).build()
     markup = "\n".join(lines)
 
     console.print(Text.from_markup(markup))

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -748,7 +748,7 @@ def _wait_for_run_completion(
             open_count = int(status_payload.get("open", 0) or 0)
             claimed_count = int(status_payload.get("claimed", 0) or 0)
             agent_count = int(health_payload.get("agent_count", 0) or 0)
-            if total > 0 and open_count == 0 and claimed_count == 0 and agent_count == 0:
+            if total > 0 and open_count == claimed_count == 0 and (agent_count == 0):
                 return status_payload
         time.sleep(poll_interval_s)
     return last_status

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -74,8 +74,7 @@ def _extract_recipe_stages(recipe_path: Path) -> list[RecipeStage]:
     raw_data = yaml.safe_load(recipe_path.read_text(encoding="utf-8"))
     if not isinstance(raw_data, dict):
         return []
-    data = cast(_CAST_DICT_STR_ANY, raw_data)
-    raw_stages = data.get("stages")
+    raw_stages = cast(_CAST_DICT_STR_ANY, raw_data).get("stages")
     if not isinstance(raw_stages, list):
         return []
 
@@ -192,7 +191,7 @@ def _format_recipe_progress(
     line = f"Sprint {sprint_done}/{max(len(stages), 1)} | {pct_complete}% complete | ${spent_usd:.2f} spent"
 
     total = int(status_payload.get("total", 0) or 0)
-    is_complete = total > 0 and open_count == 0 and claimed_count == 0 and agent_count == 0
+    is_complete = total > 0 and open_count == claimed_count == 0 and (agent_count == 0)
     return line, is_complete
 
 
@@ -395,8 +394,7 @@ def setup_demo_project(project_dir: Path, adapter: str) -> None:
     for d in SDD_DIRS:
         (project_dir / d).mkdir(parents=True, exist_ok=True)
 
-    config_path = project_dir / ".sdd" / "config.yaml"
-    config_path.write_text(
+    (project_dir / ".sdd" / "config.yaml").write_text(
         "# Bernstein demo workspace\n"
         f"server_port: {_DEMO_PORT}\n"
         "max_workers: 2\n"

--- a/src/bernstein/cli/status.py
+++ b/src/bernstein/cli/status.py
@@ -163,7 +163,7 @@ def _format_quota(snapshot: dict[str, Any]) -> str:
     tpm_obj = snapshot.get("tokens_per_minute")
     rpm = int(rpm_obj) if isinstance(rpm_obj, int) else None
     tpm = int(tpm_obj) if isinstance(tpm_obj, int) else None
-    if rpm is None and tpm is None:
+    if rpm is tpm is None:
         return "unknown"
     parts: list[str] = []
     if rpm is not None:

--- a/src/bernstein/cli/usage_provisioning.py
+++ b/src/bernstein/cli/usage_provisioning.py
@@ -148,8 +148,7 @@ def _next_midnight_ts() -> float:
     Returns:
         Seconds since epoch for the next UTC midnight.
     """
-    now = datetime.now(UTC)
-    tomorrow = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    tomorrow = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     # Add one day via timedelta to avoid DST issues
 
     tomorrow += timedelta(days=1)

--- a/src/bernstein/compliance/eu_ai_act.py
+++ b/src/bernstein/compliance/eu_ai_act.py
@@ -371,7 +371,9 @@ class _AnnexIIIClassifier:
         now = datetime.now(tz=UTC).isoformat()
 
         # Step 1: Check Article 5 prohibitions
-        article5_triggers = [description for attr, description in self._ARTICLE5_CHECKS if getattr(descriptor, attr, False)]
+        article5_triggers = [
+            description for attr, description in self._ARTICLE5_CHECKS if getattr(descriptor, attr, False)
+        ]
 
         # Step 2: Check Annex III high-risk domains
         annex_iii_domain = AnnexIIIDomain.NOT_APPLICABLE
@@ -383,7 +385,9 @@ class _AnnexIIIClassifier:
                 break  # First match determines domain (most critical first)
 
         # Step 3: Check Article 50 transparency obligations
-        article50_triggers = [description for attr, description in self._ARTICLE50_CHECKS if getattr(descriptor, attr, False)]
+        article50_triggers = [
+            description for attr, description in self._ARTICLE50_CHECKS if getattr(descriptor, attr, False)
+        ]
 
         # Step 4: Determine risk category
         if article5_triggers:

--- a/src/bernstein/compliance/eu_ai_act.py
+++ b/src/bernstein/compliance/eu_ai_act.py
@@ -371,10 +371,7 @@ class _AnnexIIIClassifier:
         now = datetime.now(tz=UTC).isoformat()
 
         # Step 1: Check Article 5 prohibitions
-        article5_triggers: list[str] = []
-        for attr, description in self._ARTICLE5_CHECKS:
-            if getattr(descriptor, attr, False):
-                article5_triggers.append(description)
+        article5_triggers = [description for attr, description in self._ARTICLE5_CHECKS if getattr(descriptor, attr, False)]
 
         # Step 2: Check Annex III high-risk domains
         annex_iii_domain = AnnexIIIDomain.NOT_APPLICABLE
@@ -386,10 +383,7 @@ class _AnnexIIIClassifier:
                 break  # First match determines domain (most critical first)
 
         # Step 3: Check Article 50 transparency obligations
-        article50_triggers: list[str] = []
-        for attr, description in self._ARTICLE50_CHECKS:
-            if getattr(descriptor, attr, False):
-                article50_triggers.append(description)
+        article50_triggers = [description for attr, description in self._ARTICLE50_CHECKS if getattr(descriptor, attr, False)]
 
         # Step 4: Determine risk category
         if article5_triggers:

--- a/src/bernstein/core/agents/agent_discovery.py
+++ b/src/bernstein/core/agents/agent_discovery.py
@@ -962,8 +962,7 @@ def recommend_routing_by_capabilities(
 
     from bernstein.core.capability_router import CapabilityRouter
 
-    router = CapabilityRouter(discovery=discovery)
-    match = router.best_match(required, preferred_agent=preferred_agent)
+    match = CapabilityRouter(discovery=discovery).best_match(required, preferred_agent=preferred_agent)
     if match is None:
         return None
 

--- a/src/bernstein/core/agents/agent_recycling.py
+++ b/src/bernstein/core/agents/agent_recycling.py
@@ -58,8 +58,7 @@ def _build_snapshot_indexes(
     """Build resolved IDs, open-per-role, and active-per-role indexes from snapshot."""
     resolved_ids: set[str] = set()
     for status in ("done", "failed", "blocked"):
-        for t in tasks_snapshot.get(status, []):
-            resolved_ids.add(t.id)
+        resolved_ids.update(t.id for t in tasks_snapshot.get(status, []))
 
     open_per_role: dict[str, int] = {}
     for t in tasks_snapshot.get("open", []):

--- a/src/bernstein/core/agents/agent_turn_state.py
+++ b/src/bernstein/core/agents/agent_turn_state.py
@@ -296,8 +296,5 @@ class AgentTurnStateMachine:
         Returns:
             A list of ``(event_name, next_state_name)`` tuples.
         """
-        result: list[tuple[str, str]] = []
-        for (src, evt), tgt in _VALID_TRANSITIONS.items():
-            if src is state:
-                result.append((evt.value, tgt.value))
+        result = [(evt.value, tgt.value) for (src, evt), tgt in _VALID_TRANSITIONS.items() if src is state]
         return result

--- a/src/bernstein/core/agents/spawn_dry_run.py
+++ b/src/bernstein/core/agents/spawn_dry_run.py
@@ -135,18 +135,12 @@ class SpawnDryRunValidator:
         """
         report = DryRunReport(adapter_name=adapter_name)
 
-        report.checks.append(self._check_adapter(adapter_name))
-        report.checks.append(self._check_binary(adapter_name))
-        report.checks.append(self._check_model(adapter_name, model))
-        report.checks.append(self._check_repo_root())
-        report.checks.append(self._check_sdd_dir())
-        report.checks.append(self._check_tasks(tasks))
+        report.checks.extend((self._check_adapter(adapter_name), self._check_binary(adapter_name), self._check_model(adapter_name, model), self._check_repo_root(), self._check_sdd_dir(), self._check_tasks(tasks)))
 
         if mcp_config:
             report.checks.append(self._check_mcp(mcp_config))
 
-        report.checks.append(self._check_git())
-        report.checks.append(self._check_disk_space())
+        report.checks.extend((self._check_git(), self._check_disk_space()))
 
         if report.passed:
             report.would_spawn = max(1, len(tasks))

--- a/src/bernstein/core/agents/spawn_dry_run.py
+++ b/src/bernstein/core/agents/spawn_dry_run.py
@@ -135,7 +135,16 @@ class SpawnDryRunValidator:
         """
         report = DryRunReport(adapter_name=adapter_name)
 
-        report.checks.extend((self._check_adapter(adapter_name), self._check_binary(adapter_name), self._check_model(adapter_name, model), self._check_repo_root(), self._check_sdd_dir(), self._check_tasks(tasks)))
+        report.checks.extend(
+            (
+                self._check_adapter(adapter_name),
+                self._check_binary(adapter_name),
+                self._check_model(adapter_name, model),
+                self._check_repo_root(),
+                self._check_sdd_dir(),
+                self._check_tasks(tasks),
+            )
+        )
 
         if mcp_config:
             report.checks.append(self._check_mcp(mcp_config))

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -153,8 +153,7 @@ def section_is_relevant(
     Returns:
         True if the section should be included.
     """
-    rule_table = rules if rules is not None else SECTION_RULES
-    rule = rule_table.get(section_name)
+    rule = (rules if rules is not None else SECTION_RULES).get(section_name)
     if rule is None:
         # No rule means always include (critical section).
         return True
@@ -865,10 +864,7 @@ def _render_prompt(
     if rich_context:
         named_sections.append(("context", f"\n{rich_context}\n"))
     # Parent context inheritance: inject parent's context summary
-    parent_ctx_parts: list[str] = []
-    for t in tasks:
-        if t.parent_context:
-            parent_ctx_parts.append(t.parent_context)
+    parent_ctx_parts = [t.parent_context for t in tasks if t.parent_context]
     if parent_ctx_parts:
         named_sections.append(
             (

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -703,10 +703,7 @@ def _render_prompt(
         sections.append(deduplicate_section(f"\n## File-scope context\n{file_scope_context}\n"))
     # Parent context inheritance: inject parent's context summary
     # when a task was created from decomposing a larger parent task.
-    parent_ctx_parts: list[str] = []
-    for t in tasks:
-        if t.parent_context:
-            parent_ctx_parts.append(t.parent_context)
+    parent_ctx_parts = [t.parent_context for t in tasks if t.parent_context]
     if parent_ctx_parts:
         sections.append(
             "\n## Parent context (inherited)\n"

--- a/src/bernstein/core/autofix/classifier.py
+++ b/src/bernstein/core/autofix/classifier.py
@@ -128,10 +128,7 @@ class Classification:
 
 def _matches(text: str, patterns: tuple[str, ...]) -> tuple[str, ...]:
     """Return the subset of ``patterns`` that fire against ``text``."""
-    found: list[str] = []
-    for pattern in patterns:
-        if re.search(pattern, text, re.IGNORECASE):
-            found.append(pattern)
+    found = [pattern for pattern in patterns if re.search(pattern, text, re.IGNORECASE)]
     return tuple(found)
 
 

--- a/src/bernstein/core/autofix/gh_logs.py
+++ b/src/bernstein/core/autofix/gh_logs.py
@@ -119,7 +119,7 @@ def extract_failed_log(
         A :class:`LogExtraction` describing the outcome.  Callers
         should always inspect ``ok`` before using ``body``.
     """
-    if shutil.which('gh') is runner is None:
+    if shutil.which("gh") is runner is None:
         return LogExtraction(
             ok=False,
             body="",

--- a/src/bernstein/core/autofix/gh_logs.py
+++ b/src/bernstein/core/autofix/gh_logs.py
@@ -119,7 +119,7 @@ def extract_failed_log(
         A :class:`LogExtraction` describing the outcome.  Callers
         should always inspect ``ok`` before using ``body``.
     """
-    if shutil.which("gh") is None and runner is None:
+    if shutil.which('gh') is runner is None:
         return LogExtraction(
             ok=False,
             body="",

--- a/src/bernstein/core/communication/bulletin.py
+++ b/src/bernstein/core/communication/bulletin.py
@@ -903,7 +903,7 @@ class DirectChannel:
                     continue
                 matches_agent = agent_id and q.target_agent == agent_id
                 matches_role = role and q.target_role == role
-                matches_broadcast = q.target_agent is None and q.target_role is None
+                matches_broadcast = q.target_agent is q.target_role is None
                 if matches_agent or matches_role or matches_broadcast:
                     results.append(q)
             return results

--- a/src/bernstein/core/config/poll_config.py
+++ b/src/bernstein/core/config/poll_config.py
@@ -166,7 +166,7 @@ def validate_poll_config(raw: dict[str, object]) -> PollConfig:
         errors.extend(_validate_interval(watchdog_interval_ms, "watchdog_interval_ms"))
 
     # --- Liveness invariant -------------------------------------------------
-    if heartbeat_interval_ms is None and watchdog_interval_ms is None:
+    if heartbeat_interval_ms is watchdog_interval_ms is None:
         errors.append(
             "at least one liveness mechanism must be enabled: set heartbeat_interval_ms or watchdog_interval_ms"
         )

--- a/src/bernstein/core/cost/cost_estimation.py
+++ b/src/bernstein/core/cost/cost_estimation.py
@@ -94,8 +94,7 @@ def _refine_with_history(
     """Refine token estimates with historical bandit data."""
     if not metrics_dir or not metrics_dir.exists():
         return est_input, est_output, source, confidence
-    bandit = epsilon_greedy_bandit.load(metrics_dir)
-    arm = bandit.get_arm(task.role, model)
+    arm = epsilon_greedy_bandit.load(metrics_dir).get_arm(task.role, model)
     if not arm or arm.observations < min_observations:
         return est_input, est_output, source, confidence
     cost_per_1k = _model_cost(model)

--- a/src/bernstein/core/cost/d1_analytics.py
+++ b/src/bernstein/core/cost/d1_analytics.py
@@ -477,8 +477,7 @@ def _today_start_timestamp() -> float:
     from datetime import datetime
 
     now = datetime.now(tz=UTC)
-    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    return midnight.timestamp()
+    return now.replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
 
 
 def _current_period() -> str:

--- a/src/bernstein/core/git/pr_size_governor.py
+++ b/src/bernstein/core/git/pr_size_governor.py
@@ -164,10 +164,8 @@ def _parse_python_imports(source: str) -> set[str]:
         Set of top-level module name strings.
     """
     modules: set[str] = set()
-    for m in re.finditer(r"^\s*import\s+([\w.]+)", source, re.MULTILINE):
-        modules.add(m.group(1).split(".")[0])
-    for m in re.finditer(r"^\s*from\s+([\w.]+)\s+import", source, re.MULTILINE):
-        modules.add(m.group(1).split(".")[0])
+    modules.update(m.group(1).split(".")[0] for m in re.finditer(r"^\s*import\s+([\w.]+)", source, re.MULTILINE))
+    modules.update(m.group(1).split(".")[0] for m in re.finditer(r"^\s*from\s+([\w.]+)\s+import", source, re.MULTILINE))
     return modules
 
 

--- a/src/bernstein/core/git/snapshot.py
+++ b/src/bernstein/core/git/snapshot.py
@@ -275,7 +275,9 @@ def _metadata_path(cwd: Path, snapshot_id: str) -> Path:
 
 
 def _write_metadata(cwd: Path, snapshot: Snapshot) -> None:
-    _metadata_path(cwd, snapshot.snapshot_id).write_text(json.dumps(snapshot.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    _metadata_path(cwd, snapshot.snapshot_id).write_text(
+        json.dumps(snapshot.to_dict(), indent=2, sort_keys=True), encoding="utf-8"
+    )
 
 
 def _read_metadata(cwd: Path, snapshot_id: str) -> Snapshot | None:
@@ -572,7 +574,11 @@ class SnapshotStore:
         if older_than_days < 0:
             raise SnapshotError("older_than_days must be non-negative")
         cutoff_ns = time.time_ns() - older_than_days * 86_400 * 1_000_000_000
-        deleted = [snap.snapshot_id for snap in self.list() if snap.ts_ns and snap.ts_ns < cutoff_ns and self.delete(snap.snapshot_id)]
+        deleted = [
+            snap.snapshot_id
+            for snap in self.list()
+            if snap.ts_ns and snap.ts_ns < cutoff_ns and self.delete(snap.snapshot_id)
+        ]
         return deleted
 
 

--- a/src/bernstein/core/git/snapshot.py
+++ b/src/bernstein/core/git/snapshot.py
@@ -275,8 +275,7 @@ def _metadata_path(cwd: Path, snapshot_id: str) -> Path:
 
 
 def _write_metadata(cwd: Path, snapshot: Snapshot) -> None:
-    path = _metadata_path(cwd, snapshot.snapshot_id)
-    path.write_text(json.dumps(snapshot.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    _metadata_path(cwd, snapshot.snapshot_id).write_text(json.dumps(snapshot.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
 
 
 def _read_metadata(cwd: Path, snapshot_id: str) -> Snapshot | None:
@@ -573,10 +572,7 @@ class SnapshotStore:
         if older_than_days < 0:
             raise SnapshotError("older_than_days must be non-negative")
         cutoff_ns = time.time_ns() - older_than_days * 86_400 * 1_000_000_000
-        deleted: list[str] = []
-        for snap in self.list():
-            if snap.ts_ns and snap.ts_ns < cutoff_ns and self.delete(snap.snapshot_id):
-                deleted.append(snap.snapshot_id)
+        deleted = [snap.snapshot_id for snap in self.list() if snap.ts_ns and snap.ts_ns < cutoff_ns and self.delete(snap.snapshot_id)]
         return deleted
 
 
@@ -637,8 +633,7 @@ def stack_push(
         parent_branch=resolved_parent,
         ref=ref,
     )
-    meta_path = _stack_metadata_path(Path(cwd), task_id, index)
-    meta_path.write_text(
+    _stack_metadata_path(Path(cwd), task_id, index).write_text(
         json.dumps(
             {
                 "task_id": task_id,

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -402,8 +402,7 @@ def _graveyard_timestamp(now: float | None = None) -> str:
     """Return a filesystem- and ref-safe timestamp like ``20260418T103045Z``."""
     import datetime as _dt
 
-    ts = _dt.datetime.fromtimestamp(now if now is not None else time.time(), tz=_dt.UTC)
-    return ts.strftime("%Y%m%dT%H%M%SZ")
+    return _dt.datetime.fromtimestamp(now if now is not None else time.time(), tz=_dt.UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 def preserve_branch_to_graveyard(

--- a/src/bernstein/core/handoff/tokens.py
+++ b/src/bernstein/core/handoff/tokens.py
@@ -362,8 +362,7 @@ def emit_token(
     Returns:
         The freshly issued :class:`HandoffToken`.
     """
-    store = HandoffTokenStore(workdir, ttl_s=ttl_s)
-    return store.issue(
+    return HandoffTokenStore(workdir, ttl_s=ttl_s).issue(
         session_id=session_id,
         task_id=task_id,
         source_surface=source_surface,
@@ -395,5 +394,4 @@ def claim_token(
         HandoffUnknownTokenError: When the token was never issued.
         HandoffClaimError: When the token is expired or already claimed.
     """
-    store = HandoffTokenStore(workdir, ttl_s=ttl_s)
-    return store.claim(token, claimed_by=claimed_by)
+    return HandoffTokenStore(workdir, ttl_s=ttl_s).claim(token, claimed_by=claimed_by)

--- a/src/bernstein/core/knowledge/agents_md_generator.py
+++ b/src/bernstein/core/knowledge/agents_md_generator.py
@@ -248,10 +248,7 @@ def generate(repo_path: Path, options: GenerateOptions | None = None) -> list[Ag
         ("documentation-duty", _build_documentation_duty()),
     ]
 
-    sections: list[AgentsMdSection] = []
-    for _key, sec in builders:
-        if sec is not None:
-            sections.append(sec)  # type: ignore[arg-type]
+    sections = [sec for _key, sec in builders if sec is not None]
 
     sections.extend(_build_overlay_sections(repo_path, opts))
     return sections
@@ -892,8 +889,7 @@ def _parse_pyproject_scripts(pyproj: Path) -> dict[str, str]:
         data = tomllib.loads(pyproj.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         return {}
-    project = data.get("project", {})
-    scripts = project.get("scripts", {})
+    scripts = data.get("project", {}).get("scripts", {})
     return {str(k): str(v) for k, v in scripts.items()} if isinstance(scripts, dict) else {}
 
 

--- a/src/bernstein/core/knowledge/ast_symbol_graph.py
+++ b/src/bernstein/core/knowledge/ast_symbol_graph.py
@@ -179,10 +179,8 @@ class SemanticGraph:
         for _ in range(depth):
             next_frontier: set[str] = set()
             for sid in frontier:
-                for callee in self.callees_of(sid):
-                    next_frontier.add(callee)
-                for caller in self.callers_of(sid):
-                    next_frontier.add(caller)
+                next_frontier.update(self.callees_of(sid))
+                next_frontier.update(self.callers_of(sid))
             frontier = next_frontier - included
             included.update(frontier)
             if len(included) >= max_nodes:

--- a/src/bernstein/core/knowledge/file_discovery.py
+++ b/src/bernstein/core/knowledge/file_discovery.py
@@ -143,10 +143,7 @@ def available_roles(templates_dir: Path) -> list[str]:
     """
     if not templates_dir.is_dir():
         return []
-    roles: list[str] = []
-    for child in sorted(templates_dir.iterdir()):
-        if child.is_dir() and (child / "system_prompt.md").exists():
-            roles.append(child.name)
+    roles = [child.name for child in sorted(templates_dir.iterdir()) if child.is_dir() and (child / "system_prompt.md").exists()]
     return roles
 
 

--- a/src/bernstein/core/knowledge/file_discovery.py
+++ b/src/bernstein/core/knowledge/file_discovery.py
@@ -143,7 +143,11 @@ def available_roles(templates_dir: Path) -> list[str]:
     """
     if not templates_dir.is_dir():
         return []
-    roles = [child.name for child in sorted(templates_dir.iterdir()) if child.is_dir() and (child / "system_prompt.md").exists()]
+    roles = [
+        child.name
+        for child in sorted(templates_dir.iterdir())
+        if child.is_dir() and (child / "system_prompt.md").exists()
+    ]
     return roles
 
 

--- a/src/bernstein/core/knowledge/rag.py
+++ b/src/bernstein/core/knowledge/rag.py
@@ -126,10 +126,7 @@ def _extract_python_chunks(source: str, rel_path: str) -> list[dict[str, object]
     total = len(lines)
 
     # Collect top-level and nested function/class definitions.
-    nodes: list[ast.AST] = []
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            nodes.append(node)
+    nodes = [node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))]
 
     if not nodes:
         return _line_chunks(source, rel_path)

--- a/src/bernstein/core/lineage/tips.py
+++ b/src/bernstein/core/lineage/tips.py
@@ -58,11 +58,9 @@ def compute_tips(entries: Iterable[LineageEntry]) -> dict[str, TipSet]:
         referenced_as_parent: set[str] = set()
         merged_parents: set[str] = set()
         for e in group:
-            for ph in e.parent_hashes:
-                referenced_as_parent.add(ph)
+            referenced_as_parent.update(e.parent_hashes)
             if len(e.parent_hashes) >= 2:
-                for ph in e.parent_hashes:
-                    merged_parents.add(ph)
+                merged_parents.update(e.parent_hashes)
         open_tips = [h for h in hashes if h not in referenced_as_parent]
         merged_hashes = [h for h in hashes if h in merged_parents]
         result[path] = TipSet(open=open_tips, merged=merged_hashes)

--- a/src/bernstein/core/lineage/v2_store.py
+++ b/src/bernstein/core/lineage/v2_store.py
@@ -658,8 +658,7 @@ def _ns_to_iso(ts_ns: int) -> str:
 
     if ts_ns <= 0:
         return "1970-01-01T00:00:00Z"
-    dt = _dt.datetime.fromtimestamp(ts_ns / 1_000_000_000, tz=_dt.UTC)
-    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return _dt.datetime.fromtimestamp(ts_ns / 1_000_000_000, tz=_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _parent_ref_from_dict(payload: dict[str, Any]) -> ParentRef:

--- a/src/bernstein/core/observability/circuit_breaker.py
+++ b/src/bernstein/core/observability/circuit_breaker.py
@@ -115,8 +115,7 @@ def write_quarantine_metadata(
         metadata["files"] = files
     if branch:
         metadata["branch"] = branch
-    out_path = quarantine_dir / f"{session_id}.json"
-    out_path.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    (quarantine_dir / f"{session_id}.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
     logger.info("Quarantine metadata written for agent %s (branch: %s)", session_id, branch)
 
 
@@ -167,8 +166,7 @@ def enforce_kill_signal(
     if files:
         kill_payload["files"] = files
 
-    kill_file = runtime_dir / f"{session_id}.kill"
-    kill_file.write_text(json.dumps(kill_payload), encoding="utf-8")
+    (runtime_dir / f"{session_id}.kill").write_text(json.dumps(kill_payload), encoding="utf-8")
     logger.warning(
         "Kill signal written for agent %s (reason=%s): %s",
         session_id,
@@ -250,10 +248,7 @@ def _files_outside_scope(changed_files: list[str], owned_files: list[str]) -> li
     Returns:
         Files that do not match any entry in *owned_files*.
     """
-    out_of_scope: list[str] = []
-    for f in changed_files:
-        if not any(f == owned or f.startswith(owned.rstrip("/") + "/") for owned in owned_files):
-            out_of_scope.append(f)
+    out_of_scope = [f for f in changed_files if not any(f == owned or f.startswith(owned.rstrip("/") + "/") for owned in owned_files)]
     return out_of_scope
 
 

--- a/src/bernstein/core/observability/circuit_breaker.py
+++ b/src/bernstein/core/observability/circuit_breaker.py
@@ -248,7 +248,11 @@ def _files_outside_scope(changed_files: list[str], owned_files: list[str]) -> li
     Returns:
         Files that do not match any entry in *owned_files*.
     """
-    out_of_scope = [f for f in changed_files if not any(f == owned or f.startswith(owned.rstrip("/") + "/") for owned in owned_files)]
+    out_of_scope = [
+        f
+        for f in changed_files
+        if not any(f == owned or f.startswith(owned.rstrip("/") + "/") for owned in owned_files)
+    ]
     return out_of_scope
 
 

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -50,8 +50,7 @@ def iter_metric_files(metrics_dir: Path, prefix: str) -> list[Path]:
     patterns = (f"{prefix}_*.jsonl", f"{prefix}_*.jsonl.*")
     seen: set[Path] = set()
     for pattern in patterns:
-        for path in metrics_dir.glob(pattern):
-            seen.add(path)
+        seen.update(metrics_dir.glob(pattern))
     return sorted(seen)
 
 

--- a/src/bernstein/core/observability/otlp_exporter.py
+++ b/src/bernstein/core/observability/otlp_exporter.py
@@ -166,7 +166,7 @@ class GenAIOTLPExporter:
         self._provider: Any | None = tracer_provider
         self._enabled = False
 
-        if self._config.endpoint is None and tracer_provider is None:
+        if self._config.endpoint is tracer_provider is None:
             # Disabled — keep everything as None so calls become no-ops.
             return
 

--- a/src/bernstein/core/orchestration/adaptive_tick.py
+++ b/src/bernstein/core/orchestration/adaptive_tick.py
@@ -101,7 +101,7 @@ class AdaptiveTicker:
             self._history = self._history[-self.activity_window :]
 
         # Track consecutive idle ticks
-        if spawned == 0 and completed == 0 and errors == 0:
+        if spawned == completed == 0 and errors == 0:
             self._consecutive_idle += 1
         else:
             self._consecutive_idle = 0

--- a/src/bernstein/core/orchestration/compare_runner.py
+++ b/src/bernstein/core/orchestration/compare_runner.py
@@ -358,7 +358,7 @@ def _diff_against_snapshot(snapshot: Path, worktree: Path) -> dict[str, str]:
     for rel in all_rel:
         snap_text = snap_files.get(rel)
         work_text = work_files.get(rel)
-        if snap_text is None and work_text is None:
+        if snap_text is work_text is None:
             continue
         if snap_text == work_text:
             continue

--- a/src/bernstein/core/orchestration/manager_prompts.py
+++ b/src/bernstein/core/orchestration/manager_prompts.py
@@ -125,7 +125,8 @@ def render_plan_prompt(
         Fully rendered prompt ready for the LLM.
     """
     return (
-        _load_template(templates_dir, "plan.md", sdd_dir=sdd_dir, task_id=task_id).replace("{{GOAL}}", goal)
+        _load_template(templates_dir, "plan.md", sdd_dir=sdd_dir, task_id=task_id)
+        .replace("{{GOAL}}", goal)
         .replace("{{CONTEXT}}", context)
         .replace("{{AVAILABLE_ROLES}}", _format_roles(roles))
         .replace("{{EXISTING_TASKS}}", _format_existing_tasks(existing_tasks))

--- a/src/bernstein/core/orchestration/manager_prompts.py
+++ b/src/bernstein/core/orchestration/manager_prompts.py
@@ -124,9 +124,8 @@ def render_plan_prompt(
     Returns:
         Fully rendered prompt ready for the LLM.
     """
-    template = _load_template(templates_dir, "plan.md", sdd_dir=sdd_dir, task_id=task_id)
     return (
-        template.replace("{{GOAL}}", goal)
+        _load_template(templates_dir, "plan.md", sdd_dir=sdd_dir, task_id=task_id).replace("{{GOAL}}", goal)
         .replace("{{CONTEXT}}", context)
         .replace("{{AVAILABLE_ROLES}}", _format_roles(roles))
         .replace("{{EXISTING_TASKS}}", _format_existing_tasks(existing_tasks))

--- a/src/bernstein/core/orchestration/operator.py
+++ b/src/bernstein/core/orchestration/operator.py
@@ -286,8 +286,7 @@ class RunReconciler:
         run: dict[str, Any],
         plan_spec: dict[str, Any],
     ) -> None:
-        status = run.get("status", {})
-        stages_status = status.get("stages", [])
+        stages_status = run.get("status", {}).get("stages", [])
         plan_stages = plan_spec.get("stages", [])
         spec = run.get("spec", {})
         max_retries = spec.get("maxRetries", 2)

--- a/src/bernstein/core/orchestration/phase_gates.py
+++ b/src/bernstein/core/orchestration/phase_gates.py
@@ -231,8 +231,7 @@ def _r002(prior: PhaseArtifact, current: PhaseArtifact, _spec: PhaseSpec) -> Gat
     """Every ``<id:foo>`` marker must resolve against the prior artefact."""
     known: set[str] = set()
     for entry in [*prior.decisions, *prior.constraints]:
-        for marker in _ID_MARKER_RE.findall(entry):
-            known.add(marker)
+        known.update(_ID_MARKER_RE.findall(entry))
         # The plain text after a ``<id:foo>`` marker is also addressable.
         # Tokens without markers are addressable by exact-string match —
         # rare, but we want decisions like ``"python 3.12"`` to count.

--- a/src/bernstein/core/orchestration/run_changelog.py
+++ b/src/bernstein/core/orchestration/run_changelog.py
@@ -452,7 +452,7 @@ def generate_run_changelog(
     Returns:
         A :class:`RunChangelog` with all changes grouped by component.
     """
-    if since_hours is None and since_ref is None:
+    if since_hours is since_ref is None:
         since_hours = 24.0
 
     since_ts = time.time() - (since_hours * 3600) if since_hours else 0.0

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -242,8 +242,7 @@ def fail_task(client: httpx.Client, base_url: str, task_id: str, reason: str) ->
         task_id: ID of the task to fail.
         reason: Why the task failed.
     """
-    resp = client.post(f"{base_url}/tasks/{task_id}/fail", json={"reason": reason})
-    resp.raise_for_status()
+    client.post(f"{base_url}/tasks/{task_id}/fail", json={"reason": reason}).raise_for_status()
 
 
 def block_task(client: httpx.Client, base_url: str, task_id: str, reason: str) -> None:
@@ -255,8 +254,7 @@ def block_task(client: httpx.Client, base_url: str, task_id: str, reason: str) -
         task_id: ID of the task to block.
         reason: Why the task is blocked.
     """
-    resp = client.post(f"{base_url}/tasks/{task_id}/block", json={"reason": reason})
-    resp.raise_for_status()
+    client.post(f"{base_url}/tasks/{task_id}/block", json={"reason": reason}).raise_for_status()
 
 
 def close_task(client: httpx.Client, base_url: str, task_id: str) -> None:
@@ -267,8 +265,7 @@ def close_task(client: httpx.Client, base_url: str, task_id: str) -> None:
         base_url: Server base URL.
         task_id: ID of the task to close.
     """
-    resp = client.post(f"{base_url}/tasks/{task_id}/close", json={})
-    resp.raise_for_status()
+    client.post(f"{base_url}/tasks/{task_id}/close", json={}).raise_for_status()
 
 
 def complete_task(

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -740,10 +740,14 @@ class ClaimLedger:
 
     def attempt_count(self, *, tracker: str, ticket_id: str, role: str) -> int:
         """Return ``stage_attempt`` for the live or last claim row, or ``0``."""
-        row = self._connect().execute(
-            "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
-            (tracker, ticket_id, role),
-        ).fetchone()
+        row = (
+            self._connect()
+            .execute(
+                "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
+                (tracker, ticket_id, role),
+            )
+            .fetchone()
+        )
         if row is None:
             return 0
         return int(row[0])

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -708,8 +708,7 @@ class ClaimLedger:
         callers can render a deterministic snapshot.
         """
         current = float(time.time() if now is None else now)
-        conn = self._connect()
-        cursor = conn.execute(
+        cursor = self._connect().execute(
             "SELECT tracker, ticket_id, role, claimer_id, lease_expires_at, "
             "stage_attempt FROM claims WHERE lease_expires_at > ? "
             "ORDER BY tracker, role, ticket_id",
@@ -733,8 +732,7 @@ class ClaimLedger:
 
         Returns ``True`` when a row was removed.
         """
-        conn = self._connect()
-        cursor = conn.execute(
+        cursor = self._connect().execute(
             "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
             (tracker, ticket_id, role, claimer_id),
         )
@@ -742,8 +740,7 @@ class ClaimLedger:
 
     def attempt_count(self, *, tracker: str, ticket_id: str, role: str) -> int:
         """Return ``stage_attempt`` for the live or last claim row, or ``0``."""
-        conn = self._connect()
-        row = conn.execute(
+        row = self._connect().execute(
             "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
             (tracker, ticket_id, role),
         ).fetchone()

--- a/src/bernstein/core/persistence/team_state.py
+++ b/src/bernstein/core/persistence/team_state.py
@@ -244,8 +244,7 @@ class TeamStateStore:
 
     def get_member(self, agent_id: str) -> TeamMember | None:
         """Look up a single team member by agent ID."""
-        members = self._read_all()
-        return members.get(agent_id)
+        return self._read_all().get(agent_id)
 
     def list_members(self, *, active_only: bool = False) -> list[TeamMember]:
         """Return all team members, optionally filtered to active ones.

--- a/src/bernstein/core/planning/spec_assertions.py
+++ b/src/bernstein/core/planning/spec_assertions.py
@@ -131,8 +131,7 @@ class AssertionReport:
         return [r for r in self.results if not r.passed]
 
     def failed_feature_ids(self) -> list[str]:
-        seen = [r.feature_id for r in self.results if not r.passed and r.feature_id not in seen]
-        return seen
+        return list(dict.fromkeys(r.feature_id for r in self.results if not r.passed))
 
 
 def load_contract(path: Path = DEFAULT_CONTRACT_PATH) -> FeatureContract | None:

--- a/src/bernstein/core/planning/spec_assertions.py
+++ b/src/bernstein/core/planning/spec_assertions.py
@@ -131,10 +131,7 @@ class AssertionReport:
         return [r for r in self.results if not r.passed]
 
     def failed_feature_ids(self) -> list[str]:
-        seen: list[str] = []
-        for r in self.results:
-            if not r.passed and r.feature_id not in seen:
-                seen.append(r.feature_id)
+        seen = [r.feature_id for r in self.results if not r.passed and r.feature_id not in seen]
         return seen
 
 

--- a/src/bernstein/core/planning/workflow_dsl.py
+++ b/src/bernstein/core/planning/workflow_dsl.py
@@ -983,7 +983,11 @@ class DAGExecutor:
         task_id = f"{node.id}-{uuid.uuid4().hex[:8]}"
 
         # Collect unconditional blocking dependencies.
-        dep_ids = [edge.source for edge in self._edges_by_target.get(node.id, []) if edge.condition is None and edge.edge_type in {EdgeType.BLOCKS, EdgeType.VALIDATES}]
+        dep_ids = [
+            edge.source
+            for edge in self._edges_by_target.get(node.id, [])
+            if edge.condition is None and edge.edge_type in {EdgeType.BLOCKS, EdgeType.VALIDATES}
+        ]
 
         return Task(
             id=task_id,

--- a/src/bernstein/core/planning/workflow_dsl.py
+++ b/src/bernstein/core/planning/workflow_dsl.py
@@ -983,10 +983,7 @@ class DAGExecutor:
         task_id = f"{node.id}-{uuid.uuid4().hex[:8]}"
 
         # Collect unconditional blocking dependencies.
-        dep_ids: list[str] = []
-        for edge in self._edges_by_target.get(node.id, []):
-            if edge.condition is None and edge.edge_type in {EdgeType.BLOCKS, EdgeType.VALIDATES}:
-                dep_ids.append(edge.source)
+        dep_ids = [edge.source for edge in self._edges_by_target.get(node.id, []) if edge.condition is None and edge.edge_type in {EdgeType.BLOCKS, EdgeType.VALIDATES}]
 
         return Task(
             id=task_id,

--- a/src/bernstein/core/protocols/mcp/mcp_client.py
+++ b/src/bernstein/core/protocols/mcp/mcp_client.py
@@ -177,8 +177,7 @@ class MCPClientSession:
         Raises:
             MCPClientError: If the request fails.
         """
-        result = await self._send_jsonrpc("tools/list")
-        raw_tools = result.get("tools", [])
+        raw_tools = (await self._send_jsonrpc("tools/list")).get("tools", [])
 
         self._tools = []
         for tool_data in raw_tools:
@@ -225,10 +224,7 @@ class MCPClientSession:
 
         # Parse MCP tool result content
         content_parts = result.get("content", [])
-        text_parts: list[str] = []
-        for part in content_parts:
-            if isinstance(part, dict) and part.get("type") == "text":
-                text_parts.append(part.get("text", ""))
+        text_parts = [part.get("text", "") for part in content_parts if isinstance(part, dict) and part.get("type") == "text"]
 
         return ToolCallResult(
             content="\n".join(text_parts) if text_parts else json.dumps(result),

--- a/src/bernstein/core/protocols/mcp/mcp_client.py
+++ b/src/bernstein/core/protocols/mcp/mcp_client.py
@@ -224,7 +224,9 @@ class MCPClientSession:
 
         # Parse MCP tool result content
         content_parts = result.get("content", [])
-        text_parts = [part.get("text", "") for part in content_parts if isinstance(part, dict) and part.get("type") == "text"]
+        text_parts = [
+            part.get("text", "") for part in content_parts if isinstance(part, dict) and part.get("type") == "text"
+        ]
 
         return ToolCallResult(
             content="\n".join(text_parts) if text_parts else json.dumps(result),

--- a/src/bernstein/core/protocols/mcp/mcp_manager.py
+++ b/src/bernstein/core/protocols/mcp/mcp_manager.py
@@ -597,7 +597,7 @@ class MCPManager:
         """
         task_config = self.build_mcp_config(server_names=task_mcp_servers)
 
-        if base_config is None and task_config is None:
+        if base_config is task_config is None:
             return None
         if base_config is None:
             return task_config

--- a/src/bernstein/core/protocols/mcp/mcp_protocol_test.py
+++ b/src/bernstein/core/protocols/mcp/mcp_protocol_test.py
@@ -232,10 +232,7 @@ def _required_arguments(schema: dict[str, Any]) -> tuple[str, ...]:
     raw_required = schema.get("required")
     if not isinstance(raw_required, list):
         return ()
-    required_names: list[str] = []
-    for item in cast("list[object]", raw_required):
-        if isinstance(item, str) and item.strip():
-            required_names.append(item)
+    required_names = [item for item in cast("list[object]", raw_required) if isinstance(item, str) and item.strip()]
     return tuple(required_names)
 
 

--- a/src/bernstein/core/protocols/mcp/mcp_registry.py
+++ b/src/bernstein/core/protocols/mcp/mcp_registry.py
@@ -388,7 +388,7 @@ class MCPRegistry:
         auto_config = self.build_mcp_config(available)
 
         # Merge: base_config wins on conflicts (user explicitly configured those)
-        if base_config is None and auto_config is None:
+        if base_config is auto_config is None:
             return None
         if base_config is None:
             return auto_config

--- a/src/bernstein/core/protocols/mcp_catalog/service.py
+++ b/src/bernstein/core/protocols/mcp_catalog/service.py
@@ -159,8 +159,7 @@ class CatalogService:
     # ------------------------------------------------------------------
     def browse(self, *, force_refresh: bool = False) -> Catalog:
         """Fetch the catalog (using cache when fresh) and return it."""
-        result = self._fetch(force=force_refresh)
-        return result.catalog
+        return self._fetch(force=force_refresh).catalog
 
     def search(self, query: str, *, force_refresh: bool = False) -> list[CatalogEntry]:
         """Substring search over id / name / description."""
@@ -168,10 +167,7 @@ class CatalogService:
         needle = query.strip().lower()
         if not needle:
             return list(catalog.entries)
-        out: list[CatalogEntry] = []
-        for entry in catalog.entries:
-            if needle in entry.id.lower() or needle in entry.name.lower() or needle in entry.description.lower():
-                out.append(entry)
+        out = [entry for entry in catalog.entries if needle in entry.id.lower() or needle in entry.name.lower() or needle in entry.description.lower()]
         return out
 
     def info(self, entry_id: str, *, force_refresh: bool = False) -> CatalogEntry | None:
@@ -199,8 +195,7 @@ class CatalogService:
         On any of those paths the cache and the user config are left
         untouched (acceptance criterion).
         """
-        catalog = self.browse(force_refresh=force_refresh)
-        entry = catalog.find(entry_id)
+        entry = self.browse(force_refresh=force_refresh).find(entry_id)
         if entry is None:
             raise KeyError(f"Catalog entry {entry_id!r} not found")
 
@@ -291,13 +286,11 @@ class CatalogService:
         force_refresh: bool = False,
     ) -> UpgradeOutcome:
         """Upgrade a single installed entry to the catalog's pin."""
-        installed_lookup = {e.id: e for e in self.list_installed()}
-        installed = installed_lookup.get(entry_id)
+        installed = ({e.id: e for e in self.list_installed()}).get(entry_id)
         if installed is None:
             raise KeyError(f"Entry {entry_id!r} is not installed")
 
-        catalog = self.browse(force_refresh=force_refresh)
-        catalog_entry = catalog.find(entry_id)
+        catalog_entry = self.browse(force_refresh=force_refresh).find(entry_id)
         if catalog_entry is None:
             return UpgradeOutcome(
                 entry_id=entry_id,

--- a/src/bernstein/core/protocols/mcp_catalog/service.py
+++ b/src/bernstein/core/protocols/mcp_catalog/service.py
@@ -167,7 +167,11 @@ class CatalogService:
         needle = query.strip().lower()
         if not needle:
             return list(catalog.entries)
-        out = [entry for entry in catalog.entries if needle in entry.id.lower() or needle in entry.name.lower() or needle in entry.description.lower()]
+        out = [
+            entry
+            for entry in catalog.entries
+            if needle in entry.id.lower() or needle in entry.name.lower() or needle in entry.description.lower()
+        ]
         return out
 
     def info(self, entry_id: str, *, force_refresh: bool = False) -> CatalogEntry | None:

--- a/src/bernstein/core/protocols/mcp_catalog/user_config.py
+++ b/src/bernstein/core/protocols/mcp_catalog/user_config.py
@@ -152,8 +152,7 @@ def _ensure_managed_block(config: dict[str, Any]) -> dict[str, Any]:
 
 def list_installed(path: Path) -> list[InstalledEntry]:
     """List catalog-installed entries from the user config."""
-    config = _load_raw(path)
-    block = config.get(BERNSTEIN_MANAGED_KEY)
+    block = _load_raw(path).get(BERNSTEIN_MANAGED_KEY)
     if not isinstance(block, dict):
         return []
     servers = block.get(SERVERS_KEY)

--- a/src/bernstein/core/quality/ab_test_results.py
+++ b/src/bernstein/core/quality/ab_test_results.py
@@ -309,8 +309,7 @@ def generate_ab_report(workdir: Path) -> ABTestReport:
         When fewer than two distinct models have been recorded, the winner is
         ``"insufficient_data"``.
     """
-    store = ABTestStore(workdir)
-    records = store.load()
+    records = ABTestStore(workdir).load()
 
     if not records:
         empty = ModelStats("(none)", 0, 0, 0, 0.0, 0.0, 0.0, 0)

--- a/src/bernstein/core/quality/comment_quality.py
+++ b/src/bernstein/core/quality/comment_quality.py
@@ -162,8 +162,7 @@ def _extract_documented_params_google(docstring: str) -> set[str]:
         return set()
     args_block = args_match.group(1)
     params: set[str] = set()
-    for m in _GOOGLE_PARAM_RE.finditer(args_block):
-        params.add(m.group(1))
+    params.update(m.group(1) for m in _GOOGLE_PARAM_RE.finditer(args_block))
     return params
 
 

--- a/src/bernstein/core/quality/coverage_gate.py
+++ b/src/bernstein/core/quality/coverage_gate.py
@@ -323,12 +323,10 @@ class CoverageGate:
             raise RuntimeError(f"Failed to read coverage report: {exc}") from exc
         if not isinstance(raw, dict):
             raise RuntimeError("Coverage report has invalid structure")
-        data = cast("dict[str, object]", raw)
-        totals = data.get("totals")
+        totals = cast("dict[str, object]", raw).get("totals")
         if not isinstance(totals, dict):
             raise RuntimeError("Coverage report missing totals")
-        totals_map = cast("dict[str, object]", totals)
-        percent_covered = totals_map.get("percent_covered")
+        percent_covered = cast("dict[str, object]", totals).get("percent_covered")
         if isinstance(percent_covered, (int, float, str)):
             try:
                 return float(percent_covered)

--- a/src/bernstein/core/quality/output_fingerprint.py
+++ b/src/bernstein/core/quality/output_fingerprint.py
@@ -396,8 +396,5 @@ def check_fingerprint(
 
 def extract_code_from_diff(diff: str) -> str:
     """Extract added lines from a unified diff for fingerprinting."""
-    added_lines: list[str] = []
-    for line in diff.splitlines():
-        if line.startswith("+") and not line.startswith("+++"):
-            added_lines.append(line[1:])
+    added_lines = [line[1:] for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++")]
     return "\n".join(added_lines)

--- a/src/bernstein/core/quality/pr_review_aggregator.py
+++ b/src/bernstein/core/quality/pr_review_aggregator.py
@@ -729,10 +729,7 @@ def render_report_markdown(report: PRReviewReport) -> str:
 
     # Stable file order: scored clusters keep their rank position so the
     # by-file traversal is well-defined.
-    seen_files: list[str] = []
-    for cluster in report.clusters:
-        if cluster.file not in seen_files:
-            seen_files.append(cluster.file)
+    seen_files = [cluster.file for cluster in report.clusters if cluster.file not in seen_files]
 
     for file in seen_files:
         header = file or "_(unattributed)_"

--- a/src/bernstein/core/quality/pr_review_aggregator.py
+++ b/src/bernstein/core/quality/pr_review_aggregator.py
@@ -729,7 +729,7 @@ def render_report_markdown(report: PRReviewReport) -> str:
 
     # Stable file order: scored clusters keep their rank position so the
     # by-file traversal is well-defined.
-    seen_files = [cluster.file for cluster in report.clusters if cluster.file not in seen_files]
+    seen_files = list(dict.fromkeys(cluster.file for cluster in report.clusters))
 
     for file in seen_files:
         header = file or "_(unattributed)_"

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -174,7 +174,7 @@ def _write_token_breakdown(lines: list[str], task_metrics: dict[str, TaskMetrics
     """Write the token usage sub-section if token data is available."""
     total_prompt = sum(tm.tokens_prompt for tm in task_metrics.values())
     total_completion = sum(tm.tokens_completion for tm in task_metrics.values())
-    if total_prompt == 0 and total_completion == 0:
+    if total_prompt == total_completion == 0:
         return
 
     model_token_data: dict[str, dict[str, int]] = defaultdict(lambda: {"prompt": 0, "completion": 0})
@@ -222,7 +222,7 @@ def _write_agent_summary(lines: list[str], collector: MetricsCollector) -> None:
         lines.append(
             f"| {am.agent_id[:8]} | {am.role} | {am.tasks_completed} | {am.tasks_failed} | ${am.total_cost_usd:.4f} |"
         )
-        if am.tasks_completed == 0 and am.tasks_failed == 0 and am.end_time is not None:
+        if am.tasks_completed == am.tasks_failed == 0 and am.end_time is not None:
             timed_out_or_killed.append(f"{am.agent_id[:8]} ({am.role})")
         tot = am.tasks_completed + am.tasks_failed
         if tot >= 2 and am.tasks_failed / tot > 0.5:

--- a/src/bernstein/core/quality/verification_nudge.py
+++ b/src/bernstein/core/quality/verification_nudge.py
@@ -301,5 +301,4 @@ def load_nudge_summary(metrics_dir: Path, *, threshold: float = DEFAULT_NUDGE_TH
     Returns:
         NudgeSummary computed from the on-disk ledger.
     """
-    tracker = VerificationNudgeTracker(metrics_dir=metrics_dir, nudge_threshold=threshold)
-    return tracker.summary()
+    return VerificationNudgeTracker(metrics_dir=metrics_dir, nudge_threshold=threshold).summary()

--- a/src/bernstein/core/review_responder/models.py
+++ b/src/bernstein/core/review_responder/models.py
@@ -94,10 +94,7 @@ class ReviewRound:
     @property
     def reviewers(self) -> tuple[str, ...]:
         """Distinct reviewer usernames present in the bundle, in arrival order."""
-        seen: list[str] = []
-        for c in self.comments:
-            if c.reviewer not in seen:
-                seen.append(c.reviewer)
+        seen = [c.reviewer for c in self.comments if c.reviewer not in seen]
         return tuple(seen)
 
 

--- a/src/bernstein/core/review_responder/models.py
+++ b/src/bernstein/core/review_responder/models.py
@@ -94,8 +94,7 @@ class ReviewRound:
     @property
     def reviewers(self) -> tuple[str, ...]:
         """Distinct reviewer usernames present in the bundle, in arrival order."""
-        seen = [c.reviewer for c in self.comments if c.reviewer not in seen]
-        return tuple(seen)
+        return tuple(dict.fromkeys(c.reviewer for c in self.comments))
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/routes/acp.py
+++ b/src/bernstein/core/routes/acp.py
@@ -110,8 +110,7 @@ def _get_acp_handler(request: Request) -> ACPHandler:
 @router.get("/.well-known/acp.json")
 def acp_discovery(request: Request) -> ACPDiscoveryResponse:
     """ACP discovery document — editors poll this to find ACP-compatible agents."""
-    handler = _get_acp_handler(request)
-    doc = handler.discovery_doc()
+    doc = _get_acp_handler(request).discovery_doc()
     return ACPDiscoveryResponse(
         protocol=doc["protocol"],
         version=doc["version"],
@@ -127,8 +126,7 @@ def acp_discovery(request: Request) -> ACPDiscoveryResponse:
 @router.get("/acp/v0/agents")
 def list_acp_agents(request: Request) -> list[ACPAgentListEntry]:
     """List all ACP-advertised agents."""
-    handler = _get_acp_handler(request)
-    doc = handler.discovery_doc()
+    doc = _get_acp_handler(request).discovery_doc()
     return [ACPAgentListEntry(**a) for a in doc["agents"]]
 
 
@@ -140,8 +138,7 @@ def get_acp_agent(agent_id: str, request: Request) -> ACPAgentResponse:
     """Get detailed metadata for a specific ACP agent."""
     if agent_id != "bernstein":
         raise HTTPException(status_code=404, detail=f"ACP agent '{agent_id}' not found")
-    handler = _get_acp_handler(request)
-    meta = handler.agent_metadata()
+    meta = _get_acp_handler(request).agent_metadata()
     return ACPAgentResponse(
         name=meta["name"],
         description=meta["description"],

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -347,8 +347,7 @@ def approvals_live_fragment(session_id: str | None = None) -> HTMLResponse:
     intentionally minimal so it can be inlined into the existing live
     dashboard without pulling a new framework.
     """
-    queue = get_default_queue()
-    pending = queue.list_pending(session_id=session_id)
+    pending = get_default_queue().list_pending(session_id=session_id)
     if not pending:
         return HTMLResponse(
             '<div class="approvals-empty">No pending approvals</div>',

--- a/src/bernstein/core/routes/auth.py
+++ b/src/bernstein/core/routes/auth.py
@@ -311,8 +311,7 @@ window.location.href = '/dashboard';
 @router.get("/saml/metadata", responses={503: {"description": "SSO authentication not configured"}})
 def saml_metadata(request: Request) -> Response:
     """SAML SP metadata endpoint for IdP configuration."""
-    svc = _get_auth_service(request)
-    metadata = svc.get_saml_sp_metadata()
+    metadata = _get_auth_service(request).get_saml_sp_metadata()
     return Response(content=metadata, media_type="application/xml")
 
 
@@ -332,8 +331,7 @@ def device_code_request(request: Request, body: DeviceCodeRequest) -> DeviceCode
     The user enters the user_code in the web dashboard after SSO login
     to authorize the CLI session.
     """
-    svc = _get_auth_service(request)
-    req = svc.create_device_request()
+    req = _get_auth_service(request).create_device_request()
 
     server_url = str(request.base_url).rstrip("/")
     return DeviceCodeResponse(
@@ -424,14 +422,12 @@ def get_profile(request: Request) -> UserProfileResponse:
 @router.post("/logout", responses={503: {"description": "SSO authentication not configured"}})
 def logout(request: Request) -> JSONResponse:
     """Logout and revoke the current session."""
-    claims = getattr(request.state, "auth_claims", {})
-    session_id = claims.get("session_id", "")
+    session_id = getattr(request.state, "auth_claims", {}).get("session_id", "")
 
     if not session_id:
         return JSONResponse(content={"status": "ok", "detail": "No active session"})
 
-    svc = _get_auth_service(request)
-    svc.logout(session_id)
+    _get_auth_service(request).logout(session_id)
     return JSONResponse(content={"status": "ok", "detail": "Session revoked"})
 
 
@@ -446,8 +442,7 @@ def logout(request: Request) -> JSONResponse:
 )
 def get_group_mappings(request: Request) -> GroupMappingsResponse:
     """Get current SSO group → role mappings."""
-    svc = _get_auth_service(request)
-    mappings = svc.group_role_map
+    mappings = _get_auth_service(request).group_role_map
     return GroupMappingsResponse(mappings=[GroupMappingEntry(group=g, role=r.value) for g, r in mappings.items()])
 
 
@@ -510,8 +505,7 @@ def list_users(request: Request) -> JSONResponse:
     if not user.has_permission("auth:manage"):
         raise HTTPException(status_code=403, detail="Admin role required")
 
-    svc = _get_auth_service(request)
-    users = svc.store.list_users()
+    users = _get_auth_service(request).store.list_users()
     return JSONResponse(
         content={
             "users": [u.to_dict() for u in users],

--- a/src/bernstein/core/routes/export.py
+++ b/src/bernstein/core/routes/export.py
@@ -110,8 +110,7 @@ def export_tasks(request: Request, format: str = "json") -> Response:
     Query params:
         format: ``csv`` or ``json`` (default ``json``).
     """
-    store = _get_store(request)
-    all_tasks = store.list_tasks()
+    all_tasks = _get_store(request).list_tasks()
     rows = [_task_to_export_dict(t) for t in all_tasks]
 
     if format == "csv":

--- a/src/bernstein/core/routes/file_health.py
+++ b/src/bernstein/core/routes/file_health.py
@@ -53,8 +53,7 @@ def list_file_health(request: Request) -> JSONResponse:
 
     grade_filter = params.get("grade", "").upper() or None
 
-    tracker = _get_tracker(request)
-    scores = tracker.get_all()
+    scores = _get_tracker(request).get_all()
 
     # Apply filters
     if min_score is not None:
@@ -92,8 +91,7 @@ def list_flagged_files(request: Request) -> JSONResponse:
 
     Returns ``files`` list with detailed health scores and degradation context.
     """
-    tracker = _get_tracker(request)
-    flagged = tracker.get_flagged()
+    flagged = _get_tracker(request).get_flagged()
 
     return JSONResponse(
         {
@@ -113,8 +111,7 @@ def get_file_health(file_path: str, request: Request) -> JSONResponse:
 
     Returns 404 if the file has never been tracked.
     """
-    tracker = _get_tracker(request)
-    score = tracker.get(file_path)
+    score = _get_tracker(request).get(file_path)
     if score is None:
         raise HTTPException(status_code=404, detail=f"File '{file_path}' not tracked yet")
 

--- a/src/bernstein/core/routes/graduation.py
+++ b/src/bernstein/core/routes/graduation.py
@@ -76,8 +76,7 @@ def graduation_status(request: Request) -> JSONResponse:
     Returns:
         JSON with ``sessions`` list and ``total`` count.
     """
-    store = _store(request)
-    records = store.list_all()
+    records = _store(request).list_all()
     evaluator = GraduationEvaluator()
     return JSONResponse(
         {
@@ -129,15 +128,13 @@ def session_graduation(request: Request, session_id: str) -> JSONResponse:
     Raises:
         HTTPException: 404 when no record exists for *session_id*.
     """
-    store = _store(request)
-    record = store.load(session_id)
+    record = _store(request).load(session_id)
     if record is None:
         raise HTTPException(
             status_code=404,
             detail=f"No graduation record for {session_id!r}",
         )
-    evaluator = GraduationEvaluator()
-    can_grad, grad_reason = evaluator.can_graduate(record)
+    can_grad, grad_reason = GraduationEvaluator().can_graduate(record)
     return JSONResponse(
         record.to_dict()
         | {
@@ -232,8 +229,7 @@ def record_task_event(
             detail=f"Invalid stage {body.initial_stage!r}. Valid values: {valid}",
         )
 
-    store = _store(request)
-    record = store.record_task_event(
+    record = _store(request).record_task_event(
         session_id,
         success=body.success,
         task_id=body.task_id,
@@ -241,8 +237,7 @@ def record_task_event(
         cost_usd=body.cost_usd,
         initial_stage=initial_stage,
     )
-    evaluator = GraduationEvaluator()
-    can_grad, grad_reason = evaluator.can_graduate(record)
+    can_grad, grad_reason = GraduationEvaluator().can_graduate(record)
     return JSONResponse(
         {
             "session_id": session_id,

--- a/src/bernstein/core/routes/identities.py
+++ b/src/bernstein/core/routes/identities.py
@@ -72,8 +72,7 @@ def list_identities(
 @router.get("/identities/{identity_id}", responses={404: {"description": "Identity not found"}})
 def get_identity(request: Request, identity_id: str) -> JSONResponse:
     """Get details for a single agent identity."""
-    store = _identity_store(request)
-    identity = store.get(identity_id)
+    identity = _identity_store(request).get(identity_id)
     if identity is None:
         raise HTTPException(status_code=404, detail=f"Identity {identity_id!r} not found")
 
@@ -111,8 +110,7 @@ async def revoke_identity(request: Request, identity_id: str) -> JSONResponse:
 @router.get("/identities/{identity_id}/audit")
 def identity_audit(request: Request, identity_id: str, limit: int = 100) -> JSONResponse:
     """Return the audit trail for an agent identity."""
-    store = _identity_store(request)
-    events = store.get_audit_trail(identity_id, limit=limit)
+    events = _identity_store(request).get_audit_trail(identity_id, limit=limit)
     return JSONResponse(
         {
             "identity_id": identity_id,

--- a/src/bernstein/core/routes/observability.py
+++ b/src/bernstein/core/routes/observability.py
@@ -197,8 +197,7 @@ def observability_budget(request: Request) -> dict[str, Any]:
 @router.get("/observability/deps")
 def observability_deps(request: Request) -> dict[str, Any]:
     """Return dependency-graph validation status for current tasks."""
-    store = _get_store(request)
-    tasks = store.list_tasks()
+    tasks = _get_store(request).list_tasks()
     validator = DependencyValidator()
     validation = validator.validate(tasks)
     return {
@@ -879,7 +878,7 @@ def token_breakdown(request: Request) -> dict[str, Any]:
         session_id = tokens_file.stem
         input_tokens, output_tokens = _parse_token_file(tokens_file)
 
-        if input_tokens == 0 and output_tokens == 0:
+        if input_tokens == output_tokens == 0:
             continue
 
         info = session_info.get(session_id, {})

--- a/src/bernstein/core/routes/plans.py
+++ b/src/bernstein/core/routes/plans.py
@@ -69,8 +69,7 @@ def list_plans(request: Request, status: str | None = None) -> list[dict[str, An
 )
 def get_plan(request: Request, plan_id: str) -> dict[str, Any]:
     """Get a single plan by ID."""
-    store = _get_plan_store(request)
-    plan = store.get_plan(plan_id)
+    plan = _get_plan_store(request).get_plan(plan_id)
     if plan is None:
         raise HTTPException(status_code=404, detail=f"Plan {plan_id} not found")
     return plan.to_dict()

--- a/src/bernstein/core/routes/provider_latency.py
+++ b/src/bernstein/core/routes/provider_latency.py
@@ -33,8 +33,7 @@ def provider_latency_current(request: Request) -> JSONResponse:
     entry carries ``"degraded": true``.
     """
     metrics_dir = _get_metrics_dir(request)
-    tracker = get_tracker(metrics_dir)
-    entries = tracker.all_percentiles()
+    entries = get_tracker(metrics_dir).all_percentiles()
 
     data = []
     for p in entries:
@@ -66,8 +65,7 @@ def provider_latency_history(
     window (default 24h, max 7 days).
     """
     metrics_dir = _get_metrics_dir(request)
-    tracker = get_tracker(metrics_dir)
-    samples = tracker.get_history(provider=provider, model=model, hours=hours)
+    samples = get_tracker(metrics_dir).get_history(provider=provider, model=model, hours=hours)
 
     return JSONResponse(
         {

--- a/src/bernstein/core/routes/quality.py
+++ b/src/bernstein/core/routes/quality.py
@@ -378,13 +378,12 @@ def get_budget_forecast(request: Request) -> JSONResponse:
     sdd_dir = _get_sdd_dir(request)
     store = _get_store(request)
     metrics_dir = sdd_dir / "metrics"
-    forecast = forecast_planned_backlog(
+    payload = (forecast_planned_backlog(
         store.list_tasks(),
         metrics_dir=metrics_dir if metrics_dir.exists() else None,
         current_spend_usd=_read_current_spend(metrics_dir),
         budget_usd=_load_budget_from_seed(sdd_dir),
-    )
-    payload = forecast.to_dict()
+    )).to_dict()
     payload["generated_at"] = time.time()
     return JSONResponse(payload)
 

--- a/src/bernstein/core/routes/quality.py
+++ b/src/bernstein/core/routes/quality.py
@@ -378,12 +378,14 @@ def get_budget_forecast(request: Request) -> JSONResponse:
     sdd_dir = _get_sdd_dir(request)
     store = _get_store(request)
     metrics_dir = sdd_dir / "metrics"
-    payload = (forecast_planned_backlog(
-        store.list_tasks(),
-        metrics_dir=metrics_dir if metrics_dir.exists() else None,
-        current_spend_usd=_read_current_spend(metrics_dir),
-        budget_usd=_load_budget_from_seed(sdd_dir),
-    )).to_dict()
+    payload = (
+        forecast_planned_backlog(
+            store.list_tasks(),
+            metrics_dir=metrics_dir if metrics_dir.exists() else None,
+            current_spend_usd=_read_current_spend(metrics_dir),
+            budget_usd=_load_budget_from_seed(sdd_dir),
+        )
+    ).to_dict()
     payload["generated_at"] = time.time()
     return JSONResponse(payload)
 

--- a/src/bernstein/core/routes/sandbox.py
+++ b/src/bernstein/core/routes/sandbox.py
@@ -90,8 +90,7 @@ class SolutionPackInfo(BaseModel):
 @router.get("/packs", response_model=list[SolutionPackInfo], responses={503: {"description": "Sandbox not enabled"}})
 async def list_solution_packs(request: Request) -> list[dict[str, Any]]:
     """List available solution packs."""
-    mgr = _get_manager(request)
-    return mgr.get_solution_packs()
+    return _get_manager(request).get_solution_packs()
 
 
 @router.post(
@@ -126,8 +125,7 @@ async def create_session(body: CreateSessionRequest, request: Request) -> dict[s
 @router.get("/sessions", response_model=list[SessionResponse], responses={503: {"description": "Sandbox not enabled"}})
 async def list_sessions(request: Request, include_finished: bool = False) -> list[dict[str, Any]]:
     """List sandbox sessions."""
-    mgr = _get_manager(request)
-    return mgr.list_sessions(include_finished=include_finished)
+    return _get_manager(request).list_sessions(include_finished=include_finished)
 
 
 @router.get(
@@ -137,8 +135,7 @@ async def list_sessions(request: Request, include_finished: bool = False) -> lis
 )
 async def get_session(session_id: str, request: Request) -> dict[str, Any]:
     """Get sandbox session details."""
-    mgr = _get_manager(request)
-    session = mgr.get_session(session_id)
+    session = _get_manager(request).get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     return session.to_dict()
@@ -173,8 +170,7 @@ async def cancel_session(session_id: str, request: Request) -> dict[str, str]:
 async def sandbox_dashboard(session_id: str, request: Request) -> HTMLResponse:
     """Serve the sandbox session dashboard page."""
     session_id = _validate_session_id(session_id)
-    mgr = _get_manager(request)
-    session = mgr.get_session(session_id)
+    session = _get_manager(request).get_session(session_id)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     # html.escape at the call site so CodeQL's taint tracker sees the

--- a/src/bernstein/core/routes/slo.py
+++ b/src/bernstein/core/routes/slo.py
@@ -36,8 +36,7 @@ def _get_tracker(request: Request) -> SLOTracker:
 @router.get("/slo")
 def get_slo_status(request: Request) -> JSONResponse:
     """Return current SLO dashboard data."""
-    tracker = _get_tracker(request)
-    dashboard = tracker.get_dashboard()
+    dashboard = _get_tracker(request).get_dashboard()
     return JSONResponse(dashboard)
 
 

--- a/src/bernstein/core/routes/status_lifecycle.py
+++ b/src/bernstein/core/routes/status_lifecycle.py
@@ -186,8 +186,7 @@ async def shutdown_server(request: Request) -> JSONResponse:
     # is delivered before the process starts tearing down.
     from bernstein.core.platform_compat import kill_process
 
-    loop = asyncio.get_running_loop()
-    loop.call_later(0.5, kill_process, os.getpid(), signal.SIGTERM)
+    asyncio.get_running_loop().call_later(0.5, kill_process, os.getpid(), signal.SIGTERM)
 
     return JSONResponse(
         content={"status": "shutting_down", "message": "Shutdown signal received"},
@@ -254,10 +253,8 @@ def metrics_endpoint(request: Request) -> PlainTextResponse:
     Updates all gauges from the current task store state, then
     returns the full metric exposition in Prometheus text format.
     """
-    store = _get_store(request)
-    status_dict = store.status_summary()
-    live_costs = _load_live_costs(request)
-    per_model = live_costs.get("per_model")
+    status_dict = _get_store(request).status_summary()
+    per_model = _load_live_costs(request).get("per_model")
     if isinstance(per_model, dict):
         status_dict["cost_by_model_usd"] = per_model
     update_metrics_from_status(status_dict)

--- a/src/bernstein/core/routes/task_a2a.py
+++ b/src/bernstein/core/routes/task_a2a.py
@@ -64,8 +64,7 @@ def agent_card(request: Request) -> A2AAgentCardResponse:
     historically pulled the orchestrator's own A2A card.
     """
     a2a_handler = _get_a2a_handler(request)
-    card = a2a_handler.orchestrator_card()
-    d = card.to_dict()
+    d = a2a_handler.orchestrator_card().to_dict()
     return A2AAgentCardResponse(**d)
 
 

--- a/src/bernstein/core/routes/task_cluster.py
+++ b/src/bernstein/core/routes/task_cluster.py
@@ -128,8 +128,7 @@ def cordon_node(node_id: str, request: Request) -> dict[str, str]:
     from bernstein.core.cluster_auth import SCOPE_NODE_ADMIN
 
     _verify_cluster_auth(request, SCOPE_NODE_ADMIN)
-    registry = _get_node_registry(request)
-    node = registry.cordon(node_id)
+    node = _get_node_registry(request).cordon(node_id)
     if node is None:
         raise HTTPException(status_code=404, detail=f"Node {node_id} not found")
     return {"status": "cordoned", "node_id": node_id}
@@ -141,8 +140,7 @@ def uncordon_node(node_id: str, request: Request) -> dict[str, str]:
     from bernstein.core.cluster_auth import SCOPE_NODE_ADMIN
 
     _verify_cluster_auth(request, SCOPE_NODE_ADMIN)
-    registry = _get_node_registry(request)
-    node = registry.uncordon(node_id)
+    node = _get_node_registry(request).uncordon(node_id)
     if node is None:
         raise HTTPException(status_code=404, detail=f"Node {node_id} not found")
     return {"status": "uncordoned", "node_id": node_id}
@@ -154,8 +152,7 @@ def drain_node(node_id: str, request: Request) -> dict[str, str]:
     from bernstein.core.cluster_auth import SCOPE_NODE_ADMIN
 
     _verify_cluster_auth(request, SCOPE_NODE_ADMIN)
-    registry = _get_node_registry(request)
-    node = registry.start_drain(node_id)
+    node = _get_node_registry(request).start_drain(node_id)
     if node is None:
         raise HTTPException(status_code=404, detail=f"Node {node_id} not found")
     return {"status": "draining", "node_id": node_id}
@@ -180,8 +177,7 @@ def list_nodes(request: Request, status: str | None = None) -> list[NodeResponse
 @router.get("/cluster/status")
 def cluster_status(request: Request) -> ClusterStatusResponse:
     """Get cluster status summary."""
-    node_registry = _get_node_registry(request)
-    summary = node_registry.cluster_summary()
+    summary = _get_node_registry(request).cluster_summary()
     return ClusterStatusResponse(
         topology=summary["topology"],
         total_nodes=summary["total_nodes"],
@@ -207,8 +203,7 @@ async def steal_tasks(body: TaskStealRequest, request: Request) -> TaskStealResp
     node_registry = _get_node_registry(request)
     store = _get_store(request)
 
-    policy = TaskStealPolicy()
-    pairs = policy.find_steal_pairs(node_registry, body.queue_depths)
+    pairs = TaskStealPolicy().find_steal_pairs(node_registry, body.queue_depths)
 
     actions: list[TaskStealAction] = []
     total_stolen = 0

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -910,7 +910,7 @@ async def block_task(task_id: str, body: TaskBlockRequest, request: Request) -> 
 
 def _store_progress_snapshot(store: Any, task_id: str, body: Any) -> None:
     """Store structured snapshot for stall detection when snapshot fields are present."""
-    if body.files_changed is None and body.tests_passing is None:
+    if body.files_changed is body.tests_passing is None:
         return
     store.add_snapshot(
         task_id,
@@ -1215,8 +1215,7 @@ def task_counts(
 @router.get("/tasks/archive", responses=_TENANT_RESPONSES)
 def get_archive(request: Request, limit: int = 50, tenant: str | None = None) -> list[ArchiveRecord]:
     """Return the last N archived (done/failed) task records."""
-    store = _get_store(request)
-    return store.read_archive(limit=limit, tenant_id=_resolve_request_tenant_scope(request, tenant))
+    return _get_store(request).read_archive(limit=limit, tenant_id=_resolve_request_tenant_scope(request, tenant))
 
 
 @router.get("/tasks/graph", responses=_TENANT_RESPONSES)
@@ -1233,10 +1232,8 @@ def get_task_graph(request: Request) -> JSONResponse:
     """
     from bernstein.core.knowledge.task_graph import TaskGraph
 
-    store = _get_store(request)
-    tasks = store.list_tasks(tenant_id=_resolve_request_tenant_scope(request))
-    graph = TaskGraph(tasks)
-    data = graph.to_dict()
+    tasks = _get_store(request).list_tasks(tenant_id=_resolve_request_tenant_scope(request))
+    data = TaskGraph(tasks).to_dict()
     # Enrich nodes with title for CLI rendering
     task_map = {t.id: t for t in tasks}
     for node in data["nodes"]:
@@ -1247,8 +1244,7 @@ def get_task_graph(request: Request) -> JSONResponse:
 @router.get("/tasks/{task_id}", responses={404: {"description": "Task not found"}})
 def get_task(task_id: str, request: Request) -> TaskResponse:
     """Get a single task by ID."""
-    store = _get_store(request)
-    task = store.get_task(task_id)
+    task = _get_store(request).get_task(task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
     _require_task_access(task, request)
@@ -1321,8 +1317,7 @@ def get_task_graph_neighbors(task_id: str, request: Request) -> dict[str, Any]:
 )
 def get_task_gates(task_id: str, request: Request) -> JSONResponse:
     """Return the persisted quality-gate report for a task."""
-    store = _get_store(request)
-    task = store.get_task(task_id)
+    task = _get_store(request).get_task(task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
     _require_task_access(task, request)
@@ -1464,8 +1459,7 @@ def agent_kill(session_id: str, request: Request) -> AgentKillResponse:
     runtime_dir = _get_runtime_dir(request)
     sse_bus = _get_sse_bus(request)
     runtime_dir.mkdir(parents=True, exist_ok=True)
-    kill_path = runtime_dir / f"{session_id}.kill"
-    kill_path.write_text(str(time.time()))
+    (runtime_dir / f"{session_id}.kill").write_text(str(time.time()))
     sse_bus.publish(
         "session_kill",
         json.dumps({"session_id": session_id}),
@@ -1545,8 +1539,7 @@ def post_bulletin(body: BulletinPostRequest, request: Request) -> BulletinMessag
     stored = bulletin.post(msg)
 
     # Broadcast to SSE bus
-    sse_bus = _get_sse_bus(request)
-    sse_bus.publish(
+    _get_sse_bus(request).publish(
         "bulletin",
         json.dumps(
             {
@@ -1571,8 +1564,7 @@ def post_bulletin(body: BulletinPostRequest, request: Request) -> BulletinMessag
 @router.get("/bulletin")
 def get_bulletin(request: Request, since: float = 0.0) -> list[BulletinMessageResponse]:
     """Get bulletin messages since a given timestamp."""
-    bulletin = _get_bulletin(request)
-    messages = bulletin.read_since(since)
+    messages = _get_bulletin(request).read_since(since)
     return [
         BulletinMessageResponse(
             agent_id=m.agent_id,
@@ -1593,8 +1585,7 @@ def get_bulletin(request: Request, since: float = 0.0) -> list[BulletinMessageRe
 @router.post("/channel/query", status_code=201)
 def post_channel_query(body: ChannelQueryRequest, request: Request) -> ChannelQueryResponse:
     """Post a coordination query targeted at an agent or role."""
-    channel = _get_direct_channel(request)
-    q = channel.post_query(
+    q = _get_direct_channel(request).post_query(
         sender_agent=body.sender_agent,
         topic=body.topic,
         content=body.content,
@@ -1622,8 +1613,7 @@ def post_channel_query(body: ChannelQueryRequest, request: Request) -> ChannelQu
 )
 def post_channel_response(query_id: str, body: ChannelResponseRequest, request: Request) -> ChannelResponseResponse:
     """Respond to a channel query."""
-    channel = _get_direct_channel(request)
-    r = channel.post_response(
+    r = _get_direct_channel(request).post_response(
         query_id=query_id,
         responder_agent=body.responder_agent,
         content=body.content,
@@ -1644,8 +1634,7 @@ def get_channel_queries(
     request: Request, agent_id: str | None = None, role: str | None = None
 ) -> list[ChannelQueryResponse]:
     """Get pending queries, optionally filtered by agent_id or role."""
-    channel = _get_direct_channel(request)
-    queries = channel.get_pending_queries(agent_id=agent_id, role=role)
+    queries = _get_direct_channel(request).get_pending_queries(agent_id=agent_id, role=role)
     return [
         ChannelQueryResponse(
             id=q.id,
@@ -1667,8 +1656,7 @@ def get_channel_queries(
 )
 def get_channel_responses(query_id: str, request: Request) -> list[ChannelResponseResponse]:
     """Get all responses for a channel query."""
-    channel = _get_direct_channel(request)
-    responses = channel.get_responses(query_id)
+    responses = _get_direct_channel(request).get_responses(query_id)
     return [
         ChannelResponseResponse(
             id=r.id,

--- a/src/bernstein/core/routes/task_detail.py
+++ b/src/bernstein/core/routes/task_detail.py
@@ -74,8 +74,7 @@ def task_detail(request: Request, task_id: str) -> TaskDetailResponse:
     Args:
         task_id: Task identifier.
     """
-    store = _get_store(request)
-    task = store.get_task(task_id)
+    task = _get_store(request).get_task(task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
 
@@ -457,8 +456,7 @@ def task_diff(request: Request, task_id: str) -> TaskDiffResponse:
            a structured per-file representation.
         3. Cap the unified diff at ``_DIFF_MAX_BYTES`` to keep payloads sane.
     """
-    store = _get_store(request)
-    task = store.get_task(task_id)
+    task = _get_store(request).get_task(task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
 

--- a/src/bernstein/core/routes/task_trace.py
+++ b/src/bernstein/core/routes/task_trace.py
@@ -233,8 +233,7 @@ def task_trace(
     valid task with no trace returns 200 + an empty events list (the FE
     renders an empty-state card in that case).
     """
-    store = _get_store(request)
-    task = store.get_task(task_id)
+    task = _get_store(request).get_task(task_id)
     if task is None:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
 

--- a/src/bernstein/core/routes/team.py
+++ b/src/bernstein/core/routes/team.py
@@ -46,8 +46,7 @@ def team_summary(request: Request) -> JSONResponse:
 @router.get("/team/active")
 def team_active(request: Request) -> JSONResponse:
     """Return only active team members."""
-    store = TeamStateStore(_get_sdd_dir(request))
-    members = store.list_members(active_only=True)
+    members = TeamStateStore(_get_sdd_dir(request)).list_members(active_only=True)
     return JSONResponse({"members": [m.to_dict() for m in members]})
 
 
@@ -62,8 +61,7 @@ def team_member(request: Request, agent_id: str) -> JSONResponse:
 
     Returns 404 if the agent is not in the team roster.
     """
-    store = TeamStateStore(_get_sdd_dir(request))
-    member = store.get_member(agent_id)
+    member = TeamStateStore(_get_sdd_dir(request)).get_member(agent_id)
     if member is None:
         return JSONResponse({"error": f"Agent {agent_id!r} not found in team"}, status_code=404)
     return JSONResponse(member.to_dict())

--- a/src/bernstein/core/routing/bandit_router.py
+++ b/src/bernstein/core/routing/bandit_router.py
@@ -505,7 +505,7 @@ def _validate_raw_matrices(
     raw_mat = raw_data.get("A")
     raw_vec = raw_data.get("b", {})
 
-    if raw_inv is None and raw_mat is None:
+    if raw_inv is raw_mat is None:
         logger.info("BanditPolicy: resetting %s because policy matrices are missing", path)
         return None
     if raw_inv is not None and not isinstance(raw_inv, dict):

--- a/src/bernstein/core/routing/cascade_router.py
+++ b/src/bernstein/core/routing/cascade_router.py
@@ -586,8 +586,7 @@ class CascadeRouter:
         cost_usd: float,
         latency_s: float,
     ) -> None:
-        bandit = self._get_bandit()
-        bandit.record(role=role, model=model, success=success, cost_usd=cost_usd, latency_s=latency_s)
+        self._get_bandit().record(role=role, model=model, success=success, cost_usd=cost_usd, latency_s=latency_s)
 
     def _select_initial_model(self, task: Task) -> tuple[str, str]:
         """Pick the cheapest viable model for the first attempt.
@@ -674,7 +673,7 @@ class CascadeRouter:
             Tuple of (should_escalate, reason_string).
         """
         # Hard failure — explicit task failure
-        if not attempt.success and janitor_passed is None and output is None:
+        if not attempt.success and janitor_passed is output is None:
             # Caller explicitly set success=False without further info
             return True, "task failed"
 

--- a/src/bernstein/core/routing/hijacker.py
+++ b/src/bernstein/core/routing/hijacker.py
@@ -98,13 +98,15 @@ class EnvVarTierDetector:
 
     def _estimate_tokens(self, tier: ApiTier) -> int:
         """Estimate free token allocation based on tier."""
-        return ({
-            ApiTier.FREE: 100_000,
-            ApiTier.PLUS: 500_000,
-            ApiTier.PRO: 1_000_000,
-            ApiTier.ENTERPRISE: 10_000_000,
-            ApiTier.UNLIMITED: 100_000_000,
-        }).get(tier, 100_000)
+        return (
+            {
+                ApiTier.FREE: 100_000,
+                ApiTier.PLUS: 500_000,
+                ApiTier.PRO: 1_000_000,
+                ApiTier.ENTERPRISE: 10_000_000,
+                ApiTier.UNLIMITED: 100_000_000,
+            }
+        ).get(tier, 100_000)
 
 
 class QuotaTracker:
@@ -398,14 +400,16 @@ class TierHijacker:
 
     def _opportunity_to_tier(self, opportunity: HijackOpportunity) -> Tier:
         """Convert HijackOpportunity source to Tier."""
-        return ({
-            FreeTierSource.NEW_PROVIDER_TRIAL: Tier.FREE,
-            FreeTierSource.UNUSED_QUOTA: Tier.FREE,
-            FreeTierSource.PROMOTIONAL_CREDITS: Tier.FREE,
-            FreeTierSource.OPEN_SOURCE_ALTERNATIVE: Tier.FREE,
-            FreeTierSource.COMMUNITY_TIER: Tier.FREE,
-            FreeTierSource.EDUCATIONAL_ACCESS: Tier.FREE,
-        }).get(opportunity.source, Tier.FREE)
+        return (
+            {
+                FreeTierSource.NEW_PROVIDER_TRIAL: Tier.FREE,
+                FreeTierSource.UNUSED_QUOTA: Tier.FREE,
+                FreeTierSource.PROMOTIONAL_CREDITS: Tier.FREE,
+                FreeTierSource.OPEN_SOURCE_ALTERNATIVE: Tier.FREE,
+                FreeTierSource.COMMUNITY_TIER: Tier.FREE,
+                FreeTierSource.EDUCATIONAL_ACCESS: Tier.FREE,
+            }
+        ).get(opportunity.source, Tier.FREE)
 
     def _get_models_for_opportunity(
         self,

--- a/src/bernstein/core/routing/hijacker.py
+++ b/src/bernstein/core/routing/hijacker.py
@@ -98,14 +98,13 @@ class EnvVarTierDetector:
 
     def _estimate_tokens(self, tier: ApiTier) -> int:
         """Estimate free token allocation based on tier."""
-        estimates = {
+        return ({
             ApiTier.FREE: 100_000,
             ApiTier.PLUS: 500_000,
             ApiTier.PRO: 1_000_000,
             ApiTier.ENTERPRISE: 10_000_000,
             ApiTier.UNLIMITED: 100_000_000,
-        }
-        return estimates.get(tier, 100_000)
+        }).get(tier, 100_000)
 
 
 class QuotaTracker:
@@ -399,15 +398,14 @@ class TierHijacker:
 
     def _opportunity_to_tier(self, opportunity: HijackOpportunity) -> Tier:
         """Convert HijackOpportunity source to Tier."""
-        mapping = {
+        return ({
             FreeTierSource.NEW_PROVIDER_TRIAL: Tier.FREE,
             FreeTierSource.UNUSED_QUOTA: Tier.FREE,
             FreeTierSource.PROMOTIONAL_CREDITS: Tier.FREE,
             FreeTierSource.OPEN_SOURCE_ALTERNATIVE: Tier.FREE,
             FreeTierSource.COMMUNITY_TIER: Tier.FREE,
             FreeTierSource.EDUCATIONAL_ACCESS: Tier.FREE,
-        }
-        return mapping.get(opportunity.source, Tier.FREE)
+        }).get(opportunity.source, Tier.FREE)
 
     def _get_models_for_opportunity(
         self,

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -671,7 +671,7 @@ class TierAwareRouter:
     ) -> ResidencyAttestation | None:
         """Build an attestation record when routing is residency constrained."""
         required_region = self.state.model_policy.required_region
-        if required_region is None and provider.residency_attestation is None:
+        if required_region is provider.residency_attestation is None:
             return None
         return ResidencyAttestation(
             provider=provider.name,

--- a/src/bernstein/core/sandbox/ssh_backend.py
+++ b/src/bernstein/core/sandbox/ssh_backend.py
@@ -622,8 +622,7 @@ class SSHSandboxBackend:
 
         - ``session_id``: Pinned session identifier. Random when absent.
         """
-        opts = dict(options or {})
-        hint = opts.get("session_id")
+        hint = dict(options or {}).get("session_id")
         session_id = hint if isinstance(hint, str) and hint else f"sbx-{secrets.token_hex(6)}"
         workdir = await self.create_remote_worktree(manifest, session_id)
 

--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -142,8 +142,7 @@ def ed25519_public_jwk(public_key_pem: bytes, *, kid: str) -> dict[str, str]:
     """
     from cryptography.hazmat.primitives import serialization
 
-    public_key = serialization.load_pem_public_key(public_key_pem)
-    raw = public_key.public_bytes(
+    raw = serialization.load_pem_public_key(public_key_pem).public_bytes(
         serialization.Encoding.Raw,
         serialization.PublicFormat.Raw,
     )

--- a/src/bernstein/core/security/auto_approve.py
+++ b/src/bernstein/core/security/auto_approve.py
@@ -461,8 +461,7 @@ def _parse_extra_patterns(raw: str | None) -> list[re.Pattern[str]]:
     if not raw:
         return []
     # Normalize newlines to the separator, then split
-    payload = raw.replace("\r\n", "\n").replace("\n", _EXTRA_ALLOW_SEPARATOR)
-    raw_entries = payload.split(_EXTRA_ALLOW_SEPARATOR)
+    raw_entries = raw.replace("\r\n", "\n").replace("\n", _EXTRA_ALLOW_SEPARATOR).split(_EXTRA_ALLOW_SEPARATOR)
     out: list[re.Pattern[str]] = []
     for entry in raw_entries:
         pattern = entry.strip()
@@ -698,10 +697,7 @@ def classify_command(cmd: str) -> ApprovalResult:
                 matched_pattern=deny_pat,
             )
 
-    unmatched: list[str] = []
-    for sub in sub_commands:
-        if _match_allow(sub) is None:
-            unmatched.append(sub)
+    unmatched = [sub for sub in sub_commands if _match_allow(sub) is None]
 
     if unmatched:
         return ApprovalResult(

--- a/src/bernstein/core/security/capability_matrix.py
+++ b/src/bernstein/core/security/capability_matrix.py
@@ -362,7 +362,9 @@ def record_spawn_capabilities(
     import json
     from datetime import UTC, datetime
 
-    decision = (registry if registry is not None else CapabilityRegistry.load_default(workdir=workdir)).evaluate_chain(tools)
+    decision = (registry if registry is not None else CapabilityRegistry.load_default(workdir=workdir)).evaluate_chain(
+        tools
+    )
 
     runtime_dir = workdir / ".sdd" / "runtime" / "spawn_capabilities"
     try:

--- a/src/bernstein/core/security/capability_matrix.py
+++ b/src/bernstein/core/security/capability_matrix.py
@@ -275,8 +275,7 @@ def _load_yaml_file(path: Path) -> list[ToolCapabilities]:
     if not isinstance(raw, dict):
         return []
 
-    mapping = cast("dict[str, object]", raw)
-    items = mapping.get("tools", [])
+    items = cast("dict[str, object]", raw).get("tools", [])
     if not isinstance(items, list):
         return []
 
@@ -363,8 +362,7 @@ def record_spawn_capabilities(
     import json
     from datetime import UTC, datetime
 
-    reg = registry if registry is not None else CapabilityRegistry.load_default(workdir=workdir)
-    decision = reg.evaluate_chain(tools)
+    decision = (registry if registry is not None else CapabilityRegistry.load_default(workdir=workdir)).evaluate_chain(tools)
 
     runtime_dir = workdir / ".sdd" / "runtime" / "spawn_capabilities"
     try:

--- a/src/bernstein/core/security/claude_permission_profiles.py
+++ b/src/bernstein/core/security/claude_permission_profiles.py
@@ -188,8 +188,7 @@ class PermissionProfileManager:
         Returns:
             Dict suitable for .claude/settings.json.
         """
-        profile = self.get_profile(role)
-        return profile.to_settings_json()
+        return self.get_profile(role).to_settings_json()
 
     def inject_settings(self, role: str, workdir: Path) -> Path:
         """Write permission settings to the agent's working directory.

--- a/src/bernstein/core/security/compliance_library.py
+++ b/src/bernstein/core/security/compliance_library.py
@@ -364,8 +364,7 @@ def check_session_management(project_root: Path) -> PolicyResult:
 def check_password_policy(project_root: Path) -> PolicyResult:
     """Verify that a minimum password length policy is configured."""
     config = _load_yaml_config(project_root)
-    security = config.get("security", {})
-    min_len = security.get("password_min_length", 0)
+    min_len = config.get("security", {}).get("password_min_length", 0)
     passed = min_len >= 12  # NIST 800-63B recommendation
     evidence = f"Password min length: {min_len}" if min_len > 0 else "No password policy configured"
     remediation = "" if passed else "Set security.password_min_length to at least 12 characters (NIST 800-63B)."

--- a/src/bernstein/core/security/differential_privacy.py
+++ b/src/bernstein/core/security/differential_privacy.py
@@ -118,8 +118,7 @@ def _perturb(value: Any, sensitivity: float, config: DPConfig) -> Any:
     """Apply DP noise to *value* if it is a non-None number, else return as-is."""
     if value is None or not isinstance(value, (int, float)):
         return value
-    mech = GaussianMechanism(sensitivity=sensitivity, config=config)
-    return mech.add_noise(float(value))
+    return GaussianMechanism(sensitivity=sensitivity, config=config).add_noise(float(value))
 
 
 def _perturb_fields(

--- a/src/bernstein/core/security/dp_telemetry.py
+++ b/src/bernstein/core/security/dp_telemetry.py
@@ -234,8 +234,7 @@ class DPTelemetryExporter:
             return value
 
         sensitivity = self._sensitivities.get(field_name, 1.0)
-        mechanism = GaussianMechanism(sensitivity=sensitivity, config=self._dp_config)
-        return mechanism.add_noise(float(value))
+        return GaussianMechanism(sensitivity=sensitivity, config=self._dp_config).add_noise(float(value))
 
     def _perturb_dict(self, data: dict[str, Any]) -> tuple[dict[str, Any], int]:
         """Apply DP noise to all numeric fields in a dict.

--- a/src/bernstein/core/security/eu_ai_act.py
+++ b/src/bernstein/core/security/eu_ai_act.py
@@ -259,7 +259,9 @@ def _normalize_task_text(task: TaskLike) -> str:
 
 
 def _matched_reasons(haystack: str, rules: dict[str, tuple[str, ...]]) -> tuple[str, ...]:
-    reasons = [label.replace("_", " ") for label, keywords in rules.items() if any(keyword in haystack for keyword in keywords)]
+    reasons = [
+        label.replace("_", " ") for label, keywords in rules.items() if any(keyword in haystack for keyword in keywords)
+    ]
     return tuple(reasons)
 
 

--- a/src/bernstein/core/security/eu_ai_act.py
+++ b/src/bernstein/core/security/eu_ai_act.py
@@ -259,10 +259,7 @@ def _normalize_task_text(task: TaskLike) -> str:
 
 
 def _matched_reasons(haystack: str, rules: dict[str, tuple[str, ...]]) -> tuple[str, ...]:
-    reasons: list[str] = []
-    for label, keywords in rules.items():
-        if any(keyword in haystack for keyword in keywords):
-            reasons.append(label.replace("_", " "))
+    reasons = [label.replace("_", " ") for label, keywords in rules.items() if any(keyword in haystack for keyword in keywords)]
     return tuple(reasons)
 
 

--- a/src/bernstein/core/security/guardrail_pipeline.py
+++ b/src/bernstein/core/security/guardrail_pipeline.py
@@ -90,7 +90,11 @@ class ScopeGuardrail:
         modified_files: list[str] = context.get("modified_files", [])
         if not scope or not modified_files:
             return GuardrailResult(passed=True, guardrail_name=self.name)
-        violations = [f"File {f} is outside allowed scope {scope}" for f in modified_files if not any(f.startswith(s) for s in scope)]
+        violations = [
+            f"File {f} is outside allowed scope {scope}"
+            for f in modified_files
+            if not any(f.startswith(s) for s in scope)
+        ]
         return GuardrailResult(
             passed=len(violations) == 0,
             guardrail_name=self.name,
@@ -138,7 +142,9 @@ class SecretLeakGuardrail:
         return GuardrailResult(passed=True, guardrail_name=self.name)
 
     def check_output(self, output: str, _context: dict[str, Any]) -> GuardrailResult:
-        violations = [f"Potential secret leak detected: {pattern.pattern}" for pattern in self._compiled if pattern.search(output)]
+        violations = [
+            f"Potential secret leak detected: {pattern.pattern}" for pattern in self._compiled if pattern.search(output)
+        ]
         return GuardrailResult(
             passed=len(violations) == 0,
             guardrail_name=self.name,

--- a/src/bernstein/core/security/guardrail_pipeline.py
+++ b/src/bernstein/core/security/guardrail_pipeline.py
@@ -90,10 +90,7 @@ class ScopeGuardrail:
         modified_files: list[str] = context.get("modified_files", [])
         if not scope or not modified_files:
             return GuardrailResult(passed=True, guardrail_name=self.name)
-        violations: list[str] = []
-        for f in modified_files:
-            if not any(f.startswith(s) for s in scope):
-                violations.append(f"File {f} is outside allowed scope {scope}")
+        violations = [f"File {f} is outside allowed scope {scope}" for f in modified_files if not any(f.startswith(s) for s in scope)]
         return GuardrailResult(
             passed=len(violations) == 0,
             guardrail_name=self.name,
@@ -141,10 +138,7 @@ class SecretLeakGuardrail:
         return GuardrailResult(passed=True, guardrail_name=self.name)
 
     def check_output(self, output: str, _context: dict[str, Any]) -> GuardrailResult:
-        violations: list[str] = []
-        for pattern in self._compiled:
-            if pattern.search(output):
-                violations.append(f"Potential secret leak detected: {pattern.pattern}")
+        violations = [f"Potential secret leak detected: {pattern.pattern}" for pattern in self._compiled if pattern.search(output)]
         return GuardrailResult(
             passed=len(violations) == 0,
             guardrail_name=self.name,

--- a/src/bernstein/core/security/guardrails.py
+++ b/src/bernstein/core/security/guardrails.py
@@ -404,10 +404,7 @@ def check_secrets(diff: str) -> list[PermissionDecision]:
     Returns:
         List with one PermissionDecision for the "secret_detection" check.
     """
-    found: list[str] = []
-    for name, pattern in _SECRET_PATTERNS:
-        if pattern.search(diff):
-            found.append(name)
+    found = [name for name, pattern in _SECRET_PATTERNS if pattern.search(diff)]
 
     if found:
         return [

--- a/src/bernstein/core/security/hipaa.py
+++ b/src/bernstein/core/security/hipaa.py
@@ -436,8 +436,7 @@ def decrypt_file_aes256gcm(enc_path: Path, key: bytes) -> Path:
     nonce = blob[:12]
     ciphertext = blob[12:]
 
-    aesgcm = AESGCM(key)
-    plaintext = aesgcm.decrypt(nonce, ciphertext, None)
+    plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
 
     out_path = enc_path.with_suffix("")  # strip .enc
     out_path.write_bytes(plaintext)
@@ -555,8 +554,7 @@ def generate_hipaa_report(
             audit_chain_valid = valid
 
     # Check encryption at rest
-    key_path = sdd_dir / "config" / "hipaa-enc-key"
-    enc_at_rest = key_path.exists()
+    enc_at_rest = (sdd_dir / "config" / "hipaa-enc-key").exists()
 
     controls: dict[str, bool] = {
         "phi_detection": True,

--- a/src/bernstein/core/security/key_rotation_support.py
+++ b/src/bernstein/core/security/key_rotation_support.py
@@ -262,10 +262,7 @@ class AgentKeyUpdater:
         Returns:
             List of update results for each agent.
         """
-        results: list[AgentUpdateResult] = []
-        for agent_id in self._agent_env:
-            if env_var in self._agent_env[agent_id]:
-                results.append(self.update_agent(agent_id, env_var, new_value))
+        results = [self.update_agent(agent_id, env_var, new_value) for agent_id in self._agent_env if env_var in self._agent_env[agent_id]]
         return results
 
     def get_agent_env(self, agent_id: str) -> dict[str, str] | None:

--- a/src/bernstein/core/security/key_rotation_support.py
+++ b/src/bernstein/core/security/key_rotation_support.py
@@ -262,7 +262,11 @@ class AgentKeyUpdater:
         Returns:
             List of update results for each agent.
         """
-        results = [self.update_agent(agent_id, env_var, new_value) for agent_id in self._agent_env if env_var in self._agent_env[agent_id]]
+        results = [
+            self.update_agent(agent_id, env_var, new_value)
+            for agent_id in self._agent_env
+            if env_var in self._agent_env[agent_id]
+        ]
         return results
 
     def get_agent_env(self, agent_id: str) -> dict[str, str] | None:

--- a/src/bernstein/core/security/permission_matrix.py
+++ b/src/bernstein/core/security/permission_matrix.py
@@ -201,8 +201,7 @@ def resolve_permission(
     Returns:
         ResolutionOutcome.
     """
-    matrix = PermissionResolutionMatrix()
-    return matrix.resolve_simple(rule_outcome, hook_outcome)
+    return PermissionResolutionMatrix().resolve_simple(rule_outcome, hook_outcome)
 
 
 def log_resolution(

--- a/src/bernstein/core/security/permissions.py
+++ b/src/bernstein/core/security/permissions.py
@@ -344,10 +344,7 @@ def check_file_permissions(
     if not changed_files:
         return [PermissionDecision(type=DecisionType.ALLOW, reason="No files changed")]
 
-    violations: list[str] = []
-    for filepath in changed_files:
-        if not is_path_allowed(filepath, permissions):
-            violations.append(filepath)
+    violations = [filepath for filepath in changed_files if not is_path_allowed(filepath, permissions)]
 
     if violations:
         return [

--- a/src/bernstein/core/security/policy_engine.py
+++ b/src/bernstein/core/security/policy_engine.py
@@ -544,8 +544,7 @@ def _run_opa_eval(policy_path: Path, payload: dict[str, Any]) -> object:
         input_path.unlink(missing_ok=True)
     if completed.returncode != 0:
         raise OSError(completed.stderr.strip() or completed.stdout.strip() or "opa eval failed")
-    parsed = json.loads(completed.stdout)
-    results = parsed.get("result", [])
+    results = json.loads(completed.stdout).get("result", [])
     if not results:
         return []
     expressions = results[0].get("expressions", [])

--- a/src/bernstein/core/security/resource_limits.py
+++ b/src/bernstein/core/security/resource_limits.py
@@ -220,7 +220,7 @@ def make_preexec_fn(limits: ResourceLimits) -> Callable[[], None] | None:
     """
     if not _IS_POSIX:
         return None
-    if limits.memory_mb == 0 and limits.cpu_seconds == 0 and limits.open_files == 0:
+    if limits.memory_mb == limits.cpu_seconds == 0 and limits.open_files == 0:
         return None
 
     _limits = limits  # capture for closure

--- a/src/bernstein/core/security/rfc3161_verifier.py
+++ b/src/bernstein/core/security/rfc3161_verifier.py
@@ -590,13 +590,10 @@ def _walk_chain(
         None,
     )
     ee_policy = ExtensionPolicy.permit_all()
-    builder = (
-        PolicyBuilder()
+    verifier = (PolicyBuilder()
         .store(store)
         .time(verification_time)
-        .extension_policies(ca_policy=ca_policy, ee_policy=ee_policy)
-    )
-    verifier = builder.build_client_verifier()
+        .extension_policies(ca_policy=ca_policy, ee_policy=ee_policy)).build_client_verifier()
     # ``verify`` raises VerificationError on failure; we use the client
     # verifier (no SAN required) because TSA certs do not carry server
     # SANs. The time-stamping EKU is checked via ``_has_timestamping_eku``

--- a/src/bernstein/core/security/rfc3161_verifier.py
+++ b/src/bernstein/core/security/rfc3161_verifier.py
@@ -590,10 +590,12 @@ def _walk_chain(
         None,
     )
     ee_policy = ExtensionPolicy.permit_all()
-    verifier = (PolicyBuilder()
+    verifier = (
+        PolicyBuilder()
         .store(store)
         .time(verification_time)
-        .extension_policies(ca_policy=ca_policy, ee_policy=ee_policy)).build_client_verifier()
+        .extension_policies(ca_policy=ca_policy, ee_policy=ee_policy)
+    ).build_client_verifier()
     # ``verify`` raises VerificationError on failure; we use the client
     # verifier (no SAN required) because TSA certs do not carry server
     # SANs. The time-stamping EKU is checked via ``_has_timestamping_eku``

--- a/src/bernstein/core/security/secrets.py
+++ b/src/bernstein/core/security/secrets.py
@@ -512,5 +512,4 @@ def check_provider_connectivity(config: SecretsConfig) -> tuple[bool, str]:
     Returns:
         Tuple of (ok, detail_message).
     """
-    provider = _create_provider(config.provider)
-    return provider.check_connectivity()
+    return _create_provider(config.provider).check_connectivity()

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -464,8 +464,7 @@ def verify_local_attestation(bundle_path: Path, attestation_dir: Path) -> bool:
         raise ValueError(msg)
     public_key = serialization.load_pem_public_key(pub_key_file.read_bytes())
 
-    payload_obj = AttestationPayload(**bundle["payload"])
-    payload_bytes = payload_obj.canonical_json().encode()
+    payload_bytes = AttestationPayload(**bundle["payload"]).canonical_json().encode()
     signature = bytes.fromhex(bundle["signature_hex"])
 
     try:

--- a/src/bernstein/core/security/state_encryption.py
+++ b/src/bernstein/core/security/state_encryption.py
@@ -71,12 +71,14 @@ def derive_key(password: str, salt: bytes | None = None) -> tuple[bytes, bytes]:
 
         salt = secrets.token_bytes(16)
 
-    key = (PBKDF2HMAC(
-        algorithm=hashes.SHA256(),
-        length=32,
-        salt=salt,
-        iterations=600_000,  # OWASP 2023 recommendation
-    )).derive(password.encode("utf-8"))
+    key = (
+        PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=600_000,  # OWASP 2023 recommendation
+        )
+    ).derive(password.encode("utf-8"))
     return key, salt
 
 

--- a/src/bernstein/core/security/state_encryption.py
+++ b/src/bernstein/core/security/state_encryption.py
@@ -71,13 +71,12 @@ def derive_key(password: str, salt: bytes | None = None) -> tuple[bytes, bytes]:
 
         salt = secrets.token_bytes(16)
 
-    kdf = PBKDF2HMAC(
+    key = (PBKDF2HMAC(
         algorithm=hashes.SHA256(),
         length=32,
         salt=salt,
         iterations=600_000,  # OWASP 2023 recommendation
-    )
-    key = kdf.derive(password.encode("utf-8"))
+    )).derive(password.encode("utf-8"))
     return key, salt
 
 
@@ -414,8 +413,7 @@ class KeyManager:
         salt = secrets.token_bytes(_KEY_SALT_LEN)
         kek, _ = derive_key(passphrase, salt=salt)
         iv = secrets.token_bytes(_KEY_IV_LEN)
-        aesgcm = AESGCM(kek)
-        wrapped = aesgcm.encrypt(iv, raw_key, _KEY_FILE_MAGIC)
+        wrapped = AESGCM(kek).encrypt(iv, raw_key, _KEY_FILE_MAGIC)
         return _KEY_FILE_MAGIC + salt + iv + wrapped
 
     @classmethod

--- a/src/bernstein/core/security/tenant_isolation.py
+++ b/src/bernstein/core/security/tenant_isolation.py
@@ -202,10 +202,8 @@ class TenantIsolationManager:
             Sorted list of tenant identifiers.
         """
         tenants: set[str] = set()
-        for cfg in self._registry.tenants:
-            tenants.add(cfg.id)
-        for tid in self._contexts:
-            tenants.add(tid)
+        tenants.update(cfg.id for cfg in self._registry.tenants)
+        tenants.update(self._contexts)
         return sorted(tenants)
 
     def persist_state(self) -> None:
@@ -225,8 +223,7 @@ class TenantIsolationManager:
                 for tid, ctx in self._contexts.items()
             },
         }
-        path = state_dir / "tenant_isolation.json"
-        path.write_text(json.dumps(state, indent=2))
+        (state_dir / "tenant_isolation.json").write_text(json.dumps(state, indent=2))
 
     def load_state(self) -> None:
         """Load persisted tenant isolation state from disk."""

--- a/src/bernstein/core/security/tenanting.py
+++ b/src/bernstein/core/security/tenanting.py
@@ -100,7 +100,9 @@ def tenant_registry_from_seed(seed_config: object | None) -> TenantRegistry:
     tenants = getattr(seed_config, "tenants", ())
     if not isinstance(tenants, tuple):
         return TenantRegistry()
-    typed_tenants = [candidate for candidate in cast("tuple[object, ...]", tenants) if isinstance(candidate, TenantConfig)]
+    typed_tenants = [
+        candidate for candidate in cast("tuple[object, ...]", tenants) if isinstance(candidate, TenantConfig)
+    ]
     return build_tenant_registry(typed_tenants)
 
 

--- a/src/bernstein/core/security/tenanting.py
+++ b/src/bernstein/core/security/tenanting.py
@@ -100,10 +100,7 @@ def tenant_registry_from_seed(seed_config: object | None) -> TenantRegistry:
     tenants = getattr(seed_config, "tenants", ())
     if not isinstance(tenants, tuple):
         return TenantRegistry()
-    typed_tenants: list[TenantConfig] = []
-    for candidate in cast("tuple[object, ...]", tenants):
-        if isinstance(candidate, TenantConfig):
-            typed_tenants.append(candidate)
+    typed_tenants = [candidate for candidate in cast("tuple[object, ...]", tenants) if isinstance(candidate, TenantConfig)]
     return build_tenant_registry(typed_tenants)
 
 

--- a/src/bernstein/core/security/vault/backend_file.py
+++ b/src/bernstein/core/security/vault/backend_file.py
@@ -101,8 +101,7 @@ class FileBackend(CredentialVault):
         path: Path | None = None,
         environ: Mapping[str, str] | None = None,
     ) -> None:
-        env = environ if environ is not None else os.environ
-        passphrase = env.get(passphrase_env, "")
+        passphrase = (environ if environ is not None else os.environ).get(passphrase_env, "")
         if not passphrase:
             raise FileBackendUnavailable(
                 f"Vault file backend requires a passphrase in {passphrase_env}; the variable is unset or empty."
@@ -121,13 +120,12 @@ class FileBackend(CredentialVault):
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
-        kdf = PBKDF2HMAC(
+        return (PBKDF2HMAC(
             algorithm=hashes.SHA256(),
             length=_KEY_LEN,
             salt=salt,
             iterations=_KDF_ITERATIONS,
-        )
-        return kdf.derive(self._passphrase)
+        )).derive(self._passphrase)
 
     def _encrypt(self, plaintext: bytes, salt: bytes) -> str:
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM

--- a/src/bernstein/core/security/vault/backend_file.py
+++ b/src/bernstein/core/security/vault/backend_file.py
@@ -120,12 +120,14 @@ class FileBackend(CredentialVault):
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
-        return (PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=_KEY_LEN,
-            salt=salt,
-            iterations=_KDF_ITERATIONS,
-        )).derive(self._passphrase)
+        return (
+            PBKDF2HMAC(
+                algorithm=hashes.SHA256(),
+                length=_KEY_LEN,
+                salt=salt,
+                iterations=_KDF_ITERATIONS,
+            )
+        ).derive(self._passphrase)
 
     def _encrypt(self, plaintext: bytes, salt: bytes) -> str:
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM

--- a/src/bernstein/core/streaming_merge.py
+++ b/src/bernstein/core/streaming_merge.py
@@ -186,11 +186,10 @@ def _extract_file_references(text: str) -> list[str]:
     """
     # Pattern for file paths with common extensions.
     # Group 1: action-word + path.  Group 2: bare path with known prefix.
-    file_pattern = re.compile(
+    matches = (re.compile(
         r"(?:Creating|Writing|Modified|Updated|Created)\s+(?:file\s+)?[`']?([^\s`'\"]+\.\w{1,10})[`']?"
         r"|((?:src|lib|tests?|examples|docs?|scripts?|pkg)/[^\s`'\"]+\.\w{1,10})"
-    )
-    matches = file_pattern.findall(text)
+    )).findall(text)
 
     # Each match is a tuple (group1, group2); pick whichever matched.
     files: list[str] = []

--- a/src/bernstein/core/streaming_merge.py
+++ b/src/bernstein/core/streaming_merge.py
@@ -186,10 +186,12 @@ def _extract_file_references(text: str) -> list[str]:
     """
     # Pattern for file paths with common extensions.
     # Group 1: action-word + path.  Group 2: bare path with known prefix.
-    matches = (re.compile(
-        r"(?:Creating|Writing|Modified|Updated|Created)\s+(?:file\s+)?[`']?([^\s`'\"]+\.\w{1,10})[`']?"
-        r"|((?:src|lib|tests?|examples|docs?|scripts?|pkg)/[^\s`'\"]+\.\w{1,10})"
-    )).findall(text)
+    matches = (
+        re.compile(
+            r"(?:Creating|Writing|Modified|Updated|Created)\s+(?:file\s+)?[`']?([^\s`'\"]+\.\w{1,10})[`']?"
+            r"|((?:src|lib|tests?|examples|docs?|scripts?|pkg)/[^\s`'\"]+\.\w{1,10})"
+        )
+    ).findall(text)
 
     # Each match is a tuple (group1, group2); pick whichever matched.
     files: list[str] = []

--- a/src/bernstein/core/tasks/abort_chain.py
+++ b/src/bernstein/core/tasks/abort_chain.py
@@ -283,10 +283,7 @@ class AbortChain:
         with self._lock:
             siblings = set(self._graph.get(parent_id, set())) - {session_id}
 
-        aborted: list[str] = []
-        for sibling_id in siblings:
-            if self._write_sibling_shutdown(sibling_id, triggering_session_id, reason):
-                aborted.append(sibling_id)
+        aborted = [sibling_id for sibling_id in siblings if self._write_sibling_shutdown(sibling_id, triggering_session_id, reason)]
 
         if aborted:
             logger.info(

--- a/src/bernstein/core/tasks/abort_chain.py
+++ b/src/bernstein/core/tasks/abort_chain.py
@@ -283,7 +283,11 @@ class AbortChain:
         with self._lock:
             siblings = set(self._graph.get(parent_id, set())) - {session_id}
 
-        aborted = [sibling_id for sibling_id in siblings if self._write_sibling_shutdown(sibling_id, triggering_session_id, reason)]
+        aborted = [
+            sibling_id
+            for sibling_id in siblings
+            if self._write_sibling_shutdown(sibling_id, triggering_session_id, reason)
+        ]
 
         if aborted:
             logger.info(

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2278,12 +2278,14 @@ def _resolve_approval_workflow(orch: Any, task: Task) -> tuple[Any, float | None
         return None, None
 
     risk = getattr(task, "risk_level", "low")
-    mode_str = ({
-        "low": wf.low_risk,
-        "medium": wf.medium_risk,
-        "high": wf.high_risk,
-        "critical": getattr(wf, "critical_risk", wf.high_risk),
-    }).get(risk, "auto")
+    mode_str = (
+        {
+            "low": wf.low_risk,
+            "medium": wf.medium_risk,
+            "high": wf.high_risk,
+            "critical": getattr(wf, "critical_risk", wf.high_risk),
+        }
+    ).get(risk, "auto")
 
     from bernstein.core.approval import ApprovalMode
 
@@ -2315,7 +2317,9 @@ def _create_approval_pr(
 
     task_m = get_collector(orch._workdir / ".sdd" / "metrics").task_metrics.get(task.id)
     cost_usd = task_m.cost_usd if task_m else 0.0
-    test_summary = (completion_data or {"files_modified": [], "test_results": {}}).get("test_results", {}).get("summary", "")
+    test_summary = (
+        (completion_data or {"files_modified": [], "test_results": {}}).get("test_results", {}).get("summary", "")
+    )
     pr_url = orch._approval_gate.create_pr(
         task,
         worktree_path=worktree_path,

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -1310,8 +1310,7 @@ def claim_and_spawn_batches(
     _claimed_titles: set[str] = set()
     for agent in orch._agents.values():
         if agent.status != "dead":
-            for tid in agent.task_ids:
-                _claimed_titles.add(tid)
+            _claimed_titles.update(agent.task_ids)
 
     for batch in batches:
         if getattr(orch, "is_shutting_down", bool)():
@@ -2279,13 +2278,12 @@ def _resolve_approval_workflow(orch: Any, task: Task) -> tuple[Any, float | None
         return None, None
 
     risk = getattr(task, "risk_level", "low")
-    mapping = {
+    mode_str = ({
         "low": wf.low_risk,
         "medium": wf.medium_risk,
         "high": wf.high_risk,
         "critical": getattr(wf, "critical_risk", wf.high_risk),
-    }
-    mode_str = mapping.get(risk, "auto")
+    }).get(risk, "auto")
 
     from bernstein.core.approval import ApprovalMode
 
@@ -2315,11 +2313,9 @@ def _create_approval_pr(
         logger.warning("Approval gate PR mode: no worktree for agent %s -- cannot create PR", session.id)
         return
 
-    collector = get_collector(orch._workdir / ".sdd" / "metrics")
-    task_m = collector.task_metrics.get(task.id)
+    task_m = get_collector(orch._workdir / ".sdd" / "metrics").task_metrics.get(task.id)
     cost_usd = task_m.cost_usd if task_m else 0.0
-    completion = completion_data or {"files_modified": [], "test_results": {}}
-    test_summary = completion.get("test_results", {}).get("summary", "")
+    test_summary = (completion_data or {"files_modified": [], "test_results": {}}).get("test_results", {}).get("summary", "")
     pr_url = orch._approval_gate.create_pr(
         task,
         worktree_path=worktree_path,

--- a/src/bernstein/core/telemetry/config.py
+++ b/src/bernstein/core/telemetry/config.py
@@ -92,8 +92,7 @@ def _file_enabled(home: Path | None) -> bool | None:
     path = config_file_path(home)
     if not path.exists():
         return None
-    cfg = _load_yaml_config(path)
-    value = cfg.get("enabled")
+    value = _load_yaml_config(path).get("enabled")
     if isinstance(value, bool):
         return value
     return None

--- a/src/bernstein/core/tokens/context_compression.py
+++ b/src/bernstein/core/tokens/context_compression.py
@@ -46,10 +46,7 @@ def _should_skip(rel_parts: tuple[str, ...]) -> bool:
 
 def _iter_python_files(workdir: Path) -> list[Path]:
     """Collect all .py files in workdir, skipping hidden/vendored dirs."""
-    result: list[Path] = []
-    for fpath in workdir.rglob("*.py"):
-        if not _should_skip(fpath.relative_to(workdir).parts):
-            result.append(fpath)
+    result = [fpath for fpath in workdir.rglob("*.py") if not _should_skip(fpath.relative_to(workdir).parts)]
     return result
 
 
@@ -141,8 +138,7 @@ class DependencyGraph:
         imports: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
-                for alias in node.names:
-                    imports.add(alias.name)
+                imports.update(alias.name for alias in node.names)
             elif isinstance(node, ast.ImportFrom) and node.module:
                 imports.add(node.module)
         return imports

--- a/src/bernstein/core/tokens/context_fallback.py
+++ b/src/bernstein/core/tokens/context_fallback.py
@@ -330,5 +330,4 @@ def should_compact(log_path: Path) -> bool:
         True if context overflow indicators were found, False otherwise
         (including when the file does not exist or cannot be read).
     """
-    tracker = RateLimitTracker()
-    return tracker.scan_log_for_context_overflow(log_path)
+    return RateLimitTracker().scan_log_for_context_overflow(log_path)

--- a/src/bernstein/core/tokens/context_recommendations.py
+++ b/src/bernstein/core/tokens/context_recommendations.py
@@ -243,8 +243,7 @@ class RecommendationEngine:
         raw_data: object = yaml.safe_load(path.read_text(encoding="utf-8"))
         if not isinstance(raw_data, dict):
             return
-        raw_mapping = cast("dict[str, Any]", raw_data)
-        raw_items = raw_mapping.get("recommendations", [])
+        raw_items = cast("dict[str, Any]", raw_data).get("recommendations", [])
         if not isinstance(raw_items, list):
             return
         raw_items_list = cast("list[object]", raw_items)
@@ -314,7 +313,7 @@ class RecommendationEngine:
 
     def _failure_history_text(self, gate: str) -> str:
         """Return a canned recommendation for repeated gate failures."""
-        mapping = {
+        return ({
             "lint": "Recent lint failures suggest running `uv run ruff check` before completing the task.",
             "type_check": "Recent type-check failures suggest running `uv run pyright` before completing the task.",
             "tests": (
@@ -323,5 +322,4 @@ class RecommendationEngine:
             "coverage_delta": (
                 "Recent coverage regressions suggest running the coverage command locally before completion."
             ),
-        }
-        return mapping.get(gate, "")
+        }).get(gate, "")

--- a/src/bernstein/core/tokens/context_recommendations.py
+++ b/src/bernstein/core/tokens/context_recommendations.py
@@ -313,13 +313,16 @@ class RecommendationEngine:
 
     def _failure_history_text(self, gate: str) -> str:
         """Return a canned recommendation for repeated gate failures."""
-        return ({
-            "lint": "Recent lint failures suggest running `uv run ruff check` before completing the task.",
-            "type_check": "Recent type-check failures suggest running `uv run pyright` before completing the task.",
-            "tests": (
-                "Recent test failures suggest running targeted `uv run pytest ... -x -q` before completing the task."
-            ),
-            "coverage_delta": (
-                "Recent coverage regressions suggest running the coverage command locally before completion."
-            ),
-        }).get(gate, "")
+        return (
+            {
+                "lint": "Recent lint failures suggest running `uv run ruff check` before completing the task.",
+                "type_check": "Recent type-check failures suggest running `uv run pyright` before completing the task.",
+                "tests": (
+                    "Recent test failures suggest running targeted `uv run pytest ... -x -q` "
+                    "before completing the task."
+                ),
+                "coverage_delta": (
+                    "Recent coverage regressions suggest running the coverage command locally before completion."
+                ),
+            }
+        ).get(gate, "")

--- a/src/bernstein/core/tokens/token_binding.py
+++ b/src/bernstein/core/tokens/token_binding.py
@@ -211,7 +211,11 @@ class TokenBindingValidator:
             Number of entries removed.
         """
         now = time.time()
-        stale_jtis = [jti for jti, entry in self._rate_entries.items() if not entry.request_timestamps or now - entry.request_timestamps[-1] > max_age_s]
+        stale_jtis = [
+            jti
+            for jti, entry in self._rate_entries.items()
+            if not entry.request_timestamps or now - entry.request_timestamps[-1] > max_age_s
+        ]
 
         for jti in stale_jtis:
             del self._rate_entries[jti]

--- a/src/bernstein/core/tokens/token_binding.py
+++ b/src/bernstein/core/tokens/token_binding.py
@@ -211,10 +211,7 @@ class TokenBindingValidator:
             Number of entries removed.
         """
         now = time.time()
-        stale_jtis: list[str] = []
-        for jti, entry in self._rate_entries.items():
-            if not entry.request_timestamps or now - entry.request_timestamps[-1] > max_age_s:
-                stale_jtis.append(jti)
+        stale_jtis = [jti for jti, entry in self._rate_entries.items() if not entry.request_timestamps or now - entry.request_timestamps[-1] > max_age_s]
 
         for jti in stale_jtis:
             del self._rate_entries[jti]

--- a/src/bernstein/core/trigger_sources/github.py
+++ b/src/bernstein/core/trigger_sources/github.py
@@ -24,8 +24,7 @@ def normalize_push(payload: dict[str, Any], sender: str, repo: str) -> TriggerEv
 
     commits = payload.get("commits", [])
     commit_messages = "\n".join(c.get("message", "") for c in commits)
-    head_commit = payload.get("head_commit", {})
-    sha = head_commit.get("id", payload.get("after", ""))
+    sha = payload.get("head_commit", {}).get("id", payload.get("after", ""))
 
     # Collect all changed files from all commits
     changed_files: list[str] = []

--- a/src/bernstein/eval/scenario_generator.py
+++ b/src/bernstein/eval/scenario_generator.py
@@ -532,8 +532,7 @@ def build_default_registry() -> ScenarioRegistry:
 
 def is_disabled(env: Mapping[str, str] | None = None) -> bool:
     """Return True when ``BERNSTEIN_SYNTHETIC_EVAL_OFF=1`` is set."""
-    src = env if env is not None else os.environ
-    value = src.get(DISABLE_ENV, "")
+    value = (env if env is not None else os.environ).get(DISABLE_ENV, "")
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
@@ -587,8 +586,7 @@ def materialise(
         raise ValueError("count must be non-negative")
     if is_disabled():
         return []
-    reg = registry or build_default_registry()
-    gen = reg.get(scenario_id)
+    gen = (registry or build_default_registry()).get(scenario_id)
     base_params = dict(params or {})
 
     out: list[SyntheticCase] = []
@@ -742,8 +740,7 @@ def generate_from_traces(
             if not records:
                 result.skipped_invalid_traces += 1
                 continue
-            for sid in _detect_scenarios(records):
-                detected.add(sid)
+            detected.update(_detect_scenarios(records))
 
     # Always emit at least the P0 prompt-injection scenario when nothing
     # is detected — operators want a non-empty corpus to attach to the

--- a/src/bernstein/evolution/gate.py
+++ b/src/bernstein/evolution/gate.py
@@ -711,12 +711,14 @@ def eval_gate(
     Returns:
         EvalGateResult with accept/reject decision.
     """
-    return (EvalGate(
-        eval_harness=eval_harness,
-        state_dir=state_dir,
-        regression_tolerance=regression_tolerance,
-        promotion_threshold=promotion_threshold,
-    )).evaluate(proposal, risk_level, sandbox_dir=sandbox_dir)
+    return (
+        EvalGate(
+            eval_harness=eval_harness,
+            state_dir=state_dir,
+            regression_tolerance=regression_tolerance,
+            promotion_threshold=promotion_threshold,
+        )
+    ).evaluate(proposal, risk_level, sandbox_dir=sandbox_dir)
 
 
 # ======================================================================

--- a/src/bernstein/evolution/gate.py
+++ b/src/bernstein/evolution/gate.py
@@ -711,13 +711,12 @@ def eval_gate(
     Returns:
         EvalGateResult with accept/reject decision.
     """
-    gate = EvalGate(
+    return (EvalGate(
         eval_harness=eval_harness,
         state_dir=state_dir,
         regression_tolerance=regression_tolerance,
         promotion_threshold=promotion_threshold,
-    )
-    return gate.evaluate(proposal, risk_level, sandbox_dir=sandbox_dir)
+    )).evaluate(proposal, risk_level, sandbox_dir=sandbox_dir)
 
 
 # ======================================================================

--- a/src/bernstein/github_app/webhooks.py
+++ b/src/bernstein/github_app/webhooks.py
@@ -66,8 +66,7 @@ def parse_webhook(headers: dict[str, str], body: bytes) -> WebhookEvent:
         ValueError: If required headers or payload fields are missing.
     """
     # Normalise header keys to lowercase for case-insensitive lookup
-    lower_headers = {k.lower(): v for k, v in headers.items()}
-    event_type = lower_headers.get("x-github-event", "")
+    event_type = ({k.lower(): v for k, v in headers.items()}).get("x-github-event", "")
     if not event_type:
         msg = "Missing X-GitHub-Event header"
         raise ValueError(msg)

--- a/src/bernstein/gui/cli.py
+++ b/src/bernstein/gui/cli.py
@@ -137,8 +137,7 @@ def _start_tunnel(port: int, provider: str) -> TunnelHandle:
     The caller is responsible for tearing the tunnel down (SIGTERM on the
     handle's PID + registry destroy).
     """
-    reg = _build_tunnel_registry()
-    return reg.create(port=port, provider=provider)
+    return _build_tunnel_registry().create(port=port, provider=provider)
 
 
 def _stop_tunnel(name: str) -> None:

--- a/src/bernstein/mcp/routine_tools.py
+++ b/src/bernstein/mcp/routine_tools.py
@@ -76,8 +76,7 @@ def get_scenario_detail(scenario_id: str, scenarios_dir: Path | None = None) -> 
     Returns full scenario with task breakdown, or None if not found.
     """
     root = scenarios_dir or _SCENARIOS_DIR
-    library = load_scenario_library(root)
-    recipe = library.get(scenario_id)
+    recipe = load_scenario_library(root).get(scenario_id)
     if recipe is None:
         return None
     return {
@@ -129,8 +128,7 @@ async def invoke_scenario_via_server(
         ``estimated_minutes``, and ``task_ids``. On failure to POST, returns
         a dict with an ``error`` key.
     """
-    library = load_scenario_library(scenarios_dir or _SCENARIOS_DIR)
-    recipe = library.get(scenario_id)
+    recipe = load_scenario_library(scenarios_dir or _SCENARIOS_DIR).get(scenario_id)
     if recipe is None:
         return {"error": f"Unknown scenario: {scenario_id}"}
 

--- a/src/bernstein/tui/app.py
+++ b/src/bernstein/tui/app.py
@@ -798,8 +798,7 @@ class BernsteinApp(App[None]):
         from bernstein.core.traces import TraceStore, group_trace_steps_into_batches
 
         traces_dir = Path(".sdd/traces")
-        store = TraceStore(traces_dir)
-        traces = store.list_traces(limit=1)
+        traces = TraceStore(traces_dir).list_traces(limit=1)
         if not traces:
             return
         latest = traces[0]
@@ -1085,8 +1084,7 @@ class BernsteinApp(App[None]):
 
     def _refresh_notification_center(self) -> None:
         """Render the latest notification history into the side panel."""
-        panel = self.query_one("#notification-center", NotificationCenterPanel)
-        panel.set_history(self._notifications.get_history(limit=5), self._notifications.get_unread_count())
+        self.query_one("#notification-center", NotificationCenterPanel).set_history(self._notifications.get_history(limit=5), self._notifications.get_unread_count())
 
     @staticmethod
     def _count_active_agents() -> int:

--- a/src/bernstein/tui/app.py
+++ b/src/bernstein/tui/app.py
@@ -1084,7 +1084,9 @@ class BernsteinApp(App[None]):
 
     def _refresh_notification_center(self) -> None:
         """Render the latest notification history into the side panel."""
-        self.query_one("#notification-center", NotificationCenterPanel).set_history(self._notifications.get_history(limit=5), self._notifications.get_unread_count())
+        self.query_one("#notification-center", NotificationCenterPanel).set_history(
+            self._notifications.get_history(limit=5), self._notifications.get_unread_count()
+        )
 
     @staticmethod
     def _count_active_agents() -> int:

--- a/src/bernstein/tui/approval_panel.py
+++ b/src/bernstein/tui/approval_panel.py
@@ -192,8 +192,7 @@ def _waterfall_type_color(step_type: str) -> str:
 
 def _unique_step_types(batch: Any) -> list[str]:
     """Return deduplicated step types in order of first appearance."""
-    seen = [step.type for step in batch.steps if step.type not in seen]
-    return seen
+    return list(dict.fromkeys(step.type for step in batch.steps))
 
 
 def _waterfall_batch_label(batch: Any) -> tuple[str, str]:

--- a/src/bernstein/tui/approval_panel.py
+++ b/src/bernstein/tui/approval_panel.py
@@ -192,10 +192,7 @@ def _waterfall_type_color(step_type: str) -> str:
 
 def _unique_step_types(batch: Any) -> list[str]:
     """Return deduplicated step types in order of first appearance."""
-    seen: list[str] = []
-    for step in batch.steps:
-        if step.type not in seen:
-            seen.append(step.type)
+    seen = [step.type for step in batch.steps if step.type not in seen]
     return seen
 
 

--- a/src/bernstein/tui/away_summary.py
+++ b/src/bernstein/tui/away_summary.py
@@ -108,10 +108,7 @@ def _fetch_task_completion_events(workdir: Path, since_ts: float) -> list[dict[s
     tasks_jsonl = workdir / ".sdd" / "runtime" / "tasks.jsonl"
     if not tasks_jsonl.exists():
         return []
-    records: list[dict[str, Any]] = []
-    for rec in _read_jsonl(tasks_jsonl, since_ts):
-        if rec.get("status") in {"done", "failed"}:
-            records.append(rec)
+    records = [rec for rec in _read_jsonl(tasks_jsonl, since_ts) if rec.get("status") in {"done", "failed"}]
     return records
 
 

--- a/src/bernstein/tui/diff_render.py
+++ b/src/bernstein/tui/diff_render.py
@@ -76,8 +76,7 @@ def word_diff(
     old_tokens = _tokenize(old_line)
     new_tokens = _tokenize(new_line)
 
-    matcher = SequenceMatcher(None, old_tokens, new_tokens)
-    opcodes = matcher.get_opcodes()
+    opcodes = SequenceMatcher(None, old_tokens, new_tokens).get_opcodes()
 
     old_result: list[tuple[str, bool]] = []
     new_result: list[tuple[str, bool]] = []

--- a/src/bernstein/tui/session_recorder.py
+++ b/src/bernstein/tui/session_recorder.py
@@ -144,8 +144,7 @@ class SessionPlayer:
 
 def summarize_recording(recording_path: Path) -> RecordingSummary | None:
     """Build a compact summary for a recording JSONL file."""
-    player = SessionPlayer(recording_path)
-    frames = player.load_frames()
+    frames = SessionPlayer(recording_path).load_frames()
     if not frames:
         return None
     try:

--- a/src/bernstein/tui/snapshot_testing.py
+++ b/src/bernstein/tui/snapshot_testing.py
@@ -79,8 +79,7 @@ def capture_widget_text(_widget_class_name: str, render_text: str) -> str:
     Returns:
         Normalized text ready for diffing.
     """
-    cleaned = _strip_ansi(render_text)
-    lines = cleaned.splitlines()
+    lines = _strip_ansi(render_text).splitlines()
     normalized: list[str] = []
     for line in lines:
         # Collapse internal whitespace runs and strip trailing spaces.


### PR DESCRIPTION
## Summary

Bulk conservative refurb rewrites across `src/`. Per-file rollback on any post-rewrite SyntaxError; comments preserved when between consecutive appends.

## Before / after (open alerts in `src/`)

| Rule | Before | After | Fixed |
|------|-------:|------:|------:|
| FURB184 | 197 | 34 | 163 |
| FURB138 | 42 | 8 | 34 |
| FURB124 | 29 | 3 | 26 |
| FURB142 | 16 | 0 | 16 |
| FURB113 | 23 | 21 | 2 |

Auto-fixed: **241**. Deferred (remaining safe-by-conservative-rule cases): 66.

## Rule notes

- **FURB184** (`x = factory(); y = x.method()` -> `y = factory().method()`): requires `x` used exactly once in the immediately-following stmt, no other reads/writes/aug-assigns/attribute writes in the same body, chain root binds back to `x`, RHS does not self-reference, decl + use share the same indent and are line-adjacent. Multi-line RHS source is wrapped in parens to preserve implicit continuation.
- **FURB138**: handles both `x = []` and `x: list[T] = []` declarations; supports an optional `if cond:` filter; skips when filter contains `await`, `yield`, or walrus.
- **FURB113**: merges consecutive `lst.append(...)` runs only when no comment line separates the appends (preserves section dividers).
- **FURB142**: converts `for x in y: s.add(x)` -> `s.update(y)`; non-identity argument becomes `s.update(expr for x in y)`.
- **FURB124**: chains `x == y and z == y` -> `x == y == z` (same for `is`); prefers constant on the right; multi-line BoolOps left untouched.

## Test plan

- [x] All modified files parse (`python -c "import ast; ast.parse(...)"`).
- [x] Sampled pytest subsets pass: `tests/unit/security`, `tests/unit/orchestration`, `tests/unit/cli`, `tests/unit/git`, `tests/unit/cost`, `tests/unit/core`, `tests/unit/adapters`.
- [ ] Full CI run on PR.