### PR TITLE
feat(planning): auto spec-quality checklist refuses to advance until clean

### DIFF
--- a/docs/planning/spec-quality-gate.md
+++ b/docs/planning/spec-quality-gate.md
@@ -1,0 +1,115 @@
+# Spec-quality checklist gate
+
+The spec-quality gate evaluates a feature spec against a small set of
+deterministic content rules before the orchestrator dispatches an
+implementer agent. Specs that fail any required rule are routed through
+an auto-fix loop with a bounded number of attempts; when the loop
+exhausts its budget the gate refuses to advance and surfaces the
+checklist report to the operator.
+
+## Why the gate exists
+
+Tasks generated from a thin spec produce thin implementations and
+re-work loops. Catching the gap at spec time avoids spending agent
+context on under-specified work. Because the gate runs locally and is
+purely text-driven it has no LLM cost and adds milliseconds to the
+planning path.
+
+## Default rules
+
+| Rule id | Required | What it checks |
+|---|---|---|
+| `acceptance_criteria_present` | yes | The spec has an `## Acceptance criteria` heading. |
+| `out_of_scope_present` | yes | The spec has an `## Out of scope` heading. |
+| `tested_via_present` | yes | The spec mentions how the change is tested. |
+| `no_todo_markers` | yes | No `TODO` markers remain in the spec body. |
+| `no_placeholder_tokens` | yes | No `<PLACEHOLDER>`, `TBD`, or `XXX` tokens remain. |
+| `ref_paths_exist` | yes | Every backtick-quoted path with a `/` separator exists in the workspace. |
+
+All rules are pluggable; project plugins register additional rules via
+the `bernstein.spec_quality_rules` entry-point group. Each entry must
+resolve to a zero-arg callable that returns a
+`bernstein.core.planning.spec_quality.Rule`. Optional rules
+(`required=False`) are reported but never block the gate.
+
+## CLI surface
+
+```
+bernstein spec check <path>            # evaluate, exit 2 on failure
+bernstein spec check <path> --no-strict
+bernstein spec auto-fix <path>         # heuristic fix loop, dry-run by default
+bernstein spec auto-fix <path> --write
+```
+
+`--max-iter` (default `3`) controls how many auto-fix iterations are
+attempted before the gate refuses to advance. The local heuristic
+patcher adds missing section headings and rewrites stray `TODO`
+markers; semantic gaps (e.g. a missing referenced file) require
+operator intervention.
+
+## Pipeline integration
+
+Orchestrator code that dispatches an implementer agent should wrap the
+call site with `refuse_to_advance`:
+
+```python
+from bernstein.core.planning.spec_quality import (
+    SpecQualityUnresolvedError,
+    refuse_to_advance,
+)
+
+try:
+    report = refuse_to_advance(
+        spec_path,
+        workspace_root=repo_root,
+        autofix=heuristic_or_llm_fixer,
+        max_iterations=3,
+    )
+except SpecQualityUnresolvedError as exc:
+    # Surface ``exc.report`` to the operator; do not dispatch the
+    # implementer.
+    return
+```
+
+`refuse_to_advance` returns the final report when the gate passes and
+raises `SpecQualityUnresolvedError` when it does not. The exception
+carries the last `ChecklistReport` so callers can render the failed
+items without re-evaluating the spec.
+
+## Authoring new rules
+
+A rule is a small dataclass containing an id, description, and a
+callable:
+
+```python
+from bernstein.core.planning.spec_quality import Rule, RuleResult
+
+def _check(spec_text, workspace_root):
+    if "stakeholder" not in spec_text.lower():
+        return RuleResult(
+            rule_id="stakeholder_named",
+            passed=False,
+            message="Spec does not name a stakeholder.",
+            hint="Add a 'Stakeholder' heading or sentence.",
+        )
+    return RuleResult(rule_id="stakeholder_named", passed=True)
+
+def factory() -> Rule:
+    return Rule(
+        rule_id="stakeholder_named",
+        description="Spec names a stakeholder.",
+        check=_check,
+    )
+```
+
+Register the factory in your plugin's `pyproject.toml`:
+
+```toml
+[project.entry-points."bernstein.spec_quality_rules"]
+stakeholder_named = "my_pkg.spec_rules:factory"
+```
+
+Plugins discovered at startup are merged after the default rule set;
+rule ids must be unique across the registry. Rules that raise during
+evaluation are converted into a failing `RuleResult` so a broken plugin
+cannot crash the gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,6 +276,13 @@ bernstein-worker = "bernstein.core.worker:main"
 # this group. Example:
 # my_sink = "my_pkg.storage:MyArtifactSink"
 
+[project.entry-points."bernstein.spec_quality_rules"]
+# Spec-quality checklist rules (Rule factories). Each entry resolves to a
+# zero-arg callable returning a
+# ``bernstein.core.planning.spec_quality.Rule`` instance.
+# Example:
+# stakeholder = "my_pkg.spec_rules:stakeholder_factory"
+
 [project.entry-points."bernstein.notification_sinks"]
 # Outbound notification drivers (release 1.9). First-party drivers
 # (telegram, slack, discord, email_smtp, webhook, shell) ship in core

--- a/src/bernstein/cli/commands/spec_cmd.py
+++ b/src/bernstein/cli/commands/spec_cmd.py
@@ -1,0 +1,149 @@
+"""``bernstein spec`` command group: spec-quality checklist gate (#1631).
+
+Provides two subcommands:
+
+* ``bernstein spec check <path>`` -- evaluate a spec file against the
+  default rule set and render the checklist. Exits non-zero when any
+  required rule fails.
+* ``bernstein spec auto-fix <path>`` -- run the auto-fix loop with a
+  best-effort heuristic patcher (adds missing sections, strips TODO
+  markers, etc.) up to ``--max-iter`` attempts. Writes the rewritten
+  spec back to ``<path>`` only when ``--write`` is supplied.
+
+The implementation delegates rule evaluation to
+:mod:`bernstein.core.planning.spec_quality`; this module exists only to
+wire the CLI surface and a deterministic local autofix heuristic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.planning.spec_quality import (
+    DEFAULT_MAX_AUTO_FIX_ITERATIONS,
+    ChecklistReport,
+    SpecQualityUnresolvedError,
+    evaluate,
+    refuse_to_advance,
+    render_report,
+)
+
+__all__ = ["spec_group"]
+
+
+def _heuristic_autofix(report: ChecklistReport) -> str | None:
+    """Apply a deterministic local fix per failed rule.
+
+    The heuristic targets the cheap structural failures (missing section
+    headings, stray TODO markers). It cannot fabricate semantic content,
+    so rules like ``ref_paths_exist`` are left to the operator. Returns
+    the rewritten spec text, or ``None`` when no progress is possible.
+    """
+    try:
+        text = report.spec_path.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return None
+    original = text
+    for failure in report.required_failures:
+        text = _apply_one_fix(text, failure.rule_id)
+    return text if text != original else None
+
+
+def _apply_one_fix(text: str, rule_id: str) -> str:
+    """Best-effort patch for a single failing rule id."""
+    if rule_id == "acceptance_criteria_present":
+        return text.rstrip() + ("\n\n## Acceptance criteria\n\n- (auto-generated stub; fill in)\n")
+    if rule_id == "out_of_scope_present":
+        return text.rstrip() + ("\n\n## Out of scope\n\n- (auto-generated stub; fill in)\n")
+    if rule_id == "tested_via_present":
+        return text.rstrip() + ("\n\n## Tested via\n\n- (auto-generated stub; list pytest selectors)\n")
+    if rule_id == "no_todo_markers":
+        # Strip TODO markers but keep the surrounding sentence so the
+        # operator can review the gap on the next pass.
+        return text.replace("TODO", "[follow-up]").replace("todo", "[follow-up]")
+    return text
+
+
+@click.group("spec")
+def spec_group() -> None:
+    """Spec-quality checklist gate (issue #1631)."""
+
+
+@spec_group.command("check")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--workspace-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Workspace root used by path-existence rules. Defaults to cwd.",
+)
+@click.option(
+    "--strict/--no-strict",
+    default=True,
+    help="Exit non-zero when any required rule fails (default: strict).",
+)
+def spec_check(path: Path, workspace_root: Path | None, strict: bool) -> None:
+    """Evaluate a spec file and print the checklist report."""
+    root = workspace_root or Path.cwd()
+    report = evaluate(path, workspace_root=root)
+    console.print(render_report(report))
+    if strict and not report.passed:
+        sys.exit(2)
+
+
+@spec_group.command("auto-fix")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--workspace-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Workspace root used by path-existence rules. Defaults to cwd.",
+)
+@click.option(
+    "--max-iter",
+    type=click.IntRange(min=0, max=10),
+    default=DEFAULT_MAX_AUTO_FIX_ITERATIONS,
+    help="Maximum auto-fix iterations before the gate refuses to advance.",
+)
+@click.option(
+    "--write/--dry-run",
+    default=False,
+    help="Persist the rewritten spec to disk (default: dry-run).",
+)
+def spec_auto_fix(
+    path: Path,
+    workspace_root: Path | None,
+    max_iter: int,
+    write: bool,
+) -> None:
+    """Run the auto-fix loop and optionally write the patched spec back."""
+    root = workspace_root or Path.cwd()
+    last_text: dict[str, str] = {"text": ""}
+
+    def _autofix(report: ChecklistReport) -> str | None:
+        patched = _heuristic_autofix(report)
+        if patched is None:
+            return None
+        last_text["text"] = patched
+        if write:
+            path.write_text(patched, encoding="utf-8")
+        return patched
+
+    try:
+        report = refuse_to_advance(
+            path,
+            workspace_root=root,
+            autofix=_autofix,
+            max_iterations=max_iter,
+        )
+    except SpecQualityUnresolvedError as exc:
+        console.print(render_report(exc.report))
+        console.print(f"[red]Refused to advance after {exc.report.iteration} iteration(s).[/red]")
+        sys.exit(2)
+    console.print(render_report(report))
+    if not write and last_text["text"]:
+        console.print("[yellow]--dry-run set; rewritten spec not persisted.[/yellow]")

--- a/src/bernstein/cli/commands/spec_cmd.py
+++ b/src/bernstein/cli/commands/spec_cmd.py
@@ -130,7 +130,10 @@ def spec_auto_fix(
             return None
         last_text["text"] = patched
         if write:
-            path.write_text(patched, encoding="utf-8")
+            try:
+                path.write_text(patched, encoding="utf-8")
+            except OSError as exc:
+                raise click.ClickException(f"Failed to write patched spec: {path} ({exc})") from exc
         return patched
 
     try:

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -69,6 +69,7 @@ from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.skills_cmd import skills_group
+from bernstein.cli.commands.spec_cmd import spec_group
 from bernstein.cli.commands.trackers_cmd import trackers_group
 from bernstein.cli.compliance_cmd import compliance_group
 from bernstein.cli.config_path_cmd import config_path_cmd
@@ -862,6 +863,7 @@ plan.add_command(plan_show)
 plan.add_command(plan_dag)
 cli.add_command(plan)
 cli.add_command(plan, "tasks")
+cli.add_command(spec_group)
 cli.add_command(backlog_group, "backlog")
 cli.add_command(logs_group, "logs")
 cli.add_command(decisions_group, "decisions")

--- a/src/bernstein/core/planning/spec_quality.py
+++ b/src/bernstein/core/planning/spec_quality.py
@@ -1,0 +1,517 @@
+"""Spec-quality checklist gate (issue #1631).
+
+When an operator authors a feature spec, this module evaluates it against a
+small set of deterministic content rules and refuses to advance into task
+generation until every required rule passes.
+
+Rules return a :class:`RuleResult` with a pass/fail flag and an optional
+``hint`` describing how to fix the violation. :func:`evaluate` aggregates
+results into a :class:`ChecklistReport`. Pipeline integration drives the
+auto-fix loop via :func:`refuse_to_advance`.
+
+Rules are pluggable via the ``bernstein.spec_quality_rules`` entry-points
+group: each entry resolves to a zero-arg callable that returns a
+:class:`Rule`. Default rules check for the presence of:
+
+* an *Acceptance criteria* heading,
+* an *Out of scope* heading,
+* no ``TODO`` markers in spec body,
+* no placeholder strings (``<...>``, ``TBD``, ``XXX``),
+* every referenced ``path/file`` exists on disk relative to the workspace
+  root (best-effort; missing workspace = skip the rule with a hint).
+
+The module is deliberately library-only: the CLI surface lives in
+:mod:`bernstein.cli.commands.spec_cmd` and pipeline integration is driven
+by the orchestrator. The functions here have no I/O side effects beyond
+reading the spec path passed in by the caller.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+__all__ = [
+    "DEFAULT_MAX_AUTO_FIX_ITERATIONS",
+    "ChecklistReport",
+    "Rule",
+    "RuleResult",
+    "SpecQualityUnresolvedError",
+    "auto_fix_loop",
+    "default_rules",
+    "evaluate",
+    "load_plugin_rules",
+    "refuse_to_advance",
+    "render_report",
+]
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+#: Default upper bound on auto-fix iterations before the gate refuses to
+#: advance. Aligns with the issue spec ("up to 3 iterations").
+DEFAULT_MAX_AUTO_FIX_ITERATIONS: int = 3
+
+#: Entry-point group name used to register third-party rules.
+ENTRY_POINT_GROUP: str = "bernstein.spec_quality_rules"
+
+
+@dataclass(frozen=True, slots=True)
+class RuleResult:
+    """Outcome of a single :class:`Rule` evaluation against a spec.
+
+    Attributes:
+        rule_id: Stable identifier of the producing rule (matches
+            :attr:`Rule.rule_id`).
+        passed: ``True`` when the spec satisfies the rule.
+        message: Human-readable summary; empty string when ``passed``.
+        hint: Optional remediation hint for the operator / auto-fix loop.
+    """
+
+    rule_id: str
+    passed: bool
+    message: str = ""
+    hint: str = ""
+
+
+class _RuleCheck(Protocol):
+    """Callable signature for rule evaluation.
+
+    Implementations must be pure functions of (spec_text, workspace_root).
+    They must not raise; any failure to evaluate is reported as a
+    :class:`RuleResult` with ``passed=False``.
+    """
+
+    def __call__(self, spec_text: str, workspace_root: Path | None) -> RuleResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class Rule:
+    """A pluggable spec-quality rule.
+
+    Attributes:
+        rule_id: Stable, slug-style identifier (``[a-z0-9_-]+``).
+        description: One-line human description of what the rule checks.
+        check: Callable that returns a :class:`RuleResult`.
+        required: When ``True`` (default), a failed result blocks advancement.
+            Optional rules are reported but never gate the pipeline.
+    """
+
+    rule_id: str
+    description: str
+    check: _RuleCheck
+    required: bool = True
+
+    def evaluate(self, spec_text: str, workspace_root: Path | None) -> RuleResult:
+        """Run the rule against ``spec_text``, swallowing any exceptions."""
+        try:
+            return self.check(spec_text, workspace_root)
+        except Exception as exc:
+            return RuleResult(
+                rule_id=self.rule_id,
+                passed=False,
+                message=f"rule raised {type(exc).__name__}: {exc}",
+                hint="Fix the rule implementation or remove it from the registry.",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ChecklistReport:
+    """Aggregated outcome of evaluating every rule against a spec.
+
+    Attributes:
+        spec_path: Source path of the evaluated spec (informational).
+        results: Ordered list of :class:`RuleResult` records, one per rule.
+        iteration: Loop counter from :func:`auto_fix_loop` (0 = single eval).
+        required_rule_ids: Set of rule ids whose failure blocks advancement.
+            Populated by :func:`evaluate`; an empty set means "treat every
+            failed result as required" (back-compat for hand-built reports).
+    """
+
+    spec_path: Path
+    results: tuple[RuleResult, ...]
+    iteration: int = 0
+    required_rule_ids: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def passed(self) -> bool:
+        """``True`` when every *required* rule passed."""
+        return not self.required_failures
+
+    @property
+    def required_failures(self) -> tuple[RuleResult, ...]:
+        """Failed results that block advancement."""
+        required = self.required_rule_ids
+        if not required:
+            return tuple(r for r in self.results if not r.passed)
+        return tuple(r for r in self.results if not r.passed and r.rule_id in required)
+
+    @property
+    def failure_count(self) -> int:
+        """Number of failed results regardless of ``required`` flag."""
+        return sum(1 for r in self.results if not r.passed)
+
+
+# ---------------------------------------------------------------------------
+# Default rules
+# ---------------------------------------------------------------------------
+
+_RE_HEADING_ACCEPTANCE = re.compile(r"^\s{0,3}#{1,6}\s*acceptance\s+criteria\b", re.IGNORECASE | re.MULTILINE)
+_RE_HEADING_OUT_OF_SCOPE = re.compile(r"^\s{0,3}#{1,6}\s*out[\s-]+of[\s-]+scope\b", re.IGNORECASE | re.MULTILINE)
+_RE_HEADING_TESTED_VIA = re.compile(r"^\s{0,3}#{1,6}\s*tested[\s-]+via\b", re.IGNORECASE | re.MULTILINE)
+_RE_TODO = re.compile(r"\bTODO\b", re.IGNORECASE)
+_RE_PLACEHOLDER = re.compile(r"<[A-Z][A-Z0-9_\s-]{2,}>|\bTBD\b|\bXXX\b")
+_RE_PATH_TOKEN = re.compile(r"`(?P<path>[\w./_-]+\.[A-Za-z0-9]{1,6})`")
+
+
+def _check_acceptance_criteria(spec_text: str, workspace_root: Path | None) -> RuleResult:
+    """Require a ``## Acceptance criteria`` heading."""
+    del workspace_root
+    if _RE_HEADING_ACCEPTANCE.search(spec_text):
+        return RuleResult(rule_id="acceptance_criteria_present", passed=True)
+    return RuleResult(
+        rule_id="acceptance_criteria_present",
+        passed=False,
+        message="Spec is missing an 'Acceptance criteria' heading.",
+        hint="Add a section '## Acceptance criteria' with one or more bullet items.",
+    )
+
+
+def _check_out_of_scope(spec_text: str, workspace_root: Path | None) -> RuleResult:
+    """Require a ``## Out of scope`` heading."""
+    del workspace_root
+    if _RE_HEADING_OUT_OF_SCOPE.search(spec_text):
+        return RuleResult(rule_id="out_of_scope_present", passed=True)
+    return RuleResult(
+        rule_id="out_of_scope_present",
+        passed=False,
+        message="Spec is missing an 'Out of scope' heading.",
+        hint="Add a section '## Out of scope' listing what this spec explicitly excludes.",
+    )
+
+
+def _check_tested_via(spec_text: str, workspace_root: Path | None) -> RuleResult:
+    """Require either a ``Tested via`` section or the substring in body."""
+    del workspace_root
+    if _RE_HEADING_TESTED_VIA.search(spec_text):
+        return RuleResult(rule_id="tested_via_present", passed=True)
+    if re.search(r"\btested\s+via\b", spec_text, re.IGNORECASE):
+        return RuleResult(rule_id="tested_via_present", passed=True)
+    return RuleResult(
+        rule_id="tested_via_present",
+        passed=False,
+        message="Spec does not mention how the change will be tested.",
+        hint=(
+            "Add a 'Tested via' heading or sentence describing the test files / pytest selectors that cover the change."
+        ),
+    )
+
+
+def _check_no_todo(spec_text: str, workspace_root: Path | None) -> RuleResult:
+    """Forbid ``TODO`` markers in the spec body."""
+    del workspace_root
+    matches = _RE_TODO.findall(spec_text)
+    if not matches:
+        return RuleResult(rule_id="no_todo_markers", passed=True)
+    return RuleResult(
+        rule_id="no_todo_markers",
+        passed=False,
+        message=f"Spec contains {len(matches)} TODO marker(s).",
+        hint="Resolve every TODO into a concrete acceptance bullet before advancing.",
+    )
+
+
+def _check_no_placeholders(spec_text: str, workspace_root: Path | None) -> RuleResult:
+    """Forbid ``<PLACEHOLDER>``, ``TBD``, ``XXX`` tokens."""
+    del workspace_root
+    matches = _RE_PLACEHOLDER.findall(spec_text)
+    if not matches:
+        return RuleResult(rule_id="no_placeholder_tokens", passed=True)
+    sample = ", ".join(sorted({m for m in matches})[:3])
+    return RuleResult(
+        rule_id="no_placeholder_tokens",
+        passed=False,
+        message=f"Spec contains placeholder tokens (e.g. {sample}).",
+        hint="Replace placeholder tokens with concrete values.",
+    )
+
+
+def _extract_path_tokens(spec_text: str) -> list[str]:
+    """Return every backtick-quoted path-like token from the spec."""
+    return [m.group("path") for m in _RE_PATH_TOKEN.finditer(spec_text)]
+
+
+def _check_ref_paths_exist(spec_text: str, workspace_root: Path | None) -> RuleResult:
+    """Every backtick-quoted path token must resolve under ``workspace_root``.
+
+    When ``workspace_root`` is ``None`` the rule passes with an informational
+    hint — we cannot verify paths without a checkout.
+    """
+    if workspace_root is None:
+        return RuleResult(
+            rule_id="ref_paths_exist",
+            passed=True,
+            hint="Workspace root not supplied; skipping path-existence check.",
+        )
+    tokens = _extract_path_tokens(spec_text)
+    if not tokens:
+        return RuleResult(rule_id="ref_paths_exist", passed=True)
+    missing: list[str] = []
+    for token in tokens:
+        # Heuristic: only treat tokens that look like actual repo paths
+        # (contain a directory separator) as referenced. Bare filenames
+        # like ``README.md`` are ambiguous and are skipped to keep the
+        # rule low-false-positive.
+        if "/" not in token:
+            continue
+        candidate = (workspace_root / token).resolve()
+        try:
+            candidate.relative_to(workspace_root.resolve())
+        except ValueError:
+            # Escapes workspace -- treat as missing.
+            missing.append(token)
+            continue
+        if not candidate.exists():
+            missing.append(token)
+    if not missing:
+        return RuleResult(rule_id="ref_paths_exist", passed=True)
+    sample = ", ".join(missing[:3])
+    return RuleResult(
+        rule_id="ref_paths_exist",
+        passed=False,
+        message=f"{len(missing)} referenced path(s) do not exist (e.g. {sample}).",
+        hint="Fix typos or create the referenced files before advancing.",
+    )
+
+
+def default_rules() -> list[Rule]:
+    """Return the built-in rule set in deterministic evaluation order."""
+    return [
+        Rule(
+            rule_id="acceptance_criteria_present",
+            description="Spec has an 'Acceptance criteria' section.",
+            check=_check_acceptance_criteria,
+        ),
+        Rule(
+            rule_id="out_of_scope_present",
+            description="Spec has an 'Out of scope' section.",
+            check=_check_out_of_scope,
+        ),
+        Rule(
+            rule_id="tested_via_present",
+            description="Spec describes how the change will be tested.",
+            check=_check_tested_via,
+        ),
+        Rule(
+            rule_id="no_todo_markers",
+            description="Spec contains no TODO markers.",
+            check=_check_no_todo,
+        ),
+        Rule(
+            rule_id="no_placeholder_tokens",
+            description="Spec contains no <PLACEHOLDER>/TBD/XXX tokens.",
+            check=_check_no_placeholders,
+        ),
+        Rule(
+            rule_id="ref_paths_exist",
+            description="Every referenced path exists in the workspace.",
+            check=_check_ref_paths_exist,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Entry-point loading
+# ---------------------------------------------------------------------------
+
+
+def load_plugin_rules() -> list[Rule]:
+    """Load rules registered via the ``bernstein.spec_quality_rules`` group.
+
+    Each entry-point must resolve to a zero-arg callable returning a
+    :class:`Rule`. Errors during discovery or instantiation are swallowed
+    and the offending plugin is omitted; we never let a third-party rule
+    break the gate.
+    """
+    rules: list[Rule] = []
+    try:
+        eps = entry_points(group=ENTRY_POINT_GROUP)
+    except Exception:
+        return rules
+    for ep in eps:
+        try:
+            factory = ep.load()
+            rule = factory()
+        except Exception:
+            continue
+        if isinstance(rule, Rule):
+            rules.append(rule)
+    return rules
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate(
+    spec: Path | str,
+    *,
+    workspace_root: Path | None = None,
+    rules: Sequence[Rule] | None = None,
+) -> ChecklistReport:
+    """Evaluate every rule against ``spec`` and return a :class:`ChecklistReport`.
+
+    Args:
+        spec: Path to a markdown spec file *or* the raw spec text.
+        workspace_root: Optional repo root used by path-existence rules.
+        rules: Override the default rule set (typically used in tests).
+    """
+    spec_path, spec_text = _resolve_spec_input(spec)
+    effective_rules = list(rules) if rules is not None else (default_rules() + load_plugin_rules())
+    results = tuple(r.evaluate(spec_text, workspace_root) for r in effective_rules)
+    required_ids = frozenset(r.rule_id for r in effective_rules if r.required)
+    return ChecklistReport(
+        spec_path=spec_path,
+        results=results,
+        required_rule_ids=required_ids,
+    )
+
+
+def _resolve_spec_input(spec: Path | str) -> tuple[Path, str]:
+    """Normalise the ``spec`` argument into ``(path, text)``.
+
+    A :class:`Path` is read from disk; a ``str`` is treated as raw spec
+    content unless it points at an existing file, in which case the file
+    contents are returned. The path component of the return value is
+    informational only — callers persist it on the report for display.
+    """
+    if isinstance(spec, Path):
+        return spec, spec.read_text(encoding="utf-8")
+    candidate = Path(spec)
+    if candidate.exists() and candidate.is_file():
+        return candidate, candidate.read_text(encoding="utf-8")
+    return Path("<inline>"), spec
+
+
+# ---------------------------------------------------------------------------
+# Auto-fix loop + refuse-to-advance
+# ---------------------------------------------------------------------------
+
+
+class SpecQualityUnresolvedError(RuntimeError):
+    """Raised by :func:`refuse_to_advance` when the gate refuses the pipeline.
+
+    Attributes:
+        report: The final :class:`ChecklistReport` after the last attempt.
+    """
+
+    def __init__(self, report: ChecklistReport) -> None:
+        super().__init__(
+            f"Spec-quality gate refused to advance after {report.iteration} iteration(s); "
+            f"{len(report.required_failures)} required rule(s) still failing."
+        )
+        self.report = report
+
+
+def auto_fix_loop(
+    spec: Path | str,
+    *,
+    workspace_root: Path | None = None,
+    rules: Sequence[Rule] | None = None,
+    autofix: Callable[[ChecklistReport], str | None] | None = None,
+    max_iterations: int = DEFAULT_MAX_AUTO_FIX_ITERATIONS,
+) -> ChecklistReport:
+    """Iterate evaluate -> autofix until the report passes or budget is spent.
+
+    The ``autofix`` callable receives the latest report and must return the
+    rewritten spec text (or ``None`` to abort the loop without further
+    attempts). When ``autofix`` is ``None`` the loop degenerates to a
+    single evaluate call. The returned report's ``iteration`` field
+    reflects how many *fix attempts* were spent (0 = passed on first
+    evaluate, ``max_iterations`` = budget exhausted).
+    """
+    if max_iterations < 0:
+        raise ValueError("max_iterations must be >= 0")
+    current_text: Path | str = spec
+    report = evaluate(current_text, workspace_root=workspace_root, rules=rules)
+    if report.passed or autofix is None or max_iterations == 0:
+        return report
+
+    original_path = report.spec_path
+    attempts = 0
+    while attempts < max_iterations and not report.passed:
+        attempts += 1
+        rewritten = autofix(report)
+        if rewritten is None:
+            break
+        current_text = rewritten
+        report = evaluate(current_text, workspace_root=workspace_root, rules=rules)
+        report = ChecklistReport(
+            spec_path=original_path,
+            results=report.results,
+            iteration=attempts,
+            required_rule_ids=report.required_rule_ids,
+        )
+    return report
+
+
+def refuse_to_advance(
+    spec: Path | str,
+    *,
+    workspace_root: Path | None = None,
+    rules: Sequence[Rule] | None = None,
+    autofix: Callable[[ChecklistReport], str | None] | None = None,
+    max_iterations: int = DEFAULT_MAX_AUTO_FIX_ITERATIONS,
+) -> ChecklistReport:
+    """Drive the auto-fix loop and raise if the gate is still failing.
+
+    Returns the final :class:`ChecklistReport` when the gate passes; raises
+    :class:`SpecQualityUnresolvedError` otherwise. Use this in pipeline
+    integration just before dispatching the implementer agent.
+    """
+    report = auto_fix_loop(
+        spec,
+        workspace_root=workspace_root,
+        rules=rules,
+        autofix=autofix,
+        max_iterations=max_iterations,
+    )
+    if not report.passed:
+        raise SpecQualityUnresolvedError(report)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_report(report: ChecklistReport) -> str:
+    """Render ``report`` as a human-readable markdown block.
+
+    The output is stable and safe to write to a checklist artefact alongside
+    the spec or to stream from the CLI.
+    """
+    lines: list[str] = [
+        f"# Spec-quality checklist for `{report.spec_path}`",
+        "",
+        f"Iteration: {report.iteration} | Passed: {len(report.results) - report.failure_count}/{len(report.results)}",
+        "",
+    ]
+    for result in report.results:
+        marker = "[x]" if result.passed else "[ ]"
+        lines.append(f"- {marker} `{result.rule_id}`")
+        if not result.passed:
+            if result.message:
+                lines.append(f"  - {result.message}")
+            if result.hint:
+                lines.append(f"  - hint: {result.hint}")
+    return "\n".join(lines) + "\n"

--- a/src/bernstein/core/planning/spec_quality.py
+++ b/src/bernstein/core/planning/spec_quality.py
@@ -28,6 +28,7 @@ reading the spec path passed in by the caller.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
@@ -36,6 +37,8 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "DEFAULT_MAX_AUTO_FIX_ITERATIONS",
@@ -110,9 +113,22 @@ class Rule:
     required: bool = True
 
     def evaluate(self, spec_text: str, workspace_root: Path | None) -> RuleResult:
-        """Run the rule against ``spec_text``, swallowing any exceptions."""
+        """Run the rule against ``spec_text``, swallowing any exceptions.
+
+        The ``rule_id`` of the returned result is normalised to this rule's
+        own ``rule_id`` so a misbehaving plugin cannot smuggle a mismatched
+        id past the ``required_failures`` filter.
+        """
         try:
-            return self.check(spec_text, workspace_root)
+            result = self.check(spec_text, workspace_root)
+            if result.rule_id != self.rule_id:
+                return RuleResult(
+                    rule_id=self.rule_id,
+                    passed=result.passed,
+                    message=result.message or f"rule returned mismatched id '{result.rule_id}'",
+                    hint=result.hint,
+                )
+            return result
         except Exception as exc:
             return RuleResult(
                 rule_id=self.rule_id,
@@ -344,12 +360,22 @@ def load_plugin_rules() -> list[Rule]:
     try:
         eps = entry_points(group=ENTRY_POINT_GROUP)
     except Exception:
+        logger.warning(
+            "Failed to discover spec-quality entry points for group %s",
+            ENTRY_POINT_GROUP,
+            exc_info=True,
+        )
         return rules
     for ep in eps:
         try:
             factory = ep.load()
             rule = factory()
         except Exception:
+            logger.warning(
+                "Failed to load spec-quality plugin rule: %s",
+                ep.name,
+                exc_info=True,
+            )
             continue
         if isinstance(rule, Rule):
             rules.append(rule)
@@ -376,6 +402,16 @@ def evaluate(
     """
     spec_path, spec_text = _resolve_spec_input(spec)
     effective_rules = list(rules) if rules is not None else (default_rules() + load_plugin_rules())
+    # Deduplicate by rule_id (keep first occurrence) so a plugin cannot
+    # reuse a default rule's id and flip its required/optional status.
+    seen: set[str] = set()
+    deduped_rules: list[Rule] = []
+    for rule in effective_rules:
+        if rule.rule_id in seen:
+            continue
+        seen.add(rule.rule_id)
+        deduped_rules.append(rule)
+    effective_rules = deduped_rules
     results = tuple(r.evaluate(spec_text, workspace_root) for r in effective_rules)
     required_ids = frozenset(r.rule_id for r in effective_rules if r.required)
     return ChecklistReport(
@@ -395,9 +431,14 @@ def _resolve_spec_input(spec: Path | str) -> tuple[Path, str]:
     """
     if isinstance(spec, Path):
         return spec, spec.read_text(encoding="utf-8")
-    candidate = Path(spec)
-    if candidate.exists() and candidate.is_file():
-        return candidate, candidate.read_text(encoding="utf-8")
+    try:
+        candidate = Path(spec)
+        if candidate.exists() and candidate.is_file():
+            return candidate, candidate.read_text(encoding="utf-8")
+    except OSError:
+        # Inline spec text that is not a valid filesystem path (e.g. embedded
+        # NUL bytes or an over-long name) falls back to inline mode.
+        pass
     return Path("<inline>"), spec
 
 

--- a/tests/unit/cli/test_spec_cmd.py
+++ b/tests/unit/cli/test_spec_cmd.py
@@ -1,0 +1,96 @@
+"""Smoke tests for ``bernstein spec`` CLI subcommands (issue #1631)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.spec_cmd import spec_group
+
+CLEAN_SPEC = """# Add cohort export
+
+## Acceptance criteria
+- New endpoint returns CSV.
+
+## Out of scope
+- nothing else
+
+## Tested via
+- pytest tests/unit/api/test_cohort_export.py
+"""
+
+MISSING_AC_SPEC = """# Spec
+
+## Out of scope
+- nothing
+
+## Tested via
+- pytest
+"""
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_spec_check_passes_on_clean_spec(runner: CliRunner, tmp_path: Path) -> None:
+    spec = tmp_path / "spec.md"
+    spec.write_text(CLEAN_SPEC)
+    result = runner.invoke(spec_group, ["check", str(spec), "--workspace-root", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "acceptance_criteria_present" in result.output
+
+
+def test_spec_check_fails_on_dirty_spec(runner: CliRunner, tmp_path: Path) -> None:
+    spec = tmp_path / "spec.md"
+    spec.write_text(MISSING_AC_SPEC)
+    result = runner.invoke(spec_group, ["check", str(spec), "--workspace-root", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "acceptance_criteria_present" in result.output
+
+
+def test_spec_check_no_strict_returns_zero(runner: CliRunner, tmp_path: Path) -> None:
+    spec = tmp_path / "spec.md"
+    spec.write_text(MISSING_AC_SPEC)
+    result = runner.invoke(
+        spec_group,
+        ["check", str(spec), "--workspace-root", str(tmp_path), "--no-strict"],
+    )
+    assert result.exit_code == 0
+
+
+def test_spec_auto_fix_dry_run_does_not_persist(runner: CliRunner, tmp_path: Path) -> None:
+    spec = tmp_path / "spec.md"
+    spec.write_text(MISSING_AC_SPEC)
+    result = runner.invoke(
+        spec_group,
+        ["auto-fix", str(spec), "--workspace-root", str(tmp_path), "--max-iter", "3"],
+    )
+    # Heuristic patcher adds a stub Acceptance criteria section, so the gate
+    # converges and exits 0; the file on disk must still be untouched.
+    assert result.exit_code == 0, result.output
+    assert spec.read_text() == MISSING_AC_SPEC
+
+
+def test_spec_auto_fix_write_persists_changes(runner: CliRunner, tmp_path: Path) -> None:
+    spec = tmp_path / "spec.md"
+    spec.write_text(MISSING_AC_SPEC)
+    result = runner.invoke(
+        spec_group,
+        [
+            "auto-fix",
+            str(spec),
+            "--workspace-root",
+            str(tmp_path),
+            "--max-iter",
+            "3",
+            "--write",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    new_text = spec.read_text()
+    assert "Acceptance criteria" in new_text
+    assert new_text != MISSING_AC_SPEC

--- a/tests/unit/planning/test_spec_quality.py
+++ b/tests/unit/planning/test_spec_quality.py
@@ -1,0 +1,286 @@
+"""Unit tests for the spec-quality checklist gate (issue #1631)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.planning.spec_quality import (
+    DEFAULT_MAX_AUTO_FIX_ITERATIONS,
+    ChecklistReport,
+    Rule,
+    RuleResult,
+    SpecQualityUnresolvedError,
+    auto_fix_loop,
+    default_rules,
+    evaluate,
+    refuse_to_advance,
+    render_report,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture text
+# ---------------------------------------------------------------------------
+
+CLEAN_SPEC = """# Add cohort export
+
+## Acceptance criteria
+
+- New endpoint `/cohorts/export` returns CSV.
+- Tested via `tests/unit/api/test_cohort_export.py`.
+
+## Out of scope
+
+- Anything outside cohort export.
+
+## Tested via
+
+- pytest tests/unit/api/test_cohort_export.py
+"""
+
+DIRTY_SPEC_MISSING_AC = """# Add cohort export
+
+## Out of scope
+
+- Anything outside cohort export.
+
+## Tested via
+
+- pytest tests/unit/api/test_cohort_export.py
+"""
+
+DIRTY_SPEC_TODO = """# Spec
+
+## Acceptance criteria
+- TODO: figure this out.
+
+## Out of scope
+- nothing
+
+## Tested via
+- pytest -k something
+"""
+
+DIRTY_SPEC_PLACEHOLDER = """# Spec
+
+## Acceptance criteria
+- Replace <FEATURE NAME> with something.
+
+## Out of scope
+- nothing
+
+## Tested via
+- pytest
+"""
+
+
+# ---------------------------------------------------------------------------
+# Individual rule pass/fail
+# ---------------------------------------------------------------------------
+
+
+def test_default_rules_pass_on_clean_spec() -> None:
+    report = evaluate(CLEAN_SPEC)
+    assert report.passed
+    assert report.failure_count == 0
+    assert {r.rule_id for r in report.results} == {r.rule_id for r in default_rules()}
+
+
+def test_acceptance_criteria_missing_fails() -> None:
+    report = evaluate(DIRTY_SPEC_MISSING_AC)
+    assert not report.passed
+    failures = {f.rule_id for f in report.required_failures}
+    assert "acceptance_criteria_present" in failures
+
+
+def test_out_of_scope_missing_fails() -> None:
+    spec = "# X\n\n## Acceptance criteria\n- a\n\n## Tested via\n- pytest\n"
+    report = evaluate(spec)
+    assert not report.passed
+    assert any(f.rule_id == "out_of_scope_present" for f in report.required_failures)
+
+
+def test_tested_via_missing_fails() -> None:
+    spec = "# X\n\n## Acceptance criteria\n- a\n\n## Out of scope\n- none\n"
+    report = evaluate(spec)
+    assert not report.passed
+    assert any(f.rule_id == "tested_via_present" for f in report.required_failures)
+
+
+def test_todo_markers_fail() -> None:
+    report = evaluate(DIRTY_SPEC_TODO)
+    assert not report.passed
+    assert any(f.rule_id == "no_todo_markers" for f in report.required_failures)
+
+
+def test_placeholder_tokens_fail() -> None:
+    report = evaluate(DIRTY_SPEC_PLACEHOLDER)
+    assert not report.passed
+    assert any(f.rule_id == "no_placeholder_tokens" for f in report.required_failures)
+
+
+def test_ref_paths_exist_fails_when_path_missing(tmp_path: Path) -> None:
+    spec = (
+        "# X\n\n## Acceptance criteria\n- a\n\n## Out of scope\n- none\n\n"
+        "## Tested via\n- pytest\n\n"
+        "References `src/bernstein/does_not_exist/missing.py` here.\n"
+    )
+    report = evaluate(spec, workspace_root=tmp_path)
+    assert not report.passed
+    assert any(f.rule_id == "ref_paths_exist" for f in report.required_failures)
+
+
+def test_ref_paths_exist_passes_when_path_present(tmp_path: Path) -> None:
+    (tmp_path / "src" / "bernstein").mkdir(parents=True)
+    (tmp_path / "src" / "bernstein" / "real.py").write_text("x = 1\n")
+    spec = (
+        "# X\n\n## Acceptance criteria\n- a\n\n## Out of scope\n- none\n\n"
+        "## Tested via\n- pytest\n\n"
+        "References `src/bernstein/real.py` here.\n"
+    )
+    report = evaluate(spec, workspace_root=tmp_path)
+    assert report.passed
+
+
+def test_ref_paths_skipped_when_no_workspace() -> None:
+    spec = CLEAN_SPEC + "\nReferences `src/bernstein/anything.py` here.\n"
+    report = evaluate(spec, workspace_root=None)
+    # Without a workspace root the rule is informational; gate still passes.
+    assert report.passed
+
+
+def test_evaluate_from_path(tmp_path: Path) -> None:
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text(CLEAN_SPEC)
+    report = evaluate(spec_file)
+    assert report.passed
+    assert report.spec_path == spec_file
+
+
+# ---------------------------------------------------------------------------
+# Rule plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_rule_swallows_exceptions() -> None:
+    def explode(_text: str, _root: Path | None) -> RuleResult:
+        raise RuntimeError("boom")
+
+    rule = Rule(rule_id="explodes", description="raises", check=explode)
+    result = rule.evaluate("anything", None)
+    assert not result.passed
+    assert "RuntimeError" in result.message
+
+
+def test_optional_rules_do_not_block_advancement() -> None:
+    def always_fail(_text: str, _root: Path | None) -> RuleResult:
+        return RuleResult(rule_id="optional_fail", passed=False, message="nope")
+
+    optional = Rule(
+        rule_id="optional_fail",
+        description="never passes",
+        check=always_fail,
+        required=False,
+    )
+    report = evaluate(CLEAN_SPEC, rules=[*default_rules(), optional])
+    assert report.passed
+    assert report.failure_count == 1
+
+
+def test_render_report_includes_failed_hints() -> None:
+    report = evaluate(DIRTY_SPEC_MISSING_AC)
+    rendered = render_report(report)
+    assert "acceptance_criteria_present" in rendered
+    assert "hint:" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Auto-fix loop
+# ---------------------------------------------------------------------------
+
+
+def test_auto_fix_loop_converges() -> None:
+    """A fixer that patches every flagged rule must converge inside the budget."""
+    calls = {"n": 0}
+
+    def fixer(report: ChecklistReport) -> str:
+        calls["n"] += 1
+        # Add whatever's missing on each pass.
+        text = "# X\n"
+        text += "\n## Acceptance criteria\n- one\n"
+        text += "\n## Out of scope\n- none\n"
+        text += "\n## Tested via\n- pytest\n"
+        return text
+
+    starting = "# X\n"
+    final = auto_fix_loop(starting, autofix=fixer, max_iterations=3)
+    assert final.passed
+    assert final.iteration == 1
+    assert calls["n"] == 1
+
+
+def test_auto_fix_loop_returns_first_eval_when_already_passing() -> None:
+    final = auto_fix_loop(CLEAN_SPEC, autofix=lambda _r: pytest.fail("should not be called"))
+    assert final.passed
+    assert final.iteration == 0
+
+
+def test_auto_fix_loop_respects_zero_budget() -> None:
+    final = auto_fix_loop(DIRTY_SPEC_MISSING_AC, autofix=lambda _r: CLEAN_SPEC, max_iterations=0)
+    assert not final.passed
+    assert final.iteration == 0
+
+
+def test_auto_fix_loop_negative_budget_raises() -> None:
+    with pytest.raises(ValueError):
+        auto_fix_loop(CLEAN_SPEC, max_iterations=-1)
+
+
+def test_auto_fix_loop_stops_when_fixer_returns_none() -> None:
+    final = auto_fix_loop(DIRTY_SPEC_MISSING_AC, autofix=lambda _r: None, max_iterations=3)
+    assert not final.passed
+
+
+# ---------------------------------------------------------------------------
+# Refuse-to-advance gate
+# ---------------------------------------------------------------------------
+
+
+def test_refuse_to_advance_blocks_after_max_iterations() -> None:
+    """A no-op fixer must exhaust the budget and raise."""
+    calls = {"n": 0}
+
+    def noop(_report: ChecklistReport) -> str:
+        calls["n"] += 1
+        return DIRTY_SPEC_MISSING_AC
+
+    with pytest.raises(SpecQualityUnresolvedError) as excinfo:
+        refuse_to_advance(
+            DIRTY_SPEC_MISSING_AC,
+            autofix=noop,
+            max_iterations=DEFAULT_MAX_AUTO_FIX_ITERATIONS,
+        )
+    assert calls["n"] == DEFAULT_MAX_AUTO_FIX_ITERATIONS
+    assert excinfo.value.report.iteration == DEFAULT_MAX_AUTO_FIX_ITERATIONS
+    assert not excinfo.value.report.passed
+
+
+def test_refuse_to_advance_passes_clean_spec() -> None:
+    report = refuse_to_advance(CLEAN_SPEC)
+    assert report.passed
+
+
+def test_refuse_to_advance_passes_after_autofix() -> None:
+    def fix(_r: ChecklistReport) -> str:
+        return CLEAN_SPEC
+
+    report = refuse_to_advance(DIRTY_SPEC_MISSING_AC, autofix=fix, max_iterations=3)
+    assert report.passed
+    assert report.iteration == 1
+
+
+def test_refuse_to_advance_blocks_without_autofix() -> None:
+    """No fixer wired -> single eval -> raises immediately on failure."""
+    with pytest.raises(SpecQualityUnresolvedError):
+        refuse_to_advance(DIRTY_SPEC_MISSING_AC, max_iterations=3)

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -229,6 +229,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "secrets",
         "trackers",
         "trend-scan",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "spec",
     }
 )
 


### PR DESCRIPTION
## Summary

- New library `bernstein.core.planning.spec_quality` with pluggable `Rule`/`RuleResult` interface, `evaluate`, `auto_fix_loop`, `refuse_to_advance`, and a stable `render_report`.
- Default rules: acceptance-criteria, out-of-scope, tested-via, no-TODO, no-placeholder, ref-paths-exist.
- `bernstein spec check <path>` and `bernstein spec auto-fix <path>` CLI surfaces under `bernstein.cli.commands.spec_cmd`.
- Rules are extensible via the `bernstein.spec_quality_rules` entry-point group; broken plugins are swallowed so they cannot crash the gate.
- Auto-fix loop is bounded (default 3); on exhaustion `refuse_to_advance` raises `SpecQualityUnresolvedError` carrying the final `ChecklistReport` for operator surfaces.

## Test plan

- [x] `uv run pytest tests/unit/planning/test_spec_quality.py tests/unit/cli/test_spec_cmd.py` (27 passed)
- [x] `uv run pytest tests/unit/planning/` (76 passed, no regressions)
- [x] `uv run ruff check` on touched files clean
- [x] `bernstein spec --help` and `bernstein spec check` smoke

Closes #1631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level bernstein "spec" CLI with `check` (strict mode) and `auto-fix` (iterative, dry-run or write) to validate and remediate feature specs
  * Pluggable rule system so custom validation rules can be registered

* **Documentation**
  * New spec-quality gate docs with usage, CLI examples, and rule-authoring guidance

* **Tests**
  * New unit tests covering validation, auto-fix behavior, and rule evaluations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->