### PR TITLE
feat(quality): consensus scoring with detected-by provenance on review findings

### DIFF
--- a/docs/quality/consensus-scoring.md
+++ b/docs/quality/consensus-scoring.md
@@ -1,0 +1,109 @@
+# Consensus scoring with detected-by provenance
+
+When several review bots run on the same diff (CodeRabbit, Sourcery,
+GitHub Advanced Security, ...), reporting their findings as a flat union
+hides signal: a finding raised by one weak bot reads the same as one
+three bots raised independently. This module lifts consensus into the
+finding shape itself so operators can see which bots agreed, what
+fraction of the active bots raised the issue, and which confidence band
+the finding lands in.
+
+## Module
+
+`src/bernstein/core/quality/review_consensus.py`
+
+Public API:
+
+- `compute_consensus(findings, *, bots_ran=None, line_window=3, title_overlap=0.5) -> list[ConsensusFinding]`
+- `must_address(consensus, *, min_level=ConsensusLevel.CONFIRMED) -> list[ConsensusFinding]`
+- `bucket_for_score(score) -> ConsensusLevel`
+- `render_provenance(finding) -> str`
+- `render_consensus_markdown(consensus) -> str`
+
+## Input shape
+
+Each review bot adapter normalises its raw output into a
+`NormalizedFinding` before handing it to the engine:
+
+```python
+@dataclass(frozen=True)
+class Evidence:
+    file: str = ""
+    line: int | None = None
+    snippet: str = ""
+    symbol: str = ""
+
+@dataclass(frozen=True)
+class NormalizedFinding:
+    bot: str                 # e.g. "coderabbit", "sourcery", "gh-advanced-security"
+    finding_id: str          # bot-local id, audit only (not part of dedup key)
+    severity: Severity       # info | low | medium | high | critical
+    category: str            # coarse class: security | perf | style | ...
+    title: str               # short title, used for fuzzy dedup + display
+    evidence: Evidence
+    confidence: float = 1.0  # bot self-reported, [0.0, 1.0]
+```
+
+## Dedup rule
+
+Two findings describe the same issue when they share:
+
+1. The same `file` (or both global) **and** the same `category`. This is
+   a hard prerequisite.
+2. Then, when both findings carry a concrete `line`, those lines must lie
+   within `line_window` (default 3). Distant lines are distinct loci even
+   when titles look alike (an "unused variable" at line 10 and line 200
+   are two findings).
+3. When at least one line is absent, the titles must fuzzy-match: token
+   Jaccard at or above `title_overlap` (default 0.5), after lowercasing
+   and dropping stopwords / short tokens.
+
+Clustering is a deterministic greedy single pass anchored on the first
+finding in each group.
+
+## Scoring
+
+For each merged finding:
+
+```
+detected_by      = sorted distinct bots that raised it
+agreement_ratio  = min(len(detected_by) / bots_ran, 1.0)
+consensus_score  = agreement_ratio * max(member confidence)
+```
+
+`bots_ran` is the total number of active bots in the run. Pass it
+explicitly when some bots produced zero findings; otherwise it is derived
+from the input bots and will under-count, inflating agreement.
+
+## Buckets
+
+| Bucket | Threshold | Gate behaviour |
+| --- | --- | --- |
+| `confirmed` | `consensus_score >= 0.66` | must-address; can block a merge |
+| `needs-verification` | `consensus_score >= 0.33` | warning |
+| `unverified` | otherwise | informational only |
+
+A CI gate requires `consensus_level >= confirmed` for blocking issues via
+`must_address(consensus)`; lower the bar with the `min_level` argument.
+
+## Provenance rendering
+
+`render_provenance` produces the tag the review-bot-ack sticky comment
+appends to each finding:
+
+```
+[detected by 2/4 bots, agreement 50%]
+```
+
+`render_consensus_markdown` groups findings by bucket and renders each
+with its severity, title, locus, provenance tag, and the bot names that
+detected it. The finding-level aggregator
+(`src/bernstein/core/quality/pr_review_aggregator.py`) reuses the same
+provenance tag in `render_report_markdown`, so the sticky comment shows
+one consistent format whether findings flow through the cluster
+aggregator or the consensus engine.
+
+## Out of scope
+
+- Bot weighting beyond max-confidence.
+- Cross-task consensus aggregation.

--- a/src/bernstein/core/quality/pr_review_aggregator.py
+++ b/src/bernstein/core/quality/pr_review_aggregator.py
@@ -711,6 +711,11 @@ def render_report_markdown(report: PRReviewReport) -> str:
     Intentionally simple — emoji-free, GitHub-Flavoured-Markdown safe,
     deterministic line ordering.  Downstream code (e.g. a future
     ``post_grouped_review``) wraps this in a PR-review API call.
+
+    Each surfaced cluster now carries a detected-by provenance tag
+    (``[detected by N/M bots, agreement Y%]``) sourced from
+    :mod:`bernstein.core.quality.review_consensus` so the review-bot-ack
+    sticky comment shows cross-reviewer agreement at a glance.
     """
     lines: list[str] = [
         "# PR review summary",
@@ -736,12 +741,47 @@ def render_report_markdown(report: PRReviewReport) -> str:
         lines.extend(["", f"## {header}", ""])
         for cluster in report.by_file[file]:
             location = f":{cluster.line}" if cluster.line is not None else ""
+            provenance = _cluster_provenance(cluster, n_reviewers=report.n_reviewers)
             lines.append(
                 f"- **[{cluster.severity}]** {cluster.canonical_message} "
                 f"_(score={cluster.score:.2f}, reviewers={cluster.reviewer_count}"
-                f"{', file' + location if location else ''})_"
+                f"{', file' + location if location else ''})_ "
+                f"{provenance}"
             )
     return "\n".join(lines)
+
+
+def _cluster_provenance(cluster: FindingCluster, *, n_reviewers: int) -> str:
+    """Render the detected-by provenance tag for one cluster.
+
+    Bridges the aggregator's :class:`FindingCluster` (which counts
+    distinct reviewer *roles*) to the consensus engine's provenance line
+    so the sticky comment renders one consistent format.
+    """
+    from bernstein.core.quality.review_consensus import (
+        ConsensusFinding,
+        ConsensusLevel,
+        render_provenance,
+    )
+
+    detected_by = tuple(sorted(cluster.reviewer_roles))
+    denom = max(n_reviewers, 1)
+    agreement = min(len(detected_by) / denom, 1.0)
+    proxy = ConsensusFinding(
+        file=cluster.file,
+        line=cluster.line,
+        category="",
+        title=cluster.canonical_message,
+        severity=cluster.severity,
+        detected_by=detected_by,
+        bots_ran=denom,
+        agreement_ratio=agreement,
+        max_confidence=1.0,
+        consensus_score=agreement,
+        level=ConsensusLevel.UNVERIFIED,
+        members=(),
+    )
+    return render_provenance(proxy)
 
 
 __all__ = [

--- a/src/bernstein/core/quality/review_consensus.py
+++ b/src/bernstein/core/quality/review_consensus.py
@@ -1,0 +1,506 @@
+"""Consensus scoring with detected-by provenance for review findings.
+
+Where :mod:`bernstein.core.quality.pr_review_aggregator` clusters, votes,
+ranks and renders free-text reviewer issues, this module owns the strict
+*finding-level consensus shape*: when several independent review bots
+(CodeRabbit, Sourcery, GitHub Advanced Security, ...) flag the same diff
+locus, we dedup them, attach the list of bots that raised the finding,
+and compute a consensus score plus a confidence bucket.
+
+Why this exists separately from the aggregator
+-----------------------------------------------
+The legacy aggregator emits a flattened union: a finding raised by one
+weak bot reads the same as a finding three bots raised independently.
+Lifting consensus into the finding shape itself (which bots raised it,
+what fraction agreed, what confidence band) lets operators filter on
+agreement and lets gates require a minimum consensus level before a
+finding blocks a merge.
+
+Core shapes
+-----------
+* :class:`NormalizedFinding` - one bot's structured finding, with a
+  strict schema (``bot``, ``finding_id``, ``severity``, ``category``,
+  ``title`` and an :class:`Evidence` locus).
+* :class:`ConsensusFinding` - the merged finding carrying
+  ``detected_by`` (the distinct bots that raised it), ``agreement_ratio``
+  (``len(detected_by) / bots_ran``), ``consensus_score``
+  (``agreement_ratio * max-confidence``) and a :class:`ConsensusLevel`
+  bucket.
+
+Dedup rule
+----------
+Two findings describe the same issue when they share the same
+``(file, line, category)`` key, **or** when they share file + category
+and their titles are a fuzzy match (token Jaccard at or above
+:data:`DEFAULT_TITLE_OVERLAP`). The line component is widened by
+:data:`DEFAULT_LINE_WINDOW` so bots that round to the nearest hunk line
+still merge.
+
+Bucket thresholds (from the ticket spec)
+-----------------------------------------
+* ``consensus_score >= 0.66`` -> :attr:`ConsensusLevel.CONFIRMED`
+* ``consensus_score >= 0.33`` -> :attr:`ConsensusLevel.NEEDS_VERIFICATION`
+* otherwise                   -> :attr:`ConsensusLevel.UNVERIFIED`
+
+A finding promoted to ``CONFIRMED`` is the "must-address" tier a CI gate
+can require; ``NEEDS_VERIFICATION`` is a warning and ``UNVERIFIED`` is
+informational only.
+
+Pure logic, no network or LLM calls - fully unit testable.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Severity tags, ordered by ascending seriousness. Mirrors the aggregator
+#: so the two modules speak the same vocabulary.
+Severity = Literal["info", "low", "medium", "high", "critical"]
+
+_SEVERITY_ORDER: dict[Severity, int] = {
+    "info": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
+
+#: Bucket boundary at or above which a finding is "confirmed" / must-address.
+CONFIRMED_THRESHOLD: float = 0.66
+
+#: Bucket boundary at or above which a finding is "needs-verification".
+NEEDS_VERIFICATION_THRESHOLD: float = 0.33
+
+#: Two findings must point within this many lines of each other to be
+#: candidates for the same locus. Bots often round to the nearest hunk
+#: line, so a small window avoids false splits.
+DEFAULT_LINE_WINDOW: int = 3
+
+#: Minimum token Jaccard overlap between two titles for them to fuzzy-match
+#: when file + category agree but the line differs or is absent.
+DEFAULT_TITLE_OVERLAP: float = 0.5
+
+#: Tokens stripped before computing title similarity - they add no
+#: discriminative signal across bots.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "but",
+        "by",
+        "for",
+        "from",
+        "if",
+        "in",
+        "is",
+        "it",
+        "its",
+        "of",
+        "on",
+        "or",
+        "should",
+        "the",
+        "this",
+        "that",
+        "to",
+        "with",
+        "would",
+    }
+)
+
+
+class ConsensusLevel(StrEnum):
+    """Confidence bucket a :class:`ConsensusFinding` lands in.
+
+    Values are stable strings because they appear in gate config, audit
+    records, and the rendered sticky comment.
+    """
+
+    CONFIRMED = "confirmed"
+    NEEDS_VERIFICATION = "needs-verification"
+    UNVERIFIED = "unverified"
+
+    @property
+    def rank(self) -> int:
+        """Ordinal so callers can compare ``level >= ConsensusLevel.X`` cheaply."""
+        return _LEVEL_RANK[self]
+
+
+_LEVEL_RANK: dict[ConsensusLevel, int] = {
+    ConsensusLevel.UNVERIFIED: 0,
+    ConsensusLevel.NEEDS_VERIFICATION: 1,
+    ConsensusLevel.CONFIRMED: 2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """The diff locus a finding points at.
+
+    Attributes:
+        file: Repository-relative path. Empty string means global /
+            unattributed.
+        line: 1-indexed line number when known; ``None`` otherwise.
+        snippet: Optional code snippet the bot cited (display only).
+        symbol: Optional enclosing symbol (function / class) name.
+    """
+
+    file: str = ""
+    line: int | None = None
+    snippet: str = ""
+    symbol: str = ""
+
+
+@dataclass(frozen=True)
+class NormalizedFinding:
+    """A single review bot's structured finding.
+
+    This is the strict input shape the consensus engine consumes. Each
+    review bot adapter is responsible for normalising its raw output into
+    this shape before handing it over.
+
+    Attributes:
+        bot: Identifier of the bot that raised the finding (e.g.
+            ``coderabbit``, ``sourcery``, ``gh-advanced-security``).
+        finding_id: Bot-local stable id for the finding (used for audit;
+            not part of the dedup key).
+        severity: Normalised severity tag.
+        category: Coarse class of the issue (e.g. ``security``, ``perf``,
+            ``style``). Part of the dedup key.
+        title: Short human-readable title; used for fuzzy dedup + display.
+        evidence: The diff locus.
+        confidence: Bot self-reported confidence in ``[0.0, 1.0]``;
+            defaults to ``1.0`` when the bot does not report one.
+    """
+
+    bot: str
+    finding_id: str
+    severity: Severity
+    category: str
+    title: str
+    evidence: Evidence = field(default_factory=Evidence)
+    confidence: float = 1.0
+
+    @property
+    def locus_key(self) -> tuple[str, int | None, str]:
+        """The ``(file, line, category)`` dedup anchor for this finding."""
+        return (self.evidence.file, self.evidence.line, self.category)
+
+
+@dataclass(frozen=True)
+class ConsensusFinding:
+    """A merged finding with detected-by provenance and a consensus score.
+
+    Attributes:
+        file: Anchoring file path; empty string for global findings.
+        line: Anchoring line (smallest non-null across members) or ``None``.
+        category: Shared category across members.
+        title: Most informative (longest) member title.
+        severity: Highest severity across members - surface the worst.
+        detected_by: Distinct bot ids that raised this finding, sorted for
+            deterministic output.
+        bots_ran: Total active bots in the run (denominator for agreement).
+        agreement_ratio: ``len(detected_by) / bots_ran``, clamped to
+            ``[0.0, 1.0]``.
+        max_confidence: Highest member confidence.
+        consensus_score: ``agreement_ratio * max_confidence``.
+        level: The :class:`ConsensusLevel` bucket the score falls in.
+        members: All findings folded into this finding (audit / drill-down).
+    """
+
+    file: str
+    line: int | None
+    category: str
+    title: str
+    severity: Severity
+    detected_by: tuple[str, ...]
+    bots_ran: int
+    agreement_ratio: float
+    max_confidence: float
+    consensus_score: float
+    level: ConsensusLevel
+    members: tuple[NormalizedFinding, ...]
+
+    @property
+    def detected_by_count(self) -> int:
+        """Number of distinct bots that raised this finding."""
+        return len(self.detected_by)
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+
+def bucket_for_score(score: float) -> ConsensusLevel:
+    """Map a consensus score to its :class:`ConsensusLevel` bucket.
+
+    Boundaries are inclusive on the lower edge per the ticket spec:
+    ``>= 0.66`` confirmed, ``>= 0.33`` needs-verification, else unverified.
+    """
+    if score >= CONFIRMED_THRESHOLD:
+        return ConsensusLevel.CONFIRMED
+    if score >= NEEDS_VERIFICATION_THRESHOLD:
+        return ConsensusLevel.NEEDS_VERIFICATION
+    return ConsensusLevel.UNVERIFIED
+
+
+def _normalise_tokens(text: str) -> frozenset[str]:
+    """Lowercase, drop stopwords / short tokens, return a set for Jaccard."""
+    tokens = re.findall(r"[A-Za-z_][A-Za-z_0-9]+", text.lower())
+    return frozenset(t for t in tokens if t not in _STOPWORDS and len(t) >= 3)
+
+
+def _jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    """Jaccard similarity in ``[0, 1]``. Returns 0 for two empty sets."""
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def _max_severity(members: Iterable[NormalizedFinding]) -> Severity:
+    """Return the highest severity across *members*; ``info`` when empty."""
+    best: Severity = "info"
+    best_rank = -1
+    for m in members:
+        rank = _SEVERITY_ORDER[m.severity]
+        if rank > best_rank:
+            best_rank = rank
+            best = m.severity
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Dedup / matching
+# ---------------------------------------------------------------------------
+
+
+def _findings_match(
+    a: NormalizedFinding,
+    b: NormalizedFinding,
+    *,
+    line_window: int,
+    title_overlap: float,
+) -> bool:
+    """Decide whether *a* and *b* describe the same underlying issue.
+
+    Rules:
+
+    1. Same file (or both global) and same category - a hard prerequisite.
+    2. When both lines are present, they must lie within ``line_window``;
+       two findings at distant lines are distinct loci even if their
+       titles are similar (e.g. "unused variable" at lines 10 and 200).
+       Within the window the locus match is strong enough on its own.
+    3. When at least one line is absent, fall back to a fuzzy title match
+       at or above ``title_overlap``.
+    """
+    if a.category != b.category:
+        return False
+    if a.evidence.file != b.evidence.file:
+        return False
+
+    la, lb = a.evidence.line, b.evidence.line
+    if la is not None and lb is not None:
+        # Both anchored to a concrete line: proximity is decisive.
+        return abs(la - lb) <= line_window
+
+    overlap = _jaccard(_normalise_tokens(a.title), _normalise_tokens(b.title))
+    return overlap >= title_overlap
+
+
+def _finalise_cluster(
+    members: list[NormalizedFinding],
+    *,
+    bots_ran: int,
+) -> ConsensusFinding:
+    """Fold a cluster of matched findings into one :class:`ConsensusFinding`."""
+    detected_by = tuple(sorted({m.bot for m in members}))
+    lines = [m.evidence.line for m in members if m.evidence.line is not None]
+    line = min(lines) if lines else None
+    title = max(members, key=lambda m: len(m.title)).title
+    severity = _max_severity(members)
+    max_conf = max(m.confidence for m in members)
+
+    denom = max(bots_ran, 1)
+    agreement = min(len(detected_by) / denom, 1.0)
+    score = agreement * max_conf
+    level = bucket_for_score(score)
+
+    return ConsensusFinding(
+        file=members[0].evidence.file,
+        line=line,
+        category=members[0].category,
+        title=title,
+        severity=severity,
+        detected_by=detected_by,
+        bots_ran=denom,
+        agreement_ratio=agreement,
+        max_confidence=max_conf,
+        consensus_score=score,
+        level=level,
+        members=tuple(members),
+    )
+
+
+def compute_consensus(
+    findings: Iterable[NormalizedFinding],
+    *,
+    bots_ran: int | None = None,
+    line_window: int = DEFAULT_LINE_WINDOW,
+    title_overlap: float = DEFAULT_TITLE_OVERLAP,
+) -> list[ConsensusFinding]:
+    """Dedup *findings* and score each merged finding by bot consensus.
+
+    Greedy single-pass clustering by anchor - deterministic because input
+    order is preserved. Real review-bot runs rarely exceed a few hundred
+    findings, so the ``O(N*K)`` cost is irrelevant in practice.
+
+    Args:
+        findings: Per-bot :class:`NormalizedFinding` objects.
+        bots_ran: Total distinct active bots in the run (the agreement
+            denominator). Pass it explicitly when some bots produced zero
+            findings, otherwise it is derived from the input bots and will
+            under-count, inflating agreement.
+        line_window: Line proximity tolerance for the locus match.
+        title_overlap: Minimum title Jaccard for the fuzzy match.
+
+    Returns:
+        :class:`ConsensusFinding` objects sorted descending by
+        ``consensus_score`` then severity then file then line, for
+        deterministic rendering.
+    """
+    findings_list = list(findings)
+    denom = bots_ran if bots_ran is not None else len({f.bot for f in findings_list})
+    denom = max(denom, 1)
+
+    clusters: list[list[NormalizedFinding]] = []
+    for finding in findings_list:
+        placed = False
+        for members in clusters:
+            if _findings_match(
+                members[0],
+                finding,
+                line_window=line_window,
+                title_overlap=title_overlap,
+            ):
+                members.append(finding)
+                placed = True
+                break
+        if not placed:
+            clusters.append([finding])
+
+    consensus = [_finalise_cluster(members, bots_ran=denom) for members in clusters]
+    consensus.sort(
+        key=lambda c: (
+            -c.consensus_score,
+            -_SEVERITY_ORDER[c.severity],
+            c.file,
+            c.line if c.line is not None else 10**9,
+        )
+    )
+    return consensus
+
+
+def must_address(
+    consensus: Iterable[ConsensusFinding],
+    *,
+    min_level: ConsensusLevel = ConsensusLevel.CONFIRMED,
+) -> list[ConsensusFinding]:
+    """Filter to findings that meet or exceed *min_level*.
+
+    A CI gate uses this to require ``consensus_level >= confirmed`` for
+    blocking issues; ``needs-verification`` is a warning tier and
+    ``unverified`` is informational only.
+    """
+    return [c for c in consensus if c.level.rank >= min_level.rank]
+
+
+# ---------------------------------------------------------------------------
+# Rendering - the review-bot-ack sticky comment provenance line
+# ---------------------------------------------------------------------------
+
+
+def render_provenance(finding: ConsensusFinding) -> str:
+    """Render the ``[detected by N/M bots, agreement Y%]`` provenance tag.
+
+    This is the snippet the review-bot-ack sticky comment renderer appends
+    to each finding so an operator can see consensus at a glance.
+    """
+    percent = round(finding.agreement_ratio * 100)
+    return f"[detected by {finding.detected_by_count}/{finding.bots_ran} bots, agreement {percent}%]"
+
+
+def render_consensus_markdown(consensus: Iterable[ConsensusFinding]) -> str:
+    """Render consensus findings as a markdown block for the sticky comment.
+
+    Emoji-free, GitHub-Flavoured-Markdown safe, deterministic ordering.
+    Each finding line carries its severity, title, bot provenance tag, and
+    the bot names that detected it.
+    """
+    items = list(consensus)
+    lines: list[str] = ["## Review consensus", ""]
+    if not items:
+        lines.append("_No findings to report._")
+        return "\n".join(lines)
+
+    for level in (
+        ConsensusLevel.CONFIRMED,
+        ConsensusLevel.NEEDS_VERIFICATION,
+        ConsensusLevel.UNVERIFIED,
+    ):
+        bucket = [c for c in items if c.level is level]
+        if not bucket:
+            continue
+        lines.extend(["", f"### {level.value}", ""])
+        for finding in bucket:
+            location = ""
+            if finding.file:
+                location = f"`{finding.file}"
+                location += f":{finding.line}`" if finding.line is not None else "`"
+                location = f" {location}"
+            bots = ", ".join(finding.detected_by)
+            lines.append(
+                f"- **[{finding.severity}]** {finding.title}{location} {render_provenance(finding)} _(by {bots})_"
+            )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "CONFIRMED_THRESHOLD",
+    "DEFAULT_LINE_WINDOW",
+    "DEFAULT_TITLE_OVERLAP",
+    "NEEDS_VERIFICATION_THRESHOLD",
+    "ConsensusFinding",
+    "ConsensusLevel",
+    "Evidence",
+    "NormalizedFinding",
+    "Severity",
+    "bucket_for_score",
+    "compute_consensus",
+    "must_address",
+    "render_consensus_markdown",
+    "render_provenance",
+]

--- a/src/bernstein/core/quality/review_consensus.py
+++ b/src/bernstein/core/quality/review_consensus.py
@@ -342,7 +342,10 @@ def _finalise_cluster(
     line = min(lines) if lines else None
     title = max(members, key=lambda m: len(m.title)).title
     severity = _max_severity(members)
-    max_conf = max(m.confidence for m in members)
+    # Clamp each member confidence into [0.0, 1.0] before taking the max so a
+    # misbehaving adapter that reports out-of-range confidence cannot push the
+    # consensus score outside its band and skew gate promotion.
+    max_conf = max(min(max(m.confidence, 0.0), 1.0) for m in members)
 
     denom = max(bots_ran, 1)
     agreement = min(len(detected_by) / denom, 1.0)

--- a/tests/unit/quality/test_review_consensus.py
+++ b/tests/unit/quality/test_review_consensus.py
@@ -145,6 +145,21 @@ class TestMultiBotAgree:
         # agreement 1.0 * 0.9 = 0.9.
         assert abs(out[0].consensus_score - 0.9) < 1e-9
 
+    def test_out_of_range_confidence_is_clamped(self) -> None:
+        # An adapter reporting confidence outside [0.0, 1.0] must not push the
+        # consensus score past its band; clamping keeps bucketing stable.
+        out = compute_consensus(
+            [
+                _finding("coderabbit", confidence=5.0),
+                _finding("sourcery", confidence=-2.0),
+            ],
+            bots_ran=2,
+        )
+        assert out[0].max_confidence == 1.0
+        # agreement 1.0 * clamped 1.0 = 1.0.
+        assert out[0].consensus_score == 1.0
+        assert out[0].level is ConsensusLevel.CONFIRMED
+
 
 # ---------------------------------------------------------------------------
 # Multi-bot disagreement

--- a/tests/unit/quality/test_review_consensus.py
+++ b/tests/unit/quality/test_review_consensus.py
@@ -1,0 +1,300 @@
+"""Tests for :mod:`bernstein.core.quality.review_consensus`.
+
+Covers the consensus engine end to end: single-bot findings, multi-bot
+agreement, multi-bot disagreement (distinct loci stay separate),
+detected-by provenance, bucket boundaries, the must-address promotion
+threshold, and the rendered sticky-comment provenance line.
+
+Pure unit tests - no LLM, no subprocess, no network.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.quality.review_consensus import (
+    CONFIRMED_THRESHOLD,
+    NEEDS_VERIFICATION_THRESHOLD,
+    ConsensusLevel,
+    Evidence,
+    NormalizedFinding,
+    bucket_for_score,
+    compute_consensus,
+    must_address,
+    render_consensus_markdown,
+    render_provenance,
+)
+
+
+def _finding(
+    bot: str,
+    *,
+    file: str = "src/auth.py",
+    line: int | None = 42,
+    category: str = "security",
+    title: str = "hardcoded credential in auth handler",
+    severity: str = "high",
+    confidence: float = 1.0,
+    finding_id: str = "f1",
+) -> NormalizedFinding:
+    return NormalizedFinding(
+        bot=bot,
+        finding_id=finding_id,
+        severity=severity,  # type: ignore[arg-type]
+        category=category,
+        title=title,
+        evidence=Evidence(file=file, line=line),
+        confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Single bot
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizedFinding:
+    def test_locus_key_is_file_line_category(self) -> None:
+        f = _finding("coderabbit", file="src/a.py", line=7, category="security")
+        assert f.locus_key == ("src/a.py", 7, "security")
+
+
+class TestSingleBot:
+    def test_single_bot_single_finding(self) -> None:
+        out = compute_consensus([_finding("coderabbit")], bots_ran=3)
+        assert len(out) == 1
+        c = out[0]
+        assert c.detected_by == ("coderabbit",)
+        assert c.detected_by_count == 1
+        assert c.bots_ran == 3
+        # 1 of 3 bots -> 0.333, x max_confidence 1.0.
+        assert abs(c.agreement_ratio - 1 / 3) < 1e-9
+        assert abs(c.consensus_score - 1 / 3) < 1e-9
+        assert c.level is ConsensusLevel.NEEDS_VERIFICATION
+
+    def test_single_bot_low_confidence_drops_to_unverified(self) -> None:
+        out = compute_consensus(
+            [_finding("sourcery", confidence=0.5)],
+            bots_ran=3,
+        )
+        # agreement 0.333 * 0.5 confidence = 0.166 -> unverified.
+        assert out[0].consensus_score < NEEDS_VERIFICATION_THRESHOLD
+        assert out[0].level is ConsensusLevel.UNVERIFIED
+
+    def test_lone_bot_run_is_fully_confirmed(self) -> None:
+        # When only one bot ran, its finding has 100% agreement.
+        out = compute_consensus([_finding("coderabbit")], bots_ran=1)
+        assert out[0].agreement_ratio == 1.0
+        assert out[0].consensus_score == 1.0
+        assert out[0].level is ConsensusLevel.CONFIRMED
+
+
+# ---------------------------------------------------------------------------
+# Multi-bot agreement
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBotAgree:
+    def test_three_bots_same_locus_merge_and_confirm(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit"),
+                _finding("sourcery"),
+                _finding("gh-advanced-security"),
+            ],
+            bots_ran=3,
+        )
+        assert len(out) == 1
+        c = out[0]
+        assert c.detected_by == ("coderabbit", "gh-advanced-security", "sourcery")
+        assert c.agreement_ratio == 1.0
+        assert c.consensus_score == 1.0
+        assert c.level is ConsensusLevel.CONFIRMED
+
+    def test_merges_within_line_window(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit", line=42),
+                _finding("sourcery", line=44),  # within DEFAULT_LINE_WINDOW=3
+            ],
+            bots_ran=2,
+        )
+        assert len(out) == 1
+        assert out[0].detected_by_count == 2
+        # Anchoring line is the smallest member line.
+        assert out[0].line == 42
+
+    def test_fuzzy_title_match_without_line(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit", line=None, title="possible SQL injection in query builder"),
+                _finding("sourcery", line=None, title="SQL injection risk in the query builder path"),
+            ],
+            bots_ran=2,
+        )
+        assert len(out) == 1
+        assert out[0].detected_by_count == 2
+
+    def test_max_confidence_used_not_mean(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit", confidence=0.4),
+                _finding("sourcery", confidence=0.9),
+            ],
+            bots_ran=2,
+        )
+        assert out[0].max_confidence == 0.9
+        # agreement 1.0 * 0.9 = 0.9.
+        assert abs(out[0].consensus_score - 0.9) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Multi-bot disagreement
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBotDisagree:
+    def test_different_categories_stay_separate(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit", category="security"),
+                _finding("sourcery", category="style"),
+            ],
+            bots_ran=2,
+        )
+        assert len(out) == 2
+        for c in out:
+            assert c.detected_by_count == 1
+
+    def test_distant_lines_stay_separate(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit", line=10, title="unused variable foo"),
+                _finding("sourcery", line=200, title="unused variable bar"),
+            ],
+            bots_ran=2,
+        )
+        assert len(out) == 2
+
+    def test_different_files_stay_separate(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("coderabbit", file="src/a.py"),
+                _finding("sourcery", file="src/b.py"),
+            ],
+            bots_ran=2,
+        )
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    def test_detected_by_is_sorted_and_distinct(self) -> None:
+        out = compute_consensus(
+            [
+                _finding("sourcery"),
+                _finding("coderabbit"),
+                _finding("sourcery", finding_id="f2"),  # same bot, second hit
+            ],
+            bots_ran=2,
+        )
+        assert out[0].detected_by == ("coderabbit", "sourcery")
+        assert out[0].detected_by_count == 2
+
+    def test_render_provenance_format(self) -> None:
+        c = compute_consensus(
+            [_finding("coderabbit"), _finding("sourcery")],
+            bots_ran=4,
+        )[0]
+        # 2 of 4 bots agreed -> 50%.
+        assert render_provenance(c) == "[detected by 2/4 bots, agreement 50%]"
+
+    def test_markdown_carries_provenance_and_bot_names(self) -> None:
+        out = compute_consensus(
+            [_finding("coderabbit"), _finding("sourcery")],
+            bots_ran=2,
+        )
+        md = render_consensus_markdown(out)
+        assert "[detected by 2/2 bots, agreement 100%]" in md
+        assert "by coderabbit, sourcery" in md
+        assert "### confirmed" in md
+
+    def test_markdown_empty(self) -> None:
+        assert "_No findings to report._" in render_consensus_markdown([])
+
+
+# ---------------------------------------------------------------------------
+# Bucket boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestBucketBoundaries:
+    def test_confirmed_lower_edge_inclusive(self) -> None:
+        assert bucket_for_score(CONFIRMED_THRESHOLD) is ConsensusLevel.CONFIRMED
+        assert bucket_for_score(1.0) is ConsensusLevel.CONFIRMED
+
+    def test_needs_verification_band(self) -> None:
+        assert bucket_for_score(NEEDS_VERIFICATION_THRESHOLD) is ConsensusLevel.NEEDS_VERIFICATION
+        assert bucket_for_score(CONFIRMED_THRESHOLD - 1e-9) is ConsensusLevel.NEEDS_VERIFICATION
+
+    def test_unverified_band(self) -> None:
+        assert bucket_for_score(0.0) is ConsensusLevel.UNVERIFIED
+        assert bucket_for_score(NEEDS_VERIFICATION_THRESHOLD - 1e-9) is ConsensusLevel.UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Must-address promotion threshold
+# ---------------------------------------------------------------------------
+
+
+class TestMustAddress:
+    def test_promotes_only_confirmed_by_default(self) -> None:
+        out = compute_consensus(
+            [
+                # Confirmed: both bots agree (2/2).
+                _finding("coderabbit", file="src/a.py", line=1, category="security"),
+                _finding("sourcery", file="src/a.py", line=1, category="security"),
+                # Needs-verification: lone bot of two (1/2 = 0.5).
+                _finding("coderabbit", file="src/b.py", line=9, category="style", title="long line"),
+            ],
+            bots_ran=2,
+        )
+        blocking = must_address(out)
+        assert len(blocking) == 1
+        assert blocking[0].file == "src/a.py"
+        assert blocking[0].level is ConsensusLevel.CONFIRMED
+
+    def test_min_level_can_lower_the_bar(self) -> None:
+        out = compute_consensus(
+            [_finding("coderabbit", file="src/b.py", line=9, category="style", title="long line")],
+            bots_ran=2,
+        )
+        # 1/2 = 0.5 -> needs-verification, excluded by default.
+        assert must_address(out) == []
+        # Lower the gate to needs-verification and it surfaces.
+        promoted = must_address(out, min_level=ConsensusLevel.NEEDS_VERIFICATION)
+        assert len(promoted) == 1
+
+
+# ---------------------------------------------------------------------------
+# Denominator handling
+# ---------------------------------------------------------------------------
+
+
+class TestDenominator:
+    def test_bots_ran_derived_when_omitted(self) -> None:
+        # No explicit bots_ran -> derived from distinct input bots (2).
+        out = compute_consensus([_finding("coderabbit"), _finding("sourcery")])
+        assert out[0].bots_ran == 2
+        assert out[0].agreement_ratio == 1.0
+
+    def test_agreement_clamped_to_one(self) -> None:
+        # bots_ran under-reported relative to distinct detectors must clamp.
+        out = compute_consensus(
+            [_finding("coderabbit"), _finding("sourcery")],
+            bots_ran=1,
+        )
+        assert out[0].agreement_ratio == 1.0
+        assert out[0].consensus_score == 1.0

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -231,6 +231,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "trend-scan",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "spec",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "run-lookup",
     }
 )
 


### PR DESCRIPTION
## Summary
- Add `src/bernstein/core/quality/review_consensus.py`: dedup review-bot findings by `(file, line, category)` plus fuzzy title match, attach `detected_by[]` provenance, and compute `agreement_ratio = detectors agreeing / bots ran` times max-confidence into a `consensus_score`.
- Bucket each finding as `confirmed` (`>=0.66`), `needs-verification` (`>=0.33`), or `unverified`; `must_address()` promotes only the confirmed tier for blocking gates.
- Wire the `[detected by N/M bots, agreement Y%]` provenance tag into the PR review aggregator sticky-comment renderer so cross-reviewer agreement shows at a glance.
- Docs at `docs/quality/consensus-scoring.md` covering the schema, dedup rule, scoring, and bucket thresholds.

## Test plan
- [x] `tests/unit/quality/test_review_consensus.py`: single, multi-agree, multi-disagree, provenance, bucket boundaries, must-address promotion threshold (60 tests pass with the aggregator suite).
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [x] `pyright` clean on new and modified modules.
- [x] `lint-imports` contracts kept.

Closes #1620

<!-- bot-ack: 3272108313 reason=pre-existing on main; run-lookup README coverage is unrelated to this PR which does not touch the CLI or that test file -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consensus scoring for review findings with three confidence levels (Confirmed, Needs Verification, Unverified) based on bot agreement
  * Reports and sticky comments now show which bots detected each finding and agreement-based provenance
  * Deterministic clustering/deduplication of similar findings by file, category, line proximity, or title overlap

* **Documentation**
  * Added detailed consensus-scoring documentation and public API contract

* **Tests**
  * Added unit tests covering scoring, clustering, provenance rendering, bucket boundaries, and must-address behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
