### PR TITLE
feat(quality): empirical confidence from outcome history

### DIFF
--- a/docs/quality/empirical-confidence.md
+++ b/docs/quality/empirical-confidence.md
@@ -1,0 +1,87 @@
+# Empirical confidence from outcome history
+
+Routing and review surfaces previously relied on a model's self-reported
+confidence or a single recent run's outcome. Self-rated confidence is
+uncorrelated with actual correctness, and a single run is too noisy to gate
+decisions on. This module records explicit outcomes and exposes a
+sample-size-gated query.
+
+## Module
+
+`src/bernstein/core/quality/empirical_confidence.py`
+
+Public API:
+
+- `record_outcome(agent_type, decision_key, outcome, *, evidence_uri=None, sampled_at=None)`
+- `confidence(agent_type, decision_key) -> Confidence`
+- `ConfidenceQuery(db_path=..., min_samples=...)` for dependency injection
+
+Return type:
+
+```python
+@dataclass(frozen=True)
+class Confidence:
+    value: float | None        # mean outcome in [0,1], or None
+    samples: int               # total recorded rows
+    insufficient_data: bool    # True when samples < min_samples
+    min_samples: int           # threshold used for this query
+```
+
+## Storage
+
+Single SQLite table, append-only:
+
+```
+agent_outcomes(
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_type   TEXT    NOT NULL,
+    decision_key TEXT    NOT NULL,
+    outcome      INTEGER NOT NULL CHECK (outcome IN (0, 1)),
+    sampled_at   REAL    NOT NULL,   -- POSIX seconds, UTC
+    evidence_uri TEXT
+);
+CREATE INDEX idx_agent_outcomes_lookup ON agent_outcomes (agent_type, decision_key);
+```
+
+Default path: `${XDG_DATA_HOME:-~/.local/share}/bernstein/empirical-confidence.db`.
+
+## Sample-size gate
+
+The default minimum sample count is `5`. Below this threshold,
+`confidence(...)` returns `value=None` and `insufficient_data=True`. The
+caller is expected to fall back to a documented uniform prior (the module
+exposes `DEFAULT_PRIOR = 0.5`) or another signal of its choice.
+
+Override via:
+
+- `BERNSTEIN_CONFIDENCE_MIN_SAMPLES` environment variable
+- `ConfidenceQuery(min_samples=...)` constructor argument
+
+## Routing integration
+
+`bernstein.core.routing.model_recommender.recommend_models` queries the
+empirical ledger first under the decision key
+`role:<task.role>|model:<model_key>`. The previous epsilon-greedy bandit
+data still fills in for cells that have not yet accumulated enough samples
+in the ledger, and the capability-tier heuristic is the final fallback.
+
+The ordering is:
+
+1. Empirical confidence with `samples >= min_samples`.
+2. Bandit arm success rate with `observations >= MIN_OBSERVATIONS`.
+3. Capability-tier heuristic (0.8 / 0.6 / 0.4).
+
+## Why decoupled from the run log
+
+Outcome population may lag the run that produced it (a review verdict can
+arrive minutes or hours later, or be replayed). Keeping a separate
+append-only table lets the run-log semantics stay simple and lets backfill
+or replay add rows without touching run history.
+
+## Configuration summary
+
+| Variable                             | Default                                                | Effect                          |
+|--------------------------------------|--------------------------------------------------------|---------------------------------|
+| `BERNSTEIN_CONFIDENCE_DB`            | `~/.local/share/bernstein/empirical-confidence.db`     | Override SQLite file location   |
+| `BERNSTEIN_CONFIDENCE_MIN_SAMPLES`   | `5`                                                    | Sample-size gate threshold      |
+| `XDG_DATA_HOME`                      | `~/.local/share`                                       | Base for the default DB path    |

--- a/src/bernstein/core/quality/empirical_confidence.py
+++ b/src/bernstein/core/quality/empirical_confidence.py
@@ -1,0 +1,373 @@
+"""Empirical confidence from outcome history.
+
+Records per-decision outcomes in an append-only SQLite table and exposes a
+sample-size-gated confidence query. The query refuses to return a value when
+the sample size is below a documented threshold; callers fall back to a
+uniform prior or another signal of their choice.
+
+The table is decoupled from any run-log so that outcome population can lag,
+backfill, or be replayed without disturbing run-history semantics.
+
+Public API:
+    * ``record_outcome(agent_type, decision_key, outcome, ...)``
+    * ``confidence(agent_type, decision_key, ...) -> Confidence``
+    * ``ConfidenceQuery`` for ergonomic dependency injection.
+
+Schema (single table, ``agent_outcomes``):
+    id              INTEGER PRIMARY KEY AUTOINCREMENT
+    agent_type      TEXT    NOT NULL
+    decision_key    TEXT    NOT NULL
+    outcome         INTEGER NOT NULL   -- 1 = correct, 0 = incorrect
+    sampled_at      REAL    NOT NULL   -- POSIX seconds, UTC
+    evidence_uri    TEXT                -- optional reference to a run or artefact
+
+Indexes are created on ``(agent_type, decision_key)`` for fast aggregate
+queries.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults and configuration
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_MIN_SAMPLES: int = 5
+"""Minimum sample count before :func:`confidence` returns a value.
+
+Callers receive a :class:`Confidence` with ``value=None`` and
+``insufficient_data=True`` below this threshold. The default of 5 is the
+smallest sample size at which the binomial confidence interval narrows
+enough to discriminate adjacent decision keys; tune via
+``BERNSTEIN_CONFIDENCE_MIN_SAMPLES`` for stricter gating.
+"""
+
+
+DEFAULT_PRIOR: float = 0.5
+"""Uniform prior returned by ``ConfidenceQuery.get_or_default`` when no
+sufficient sample is available. Documented so routing decisions are
+reproducible.
+"""
+
+
+_ENV_MIN_SAMPLES = "BERNSTEIN_CONFIDENCE_MIN_SAMPLES"
+_ENV_DB_PATH = "BERNSTEIN_CONFIDENCE_DB"
+
+
+def _xdg_data_home() -> Path:
+    """Return the XDG_DATA_HOME path with the documented fallback."""
+    raw = os.environ.get("XDG_DATA_HOME", "").strip()
+    if raw:
+        return Path(raw)
+    return Path.home() / ".local" / "share"
+
+
+def default_db_path() -> Path:
+    """Resolved on-disk path for the empirical confidence SQLite file.
+
+    Honours ``BERNSTEIN_CONFIDENCE_DB`` for test override, otherwise the
+    XDG-conventional ``~/.local/share/bernstein/empirical-confidence.db``.
+    """
+    override = os.environ.get(_ENV_DB_PATH, "").strip()
+    if override:
+        return Path(override)
+    return _xdg_data_home() / "bernstein" / "empirical-confidence.db"
+
+
+def _resolve_min_samples(explicit: int | None) -> int:
+    """Resolve the sample-size threshold from arg, env, or default."""
+    if explicit is not None:
+        return max(1, int(explicit))
+    raw = os.environ.get(_ENV_MIN_SAMPLES, "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+            if parsed >= 1:
+                return parsed
+        except ValueError:
+            logger.warning("Ignoring invalid %s=%r", _ENV_MIN_SAMPLES, raw)
+    return DEFAULT_MIN_SAMPLES
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Confidence:
+    """Sample-size-gated confidence value.
+
+    Attributes:
+        value: Historical accuracy in ``[0.0, 1.0]`` if the sample is large
+            enough; otherwise ``None``.
+        samples: Number of recorded outcomes for the queried key.
+        insufficient_data: ``True`` when ``samples < min_samples``.
+        min_samples: Threshold used for this query.
+    """
+
+    value: float | None
+    samples: int
+    insufficient_data: bool
+    min_samples: int
+
+    def as_float(self, default: float = DEFAULT_PRIOR) -> float:
+        """Return ``value`` if available, otherwise ``default``."""
+        return self.value if self.value is not None else default
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "value": None if self.value is None else round(self.value, 4),
+            "samples": self.samples,
+            "insufficient_data": self.insufficient_data,
+            "min_samples": self.min_samples,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Storage layer
+# ---------------------------------------------------------------------------
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_outcomes (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_type    TEXT    NOT NULL,
+    decision_key  TEXT    NOT NULL,
+    outcome       INTEGER NOT NULL CHECK (outcome IN (0, 1)),
+    sampled_at    REAL    NOT NULL,
+    evidence_uri  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_agent_outcomes_lookup
+    ON agent_outcomes (agent_type, decision_key);
+"""
+
+
+class _OutcomeStore:
+    """Thin SQLite wrapper around the ``agent_outcomes`` table.
+
+    Connections are short-lived per operation. A module-level lock keeps
+    schema migrations race-free; SQLite itself handles concurrent appends.
+    """
+
+    _migration_lock = threading.Lock()
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._ensure_parent()
+        self._migrate()
+
+    def _ensure_parent(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _migrate(self) -> None:
+        with self._migration_lock, self._connect() as conn:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self._db_path, timeout=5.0, isolation_level=None)
+        try:
+            # WAL keeps reads non-blocking against concurrent appends. Not
+            # every SQLite build ships WAL; the fall-back is silent.
+            with suppress(sqlite3.DatabaseError):
+                conn.execute("PRAGMA journal_mode=WAL;")
+            yield conn
+        finally:
+            conn.close()
+
+    def append(
+        self,
+        *,
+        agent_type: str,
+        decision_key: str,
+        outcome: int,
+        sampled_at: float,
+        evidence_uri: str | None,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO agent_outcomes "
+                "(agent_type, decision_key, outcome, sampled_at, evidence_uri) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (agent_type, decision_key, outcome, sampled_at, evidence_uri),
+            )
+
+    def aggregate(self, *, agent_type: str, decision_key: str) -> tuple[int, float]:
+        """Return ``(sample_count, mean_outcome)`` for the key."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*), COALESCE(AVG(outcome), 0.0) "
+                "FROM agent_outcomes "
+                "WHERE agent_type = ? AND decision_key = ?",
+                (agent_type, decision_key),
+            ).fetchone()
+        if row is None:
+            return 0, 0.0
+        return int(row[0]), float(row[1])
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class ConfidenceQuery:
+    """Read-side facade over the outcome ledger.
+
+    Useful for dependency injection: callers that need ``get(agent, key)``
+    can hold a single instance rather than the function-level API.
+    """
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | None = None,
+        min_samples: int | None = None,
+    ) -> None:
+        self._db_path = db_path or default_db_path()
+        self._store = _OutcomeStore(self._db_path)
+        self._min_samples = _resolve_min_samples(min_samples)
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    @property
+    def min_samples(self) -> int:
+        return self._min_samples
+
+    def record(
+        self,
+        agent_type: str,
+        decision_key: str,
+        outcome: bool | int,
+        *,
+        evidence_uri: str | None = None,
+        sampled_at: float | None = None,
+    ) -> None:
+        """Append a single outcome row.
+
+        ``outcome`` is coerced to ``1`` for truthy values and ``0`` otherwise
+        so callers can pass either booleans or explicit ints.
+        """
+        _validate_key(agent_type, "agent_type")
+        _validate_key(decision_key, "decision_key")
+        ts = sampled_at if sampled_at is not None else time.time()
+        self._store.append(
+            agent_type=agent_type,
+            decision_key=decision_key,
+            outcome=1 if bool(outcome) else 0,
+            sampled_at=float(ts),
+            evidence_uri=evidence_uri,
+        )
+
+    def get(self, agent_type: str, decision_key: str) -> Confidence:
+        """Return the sample-gated empirical confidence for the key."""
+        _validate_key(agent_type, "agent_type")
+        _validate_key(decision_key, "decision_key")
+        samples, mean = self._store.aggregate(agent_type=agent_type, decision_key=decision_key)
+        if samples < self._min_samples:
+            return Confidence(
+                value=None,
+                samples=samples,
+                insufficient_data=True,
+                min_samples=self._min_samples,
+            )
+        return Confidence(
+            value=mean,
+            samples=samples,
+            insufficient_data=False,
+            min_samples=self._min_samples,
+        )
+
+    def get_or_default(
+        self,
+        agent_type: str,
+        decision_key: str,
+        *,
+        default: float = DEFAULT_PRIOR,
+    ) -> float:
+        """Convenience: empirical value if available, else the prior."""
+        return self.get(agent_type, decision_key).as_float(default=default)
+
+
+def _validate_key(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        msg = f"{field_name} must be a non-empty string"
+        raise ValueError(msg)
+
+
+# Module-level default query, lazy so tests can override the DB path before
+# the first call.
+_default_query: ConfidenceQuery | None = None
+_default_lock = threading.Lock()
+
+
+def _get_default_query() -> ConfidenceQuery:
+    global _default_query
+    if _default_query is None:
+        with _default_lock:
+            if _default_query is None:
+                _default_query = ConfidenceQuery()
+    return _default_query
+
+
+def reset_default_query() -> None:
+    """Drop the cached module-level query. Intended for tests."""
+    global _default_query
+    with _default_lock:
+        _default_query = None
+
+
+def record_outcome(
+    agent_type: str,
+    decision_key: str,
+    outcome: bool | int,
+    *,
+    evidence_uri: str | None = None,
+    sampled_at: float | None = None,
+) -> None:
+    """Append a single outcome row via the default query."""
+    _get_default_query().record(
+        agent_type,
+        decision_key,
+        outcome,
+        evidence_uri=evidence_uri,
+        sampled_at=sampled_at,
+    )
+
+
+def confidence(agent_type: str, decision_key: str) -> Confidence:
+    """Return sample-gated empirical confidence via the default query."""
+    return _get_default_query().get(agent_type, decision_key)
+
+
+__all__ = [
+    "DEFAULT_MIN_SAMPLES",
+    "DEFAULT_PRIOR",
+    "Confidence",
+    "ConfidenceQuery",
+    "confidence",
+    "default_db_path",
+    "record_outcome",
+    "reset_default_query",
+]

--- a/src/bernstein/core/routing/model_recommender.py
+++ b/src/bernstein/core/routing/model_recommender.py
@@ -158,11 +158,35 @@ def recommend_models(
     # Determine minimum capability
     min_cap = _MIN_CAPABILITY.get(complexity_str, 2)
 
-    # Load historical success data if available
+    # Load historical success data if available. Empirical outcome history
+    # is preferred over the bandit arm because it is decoupled from the
+    # exploration policy and uses a documented sample-size gate. Bandit data
+    # only fills in when the empirical ledger has no qualifying sample.
+    from bernstein.core.quality.empirical_confidence import ConfidenceQuery
+
     historical_rates: dict[str, float] = {}
+
+    confidence_query: ConfidenceQuery | None = None
+    try:
+        confidence_query = ConfidenceQuery()
+    except Exception:  # pragma: no cover - storage failures must not break routing
+        logger.debug("Empirical confidence store unavailable; falling back", exc_info=True)
+
+    if confidence_query is not None:
+        for model_key in _MODEL_CAPABILITY:
+            decision_key = f"role:{task.role}|model:{model_key}"
+            measured = confidence_query.get(
+                agent_type="model_recommender",
+                decision_key=decision_key,
+            )
+            if measured.value is not None:
+                historical_rates[model_key] = measured.value
+
     if metrics_dir and metrics_dir.exists():
         bandit = EpsilonGreedyBandit.load(metrics_dir)
         for model_key in _MODEL_CAPABILITY:
+            if model_key in historical_rates:
+                continue  # empirical history wins
             arm = bandit.get_arm(task.role, model_key)
             if arm and arm.observations >= MIN_OBSERVATIONS:
                 historical_rates[model_key] = arm.success_rate
@@ -183,7 +207,9 @@ def recommend_models(
         savings = current_cost - est_cost
         savings_pct = (savings / current_cost * 100) if current_cost > 0 else 0.0
 
-        # Confidence from historical data or heuristic
+        # Confidence from historical data or heuristic. Empirical outcomes
+        # take precedence; the capability-tier defaults only apply when no
+        # measurement has accumulated past the sample-size gate.
         if model_key in historical_rates:
             confidence = historical_rates[model_key]
             reason = f"Historical success rate {confidence:.0%} for role '{task.role}'"

--- a/tests/unit/quality/test_empirical_confidence.py
+++ b/tests/unit/quality/test_empirical_confidence.py
@@ -1,0 +1,238 @@
+"""Unit tests for the empirical-confidence ledger.
+
+Covers:
+    * record + read round trip
+    * sample-size gate (returns ``None`` below threshold)
+    * persistence across :class:`ConfidenceQuery` instances
+    * router integration prefers empirical outcomes over the heuristic tier
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.core.quality.empirical_confidence import (
+    DEFAULT_MIN_SAMPLES,
+    Confidence,
+    ConfidenceQuery,
+    default_db_path,
+)
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated DB path; clears env var that could leak between tests."""
+    target = tmp_path / "empirical.db"
+    monkeypatch.delenv("BERNSTEIN_CONFIDENCE_MIN_SAMPLES", raising=False)
+    monkeypatch.setenv("BERNSTEIN_CONFIDENCE_DB", str(target))
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Basic record / confidence round trip
+# ---------------------------------------------------------------------------
+
+
+def test_record_then_query_returns_mean_above_threshold(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path, min_samples=3)
+    for value in (1, 1, 0, 1, 0):
+        query.record("router", "decision-a", value)
+
+    result = query.get("router", "decision-a")
+
+    assert result.samples == 5
+    assert result.insufficient_data is False
+    assert result.value is not None
+    assert pytest.approx(result.value, abs=1e-9) == 3 / 5
+
+
+def test_record_accepts_boolean(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path, min_samples=1)
+    query.record("router", "k", True)
+    query.record("router", "k", False)
+
+    result = query.get("router", "k")
+
+    assert result.samples == 2
+    assert result.value == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Sample-size gate
+# ---------------------------------------------------------------------------
+
+
+def test_below_threshold_returns_insufficient_data(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path, min_samples=5)
+    for _ in range(4):
+        query.record("router", "decision-b", 1)
+
+    result = query.get("router", "decision-b")
+
+    assert result.samples == 4
+    assert result.insufficient_data is True
+    assert result.value is None
+
+
+def test_threshold_default_is_five(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path)
+    assert query.min_samples == DEFAULT_MIN_SAMPLES
+
+
+def test_env_override_for_threshold(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_CONFIDENCE_MIN_SAMPLES", "2")
+    query = ConfidenceQuery(db_path=db_path)
+    assert query.min_samples == 2
+
+
+def test_get_or_default_falls_back_to_prior(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path, min_samples=5)
+    query.record("router", "rare-key", 1)
+
+    assert query.get_or_default("router", "rare-key", default=0.42) == 0.42
+
+
+def test_missing_key_returns_zero_samples(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path, min_samples=5)
+    result = query.get("router", "unknown")
+
+    assert result == Confidence(value=None, samples=0, insufficient_data=True, min_samples=5)
+
+
+# ---------------------------------------------------------------------------
+# Persistence across instances
+# ---------------------------------------------------------------------------
+
+
+def test_persistence_across_instances(db_path: Path) -> None:
+    writer = ConfidenceQuery(db_path=db_path, min_samples=3)
+    for _ in range(3):
+        writer.record("router", "persisted", 1)
+
+    reader = ConfidenceQuery(db_path=db_path, min_samples=3)
+    result = reader.get("router", "persisted")
+
+    assert result.samples == 3
+    assert result.value == pytest.approx(1.0)
+
+
+def test_evidence_uri_stored(db_path: Path) -> None:
+    query = ConfidenceQuery(db_path=db_path, min_samples=1)
+    query.record("router", "trace", 1, evidence_uri="run://abc")
+
+    # Cross-check by reading the raw table; the public API does not yet
+    # expose evidence_uri, but the row must be present for replay tooling.
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT evidence_uri FROM agent_outcomes WHERE decision_key = ?",
+            ("trace",),
+        ).fetchone()
+    assert row == ("run://abc",)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "   "])
+def test_rejects_empty_agent_type(db_path: Path, bad: str) -> None:
+    query = ConfidenceQuery(db_path=db_path)
+    with pytest.raises(ValueError):
+        query.record(bad, "k", 1)
+    with pytest.raises(ValueError):
+        query.get(bad, "k")
+
+
+@pytest.mark.parametrize("bad", ["", "   "])
+def test_rejects_empty_decision_key(db_path: Path, bad: str) -> None:
+    query = ConfidenceQuery(db_path=db_path)
+    with pytest.raises(ValueError):
+        query.record("router", bad, 1)
+
+
+# ---------------------------------------------------------------------------
+# Default DB path
+# ---------------------------------------------------------------------------
+
+
+def test_default_db_path_uses_xdg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("BERNSTEIN_CONFIDENCE_DB", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    resolved = default_db_path()
+
+    assert resolved == tmp_path / "bernstein" / "empirical-confidence.db"
+
+
+# ---------------------------------------------------------------------------
+# Router integration: empirical confidence beats the heuristic tier
+# ---------------------------------------------------------------------------
+
+
+class _StubTask:
+    """Light Task stand-in matching the attributes model_recommender reads."""
+
+    def __init__(self, role: str = "code", complexity: str = "medium", scope: str = "medium") -> None:
+        self.id = "task-1"
+        self.role = role
+        self.model = "opus"
+        self.complexity = complexity
+        self.scope = scope
+
+
+def _make_task(role: str = "code", complexity: str = "medium", scope: str = "medium") -> _StubTask:
+    return _StubTask(role=role, complexity=complexity, scope=scope)
+
+
+def test_router_prefers_empirical_confidence(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empirical samples should override the heuristic 0.8 / 0.6 tier values."""
+    from bernstein.core.routing import model_recommender
+
+    # Seed empirical outcomes for the haiku model under role 'code'.
+    seeder = ConfidenceQuery(db_path=db_path, min_samples=5)
+    for _ in range(5):
+        seeder.record("model_recommender", "role:code|model:haiku", 1, evidence_uri="seed")
+
+    # Stub out the cost module so the test does not need real pricing tables.
+    fake_cost = MagicMock()
+    fake_cost.MIN_OBSERVATIONS = 5
+    fake_cost.EpsilonGreedyBandit.load.return_value = MagicMock(get_arm=MagicMock(return_value=None))
+    fake_cost._model_cost.side_effect = lambda model: 0.001 if model == "haiku" else 0.01
+    fake_cost.get_cascade_model.return_value = "opus"
+
+    with patch.dict("sys.modules", {"bernstein.core.cost": fake_cost}):
+        report = model_recommender.recommend_models(_make_task(complexity="low"), metrics_dir=None)
+
+    haiku = next(r for r in report.recommendations if r.model == "haiku")
+    assert haiku.confidence == pytest.approx(1.0)
+    assert "Historical success rate" in haiku.reason
+
+
+def test_router_falls_back_to_tier_without_sample(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without enough samples, recommender keeps the documented tier default."""
+    from bernstein.core.routing import model_recommender
+
+    seeder = ConfidenceQuery(db_path=db_path, min_samples=5)
+    # Only 2 samples for haiku, below the gate.
+    for _ in range(2):
+        seeder.record("model_recommender", "role:code|model:haiku", 1)
+
+    fake_cost = MagicMock()
+    fake_cost.MIN_OBSERVATIONS = 5
+    fake_cost.EpsilonGreedyBandit.load.return_value = MagicMock(get_arm=MagicMock(return_value=None))
+    fake_cost._model_cost.side_effect = lambda model: 0.001 if model == "haiku" else 0.01
+    fake_cost.get_cascade_model.return_value = "opus"
+
+    with patch.dict("sys.modules", {"bernstein.core.cost": fake_cost}):
+        report = model_recommender.recommend_models(_make_task(complexity="low"), metrics_dir=None)
+
+    haiku = next(r for r in report.recommendations if r.model == "haiku")
+    # Falls back to the heuristic tier confidence, not 1.0.
+    assert haiku.confidence != pytest.approx(1.0)
+    assert haiku.confidence in (0.4, 0.6, 0.8)


### PR DESCRIPTION
## Summary

- Adds `src/bernstein/core/quality/empirical_confidence.py`: an append-only SQLite ledger (`agent_outcomes` table) of per-decision outcomes, with a sample-size-gated `ConfidenceQuery` that returns `None` below the documented threshold (default 5) instead of fabricating a value.
- Wires the ledger into `core/routing/model_recommender.py`: empirical outcomes win over the existing capability-tier heuristic and over the bandit arm; both remain as fall-backs for cells that have not accumulated enough samples.
- Default DB path: `${XDG_DATA_HOME:-~/.local/share}/bernstein/empirical-confidence.db`. Overridable via `BERNSTEIN_CONFIDENCE_DB`; threshold via `BERNSTEIN_CONFIDENCE_MIN_SAMPLES`.
- Docs at `docs/quality/empirical-confidence.md` cover the schema, the sample-size rationale, and the routing precedence order.

Closes #1622.

## Test plan

- [x] `uv run pytest tests/unit/quality/test_empirical_confidence.py` (16 new tests pass: record/read, sample-size gate, env override, missing key, persistence across instances, evidence_uri storage, key validation, default path, router integration with empirical preference, router fall-back when under-sampled).
- [x] `uv run pytest tests/unit/test_model_recommender.py` regression (8 existing tests still pass).
- [x] `uv run pre-commit run --files <changed>` clean.

## Notes

- v1 is uniform-prior; Bayesian tuning and decay weighting are out of scope per the issue.
- The ledger is decoupled from `agent_runs` so backfill and replay can add rows without touching run-history semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced empirical confidence module that records and aggregates outcome data using SQLite storage.
  * Model recommender now sources historical confidence measurements when available.

* **Documentation**
  * Added documentation for the empirical confidence quality module.

* **Tests**
  * Added comprehensive test coverage for empirical confidence recording, querying, and model recommender integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->