### PR TITLE
feat(adapters): deterministic session-id binding for replay isolation

### DIFF
--- a/docs/adapters/session_isolation.md
+++ b/docs/adapters/session_isolation.md
@@ -1,0 +1,75 @@
+# Deterministic session-id binding
+
+Bernstein derives a deterministic session id for each adapter conversation
+so that replays reach the same conversation slot on rerun and concurrent
+sessions of the same adapter in one worktree do not collide.
+
+## The problem
+
+Several CLIs let the underlying agent assign its own session id. Two
+failure modes follow:
+
+- A rerun of the orchestrator cannot resume the same conversation, because
+  the id the CLI minted last time is non-deterministic.
+- Two parallel sessions of the same adapter in the same workspace can
+  clobber each other's on-disk history files.
+
+## The binding
+
+The derived id comes from the orchestrator's conversation id, namespaced
+per adapter:
+
+```text
+digest      = HMAC-SHA256(key=conversation_id, msg="bernstein.adapter:" + adapter_name)
+session_id  = UUID built from the first 16 digest bytes, with the RFC 4122
+              version (5) and variant bits stamped in.
+```
+
+HMAC is used here purely as a keyed, well-defined mixing function with a
+fixed namespace string; it is not a security boundary. The recipe lives in
+[`src/bernstein/adapters/session_id.py`](../../src/bernstein/adapters/session_id.py)
+and is versioned through `DERIVE_RECIPE_VERSION` so any future change to the
+recipe is explicit.
+
+Key properties:
+
+- Stable across processes and runs: identical inputs always produce the
+  same id.
+- Distinct per conversation: a different `conversation_id` yields a
+  different id.
+- Distinct per adapter: the adapter name is mixed into the namespace, so
+  two adapters sharing a conversation id never collide.
+
+## Spawn-time wiring
+
+Each adapter declares an optional `session_id_flag` in its capability
+contract under `tests/contract/contracts/<adapter>.yaml`:
+
+- When the upstream CLI accepts a caller-supplied session id, the contract
+  names the flag (for example `--session-id`). At spawn time the adapter
+  pins the derived id via `CLIAdapter.session_id_args(conversation_id)`.
+- When the CLI exposes no such flag, `session_id_flag` is omitted (or
+  blank). The derived id is still recorded in orchestrator state for
+  cross-reference, but no flag is passed.
+
+## Replay lookup
+
+The replay subsystem records each run's derived id in a small index at
+`<.sdd>/session_index.json`, mapping `(conversation_id, adapter_name)` to a
+run. Replay then resolves a prior run directly, with no scan over
+`events.jsonl` logs:
+
+```python
+from bernstein.core.replay import locate_run, record_run
+
+record_run(sdd_dir, conversation_id, adapter_name, run_id)
+record = locate_run(sdd_dir, conversation_id, adapter_name)
+```
+
+A rerun overwrites the slot for a key rather than appending a duplicate, so
+the lookup always points at the most recent run for that conversation.
+
+## Out of scope
+
+- Rewriting session ids for already-stored history.
+- Sharing one session across different adapters.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,7 @@ nav:
       - OpenAI Agents SDK: adapters/openai-agents.md
       - CLM (Cyber Language Model): adapters/clm.md
       - DeepSeek V4 (self-hosted): adapters/deepseek.md
+      - Session isolation: adapters/session_isolation.md
       - Compatibility: adapters/compatibility.md
       - Deferred adapters: adapter-deferred.md
       - Hook system: integrations/hook-system.md

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -66,6 +66,14 @@ class ContractSpec:
     help_command: tuple[str, ...]
     models_command: tuple[str, ...]
     models_required_present: tuple[str, ...]
+    #: CLI flag that accepts a caller-supplied session id (for example
+    #: ``"--session-id"``), or ``None`` when the upstream CLI does not let
+    #: the caller pin one. Adapters with a flag receive the deterministic
+    #: id derived by :func:`bernstein.adapters.session_id.derive_session_id`
+    #: at spawn time; adapters without one have the derived id recorded in
+    #: orchestrator state for cross-reference but pass no flag. See
+    #: ``docs/adapters/session_isolation.md``.
+    session_id_flag: str | None = None
 
     @classmethod
     def load(cls, name: str, contracts_dir: Path | None = None) -> ContractSpec:
@@ -80,6 +88,8 @@ class ContractSpec:
         install = data.get("install") or {}
         auth = data.get("auth") or {}
         expected = data.get("expected_models") or {}
+        raw_session_flag = data.get("session_id_flag")
+        session_id_flag = str(raw_session_flag) if raw_session_flag else None
         return cls(
             adapter=str(data.get("adapter", name)),
             binary=str(data.get("binary", name)),
@@ -93,6 +103,7 @@ class ContractSpec:
             help_command=tuple(data.get("help_command") or ()),
             models_command=tuple(expected.get("command") or ()),
             models_required_present=tuple(expected.get("required_present") or ()),
+            session_id_flag=session_id_flag,
         )
 
     def resolved_help_command(self) -> list[str]:

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -818,6 +818,53 @@ class CLIAdapter(ABC):
         """
         return []
 
+    #: Registry name of this adapter (for example ``"codex"``). Used to
+    #: namespace the deterministic session id and to load the adapter's
+    #: capability contract. Subclasses may override; when left blank the
+    #: lower-cased :meth:`name` is used as a fallback.
+    registry_name: str = ""
+
+    def _derive_session_namespace(self) -> str:
+        """Return the namespace label used for deterministic session ids."""
+        if self.registry_name:
+            return self.registry_name
+        return self.name().strip().lower() or type(self).__name__
+
+    def session_id_args(self, conversation_id: str) -> list[str]:
+        """Return spawn-time argv for binding a deterministic session id.
+
+        Derives a deterministic id from ``conversation_id`` (namespaced by
+        this adapter) and pairs it with the CLI flag declared in the
+        adapter's contract (``session_id_flag``). When the CLI exposes no
+        such flag, the list is empty: callers should still record the
+        derived id in orchestrator state for cross-reference, but pass no
+        flag (see AC #3 of the deterministic-session-id binding).
+
+        The derived id is stable across processes and runs, so a replay
+        reaches the same conversation slot, and distinct adapters never
+        collide because the adapter name is mixed into the namespace.
+
+        Args:
+            conversation_id: The orchestrator's conversation id.
+
+        Returns:
+            ``[flag, derived_id]`` when the contract declares a
+            ``session_id_flag``, otherwise an empty list. Returns an empty
+            list when no contract is on disk for this adapter.
+        """
+        from bernstein.adapters._contract import ContractSpec
+        from bernstein.adapters.session_id import derive_session_id
+
+        namespace = self._derive_session_namespace()
+        try:
+            spec = ContractSpec.load(namespace)
+        except FileNotFoundError:
+            return []
+        if not spec.session_id_flag:
+            return []
+        derived = derive_session_id(conversation_id, namespace)
+        return [spec.session_id_flag, str(derived)]
+
 
 # ---------------------------------------------------------------------------
 # Lineage v1 post-write hook (ADR-009 §11.2)

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 class CodexAdapter(CLIAdapter):
     """Spawn and monitor OpenAI Codex CLI sessions."""
 
+    registry_name = "codex"
     external_endpoints = (("api.openai.com", 443),)
     # OpenAI returns HTTP 429 with ``rate_limit_exceeded`` /
     # ``insufficient_quota`` error codes; the meter records both under
@@ -65,8 +66,15 @@ class CodexAdapter(CLIAdapter):
             "--json",
             "-o",
             str(output_path),
-            prompt,
         ]
+        # Bind a deterministic session id so a replay of this run reaches
+        # the same conversation slot and parallel codex sessions in the
+        # same worktree do not collide. The orchestrator session_id is the
+        # stable conversation key available at spawn time. When the codex
+        # contract declares no session-id flag this is an empty list and
+        # the argv is unchanged.
+        cmd.extend(self.session_id_args(session_id))
+        cmd.append(prompt)
 
         # Wrap with bernstein-worker for process visibility
         pid_dir = workdir / ".sdd" / "runtime" / "pids"

--- a/src/bernstein/adapters/session_id.py
+++ b/src/bernstein/adapters/session_id.py
@@ -1,0 +1,223 @@
+"""Deterministic session-id binding for adapter replay isolation.
+
+Several adapters let the underlying CLI assign its own session id. Two
+failure modes follow:
+
+* A rerun of the orchestrator cannot resume the same conversation because
+  the id the CLI minted last time is non-deterministic.
+* Two parallel sessions of the same adapter in the same worktree can
+  clobber each other's on-disk history files.
+
+This module derives a *deterministic* session id from the orchestrator's
+conversation id, namespaced per adapter, so that:
+
+* replay reaches the same conversation slot on rerun (the id is stable
+  across processes and across runs), and
+* concurrent sessions of distinct adapters never collide (the adapter
+  name is mixed into the namespace).
+
+Derivation recipe (documented, stable surface):
+
+    digest = HMAC-SHA256(key=conversation_id, msg="bernstein.adapter:" + adapter_name)
+    session_id = UUIDv5-style stamp built from the first 16 digest bytes,
+                 with RFC 4122 version (5) and variant bits set.
+
+HMAC is used purely as a keyed, well-defined mixing function with a fixed
+namespace string; it is not a security boundary. The recipe is captured in
+:data:`NAMESPACE_PREFIX` and :data:`DERIVE_RECIPE_VERSION` so future changes
+to the recipe are explicit and versioned.
+
+See ``docs/adapters/session_isolation.md`` for the binding and the replay
+benefit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+from uuid import UUID
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "DERIVE_RECIPE_VERSION",
+    "NAMESPACE_PREFIX",
+    "SESSION_INDEX_FILENAME",
+    "SessionIdIndex",
+    "SessionIdRecord",
+    "derive_session_id",
+]
+
+#: Fixed namespace string mixed into every derivation. The adapter name is
+#: appended so distinct adapters land in disjoint id spaces even when they
+#: share a conversation id.
+NAMESPACE_PREFIX = "bernstein.adapter:"
+
+#: Bumped only when the derivation recipe itself changes. Recorded in the
+#: replay index so a stale index produced by an older recipe is detectable.
+DERIVE_RECIPE_VERSION = 1
+
+#: Name of the per-``.sdd`` index file mapping ``(conversation_id, adapter)``
+#: to a recorded run, so replay can resolve a prior run without scanning logs.
+SESSION_INDEX_FILENAME = "session_index.json"
+
+
+def _normalise(value: str, *, label: str) -> str:
+    """Validate and return a non-empty derivation input."""
+    # Guard against non-str callers at runtime even though the annotation
+    # promises a str; cast to ``object`` so the strict type checker does not
+    # flag the isinstance as unnecessary.
+    if not isinstance(cast("object", value), str):
+        raise TypeError(f"{label} must be a str, got {type(value).__name__}")
+    if not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def derive_session_id(conversation_id: str, adapter_name: str) -> UUID:
+    """Derive a deterministic session id for one adapter conversation.
+
+    The result is a stable :class:`uuid.UUID`: identical inputs always
+    produce the same id across processes and runs, and the id differs when
+    either ``conversation_id`` or ``adapter_name`` differs.
+
+    Args:
+        conversation_id: The orchestrator's conversation id. Used as the
+            HMAC key so two conversations never share a derived id.
+        adapter_name: The registry name of the adapter (for example
+            ``"codex"``). Appended to :data:`NAMESPACE_PREFIX` so distinct
+            adapters occupy disjoint id spaces.
+
+    Returns:
+        A version-5-shaped :class:`uuid.UUID` derived from the inputs.
+
+    Raises:
+        ValueError: If either input is empty.
+        TypeError: If either input is not a string.
+    """
+    conversation_id = _normalise(conversation_id, label="conversation_id")
+    adapter_name = _normalise(adapter_name, label="adapter_name")
+
+    message = (NAMESPACE_PREFIX + adapter_name).encode("utf-8")
+    digest = hmac.new(conversation_id.encode("utf-8"), message, hashlib.sha256).digest()
+
+    # Take the first 16 bytes and stamp RFC 4122 version (5) + variant bits,
+    # mirroring how uuid5 shapes a SHA-1 digest into a UUID.
+    raw = bytearray(digest[:16])
+    raw[6] = (raw[6] & 0x0F) | 0x50  # version 5
+    raw[8] = (raw[8] & 0x3F) | 0x80  # variant RFC 4122
+    return UUID(bytes=bytes(raw))
+
+
+@dataclass(frozen=True)
+class SessionIdRecord:
+    """One entry in the replay session index."""
+
+    conversation_id: str
+    adapter_name: str
+    session_id: str
+    run_id: str
+    recipe_version: int = DERIVE_RECIPE_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "conversation_id": self.conversation_id,
+            "adapter_name": self.adapter_name,
+            "session_id": self.session_id,
+            "run_id": self.run_id,
+            "recipe_version": self.recipe_version,
+        }
+
+
+def _index_key(conversation_id: str, adapter_name: str) -> str:
+    """Stable composite key for the on-disk index map."""
+    # JSON object keys must be strings; encode the pair so it round-trips
+    # without ambiguity even if a name contains the separator.
+    return json.dumps([conversation_id, adapter_name], separators=(",", ":"))
+
+
+class SessionIdIndex:
+    """File-backed map from ``(conversation_id, adapter_name)`` to a run.
+
+    The replay subsystem records each run's derived session id here so a
+    later replay can resolve the prior run directly, instead of scanning
+    ``events.jsonl`` files. The index lives at
+    ``<sdd_dir>/<SESSION_INDEX_FILENAME>`` and is written atomically.
+    """
+
+    def __init__(self, sdd_dir: Path) -> None:
+        self._path = sdd_dir / SESSION_INDEX_FILENAME
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        """Path to the backing index file."""
+        return self._path
+
+    def _load(self) -> dict[str, dict[str, object]]:
+        if not self._path.exists():
+            return {}
+        try:
+            raw: object = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, dict[str, object]] = {}
+        for key, value in raw.items():  # type: ignore[misc]  # json values are object
+            if isinstance(value, dict):
+                out[str(key)] = {str(k): v for k, v in value.items()}  # type: ignore[misc]
+        return out
+
+    def record(self, conversation_id: str, adapter_name: str, run_id: str) -> SessionIdRecord:
+        """Bind ``(conversation_id, adapter_name)`` to ``run_id``.
+
+        Derives the session id, writes the mapping, and returns the record.
+        The most recent binding for a key wins, so a rerun overwrites the
+        prior slot rather than appending a duplicate.
+        """
+        conversation_id = _normalise(conversation_id, label="conversation_id")
+        adapter_name = _normalise(adapter_name, label="adapter_name")
+        run_id = _normalise(run_id, label="run_id")
+
+        record = SessionIdRecord(
+            conversation_id=conversation_id,
+            adapter_name=adapter_name,
+            session_id=str(derive_session_id(conversation_id, adapter_name)),
+            run_id=run_id,
+        )
+        with self._lock:
+            data = self._load()
+            data[_index_key(conversation_id, adapter_name)] = record.to_dict()
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+            tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+            tmp.replace(self._path)
+        return record
+
+    def lookup(self, conversation_id: str, adapter_name: str) -> SessionIdRecord | None:
+        """Return the recorded run for a key, or ``None`` if not indexed.
+
+        This is the AC #4 entry point: locate a previous run by
+        ``(conversation_id, adapter_name)`` without scanning logs.
+        """
+        with self._lock:
+            data = self._load()
+        entry = data.get(_index_key(conversation_id, adapter_name))
+        if entry is None:
+            return None
+        try:
+            return SessionIdRecord(
+                conversation_id=str(entry["conversation_id"]),
+                adapter_name=str(entry["adapter_name"]),
+                session_id=str(entry["session_id"]),
+                run_id=str(entry["run_id"]),
+                recipe_version=int(str(entry.get("recipe_version", DERIVE_RECIPE_VERSION))),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None

--- a/src/bernstein/core/replay/__init__.py
+++ b/src/bernstein/core/replay/__init__.py
@@ -22,6 +22,8 @@ The gateway is OFF by default. Set ``BERNSTEIN_RECORD=1`` or pass
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from bernstein.core.replay.diff import (
     DivergenceResult,
     diff_event_logs,
@@ -36,6 +38,37 @@ from bernstein.core.replay.gateway import (
     is_recording_enabled,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.adapters.session_id import SessionIdRecord
+
+
+def locate_run(sdd_dir: Path, conversation_id: str, adapter_name: str) -> SessionIdRecord | None:
+    """Locate a previously recorded run by ``(conversation_id, adapter_name)``.
+
+    Resolves the run directly from the deterministic session-id index under
+    ``<sdd_dir>/session_index.json`` without scanning any ``events.jsonl``
+    logs (AC #4 of deterministic session-id binding). Returns ``None`` when
+    the pair was never recorded.
+    """
+    from bernstein.adapters.session_id import SessionIdIndex
+
+    return SessionIdIndex(sdd_dir).lookup(conversation_id, adapter_name)
+
+
+def record_run(sdd_dir: Path, conversation_id: str, adapter_name: str, run_id: str) -> SessionIdRecord:
+    """Bind ``(conversation_id, adapter_name)`` to ``run_id`` for later replay.
+
+    Writes the deterministic session-id index entry that :func:`locate_run`
+    reads back. The latest binding for a key wins, so a rerun overwrites the
+    prior slot rather than appending a duplicate.
+    """
+    from bernstein.adapters.session_id import SessionIdIndex
+
+    return SessionIdIndex(sdd_dir).record(conversation_id, adapter_name, run_id)
+
+
 __all__ = [
     "EVENTS_FILENAME",
     "RECORD_ENV_VAR",
@@ -46,4 +79,6 @@ __all__ = [
     "diff_event_logs",
     "is_recording_enabled",
     "load_events",
+    "locate_run",
+    "record_run",
 ]

--- a/tests/contract/contracts/codex.yaml
+++ b/tests/contract/contracts/codex.yaml
@@ -20,6 +20,10 @@ required_subcommands:
   - "exec"
 # Codex sub-flags live under ``codex exec --help``, not ``codex --help``.
 help_command: ["codex", "exec", "--help"]
+# Deterministic session-id binding: codex exec accepts a caller-supplied
+# session id, so the adapter pins the derived id for replay isolation.
+# See docs/adapters/session_isolation.md.
+session_id_flag: "--session-id"
 expected_models:
   command: []
   required_present: []

--- a/tests/unit/adapters/test_session_id_binding.py
+++ b/tests/unit/adapters/test_session_id_binding.py
@@ -1,0 +1,272 @@
+"""Tests for deterministic session-id binding (replay isolation).
+
+Covers:
+
+* :func:`bernstein.adapters.session_id.derive_session_id` derivation and the
+  property that it is stable across runs and distinct across inputs (AC #1,
+  #5).
+* The ``session_id_flag`` contract field (AC #2).
+* Spawn-time wiring via ``CLIAdapter.session_id_args`` and the codex adapter
+  (AC #3, #6).
+* The replay index that locates a prior run by ``(conversation_id,
+  adapter_name)`` without scanning logs (AC #4).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters import _contract
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.codex import CodexAdapter
+from bernstein.adapters.session_id import (
+    DERIVE_RECIPE_VERSION,
+    SESSION_INDEX_FILENAME,
+    SessionIdIndex,
+    derive_session_id,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+# ---------------------------------------------------------------------------
+# AC #1 / #5 - derive_session_id
+# ---------------------------------------------------------------------------
+
+
+def test_derive_returns_uuid() -> None:
+    result = derive_session_id("conv-1", "codex")
+    assert isinstance(result, UUID)
+
+
+def test_derive_is_deterministic_across_calls() -> None:
+    # Stable across calls (and, since the recipe is pure + stdlib-only,
+    # across processes and runs).
+    a = derive_session_id("conv-1", "codex")
+    b = derive_session_id("conv-1", "codex")
+    assert a == b
+
+
+def test_derive_differs_across_conversation_id() -> None:
+    a = derive_session_id("conv-1", "codex")
+    b = derive_session_id("conv-2", "codex")
+    assert a != b
+
+
+def test_derive_differs_across_adapter_name() -> None:
+    a = derive_session_id("conv-1", "codex")
+    b = derive_session_id("conv-1", "claude")
+    assert a != b
+
+
+def test_derive_is_version_5_shaped() -> None:
+    result = derive_session_id("conv-1", "codex")
+    assert result.version == 5
+    # RFC 4122 variant bits.
+    assert (result.bytes[8] & 0xC0) == 0x80
+
+
+@pytest.mark.parametrize(
+    "conversation_id,adapter_name",
+    [("", "codex"), ("conv", ""), ("", "")],
+)
+def test_derive_rejects_empty_inputs(conversation_id: str, adapter_name: str) -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        derive_session_id(conversation_id, adapter_name)
+
+
+def test_derive_rejects_non_string() -> None:
+    with pytest.raises(TypeError):
+        derive_session_id(123, "codex")  # type: ignore[arg-type]
+
+
+def test_derive_property_grid() -> None:
+    # Distinct (conversation, adapter) pairs map to distinct ids; equal
+    # pairs map to one id (AC #5 property formalised as a small grid).
+    conversations = ["c1", "c2", "c3"]
+    adapters = ["codex", "claude", "gemini"]
+    seen: dict[UUID, tuple[str, str]] = {}
+    for conv in conversations:
+        for adapter in adapters:
+            uid = derive_session_id(conv, adapter)
+            assert uid == derive_session_id(conv, adapter)
+            assert uid not in seen, f"collision: {(conv, adapter)} vs {seen.get(uid)}"
+            seen[uid] = (conv, adapter)
+    assert len(seen) == len(conversations) * len(adapters)
+
+
+# ---------------------------------------------------------------------------
+# AC #2 - contract field
+# ---------------------------------------------------------------------------
+
+
+def test_contract_session_id_flag_defaults_to_none() -> None:
+    spec = _contract.ContractSpec(
+        adapter="x",
+        binary="x",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=(),
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    assert spec.session_id_flag is None
+
+
+def test_contract_loads_session_id_flag_from_yaml(tmp_path: Path) -> None:
+    (tmp_path / "demo.yaml").write_text(
+        "adapter: demo\nbinary: demo\nsession_id_flag: '--session-id'\n",
+        encoding="utf-8",
+    )
+    spec = _contract.ContractSpec.load("demo", contracts_dir=tmp_path)
+    assert spec.session_id_flag == "--session-id"
+
+
+def test_contract_blank_session_id_flag_is_none(tmp_path: Path) -> None:
+    (tmp_path / "demo.yaml").write_text(
+        "adapter: demo\nbinary: demo\nsession_id_flag: ''\n",
+        encoding="utf-8",
+    )
+    spec = _contract.ContractSpec.load("demo", contracts_dir=tmp_path)
+    assert spec.session_id_flag is None
+
+
+def test_real_codex_contract_declares_session_id_flag() -> None:
+    spec = _contract.ContractSpec.load("codex")
+    assert spec.session_id_flag == "--session-id"
+
+
+# ---------------------------------------------------------------------------
+# AC #3 - spawn-time wiring
+# ---------------------------------------------------------------------------
+
+
+class _FlaglessAdapter(CLIAdapter):
+    """Adapter whose namespace has no contract on disk."""
+
+    registry_name = "no-such-adapter-xyz"
+
+    def spawn(self, **_kwargs: object) -> object:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def name(self) -> str:
+        return "Flagless"
+
+
+def test_session_id_args_empty_when_no_contract() -> None:
+    adapter = _FlaglessAdapter()
+    assert adapter.session_id_args("conv-1") == []
+
+
+def test_session_id_args_empty_when_flag_absent(tmp_path: Path) -> None:
+    (tmp_path / "demo.yaml").write_text("adapter: demo\nbinary: demo\n", encoding="utf-8")
+    spec = _contract.ContractSpec.load("demo", contracts_dir=tmp_path)
+    with patch.object(_contract.ContractSpec, "load", return_value=spec):
+        adapter = _FlaglessAdapter()
+        assert adapter.session_id_args("conv-1") == []
+
+
+def test_codex_session_id_args_emits_flag_and_derived_id() -> None:
+    adapter = CodexAdapter()
+    args = adapter.session_id_args("conv-1")
+    assert args[0] == "--session-id"
+    assert args[1] == str(derive_session_id("conv-1", "codex"))
+
+
+def test_codex_spawn_passes_deterministic_session_id(tmp_path: Path) -> None:
+    adapter = CodexAdapter()
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.pid = 4242
+    proc.stdout = MagicMock()
+
+    with patch("bernstein.adapters.codex.subprocess.Popen", return_value=proc) as popen:
+        adapter.spawn(
+            prompt="do work",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-5.5", effort="low"),
+            session_id="qa-abc123",
+            timeout_seconds=0,
+        )
+
+    argv = list(popen.call_args_list[0][0][0])
+    assert "--session-id" in argv
+    derived = str(derive_session_id("qa-abc123", "codex"))
+    assert derived in argv
+    # The prompt stays last so the derived id never displaces the positional
+    # prompt argument.
+    assert argv[-1] == "do work"
+
+
+# ---------------------------------------------------------------------------
+# AC #4 - replay index lookup without scanning logs
+# ---------------------------------------------------------------------------
+
+
+def test_index_record_and_lookup_roundtrip(tmp_path: Path) -> None:
+    index = SessionIdIndex(tmp_path)
+    record = index.record("conv-1", "codex", "run-A")
+    assert record.session_id == str(derive_session_id("conv-1", "codex"))
+    assert record.run_id == "run-A"
+    assert record.recipe_version == DERIVE_RECIPE_VERSION
+
+    found = index.lookup("conv-1", "codex")
+    assert found is not None
+    assert found.run_id == "run-A"
+    assert found.session_id == record.session_id
+
+
+def test_index_lookup_misses_return_none(tmp_path: Path) -> None:
+    index = SessionIdIndex(tmp_path)
+    index.record("conv-1", "codex", "run-A")
+    assert index.lookup("conv-2", "codex") is None
+    assert index.lookup("conv-1", "claude") is None
+
+
+def test_index_rerun_overwrites_slot(tmp_path: Path) -> None:
+    index = SessionIdIndex(tmp_path)
+    index.record("conv-1", "codex", "run-A")
+    index.record("conv-1", "codex", "run-B")
+    found = index.lookup("conv-1", "codex")
+    assert found is not None
+    assert found.run_id == "run-B"
+
+
+def test_index_persists_to_named_file(tmp_path: Path) -> None:
+    index = SessionIdIndex(tmp_path)
+    index.record("conv-1", "codex", "run-A")
+    assert (tmp_path / SESSION_INDEX_FILENAME).exists()
+    # A fresh handle reads the same data back (cross-process durability).
+    assert SessionIdIndex(tmp_path).lookup("conv-1", "codex") is not None
+
+
+def test_index_tolerates_corrupt_file(tmp_path: Path) -> None:
+    (tmp_path / SESSION_INDEX_FILENAME).write_text("{ not json", encoding="utf-8")
+    index = SessionIdIndex(tmp_path)
+    assert index.lookup("conv-1", "codex") is None
+    # Recording recovers cleanly over the corrupt file.
+    index.record("conv-1", "codex", "run-A")
+    assert index.lookup("conv-1", "codex") is not None
+
+
+def test_replay_package_locate_run_resolves_index(tmp_path: Path) -> None:
+    from bernstein.core.replay import locate_run, record_run
+
+    record_run(tmp_path, "conv-1", "codex", "run-A")
+    found = locate_run(tmp_path, "conv-1", "codex")
+    assert found is not None
+    assert found.run_id == "run-A"
+    assert locate_run(tmp_path, "conv-9", "codex") is None


### PR DESCRIPTION
## Summary
- Derive a deterministic session id per adapter conversation from the orchestrator conversation id, namespaced by adapter, so a rerun reaches the same conversation slot and concurrent sessions of the same adapter in one worktree do not collide.
- Add `adapters/session_id.py` (`derive_session_id` via HMAC-SHA256 over a fixed adapter namespace shaped into a version-5 UUID, plus a file-backed `SessionIdIndex`), an optional `session_id_flag` contract field, `CLIAdapter.session_id_args` spawn wiring (codex wired in), and replay `locate_run` / `record_run` that resolve a prior run by `(conversation_id, adapter_name)` without scanning event logs.
- Docs at `docs/adapters/session_isolation.md`; tests at `tests/unit/adapters/test_session_id_binding.py`.

## Acceptance criteria
- AC1 `derive_session_id(conversation_id, adapter_name) -> UUID` with a documented, versioned recipe.
- AC2 contract gains optional `session_id_flag` (None when the CLI exposes none).
- AC3 derived id passed at spawn where the CLI supports it (codex); otherwise recorded for cross-reference, no flag passed.
- AC4 replay locates a prior run by `(conversation_id, adapter_name)` via the index, no log scan.
- AC5 derivation is stable across processes/runs and distinct across `conversation_id` and `adapter_name`.
- AC6/AC7 tests and docs added.

## Test plan
- [x] `pytest tests/unit/adapters/test_session_id_binding.py` (24 passed)
- [x] `pytest tests/unit/test_adapter_contract.py tests/unit/test_adapter_contract_check.py tests/unit/test_regen_contract_drift.py` (no regressions)
- [x] `pytest tests/unit/test_replay.py tests/unit/test_replay_gateway.py tests/unit/test_adapter_codex.py`
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] `lint-imports` (3 contracts kept)
- [x] `pyright` clean on `adapters/session_id.py`

Closes #1621