### PR TITLE
feat(adapters): strict structured-output schemas with user-field blacklist

### DIFF
--- a/docs/adapters/schemas.md
+++ b/docs/adapters/schemas.md
@@ -1,0 +1,89 @@
+# Strict structured-output schemas
+
+Adapters parse model-emitted structured output and merge it into stored
+artefacts. A lenient parse opens two failure modes:
+
+1. Hallucinated keys land in storage and break downstream consumers that did
+   not expect them.
+2. AI updates overwrite operator-owned fields (notes, tags, `id`).
+
+The strict contract closes both. The shared primitives live in
+`bernstein.adapters.strict_schema`.
+
+## The strict contract
+
+Every schema that parses AI output forbids extra keys.
+
+- JSON Schema artefacts (the per-phase schemas in
+  `bernstein.core.orchestration.phase_schemas`) declare
+  `additionalProperties: false` on every object node. Use `seal_schema` to
+  produce a sealed copy and `assert_schema_sealed` to prove a schema cannot
+  accept undeclared keys.
+- Dataclass-backed payloads (the refinement `Critique` in
+  `bernstein.core.orchestration.refinement_schemas`) expose a
+  `from_dict_strict` parse path. A hallucinated top-level key, or a
+  hallucinated key inside any nested issue, raises `SchemaViolation` rather
+  than being silently dropped.
+
+A `SchemaViolation` is deterministic, so the retry path treats it as
+non-transient and bounds its attempts.
+
+## User-owned field registry
+
+Some fields are managed by operators or by the store, never by AI output.
+`USER_OWNED_FIELDS` is the global floor:
+
+| Field | Owner |
+| --- | --- |
+| `user_notes` | operator |
+| `operator_overrides` | operator |
+| `id` | store |
+| `created_at` | store |
+
+A schema may add to this floor through `UserOwnedFieldRegistry.register`.
+Per-schema entries are unioned with the floor, so a registration can never
+weaken the global protection.
+
+### Stripping AI writes
+
+Before an AI update reaches the merge layer, pass it through
+`strip_user_owned_fields`:
+
+```python
+from bernstein.adapters.strict_schema import strip_user_owned_fields
+
+safe_update, rejected = strip_user_owned_fields(schema_id, ai_update)
+if rejected is not None:
+    # rejected names the schema and the stripped operator-owned fields.
+    audit_log.record(rejected)
+merge(safe_update)
+```
+
+Any blacklisted key is removed from a copy of the update. When at least one
+field is stripped, an `AIWriteRejected{schema, fields}` event is logged and
+returned so the audit surface can attribute the attempt.
+
+## Provider error classification
+
+A provider may reject a structured-output request because the response
+carried undeclared keys. `classify_schema_violation` maps those messages to a
+`SchemaViolation` carrying any field names lifted from the message:
+
+```python
+from bernstein.adapters.strict_schema import classify_schema_violation
+
+violation = classify_schema_violation(provider_error)
+if violation is not None:
+    # Deterministic schema fault: do not retry without changing the payload.
+    raise violation
+```
+
+Unrelated errors return `None` so the caller falls back to its general error
+path.
+
+## Fixtures
+
+`tests/fixtures/adapter_outputs/` holds strict-clean fixtures that must parse
+under the strict contract. Payloads that carried previously-tolerated extras
+live under `tests/fixtures/adapter_outputs/legacy/`; the migration test
+asserts they are rejected under strict mode.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ nav:
       - Troubleshooting: gui/troubleshooting.md
   - Adapters & integrations:
       - Adapter guide: adapters/ADAPTER_GUIDE.md
+      - Strict output schemas: adapters/schemas.md
       - OpenAI Agents SDK: adapters/openai-agents.md
       - CLM (Cyber Language Model): adapters/clm.md
       - DeepSeek V4 (self-hosted): adapters/deepseek.md

--- a/src/bernstein/adapters/strict_schema.py
+++ b/src/bernstein/adapters/strict_schema.py
@@ -1,0 +1,306 @@
+"""Strict structured-output validation and user-owned-field protection.
+
+Adapters parse model-emitted structured output and merge it into stored
+artefacts. Two failure modes follow when that parse is lenient:
+
+* Hallucinated keys land in storage and break downstream consumers that
+  did not expect them. The defence is to reject extra keys at parse time
+  (``additionalProperties: false`` for JSON Schema, ``extra="forbid"``
+  for Pydantic).
+* AI updates overwrite operator-owned fields (notes, tags, ``id``). The
+  defence is an explicit blacklist of user-owned fields that are stripped
+  from any incoming AI update before merge, never trusted from the model.
+
+This module provides the shared primitives both defences need so each
+adapter and schema does not reinvent them:
+
+* :func:`seal_schema` and :func:`assert_schema_sealed` make a JSON Schema
+  strict (no additional properties) and assert that it is.
+* :class:`UserOwnedFieldRegistry` maps a schema id to the set of fields
+  that the model must never write.
+* :func:`strip_user_owned_fields` removes blacklisted keys from an
+  incoming AI update and logs an ``AIWriteRejected`` event naming the
+  schema and the rejected fields.
+* :class:`SchemaViolation` and :func:`classify_schema_violation` let the
+  API-level error path mark ``additional_properties`` rejections as a
+  bounded, retryable schema fault rather than an opaque error.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+__all__ = [
+    "USER_OWNED_FIELDS",
+    "AIWriteRejected",
+    "SchemaViolation",
+    "UserOwnedFieldRegistry",
+    "assert_schema_sealed",
+    "classify_schema_violation",
+    "default_user_owned_registry",
+    "seal_schema",
+    "strip_user_owned_fields",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# User-owned field blacklist
+# ---------------------------------------------------------------------------
+
+
+USER_OWNED_FIELDS: frozenset[str] = frozenset(
+    {
+        "user_notes",
+        "operator_overrides",
+        "id",
+        "created_at",
+    }
+)
+"""Default set of operator-owned fields the model must never write.
+
+These fields are managed by operators or by the store, not by AI output.
+An AI update that touches any of them is stripped before merge. Schemas
+may extend this set via :class:`UserOwnedFieldRegistry`.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class AIWriteRejected:
+    """Audit record for a rejected AI write of an operator-owned field.
+
+    Emitted whenever :func:`strip_user_owned_fields` removes one or more
+    blacklisted keys from an incoming AI update. The record names the
+    schema and the rejected fields so the audit surface can attribute the
+    attempt without inspecting the raw payload.
+
+    Attributes:
+        schema: Stable schema id (or logical name) the update targeted.
+        fields: Sorted tuple of the rejected field names.
+    """
+
+    schema: str
+    fields: tuple[str, ...]
+
+    def __str__(self) -> str:
+        joined = ", ".join(self.fields)
+        return f"AIWriteRejected{{schema={self.schema!r}, fields=[{joined}]}}"
+
+
+class UserOwnedFieldRegistry:
+    """Per-schema registry of operator-owned (AI-write-forbidden) fields.
+
+    Each schema id maps to the set of fields the model must never write.
+    The default set (:data:`USER_OWNED_FIELDS`) applies to every schema;
+    per-schema entries add to it rather than replacing it, so the global
+    floor is never weakened by a per-schema registration.
+    """
+
+    def __init__(self, default_fields: Iterable[str] = USER_OWNED_FIELDS) -> None:
+        self._default: frozenset[str] = frozenset(default_fields)
+        self._by_schema: dict[str, frozenset[str]] = {}
+
+    def register(self, schema_id: str, fields: Iterable[str]) -> None:
+        """Register additional user-owned *fields* for *schema_id*.
+
+        The registered fields are unioned with the global default set;
+        re-registering a schema id replaces only its per-schema extras.
+        """
+        self._by_schema[schema_id] = frozenset(fields)
+
+    def fields_for(self, schema_id: str) -> frozenset[str]:
+        """Return the full user-owned field set for *schema_id*.
+
+        The global default is always included so an unregistered schema id
+        still protects the floor fields.
+        """
+        return self._default | self._by_schema.get(schema_id, frozenset())
+
+
+_DEFAULT_REGISTRY = UserOwnedFieldRegistry()
+
+
+def default_user_owned_registry() -> UserOwnedFieldRegistry:
+    """Return the process-wide default :class:`UserOwnedFieldRegistry`."""
+    return _DEFAULT_REGISTRY
+
+
+def strip_user_owned_fields(
+    schema_id: str,
+    update: Mapping[str, Any],
+    *,
+    registry: UserOwnedFieldRegistry | None = None,
+) -> tuple[dict[str, Any], AIWriteRejected | None]:
+    """Strip operator-owned fields from an incoming AI *update*.
+
+    Any key in the schema's user-owned field set is removed from a copy of
+    *update* before the merge layer sees it. When at least one field is
+    stripped, an ``AIWriteRejected`` event is logged and returned so the
+    caller can surface it on the audit trail.
+
+    Args:
+        schema_id: Stable schema id (or logical name) the update targets.
+        update: Decoded AI update mapping. Not mutated.
+        registry: Override registry; defaults to the process-wide one.
+
+    Returns:
+        A ``(safe_update, rejected)`` pair. ``safe_update`` is a new dict
+        with blacklisted keys removed. ``rejected`` is ``None`` when no
+        field was stripped, else the :class:`AIWriteRejected` record.
+    """
+    reg = registry or _DEFAULT_REGISTRY
+    owned = reg.fields_for(schema_id)
+    safe: dict[str, Any] = {}
+    rejected_fields: list[str] = []
+    for key, value in update.items():
+        if key in owned:
+            rejected_fields.append(key)
+            continue
+        safe[key] = value
+    if not rejected_fields:
+        return safe, None
+    record = AIWriteRejected(schema=schema_id, fields=tuple(sorted(rejected_fields)))
+    logger.warning(
+        "AIWriteRejected schema=%s rejected operator-owned fields=%s",
+        schema_id,
+        ", ".join(record.fields),
+        extra={"schema": schema_id, "rejected_fields": list(record.fields)},
+    )
+    return safe, record
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema sealing (additionalProperties: false)
+# ---------------------------------------------------------------------------
+
+
+def seal_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *schema* with object nodes sealed against extras.
+
+    Recursively sets ``additionalProperties: false`` on every object node
+    that declares ``properties``. Nodes that already pin
+    ``additionalProperties`` (to any value) are left untouched so a schema
+    that deliberately opens a sub-object is not silently re-sealed.
+
+    Args:
+        schema: A JSON Schema mapping. Not mutated.
+
+    Returns:
+        A new schema dict with object nodes sealed.
+    """
+
+    def _seal(node: object) -> object:
+        if isinstance(node, dict):
+            mapping = cast("dict[str, Any]", node)
+            sealed: dict[str, Any] = {key: _seal(value) for key, value in mapping.items()}
+            if "properties" in sealed and "additionalProperties" not in sealed:
+                sealed["additionalProperties"] = False
+            return sealed
+        if isinstance(node, list):
+            items = cast("list[Any]", node)
+            return [_seal(item) for item in items]
+        return node
+
+    return cast("dict[str, Any]", _seal(schema))
+
+
+def assert_schema_sealed(schema: Mapping[str, Any]) -> None:
+    """Raise :class:`ValueError` if any object node permits extra keys.
+
+    Walks the schema and fails on the first object node that declares
+    ``properties`` without ``additionalProperties: false``. Use this in
+    tests and at registration time to prove a structured-output schema
+    cannot accept hallucinated keys.
+
+    Args:
+        schema: A JSON Schema mapping.
+
+    Raises:
+        ValueError: If any object node leaves additional properties open.
+    """
+
+    def _walk(node: object, path: str) -> None:
+        if isinstance(node, dict):
+            mapping = cast("dict[str, Any]", node)
+            if "properties" in mapping and mapping.get("additionalProperties") is not False:
+                location = path or "<root>"
+                msg = f"object node at {location} does not seal additionalProperties"
+                raise ValueError(msg)
+            for key, value in mapping.items():
+                _walk(value, f"{path}/{key}" if path else str(key))
+        elif isinstance(node, list):
+            items = cast("list[Any]", node)
+            for index, item in enumerate(items):
+                _walk(item, f"{path}/{index}")
+
+    _walk(dict(schema), "")
+
+
+# ---------------------------------------------------------------------------
+# Provider error classification
+# ---------------------------------------------------------------------------
+
+
+class SchemaViolation(ValueError):
+    """A structured-output response violated its strict schema.
+
+    Carries the offending fields (when known) so the retry path can bound
+    its attempts: a schema violation is deterministic, so an unbounded
+    retry would loop. Callers should treat this as a non-transient fault.
+
+    Attributes:
+        fields: Field names the provider flagged as additional / invalid.
+            Empty when the provider did not name them.
+    """
+
+    def __init__(self, message: str, fields: tuple[str, ...] = ()) -> None:
+        super().__init__(message)
+        self.fields = fields
+
+
+# Substrings that providers and the local validator use to flag a payload
+# carrying keys the schema did not declare. Compared case-insensitively.
+_ADDITIONAL_PROPERTY_MARKERS: tuple[str, ...] = (
+    "additionalproperties",
+    "additional properties",
+    "additional_properties",
+    "extra fields not permitted",
+    "unexpected keyword argument",
+    "is not allowed",
+)
+
+_FIELD_NAME_RE = re.compile(r"'([^']+)'")
+
+
+def classify_schema_violation(error: Exception | str) -> SchemaViolation | None:
+    """Classify *error* as a strict-schema ``additional_properties`` fault.
+
+    Inspects the rendered error message for the markers providers use when
+    a structured-output payload carried undeclared keys. When matched,
+    returns a :class:`SchemaViolation` (with any quoted field names lifted
+    from the message); otherwise returns ``None`` so the caller can fall
+    back to its general error path.
+
+    Args:
+        error: The raised exception or a pre-rendered provider message.
+
+    Returns:
+        A :class:`SchemaViolation` when the error is an additional-property
+        rejection, else ``None``.
+    """
+    message = str(error)
+    lowered = message.lower()
+    if not any(marker in lowered for marker in _ADDITIONAL_PROPERTY_MARKERS):
+        return None
+    fields = tuple(_FIELD_NAME_RE.findall(message))
+    return SchemaViolation(
+        f"structured output rejected for additional properties: {message}",
+        fields=fields,
+    )

--- a/src/bernstein/core/orchestration/refinement_schemas.py
+++ b/src/bernstein/core/orchestration/refinement_schemas.py
@@ -18,11 +18,41 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+from bernstein.adapters.strict_schema import SchemaViolation
+
 __all__ = [
+    "CRITIQUE_ALLOWED_FIELDS",
+    "CRITIQUE_ISSUE_ALLOWED_FIELDS",
+    "CRITIQUE_SCHEMA_ID",
     "Critique",
     "CritiqueIssue",
     "clamp_score",
 ]
+
+CRITIQUE_SCHEMA_ID = "bernstein://refinement/critique/v1"
+"""Stable schema id for the per-round critique payload."""
+
+CRITIQUE_ISSUE_ALLOWED_FIELDS: frozenset[str] = frozenset({"severity", "message", "suggestion"})
+"""Keys a model may emit for a single critique issue."""
+
+CRITIQUE_ALLOWED_FIELDS: frozenset[str] = frozenset({"score", "issues", "veto", "rationale"})
+"""Keys a model may emit for a critique payload."""
+
+
+def _reject_extra_keys(data: dict[str, Any], allowed: frozenset[str], where: str) -> None:
+    """Raise :class:`SchemaViolation` if *data* carries undeclared keys.
+
+    Mirrors ``additionalProperties: false`` for the dataclass-backed
+    critique payload so a hallucinated key is rejected at parse time
+    rather than silently dropped.
+    """
+    extras = sorted(set(data) - allowed)
+    if extras:
+        joined = ", ".join(extras)
+        raise SchemaViolation(
+            f"{where} carried undeclared fields (additionalProperties): {joined}",
+            fields=tuple(extras),
+        )
 
 
 def clamp_score(value: float) -> float:
@@ -80,6 +110,17 @@ class CritiqueIssue:
             suggestion=str(data.get("suggestion", "")),
         )
 
+    @classmethod
+    def from_dict_strict(cls, data: dict[str, Any]) -> CritiqueIssue:
+        """Build a :class:`CritiqueIssue`, rejecting any undeclared key.
+
+        Raises:
+            SchemaViolation: If *data* carries a key outside
+                :data:`CRITIQUE_ISSUE_ALLOWED_FIELDS`.
+        """
+        _reject_extra_keys(data, CRITIQUE_ISSUE_ALLOWED_FIELDS, "critique issue")
+        return cls.from_dict(data)
+
 
 @dataclass(frozen=True)
 class Critique:
@@ -126,6 +167,33 @@ class Critique:
             for entry in raw_issues:
                 if isinstance(entry, dict):
                     issues.append(CritiqueIssue.from_dict(cast(dict[str, Any], entry)))
+        return cls(
+            score=clamp_score(float(data.get("score", 0.0))),
+            issues=issues,
+            veto=bool(data.get("veto", False)),
+            rationale=str(data.get("rationale", "")),
+        )
+
+    @classmethod
+    def from_dict_strict(cls, data: dict[str, Any]) -> Critique:
+        """Build a :class:`Critique`, rejecting any undeclared key.
+
+        Use on the AI-output parse path: a hallucinated top-level key (or a
+        hallucinated key inside any issue) raises rather than being
+        silently dropped, so the runner can bound its retries.
+
+        Raises:
+            SchemaViolation: If the payload or any issue carries a key
+                outside the declared field set.
+        """
+        _reject_extra_keys(data, CRITIQUE_ALLOWED_FIELDS, "critique")
+        raw_issues_any: Any = data.get("issues", []) or []
+        issues: list[CritiqueIssue] = []
+        if isinstance(raw_issues_any, list):
+            raw_issues = cast(list[Any], raw_issues_any)
+            for entry in raw_issues:
+                if isinstance(entry, dict):
+                    issues.append(CritiqueIssue.from_dict_strict(cast(dict[str, Any], entry)))
         return cls(
             score=clamp_score(float(data.get("score", 0.0))),
             issues=issues,

--- a/tests/fixtures/adapter_outputs/critique_valid.json
+++ b/tests/fixtures/adapter_outputs/critique_valid.json
@@ -1,0 +1,16 @@
+{
+  "score": 0.72,
+  "issues": [
+    {
+      "severity": "high",
+      "message": "missing error handling on the parse path",
+      "suggestion": "wrap the decode in a try/except and classify the fault"
+    },
+    {
+      "severity": "low",
+      "message": "docstring omits the raises section"
+    }
+  ],
+  "veto": false,
+  "rationale": "close to acceptance once the parse path is hardened"
+}

--- a/tests/fixtures/adapter_outputs/legacy/README.md
+++ b/tests/fixtures/adapter_outputs/legacy/README.md
@@ -1,0 +1,13 @@
+# Legacy adapter-output fixtures
+
+Fixtures in this folder were tolerated before the strict structured-output
+contract landed. Each one carries a key the schema no longer accepts.
+
+They are kept as regression fixtures: the migration test asserts that every
+file here is rejected under strict mode, proving the strict contract is what
+moved them out of the main fixture set. They are never parsed by production
+code.
+
+The main fixture set (the parent folder) must parse cleanly under strict
+mode. Add a new strict-clean fixture there; add a previously-tolerated payload
+here.

--- a/tests/fixtures/adapter_outputs/legacy/research_phase_extra_field.json
+++ b/tests/fixtures/adapter_outputs/legacy/research_phase_extra_field.json
@@ -1,0 +1,10 @@
+{
+  "schema": "research",
+  "payload": {
+    "summary": "scanned the orchestrator package and located the artefact boundary",
+    "decisions": ["reuse the existing TaskStore"],
+    "constraints": ["python 3.12"],
+    "open_questions": ["how does the batch policy interact with re-fire?"],
+    "hallucinated_field": "this key was tolerated before the strict contract"
+  }
+}

--- a/tests/fixtures/adapter_outputs/research_phase_valid.json
+++ b/tests/fixtures/adapter_outputs/research_phase_valid.json
@@ -1,0 +1,9 @@
+{
+  "schema": "research",
+  "payload": {
+    "summary": "scanned the orchestrator package and located the artefact boundary",
+    "decisions": ["reuse the existing TaskStore"],
+    "constraints": ["python 3.12"],
+    "open_questions": ["how does the batch policy interact with re-fire?"]
+  }
+}

--- a/tests/fixtures/adapter_outputs/verify_phase_valid.json
+++ b/tests/fixtures/adapter_outputs/verify_phase_valid.json
@@ -1,0 +1,10 @@
+{
+  "schema": "verify",
+  "payload": {
+    "summary": "all boundary gates passed and the verifier accepted the artefact",
+    "decisions": ["accept"],
+    "constraints": [],
+    "open_questions": [],
+    "verdict": "pass"
+  }
+}

--- a/tests/unit/adapters/test_strict_schema_fixtures.py
+++ b/tests/unit/adapters/test_strict_schema_fixtures.py
@@ -1,0 +1,67 @@
+"""Migration test for adapter-output fixtures under the strict contract.
+
+Every fixture under ``tests/fixtures/adapter_outputs/`` must parse cleanly
+under strict mode. Fixtures that carried previously-tolerated extras live
+under ``legacy/`` and must be rejected, proving the strict contract is what
+moved them.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.adapters.strict_schema import SchemaViolation
+from bernstein.core.orchestration.phase_schemas import validate_phase_output
+from bernstein.core.orchestration.refinement_schemas import Critique
+
+_FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "fixtures" / "adapter_outputs"
+
+
+def _strict_fixtures() -> list[Path]:
+    return sorted(p for p in _FIXTURE_ROOT.glob("*.json"))
+
+
+def _legacy_fixtures() -> list[Path]:
+    return sorted(p for p in (_FIXTURE_ROOT / "legacy").glob("*.json"))
+
+
+def _parse_strict(payload: dict[str, Any]) -> None:
+    """Parse *payload* under the strict contract, raising on any violation.
+
+    Phase fixtures wrap their artefact under ``{"schema": ..., "payload":
+    ...}``; critique fixtures are the bare payload.
+    """
+    schema = payload.get("schema")
+    if isinstance(schema, str):
+        errors = validate_phase_output(schema, payload["payload"])
+        if errors:
+            raise SchemaViolation(
+                f"phase {schema} fixture rejected: {errors[0].field_path}: {errors[0].message}",
+                fields=(errors[0].field_path,),
+            )
+        return
+    # Bare critique payload.
+    Critique.from_dict_strict(payload)
+
+
+def test_fixture_root_is_present() -> None:
+    assert _FIXTURE_ROOT.is_dir()
+    assert _strict_fixtures(), "expected at least one strict-clean fixture"
+    assert _legacy_fixtures(), "expected at least one legacy regression fixture"
+
+
+@pytest.mark.parametrize("fixture", _strict_fixtures(), ids=lambda p: p.name)
+def test_strict_fixture_parses_cleanly(fixture: Path) -> None:
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    _parse_strict(payload)  # must not raise
+
+
+@pytest.mark.parametrize("fixture", _legacy_fixtures(), ids=lambda p: p.name)
+def test_legacy_fixture_rejected_under_strict_mode(fixture: Path) -> None:
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    with pytest.raises(SchemaViolation):
+        _parse_strict(payload)

--- a/tests/unit/adapters/test_strict_schemas.py
+++ b/tests/unit/adapters/test_strict_schemas.py
@@ -1,0 +1,213 @@
+"""Unit tests for the strict structured-output schema primitives.
+
+Covers the three contract guarantees:
+
+* forbid: extra keys are rejected, never silently dropped;
+* blacklist: operator-owned fields are stripped before merge and the
+  attempt is recorded;
+* provider error classification: additional-property rejections map to a
+  bounded :class:`SchemaViolation`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bernstein.adapters.strict_schema import (
+    USER_OWNED_FIELDS,
+    AIWriteRejected,
+    SchemaViolation,
+    UserOwnedFieldRegistry,
+    assert_schema_sealed,
+    classify_schema_violation,
+    seal_schema,
+    strip_user_owned_fields,
+)
+from bernstein.core.orchestration.refinement_schemas import (
+    CRITIQUE_SCHEMA_ID,
+    Critique,
+)
+
+# ---------------------------------------------------------------------------
+# forbid: extra keys rejected
+# ---------------------------------------------------------------------------
+
+
+def test_seal_schema_seals_object_nodes() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "nested": {
+                "type": "object",
+                "properties": {"inner": {"type": "string"}},
+            },
+        },
+    }
+    sealed = seal_schema(schema)
+    assert sealed["additionalProperties"] is False
+    assert sealed["properties"]["nested"]["additionalProperties"] is False
+    # Original is not mutated.
+    assert "additionalProperties" not in schema
+
+
+def test_seal_schema_respects_explicit_open_node() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"freeform": {"type": "object", "additionalProperties": True}},
+    }
+    sealed = seal_schema(schema)
+    assert sealed["properties"]["freeform"]["additionalProperties"] is True
+
+
+def test_assert_schema_sealed_passes_for_sealed_schema() -> None:
+    schema = seal_schema({"type": "object", "properties": {"name": {"type": "string"}}})
+    assert_schema_sealed(schema)  # must not raise
+
+
+def test_assert_schema_sealed_rejects_open_schema() -> None:
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    with pytest.raises(ValueError, match="additionalProperties"):
+        assert_schema_sealed(schema)
+
+
+def test_critique_strict_rejects_extra_field() -> None:
+    payload = {
+        "score": 0.5,
+        "issues": [],
+        "veto": False,
+        "rationale": "ok",
+        "hallucinated": "leak",
+    }
+    with pytest.raises(SchemaViolation) as excinfo:
+        Critique.from_dict_strict(payload)
+    assert "hallucinated" in excinfo.value.fields
+
+
+def test_critique_strict_rejects_extra_field_inside_issue() -> None:
+    payload = {
+        "score": 0.5,
+        "issues": [{"severity": "low", "message": "x", "rogue": "leak"}],
+    }
+    with pytest.raises(SchemaViolation) as excinfo:
+        Critique.from_dict_strict(payload)
+    assert "rogue" in excinfo.value.fields
+
+
+# ---------------------------------------------------------------------------
+# valid passes
+# ---------------------------------------------------------------------------
+
+
+def test_critique_strict_accepts_valid_payload() -> None:
+    payload = {
+        "score": 0.8,
+        "issues": [{"severity": "high", "message": "fix the parse path"}],
+        "veto": False,
+        "rationale": "almost there",
+    }
+    critique = Critique.from_dict_strict(payload)
+    assert critique.score == pytest.approx(0.8)
+    assert critique.issues[0].severity == "high"
+
+
+def test_critique_strict_accepts_minimal_payload() -> None:
+    critique = Critique.from_dict_strict({"score": 0.0})
+    assert critique.score == 0.0
+    assert critique.issues == []
+
+
+# ---------------------------------------------------------------------------
+# blacklist: operator-owned fields stripped
+# ---------------------------------------------------------------------------
+
+
+def test_strip_user_owned_fields_removes_blacklisted_keys() -> None:
+    update = {
+        "summary": "model wrote this",
+        "id": "task-123",
+        "user_notes": "operator only",
+        "created_at": "2026-01-01",
+    }
+    safe, rejected = strip_user_owned_fields(CRITIQUE_SCHEMA_ID, update)
+    assert safe == {"summary": "model wrote this"}
+    assert rejected is not None
+    assert rejected.schema == CRITIQUE_SCHEMA_ID
+    assert set(rejected.fields) == {"id", "user_notes", "created_at"}
+
+
+def test_strip_user_owned_fields_passes_clean_update() -> None:
+    update = {"summary": "clean", "decisions": ["a"]}
+    safe, rejected = strip_user_owned_fields(CRITIQUE_SCHEMA_ID, update)
+    assert safe == update
+    assert safe is not update  # a copy, never the caller's mapping
+    assert rejected is None
+
+
+def test_strip_user_owned_fields_logs_rejection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    update = {"summary": "x", "operator_overrides": {"priority": "high"}}
+    with caplog.at_level(logging.WARNING, logger="bernstein.adapters.strict_schema"):
+        _, rejected = strip_user_owned_fields("schema://x", update)
+    assert rejected is not None
+    assert any("AIWriteRejected" in record.message for record in caplog.records)
+
+
+def test_registry_unions_with_global_default() -> None:
+    registry = UserOwnedFieldRegistry()
+    registry.register("schema://x", {"tags"})
+    fields = registry.fields_for("schema://x")
+    assert "tags" in fields
+    # Global floor is never weakened by a per-schema registration.
+    assert fields >= USER_OWNED_FIELDS
+
+
+def test_registry_default_floor_for_unregistered_schema() -> None:
+    registry = UserOwnedFieldRegistry()
+    assert registry.fields_for("schema://unknown") == USER_OWNED_FIELDS
+
+
+def test_ai_write_rejected_str_names_schema_and_fields() -> None:
+    record = AIWriteRejected(schema="schema://x", fields=("id", "user_notes"))
+    text = str(record)
+    assert "schema://x" in text
+    assert "id" in text
+    assert "user_notes" in text
+
+
+# ---------------------------------------------------------------------------
+# provider error classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Additional properties are not allowed ('rogue' was unexpected)",
+        "response did not match schema: additionalProperties 'extra'",
+        "extra fields not permitted",
+        "__init__() got an unexpected keyword argument 'rogue'",
+    ],
+)
+def test_classify_schema_violation_detects_additional_properties(message: str) -> None:
+    violation = classify_schema_violation(message)
+    assert isinstance(violation, SchemaViolation)
+
+
+def test_classify_schema_violation_lifts_field_names() -> None:
+    violation = classify_schema_violation("Additional properties are not allowed ('rogue' was unexpected)")
+    assert violation is not None
+    assert "rogue" in violation.fields
+
+
+def test_classify_schema_violation_ignores_unrelated_error() -> None:
+    assert classify_schema_violation("connection reset by peer") is None
+
+
+def test_classify_schema_violation_accepts_exception() -> None:
+    err = ValueError("additionalProperties: 'x' not permitted")
+    violation = classify_schema_violation(err)
+    assert isinstance(violation, SchemaViolation)


### PR DESCRIPTION
## Summary
- Add `bernstein.adapters.strict_schema`: `seal_schema` / `assert_schema_sealed` enforce `additionalProperties: false` on JSON Schema object nodes; `USER_OWNED_FIELDS` plus `UserOwnedFieldRegistry` name operator-owned fields; `strip_user_owned_fields` removes blacklisted keys before merge and logs `AIWriteRejected{schema, fields}`; `SchemaViolation` plus `classify_schema_violation` map additional-property rejections to a bounded, non-transient fault.
- Give `Critique` a `from_dict_strict` parse path that rejects undeclared top-level and per-issue keys instead of dropping them silently.
- Add fixtures under `tests/fixtures/adapter_outputs/` (strict-clean) and `legacy/` (previously-tolerated extras) with a migration test.
- Docs at `docs/adapters/schemas.md` describing the strict contract and the user-owned-field registry.

## Test plan
- [x] `pytest tests/unit/adapters/test_strict_schemas.py tests/unit/adapters/test_strict_schema_fixtures.py` (26 passed)
- [x] `pytest tests/unit/test_phase_schemas.py tests/unit/test_refinement_loop.py tests/unit/adapters/` (302 passed)
- [x] `ruff check`, `ruff format --check`, `pyright` clean on changed source
- [x] `lint-imports` all contracts kept

Closes #1633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict structured-output schema validation to prevent AI models from generating undeclared fields.
  * Implemented protection for user-owned fields (e.g., `user_notes`, `id`, `created_at`) that AI outputs cannot overwrite.
  * Added schema violation error classification for deterministic retry handling.

* **Documentation**
  * Added comprehensive guide on strict output schemas for adapter integration.

* **Tests**
  * Added test coverage for strict schema validation and field sanitization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->