### PR TITLE
refactor: refurb cluster D (FURB139/143/179 strings/enumerate)

### DIFF
--- a/src/bernstein/core/communication/bulletin.py
+++ b/src/bernstein/core/communication/bulletin.py
@@ -11,6 +11,7 @@ and optionally waits for a response.
 
 from __future__ import annotations
 
+import itertools
 import json
 import threading
 import time
@@ -978,7 +979,7 @@ class DirectChannel:
         """
         with self._lock:
             queries = list(self._queries.values())
-            responses = [r for rs in self._responses.values() for r in rs]
+            responses = list(itertools.chain.from_iterable(self._responses.values()))
 
         if not queries and not responses:
             return 0

--- a/src/bernstein/core/integrations/tickets/linear.py
+++ b/src/bernstein/core/integrations/tickets/linear.py
@@ -27,7 +27,7 @@ _TIMEOUT_S = 10.0
 _KEY_RE = re.compile(r"([A-Z0-9]{1,16}-\d{1,8})", re.IGNORECASE)
 
 
-_QUERY = """
+_QUERY = """\
 query IssueByIdentifier($id: String!) {
   issue(id: $id) {
     id
@@ -38,8 +38,8 @@ query IssueByIdentifier($id: String!) {
     labels { nodes { name } }
     assignee { name displayName }
   }
-}
-""".strip()
+}\
+"""
 
 
 def _extract_key(url: str) -> str:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import collections
 import concurrent.futures
 import contextlib
+import itertools
 import json
 import logging
 import os
@@ -1242,7 +1243,7 @@ class Orchestrator:
         # 1c. Build task graph and compute optimal parallelism
         #     Graph analysis + dependency validation are expensive — gate behind
         #     _run_normal. The all_tasks list and task ID cache are always needed.
-        all_tasks = [t for status_tasks in tasks_by_status.values() for t in status_tasks]
+        all_tasks = list(itertools.chain.from_iterable(tasks_by_status.values()))
         self._latest_tasks_by_id = {task.id: task for task in all_tasks}
 
         task_graph: TaskGraph | None = None
@@ -1398,13 +1399,13 @@ class Orchestrator:
         # batched tasks' model fields in place for DOWNGRADE_MODEL so the
         # spawner picks up the cheaper tier.
         budget_decision = self._evaluate_budget_policy(
-            [t for b in batches for t in b],
+            list(itertools.chain.from_iterable(batches)),
         )
         if self._cost_autopilot is not None:
             _ap_override = self._cost_autopilot.evaluate()
             if _ap_override is not None:
                 logger.info("CostAutopilot: %s", _ap_override.reason)
-                for _task in [t for b in batches for t in b]:
+                for _task in itertools.chain.from_iterable(batches):
                     if not _task.model or _task.model == _ap_override.from_model:
                         _task.model = _ap_override.to_model
         if self._config.dry_run:
@@ -1483,7 +1484,7 @@ class Orchestrator:
 
         # 4a-wf. Governed workflow: try to advance phase after processing completions
         if self._workflow_executor is not None and not self._workflow_executor.is_completed:
-            all_tasks = [t for status_tasks in tasks_by_status.values() for t in status_tasks]
+            all_tasks = list(itertools.chain.from_iterable(tasks_by_status.values()))
             phase_event = self._workflow_executor.try_advance(all_tasks)
             if phase_event is not None:
                 self._recorder.record(

--- a/src/bernstein/core/security/capability_matrix.py
+++ b/src/bernstein/core/security/capability_matrix.py
@@ -27,6 +27,7 @@ Usage::
 
 from __future__ import annotations
 
+import itertools
 import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -177,7 +178,7 @@ class CapabilityRegistry:
                 mode=self.mode,
             )
 
-        offending_tools = tuple(sorted({tool for tools_list in offending.values() for tool in tools_list}))
+        offending_tools = tuple(sorted(set(itertools.chain.from_iterable(offending.values()))))
         reason = self.UNKNOWN_REASON if unknown else self.DEFAULT_REASON
 
         if self.mode is EnforcementMode.OFF:

--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -207,7 +207,7 @@ class _TokenBucket:
 # ---------------------------------------------------------------------------
 
 
-_QUERY_PROJECT_ID = """
+_QUERY_PROJECT_ID = """\
 query($login: String!, $number: Int!) {
   organization(login: $login) {
     projectV2(number: $number) {
@@ -237,11 +237,11 @@ query($login: String!, $number: Int!) {
       }
     }
   }
-}
-""".strip()
+}\
+"""
 
 
-_QUERY_ITEMS = """
+_QUERY_ITEMS = """\
 query($projectId: ID!, $first: Int!, $after: String) {
   node(id: $projectId) {
     ... on ProjectV2 {
@@ -280,20 +280,20 @@ query($projectId: ID!, $first: Int!, $after: String) {
       }
     }
   }
-}
-""".strip()
+}\
+"""
 
 
-_MUTATION_ADD_COMMENT = """
+_MUTATION_ADD_COMMENT = """\
 mutation($subjectId: ID!, $body: String!, $clientMutationId: String) {
   addComment(input: { subjectId: $subjectId, body: $body, clientMutationId: $clientMutationId }) {
     commentEdge { node { id } }
   }
-}
-""".strip()
+}\
+"""
 
 
-_MUTATION_UPDATE_STATUS = """
+_MUTATION_UPDATE_STATUS = """\
 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!, $clientMutationId: String) {
   updateProjectV2ItemFieldValue(input: {
     projectId: $projectId,
@@ -304,8 +304,8 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!, $clie
   }) {
     projectV2Item { id }
   }
-}
-""".strip()
+}\
+"""
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/trackers/builtin/jira_dc_adapter.py
+++ b/src/bernstein/core/trackers/builtin/jira_dc_adapter.py
@@ -378,7 +378,7 @@ class JiraDataCenterAdapter(AbstractTrackerAdapter):
             id=key,
             external_url=external_url,
             title=str(fields_block.get("summary") or ""),
-            body=str(fields_block.get("description") or "") or "",
+            body=str(fields_block.get("description") or ""),
             status=str(status_block.get("name") or ""),
             labels=labels,
             etag=None,

--- a/src/bernstein/core/trackers/linear.py
+++ b/src/bernstein/core/trackers/linear.py
@@ -159,7 +159,7 @@ class _TokenBucket:
 # ---------------------------------------------------------------------------
 
 
-_QUERY_TEAM = """
+_QUERY_TEAM = """\
 query($key: String!) {
   teams(filter: { key: { eq: $key } }, first: 1) {
     nodes {
@@ -171,11 +171,11 @@ query($key: String!) {
       }
     }
   }
-}
-""".strip()
+}\
+"""
 
 
-_QUERY_ISSUES = """
+_QUERY_ISSUES = """\
 query($teamId: String!, $first: Int!, $after: String, $includeArchived: Boolean) {
   issues(
     filter: { team: { id: { eq: $teamId } } }
@@ -196,28 +196,28 @@ query($teamId: String!, $first: Int!, $after: String, $includeArchived: Boolean)
       labels(first: 20) { nodes { name } }
     }
   }
-}
-""".strip()
+}\
+"""
 
 
-_MUTATION_ADD_COMMENT = """
+_MUTATION_ADD_COMMENT = """\
 mutation($issueId: String!, $body: String!) {
   commentCreate(input: { issueId: $issueId, body: $body }) {
     success
     comment { id }
   }
-}
-""".strip()
+}\
+"""
 
 
-_MUTATION_UPDATE_STATE = """
+_MUTATION_UPDATE_STATE = """\
 mutation($issueId: String!, $stateId: String!) {
   issueUpdate(id: $issueId, input: { stateId: $stateId }) {
     success
     issue { id updatedAt }
   }
-}
-""".strip()
+}\
+"""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Apply 16 refurb autofixes across three rule families.

| Rule | Count | Change |
|---|---|---|
| FURB139 | 9 | Replace `"""\n...\n""".strip()` with line-continuation backslash form on module-level GraphQL query/mutation constants |
| FURB143 | 1 | Drop redundant outer `or ""` after `str(... or "")` in `jira_dc_adapter` |
| FURB179 | 6 | Flatten nested list/set comprehensions to `itertools.chain.from_iterable` in `bulletin`, `orchestrator` (x4), `capability_matrix` |

## Skipped

Three FURB143 alerts were left in place intentionally: defensive `or ""` at external API boundaries (`importlib.metadata` fields in `sbom.py`, externally-supplied input string in `trend_scan.py`) where None remains a runtime possibility despite the declared type.

## Verification

- `refurb --enable-all src` shows the 16 alerts resolved (only the 3 deliberately-skipped FURB143 entries remain).
- `ruff check` + `ruff format --check` clean on all 7 modified files.
- Module-level GraphQL string constants verified to produce byte-identical content (no leading/trailing newline change vs prior `.strip()` output).
- `pytest tests/unit/test_bulletin.py tests/unit/test_capability_matrix.py tests/unit/trackers/test_github_projects_adapter.py tests/unit/trackers/test_jira_dc_adapter.py tests/unit/core/trackers/test_linear.py tests/unit/test_orchestrator*.py tests/unit/test_bulletin_*.py tests/unit/test_capability_matrix_adversarial.py` -> 341 passed.

## Test plan

- [ ] CI green
- [ ] Lint/refurb job no longer flags the resolved alerts

## Summary by Sourcery

Refine GraphQL query constants and flatten collection handling across core modules while simplifying Jira ticket field normalization.

Bug Fixes:
- Avoid redundant fallback when normalizing Jira issue description bodies by relying on str() coercion alone in the Jira DC adapter.

Enhancements:
- Define module-level GraphQL query and mutation strings without trailing strip calls by using explicit line-continuation syntax.
- Replace nested list and tuple comprehensions with itertools.chain.from_iterable when aggregating task, response, and capability collections for orchestration, bulletin flushing, and capability evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Jira issue description field to consistently default to empty string when absent.

* **Refactor**
  * Optimized internal data flattening operations across multiple modules for improved performance and maintainability.

* **Style**
  * Updated GraphQL query string formatting for improved code consistency across tracker integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->