### PR TITLE
docs(refresh): concepts + gui + sdd partitions per drift playbook

### DIFF
--- a/docs/concepts/abstracted-code-review.md
+++ b/docs/concepts/abstracted-code-review.md
@@ -42,10 +42,13 @@ from bernstein.core.quality.review_pipeline.abstract_diff import (
     summarize_diff, pseudo_for_function,
 )
 
-summary = summarize_diff(diff_text, task_context)
-print(summary.bullet_points)
-print(summary.pseudocode_blocks)
-print(summary.raw_diff_link)
+# summarize_diff is async and returns one IntentSummary per file
+summaries = await summarize_diff(diff_text, task_context)
+for summary in summaries:
+    print(summary.path)
+    print(summary.bullet_points)
+    print(summary.pseudocode_blocks)
+    print(summary.raw_diff_link)
 ```
 
 The summariser uses the cheap-tier model via the cascade router; cost

--- a/docs/concepts/action-cache.md
+++ b/docs/concepts/action-cache.md
@@ -37,16 +37,15 @@ bernstein run plan.yaml --cache replay
 bernstein run plan.yaml --cache hybrid
 
 # Re-execute a past run against its cache; emit a diff report on drift
-bernstein replay <run_id>
+bernstein cache action replay <run_id>
 
-# Inspect / prune the cache
-bernstein cache action ls
-bernstein cache action prune --older-than 30d
+# Inspect on-disk size and entry count
+bernstein cache action stats
 ```
 
-The `replay` subcommand walks the run's recorded actions, executes
-each against the cache, and reports any divergence between recorded
-and live output. Useful for catching model-version drift.
+The `cache action replay` subcommand walks the run's recorded actions,
+executes each against the cache, and reports any divergence between
+recorded and live output. Useful for catching model-version drift.
 
 ## Configuration
 
@@ -58,9 +57,9 @@ and live output. Useful for catching model-version drift.
 
 Metrics:
 
-- `bernstein_action_cache_hits_total{site}`
-- `bernstein_action_cache_savings_usd` — estimated token-cost saved by
-  replay hits.
+- `action_cache_hits_total{model}`
+- `action_cache_savings_usd_total{model}` - estimated token-cost saved
+  by replay hits.
 
 ## Limitations
 

--- a/docs/concepts/artifact-lineage.md
+++ b/docs/concepts/artifact-lineage.md
@@ -49,16 +49,20 @@ bernstein lineage verify r-2026-05-05
 
 The chain walks output → producing prompt → input artefact → upstream
 producer recursively. CLI text output prints the most recent producer
-first; `--full` walks to the leaves.
+first; `--limit` caps how many records are shown.
 
 ## Programmatic access
 
 ```python
+from pathlib import Path
 from bernstein.core.persistence.lineage import LineageReader
 
-reader = LineageReader(sdd_dir=".sdd")
-for record in reader.iter_records(path="src/foo.py", line=42):
-    print(record.producer.agent_id, record.prompt_sha, record.cost_usd)
+reader = LineageReader(sdd_dir=Path(".sdd"))
+# iter_records optionally filters by run_id; filter on the artefact
+# path yourself when you only want one file's chain.
+for record in reader.iter_records(run_id="r-2026-05-05"):
+    if record.output_artifact.path == "src/foo.py":
+        print(record.producer.agent_id, record.prompt_sha, record.cost_usd)
 ```
 
 Each `LineageRecord` carries:

--- a/docs/concepts/best-of-n.md
+++ b/docs/concepts/best-of-n.md
@@ -58,9 +58,13 @@ verify.
 
 | Knob | Default | Controls |
 |---|--:|---|
-| `defaults.BEST_OF_N_DEFAULT` | `1` (off) | Default `best_of_n` for tasks that don't set one. |
-| `defaults.BEST_OF_N_MAX` | `5` | Hard cap, regardless of what a plan asks for. |
-| `defaults.BEST_OF_N_JUDGE_RUBRIC_PATH` | `templates/prompts/best_of_n_judge.md` | Rubric the LLM judge uses. |
+| `defaults.BEST_OF_N.enabled` | `false` | Master switch; tasks must set `best_of_n=K` *and* this must be on to fan out. |
+| `defaults.BEST_OF_N.default_candidates` | `1` (off) | Default `best_of_n` for tasks that don't set one. |
+| `defaults.BEST_OF_N.max_candidates` | `5` | Hard cap, regardless of what a plan asks for. |
+| `defaults.BEST_OF_N.judge_model` | `haiku` | Cheap-tier model the LLM judge runs on. |
+
+The judge rubric is an in-module default (`_DEFAULT_RUBRIC`); override
+it per run by passing `rubric=` to `BestOfNRunner`.
 
 Metrics:
 

--- a/docs/concepts/feature-contract.md
+++ b/docs/concepts/feature-contract.md
@@ -21,55 +21,57 @@ across sessions.
 
 ## How to use it
 
-Add a `features:` block to a step in your plan YAML:
+The contract is a JSON document at `.sdd/contract/features.json`. Each
+entry is a `Feature` with `id`, `category`, `description`,
+`acceptance_steps`, `acceptance_check`, and a `passes` flag:
 
-```yaml
-# plans/jwt-auth.yaml
-stages:
-  - name: backend
-    steps:
-      - role: backend
-        goal: "Add JWT auth with refresh tokens"
-        features:
-          - id: jwt-issue
-            description: "POST /auth/login returns a JWT"
-            acceptance_steps:
-              - "Login with valid creds"
-            acceptance_check: "pytest tests/auth/test_login.py::test_jwt_issued"
-          - id: jwt-refresh
-            description: "POST /auth/refresh exchanges a refresh token for a new JWT"
-            acceptance_steps:
-              - "Refresh with a valid refresh token"
-            acceptance_check: "pytest tests/auth/test_refresh.py"
-          - id: revocation
-            description: "Revoked refresh tokens cannot be reused"
-            acceptance_check: "pytest tests/auth/test_revocation.py"
+```json
+{
+  "schema_version": 1,
+  "anchor": "<sha256 of the canonical features list>",
+  "features": [
+    {
+      "id": "jwt-issue",
+      "category": "auth",
+      "description": "POST /auth/login returns a JWT",
+      "acceptance_steps": ["Login with valid creds"],
+      "acceptance_check": "pytest tests/auth/test_login.py::test_jwt_issued"
+    },
+    {
+      "id": "revocation",
+      "category": "auth",
+      "description": "Revoked refresh tokens cannot be reused",
+      "acceptance_check": "pytest tests/auth/test_revocation.py"
+    }
+  ]
+}
 ```
 
-Run the plan as usual. Inspect feature state at any time:
+Load and verify the contract programmatically:
 
-```bash
-# Per-feature pass/fail board (exits non-zero if any feature is pending or failed)
-bernstein contract status
+```python
+from bernstein.core.planning.feature_contract import FeatureContract
+from bernstein.core.planning.spec_assertions import verify_contract
 
-# Force-run every acceptance check now
-bernstein contract verify
+contract = FeatureContract.load()              # raises on tampering
+extraction, results = verify_contract(apply=True)  # run checks, flip passes
 ```
 
-When an agent calls `POST /tasks/{id}/complete` while a feature is
-still `passes: false`, the server replies `400` and lists the failing
-ids. Pass `--allow-partial` (operator-only flag) to override.
+The contract feeds the [spec-as-test loop](spec-as-test.md): each
+feature's `acceptance_steps` and `acceptance_check` are compiled into
+executable assertions and run after each stage drain.
 
 ## How tamper-detection works
 
 The contract is persisted at `.sdd/contract/features.json`. Its
-canonical sha256 is stored in the HMAC-chained audit log. Any
-in-place edit by an agent is detected on the next chain validation.
+canonical sha256 is stored as the `anchor` field (`compute_anchor`);
+loading via `FeatureContract.load` raises `TamperingDetectedError` when
+the stored anchor no longer matches the features list, so an in-place
+edit by an agent is detected on the next load.
 
-The janitor re-runs each `acceptance_check` post-merge. If a
-previously-passing check becomes a no-op (test file deleted, assertion
-weakened to `assert True`), the janitor flags it as
-`acceptance_check_decay`.
+`verify_contract` re-runs each `acceptance_check` and writes the
+`passes` flag per feature, so a check that has been weakened or deleted
+flips back to failing.
 
 ## Configuration
 

--- a/docs/concepts/fingerprint-memoization.md
+++ b/docs/concepts/fingerprint-memoization.md
@@ -26,13 +26,14 @@ Decorate any deterministic function whose result is expensive to
 recompute and depends only on its arguments:
 
 ```python
+from pathlib import Path
 from bernstein.core.persistence.fingerprint import (
-    MemoStore, memoize_persistent,
+    default_store, memoize_persistent,
 )
 
-store = MemoStore.default()
+store = default_store(Path("."))  # rooted at .sdd/runtime/memo
 
-@memoize_persistent(store)
+@memoize_persistent(store, site="embed")
 def embed_chunk(chunk_text: str, embedder_id: str) -> list[float]:
     # expensive embedding call
     ...

--- a/docs/concepts/orchestrator-hardening.md
+++ b/docs/concepts/orchestrator-hardening.md
@@ -34,8 +34,8 @@ Default behaviour:
 | Condition | Effect |
 |---|---|
 | Error rate > 20% over the recent window | Effective max drops by 1 (floor 1). |
-| Error rate < 5% for 10 minutes | Effective max raises by 1 (up to configured max). |
-| CPU > 80% | Spawning paused (`effective_max = 0`) until load drops. |
+| Error rate < 5% sustained ~2 min (within the 10 min window) | Effective max raises by 1 (up to configured max). |
+| Load average per CPU above the pause threshold | Spawning paused (`effective_max = 0`) until load drops. |
 
 Surface: `bernstein status` and the
 `bernstein_parallelism_level` Prometheus gauge expose the
@@ -88,7 +88,7 @@ silently disables the guard.
 | `BERNSTEIN_MAX_COST_USD` | unset | Hard cap on cumulative routed spend per run. |
 | `seed.budget_usd` | unset | Per-run budget read from `bernstein.yaml`. |
 | `defaults.PARALLELISM.error_rate_high` | `0.20` | Error rate above which adaptive parallelism shrinks. |
-| `defaults.PARALLELISM.cpu_pause_threshold` | `0.80` | CPU load above which spawning pauses. |
+| `defaults.PARALLELISM.cpu_pause_threshold` | `300.0` | Load-average percent-per-CPU above which spawning pauses (default ~3 pinned cores). |
 
 ## Metrics
 

--- a/docs/concepts/phase-pipeline.md
+++ b/docs/concepts/phase-pipeline.md
@@ -49,16 +49,19 @@ Existing single-phase plans (no `phases:` field) run unchanged.
 
 ## Routing per phase
 
-`core/routing/router.py` consults the phase to pick a model:
+`phase_pipeline.route_for_phase(phase)` returns a `(model, effort)`
+pair from the per-phase defaults (`_DEFAULT_MODEL_BY_PHASE` /
+`_DEFAULT_EFFORT_BY_PHASE`):
 
-| Phase | Default model class | Why |
-|---|---|---|
-| `research` | high-reasoning (sonnet / opus tier) | broad codebase reading, gap analysis |
-| `plan` | high-reasoning | cross-cutting design |
-| `implement` | cheap-tier | bounded, high-throughput edits |
-| `verify` | cheap-tier | structured assertion runner |
+| Phase | Default model | Effort | Why |
+|---|---|---|---|
+| `research` | `opus` | high | broad codebase reading, gap analysis |
+| `plan` | `opus` | high | cross-cutting design |
+| `implement` | `sonnet` | normal | bounded, high-throughput edits |
+| `verify` | `sonnet` | normal | structured assertion runner |
 
-Override per task via the existing `model:` field on the step.
+Manager-supplied `task_model` / `task_effort` overrides win over the
+phase default when present.
 
 ## Configuration
 
@@ -81,6 +84,7 @@ Override per task via the existing `model:` field on the step.
 ## Related
 
 - Source: `src/bernstein/core/orchestration/phase_pipeline.py`
+  (`route_for_phase`, `PhasedRunner`, `ArtifactStore`)
 - Plan loader: `src/bernstein/core/planning/plan_loader.py`
-- Routing: `src/bernstein/core/routing/router.py`
+- Model router: `src/bernstein/core/routing/router.py`
 - PR #1000

--- a/docs/concepts/sandbox-selector.md
+++ b/docs/concepts/sandbox-selector.md
@@ -43,16 +43,18 @@ sorted-name order so plug-in backends still get a stable position.
 
 ## How to use it
 
-Most callers compose `select_backend` with `get_backend` to
-materialise the chosen backend instance:
+Most callers materialise the registered backends with `list_backends`
+and hand them to `select_sandbox`, which returns the chosen backend
+instance directly:
 
 ```python
 from bernstein.core.sandbox.selector import (
     SandboxEnvironment,
     SandboxPolicy,
-    select_backend,
+    SandboxSelectionError,
+    select_sandbox,
 )
-from bernstein.core.sandbox.registry import get_backend
+from bernstein.core.sandbox.registry import list_backends
 
 policy = SandboxPolicy(allow_paid=False)  # cheap backends only
 env = SandboxEnvironment(
@@ -60,8 +62,7 @@ env = SandboxEnvironment(
     budget_remaining_usd=2.50,
 )
 
-choice = select_backend(manifest=manifest, policy=policy, env=env)
-backend = get_backend(choice.name)
+backend = select_sandbox(list_backends(), policy=policy, environment=env)
 ```
 
 Force a specific backend with an override:
@@ -70,11 +71,15 @@ Force a specific backend with an override:
 policy = SandboxPolicy(override="docker")
 ```
 
-Inspect why a candidate was filtered out:
+When no backend satisfies the policy, `select_sandbox` raises
+`SandboxSelectionError`; its `attempted` attribute lists the backends
+that were considered:
 
 ```python
-for skipped in choice.skipped:
-    print(skipped.name, skipped.reason)
+try:
+    backend = select_sandbox(list_backends(), policy=policy, environment=env)
+except SandboxSelectionError as exc:
+    print("no eligible backend; attempted:", exc.attempted)
 ```
 
 ## Configuration

--- a/docs/concepts/schema-validation-retry.md
+++ b/docs/concepts/schema-validation-retry.md
@@ -32,24 +32,31 @@ class PlannerOutput(BaseModel):
 
 ctx = SchemaRetryContext()
 
+def validate(raw: str) -> PlannerOutput:
+    # raise ValueError on bad input; the retry loop catches it
+    return PlannerOutput.model_validate_json(raw)
+
 def ask_again(prompt_with_errors: str) -> str:
     # call your spawned agent / model with the augmented prompt
     return run_agent(prompt_with_errors)
 
 result = validate_with_retry(
-    payload=raw_text,
-    schema=PlannerOutput,
-    ctx=ctx,
-    max_attempts=3,
+    raw_text,             # initial_response (positional)
+    validate,             # parses-or-raises ValueError
+    ctx,
     ask_again=ask_again,
+    max_attempts=3,
 )
 ```
 
-On a malformed payload the helper:
+The second positional argument is a `validate` callable that parses the
+response or raises `ValueError`, not a schema class directly, so any
+validator (Pydantic, JSONSchema, hand-rolled) plugs in. On a malformed
+payload the helper:
 
-1. Runs the schema validator (Pydantic / JSONSchema).
-2. Records the error into `ctx`.
-3. Calls `ask_again(prompt + "you previously got these errors: …")`.
+1. Runs the `validate` callable.
+2. Records the `ValueError` into `ctx`.
+3. Calls `ask_again(base_prompt + "you previously got these errors: …")`.
 4. Loops up to `max_attempts`; raises `SchemaRetryExhausted` with the
    full error trail on terminal failure.
 

--- a/docs/concepts/spec-as-test.md
+++ b/docs/concepts/spec-as-test.md
@@ -1,10 +1,10 @@
 # Spec-as-test loop
 
-Plan files describe acceptance criteria as free-text. The
-`spec_assertions` module turns those bullets into **executable
-assertions** — file-exists / import-resolves / regex-in-file /
-test-passes — runs them after each stage drain, and routes failures
-back as auto-fix tasks or human-review bulletins.
+The [feature contract](feature-contract.md) describes acceptance
+criteria as free-text steps. The `spec_assertions` module turns those
+steps into **executable assertions** (file-exists / import-resolves /
+regex-in-file / test-passes), runs them after each stage drain, and
+routes failures back as auto-fix tasks or human-review bulletins.
 
 ## Why it exists
 
@@ -16,50 +16,63 @@ spec-as-test verifies the IS.
 
 ## How to use it
 
-Write your plan with explicit `acceptance:` bullets:
+Assertions are derived from the feature contract at
+`.sdd/contract/features.json`. Each `Feature` carries free-text
+`acceptance_steps` plus an `acceptance_check`:
 
-```yaml
-stages:
-  - name: feature
-    steps:
-      - role: backend
-        goal: "Add /healthz endpoint"
-        acceptance:
-          - "file_exists: src/api/healthz.py"
-          - "import_resolves: api.healthz.healthz_view"
-          - "regex_in_file: src/api/__init__.py /from .healthz import/"
-          - "test_passes: pytest tests/api/test_healthz.py"
+```json
+{
+  "features": [
+    {
+      "id": "healthz",
+      "description": "Add /healthz endpoint",
+      "acceptance_steps": [
+        "exists src/api/healthz.py",
+        "import api.healthz",
+        "contains src/api/__init__.py /from .healthz import/"
+      ],
+      "acceptance_check": "pytest tests/api/test_healthz.py"
+    }
+  ]
+}
 ```
 
-`extract_assertions(plan)` parses the bullets into typed `Assertion`
-records. `run_assertions(assertions, repo_root)` executes them after
-every stage drain. Failures post a bulletin and create an auto-fix
-task targeting the offending step.
+`extract_assertions(contract)` parses each feature into typed
+`Assertion` records, returned inside an `AssertionExtractionReport`
+(with `.assertions`, `.unparsed`, and `.skipped_features`). The
+`acceptance_check` becomes a `test_passes` assertion; each parseable
+step becomes a `file_exists` / `import_resolves` / `regex_in_file`
+assertion. `run_assertions(assertions, repo_root)` executes them after
+every stage drain; `verify_contract()` is the top-level entry point.
+Failures post a bulletin and create an auto-fix task targeting the
+offending feature.
 
 You can emit the assertions as a real pytest file for CI:
 
 ```python
+from pathlib import Path
 from bernstein.core.planning.spec_assertions import (
-    extract_assertions, assertions_to_pytest,
+    load_contract, extract_assertions, assertions_to_pytest,
 )
 
-assertions = extract_assertions(plan)
-assertions_to_pytest(assertions, out_path="tests/spec/test_plan_jwt.py")
+contract = load_contract()
+report = extract_assertions(contract)
+assertions_to_pytest(report.assertions, out_path=Path("tests/spec/test_plan_jwt.py"))
 ```
-
-Disable the loop for a run with `--no-spec-test` (default-on).
 
 ## Supported assertion kinds
 
-| Kind | Predicate |
-|---|---|
-| `file_exists` | path resolves to a regular file |
-| `import_resolves` | dotted import succeeds in the project venv |
-| `test_passes` | named pytest selector exits 0 |
-| `regex_in_file` | regex matches at least once in the file's bytes |
+The step grammar parsed out of `acceptance_steps`:
 
-Unknown kinds parse as `unknown` and are skipped with a logged
-warning.
+| Step syntax | Kind | Predicate |
+|---|---|---|
+| `exists <path>` (or `file exists <path>`) | `file_exists` | path resolves to a regular file |
+| `import <module>` | `import_resolves` | dotted import succeeds in the project venv |
+| `contains <path> /<regex>/` | `regex_in_file` | regex matches at least once in the file's bytes |
+| (the feature's `acceptance_check`) | `test_passes` | the command / pytest selector exits 0 |
+
+Steps that match no rule land in the report's `unparsed` list rather
+than running.
 
 ## Configuration
 
@@ -73,8 +86,8 @@ warning.
 
 - Only the four kinds listed above. Property-based testing,
   Gherkin/BDD, and LLM-generated assertions are out of scope.
-- Assertions are derived from the existing `acceptance:` field; no
-  separate spec format.
+- Assertions are derived from the feature contract's
+  `acceptance_steps` / `acceptance_check`; no separate spec format.
 - The pytest emitter writes synchronous tests; async-only test suites
   need a custom runner wrap.
 - Failures attach an auto-fix task but never block merge by themselves

--- a/docs/concepts/swarm-migration.md
+++ b/docs/concepts/swarm-migration.md
@@ -27,14 +27,21 @@ bernstein migrate \
     --chunk-size 5 \
     --max-parallel 20
 
-# Use a saved migration plan
-bernstein migrate --plan templates/migrations/flask-to-fastapi.yaml
+# Pin a stable id for idempotent re-runs, and preview without spawning
+bernstein migrate \
+    --glob 'src/**/*.py' \
+    --transform 'convert all sync handler functions to async' \
+    --id sync-to-async \
+    --dry-run
 ```
 
-A migration plan YAML lives under `templates/migrations/`:
+The CLI takes the glob and transform inline. Reference migration plan
+YAMLs (`templates/migrations/sync_to_async.yaml`,
+`templates/migrations/pytest_asyncio.yaml`) document the same shape the
+`MigrationPlan` dataclass accepts:
 
 ```yaml
-# templates/migrations/sync-to-async.yaml
+# templates/migrations/sync_to_async.yaml
 glob: 'src/**/*.py'
 transform_prompt: |
   Convert every sync function in this file to async, replacing every
@@ -60,9 +67,9 @@ Re-running the same plan ID skips already-completed chunks
 
 | Knob | Default | Controls |
 |---|--:|---|
-| `--max-parallel` | `min(20, len(chunks))` | Parallel agent count; respects `adaptive_parallelism` cap. |
+| `--max-parallel` | `20` | Parallel agent count; clamped to the chunk count and the hard ceiling. |
 | `--chunk-size` | `5` | Files per chunk. |
-| `--plan-id` | hash of plan file | Idempotency key. |
+| `--id` | derived from the transform | Idempotency key for re-runs. |
 
 ## Limitations
 

--- a/docs/concepts/team-hub.md
+++ b/docs/concepts/team-hub.md
@@ -54,7 +54,7 @@ Manifest example (`team-hub.yaml`):
 
 ```yaml
 name: acme-platform-hub
-version: 1
+version: "1"
 ships:
   agents:
     - reviewer
@@ -83,7 +83,7 @@ ships:
 - Read-only by design. Clone, pull, and resolution-path merging
   live in later slices, so this loader can be unit-tested against
   a fixture directory without touching git.
-- Manifest size is capped at 4 KiB; a real `team-hub.yaml` is
+- Manifest size is capped at 64 KiB; a real `team-hub.yaml` is
   well under that. The cap prevents pathological YAML inputs from
   exhausting the loader.
 - Bucket vocabulary is fixed at `agents`, `skills`, `rules` for

--- a/docs/gui/install.md
+++ b/docs/gui/install.md
@@ -14,7 +14,7 @@ tags:
 pip install 'bernstein[gui]'
 ```
 
-The `gui` extra adds one runtime dep — `sse-starlette>=2.1.0` — for the streaming endpoints. The React bundle is committed under `src/bernstein/gui/static/` and ships in the wheel, so **no Node toolchain is required at install time**.
+The `gui` extra lists two pure-Python deps: `sse-starlette>=2.1.0` (streaming endpoints) and `qrcode>=7.4` (terminal QR for `bernstein gui qr` / `--tunnel`). The label is kept for forward-compat: `sse-starlette` already arrives transitively via core deps and `fastapi` / `uvicorn` are already required, so there is **no runtime extras gate** and `bernstein gui serve` works on a plain install. The React bundle is committed under `src/bernstein/gui/static/` and ships in the wheel, so **no Node toolchain is required at install time**.
 
 The extras list lives in `pyproject.toml` (`[project.optional-dependencies]`, key `gui`).
 
@@ -26,17 +26,21 @@ bernstein gui serve
 
 Defaults:
 
-| Flag         | Default     | Notes                                                   |
-|--------------|-------------|---------------------------------------------------------|
-| `--host`     | `127.0.0.1` | Loopback only. Bind a routable address explicitly.      |
-| `--port`     | `8000`      | Same port as the Bernstein API.                         |
-| `--no-open`  | off         | By default, the launcher opens `/ui/` in your browser.  |
-| `--dev`      | off         | Skips browser auto-open. Pair with `cd web && npm run dev` for HMR on `:5173`. |
-| `--minimal`  | off         | Mounts only the GUI + `/api/v1/gui-meta`. Skips full API. Smoke-test only. |
+| Flag                | Default     | Notes                                                   |
+|---------------------|-------------|---------------------------------------------------------|
+| `--host`            | `127.0.0.1` | Loopback only. Bind a routable address explicitly.      |
+| `--port`            | `8052`      | Canonical Bernstein orchestrator port.                  |
+| `--no-open`         | off         | By default, the launcher opens `/ui/` in your browser.  |
+| `--dev`             | off         | Skips browser auto-open. Pair with `cd web && npm run dev` for HMR on `:5173`. |
+| `--minimal`         | off         | Mounts only the GUI + `/api/v1/gui-meta`. Skips full API. Smoke-test only. |
+| `--tunnel`          | off         | Publish the GUI through a tunnel and print a QR + passphrase for phone onboarding. |
+| `--tunnel-provider` | `auto`      | Tunnel driver when `--tunnel` is set (`auto`/`cloudflared`/`ngrok`/`bore`/`tailscale`). |
+
+A sibling `bernstein gui qr` subcommand reprints the last QR; see [Mobile + tunnel](mobile.md).
 
 The CLI is defined in `src/bernstein/gui/cli.py`. The mount logic is `src/bernstein/gui/__init__.py` (`mount(app)` attaches the SPA at `/ui/` and registers `/api/v1/gui-meta`).
 
-URL after launch: `http://127.0.0.1:8000/ui/`.
+URL after launch: `http://127.0.0.1:8052/ui/`.
 
 ## First-run notes
 
@@ -50,17 +54,17 @@ URL after launch: `http://127.0.0.1:8000/ui/`.
 
 2. **Disable auth (dev only).** `BERNSTEIN_AUTH_DISABLED=1 bernstein gui serve` — middleware logs a loud warning. Never expose this on a network-reachable host.
 
-3. **Port collision.** If `:8000` is taken, pass `--port`. The launcher does not auto-fallback.
+3. **Port collision.** If `:8052` is taken, pass `--port`. The launcher does not auto-fallback.
 
 4. **Static assets missing.** `bernstein gui serve` will exit with `GUI static assets not found at …` if the wheel was built without the `static/` bundle. Rebuild with `cd web && npm install && npm run build` (writes to `../src/bernstein/gui/static/`).
 
-5. **GUI extras missing.** `pip install 'bernstein[gui]'` is mandatory — `bernstein gui --help` works without it, but `bernstein gui serve` prints the install hint and exits non-zero.
+5. **No extras gate.** `bernstein gui serve` runs on a plain install; the `[gui]` extra is forward-compat only and is not required at runtime. Install it (`pip install 'bernstein[gui]'`) only to pin the `qrcode` dep for `bernstein gui qr` / `--tunnel`.
 
 ## Verify
 
 ```bash
 curl -fsS -H "Authorization: Bearer $BERNSTEIN_AUTH_TOKEN" \
-  http://127.0.0.1:8000/api/v1/gui-meta
+  http://127.0.0.1:8052/api/v1/gui-meta
 ```
 
 Returns `{"version": "...", "commit": "...", "build_time": "..."}`.

--- a/docs/gui/playground.md
+++ b/docs/gui/playground.md
@@ -51,9 +51,9 @@ npm install        # first time
 npm run dev
 ```
 
-Vite serves the SPA on `http://127.0.0.1:5173` and proxies `/api/*` to FastAPI on `:8000`.
+Vite serves the SPA on `http://127.0.0.1:5173` and proxies `/api/*` to FastAPI on `:8052`.
 
-If you'd rather hit the built bundle (no HMR), run `bernstein gui serve --dev` in this terminal instead and open `http://127.0.0.1:8000/ui/`.
+If you'd rather hit the built bundle (no HMR), run `bernstein gui serve --dev` in this terminal instead and open `http://127.0.0.1:8052/ui/`.
 
 ## Tuning the idle interval
 

--- a/docs/gui/troubleshooting.md
+++ b/docs/gui/troubleshooting.md
@@ -8,14 +8,9 @@ tags:
 
 # Troubleshooting
 
-## "Bernstein GUI requires the `gui` extra"
+## `ModuleNotFoundError: sse_starlette` or `qrcode`
 
-```text
-Bernstein GUI requires the `gui` extra:
-    pip install 'bernstein[gui]'
-```
-
-**Cause.** `sse-starlette` is not importable. The extras gate is in `src/bernstein/gui/cli.py` (`_check_gui_extras`).
+There is no runtime extras gate: `bernstein gui serve` runs on a plain install because `sse-starlette` arrives transitively via core deps and `fastapi` / `uvicorn` are already required (`src/bernstein/gui/cli.py` module docstring). You only need the `[gui]` extra to pin `qrcode` for `bernstein gui qr` / `--tunnel`.
 
 **Fix.**
 
@@ -48,13 +43,13 @@ npm run build      # writes to ../src/bernstein/gui/static/
 
 The committed `static/` directory is what the wheel ships; rebuild whenever `web/src/` changes.
 
-## Port collision on `:8000`
+## Port collision on `:8052`
 
 ```text
 [Errno 48] Address already in use
 ```
 
-**Cause.** Another Bernstein server, FastAPI process, or unrelated service holds `:8000`.
+**Cause.** Another Bernstein server, FastAPI process, or unrelated service holds `:8052`.
 
 **Fix.** Pass `--port`:
 
@@ -65,7 +60,7 @@ bernstein gui serve --port 8765
 Or kill the holder:
 
 ```bash
-lsof -i :8000           # macOS / Linux
+lsof -i :8052           # macOS / Linux
 kill <pid>
 ```
 


### PR DESCRIPTION
## Summary

Documentation refresh sweep for the `docs/concepts/` and `docs/gui/` partitions, reconciling prose with the current source-of-truth public surfaces per `docs/playbooks/docs-drift.md`. The `docs/sdd/` partition was reviewed and is already in sync (no change).

`manual-prose` remediation applied where the doc described a renamed function, a changed signature, a stale CLI flag, or an outdated default. The drift gate is path-existence only, so these prose-level discrepancies are not caught by CI; this closes that gap.

### concepts (13 files)

| Doc | Drift corrected |
|-----|-----------------|
| action-cache | `cache action ls/prune` -> `stats`/`replay`; metric names (`action_cache_*`, label `model`) |
| swarm-migration | `--id` (was `--plan-id`); CLI takes inline glob/transform, no `--plan` |
| schema-validation-retry | `validate_with_retry(initial_response, validate, ctx, ...)` positional + validator-callable shape |
| spec-as-test | now FeatureContract-driven; corrected step grammar + `extract_assertions(contract)` |
| sandbox-selector | `select_sandbox(backends, ...)` returns a backend / raises `SandboxSelectionError` (was `select_backend(manifest=...)`) |
| team-hub | manifest cap 64 KiB (was 4 KiB); `version` is a string |
| best-of-n | `BestOfNDefaults` config knobs; judge rubric is in-module, no rubric-path knob |
| orchestrator-hardening | `cpu_pause_threshold` default `300.0` load-units (was `0.80`) |
| phase-pipeline | per-phase routing is `route_for_phase`, not `router.py`; default model/effort table |
| fingerprint-memoization | `default_store(path)` factory (was `MemoStore.default()`) |
| artifact-lineage | `LineageReader.iter_records(run_id=...)`; walk uses `--limit`, no `--full` |
| abstracted-code-review | `summarize_diff` is async and returns a per-file list |
| feature-contract | aligned to the contract data model + spec-as-test consumer (removed unimplemented CLI/server claims) |

### gui (3 files)

- Default GUI port `8052` (was `8000`) across install / troubleshooting / playground.
- No runtime extras gate (`bernstein gui serve` runs on a plain install); `[gui]` extra now lists two deps (`sse-starlette`, `qrcode`).
- Documented `--tunnel` / `--tunnel-provider` flags and the `gui qr` subcommand.

## Test plan

- [x] `uv run python scripts/check_docs_drift.py --strict` exits 0
- [x] No `docs/compare/*` or `CHANGELOG.md` changes
- [x] Plain hyphens only in changed lines (no em-dashes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GUI installation and troubleshooting guides for port 8052 migration.
  * Revised feature contract documentation to reflect new JSON format at `.sdd/contract/features.json`.
  * Updated CLI migration tool documentation with new `--id` and `--dry-run` options.
  * Documented updated API signatures for `summarize_diff` (now async) and sandbox selection functions.
  * Updated action cache metrics naming and orchestrator concurrency limits.
  * Refreshed programmatic access examples across artifact lineage, fingerprint memoization, and schema validation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->