### PR TITLE
refactor: refurb cluster B (FURB109/108/126 control flow)

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -465,7 +465,7 @@ uv run pytest tests/unit -x -q
 exit 0
 """
 
-    for hook_name, script in [("pre-commit", pre_commit_script), ("pre-push", pre_push_script)]:
+    for hook_name, script in (("pre-commit", pre_commit_script), ("pre-push", pre_push_script)):
         hook_path = hooks_dir / hook_name
         if hook_path.exists() and not force:
             console.print(f"[dim]Hook exists (use --force to overwrite):[/dim] {hook_path}")

--- a/src/bernstein/cli/commands/changelog_cmd.py
+++ b/src/bernstein/cli/commands/changelog_cmd.py
@@ -220,7 +220,7 @@ def _format_simple(
     lines: list[str] = [f"## {version}"]
     lines.append("")
 
-    for ctype in ["feat", "fix", "perf", "refactor", "docs", "build", "ci", "chore", "test", "style", "revert"]:
+    for ctype in ("feat", "fix", "perf", "refactor", "docs", "build", "ci", "chore", "test", "style", "revert"):
         type_entries = grouped.get(ctype, [])
         if not type_entries:
             continue

--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -301,7 +301,7 @@ def _compute_downgrade_tip(records: list[dict[str, Any]]) -> tuple[str, float] |
             opus_simple += 1
             opus_simple_cost += float(rec.get("cost_usd", 0.0) or 0.0)
 
-    if opus_total == 0 or opus_simple == 0:
+    if 0 in (opus_total, opus_simple):
         return None
 
     # Sonnet is roughly 60% of opus cost

--- a/src/bernstein/cli/commands/diff_cmd.py
+++ b/src/bernstein/cli/commands/diff_cmd.py
@@ -69,7 +69,7 @@ def _get_numstat(args: list[str], cwd: Path) -> list[FileDiffStat]:
                         path=parts[2],
                         additions=add,
                         deletions=dele,
-                        is_binary=parts[0] == "-" or parts[1] == "-",
+                        is_binary="-" in (parts[0], parts[1]),
                     )
                 )
             except ValueError:
@@ -273,11 +273,11 @@ def resolve_diff(identifier: str, root: Path, agents: list[dict[str, Any]], base
     file_stats: list[FileDiffStat] = []
 
     if session_id:
-        for try_fn in [
+        for try_fn in (
             lambda: _try_worktree_diff(session_id, root, base),
             lambda: _try_branch_diff(session_id, root, base),
             lambda: _try_merge_commit_diff(session_id, root),
-        ]:
+        ):
             diff_text, source_label, stat_text, file_stats = try_fn()
             if diff_text:
                 break

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -110,7 +110,7 @@ def _fallback_table_render(aggregator: FleetAggregator, config: FleetConfig) -> 
 
     rows, total = build_rows(aggregator)
     table = Table(title="Bernstein fleet")
-    for col in [
+    for col in (
         "Project",
         "State",
         "Run",
@@ -120,7 +120,7 @@ def _fallback_table_render(aggregator: FleetAggregator, config: FleetConfig) -> 
         "Cost (7d)",
         "Sparkline",
         "Chain",
-    ]:
+    ):
         table.add_column(col)
     for row in rows:
         table.add_row(

--- a/src/bernstein/cli/commands/quickstart_cmd.py
+++ b/src/bernstein/cli/commands/quickstart_cmd.py
@@ -203,11 +203,11 @@ def _stop_quickstart_processes(project_dir: Path) -> None:
         project_dir: Quickstart project root whose .sdd/runtime/ holds PID files.
     """
     runtime_dir = project_dir / ".sdd" / "runtime"
-    for pid_filename, _label in [
+    for pid_filename, _label in (
         ("watchdog.pid", "Watchdog"),
         ("spawner.pid", "Spawner"),
         ("server.pid", "Task server"),
-    ]:
+    ):
         pid_file = runtime_dir / pid_filename
         if not pid_file.exists():
             continue

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -86,7 +86,7 @@ def _match_discovered_agent(
     command_token = Path(command_token).name
     for agent in discovery.agents:
         binary_name = Path(agent.binary).name.lower()
-        if command_token and (agent.name.lower() == command_token or binary_name == command_token):
+        if command_token and command_token in (agent.name.lower(), binary_name):
             return agent
 
     model_lower = model.lower()

--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -149,14 +149,14 @@ def return_claimed_to_open() -> int:
     closed_nums: set[str] = set()
     closed_dir = Path(".sdd/backlog/closed")
     if closed_dir.exists():
-        closed_nums = {f.name.split("-")[0] for f in [*closed_dir.glob(_YAML_GLOB), *closed_dir.glob("*.md")]}
+        closed_nums = {f.name.split("-")[0] for f in (*closed_dir.glob(_YAML_GLOB), *closed_dir.glob("*.md"))}
     # Also check backlog/done/ which some codepaths use
     done_dir = Path(".sdd/backlog/done")
     if done_dir.exists():
-        closed_nums |= {f.name.split("-")[0] for f in [*done_dir.glob(_YAML_GLOB), *done_dir.glob("*.md")]}
+        closed_nums |= {f.name.split("-")[0] for f in (*done_dir.glob(_YAML_GLOB), *done_dir.glob("*.md"))}
 
     count = 0
-    for f in [*claimed_dir.glob(_YAML_GLOB), *claimed_dir.glob("*.md")]:
+    for f in (*claimed_dir.glob(_YAML_GLOB), *claimed_dir.glob("*.md")):
         if not f.exists():
             continue
         num = f.name.split("-")[0]

--- a/src/bernstein/cli/display/image_renderer.py
+++ b/src/bernstein/cli/display/image_renderer.py
@@ -344,8 +344,7 @@ def _make_renderer(caps: TerminalCaps) -> BaseRenderer:
             return HalfBlockRenderer()
         case Protocol.BRAILLE:
             return BrailleRenderer()
-        case _:
-            return NullRenderer()
+    return NullRenderer()
 
 
 # ── Public API ─────────────────────────────────────────────────────────────

--- a/src/bernstein/cli/display/summary_card.py
+++ b/src/bernstein/cli/display/summary_card.py
@@ -91,7 +91,7 @@ def build_summary_card(data: RunSummaryData) -> Table:
     total = data.tasks_total
     failed = data.tasks_failed
 
-    if total == 0 or failed == 0:
+    if 0 in (total, failed):
         header_color = "green"
     elif failed / total >= 0.5:
         header_color = "red"

--- a/src/bernstein/cli/display/terminal_caps.py
+++ b/src/bernstein/cli/display/terminal_caps.py
@@ -109,17 +109,12 @@ class TerminalCaps:
         color256 = "256color" in term or truecolor
 
         # Kitty: native env var, WezTerm (full Kitty support), Ghostty
-        kitty = (
-            bool(os.environ.get("KITTY_WINDOW_ID"))
-            or term_program_lower == "wezterm"
-            or term_program_lower == "ghostty"
-        )
+        kitty = bool(os.environ.get("KITTY_WINDOW_ID")) or term_program_lower in ("wezterm", "ghostty")
 
         # iTerm2: native iTerm2, WezTerm, VS Code, Konsole
         iterm2 = (
             "iterm" in term_program_lower
-            or term_program_lower == "wezterm"
-            or term_program_lower == "vscode"
+            or term_program_lower in ("wezterm", "vscode")
             or bool(os.environ.get("KONSOLE_VERSION"))
         )
 
@@ -128,9 +123,7 @@ class TerminalCaps:
         #        of emulators set it without sixel support (Tabby, Alacritty,
         #        Terminal.app, etc.).  Only match explicit TERM_PROGRAM values.
         sixel = (
-            term_program_lower in ("wezterm", "foot")
-            or term_program_lower == "mlterm"
-            or term_program_lower == "vscode"
+            term_program_lower in ("wezterm", "foot", "mlterm", "vscode")
             or bool(os.environ.get("WT_SESSION"))
             or bool(os.environ.get("KONSOLE_VERSION"))
         )

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -417,11 +417,11 @@ def _stop_demo_processes(project_dir: Path) -> None:
         project_dir: Demo project root whose .sdd/runtime/ holds PID files.
     """
     runtime_dir = project_dir / ".sdd" / "runtime"
-    for pid_filename, _label in [
+    for pid_filename, _label in (
         ("watchdog.pid", "Watchdog"),
         ("spawner.pid", "Spawner"),
         ("server.pid", "Task server"),
-    ]:
+    ):
         pid_file = runtime_dir / pid_filename
         if not pid_file.exists():
             continue

--- a/src/bernstein/core/agents/heartbeat_escalation.py
+++ b/src/bernstein/core/agents/heartbeat_escalation.py
@@ -63,12 +63,12 @@ class EscalationThresholds:
         errors: list[str] = []
         active = [
             (name, val)
-            for name, val in [
+            for name, val in (
                 ("warn_s", self.warn_s),
                 ("sigusr1_s", self.sigusr1_s),
                 ("sigterm_s", self.sigterm_s),
                 ("sigkill_s", self.sigkill_s),
-            ]
+            )
             if val > 0
         ]
 

--- a/src/bernstein/core/cost/claude_cost_tracking.py
+++ b/src/bernstein/core/cost/claude_cost_tracking.py
@@ -134,7 +134,7 @@ def parse_session_output(
                 typed_obj = cast("dict[str, Any]", obj)
                 _extract_from_json(typed_obj, data)
                 # Count assistant turns.
-                if typed_obj.get("type") == "assistant" or typed_obj.get("role") == "assistant":
+                if "assistant" in (typed_obj.get("type"), typed_obj.get("role")):
                     turns += 1
                 continue
 

--- a/src/bernstein/core/cost/preflight.py
+++ b/src/bernstein/core/cost/preflight.py
@@ -109,7 +109,7 @@ def _sanitize(value: float) -> float:
         return 0.0
     if amount < 0.0:
         return 0.0
-    if amount == float("inf") or amount == float("-inf"):
+    if amount in (float("inf"), float("-inf")):
         return 0.0
     return round(amount, 2)
 

--- a/src/bernstein/core/errors/categorization.py
+++ b/src/bernstein/core/errors/categorization.py
@@ -91,7 +91,7 @@ def _categorize_oserror(exc: OSError) -> ErrorCategory | None:
         return ErrorCategory.MODEL_UNREACHABLE
     if err == errno.ETIMEDOUT:
         return ErrorCategory.TIMEOUT
-    if err == errno.EACCES or err == errno.EPERM:
+    if err in (errno.EACCES, errno.EPERM):
         return ErrorCategory.PERMISSION_DENIED
     if err == errno.ENOENT and _filename_looks_like_config(getattr(exc, "filename", None)):
         return ErrorCategory.CONFIG_MISSING

--- a/src/bernstein/core/git/github.py
+++ b/src/bernstein/core/git/github.py
@@ -960,7 +960,7 @@ def _collect_existing_titles(workdir: Path, backlog_open: Path) -> set[str]:
     for src_dir in (backlog_open, workdir / ".sdd" / "backlog" / "issues"):
         if not src_dir.is_dir():
             continue
-        for path in [*src_dir.glob("*.yaml"), *src_dir.glob("*.md")]:
+        for path in (*src_dir.glob("*.yaml"), *src_dir.glob("*.md")):
             if path.name.startswith("gh-"):
                 continue
             title = _extract_title_from_frontmatter(path)

--- a/src/bernstein/core/orchestration/phase_gates.py
+++ b/src/bernstein/core/orchestration/phase_gates.py
@@ -230,7 +230,7 @@ _ID_MARKER_RE = re.compile(r"<id:([^>]+)>")
 def _r002(prior: PhaseArtifact, current: PhaseArtifact, _spec: PhaseSpec) -> GateResult:
     """Every ``<id:foo>`` marker must resolve against the prior artefact."""
     known: set[str] = set()
-    for entry in [*prior.decisions, *prior.constraints]:
+    for entry in (*prior.decisions, *prior.constraints):
         known.update(_ID_MARKER_RE.findall(entry))
         # The plain text after a ``<id:foo>`` marker is also addressable.
         # Tokens without markers are addressable by exact-string match —

--- a/src/bernstein/core/orchestration/workload_prediction.py
+++ b/src/bernstein/core/orchestration/workload_prediction.py
@@ -147,8 +147,7 @@ def _calculate_recommended_agents(total_tasks: int, estimated_hours: float) -> i
     target_hours = 8.0
     if estimated_hours <= target_hours:
         return min(total_tasks, 3)
-    else:
-        return min(total_tasks, max(3, int(estimated_hours / target_hours) + 1))
+    return min(total_tasks, max(3, int(estimated_hours / target_hours) + 1))
 
 
 def _breakdown_by_role(

--- a/src/bernstein/core/persistence/file_health.py
+++ b/src/bernstein/core/persistence/file_health.py
@@ -329,14 +329,13 @@ def _score_to_grade(score: int) -> str:
     """Map 0-100 score to letter grade."""
     if score >= 90:
         return "A"
-    elif score >= 80:
+    if score >= 80:
         return "B"
-    elif score >= 70:
+    if score >= 70:
         return "C"
-    elif score >= 60:
+    if score >= 60:
         return "D"
-    else:
-        return "F"
+    return "F"
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/protocols/mcp/mcp_protocol_test.py
+++ b/src/bernstein/core/protocols/mcp/mcp_protocol_test.py
@@ -83,7 +83,7 @@ def resolve_catalog_server(server_name: str, catalog_path: Path) -> MCPServerEnt
     """Return a catalog entry by case-insensitive name."""
     normalized = server_name.strip().lower()
     for entry in load_catalog_entries(catalog_path):
-        if entry.name.lower() == normalized or entry.namespaced_name.lower() == normalized:
+        if normalized in (entry.name.lower(), entry.namespaced_name.lower()):
             return entry
     return None
 

--- a/src/bernstein/core/protocols/mcp/mcp_task_filter.py
+++ b/src/bernstein/core/protocols/mcp/mcp_task_filter.py
@@ -54,7 +54,7 @@ class RoleServerRule:
 
     def matches_role(self, task_role: str) -> bool:
         """Return True if this rule applies to the given role."""
-        return self.role == "*" or self.role == task_role
+        return self.role in ("*", task_role)
 
     def matches_scope(self, owned_files: list[str]) -> bool:
         """Return True if scope patterns match at least one owned file.

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -76,8 +76,7 @@ def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]
         case "llm_judge":
             # llm_judge requires async evaluation — use judge_task() instead.
             return False, "llm_judge requires async evaluation via judge_task()"
-        case _:  # pyright: ignore[reportUnnecessaryComparison]
-            return False, f"unknown signal type: {signal.type}"
+    return False, f"unknown signal type: {signal.type}"
 
 
 def verify_task(task: Task, workdir: Path) -> tuple[bool, list[str]]:

--- a/src/bernstein/core/routes/costs.py
+++ b/src/bernstein/core/routes/costs.py
@@ -614,15 +614,14 @@ def export_costs(request: Request, format: str = "json") -> Response:
             media_type="text/csv",
             headers={"Content-Disposition": "attachment; filename=costs_export.csv"},
         )
-    else:
-        return JSONResponse(
-            content={
-                "total_spent_usd": round(total_spent, 6),
-                "total_records": len(all_usages),
-                "runs": all_usages,
-            },
-            headers={"Content-Disposition": "attachment; filename=costs_export.json"},
-        )
+    return JSONResponse(
+        content={
+            "total_spent_usd": round(total_spent, 6),
+            "total_records": len(all_usages),
+            "runs": all_usages,
+        },
+        headers={"Content-Disposition": "attachment; filename=costs_export.json"},
+    )
 
 
 @router.get("/costs/forecast")

--- a/src/bernstein/core/routes/graphql_api.py
+++ b/src/bernstein/core/routes/graphql_api.py
@@ -213,8 +213,7 @@ def execute_graphql(
             return {"data": {"agents": []}}
         case "costs":
             return {"data": {"costs": {"total_usd": 0.0, "per_model": []}}}
-        case _:
-            return {"errors": [{"message": f"Unknown operation: {parsed.operation}"}]}
+    return {"errors": [{"message": f"Unknown operation: {parsed.operation}"}]}
 
 
 @router.post("/graphql")

--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -291,8 +291,7 @@ def _dispatch_github_event(event: Any, store: TaskStore) -> list[dict[str, Any]]
             return list(push_to_tasks(event))
         case ("workflow_run", "completed"):
             return _handle_workflow_run(event, store)
-        case _:
-            return []
+    return []
 
 
 @router.post("/webhooks/github", status_code=200)

--- a/src/bernstein/core/routing/hijacker.py
+++ b/src/bernstein/core/routing/hijacker.py
@@ -354,10 +354,10 @@ class TierHijacker:
             return True
 
         # Trial/promotional credits usually support standard models
-        if opportunity.source in [
+        if opportunity.source in (
             FreeTierSource.NEW_PROVIDER_TRIAL,
             FreeTierSource.PROMOTIONAL_CREDITS,
-        ]:
+        ):
             supported_models = ["haiku", "sonnet", "opus", "gpt-4", "gpt-3.5"]
             return any(m in model.lower() for m in supported_models)
 
@@ -423,12 +423,11 @@ class TierHijacker:
                 "mistral": ModelConfig("mistral", "high"),
                 "qwen": ModelConfig("qwen", "high"),
             }
-        else:
-            # Default to standard models
-            return {
-                "claude-sonnet": ModelConfig("sonnet", "high"),
-                "claude-opus": ModelConfig("opus", "max"),
-            }
+        # Default to standard models
+        return {
+            "claude-sonnet": ModelConfig("sonnet", "high"),
+            "claude-opus": ModelConfig("opus", "max"),
+        }
 
     def get_hijack_history(self) -> list[HijackResult]:
         """Get history of hijack attempts."""

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -556,7 +556,7 @@ class TierAwareRouter:
 
         # Fallback to other tiers if enabled
         if self.state.fallback_enabled:
-            for tier in [Tier.STANDARD, Tier.PREMIUM]:
+            for tier in (Tier.STANDARD, Tier.PREMIUM):
                 if tier == self.state.preferred_tier:
                     continue
 

--- a/src/bernstein/core/routing/router_policies.py
+++ b/src/bernstein/core/routing/router_policies.py
@@ -408,7 +408,7 @@ def consider_cache_pricing_in_routing(
     recommended = (
         tier.savings_percentage >= 0.8  # At least 80% savings
         and estimated_tokens >= 1000  # At least 1k tokens
-        and task_complexity in ["high", "medium"]  # Complex tasks
+        and task_complexity in ("high", "medium")  # Complex tasks
     )
 
     return {

--- a/src/bernstein/core/sandbox/backends/docker.py
+++ b/src/bernstein/core/sandbox/backends/docker.py
@@ -116,7 +116,7 @@ def _safe_extract_single_file(tf: tarfile.TarFile, *, expected_name: str, resolv
         if member.name.startswith("/"):
             continue
 
-        if member.name == expected_name or member.name == absolute_form:
+        if member.name in (expected_name, absolute_form):
             acceptable.append(member)
 
     if not acceptable:

--- a/src/bernstein/core/security/permission_matrix.py
+++ b/src/bernstein/core/security/permission_matrix.py
@@ -145,7 +145,7 @@ class PermissionResolutionMatrix:
                 hook_outcome=hook_outcome,
                 metadata={"source": "hook_deny_no_rule"},
             )
-        elif hook_outcome == "allow":
+        if hook_outcome == "allow":
             # Case 7: Hook allow without rule → ALLOW
             return ResolutionResult(
                 outcome=ResolutionOutcome.ALLOW,
@@ -154,15 +154,14 @@ class PermissionResolutionMatrix:
                 hook_outcome=hook_outcome,
                 metadata={"source": "hook_allow_no_rule"},
             )
-        else:
-            # Case 8: No rule, hook neutral → ASK (default to safety)
-            return ResolutionResult(
-                outcome=ResolutionOutcome.ASK,
-                reason="No rule or hook decision, defaulting to approval",
-                rule_outcome=rule_outcome,
-                hook_outcome=hook_outcome,
-                metadata={"source": "default_ask"},
-            )
+        # Case 8: No rule, hook neutral → ASK (default to safety)
+        return ResolutionResult(
+            outcome=ResolutionOutcome.ASK,
+            reason="No rule or hook decision, defaulting to approval",
+            rule_outcome=rule_outcome,
+            hook_outcome=hook_outcome,
+            metadata={"source": "default_ask"},
+        )
 
     def resolve_simple(
         self,

--- a/src/bernstein/core/security/soc2_report.py
+++ b/src/bernstein/core/security/soc2_report.py
@@ -279,11 +279,11 @@ def _collect_audit_evidence(
     file_count, entry_count = _count_jsonl_entries(audit_dir, period_start, period_end)
     if file_count <= 0:
         return
-    for control_id, desc in [
+    for control_id, desc in (
         ("CC6.1", "HMAC-chained audit event log entries"),
         ("CC6.3", "Authorization change audit trail"),
         (_CC7_1, "Change management audit trail"),
-    ]:
+    ):
         evidence.append(
             EvidenceSummary(
                 control_id=control_id,
@@ -365,10 +365,10 @@ def _collect_wal_evidence(wal_dir: Path, evidence: list[EvidenceSummary]) -> Non
     if not wal_files:
         return
     wal_entries = sum(1 for wf in wal_files for line in wf.read_text().splitlines() if line.strip())
-    for control_id, desc in [
+    for control_id, desc in (
         (_CC7_1, "Write-ahead log decision records"),
         (_CC9_2, "Decision integrity via hash-chained WAL"),
-    ]:
+    ):
         evidence.append(
             EvidenceSummary(
                 control_id=control_id,
@@ -387,10 +387,10 @@ def _collect_metrics_evidence(metrics_dir: Path, evidence: list[EvidenceSummary]
     metrics_files = list(metrics_dir.glob("*"))
     if not metrics_files:
         return
-    for control_id, desc in [
+    for control_id, desc in (
         ("CC7.2", "System monitoring and metrics data"),
         ("CC8.1", "Capacity monitoring data"),
-    ]:
+    ):
         evidence.append(
             EvidenceSummary(
                 control_id=control_id,

--- a/src/bernstein/core/server/json_logging.py
+++ b/src/bernstein/core/server/json_logging.py
@@ -41,7 +41,7 @@ class JsonFormatter(logging.Formatter):
         }
 
         # Context fields from CorrelationFilter
-        for field in ["task_id", "agent_id", "correlation_id"]:
+        for field in ("task_id", "agent_id", "correlation_id"):
             if hasattr(record, field):
                 log_data[field] = getattr(record, field)
             else:

--- a/src/bernstein/core/tasks/lifecycle_diagrams.py
+++ b/src/bernstein/core/tasks/lifecycle_diagrams.py
@@ -281,10 +281,10 @@ def generate_all_diagrams(output_dir: str | Path) -> list[Path]:
 
     generated: list[Path] = []
 
-    for extractor, filename, title in [
+    for extractor, filename, title in (
         (extract_task_lifecycle, "task_lifecycle.md", "Task Lifecycle"),
         (extract_agent_lifecycle, "agent_lifecycle.md", "Agent Lifecycle"),
-    ]:
+    ):
         sm = extractor()
         mermaid = render_mermaid(sm)
         # Indent mermaid body inside the fenced block.

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3109,7 +3109,7 @@ def _move_backlog_ticket(workdir: Any, task: Any) -> None:
 
     # --- Strategy 2: exact normalised-title match (no substring!) ---
     title_slug = re.sub(r"[^a-z0-9]+", "-", task.title.lower()).strip("-")
-    for md_file in [*open_dir.glob("*.yaml"), *open_dir.glob("*.md")]:
+    for md_file in (*open_dir.glob("*.yaml"), *open_dir.glob("*.md")):
         # Parse the ticket heading and normalise it
         try:
             text = md_file.read_text(encoding="utf-8")

--- a/src/bernstein/core/tokens/prompt_caching.py
+++ b/src/bernstein/core/tokens/prompt_caching.py
@@ -292,7 +292,7 @@ def extract_system_prefix(prompt: str) -> tuple[str, str]:
     signal_marker = "\n## Signal files —"
 
     split_points: list[int] = []
-    for marker in [task_marker, instruction_marker, signal_marker]:
+    for marker in (task_marker, instruction_marker, signal_marker):
         idx = prompt.find(marker)
         if idx != -1:
             split_points.append(idx)

--- a/src/bernstein/core/tokens/prompt_versioning.py
+++ b/src/bernstein/core/tokens/prompt_versioning.py
@@ -101,10 +101,9 @@ def _ab_winner(m1: VersionMetrics, m2: VersionMetrics, v1: int, v2: int) -> str:
     """Determine A/B test winner from two version metrics."""
     if m2.success_rate > m1.success_rate + CONFIDENCE_THRESHOLD:
         return f"v{v2}"
-    elif m1.success_rate > m2.success_rate + CONFIDENCE_THRESHOLD:
+    if m1.success_rate > m2.success_rate + CONFIDENCE_THRESHOLD:
         return f"v{v1}"
-    else:
-        return "no clear winner"
+    return "no clear winner"
 
 
 @dataclass

--- a/src/bernstein/core/trackers/__init__.py
+++ b/src/bernstein/core/trackers/__init__.py
@@ -75,7 +75,7 @@ def get_tracker(name: str, **kwargs: object) -> AbstractTrackerAdapter:
         return ServiceNowTracker(**kwargs)  # type: ignore[arg-type]
     if name == "linear":
         return LinearTracker(**kwargs)  # type: ignore[arg-type]
-    if name == "github_projects" or name == "github_projects_v2":
+    if name in ("github_projects", "github_projects_v2"):
         from bernstein.core.trackers.builtin import (
             GitHubProjectsV2Adapter,
         )

--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -508,7 +508,7 @@ class GitHubProjectsV2Adapter(AbstractTrackerAdapter):
         """Resolve ``status_id`` (id, name, or mapped name) to an option id."""
         mapped = self._config.status_map.get(status_id, status_id)
         for option in field_node.get("options") or []:
-            if option.get("id") == mapped or option.get("name") == mapped:
+            if mapped in (option.get("id"), option.get("name")):
                 return str(option["id"])
         msg = f"Status '{status_id}' (mapped='{mapped}') not found in field '{field_node.get('name')}'"
         raise TrackerUnavailable(msg)

--- a/src/bernstein/core/trackers/builtin/jira_dc_adapter.py
+++ b/src/bernstein/core/trackers/builtin/jira_dc_adapter.py
@@ -436,7 +436,7 @@ class JiraDataCenterAdapter(AbstractTrackerAdapter):
         if status_code == 412:
             msg = "Precondition Failed (etag mismatch)"
             raise OptimisticConcurrencyError(msg)
-        if status_code == 429 or status_code == 503:
+        if status_code in (429, 503):
             retry_after = _parse_retry_after(response)
             if status_code == 429 or retry_after is not None:
                 msg = f"Jira DC rate-limited (status={status_code})"

--- a/src/bernstein/evolution/__init__.py
+++ b/src/bernstein/evolution/__init__.py
@@ -350,11 +350,11 @@ class EvolutionCoordinator:
             p
             for p in self._pending_upgrades
             if p.status
-            not in [
+            not in (
                 UpgradeStatus.APPLIED,
                 UpgradeStatus.REJECTED,
                 UpgradeStatus.ROLLED_BACK,
-            ]
+            )
         ]
 
         return executed

--- a/src/bernstein/testing/chaos_framework.py
+++ b/src/bernstein/testing/chaos_framework.py
@@ -187,7 +187,7 @@ def _compute_grade(total: int, failed: int) -> str:
 
     When *total* is 0, returns ``"A"`` (vacuous truth).
     """
-    if total == 0 or failed == 0:
+    if 0 in (total, failed):
         return "A"
     idx = min(failed, len(_GRADE_THRESHOLDS) - 1)
     return _GRADE_THRESHOLDS[idx]

--- a/src/bernstein/tui/agent_duration.py
+++ b/src/bernstein/tui/agent_duration.py
@@ -20,8 +20,7 @@ def format_agent_duration(start_time: float) -> str:
 
     if hours > 0:
         return f"{hours}h {minutes:02d}m"
-    else:
-        return f"{minutes}m {seconds:02d}s"
+    return f"{minutes}m {seconds:02d}s"
 
 
 def get_duration_color(start_time: float) -> str:
@@ -38,7 +37,6 @@ def get_duration_color(start_time: float) -> str:
 
     if minutes < 10:
         return "green"
-    elif minutes < 30:
+    if minutes < 30:
         return "yellow"
-    else:
-        return "red"
+    return "red"

--- a/src/bernstein/tui/color_mode.py
+++ b/src/bernstein/tui/color_mode.py
@@ -38,7 +38,7 @@ def detect_color_mode() -> ColorMode:
         return ColorMode.TRUECOLOR
 
     # Known CI environments
-    if os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true":
+    if "true" in (os.environ.get("CI"), os.environ.get("GITHUB_ACTIONS")):
         return ColorMode.ANSI
 
     # TERM variable encoding - check if it's explicitly set


### PR DESCRIPTION
## Summary

- **FURB109** (23 sites): use tuples instead of lists for static `in` membership and `for` iteration over fixed sequences.
- **FURB108** (18 sites): collapse `x == a or x == b` chains to `x in (a, b)`.
- **FURB126** (12 sites): drop redundant `else` / `case _` after a `return` and rely on fall-through.

44 files touched in `src/bernstein/`. Pure control-flow / literal rewrites; no behavioural change.

## Test plan

- [x] `refurb src/` reports 0 hits for FURB109/108/126 after the change.
- [x] `ruff check` clean on the 44 touched files.
- [x] `python -m compileall` clean.
- [x] Targeted `pytest` sweep over touched modules (color_mode, terminal_caps, chaos_framework, soc2_report, router, file_health, hijacker, summary_card, prompt_versioning, preflight, permission_delegation_and_matrix, mcp_task_filter, json_logging, heartbeat_escalation): 320+ tests pass.
- [ ] Full CI on branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal cleanup and conditional simplifications across the CLI, core, and TUI with no user-facing behavior changes.
  * Improved terminal graphics protocol detection for broader compatibility.
* **Bug Fixes**
  * CI environment detection for color mode is more reliable in CI-like environments.
  * JSON cost exports now include proper attachment headers when downloading.
* **UX**
  * Unknown GraphQL operations return a clearer immediate error message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->