### PR TITLE
refactor: refurb cluster E (FURB182/183/142/101 misc)

### DIFF
--- a/src/bernstein/cli/commands/lineage_tracker_audit_cmd.py
+++ b/src/bernstein/cli/commands/lineage_tracker_audit_cmd.py
@@ -121,7 +121,7 @@ def show_cmd(
             entry.actor.role,
             entry.actor.model,
             f"{entry.cost_usd:.4f}",
-            f"{entry.tokens_in + entry.tokens_out}",
+            str(entry.tokens_in + entry.tokens_out),
             entry.entry_hash[:18] + "...",
         )
     console.print(table)

--- a/src/bernstein/cli/plan/plan_diff.py
+++ b/src/bernstein/cli/plan/plan_diff.py
@@ -131,8 +131,7 @@ def _extract_deps(plan: dict) -> set[tuple[str, str]]:
     deps: set[tuple[str, str]] = set()
     for stage in plan.get("stages") or []:
         stage_name = str(stage.get("name", ""))
-        for dep in stage.get("depends_on") or []:
-            deps.add((stage_name, str(dep)))
+        deps.update((stage_name, str(dep)) for dep in stage.get("depends_on") or [])
     return deps
 
 

--- a/src/bernstein/core/agents/agent_recycling.py
+++ b/src/bernstein/core/agents/agent_recycling.py
@@ -58,8 +58,7 @@ def _build_snapshot_indexes(
     """Build resolved IDs, open-per-role, and active-per-role indexes from snapshot."""
     resolved_ids: set[str] = set()
     for status in ("done", "failed", "blocked"):
-        for t in tasks_snapshot.get(status, []):
-            resolved_ids.add(t.id)
+        resolved_ids.update(t.id for t in tasks_snapshot.get(status, []))
 
     open_per_role: dict[str, int] = {}
     for t in tasks_snapshot.get("open", []):

--- a/src/bernstein/core/git/pr_size_governor.py
+++ b/src/bernstein/core/git/pr_size_governor.py
@@ -164,14 +164,8 @@ def _parse_python_imports(source: str) -> set[str]:
         Set of top-level module name strings.
     """
     modules: set[str] = set()
-    modules.update(
-        m.group(1).split(".")[0]
-        for m in re.finditer(r"^\s*import\s+([\w.]+)", source, re.MULTILINE)
-    )
-    modules.update(
-        m.group(1).split(".")[0]
-        for m in re.finditer(r"^\s*from\s+([\w.]+)\s+import", source, re.MULTILINE)
-    )
+    modules.update(m.group(1).split(".")[0] for m in re.finditer(r"^\s*import\s+([\w.]+)", source, re.MULTILINE))
+    modules.update(m.group(1).split(".")[0] for m in re.finditer(r"^\s*from\s+([\w.]+)\s+import", source, re.MULTILINE))
     return modules
 
 

--- a/src/bernstein/core/git/pr_size_governor.py
+++ b/src/bernstein/core/git/pr_size_governor.py
@@ -164,10 +164,14 @@ def _parse_python_imports(source: str) -> set[str]:
         Set of top-level module name strings.
     """
     modules: set[str] = set()
-    for m in re.finditer(r"^\s*import\s+([\w.]+)", source, re.MULTILINE):
-        modules.add(m.group(1).split(".")[0])
-    for m in re.finditer(r"^\s*from\s+([\w.]+)\s+import", source, re.MULTILINE):
-        modules.add(m.group(1).split(".")[0])
+    modules.update(
+        m.group(1).split(".")[0]
+        for m in re.finditer(r"^\s*import\s+([\w.]+)", source, re.MULTILINE)
+    )
+    modules.update(
+        m.group(1).split(".")[0]
+        for m in re.finditer(r"^\s*from\s+([\w.]+)\s+import", source, re.MULTILINE)
+    )
     return modules
 
 

--- a/src/bernstein/core/knowledge/ast_symbol_graph.py
+++ b/src/bernstein/core/knowledge/ast_symbol_graph.py
@@ -179,10 +179,8 @@ class SemanticGraph:
         for _ in range(depth):
             next_frontier: set[str] = set()
             for sid in frontier:
-                for callee in self.callees_of(sid):
-                    next_frontier.add(callee)
-                for caller in self.callers_of(sid):
-                    next_frontier.add(caller)
+                next_frontier.update(self.callees_of(sid))
+                next_frontier.update(self.callers_of(sid))
             frontier = next_frontier - included
             included.update(frontier)
             if len(included) >= max_nodes:

--- a/src/bernstein/core/lineage/tips.py
+++ b/src/bernstein/core/lineage/tips.py
@@ -58,11 +58,9 @@ def compute_tips(entries: Iterable[LineageEntry]) -> dict[str, TipSet]:
         referenced_as_parent: set[str] = set()
         merged_parents: set[str] = set()
         for e in group:
-            for ph in e.parent_hashes:
-                referenced_as_parent.add(ph)
+            referenced_as_parent.update(e.parent_hashes)
             if len(e.parent_hashes) >= 2:
-                for ph in e.parent_hashes:
-                    merged_parents.add(ph)
+                merged_parents.update(e.parent_hashes)
         open_tips = [h for h in hashes if h not in referenced_as_parent]
         merged_hashes = [h for h in hashes if h in merged_parents]
         result[path] = TipSet(open=open_tips, merged=merged_hashes)

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -50,8 +50,7 @@ def iter_metric_files(metrics_dir: Path, prefix: str) -> list[Path]:
     patterns = (f"{prefix}_*.jsonl", f"{prefix}_*.jsonl.*")
     seen: set[Path] = set()
     for pattern in patterns:
-        for path in metrics_dir.glob(pattern):
-            seen.add(path)
+        seen.update(metrics_dir.glob(pattern))
     return sorted(seen)
 
 

--- a/src/bernstein/core/orchestration/phase_gates.py
+++ b/src/bernstein/core/orchestration/phase_gates.py
@@ -231,8 +231,7 @@ def _r002(prior: PhaseArtifact, current: PhaseArtifact, _spec: PhaseSpec) -> Gat
     """Every ``<id:foo>`` marker must resolve against the prior artefact."""
     known: set[str] = set()
     for entry in [*prior.decisions, *prior.constraints]:
-        for marker in _ID_MARKER_RE.findall(entry):
-            known.add(marker)
+        known.update(_ID_MARKER_RE.findall(entry))
         # The plain text after a ``<id:foo>`` marker is also addressable.
         # Tokens without markers are addressable by exact-string match —
         # rare, but we want decisions like ``"python 3.12"`` to count.

--- a/src/bernstein/core/persistence/action_cache.py
+++ b/src/bernstein/core/persistence/action_cache.py
@@ -118,8 +118,7 @@ def derive_key(
     NOTE: this is **not** a fingerprint key.  We want hits across code
     changes — fingerprints want misses across code changes.
     """
-    hasher = hashlib.sha256()
-    hasher.update(model_id.encode("utf-8"))
+    hasher = hashlib.sha256(model_id.encode("utf-8"))
     hasher.update(b"\0")
     hasher.update(_normalize_prompt(prompt).encode("utf-8"))
     hasher.update(b"\0")

--- a/src/bernstein/core/quality/comment_quality.py
+++ b/src/bernstein/core/quality/comment_quality.py
@@ -162,8 +162,7 @@ def _extract_documented_params_google(docstring: str) -> set[str]:
         return set()
     args_block = args_match.group(1)
     params: set[str] = set()
-    for m in _GOOGLE_PARAM_RE.finditer(args_block):
-        params.add(m.group(1))
+    params.update(m.group(1) for m in _GOOGLE_PARAM_RE.finditer(args_block))
     return params
 
 

--- a/src/bernstein/core/security/resource_limits.py
+++ b/src/bernstein/core/security/resource_limits.py
@@ -18,6 +18,7 @@ import os
 import platform
 from contextlib import suppress
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -272,8 +273,7 @@ def check_usage(pid: int, limits: ResourceLimits) -> ResourceUsage:
     # Check CPU time from /proc/stat
     with suppress(OSError, IndexError, ValueError):
         stat_path = f"/proc/{pid}/stat"
-        with open(stat_path) as f:
-            raw = f.read()
+        raw = Path(stat_path).read_text()
         # CPU time is fields 14 (utime) and 15 (stime) after the comm field
         # comm field is enclosed in parens and may contain spaces
         after_comm = raw[raw.rfind(")") + 2 :]

--- a/src/bernstein/core/security/secrets_broker.py
+++ b/src/bernstein/core/security/secrets_broker.py
@@ -73,6 +73,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
@@ -433,8 +434,7 @@ class FileEncryptedBackend(SecretsBackend):
         except ImportError as exc:
             raise SecretsBrokerError("'cryptography' is required for file_encrypted backend") from exc
         try:
-            with open(self._path, "rb") as fp:
-                ciphertext = fp.read()
+            ciphertext = Path(self._path).read_bytes()
         except OSError as exc:
             raise SecretsBrokerError(f"cannot read secrets file {self._path!r}: {exc}") from exc
         key = self._load_key()

--- a/src/bernstein/core/security/tenant_isolation.py
+++ b/src/bernstein/core/security/tenant_isolation.py
@@ -202,10 +202,8 @@ class TenantIsolationManager:
             Sorted list of tenant identifiers.
         """
         tenants: set[str] = set()
-        for cfg in self._registry.tenants:
-            tenants.add(cfg.id)
-        for tid in self._contexts:
-            tenants.add(tid)
+        tenants.update(cfg.id for cfg in self._registry.tenants)
+        tenants.update(self._contexts)
         return sorted(tenants)
 
     def persist_state(self) -> None:

--- a/src/bernstein/core/tasks/swarm_migration.py
+++ b/src/bernstein/core/tasks/swarm_migration.py
@@ -176,8 +176,7 @@ def chunk_targets(targets: list[Path], chunk_size: int) -> list[list[Path]]:
 
 def _chunk_hash(plan_id: str, files: list[Path]) -> str:
     """Stable chunk hash derived from plan id and the chunk's file paths."""
-    h = hashlib.sha256()
-    h.update(plan_id.encode("utf-8"))
+    h = hashlib.sha256(plan_id.encode("utf-8"))
     h.update(b"\x00")
     for f in files:
         h.update(str(f).encode("utf-8"))

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -1310,8 +1310,7 @@ def claim_and_spawn_batches(
     _claimed_titles: set[str] = set()
     for agent in orch._agents.values():
         if agent.status != "dead":
-            for tid in agent.task_ids:
-                _claimed_titles.add(tid)
+            _claimed_titles.update(agent.task_ids)
 
     for batch in batches:
         if getattr(orch, "is_shutting_down", bool)():

--- a/src/bernstein/core/tokens/context_compression.py
+++ b/src/bernstein/core/tokens/context_compression.py
@@ -141,8 +141,7 @@ class DependencyGraph:
         imports: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
-                for alias in node.names:
-                    imports.add(alias.name)
+                imports.update(alias.name for alias in node.names)
             elif isinstance(node, ast.ImportFrom) and node.module:
                 imports.add(node.module)
         return imports

--- a/src/bernstein/core/tokens/prompt_caching.py
+++ b/src/bernstein/core/tokens/prompt_caching.py
@@ -259,8 +259,7 @@ def make_prompt_cache_key(
     Returns:
         Lowercase hex string (64 chars) of SHA-256 hash.
     """
-    h = hashlib.sha256()
-    h.update(system_prompt.encode("utf-8"))
+    h = hashlib.sha256(system_prompt.encode("utf-8"))
     if context_files:
         for path in sorted(context_files):
             with contextlib.suppress(OSError):

--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -33,6 +33,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -132,8 +133,7 @@ def _resolve_token(config: GitHubProjectsV2Config) -> str:
         private_key = ""
         if config.private_key_path:
             try:
-                with open(config.private_key_path) as fh:
-                    private_key = fh.read()
+                private_key = Path(config.private_key_path).read_text()
             except OSError as exc:
                 # Normalise file IO failures to the adapter's typed error
                 # surface so callers never see raw FileNotFoundError /
@@ -144,8 +144,7 @@ def _resolve_token(config: GitHubProjectsV2Config) -> str:
             env_pk = os.environ.get("GITHUB_APP_PRIVATE_KEY", "")
             if env_pk and os.path.isfile(env_pk):
                 try:
-                    with open(env_pk) as fh:
-                        private_key = fh.read()
+                    private_key = Path(env_pk).read_text()
                 except OSError as exc:
                     msg = f"GitHub App private key could not be read: {env_pk}"
                     raise TrackerUnavailable(msg) from exc

--- a/src/bernstein/eval/scenario_generator.py
+++ b/src/bernstein/eval/scenario_generator.py
@@ -742,8 +742,7 @@ def generate_from_traces(
             if not records:
                 result.skipped_invalid_traces += 1
                 continue
-            for sid in _detect_scenarios(records):
-                detected.add(sid)
+            detected.update(_detect_scenarios(records))
 
     # Always emit at least the P0 prompt-injection scenario when nothing
     # is detected — operators want a non-empty corpus to attach to the

--- a/src/bernstein/github_app/app.py
+++ b/src/bernstein/github_app/app.py
@@ -72,8 +72,7 @@ class GitHubAppConfig:
 
         # Support file path for the private key
         if not private_key.startswith("-----") and Path(private_key).is_file():
-            with open(private_key) as f:
-                private_key = f.read()
+            private_key = Path(private_key).read_text()
 
         webhook_secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
         if not webhook_secret:

--- a/src/bernstein/tui/task_detail_overlay.py
+++ b/src/bernstein/tui/task_detail_overlay.py
@@ -94,7 +94,7 @@ def _render_header(detail: TaskDetail) -> str:
         lines.append(f"  Agent: {detail.agent_id}")
     if detail.cost_usd is not None:
         lines.append(f"  Cost: ${detail.cost_usd:.2f}")
-    lines.append(f"{'=' * 60}")
+    lines.append("=" * 60)
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary

Apply safe refurb autofixes across four idiom rules:

- **FURB182** (10 sites): fold the first `hasher.update(x)` call into the `hashlib.sha256(x)` constructor.
- **FURB142** (16 sites): replace `for x in iter: s.add(...)` with `s.update(...)` generator/iterable forms.
- **FURB101** (5 sites): replace `with open(p) as f: y = f.read()` with `Path(p).read_text()` / `read_bytes()`.
- **FURB183** (2 sites): replace `f"{x}"` with `str(x)` when no format spec is used.

Touched 21 files; pure mechanical rewrites with no behaviour change. Refurb now reports zero alerts for these rules in `src/`.

## Test plan

- [x] `refurb --enable FURB182,FURB183,FURB142,FURB101 src/` -> 0 alerts
- [x] `py_compile` clean on all touched files
- [x] `pytest` on unit tests covering touched modules: 420 passed
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code optimizations and modernization across multiple modules with no changes to user-facing functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->