### PR TITLE
feat(observability): GlitchTip insights surface + doctor subcommand + daily alert workflow

### DIFF
--- a/.github/workflows/glitchtip-insights.yml
+++ b/.github/workflows/glitchtip-insights.yml
@@ -1,0 +1,204 @@
+name: glitchtip-insights
+
+# Daily 06:30 UTC sweep of GlitchTip for the bernstein project. When a
+# CRITICAL (fatal-level) issue is observed the workflow opens a sticky
+# GitHub issue with the GlitchTip title, first-seen time, and event
+# count. Resolved GlitchTip issues auto-close the GitHub mirror.
+#
+# The workflow soft-fails (exit 0) when GLITCHTIP_API_TOKEN is not
+# configured so a fresh fork stays green until the operator wires the
+# token. The token is minted by the operator in GlitchTip and stored as
+# a repo secret named GLITCHTIP_API_TOKEN.
+
+on:
+  schedule:
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+    inputs:
+      org_slug:
+        description: "GlitchTip organisation slug (default: bernstein)"
+        required: false
+        default: "bernstein"
+      base_url:
+        description: "GlitchTip base URL (default: https://errors.bernstein.run)"
+        required: false
+        default: "https://errors.bernstein.run"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: glitchtip-insights
+  cancel-in-progress: false
+
+env:
+  GLITCHTIP_API_TOKEN: ${{ secrets.GLITCHTIP_API_TOKEN }}
+  GLITCHTIP_BASE_URL: ${{ github.event.inputs.base_url || 'https://errors.bernstein.run' }}
+  GLITCHTIP_ORG: ${{ github.event.inputs.org_slug || 'bernstein' }}
+  GLITCHTIP_LABEL: glitchtip-alert
+
+jobs:
+  sweep:
+    name: sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check token presence
+        id: check_token
+        env:
+          TOKEN_PRESENT: ${{ secrets.GLITCHTIP_API_TOKEN != '' }}
+        run: |
+          if [ "${TOKEN_PRESENT}" != "true" ]; then
+            echo "GLITCHTIP_API_TOKEN is not configured; skipping sweep."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch fatal-level issues (last 24h)
+        if: steps.check_token.outputs.skip == 'false'
+        id: fetch
+        run: |
+          set -euo pipefail
+          mkdir -p .glitchtip-sweep
+          url="${GLITCHTIP_BASE_URL%/}/api/0/organizations/${GLITCHTIP_ORG}/issues/?statsPeriod=24h&query=level:fatal+is:unresolved&limit=100"
+          http_code=$(curl -sS -o .glitchtip-sweep/unresolved.json -w "%{http_code}" \
+              -H "Authorization: Bearer ${GLITCHTIP_API_TOKEN}" \
+              "$url")
+          if [ "$http_code" != "200" ]; then
+            echo "GlitchTip API returned HTTP $http_code; aborting." >&2
+            cat .glitchtip-sweep/unresolved.json >&2 || true
+            exit 1
+          fi
+          # Resolved+ignored mirror so we can close stale GitHub issues.
+          resolved_url="${GLITCHTIP_BASE_URL%/}/api/0/organizations/${GLITCHTIP_ORG}/issues/?statsPeriod=7d&query=level:fatal+is:resolved&limit=100"
+          curl -sS -H "Authorization: Bearer ${GLITCHTIP_API_TOKEN}" \
+              "$resolved_url" > .glitchtip-sweep/resolved.json
+
+      - name: Reconcile GitHub issues
+        if: steps.check_token.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          LABEL = os.environ["GLITCHTIP_LABEL"]
+          REPO = os.environ["REPO"]
+          BASE_URL = os.environ["GLITCHTIP_BASE_URL"].rstrip("/")
+          ORG = os.environ["GLITCHTIP_ORG"]
+
+          def gh(*args: str, capture: bool = False) -> str:
+              proc = subprocess.run(
+                  ["gh", *args, "--repo", REPO],
+                  check=True,
+                  text=True,
+                  capture_output=True,
+              )
+              return proc.stdout if capture else ""
+
+          def ensure_label() -> None:
+              try:
+                  subprocess.run(
+                      ["gh", "label", "create", LABEL,
+                       "--repo", REPO,
+                       "--color", "B60205",
+                       "--description", "Auto-opened by glitchtip-insights workflow"],
+                      check=False, capture_output=True,
+                  )
+              except Exception:
+                  pass
+
+          def load(path: str) -> list[dict]:
+              raw = Path(path).read_text(encoding="utf-8")
+              try:
+                  data = json.loads(raw)
+              except json.JSONDecodeError:
+                  return []
+              return data if isinstance(data, list) else []
+
+          unresolved = load(".glitchtip-sweep/unresolved.json")
+          resolved = load(".glitchtip-sweep/resolved.json")
+
+          ensure_label()
+
+          # Map existing GH issues by short_id encoded in the title prefix.
+          existing_raw = subprocess.run(
+              ["gh", "issue", "list", "--repo", REPO,
+               "--label", LABEL, "--state", "all",
+               "--limit", "200",
+               "--json", "number,title,state,url"],
+              check=True, capture_output=True, text=True,
+          ).stdout
+          existing = {}
+          for row in json.loads(existing_raw):
+              title = row.get("title", "")
+              prefix = title.split(" ", 1)[0].strip()
+              if prefix.startswith("[") and prefix.endswith("]"):
+                  existing[prefix[1:-1]] = row
+
+          for issue in unresolved:
+              short_id = str(issue.get("shortId", ""))
+              if not short_id:
+                  continue
+              title = f"[{short_id}] {issue.get('title', '')[:120]}"
+              first_seen = issue.get("firstSeen", "?")
+              count = issue.get("count", "?")
+              permalink = issue.get("permalink") or f"{BASE_URL}/{ORG}/issues/{short_id}"
+              body = (
+                  f"Auto-opened by `.github/workflows/glitchtip-insights.yml`.\n\n"
+                  f"- GlitchTip id: `{short_id}`\n"
+                  f"- Level: `{issue.get('level', '?')}`\n"
+                  f"- First seen: `{first_seen}`\n"
+                  f"- Event count (24h): `{count}`\n"
+                  f"- Link: {permalink}\n\n"
+                  f"This issue auto-closes when the matching GlitchTip issue moves to resolved."
+              )
+              if short_id in existing:
+                  row = existing[short_id]
+                  if row.get("state") == "CLOSED":
+                      subprocess.run(
+                          ["gh", "issue", "reopen", str(row["number"]), "--repo", REPO],
+                          check=False, capture_output=True,
+                      )
+                  subprocess.run(
+                      ["gh", "issue", "edit", str(row["number"]),
+                       "--repo", REPO, "--body", body],
+                      check=False, capture_output=True,
+                  )
+              else:
+                  subprocess.run(
+                      ["gh", "issue", "create", "--repo", REPO,
+                       "--title", title, "--label", LABEL, "--body", body],
+                      check=False, capture_output=True,
+                  )
+
+          # Auto-close GH mirrors whose GlitchTip side is resolved.
+          for issue in resolved:
+              short_id = str(issue.get("shortId", ""))
+              if not short_id or short_id not in existing:
+                  continue
+              row = existing[short_id]
+              if row.get("state") == "OPEN":
+                  subprocess.run(
+                      ["gh", "issue", "close", str(row["number"]),
+                       "--repo", REPO,
+                       "--comment", "GlitchTip issue is resolved; closing the auto-opened mirror."],
+                      check=False, capture_output=True,
+                  )
+          PY
+
+      - name: Upload sweep artefacts
+        if: steps.check_token.outputs.skip == 'false'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: glitchtip-sweep
+          path: .glitchtip-sweep/
+          retention-days: 14

--- a/.github/workflows/glitchtip-insights.yml
+++ b/.github/workflows/glitchtip-insights.yml
@@ -73,8 +73,14 @@ jobs:
           fi
           # Resolved+ignored mirror so we can close stale GitHub issues.
           resolved_url="${GLITCHTIP_BASE_URL%/}/api/0/organizations/${GLITCHTIP_ORG}/issues/?statsPeriod=7d&query=level:fatal+is:resolved&limit=100"
-          curl -sS -H "Authorization: Bearer ${GLITCHTIP_API_TOKEN}" \
-              "$resolved_url" > .glitchtip-sweep/resolved.json
+          resolved_http_code=$(curl -sS -o .glitchtip-sweep/resolved.json -w "%{http_code}" \
+              -H "Authorization: Bearer ${GLITCHTIP_API_TOKEN}" \
+              "$resolved_url")
+          if [ "$resolved_http_code" != "200" ]; then
+            echo "GlitchTip resolved API returned HTTP $resolved_http_code; aborting." >&2
+            cat .glitchtip-sweep/resolved.json >&2 || true
+            exit 1
+          fi
 
       - name: Reconcile GitHub issues
         if: steps.check_token.outputs.skip == 'false'
@@ -166,18 +172,18 @@ jobs:
                   if row.get("state") == "CLOSED":
                       subprocess.run(
                           ["gh", "issue", "reopen", str(row["number"]), "--repo", REPO],
-                          check=False, capture_output=True,
+                          check=True, capture_output=True,
                       )
                   subprocess.run(
                       ["gh", "issue", "edit", str(row["number"]),
                        "--repo", REPO, "--body", body],
-                      check=False, capture_output=True,
+                      check=True, capture_output=True,
                   )
               else:
                   subprocess.run(
                       ["gh", "issue", "create", "--repo", REPO,
                        "--title", title, "--label", LABEL, "--body", body],
-                      check=False, capture_output=True,
+                      check=True, capture_output=True,
                   )
 
           # Auto-close GH mirrors whose GlitchTip side is resolved.
@@ -191,7 +197,7 @@ jobs:
                       ["gh", "issue", "close", str(row["number"]),
                        "--repo", REPO,
                        "--comment", "GlitchTip issue is resolved; closing the auto-opened mirror."],
-                      check=False, capture_output=True,
+                      check=True, capture_output=True,
                   )
           PY
 

--- a/docs/observability/glitchtip-insights.md
+++ b/docs/observability/glitchtip-insights.md
@@ -1,0 +1,99 @@
+# GlitchTip insights
+
+Bernstein surfaces the read-side of the GlitchTip error sink so the
+operator can see live issue counts, severity buckets, and the top
+unresolved issues without leaving the terminal.
+
+## TL;DR
+
+- Runtime events flow to GlitchTip via `BERNSTEIN_GLITCHTIP_DSN`
+  (existing wiring).
+- Operators export `BERNSTEIN_GLITCHTIP_TOKEN` and run
+  `bernstein doctor glitchtip` to pull the current state.
+- A periodic nudge fires from `bernstein doctor --suggest-docs` when
+  the API reports new unresolved issues since the last check.
+- A daily workflow (`.github/workflows/glitchtip-insights.yml`)
+  mirrors CRITICAL (fatal-level) GlitchTip issues into sticky GitHub
+  issues labelled `glitchtip-alert`. The GitHub mirror auto-closes
+  when the GlitchTip side resolves.
+
+## Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `BERNSTEIN_GLITCHTIP_TOKEN` | API token with org read scope. | (required for non-trivial output) |
+| `BERNSTEIN_GLITCHTIP_DSN` | Runtime DSN for event submission. | (informational here) |
+| `BERNSTEIN_GLITCHTIP_BASE_URL` | Override for the API base URL. | `https://errors.bernstein.run` |
+| `BERNSTEIN_GLITCHTIP_ORG` | Organisation slug. | `bernstein` |
+| `BERNSTEIN_GLITCHTIP_BASELINE` | Override for the baseline cache path. | `~/.local/share/bernstein/glitchtip-baseline.json` |
+
+If both `BERNSTEIN_GLITCHTIP_TOKEN` and `BERNSTEIN_GLITCHTIP_DSN` are
+missing, the doctor soft-fails with a one-line hint and exit code 0.
+No operator workflow is interrupted.
+
+## CLI
+
+```
+bernstein doctor glitchtip             # Rich tables
+bernstein doctor glitchtip --json      # machine-readable snapshot
+bernstein doctor glitchtip --top-n 10  # surface more issues
+bernstein doctor glitchtip --no-baseline  # skip the baseline cache update
+```
+
+The Rich output contains four sections:
+
+1. Header with the org slug and base URL.
+2. 24h severity table (fatal / error / warning / info / debug / other).
+3. 7-day trend sparkline bucketed by `firstSeen`.
+4. Top-N unresolved table sorted by event count, then user count.
+
+The JSON output mirrors the same fields under a single object:
+
+```json
+{
+  "ok": true,
+  "issues_24h": 2,
+  "new_24h": 2,
+  "severity_24h": {"fatal": 0, "error": 2, "warning": 0, ...},
+  "trend_7d": [0, 0, 0, 0, 0, 0, 2],
+  "top_unresolved": [{"short_id": "BERNSTEIN-2", ...}, ...]
+}
+```
+
+## Baseline cache
+
+The command writes a baseline snapshot at
+`~/.local/share/bernstein/glitchtip-baseline.json` (overridable via
+`BERNSTEIN_GLITCHTIP_BASELINE` or `XDG_DATA_HOME`). The file captures
+the last observed 24h issue count, the top issue id, and the wall-clock
+checkpoint. `bernstein doctor --suggest-docs` compares the current
+state against this baseline and prints a single-line nudge when new
+unresolved issues are detected.
+
+## Daily workflow
+
+`.github/workflows/glitchtip-insights.yml` runs at 06:30 UTC and on
+`workflow_dispatch`. It:
+
+- queries GlitchTip for fatal-level unresolved issues in the last 24h,
+- creates a sticky GitHub issue per fresh fatal with label
+  `glitchtip-alert`,
+- updates the body of an existing mirror when the GlitchTip side is
+  still active,
+- reopens a closed mirror if the GlitchTip side returns,
+- closes the mirror automatically when the GlitchTip issue moves to
+  resolved.
+
+The workflow soft-fails (exit 0) when `GLITCHTIP_API_TOKEN` is not
+configured so fresh forks stay green.
+
+## Secrets
+
+The repo expects a single secret:
+
+| Secret | Where minted | Used by |
+|---|---|---|
+| `GLITCHTIP_API_TOKEN` | GlitchTip org settings -> API tokens. | `glitchtip-insights.yml`. |
+
+Set it with `gh secret set GLITCHTIP_API_TOKEN --repo <owner>/<repo>`
+and feed the operator-minted value via stdin.

--- a/docs/observability/glitchtip-insights.md
+++ b/docs/observability/glitchtip-insights.md
@@ -27,9 +27,9 @@ unresolved issues without leaving the terminal.
 | `BERNSTEIN_GLITCHTIP_ORG` | Organisation slug. | `bernstein` |
 | `BERNSTEIN_GLITCHTIP_BASELINE` | Override for the baseline cache path. | `~/.local/share/bernstein/glitchtip-baseline.json` |
 
-If both `BERNSTEIN_GLITCHTIP_TOKEN` and `BERNSTEIN_GLITCHTIP_DSN` are
-missing, the doctor soft-fails with a one-line hint and exit code 0.
-No operator workflow is interrupted.
+If `BERNSTEIN_GLITCHTIP_TOKEN` is missing, the doctor soft-fails with a
+one-line hint and exit code 0. `BERNSTEIN_GLITCHTIP_DSN` is informational
+only and does not affect the soft-fail. No operator workflow is interrupted.
 
 ## CLI
 

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import contextlib
 import datetime as dt
 import json
+import logging
 import sys
 import time
 from pathlib import Path
@@ -36,6 +37,8 @@ from bernstein.cli.mcp_cmd import mcp_server as mcp_server  # re-exported for ma
 from bernstein.core.runtime_state import read_session_replay_metadata
 from bernstein.core.traces import TraceStore, build_replay_task_request, render_replay_diff
 from bernstein.core.visual_config import VisualConfig, resolve_visual_config
+
+_LOGGER = logging.getLogger(__name__)
 
 _STYLE_BOLD_CYAN = "bold cyan"
 
@@ -641,11 +644,14 @@ def _maybe_print_glitchtip_nudge(*, as_json: bool) -> None:
         return
     try:
         from bernstein.cli.commands.doctor.glitchtip import suggest_nudge_line
-    except Exception:  # pragma: no cover - defensive
+    except ImportError:  # pragma: no cover - defensive
         return
     try:
         line = suggest_nudge_line()
     except Exception:  # pragma: no cover - defensive
+        # Log unexpected failures so we can diagnose regressions, but never
+        # raise: the nudge is advisory and must not crash `bernstein doctor`.
+        _LOGGER.warning("GlitchTip nudge failed", exc_info=True)
         return
     if line:
         console.print(f"[dim yellow]{line}[/dim yellow]")

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -528,7 +528,7 @@ def plugins_cmd(workdir: str) -> None:
 @click.group(
     name="doctor",
     invoke_without_command=True,
-    subcommand_metavar="[airgap|sonar|...]",
+    subcommand_metavar="[airgap|sonar|glitchtip|...]",
 )
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 @click.option("--fix", "auto_fix", is_flag=True, default=False, help="Attempt to auto-fix issues.")
@@ -550,6 +550,7 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
       bernstein doctor --suggest-docs # surface top curated documentation gaps
       bernstein doctor airgap         # battery of checks for an air-gapped run
       bernstein doctor sonar          # surface SonarQube insights for the project
+      bernstein doctor glitchtip      # surface GlitchTip issue counts and top unresolved
     """
     if ctx.invoked_subcommand is not None:
         ctx.obj = {"as_json": as_json, "auto_fix": auto_fix}
@@ -565,6 +566,7 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
         topics = load_unanswered_topics()
         render_suggestions(console, topics, limit=DEFAULT_TOP_N)
         _maybe_print_sonar_nudge(as_json=as_json)
+        _maybe_print_glitchtip_nudge(as_json=as_json)
         return
 
     from bernstein.cli.doctor.suggest_docs import hint_line
@@ -582,6 +584,7 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
     if not as_json:
         console.print(f"[dim]{hint_line()}[/dim]")
         _maybe_print_sonar_nudge(as_json=as_json)
+        _maybe_print_glitchtip_nudge(as_json=as_json)
 
     if exit_code:
         raise SystemExit(exit_code)
@@ -623,6 +626,29 @@ def _maybe_print_sonar_nudge(*, as_json: bool) -> None:
     console.print(
         f"[dim yellow]Sonar nudge: {summary}. Run `bernstein doctor sonar` for the full surface.[/dim yellow]"
     )
+
+
+def _maybe_print_glitchtip_nudge(*, as_json: bool) -> None:
+    """Print a single-line GlitchTip nudge when new unresolved issues exist.
+
+    No-op when ``--json`` was requested (advisory output must not leak
+    into machine-readable streams), when ``BERNSTEIN_GLITCHTIP_TOKEN``
+    is not set, or when there is no delta against the cached baseline.
+    All exceptions are swallowed so the doctor command never crashes
+    because of a side integration.
+    """
+    if as_json:
+        return
+    try:
+        from bernstein.cli.commands.doctor.glitchtip import suggest_nudge_line
+    except Exception:  # pragma: no cover - defensive
+        return
+    try:
+        line = suggest_nudge_line()
+    except Exception:  # pragma: no cover - defensive
+        return
+    if line:
+        console.print(f"[dim yellow]{line}[/dim yellow]")
 
 
 @doctor.command("airgap")
@@ -915,6 +941,17 @@ def doctor_sonar_cmd(
             update_baseline=not no_update_baseline,
         )
     )
+
+
+# Attach the GlitchTip insights subcommand to the existing ``doctor`` group.
+# Registration runs at import time so ``bernstein doctor glitchtip`` is
+# wired without circular imports between the per-backend module and the
+# group definition above.
+from bernstein.cli.commands.doctor.glitchtip import (  # noqa: E402
+    register as _register_doctor_glitchtip,
+)
+
+_register_doctor_glitchtip(doctor)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/doctor/__init__.py
+++ b/src/bernstein/cli/commands/doctor/__init__.py
@@ -1,0 +1,35 @@
+"""Observability doctor subcommands for Bernstein.
+
+This package collects the per-backend ``bernstein doctor`` probes for
+the operator-facing observability surface.
+
+Currently registered subcommands:
+
+* ``bernstein doctor glitchtip`` -- GlitchTip issue counts and the top
+  unresolved issues for the last 24h, plus a 7-day trend.
+
+Each per-backend module exposes a ``register(parent_group)`` function
+that the CLI bootstrap calls from
+:mod:`bernstein.cli.commands.advanced_cmd` so the subcommands attach to
+the existing ``bernstein doctor`` Click group without circular imports.
+"""
+
+from __future__ import annotations
+
+from bernstein.cli.commands.doctor.glitchtip import (
+    glitchtip_cmd,
+)
+from bernstein.cli.commands.doctor.glitchtip import (
+    register as register_glitchtip,
+)
+
+__all__ = [
+    "glitchtip_cmd",
+    "register_glitchtip",
+]
+
+
+def register_all(parent_group: object) -> None:
+    """Attach every per-backend subcommand to a Click group."""
+
+    register_glitchtip(parent_group)

--- a/src/bernstein/cli/commands/doctor/glitchtip.py
+++ b/src/bernstein/cli/commands/doctor/glitchtip.py
@@ -1,0 +1,405 @@
+"""``bernstein doctor glitchtip`` -- GlitchTip insights surface.
+
+Pulls the GlitchTip API for last-24h issue counts by severity, a 7-day
+trend, and the top 5 unresolved issues. Outputs a Rich table or JSON.
+
+Soft-fail behaviour
+-------------------
+The command exits with code 0 when both env vars are unset
+(``BERNSTEIN_GLITCHTIP_TOKEN`` and ``BERNSTEIN_GLITCHTIP_DSN``) so the
+fresh-checkout case does not block any operator workflow. When the
+token is set but the API call fails, the command exits with code 0 and
+prints the failure reason on stderr -- the operator can re-run with
+``--json`` for a machine-readable signal.
+
+Baseline cache
+--------------
+The command persists a tiny baseline file at
+``~/.local/share/bernstein/glitchtip-baseline.json`` capturing the last
+observed issue count and timestamp. The ``--suggest-docs`` hook reads
+this cache to decide whether to nudge the operator about new unresolved
+issues since their last check.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.observability.glitchtip_insights import (
+    DEFAULT_TOP_N,
+    ENV_GLITCHTIP_TOKEN,
+    InsightsResult,
+    fetch_insights,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from rich.console import Console
+
+#: Environment variable carrying the runtime DSN. We only read this so we
+#: can produce a precise soft-fail reason when neither the token nor the
+#: DSN is configured (the operator has not started observability at all).
+ENV_GLITCHTIP_DSN = "BERNSTEIN_GLITCHTIP_DSN"
+
+#: Override for the baseline cache location. Used by the test-suite so
+#: ``~/.local/share/bernstein/`` is never touched.
+ENV_BASELINE_PATH = "BERNSTEIN_GLITCHTIP_BASELINE"
+
+
+# ---------------------------------------------------------------------------
+# Baseline cache
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """Captured insights signature used by the periodic nudge."""
+
+    checked_at: str
+    issues_24h: int
+    last_short_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable mapping."""
+        return {
+            "checked_at": self.checked_at,
+            "issues_24h": self.issues_24h,
+            "last_short_id": self.last_short_id,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> Baseline | None:
+        """Build a baseline from a parsed JSON object.
+
+        Returns ``None`` for malformed input so the nudge degrades to
+        a "no baseline yet" state rather than crashing.
+        """
+        try:
+            return cls(
+                checked_at=str(raw["checked_at"]),
+                issues_24h=int(raw.get("issues_24h", 0)),
+                last_short_id=str(raw.get("last_short_id", "")),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+def default_baseline_path() -> Path:
+    """Resolve the baseline cache path with env override and XDG fallback.
+
+    Resolution order:
+
+    1. ``BERNSTEIN_GLITCHTIP_BASELINE`` -- used by tests.
+    2. ``$XDG_DATA_HOME/bernstein/glitchtip-baseline.json``.
+    3. ``~/.local/share/bernstein/glitchtip-baseline.json``.
+    """
+    override = os.environ.get(ENV_BASELINE_PATH)
+    if override:
+        return Path(override).expanduser()
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "bernstein" / "glitchtip-baseline.json"
+    return Path.home() / ".local" / "share" / "bernstein" / "glitchtip-baseline.json"
+
+
+def load_baseline(path: Path | None = None) -> Baseline | None:
+    """Load a baseline from disk, returning ``None`` when absent or bad."""
+    target = path if path is not None else default_baseline_path()
+    if not target.exists():
+        return None
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return Baseline.from_dict(raw)
+
+
+def write_baseline(baseline: Baseline, path: Path | None = None) -> None:
+    """Persist ``baseline`` atomically to disk.
+
+    The target directory is created if missing. Errors are swallowed
+    silently because failing to update the cache must never block the
+    doctor command itself.
+    """
+    target = path if path is not None else default_baseline_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(baseline.to_dict(), sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        tmp.replace(target)
+    except OSError:
+        return
+
+
+def baseline_from_result(result: InsightsResult) -> Baseline:
+    """Construct a baseline snapshot from a populated insights result."""
+    last_id = result.top_unresolved[0].short_id if result.top_unresolved else ""
+    return Baseline(
+        checked_at=dt.datetime.now(dt.UTC).isoformat(timespec="seconds"),
+        issues_24h=result.issues_24h,
+        last_short_id=last_id,
+    )
+
+
+def detect_new_issues(
+    result: InsightsResult,
+    baseline: Baseline | None,
+) -> int:
+    """Return the number of new unresolved issues since the baseline.
+
+    The 24h ``new_24h`` count from the API already reflects deltas
+    against the rolling window, but we additionally compare against
+    the persisted baseline so the nudge fires when the operator has
+    not run the doctor in over a day.
+    """
+    if not result.ok:
+        return 0
+    if baseline is None:
+        return result.new_24h
+    delta = max(0, result.issues_24h - baseline.issues_24h)
+    return max(result.new_24h, delta)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+_LEVEL_STYLE: dict[str, str] = {
+    "fatal": "bold red",
+    "error": "red",
+    "warning": "yellow",
+    "info": "cyan",
+    "debug": "dim",
+    "other": "white",
+}
+
+
+def _format_short(ts: str) -> str:
+    """Render an ISO8601 timestamp as ``YYYY-MM-DD HH:MM`` UTC."""
+    if not ts:
+        return "-"
+    try:
+        normalised = ts.replace("Z", "+00:00")
+        parsed = dt.datetime.fromisoformat(normalised)
+    except ValueError:
+        return ts
+    return parsed.astimezone(dt.UTC).strftime("%Y-%m-%d %H:%M")
+
+
+def render_severity_table(result: InsightsResult, target: Console) -> None:
+    """Render the 24h severity summary table."""
+    table = Table(title="GlitchTip - last 24h by severity", show_header=True)
+    table.add_column("Level", style="bold")
+    table.add_column("Events", justify="right")
+    for level, count in result.severity_24h.items():
+        style = _LEVEL_STYLE.get(level, "white")
+        table.add_row(f"[{style}]{level}[/{style}]", str(count))
+    target.print(table)
+
+
+def render_top_issues_table(result: InsightsResult, target: Console) -> None:
+    """Render the top-N unresolved issues table."""
+    table = Table(
+        title=f"Top {len(result.top_unresolved)} unresolved issues",
+        show_header=True,
+    )
+    table.add_column("Id", style="cyan")
+    table.add_column("Level")
+    table.add_column("Events", justify="right")
+    table.add_column("Users", justify="right")
+    table.add_column("First seen")
+    table.add_column("Last seen")
+    table.add_column("Title", overflow="fold")
+    for issue in result.top_unresolved:
+        style = _LEVEL_STYLE.get(issue.level, "white")
+        table.add_row(
+            issue.short_id or "-",
+            f"[{style}]{issue.level}[/{style}]",
+            str(issue.count),
+            str(issue.user_count),
+            _format_short(issue.first_seen),
+            _format_short(issue.last_seen),
+            issue.title or "-",
+        )
+    target.print(table)
+
+
+def render_trend_line(result: InsightsResult, target: Console) -> None:
+    """Render a single-line 7-day trend sparkline."""
+    if not result.trend_7d:
+        target.print("[dim]7-day trend: (no data)[/dim]")
+        return
+    blocks = " ▁▂▃▄▅▆▇█"
+    peak = max(result.trend_7d) or 1
+    spark = "".join(blocks[min(len(blocks) - 1, int((n / peak) * (len(blocks) - 1)))] for n in result.trend_7d)
+    target.print(f"7-day trend (oldest -> newest): [cyan]{spark}[/cyan]")
+
+
+def render_report(result: InsightsResult, target: Console | None = None) -> None:
+    """Print the full GlitchTip insights report."""
+    out = target if target is not None else console
+    if not result.ok:
+        out.print(f"[yellow]GlitchTip insights unavailable:[/yellow] {result.reason}")
+        return
+
+    out.print(f"GlitchTip [cyan]{result.org_slug}[/cyan] @ [dim]{result.base_url}[/dim]")
+    out.print(f"Issues in last 24h: [bold]{result.issues_24h}[/bold] (new: [bold]{result.new_24h}[/bold])")
+    render_severity_table(result, out)
+    render_trend_line(result, out)
+    if result.top_unresolved:
+        render_top_issues_table(result, out)
+    else:
+        out.print("[dim]No unresolved issues to surface.[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Nudge helper for ``bernstein doctor --suggest-docs``
+# ---------------------------------------------------------------------------
+
+
+def suggest_nudge_line(
+    *,
+    env: dict[str, str] | None = None,
+    baseline_path: Path | None = None,
+    fetcher: Any = None,
+) -> str | None:
+    """Return a one-line nudge string when GlitchTip shows new issues.
+
+    Returns ``None`` when:
+
+    * the GlitchTip token is not configured (no signal to nudge with)
+    * the API call soft-fails
+    * there are no new issues since the last baseline
+
+    The function is wired into ``bernstein doctor --suggest-docs`` so the
+    operator sees a single concise line at the end of the diagnostic
+    report rather than another full table.
+    """
+    source = env if env is not None else dict(os.environ)
+    if not source.get(ENV_GLITCHTIP_TOKEN):
+        return None
+
+    fetch = fetcher if fetcher is not None else fetch_insights
+    try:
+        result: InsightsResult = fetch(env=source)
+    except Exception:
+        return None
+
+    if not result.ok:
+        return None
+
+    baseline = load_baseline(baseline_path)
+    new_count = detect_new_issues(result, baseline)
+
+    # Always refresh the baseline so the next invocation compares against
+    # the freshest observation.
+    write_baseline(baseline_from_result(result), baseline_path)
+
+    if new_count <= 0:
+        return None
+    plural = "issues" if new_count != 1 else "issue"
+    return (
+        f"GlitchTip has {new_count} new unresolved {plural} since your "
+        "last check -- run 'bernstein doctor glitchtip' for details."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Click command
+# ---------------------------------------------------------------------------
+
+
+@click.command("glitchtip")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of the Rich tables.",
+)
+@click.option(
+    "--top-n",
+    "top_n",
+    type=int,
+    default=DEFAULT_TOP_N,
+    show_default=True,
+    help="Number of top unresolved issues to surface.",
+)
+@click.option(
+    "--no-baseline",
+    "skip_baseline",
+    is_flag=True,
+    default=False,
+    help="Do not update the baseline cache after the report.",
+)
+def glitchtip_cmd(as_json: bool, top_n: int, skip_baseline: bool) -> None:
+    """Surface GlitchTip issue counts and top unresolved issues.
+
+    \b
+    Reads:
+      - BERNSTEIN_GLITCHTIP_TOKEN  (API token, required for non-trivial output)
+      - BERNSTEIN_GLITCHTIP_DSN    (runtime DSN, informational only here)
+      - BERNSTEIN_GLITCHTIP_BASE_URL (optional override, default: errors.bernstein.run)
+      - BERNSTEIN_GLITCHTIP_ORG    (optional override, default: bernstein)
+
+    \b
+    Examples:
+      bernstein doctor glitchtip
+      bernstein doctor glitchtip --json
+      bernstein doctor glitchtip --top-n 10
+    """
+    env = dict(os.environ)
+    has_token = bool(env.get(ENV_GLITCHTIP_TOKEN))
+    has_dsn = bool(env.get(ENV_GLITCHTIP_DSN))
+
+    if not has_token and not has_dsn:
+        if as_json:
+            sys.stdout.write(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "reason": (
+                            f"{ENV_GLITCHTIP_TOKEN} and {ENV_GLITCHTIP_DSN} are both unset; observability is not wired"
+                        ),
+                    }
+                )
+                + "\n"
+            )
+            return
+        console.print(
+            "[yellow]GlitchTip insights unavailable:[/yellow] "
+            f"export {ENV_GLITCHTIP_TOKEN} to enable the read-side surface."
+        )
+        return
+
+    result = fetch_insights(env=env, top_n=top_n)
+
+    if as_json:
+        sys.stdout.write(json.dumps(result.as_dict(), sort_keys=True) + "\n")
+    else:
+        render_report(result)
+
+    if result.ok and not skip_baseline:
+        write_baseline(baseline_from_result(result))
+
+
+def register(parent: click.Group) -> None:
+    """Attach the GlitchTip subcommand to the parent ``doctor`` group."""
+    parent.add_command(glitchtip_cmd)

--- a/src/bernstein/cli/commands/doctor/glitchtip.py
+++ b/src/bernstein/cli/commands/doctor/glitchtip.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import logging
 import os
 import sys
 from dataclasses import dataclass
@@ -46,6 +47,8 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from rich.console import Console
+
+_LOGGER = logging.getLogger(__name__)
 
 #: Environment variable carrying the runtime DSN. We only read this so we
 #: can produce a precise soft-fail reason when neither the token nor the
@@ -300,6 +303,10 @@ def suggest_nudge_line(
     try:
         result: InsightsResult = fetch(env=source)
     except Exception:
+        # The nudge is purely advisory: log the unexpected failure so we
+        # can diagnose regressions, but never propagate it to the doctor
+        # command above us.
+        _LOGGER.warning("GlitchTip fetch failed in suggest_nudge_line", exc_info=True)
         return None
 
     if not result.ok:
@@ -337,7 +344,7 @@ def suggest_nudge_line(
 @click.option(
     "--top-n",
     "top_n",
-    type=int,
+    type=click.IntRange(min=1),
     default=DEFAULT_TOP_N,
     show_default=True,
     help="Number of top unresolved issues to surface.",

--- a/src/bernstein/core/observability/glitchtip_insights.py
+++ b/src/bernstein/core/observability/glitchtip_insights.py
@@ -1,0 +1,339 @@
+"""GlitchTip insights fetcher for ``bernstein doctor glitchtip``.
+
+Pulls last-24h issue counts by severity and last-7d trend, plus the top
+unresolved issues ranked by event count. The module is pure data: it
+returns dataclasses that the CLI layer renders.
+
+Soft-fail policy
+----------------
+The fetcher returns an :class:`InsightsResult` with ``ok=False`` and a
+human-readable ``reason`` when:
+
+* ``BERNSTEIN_GLITCHTIP_TOKEN`` is not set (operator has not yet wired
+  the API token)
+* the configured base URL cannot be reached
+* the API returns a non-2xx response
+
+The CLI layer treats a soft-fail as a warning rather than a hard error
+so that running ``bernstein doctor glitchtip`` on a fresh checkout does
+not block any operator workflow.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: Environment variable carrying the GlitchTip API token. Distinct from
+#: ``BERNSTEIN_GLITCHTIP_DSN`` (used for runtime event submission) so
+#: that operators can opt into the read-side surface without giving the
+#: orchestrator process write credentials.
+ENV_GLITCHTIP_TOKEN = "BERNSTEIN_GLITCHTIP_TOKEN"
+
+#: Environment variable carrying the optional override for the base
+#: URL. Defaults to the public bernstein.run endpoint so a typical
+#: operator only needs to export the token.
+ENV_GLITCHTIP_BASE_URL = "BERNSTEIN_GLITCHTIP_BASE_URL"
+
+#: Environment variable carrying the GlitchTip organisation slug. Most
+#: operators run a single org, so the default matches the bernstein.run
+#: deployment.
+ENV_GLITCHTIP_ORG = "BERNSTEIN_GLITCHTIP_ORG"
+
+DEFAULT_BASE_URL = "https://errors.bernstein.run"
+DEFAULT_ORG_SLUG = "bernstein"
+
+#: Severity labels used by the Sentry-protocol API. Anything outside this
+#: set is bucketed under ``other`` so the summary table stays narrow.
+KNOWN_LEVELS: tuple[str, ...] = ("fatal", "error", "warning", "info", "debug")
+
+#: Number of top unresolved issues surfaced by default.
+DEFAULT_TOP_N = 5
+
+
+@dataclass(frozen=True)
+class GlitchTipIssue:
+    """A single GlitchTip issue as surfaced to the operator."""
+
+    short_id: str
+    title: str
+    level: str
+    status: str
+    count: int
+    user_count: int
+    first_seen: str
+    last_seen: str
+    permalink: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable mapping for the ``--json`` flag."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InsightsResult:
+    """Aggregate report returned by :func:`fetch_insights`."""
+
+    ok: bool
+    reason: str = ""
+    base_url: str = ""
+    org_slug: str = ""
+    issues_24h: int = 0
+    new_24h: int = 0
+    severity_24h: dict[str, int] = field(default_factory=dict)
+    trend_7d: list[int] = field(default_factory=list)
+    top_unresolved: list[GlitchTipIssue] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable mapping for the ``--json`` flag."""
+        payload = asdict(self)
+        payload["top_unresolved"] = [i.as_dict() for i in self.top_unresolved]
+        return payload
+
+
+def _read_env(
+    env: dict[str, str] | None,
+) -> tuple[str | None, str, str]:
+    """Resolve token, base URL, and org slug from env with defaults.
+
+    A ``None`` ``env`` argument means read ``os.environ``. The token is
+    returned verbatim (``None`` when missing) so the caller can soft-fail
+    with a precise reason string.
+    """
+    source = env if env is not None else dict(os.environ)
+    token = source.get(ENV_GLITCHTIP_TOKEN) or None
+    base_url = source.get(ENV_GLITCHTIP_BASE_URL) or DEFAULT_BASE_URL
+    org_slug = source.get(ENV_GLITCHTIP_ORG) or DEFAULT_ORG_SLUG
+    return token, base_url.rstrip("/"), org_slug
+
+
+def _coerce_issue(raw: Any) -> GlitchTipIssue | None:
+    """Convert a single API response row into a :class:`GlitchTipIssue`.
+
+    Returns ``None`` for malformed rows so partial responses still
+    surface the valid entries.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        count_raw = raw.get("count", 0)
+        user_raw = raw.get("userCount", 0)
+        return GlitchTipIssue(
+            short_id=str(raw.get("shortId", "")),
+            title=str(raw.get("title", ""))[:200],
+            level=str(raw.get("level", "")).lower() or "unknown",
+            status=str(raw.get("status", "unresolved")),
+            count=int(count_raw) if str(count_raw).isdigit() else 0,
+            user_count=int(user_raw) if str(user_raw).isdigit() else 0,
+            first_seen=str(raw.get("firstSeen", "")),
+            last_seen=str(raw.get("lastSeen", "")),
+            permalink=str(raw.get("permalink", "")),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def summarise_severity(issues: Iterable[GlitchTipIssue]) -> dict[str, int]:
+    """Bucket issues by severity level.
+
+    Unknown levels fall into the ``other`` bucket so the table stays
+    narrow. All known buckets are present in the result (zero-filled)
+    so renderers can iterate ``KNOWN_LEVELS`` without branching.
+    """
+    counts: dict[str, int] = {level: 0 for level in KNOWN_LEVELS}
+    counts["other"] = 0
+    for issue in issues:
+        bucket = issue.level if issue.level in KNOWN_LEVELS else "other"
+        counts[bucket] += issue.count or 1
+    return counts
+
+
+def top_unresolved(
+    issues: Iterable[GlitchTipIssue],
+    limit: int = DEFAULT_TOP_N,
+) -> list[GlitchTipIssue]:
+    """Return the top ``limit`` unresolved issues by event count.
+
+    Resolved / ignored issues are filtered out so the operator sees only
+    actionable surfaces.
+    """
+    unresolved = [i for i in issues if i.status == "unresolved"]
+    return sorted(unresolved, key=lambda i: (i.count, i.user_count), reverse=True)[:limit]
+
+
+def _parse_iso8601(value: str) -> dt.datetime | None:
+    """Parse an ISO8601 timestamp, returning ``None`` on bad input."""
+    if not value:
+        return None
+    try:
+        normalised = value.replace("Z", "+00:00")
+        parsed = dt.datetime.fromisoformat(normalised)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.UTC)
+    return parsed
+
+
+def count_new_since(
+    issues: Iterable[GlitchTipIssue],
+    cutoff: dt.datetime,
+) -> int:
+    """Return the number of issues first seen at or after ``cutoff``.
+
+    Used by the periodic nudge to surface only deltas since the last
+    operator check.
+    """
+    n = 0
+    for issue in issues:
+        first = _parse_iso8601(issue.first_seen)
+        if first is not None and first >= cutoff:
+            n += 1
+    return n
+
+
+def _http_get(url: str, token: str, timeout: float) -> tuple[int, Any]:
+    """Issue a GET against the GlitchTip API.
+
+    Returns ``(status_code, parsed_json)``. JSON parse failures yield
+    ``parsed_json = None`` so the caller can soft-fail with a precise
+    reason. Imports ``httpx`` lazily so minimal installs do not pay the
+    cost when this module is not used.
+    """
+    import httpx
+
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    try:
+        resp = httpx.get(url, headers=headers, timeout=timeout)
+    except httpx.HTTPError as exc:
+        raise GlitchTipHTTPError(str(exc)) from exc
+
+    try:
+        return resp.status_code, resp.json()
+    except ValueError:
+        return resp.status_code, None
+
+
+class GlitchTipHTTPError(RuntimeError):
+    """Raised when the underlying HTTP call cannot complete."""
+
+
+def fetch_insights(
+    *,
+    env: dict[str, str] | None = None,
+    timeout: float = 5.0,
+    http_get: Any = None,
+    top_n: int = DEFAULT_TOP_N,
+) -> InsightsResult:
+    """Fetch insights from the GlitchTip API.
+
+    Parameters
+    ----------
+    env:
+        Optional mapping to read configuration from. Defaults to
+        ``os.environ``. Useful for tests so they can pass a known
+        configuration without touching process state.
+    timeout:
+        Per-request timeout in seconds.
+    http_get:
+        Optional callable matching :func:`_http_get` for dependency
+        injection in tests. The callable receives ``(url, token,
+        timeout)`` and returns ``(status_code, parsed_json)``.
+    top_n:
+        Number of top unresolved issues to surface.
+
+    Returns
+    -------
+    InsightsResult
+        ``ok=False`` with a reason string for any soft-fail; ``ok=True``
+        with populated counts and a top-N list otherwise.
+    """
+    token, base_url, org_slug = _read_env(env)
+    if not token:
+        return InsightsResult(
+            ok=False,
+            reason=f"{ENV_GLITCHTIP_TOKEN} not set; cannot query GlitchTip API",
+            base_url=base_url,
+            org_slug=org_slug,
+        )
+
+    issues_url = f"{base_url}/api/0/organizations/{org_slug}/issues/?statsPeriod=24h&limit=100"
+    trend_url = f"{base_url}/api/0/organizations/{org_slug}/issues/?statsPeriod=7d&limit=100"
+
+    getter = http_get if http_get is not None else _http_get
+
+    try:
+        status_24h, payload_24h = getter(issues_url, token, timeout)
+    except GlitchTipHTTPError as exc:
+        return InsightsResult(
+            ok=False,
+            reason=f"GlitchTip API unreachable: {exc}",
+            base_url=base_url,
+            org_slug=org_slug,
+        )
+
+    if status_24h < 200 or status_24h >= 300:
+        return InsightsResult(
+            ok=False,
+            reason=f"GlitchTip API returned HTTP {status_24h}",
+            base_url=base_url,
+            org_slug=org_slug,
+        )
+    if not isinstance(payload_24h, list):
+        return InsightsResult(
+            ok=False,
+            reason="GlitchTip API returned a non-list payload for 24h issues",
+            base_url=base_url,
+            org_slug=org_slug,
+        )
+
+    issues_24h = [coerced for raw in payload_24h if (coerced := _coerce_issue(raw))]
+
+    # Trend pull is best-effort -- if it fails we still surface the 24h
+    # numbers rather than failing the whole report.
+    trend_counts: list[int] = []
+    try:
+        status_7d, payload_7d = getter(trend_url, token, timeout)
+        if 200 <= status_7d < 300 and isinstance(payload_7d, list):
+            issues_7d = [coerced for raw in payload_7d if (coerced := _coerce_issue(raw))]
+            trend_counts = _bucket_trend_by_day(issues_7d)
+    except GlitchTipHTTPError:
+        trend_counts = []
+
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(hours=24)
+    new_24h = count_new_since(issues_24h, cutoff)
+
+    return InsightsResult(
+        ok=True,
+        base_url=base_url,
+        org_slug=org_slug,
+        issues_24h=len(issues_24h),
+        new_24h=new_24h,
+        severity_24h=summarise_severity(issues_24h),
+        trend_7d=trend_counts,
+        top_unresolved=top_unresolved(issues_24h, limit=top_n),
+    )
+
+
+def _bucket_trend_by_day(issues: Iterable[GlitchTipIssue]) -> list[int]:
+    """Bucket a 7-day issue list into seven daily counts (oldest first).
+
+    The GlitchTip API does not expose a per-day histogram in the issues
+    endpoint, so we bucket by ``firstSeen`` ourselves. Issues without a
+    parseable ``firstSeen`` are skipped.
+    """
+    now = dt.datetime.now(dt.UTC)
+    buckets = [0] * 7
+    for issue in issues:
+        first = _parse_iso8601(issue.first_seen)
+        if first is None:
+            continue
+        age_days = (now - first).days
+        if 0 <= age_days < 7:
+            buckets[6 - age_days] += issue.count or 1
+    return buckets

--- a/src/bernstein/core/observability/glitchtip_insights.py
+++ b/src/bernstein/core/observability/glitchtip_insights.py
@@ -149,7 +149,7 @@ def summarise_severity(issues: Iterable[GlitchTipIssue]) -> dict[str, int]:
     counts["other"] = 0
     for issue in issues:
         bucket = issue.level if issue.level in KNOWN_LEVELS else "other"
-        counts[bucket] += issue.count or 1
+        counts[bucket] += issue.count
     return counts
 
 
@@ -335,5 +335,5 @@ def _bucket_trend_by_day(issues: Iterable[GlitchTipIssue]) -> list[int]:
             continue
         age_days = (now - first).days
         if 0 <= age_days < 7:
-            buckets[6 - age_days] += issue.count or 1
+            buckets[6 - age_days] += issue.count
     return buckets

--- a/tests/unit/cli/doctor/test_glitchtip.py
+++ b/tests/unit/cli/doctor/test_glitchtip.py
@@ -1,0 +1,406 @@
+"""Tests for the GlitchTip insights surface and ``bernstein doctor glitchtip``.
+
+Covers the data fetcher, baseline persistence, nudge logic, soft-fail
+behaviour when env vars are missing, and the Click wiring. The HTTP
+client is replaced by a tiny dependency-injected stub so the suite
+stays hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import doctor as doctor_group
+from bernstein.cli.commands.doctor.glitchtip import (
+    Baseline,
+    baseline_from_result,
+    default_baseline_path,
+    detect_new_issues,
+    glitchtip_cmd,
+    load_baseline,
+    suggest_nudge_line,
+    write_baseline,
+)
+from bernstein.core.observability.glitchtip_insights import (
+    DEFAULT_BASE_URL,
+    DEFAULT_ORG_SLUG,
+    ENV_GLITCHTIP_BASE_URL,
+    ENV_GLITCHTIP_ORG,
+    ENV_GLITCHTIP_TOKEN,
+    KNOWN_LEVELS,
+    GlitchTipIssue,
+    InsightsResult,
+    count_new_since,
+    fetch_insights,
+    summarise_severity,
+    top_unresolved,
+)
+
+# ---------------------------------------------------------------------------
+# Stub HTTP getter
+# ---------------------------------------------------------------------------
+
+
+def _issue_row(
+    short_id: str,
+    *,
+    level: str = "error",
+    status: str = "unresolved",
+    count: int = 1,
+    first_seen: str = "2026-05-20T00:00:00Z",
+) -> dict[str, Any]:
+    """Build a minimal GlitchTip API row used by the stub responder."""
+    return {
+        "shortId": short_id,
+        "title": f"issue {short_id}",
+        "level": level,
+        "status": status,
+        "count": str(count),
+        "userCount": "0",
+        "firstSeen": first_seen,
+        "lastSeen": first_seen,
+        "permalink": f"https://errors.bernstein.run/bernstein/issues/{short_id}",
+    }
+
+
+def _make_getter(payload_24h: Any, payload_7d: Any | None = None) -> Any:
+    """Return a getter callable matching ``_http_get`` for injection."""
+
+    def _getter(url: str, token: str, timeout: float) -> tuple[int, Any]:
+        assert token, "stub getter requires a non-empty token"
+        if "7d" in url:
+            return 200, payload_7d if payload_7d is not None else []
+        return 200, payload_24h
+
+    return _getter
+
+
+# ---------------------------------------------------------------------------
+# fetch_insights
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_insights_soft_fails_when_token_missing() -> None:
+    """No token -> ok=False with a precise reason; no HTTP call."""
+    called = {"n": 0}
+
+    def _getter(*_args: Any, **_kwargs: Any) -> tuple[int, Any]:
+        called["n"] += 1
+        return 200, []
+
+    result = fetch_insights(env={}, http_get=_getter)
+
+    assert called["n"] == 0
+    assert not result.ok
+    assert ENV_GLITCHTIP_TOKEN in result.reason
+    assert result.base_url == DEFAULT_BASE_URL
+    assert result.org_slug == DEFAULT_ORG_SLUG
+
+
+def test_fetch_insights_populates_from_24h_payload() -> None:
+    """A well-formed payload yields severity buckets and top unresolved."""
+    payload = [
+        _issue_row("A", level="error", count=5),
+        _issue_row("B", level="warning", count=2),
+        _issue_row("C", level="error", status="resolved", count=99),
+    ]
+    result = fetch_insights(
+        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        http_get=_make_getter(payload),
+    )
+
+    assert result.ok
+    assert result.issues_24h == 3
+    assert result.severity_24h["error"] == 5 + 99
+    assert result.severity_24h["warning"] == 2
+    # resolved issues drop out of the top-N list
+    ids = [i.short_id for i in result.top_unresolved]
+    assert "C" not in ids
+    assert ids[0] == "A"  # higher count wins
+
+
+def test_fetch_insights_handles_non_2xx() -> None:
+    """A 5xx response soft-fails with the status code in the reason."""
+
+    def _getter(*_args: Any, **_kwargs: Any) -> tuple[int, Any]:
+        return 503, None
+
+    result = fetch_insights(
+        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        http_get=_getter,
+    )
+    assert not result.ok
+    assert "503" in result.reason
+
+
+def test_fetch_insights_uses_env_overrides() -> None:
+    """Base URL and org slug overrides flow into the result."""
+    captured: dict[str, str] = {}
+
+    def _getter(url: str, token: str, timeout: float) -> tuple[int, Any]:
+        captured["url"] = url
+        return 200, []
+
+    fetch_insights(
+        env={
+            ENV_GLITCHTIP_TOKEN: "tok",
+            ENV_GLITCHTIP_BASE_URL: "https://custom.example.test/",
+            ENV_GLITCHTIP_ORG: "custom-org",
+        },
+        http_get=_getter,
+    )
+    assert captured["url"].startswith("https://custom.example.test/api/0/organizations/custom-org/issues/")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_summarise_severity_zero_fills_known_levels() -> None:
+    """Every known level is present even when there are no matching issues."""
+    counts = summarise_severity([])
+    for level in KNOWN_LEVELS:
+        assert level in counts
+    assert counts["other"] == 0
+
+
+def test_top_unresolved_orders_by_count_desc() -> None:
+    """Higher count beats lower count regardless of input order."""
+    issues = [
+        GlitchTipIssue("A", "a", "error", "unresolved", 1, 0, "", "", ""),
+        GlitchTipIssue("B", "b", "error", "unresolved", 9, 0, "", "", ""),
+        GlitchTipIssue("C", "c", "error", "unresolved", 4, 0, "", "", ""),
+    ]
+    top = top_unresolved(issues, limit=2)
+    assert [i.short_id for i in top] == ["B", "C"]
+
+
+def test_top_unresolved_filters_resolved() -> None:
+    """Resolved issues are excluded from the surfaced list."""
+    issues = [
+        GlitchTipIssue("A", "a", "error", "resolved", 99, 0, "", "", ""),
+        GlitchTipIssue("B", "b", "error", "unresolved", 1, 0, "", "", ""),
+    ]
+    assert [i.short_id for i in top_unresolved(issues)] == ["B"]
+
+
+def test_count_new_since_uses_first_seen() -> None:
+    """Only issues first-seen at or after the cutoff are counted."""
+    cutoff = dt.datetime(2026, 5, 20, tzinfo=dt.UTC)
+    issues = [
+        GlitchTipIssue("A", "a", "error", "unresolved", 1, 0, "2026-05-19T23:59:59Z", "", ""),
+        GlitchTipIssue("B", "b", "error", "unresolved", 1, 0, "2026-05-20T00:00:01Z", "", ""),
+        GlitchTipIssue("C", "c", "error", "unresolved", 1, 0, "not-iso", "", ""),
+    ]
+    assert count_new_since(issues, cutoff) == 1
+
+
+# ---------------------------------------------------------------------------
+# Baseline cache
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_roundtrip(tmp_path: Path) -> None:
+    """A written baseline reloads with the same shape."""
+    target = tmp_path / "baseline.json"
+    baseline = Baseline(checked_at="2026-05-20T00:00:00+00:00", issues_24h=3, last_short_id="BERNSTEIN-7")
+    write_baseline(baseline, target)
+    loaded = load_baseline(target)
+    assert loaded == baseline
+
+
+def test_load_baseline_returns_none_for_missing_file(tmp_path: Path) -> None:
+    """A non-existent path is the expected fresh-install state."""
+    assert load_baseline(tmp_path / "missing.json") is None
+
+
+def test_load_baseline_returns_none_for_malformed_json(tmp_path: Path) -> None:
+    """Corrupt JSON degrades to None rather than crashing."""
+    target = tmp_path / "bad.json"
+    target.write_text("{not json", encoding="utf-8")
+    assert load_baseline(target) is None
+
+
+def test_default_baseline_path_uses_override(monkeypatch: Any, tmp_path: Path) -> None:
+    """The env override wins over XDG and the home fallback."""
+    custom = tmp_path / "custom" / "baseline.json"
+    monkeypatch.setenv("BERNSTEIN_GLITCHTIP_BASELINE", str(custom))
+    assert default_baseline_path() == custom
+
+
+def test_default_baseline_path_uses_xdg(monkeypatch: Any, tmp_path: Path) -> None:
+    """XDG_DATA_HOME wins over the home fallback when the override is absent."""
+    monkeypatch.delenv("BERNSTEIN_GLITCHTIP_BASELINE", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert default_baseline_path() == tmp_path / "bernstein" / "glitchtip-baseline.json"
+
+
+def test_detect_new_issues_no_baseline() -> None:
+    """Without a baseline the result reports its own ``new_24h`` count."""
+    result = InsightsResult(ok=True, issues_24h=4, new_24h=2)
+    assert detect_new_issues(result, None) == 2
+
+
+def test_detect_new_issues_with_baseline_diff() -> None:
+    """The larger of ``new_24h`` and the baseline delta wins."""
+    baseline = Baseline(checked_at="2026-05-19T00:00:00+00:00", issues_24h=3, last_short_id="X")
+    result = InsightsResult(ok=True, issues_24h=10, new_24h=1)
+    # delta = 7, new_24h = 1 -> 7 wins
+    assert detect_new_issues(result, baseline) == 7
+
+
+def test_detect_new_issues_ignores_unfetched_result() -> None:
+    """A soft-failed result never yields a positive delta."""
+    result = InsightsResult(ok=False, reason="unreachable")
+    baseline = Baseline(checked_at="2026-05-19T00:00:00+00:00", issues_24h=0, last_short_id="")
+    assert detect_new_issues(result, baseline) == 0
+
+
+# ---------------------------------------------------------------------------
+# Nudge helper
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_nudge_line_returns_none_without_token(tmp_path: Path) -> None:
+    """Missing token -> no nudge line."""
+    assert suggest_nudge_line(env={}, baseline_path=tmp_path / "baseline.json") is None
+
+
+def test_suggest_nudge_line_returns_none_on_soft_fail(tmp_path: Path) -> None:
+    """A soft-failed fetch yields no nudge line."""
+
+    def _fail(*_args: Any, **_kwargs: Any) -> InsightsResult:
+        return InsightsResult(ok=False, reason="api down")
+
+    line = suggest_nudge_line(
+        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        baseline_path=tmp_path / "baseline.json",
+        fetcher=_fail,
+    )
+    assert line is None
+
+
+def test_suggest_nudge_line_emits_when_new_issues_detected(tmp_path: Path) -> None:
+    """A populated result with deltas produces a single-line nudge."""
+
+    def _fetch(*_args: Any, **_kwargs: Any) -> InsightsResult:
+        return InsightsResult(ok=True, issues_24h=5, new_24h=3)
+
+    line = suggest_nudge_line(
+        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        baseline_path=tmp_path / "baseline.json",
+        fetcher=_fetch,
+    )
+    assert line is not None
+    assert "3 new unresolved" in line
+    # Baseline must be persisted so the next invocation compares against it.
+    assert (tmp_path / "baseline.json").exists()
+
+
+def test_suggest_nudge_line_silent_when_no_delta(tmp_path: Path) -> None:
+    """A populated result with no deltas yields no nudge line."""
+
+    target = tmp_path / "baseline.json"
+    write_baseline(
+        Baseline(checked_at="2026-05-20T00:00:00+00:00", issues_24h=5, last_short_id="X"),
+        target,
+    )
+
+    def _fetch(*_args: Any, **_kwargs: Any) -> InsightsResult:
+        return InsightsResult(ok=True, issues_24h=5, new_24h=0)
+
+    line = suggest_nudge_line(
+        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        baseline_path=target,
+        fetcher=_fetch,
+    )
+    assert line is None
+
+
+# ---------------------------------------------------------------------------
+# Baseline-from-result
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_from_result_captures_count_and_top_id() -> None:
+    """The baseline records the 24h count and the first top issue's id."""
+    result = InsightsResult(
+        ok=True,
+        issues_24h=4,
+        new_24h=4,
+        top_unresolved=[
+            GlitchTipIssue("X", "x", "error", "unresolved", 9, 0, "", "", ""),
+        ],
+    )
+    baseline = baseline_from_result(result)
+    assert baseline.issues_24h == 4
+    assert baseline.last_short_id == "X"
+
+
+# ---------------------------------------------------------------------------
+# Click wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_soft_fails_when_env_not_wired(monkeypatch: Any, tmp_path: Path) -> None:
+    """No token, no DSN -> the command exits 0 with a yellow warning."""
+    monkeypatch.delenv(ENV_GLITCHTIP_TOKEN, raising=False)
+    monkeypatch.delenv("BERNSTEIN_GLITCHTIP_DSN", raising=False)
+    monkeypatch.setenv("BERNSTEIN_GLITCHTIP_BASELINE", str(tmp_path / "baseline.json"))
+
+    runner = CliRunner()
+    result = runner.invoke(glitchtip_cmd, [])
+    assert result.exit_code == 0
+    assert "unavailable" in result.output.lower()
+
+
+def test_cli_json_output_when_unwired(monkeypatch: Any, tmp_path: Path) -> None:
+    """``--json`` returns a machine-readable soft-fail payload."""
+    monkeypatch.delenv(ENV_GLITCHTIP_TOKEN, raising=False)
+    monkeypatch.delenv("BERNSTEIN_GLITCHTIP_DSN", raising=False)
+    monkeypatch.setenv("BERNSTEIN_GLITCHTIP_BASELINE", str(tmp_path / "baseline.json"))
+
+    runner = CliRunner()
+    result = runner.invoke(glitchtip_cmd, ["--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+
+
+def test_cli_renders_table_when_wired(monkeypatch: Any, tmp_path: Path) -> None:
+    """A live-style fetch returns issue counts and writes the baseline."""
+
+    monkeypatch.setenv(ENV_GLITCHTIP_TOKEN, "tok")
+    monkeypatch.setenv("BERNSTEIN_GLITCHTIP_BASELINE", str(tmp_path / "baseline.json"))
+
+    payload_24h = [_issue_row("Q", level="error", count=4)]
+
+    # Patch the module-level fetcher so the CLI hits the stub instead of the network.
+    from bernstein.cli.commands.doctor import glitchtip as gt_module
+
+    def _fake(env: Any = None, top_n: int = 5) -> InsightsResult:
+        from bernstein.core.observability.glitchtip_insights import fetch_insights
+
+        return fetch_insights(env=env, http_get=_make_getter(payload_24h), top_n=top_n)
+
+    monkeypatch.setattr(gt_module, "fetch_insights", _fake)
+
+    runner = CliRunner()
+    result = runner.invoke(glitchtip_cmd, ["--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["issues_24h"] == 1
+    assert any(i["short_id"] == "Q" for i in payload["top_unresolved"])
+    assert (tmp_path / "baseline.json").exists()
+
+
+def test_doctor_group_lists_glitchtip_subcommand() -> None:
+    """The ``glitchtip`` subcommand is attached to the existing doctor group."""
+    assert "glitchtip" in doctor_group.commands


### PR DESCRIPTION
## Summary

- Adds `bernstein doctor glitchtip` -- read-side surface for the GlitchTip error sink. Renders last-24h severity buckets, a 7-day trend sparkline, and the top unresolved issues as a Rich table or JSON. Soft-fails (exit 0) when env vars are unset so fresh checkouts stay green.
- Hooks `bernstein doctor --suggest-docs` to print a one-line nudge when the GlitchTip API reports new unresolved issues since the cached baseline at `~/.local/share/bernstein/glitchtip-baseline.json`.
- Adds `.github/workflows/glitchtip-insights.yml` -- daily 06:30 UTC sweep (plus `workflow_dispatch`) that mirrors fatal-level GlitchTip issues into sticky GitHub issues labelled `glitchtip-alert`. The mirror auto-closes when the GlitchTip side resolves.
- Operator doc at `docs/observability/glitchtip-insights.md`.
- 25 new unit tests at `tests/unit/cli/doctor/test_glitchtip.py` covering the fetcher, baseline persistence, nudge logic, soft-fail behaviour, and the Click wiring.

## Configuration

| Env var | Purpose |
|---|---|
| `BERNSTEIN_GLITCHTIP_TOKEN` | API token (new). |
| `BERNSTEIN_GLITCHTIP_DSN` | Runtime DSN (existing). |
| `BERNSTEIN_GLITCHTIP_BASE_URL` | Optional base URL override (default: `https://errors.bernstein.run`). |
| `BERNSTEIN_GLITCHTIP_ORG` | Optional org slug override (default: `bernstein`). |
| `BERNSTEIN_GLITCHTIP_BASELINE` | Optional baseline cache path override. |

GitHub secret `GLITCHTIP_API_TOKEN` already set on this repo.

## Test plan

- [x] `uv run pytest tests/unit/cli/doctor/ -q` -> 25 passed.
- [x] `uv run pytest tests/unit/cli/ -q` -> 115 passed.
- [x] `uv run ruff check` on the new files.
- [x] Verified live end-to-end against `https://errors.bernstein.run` with the operator-minted token (2 unresolved issues observed).
- [x] `bernstein doctor --help` shows the new subcommand.
- [ ] CI green on this PR.
- [ ] Workflow dry-run via `workflow_dispatch` after merge.

## Summary by Sourcery

Add a GlitchTip-powered observability surface to the `bernstein doctor` CLI and wire it into both interactive diagnostics and a daily GitHub alert workflow.

New Features:
- Introduce `bernstein doctor glitchtip` subcommand to surface GlitchTip issue counts, severity breakdown, 7‑day trend, and top unresolved issues with Rich and JSON output.
- Add a GlitchTip insights data layer that fetches and aggregates issues from the GlitchTip API for reuse by CLI and other components.
- Integrate a lightweight GlitchTip nudge into `bernstein doctor --suggest-docs` to hint when new unresolved issues have appeared since the last baseline.

Enhancements:
- Persist and manage a local GlitchTip baseline cache to support delta detection across doctor runs.
- Extend the `bernstein doctor` command group wiring to support pluggable observability backends via a dedicated doctor package.

CI:
- Introduce a scheduled `glitchtip-insights` GitHub Actions workflow that sweeps GlitchTip daily and mirrors fatal-level issues into labelled GitHub issues, auto-closing them when resolved.

Documentation:
- Document GlitchTip insights setup, configuration, CLI usage, baseline cache behaviour, and the daily alert workflow in a new operator guide.

Tests:
- Add a comprehensive GlitchTip test suite covering insights fetching, baseline persistence, delta detection, nudge behaviour, CLI wiring, and soft-fail semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `bernstein doctor glitchtip` command to query GlitchTip error insights with Rich table or JSON output
  * Added GitHub Actions workflow for daily GlitchTip error reconciliation with GitHub issues
  * Enhanced CLI to display GlitchTip nudge suggestions

* **Documentation**
  * Added comprehensive guide for GlitchTip observability integration and workflow setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->