### PR TITLE
fix(ci): repair sonar-scan workflow_run trigger so first scan populates the project

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -50,12 +50,49 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
 
-      - name: Download coverage artifact from CI
+      - name: Download coverage artifact (workflow_run)
         if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: coverage-report
           run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # When triggered manually we have no upstream run-id, so resolve the
+      # most recent successful CI run on main and pull its coverage-report
+      # artifact. This lets an operator bootstrap or re-scan the project with
+      # full Python coverage even when the latest main CI runs were cancelled
+      # by ci.yml's cancel-in-progress concurrency (which is the normal state
+      # under a rapid merge cadence and is why workflow_run almost never sees
+      # a 'success' conclusion to fire on).
+      - name: Resolve latest successful CI run (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: ci_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow ci.yml \
+            --branch main \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+          if [ -n "$run_id" ]; then
+            echo "Found successful CI run: $run_id"
+            echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No successful CI run found on main; scanning without coverage"
+          fi
+
+      - name: Download coverage artifact (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch' && steps.ci_run.outputs.run_id != ''
+        continue-on-error: true  # coverage is advisory; never block the bootstrap scan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: coverage-report
+          run-id: ${{ steps.ci_run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify coverage.xml present


### PR DESCRIPTION
## Summary

The `sonar-scan.yml` job has been skipping on every `workflow_run` event, so the SonarQube project `bernstein` was never populated (the API returns "Component key 'bernstein' not found").

Root cause: the job `if:` requires `github.event.workflow_run.conclusion == 'success'`, but `ci.yml` uses `cancel-in-progress: true` concurrency keyed on the branch. Under the normal main merge cadence, each new push cancels the prior in-flight CI run, so main CI almost never reaches a `success` conclusion. The scan job therefore always skips and the project was never bootstrapped.

The trigger config itself is otherwise correct: the CI workflow name is `CI` (matches `workflows: ['CI']`), the artifact name `coverage-report` matches what CI uploads, and `vars.SONAR_HOST_URL` is set as a repository variable.

## Changes

- Make `workflow_dispatch` a reliable bootstrap and re-scan path: resolve the most recent successful CI run on main and download its `coverage-report` artifact, so a manual scan carries full Python coverage instead of warning and scanning coverage-less.
- The existing `workflow_run` path is unchanged.

## Test plan

- [ ] After merge, trigger `gh workflow run sonar-scan.yml --ref main`.
- [ ] Confirm the scan job runs (not skipped) and uploads results.
- [ ] Verify `GET /api/measures/component?component=bernstein&metricKeys=coverage,bugs,code_smells,vulnerabilities,ncloc` returns real numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality scanning workflow to support coverage bootstrap for both automated continuous integration and manual workflow dispatch triggers.
  * Improved coverage artifact resolution by automatically retrieving and downloading the most recent successful build artifacts when available.
  * Added fallback scanning mechanism to ensure code quality analysis continues when coverage artifacts are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->