### PR TITLE
feat(lifecycle): permission-rule prefilter on hooks before spawn

### DIFF
--- a/docs/operations/hooks.md
+++ b/docs/operations/hooks.md
@@ -1,0 +1,94 @@
+# Hook permission-rule prefilter
+
+This page documents the optional `if:` filter on config-declared hooks.
+For the full hook contract (event vocabulary, payload schemas, the
+allow/deny/mutate/annotate stdout protocol, and discovery) see
+[the hook contract reference](../contributing/hooks.md).
+
+## TL;DR
+
+| Item | Value |
+|------|-------|
+| Where | `bernstein.yaml`, under a `script:` entry's `if:` key |
+| Purpose | Skip the hook subprocess spawn when the event does not match |
+| Grammar | `Bash(git *)`, `Read(/path/*)`, `Tool(name)`, or a bare `Bash` |
+| Default | No `if:` means the hook always runs (legacy behaviour) |
+| On non-match | The spawn is skipped and a `hook.filtered` metric is emitted |
+| On bad filter | A parse error is raised at config load, before the hook registers |
+
+## Why
+
+A config-declared hook subscribes to one event type and is spawned for
+every occurrence of that event. The hook script then parses its input and
+decides whether it applies. For hooks that only care about a narrow slice
+of events, the subprocess cold-start cost dominates.
+
+The `if:` filter lets the lifecycle runner evaluate a declarative rule
+against the event payload first, and short-circuit before paying the spawn
+cost on irrelevant events. The grammar is the same one used by the
+permission engine, so the filter language is already familiar.
+
+## Grammar
+
+A filter is a single tool selector with an optional argument glob:
+
+| Form | Matches |
+|------|---------|
+| `Bash(git *)` | a `Bash` tool whose `command` glob-matches `git *` |
+| `Read(/etc/**)` | a `Read` tool whose `path` glob-matches `/etc/**` |
+| `Tool(grep)` | any tool whose name glob-matches `grep`, with no argument constraint |
+| `Bash` | any `Bash` invocation, regardless of arguments |
+
+Notes:
+
+- Tool names match case-insensitively.
+- The argument is treated as a `command` glob for shell-like tools
+  (`Bash`, `shell`, `sh`, `exec`, `run`) and as a `path` glob otherwise.
+- Globs support `*`, `?`, `[seq]`, and `**` for deep path matching, exactly
+  as the permission engine does.
+- A filter only matches event payloads that carry a `tool` key (the
+  tool-scoped events). Events without a tool never match a tool-scoped
+  filter and are skipped.
+
+## Where the filter reads from
+
+The filter is evaluated against the event payload's `data` mapping. For
+tool-scoped events that mapping carries:
+
+- `tool` -- the tool name.
+- `args` -- the tool input mapping (for example `{"command": "git push"}`
+  or `{"path": "/etc/passwd"}`).
+
+## Examples (one per event family)
+
+```yaml
+hooks:
+  # Cross-CLI tool events: filter on the tool and its arguments.
+  preToolUse:
+    - script: "scripts/guard-force-push.sh"
+      if: "Bash(git push *--force*)"
+  postToolUse:
+    - script: "scripts/audit-writes.sh"
+      if: "Write(/etc/**)"
+
+  # A name-only selector: run for one tool regardless of arguments.
+  errorOccurred:
+    - script: "scripts/page-on-grep-error.sh"
+      if: "Tool(grep)"
+
+  # Bernstein-native lifecycle events carry no tool payload, so a
+  # tool-scoped filter would skip every invocation. Omit `if:` for these
+  # so the hook always runs.
+  post_merge:
+    - script: "scripts/notify.sh"
+      timeout: 10
+```
+
+## Failure modes
+
+- A malformed filter (`Bash(`, `Tool()`, empty string, trailing tokens)
+  raises a config error at load time. The hook does not register and the
+  operator gets a clear message naming the bad expression.
+- A non-matching filter is not an error: the spawn is skipped and a
+  `hook.filtered` metric is emitted with the unmatched filter as its
+  reason. Use this metric to confirm a filter is doing what you expect.

--- a/src/bernstein/core/config/hook_config.py
+++ b/src/bernstein/core/config/hook_config.py
@@ -13,6 +13,19 @@ Example::
         - script: "scripts/notify.sh"
           timeout: 10
         - plugin: "bernstein_plugin_jira"
+
+A ``script:`` entry may carry an optional ``if:`` filter in the
+permission-rule grammar. The lifecycle runner evaluates the filter against
+the event payload before spawning the subprocess; a non-match skips the
+spawn entirely::
+
+    hooks:
+      preToolUse:
+        - script: "scripts/guard-push.sh"
+          if: "Bash(git push *)"
+
+Filters are parsed at config-load time, so a malformed ``if:`` raises
+:class:`HookConfigError` before the hook ever registers.
 """
 
 from __future__ import annotations
@@ -21,6 +34,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
 
+from bernstein.core.lifecycle.hook_filter import HookFilter, HookFilterError, parse_hook_filter
 from bernstein.core.lifecycle.hooks import DEFAULT_TIMEOUT_SECONDS, HookRegistry, LifecycleEvent
 
 __all__ = [
@@ -39,10 +53,18 @@ class HookConfigError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class ScriptHookEntry:
-    """A script-hook declaration resolved from config."""
+    """A script-hook declaration resolved from config.
+
+    Attributes:
+        path: Filesystem path to the hook script.
+        timeout: Maximum wall-clock seconds before the subprocess is killed.
+        hook_filter: Optional permission-rule prefilter parsed from the
+            ``if:`` field. ``None`` means the hook always runs.
+    """
 
     path: Path
     timeout: int = DEFAULT_TIMEOUT_SECONDS
+    hook_filter: HookFilter | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,7 +142,10 @@ def _parse_entry(event: LifecycleEvent, item: object, config: HookConfig) -> Non
         timeout_raw = item_map.get("timeout", DEFAULT_TIMEOUT_SECONDS)
         if not isinstance(timeout_raw, int) or isinstance(timeout_raw, bool):
             raise HookConfigError(f"hooks.{event.value}[].timeout must be an integer (seconds)")
-        config.scripts[event].append(ScriptHookEntry(path=Path(path_value), timeout=timeout_raw))
+        hook_filter = _parse_entry_filter(event, item_map)
+        config.scripts[event].append(
+            ScriptHookEntry(path=Path(path_value), timeout=timeout_raw, hook_filter=hook_filter),
+        )
         return
 
     if "plugin" in item_map:
@@ -135,6 +160,23 @@ def _parse_entry(event: LifecycleEvent, item: object, config: HookConfig) -> Non
     )
 
 
+def _parse_entry_filter(event: LifecycleEvent, item_map: dict[object, object]) -> HookFilter | None:
+    """Parse and validate the optional ``if:`` filter on a script entry.
+
+    Parse errors surface as :class:`HookConfigError` at config-load time so
+    a malformed filter prevents the hook from registering.
+    """
+    if "if" not in item_map:
+        return None
+    filter_value = item_map["if"]
+    if not isinstance(filter_value, str):
+        raise HookConfigError(f"hooks.{event.value}[].if must be a string filter expression")
+    try:
+        return parse_hook_filter(filter_value)
+    except HookFilterError as exc:
+        raise HookConfigError(f"hooks.{event.value}[].if is invalid: {exc}") from exc
+
+
 def apply_config(registry: HookRegistry, config: HookConfig) -> None:
     """Register every script declaration from ``config`` against ``registry``.
 
@@ -143,4 +185,9 @@ def apply_config(registry: HookRegistry, config: HookConfig) -> None:
     """
     for event, entries in config.scripts.items():
         for entry in entries:
-            registry.register_script(event, entry.path, timeout=entry.timeout)
+            registry.register_script(
+                event,
+                entry.path,
+                timeout=entry.timeout,
+                hook_filter=entry.hook_filter,
+            )

--- a/src/bernstein/core/lifecycle/hook_filter.py
+++ b/src/bernstein/core/lifecycle/hook_filter.py
@@ -1,0 +1,187 @@
+"""Permission-rule prefilter for lifecycle hooks.
+
+A hook registration may carry an optional ``if:`` filter expressed in the
+same permission-rule grammar the security subpackage already uses:
+
+* ``Bash(git *)`` -- matches a ``Bash`` tool whose ``command`` matches the
+  glob ``git *``.
+* ``Read(/path/*)`` -- matches a ``Read`` tool whose ``path`` matches the
+  glob ``/path/*``.
+* ``Tool(name)`` -- matches a tool whose name matches the glob ``name``
+  with no argument constraint.
+* ``Bash`` (no parentheses) -- matches any ``Bash`` invocation.
+
+The lifecycle runner evaluates the filter against a hook event payload
+*before* spawning the hook subprocess. A non-matching event short-circuits
+the spawn and skips the cold-start cost.
+
+The filter reuses :class:`~bernstein.core.security.permission_rules.PermissionRule`
+and its glob matcher so the grammar stays identical to the permission engine.
+Parse errors are raised eagerly at config-load time via
+:func:`parse_hook_filter`, never at dispatch time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, cast
+
+from bernstein.core.security.permission_rules import (
+    PermissionRule,
+    PermissionRuleEngine,
+    RuleAction,
+)
+
+__all__ = [
+    "HookFilter",
+    "HookFilterError",
+    "parse_hook_filter",
+]
+
+
+class HookFilterError(ValueError):
+    """Raised when an ``if:`` filter string is syntactically invalid.
+
+    Surfaced at config-load time so a malformed filter prevents the hook
+    from registering with a clear error, rather than failing at dispatch.
+    """
+
+
+# ``Bash(git *)`` -> tool="Bash", arg="git *"
+# ``Read(/p/*)``  -> tool="Read", arg="/p/*"
+# ``Tool(name)``  -> tool=<the literal grammar form `Tool`>, arg="name"
+# ``Bash``        -> tool="Bash", arg=None
+_FILTER_RE = re.compile(
+    r"""
+    ^\s*
+    (?P<tool>[A-Za-z_][A-Za-z0-9_]*)   # tool selector token
+    (?:
+        \(                              # opening paren
+        (?P<arg>[^)]*)                  # argument glob (may be empty)
+        \)                              # closing paren
+    )?
+    \s*$
+    """,
+    re.VERBOSE,
+)
+
+# The ``Tool(...)`` form is a tool-name selector with no argument
+# constraint: ``Tool(grep)`` matches the tool whose name globs ``grep``.
+_TOOL_KEYWORD = "Tool"
+
+# Tools whose single positional argument is a command string rather than a
+# filesystem path. Everything else treats the argument as a path glob.
+_COMMAND_TOOLS = frozenset({"bash", "shell", "sh", "exec", "run"})
+
+
+@dataclass(frozen=True, slots=True)
+class HookFilter:
+    """A parsed hook ``if:`` filter.
+
+    Wraps a single :class:`PermissionRule` (with ``action=allow``) and
+    evaluates it against a hook event payload's ``tool`` / ``args`` fields.
+    """
+
+    source: str
+    rule: PermissionRule
+
+    def matches(self, payload: dict[str, Any]) -> bool:
+        """Return True if this filter matches the given hook event payload.
+
+        The payload is the ``data`` mapping carried on a
+        :class:`~bernstein.core.lifecycle.hooks.LifecycleContext`. For
+        tool-scoped events it carries ``tool`` (the tool name) and ``args``
+        (the tool input mapping). Events without a ``tool`` key never match
+        a tool-scoped filter.
+
+        Matching is delegated to a single-rule
+        :class:`~bernstein.core.security.permission_rules.PermissionRuleEngine`
+        so the grammar stays identical to the permission engine.
+
+        Args:
+            payload: The event ``data`` mapping.
+
+        Returns:
+            True when the filter's tool and argument globs both match.
+        """
+        tool_name = payload.get("tool")
+        if not isinstance(tool_name, str):
+            return False
+        args = payload.get("args")
+        tool_input: dict[str, Any] = cast("dict[str, Any]", args) if isinstance(args, dict) else {}
+        return PermissionRuleEngine(rules=[self.rule]).evaluate(tool_name, tool_input).matched
+
+
+def parse_hook_filter(source: str | None) -> HookFilter | None:
+    """Parse an ``if:`` filter string into a :class:`HookFilter`.
+
+    Args:
+        source: The raw filter string, or ``None`` when no filter was
+            declared (the hook then always matches).
+
+    Returns:
+        A :class:`HookFilter`, or ``None`` when *source* is ``None``.
+
+    Raises:
+        HookFilterError: When *source* is non-empty but does not parse as a
+            valid permission-rule selector.
+    """
+    if source is None:
+        return None
+
+    stripped = source.strip()
+    if not stripped:
+        raise HookFilterError("hook filter must not be empty; omit 'if:' to always match")
+
+    match = _FILTER_RE.match(stripped)
+    if match is None:
+        raise HookFilterError(
+            f"invalid hook filter {source!r}; expected forms like "
+            "'Bash(git *)', 'Read(/path/*)', 'Tool(name)', or 'Bash'",
+        )
+
+    selector = match.group("tool")
+    arg = match.group("arg")
+
+    if selector == _TOOL_KEYWORD:
+        # ``Tool(name)`` -> tool-name glob, no argument constraint.
+        if arg is None:
+            raise HookFilterError(
+                f"invalid hook filter {source!r}; 'Tool' requires a name, e.g. 'Tool(grep)'",
+            )
+        tool_glob = arg.strip()
+        if not tool_glob:
+            raise HookFilterError(
+                f"invalid hook filter {source!r}; 'Tool(...)' name must not be empty",
+            )
+        rule = PermissionRule(id=f"hook-filter:{source}", action=RuleAction.ALLOW, tool=tool_glob)
+        return HookFilter(source=source, rule=rule)
+
+    tool_glob = selector
+    if arg is None:
+        # ``Bash`` -> match any invocation of that tool.
+        rule = PermissionRule(id=f"hook-filter:{source}", action=RuleAction.ALLOW, tool=tool_glob)
+        return HookFilter(source=source, rule=rule)
+
+    arg_glob = arg.strip()
+    if not arg_glob:
+        raise HookFilterError(
+            f"invalid hook filter {source!r}; argument inside '(...)' must not be empty",
+        )
+
+    if selector.lower() in _COMMAND_TOOLS:
+        rule = PermissionRule(
+            id=f"hook-filter:{source}",
+            action=RuleAction.ALLOW,
+            tool=tool_glob,
+            command=arg_glob,
+        )
+    else:
+        rule = PermissionRule(
+            id=f"hook-filter:{source}",
+            action=RuleAction.ALLOW,
+            tool=tool_glob,
+            path=arg_glob,
+        )
+    return HookFilter(source=source, rule=rule)

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -7,6 +7,7 @@ unavailable or undesired.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -21,6 +22,8 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from collections.abc import Callable
     from types import MappingProxyType
+
+    from bernstein.core.lifecycle.hook_filter import HookFilter
 
 log = logging.getLogger(__name__)
 
@@ -274,6 +277,7 @@ class HookFailure(RuntimeError):
 class _ScriptHook:
     path: Path
     timeout: int
+    hook_filter: HookFilter | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -304,6 +308,23 @@ class HookRegistry:
         self._executor: ThreadPoolExecutor | None = None
         # The pluggy bridge attaches itself here when installed.
         self._pluggy_dispatcher: Callable[[LifecycleEvent, LifecycleContext], None] | None = None
+        # Optional sink for ``hook.filtered`` metrics. Bound by the
+        # orchestrator; defaults to a no-op so the registry stays usable
+        # standalone in tests.
+        self._filtered_metric_sink: Callable[[LifecycleEvent, str, str], None] | None = None
+
+    def bind_filtered_metric_sink(
+        self,
+        sink: Callable[[LifecycleEvent, str, str], None],
+    ) -> None:
+        """Install a callback invoked when a hook is skipped by its filter.
+
+        The callback receives ``(event, hook_label, reason)``. ``reason`` is
+        the human-readable filter that did not match, e.g.
+        ``filter 'Bash(git *)' did not match``. This is the
+        ``hook.filtered{reason}`` metric described by issue #1628.
+        """
+        self._filtered_metric_sink = sink
 
     # ------------------------------------------------------------------ registration
 
@@ -312,6 +333,8 @@ class HookRegistry:
         event: LifecycleEvent,
         path: str | os.PathLike[str],
         timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        *,
+        hook_filter: HookFilter | None = None,
     ) -> None:
         """Register a shell script to run when ``event`` fires.
 
@@ -319,8 +342,12 @@ class HookRegistry:
             event: Lifecycle event to subscribe to.
             path: Filesystem path to the script; need not exist yet.
             timeout: Maximum wall-clock seconds before the subprocess is killed.
+            hook_filter: Optional parsed ``if:`` filter. When present, the
+                runner evaluates it against the event payload before
+                spawning the subprocess; a non-match skips the spawn and
+                emits a ``hook.filtered`` metric. ``None`` always matches.
         """
-        hook = _ScriptHook(path=Path(path), timeout=timeout)
+        hook = _ScriptHook(path=Path(path), timeout=timeout, hook_filter=hook_filter)
         idx = len(self._scripts[event])
         self._scripts[event].append(hook)
         self._order[event].append(("script", idx))
@@ -386,7 +413,10 @@ class HookRegistry:
         current = context
         for kind, idx in self._order[event]:
             if kind == "script":
-                decision = self._run_script(event, self._scripts[event][idx], current)
+                hook = self._scripts[event][idx]
+                if not self._filter_admits(event, hook, current):
+                    continue
+                decision = self._run_script(event, hook, current)
                 current = _apply_decision(event, current, decision)
             else:
                 self._run_callable(event, self._callables[event][idx], current)
@@ -417,6 +447,29 @@ class HookRegistry:
             self._executor = None
 
     # ------------------------------------------------------------------ internals
+
+    def _filter_admits(
+        self,
+        event: LifecycleEvent,
+        hook: _ScriptHook,
+        context: LifecycleContext,
+    ) -> bool:
+        """Return True if ``hook`` should run for this event payload.
+
+        A hook with no filter always runs. A hook whose filter does not
+        match the event payload is skipped before any subprocess spawn,
+        and a ``hook.filtered`` metric is emitted via the bound sink.
+        """
+        if hook.hook_filter is None:
+            return True
+        if hook.hook_filter.matches(context.data):
+            return True
+        reason = f"filter '{hook.hook_filter.source}' did not match"
+        log.debug("skipping hook %s for %s: %s", hook.path, event.value, reason)
+        if self._filtered_metric_sink is not None:
+            with contextlib.suppress(Exception):
+                self._filtered_metric_sink(event, f"script:{hook.path}", reason)
+        return False
 
     def _run_callable(
         self,

--- a/tests/unit/lifecycle/test_hook_filter.py
+++ b/tests/unit/lifecycle/test_hook_filter.py
@@ -1,0 +1,337 @@
+"""Unit tests for the permission-rule prefilter on lifecycle hooks.
+
+Covers the hook ``if:`` filter grammar parser (match, non-match, parse
+error, legacy no-filter), plus the registry-level deny-fast behaviour:
+a non-matching filter skips the subprocess spawn and emits a
+``hook.filtered`` metric, while a matching filter runs the script.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.config.hook_config import HookConfigError, apply_config, parse_hook_config
+from bernstein.core.lifecycle.hook_filter import (
+    HookFilter,
+    HookFilterError,
+    parse_hook_filter,
+)
+from bernstein.core.lifecycle.hooks import (
+    HookRegistry,
+    LifecycleContext,
+    LifecycleEvent,
+)
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _write_script(path: Path, body: str) -> Path:
+    path.write_text("#!/usr/bin/env bash\n" + body, encoding="utf-8")
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+# --------------------------------------------------------------------------- parsing
+
+
+def test_parse_none_returns_no_filter() -> None:
+    """The legacy no-filter case: absent ``if:`` always matches."""
+    assert parse_hook_filter(None) is None
+
+
+def test_parse_bash_command_filter() -> None:
+    f = parse_hook_filter("Bash(git *)")
+    assert isinstance(f, HookFilter)
+    assert f.rule.tool == "Bash"
+    assert f.rule.command == "git *"
+    assert f.rule.path is None
+
+
+def test_parse_read_path_filter() -> None:
+    f = parse_hook_filter("Read(/etc/*)")
+    assert f is not None
+    assert f.rule.tool == "Read"
+    assert f.rule.path == "/etc/*"
+    assert f.rule.command is None
+
+
+def test_parse_tool_keyword_filter() -> None:
+    f = parse_hook_filter("Tool(grep)")
+    assert f is not None
+    assert f.rule.tool == "grep"
+    assert f.rule.command is None
+    assert f.rule.path is None
+
+
+def test_parse_bare_tool_filter() -> None:
+    f = parse_hook_filter("Bash")
+    assert f is not None
+    assert f.rule.tool == "Bash"
+    assert f.rule.command is None
+    assert f.rule.path is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "   ",
+        "Bash(",
+        "Bash)",
+        "Bash()",
+        "Tool",
+        "Tool()",
+        "Bash(git *) extra",
+        "123(x)",
+    ],
+)
+def test_parse_error_surfaces_eagerly(bad: str) -> None:
+    """Malformed filters raise at parse time, not at dispatch time."""
+    with pytest.raises(HookFilterError):
+        parse_hook_filter(bad)
+
+
+# --------------------------------------------------------------------------- matching
+
+
+def test_command_filter_matches_payload() -> None:
+    f = parse_hook_filter("Bash(git *)")
+    assert f is not None
+    assert f.matches({"tool": "Bash", "args": {"command": "git push"}}) is True
+
+
+def test_command_filter_non_match() -> None:
+    f = parse_hook_filter("Bash(git *)")
+    assert f is not None
+    assert f.matches({"tool": "Bash", "args": {"command": "rm -rf /"}}) is False
+
+
+def test_path_filter_matches_and_non_match() -> None:
+    f = parse_hook_filter("Read(/etc/**)")
+    assert f is not None
+    assert f.matches({"tool": "Read", "args": {"path": "/etc/passwd"}}) is True
+    assert f.matches({"tool": "Read", "args": {"file_path": "/home/x"}}) is False
+
+
+def test_tool_name_mismatch_does_not_match() -> None:
+    f = parse_hook_filter("Bash(git *)")
+    assert f is not None
+    assert f.matches({"tool": "Write", "args": {"command": "git push"}}) is False
+
+
+def test_payload_without_tool_never_matches() -> None:
+    f = parse_hook_filter("Bash")
+    assert f is not None
+    assert f.matches({}) is False
+    assert f.matches({"session_id": "S-1"}) is False
+
+
+def test_tool_name_match_is_case_insensitive() -> None:
+    f = parse_hook_filter("Bash")
+    assert f is not None
+    assert f.matches({"tool": "bash"}) is True
+
+
+# --------------------------------------------------------------------------- registry: allow path
+
+
+def test_matching_filter_runs_script(tmp_path: Path) -> None:
+    """Allow path: a matching filter spawns the hook subprocess."""
+    marker = tmp_path / "ran.txt"
+    script = _write_script(tmp_path / "hook.sh", f"echo ran > {marker}\n")
+
+    registry = HookRegistry()
+    registry.register_script(
+        LifecycleEvent.PRE_TOOL_USE,
+        script,
+        hook_filter=parse_hook_filter("Bash(git *)"),
+    )
+    ctx = LifecycleContext(
+        event=LifecycleEvent.PRE_TOOL_USE,
+        workdir=tmp_path,
+        data={"tool": "Bash", "args": {"command": "git status"}},
+    )
+    registry.run(LifecycleEvent.PRE_TOOL_USE, ctx)
+
+    assert marker.exists()
+
+
+def test_no_filter_always_runs(tmp_path: Path) -> None:
+    """Legacy no-filter case: the hook runs regardless of payload."""
+    marker = tmp_path / "ran.txt"
+    script = _write_script(tmp_path / "hook.sh", f"echo ran > {marker}\n")
+
+    registry = HookRegistry()
+    registry.register_script(LifecycleEvent.PRE_TOOL_USE, script)
+    ctx = LifecycleContext(
+        event=LifecycleEvent.PRE_TOOL_USE,
+        workdir=tmp_path,
+        data={"tool": "Write", "args": {"path": "/x"}},
+    )
+    registry.run(LifecycleEvent.PRE_TOOL_USE, ctx)
+
+    assert marker.exists()
+
+
+# --------------------------------------------------------------------------- registry: deny-fast path
+
+
+def test_non_matching_filter_skips_spawn_and_emits_metric(tmp_path: Path) -> None:
+    """Deny-fast path: a non-matching filter never spawns the subprocess."""
+    marker = tmp_path / "ran.txt"
+    script = _write_script(tmp_path / "hook.sh", f"echo ran > {marker}\n")
+
+    emitted: list[tuple[str, str, str]] = []
+
+    registry = HookRegistry()
+    registry.bind_filtered_metric_sink(
+        lambda event, hook, reason: emitted.append((event.value, hook, reason)),
+    )
+    registry.register_script(
+        LifecycleEvent.PRE_TOOL_USE,
+        script,
+        hook_filter=parse_hook_filter("Bash(git *)"),
+    )
+    ctx = LifecycleContext(
+        event=LifecycleEvent.PRE_TOOL_USE,
+        workdir=tmp_path,
+        data={"tool": "Bash", "args": {"command": "rm -rf /"}},
+    )
+    registry.run(LifecycleEvent.PRE_TOOL_USE, ctx)
+
+    assert not marker.exists()  # subprocess never ran
+    assert len(emitted) == 1
+    event_value, hook_label, reason = emitted[0]
+    assert event_value == LifecycleEvent.PRE_TOOL_USE.value
+    assert str(script) in hook_label
+    assert "Bash(git *)" in reason
+
+
+def test_metric_sink_failure_is_swallowed(tmp_path: Path) -> None:
+    """A broken metric sink must not break the dispatch loop."""
+    script = _write_script(tmp_path / "hook.sh", "echo ran\n")
+
+    def _boom(*_args: object) -> None:
+        raise RuntimeError("sink down")
+
+    registry = HookRegistry()
+    registry.bind_filtered_metric_sink(_boom)
+    registry.register_script(
+        LifecycleEvent.PRE_TOOL_USE,
+        script,
+        hook_filter=parse_hook_filter("Bash(git *)"),
+    )
+    ctx = LifecycleContext(
+        event=LifecycleEvent.PRE_TOOL_USE,
+        workdir=tmp_path,
+        data={"tool": "Write", "args": {}},
+    )
+    # Should not raise even though the sink raises.
+    registry.run(LifecycleEvent.PRE_TOOL_USE, ctx)
+
+
+# --------------------------------------------------------------------------- rule precedence
+
+
+def test_rule_precedence_first_matching_hook_runs(tmp_path: Path) -> None:
+    """Hooks fire in registration order; only filters that match run.
+
+    Two hooks are registered for the same event with disjoint filters. For
+    a given payload exactly one runs, and a third no-filter hook always
+    runs, preserving declaration order among the survivors.
+    """
+    ran: list[str] = []
+    script_a = _write_script(tmp_path / "a.sh", f"echo a >> {tmp_path / 'log'}\n")
+    script_b = _write_script(tmp_path / "b.sh", f"echo b >> {tmp_path / 'log'}\n")
+    script_c = _write_script(tmp_path / "c.sh", f"echo c >> {tmp_path / 'log'}\n")
+
+    registry = HookRegistry()
+    registry.register_script(
+        LifecycleEvent.PRE_TOOL_USE,
+        script_a,
+        hook_filter=parse_hook_filter("Bash(git *)"),
+    )
+    registry.register_script(
+        LifecycleEvent.PRE_TOOL_USE,
+        script_b,
+        hook_filter=parse_hook_filter("Write(/secret/*)"),
+    )
+    registry.register_script(LifecycleEvent.PRE_TOOL_USE, script_c)
+
+    ctx = LifecycleContext(
+        event=LifecycleEvent.PRE_TOOL_USE,
+        workdir=tmp_path,
+        data={"tool": "Bash", "args": {"command": "git commit"}},
+    )
+    registry.run(LifecycleEvent.PRE_TOOL_USE, ctx)
+
+    ran = (tmp_path / "log").read_text(encoding="utf-8").split()
+    # script_a matches the Bash payload, script_b does not, script_c always runs.
+    assert ran == ["a", "c"]
+
+
+# --------------------------------------------------------------------------- config integration
+
+
+def test_config_parses_if_filter(tmp_path: Path) -> None:
+    raw = {
+        "preToolUse": [
+            {"script": "scripts/guard.sh", "if": "Bash(git push *)"},
+        ],
+    }
+    config = parse_hook_config(raw)
+    entries = config.scripts[LifecycleEvent.PRE_TOOL_USE]
+    assert len(entries) == 1
+    assert entries[0].hook_filter is not None
+    assert entries[0].hook_filter.rule.command == "git push *"
+
+
+def test_config_malformed_filter_raises_at_load() -> None:
+    """A malformed ``if:`` prevents registration with a clear config error."""
+    raw = {"preToolUse": [{"script": "scripts/guard.sh", "if": "Bash("}]}
+    with pytest.raises(HookConfigError) as excinfo:
+        parse_hook_config(raw)
+    assert "if is invalid" in str(excinfo.value)
+
+
+def test_config_non_string_filter_raises() -> None:
+    raw = {"preToolUse": [{"script": "scripts/guard.sh", "if": 42}]}
+    with pytest.raises(HookConfigError):
+        parse_hook_config(raw)
+
+
+def test_apply_config_propagates_filter(tmp_path: Path) -> None:
+    """apply_config carries the parsed filter through to the registry."""
+    marker = tmp_path / "ran.txt"
+    script = _write_script(tmp_path / "guard.sh", f"echo ran > {marker}\n")
+    raw = {"preToolUse": [{"script": str(script), "if": "Bash(git *)"}]}
+    config = parse_hook_config(raw)
+
+    registry = HookRegistry()
+    apply_config(registry, config)
+
+    # Non-matching payload -> skipped.
+    registry.run(
+        LifecycleEvent.PRE_TOOL_USE,
+        LifecycleContext(
+            event=LifecycleEvent.PRE_TOOL_USE,
+            workdir=tmp_path,
+            data={"tool": "Bash", "args": {"command": "ls"}},
+        ),
+    )
+    assert not marker.exists()
+
+    # Matching payload -> runs.
+    registry.run(
+        LifecycleEvent.PRE_TOOL_USE,
+        LifecycleContext(
+            event=LifecycleEvent.PRE_TOOL_USE,
+            workdir=tmp_path,
+            data={"tool": "Bash", "args": {"command": "git log"}},
+        ),
+    )
+    assert marker.exists()


### PR DESCRIPTION
## Summary
- Add an optional `if:` filter to config-declared script hooks, using the existing permission-rule grammar (`Bash(git *)`, `Read(/path/*)`, `Tool(name)`, or a bare `Bash`).
- The lifecycle runner evaluates the filter against the event payload before spawning the subprocess; a non-match skips the spawn and emits a `hook.filtered` metric via a bound sink.
- Filters parse at config-load time, so a malformed `if:` raises a clear `HookConfigError` before the hook registers, never at runtime.

## Changes
- `core/lifecycle/hook_filter.py`: parse and evaluate the filter grammar, delegating matching to `PermissionRuleEngine`.
- `core/config/hook_config.py`: `ScriptHookEntry` gains an optional filter; parse errors surface as `HookConfigError`.
- `core/lifecycle/hooks.py`: `HookRegistry` prefilters scripts and exposes a filtered-metric sink.
- `docs/operations/hooks.md`: filter grammar plus one example per event type.

## Test plan
- [x] `tests/unit/lifecycle/test_hook_filter.py` covers allow, deny-fast (skip spawn + metric), rule precedence, parse error, and the legacy no-filter case.
- [x] Existing `tests/unit/test_lifecycle_hooks.py` still passes (no regressions).
- [x] ruff, ruff-format, and pyright (strict) clean on changed files.

Closes #1628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `if:` filter rules on lifecycle hooks in configuration, enabling conditional hook execution based on event properties (`tool`, `args`).
  * Hooks with non-matching filters are skipped and emit a `hook.filtered` metric.

* **Documentation**
  * Added guide documenting filter syntax, matching rules, configuration examples, and failure modes.

* **Tests**
  * Added comprehensive test coverage for hook filter parsing and execution semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->