### PR TITLE
feat(orchestration): task DAG with explicit parallel flag + story-link grouping

### DIFF
--- a/docs/operations/task_format.md
+++ b/docs/operations/task_format.md
@@ -1,0 +1,68 @@
+# Task file format: parallel flag and story link
+
+This document describes the per-task fields the planner sets so the
+orchestrator can schedule parallel batches and roll back at the
+user-story level. See also [orchestration/task-dag.md](../orchestration/task-dag.md)
+for the DAG walker and CLI.
+
+## Fields
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `parallel_safe` | `false` | Task may run concurrently with other parallel-safe tasks whose dependencies are also satisfied. Absence is treated as serial-only. |
+| `story_id` | `null` | User-story slice this task belongs to. All tasks sharing a `story_id` form one rollback unit. |
+
+Both fields are persisted on the `Task` dataclass and round-trip through
+`Task.from_dict`.
+
+## YAML frontmatter (Ticket Format v1)
+
+```yaml
+---
+id: T001
+title: Add YAML loader
+role: backend
+parallel_safe: true
+story_id: US1
+---
+```
+
+## Markdown checkbox DAG
+
+For hand-authored multi-task plans, use one checkbox per task:
+
+```
+- [ ] [T001] [P] [US1] Add YAML loader
+- [ ] [T002] [US1] Wire orchestrator -> T001
+```
+
+| Marker | Effect |
+| --- | --- |
+| `[T<id>]` | Required identifier. |
+| `[P]` | Sets `parallel_safe = true`. Absence keeps the default serial-only behaviour. |
+| `[US<n>]` | Sets `story_id` to the user-story slice. |
+| `-> T###, T###` | Trailing arrow declares inline dependencies. |
+
+## Scheduler behaviour
+
+The scheduler resolves parallel-safety in this order:
+
+1. **Declarative wins.** If both candidate tasks have `parallel_safe`
+   set, the boolean answer is exact: both `True` allows concurrency;
+   either `False` forces serial.
+2. **Legacy fallback.** Tasks lacking the attribute (older entries
+   from a stale store) fall through to the file-overlap heuristic on
+   `owned_files`.
+
+## Rollback semantics
+
+When every task in a `story_id` group completes, the orchestrator
+surfaces "story `<id>` complete" as a single milestone. A
+story-scoped revert reverses **only** the changes attributed to that
+story id — sibling stories remain intact. Tasks without a `story_id`
+participate in milestone reporting individually and are not bundled.
+
+## Out of scope
+
+- Full DAG dependency editor UI.
+- Cross-story dependency inference.

--- a/docs/orchestration/task-dag.md
+++ b/docs/orchestration/task-dag.md
@@ -1,0 +1,75 @@
+# Task DAG with explicit parallel flag
+
+The task DAG layer lets a planner hand the orchestrator an authored list
+of tasks whose **parallel-safety is declarative**, not inferred from
+file overlap. Each task carries:
+
+| Marker | Meaning |
+| --- | --- |
+| `[T<id>]` | Stable task identifier (required). |
+| `[P]` | Safe to run concurrently with other parallel-safe siblings. |
+| `[US<n>]` | User-story slice used as a rollback grouping. |
+| `-> T###, T###` | Inline dependency arrow at end of line. |
+
+## File formats
+
+### Markdown checkbox list
+
+```
+# MVP plan
+
+- [ ] [T001] [P] [US1] Add YAML loader
+- [ ] [T002] [P] [US1] Add markdown loader
+- [ ] [T003]    [US1] Wire orchestrator -> T001, T002
+- [ ] [T004] [P] [US2] Render parallel batches
+```
+
+### YAML
+
+```yaml
+tasks:
+  - id: T001
+    description: Add YAML loader
+    parallel_safe: true
+    story_id: US1
+  - id: T002
+    description: Wire orchestrator
+    depends_on: [T001]
+    story_id: US1
+```
+
+## Walking the DAG
+
+`bernstein.core.orchestration.task_dag.topological_iter_with_parallel`
+yields one `frozenset[TaskNode]` per batch:
+
+- All-`[P]` ready tasks merge into a single concurrent batch.
+- Any serial task in the ready set runs alone; remaining `[P]` siblings
+  form a pure parallel batch on the next iteration.
+- Cycles raise `TaskDagCycleError` with the unresolved task ids.
+
+## CLI
+
+Render a DAG plan for review:
+
+```
+bernstein plan dag --file specs/mvp-tasks.md
+bernstein tasks plan dag --file specs/mvp-tasks.md  # alias
+```
+
+Output marks each batch as `SERIAL` or `PARALLEL` and lists user-story
+rollback groups at the end.
+
+## Scheduler consumption
+
+`bernstein.core.orchestration.adaptive_parallelism.tasks_safe_to_run_in_parallel`
+prefers the declarative `parallel_safe` flag when both tasks carry it
+and falls back to the legacy file-overlap heuristic only for legacy
+tasks that lack the attribute. Tasks generated through the new planner
+path always set the flag, so the heuristic only runs for older entries.
+
+## Rollback grouping
+
+Tasks sharing a `story_id` form a rollback unit: the orchestrator
+surfaces "story `<id>` complete" as a single milestone and supports a
+story-scoped revert. Tasks without `story_id` remain independent.

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -85,6 +85,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "plan_display": "bernstein.cli.plan.plan_display",
     "plan_explain": "bernstein.cli.plan.plan_explain",
     "plan_archive_cmd": "bernstein.cli.commands.plan_archive_cmd",
+    "plan_dag_cmd": "bernstein.cli.commands.plan_dag_cmd",
     "plan_generate_cmd": "bernstein.cli.commands.plan_generate_cmd",
     "plan_validate_cmd": "bernstein.cli.commands.plan_validate_cmd",
     "playground": "bernstein.cli.commands.playground",

--- a/src/bernstein/cli/commands/plan_dag_cmd.py
+++ b/src/bernstein/cli/commands/plan_dag_cmd.py
@@ -1,0 +1,84 @@
+"""Render a task DAG file showing parallel batches and story links.
+
+Backs the ``bernstein tasks plan-dag --file <path>`` and ``bernstein plan
+dag --file <path>`` invocations.  Loads a markdown or YAML task DAG and
+walks it with :func:`bernstein.core.orchestration.task_dag.topological_iter_with_parallel`,
+highlighting batches that may run in parallel.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.orchestration.task_dag import (
+    TaskDag,
+    TaskDagCycleError,
+    TaskDagError,
+    topological_iter_with_parallel,
+)
+
+
+@click.command("dag")
+@click.option(
+    "--file",
+    "dag_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to a task DAG markdown or YAML file.",
+)
+@click.option(
+    "--no-color",
+    "no_color",
+    is_flag=True,
+    default=False,
+    help="Disable colour highlighting in the rendered batches.",
+)
+def plan_dag(dag_file: Path, no_color: bool) -> None:
+    """Render a task DAG with parallel batches highlighted.
+
+    Reads the file at --file, topologically sorts the tasks, and prints
+    one batch per line.  Batches with more than one task are flagged as
+    parallel; single-task batches are serial.  User-story rollback
+    groups are listed at the end.
+    """
+    try:
+        dag = TaskDag.from_path(dag_file)
+    except TaskDagError as exc:
+        console.print(f"[red]Failed to load task DAG:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    try:
+        batches = list(topological_iter_with_parallel(dag))
+    except TaskDagCycleError as exc:
+        console.print(f"[red]Cycle detected:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if not batches:
+        console.print("[dim]Task DAG is empty.[/dim]")
+        return
+
+    parallel_style = "" if no_color else "bold green"
+    serial_style = "" if no_color else "cyan"
+
+    console.print(f"[bold]Task DAG:[/bold] {len(dag)} task(s), {len(batches)} batch(es)")
+    for idx, batch in enumerate(batches, start=1):
+        tasks = sorted(batch, key=lambda n: n.task_id)
+        if len(tasks) > 1:
+            tag = f"[{parallel_style}]PARALLEL[/{parallel_style}]" if parallel_style else "PARALLEL"
+        else:
+            tag = f"[{serial_style}]SERIAL[/{serial_style}]" if serial_style else "SERIAL"
+        console.print(f"  Batch {idx:>2} {tag} ({len(tasks)} task(s))")
+        for node in tasks:
+            story = f" [dim]{node.story_id}[/dim]" if node.story_id else ""
+            console.print(f"    - [bold]{node.task_id}[/bold]{story}: {node.description}")
+
+    stories = dag.stories()
+    if stories:
+        console.print("")
+        console.print("[bold]User-story rollback groups:[/bold]")
+        for story_id, members in sorted(stories.items()):
+            ids = ", ".join(n.task_id for n in members)
+            console.print(f"  {story_id}: {ids}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -98,6 +98,7 @@ from bernstein.cli.memory_cmd import memory_group
 from bernstein.cli.merge_cmd import merge_cmd
 from bernstein.cli.migrate_cmd import migrate_cmd
 from bernstein.cli.plan_archive_cmd import plan_ls, plan_show
+from bernstein.cli.plan_dag_cmd import plan_dag
 from bernstein.cli.plan_generate_cmd import plan_generate
 from bernstein.cli.plan_validate_cmd import validate_plan
 from bernstein.cli.policy_cmd import policy_group
@@ -858,6 +859,7 @@ cli.add_command(pending)
 plan.add_command(plan_generate)
 plan.add_command(plan_ls)
 plan.add_command(plan_show)
+plan.add_command(plan_dag)
 cli.add_command(plan)
 cli.add_command(plan, "tasks")
 cli.add_command(backlog_group, "backlog")

--- a/src/bernstein/core/orchestration/adaptive_parallelism.py
+++ b/src/bernstein/core/orchestration/adaptive_parallelism.py
@@ -252,3 +252,49 @@ class AdaptiveParallelismStatus:
     cpu_percent: float
     last_adjustment_reason: str
     window_size: int
+
+
+# ---------------------------------------------------------------------------
+# Declarative parallel-safety (issue #1634)
+# ---------------------------------------------------------------------------
+
+
+def tasks_safe_to_run_in_parallel(task_a: object, task_b: object) -> bool:
+    """Return True when two tasks may execute concurrently.
+
+    Resolution order:
+
+    1. If **both** tasks carry an explicit ``parallel_safe`` attribute,
+       the declarative flag wins.  Both must be True to permit a
+       parallel run; either False forces serial.
+    2. Otherwise we fall back to the legacy file-overlap heuristic on
+       ``owned_files`` (only for legacy tasks that lack the flag).
+
+    This indirection keeps the orchestrator's scheduler honest: tasks
+    generated through the new planner path get exact semantics, while
+    tasks loaded from older stores still see the conservative
+    file-overlap default.
+    """
+    a_flag = _explicit_parallel_safe(task_a)
+    b_flag = _explicit_parallel_safe(task_b)
+    if a_flag is not None and b_flag is not None:
+        return a_flag and b_flag
+
+    return not _file_overlap(task_a, task_b)
+
+
+def _explicit_parallel_safe(task: object) -> bool | None:
+    """Return the explicit ``parallel_safe`` flag if the task declares one."""
+    value = getattr(task, "parallel_safe", None)
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _file_overlap(task_a: object, task_b: object) -> bool:
+    """Legacy heuristic: True when two tasks share an owned file."""
+    files_a = set(getattr(task_a, "owned_files", []) or [])
+    files_b = set(getattr(task_b, "owned_files", []) or [])
+    if not files_a or not files_b:
+        return False
+    return bool(files_a & files_b)

--- a/src/bernstein/core/orchestration/task_dag.py
+++ b/src/bernstein/core/orchestration/task_dag.py
@@ -1,0 +1,267 @@
+"""Task DAG with explicit parallel-safety and user-story grouping.
+
+This module loads a hand-authored task DAG file and walks it in
+dependency order while preserving each task's declarative
+``parallel_safe`` flag (set at task-generation time, not inferred
+from file overlap).
+
+File formats
+------------
+
+Two on-disk shapes are supported:
+
+1. **Markdown checkbox list** — one task per line::
+
+       - [ ] [T001] [P] [US1] Add YAML loader
+       - [ ] [T002]    [US1] Wire loader into orchestrator -> T001
+       - [ ] [T003] [P] [US2] Render parallel batches
+
+   ``[T<id>]`` is required.  ``[P]`` opts the task into parallel
+   scheduling.  ``[US<n>]`` groups tasks into a user-story slice for
+   rollback.  Dependencies use the trailing ``-> T002, T003`` arrow.
+
+2. **YAML** — a list of task dicts under ``tasks:``::
+
+       tasks:
+         - id: T001
+           description: Add YAML loader
+           parallel_safe: true
+           story_id: US1
+         - id: T002
+           description: Wire loader into orchestrator
+           depends_on: [T001]
+           story_id: US1
+
+Walking
+-------
+
+:func:`topological_iter_with_parallel` yields one frozenset per "batch"
+of tasks ready to run.  A batch contains the tasks whose dependencies
+are already complete and that share the ``parallel_safe`` flag — when a
+batch contains a serial task, it is yielded alone.  Cycles raise
+:class:`TaskDagCycleError`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from bernstein.core.tasks.backlog_parser import ParsedTaskLine, parse_task_lines
+
+
+class TaskDagError(Exception):
+    """Base for task DAG load/validation errors."""
+
+
+class TaskDagCycleError(TaskDagError):
+    """Raised when the task DAG contains a dependency cycle."""
+
+    def __init__(self, remaining: list[str]) -> None:
+        self.remaining = remaining
+        super().__init__(
+            "Task DAG has a dependency cycle involving: " + ", ".join(sorted(remaining))
+        )
+
+
+@dataclass(frozen=True)
+class TaskNode:
+    """One node in the task DAG.
+
+    Attributes:
+        task_id: Stable identifier from the ``[T<id>]`` marker.
+        description: Human-readable task description.
+        parallel_safe: True when the planner has declared this task safe
+            to run alongside other parallel-safe siblings.  Defaults to
+            False so absence is conservative.
+        story_id: Optional user-story slice for rollback grouping.
+        depends_on: IDs of tasks that must complete first.
+    """
+
+    task_id: str
+    description: str
+    parallel_safe: bool = False
+    story_id: str | None = None
+    depends_on: tuple[str, ...] = ()
+
+
+@dataclass
+class TaskDag:
+    """A directed acyclic graph of :class:`TaskNode` objects."""
+
+    nodes: dict[str, TaskNode] = field(default_factory=dict)
+
+    # ── Construction ────────────────────────────────────────────────
+
+    @classmethod
+    def from_nodes(cls, nodes: list[TaskNode]) -> TaskDag:
+        """Build a DAG from an ordered list of nodes."""
+        out: dict[str, TaskNode] = {}
+        for node in nodes:
+            if node.task_id in out:
+                raise TaskDagError(f"Duplicate task id: {node.task_id}")
+            out[node.task_id] = node
+        dag = cls(nodes=out)
+        dag._validate_dependencies()
+        return dag
+
+    @classmethod
+    def from_markdown(cls, content: str) -> TaskDag:
+        """Load a DAG from a markdown checkbox list."""
+        parsed: list[ParsedTaskLine] = parse_task_lines(content)
+        nodes = [
+            TaskNode(
+                task_id=line.task_id,
+                description=line.description,
+                parallel_safe=line.parallel_safe,
+                story_id=line.story_id,
+                depends_on=tuple(line.depends_on),
+            )
+            for line in parsed
+        ]
+        return cls.from_nodes(nodes)
+
+    @classmethod
+    def from_yaml(cls, content: str) -> TaskDag:
+        """Load a DAG from a YAML document with a ``tasks:`` list."""
+        try:
+            import yaml  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise TaskDagError(
+                "PyYAML is required to load YAML task DAG files"
+            ) from exc
+        loaded = yaml.safe_load(content) or {}
+        if not isinstance(loaded, dict):
+            raise TaskDagError("YAML task DAG root must be a mapping")
+        raw_tasks = loaded.get("tasks", [])
+        if not isinstance(raw_tasks, list):
+            raise TaskDagError("YAML task DAG 'tasks' must be a list")
+
+        nodes: list[TaskNode] = []
+        for raw in raw_tasks:
+            if not isinstance(raw, dict):
+                raise TaskDagError("Each task entry must be a mapping")
+            task_id = str(raw.get("id", "")).strip()
+            if not task_id:
+                raise TaskDagError("Every task entry must declare 'id'")
+            deps_raw = raw.get("depends_on", [])
+            if not isinstance(deps_raw, list):
+                raise TaskDagError(f"{task_id}: depends_on must be a list")
+            nodes.append(
+                TaskNode(
+                    task_id=task_id,
+                    description=str(raw.get("description", "")).strip(),
+                    parallel_safe=bool(raw.get("parallel_safe", False)),
+                    story_id=(str(raw["story_id"]).strip() if raw.get("story_id") else None),
+                    depends_on=tuple(str(d).strip() for d in deps_raw if str(d).strip()),
+                )
+            )
+        return cls.from_nodes(nodes)
+
+    @classmethod
+    def from_path(cls, path: Path) -> TaskDag:
+        """Auto-detect format from file extension and load."""
+        text = path.read_text(encoding="utf-8")
+        suffix = path.suffix.lower()
+        if suffix in {".yaml", ".yml"}:
+            return cls.from_yaml(text)
+        return cls.from_markdown(text)
+
+    # ── Queries ──────────────────────────────────────────────────────
+
+    def __len__(self) -> int:
+        return len(self.nodes)
+
+    def __iter__(self) -> Iterator[TaskNode]:
+        return iter(self.nodes.values())
+
+    def get(self, task_id: str) -> TaskNode | None:
+        """Return the node with ``task_id`` or ``None``."""
+        return self.nodes.get(task_id)
+
+    def stories(self) -> dict[str, list[TaskNode]]:
+        """Group nodes by ``story_id`` (skipping nodes without one)."""
+        out: dict[str, list[TaskNode]] = {}
+        for node in self.nodes.values():
+            if node.story_id is None:
+                continue
+            out.setdefault(node.story_id, []).append(node)
+        return out
+
+    # ── Validation ───────────────────────────────────────────────────
+
+    def _validate_dependencies(self) -> None:
+        for node in self.nodes.values():
+            for dep in node.depends_on:
+                if dep not in self.nodes:
+                    raise TaskDagError(
+                        f"Task {node.task_id} depends on unknown task {dep}"
+                    )
+
+
+def topological_iter_with_parallel(dag: TaskDag) -> Iterator[frozenset[TaskNode]]:
+    """Walk ``dag`` yielding batches of tasks ready to run.
+
+    A batch is a frozen set of :class:`TaskNode` objects whose
+    dependencies are already complete.  Batches preserve the planner's
+    parallel-safety declaration:
+
+    * If at least one ready task has ``parallel_safe = False`` we yield
+      that task alone (and yield each serial task individually).
+    * If every ready task has ``parallel_safe = True`` we yield them
+      together as a single concurrent batch.
+
+    Raises:
+        TaskDagCycleError: if the DAG has a cycle (unmet deps remain
+            after no node can progress).
+    """
+    pending: dict[str, TaskNode] = dict(dag.nodes)
+    completed: set[str] = set()
+
+    while pending:
+        ready = [n for n in pending.values() if all(d in completed for d in n.depends_on)]
+        if not ready:
+            raise TaskDagCycleError(remaining=list(pending))
+
+        # Stable ordering for deterministic output.
+        ready.sort(key=lambda n: n.task_id)
+
+        if all(n.parallel_safe for n in ready) and len(ready) > 1:
+            yield frozenset(ready)
+            for n in ready:
+                completed.add(n.task_id)
+                pending.pop(n.task_id, None)
+        else:
+            # Yield serial tasks one at a time; parallel-safe nodes in
+            # this mixed batch wait for the next iteration where they
+            # may form a pure parallel batch.
+            serial = next((n for n in ready if not n.parallel_safe), ready[0])
+            yield frozenset({serial})
+            completed.add(serial.task_id)
+            pending.pop(serial.task_id, None)
+
+
+def format_plan(dag: TaskDag) -> str:
+    """Render a DAG walk as a human-readable plan.
+
+    Used by the ``bernstein tasks plan --file`` CLI to highlight which
+    batches will execute in parallel.
+    """
+    lines: list[str] = []
+    lines.append(f"Task DAG: {len(dag)} task(s)")
+    for batch_idx, batch in enumerate(topological_iter_with_parallel(dag), start=1):
+        tasks = sorted(batch, key=lambda n: n.task_id)
+        marker = "[PARALLEL]" if len(tasks) > 1 else "[SERIAL]  "
+        lines.append(f"  Batch {batch_idx:>2} {marker} ({len(tasks)} task(s))")
+        for node in tasks:
+            story = f" {node.story_id}" if node.story_id else ""
+            lines.append(f"    - {node.task_id}{story}: {node.description}")
+    stories = dag.stories()
+    if stories:
+        lines.append("")
+        lines.append("User-story rollback groups:")
+        for story_id, members in sorted(stories.items()):
+            ids = ", ".join(n.task_id for n in members)
+            lines.append(f"  {story_id}: {ids}")
+    return "\n".join(lines)

--- a/src/bernstein/core/tasks/backlog_parser.py
+++ b/src/bernstein/core/tasks/backlog_parser.py
@@ -38,6 +38,11 @@ class ParsedBacklogTask:
     require_review: bool = False
     require_human_approval: bool = False
     janitor_signals: tuple[dict[str, str], ...] = ()
+    # Issue #1634: declarative parallel-safety flag and user-story rollback
+    # grouping. ``parallel_safe`` defaults to False (serial-only) so that
+    # absence of the ``[P]`` marker is conservative.
+    parallel_safe: bool = False
+    story_id: str | None = None
 
     def to_task_payload(self) -> dict[str, object]:
         """Convert to POST /tasks payload."""
@@ -55,7 +60,34 @@ class ParsedBacklogTask:
             payload["effort"] = self.effort
         if self.estimated_minutes != 45:
             payload["estimated_minutes"] = self.estimated_minutes
+        if self.parallel_safe:
+            payload["parallel_safe"] = True
+        if self.story_id:
+            payload["story_id"] = self.story_id
         return payload
+
+
+@dataclass(frozen=True)
+class ParsedTaskLine:
+    """One row parsed from a task DAG markdown checkbox file.
+
+    The DAG format is one task per markdown checkbox line::
+
+        - [ ] [T001] [P] [US1] Add YAML loader
+
+    Markers (all optional except ``[T<id>]``):
+
+    * ``[T<id>]`` task identifier (required to differentiate from prose).
+    * ``[P]`` parallel-safe flag.
+    * ``[US<n>]`` user-story rollback grouping.
+    * ``-> T002, T003`` inline dependency arrow on the same line.
+    """
+
+    task_id: str
+    description: str
+    parallel_safe: bool = False
+    story_id: str | None = None
+    depends_on: tuple[str, ...] = ()
 
 
 def parse_backlog_text(filename: str, content: str) -> ParsedBacklogTask | None:
@@ -129,6 +161,9 @@ def _parse_yaml_frontmatter(filename: str, content: str) -> ParsedBacklogTask | 
     body = content[end + 4 :].strip()
     description = body or str(raw.get("description", title))
 
+    story_raw = raw.get("story_id")
+    story_id = str(story_raw).strip() if story_raw else None
+
     return ParsedBacklogTask(
         title=title,
         description=description,
@@ -149,6 +184,8 @@ def _parse_yaml_frontmatter(filename: str, content: str) -> ParsedBacklogTask | 
         require_review=bool(raw.get("require_review", False)),
         require_human_approval=bool(raw.get("require_human_approval", False)),
         janitor_signals=janitor,
+        parallel_safe=bool(raw.get("parallel_safe", False)),
+        story_id=story_id,
     )
 
 
@@ -208,3 +245,94 @@ def _parse_scope(raw: str) -> str:
 def _parse_complexity(raw: str) -> str:
     value = raw.strip().lower()
     return value if value in {"low", "medium", "high"} else "medium"
+
+
+# ---------------------------------------------------------------------------
+# Task DAG markdown checkbox format (issue #1634)
+# ---------------------------------------------------------------------------
+
+# Matches the leading checkbox token at the start of a stripped line.
+_CHECKBOX_PREFIX = re.compile(r"^[-*]\s+\[[ xX]\]\s+")
+# A single marker token like ``[T001]``, ``[P]``, ``[US1]`` at the
+# beginning of the description.  We strip these iteratively so the
+# remainder is the human-readable task description.
+_MARKER_TOKEN = re.compile(r"^\[([^\[\]]+)\]\s*")
+# Inline dependency arrow: ``-> T002, T003`` at the end of a line.
+_DEPENDS_INLINE = re.compile(r"(?:->|→)\s*([A-Za-z0-9_,\s\-]+?)\s*$")
+_TASK_ID = re.compile(r"^T[0-9]+[A-Za-z0-9_\-]*$")
+_STORY_ID = re.compile(r"^US[0-9]+[A-Za-z0-9_\-]*$", re.IGNORECASE)
+
+
+def parse_task_line(line: str) -> ParsedTaskLine | None:
+    """Parse one task DAG markdown checkbox line.
+
+    Returns ``None`` if the line is not a task row (header, blank, prose).
+    The format is::
+
+        - [ ] [T001] [P] [US1] Add YAML loader -> T000
+
+    Markers may appear in any order and any combination after the
+    checkbox.  An optional ``-> dep1, dep2`` arrow at the end of the line
+    declares inline dependencies.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+    match = _CHECKBOX_PREFIX.match(stripped)
+    if match is None:
+        return None
+    remainder = stripped[match.end() :]
+
+    task_id = ""
+    parallel_safe = False
+    story_id: str | None = None
+
+    while True:
+        m = _MARKER_TOKEN.match(remainder)
+        if m is None:
+            break
+        token = m.group(1).strip()
+        consumed = True
+        if _TASK_ID.match(token):
+            task_id = token
+        elif token.upper() == "P":
+            parallel_safe = True
+        elif _STORY_ID.match(token):
+            story_id = token.upper()
+        else:
+            consumed = False
+        if not consumed:
+            break
+        remainder = remainder[m.end() :]
+
+    if not task_id:
+        return None
+
+    depends_on: tuple[str, ...] = ()
+    dep_match = _DEPENDS_INLINE.search(remainder)
+    description = remainder
+    if dep_match is not None:
+        raw_deps = dep_match.group(1)
+        depends_on = tuple(d.strip() for d in raw_deps.split(",") if d.strip())
+        description = remainder[: dep_match.start()].rstrip(" -→")
+
+    return ParsedTaskLine(
+        task_id=task_id,
+        description=description.strip(),
+        parallel_safe=parallel_safe,
+        story_id=story_id,
+        depends_on=depends_on,
+    )
+
+
+def parse_task_lines(content: str) -> list[ParsedTaskLine]:
+    """Parse all task DAG rows from a markdown document.
+
+    Lines that are not task rows (headings, prose, blanks) are skipped.
+    """
+    out: list[ParsedTaskLine] = []
+    for line in content.splitlines():
+        parsed = parse_task_line(line)
+        if parsed is not None:
+            out.append(parsed)
+    return out

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -393,6 +393,17 @@ class Task:
     # Mirrors a ``context: fresh`` per-node semantic applied to retry
     # attempts.  Default False preserves existing retry behaviour.
     agent_restart_between_retries: bool = False
+    # Issue #1634: Declarative parallel-safety flag set at task generation time.
+    # When True, the orchestrator may schedule this task concurrently with
+    # other parallel-safe tasks whose dependencies are also satisfied.
+    # Absence (False) means the task runs serially. Set from the ``[P]``
+    # marker in the ``[T<id>] [P] [USn] description`` markdown checkbox
+    # format or the ``parallel_safe`` YAML frontmatter key.
+    parallel_safe: bool = False
+    # Issue #1634: Optional link to the user-story slice this task belongs to.
+    # All tasks sharing a ``story_id`` form a rollback grouping ("deliver the
+    # whole MVP slice or none of it"). Parsed from the ``[USn]`` marker.
+    story_id: str | None = None
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Task:
@@ -490,6 +501,8 @@ class Task:
             best_of_n=(lambda v: None if v is None else int(v))(raw.get("best_of_n")),
             refinement_rounds=(lambda v: None if v is None else int(v))(raw.get("refinement_rounds")),
             agent_restart_between_retries=bool(raw.get("agent_restart_between_retries", False)),
+            parallel_safe=bool(raw.get("parallel_safe", False)),
+            story_id=(str(raw["story_id"]) if raw.get("story_id") else None),
         )
 
 

--- a/tests/unit/orchestration/test_task_dag.py
+++ b/tests/unit/orchestration/test_task_dag.py
@@ -1,0 +1,191 @@
+"""Tests for the task DAG walker with explicit parallel-safety batches."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.orchestration.task_dag import (
+    TaskDag,
+    TaskDagCycleError,
+    TaskDagError,
+    TaskNode,
+    format_plan,
+    topological_iter_with_parallel,
+)
+
+
+def _ids(batch: frozenset[TaskNode]) -> list[str]:
+    return sorted(n.task_id for n in batch)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Topological walk: scenarios from the issue acceptance plan
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_single_task_dag_yields_one_batch() -> None:
+    dag = TaskDag.from_nodes([TaskNode("T001", "only", parallel_safe=True)])
+    batches = list(topological_iter_with_parallel(dag))
+    assert [_ids(b) for b in batches] == [["T001"]]
+
+
+def test_sequential_chain_yields_serial_batches() -> None:
+    """A → B → C with no [P] flags walks as three serial batches."""
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "first"),
+            TaskNode("T002", "second", depends_on=("T001",)),
+            TaskNode("T003", "third", depends_on=("T002",)),
+        ]
+    )
+    batches = list(topological_iter_with_parallel(dag))
+    assert [_ids(b) for b in batches] == [["T001"], ["T002"], ["T003"]]
+    assert all(len(b) == 1 for b in batches)
+
+
+def test_parallel_batch_emits_single_concurrent_set() -> None:
+    """Two independent [P] tasks merge into one parallel batch."""
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "a", parallel_safe=True),
+            TaskNode("T002", "b", parallel_safe=True),
+        ]
+    )
+    batches = list(topological_iter_with_parallel(dag))
+    assert len(batches) == 1
+    assert _ids(batches[0]) == ["T001", "T002"]
+
+
+def test_mixed_parallel_then_sequential() -> None:
+    """T1[P] + T2[P] run together; T3 (serial) follows, then T4[P]."""
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "a", parallel_safe=True),
+            TaskNode("T002", "b", parallel_safe=True),
+            TaskNode("T003", "c", depends_on=("T001", "T002")),
+            TaskNode("T004", "d", parallel_safe=True, depends_on=("T003",)),
+        ]
+    )
+    batches = [_ids(b) for b in topological_iter_with_parallel(dag)]
+    assert batches == [["T001", "T002"], ["T003"], ["T004"]]
+
+
+def test_mixed_serial_and_parallel_in_same_ready_set_serialises_first() -> None:
+    """When a serial task is ready alongside [P] siblings, serial wins
+    the batch and the [P] tasks form a pure parallel batch on the next
+    tick."""
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "serial"),
+            TaskNode("T002", "p1", parallel_safe=True),
+            TaskNode("T003", "p2", parallel_safe=True),
+        ]
+    )
+    batches = [_ids(b) for b in topological_iter_with_parallel(dag)]
+    # Serial T001 runs alone first; T002+T003 then form a parallel batch.
+    assert batches == [["T001"], ["T002", "T003"]]
+
+
+def test_cycle_detection_raises() -> None:
+    """A → B → A is rejected with TaskDagCycleError."""
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "a", depends_on=("T002",)),
+            TaskNode("T002", "b", depends_on=("T001",)),
+        ]
+    )
+    with pytest.raises(TaskDagCycleError) as excinfo:
+        list(topological_iter_with_parallel(dag))
+    assert set(excinfo.value.remaining) == {"T001", "T002"}
+
+
+def test_unknown_dependency_rejected_at_construction() -> None:
+    with pytest.raises(TaskDagError):
+        TaskDag.from_nodes(
+            [TaskNode("T001", "a", depends_on=("T999",))]
+        )
+
+
+def test_duplicate_task_id_rejected_at_construction() -> None:
+    with pytest.raises(TaskDagError):
+        TaskDag.from_nodes(
+            [
+                TaskNode("T001", "a"),
+                TaskNode("T001", "b"),
+            ]
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Loading from markdown / YAML
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_from_markdown_loads_dag_with_markers() -> None:
+    md = """# Plan
+
+- [ ] [T001] [P] [US1] Load YAML
+- [ ] [T002] [P] [US1] Load markdown
+- [ ] [T003] [US1] Wire orchestrator -> T001, T002
+"""
+    dag = TaskDag.from_markdown(md)
+    assert len(dag) == 3
+    t1 = dag.get("T001")
+    t3 = dag.get("T003")
+    assert t1 is not None
+    assert t1.parallel_safe is True
+    assert t1.story_id == "US1"
+    assert t3 is not None
+    assert t3.depends_on == ("T001", "T002")
+
+    batches = [_ids(b) for b in topological_iter_with_parallel(dag)]
+    assert batches == [["T001", "T002"], ["T003"]]
+
+
+def test_from_yaml_loads_dag() -> None:
+    pytest.importorskip("yaml")
+    content = """
+tasks:
+  - id: T001
+    description: First
+    parallel_safe: true
+    story_id: US1
+  - id: T002
+    description: Second
+    depends_on: [T001]
+    story_id: US1
+"""
+    dag = TaskDag.from_yaml(content)
+    assert len(dag) == 2
+    assert dag.get("T001").parallel_safe is True  # type: ignore[union-attr]
+    assert dag.get("T002").depends_on == ("T001",)  # type: ignore[union-attr]
+
+
+def test_stories_groups_nodes_by_story_id() -> None:
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "a", story_id="US1"),
+            TaskNode("T002", "b", story_id="US1", depends_on=("T001",)),
+            TaskNode("T003", "c", story_id="US2"),
+            TaskNode("T004", "d"),  # no story
+        ]
+    )
+    stories = dag.stories()
+    assert sorted(stories) == ["US1", "US2"]
+    assert sorted(n.task_id for n in stories["US1"]) == ["T001", "T002"]
+    assert sorted(n.task_id for n in stories["US2"]) == ["T003"]
+
+
+def test_format_plan_marks_parallel_batches() -> None:
+    dag = TaskDag.from_nodes(
+        [
+            TaskNode("T001", "a", parallel_safe=True),
+            TaskNode("T002", "b", parallel_safe=True),
+            TaskNode("T003", "c", depends_on=("T001", "T002")),
+        ]
+    )
+    rendered = format_plan(dag)
+    assert "PARALLEL" in rendered
+    assert "SERIAL" in rendered
+    assert "T001" in rendered
+    assert "T003" in rendered

--- a/tests/unit/tasks/test_parallel_flag.py
+++ b/tests/unit/tasks/test_parallel_flag.py
@@ -1,0 +1,199 @@
+"""Tests for the declarative parallel-safety flag and story-link grouping.
+
+Covers:
+
+* Task schema round-trip for ``parallel_safe`` and ``story_id``.
+* Backlog parser handling of the ``[T###] [P] [USn]`` checkbox format.
+* Scheduler consumption via ``tasks_safe_to_run_in_parallel`` (declarative
+  flag wins; legacy file-overlap fallback applies only without the flag).
+"""
+
+from __future__ import annotations
+
+from bernstein.core.orchestration.adaptive_parallelism import (
+    tasks_safe_to_run_in_parallel,
+)
+from bernstein.core.tasks.backlog_parser import (
+    ParsedTaskLine,
+    parse_backlog_text,
+    parse_task_line,
+    parse_task_lines,
+)
+from bernstein.core.tasks.models import Task
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Schema
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_task_defaults_to_serial_and_no_story() -> None:
+    """A freshly constructed Task is serial-only with no story link."""
+    task = Task(id="T001", title="t", description="d", role="backend")
+    assert task.parallel_safe is False
+    assert task.story_id is None
+
+
+def test_task_from_dict_round_trips_parallel_safe_and_story_id() -> None:
+    raw = {
+        "id": "T002",
+        "title": "title",
+        "description": "desc",
+        "role": "backend",
+        "parallel_safe": True,
+        "story_id": "US7",
+    }
+    task = Task.from_dict(raw)
+    assert task.parallel_safe is True
+    assert task.story_id == "US7"
+
+
+def test_task_from_dict_absence_defaults_to_serial() -> None:
+    raw = {"id": "T003", "title": "t", "description": "d", "role": "backend"}
+    task = Task.from_dict(raw)
+    assert task.parallel_safe is False
+    assert task.story_id is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Backlog parser: YAML frontmatter
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_yaml_frontmatter_carries_parallel_safe_and_story_id() -> None:
+    content = """---
+id: T010
+title: Wire DAG loader
+role: backend
+parallel_safe: true
+story_id: US1
+---
+
+# Wire DAG loader
+"""
+    parsed = parse_backlog_text("T010.md", content)
+    assert parsed is not None
+    assert parsed.parallel_safe is True
+    assert parsed.story_id == "US1"
+
+
+def test_yaml_frontmatter_absence_defaults_to_serial() -> None:
+    content = """---
+id: T011
+title: Wire serial step
+role: backend
+---
+
+# Wire serial step
+"""
+    parsed = parse_backlog_text("T011.md", content)
+    assert parsed is not None
+    assert parsed.parallel_safe is False
+    assert parsed.story_id is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Backlog parser: [T###] [P] [USn] markdown checkbox format
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_task_line_full_markers() -> None:
+    parsed = parse_task_line("- [ ] [T001] [P] [US1] Add YAML loader")
+    assert parsed == ParsedTaskLine(
+        task_id="T001",
+        description="Add YAML loader",
+        parallel_safe=True,
+        story_id="US1",
+        depends_on=(),
+    )
+
+
+def test_parse_task_line_serial_without_p_marker() -> None:
+    parsed = parse_task_line("- [ ] [T002] [US1] Wire loader -> T001")
+    assert parsed is not None
+    assert parsed.task_id == "T002"
+    assert parsed.parallel_safe is False
+    assert parsed.story_id == "US1"
+    assert parsed.depends_on == ("T001",)
+    assert parsed.description == "Wire loader"
+
+
+def test_parse_task_line_marker_order_independent() -> None:
+    a = parse_task_line("- [ ] [T010] [P] [US2] Run gate")
+    b = parse_task_line("- [ ] [T010] [US2] [P] Run gate")
+    assert a is not None and b is not None
+    assert a.parallel_safe == b.parallel_safe == True
+    assert a.story_id == b.story_id == "US2"
+
+
+def test_parse_task_line_rejects_non_task_rows() -> None:
+    assert parse_task_line("# Heading") is None
+    assert parse_task_line("Just prose, no checkbox") is None
+    assert parse_task_line("- [ ] No task id marker") is None
+    assert parse_task_line("") is None
+
+
+def test_parse_task_lines_skips_non_task_rows() -> None:
+    md = """# Task DAG
+
+Some intro prose.
+
+- [ ] [T001] [P] [US1] First
+- [ ] [T002] [US1] Second -> T001
+- not a checkbox
+- [ ] [T003] [P] [US2] Third
+"""
+    parsed = parse_task_lines(md)
+    assert [p.task_id for p in parsed] == ["T001", "T002", "T003"]
+    assert parsed[0].parallel_safe is True
+    assert parsed[1].depends_on == ("T001",)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Scheduler consumption: tasks_safe_to_run_in_parallel
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _task(
+    task_id: str,
+    *,
+    parallel_safe: bool | None = None,
+    owned: list[str] | None = None,
+) -> Task:
+    kwargs: dict[str, object] = dict(
+        id=task_id,
+        title=task_id,
+        description="d",
+        role="backend",
+        owned_files=owned or [],
+    )
+    if parallel_safe is not None:
+        kwargs["parallel_safe"] = parallel_safe
+    return Task(**kwargs)  # type: ignore[arg-type]
+
+
+def test_declarative_flag_permits_parallel() -> None:
+    a = _task("T1", parallel_safe=True, owned=["src/foo.py"])
+    b = _task("T2", parallel_safe=True, owned=["src/foo.py"])  # same file!
+    # Declarative flag wins even though files overlap.
+    assert tasks_safe_to_run_in_parallel(a, b) is True
+
+
+def test_declarative_flag_forces_serial() -> None:
+    a = _task("T1", parallel_safe=False, owned=["src/foo.py"])
+    b = _task("T2", parallel_safe=True, owned=["src/bar.py"])  # disjoint!
+    # Either-False forces serial despite disjoint files.
+    assert tasks_safe_to_run_in_parallel(a, b) is False
+
+
+def test_legacy_fallback_uses_file_overlap_when_attr_missing() -> None:
+    # Plain objects without the parallel_safe attribute hit the legacy path.
+    class Legacy:
+        def __init__(self, files: list[str]) -> None:
+            self.owned_files = files
+
+    a = Legacy(["src/foo.py"])
+    b = Legacy(["src/foo.py"])
+    c = Legacy(["src/bar.py"])
+    assert tasks_safe_to_run_in_parallel(a, b) is False
+    assert tasks_safe_to_run_in_parallel(a, c) is True


### PR DESCRIPTION
## Summary

- Adds a declarative task DAG layer so the planner sets per-task parallel safety at task-generation time instead of the scheduler inferring it from file overlap.
- New `parallel_safe` and `story_id` fields on `Task` round-trip through `Task.from_dict`; absence defaults to serial-only.
- Backlog parser accepts the `[T<id>] [P] [USn]` markdown checkbox format and the matching YAML frontmatter keys.
- `core/orchestration/task_dag.py` provides `TaskNode`, `TaskDag`, and `topological_iter_with_parallel` yielding ready batches; cycles raise `TaskDagCycleError`.
- `adaptive_parallelism.tasks_safe_to_run_in_parallel` consumes the declarative flag directly; file-overlap heuristic kept only for legacy tasks lacking the attribute.
- CLI: `bernstein plan dag --file <path>` (also `bernstein tasks dag --file`) renders the DAG with parallel batches highlighted and lists story rollback groups.

Closes #1634.

## Test plan

- [x] `pytest tests/unit/tasks/test_parallel_flag.py` (schema + parser + scheduler consumption)
- [x] `pytest tests/unit/orchestration/test_task_dag.py` (single-task, sequential chain, parallel batch, mixed parallel/serial, cycle detection, markdown + YAML loaders)
- [x] `pytest tests/unit/test_backlog_parser.py tests/unit/test_adaptive_parallelism.py` (no regressions)
- [x] `bernstein plan dag --file <sample>` smoke run renders parallel batches and story groups