### PR TITLE
feat(skills): three-layer customization with deterministic merge

### DIFF
--- a/docs/skills/layered-merge.md
+++ b/docs/skills/layered-merge.md
@@ -1,0 +1,145 @@
+# Layered skill customisation
+
+Bernstein resolves every skill from up to three optional layers. A
+higher-precedence layer can override a lower one on a per-field basis,
+without forking the in-package skill and without losing the ability to
+keep a personal note out of git.
+
+## Layers
+
+| Layer | Path                                          | Intent                                       | Tracked in git |
+|-------|-----------------------------------------------|----------------------------------------------|----------------|
+| base  | `~/.local/share/bernstein/skills/base/`       | In-package skill shipped with Bernstein.     | n/a            |
+| team  | `~/.config/bernstein/skills/team/`            | Project-shared override.                     | usually yes    |
+| user  | `~/.config/bernstein/skills/user/`            | Personal override.                           | no             |
+
+Precedence runs `user > team > base`. Missing layers fall through: if
+only the team layer is on disk, the team values are returned as-is.
+
+The XDG environment variables `XDG_DATA_HOME` and `XDG_CONFIG_HOME` are
+honoured, so operators with non-standard layouts (or CI sandboxes) can
+redirect every layer cleanly.
+
+## On-disk forms
+
+Each layer can store a skill in any of these forms:
+
+- `<layer>/<name>.yaml` or `<name>.yml` - flat YAML mapping.
+- `<layer>/<name>/SKILL.md` - frontmatter + body (the in-package shape).
+- `<layer>/<name>.toml` - flat fragment (treated as YAML-compatible).
+
+The loader picks the first form that exists per layer in the order
+above.
+
+## Merge rules
+
+Every top-level field has a documented strategy in `MergeSpec`. Unknown
+fields raise `UnknownFieldError` rather than silently no-opping, so a
+typo in an override is caught immediately.
+
+| Strategy        | When it applies                                                          | Behaviour                                                                            |
+|-----------------|--------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `OVERRIDE`      | Scalars (`name`, `description`, `version`, `author`, `body`).            | Higher layer replaces the lower layer's value wholesale.                             |
+| `APPEND`        | Unkeyed arrays (`trigger_keywords`).                                     | Higher layer's items are concatenated after lower layer's items in encounter order.  |
+| `KEYED_REPLACE` | Arrays of mappings keyed by `name` / `id` / `code` (`references`, etc.). | Higher layer replaces lower-layer entries with the same key; new keys are appended.  |
+| `DEEP_MERGE`    | Nested mappings (`metadata`).                                            | Recurse: identical paths use OVERRIDE semantics, distinct paths coexist.             |
+
+## CLI
+
+```
+bernstein skills list --layered             # show base/team/user origin
+bernstein skills show <name> --per-layer    # merged + per-layer diff
+```
+
+`--per-layer` prints the merged skill as deterministic JSON
+(`sort_keys=True`), then each contributing layer as raw JSON so an
+operator can debug exactly which value won.
+
+## Determinism
+
+The merge function is pure. Given identical input fragments, it
+produces identical output every time:
+
+- `merge_layers({...})` is idempotent (re-running on the same input
+  gives the same result).
+- `Skill.as_dict()` returns a JSON-stable shape (no tuples, sorted
+  keys when serialised).
+
+This matters for review: a layered skill committed to git produces
+byte-identical effective skill manifests across machines.
+
+## Examples
+
+### Per-field override
+
+`base/writer.yaml`:
+
+```yaml
+description: base description
+author: core
+trigger_keywords: [base-kw]
+```
+
+`user/writer.yaml`:
+
+```yaml
+author: me
+```
+
+Effective skill: description from `base`, author from `user`, keywords
+unchanged.
+
+### Keyed replace
+
+`base/writer.yaml`:
+
+```yaml
+references:
+  - name: style
+    url: base-style
+```
+
+`user/writer.yaml`:
+
+```yaml
+references:
+  - name: style
+    url: user-style
+  - name: extras
+    url: user-extras
+```
+
+Effective `references`: `style` is replaced (URL from user), `extras`
+appended.
+
+### Deep merge
+
+`base/writer.yaml`:
+
+```yaml
+metadata:
+  limits:
+    max_tokens: 1000
+    temperature: 0.2
+```
+
+`user/writer.yaml`:
+
+```yaml
+metadata:
+  limits:
+    max_tokens: 2000
+```
+
+Effective `metadata.limits`: `{"max_tokens": 2000, "temperature": 0.2}`.
+
+## Acceptance tests
+
+`tests/unit/skills/test_layered.py` pins:
+
+- Layer precedence for each strategy.
+- Per-field override granularity.
+- Deterministic merge across runs.
+- Missing-layer fall-through (base-only, user-only, team+user).
+- Unknown-field rejection.
+- Filesystem loading for YAML and SKILL.md forms.

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -1,7 +1,16 @@
-"""``bernstein skills``: list / show / verify skill packs (oai-004)."""
+"""``bernstein skills``: list / show / verify skill packs (oai-004).
+
+Layered customisation (issue 1624) is wired in via the
+``--layered`` / ``--per-layer`` options on ``list`` and ``show``: when
+set, the CLI consults :mod:`bernstein.core.skills.layered` instead of
+the in-package skill loader. The two paths intentionally coexist so
+existing operators keep their plugin-source view while teams adopting
+the BASE/TEAM/USER layout get the layered view on demand.
+"""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import click
@@ -16,8 +25,10 @@ def skills_group() -> None:
 
     \b
       bernstein skills list           # compact overview
+      bernstein skills list --layered # show layered (base/team/user) view
       bernstein skills show backend   # print SKILL.md body
       bernstein skills show backend --reference python-conventions.md
+      bernstein skills show backend --per-layer  # merged + per-layer diff
     """
 
 
@@ -29,9 +40,20 @@ def skills_group() -> None:
     default=False,
     help="Skip third-party ``bernstein.skill_sources`` plugins.",
 )
-def skills_list(no_plugins: bool) -> None:
+@click.option(
+    "--layered",
+    "layered",
+    is_flag=True,
+    default=False,
+    help="List skills from the BASE/TEAM/USER layers, showing layer-of-origin.",
+)
+def skills_list(no_plugins: bool, layered: bool) -> None:
     """List every discoverable skill with a one-line description."""
     from rich.table import Table
+
+    if layered:
+        _skills_list_layered()
+        return
 
     from bernstein.core.planning.role_resolver import get_loader
 
@@ -79,8 +101,19 @@ def skills_list(no_plugins: bool) -> None:
 @click.argument("name")
 @click.option("--reference", "reference", help="Reference filename to load.")
 @click.option("--script", "script", help="Script filename to load.")
-def skills_show(name: str, reference: str | None, script: str | None) -> None:
+@click.option(
+    "--per-layer",
+    "per_layer",
+    is_flag=True,
+    default=False,
+    help="Print the merged skill plus a per-layer diff (BASE/TEAM/USER).",
+)
+def skills_show(name: str, reference: str | None, script: str | None, per_layer: bool) -> None:
     """Print the SKILL.md body for a skill (optionally a reference/script)."""
+    if per_layer:
+        _skills_show_layered(name)
+        return
+
     from bernstein.core.skills.load_skill_tool import load_skill
 
     templates_root = get_templates_dir(Path.cwd())
@@ -107,3 +140,75 @@ def skills_show(name: str, reference: str | None, script: str | None) -> None:
         console.print("\n[dim]references: " + ", ".join(result.available_references) + "[/dim]")
     if result.available_scripts:
         console.print("[dim]scripts: " + ", ".join(result.available_scripts) + "[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Layered (issue 1624) helpers
+# ---------------------------------------------------------------------------
+
+
+def _skills_list_layered() -> None:
+    """Render the layered (BASE/TEAM/USER) skill table."""
+    from rich.table import Table
+
+    from bernstein.core.skills.layered import LayeredSkillPaths, list_skills
+
+    paths = LayeredSkillPaths.defaults()
+    entries = list_skills(paths=paths)
+
+    if not entries:
+        console.print(
+            "[dim]No layered skills found. Expected one of:\n"
+            f"  base: {paths.base}\n  team: {paths.team}\n  user: {paths.user}[/dim]"
+        )
+        return
+
+    table = Table(
+        title="Skills (layered view)",
+        show_lines=False,
+        header_style="bold cyan",
+    )
+    table.add_column("NAME", style="dim", min_width=14)
+    table.add_column("BASE", justify="center", min_width=4)
+    table.add_column("TEAM", justify="center", min_width=4)
+    table.add_column("USER", justify="center", min_width=4)
+    table.add_column("ORIGIN", min_width=12)
+
+    for name, layers in entries:
+        labels = [layer.label for layer in layers]
+        table.add_row(
+            name,
+            "x" if "base" in labels else "",
+            "x" if "team" in labels else "",
+            "x" if "user" in labels else "",
+            "+".join(labels),
+        )
+
+    console.print(table)
+    console.print(f"\n[dim]{len(entries)} skill(s) total[/dim]")
+
+
+def _skills_show_layered(name: str) -> None:
+    """Render the merged skill plus a per-layer diff."""
+    from bernstein.core.skills.layered import (
+        LayeredSkillPaths,
+        SkillNotFoundError,
+        load_skill,
+        per_layer_view,
+    )
+
+    paths = LayeredSkillPaths.defaults()
+    try:
+        merged = load_skill(name, paths=paths)
+    except SkillNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+
+    console.print(f"[bold cyan]merged skill: {merged.name}[/bold cyan]")
+    console.print("[dim]layers present: " + ", ".join(layer.label for layer in merged.layers_present) + "[/dim]")
+    console.print(json.dumps(merged.as_dict(), indent=2, sort_keys=True))
+
+    fragments = per_layer_view(name, paths=paths)
+    for layer in sorted(fragments, key=lambda layer: layer.value):
+        console.print(f"\n[bold]layer: {layer.label}[/bold] ([dim]{paths.for_layer(layer)}[/dim])")
+        console.print(json.dumps(fragments[layer], indent=2, sort_keys=True))

--- a/src/bernstein/core/skills/layered.py
+++ b/src/bernstein/core/skills/layered.py
@@ -128,7 +128,7 @@ class SkillNotFoundError(FileNotFoundError):
         joined = ", ".join(str(p) for p in searched)
         super().__init__(f"skill {name!r} not found in any layer (searched: {joined})")
         self.skill_name = name
-        self.searched = list(searched)
+        self.searched = searched.copy()
 
 
 @dataclass(frozen=True)
@@ -168,9 +168,9 @@ class Skill:
             "author": self.author,
             "body": self.body,
             "trigger_keywords": list(self.trigger_keywords),
-            "references": [dict(r) for r in self.references],
-            "scripts": [dict(s) for s in self.scripts],
-            "assets": [dict(a) for a in self.assets],
+            "references": [r.copy() for r in self.references],
+            "scripts": [s.copy() for s in self.scripts],
+            "assets": [a.copy() for a in self.assets],
             "metadata": _deep_copy(self.metadata),
             "layers_present": [layer.label for layer in self.layers_present],
         }
@@ -310,7 +310,7 @@ def _merge_deep(field_name: str, values: list[Any]) -> dict[str, Any]:
 
 
 def _deep_merge_dicts(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
-    out: dict[str, Any] = dict(left)
+    out: dict[str, Any] = left.copy()
     for k, v in right.items():
         if k in out and isinstance(out[k], dict) and isinstance(v, dict):
             out[k] = _deep_merge_dicts(cast("dict[str, Any]", out[k]), cast("dict[str, Any]", v))

--- a/src/bernstein/core/skills/layered.py
+++ b/src/bernstein/core/skills/layered.py
@@ -1,0 +1,578 @@
+"""Three-layer skill customisation with deterministic merge.
+
+A skill's effective definition is the deterministic merge of up to three
+optional layers stacked in this order (lowest precedence first):
+
+1. ``base``   - the in-package SKILL.md shipped with Bernstein.
+2. ``team``   - a project-shared override committed to git.
+3. ``user``   - a personal override that stays out of git.
+
+The merge is pure (no I/O once layers are loaded), order-independent for
+equal-precedence siblings, and stable across runs - identical inputs
+always produce identical outputs (byte-identical when serialised to JSON
+with ``sort_keys=True``).
+
+Merge rules
+-----------
+
+Per-field, the strategy is declared in :class:`MergeSpec`:
+
+- ``OVERRIDE``      scalar / opaque value: a higher layer replaces it.
+- ``DEEP_MERGE``    table (mapping): recurse, applying per-key strategy.
+- ``KEYED_REPLACE`` array of mappings keyed by ``name`` / ``id`` / ``code``:
+                    higher-layer entries replace lower-layer entries with
+                    the same key; entries with new keys are appended in
+                    the higher layer's order.
+- ``APPEND``        unkeyed array: higher-layer values are appended after
+                    lower-layer values, preserving order.
+
+The strategy table is exhaustive: every field of :class:`Skill` is
+declared, so a typo in :class:`MergeSpec` is a hard error rather than a
+silent ``OVERRIDE`` fallback.
+
+The module is intentionally I/O-light at its core. :func:`merge_layers`
+is the pure function the tests pin; :func:`load_skill` wires it up to
+the filesystem layout under
+``~/.local/share/bernstein/skills/base/``,
+``~/.config/bernstein/skills/team/``, and
+``~/.config/bernstein/skills/user/``.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+# Keys we recognise for identifying an array entry in a KEYED_REPLACE
+# strategy. Order matters: the first key present in an entry wins, so a
+# list of dicts that all carry ``name`` will be keyed by name even when
+# some also carry ``id``. This keeps the merge deterministic.
+_KEYED_REPLACE_KEYS: tuple[str, ...] = ("name", "id", "code")
+
+
+class SkillLayer(enum.Enum):
+    """Origin layer of a skill fragment.
+
+    Layers are ordered from lowest to highest precedence by their
+    integer value. ``SkillLayer.USER`` always wins on conflict.
+    """
+
+    BASE = 0
+    TEAM = 1
+    USER = 2
+
+    @property
+    def label(self) -> str:
+        """Lowercase human label used in CLI output and on-disk paths."""
+        return self.name.lower()
+
+
+class MergeStrategy(enum.Enum):
+    """Per-field merge strategy."""
+
+    OVERRIDE = "override"
+    DEEP_MERGE = "deep-merge"
+    KEYED_REPLACE = "keyed-replace"
+    APPEND = "append"
+
+
+@dataclass(frozen=True)
+class MergeSpec:
+    """Per-field merge strategy table.
+
+    The default spec mirrors the shape of :class:`Skill`. Callers that
+    introduce a new field MUST extend the spec; :func:`merge_layers`
+    raises :class:`UnknownFieldError` for any field not listed here.
+    """
+
+    strategies: dict[str, MergeStrategy] = field(
+        default_factory=lambda: {
+            "name": MergeStrategy.OVERRIDE,
+            "description": MergeStrategy.OVERRIDE,
+            "version": MergeStrategy.OVERRIDE,
+            "author": MergeStrategy.OVERRIDE,
+            "body": MergeStrategy.OVERRIDE,
+            "trigger_keywords": MergeStrategy.APPEND,
+            "references": MergeStrategy.KEYED_REPLACE,
+            "scripts": MergeStrategy.KEYED_REPLACE,
+            "assets": MergeStrategy.KEYED_REPLACE,
+            "metadata": MergeStrategy.DEEP_MERGE,
+        }
+    )
+
+    def for_field(self, name: str) -> MergeStrategy:
+        """Return the strategy for ``name`` or raise."""
+        try:
+            return self.strategies[name]
+        except KeyError as exc:
+            raise UnknownFieldError(name) from exc
+
+
+class UnknownFieldError(KeyError):
+    """Raised when a layer carries a field not declared in :class:`MergeSpec`."""
+
+    def __init__(self, field_name: str) -> None:
+        super().__init__(f"unknown skill field {field_name!r}: extend MergeSpec to add it")
+        self.field_name = field_name
+
+
+class SkillNotFoundError(FileNotFoundError):
+    """Raised when no layer provides a skill with the requested name."""
+
+    def __init__(self, name: str, searched: list[Path]) -> None:
+        joined = ", ".join(str(p) for p in searched)
+        super().__init__(f"skill {name!r} not found in any layer (searched: {joined})")
+        self.skill_name = name
+        self.searched = list(searched)
+
+
+@dataclass(frozen=True)
+class Skill:
+    """The effective, merged skill returned by :func:`load_skill`.
+
+    All fields are populated even when absent from on-disk data: the
+    string fields fall back to ``""``, the array fields fall back to
+    ``[]``, and ``metadata`` falls back to ``{}``. This keeps the
+    downstream API total - callers never need ``getattr`` with a
+    default.
+    """
+
+    name: str
+    description: str
+    version: str
+    author: str
+    body: str
+    trigger_keywords: tuple[str, ...]
+    references: tuple[dict[str, Any], ...]
+    scripts: tuple[dict[str, Any], ...]
+    assets: tuple[dict[str, Any], ...]
+    metadata: dict[str, Any]
+    layers_present: tuple[SkillLayer, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-stable serialisation of the skill.
+
+        The returned dict is plain (no tuples), so callers can hand it
+        to ``json.dumps(..., sort_keys=True)`` and get a deterministic
+        byte sequence.
+        """
+        return {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "author": self.author,
+            "body": self.body,
+            "trigger_keywords": list(self.trigger_keywords),
+            "references": [dict(r) for r in self.references],
+            "scripts": [dict(s) for s in self.scripts],
+            "assets": [dict(a) for a in self.assets],
+            "metadata": _deep_copy(self.metadata),
+            "layers_present": [layer.label for layer in self.layers_present],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pure merge core
+# ---------------------------------------------------------------------------
+
+
+def merge_layers(
+    fragments: dict[SkillLayer, dict[str, Any]],
+    *,
+    spec: MergeSpec | None = None,
+) -> dict[str, Any]:
+    """Merge per-layer fragments into a single dict using ``spec``.
+
+    Args:
+        fragments: Mapping of layer -> raw skill dict. Missing layers
+            are simply absent from the mapping.
+        spec: Per-field strategy table. Defaults to :class:`MergeSpec`'s
+            built-in table.
+
+    Returns:
+        A dict with every field declared in ``spec``, populated either
+        from the layers or with the documented fallback default.
+
+    Raises:
+        UnknownFieldError: if any layer carries a key not in ``spec``.
+    """
+    effective_spec = spec or MergeSpec()
+    ordered_layers = [layer for layer in (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER) if layer in fragments]
+
+    # Defensive: reject unknown top-level fields up front so a typo in a
+    # user override does not silently no-op.
+    for layer in ordered_layers:
+        for key in fragments[layer]:
+            _ = effective_spec.for_field(key)
+
+    out: dict[str, Any] = {}
+    for field_name, strategy in effective_spec.strategies.items():
+        values = [fragments[layer][field_name] for layer in ordered_layers if field_name in fragments[layer]]
+        out[field_name] = _merge_field(field_name, strategy, values)
+    return out
+
+
+def _merge_field(field_name: str, strategy: MergeStrategy, values: list[Any]) -> Any:
+    """Apply ``strategy`` to a left-to-right list of layer values."""
+    if not values:
+        return _default_for(strategy)
+    if strategy == MergeStrategy.OVERRIDE:
+        return values[-1]
+    if strategy == MergeStrategy.APPEND:
+        return _merge_append(field_name, values)
+    if strategy == MergeStrategy.KEYED_REPLACE:
+        return _merge_keyed_replace(field_name, values)
+    if strategy == MergeStrategy.DEEP_MERGE:
+        return _merge_deep(field_name, values)
+    # Unreachable - all enum members covered. Re-raise so a future enum
+    # extension that forgets to wire the merge is caught at runtime.
+    raise AssertionError(f"unhandled merge strategy {strategy!r} for {field_name!r}")
+
+
+def _default_for(strategy: MergeStrategy) -> Any:
+    if strategy == MergeStrategy.OVERRIDE:
+        return ""
+    if strategy == MergeStrategy.APPEND:
+        return []
+    if strategy == MergeStrategy.KEYED_REPLACE:
+        return []
+    if strategy == MergeStrategy.DEEP_MERGE:
+        return {}
+    raise AssertionError(f"unhandled merge strategy {strategy!r}")
+
+
+def _merge_append(field_name: str, values: list[Any]) -> list[Any]:
+    result: list[Any] = []
+    for v in values:
+        if not isinstance(v, list):
+            raise TypeError(f"field {field_name!r} expects a list for APPEND merge, got {type(v).__name__}")
+        result.extend(cast("list[Any]", v))
+    return result
+
+
+def _merge_keyed_replace(field_name: str, values: list[list[dict[str, Any]] | Any]) -> list[dict[str, Any]]:
+    # Preserve insertion order across layers. We use a list-of-(key, entry)
+    # rather than a dict so duplicate-key handling stays explicit.
+    ordered_keys: list[str] = []
+    by_key: dict[str, dict[str, Any]] = {}
+    # Entries without a recognised key get appended in encounter order,
+    # tagged with a sentinel so two unkeyed entries from the same layer
+    # do not collapse onto each other.
+    unkeyed: list[dict[str, Any]] = []
+
+    for layer_value in values:
+        if not isinstance(layer_value, list):
+            raise TypeError(
+                f"field {field_name!r} expects a list of mappings for KEYED_REPLACE, got {type(layer_value).__name__}"
+            )
+        entries = cast("list[Any]", layer_value)
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise TypeError(
+                    f"field {field_name!r} expects a list of mappings; saw {type(entry).__name__} inside the list"
+                )
+            typed_entry = cast("dict[str, Any]", entry)
+            key = _entry_key(typed_entry)
+            if key is None:
+                unkeyed.append(typed_entry)
+                continue
+            if key not in by_key:
+                ordered_keys.append(key)
+            by_key[key] = typed_entry
+
+    result: list[dict[str, Any]] = [by_key[k] for k in ordered_keys]
+    result.extend(unkeyed)
+    return result
+
+
+def _entry_key(entry: dict[str, Any]) -> str | None:
+    for key_field in _KEYED_REPLACE_KEYS:
+        if key_field in entry:
+            value = entry[key_field]
+            if isinstance(value, str) and value:
+                return f"{key_field}:{value}"
+    return None
+
+
+def _merge_deep(field_name: str, values: list[Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for v in values:
+        if not isinstance(v, dict):
+            raise TypeError(f"field {field_name!r} expects a mapping for DEEP_MERGE, got {type(v).__name__}")
+        typed_v = cast("dict[str, Any]", v)
+        result = _deep_merge_dicts(result, typed_v)
+    return result
+
+
+def _deep_merge_dicts(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = dict(left)
+    for k, v in right.items():
+        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
+            out[k] = _deep_merge_dicts(cast("dict[str, Any]", out[k]), cast("dict[str, Any]", v))
+        else:
+            out[k] = _deep_copy(v)
+    return out
+
+
+def _deep_copy(value: Any) -> Any:
+    if isinstance(value, dict):
+        typed_dict = cast("dict[Any, Any]", value)
+        return {k: _deep_copy(v) for k, v in typed_dict.items()}
+    if isinstance(value, list):
+        typed_list = cast("list[Any]", value)
+        return [_deep_copy(item) for item in typed_list]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Filesystem wiring
+# ---------------------------------------------------------------------------
+
+
+def default_layer_root(layer: SkillLayer, *, env: dict[str, str] | None = None) -> Path:
+    """Return the canonical directory for ``layer``.
+
+    The defaults follow the XDG layout the task spec lists:
+
+    - BASE: ``~/.local/share/bernstein/skills/base/``
+    - TEAM: ``~/.config/bernstein/skills/team/``
+    - USER: ``~/.config/bernstein/skills/user/``
+
+    ``XDG_DATA_HOME`` / ``XDG_CONFIG_HOME`` overrides are honoured when
+    set so the test-suite (and operators with non-standard layouts) can
+    redirect the layers cleanly.
+    """
+    e = env if env is not None else os.environ
+    xdg_data = e.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    xdg_config = e.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    if layer == SkillLayer.BASE:
+        return Path(xdg_data) / "bernstein" / "skills" / "base"
+    if layer == SkillLayer.TEAM:
+        return Path(xdg_config) / "bernstein" / "skills" / "team"
+    if layer == SkillLayer.USER:
+        return Path(xdg_config) / "bernstein" / "skills" / "user"
+    raise AssertionError(f"unhandled layer {layer!r}")
+
+
+@dataclass(frozen=True)
+class LayeredSkillPaths:
+    """Resolved on-disk directories for the three layers."""
+
+    base: Path
+    team: Path
+    user: Path
+
+    @classmethod
+    def defaults(cls, *, env: dict[str, str] | None = None) -> LayeredSkillPaths:
+        return cls(
+            base=default_layer_root(SkillLayer.BASE, env=env),
+            team=default_layer_root(SkillLayer.TEAM, env=env),
+            user=default_layer_root(SkillLayer.USER, env=env),
+        )
+
+    def for_layer(self, layer: SkillLayer) -> Path:
+        if layer == SkillLayer.BASE:
+            return self.base
+        if layer == SkillLayer.TEAM:
+            return self.team
+        if layer == SkillLayer.USER:
+            return self.user
+        raise AssertionError(f"unhandled layer {layer!r}")
+
+
+def _candidate_files(directory: Path, name: str) -> list[Path]:
+    """Return possible on-disk locations for a skill fragment.
+
+    Each layer may store a skill as either:
+
+    - ``<dir>/<name>.yaml`` / ``<name>.yml`` - flat file fragment.
+    - ``<dir>/<name>/SKILL.md`` - directory-form skill (frontmatter + body).
+    - ``<dir>/<name>.toml`` - flat TOML fragment (read as YAML-compatible
+      after :pep:`680` style flattening; we accept it via PyYAML only
+      when the contents are also valid YAML, otherwise we ignore it).
+
+    Order is intentional: YAML wins over the TOML form so an operator
+    upgrading from a TOML override can drop a YAML file beside it
+    without removing the old one first.
+    """
+    return [
+        directory / f"{name}.yaml",
+        directory / f"{name}.yml",
+        directory / name / "SKILL.md",
+        directory / f"{name}.toml",
+    ]
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    raw = path.read_text(encoding="utf-8")
+    parsed: object = yaml.safe_load(raw)
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path}: expected a YAML mapping, got {type(parsed).__name__}")
+    typed_parsed = cast("dict[Any, Any]", parsed)
+    cleaned: dict[str, Any] = {}
+    for key, value in typed_parsed.items():
+        if not isinstance(key, str):
+            raise ValueError(f"{path}: non-string key {key!r}")
+        cleaned[key] = value
+    return cleaned
+
+
+def _load_skill_md(path: Path) -> dict[str, Any]:
+    """Parse a frontmatter + body file into a dict fragment."""
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        # No frontmatter: treat the whole file as the body.
+        return {"body": text.strip()}
+    lines = text.splitlines()
+    close_idx: int | None = None
+    for i in range(1, len(lines)):
+        stripped = lines[i].rstrip()
+        if stripped == "---":
+            close_idx = i
+            break
+    if close_idx is None:
+        raise ValueError(f"{path}: unterminated YAML frontmatter")
+    front = "\n".join(lines[1:close_idx])
+    body = "\n".join(lines[close_idx + 1 :]).strip()
+    parsed: object = yaml.safe_load(front) if front.strip() else {}
+    if parsed is None:
+        parsed = {}
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path}: frontmatter must be a YAML mapping")
+    typed_parsed = cast("dict[Any, Any]", parsed)
+    cleaned: dict[str, Any] = {}
+    for key, value in typed_parsed.items():
+        if not isinstance(key, str):
+            raise ValueError(f"{path}: non-string frontmatter key {key!r}")
+        cleaned[key] = value
+    if body:
+        cleaned["body"] = body
+    return cleaned
+
+
+def _load_layer_fragment(directory: Path, name: str) -> dict[str, Any] | None:
+    """Try every candidate file; return the first one that parses, or ``None``."""
+    for candidate in _candidate_files(directory, name):
+        if not candidate.is_file():
+            continue
+        if candidate.name == "SKILL.md":
+            return _load_skill_md(candidate)
+        return _load_yaml_mapping(candidate)
+    return None
+
+
+def collect_layers(
+    name: str,
+    *,
+    paths: LayeredSkillPaths | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[SkillLayer, dict[str, Any]]:
+    """Load every available fragment for ``name`` keyed by its layer.
+
+    Layers that have no on-disk file are simply absent from the result.
+    """
+    resolved_paths = paths or LayeredSkillPaths.defaults(env=env)
+    fragments: dict[SkillLayer, dict[str, Any]] = {}
+    for layer in (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER):
+        directory = resolved_paths.for_layer(layer)
+        if not directory.is_dir():
+            continue
+        fragment = _load_layer_fragment(directory, name)
+        if fragment is not None:
+            fragments[layer] = fragment
+    return fragments
+
+
+def load_skill(
+    name: str,
+    *,
+    paths: LayeredSkillPaths | None = None,
+    env: dict[str, str] | None = None,
+    spec: MergeSpec | None = None,
+) -> Skill:
+    """Load ``name`` from every layer and return the merged :class:`Skill`.
+
+    Raises:
+        SkillNotFoundError: when no layer provides a fragment.
+    """
+    resolved_paths = paths or LayeredSkillPaths.defaults(env=env)
+    fragments = collect_layers(name, paths=resolved_paths, env=env)
+    if not fragments:
+        searched = [resolved_paths.for_layer(layer) for layer in SkillLayer]
+        raise SkillNotFoundError(name, searched)
+    merged = merge_layers(fragments, spec=spec)
+    layers_present = tuple(layer for layer in (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER) if layer in fragments)
+    # ``name`` from the merged dict wins, but if no layer set one, fall
+    # back to the requested name so the Skill is self-describing.
+    effective_name = merged.get("name") or name
+    return Skill(
+        name=effective_name,
+        description=str(merged.get("description") or ""),
+        version=str(merged.get("version") or ""),
+        author=str(merged.get("author") or ""),
+        body=str(merged.get("body") or ""),
+        trigger_keywords=tuple(merged.get("trigger_keywords") or []),
+        references=tuple(merged.get("references") or []),
+        scripts=tuple(merged.get("scripts") or []),
+        assets=tuple(merged.get("assets") or []),
+        metadata=dict(merged.get("metadata") or {}),
+        layers_present=layers_present,
+    )
+
+
+def list_skills(
+    *,
+    paths: LayeredSkillPaths | None = None,
+    env: dict[str, str] | None = None,
+) -> list[tuple[str, tuple[SkillLayer, ...]]]:
+    """Return every (name, layers-of-origin) pair across the three layers.
+
+    Names are sorted alphabetically so the CLI output is deterministic.
+    """
+    resolved_paths = paths or LayeredSkillPaths.defaults(env=env)
+    by_name: dict[str, set[SkillLayer]] = {}
+    for layer in (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER):
+        directory = resolved_paths.for_layer(layer)
+        if not directory.is_dir():
+            continue
+        for child in sorted(directory.iterdir()):
+            skill_name = _skill_name_from_path(child)
+            if skill_name is None:
+                continue
+            by_name.setdefault(skill_name, set()).add(layer)
+    return [
+        (
+            name,
+            tuple(layer for layer in (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER) if layer in by_name[name]),
+        )
+        for name in sorted(by_name)
+    ]
+
+
+def _skill_name_from_path(path: Path) -> str | None:
+    if path.is_dir() and (path / "SKILL.md").is_file():
+        return path.name
+    if path.is_file() and path.suffix in {".yaml", ".yml", ".toml"}:
+        return path.stem
+    return None
+
+
+def per_layer_view(
+    name: str,
+    *,
+    paths: LayeredSkillPaths | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[SkillLayer, dict[str, Any]]:
+    """Return raw fragments for ``name`` keyed by layer.
+
+    Convenience wrapper around :func:`collect_layers` for the CLI's
+    ``skills show`` per-layer diff output.
+    """
+    return collect_layers(name, paths=paths, env=env)

--- a/tests/unit/skills/test_layered.py
+++ b/tests/unit/skills/test_layered.py
@@ -1,0 +1,403 @@
+"""Tests for the three-layer skill merge (issue 1624)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.skills.layered import (
+    LayeredSkillPaths,
+    MergeSpec,
+    MergeStrategy,
+    Skill,
+    SkillLayer,
+    SkillNotFoundError,
+    UnknownFieldError,
+    collect_layers,
+    default_layer_root,
+    list_skills,
+    load_skill,
+    merge_layers,
+    per_layer_view,
+)
+
+
+def _base_fragment() -> dict[str, Any]:
+    return {
+        "name": "writer",
+        "description": "base description",
+        "version": "1.0.0",
+        "author": "core",
+        "body": "base body",
+        "trigger_keywords": ["base-kw"],
+        "references": [{"name": "style", "url": "base-style"}],
+        "scripts": [{"name": "lint", "cmd": "base-lint"}],
+        "assets": [],
+        "metadata": {"limits": {"max_tokens": 1000, "temperature": 0.2}, "tags": ["base"]},
+    }
+
+
+def _team_fragment() -> dict[str, Any]:
+    return {
+        "description": "team description",
+        "trigger_keywords": ["team-kw"],
+        "references": [
+            {"name": "style", "url": "team-style"},
+            {"name": "team-conventions", "url": "team-conv"},
+        ],
+        "metadata": {"limits": {"temperature": 0.5}, "tags": ["team"]},
+    }
+
+
+def _user_fragment() -> dict[str, Any]:
+    return {
+        "author": "personal",
+        "trigger_keywords": ["user-kw"],
+        "references": [{"name": "style", "url": "user-style"}],
+        "metadata": {"limits": {"max_tokens": 2000}, "personal": True},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure merge tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeLayers:
+    def test_layer_precedence_override(self) -> None:
+        """USER > TEAM > BASE for OVERRIDE strategy."""
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: _base_fragment(),
+                SkillLayer.TEAM: _team_fragment(),
+                SkillLayer.USER: _user_fragment(),
+            }
+        )
+        # description: team wins over base, user has no description
+        assert merged["description"] == "team description"
+        # author: user wins
+        assert merged["author"] == "personal"
+        # body: only base provides it
+        assert merged["body"] == "base body"
+
+    def test_append_strategy_preserves_order(self) -> None:
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: _base_fragment(),
+                SkillLayer.TEAM: _team_fragment(),
+                SkillLayer.USER: _user_fragment(),
+            }
+        )
+        assert merged["trigger_keywords"] == ["base-kw", "team-kw", "user-kw"]
+
+    def test_keyed_replace_by_name(self) -> None:
+        """Same ``name`` key gets replaced; new entries appended."""
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: _base_fragment(),
+                SkillLayer.TEAM: _team_fragment(),
+                SkillLayer.USER: _user_fragment(),
+            }
+        )
+        refs = merged["references"]
+        # 'style' overridden by user (last writer), 'team-conventions' appended
+        assert refs == [
+            {"name": "style", "url": "user-style"},
+            {"name": "team-conventions", "url": "team-conv"},
+        ]
+
+    def test_keyed_replace_by_id(self) -> None:
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: {"references": [{"id": "r1", "v": "base"}]},
+                SkillLayer.USER: {"references": [{"id": "r1", "v": "user"}, {"id": "r2", "v": "new"}]},
+            }
+        )
+        assert merged["references"] == [{"id": "r1", "v": "user"}, {"id": "r2", "v": "new"}]
+
+    def test_keyed_replace_unkeyed_entries_appended(self) -> None:
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: {"references": [{"v": "unkeyed-base"}]},
+                SkillLayer.USER: {"references": [{"v": "unkeyed-user"}, {"name": "keyed", "v": "u"}]},
+            }
+        )
+        refs = merged["references"]
+        # Keyed first (insertion order), unkeyed appended in encounter order.
+        assert refs == [
+            {"name": "keyed", "v": "u"},
+            {"v": "unkeyed-base"},
+            {"v": "unkeyed-user"},
+        ]
+
+    def test_deep_merge_metadata(self) -> None:
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: _base_fragment(),
+                SkillLayer.TEAM: _team_fragment(),
+                SkillLayer.USER: _user_fragment(),
+            }
+        )
+        # limits.max_tokens: user wins (2000), team contributes nothing
+        # limits.temperature: team overrides base
+        # tags: user does not provide -> team's value wins (last writer is team)
+        # personal: only user
+        assert merged["metadata"] == {
+            "limits": {"max_tokens": 2000, "temperature": 0.5},
+            "tags": ["team"],
+            "personal": True,
+        }
+
+    def test_missing_layer_fall_through_base_only(self) -> None:
+        merged = merge_layers({SkillLayer.BASE: _base_fragment()})
+        assert merged["description"] == "base description"
+        assert merged["trigger_keywords"] == ["base-kw"]
+        assert merged["references"] == [{"name": "style", "url": "base-style"}]
+
+    def test_missing_layer_fall_through_user_only(self) -> None:
+        merged = merge_layers({SkillLayer.USER: {"description": "user-only"}})
+        assert merged["description"] == "user-only"
+        # body defaults to empty string per spec.
+        assert merged["body"] == ""
+        # references defaults to empty list per spec.
+        assert merged["references"] == []
+
+    def test_missing_layer_fall_through_team_user(self) -> None:
+        """Skipping BASE layer is supported - TEAM/USER alone still merge."""
+        merged = merge_layers(
+            {
+                SkillLayer.TEAM: {"description": "team", "trigger_keywords": ["t"]},
+                SkillLayer.USER: {"trigger_keywords": ["u"]},
+            }
+        )
+        assert merged["description"] == "team"
+        assert merged["trigger_keywords"] == ["t", "u"]
+
+    def test_no_layers_returns_defaults(self) -> None:
+        merged = merge_layers({})
+        assert merged == {
+            "name": "",
+            "description": "",
+            "version": "",
+            "author": "",
+            "body": "",
+            "trigger_keywords": [],
+            "references": [],
+            "scripts": [],
+            "assets": [],
+            "metadata": {},
+        }
+
+    def test_unknown_field_rejected(self) -> None:
+        with pytest.raises(UnknownFieldError) as exc_info:
+            merge_layers({SkillLayer.USER: {"not_a_field": 1}})
+        assert exc_info.value.field_name == "not_a_field"
+
+    def test_deterministic_across_runs(self) -> None:
+        """Same inputs produce byte-identical JSON output every time."""
+        fragments = {
+            SkillLayer.BASE: _base_fragment(),
+            SkillLayer.TEAM: _team_fragment(),
+            SkillLayer.USER: _user_fragment(),
+        }
+        first = json.dumps(merge_layers(fragments), sort_keys=True)
+        second = json.dumps(merge_layers(fragments), sort_keys=True)
+        third = json.dumps(merge_layers(fragments), sort_keys=True)
+        assert first == second == third
+
+    def test_per_field_override_granularity(self) -> None:
+        """User can override one scalar without touching others."""
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: _base_fragment(),
+                SkillLayer.USER: {"author": "me"},
+            }
+        )
+        # author overridden, description preserved from base, body preserved.
+        assert merged["author"] == "me"
+        assert merged["description"] == "base description"
+        assert merged["body"] == "base body"
+
+    def test_append_type_mismatch(self) -> None:
+        with pytest.raises(TypeError):
+            merge_layers({SkillLayer.BASE: {"trigger_keywords": "not-a-list"}})
+
+    def test_keyed_replace_type_mismatch(self) -> None:
+        with pytest.raises(TypeError):
+            merge_layers({SkillLayer.BASE: {"references": "nope"}})
+
+    def test_keyed_replace_non_mapping_entry(self) -> None:
+        with pytest.raises(TypeError):
+            merge_layers({SkillLayer.BASE: {"references": ["not-a-mapping"]}})
+
+    def test_deep_merge_type_mismatch(self) -> None:
+        with pytest.raises(TypeError):
+            merge_layers({SkillLayer.BASE: {"metadata": "not-a-mapping"}})
+
+    def test_custom_merge_spec(self) -> None:
+        """A custom MergeSpec can change a field's strategy."""
+        spec = MergeSpec(
+            strategies={
+                "name": MergeStrategy.OVERRIDE,
+                "description": MergeStrategy.OVERRIDE,
+                "version": MergeStrategy.OVERRIDE,
+                "author": MergeStrategy.OVERRIDE,
+                "body": MergeStrategy.OVERRIDE,
+                # Force OVERRIDE so the user wholly replaces the keyword list.
+                "trigger_keywords": MergeStrategy.OVERRIDE,
+                "references": MergeStrategy.KEYED_REPLACE,
+                "scripts": MergeStrategy.KEYED_REPLACE,
+                "assets": MergeStrategy.KEYED_REPLACE,
+                "metadata": MergeStrategy.DEEP_MERGE,
+            }
+        )
+        merged = merge_layers(
+            {
+                SkillLayer.BASE: {"trigger_keywords": ["base"]},
+                SkillLayer.USER: {"trigger_keywords": ["user"]},
+            },
+            spec=spec,
+        )
+        assert merged["trigger_keywords"] == ["user"]
+
+
+# ---------------------------------------------------------------------------
+# Filesystem integration tests
+# ---------------------------------------------------------------------------
+
+
+def _write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    import yaml
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+@pytest.fixture
+def layered_paths(tmp_path: Path) -> LayeredSkillPaths:
+    base = tmp_path / "base"
+    team = tmp_path / "team"
+    user = tmp_path / "user"
+    base.mkdir(parents=True)
+    team.mkdir(parents=True)
+    user.mkdir(parents=True)
+    return LayeredSkillPaths(base=base, team=team, user=user)
+
+
+class TestLoadSkill:
+    def test_loads_from_base_only(self, layered_paths: LayeredSkillPaths) -> None:
+        _write_yaml(layered_paths.base / "writer.yaml", _base_fragment())
+        skill = load_skill("writer", paths=layered_paths)
+        assert isinstance(skill, Skill)
+        assert skill.description == "base description"
+        assert skill.layers_present == (SkillLayer.BASE,)
+
+    def test_loads_with_all_three_layers(self, layered_paths: LayeredSkillPaths) -> None:
+        _write_yaml(layered_paths.base / "writer.yaml", _base_fragment())
+        _write_yaml(layered_paths.team / "writer.yaml", _team_fragment())
+        _write_yaml(layered_paths.user / "writer.yaml", _user_fragment())
+        skill = load_skill("writer", paths=layered_paths)
+        assert skill.layers_present == (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER)
+        assert skill.description == "team description"
+        assert skill.author == "personal"
+        assert skill.trigger_keywords == ("base-kw", "team-kw", "user-kw")
+
+    def test_team_only_then_user_added(self, layered_paths: LayeredSkillPaths) -> None:
+        _write_yaml(layered_paths.team / "writer.yaml", {"description": "team-only"})
+        skill = load_skill("writer", paths=layered_paths)
+        assert skill.layers_present == (SkillLayer.TEAM,)
+        assert skill.description == "team-only"
+
+        _write_yaml(layered_paths.user / "writer.yaml", {"description": "user-override"})
+        skill_after = load_skill("writer", paths=layered_paths)
+        assert skill_after.layers_present == (SkillLayer.TEAM, SkillLayer.USER)
+        assert skill_after.description == "user-override"
+
+    def test_raises_when_no_layer_provides_skill(self, layered_paths: LayeredSkillPaths) -> None:
+        with pytest.raises(SkillNotFoundError):
+            load_skill("missing", paths=layered_paths)
+
+    def test_skill_md_form(self, layered_paths: LayeredSkillPaths) -> None:
+        (layered_paths.base / "writer").mkdir()
+        (layered_paths.base / "writer" / "SKILL.md").write_text(
+            "---\nname: writer\ndescription: from skill md\n---\nbody-line-1\nbody-line-2\n",
+            encoding="utf-8",
+        )
+        skill = load_skill("writer", paths=layered_paths)
+        assert skill.description == "from skill md"
+        assert skill.body == "body-line-1\nbody-line-2"
+
+    def test_deterministic_serialisation(self, layered_paths: LayeredSkillPaths) -> None:
+        _write_yaml(layered_paths.base / "writer.yaml", _base_fragment())
+        _write_yaml(layered_paths.team / "writer.yaml", _team_fragment())
+        _write_yaml(layered_paths.user / "writer.yaml", _user_fragment())
+        first = json.dumps(load_skill("writer", paths=layered_paths).as_dict(), sort_keys=True)
+        second = json.dumps(load_skill("writer", paths=layered_paths).as_dict(), sort_keys=True)
+        assert first == second
+
+
+class TestListSkills:
+    def test_lists_layer_of_origin(self, layered_paths: LayeredSkillPaths) -> None:
+        _write_yaml(layered_paths.base / "writer.yaml", _base_fragment())
+        _write_yaml(layered_paths.team / "writer.yaml", {"description": "t"})
+        _write_yaml(layered_paths.user / "writer.yaml", {"description": "u"})
+        _write_yaml(layered_paths.team / "team-only.yaml", {"description": "t-only"})
+        _write_yaml(layered_paths.user / "user-only.yaml", {"description": "u-only"})
+
+        entries = list_skills(paths=layered_paths)
+        names = [name for name, _ in entries]
+        assert names == sorted(names)
+        as_dict = {name: layers for name, layers in entries}
+        assert as_dict["writer"] == (SkillLayer.BASE, SkillLayer.TEAM, SkillLayer.USER)
+        assert as_dict["team-only"] == (SkillLayer.TEAM,)
+        assert as_dict["user-only"] == (SkillLayer.USER,)
+
+    def test_empty_dirs_return_empty_list(self, layered_paths: LayeredSkillPaths) -> None:
+        assert list_skills(paths=layered_paths) == []
+
+
+class TestPerLayerView:
+    def test_returns_raw_fragments(self, layered_paths: LayeredSkillPaths) -> None:
+        _write_yaml(layered_paths.base / "writer.yaml", {"description": "base", "author": "b"})
+        _write_yaml(layered_paths.user / "writer.yaml", {"author": "u"})
+        fragments = per_layer_view("writer", paths=layered_paths)
+        assert fragments == {
+            SkillLayer.BASE: {"description": "base", "author": "b"},
+            SkillLayer.USER: {"author": "u"},
+        }
+
+    def test_collect_layers_skips_missing_dirs(self, tmp_path: Path) -> None:
+        # Pointing to non-existent dirs is fine - missing-layer fall-through.
+        paths = LayeredSkillPaths(
+            base=tmp_path / "nope-base",
+            team=tmp_path / "nope-team",
+            user=tmp_path / "nope-user",
+        )
+        assert collect_layers("anything", paths=paths) == {}
+
+
+class TestDefaultLayerRoot:
+    def test_xdg_overrides_honoured(self, tmp_path: Path) -> None:
+        env = {
+            "XDG_DATA_HOME": str(tmp_path / "data"),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+        }
+        assert default_layer_root(SkillLayer.BASE, env=env) == tmp_path / "data" / "bernstein" / "skills" / "base"
+        assert default_layer_root(SkillLayer.TEAM, env=env) == tmp_path / "config" / "bernstein" / "skills" / "team"
+        assert default_layer_root(SkillLayer.USER, env=env) == tmp_path / "config" / "bernstein" / "skills" / "user"
+
+    def test_default_paths_under_home_when_xdg_absent(self) -> None:
+        env: dict[str, str] = {}
+        base = default_layer_root(SkillLayer.BASE, env=env)
+        team = default_layer_root(SkillLayer.TEAM, env=env)
+        user = default_layer_root(SkillLayer.USER, env=env)
+        # Concrete shape check: ends with bernstein/skills/<layer>
+        assert base.parent.parent.name == "bernstein"
+        assert team.parent.parent.name == "bernstein"
+        assert user.parent.parent.name == "bernstein"
+        assert base.name == "base"
+        assert team.name == "team"
+        assert user.name == "user"


### PR DESCRIPTION
## Summary

- Add `src/bernstein/core/skills/layered.py` with `SkillLayer` (BASE/TEAM/USER), `MergeSpec` per-field strategies, and pure `merge_layers` / `load_skill` / `list_skills` / `per_layer_view` helpers.
- Per-field strategies: `OVERRIDE` for scalars, `APPEND` for unkeyed arrays, `KEYED_REPLACE` (by `name` / `id` / `code`) for keyed arrays, `DEEP_MERGE` for nested mappings. Unknown fields raise `UnknownFieldError` so typos in overrides fail loudly.
- Layered storage under XDG paths: `~/.local/share/bernstein/skills/base/`, `~/.config/bernstein/skills/team/`, `~/.config/bernstein/skills/user/`. `XDG_DATA_HOME` / `XDG_CONFIG_HOME` overrides honoured. Per-layer files may be `<name>.yaml`, `<name>.yml`, `<name>/SKILL.md`, or `<name>.toml`.
- Wire `bernstein skills list --layered` (layer-of-origin table) and `bernstein skills show <name> --per-layer` (merged JSON + raw per-layer fragments) without disturbing the existing plugin-source view.
- Add `docs/skills/layered-merge.md` documenting layers, merge rules, CLI usage, and determinism guarantees.
- 30 new tests in `tests/unit/skills/test_layered.py` pin layer precedence, per-field override granularity, deterministic merge across runs, missing-layer fall-through (base-only, user-only, team+user), and unknown-field rejection. Filesystem integration covered for YAML and SKILL.md forms.

Closes #1624.

## Test plan

- [x] `pytest tests/unit/skills/test_layered.py` (30 passed)
- [x] `pytest tests/unit/skills/` (211 passed, no regressions in adjacent suites)
- [x] `ruff check` + `ruff format` on new/changed files
- [x] `pyright` on new/changed files
- [ ] CI runs the full matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added layered skill customization supporting base, team, and user override layers with deterministic merging
  * Added `--layered` flag to `skills list` command to display which layers contribute to each skill
  * Added `--per-layer` flag to `skills show` command to view merged results and per-layer details
* **Documentation**
  * Added documentation page describing layered skill customization, merge behavior, CLI usage, and acceptance criteria

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->