### PR TITLE
fix(lint): repair main-red after #1655 task-DAG merge

### DIFF
--- a/src/bernstein/core/orchestration/task_dag.py
+++ b/src/bernstein/core/orchestration/task_dag.py
@@ -44,11 +44,14 @@ batch contains a serial task, it is yielded alone.  Cycles raise
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from bernstein.core.tasks.backlog_parser import ParsedTaskLine, parse_task_lines
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
 
 
 class TaskDagError(Exception):
@@ -60,9 +63,7 @@ class TaskDagCycleError(TaskDagError):
 
     def __init__(self, remaining: list[str]) -> None:
         self.remaining = remaining
-        super().__init__(
-            "Task DAG has a dependency cycle involving: " + ", ".join(sorted(remaining))
-        )
+        super().__init__("Task DAG has a dependency cycle involving: " + ", ".join(sorted(remaining)))
 
 
 @dataclass(frozen=True)
@@ -128,9 +129,7 @@ class TaskDag:
         try:
             import yaml  # type: ignore[import-untyped]
         except ImportError as exc:
-            raise TaskDagError(
-                "PyYAML is required to load YAML task DAG files"
-            ) from exc
+            raise TaskDagError("PyYAML is required to load YAML task DAG files") from exc
         loaded = yaml.safe_load(content) or {}
         if not isinstance(loaded, dict):
             raise TaskDagError("YAML task DAG root must be a mapping")
@@ -195,9 +194,7 @@ class TaskDag:
         for node in self.nodes.values():
             for dep in node.depends_on:
                 if dep not in self.nodes:
-                    raise TaskDagError(
-                        f"Task {node.task_id} depends on unknown task {dep}"
-                    )
+                    raise TaskDagError(f"Task {node.task_id} depends on unknown task {dep}")
 
 
 def topological_iter_with_parallel(dag: TaskDag) -> Iterator[frozenset[TaskNode]]:

--- a/tests/unit/cli/doctor/test_sonar.py
+++ b/tests/unit/cli/doctor/test_sonar.py
@@ -335,9 +335,7 @@ def test_load_baseline_returns_empty_on_malformed(tmp_path: Path) -> None:
     assert load_baseline(target) == {}
 
 
-def test_baseline_path_honours_xdg_data_home(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_baseline_path_honours_xdg_data_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
     resolved = baseline_path()
     assert resolved == tmp_path / "bernstein" / "sonar-baseline.json"
@@ -386,9 +384,7 @@ def test_nudge_threshold_is_override_aware() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_run_doctor_sonar_soft_fails_without_env(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_run_doctor_sonar_soft_fails_without_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv(ENV_HOST, raising=False)
     monkeypatch.delenv(ENV_TOKEN, raising=False)
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
@@ -418,9 +414,7 @@ def test_doctor_group_exposes_sonar_subcommand() -> None:
     assert "sonar" in doctor_group.commands
 
 
-def test_cli_sonar_soft_fail_does_not_crash(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_cli_sonar_soft_fail_does_not_crash(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv(ENV_HOST, raising=False)
     monkeypatch.delenv(ENV_TOKEN, raising=False)
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
@@ -430,9 +424,7 @@ def test_cli_sonar_soft_fail_does_not_crash(
     assert "not configured" in result.output
 
 
-def test_cli_sonar_json_flag_emits_json(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_cli_sonar_json_flag_emits_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv(ENV_HOST, raising=False)
     monkeypatch.delenv(ENV_TOKEN, raising=False)
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))

--- a/tests/unit/orchestration/test_task_dag.py
+++ b/tests/unit/orchestration/test_task_dag.py
@@ -101,9 +101,7 @@ def test_cycle_detection_raises() -> None:
 
 def test_unknown_dependency_rejected_at_construction() -> None:
     with pytest.raises(TaskDagError):
-        TaskDag.from_nodes(
-            [TaskNode("T001", "a", depends_on=("T999",))]
-        )
+        TaskDag.from_nodes([TaskNode("T001", "a", depends_on=("T999",))])
 
 
 def test_duplicate_task_id_rejected_at_construction() -> None:

--- a/tests/unit/review_gate/test_review_gate.py
+++ b/tests/unit/review_gate/test_review_gate.py
@@ -81,9 +81,7 @@ def _run(coro: object) -> object:
 
 class TestFreshContextSeparation:
     def test_reviewer_session_distinct_from_implementer(self) -> None:
-        gate, captured = _make_gate(
-            json.dumps({"state": "pass", "summary": "lgtm", "issues": []})
-        )
+        gate, captured = _make_gate(json.dumps({"state": "pass", "summary": "lgtm", "issues": []}))
         verdict = _run(
             gate.run(
                 _impl(),
@@ -99,9 +97,7 @@ class TestFreshContextSeparation:
         # A long, distinctive transcript -- if any 80-char slice leaks
         # into the prompt, the gate raises.
         secret_transcript = "X" * 200 + "implementer-private-thoughts-" * 5
-        gate, captured = _make_gate(
-            json.dumps({"state": "pass", "summary": "ok", "issues": []})
-        )
+        gate, captured = _make_gate(json.dumps({"state": "pass", "summary": "ok", "issues": []}))
         verdict = _run(
             gate.run(
                 _impl(transcript=secret_transcript),
@@ -115,9 +111,7 @@ class TestFreshContextSeparation:
         assert "implementer-private-thoughts" not in prompt
 
     def test_prompt_built_only_from_spec_diff_test_output(self) -> None:
-        gate, captured = _make_gate(
-            json.dumps({"state": "pass", "summary": "ok", "issues": []})
-        )
+        gate, captured = _make_gate(json.dumps({"state": "pass", "summary": "ok", "issues": []}))
         _run(
             gate.run(
                 _impl(transcript="hidden transcript content"),
@@ -135,9 +129,7 @@ class TestFreshContextSeparation:
         # If a caller tries to paste the implementer transcript into the
         # spec field, the post-condition check should catch it.
         long_transcript = "leaked-priming-fragment-" * 20
-        gate, _captured = _make_gate(
-            json.dumps({"state": "pass", "summary": "ok", "issues": []})
-        )
+        gate, _captured = _make_gate(json.dumps({"state": "pass", "summary": "ok", "issues": []}))
         with pytest.raises(FreshContextViolation):
             _run(
                 gate.run(
@@ -375,9 +367,7 @@ class TestFailBlocksMerge:
                 }
             )
         )
-        verdict = _run(
-            gate.run(_impl(), _inputs(), candidates=["openai/gpt-review"])
-        )
+        verdict = _run(gate.run(_impl(), _inputs(), candidates=["openai/gpt-review"]))
         assert isinstance(verdict, ReviewVerdict)
         assert verdict.state == "fail"
         assert verdict.blocks_merge() is True
@@ -400,9 +390,7 @@ class TestQuestionsBlocksMerge:
                 }
             )
         )
-        verdict = _run(
-            gate.run(_impl(), _inputs(), candidates=["openai/gpt-review"])
-        )
+        verdict = _run(gate.run(_impl(), _inputs(), candidates=["openai/gpt-review"]))
         assert isinstance(verdict, ReviewVerdict)
         assert verdict.state == "questions"
         assert verdict.blocks_merge() is True
@@ -411,12 +399,8 @@ class TestQuestionsBlocksMerge:
         assert verdict.issues == []
 
     def test_pass_verdict_does_not_block_merge(self) -> None:
-        gate, _captured = _make_gate(
-            json.dumps({"state": "pass", "summary": "lgtm"})
-        )
-        verdict = _run(
-            gate.run(_impl(), _inputs(), candidates=["openai/gpt-review"])
-        )
+        gate, _captured = _make_gate(json.dumps({"state": "pass", "summary": "lgtm"}))
+        verdict = _run(gate.run(_impl(), _inputs(), candidates=["openai/gpt-review"]))
         assert isinstance(verdict, ReviewVerdict)
         assert verdict.state == "pass"
         assert verdict.blocks_merge() is False

--- a/tests/unit/tasks/test_parallel_flag.py
+++ b/tests/unit/tasks/test_parallel_flag.py
@@ -21,7 +21,6 @@ from bernstein.core.tasks.backlog_parser import (
 )
 from bernstein.core.tasks.models import Task
 
-
 # ──────────────────────────────────────────────────────────────────────────
 # Schema
 # ──────────────────────────────────────────────────────────────────────────
@@ -122,7 +121,7 @@ def test_parse_task_line_marker_order_independent() -> None:
     a = parse_task_line("- [ ] [T010] [P] [US2] Run gate")
     b = parse_task_line("- [ ] [T010] [US2] [P] Run gate")
     assert a is not None and b is not None
-    assert a.parallel_safe == b.parallel_safe == True
+    assert a.parallel_safe is True and b.parallel_safe is True
     assert a.story_id == b.story_id == "US2"
 
 


### PR DESCRIPTION
## Summary

Repairs main-red on `ec430dff` (CI run 26134843273) after the task-DAG merge.

- Move `Iterator` and `Path` imports into a `TYPE_CHECKING` block in `task_dag.py` (TC003, 2 errors).
- Replace `== True` with `is True` in `test_parallel_flag.py` (E712).
- Apply `ruff format` across the four files added or touched by #1655.

## Verification

- `uv run ruff format --check src/ tests/` -> all formatted
- `uv run ruff check src/ tests/` -> all checks pass

## Test plan

- [x] Lint passes locally
- [ ] CI lint job green on this branch