### PR TITLE
fix(lint): move type-only imports under TYPE_CHECKING in task_dag

### DIFF
--- a/src/bernstein/core/orchestration/task_dag.py
+++ b/src/bernstein/core/orchestration/task_dag.py
@@ -44,11 +44,14 @@ batch contains a serial task, it is yielded alone.  Cycles raise
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from bernstein.core.tasks.backlog_parser import ParsedTaskLine, parse_task_lines
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
 
 
 class TaskDagError(Exception):
@@ -60,9 +63,7 @@ class TaskDagCycleError(TaskDagError):
 
     def __init__(self, remaining: list[str]) -> None:
         self.remaining = remaining
-        super().__init__(
-            "Task DAG has a dependency cycle involving: " + ", ".join(sorted(remaining))
-        )
+        super().__init__("Task DAG has a dependency cycle involving: " + ", ".join(sorted(remaining)))
 
 
 @dataclass(frozen=True)
@@ -128,9 +129,7 @@ class TaskDag:
         try:
             import yaml  # type: ignore[import-untyped]
         except ImportError as exc:
-            raise TaskDagError(
-                "PyYAML is required to load YAML task DAG files"
-            ) from exc
+            raise TaskDagError("PyYAML is required to load YAML task DAG files") from exc
         loaded = yaml.safe_load(content) or {}
         if not isinstance(loaded, dict):
             raise TaskDagError("YAML task DAG root must be a mapping")
@@ -195,9 +194,7 @@ class TaskDag:
         for node in self.nodes.values():
             for dep in node.depends_on:
                 if dep not in self.nodes:
-                    raise TaskDagError(
-                        f"Task {node.task_id} depends on unknown task {dep}"
-                    )
+                    raise TaskDagError(f"Task {node.task_id} depends on unknown task {dep}")
 
 
 def topological_iter_with_parallel(dag: TaskDag) -> Iterator[frozenset[TaskNode]]:


### PR DESCRIPTION
## Summary

- Ruff `TC003` fired on `src/bernstein/core/orchestration/task_dag.py:47` and `:49` after #1655 landed, leaving the Lint job red on main.
- Both `collections.abc.Iterator` and `pathlib.Path` are used only in annotations. With `from __future__ import annotations`, annotations evaluate as strings, so the imports are safe to move under `TYPE_CHECKING`.
- Format pass collapses two trailing-comma wrappings that ruff format wanted under the 120-character line length.

## Test plan

- [x] `uv run ruff check src/bernstein/core/orchestration/task_dag.py` clean.
- [x] `uv run ruff check src/` clean.
- [x] `uv run ruff format --check src/bernstein/core/orchestration/task_dag.py` clean.
- [x] `uv run pytest tests/unit/orchestration/test_task_dag.py -q` -> 12 passed.
- [x] `python -c "from bernstein.core.orchestration.task_dag import TaskDag, TaskNode, topological_iter_with_parallel"` clean.

## Summary by Sourcery

Fix lint issues in task DAG orchestration module and adjust formatting to satisfy style checks.

Bug Fixes:
- Resolve type-only import lint violations by moving Iterator and Path imports under a TYPE_CHECKING guard.

Enhancements:
- Apply code formatting updates in task_dag error messages to conform to the project style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code optimization to reduce unnecessary runtime imports and reformatting of error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->