### PR TITLE
feat(observability): sonar insights surface + doctor subcommand + delta nudge

### DIFF
--- a/.github/workflows/sonar-pr-comment.yml
+++ b/.github/workflows/sonar-pr-comment.yml
@@ -1,0 +1,142 @@
+name: SonarQube PR insights comment
+
+# Posts a sticky, advisory PR comment summarising the current Sonar
+# smells / bugs / vulnerabilities for the project. This is intentionally
+# a soft signal: the workflow never sets a failing check and never
+# blocks merge. The Sonar scan itself runs on push to main via
+# sonar-scan.yml; this comment is the operator-facing surface so a PR
+# author can see "we currently sit at N smells" without leaving the PR
+# tab.
+#
+# Skipped on fork PRs (no secret access) and when SONAR_HOST_URL is
+# unset (host not configured for this repo). Both cases degrade
+# silently rather than failing the workflow.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: sonar-pr-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: Sonar smells delta comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip on forks (no secret access) and when the Sonar host is
+    # unconfigured for this repo. Both checks keep this advisory and
+    # avoid noisy failures.
+    if: >-
+      ${{ vars.SONAR_HOST_URL != '' &&
+          github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Query Sonar measures
+        id: query
+        env:
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Tolerate the case where the project has not been scanned
+          # yet: this workflow stays advisory either way.
+          http_code=$(curl -sS -o response.json -w '%{http_code}' \
+            -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL%/}/api/measures/component?component=bernstein&metricKeys=code_smells,bugs,vulnerabilities,security_hotspots,coverage")
+          echo "status=${http_code}" >> "$GITHUB_OUTPUT"
+          if [ "${http_code}" != "200" ]; then
+            echo "Sonar returned ${http_code}; will post a placeholder comment."
+            echo '{"component":{"measures":[]}}' > response.json
+          fi
+          # Extract metrics defensively. ``jq -r`` returns ``null`` when
+          # absent; we coerce to ``-`` so the comment table never breaks.
+          extract() {
+            jq -r --arg k "$1" '
+              .component.measures
+              | map(select(.metric == $k))
+              | .[0].value // "-"
+            ' response.json
+          }
+          {
+            echo "code_smells=$(extract code_smells)"
+            echo "bugs=$(extract bugs)"
+            echo "vulnerabilities=$(extract vulnerabilities)"
+            echo "security_hotspots=$(extract security_hotspots)"
+            echo "coverage=$(extract coverage)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update sticky comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SONAR_STATUS: ${{ steps.query.outputs.status }}
+          CODE_SMELLS: ${{ steps.query.outputs.code_smells }}
+          BUGS: ${{ steps.query.outputs.bugs }}
+          VULNS: ${{ steps.query.outputs.vulnerabilities }}
+          HOTSPOTS: ${{ steps.query.outputs.security_hotspots }}
+          COVERAGE: ${{ steps.query.outputs.coverage }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        with:
+          script: |
+            const marker = '<!-- sonar-pr-comment:smells -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const status = process.env.SONAR_STATUS || '';
+            const host = (process.env.SONAR_HOST_URL || '').replace(/\/$/, '');
+
+            const lines = [
+              marker,
+              '## Sonar insights (advisory, no merge-block)',
+              '',
+              status === '200'
+                ? `Snapshot of \`bernstein\` on ${host}/dashboard?id=bernstein:`
+                : `Sonar query returned status ${status || 'unknown'}; this is advisory only.`,
+              '',
+              '| Metric | Value |',
+              '|---|---|',
+              `| Coverage | ${process.env.COVERAGE || '-'} |`,
+              `| Code smells | ${process.env.CODE_SMELLS || '-'} |`,
+              `| Bugs | ${process.env.BUGS || '-'} |`,
+              `| Vulnerabilities | ${process.env.VULNS || '-'} |`,
+              `| Security hotspots | ${process.env.HOTSPOTS || '-'} |`,
+              '',
+              'Run `bernstein doctor sonar` locally for the full surface.',
+              '',
+              '_This comment is a soft signal. The Sonar scan runs on push to `main`; the PR check itself never fails on smells._',
+            ];
+            const body = lines.join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated sticky sonar comment #${existing.id}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info('Posted sticky sonar comment.');
+            }

--- a/docs/observability/sonar.md
+++ b/docs/observability/sonar.md
@@ -1,0 +1,107 @@
+# SonarQube integration
+
+Bernstein surfaces SonarQube measures (coverage, code smells, bugs,
+vulnerabilities, security hotspots, cognitive-complexity hotspots) in
+the operator's terminal so the daily diagnostic flow includes static
+analysis without a context switch to the Sonar UI.
+
+## TL;DR
+
+- CI publishes coverage to SonarQube via `.github/workflows/sonar-scan.yml`.
+- Operators run `bernstein doctor sonar` to pull the current measures.
+- A periodic nudge fires from the parent `bernstein doctor` group when
+  thresholds (>50 open code smells or any new vulnerability) are crossed.
+- PRs receive a sticky advisory comment summarising the project-level
+  numbers. The comment never blocks merge.
+
+## Configuration
+
+The doctor reads two env vars (identical to the CI contract):
+
+| Env var | Purpose | Example |
+|---|---|---|
+| `SONAR_HOST_URL` | Sonar server base URL | `https://sonar.bernstein.run` |
+| `SONAR_TOKEN` | User token with `Browse` permission on the project | (45 chars) |
+| `SONAR_PROJECT_KEY` | Optional. Defaults to `bernstein`. | `bernstein` |
+
+If either of the first two is missing, the doctor soft-fails with a
+one-line hint and exit code 0. No operator workflow is interrupted.
+
+## CLI
+
+```
+bernstein doctor sonar             # rich table view
+bernstein doctor sonar --json      # machine-readable snapshot
+bernstein doctor sonar --smell-threshold 100  # custom nudge threshold
+bernstein doctor sonar --no-update-baseline   # do not persist a new baseline
+```
+
+Output sections, default mode:
+
+- Headline measures: coverage, code smells (total), bugs, vulnerabilities,
+  security hotspots, cognitive complexity, ncloc.
+- Smells by severity: BLOCKER / CRITICAL / MAJOR / MINOR / INFO counts.
+- Cognitive complexity hotspots: top-5 files by `cognitive_complexity`.
+- Nudge panel: only shown when the snapshot crosses a threshold.
+
+JSON mode emits a single object with the same fields plus an
+embedded `nudge` block (`should_nudge`, `reasons`, `smell_threshold`).
+
+## Baseline file
+
+The last-seen counts are cached at:
+
+```
+$XDG_DATA_HOME/bernstein/sonar-baseline.json
+```
+
+(Defaulting to `~/.local/share/bernstein/sonar-baseline.json` when
+`XDG_DATA_HOME` is unset.)
+
+The file is written on every successful `bernstein doctor sonar` run
+unless `--no-update-baseline` is passed. Deleting the file resets the
+nudge so the next run records a fresh baseline instead of firing.
+
+## Periodic nudge
+
+When the operator runs the parent `bernstein doctor` (no subcommand)
+or `bernstein doctor --suggest-docs`, the group appends a single-line
+yellow hint when either of the following is true:
+
+- The current snapshot reports more than 50 open code smells.
+- The current snapshot reports more vulnerabilities than the baseline.
+
+The hint points back at `bernstein doctor sonar` for the full surface.
+The nudge is suppressed under `--json` so machine-readable output stays
+clean.
+
+## CI workflows
+
+Two workflows drive the integration:
+
+- `.github/workflows/sonar-scan.yml` runs after the main CI workflow
+  succeeds on `main`, downloads the coverage artifact, and pushes a
+  scan to the Sonar server. Triggered via `workflow_run`.
+- `.github/workflows/sonar-pr-comment.yml` runs on `pull_request`
+  (same-repo only; forks are skipped because they cannot access the
+  Sonar token). It posts a sticky comment summarising the current
+  project measures and never sets a failing check.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Sonar integration not configured` | Env vars unset | Export `SONAR_HOST_URL` / `SONAR_TOKEN`. |
+| `server unreachable or project not yet scanned` | Project key not yet present on the server | Wait for the next `sonar-scan` workflow run on `main`. |
+| `403` from `/api/measures/component` | Token lacks `Browse` permission | Regenerate the token with the right scope. |
+| Sticky PR comment missing on a fork PR | Forks cannot read repo secrets | Expected. The workflow opts out for fork PRs. |
+
+## Implementation map
+
+| Module | Purpose |
+|---|---|
+| `src/bernstein/core/observability/sonar.py` | API client, baseline I/O, nudge logic. |
+| `src/bernstein/cli/commands/doctor_sonar_cmd.py` | Click command + Rich renderer. |
+| `tests/unit/cli/doctor/test_sonar.py` | Coverage for the client, baseline, nudge, and CLI wiring. |
+| `.github/workflows/sonar-scan.yml` | Scan workflow (push to main). |
+| `.github/workflows/sonar-pr-comment.yml` | Sticky advisory PR comment. |

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -528,7 +528,7 @@ def plugins_cmd(workdir: str) -> None:
 @click.group(
     name="doctor",
     invoke_without_command=True,
-    subcommand_metavar="[airgap]",
+    subcommand_metavar="[airgap|sonar|...]",
 )
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 @click.option("--fix", "auto_fix", is_flag=True, default=False, help="Attempt to auto-fix issues.")
@@ -549,6 +549,7 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
       bernstein doctor --fix          # attempt to auto-fix issues
       bernstein doctor --suggest-docs # surface top curated documentation gaps
       bernstein doctor airgap         # battery of checks for an air-gapped run
+      bernstein doctor sonar          # surface SonarQube insights for the project
     """
     if ctx.invoked_subcommand is not None:
         ctx.obj = {"as_json": as_json, "auto_fix": auto_fix}
@@ -563,6 +564,7 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
 
         topics = load_unanswered_topics()
         render_suggestions(console, topics, limit=DEFAULT_TOP_N)
+        _maybe_print_sonar_nudge(as_json=as_json)
         return
 
     from bernstein.cli.doctor.suggest_docs import hint_line
@@ -579,9 +581,48 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
 
     if not as_json:
         console.print(f"[dim]{hint_line()}[/dim]")
+        _maybe_print_sonar_nudge(as_json=as_json)
 
     if exit_code:
         raise SystemExit(exit_code)
+
+
+def _maybe_print_sonar_nudge(*, as_json: bool) -> None:
+    """Print a single-line Sonar nudge when thresholds are crossed.
+
+    No-op when Sonar is not configured, the snapshot could not be
+    fetched, or when ``--json`` was requested (the nudge is advisory
+    and must not contaminate machine-readable output). All failures
+    here are swallowed so the doctor never crashes because of a side
+    integration.
+    """
+    if as_json:
+        return
+    try:
+        from bernstein.core.observability.sonar import (
+            collect_insights,
+            evaluate_nudge,
+            load_baseline,
+            load_config,
+        )
+    except Exception:  # pragma: no cover - defensive
+        return
+    config = load_config()
+    if config is None:
+        return
+    try:
+        insights = collect_insights(config)
+    except Exception:  # pragma: no cover - defensive
+        return
+    if not insights.fetched:
+        return
+    nudge = evaluate_nudge(insights, load_baseline())
+    if not nudge.should_nudge:
+        return
+    summary = "; ".join(nudge.reasons)
+    console.print(
+        f"[dim yellow]Sonar nudge: {summary}. Run `bernstein doctor sonar` for the full surface.[/dim yellow]"
+    )
 
 
 @doctor.command("airgap")
@@ -812,6 +853,66 @@ def doctor_promptware_scan_cmd(
             workdir=Path(workdir),
             threshold=threshold,
             as_json=as_json,
+        )
+    )
+
+
+@doctor.command("sonar")
+@click.option(
+    "--json",
+    "as_json_flag",
+    is_flag=True,
+    default=False,
+    help="Emit JSON instead of the Rich table.",
+)
+@click.option(
+    "--smell-threshold",
+    "smell_threshold",
+    type=int,
+    default=None,
+    help="Override the default code-smell nudge threshold (50).",
+)
+@click.option(
+    "--no-update-baseline",
+    "no_update_baseline",
+    is_flag=True,
+    default=False,
+    help="Do not write the current snapshot to the baseline file.",
+)
+@click.pass_context
+def doctor_sonar_cmd(
+    ctx: click.Context,
+    as_json_flag: bool,
+    smell_threshold: int | None,
+    no_update_baseline: bool,
+) -> None:
+    """Surface SonarQube insights for the current project.
+
+    \b
+    Reads SONAR_HOST_URL and SONAR_TOKEN from the environment, then
+    fetches:
+      - coverage % (line coverage as reported by Sonar)
+      - code smells total and counts by severity
+      - bugs, vulnerabilities, security hotspots
+      - cognitive complexity hotspots (top 5 files)
+
+    \b
+    Soft-fails (exit 0) when env vars are not set or the server is
+    unreachable. Use --json to pipe the snapshot into other tools.
+    """
+    from bernstein.cli.commands.doctor_sonar_cmd import (
+        DEFAULT_SMELL_NUDGE,
+        run_doctor_sonar,
+    )
+
+    parent = ctx.obj if isinstance(ctx.obj, dict) else {}
+    inherited_json = bool(parent.get("as_json", False))
+    threshold = smell_threshold if smell_threshold is not None else DEFAULT_SMELL_NUDGE
+    raise SystemExit(
+        run_doctor_sonar(
+            as_json=as_json_flag or inherited_json,
+            smell_threshold=threshold,
+            update_baseline=not no_update_baseline,
         )
     )
 

--- a/src/bernstein/cli/commands/doctor_sonar_cmd.py
+++ b/src/bernstein/cli/commands/doctor_sonar_cmd.py
@@ -1,0 +1,219 @@
+"""Renderer for ``bernstein doctor sonar``.
+
+Surfaces SonarQube measures in the operator's terminal so the daily
+flow includes coverage / smells / bugs / vulnerabilities / hotspots
+without a context switch to the Sonar UI. Pure CLI layer; the API
+client lives in :mod:`bernstein.core.observability.sonar`.
+
+Output modes:
+- Default: a Rich table with the headline numbers, severity row,
+  and top-5 cognitive-complexity hotspots.
+- ``--json``: machine-readable payload for piping into other tools.
+
+The command soft-fails (exit 0) when ``SONAR_HOST_URL`` /
+``SONAR_TOKEN`` are not set, so the doctor never breaks operator
+flow on machines that have not opted into the integration. A
+short doc pointer is printed in that case.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from rich.panel import Panel
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.observability.sonar import (
+    DEFAULT_SMELL_NUDGE,
+    DOC_POINTER,
+    NudgeSignal,
+    SonarInsights,
+    baseline_path,
+    collect_insights,
+    evaluate_nudge,
+    load_baseline,
+    load_config,
+    save_baseline,
+)
+
+_NOT_CONFIGURED_HINT = (
+    "[yellow]Sonar integration not configured.[/yellow]\n"
+    "Set [bold]SONAR_HOST_URL[/bold] and [bold]SONAR_TOKEN[/bold] to enable. "
+    f"See [dim]{DOC_POINTER}[/dim] for the setup walkthrough."
+)
+
+
+def _format_coverage(coverage: float | None) -> str:
+    if coverage is None:
+        return "n/a"
+    return f"{coverage:.1f}%"
+
+
+def _format_hotspot(path: str, max_width: int = 60) -> str:
+    """Truncate long file paths from the left so the basename stays visible."""
+    if len(path) <= max_width:
+        return path
+    return "..." + path[-(max_width - 3) :]
+
+
+def _render_human(
+    insights: SonarInsights,
+    nudge: NudgeSignal,
+    *,
+    smell_threshold: int,
+) -> None:
+    """Print the headline metrics + severity row + hotspots table."""
+    console.print()
+    if not insights.fetched:
+        console.print(
+            Panel(
+                f"[bold yellow]Sonar insights unavailable[/bold yellow]\n"
+                f"project: [cyan]{insights.project_key}[/cyan]\n"
+                f"note: {insights.note}",
+                border_style="yellow",
+                expand=False,
+            )
+        )
+        return
+
+    headline = Table(
+        title=f"Sonar insights: {insights.project_key}",
+        header_style="bold cyan",
+        show_lines=False,
+    )
+    headline.add_column("Metric")
+    headline.add_column("Value", justify="right")
+    headline.add_row("Coverage", _format_coverage(insights.coverage_pct))
+    headline.add_row("Code smells (total)", str(insights.code_smells_total))
+    headline.add_row("Bugs", str(insights.bugs))
+    headline.add_row("Vulnerabilities", str(insights.vulnerabilities))
+    headline.add_row("Security hotspots", str(insights.security_hotspots))
+    headline.add_row("Cognitive complexity", str(insights.cognitive_complexity))
+    headline.add_row("Lines of code (ncloc)", str(insights.ncloc))
+    console.print(headline)
+
+    sev = Table(
+        title="Smells by severity",
+        header_style="bold cyan",
+        show_lines=False,
+    )
+    sev.add_column("BLOCKER", justify="right")
+    sev.add_column("CRITICAL", justify="right")
+    sev.add_column("MAJOR", justify="right")
+    sev.add_column("MINOR", justify="right")
+    sev.add_column("INFO", justify="right")
+    by_sev = insights.smells_by_severity
+    sev.add_row(
+        str(by_sev.get("BLOCKER", 0)),
+        str(by_sev.get("CRITICAL", 0)),
+        str(by_sev.get("MAJOR", 0)),
+        str(by_sev.get("MINOR", 0)),
+        str(by_sev.get("INFO", 0)),
+    )
+    console.print(sev)
+
+    if insights.hotspots:
+        ht = Table(
+            title="Cognitive complexity hotspots (top 5)",
+            header_style="bold cyan",
+            show_lines=False,
+        )
+        ht.add_column("#", justify="right", no_wrap=True)
+        ht.add_column("File")
+        ht.add_column("Cognitive complexity", justify="right")
+        for idx, hotspot in enumerate(insights.hotspots, start=1):
+            ht.add_row(str(idx), _format_hotspot(hotspot.path), str(hotspot.cognitive_complexity))
+        console.print(ht)
+    else:
+        console.print("[dim]No cognitive complexity hotspots reported.[/dim]")
+
+    if nudge.should_nudge:
+        body = "\n".join(f"- {r}" for r in nudge.reasons)
+        console.print(
+            Panel(
+                f"[bold yellow]Sonar nudge[/bold yellow] (threshold: {smell_threshold} smells)\n{body}",
+                border_style="yellow",
+                expand=False,
+            )
+        )
+    console.print()
+
+
+def _render_json(
+    insights: SonarInsights,
+    nudge: NudgeSignal,
+    *,
+    smell_threshold: int,
+) -> None:
+    """Emit a single JSON object combining insights and the nudge signal."""
+    payload = {
+        "project_key": insights.project_key,
+        "fetched": insights.fetched,
+        "note": insights.note,
+        "coverage_pct": insights.coverage_pct,
+        "code_smells_total": insights.code_smells_total,
+        "smells_by_severity": dict(insights.smells_by_severity),
+        "bugs": insights.bugs,
+        "vulnerabilities": insights.vulnerabilities,
+        "security_hotspots": insights.security_hotspots,
+        "cognitive_complexity": insights.cognitive_complexity,
+        "ncloc": insights.ncloc,
+        "hotspots": [asdict(h) for h in insights.hotspots],
+        "nudge": {
+            "should_nudge": nudge.should_nudge,
+            "reasons": list(nudge.reasons),
+            "smell_threshold": smell_threshold,
+        },
+    }
+    console.print_json(json.dumps(payload))
+
+
+def run_doctor_sonar(
+    *,
+    as_json: bool = False,
+    smell_threshold: int = DEFAULT_SMELL_NUDGE,
+    update_baseline: bool = True,
+) -> int:
+    """Entry point used by both the CLI command and tests.
+
+    Returns ``0`` in every soft-fail path so the doctor surface
+    remains advisory. Returning a non-zero code is reserved for the
+    case where the CLI is invoked with a flag that explicitly
+    requests gate semantics (none yet - the renderer stays advisory
+    by design).
+    """
+    config = load_config()
+    if config is None:
+        if as_json:
+            console.print_json(
+                json.dumps(
+                    {
+                        "configured": False,
+                        "note": "SONAR_HOST_URL or SONAR_TOKEN not set",
+                        "doc": DOC_POINTER,
+                    }
+                )
+            )
+        else:
+            console.print(_NOT_CONFIGURED_HINT)
+        return 0
+    insights = collect_insights(config)
+    baseline = load_baseline()
+    nudge = evaluate_nudge(insights, baseline, smell_threshold=smell_threshold)
+    if as_json:
+        _render_json(insights, nudge, smell_threshold=smell_threshold)
+    else:
+        _render_human(insights, nudge, smell_threshold=smell_threshold)
+    if update_baseline and insights.fetched:
+        save_baseline(insights)
+    return 0
+
+
+__all__ = [
+    "DEFAULT_SMELL_NUDGE",
+    "DOC_POINTER",
+    "baseline_path",
+    "run_doctor_sonar",
+]

--- a/src/bernstein/core/observability/sonar.py
+++ b/src/bernstein/core/observability/sonar.py
@@ -1,0 +1,429 @@
+"""SonarQube insights client and baseline tracking for Bernstein.
+
+Surfaces SonarQube measures (coverage, code smells by severity, bugs,
+vulnerabilities, security hotspots, cognitive complexity hotspots) into
+the operator's terminal flow via ``bernstein doctor sonar``.
+
+Design notes
+------------
+- Network calls go through ``httpx`` with a short, explicit timeout so
+  the doctor never hangs an operator's terminal.
+- All inputs are validated and the module degrades to an empty
+  ``SonarInsights`` rather than raising when env vars are missing or
+  the server is unreachable. The doctor renders a "not configured"
+  hint in that case.
+- The baseline file lives under
+  ``~/.local/share/bernstein/sonar-baseline.json`` and stores the
+  last-seen counts plus a timestamp so the periodic nudge can compute
+  deltas without paging through Sonar history.
+
+Env vars (matching the CI contract):
+  - ``SONAR_HOST_URL``: e.g. ``https://sonar.bernstein.run``
+  - ``SONAR_TOKEN``: a user token with ``Browse`` permission on the project
+  - ``SONAR_PROJECT_KEY``: optional, defaults to ``bernstein``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_PROJECT_KEY = "bernstein"
+ENV_HOST = "SONAR_HOST_URL"
+ENV_TOKEN = "SONAR_TOKEN"
+ENV_PROJECT_KEY = "SONAR_PROJECT_KEY"
+
+# Metric keys we request from /api/measures/component. See
+# https://docs.sonarsource.com/sonarqube-server/latest/user-guide/metric-definitions/
+_METRIC_KEYS = (
+    "coverage",
+    "code_smells",
+    "bugs",
+    "vulnerabilities",
+    "security_hotspots",
+    "cognitive_complexity",
+    "ncloc",
+)
+
+_SEVERITIES = ("BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO")
+
+# Severity counts default to zero so callers can show a complete table
+# even when Sonar omits buckets with no issues.
+_SEVERITY_ZERO: dict[str, int] = dict.fromkeys(_SEVERITIES, 0)
+
+# Default soft-fail nudge thresholds. The CLI may override via flags;
+# this module only surfaces the raw values + deltas.
+DEFAULT_SMELL_NUDGE = 50
+
+DOC_POINTER = "docs/observability/sonar.md"
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class HotspotFile:
+    """One file in the cognitive-complexity hotspot ranking."""
+
+    path: str
+    cognitive_complexity: int
+
+
+@dataclass(frozen=True)
+class SonarInsights:
+    """Snapshot of Sonar measures for a single project at a single time."""
+
+    project_key: str
+    coverage_pct: float | None = None
+    code_smells_total: int = 0
+    smells_by_severity: dict[str, int] = field(default_factory=lambda: dict(_SEVERITY_ZERO))
+    bugs: int = 0
+    vulnerabilities: int = 0
+    security_hotspots: int = 0
+    cognitive_complexity: int = 0
+    ncloc: int = 0
+    hotspots: tuple[HotspotFile, ...] = field(default_factory=tuple)
+    fetched: bool = True
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class SonarConfig:
+    """Resolved configuration for talking to a Sonar server."""
+
+    host: str
+    token: str
+    project_key: str
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def load_config(env: dict[str, str] | None = None) -> SonarConfig | None:
+    """Return a :class:`SonarConfig` from env vars, or ``None`` when missing."""
+    src = env if env is not None else os.environ
+    host = (src.get(ENV_HOST) or "").strip()
+    token = (src.get(ENV_TOKEN) or "").strip()
+    if not host or not token:
+        return None
+    project_key = (src.get(ENV_PROJECT_KEY) or DEFAULT_PROJECT_KEY).strip() or DEFAULT_PROJECT_KEY
+    return SonarConfig(host=host.rstrip("/"), token=token, project_key=project_key)
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+def _auth(token: str) -> tuple[str, str]:
+    """Sonar uses HTTP basic with the token as username and empty password."""
+    return token, ""
+
+
+def _safe_int(value: Any) -> int:
+    """Coerce a Sonar metric value to int, returning ``0`` on parse failure."""
+    if value is None:
+        return 0
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_float(value: Any) -> float | None:
+    """Coerce a Sonar metric value to float, returning ``None`` on failure."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_measures(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any] | None:
+    """Fetch raw measures for the configured project."""
+    url = f"{config.host}/api/measures/component"
+    params = {
+        "component": config.project_key,
+        "metricKeys": ",".join(_METRIC_KEYS),
+    }
+    try:
+        if client is None:
+            with httpx.Client(timeout=timeout, auth=_auth(config.token)) as c:
+                resp = c.get(url, params=params)
+        else:
+            resp = client.get(url, params=params)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    component = payload.get("component")
+    if not isinstance(component, dict):
+        return None
+    measures = component.get("measures", [])
+    if not isinstance(measures, list):
+        return None
+    by_metric: dict[str, Any] = {}
+    for item in measures:
+        if not isinstance(item, dict):
+            continue
+        metric = item.get("metric")
+        if isinstance(metric, str):
+            by_metric[metric] = item.get("value")
+    return by_metric
+
+
+def fetch_smell_severities(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, int]:
+    """Return ``{severity: count}`` for open CODE_SMELL issues."""
+    url = f"{config.host}/api/issues/search"
+    params = {
+        "componentKeys": config.project_key,
+        "types": "CODE_SMELL",
+        "resolved": "false",
+        "facets": "severities",
+        "ps": "1",
+    }
+    out: dict[str, int] = dict(_SEVERITY_ZERO)
+    try:
+        if client is None:
+            with httpx.Client(timeout=timeout, auth=_auth(config.token)) as c:
+                resp = c.get(url, params=params)
+        else:
+            resp = client.get(url, params=params)
+    except httpx.HTTPError:
+        return out
+    if resp.status_code != 200:
+        return out
+    try:
+        payload = resp.json()
+    except ValueError:
+        return out
+    if not isinstance(payload, dict):
+        return out
+    facets = payload.get("facets", [])
+    if not isinstance(facets, list):
+        return out
+    for facet in facets:
+        if not isinstance(facet, dict) or facet.get("property") != "severities":
+            continue
+        values = facet.get("values", [])
+        if not isinstance(values, list):
+            continue
+        for entry in values:
+            if not isinstance(entry, dict):
+                continue
+            severity = entry.get("val")
+            count = entry.get("count")
+            if isinstance(severity, str) and severity in out:
+                out[severity] = _safe_int(count)
+    return out
+
+
+def fetch_complexity_hotspots(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+    top_n: int = 5,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> tuple[HotspotFile, ...]:
+    """Return the top-N files ranked by cognitive complexity."""
+    if top_n <= 0:
+        return ()
+    url = f"{config.host}/api/measures/component_tree"
+    params = {
+        "component": config.project_key,
+        "metricKeys": "cognitive_complexity",
+        "qualifiers": "FIL",
+        "s": "metric",
+        "metricSort": "cognitive_complexity",
+        "asc": "false",
+        "ps": str(top_n),
+    }
+    try:
+        if client is None:
+            with httpx.Client(timeout=timeout, auth=_auth(config.token)) as c:
+                resp = c.get(url, params=params)
+        else:
+            resp = client.get(url, params=params)
+    except httpx.HTTPError:
+        return ()
+    if resp.status_code != 200:
+        return ()
+    try:
+        payload = resp.json()
+    except ValueError:
+        return ()
+    if not isinstance(payload, dict):
+        return ()
+    components = payload.get("components", [])
+    if not isinstance(components, list):
+        return ()
+    out: list[HotspotFile] = []
+    for comp in components:
+        if not isinstance(comp, dict):
+            continue
+        path = comp.get("path") or comp.get("key")
+        if not isinstance(path, str):
+            continue
+        measures = comp.get("measures", [])
+        if not isinstance(measures, list):
+            continue
+        value: int = 0
+        for measure in measures:
+            if isinstance(measure, dict) and measure.get("metric") == "cognitive_complexity":
+                value = _safe_int(measure.get("value"))
+                break
+        out.append(HotspotFile(path=path, cognitive_complexity=value))
+    return tuple(out[:top_n])
+
+
+def collect_insights(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+    top_n_hotspots: int = 5,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> SonarInsights:
+    """Aggregate measures, severities, and hotspots into a single snapshot."""
+    measures = fetch_measures(config, client=client, timeout=timeout)
+    if measures is None:
+        return SonarInsights(
+            project_key=config.project_key,
+            fetched=False,
+            note="server unreachable or project not yet scanned",
+        )
+    severities = fetch_smell_severities(config, client=client, timeout=timeout)
+    hotspots = fetch_complexity_hotspots(
+        config,
+        client=client,
+        top_n=top_n_hotspots,
+        timeout=timeout,
+    )
+    return SonarInsights(
+        project_key=config.project_key,
+        coverage_pct=_safe_float(measures.get("coverage")),
+        code_smells_total=_safe_int(measures.get("code_smells")),
+        smells_by_severity=severities,
+        bugs=_safe_int(measures.get("bugs")),
+        vulnerabilities=_safe_int(measures.get("vulnerabilities")),
+        security_hotspots=_safe_int(measures.get("security_hotspots")),
+        cognitive_complexity=_safe_int(measures.get("cognitive_complexity")),
+        ncloc=_safe_int(measures.get("ncloc")),
+        hotspots=hotspots,
+        fetched=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Baseline tracking for the nudge
+# ---------------------------------------------------------------------------
+
+
+def _xdg_data_home() -> Path:
+    """Return the XDG_DATA_HOME path with the documented fallback."""
+    raw = os.environ.get("XDG_DATA_HOME", "").strip()
+    if raw:
+        return Path(raw)
+    return Path.home() / ".local" / "share"
+
+
+def baseline_path() -> Path:
+    """Resolved on-disk path for the baseline JSON."""
+    return _xdg_data_home() / "bernstein" / "sonar-baseline.json"
+
+
+def load_baseline(path: Path | None = None) -> dict[str, Any]:
+    """Read the last-seen baseline, returning ``{}`` on any error."""
+    target = path or baseline_path()
+    if not target.exists():
+        return {}
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
+
+
+def save_baseline(insights: SonarInsights, *, path: Path | None = None) -> None:
+    """Persist the current insights as the new baseline."""
+    target = path or baseline_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+    payload = {
+        "project_key": insights.project_key,
+        "coverage_pct": insights.coverage_pct,
+        "code_smells_total": insights.code_smells_total,
+        "smells_by_severity": dict(insights.smells_by_severity),
+        "bugs": insights.bugs,
+        "vulnerabilities": insights.vulnerabilities,
+        "security_hotspots": insights.security_hotspots,
+        "cognitive_complexity": insights.cognitive_complexity,
+        "ncloc": insights.ncloc,
+        "hotspots": [asdict(h) for h in insights.hotspots],
+    }
+    try:
+        target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError:
+        return
+
+
+@dataclass(frozen=True)
+class NudgeSignal:
+    """Operator-visible nudge derived from a snapshot + baseline."""
+
+    should_nudge: bool
+    reasons: tuple[str, ...]
+
+
+def evaluate_nudge(
+    insights: SonarInsights,
+    baseline: dict[str, Any],
+    *,
+    smell_threshold: int = DEFAULT_SMELL_NUDGE,
+) -> NudgeSignal:
+    """Decide whether to surface a nudge to the operator."""
+    if not insights.fetched:
+        return NudgeSignal(should_nudge=False, reasons=())
+    reasons: list[str] = []
+    if insights.code_smells_total > smell_threshold:
+        reasons.append(f"{insights.code_smells_total} code smells (threshold {smell_threshold})")
+    prev_vulns_raw = baseline.get("vulnerabilities")
+    prev_vulns = _safe_int(prev_vulns_raw) if prev_vulns_raw is not None else None
+    if prev_vulns is not None and insights.vulnerabilities > prev_vulns:
+        delta = insights.vulnerabilities - prev_vulns
+        reasons.append(f"{delta} new vulnerability(ies) since last check")
+    return NudgeSignal(should_nudge=bool(reasons), reasons=tuple(reasons))

--- a/tests/unit/cli/doctor/test_sonar.py
+++ b/tests/unit/cli/doctor/test_sonar.py
@@ -1,0 +1,443 @@
+"""Tests for the Sonar insights surface and ``bernstein doctor sonar``.
+
+Covers the API client adapters, baseline persistence, nudge logic,
+soft-fail behaviour when env vars are missing, and the Click wiring.
+Every HTTP interaction is patched with a tiny stub transport so the
+suite stays hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import doctor as doctor_group
+from bernstein.cli.commands.doctor_sonar_cmd import run_doctor_sonar
+from bernstein.core.observability.sonar import (
+    DEFAULT_PROJECT_KEY,
+    DEFAULT_SMELL_NUDGE,
+    ENV_HOST,
+    ENV_PROJECT_KEY,
+    ENV_TOKEN,
+    HotspotFile,
+    SonarConfig,
+    SonarInsights,
+    baseline_path,
+    collect_insights,
+    evaluate_nudge,
+    fetch_complexity_hotspots,
+    fetch_measures,
+    fetch_smell_severities,
+    load_baseline,
+    load_config,
+    save_baseline,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+_CFG = SonarConfig(host="https://sonar.example.test", token="t0k", project_key="bernstein")
+
+
+def _client(handler: Any) -> httpx.Client:
+    """Build an ``httpx.Client`` whose requests are served by ``handler``."""
+    return httpx.Client(transport=httpx.MockTransport(handler), auth=("t0k", ""))
+
+
+def _measures_response(values: dict[str, str]) -> dict[str, Any]:
+    return {
+        "component": {
+            "key": "bernstein",
+            "measures": [{"metric": k, "value": v} for k, v in values.items()],
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_returns_none_when_env_missing() -> None:
+    """No host or token -> None so the doctor can soft-fail."""
+    assert load_config({}) is None
+    assert load_config({ENV_HOST: "https://x"}) is None
+    assert load_config({ENV_TOKEN: "abc"}) is None
+
+
+def test_load_config_uses_env_defaults() -> None:
+    cfg = load_config({ENV_HOST: "https://sonar.example.test/", ENV_TOKEN: "tok"})
+    assert cfg is not None
+    assert cfg.host == "https://sonar.example.test"
+    assert cfg.project_key == DEFAULT_PROJECT_KEY
+
+
+def test_load_config_respects_project_key_override() -> None:
+    cfg = load_config(
+        {
+            ENV_HOST: "https://sonar.example.test",
+            ENV_TOKEN: "tok",
+            ENV_PROJECT_KEY: "my-project",
+        }
+    )
+    assert cfg is not None
+    assert cfg.project_key == "my-project"
+
+
+# ---------------------------------------------------------------------------
+# fetch_measures
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_measures_returns_metric_map() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/measures/component"
+        return httpx.Response(200, json=_measures_response({"coverage": "87.5", "bugs": "3"}))
+
+    with _client(handler) as client:
+        result = fetch_measures(_CFG, client=client)
+    assert result == {"coverage": "87.5", "bugs": "3"}
+
+
+def test_fetch_measures_returns_none_on_404() -> None:
+    with _client(lambda _r: httpx.Response(404, json={"errors": []})) as client:
+        assert fetch_measures(_CFG, client=client) is None
+
+
+def test_fetch_measures_returns_none_on_network_error() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    with _client(handler) as client:
+        assert fetch_measures(_CFG, client=client) is None
+
+
+def test_fetch_measures_returns_none_on_bad_json_shape() -> None:
+    with _client(lambda _r: httpx.Response(200, json={"hello": "world"})) as client:
+        assert fetch_measures(_CFG, client=client) is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_smell_severities
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_smell_severities_zero_fills_missing_buckets() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "facets": [
+                    {
+                        "property": "severities",
+                        "values": [
+                            {"val": "MAJOR", "count": 12},
+                            {"val": "CRITICAL", "count": 2},
+                        ],
+                    }
+                ]
+            },
+        )
+
+    with _client(handler) as client:
+        counts = fetch_smell_severities(_CFG, client=client)
+    assert counts == {
+        "BLOCKER": 0,
+        "CRITICAL": 2,
+        "MAJOR": 12,
+        "MINOR": 0,
+        "INFO": 0,
+    }
+
+
+def test_fetch_smell_severities_returns_zeros_on_failure() -> None:
+    with _client(lambda _r: httpx.Response(500, text="server error")) as client:
+        counts = fetch_smell_severities(_CFG, client=client)
+    assert all(v == 0 for v in counts.values())
+
+
+# ---------------------------------------------------------------------------
+# fetch_complexity_hotspots
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_complexity_hotspots_extracts_top_n_in_order() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "components": [
+                    {
+                        "path": "src/bernstein/orchestrator.py",
+                        "measures": [{"metric": "cognitive_complexity", "value": "240"}],
+                    },
+                    {
+                        "path": "src/bernstein/cli/main.py",
+                        "measures": [{"metric": "cognitive_complexity", "value": "180"}],
+                    },
+                ]
+            },
+        )
+
+    with _client(handler) as client:
+        hotspots = fetch_complexity_hotspots(_CFG, client=client, top_n=5)
+    assert hotspots == (
+        HotspotFile(path="src/bernstein/orchestrator.py", cognitive_complexity=240),
+        HotspotFile(path="src/bernstein/cli/main.py", cognitive_complexity=180),
+    )
+
+
+def test_fetch_complexity_hotspots_returns_empty_on_failure() -> None:
+    with _client(lambda _r: httpx.Response(500)) as client:
+        assert fetch_complexity_hotspots(_CFG, client=client) == ()
+
+
+def test_fetch_complexity_hotspots_returns_empty_when_top_n_non_positive() -> None:
+    with _client(lambda _r: httpx.Response(200, json={"components": []})) as client:
+        assert fetch_complexity_hotspots(_CFG, client=client, top_n=0) == ()
+
+
+# ---------------------------------------------------------------------------
+# collect_insights
+# ---------------------------------------------------------------------------
+
+
+def test_collect_insights_merges_three_calls() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/measures/component":
+            return httpx.Response(
+                200,
+                json=_measures_response(
+                    {
+                        "coverage": "82.4",
+                        "code_smells": "73",
+                        "bugs": "1",
+                        "vulnerabilities": "0",
+                        "security_hotspots": "4",
+                        "cognitive_complexity": "1234",
+                        "ncloc": "98765",
+                    }
+                ),
+            )
+        if request.url.path == "/api/issues/search":
+            return httpx.Response(
+                200,
+                json={
+                    "facets": [
+                        {
+                            "property": "severities",
+                            "values": [{"val": "MAJOR", "count": 50}, {"val": "MINOR", "count": 23}],
+                        }
+                    ]
+                },
+            )
+        if request.url.path == "/api/measures/component_tree":
+            return httpx.Response(
+                200,
+                json={
+                    "components": [
+                        {
+                            "path": "src/bernstein/foo.py",
+                            "measures": [{"metric": "cognitive_complexity", "value": "99"}],
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(404)
+
+    with _client(handler) as client:
+        insights = collect_insights(_CFG, client=client, top_n_hotspots=5)
+    assert insights.fetched is True
+    assert insights.coverage_pct == pytest.approx(82.4)
+    assert insights.code_smells_total == 73
+    assert insights.bugs == 1
+    assert insights.vulnerabilities == 0
+    assert insights.security_hotspots == 4
+    assert insights.cognitive_complexity == 1234
+    assert insights.ncloc == 98765
+    assert insights.smells_by_severity["MAJOR"] == 50
+    assert insights.smells_by_severity["MINOR"] == 23
+    assert insights.hotspots == (HotspotFile(path="src/bernstein/foo.py", cognitive_complexity=99),)
+
+
+def test_collect_insights_returns_unfetched_on_measures_failure() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    with _client(handler) as client:
+        insights = collect_insights(_CFG, client=client)
+    assert insights.fetched is False
+    assert insights.note
+
+
+# ---------------------------------------------------------------------------
+# baseline persistence
+# ---------------------------------------------------------------------------
+
+
+def _sample_insights(**overrides: Any) -> SonarInsights:
+    base = SonarInsights(
+        project_key="bernstein",
+        coverage_pct=80.0,
+        code_smells_total=10,
+        smells_by_severity={"BLOCKER": 0, "CRITICAL": 1, "MAJOR": 5, "MINOR": 4, "INFO": 0},
+        bugs=2,
+        vulnerabilities=0,
+        security_hotspots=1,
+        cognitive_complexity=100,
+        ncloc=1000,
+        hotspots=(HotspotFile(path="x.py", cognitive_complexity=50),),
+        fetched=True,
+    )
+    if not overrides:
+        return base
+    data: dict[str, Any] = {
+        "project_key": base.project_key,
+        "coverage_pct": base.coverage_pct,
+        "code_smells_total": base.code_smells_total,
+        "smells_by_severity": base.smells_by_severity,
+        "bugs": base.bugs,
+        "vulnerabilities": base.vulnerabilities,
+        "security_hotspots": base.security_hotspots,
+        "cognitive_complexity": base.cognitive_complexity,
+        "ncloc": base.ncloc,
+        "hotspots": base.hotspots,
+        "fetched": base.fetched,
+    }
+    data.update(overrides)
+    return SonarInsights(**data)
+
+
+def test_save_and_load_baseline_roundtrips(tmp_path: Path) -> None:
+    target = tmp_path / "baseline.json"
+    insights = _sample_insights(vulnerabilities=3)
+    save_baseline(insights, path=target)
+    loaded = load_baseline(target)
+    assert loaded["vulnerabilities"] == 3
+    assert loaded["smells_by_severity"]["MAJOR"] == 5
+    assert loaded["hotspots"][0]["path"] == "x.py"
+
+
+def test_load_baseline_returns_empty_when_missing(tmp_path: Path) -> None:
+    assert load_baseline(tmp_path / "absent.json") == {}
+
+
+def test_load_baseline_returns_empty_on_malformed(tmp_path: Path) -> None:
+    target = tmp_path / "broken.json"
+    target.write_text("not json ::", encoding="utf-8")
+    assert load_baseline(target) == {}
+
+
+def test_baseline_path_honours_xdg_data_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    resolved = baseline_path()
+    assert resolved == tmp_path / "bernstein" / "sonar-baseline.json"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_nudge
+# ---------------------------------------------------------------------------
+
+
+def test_nudge_quiet_when_unfetched() -> None:
+    nudge = evaluate_nudge(SonarInsights(project_key="bernstein", fetched=False), baseline={})
+    assert nudge.should_nudge is False
+
+
+def test_nudge_fires_on_smell_threshold() -> None:
+    insights = _sample_insights(code_smells_total=DEFAULT_SMELL_NUDGE + 1)
+    nudge = evaluate_nudge(insights, baseline={})
+    assert nudge.should_nudge is True
+    assert any("code smells" in r for r in nudge.reasons)
+
+
+def test_nudge_fires_on_new_vulnerability() -> None:
+    insights = _sample_insights(vulnerabilities=2)
+    nudge = evaluate_nudge(insights, baseline={"vulnerabilities": 1})
+    assert nudge.should_nudge is True
+    assert any("new vulnerability" in r for r in nudge.reasons)
+
+
+def test_nudge_quiet_when_vulns_stable() -> None:
+    insights = _sample_insights(vulnerabilities=1)
+    nudge = evaluate_nudge(insights, baseline={"vulnerabilities": 1})
+    assert nudge.should_nudge is False
+
+
+def test_nudge_threshold_is_override_aware() -> None:
+    insights = _sample_insights(code_smells_total=10)
+    quiet = evaluate_nudge(insights, baseline={}, smell_threshold=20)
+    loud = evaluate_nudge(insights, baseline={}, smell_threshold=5)
+    assert quiet.should_nudge is False
+    assert loud.should_nudge is True
+
+
+# ---------------------------------------------------------------------------
+# run_doctor_sonar entry point
+# ---------------------------------------------------------------------------
+
+
+def test_run_doctor_sonar_soft_fails_without_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ENV_HOST, raising=False)
+    monkeypatch.delenv(ENV_TOKEN, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    assert run_doctor_sonar() == 0
+
+
+def test_run_doctor_sonar_json_payload_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv(ENV_HOST, raising=False)
+    monkeypatch.delenv(ENV_TOKEN, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    rc = run_doctor_sonar(as_json=True)
+    assert rc == 0
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert payload["configured"] is False
+    assert "SONAR_HOST_URL" in payload["note"]
+
+
+# ---------------------------------------------------------------------------
+# Click wiring
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_group_exposes_sonar_subcommand() -> None:
+    assert "sonar" in doctor_group.commands
+
+
+def test_cli_sonar_soft_fail_does_not_crash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ENV_HOST, raising=False)
+    monkeypatch.delenv(ENV_TOKEN, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["sonar"])
+    assert result.exit_code == 0
+    assert "not configured" in result.output
+
+
+def test_cli_sonar_json_flag_emits_json(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ENV_HOST, raising=False)
+    monkeypatch.delenv(ENV_TOKEN, raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["sonar", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["configured"] is False


### PR DESCRIPTION
## Summary

- Add `bernstein doctor sonar` subcommand: pulls SonarQube measures (coverage, smells by severity, bugs, vulnerabilities, hotspots, complexity hotspots) into the operator terminal flow.
- Soft-fail when `SONAR_HOST_URL` / `SONAR_TOKEN` are not set (or the project has not yet been scanned); print a one-line doc pointer.
- Add a baseline file at `$XDG_DATA_HOME/bernstein/sonar-baseline.json` and a periodic nudge from the parent `bernstein doctor` group when open smells exceed the threshold (default 50) or vulnerabilities regress against the baseline.
- Add `.github/workflows/sonar-pr-comment.yml`: a sticky, advisory PR comment summarising the current project measures. Soft signal only; never blocks merge. Skipped on fork PRs.
- Document the integration in `docs/observability/sonar.md`.

Pairs with PR #1645 (sonar-scan workflow rewrite) so once the next scan on `main` populates the project, this surface lights up end-to-end against `https://sonar.bernstein.run`.

## Test plan

- [ ] `uv run pytest tests/unit/cli/doctor/test_sonar.py` (28 hermetic tests, httpx MockTransport).
- [ ] `bernstein doctor sonar` with env vars unset: prints "not configured" hint, exit 0.
- [ ] `bernstein doctor sonar` with env vars set but project unscanned: prints "server unreachable or project not yet scanned" panel, exit 0.
- [ ] `bernstein doctor sonar --json` with env vars unset: emits `{"configured": false, ...}`, exit 0.
- [ ] After Sonar populates the project, rerun and confirm coverage / smells / hotspots render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `bernstein doctor sonar` subcommand to view code quality metrics including coverage, code smells, bugs, vulnerabilities, and complexity hotspots with JSON output support.
  * Automated GitHub Actions workflow now posts SonarQube insights as sticky PR comments (non-blocking).

* **Documentation**
  * Added comprehensive documentation for SonarQube integration, configuration, and usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->