### PR TITLE
fix(ci): reuse coverage artifact in Sonar scan to stop 30m timeouts

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,17 +1,21 @@
 name: SonarQube scan
 
+# Runs after the main CI workflow completes successfully on main.
+# Reuses the coverage.xml artifact uploaded by ci.yml so we do not
+# re-run the unit suite. The unit suite takes ~25 minutes when sharded
+# per-file in CI; re-running it inline here was hitting the 30 minute
+# step timeout (the suite barely reached 5% of files within 30 minutes
+# when run as a single pytest --cov invocation).
 on:
-  push:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - '.github/workflows/sonar-scan.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: sonar-scan-${{ github.ref }}
@@ -21,8 +25,14 @@ jobs:
   scan:
     name: SonarQube scan
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    if: ${{ vars.SONAR_HOST_URL != '' }}
+    timeout-minutes: 15
+    # Only run when:
+    # - Triggered manually, or
+    # - The upstream CI run succeeded on main and SONAR_HOST_URL is set.
+    if: >-
+      ${{ vars.SONAR_HOST_URL != '' &&
+          (github.event_name == 'workflow_dispatch' ||
+           github.event.workflow_run.conclusion == 'success') }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
@@ -33,27 +43,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          fetch-depth: 0  # Sonar needs full git history for accurate blame
+          # Sonar needs full git history for accurate blame. When
+          # triggered by workflow_run, check out the SHA that CI ran
+          # against so the scan reflects that exact commit.
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - name: Download coverage artifact from CI
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
-          python-version: '3.14'
+          name: coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
-        with:
-          enable-cache: true
-
-      - name: Sync dev deps
-        timeout-minutes: 15
-        run: uv sync --group dev
-
-      - name: Run coverage
-        timeout-minutes: 30
+      - name: Verify coverage.xml present
         run: |
-          uv run pytest --cov=src/bernstein --cov-report=xml --cov-branch tests/unit/ -q || true
+          if [ ! -f coverage.xml ]; then
+            echo "::warning::coverage.xml not found; Sonar scan will run without Python coverage data"
+          else
+            echo "coverage.xml found ($(wc -c < coverage.xml) bytes)"
+          fi
 
       - name: SonarQube scan
         timeout-minutes: 10
@@ -70,3 +81,5 @@ jobs:
             -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.exclusions=src/bernstein/_default_templates/**,src/bernstein/grpc_gen/**
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha || github.sha }}
+            -Dsonar.ws.timeout=600


### PR DESCRIPTION
## Summary

- Sonar scan workflow was timing out after 30 minutes (step-level cap
  the earlier job-level bump did not lift). The single-process
  pytest --cov against tests/unit only reached 5 percent of files in
  that window; the suite requires per-file isolation in ci.yml to fit
  the runner memory budget.
- Switch sonar-scan.yml to a workflow_run trigger that fires when CI
  finishes successfully on main, downloads the coverage-report
  artifact ci.yml already publishes, and runs only the scanner.
- Pin sonar.scm.revision to the upstream CI head SHA and bump
  sonar.ws.timeout to 600 to guard against slow scanner responses.

## Test plan

- [ ] Merge and watch the first auto-triggered workflow_run on main.
- [ ] Confirm the scan job downloads coverage.xml and completes under
      15 minutes.
- [ ] Verify the Bernstein project shows fresh metrics in SonarQube.

## Summary by Sourcery

Trigger the SonarQube scan workflow after successful CI on main and reuse the existing coverage artifact to avoid rerunning tests and hitting step timeouts.

Enhancements:
- Reduce SonarQube scan job timeout and gate execution on successful upstream CI and configured Sonar host URL.
- Checkout the exact commit SHA from the upstream CI run for accurate Sonar analysis and SCM revision reporting.
- Reuse the coverage-report artifact from CI, verifying coverage.xml presence before running the Sonar scanner, and configure scanner revision and websocket timeout accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code quality scanning workflow configuration to automatically execute after successful CI builds on main, with enhanced artifact retrieval and improved scan accuracy tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->