### PR TITLE
feat(mcp): tiered tool exposure with context-budget knob

### DIFF
--- a/docs/mcp/tool_tiers.md
+++ b/docs/mcp/tool_tiers.md
@@ -1,0 +1,80 @@
+# MCP tool tiers (context-budget knob)
+
+Bernstein exposes its orchestration layer as MCP tools so any MCP client
+(Cursor, Claude Code, Cline, Windsurf, and others) can drive multi-agent
+work. Every advertised tool costs context tokens on every turn, whether or
+not the agent calls it. Tool tiers let an operator cap that budget with a
+single knob, trading capability for context.
+
+## The three tiers
+
+Tiers are named and cumulative: `core` is a subset of `standard`, which is a
+subset of `all`. Selecting a tier advertises that tier's tools and only that
+tier's tools. Out-of-tier tools are neither listed in `tools/list` nor
+callable.
+
+| Tier | Budget | Tools advertised | Use when |
+|------|--------|------------------|----------|
+| `core` | smallest | `bernstein_health`, `bernstein_run`, `bernstein_status`, `bernstein_tasks` | Cost-sensitive runs or small-context adapters; you only need to start and observe a run. |
+| `standard` (default) | medium | core plus `bernstein_cost`, `bernstein_stop`, `bernstein_approve`, `bernstein_create_subtask`, `load_skill` | The typical session: mutation, approval, and skill loading. |
+| `all` | largest | standard plus the scenario bridge (`bernstein_scenarios`, `bernstein_scenario`, `bernstein_scenario_status`) and `verify_chain` | Power-user sessions that drive scenario libraries or audit lineage. |
+
+The exact membership is declared once in
+`src/bernstein/core/protocols/mcp/tool_tiers.py` (`TOOL_TIERS`). Adding a new
+tool sets its tier at that declaration; there is no separate runtime
+registry to keep in sync.
+
+## Selecting a tier
+
+Resolution order, first match wins:
+
+1. `--mcp-tier <tier>` session flag on `bernstein mcp`.
+2. `BERNSTEIN_MCP_TOOL_TIER` environment variable.
+3. The `standard` default.
+
+```bash
+# Run the MCP server with the smallest tool surface.
+bernstein mcp --mcp-tier core
+
+# Or set it once for the session via the environment.
+export BERNSTEIN_MCP_TOOL_TIER=core
+bernstein mcp
+```
+
+An unknown tier value is rejected with a clear error rather than silently
+falling back, so a typo never quietly changes the exposed surface.
+
+## Auditing before you switch
+
+Use `bernstein mcp tools` to see exactly what each tier would advertise
+before changing the knob:
+
+```bash
+# Audit every tier.
+bernstein mcp tools
+
+# Inspect a single tier.
+bernstein mcp tools --tier core
+
+# Machine-readable output for scripts.
+bernstein mcp tools --tier all --json-output
+```
+
+## Budget-vs-capability trade
+
+- Dropping from `all` to `standard` removes the scenario bridge and the
+  lineage verifier. Pick `standard` for everyday orchestration where you do
+  not invoke scenario recipes from the agent.
+- Dropping from `standard` to `core` additionally removes cost reporting,
+  graceful stop, approval, subtask creation, and skill loading. Pick `core`
+  for the leanest surface on small-context adapters or when only the
+  start/observe loop matters.
+- The fewer tools advertised, the fewer tokens spent describing them on
+  every turn. The trade is direct: smaller tier, smaller budget, fewer
+  capabilities reachable without switching.
+
+## Out of scope
+
+- Per-user tier policy. The tier is a single global setting per process.
+- Dynamic tier promotion during a run. The tier is fixed when the server
+  starts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -269,6 +269,7 @@ nav:
       - Task lifecycle CLI: reference/cli/task-lifecycle.md
       - Replay CLI: reference/cli/replay.md
       - MCP catalog: reference/mcp-catalog.md
+      - MCP tool tiers: mcp/tool_tiers.md
       - API reference: reference/openapi-reference.md
       - ACP bridge: reference/acp-bridge.md
       - Feature matrix: reference/FEATURE_MATRIX.md

--- a/src/bernstein/cli/commands/mcp_cmd.py
+++ b/src/bernstein/cli/commands/mcp_cmd.py
@@ -43,8 +43,22 @@ def _catalog_path() -> Path:
     show_default=True,
     help="Bernstein server URL.",
 )
+@click.option(
+    "--mcp-tier",
+    "mcp_tier",
+    type=click.Choice(["core", "standard", "all"]),
+    default=None,
+    help=("Tool tier to advertise (context-budget knob). Overrides BERNSTEIN_MCP_TOOL_TIER; defaults to 'standard'."),
+)
 @click.pass_context
-def mcp_server(ctx: click.Context, transport: str, host: str, port: int, server_url: str) -> None:
+def mcp_server(
+    ctx: click.Context,
+    transport: str,
+    host: str,
+    port: int,
+    server_url: str,
+    mcp_tier: str | None,
+) -> None:
     """Run the MCP server or manage the bundled MCP marketplace."""
     if ctx.invoked_subcommand is not None:
         return
@@ -59,11 +73,11 @@ def mcp_server(ctx: click.Context, transport: str, host: str, port: int, server_
     from bernstein.mcp.server import run_sse, run_stdio
 
     if transport == "stdio":
-        run_stdio(server_url=server_url)
+        run_stdio(server_url=server_url, tier=mcp_tier)
     else:
         console.print(f"[cyan]MCP Server[/cyan] starting on SSE ({host}:{port})")
         console.print(f"[dim]Backend: {server_url}[/dim]")
-        run_sse(server_url=server_url, host=host, port=port)
+        run_sse(server_url=server_url, host=host, port=port, tier=mcp_tier)
 
 
 @mcp_server.command("list")
@@ -160,6 +174,64 @@ def test_server(server_name: str, json_output: bool) -> None:
         raise click.ClickException(
             f"MCP protocol validation failed for {entry.name} ({len(report.failures)} issue(s))."
         )
+
+
+@mcp_server.command("tools")
+@click.option(
+    "--tier",
+    "tier",
+    type=click.Choice(["core", "standard", "all"]),
+    default=None,
+    help="Show tools for a single tier. Omit to audit every tier.",
+)
+@click.option(
+    "--json-output",
+    is_flag=True,
+    default=False,
+    help="Emit the audit as JSON instead of a Rich table.",
+)
+def tools_audit(tier: str | None, json_output: bool) -> None:
+    """Enumerate which MCP tools each tier would advertise.
+
+    Operators audit this before switching the ``BERNSTEIN_MCP_TOOL_TIER``
+    knob (or the ``--mcp-tier`` session flag), trading capability for
+    context budget without surprises.
+    """
+    from rich.table import Table
+
+    from bernstein.core.protocols.mcp.tool_tiers import (
+        DEFAULT_TIER,
+        normalize_tier,
+        tier_audit,
+        tools_for_tier,
+    )
+
+    if tier is not None:
+        resolved = normalize_tier(tier)
+        names = tools_for_tier(resolved)
+        if json_output:
+            console.print_json(json.dumps({resolved: names}))
+            return
+        table = Table(title=f"MCP tools - tier {resolved}", show_header=True, header_style=_STYLE_BOLD_CYAN)
+        table.add_column("Tool")
+        for name in names:
+            table.add_row(name)
+        console.print(table)
+        console.print(f"[dim]{len(names)} tool(s) advertised under tier {resolved}.[/dim]")
+        return
+
+    audit = tier_audit()
+    if json_output:
+        console.print_json(json.dumps(audit))
+        return
+    table = Table(title="MCP tool tiers", show_header=True, header_style=_STYLE_BOLD_CYAN)
+    table.add_column("Tier")
+    table.add_column("Count")
+    table.add_column("Tools")
+    for tier_name, names in audit.items():
+        label = f"{tier_name} (default)" if tier_name == DEFAULT_TIER else tier_name
+        table.add_row(label, str(len(names)), ", ".join(names) or "--")
+    console.print(table)
 
 
 @mcp_server.command("usage")

--- a/src/bernstein/core/protocols/mcp/tool_tiers.py
+++ b/src/bernstein/core/protocols/mcp/tool_tiers.py
@@ -1,0 +1,163 @@
+"""Tiered MCP tool exposure with an explicit context-budget knob.
+
+Exposing the full MCP tool catalogue to every adapter costs context tokens
+on every turn whether or not the tools are used. Operators running
+cost-sensitive tasks or smaller-context adapters need a single knob to trade
+capability for context budget.
+
+Three named tiers cover the realistic axis without inventing a per-tool
+policy language:
+
+  * ``core``     - the small always-on subset (health + the read-only query
+                   tools needed to drive and observe a run).
+  * ``standard`` - the typical session (core plus the common mutation and
+                   skill tools). This is the default.
+  * ``all``      - everything Bernstein ships, including the scenario bridge
+                   and any optional tools.
+
+Tiers are cumulative: ``core`` is a subset of ``standard`` which is a subset
+of ``all``. Selecting a tier advertises that tier's tools and *only* that
+tier's tools in the ``tools/list`` response; out-of-tier tools are neither
+advertised nor callable.
+
+The tier annotation is a property of the tool registration, expressed once
+in :data:`TOOL_TIERS` keyed by the tool's advertised name. Adding a new tool
+means adding one entry here with its declared tier; there is no separate
+runtime registry to keep in sync.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final, Literal, get_args
+
+#: The three named tiers, ordered from smallest to largest budget.
+ToolTier = Literal["core", "standard", "all"]
+
+#: Ordered tuple of every valid tier name, smallest first.
+TIER_ORDER: Final[tuple[ToolTier, ...]] = get_args(ToolTier)
+
+#: Default tier when no env var or session flag is set.
+DEFAULT_TIER: Final[ToolTier] = "standard"
+
+#: Env var that selects the active tier (acceptance criterion 2).
+TIER_ENV_VAR: Final[str] = "BERNSTEIN_MCP_TOOL_TIER"
+
+#: The declared minimum tier for every shipped MCP tool, keyed by the name
+#: advertised over MCP. A tool with tier ``core`` is exposed in all tiers; a
+#: tool with tier ``all`` is exposed only when the active tier is ``all``.
+#:
+#: This mapping is the single source of truth for the annotation. Adding a
+#: new tool means adding one line here at declaration time.
+TOOL_TIERS: Final[dict[str, ToolTier]] = {
+    # core - always on: liveness plus the read-only surface needed to start
+    # and observe a run.
+    "bernstein_health": "core",
+    "bernstein_run": "core",
+    "bernstein_status": "core",
+    "bernstein_tasks": "core",
+    # standard - the typical session: cost, mutation, and skill tools.
+    "bernstein_cost": "standard",
+    "bernstein_stop": "standard",
+    "bernstein_approve": "standard",
+    "bernstein_create_subtask": "standard",
+    "load_skill": "standard",
+    # all - power-user surface: the scenario bridge and lineage verifier.
+    "bernstein_scenarios": "all",
+    "bernstein_scenario": "all",
+    "bernstein_scenario_status": "all",
+    "verify_chain": "all",
+}
+
+
+def tier_rank(tier: ToolTier) -> int:
+    """Return the cumulative rank of ``tier`` (``core`` = 0, ``all`` = 2).
+
+    A tool is exposed under an active tier when the tool's declared rank is
+    less than or equal to the active tier's rank.
+    """
+    return TIER_ORDER.index(tier)
+
+
+def normalize_tier(value: str | None) -> ToolTier:
+    """Coerce a raw string into a valid :data:`ToolTier`.
+
+    Args:
+        value: Raw tier string (env var or CLI flag), or ``None``.
+
+    Returns:
+        The matching tier, or :data:`DEFAULT_TIER` when ``value`` is empty.
+
+    Raises:
+        ValueError: When ``value`` is a non-empty string that is not one of
+            the named tiers.
+    """
+    if value is None:
+        return DEFAULT_TIER
+    candidate = value.strip().lower()
+    if not candidate:
+        return DEFAULT_TIER
+    if candidate not in TIER_ORDER:
+        valid = ", ".join(TIER_ORDER)
+        raise ValueError(f"Unknown MCP tool tier {value!r}. Valid tiers: {valid}.")
+    # candidate is now known to be a member of TIER_ORDER.
+    return candidate  # type: ignore[return-value]
+
+
+def resolve_active_tier(override: str | None = None) -> ToolTier:
+    """Resolve the active tier from an explicit override or the environment.
+
+    Resolution order (first wins):
+
+      1. ``override`` - the ``--mcp-tier`` session flag, when provided.
+      2. ``BERNSTEIN_MCP_TOOL_TIER`` env var.
+      3. :data:`DEFAULT_TIER`.
+
+    Args:
+        override: Optional explicit tier (e.g. from a CLI flag).
+
+    Returns:
+        The resolved, validated tier.
+    """
+    if override is not None and override.strip():
+        return normalize_tier(override)
+    return normalize_tier(os.environ.get(TIER_ENV_VAR))
+
+
+def tool_in_tier(tool_name: str, active_tier: ToolTier) -> bool:
+    """Return whether ``tool_name`` is advertised under ``active_tier``.
+
+    A tool whose name is not present in :data:`TOOL_TIERS` is treated as
+    ``all`` tier: it is only exposed at the widest budget so an unannotated
+    tool never silently leaks into a smaller tier.
+
+    Args:
+        tool_name: The MCP-advertised tool name.
+        active_tier: The currently selected tier.
+
+    Returns:
+        ``True`` when the tool should be advertised and callable.
+    """
+    declared = TOOL_TIERS.get(tool_name, "all")
+    return tier_rank(declared) <= tier_rank(active_tier)
+
+
+def tools_for_tier(active_tier: ToolTier) -> list[str]:
+    """Return the sorted names of every tool advertised under ``active_tier``.
+
+    Args:
+        active_tier: The tier to enumerate.
+
+    Returns:
+        Sorted list of advertised tool names.
+    """
+    return sorted(name for name in TOOL_TIERS if tool_in_tier(name, active_tier))
+
+
+def tier_audit() -> dict[ToolTier, list[str]]:
+    """Return a per-tier map of advertised tool names for auditing.
+
+    Powers ``bernstein mcp tools`` so operators can see what each tier would
+    advertise before switching.
+    """
+    return {tier: tools_for_tier(tier) for tier in TIER_ORDER}

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -30,6 +30,11 @@ from typing import Any
 import httpx
 from mcp.server.fastmcp import FastMCP
 
+from bernstein.core.protocols.mcp.tool_tiers import (
+    ToolTier,
+    resolve_active_tier,
+    tool_in_tier,
+)
 from bernstein.mcp.input_validation import (
     ValidatedPayload,
     ValidationError,
@@ -468,12 +473,33 @@ def _lineage_mcp_default(*, default: bool) -> bool:
     return raw.strip().lower() not in {"0", "false", "no", "off", ""}
 
 
+def _apply_tool_tier(mcp: FastMCP[None], active_tier: ToolTier) -> None:
+    """Drop every registered tool that is outside ``active_tier``.
+
+    Tools are registered unconditionally above, then filtered here so the
+    tier annotation stays a property of the registration (see
+    :data:`bernstein.core.protocols.mcp.tool_tiers.TOOL_TIERS`) rather than
+    a branch in each registrar. A dropped tool is neither advertised in the
+    ``tools/list`` response nor callable.
+
+    Args:
+        mcp: The FastMCP server whose tools should be filtered.
+        active_tier: The currently selected tier.
+    """
+    # FastMCP exposes no public per-tool filter, so drop out-of-tier tools
+    # directly from the tool manager's registry after registration.
+    out_of_tier = [name for name in list(mcp._tool_manager._tools) if not tool_in_tier(name, active_tier)]
+    for name in out_of_tier:
+        mcp._tool_manager._tools.pop(name, None)
+
+
 def create_mcp_server(
     server_url: str = _DEFAULT_SERVER_URL,
     name: str = "bernstein",
     *,
     lineage_enabled: bool = False,
     lineage_root: Path | None = None,
+    tier: str | None = None,
 ) -> FastMCP[None]:
     """Build and return the Bernstein FastMCP server instance.
 
@@ -481,14 +507,19 @@ def create_mcp_server(
         server_url: Base URL of the Bernstein task server.
         name: MCP server name advertised to clients.
         lineage_enabled: When ``True``, register the lineage resources +
-            ``verify_chain`` tool. Defaults to ``False`` — callers running
+            ``verify_chain`` tool. Defaults to ``False`` - callers running
             stdio should pass ``True`` explicitly (``run_stdio`` does).
         lineage_root: Override the lineage store path. Defaults to
             ``<cwd>/.sdd/lineage``.
+        tier: Optional explicit tool tier (``core`` / ``standard`` / ``all``)
+            overriding the ``BERNSTEIN_MCP_TOOL_TIER`` env var. When ``None``
+            the env var is consulted, falling back to the ``standard``
+            default. Out-of-tier tools are not advertised and not callable.
 
     Returns:
-        Configured FastMCP instance with all Bernstein tools registered.
+        Configured FastMCP instance with the active tier's tools registered.
     """
+    active_tier = resolve_active_tier(tier)
     mcp: FastMCP[None] = FastMCP(name)
     _register_health_tool(mcp)
     _register_query_tools(mcp, server_url)
@@ -505,10 +536,11 @@ def create_mcp_server(
         root = lineage_root if lineage_root is not None else Path.cwd() / ".sdd" / "lineage"
         register_lineage_resources(mcp, lineage_root=root, enabled=True)
 
+    _apply_tool_tier(mcp, active_tier)
     return mcp
 
 
-def run_stdio(server_url: str = _DEFAULT_SERVER_URL) -> None:
+def run_stdio(server_url: str = _DEFAULT_SERVER_URL, *, tier: str | None = None) -> None:
     """Start the MCP server in stdio transport mode (for local IDE integration).
 
     Lineage MCP resources default ON for local stdio (ADR-009 §7.3) and can
@@ -516,18 +548,27 @@ def run_stdio(server_url: str = _DEFAULT_SERVER_URL) -> None:
 
     Args:
         server_url: Bernstein task server URL.
+        tier: Optional explicit tool tier overriding
+            ``BERNSTEIN_MCP_TOOL_TIER`` (the ``--mcp-tier`` session flag).
     """
     mcp = create_mcp_server(
         server_url=server_url,
         lineage_enabled=_lineage_mcp_default(default=True),
+        tier=tier,
     )
     mcp.run(transport="stdio")
 
 
-def run_sse(server_url: str = _DEFAULT_SERVER_URL, host: str = "127.0.0.1", port: int = 8053) -> None:
+def run_sse(
+    server_url: str = _DEFAULT_SERVER_URL,
+    host: str = "127.0.0.1",
+    port: int = 8053,
+    *,
+    tier: str | None = None,
+) -> None:
     """Start the MCP server in SSE transport mode (for remote/web integration).
 
-    Lineage MCP resources default OFF for SSE (ADR-009 §7.3) — operators
+    Lineage MCP resources default OFF for SSE (ADR-009 §7.3) - operators
     that explicitly want to expose them remotely can set
     ``BERNSTEIN_LINEAGE_MCP_ENABLED=1``.
 
@@ -535,10 +576,13 @@ def run_sse(server_url: str = _DEFAULT_SERVER_URL, host: str = "127.0.0.1", port
         server_url: Bernstein task server URL.
         host: Host to bind the SSE server to.
         port: Port to bind the SSE server to.
+        tier: Optional explicit tool tier overriding
+            ``BERNSTEIN_MCP_TOOL_TIER`` (the ``--mcp-tier`` session flag).
     """
     mcp = create_mcp_server(
         server_url=server_url,
         lineage_enabled=_lineage_mcp_default(default=False),
+        tier=tier,
     )
     import uvicorn
 

--- a/tests/unit/mcp/test_tool_tiering.py
+++ b/tests/unit/mcp/test_tool_tiering.py
@@ -1,0 +1,215 @@
+"""Tests for tiered MCP tool exposure (issue #1625).
+
+Covers:
+
+  * the tier model in ``bernstein.core.protocols.mcp.tool_tiers``;
+  * tier filtering applied by ``create_mcp_server`` (only the active tier's
+    tools are advertised and callable);
+  * the default tier;
+  * the ``BERNSTEIN_MCP_TOOL_TIER`` env-var knob and the explicit override;
+  * the ``bernstein mcp tools`` audit command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.mcp_cmd import mcp_server
+from bernstein.core.protocols.mcp.tool_tiers import (
+    DEFAULT_TIER,
+    TIER_ENV_VAR,
+    TIER_ORDER,
+    TOOL_TIERS,
+    normalize_tier,
+    resolve_active_tier,
+    tier_audit,
+    tier_rank,
+    tool_in_tier,
+    tools_for_tier,
+)
+from bernstein.mcp.server import create_mcp_server
+
+
+def _advertised(tier: str | None) -> set[str]:
+    """Return the set of tool names a server advertises for ``tier``."""
+    mcp = create_mcp_server(tier=tier)
+    return {tool.name for tool in asyncio.run(mcp.list_tools())}
+
+
+# --------------------------------------------------------------------------
+# Tier model
+# --------------------------------------------------------------------------
+
+
+def test_tiers_are_three_named_values() -> None:
+    assert TIER_ORDER == ("core", "standard", "all")
+
+
+def test_default_tier_is_standard() -> None:
+    assert DEFAULT_TIER == "standard"
+
+
+def test_tier_rank_is_monotonic() -> None:
+    assert tier_rank("core") < tier_rank("standard") < tier_rank("all")
+
+
+def test_every_shipped_tool_has_a_valid_tier() -> None:
+    assert TOOL_TIERS, "tool tier map must not be empty"
+    assert all(t in TIER_ORDER for t in TOOL_TIERS.values())
+
+
+def test_tiers_are_cumulative() -> None:
+    core = set(tools_for_tier("core"))
+    standard = set(tools_for_tier("standard"))
+    every = set(tools_for_tier("all"))
+    assert core <= standard <= every
+
+
+def test_core_is_a_strict_subset_of_all() -> None:
+    assert set(tools_for_tier("core")) < set(tools_for_tier("all"))
+
+
+def test_tool_in_tier_respects_declared_rank() -> None:
+    # bernstein_cost is a standard tool: out of core, present from standard.
+    assert not tool_in_tier("bernstein_cost", "core")
+    assert tool_in_tier("bernstein_cost", "standard")
+    assert tool_in_tier("bernstein_cost", "all")
+
+
+def test_unannotated_tool_defaults_to_all_only() -> None:
+    assert not tool_in_tier("some_future_tool", "core")
+    assert not tool_in_tier("some_future_tool", "standard")
+    assert tool_in_tier("some_future_tool", "all")
+
+
+# --------------------------------------------------------------------------
+# Tier resolution / knob
+# --------------------------------------------------------------------------
+
+
+def test_normalize_tier_blank_falls_back_to_default() -> None:
+    assert normalize_tier(None) == DEFAULT_TIER
+    assert normalize_tier("") == DEFAULT_TIER
+    assert normalize_tier("   ") == DEFAULT_TIER
+
+
+def test_normalize_tier_is_case_insensitive() -> None:
+    assert normalize_tier("CORE") == "core"
+    assert normalize_tier(" All ") == "all"
+
+
+def test_normalize_tier_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unknown MCP tool tier"):
+        normalize_tier("turbo")
+
+
+def test_resolve_active_tier_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TIER_ENV_VAR, "core")
+    assert resolve_active_tier() == "core"
+
+
+def test_resolve_active_tier_default_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TIER_ENV_VAR, raising=False)
+    assert resolve_active_tier() == DEFAULT_TIER
+
+
+def test_explicit_override_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TIER_ENV_VAR, "core")
+    assert resolve_active_tier("all") == "all"
+
+
+# --------------------------------------------------------------------------
+# Server-level filtering: each tier exposes the correct subset
+# --------------------------------------------------------------------------
+
+
+def test_core_tier_exposes_only_core_tools() -> None:
+    advertised = _advertised("core")
+    assert advertised == set(tools_for_tier("core"))
+    assert "bernstein_health" in advertised
+    assert "bernstein_cost" not in advertised
+    assert "bernstein_scenario" not in advertised
+
+
+def test_standard_tier_adds_mutation_and_skill_tools() -> None:
+    advertised = _advertised("standard")
+    assert "bernstein_cost" in advertised
+    assert "load_skill" in advertised
+    assert "bernstein_scenario" not in advertised
+
+
+def test_all_tier_exposes_scenario_bridge() -> None:
+    advertised = _advertised("all")
+    assert "bernstein_scenarios" in advertised
+    assert "bernstein_scenario" in advertised
+    assert "bernstein_scenario_status" in advertised
+
+
+def test_default_server_uses_standard_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TIER_ENV_VAR, raising=False)
+    assert _advertised(None) == set(tools_for_tier("standard"))
+
+
+def test_env_var_drives_server_without_explicit_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TIER_ENV_VAR, "core")
+    assert _advertised(None) == set(tools_for_tier("core"))
+
+
+def test_out_of_tier_tool_is_not_callable() -> None:
+    mcp = create_mcp_server(tier="core")
+    # bernstein_cost is a standard tool, so calling it under core must fail.
+    with pytest.raises(Exception):  # noqa: B017 - any error proves it is unroutable
+        asyncio.run(mcp.call_tool("bernstein_cost", {}))
+
+
+def test_lineage_verify_chain_only_in_all_tier(tmp_path: object) -> None:
+    # verify_chain is an 'all'-tier tool; even with lineage enabled it must
+    # not be advertised under core.
+    mcp = create_mcp_server(tier="core", lineage_enabled=True, lineage_root=tmp_path)  # type: ignore[arg-type]
+    names = {tool.name for tool in asyncio.run(mcp.list_tools())}
+    assert "verify_chain" not in names
+
+    mcp_all = create_mcp_server(tier="all", lineage_enabled=True, lineage_root=tmp_path)  # type: ignore[arg-type]
+    names_all = {tool.name for tool in asyncio.run(mcp_all.list_tools())}
+    assert "verify_chain" in names_all
+
+
+# --------------------------------------------------------------------------
+# Audit command
+# --------------------------------------------------------------------------
+
+
+def test_tier_audit_returns_all_tiers() -> None:
+    audit = tier_audit()
+    assert set(audit) == set(TIER_ORDER)
+    assert audit["core"] == tools_for_tier("core")
+
+
+def test_mcp_tools_command_lists_every_tier() -> None:
+    runner = CliRunner()
+    result = runner.invoke(mcp_server, ["tools"])
+    assert result.exit_code == 0, result.output
+    assert "core" in result.output
+    assert "standard" in result.output
+    assert "all" in result.output
+    assert "bernstein_health" in result.output
+
+
+def test_mcp_tools_command_single_tier_json() -> None:
+    import json
+
+    runner = CliRunner()
+    result = runner.invoke(mcp_server, ["tools", "--tier", "core", "--json-output"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert set(payload) == {"core"}
+    assert payload["core"] == tools_for_tier("core")
+
+
+def test_mcp_tools_command_rejects_unknown_tier() -> None:
+    runner = CliRunner()
+    result = runner.invoke(mcp_server, ["tools", "--tier", "turbo"])
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- Add `core` / `standard` / `all` tool tiers to the MCP surface so operators cap the per-turn context cost of advertised tools.
- Active tier resolves from the `--mcp-tier` session flag, then `BERNSTEIN_MCP_TOOL_TIER`, then the `standard` default. Only the active tier's tools are advertised in `tools/list`; out-of-tier tools are not callable.
- Tier is declared once per tool in `TOOL_TIERS` at registration time (no separate runtime registry). Adds `bernstein mcp tools [--tier]` to audit each tier before switching.
- Docs at `docs/mcp/tool_tiers.md` covering the tiers and the budget-vs-capability trade.

## Implementation
- `src/bernstein/core/protocols/mcp/tool_tiers.py`: `ToolTier` literal, cumulative tier model, env/override resolution, audit helpers.
- `src/bernstein/mcp/server.py`: `create_mcp_server(tier=...)` filters the FastMCP tool registry post-registration; `run_stdio`/`run_sse` forward the tier.
- `src/bernstein/cli/commands/mcp_cmd.py`: `--mcp-tier` group flag plus the `mcp tools` audit subcommand.

## Test plan
- [x] `pytest tests/unit/mcp/` (33 passed)
- [x] each tier exposes the correct subset; cumulative subset invariant
- [x] default tier is `standard`; env var and `--mcp-tier` override respected
- [x] out-of-tier tool not advertised and not callable
- [x] `bernstein mcp tools` audit command (table + JSON, single + all tiers)
- [x] ruff check + format clean; import-linter contracts kept

Closes #1625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MCP tool tier support with three levels (core, standard, all) controlling tool availability
  * Added `mcp tools` command to audit and view available tools per tier
  * Added `--mcp-tier` option to MCP commands for tier selection

* **Documentation**
  * Added comprehensive guide to MCP tool tiers, selection mechanisms, and tool availability

* **Tests**
  * Added comprehensive test suite for tool tier functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->