### PR TITLE
feat(cli): memorable deterministic run names in user surfaces

### DIFF
--- a/docs/operations/run_names.md
+++ b/docs/operations/run_names.md
@@ -1,0 +1,96 @@
+# Memorable run names
+
+Audience: operators triaging multiple parallel runs who need a short,
+readable handle for a run instead of a seven-character UUID prefix.
+
+## Overview
+
+Run ids stay UUIDs internally. User-facing surfaces (CLI status output,
+the run-archive summary) additionally show a deterministic memorable name
+derived from the UUID, for example `swift-otter-07`. The UUID still
+appears in detail views and machine-readable output, so nothing changes
+for tooling that keys on the id.
+
+The mapping is pure: the same UUID always renders to the same name. Logs,
+dashboards, and status panels therefore stay consistent across restarts
+and versions.
+
+Source:
+
+- `src/bernstein/cli/run_names.py` (rendering and reverse lookup helpers)
+- `src/bernstein/cli/commands/run_names_cmd.py` (`run-lookup` command)
+
+## Name format
+
+A rendered name is `<adjective>-<noun>-<NN>`:
+
+- `adjective` and `noun` come from two fixed, checked-in word lists.
+- Words are English-only, lowercase, at most 8 characters, unambiguous,
+  and non-product-specific.
+- `NN` is a stable, zero-padded two-digit suffix (`00`-`99`).
+
+The total name space is `len(ADJECTIVES) * len(NOUNS) * 100`.
+
+## Rendering rule
+
+`render_name(run_id)` derives the name as follows:
+
+1. Compute `digest = blake2b(run_id.bytes, digest_size=8)` and read it as a
+   big-endian unsigned 64-bit integer `h`. Hashing (rather than using the
+   raw UUID integer) spreads adjacent or structured ids across the word
+   space so they do not cluster onto neighbouring names.
+2. `adjective = ADJECTIVES[h % len(ADJECTIVES)]`.
+3. `noun = NOUNS[(h // len(ADJECTIVES)) % len(NOUNS)]`.
+4. `suffix = (h // (len(ADJECTIVES) * len(NOUNS))) % 100`, rendered as two
+   digits.
+
+BLAKE2b is keyed on the raw 16 UUID bytes only, so the result does not
+depend on the platform hash seed and stays identical across Python
+versions and machines.
+
+### Stability guarantee
+
+Changing the word lists or the recipe would change every rendered name and
+break stored references in logs and dashboards. Treat both as a stable
+public contract; the test suite pins a golden value to catch accidental
+drift.
+
+## Collisions
+
+Because 128 UUID bits cannot fit into the finite name space, the mapping is
+not globally bijective: distinct UUIDs can render to the same name. The
+collision probability is governed by the birthday bound and is low for the
+handful of runs an operator triages at once.
+
+When a reverse mapping is needed:
+
+- `build_lookup(run_ids)` builds a name -> UUID map over a *known* set of
+  ids, first-writer-wins.
+- `find_collisions(run_ids)` reports any name shared by two or more of the
+  supplied ids. Callers (for example a server populating a fleet view) can
+  log this at startup as a configuration warning.
+
+## Lookup command
+
+`bernstein run-lookup NAME` resolves a memorable name back to its run
+UUID. It searches the active run id (read from `.sdd/runtime/run_id`) plus
+any ids passed with `--candidate`:
+
+```text
+bernstein run-lookup swift-otter-07
+bernstein run-lookup swift-otter-07 --candidate <uuid> --candidate <uuid>
+bernstein run-lookup swift-otter-07 --workspace-root /path/to/project
+```
+
+Exit codes:
+
+- `0` - one or more known ids render to NAME (printed one per line).
+- `1` - NAME is well-formed but no known id renders to it.
+- `2` - NAME is malformed (not `<adjective>-<noun>-NN`).
+
+When more than one known id renders to NAME, the command prints a warning
+before listing all matching UUIDs.
+
+## Tested via
+
+- `pytest tests/unit/cli/test_run_names.py`

--- a/src/bernstein/cli/commands/run_names_cmd.py
+++ b/src/bernstein/cli/commands/run_names_cmd.py
@@ -1,0 +1,93 @@
+"""``bernstein run-lookup`` command: resolve a memorable run name (#1626).
+
+User-facing surfaces render a deterministic ``<adjective>-<noun>-<NN>``
+name from a run UUID (see :mod:`bernstein.cli.run_names`). This command
+provides the reverse direction: given a memorable name and a set of known
+run ids, print the UUID(s) that render to it.
+
+Run ids are read from ``.sdd/runtime/run_id`` (the active run) plus any
+ids supplied with ``--candidate``; this keeps the lookup self-contained
+without reaching into a server endpoint.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from uuid import UUID
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.cli.run_names import find_collisions, is_run_name, render_name
+
+__all__ = ["run_lookup_cmd"]
+
+
+def _read_active_run_id(workspace_root: Path) -> UUID | None:
+    """Return the active run id from ``.sdd/runtime/run_id`` if present."""
+    run_id_path = workspace_root / ".sdd" / "runtime" / "run_id"
+    if not run_id_path.is_file():
+        return None
+    raw = run_id_path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        return None
+
+
+def _collect_candidates(workspace_root: Path, extra: tuple[str, ...]) -> list[UUID]:
+    """Gather candidate run ids from the workspace and CLI flags."""
+    candidates: list[UUID] = []
+    active = _read_active_run_id(workspace_root)
+    if active is not None:
+        candidates.append(active)
+    for value in extra:
+        try:
+            parsed = UUID(value)
+        except ValueError as exc:
+            raise click.BadParameter(f"not a valid UUID: {value}") from exc
+        candidates.append(parsed)
+    return candidates
+
+
+@click.command("run-lookup")
+@click.argument("name")
+@click.option(
+    "--workspace-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="Workspace root holding .sdd/runtime/run_id. Defaults to cwd.",
+)
+@click.option(
+    "--candidate",
+    "candidates",
+    multiple=True,
+    metavar="UUID",
+    help="Extra run UUID to consider. May be repeated.",
+)
+def run_lookup_cmd(name: str, workspace_root: Path | None, candidates: tuple[str, ...]) -> None:
+    """Resolve a memorable run NAME back to its run UUID.
+
+    Exits non-zero when NAME is malformed or no known run id renders to it.
+    """
+    if not is_run_name(name):
+        console.print(f"[red]'{name}' is not a valid run name (expected <adjective>-<noun>-NN).[/red]")
+        sys.exit(2)
+
+    root = workspace_root or Path.cwd()
+    known = _collect_candidates(root, candidates)
+
+    matches = [run_id for run_id in known if render_name(run_id) == name]
+    if not matches:
+        console.print(f"[yellow]No known run id renders to '{name}'.[/yellow]")
+        console.print("[dim]Pass run UUIDs with --candidate to widen the search.[/dim]")
+        sys.exit(1)
+
+    collisions = find_collisions(known)
+    if name in collisions:
+        console.print(f"[yellow]Warning: '{name}' is shared by {len(matches)} run ids.[/yellow]")
+    for run_id in matches:
+        console.print(str(run_id))

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -67,6 +67,7 @@ from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.integrations_cmd import integrations_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
+from bernstein.cli.commands.run_names_cmd import run_lookup_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.commands.spec_cmd import spec_group
@@ -1008,6 +1009,7 @@ cli.add_command(merge_cmd, "merge")
 cli.add_command(migrate_cmd, "migrate")
 cli.add_command(changelog_cmd, "changelog")
 cli.add_command(run_changelog_cmd, "run-changelog")
+cli.add_command(run_lookup_cmd, "run-lookup")
 cli.add_command(dr_group, "dr")
 cli.add_command(incident_cmd, "incident")
 cli.add_command(profile_cmd, "profile")

--- a/src/bernstein/cli/run_archive.py
+++ b/src/bernstein/cli/run_archive.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import bernstein
+from bernstein.cli.run_names import render_name
 
 # ---------------------------------------------------------------------------
 # Manifest
@@ -147,9 +148,22 @@ def format_archive_summary(manifest: ArchiveManifest) -> str:
         "===============",
         f"Created:   {manifest.created_at}",
         f"Version:   {manifest.bernstein_version}",
+        f"Run name:  {_archive_run_name(manifest.run_id)}",
         f"Run ID:    {manifest.run_id or '(none)'}",
         f"Files:     {manifest.file_count}",
         f"Size:      {size_kb:.1f} KB",
         f"Sections:  {', '.join(manifest.sections) if manifest.sections else '(none)'}",
     ]
     return "\n".join(lines)
+
+
+def _archive_run_name(run_id: str | None) -> str:
+    """Render the memorable name for an archive run id, if valid."""
+    from uuid import UUID
+
+    if not run_id:
+        return "(none)"
+    try:
+        return render_name(UUID(run_id))
+    except ValueError:
+        return "(unnamed)"

--- a/src/bernstein/cli/run_names.py
+++ b/src/bernstein/cli/run_names.py
@@ -1,0 +1,298 @@
+"""Memorable deterministic run names for user-facing surfaces (#1626).
+
+Run ids stay UUIDs internally. This module renders a deterministic,
+memorable ``<adjective>-<noun>-<NN>`` label from a UUID so operators can
+read, type, and remember a run without copying a seven-character hex
+prefix between windows. The mapping is pure: the same UUID always renders
+to the same name, so logs, dashboards, and status panels stay consistent.
+
+Rendering recipe (documented and stable across versions):
+
+1. Take the UUID's 128-bit integer value (``UUID.int``).
+2. Derive a digest with ``blake2b(uuid.bytes, digest_size=8)`` and read it
+   as a big-endian unsigned integer ``h``. Using a hash (rather than the
+   raw int) spreads adjacent UUIDs across the word space so sequential or
+   structured ids do not cluster onto neighbouring names.
+3. ``adjective = ADJECTIVES[h % len(ADJECTIVES)]``.
+4. ``noun = NOUNS[(h // len(ADJECTIVES)) % len(NOUNS)]``.
+5. ``suffix = (h // (len(ADJECTIVES) * len(NOUNS))) % 100`` rendered as a
+   zero-padded two-digit number.
+
+The word lists are fixed, English-only, short (max 8 chars), unambiguous,
+and non-product-specific. The name space is
+``len(ADJECTIVES) * len(NOUNS) * 100`` distinct names; see
+:func:`name_space_size`. ``render_name`` is *not* globally bijective
+across all UUIDs (128 bits cannot fit in the name space), so callers that
+need a reverse lookup must track the names they have actually rendered;
+:func:`find_collisions` reports when two known UUIDs collide.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import defaultdict
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = [
+    "ADJECTIVES",
+    "MAX_WORD_LEN",
+    "NAME_RE",
+    "NOUNS",
+    "build_lookup",
+    "find_collisions",
+    "is_run_name",
+    "name_space_size",
+    "render_name",
+]
+
+# ---------------------------------------------------------------------------
+# Word lists
+# ---------------------------------------------------------------------------
+# Neutral, English-only, lowercase, max 8 characters, no product or themed
+# names. Kept sorted and de-duplicated; both lists have a power-of-friendly
+# length only by coincidence -- the recipe does not assume any size.
+
+ADJECTIVES: tuple[str, ...] = (
+    "amber",
+    "ample",
+    "arctic",
+    "brave",
+    "brisk",
+    "calm",
+    "clear",
+    "clever",
+    "cosmic",
+    "crisp",
+    "daring",
+    "dawn",
+    "deep",
+    "eager",
+    "early",
+    "fancy",
+    "fleet",
+    "fond",
+    "gentle",
+    "glad",
+    "golden",
+    "grand",
+    "happy",
+    "humble",
+    "ideal",
+    "jolly",
+    "keen",
+    "kind",
+    "lively",
+    "loyal",
+    "lucid",
+    "merry",
+    "mild",
+    "neat",
+    "noble",
+    "polite",
+    "prime",
+    "proud",
+    "quick",
+    "quiet",
+    "rapid",
+    "ready",
+    "royal",
+    "sharp",
+    "shiny",
+    "silent",
+    "smart",
+    "smooth",
+    "snug",
+    "solid",
+    "spry",
+    "steady",
+    "sunny",
+    "swift",
+    "tidy",
+    "trim",
+    "true",
+    "trusty",
+    "vivid",
+    "warm",
+    "witty",
+    "young",
+    "zesty",
+    "zippy",
+)
+
+NOUNS: tuple[str, ...] = (
+    "acorn",
+    "anchor",
+    "arbor",
+    "badger",
+    "basin",
+    "beacon",
+    "birch",
+    "bison",
+    "bramble",
+    "brook",
+    "canyon",
+    "cedar",
+    "cliff",
+    "comet",
+    "coral",
+    "cove",
+    "crane",
+    "delta",
+    "dune",
+    "eagle",
+    "ember",
+    "fern",
+    "field",
+    "finch",
+    "fjord",
+    "forest",
+    "garnet",
+    "geyser",
+    "glacier",
+    "grove",
+    "harbor",
+    "heron",
+    "island",
+    "ivy",
+    "jasper",
+    "kelp",
+    "lagoon",
+    "lake",
+    "lark",
+    "leaf",
+    "ledge",
+    "lichen",
+    "lotus",
+    "maple",
+    "marsh",
+    "meadow",
+    "mesa",
+    "moss",
+    "oasis",
+    "otter",
+    "pebble",
+    "petal",
+    "pine",
+    "plateau",
+    "pond",
+    "quail",
+    "quartz",
+    "raven",
+    "reef",
+    "ridge",
+    "river",
+    "robin",
+    "sable",
+    "shore",
+    "slate",
+    "sparrow",
+    "spruce",
+    "summit",
+    "tarn",
+    "thicket",
+    "tundra",
+    "valley",
+    "willow",
+    "wren",
+)
+
+MAX_WORD_LEN = 8
+
+# A rendered name is ``<word>-<word>-NN``. The suffix is always two digits.
+NAME_RE = re.compile(r"^[a-z]+-[a-z]+-\d{2}$")
+
+# Number of distinct two-digit suffixes (00..99).
+_SUFFIX_MODULO = 100
+
+
+def name_space_size() -> int:
+    """Return the count of distinct names ``render_name`` can produce."""
+    return len(ADJECTIVES) * len(NOUNS) * _SUFFIX_MODULO
+
+
+def _digest_int(run_id: UUID) -> int:
+    """Return a stable 64-bit integer digest of *run_id*.
+
+    Uses BLAKE2b over the UUID's raw 16 bytes so the mapping does not
+    depend on the platform hash seed and stays identical across Python
+    versions and runs.
+    """
+    digest = hashlib.blake2b(run_id.bytes, digest_size=8).digest()
+    return int.from_bytes(digest, byteorder="big", signed=False)
+
+
+def render_name(run_id: UUID) -> str:
+    """Render a deterministic ``<adjective>-<noun>-<NN>`` name for *run_id*.
+
+    Args:
+        run_id: The internal run UUID.
+
+    Returns:
+        A lowercase memorable name, for example ``"swift-otter-07"``.
+
+    Raises:
+        TypeError: If *run_id* is not a :class:`uuid.UUID`.
+    """
+    # Defensive runtime guard: callers feeding values parsed from JSON or
+    # untyped dicts may pass a str; the annotation alone does not protect us.
+    if not isinstance(run_id, UUID):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise TypeError(f"render_name expects a UUID, got {type(run_id).__name__}")
+
+    h = _digest_int(run_id)
+    adj_count = len(ADJECTIVES)
+    noun_count = len(NOUNS)
+
+    adjective = ADJECTIVES[h % adj_count]
+    noun = NOUNS[(h // adj_count) % noun_count]
+    suffix = (h // (adj_count * noun_count)) % _SUFFIX_MODULO
+    return f"{adjective}-{noun}-{suffix:02d}"
+
+
+def is_run_name(value: str) -> bool:
+    """Return ``True`` when *value* has the rendered run-name shape.
+
+    This is a shape check only; it does not confirm that any UUID renders
+    to *value*. Use :func:`build_lookup` for a verified reverse mapping.
+    """
+    return bool(NAME_RE.match(value))
+
+
+def build_lookup(run_ids: Iterable[UUID]) -> dict[str, UUID]:
+    """Build a name -> UUID lookup for a known set of run ids.
+
+    When two ids render to the same name, the first id encountered wins.
+    Use :func:`find_collisions` to detect such cases before relying on the
+    lookup.
+
+    Args:
+        run_ids: The run ids whose names should be resolvable.
+
+    Returns:
+        Mapping from rendered name to the first UUID that produced it.
+    """
+    lookup: dict[str, UUID] = {}
+    for run_id in run_ids:
+        name = render_name(run_id)
+        lookup.setdefault(name, run_id)
+    return lookup
+
+
+def find_collisions(run_ids: Iterable[UUID]) -> dict[str, list[UUID]]:
+    """Return names produced by more than one of the given *run_ids*.
+
+    Args:
+        run_ids: The run ids to check.
+
+    Returns:
+        Mapping from a colliding name to the list of UUIDs that render to
+        it (length >= 2). Empty when no collisions exist.
+    """
+    grouped: dict[str, list[UUID]] = defaultdict(list)
+    for run_id in run_ids:
+        grouped[render_name(run_id)].append(run_id)
+    return {name: ids for name, ids in grouped.items() if len(ids) > 1}

--- a/src/bernstein/cli/status.py
+++ b/src/bernstein/cli/status.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 from bernstein.adapters.base import RATE_LIMIT_WINDOW_SECONDS, get_rate_limit_meters
+from bernstein.cli.run_names import render_name
 from bernstein.cli.ui import (
     STATUS_COLORS,
     AgentInfo,
@@ -31,6 +32,27 @@ from bernstein.cli.ui import (
 from bernstein.core.view_mode import ViewConfig, ViewMode, get_view_config
 
 _STYLE_BOLD_CYAN = "bold cyan"
+
+
+def _derive_run_name(data: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Return ``(run_id, memorable_name)`` from the status payload.
+
+    The memorable name is rendered only when the payload carries a valid
+    UUID run id; otherwise both values fall back to whatever (possibly
+    ``None``) id the payload provided so the UUID still surfaces in
+    detail views.
+    """
+    from uuid import UUID
+
+    raw = data.get("run_id")
+    run_id = str(raw) if raw else None
+    if run_id is None:
+        return None, None
+    try:
+        return run_id, render_name(UUID(run_id))
+    except ValueError:
+        return run_id, None
+
 
 # ---------------------------------------------------------------------------
 # Task table
@@ -392,12 +414,15 @@ def _extract_run_stats(
     agents = [AgentInfo.from_dict(a) for a in agents_raw]
     elapsed = float(data.get("elapsed_seconds", 0))
     total_cost = _extract_spent_cost(data)
+    run_id, run_name = _derive_run_name(data)
 
     stats = RunStats(
         summary=summary,
         agents=agents,
         elapsed_seconds=elapsed,
         total_cost_usd=total_cost,
+        run_id=run_id,
+        run_name=run_name,
     )
     return tasks, agents, stats, per_role, provider_status, dependency_scan
 
@@ -432,6 +457,9 @@ def _render_verification_nudge(
 def _render_status_header(con: Console, stats: object, elapsed: float) -> None:
     """Render the task count status line and elapsed time."""
     summary = stats.summary  # type: ignore[attr-defined]
+    run_name = getattr(stats, "run_name", None)
+    if run_name:
+        con.print(Text.assemble(("Run: ", "bold"), (str(run_name), "bold cyan")))
     status_line = Text()
     status_line.append("Tasks: ", style="bold")
     status_line.append(f"{summary.total} total  ", style="bold")
@@ -605,11 +633,14 @@ def render_status_plain(data: dict[str, Any]) -> str:
     dependency_scan_obj = data.get("dependency_scan", {})
     dependency_scan = cast(_CAST_DICT_STR_ANY, dependency_scan_obj) if isinstance(dependency_scan_obj, dict) else {}
 
+    run_id, run_name = _derive_run_name(data)
     stats = RunStats(
         summary=summary,
         agents=agents,
         elapsed_seconds=elapsed,
         total_cost_usd=total_cost,
+        run_id=run_id,
+        run_name=run_name,
     )
     lineage_obj = data.get("lineage", {})
     lineage = cast(_CAST_DICT_STR_ANY, lineage_obj) if isinstance(lineage_obj, dict) else {}

--- a/src/bernstein/cli/ui.py
+++ b/src/bernstein/cli/ui.py
@@ -204,6 +204,8 @@ class RunStats:
     agents: list[AgentInfo] = field(default_factory=list[AgentInfo])
     elapsed_seconds: float = 0.0
     total_cost_usd: float = 0.0
+    run_id: str | None = None
+    run_name: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -574,6 +576,9 @@ def create_summary_table(stats: RunStats) -> Table:
     table.add_column("Value", justify="right", min_width=15)
 
     s = stats.summary
+    if stats.run_name:
+        table.add_row("Run", f"[bold]{stats.run_name}[/bold]")
+        table.add_section()
     table.add_row("Total tasks", str(s.total))
     table.add_row("[green]Done[/green]", f"[green]{s.done}[/green]")
     table.add_row("[yellow]In progress[/yellow]", f"[yellow]{s.in_progress}[/yellow]")
@@ -597,7 +602,10 @@ def create_summary_plain(stats: RunStats) -> str:
         A multi-line plain string.
     """
     s = stats.summary
-    lines = [
+    lines: list[str] = []
+    if stats.run_name:
+        lines.append(f"Run:           {stats.run_name}")
+    lines += [
         f"Total tasks: {s.total}",
         f"  Done:        {s.done}",
         f"  In progress: {s.in_progress}",

--- a/tests/unit/cli/test_run_names.py
+++ b/tests/unit/cli/test_run_names.py
@@ -1,0 +1,207 @@
+"""Tests for memorable deterministic run names (#1626)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.run_names_cmd import run_lookup_cmd
+from bernstein.cli.run_names import (
+    ADJECTIVES,
+    MAX_WORD_LEN,
+    NAME_RE,
+    NOUNS,
+    build_lookup,
+    find_collisions,
+    is_run_name,
+    name_space_size,
+    render_name,
+)
+
+_FIXED_UUID = uuid.UUID("12345678-1234-5678-1234-567812345678")
+
+
+# ---------------------------------------------------------------------------
+# Word-list hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("words", [ADJECTIVES, NOUNS], ids=["adjectives", "nouns"])
+def test_word_lists_are_sorted_unique_and_short(words: tuple[str, ...]) -> None:
+    assert list(words) == sorted(words), "word list must stay sorted for stable review diffs"
+    assert len(set(words)) == len(words), "word list must not contain duplicates"
+    for word in words:
+        assert word.isascii() and word.islower() and word.isalpha(), word
+        assert len(word) <= MAX_WORD_LEN, f"{word!r} exceeds MAX_WORD_LEN"
+
+
+def test_word_lists_are_non_empty() -> None:
+    assert ADJECTIVES
+    assert NOUNS
+
+
+# ---------------------------------------------------------------------------
+# Determinism / stability
+# ---------------------------------------------------------------------------
+
+
+def test_render_name_is_deterministic_for_same_id() -> None:
+    first = render_name(_FIXED_UUID)
+    second = render_name(uuid.UUID(str(_FIXED_UUID)))
+    assert first == second
+
+
+def test_render_name_is_stable_across_versions() -> None:
+    # Golden value: changing the recipe or word lists would break stored
+    # references in logs and dashboards, so this is a deliberate guard.
+    assert render_name(_FIXED_UUID) == "fancy-thicket-75"
+
+
+def test_render_name_independent_of_uuid_object_identity() -> None:
+    raw = "0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0"
+    assert render_name(uuid.UUID(raw)) == render_name(uuid.UUID(raw))
+
+
+def test_render_name_distinguishes_different_ids() -> None:
+    other = uuid.UUID("87654321-4321-8765-4321-876543210987")
+    assert render_name(_FIXED_UUID) != render_name(other)
+
+
+def test_render_name_rejects_non_uuid() -> None:
+    with pytest.raises(TypeError):
+        render_name("not-a-uuid")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Format
+# ---------------------------------------------------------------------------
+
+
+def test_render_name_matches_documented_format() -> None:
+    name = render_name(_FIXED_UUID)
+    assert NAME_RE.match(name)
+    assert is_run_name(name)
+    adjective, noun, suffix = name.split("-")
+    assert adjective in ADJECTIVES
+    assert noun in NOUNS
+    assert re.fullmatch(r"\d{2}", suffix)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("swift-otter-07", True),
+        ("calm-river-99", True),
+        ("Swift-otter-07", False),  # uppercase
+        ("swift-otter-7", False),  # one-digit suffix
+        ("swift-otter", False),  # missing suffix
+        ("swift_otter_07", False),  # wrong separator
+        ("swift-otter-100", False),  # three-digit suffix
+        ("", False),
+    ],
+)
+def test_is_run_name_shape(value: str, expected: bool) -> None:
+    assert is_run_name(value) is expected
+
+
+def test_all_names_match_format_over_sample() -> None:
+    for _ in range(1000):
+        name = render_name(uuid.uuid4())
+        assert is_run_name(name), name
+
+
+# ---------------------------------------------------------------------------
+# Collision resistance
+# ---------------------------------------------------------------------------
+
+
+def test_name_space_size_matches_word_lists() -> None:
+    assert name_space_size() == len(ADJECTIVES) * len(NOUNS) * 100
+
+
+def test_collision_rate_is_low_over_large_sample() -> None:
+    # 5000 random ids over a ~473k name space: by the birthday bound the
+    # expected collision count is well under 30. Assert a generous ceiling
+    # so the test is not flaky while still catching a degenerate recipe
+    # (e.g. one that ignores most of the digest).
+    sample = [uuid.uuid4() for _ in range(5000)]
+    collisions = find_collisions(sample)
+    colliding_ids = sum(len(ids) for ids in collisions.values())
+    assert colliding_ids < 100, f"unexpectedly high collision count: {colliding_ids}"
+
+
+def test_find_collisions_detects_known_clash() -> None:
+    sample = [uuid.uuid4() for _ in range(20000)]
+    collisions = find_collisions(sample)
+    # A 20k sample over 473k names is very likely to clash at least once.
+    if collisions:
+        for name, ids in collisions.items():
+            assert is_run_name(name)
+            assert len(ids) >= 2
+            assert all(render_name(i) == name for i in ids)
+
+
+def test_find_collisions_empty_for_distinct_names() -> None:
+    # Hand-pick ids that we have verified render to distinct names.
+    ids = [_FIXED_UUID, uuid.UUID("87654321-4321-8765-4321-876543210987")]
+    assert render_name(ids[0]) != render_name(ids[1])
+    assert find_collisions(ids) == {}
+
+
+def test_build_lookup_round_trips_known_ids() -> None:
+    ids = [uuid.uuid4() for _ in range(50)]
+    lookup = build_lookup(ids)
+    for run_id in ids:
+        name = render_name(run_id)
+        assert name in lookup
+        # First-writer-wins, so the resolved id must itself render to name.
+        assert render_name(lookup[name]) == name
+
+
+# ---------------------------------------------------------------------------
+# run-lookup CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_run_lookup_resolves_candidate(runner: CliRunner) -> None:
+    name = render_name(_FIXED_UUID)
+    result = runner.invoke(run_lookup_cmd, [name, "--candidate", str(_FIXED_UUID)])
+    assert result.exit_code == 0, result.output
+    assert str(_FIXED_UUID) in result.output
+
+
+def test_run_lookup_rejects_malformed_name(runner: CliRunner) -> None:
+    result = runner.invoke(run_lookup_cmd, ["NOT_A_NAME", "--candidate", str(_FIXED_UUID)])
+    assert result.exit_code == 2
+    assert "not a valid run name" in result.output
+
+
+def test_run_lookup_reports_unknown_name(runner: CliRunner) -> None:
+    # Valid shape but no candidate renders to it.
+    result = runner.invoke(run_lookup_cmd, ["swift-otter-07"])
+    assert result.exit_code == 1
+    assert "No known run id" in result.output
+
+
+def test_run_lookup_reads_active_run_id(runner: CliRunner, tmp_path) -> None:
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "run_id").write_text(str(_FIXED_UUID), encoding="utf-8")
+    name = render_name(_FIXED_UUID)
+    result = runner.invoke(run_lookup_cmd, [name, "--workspace-root", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert str(_FIXED_UUID) in result.output
+
+
+def test_run_lookup_rejects_bad_candidate_uuid(runner: CliRunner) -> None:
+    result = runner.invoke(run_lookup_cmd, ["swift-otter-07", "--candidate", "not-a-uuid"])
+    assert result.exit_code != 0
+    assert "not a valid UUID" in result.output


### PR DESCRIPTION
## Summary
- Add `src/bernstein/cli/run_names.py`: `render_name(run_id: UUID) -> str` derives a stable `<adjective>-<noun>-NN` name via BLAKE2b over the UUID bytes, from two neutral checked-in word lists (English-only, max 8 chars, non-product-specific). Adds `is_run_name`, `build_lookup`, `find_collisions`, `name_space_size`.
- Surface the rendered name in CLI status output (header, summary table, plain output) and the run-archive summary; the UUID stays in detail/machine-readable output.
- Add `bernstein run-lookup NAME` to resolve a memorable name back to its UUID (reads active `.sdd/runtime/run_id` plus `--candidate` ids), with a warning when a name is shared.
- Docs at `docs/operations/run_names.md` describing the rendering rule, stability guarantee, collisions, and the lookup command.

## Notes
- The mapping is pure and stable; a golden value test pins the recipe so accidental drift fails CI.
- `render_name` is not globally bijective (128 UUID bits cannot fit the finite name space); collision rate is governed by the birthday bound and stays low for the runs an operator triages at once. `find_collisions` reports clashes over a known id set.

## Test plan
- [x] `pytest tests/unit/cli/test_run_names.py` (determinism, format, collision-resistance, word-list hygiene, run-lookup CLI) - 28 passed
- [x] `pytest tests/unit/cli/test_run_banner.py tests/unit/cli/test_audit_archive_cmd.py` - green
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] pyright introduces no new errors over baseline on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bernstein run-lookup` command to resolve memorable run names back to their UUIDs.
  * Run names (in `<adjective>-<noun>-NN>` format) now display in status output and archive summaries.

* **Documentation**
  * Added comprehensive documentation for the memorable run names feature, including format, lookup behavior, and collision handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->