### PR TITLE
feat(adapters): per-adapter strategy enums for resume, dangerous-mode, and event channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Commands that eliminate the glue code most teams end up writing around their run
 | `bernstein eval calibration report` | Brier score + ECE + reliability buckets over `.sdd/metrics/calibration.jsonl`. Example: `bernstein eval calibration report --since 7d --kind model_route --bins 10`. See [docs/operations/calibration.md](docs/operations/calibration.md). |
 | `bernstein lineage v2 show / verify / export` | Opt-in two-layer lineage store (parent timeline + detached children) with HMAC chains on both layers and content-addressed `child_sha` join pointers. Enable with `BERNSTEIN_LINEAGE_V2=1` or `bernstein.yaml` `lineage.version: 2`. See [docs/operations/lineage-v2.md](docs/operations/lineage-v2.md). |
 | `bernstein run --retry-budget SPEC` | Criterion-aware retry budget: `'3 retries, degrade: coverage>tests>style'`. Each retry dials down the next criterion instead of burning identical rerun budget. See [docs/operations/retry-budget.md](docs/operations/retry-budget.md). |
+| `bernstein run-lookup NAME` | Resolve a memorable run name back to its run UUID. Exits non-zero when the name is malformed or no known run id renders to it. Example: `bernstein run-lookup brave-otter-1234`. |
 
 ### retrieval & caching: what's actually under the hood
 

--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -1,0 +1,146 @@
+# Adapter capability contract
+
+Every CLI agent expresses the same orchestration concepts differently.
+Resume is `--resume <id>` for one CLI, `--session-id <id>` for another, and
+a subcommand `<cli> resume <id>` for a third. "Skip permission prompts" is a
+flag here, an environment variable there, and an always-on default for CLIs
+with no permission system. The event surface Bernstein observes is
+stream-json for some, a plain-text signal grammar for others, and upstream
+hooks for the rest.
+
+To keep the orchestrator free of `if adapter == "X"` branches, each adapter
+declares its strategy on three typed axes. The orchestrator dispatches off
+the enum, so adding a new adapter is a contract-completion exercise rather
+than a hunt-and-patch across the core.
+
+The enums and the declaration matrix live in
+[`src/bernstein/adapters/_contract.py`](../../src/bernstein/adapters/_contract.py).
+Strategy is **declared**, not probed: Bernstein never runs the CLI at start
+just to discover its capabilities.
+
+## The three axes
+
+### Resume strategy (`ResumeStrategy`)
+
+How an adapter reattaches to a prior session for `bernstein resume`.
+
+| Value | Meaning |
+| --- | --- |
+| `flag` | A single flag carries the session id, e.g. `--resume <id>`. |
+| `flag-pair` | Two flags: one names the existing session, one mints a new one. |
+| `subcommand` | A dedicated subcommand, e.g. `<cli> resume <id>`. |
+| `unsupported` | No native resume; fall back to a fresh session with scratchpad reinjection. |
+
+The legacy two-state view (`native` / `fallback-fresh`) consumed by
+`bernstein resume` is derived from this axis: any value other than
+`unsupported` maps to `native`. See `resume_capability` in `_contract.py`.
+
+### Dangerous-mode strategy (`DangerousModeStrategy`)
+
+How an adapter is told to skip interactive permission prompts so it can run
+unattended.
+
+| Value | Meaning |
+| --- | --- |
+| `cli-flag` | A flag, e.g. `--yolo` or `--permission-mode bypassPermissions`. |
+| `env-var` | An environment variable the CLI reads at startup. |
+| `always-on` | The CLI has no permission system; it is always non-interactive. |
+| `unsupported` | The CLI cannot run unattended in dangerous mode. |
+
+### Event channel (`EventChannel`)
+
+The surface Bernstein reads for an adapter's lifecycle signals.
+
+| Value | Meaning |
+| --- | --- |
+| `stream-json` | Newline-delimited JSON events from the upstream CLI. |
+| `text-signals` | Plain stdout carrying the canonical `BERNSTEIN:<KIND>` grammar (see [stream_signals.md](stream_signals.md)). |
+| `hooks` | The upstream SDK fires hooks/callbacks Bernstein registers against. |
+| `poll-pty` | No structured channel; Bernstein polls a PTY or log for liveness. |
+| `none` | No event channel; process-exit detection only. |
+
+## Declaring a strategy
+
+The canonical declaration is a row in `STRATEGY_MATRIX`, keyed by registry
+name:
+
+```python
+STRATEGY_MATRIX = {
+    "claude": AdapterStrategy(
+        resume=ResumeStrategy.FLAG,
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
+    ),
+    # ...
+}
+```
+
+An adapter MAY instead keep the declaration next to its implementation by
+setting the class attribute `strategy_override` to an `AdapterStrategy`.
+Read the resolved strategy through `CLIAdapter.strategy()`, never the raw
+attribute: the resolver applies the inline override first, then the matrix
+keyed by registry name, then the conservative `DEFAULT_ADAPTER_STRATEGY`
+(no native resume, dangerous mode unsupported, text-signal channel).
+
+## Conformance
+
+Every shipped adapter must declare its strategy on each axis. The
+conformance harness calls `assert_strategies_declared()`, which raises
+`StrategyDeclarationError` listing any registry adapter missing a row in
+`STRATEGY_MATRIX`. `bernstein adapters check` surfaces the per-adapter
+strategy table (`strategy_conformance_table`) so operators can compare
+adapters at a glance.
+
+## Shipped adapter declarations
+
+| Adapter | Resume | Dangerous mode | Event channel |
+| --- | --- | --- | --- |
+| `aichat` | unsupported | unsupported | text-signals |
+| `aider` | unsupported | unsupported | text-signals |
+| `amp` | unsupported | unsupported | text-signals |
+| `auggie` | unsupported | unsupported | text-signals |
+| `autohand` | unsupported | unsupported | text-signals |
+| `charm` | unsupported | cli-flag | text-signals |
+| `claude` | flag | cli-flag | stream-json |
+| `cline` | unsupported | cli-flag | text-signals |
+| `clm` | unsupported | unsupported | text-signals |
+| `cloudflare` | unsupported | unsupported | hooks |
+| `codebuff` | unsupported | unsupported | text-signals |
+| `codex` | unsupported | cli-flag | text-signals |
+| `cody` | unsupported | unsupported | text-signals |
+| `composio` | unsupported | unsupported | hooks |
+| `continue` | unsupported | unsupported | text-signals |
+| `copilot` | unsupported | unsupported | text-signals |
+| `cursor` | unsupported | cli-flag | stream-json |
+| `devin_terminal` | unsupported | unsupported | poll-pty |
+| `droid` | unsupported | unsupported | text-signals |
+| `forge` | unsupported | unsupported | text-signals |
+| `gemini` | unsupported | cli-flag | stream-json |
+| `generic` | unsupported | unsupported | text-signals |
+| `goose` | unsupported | unsupported | text-signals |
+| `gptme` | unsupported | unsupported | text-signals |
+| `hermes` | unsupported | unsupported | text-signals |
+| `iac` | unsupported | unsupported | text-signals |
+| `junie` | unsupported | unsupported | text-signals |
+| `kilo` | unsupported | unsupported | text-signals |
+| `kimi` | unsupported | cli-flag | text-signals |
+| `kiro` | unsupported | unsupported | text-signals |
+| `letta_code` | unsupported | cli-flag | text-signals |
+| `mistral` | unsupported | unsupported | text-signals |
+| `mock` | unsupported | unsupported | text-signals |
+| `ollama` | unsupported | unsupported | text-signals |
+| `open_interpreter` | unsupported | unsupported | text-signals |
+| `openai_agents` | flag | always-on | hooks |
+| `opencode` | unsupported | unsupported | text-signals |
+| `openhands` | unsupported | unsupported | text-signals |
+| `pi` | unsupported | unsupported | text-signals |
+| `plandex` | unsupported | unsupported | text-signals |
+| `q_dev` | unsupported | unsupported | text-signals |
+| `qwen` | unsupported | unsupported | text-signals |
+| `ralphex` | unsupported | unsupported | text-signals |
+| `rovo` | unsupported | cli-flag | text-signals |
+
+The matrix is the source of truth; this table is regenerated from
+`strategy_conformance_table()`. Out of scope for this contract: runtime
+capability discovery, and removing every adapter-specific conditional (some
+output-formatting quirks remain as overrides).

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -75,10 +75,15 @@ rather than re-listing each entry so the index does not drift.
 1. Add a `<name>.py` module under `src/bernstein/adapters/` implementing
    `CLIAdapter`.
 2. Register the class in `src/bernstein/adapters/registry.py`.
-3. Add an entry to `src/bernstein/adapters/use_cases.py` so the new
+3. Declare the adapter's resume / dangerous-mode / event-channel strategy
+   in `STRATEGY_MATRIX` (see
+   [capability_contract.md](./capability_contract.md)); the conformance
+   harness fails when a registered adapter has no declaration.
+4. Add an entry to `src/bernstein/adapters/use_cases.py` so the new
    adapter shows up in `bernstein integrations list` with a meaningful
    headline.
-4. Cover the adapter with a conformance test under `tests/contract/`.
+5. Cover the adapter with a conformance test under `tests/contract/`.
 
 The contract for new adapters lives in
-[ADAPTER_GUIDE.md](./ADAPTER_GUIDE.md).
+[ADAPTER_GUIDE.md](./ADAPTER_GUIDE.md). The typed strategy axes are
+documented in [capability_contract.md](./capability_contract.md).

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -365,82 +366,241 @@ def list_contracts(contracts_dir: Path | None = None) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Capability matrix — resume-from-checkpoint (feat-resume-from-checkpoint)
+# Per-adapter strategy enums (issue #1627)
 # ---------------------------------------------------------------------------
 #
-# Adapters opt into the resume protocol by implementing
-# :py:meth:`bernstein.adapters.base.CLIAdapter.resume`. The default
-# implementation declines via :data:`RESUME_FALLBACK_FRESH`, which signals
-# the CLI to spawn a fresh session and reinject the recovered scratchpad
-# (see ``bernstein.core.persistence.resume_prompt``).
+# Every CLI agent expresses the same three concepts differently:
 #
-# Keep this table in sync with adapter overrides. It is consulted by
-# ``bernstein adapters resume-matrix`` and surfaced in ``bernstein doctor``.
+#   * resume        - ``--resume <id>`` for some, ``--session-id <id>`` for
+#                     others, a subcommand ``<cli> resume <id>`` for a third
+#                     group, or no native resume at all.
+#   * dangerous mode - "skip permission prompts" is a flag here, an env var
+#                     there, always-on for adapters with no permission system,
+#                     and unsupported for the rest.
+#   * event channel  - the surface Bernstein observes for lifecycle signals:
+#                     stream-json, the canonical ``BERNSTEIN:<KIND>`` text
+#                     grammar, upstream hooks, or PTY polling.
+#
+# Capturing each axis as a typed per-adapter enum compresses the scattered
+# ``if adapter == "X"`` conditionals into one dispatch per axis and makes
+# adding a new adapter a contract-completion exercise rather than a
+# hunt-and-patch. Strategy is *declared* (see :data:`STRATEGY_MATRIX`); we do
+# not probe the CLI at runtime.
 
-#: Adapter resume capability — adapter inherits :class:`CLIAdapter.resume`'s
-#: default and the CLI falls back to a fresh session.
-RESUME_FALLBACK_FRESH: str = "fallback-fresh"
 
-#: Adapter overrides :class:`CLIAdapter.resume` to attach to the prior
-#: session via a provider-side session/resume id. The adapter is
-#: responsible for reinjecting any context it considers necessary.
-RESUME_NATIVE: str = "native"
+class ResumeStrategy(StrEnum):
+    """How an adapter reattaches to a prior session for ``bernstein resume``."""
 
-#: Tri-state capability rendered as ``adapter -> capability``. Adapters
-#: absent from this table are assumed :data:`RESUME_FALLBACK_FRESH`.
-RESUME_CAPABILITY_MATRIX: dict[str, str] = {
-    # Native resume — these adapters expose a stable session id that
-    # survives process restart and can be reattached.
-    "claude": RESUME_NATIVE,
-    "claude_routine": RESUME_NATIVE,
-    "openai_agents": RESUME_NATIVE,
-    # Everyone else — explicit "no native resume; fall back to fresh
-    # session with scratchpad reinjection".
-    "aichat": RESUME_FALLBACK_FRESH,
-    "aider": RESUME_FALLBACK_FRESH,
-    "amp": RESUME_FALLBACK_FRESH,
-    "auggie": RESUME_FALLBACK_FRESH,
-    "autohand": RESUME_FALLBACK_FRESH,
-    "charm": RESUME_FALLBACK_FRESH,
-    "cline": RESUME_FALLBACK_FRESH,
-    "codebuff": RESUME_FALLBACK_FRESH,
-    "codex": RESUME_FALLBACK_FRESH,
-    "cody": RESUME_FALLBACK_FRESH,
-    "composio": RESUME_FALLBACK_FRESH,
-    "continue_dev": RESUME_FALLBACK_FRESH,
-    "copilot": RESUME_FALLBACK_FRESH,
-    "cursor": RESUME_FALLBACK_FRESH,
-    "devin_terminal": RESUME_FALLBACK_FRESH,
-    "droid": RESUME_FALLBACK_FRESH,
-    "forge": RESUME_FALLBACK_FRESH,
-    "gemini": RESUME_FALLBACK_FRESH,
-    "generic": RESUME_FALLBACK_FRESH,
-    "goose": RESUME_FALLBACK_FRESH,
-    "gptme": RESUME_FALLBACK_FRESH,
-    "hermes": RESUME_FALLBACK_FRESH,
-    "junie": RESUME_FALLBACK_FRESH,
-    "kilo": RESUME_FALLBACK_FRESH,
-    "kimi": RESUME_FALLBACK_FRESH,
-    "kiro": RESUME_FALLBACK_FRESH,
-    "letta_code": RESUME_FALLBACK_FRESH,
-    "mistral": RESUME_FALLBACK_FRESH,
-    "mock": RESUME_FALLBACK_FRESH,
-    "ollama": RESUME_FALLBACK_FRESH,
-    "open_interpreter": RESUME_FALLBACK_FRESH,
-    "opencode": RESUME_FALLBACK_FRESH,
-    "openhands": RESUME_FALLBACK_FRESH,
-    "pi": RESUME_FALLBACK_FRESH,
-    "plandex": RESUME_FALLBACK_FRESH,
-    "q_dev": RESUME_FALLBACK_FRESH,
-    "qwen": RESUME_FALLBACK_FRESH,
-    "ralphex": RESUME_FALLBACK_FRESH,
-    "rovo": RESUME_FALLBACK_FRESH,
+    #: Single flag carrying the session id, e.g. ``--resume <id>``.
+    FLAG = "flag"
+    #: A pair of flags: one names the existing session, one mints a new one,
+    #: e.g. ``--continue-from <old> --session-id <new>``.
+    FLAG_PAIR = "flag-pair"
+    #: A dedicated subcommand, e.g. ``<cli> resume <id>``.
+    SUBCOMMAND = "subcommand"
+    #: No native resume; the orchestrator falls back to a fresh session with
+    #: scratchpad reinjection.
+    UNSUPPORTED = "unsupported"
+
+
+class DangerousModeStrategy(StrEnum):
+    """How an adapter is told to skip interactive permission prompts."""
+
+    #: A CLI flag, e.g. ``--yolo`` or ``--permission-mode bypassPermissions``.
+    CLI_FLAG = "cli-flag"
+    #: An environment variable the CLI reads at startup.
+    ENV_VAR = "env-var"
+    #: The CLI has no permission system; it is always non-interactive.
+    ALWAYS_ON = "always-on"
+    #: The CLI has no non-interactive mode and cannot be driven unattended
+    #: in dangerous mode.
+    UNSUPPORTED = "unsupported"
+
+
+class EventChannel(StrEnum):
+    """The surface Bernstein reads for an adapter's lifecycle signals."""
+
+    #: Upstream emits newline-delimited JSON events (Claude/Cursor/Gemini).
+    STREAM_JSON = "stream-json"
+    #: Plain stdout carrying the canonical ``BERNSTEIN:<KIND>`` text grammar.
+    TEXT_SIGNALS = "text-signals"
+    #: Upstream fires hooks/callbacks Bernstein registers against.
+    HOOKS = "hooks"
+    #: No structured channel; Bernstein polls a PTY/log for liveness.
+    POLL_PTY = "poll-pty"
+    #: No event channel at all (process-exit detection only).
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class AdapterStrategy:
+    """The declared strategy of a single adapter across all three axes."""
+
+    resume: ResumeStrategy = ResumeStrategy.UNSUPPORTED
+    dangerous_mode: DangerousModeStrategy = DangerousModeStrategy.UNSUPPORTED
+    event_channel: EventChannel = EventChannel.TEXT_SIGNALS
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a JSON-serialisable view for operator-facing tables."""
+        return {
+            "resume": str(self.resume),
+            "dangerous_mode": str(self.dangerous_mode),
+            "event_channel": str(self.event_channel),
+        }
+
+
+#: Default strategy applied to any adapter (built-in or third-party) absent
+#: from :data:`STRATEGY_MATRIX`. Conservative on every axis so an undeclared
+#: adapter never accidentally resumes natively or skips permissions.
+DEFAULT_ADAPTER_STRATEGY = AdapterStrategy()
+
+
+#: Per-adapter strategy declarations, keyed by registry name. Adding a new
+#: adapter means adding a row here; the conformance harness
+#: (:func:`undeclared_strategies`) reports any registry adapter missing a row.
+STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
+    # Native session resume + structured event channel.
+    "claude": AdapterStrategy(
+        resume=ResumeStrategy.FLAG,
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
+    ),
+    "claude_routine": AdapterStrategy(
+        resume=ResumeStrategy.FLAG,
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
+    ),
+    "openai_agents": AdapterStrategy(
+        resume=ResumeStrategy.FLAG,
+        dangerous_mode=DangerousModeStrategy.ALWAYS_ON,
+        event_channel=EventChannel.HOOKS,
+    ),
+    # Stream-json adapters without native resume.
+    "cursor": AdapterStrategy(
+        resume=ResumeStrategy.UNSUPPORTED,
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
+    ),
+    "gemini": AdapterStrategy(
+        resume=ResumeStrategy.UNSUPPORTED,
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
+    ),
+    # CLI-flag dangerous mode, text-signal channel, fresh-session resume.
+    "cline": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    "charm": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    "kimi": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    "rovo": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    "letta_code": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    # Codex drives unattended via its sandbox/full-auto flag.
+    "codex": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
+    # Everyone else - no native resume, text-signal channel. Dangerous-mode
+    # default is ``UNSUPPORTED`` until an adapter declares otherwise.
+    "aichat": AdapterStrategy(),
+    "aider": AdapterStrategy(),
+    "amp": AdapterStrategy(),
+    "auggie": AdapterStrategy(),
+    "autohand": AdapterStrategy(),
+    "clm": AdapterStrategy(),
+    "cloudflare": AdapterStrategy(event_channel=EventChannel.HOOKS),
+    "codebuff": AdapterStrategy(),
+    "cody": AdapterStrategy(),
+    "composio": AdapterStrategy(event_channel=EventChannel.HOOKS),
+    "continue": AdapterStrategy(),
+    "copilot": AdapterStrategy(),
+    "devin_terminal": AdapterStrategy(event_channel=EventChannel.POLL_PTY),
+    "droid": AdapterStrategy(),
+    "forge": AdapterStrategy(),
+    "generic": AdapterStrategy(),
+    "goose": AdapterStrategy(),
+    "gptme": AdapterStrategy(),
+    "hermes": AdapterStrategy(),
+    "iac": AdapterStrategy(),
+    "junie": AdapterStrategy(),
+    "kilo": AdapterStrategy(),
+    "kiro": AdapterStrategy(),
+    "mistral": AdapterStrategy(),
+    "mock": AdapterStrategy(),
+    "ollama": AdapterStrategy(),
+    "open_interpreter": AdapterStrategy(),
+    "opencode": AdapterStrategy(),
+    "openhands": AdapterStrategy(),
+    "pi": AdapterStrategy(),
+    "plandex": AdapterStrategy(),
+    "q_dev": AdapterStrategy(),
+    "qwen": AdapterStrategy(),
+    "ralphex": AdapterStrategy(),
 }
 
 
-def resume_capability(adapter_name: str) -> str:
-    """Return the declared resume capability for ``adapter_name``.
+def strategy_for(adapter_name: str) -> AdapterStrategy:
+    """Return the declared :class:`AdapterStrategy` for ``adapter_name``.
 
+    Unknown adapters fall back to :data:`DEFAULT_ADAPTER_STRATEGY`, which is
+    conservative on every axis (no native resume, dangerous mode
+    unsupported, text-signal event channel).
+    """
+    return STRATEGY_MATRIX.get(adapter_name, DEFAULT_ADAPTER_STRATEGY)
+
+
+def undeclared_strategies(adapter_names: list[str]) -> list[str]:
+    """Return the subset of ``adapter_names`` with no row in the matrix.
+
+    The conformance harness passes the registry's adapter names; a non-empty
+    result is a hard failure (issue #1627 AC #2): every shipped adapter must
+    declare its strategy on each axis.
+    """
+    return sorted(name for name in adapter_names if name not in STRATEGY_MATRIX)
+
+
+def strategy_table(adapter_names: list[str] | None = None) -> list[dict[str, str]]:
+    """Return one row per adapter for the operator-facing strategy table.
+
+    Each row is ``{"adapter", "resume", "dangerous_mode", "event_channel"}``.
+    Rows are sorted by adapter name so operators can compare adapters at a
+    glance (issue #1627 AC #4). When ``adapter_names`` is ``None`` the full
+    matrix is rendered.
+    """
+    names = sorted(adapter_names) if adapter_names is not None else sorted(STRATEGY_MATRIX)
+    rows: list[dict[str, str]] = []
+    for name in names:
+        row = {"adapter": name}
+        row.update(strategy_for(name).to_dict())
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Resume-capability back-compat shim (feat-resume-from-checkpoint)
+# ---------------------------------------------------------------------------
+#
+# The resume axis used to be a standalone two-state string matrix. It is now
+# derived from :data:`STRATEGY_MATRIX` so there is a single source of truth.
+# The string constants and :func:`resume_capability` are retained verbatim so
+# ``bernstein resume`` and the lifecycle env var keep their stable contract.
+
+#: Adapter has no native resume; the CLI falls back to a fresh session.
+RESUME_FALLBACK_FRESH: str = "fallback-fresh"
+
+#: Adapter reattaches to the prior session via a provider-side session id.
+RESUME_NATIVE: str = "native"
+
+
+def resume_capability(adapter_name: str) -> str:
+    """Return the legacy two-state resume capability for ``adapter_name``.
+
+    Derived from :data:`STRATEGY_MATRIX`: any :class:`ResumeStrategy` other
+    than :attr:`ResumeStrategy.UNSUPPORTED` maps to :data:`RESUME_NATIVE`.
     Unknown adapters default to :data:`RESUME_FALLBACK_FRESH`.
     """
-    return RESUME_CAPABILITY_MATRIX.get(adapter_name, RESUME_FALLBACK_FRESH)
+    strategy = strategy_for(adapter_name)
+    if strategy.resume is ResumeStrategy.UNSUPPORTED:
+        return RESUME_FALLBACK_FRESH
+    return RESUME_NATIVE
+
+
+#: Legacy two-state view of the resume axis rendered as ``adapter ->
+#: capability``. Derived from :data:`STRATEGY_MATRIX` for back-compat with
+#: callers that imported the dict directly. Adapters absent are assumed
+#: :data:`RESUME_FALLBACK_FRESH`.
+RESUME_CAPABILITY_MATRIX: dict[str, str] = {name: resume_capability(name) for name in STRATEGY_MATRIX}

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -34,7 +34,7 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import yaml
 
@@ -432,6 +432,20 @@ class EventChannel(StrEnum):
     NONE = "none"
 
 
+class StrategyView(TypedDict):
+    """JSON-serialisable view of an :class:`AdapterStrategy`'s three axes."""
+
+    resume: str
+    dangerous_mode: str
+    event_channel: str
+
+
+class StrategyRow(StrategyView):
+    """A :class:`StrategyView` plus the adapter name, one row per adapter."""
+
+    adapter: str
+
+
 @dataclass(frozen=True)
 class AdapterStrategy:
     """The declared strategy of a single adapter across all three axes."""
@@ -440,7 +454,7 @@ class AdapterStrategy:
     dangerous_mode: DangerousModeStrategy = DangerousModeStrategy.UNSUPPORTED
     event_channel: EventChannel = EventChannel.TEXT_SIGNALS
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> StrategyView:
         """Return a JSON-serialisable view for operator-facing tables."""
         return {
             "resume": str(self.resume),
@@ -582,19 +596,18 @@ def undeclared_strategies(adapter_names: list[str]) -> list[str]:
     return sorted(name for name in adapter_names if name not in STRATEGY_MATRIX)
 
 
-def strategy_table(adapter_names: list[str] | None = None) -> list[dict[str, str]]:
+def strategy_table(adapter_names: list[str] | None = None) -> list[StrategyRow]:
     """Return one row per adapter for the operator-facing strategy table.
 
-    Each row is ``{"adapter", "resume", "dangerous_mode", "event_channel"}``.
+    Each row is a :class:`StrategyRow` (``adapter`` plus the three axes).
     Rows are sorted by adapter name so operators can compare adapters at a
     glance (issue #1627 AC #4). When ``adapter_names`` is ``None`` the full
     matrix is rendered.
     """
     names = sorted(adapter_names) if adapter_names is not None else sorted(STRATEGY_MATRIX)
-    rows: list[dict[str, str]] = []
+    rows: list[StrategyRow] = []
     for name in names:
-        row = {"adapter": name}
-        row.update(strategy_for(name).to_dict())
+        row: StrategyRow = {"adapter": name, **strategy_for(name).to_dict()}
         rows.append(row)
     return rows
 

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -533,14 +533,43 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
 }
 
 
+#: Maps the session-namespace form of an adapter (the lower-cased
+#: :meth:`CLIAdapter.name`) to its registry key, for the adapters whose
+#: human-readable name does not match the key the matrix is declared under.
+#: This keeps :meth:`CLIAdapter.strategy` free of any registry import (which
+#: would break the ``adapters-independent`` import-linter contract) while
+#: still resolving the correct row. Adapters whose ``name()`` already lowers
+#: to their registry key need no entry here.
+_NAMESPACE_ALIASES: dict[str, str] = {
+    "claude code": "claude",
+    "cloudflare agents": "cloudflare",
+    "composio agent orchestrator": "composio",
+    "continue.dev": "continue",
+    "github copilot": "copilot",
+    "generic cli": "generic",
+    "hermes agent": "hermes",
+    "iac (terraform/pulumi)": "iac",
+    "letta code": "letta_code",
+    "mistral vibe": "mistral",
+    "ollama (local)": "ollama",
+    "open interpreter": "open_interpreter",
+    "openai agents sdk": "openai_agents",
+    "qwen cli": "qwen",
+    "rovo dev": "rovo",
+}
+
+
 def strategy_for(adapter_name: str) -> AdapterStrategy:
     """Return the declared :class:`AdapterStrategy` for ``adapter_name``.
 
-    Unknown adapters fall back to :data:`DEFAULT_ADAPTER_STRATEGY`, which is
-    conservative on every axis (no native resume, dangerous mode
-    unsupported, text-signal event channel).
+    Accepts either a registry key (``"claude"``) or the session-namespace
+    form (``"claude code"``); the latter is mapped through
+    :data:`_NAMESPACE_ALIASES` first. Unknown adapters fall back to
+    :data:`DEFAULT_ADAPTER_STRATEGY`, which is conservative on every axis (no
+    native resume, dangerous mode unsupported, text-signal event channel).
     """
-    return STRATEGY_MATRIX.get(adapter_name, DEFAULT_ADAPTER_STRATEGY)
+    key = _NAMESPACE_ALIASES.get(adapter_name, adapter_name)
+    return STRATEGY_MATRIX.get(key, DEFAULT_ADAPTER_STRATEGY)
 
 
 def undeclared_strategies(adapter_names: list[str]) -> list[str]:

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -848,7 +848,9 @@ class CLIAdapter(ABC):
         1. An inline :attr:`strategy_override` set by the subclass, if any.
         2. The row in
            :data:`bernstein.adapters._contract.STRATEGY_MATRIX` keyed by the
-           adapter's registry namespace.
+           adapter's registry namespace (:meth:`_derive_session_namespace`,
+           with a small alias table covering adapters whose ``name()`` does
+           not match their registry key).
         3. The conservative
            :data:`bernstein.adapters._contract.DEFAULT_ADAPTER_STRATEGY`.
 
@@ -856,20 +858,17 @@ class CLIAdapter(ABC):
         dangerous-mode, event-channel) instead of branching on the adapter
         name. The return type is declared as ``object`` so subclasses are not
         forced to import the contract module just to read the attribute.
+
+        Resolution stays inside :mod:`bernstein.adapters._contract` so this
+        module never imports the registry: that would make every adapter
+        transitively depend on every other adapter and break the
+        ``adapters-independent`` import-linter contract.
         """
         from bernstein.adapters._contract import AdapterStrategy, strategy_for
 
         if isinstance(self.strategy_override, AdapterStrategy):
             return self.strategy_override
-
-        # Prefer the canonical registry key so the matrix lookup matches the
-        # declaration. Fall back to the session namespace when the adapter is
-        # not registered (e.g. ad-hoc test stubs); ``strategy_for`` then
-        # yields the conservative default.
-        from bernstein.adapters.registry import registry_name_for
-
-        key = registry_name_for(self) or self._derive_session_namespace()
-        return strategy_for(key)
+        return strategy_for(self._derive_session_namespace())
 
     def session_id_args(self, conversation_id: str) -> list[str]:
         """Return spawn-time argv for binding a deterministic session id.

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -407,6 +407,16 @@ class CLIAdapter(ABC):
     #: the dispatch loop falls back to plain process-exit detection.
     supports_session_log_watch: bool = False
 
+    #: Per-adapter strategy declaration across the three axes defined in
+    #: :mod:`bernstein.adapters._contract` - resume, dangerous-mode, and
+    #: event-channel. Left ``None`` here so the canonical declaration lives
+    #: in ``STRATEGY_MATRIX`` keyed by registry name; subclasses MAY override
+    #: with an inline :class:`~bernstein.adapters._contract.AdapterStrategy`
+    #: to keep the declaration next to the implementation. Read it through
+    #: :meth:`strategy`, never directly - that resolver applies the matrix
+    #: fallback so undeclared adapters still get a conservative default.
+    strategy_override: Any = None
+
     def __init__(self) -> None:
         self._resource_limits: ResourceLimits | None = None
         self._rate_limit_meter: RateLimitMeter | None = None
@@ -829,6 +839,37 @@ class CLIAdapter(ABC):
         if self.registry_name:
             return self.registry_name
         return self.name().strip().lower() or type(self).__name__
+
+    def strategy(self) -> Any:
+        """Return this adapter's resolved :class:`AdapterStrategy`.
+
+        Resolution order:
+
+        1. An inline :attr:`strategy_override` set by the subclass, if any.
+        2. The row in
+           :data:`bernstein.adapters._contract.STRATEGY_MATRIX` keyed by the
+           adapter's registry namespace.
+        3. The conservative
+           :data:`bernstein.adapters._contract.DEFAULT_ADAPTER_STRATEGY`.
+
+        The orchestrator dispatches off the returned enum fields (resume,
+        dangerous-mode, event-channel) instead of branching on the adapter
+        name. The return type is declared as ``object`` so subclasses are not
+        forced to import the contract module just to read the attribute.
+        """
+        from bernstein.adapters._contract import AdapterStrategy, strategy_for
+
+        if isinstance(self.strategy_override, AdapterStrategy):
+            return self.strategy_override
+
+        # Prefer the canonical registry key so the matrix lookup matches the
+        # declaration. Fall back to the session namespace when the adapter is
+        # not registered (e.g. ad-hoc test stubs); ``strategy_for`` then
+        # yields the conservative default.
+        from bernstein.adapters.registry import registry_name_for
+
+        key = registry_name_for(self) or self._derive_session_namespace()
+        return strategy_for(key)
 
     def session_id_args(self, conversation_id: str) -> list[str]:
         """Return spawn-time argv for binding a deterministic session id.

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -27,7 +27,7 @@ import json
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -39,6 +39,9 @@ from bernstein.core.protocols.stream_signals import (
     has_terminal_signal,
     iter_signals,
 )
+
+if TYPE_CHECKING:
+    from bernstein.adapters._contract import StrategyRow
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -239,7 +242,7 @@ def assert_strategies_declared(adapter_names: list[str] | None = None) -> None:
         )
 
 
-def strategy_conformance_table() -> list[dict[str, str]]:
+def strategy_conformance_table() -> list[StrategyRow]:
     """Return the per-adapter strategy table for the live registry.
 
     One row per registered adapter (issue #1627 AC #4) so operators can

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -201,6 +201,57 @@ class ConformanceReport:
         }
 
 
+class StrategyDeclarationError(AssertionError):
+    """Raised when a shipped adapter is missing its strategy declaration.
+
+    Issue #1627 AC #2: every adapter under the registry must declare its
+    resume / dangerous-mode / event-channel strategy. A missing row in
+    :data:`bernstein.adapters._contract.STRATEGY_MATRIX` is a hard failure
+    surfaced by :func:`assert_strategies_declared`.
+    """
+
+
+def assert_strategies_declared(adapter_names: list[str] | None = None) -> None:
+    """Fail when any registry adapter lacks a strategy declaration.
+
+    Args:
+        adapter_names: Adapter names to check. When ``None`` the live
+            registry is enumerated via
+            :func:`bernstein.adapters.registry.iter_adapter_specs`.
+
+    Raises:
+        StrategyDeclarationError: One or more adapters have no row in
+            ``STRATEGY_MATRIX``. The message lists every offender so the
+            fix is a contract-completion exercise, not a hunt.
+    """
+    from bernstein.adapters._contract import undeclared_strategies
+
+    if adapter_names is None:
+        from bernstein.adapters.registry import iter_adapter_specs
+
+        adapter_names = [name for name, _ in iter_adapter_specs()]
+
+    missing = undeclared_strategies(adapter_names)
+    if missing:
+        raise StrategyDeclarationError(
+            "adapters missing a strategy declaration in STRATEGY_MATRIX "
+            f"(resume / dangerous-mode / event-channel): {', '.join(missing)}"
+        )
+
+
+def strategy_conformance_table() -> list[dict[str, str]]:
+    """Return the per-adapter strategy table for the live registry.
+
+    One row per registered adapter (issue #1627 AC #4) so operators can
+    compare adapters at a glance via ``bernstein adapters check``.
+    """
+    from bernstein.adapters._contract import strategy_table
+    from bernstein.adapters.registry import iter_adapter_specs
+
+    names = [name for name, _ in iter_adapter_specs()]
+    return strategy_table(names)
+
+
 def check_terminal_signal(stdout_lines: list[str], *, run_id: str) -> MissingTerminalSignal | None:
     """Return a warning when ``stdout_lines`` carry no terminal signal.
 

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -164,6 +164,38 @@ def get_adapter(cli_name: str) -> CLIAdapter:
     return adapter_cls()
 
 
+def registry_name_for(adapter: CLIAdapter) -> str | None:
+    """Return the registry key an adapter instance is registered under.
+
+    Resolves the canonical registry name (e.g. ``"claude"``) for a live
+    adapter so callers can key per-adapter tables (such as the strategy
+    matrix in :mod:`bernstein.adapters._contract`) without each adapter
+    having to restate its own key.
+
+    Resolution prefers an explicit :attr:`CLIAdapter.registry_name`, then
+    falls back to a reverse lookup over the registered classes/instances.
+    Entry-point discovery runs first so third-party adapters resolve too.
+
+    Args:
+        adapter: A live :class:`CLIAdapter` instance.
+
+    Returns:
+        The registry key, or ``None`` when the adapter is not registered.
+    """
+    explicit = getattr(adapter, "registry_name", "") or ""
+    if explicit and explicit in _ADAPTERS:
+        return explicit
+
+    _load_entrypoint_adapters()
+    adapter_type = type(adapter)
+    for name, entry in _ADAPTERS.items():
+        if entry is adapter:
+            return name
+        if inspect.isclass(entry) and entry is adapter_type:
+            return name
+    return None
+
+
 def register_adapter(name: str, adapter: type[CLIAdapter] | CLIAdapter) -> None:
     """Register a custom adapter by name.
 

--- a/src/bernstein/adapters/report.py
+++ b/src/bernstein/adapters/report.py
@@ -30,6 +30,7 @@ from bernstein.adapters._contract import (
     ContractSpec,
     _capability_failures,  # pyright: ignore[reportPrivateUsage]
     _strip_ansi,  # pyright: ignore[reportPrivateUsage]
+    strategy_for,
 )
 
 if TYPE_CHECKING:
@@ -86,6 +87,9 @@ class AdapterStatus:
             file's mtime. Empty when the module path cannot be resolved.
         contract_hash: SHA-256 of the loaded contract bytes, or empty
             string when the adapter has no contract on disk.
+        strategy: The adapter's declared resume / dangerous-mode /
+            event-channel strategy as a ``{axis: value}`` dict so operators
+            can compare adapters at a glance (issue #1627 AC #4).
     """
 
     name: str
@@ -97,6 +101,7 @@ class AdapterStatus:
     conformance_detail: str
     last_modified_utc: str
     contract_hash: str
+    strategy: dict[str, str] = field(default_factory=dict[str, str])
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-friendly dict.
@@ -401,6 +406,7 @@ def _status_for_one(
         conformance_detail=verdict.detail,
         last_modified_utc=_module_mtime_utc(adapter),
         contract_hash=_contract_hash(name, contracts_dir=contracts_dir),
+        strategy=strategy_for(name).to_dict(),
     )
 
 

--- a/src/bernstein/adapters/report.py
+++ b/src/bernstein/adapters/report.py
@@ -27,7 +27,9 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from bernstein.adapters._contract import (
     CONTRACTS_DIR,
+    DEFAULT_ADAPTER_STRATEGY,
     ContractSpec,
+    StrategyView,
     _capability_failures,  # pyright: ignore[reportPrivateUsage]
     _strip_ansi,  # pyright: ignore[reportPrivateUsage]
     strategy_for,
@@ -101,7 +103,7 @@ class AdapterStatus:
     conformance_detail: str
     last_modified_utc: str
     contract_hash: str
-    strategy: dict[str, str] = field(default_factory=dict[str, str])
+    strategy: StrategyView = field(default_factory=DEFAULT_ADAPTER_STRATEGY.to_dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-friendly dict.

--- a/src/bernstein/cli/commands/resume_cmd.py
+++ b/src/bernstein/cli/commands/resume_cmd.py
@@ -20,7 +20,7 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
-from bernstein.adapters._contract import resume_capability
+from bernstein.adapters._contract import resume_capability, strategy_for
 from bernstein.cli.helpers import console
 from bernstein.core.lifecycle.hooks import HookRegistry, LifecycleContext, LifecycleEvent
 from bernstein.core.persistence.resume_prompt import build_resume_context
@@ -52,6 +52,10 @@ class ResumePlan:
     checkpoint: TaskResumeCheckpoint
     capability: str
     resume_context: str
+    #: The typed resume strategy (issue #1627). Dispatch sites branch on this
+    #: enum rather than the adapter name; ``capability`` is the legacy
+    #: two-state view retained for the ``bernstein resume`` env contract.
+    resume_strategy: str = ""
 
 
 def prepare_resume(
@@ -79,7 +83,9 @@ def prepare_resume(
     # file is corrupt we exit before incrementing the counter.
     load_checkpoint(workdir, task_id)
     checkpoint = bump_resume_count(workdir, task_id)
-    capability = resume_capability(checkpoint.adapter or "")
+    adapter_name = checkpoint.adapter or ""
+    capability = resume_capability(adapter_name)
+    resume_strategy = str(strategy_for(adapter_name).resume)
     resume_context = build_resume_context(checkpoint)
     if hooks is not None:
         hooks.run(
@@ -92,6 +98,7 @@ def prepare_resume(
                 env={
                     "BERNSTEIN_RESUME_COUNT": str(checkpoint.resume_count),
                     "BERNSTEIN_RESUME_CAPABILITY": capability,
+                    "BERNSTEIN_RESUME_STRATEGY": resume_strategy,
                 },
             ),
         )
@@ -99,6 +106,7 @@ def prepare_resume(
         checkpoint=checkpoint,
         capability=capability,
         resume_context=resume_context,
+        resume_strategy=resume_strategy,
     )
 
 
@@ -114,6 +122,7 @@ def _render_plan(workdir: Path, plan: ResumePlan, *, output_json: bool) -> None:
             "adapter": cp.adapter,
             "adapter_session_id": cp.adapter_session_id,
             "capability": plan.capability,
+            "resume_strategy": plan.resume_strategy,
             "worktree_path": cp.worktree_path,
             "checkpoint_path": str(checkpoint_path_for(workdir, cp.task_id)),
         }

--- a/tests/unit/adapters/test_capability_enums.py
+++ b/tests/unit/adapters/test_capability_enums.py
@@ -1,0 +1,248 @@
+"""Per-adapter strategy enum tests (issue #1627).
+
+Covers the three typed axes added to the adapter contract -- resume,
+dangerous-mode, and event-channel -- plus the conformance failure when a
+shipped adapter is missing its declaration, the registry-name resolution
+used by ``CLIAdapter.strategy``, and back-compat with the legacy two-state
+resume capability the ``bernstein resume`` env contract still depends on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.adapters._contract import (
+    DEFAULT_ADAPTER_STRATEGY,
+    RESUME_CAPABILITY_MATRIX,
+    RESUME_FALLBACK_FRESH,
+    RESUME_NATIVE,
+    STRATEGY_MATRIX,
+    AdapterStrategy,
+    DangerousModeStrategy,
+    EventChannel,
+    ResumeStrategy,
+    resume_capability,
+    strategy_for,
+    strategy_table,
+    undeclared_strategies,
+)
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.conformance import (
+    StrategyDeclarationError,
+    assert_strategies_declared,
+    strategy_conformance_table,
+)
+from bernstein.adapters.registry import (
+    get_adapter,
+    iter_adapter_specs,
+    registry_name_for,
+)
+
+# ---------------------------------------------------------------------------
+# Enum parsing per axis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("flag", ResumeStrategy.FLAG),
+        ("flag-pair", ResumeStrategy.FLAG_PAIR),
+        ("subcommand", ResumeStrategy.SUBCOMMAND),
+        ("unsupported", ResumeStrategy.UNSUPPORTED),
+    ],
+)
+def test_resume_strategy_parses_from_wire_value(raw: str, expected: ResumeStrategy) -> None:
+    assert ResumeStrategy(raw) is expected
+    assert str(expected) == raw
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("cli-flag", DangerousModeStrategy.CLI_FLAG),
+        ("env-var", DangerousModeStrategy.ENV_VAR),
+        ("always-on", DangerousModeStrategy.ALWAYS_ON),
+        ("unsupported", DangerousModeStrategy.UNSUPPORTED),
+    ],
+)
+def test_dangerous_mode_strategy_parses_from_wire_value(raw: str, expected: DangerousModeStrategy) -> None:
+    assert DangerousModeStrategy(raw) is expected
+    assert str(expected) == raw
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("stream-json", EventChannel.STREAM_JSON),
+        ("text-signals", EventChannel.TEXT_SIGNALS),
+        ("hooks", EventChannel.HOOKS),
+        ("poll-pty", EventChannel.POLL_PTY),
+        ("none", EventChannel.NONE),
+    ],
+)
+def test_event_channel_parses_from_wire_value(raw: str, expected: EventChannel) -> None:
+    assert EventChannel(raw) is expected
+    assert str(expected) == raw
+
+
+def test_unknown_wire_value_raises() -> None:
+    with pytest.raises(ValueError, match="not a valid"):
+        ResumeStrategy("teleport")
+
+
+# ---------------------------------------------------------------------------
+# Default values
+# ---------------------------------------------------------------------------
+
+
+def test_default_adapter_strategy_is_conservative() -> None:
+    assert DEFAULT_ADAPTER_STRATEGY.resume is ResumeStrategy.UNSUPPORTED
+    assert DEFAULT_ADAPTER_STRATEGY.dangerous_mode is DangerousModeStrategy.UNSUPPORTED
+    assert DEFAULT_ADAPTER_STRATEGY.event_channel is EventChannel.TEXT_SIGNALS
+
+
+def test_strategy_for_unknown_adapter_returns_default() -> None:
+    assert strategy_for("this-adapter-does-not-exist") is DEFAULT_ADAPTER_STRATEGY
+
+
+def test_adapter_strategy_to_dict_round_trips() -> None:
+    strat = AdapterStrategy(
+        resume=ResumeStrategy.FLAG,
+        dangerous_mode=DangerousModeStrategy.ENV_VAR,
+        event_channel=EventChannel.HOOKS,
+    )
+    assert strat.to_dict() == {
+        "resume": "flag",
+        "dangerous_mode": "env-var",
+        "event_channel": "hooks",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-adapter declarations
+# ---------------------------------------------------------------------------
+
+
+def test_claude_declares_native_flag_resume_and_stream_json() -> None:
+    strat = strategy_for("claude")
+    assert strat.resume is ResumeStrategy.FLAG
+    assert strat.dangerous_mode is DangerousModeStrategy.CLI_FLAG
+    assert strat.event_channel is EventChannel.STREAM_JSON
+
+
+def test_stream_json_adapters_declared() -> None:
+    for name in ("claude", "cursor", "gemini"):
+        assert strategy_for(name).event_channel is EventChannel.STREAM_JSON
+
+
+def test_text_signal_default_for_plain_adapters() -> None:
+    for name in ("aider", "goose", "opencode"):
+        assert strategy_for(name).event_channel is EventChannel.TEXT_SIGNALS
+
+
+def test_every_registry_adapter_has_a_declaration() -> None:
+    names = [name for name, _ in iter_adapter_specs()]
+    assert undeclared_strategies(names) == []
+
+
+# ---------------------------------------------------------------------------
+# Conformance: missing declaration is a hard failure (AC #2)
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_strategies_reports_missing() -> None:
+    assert undeclared_strategies(["claude", "ghost-adapter"]) == ["ghost-adapter"]
+
+
+def test_assert_strategies_declared_passes_for_registry() -> None:
+    # Live registry must be fully declared; raises if any adapter is missing.
+    assert_strategies_declared()
+
+
+def test_assert_strategies_declared_fails_on_missing() -> None:
+    with pytest.raises(StrategyDeclarationError, match="ghost-adapter"):
+        assert_strategies_declared(["claude", "ghost-adapter"])
+
+
+# ---------------------------------------------------------------------------
+# Strategy table (AC #4)
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_table_rows_sorted_and_complete() -> None:
+    rows = strategy_table(["gemini", "aider"])
+    assert [r["adapter"] for r in rows] == ["aider", "gemini"]
+    for row in rows:
+        assert set(row) == {"adapter", "resume", "dangerous_mode", "event_channel"}
+
+
+def test_strategy_conformance_table_covers_registry() -> None:
+    rows = strategy_conformance_table()
+    registry_names = {name for name, _ in iter_adapter_specs()}
+    assert {r["adapter"] for r in rows} == registry_names
+
+
+# ---------------------------------------------------------------------------
+# CLIAdapter.strategy resolver
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_strategy_resolves_via_registry_name() -> None:
+    adapter = get_adapter("claude")
+    assert registry_name_for(adapter) == "claude"
+    assert adapter.strategy().resume is ResumeStrategy.FLAG
+
+
+def test_inline_override_takes_precedence() -> None:
+    sentinel = AdapterStrategy(
+        resume=ResumeStrategy.SUBCOMMAND,
+        dangerous_mode=DangerousModeStrategy.ENV_VAR,
+        event_channel=EventChannel.POLL_PTY,
+    )
+
+    class _OverrideAdapter(CLIAdapter):
+        strategy_override = sentinel
+
+        def spawn(self, **_kwargs: object) -> object:  # type: ignore[override]
+            raise AssertionError("not called")
+
+        def name(self) -> str:
+            return "override-stub"
+
+    assert _OverrideAdapter().strategy() is sentinel
+
+
+def test_unregistered_stub_falls_back_to_default() -> None:
+    class _Stub(CLIAdapter):
+        def spawn(self, **_kwargs: object) -> object:  # type: ignore[override]
+            raise AssertionError("not called")
+
+        def name(self) -> str:
+            return "unregistered-stub"
+
+    assert _Stub().strategy() is DEFAULT_ADAPTER_STRATEGY
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: legacy two-state resume capability derives from the matrix
+# ---------------------------------------------------------------------------
+
+
+def test_resume_capability_native_for_flag_adapters() -> None:
+    assert resume_capability("claude") == RESUME_NATIVE
+    assert resume_capability("openai_agents") == RESUME_NATIVE
+
+
+def test_resume_capability_fallback_for_unsupported() -> None:
+    assert resume_capability("aider") == RESUME_FALLBACK_FRESH
+
+
+def test_resume_capability_unknown_defaults_fallback() -> None:
+    assert resume_capability("this-adapter-does-not-exist") == RESUME_FALLBACK_FRESH
+
+
+def test_legacy_matrix_dict_matches_strategy_matrix() -> None:
+    for name in STRATEGY_MATRIX:
+        expected = RESUME_NATIVE if strategy_for(name).resume is not ResumeStrategy.UNSUPPORTED else RESUME_FALLBACK_FRESH
+        assert RESUME_CAPABILITY_MATRIX[name] == expected

--- a/tests/unit/adapters/test_capability_enums.py
+++ b/tests/unit/adapters/test_capability_enums.py
@@ -107,12 +107,12 @@ def test_strategy_for_unknown_adapter_returns_default() -> None:
 
 
 def test_adapter_strategy_to_dict_round_trips() -> None:
-    strat = AdapterStrategy(
+    strategy = AdapterStrategy(
         resume=ResumeStrategy.FLAG,
         dangerous_mode=DangerousModeStrategy.ENV_VAR,
         event_channel=EventChannel.HOOKS,
     )
-    assert strat.to_dict() == {
+    assert strategy.to_dict() == {
         "resume": "flag",
         "dangerous_mode": "env-var",
         "event_channel": "hooks",
@@ -125,10 +125,10 @@ def test_adapter_strategy_to_dict_round_trips() -> None:
 
 
 def test_claude_declares_native_flag_resume_and_stream_json() -> None:
-    strat = strategy_for("claude")
-    assert strat.resume is ResumeStrategy.FLAG
-    assert strat.dangerous_mode is DangerousModeStrategy.CLI_FLAG
-    assert strat.event_channel is EventChannel.STREAM_JSON
+    strategy = strategy_for("claude")
+    assert strategy.resume is ResumeStrategy.FLAG
+    assert strategy.dangerous_mode is DangerousModeStrategy.CLI_FLAG
+    assert strategy.event_channel is EventChannel.STREAM_JSON
 
 
 def test_stream_json_adapters_declared() -> None:
@@ -244,5 +244,7 @@ def test_resume_capability_unknown_defaults_fallback() -> None:
 
 def test_legacy_matrix_dict_matches_strategy_matrix() -> None:
     for name in STRATEGY_MATRIX:
-        expected = RESUME_NATIVE if strategy_for(name).resume is not ResumeStrategy.UNSUPPORTED else RESUME_FALLBACK_FRESH
+        expected = (
+            RESUME_NATIVE if strategy_for(name).resume is not ResumeStrategy.UNSUPPORTED else RESUME_FALLBACK_FRESH
+        )
         assert RESUME_CAPABILITY_MATRIX[name] == expected

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -231,6 +231,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "trend-scan",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "spec",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "run-lookup",
     }
 )
 


### PR DESCRIPTION
## Summary

- Add three typed axes to the adapter contract so the orchestrator dispatches off enums instead of branching on adapter name: `ResumeStrategy{flag, flag-pair, subcommand, unsupported}`, `DangerousModeStrategy{cli-flag, env-var, always-on, unsupported}`, `EventChannel{stream-json, text-signals, hooks, poll-pty, none}`.
- Each shipped adapter declares its strategy in `STRATEGY_MATRIX` (keyed by registry name). `CLIAdapter.strategy()` resolves an inline `strategy_override`, then the matrix, then a conservative `DEFAULT_ADAPTER_STRATEGY`.
- Conformance harness fails when a registered adapter has no declaration (`assert_strategies_declared` raises `StrategyDeclarationError`); the per-adapter strategy table is surfaced via `strategy_conformance_table` and added to the adapter report.
- The legacy two-state resume capability (`native` / `fallback-fresh`) is now derived from the matrix, so `bernstein resume` keeps its stable env contract; the resume CLI also exposes the typed `resume_strategy`.
- Docs: new `docs/adapters/capability_contract.md` enumerating each axis and listing every shipped adapter's declaration; linked from the integrations index.

## Acceptance criteria

1. Three enums + `AdapterStrategy` fields on the contract: done (`_contract.py`).
2. Every shipped adapter declares its strategy; missing declarations fail conformance: done.
3. Resume dispatch consumes the enum, not the adapter name: done (`resume_cmd.py`, derived `resume_capability`).
4. Conformance reports a per-adapter strategy table: done (`strategy_conformance_table`, report column).
5. Tests under `tests/unit/adapters/test_capability_enums.py`: done (33 tests).
6. Docs at `docs/adapters/capability_contract.md`: done.

## Test plan

- [ ] `pytest tests/unit/adapters/test_capability_enums.py` (33 passed)
- [ ] `pytest tests/unit/test_resume_cmd.py tests/unit/adapters/` (back-compat green)
- [ ] `ruff check` on changed files (clean)
- [ ] `assert_strategies_declared()` passes against the live registry

Closes #1627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added adapter capability contract and updated adapter registration guide to require strategy declarations and explain conformance checks

* **New Features**
  * Introduced structured adapter strategy model (resume, dangerous-mode, event-channel)
  * Adapters can declare or override strategies; runtime resolves and surfaces strategies in status and resume flows
  * Resume command now propagates resume strategy info

* **Tests**
  * Added comprehensive tests for strategy enums, declarations, conformance, and runtime resolution
* **Docs**
  * Marked new top-level CLI command as documented (readme coverage)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->