### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable project changes are tracked here (code + docs).
 
+## [2.4.0] - Observability surfaces, single-writer run state, approval-nonce binding
+
+14 commits since v2.3.1. Full notes: [`docs/release-notes/v2.4.0.md`](docs/release-notes/v2.4.0.md).
+
+### Added
+
+- `bernstein doctor sonar` subcommand surfacing coverage, code smells by severity, bugs, vulnerabilities, security hotspots, and cognitive-complexity hotspots from a configured SonarQube server; advisory baseline cache and parent-doctor nudge when open smells exceed the threshold or vulnerabilities regress (#1648).
+- `bernstein doctor glitchtip` subcommand surfacing last-24h issue counts by severity, a 7-day trend, and top unresolved issues; optional baseline cache and parent-doctor nudge when new unresolved issues appear (#1646).
+- Sticky PR Sonar comment workflow and daily GlitchTip alert sweep workflow (06:30 UTC) that mirrors fatal-level issues into sticky GitHub issues labelled `glitchtip-alert` and auto-closes them when the GlitchTip side resolves (#1646, #1648).
+- Canonical stream-signal protocol (`COMPLETED`, `FAILED`, `QUESTION`, `PLAN_DRAFT`, `PLAN_READY`, `BLOCKED`) parseable from any wrapped CLI stdout; optional `stream_signal_parser` hook on `CLIAdapter`; `ConformanceReport` soft-warns on missing terminal signals (#1638).
+- Single-writer `RunActor` with one async event queue, monotonic seq numbers, and a bounded `ReplayBuffer` that emits an explicit `Gap{up_to_seq}` marker on eviction; approval gate gains an opt-in `session_id` kwarg that mirrors approval events through `run_actor_registry` (#1641).
+- Empirical-confidence ledger: append-only SQLite store of per-decision outcomes plus a sample-size-gated `ConfidenceQuery` (default 5) wired into the model recommender ahead of the capability-tier heuristic and the bandit arm (#1653).
+- Declarative task DAG: `Task.parallel_safe` and `Task.story_id` fields, `[T<id>] [P] [USn]` backlog parser, `core/orchestration/task_dag.py` with `topological_iter_with_parallel` yielding ready batches, and `bernstein plan dag` / `bernstein tasks dag` CLI renderers (#1655).
+
+### Changed
+
+- HTTP approval replies now require a single-use 16-byte server-minted `nonce`; mismatches surface `409 NONCE_MISMATCH` and replays against an evicted approval surface `410 NONCE_EXPIRED` (#1642).
+- Sonar scan workflow switched from a direct trigger to `workflow_run` on the CI workflow; the scan now consumes the existing `coverage-report` artifact instead of re-running the full test suite under a single non-sharded `pytest --cov` (#1645).
+- `bernstein approve-tool` / `bernstein reject-tool` read the on-disk pending-approval record and thread the nonce back through `resolve()` (#1642).
+
+### Fixed
+
+- Re-add `str()` coercion inside the `OSError` / `TimeoutExpired` handler of `git_context._run_git` so callers passing a `Path` in the `argv` list (`test_context`, `test_context_builder`, `test_failure_reduction` via `cochange_files`) do not crash the debug formatter with `expected str instance, PosixPath found` (#1644).
+- Apply `ruff format` to `core/quality/review_pipeline/review_gate.py` after #1638 collapsed several string and comprehension wrappings under the 120-character line length, fixing `ruff format --check` on main (#1640).
+- Default empty `nonce` body field to an empty string at the schema layer so a missing field flows through the handler and surfaces as `409 NONCE_MISMATCH` instead of `422` (#1642).
+- Move `Iterator` and `Path` imports under `TYPE_CHECKING` in `core/orchestration/task_dag.py`, replace `== True` with `is True` in `tests/unit/tasks/test_parallel_flag.py`, and run `ruff format` across the four files added or touched by #1655, fixing the Lint job that turned main red after the task-DAG merge (#1657).
+
+### Internal
+
+- Refurb auto-fix wave 4: FURB184 197 -> 34, FURB138 42 -> 8, FURB124 29 -> 3, FURB142 16 -> 0, FURB113 23 -> 21 in `src/`; plus a `ruff format` pass over 36 files to wrap `E501` long-line comprehensions and four targeted fixes for broken `seen in seen` self-referential dedup comprehensions (#1643).
+- Refurb cluster D: FURB139 / FURB143 / FURB179 strings and enumerate, 16 autofixes (#1647).
+- Refurb cluster E: FURB182 / FURB183 / FURB142 / FURB101 miscellaneous, 33 autofixes across 21 files; refurb now reports 0 alerts for these rules in `src/` (#1649).
+- Review-bot acknowledgement gate caught seven CodeRabbit must-address findings on #1646: HTTP status validation, `gh issue` subprocess `check=True`, doc clarification on soft-fail conditions, narrower import-time exception handling, logging of unexpected fetch failures, `IntRange(min=1)` on `--top-n`, and dropping a truthy fallback in `summarise_severity` / `_bucket_trend_by_day` that was inflating zero counts to one.
+
 ## [2.3.1] - Maintenance
 
 4 commits since v2.3.0. Full notes: [`docs/release-notes/v2.3.1.md`](docs/release-notes/v2.3.1.md).

--- a/docs/release-notes/v2.4.0.md
+++ b/docs/release-notes/v2.4.0.md
@@ -1,0 +1,112 @@
+# v2.4.0 - Observability surfaces, single-writer run state, approval-nonce binding
+
+**Release date:** 2026-05-20
+**Commits since v2.3.1:** 14
+
+## Highlights
+
+- New `bernstein doctor sonar` and `bernstein doctor glitchtip` subcommands surface coverage, code smells, bugs, vulnerabilities, and last-24h error counts from configured backends; both soft-fail when env vars are unset so fresh checkouts stay green.
+- Single-writer `RunActor` owns canonical per-session state behind one async event queue with a bounded replay buffer that emits an explicit `Gap{up_to_seq}` marker on eviction, making reconnect-after-eviction observable instead of silently lossy.
+- Declarative task DAG: tasks gain `parallel_safe` and `story_id` fields, the backlog parser learns `[T<id>] [P] [USn]` markdown checkboxes, `topological_iter_with_parallel` yields ready batches honouring cycle detection, and `bernstein plan dag` / `bernstein tasks dag` render the DAG with parallel batches highlighted; replaces the file-overlap heuristic for tasks that declare the flag while preserving the legacy heuristic as a fall-back.
+- Approval responses are now bound to a 16-byte server-minted single-use nonce; mismatches surface as `409 NONCE_MISMATCH` and evicted replays as `410 NONCE_EXPIRED`, foreclosing stale-button replay on superseded prompts.
+- Canonical stream-signal vocabulary (`COMPLETED`, `FAILED`, `QUESTION`, `PLAN_DRAFT`, `PLAN_READY`, `BLOCKED`) parseable from any wrapped CLI stdout so non-stream-json adapters surface lifecycle events through the same channel as native stream-json adapters.
+- New empirical-confidence ledger backs the model recommender: an append-only SQLite store of per-decision outcomes feeds a sample-size-gated query that prefers measured outcomes over the capability-tier heuristic and over the bandit arm, refusing to return a value below a documented threshold (default 5).
+- Sonar scan workflow now consumes the coverage artifact CI already publishes (via `workflow_run`) instead of re-running the full suite, fixing the 30 minute step-cap timeouts that were blocking the scan job on main.
+- Two refurb auto-fix waves (waves 4 and clusters D/E) land about 240 mechanical idiom rewrites across `src/`, taking FURB142 to zero and substantially reducing the FURB184 / FURB138 / FURB124 / FURB182 / FURB101 backlog.
+
+## What ships
+
+### Observability surfaces
+
+- **`bernstein doctor sonar`** (#1648). New subcommand pulling project measures from a configured SonarQube server: coverage, code smells by severity, bugs, vulnerabilities, security hotspots, and cognitive-complexity hotspots. Rich-table or `--json` output. Soft-fails (exit 0) when `SONAR_HOST_URL` / `SONAR_TOKEN` are unset and prints a one-line hint at `docs/observability/sonar.md`. Advisory baseline at `$XDG_DATA_HOME/bernstein/sonar-baseline.json` lets the parent `bernstein doctor` group nudge when open smells exceed the threshold or vulnerabilities regress. 28 hermetic tests via `httpx.MockTransport`.
+- **`bernstein doctor glitchtip`** (#1646). New subcommand pulling last-24h issue counts by severity, a 7-day trend, and the top unresolved issues from the configured GlitchTip server. Rich-table or `--json` output. Soft-fails when `BERNSTEIN_GLITCHTIP_TOKEN` is unset. Optional baseline cache at `~/.local/share/bernstein/glitchtip-baseline.json` powers a nudge under `bernstein doctor --suggest-docs` when the GlitchTip API reports new unresolved issues since the last check. 25 unit tests cover the fetcher, baseline persistence, nudge logic, Click wiring, and soft-fail behaviour.
+- **Sticky PR Sonar comment** (#1648). New `.github/workflows/sonar-pr-comment.yml` posts a sticky advisory PR comment with project-level Sonar measures. Soft signal only, never blocks merge.
+- **Daily GlitchTip alert sweep** (#1646). New `.github/workflows/glitchtip-insights.yml` (06:30 UTC + `workflow_dispatch`) mirrors fatal-level GlitchTip issues into sticky GitHub issues labelled `glitchtip-alert`. The mirror auto-closes when the GlitchTip side resolves. Workflow now validates HTTP status on the resolved-issues fetch and runs `gh issue` subprocesses with `check=True` so reconciliation failures fail the run instead of being swallowed.
+
+### Security
+
+- **Approval-nonce binding** (#1642). Mints a 16-byte server-generated nonce per pending approval. The reply must echo the exact value or the gate refuses to resolve, foreclosing stale-button replay on superseded prompts and any path where the agent process could forge its own approval response.
+  - `core/approval/models`: `nonce` field on `PendingApproval` (hex on the wire); `to_dict(include_nonce=False)` for adapter-facing serialisations; new `ApprovalNonceMismatch` / `ApprovalNonceExpired` errors.
+  - `core/approval/queue`: `resolve()` validates the supplied nonce in constant time. Server-internal callers (TTL evict, `wait_for` timeout) keep the back-compat no-nonce path so they cannot deadlock.
+  - `core/routes/approvals`: HTTP reply now requires a nonce. Mismatches surface `409 NONCE_MISMATCH`. Replays against an evicted approval surface `410 NONCE_EXPIRED`. The live-fragment HTML threads the nonce through the button handlers.
+  - `cli/commands/approval_cmd`: `approve-tool` / `reject-tool` read the on-disk record and thread the nonce back through `resolve()`.
+  - A missing `nonce` body field defaults to an empty string at the schema layer so it flows through the handler and surfaces as `409 NONCE_MISMATCH` via the existing `_coerce_nonce` guard, instead of being rejected at the Pydantic layer with `422`.
+  - Closes #1619.
+
+### Reliability and runtime
+
+- **Single-writer `RunActor`** (#1641). Introduces a per-session actor that owns canonical run state. Mutations flow as typed events through one async queue. A pure `apply_event` reducer applies them with monotonic seq numbers. `ReplayBuffer` is a bounded ring (default 1024) that emits an explicit `Gap{up_to_seq}` marker when a subscriber asks for an evicted range, so a reconnect-after-eviction is observable instead of silently corrupt. The approval gate gains an opt-in `session_id` kwarg that mirrors approval events into a registered `RunActor` via `run_actor_registry`. The file-driven decision contract is unchanged; the actor feed runs alongside. Migrating the remaining writers (worker subprocess, watchdog, lifecycle hooks, `hooks_receiver`) is a follow-up. Refs #1630.
+- **Canonical stream-signal protocol** (#1638). New `core/protocols/stream_signals.py` defines a small text-line vocabulary (`COMPLETED`, `FAILED`, `QUESTION`, `PLAN_DRAFT`, `PLAN_READY`, `BLOCKED`), a parser, a producer-side format helper, and conformance helpers. `CLIAdapter` grows an optional `stream_signal_parser` hook; the default delegates to the canonical parser, adapters override to map a native protocol onto the canonical vocabulary. `ConformanceReport` surfaces missing terminal signals as a soft warning so adapters without canonical signals stay visible without failing. Tests cover parse, format round-trip, malformed-input resilience, concurrent multi-adapter parsing, terminal-signal check, default vs. override hook behaviour, plan, and question round-trip. Docs at `docs/adapters/stream_signals.md` describe the vocabulary with shell and Python wrapper examples. Resolves #1632.
+- **Declarative task DAG** (#1655). Adds a declarative task DAG layer so the planner sets per-task parallel safety at task-generation time instead of having the scheduler infer it from file overlap. The `Task` schema gains `parallel_safe` (default `False`) and `story_id` (Optional[str]) with round-trip support in `Task.from_dict`. The backlog parser recognises the `[T<id>] [P] [USn]` markdown checkbox format and the matching YAML frontmatter keys. New `core/orchestration/task_dag.py` provides `TaskNode`, `TaskDag` (markdown + YAML loaders), and `topological_iter_with_parallel` yielding ready batches; cycles raise `TaskDagCycleError`. `adaptive_parallelism.tasks_safe_to_run_in_parallel` consumes the declarative flag directly; the file-overlap heuristic is preserved only for legacy tasks that lack the attribute. CLI: `bernstein plan dag --file <path>` (also reachable as `bernstein tasks dag --file`) renders the DAG with parallel batches highlighted and lists story rollback groups. Docs at `docs/orchestration/task-dag.md` and `docs/operations/task_format.md`. Tests cover schema and parser round-trip, scheduler consumption, and single-task / sequential-chain / parallel-batch / mixed parallel-serial / cycle-detection paths. Closes #1634.
+
+### Quality and routing
+
+- **Empirical-confidence ledger** (#1653). New `core/quality/empirical_confidence.py`: an append-only SQLite ledger (`agent_outcomes` table) of per-decision outcomes, with a sample-size-gated `ConfidenceQuery` that returns `None` below the documented threshold (default 5) instead of fabricating a value. `core/routing/model_recommender.py` consults the ledger first; the existing capability-tier heuristic and the bandit arm remain as documented fall-backs for cells that have not accumulated enough samples. Default DB path: `${XDG_DATA_HOME:-~/.local/share}/bernstein/empirical-confidence.db`. Override via `BERNSTEIN_CONFIDENCE_DB`; threshold via `BERNSTEIN_CONFIDENCE_MIN_SAMPLES`. Docs at `docs/quality/empirical-confidence.md` cover the schema, the sample-size rationale, and the routing precedence order. 16 new ledger tests plus 8 router regression tests pass. Closes #1622.
+
+### Correctness
+
+- **`_run_git` error formatter** (#1644). Re-add the `str()` coercion inside the `OSError` / `TimeoutExpired` handler of `git_context._run_git`. The refurb wave 3 auto-fix (#1615) had dropped it, so calls with a `Path` inside the `argv` list (`test_context`, `test_context_builder`, `test_failure_reduction` all do this indirectly via `cochange_files`) raised `FileNotFoundError`, and the handler then crashed on `" ".join(...)` with `expected str instance, PosixPath found`, turning a debug log into a `TypeError` that bubbled up. Same fix as #1591, regressed by the wave-3 auto-fix.
+
+### CI and infrastructure
+
+- **Sonar scan via `workflow_run`** (#1645). The Sonar scan workflow was re-running the full unit suite under a single `pytest --cov` invocation. That suite needs per-file isolation to fit the runner memory budget, which is why `ci.yml` shards it across files and takes about 25 minutes. The naive single-process run only reached 5 percent of files within the 30 minute step timeout (the job-level timeout bump in #1616 did not lift the inner step cap). Switch `sonar-scan.yml` to a `workflow_run` trigger that fires after a successful CI run on main, download the `coverage-report` artifact CI already publishes, and feed it directly to the Sonar scanner. Also add `sonar.ws.timeout=600` to guard the scanner client against slow server responses, and pin `sonar.scm.revision` to the upstream CI head SHA so the scan reports against the right commit.
+- **Lint repair after #1638** (#1640). `ruff format --check` failed on `core/quality/review_pipeline/review_gate.py` after the stream-signal PR landed. Applying `ruff format` collapses several string and comprehension wrappings under the project's 120-character line length. No behaviour change.
+- **Lint repair after #1655** (#1657). The task-DAG merge turned main red on `Lint`. Move `Iterator` and `Path` imports under `TYPE_CHECKING` in `core/orchestration/task_dag.py` (TC003, 2 sites), replace `== True` with `is True` in `tests/unit/tasks/test_parallel_flag.py` (E712), and run `ruff format` across the four files added or touched by #1655. No behaviour change.
+
+### Quality and refurb waves
+
+- **Wave 4 (FURB184 + leftovers)** (#1643). Conservative libcst / ast-based rewrites that preserve semantics. Counts in `src/`: FURB184 197 -> 34 (163 fixed), FURB138 42 -> 8 (34 fixed), FURB124 29 -> 3 (26 fixed), FURB142 16 -> 0 (16 fixed), FURB113 23 -> 21 (2 fixed; remainder have intervening comments that act as section dividers). Followed by a `ruff format` pass over 36 files to wrap `E501` long-line comprehensions, plus four targeted fixes for broken `seen in seen` self-referential dedup comprehensions in `spec_assertions`, `pr_review_aggregator`, `review_responder.models`, and `tui.approval_panel` (replaced with `dict.fromkeys()` for order-preserving dedup).
+- **Cluster D (FURB139 / 143 / 179 strings and enumerate)** (#1647). 16 refurb autofixes: FURB139 drops leading / trailing newlines in nine multi-line GraphQL query constants by switching to line-continuation backslashes; FURB143 drops one redundant outer `or ""` after `str(... or "")` in `jira_dc_adapter`; FURB179 flattens six nested list / set comprehensions to `itertools.chain.from_iterable` in `bulletin`, `orchestrator` (x4), and `capability_matrix`. Three FURB143 alerts skipped intentionally where defensive `or ""` guards external API boundaries (`importlib.metadata` fields, externally-typed input strings).
+- **Cluster E (FURB182 / 183 / 142 / 101 misc)** (#1649). 33 safe refurb rewrites across 21 files: FURB182 folds the first `hashlib.update()` into the `sha256()` constructor (10 sites); FURB142 replaces `for x in iter: s.add(...)` with `s.update(...)` (16 sites); FURB101 replaces `with open(p) as f: y = f.read()` with `Path(p).read_text/bytes()` (5 sites); FURB183 replaces `f"{x}"` with `str(x)` where the format spec is empty (2 sites). Refurb now reports 0 alerts for these rules in `src/`.
+
+## New and changed CLI commands
+
+- `bernstein plan dag --file <path>` / `bernstein tasks dag --file <path>` (new). Renders the task DAG with parallel batches highlighted and lists story rollback groups derived from `story_id` annotations.
+- `bernstein doctor sonar` (new). Surfaces project measures from SonarQube. Flags: `--json`, baseline cache override via `XDG_DATA_HOME`.
+- `bernstein doctor glitchtip` (new). Surfaces last-24h issue counts, 7-day trend, and top unresolved issues. Flags: `--json`, `--top-n` (`IntRange(min=1)`).
+- `bernstein doctor --suggest-docs` (extended). Now also prints one-line GlitchTip and Sonar nudges when the respective APIs report new unresolved issues or threshold regressions since the cached baseline; failures are logged and suppressed (never crashes the doctor command).
+- `bernstein approve-tool` / `bernstein reject-tool` (changed). Read the on-disk pending-approval record and thread the server-minted nonce back through `resolve()`. Operators using the CLI path see no behaviour change; integrators calling `resolve()` directly must thread the nonce or use the server-internal back-compat path.
+
+## Upgrade notes
+
+- **Drop-in upgrade from v2.3.1.** No config-schema changes, no audit-chain changes.
+- **Approval API change.** HTTP approval replies now require a `nonce` field. The live-fragment HTML threads the nonce through automatically; external integrators calling the approval endpoint directly need to echo the `nonce` from the pending-approval payload. Missing or empty `nonce` returns `409 NONCE_MISMATCH`. Replays against an evicted approval return `410 NONCE_EXPIRED`.
+- **Sonar workflow trigger changed.** `.github/workflows/sonar-scan.yml` is now `workflow_run` against the CI workflow on main. Operators with a fork running their own Sonar scan should mirror the same trigger or set `SONAR_HOST_URL` / `SONAR_TOKEN` to point at their own server.
+- **New optional env vars.** `BERNSTEIN_GLITCHTIP_TOKEN` (for `bernstein doctor glitchtip`), optional overrides `BERNSTEIN_GLITCHTIP_BASE_URL` and `BERNSTEIN_GLITCHTIP_ORG`. `SONAR_HOST_URL` and `SONAR_TOKEN` for `bernstein doctor sonar`. The GitHub workflows expect `GLITCHTIP_API_TOKEN` and (for Sonar) `SONAR_TOKEN` as repo secrets. None of these are required; both commands soft-fail with a one-line hint when unset.
+- **`RunActor` is opt-in.** Existing flows that do not pass `session_id` into the approval gate continue to work unchanged.
+- **Empirical-confidence ledger is created lazily.** On first write, an SQLite file is created at `${XDG_DATA_HOME:-~/.local/share}/bernstein/empirical-confidence.db`. Override the path with `BERNSTEIN_CONFIDENCE_DB`, the sample threshold with `BERNSTEIN_CONFIDENCE_MIN_SAMPLES`. The model recommender falls back to the existing capability-tier and bandit paths when the ledger lacks a qualifying sample, so existing runs are unaffected.
+
+## Internal
+
+- Review-bot acknowledgement gate caught seven CodeRabbit must-address findings on #1646 across workflow status validation, `gh issue` subprocess `check=True`, doc clarification on soft-fail conditions, narrower import-time exception handling, logging of unexpected fetch failures, `IntRange(min=1)` on `--top-n`, and dropping a truthy fallback in `summarise_severity` / `_bucket_trend_by_day` that was inflating legitimate zero counts to one.
+- Sourcery flagged the empty-nonce-body case on #1642; default the field to an empty string at the schema layer so the documented `409 NONCE_MISMATCH` contract holds.
+- `_run_git` regression test coverage hardened by re-adding the `str()` coercion in the error formatter and re-running the three failing tests (`test_context::test_returns_list`, `test_context_builder::test_includes_file_summary_for_python_files`, `test_failure_reduction::test_task_context_includes_file_info`).
+
+## Acknowledgements
+
+This release is operator-only; no external contributor PRs landed in the v2.3.1..v2.4.0 window.
+
+## Full changelog
+
+### feat (7)
+
+- `f84bde93` feat(adapters): canonical stream-signal protocol for adapter stdout (#1638)
+- `2df0e9c1` feat(orchestration): single-writer run-state actor with bounded replay buffer (#1641)
+- `fd231bc7` feat(security): bind approval responses to single-use nonce (#1642)
+- `51f330a6` feat(observability): sonar insights surface + doctor subcommand + delta nudge (#1648)
+- `1a50c36a` feat(observability): GlitchTip insights surface + doctor subcommand + daily alert workflow (#1646)
+- `c42607b4` feat(quality): empirical confidence from outcome history (#1653)
+- `ec430dff` feat(orchestration): task DAG with explicit parallel flag + story-link grouping (#1655)
+
+### fix (4)
+
+- `80c819b8` fix(lint): repair main-red after #1638 merge (#1640)
+- `27ba6885` fix(test): restore str() coercion in _run_git error formatter (#1644)
+- `b7bc28fe` fix(ci): reuse coverage artifact in Sonar scan instead of re-running tests (#1645)
+- `a0f26de7` fix(lint): repair main-red after #1655 task-DAG merge (#1657)
+
+### refactor (3)
+
+- `6fe31edc` refactor: bulk refurb autofix wave 4 (FURB184 + leftovers) (#1643)
+- `eb112d2e` refactor: refurb cluster E (FURB182/183/142/101 misc) (#1649)
+- `2fb0d26c` refactor: refurb cluster D (FURB139/143/179 strings/enumerate) (#1647)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.3.1"
+version = "2.4.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.3.1"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
# v2.4.0 - Observability surfaces, single-writer run state, approval-nonce binding

**Release date:** 2026-05-20
**Commits since v2.3.1:** 14

## Highlights

- New `bernstein doctor sonar` and `bernstein doctor glitchtip` subcommands surface coverage, code smells, bugs, vulnerabilities, and last-24h error counts from configured backends; both soft-fail when env vars are unset so fresh checkouts stay green.
- Single-writer `RunActor` owns canonical per-session state behind one async event queue with a bounded replay buffer that emits an explicit `Gap{up_to_seq}` marker on eviction, making reconnect-after-eviction observable instead of silently lossy.
- Declarative task DAG: tasks gain `parallel_safe` and `story_id` fields, the backlog parser learns `[T<id>] [P] [USn]` markdown checkboxes, `topological_iter_with_parallel` yields ready batches honouring cycle detection, and `bernstein plan dag` / `bernstein tasks dag` render the DAG with parallel batches highlighted; replaces the file-overlap heuristic for tasks that declare the flag while preserving the legacy heuristic as a fall-back.
- Approval responses are now bound to a 16-byte server-minted single-use nonce; mismatches surface as `409 NONCE_MISMATCH` and evicted replays as `410 NONCE_EXPIRED`, foreclosing stale-button replay on superseded prompts.
- Canonical stream-signal vocabulary (`COMPLETED`, `FAILED`, `QUESTION`, `PLAN_DRAFT`, `PLAN_READY`, `BLOCKED`) parseable from any wrapped CLI stdout so non-stream-json adapters surface lifecycle events through the same channel as native stream-json adapters.
- New empirical-confidence ledger backs the model recommender: an append-only SQLite store of per-decision outcomes feeds a sample-size-gated query that prefers measured outcomes over the capability-tier heuristic and over the bandit arm, refusing to return a value below a documented threshold (default 5).
- Sonar scan workflow now consumes the coverage artifact CI already publishes (via `workflow_run`) instead of re-running the full suite, fixing the 30 minute step-cap timeouts that were blocking the scan job on main.
- Two refurb auto-fix waves (waves 4 and clusters D/E) land about 240 mechanical idiom rewrites across `src/`, taking FURB142 to zero and substantially reducing the FURB184 / FURB138 / FURB124 / FURB182 / FURB101 backlog.

## What ships

### Observability surfaces

- **`bernstein doctor sonar`** (#1648). New subcommand pulling project measures from a configured SonarQube server: coverage, code smells by severity, bugs, vulnerabilities, security hotspots, and cognitive-complexity hotspots. Rich-table or `--json` output. Soft-fails (exit 0) when `SONAR_HOST_URL` / `SONAR_TOKEN` are unset and prints a one-line hint at `docs/observability/sonar.md`. Advisory baseline at `$XDG_DATA_HOME/bernstein/sonar-baseline.json` lets the parent `bernstein doctor` group nudge when open smells exceed the threshold or vulnerabilities regress. 28 hermetic tests via `httpx.MockTransport`.
- **`bernstein doctor glitchtip`** (#1646). New subcommand pulling last-24h issue counts by severity, a 7-day trend, and the top unresolved issues from the configured GlitchTip server. Rich-table or `--json` output. Soft-fails when `BERNSTEIN_GLITCHTIP_TOKEN` is unset. Optional baseline cache at `~/.local/share/bernstein/glitchtip-baseline.json` powers a nudge under `bernstein doctor --suggest-docs` when the GlitchTip API reports new unresolved issues since the last check. 25 unit tests cover the fetcher, baseline persistence, nudge logic, Click wiring, and soft-fail behaviour.
- **Sticky PR Sonar comment** (#1648). New `.github/workflows/sonar-pr-comment.yml` posts a sticky advisory PR comment with project-level Sonar measures. Soft signal only, never blocks merge.
- **Daily GlitchTip alert sweep** (#1646). New `.github/workflows/glitchtip-insights.yml` (06:30 UTC + `workflow_dispatch`) mirrors fatal-level GlitchTip issues into sticky GitHub issues labelled `glitchtip-alert`. The mirror auto-closes when the GlitchTip side resolves. Workflow now validates HTTP status on the resolved-issues fetch and runs `gh issue` subprocesses with `check=True` so reconciliation failures fail the run instead of being swallowed.

### Security

- **Approval-nonce binding** (#1642). Mints a 16-byte server-generated nonce per pending approval. The reply must echo the exact value or the gate refuses to resolve, foreclosing stale-button replay on superseded prompts and any path where the agent process could forge its own approval response.
  - `core/approval/models`: `nonce` field on `PendingApproval` (hex on the wire); `to_dict(include_nonce=False)` for adapter-facing serialisations; new `ApprovalNonceMismatch` / `ApprovalNonceExpired` errors.
  - `core/approval/queue`: `resolve()` validates the supplied nonce in constant time. Server-internal callers (TTL evict, `wait_for` timeout) keep the back-compat no-nonce path so they cannot deadlock.
  - `core/routes/approvals`: HTTP reply now requires a nonce. Mismatches surface `409 NONCE_MISMATCH`. Replays against an evicted approval surface `410 NONCE_EXPIRED`. The live-fragment HTML threads the nonce through the button handlers.
  - `cli/commands/approval_cmd`: `approve-tool` / `reject-tool` read the on-disk record and thread the nonce back through `resolve()`.
  - A missing `nonce` body field defaults to an empty string at the schema layer so it flows through the handler and surfaces as `409 NONCE_MISMATCH` via the existing `_coerce_nonce` guard, instead of being rejected at the Pydantic layer with `422`.
  - Closes #1619.

### Reliability and runtime

- **Single-writer `RunActor`** (#1641). Introduces a per-session actor that owns canonical run state. Mutations flow as typed events through one async queue. A pure `apply_event` reducer applies them with monotonic seq numbers. `ReplayBuffer` is a bounded ring (default 1024) that emits an explicit `Gap{up_to_seq}` marker when a subscriber asks for an evicted range, so a reconnect-after-eviction is observable instead of silently corrupt. The approval gate gains an opt-in `session_id` kwarg that mirrors approval events into a registered `RunActor` via `run_actor_registry`. The file-driven decision contract is unchanged; the actor feed runs alongside. Migrating the remaining writers (worker subprocess, watchdog, lifecycle hooks, `hooks_receiver`) is a follow-up. Refs #1630.
- **Canonical stream-signal protocol** (#1638). New `core/protocols/stream_signals.py` defines a small text-line vocabulary (`COMPLETED`, `FAILED`, `QUESTION`, `PLAN_DRAFT`, `PLAN_READY`, `BLOCKED`), a parser, a producer-side format helper, and conformance helpers. `CLIAdapter` grows an optional `stream_signal_parser` hook; the default delegates to the canonical parser, adapters override to map a native protocol onto the canonical vocabulary. `ConformanceReport` surfaces missing terminal signals as a soft warning so adapters without canonical signals stay visible without failing. Tests cover parse, format round-trip, malformed-input resilience, concurrent multi-adapter parsing, terminal-signal check, default vs. override hook behaviour, plan, and question round-trip. Docs at `docs/adapters/stream_signals.md` describe the vocabulary with shell and Python wrapper examples. Resolves #1632.
- **Declarative task DAG** (#1655). Adds a declarative task DAG layer so the planner sets per-task parallel safety at task-generation time instead of having the scheduler infer it from file overlap. The `Task` schema gains `parallel_safe` (default `False`) and `story_id` (Optional[str]) with round-trip support in `Task.from_dict`. The backlog parser recognises the `[T<id>] [P] [USn]` markdown checkbox format and the matching YAML frontmatter keys. New `core/orchestration/task_dag.py` provides `TaskNode`, `TaskDag` (markdown + YAML loaders), and `topological_iter_with_parallel` yielding ready batches; cycles raise `TaskDagCycleError`. `adaptive_parallelism.tasks_safe_to_run_in_parallel` consumes the declarative flag directly; the file-overlap heuristic is preserved only for legacy tasks that lack the attribute. CLI: `bernstein plan dag --file <path>` (also reachable as `bernstein tasks dag --file`) renders the DAG with parallel batches highlighted and lists story rollback groups. Docs at `docs/orchestration/task-dag.md` and `docs/operations/task_format.md`. Tests cover schema and parser round-trip, scheduler consumption, and single-task / sequential-chain / parallel-batch / mixed parallel-serial / cycle-detection paths. Closes #1634.

### Quality and routing

- **Empirical-confidence ledger** (#1653). New `core/quality/empirical_confidence.py`: an append-only SQLite ledger (`agent_outcomes` table) of per-decision outcomes, with a sample-size-gated `ConfidenceQuery` that returns `None` below the documented threshold (default 5) instead of fabricating a value. `core/routing/model_recommender.py` consults the ledger first; the existing capability-tier heuristic and the bandit arm remain as documented fall-backs for cells that have not accumulated enough samples. Default DB path: `${XDG_DATA_HOME:-~/.local/share}/bernstein/empirical-confidence.db`. Override via `BERNSTEIN_CONFIDENCE_DB`; threshold via `BERNSTEIN_CONFIDENCE_MIN_SAMPLES`. Docs at `docs/quality/empirical-confidence.md` cover the schema, the sample-size rationale, and the routing precedence order. 16 new ledger tests plus 8 router regression tests pass. Closes #1622.

### Correctness

- **`_run_git` error formatter** (#1644). Re-add the `str()` coercion inside the `OSError` / `TimeoutExpired` handler of `git_context._run_git`. The refurb wave 3 auto-fix (#1615) had dropped it, so calls with a `Path` inside the `argv` list (`test_context`, `test_context_builder`, `test_failure_reduction` all do this indirectly via `cochange_files`) raised `FileNotFoundError`, and the handler then crashed on `" ".join(...)` with `expected str instance, PosixPath found`, turning a debug log into a `TypeError` that bubbled up. Same fix as #1591, regressed by the wave-3 auto-fix.

### CI and infrastructure

- **Sonar scan via `workflow_run`** (#1645). The Sonar scan workflow was re-running the full unit suite under a single `pytest --cov` invocation. That suite needs per-file isolation to fit the runner memory budget, which is why `ci.yml` shards it across files and takes about 25 minutes. The naive single-process run only reached 5 percent of files within the 30 minute step timeout (the job-level timeout bump in #1616 did not lift the inner step cap). Switch `sonar-scan.yml` to a `workflow_run` trigger that fires after a successful CI run on main, download the `coverage-report` artifact CI already publishes, and feed it directly to the Sonar scanner. Also add `sonar.ws.timeout=600` to guard the scanner client against slow server responses, and pin `sonar.scm.revision` to the upstream CI head SHA so the scan reports against the right commit.
- **Lint repair after #1638** (#1640). `ruff format --check` failed on `core/quality/review_pipeline/review_gate.py` after the stream-signal PR landed. Applying `ruff format` collapses several string and comprehension wrappings under the project's 120-character line length. No behaviour change.
- **Lint repair after #1655** (#1657). The task-DAG merge turned main red on `Lint`. Move `Iterator` and `Path` imports under `TYPE_CHECKING` in `core/orchestration/task_dag.py` (TC003, 2 sites), replace `== True` with `is True` in `tests/unit/tasks/test_parallel_flag.py` (E712), and run `ruff format` across the four files added or touched by #1655. No behaviour change.

### Quality and refurb waves

- **Wave 4 (FURB184 + leftovers)** (#1643). Conservative libcst / ast-based rewrites that preserve semantics. Counts in `src/`: FURB184 197 -> 34 (163 fixed), FURB138 42 -> 8 (34 fixed), FURB124 29 -> 3 (26 fixed), FURB142 16 -> 0 (16 fixed), FURB113 23 -> 21 (2 fixed; remainder have intervening comments that act as section dividers). Followed by a `ruff format` pass over 36 files to wrap `E501` long-line comprehensions, plus four targeted fixes for broken `seen in seen` self-referential dedup comprehensions in `spec_assertions`, `pr_review_aggregator`, `review_responder.models`, and `tui.approval_panel` (replaced with `dict.fromkeys()` for order-preserving dedup).
- **Cluster D (FURB139 / 143 / 179 strings and enumerate)** (#1647). 16 refurb autofixes: FURB139 drops leading / trailing newlines in nine multi-line GraphQL query constants by switching to line-continuation backslashes; FURB143 drops one redundant outer `or ""` after `str(... or "")` in `jira_dc_adapter`; FURB179 flattens six nested list / set comprehensions to `itertools.chain.from_iterable` in `bulletin`, `orchestrator` (x4), and `capability_matrix`. Three FURB143 alerts skipped intentionally where defensive `or ""` guards external API boundaries (`importlib.metadata` fields, externally-typed input strings).
- **Cluster E (FURB182 / 183 / 142 / 101 misc)** (#1649). 33 safe refurb rewrites across 21 files: FURB182 folds the first `hashlib.update()` into the `sha256()` constructor (10 sites); FURB142 replaces `for x in iter: s.add(...)` with `s.update(...)` (16 sites); FURB101 replaces `with open(p) as f: y = f.read()` with `Path(p).read_text/bytes()` (5 sites); FURB183 replaces `f"{x}"` with `str(x)` where the format spec is empty (2 sites). Refurb now reports 0 alerts for these rules in `src/`.

## New and changed CLI commands

- `bernstein plan dag --file <path>` / `bernstein tasks dag --file <path>` (new). Renders the task DAG with parallel batches highlighted and lists story rollback groups derived from `story_id` annotations.
- `bernstein doctor sonar` (new). Surfaces project measures from SonarQube. Flags: `--json`, baseline cache override via `XDG_DATA_HOME`.
- `bernstein doctor glitchtip` (new). Surfaces last-24h issue counts, 7-day trend, and top unresolved issues. Flags: `--json`, `--top-n` (`IntRange(min=1)`).
- `bernstein doctor --suggest-docs` (extended). Now also prints one-line GlitchTip and Sonar nudges when the respective APIs report new unresolved issues or threshold regressions since the cached baseline; failures are logged and suppressed (never crashes the doctor command).
- `bernstein approve-tool` / `bernstein reject-tool` (changed). Read the on-disk pending-approval record and thread the server-minted nonce back through `resolve()`. Operators using the CLI path see no behaviour change; integrators calling `resolve()` directly must thread the nonce or use the server-internal back-compat path.

## Upgrade notes

- **Drop-in upgrade from v2.3.1.** No config-schema changes, no audit-chain changes.
- **Approval API change.** HTTP approval replies now require a `nonce` field. The live-fragment HTML threads the nonce through automatically; external integrators calling the approval endpoint directly need to echo the `nonce` from the pending-approval payload. Missing or empty `nonce` returns `409 NONCE_MISMATCH`. Replays against an evicted approval return `410 NONCE_EXPIRED`.
- **Sonar workflow trigger changed.** `.github/workflows/sonar-scan.yml` is now `workflow_run` against the CI workflow on main. Operators with a fork running their own Sonar scan should mirror the same trigger or set `SONAR_HOST_URL` / `SONAR_TOKEN` to point at their own server.
- **New optional env vars.** `BERNSTEIN_GLITCHTIP_TOKEN` (for `bernstein doctor glitchtip`), optional overrides `BERNSTEIN_GLITCHTIP_BASE_URL` and `BERNSTEIN_GLITCHTIP_ORG`. `SONAR_HOST_URL` and `SONAR_TOKEN` for `bernstein doctor sonar`. The GitHub workflows expect `GLITCHTIP_API_TOKEN` and (for Sonar) `SONAR_TOKEN` as repo secrets. None of these are required; both commands soft-fail with a one-line hint when unset.
- **`RunActor` is opt-in.** Existing flows that do not pass `session_id` into the approval gate continue to work unchanged.
- **Empirical-confidence ledger is created lazily.** On first write, an SQLite file is created at `${XDG_DATA_HOME:-~/.local/share}/bernstein/empirical-confidence.db`. Override the path with `BERNSTEIN_CONFIDENCE_DB`, the sample threshold with `BERNSTEIN_CONFIDENCE_MIN_SAMPLES`. The model recommender falls back to the existing capability-tier and bandit paths when the ledger lacks a qualifying sample, so existing runs are unaffected.

## Internal

- Review-bot acknowledgement gate caught seven CodeRabbit must-address findings on #1646 across workflow status validation, `gh issue` subprocess `check=True`, doc clarification on soft-fail conditions, narrower import-time exception handling, logging of unexpected fetch failures, `IntRange(min=1)` on `--top-n`, and dropping a truthy fallback in `summarise_severity` / `_bucket_trend_by_day` that was inflating legitimate zero counts to one.
- Sourcery flagged the empty-nonce-body case on #1642; default the field to an empty string at the schema layer so the documented `409 NONCE_MISMATCH` contract holds.
- `_run_git` regression test coverage hardened by re-adding the `str()` coercion in the error formatter and re-running the three failing tests (`test_context::test_returns_list`, `test_context_builder::test_includes_file_summary_for_python_files`, `test_failure_reduction::test_task_context_includes_file_info`).

## Acknowledgements

This release is operator-only; no external contributor PRs landed in the v2.3.1..v2.4.0 window.

## Full changelog

### feat (7)

- `f84bde93` feat(adapters): canonical stream-signal protocol for adapter stdout (#1638)
- `2df0e9c1` feat(orchestration): single-writer run-state actor with bounded replay buffer (#1641)
- `fd231bc7` feat(security): bind approval responses to single-use nonce (#1642)
- `51f330a6` feat(observability): sonar insights surface + doctor subcommand + delta nudge (#1648)
- `1a50c36a` feat(observability): GlitchTip insights surface + doctor subcommand + daily alert workflow (#1646)
- `c42607b4` feat(quality): empirical confidence from outcome history (#1653)
- `ec430dff` feat(orchestration): task DAG with explicit parallel flag + story-link grouping (#1655)

### fix (4)

- `80c819b8` fix(lint): repair main-red after #1638 merge (#1640)
- `27ba6885` fix(test): restore str() coercion in _run_git error formatter (#1644)
- `b7bc28fe` fix(ci): reuse coverage artifact in Sonar scan instead of re-running tests (#1645)
- `a0f26de7` fix(lint): repair main-red after #1655 task-DAG merge (#1657)

### refactor (3)

- `6fe31edc` refactor: bulk refurb autofix wave 4 (FURB184 + leftovers) (#1643)
- `eb112d2e` refactor: refurb cluster E (FURB182/183/142/101 misc) (#1649)
- `2fb0d26c` refactor: refurb cluster D (FURB139/143/179 strings/enumerate) (#1647)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v2.4.0

* **New Features**
  * Added observability diagnostic subcommands for comprehensive system health checks
  * Introduced server-minted nonce-based approval mechanism for enhanced transaction security
  * New declarative task workflow definition layer supporting parallel-safe execution
  * Added confidence-based routing ledger for intelligent recommendations

* **Bug Fixes**
  * Corrected error message formatting in runtime operations

* **Chores**
  * Enhanced continuous integration and GitHub workflow automation
  * Code linting and formatting improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->