### PR TITLE
fix(test): restore str() coercion in _run_git error formatter (main red)

### DIFF
--- a/src/bernstein/core/git/git_context.py
+++ b/src/bernstein/core/git/git_context.py
@@ -42,7 +42,7 @@ def _run_git(args: list[str], cwd: Path, *, timeout: int = 10) -> str | None:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     except (subprocess.TimeoutExpired, OSError) as exc:
-        args_str = " ".join(a for a in args)
+        args_str = " ".join(str(a) for a in args)
         logger.debug("git %s failed: %s", args_str, exc)
     return None
 


### PR DESCRIPTION
## Summary

- Main CI red on fd231bc77; three unit tests fail with `TypeError: sequence item 6: expected str instance, PosixPath found` on ubuntu 3.12, ubuntu 3.13, macos 3.13.
- Root cause is a regression from refurb wave 3 (#1615), unrelated to the recent stream-signal / nonce-binding / run-actor / review-gate merges. That PR dropped the `str()` cast inside the `OSError` / `TimeoutExpired` handler of `git_context._run_git`. When the argv list contains a `Path` (callers in `tests/unit/test_context.py`, `test_context_builder.py`, `test_failure_reduction.py` reach this path indirectly), `subprocess.run` raises `FileNotFoundError`, and the handler then crashes on `" ".join(a for a in args)`, escalating a debug log into a `TypeError`.
- Minimal fix: re-add `str(a)` in the join, mirroring the prior repair in #1591. No behaviour change for the happy path; only the failure-log formatter is hardened.

## Failing tests now green

- `tests/unit/test_context.py::TestGitCochangedFiles::test_returns_list`
- `tests/unit/test_context_builder.py::TestTaskContextBuilder::test_includes_file_summary_for_python_files`
- `tests/unit/test_failure_reduction.py::TestFileContextDiscovery::test_task_context_includes_file_info`

## Test plan

- [x] `uv run pytest tests/unit/test_context.py tests/unit/test_context_builder.py tests/unit/test_failure_reduction.py` -> 80 passed locally.
- [x] `uv run ruff check src/bernstein/core/git/git_context.py` clean.
- [x] `uv run ruff format --check` clean.
- [ ] CI green on this PR.

## Summary by Sourcery

Bug Fixes:
- Fix TypeError in _run_git error handler when git arguments include non-string path objects, preventing test failures on missing git binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal robustness of error logging to handle edge cases more reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->