### PR TITLE
fix(docker): pin runtime images to python:3.13-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: build
-# python:3.12-slim
-FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856 AS build
+# python:3.13-slim
+FROM python:3.13-slim@sha256:0bce18a835a2d7975cb8765dad3bf4d2f0cc7aadb7d3414ce2cba8ef4004bb93 AS build
 
 WORKDIR /app
 COPY . /app
@@ -9,8 +9,8 @@ RUN pip install --no-cache-dir hatchling==1.29.0 && \
     python -m hatchling build
 
 # Stage 2: runtime
-# python:3.12-slim
-FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856
+# python:3.13-slim
+FROM python:3.13-slim@sha256:0bce18a835a2d7975cb8765dad3bf4d2f0cc7aadb7d3414ce2cba8ef4004bb93
 
 LABEL org.opencontainers.image.title="bernstein" \
       org.opencontainers.image.description="Declarative agent orchestration for engineering teams" \

--- a/docker/demo/Dockerfile
+++ b/docker/demo/Dockerfile
@@ -4,8 +4,8 @@
 #   docker build -f docker/demo/Dockerfile -t bernstein-demo .
 #
 # Stage 1: build the bernstein wheel
-# python:3.12-slim
-FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856 AS build
+# python:3.13-slim
+FROM python:3.13-slim@sha256:0bce18a835a2d7975cb8765dad3bf4d2f0cc7aadb7d3414ce2cba8ef4004bb93 AS build
 
 WORKDIR /app
 COPY . /app
@@ -14,8 +14,8 @@ RUN pip install --no-cache-dir hatchling==1.29.0 && \
     python -m hatchling build
 
 # Stage 2: runtime with Node.js for Claude Code
-# python:3.12-slim
-FROM python:3.14-slim@sha256:7a500125bc50693f2214e842a621440a1b1b9cbb2188f74ab045d29ed2ea5856
+# python:3.13-slim
+FROM python:3.13-slim@sha256:0bce18a835a2d7975cb8765dad3bf4d2f0cc7aadb7d3414ce2cba8ef4004bb93
 
 # Node.js + Claude Code + git + curl
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

- `Dockerfile` (published `ghcr.io/sipyourdrink-ltd/bernstein` runtime image) and `docker/demo/Dockerfile` referenced `python:3.14-slim`, while their inline comments still read `python:3.12-slim`.
- Both stages build the bernstein wheel and install its adapter dependencies, which require Python `<=3.13`. The repository python policy (`renovate.json` `allowedVersions: <=3.13`) reflects this.
- The `3.14-slim` tag entered these files via an earlier tag-bump (#1533) before the `<=3.13` policy was added (#1590). Renovate does not downgrade existing tags, so the runtime images were left ahead of policy.
- This pins both images back to `python:3.13-slim` by digest and corrects the stale comments.

Closes the digest-bump-on-3.14 PR #1660, which only refreshed the wrong base tag.

## Test plan

- [ ] CI builds the runtime image from `Dockerfile`
- [ ] `docker build -f docker/demo/Dockerfile -t bernstein-demo .` succeeds
- [ ] Wheel install and adapter import smoke checks pass on the 3.13 base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python runtime version to 3.13-slim in Docker images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->