### PR TITLE
fix(ci): widen Schemathesis smoke timeout to stop flaky cancellations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -840,7 +840,11 @@ jobs:
     name: Schemathesis smoke
     needs: [lint]
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # Smoke profile wall-clock runs ~7m30s, which raced the previous
+    # 8-minute window and got cancelled, failing the CI gate aggregator.
+    # Widen to 20m for headroom; uv setup is already cached via bootstrap
+    # and the in-process ASGI schema build is not separately cacheable.
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- The `Schemathesis smoke` job had an 8-minute `timeout-minutes`, but the smoke profile regularly runs ~7m30s. It raced the timeout, got cancelled, and the `CI gate` aggregator reported the cancellation as a failure, turning main red repeatedly.
- Raise `timeout-minutes` from 8 to 20 to give the job headroom to finish. This closes the recurring regression where a passing-but-slow smoke run trips the timeout window.

## Notes
- No internal deadline change needed: the contract test already runs with `deadline=None` and a `--timeout=30` per-test cap; the limiter was the job wall-clock window, not an internal Hypothesis deadline.
- uv setup is already cached via the shared `bootstrap` composite action (`enable-uv-cache: true`). The schema is built in-process from the ASGI app, so there is no separate generation step to cache.
- The job remains a member of the `CI gate` dependency set; this change only gives it room to finish rather than removing it from the gate.

## Test plan
- [ ] CI runs green with the widened window
- [ ] `Schemathesis smoke` completes without cancellation

## Summary by Sourcery

CI:
- Raise the Schemathesis smoke workflow timeout from 8 to 20 minutes to reduce flakiness from near-timeout cancellations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**No user-visible changes.** This release includes only internal CI/CD configuration adjustments.

* **Chores**
  * Updated CI job timeout configuration for reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->