### PR TITLE
feat(observability): portable side-channel telemetry across hosts

### DIFF
--- a/docs/observability/side-channel.md
+++ b/docs/observability/side-channel.md
@@ -1,0 +1,165 @@
+# Side-channel telemetry
+
+Bernstein emits its own observability stream (lineage tamper alerts, cost
+events, run lifecycle, tracker deliveries, captured errors). When Bernstein
+runs embedded inside a host application (Claude Desktop, Cursor, and similar)
+that stream travels over a side channel rather than the host's stdout, so the
+host neither intercepts nor forwards it. This page documents the portable
+contract that makes the side channel behave identically across every host.
+
+## TL;DR
+
+- One env var everywhere: `BERNSTEIN_TELEMETRY_DSN` (a Sentry-compatible URL).
+- One wire format: the Sentry store protocol (GlitchTip-compatible).
+- One default backend: GlitchTip behind a Sentry-compatible DSN.
+- Default state is off. With no DSN set, nothing is emitted and no network is
+  touched.
+- Fail-closed: a misconfigured DSN or an unreachable backend never crashes a
+  run.
+- Verify the wiring with `bernstein telemetry probe`.
+
+## Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `BERNSTEIN_TELEMETRY_DSN` | Sentry-compatible DSN for the side channel. | (unset = disabled) |
+| `BERNSTEIN_TELEMETRY_BACKPRESSURE` | Behaviour when the queue is full: `drop` or `queue`. | `drop` |
+| `BERNSTEIN_TELEMETRY_QUEUE_MAXSIZE` | Bounded in-memory queue depth. | `256` |
+
+The DSN has the standard Sentry shape:
+
+```
+<scheme>://<public_key>@<host>[:<port>]/<project_id>
+```
+
+For example:
+
+```
+BERNSTEIN_TELEMETRY_DSN=https://abc123@errors.example.com/42
+```
+
+The store endpoint derived from that DSN is
+`https://errors.example.com/api/42/store/`, and each event carries an
+`X-Sentry-Auth` header so GlitchTip (or any Sentry-protocol backend) accepts
+it.
+
+The legacy `GLITCHTIP_DSN` variable is still honoured as a fallback for the
+import-time error sink, but `BERNSTEIN_TELEMETRY_DSN` is the single,
+host-agnostic contract and takes precedence.
+
+## Event contract
+
+Every event rendered onto the side channel is a Sentry store-protocol body.
+
+### Required fields
+
+| Field | Meaning |
+|---|---|
+| `event_id` | A unique hex id (auto-generated per event). |
+| `timestamp` | ISO-8601 UTC time the event was created. |
+| `level` | One of `fatal`, `error`, `warning`, `info`, `debug`. |
+| `logger` | `bernstein.<category>`, e.g. `bernstein.lineage`. The category identifies the emitter (`lineage`, `cost`, `run`, `tracker`, `probe`, ...). |
+| `message` | Human-readable event description. |
+| `platform` | Always `python`. |
+
+### Optional fields
+
+| Field | Meaning |
+|---|---|
+| `tags` | Flat string-to-string map for backend-side filtering. Always includes `bernstein.category`. |
+| `extra` | Structured, free-form context (counts, ids, status codes). |
+| `sdk` | Emitter identity: `{ "name": "bernstein.sidechannel", "version": "1" }`. |
+
+No prompts, file contents, or secrets are placed in any field. Emitters pass
+only the structured context relevant to the event.
+
+## Backpressure
+
+The sink owns a bounded in-memory queue and a single background worker that
+posts events to the backend. The queue hand-off is the only place
+backpressure applies:
+
+| Policy | Behaviour when the queue is full |
+|---|---|
+| `drop` (default) | The newest event is discarded and counted; the producer never blocks. |
+| `queue` | The producer blocks until a slot frees up, for at most ~1 second, then drops the event rather than wedging the run. |
+
+Pick `drop` when liveness of the orchestrator matters more than completeness
+of the stream (the common case). Pick `queue` when you want to preserve as
+many events as possible and can tolerate brief producer-side blocking under a
+slow backend.
+
+## CLI
+
+```
+bernstein telemetry probe                      # emit one synthetic event
+bernstein telemetry probe --message "ci check" # custom message body
+```
+
+`probe` reads `BERNSTEIN_TELEMETRY_DSN`, ships a single synthetic event with
+`logger=bernstein.probe`, and reports whether it was queued for delivery. If
+no DSN is configured it prints a hint and exits cleanly. Use it after pointing
+a host-embedded Bernstein at your DSN to confirm the backend received the
+stream.
+
+## Per-host install
+
+The contract is identical across hosts; only the mechanism for setting the
+environment variable differs.
+
+### Generic shell / CI
+
+```
+export BERNSTEIN_TELEMETRY_DSN="https://<public_key>@<host>/<project_id>"
+bernstein telemetry probe
+```
+
+### Claude Desktop / Cursor (MCP-style host config)
+
+Hosts that launch Bernstein as a subprocess accept an `env` block in their
+server configuration. Add the DSN there so every embedded run inherits it:
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "bernstein",
+      "args": ["mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+### Docker / Compose
+
+Pass the DSN through the container environment:
+
+```yaml
+services:
+  bernstein:
+    image: bernstein:latest
+    environment:
+      BERNSTEIN_TELEMETRY_DSN: "https://<public_key>@<host>/<project_id>"
+```
+
+Because the variable name and wire format are the same everywhere, an operator
+running several hosts in parallel can point them all at one GlitchTip project
+and review every agent's activity in a single stream.
+
+## Failure behaviour
+
+- No DSN: the side channel is a no-op. Nothing is emitted; no network is used.
+- Invalid DSN: a warning is logged once and the side channel falls back to the
+  no-op sink. The run continues.
+- Unreachable backend: the background worker drops the event after the HTTP
+  timeout. The producer is never blocked beyond the backpressure budget.
+
+## Scope
+
+- Backend stays GlitchTip plus a Sentry-compatible URL. Other backends are a
+  follow-up.
+- The lineage chain itself stays in `core/lineage/`. Tamper detections are
+  mirrored onto the side channel, but the chain is not re-implemented here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,7 @@ nav:
       - A/B runner primitive: eval/ab-runner.md
       - Verification tracking: operations/verification-tracking.md
       - Observability: operations/observability-overview.md
+      - Side-channel telemetry: observability/side-channel.md
       - LLM watcher (opt-in): observability/llm-watcher.md
       - Per-ticket transcript bundle: observability/ticket-bundle.md
       - Notifications: operations/notifications.md

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -118,6 +118,58 @@ def telemetry_export(days: int, home: Path | None) -> None:
         click.echo(line)
 
 
+@telemetry_group.command("probe")
+@click.option(
+    "--message",
+    default="bernstein telemetry probe",
+    show_default=True,
+    help="Message body of the synthetic event.",
+)
+def telemetry_probe(message: str) -> None:
+    """Emit a synthetic side-channel event so operators can verify the backend.
+
+    Reads the portable ``BERNSTEIN_TELEMETRY_DSN`` and ships one synthetic
+    ``probe`` event over the Sentry-compatible side channel. Use this after
+    pointing a host-embedded Bernstein at your telemetry DSN to confirm the
+    backend received the stream. No-op (with a clear message) when no DSN is
+    configured.
+    """
+    import os
+
+    from bernstein.core.observability import sidechannel
+
+    if not os.environ.get(sidechannel.DSN_ENV):
+        click.echo(
+            f"telemetry probe: {sidechannel.DSN_ENV} is not set; nothing emitted.\n"
+            "Set it to a Sentry-compatible DSN and re-run to verify the backend."
+        )
+        return
+
+    sink = sidechannel.build_sidechannel()
+    if isinstance(sink, sidechannel.NullSideChannel):
+        click.echo(
+            f"telemetry probe: {sidechannel.DSN_ENV} is set but could not be parsed; "
+            "nothing emitted. See the log line above for the reason."
+        )
+        return
+
+    event = sidechannel.SideChannelEvent(
+        category="probe",
+        message=message,
+        level=sidechannel.EventLevel.INFO,
+        tags={"synthetic": "true"},
+        extra={"probe": True},
+    )
+    accepted = sink.emit(event)
+    sink.flush()
+    sink.close()
+    if accepted:
+        click.echo(f"telemetry probe: event {event.event_id} queued for delivery.")
+        click.echo("Check your GlitchTip project; the event carries logger=bernstein.probe.")
+    else:
+        click.echo("telemetry probe: event was dropped under backpressure.")
+
+
 def explain_source(source: OptInSource) -> str:
     """Return a one-line operator-facing description of ``source``."""
     if source is OptInSource.DO_NOT_TRACK:
@@ -142,5 +194,6 @@ __all__ = [
     "telemetry_group",
     "telemetry_off",
     "telemetry_on",
+    "telemetry_probe",
     "telemetry_status",
 ]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -315,10 +315,14 @@ def _init_error_telemetry() -> None:
     """Initialise the operator-managed error-telemetry sink, if configured.
 
     Wires sentry-sdk to a Sentry-protocol-compatible error sink whose DSN is
-    supplied via ``GLITCHTIP_DSN``.  The function is a no-op when:
+    supplied via the portable ``BERNSTEIN_TELEMETRY_DSN`` (preferred) or the
+    legacy ``GLITCHTIP_DSN``.  The portable variable is the single, host-
+    agnostic contract documented in ``docs/observability/side-channel.md``;
+    ``GLITCHTIP_DSN`` is honoured as a fallback for existing deployments.
 
-    * ``GLITCHTIP_DSN`` is unset or empty (operator has not yet stood up the
-      sink), or
+    The function is a no-op when:
+
+    * neither DSN variable is set (operator has not yet stood up the sink), or
     * the ``sentry-sdk`` package is not importable (minimal install without
       the ``observability`` extra).
 
@@ -329,7 +333,7 @@ def _init_error_telemetry() -> None:
     """
     import os
 
-    dsn = os.environ.get("GLITCHTIP_DSN")
+    dsn = os.environ.get("BERNSTEIN_TELEMETRY_DSN") or os.environ.get("GLITCHTIP_DSN")
     if not dsn:
         return
     try:

--- a/src/bernstein/core/observability/lineage_alert.py
+++ b/src/bernstein/core/observability/lineage_alert.py
@@ -143,6 +143,57 @@ class NullAlertSink:
         return True
 
 
+class SideChannelAlertSink:
+    """Mirror tamper events onto the portable side channel.
+
+    A tamper detection is a security event that the operator wants in the
+    same single stream as the rest of Bernstein's observability output,
+    regardless of which host launched the run. This sink routes the event
+    through :mod:`bernstein.core.observability.sidechannel`; it is a no-op
+    when ``BERNSTEIN_TELEMETRY_DSN`` is unset, and never raises.
+    """
+
+    def emit(self, event: LineageTamperEvent) -> bool:
+        from bernstein.core.observability import sidechannel
+
+        return sidechannel.emit(
+            "lineage",
+            "lineage chain tamper detected",
+            level=sidechannel.EventLevel.ERROR,
+            tags={"run_id": event.run_id, "source": event.source},
+            extra={
+                "errors": event.errors,
+                "record_count": event.record_count,
+                "detected_at": event.detected_at,
+            },
+        )
+
+
+class FanoutAlertSink:
+    """Deliver each event to every configured sink, best-effort.
+
+    Returns ``True`` only when every sink reported success; a single
+    failing sink does not stop delivery to the others.
+    """
+
+    __slots__ = ("_sinks",)
+
+    def __init__(self, sinks: list[LineageAlertSink]) -> None:
+        self._sinks = sinks
+
+    def emit(self, event: LineageTamperEvent) -> bool:
+        results = [self._safe_emit(sink, event) for sink in self._sinks]
+        return all(results) if results else True
+
+    @staticmethod
+    def _safe_emit(sink: LineageAlertSink, event: LineageTamperEvent) -> bool:
+        try:
+            return sink.emit(event)
+        except Exception as exc:
+            logger.warning("lineage alert: sink %r raised: %s", type(sink).__name__, exc)
+            return False
+
+
 def _event_to_dict(event: LineageTamperEvent) -> dict[str, Any]:
     return {
         "type": "lineage_tamper_detected",
@@ -162,28 +213,47 @@ def sink_from_config(
     headers: dict[str, str] | None = None,
     timeout_secs: float = DEFAULT_WEBHOOK_TIMEOUT_SECS,
     max_retries: int = DEFAULT_WEBHOOK_MAX_RETRIES,
+    mirror_side_channel: bool = True,
 ) -> LineageAlertSink:
     """Build a sink from bernstein.yaml-shaped config.
 
-    Returns ``NullAlertSink`` when alerting is disabled or the
-    webhook URL is missing. The orchestrator never raises here -- a
-    misconfigured SIEM is loud-by-counter-and-audit, not a crash.
+    Tamper events are always mirrored onto the portable side channel
+    (when a ``BERNSTEIN_TELEMETRY_DSN`` is configured) so the operator sees
+    them in the same single stream as the rest of Bernstein's observability
+    output. The optional SIEM webhook is delivered alongside it.
+
+    Returns ``NullAlertSink`` only when alerting is disabled. When the
+    webhook URL is missing or invalid the side-channel mirror still applies.
+    The orchestrator never raises here -- a misconfigured SIEM is
+    loud-by-counter-and-audit, not a crash.
     """
-    if not enabled or not webhook_url:
+    if not enabled:
         return NullAlertSink()
-    try:
-        return WebhookAlertSink(
-            webhook_url,
-            headers=headers,
-            timeout_secs=timeout_secs,
-            max_retries=max_retries,
-        )
-    except UrlSchemeError as exc:
-        # Maintain the "orchestrator never raises here" contract: log the
-        # invalid scheme and fall back to the no-op sink so a misconfigured
-        # webhook URL does not crash the run.
-        logger.warning(
-            "lineage alert: webhook URL rejected (%s); falling back to NullAlertSink",
-            exc,
-        )
+
+    sinks: list[LineageAlertSink] = []
+    if webhook_url:
+        try:
+            sinks.append(
+                WebhookAlertSink(
+                    webhook_url,
+                    headers=headers,
+                    timeout_secs=timeout_secs,
+                    max_retries=max_retries,
+                )
+            )
+        except UrlSchemeError as exc:
+            # Maintain the "orchestrator never raises here" contract: log the
+            # invalid scheme and skip the webhook so a misconfigured URL does
+            # not crash the run.
+            logger.warning(
+                "lineage alert: webhook URL rejected (%s); skipping webhook sink",
+                exc,
+            )
+    if mirror_side_channel:
+        sinks.append(SideChannelAlertSink())
+
+    if not sinks:
         return NullAlertSink()
+    if len(sinks) == 1:
+        return sinks[0]
+    return FanoutAlertSink(sinks)

--- a/src/bernstein/core/observability/sidechannel.py
+++ b/src/bernstein/core/observability/sidechannel.py
@@ -1,0 +1,525 @@
+"""Portable side-channel telemetry for Bernstein.
+
+When Bernstein runs embedded inside a host application (Claude Desktop,
+Cursor, and similar) it cannot rely on the host's stdout to surface what
+the agents did: the host neither intercepts nor forwards Bernstein's own
+observability stream. This module ships that stream over a side channel
+the operator controls, with a single contract that is identical across
+every host:
+
+* One environment variable everywhere: ``BERNSTEIN_TELEMETRY_DSN``.
+* One wire format: the Sentry store protocol (GlitchTip-compatible).
+* One default backend: GlitchTip behind a Sentry-compatible DSN.
+
+The full contract is documented in ``docs/observability/side-channel.md``.
+
+Design constraints (mirrors the rest of the observability boundary):
+
+* Default state is off. With no DSN configured, :func:`get_sidechannel`
+  returns a sink that drops every event and touches no network.
+* The boundary is fail-closed: no exception raised inside the sink ever
+  propagates to the caller. A misconfigured DSN must not crash a run.
+* Backpressure is explicit. The sink has a bounded in-memory queue; when
+  it is full the configured policy decides between dropping the newest
+  event (``drop``, the default) or blocking the producer until a slot
+  frees up (``queue``).
+
+The module is intentionally transport-light: it speaks the Sentry store
+protocol directly over ``httpx`` rather than depending on ``sentry-sdk``,
+so a minimal install without the ``observability`` extra still emits.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import queue
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Final
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_LOG = logging.getLogger(__name__)
+
+#: Portable env var carrying the Sentry-compatible DSN. The same name is
+#: honoured regardless of which host launched Bernstein.
+DSN_ENV: Final[str] = "BERNSTEIN_TELEMETRY_DSN"
+
+#: Env var selecting the backpressure policy when the queue is full.
+#: ``drop`` (default) discards the newest event; ``queue`` blocks the
+#: producer until a slot frees up (bounded by :data:`QUEUE_BLOCK_SECONDS`).
+BACKPRESSURE_ENV: Final[str] = "BERNSTEIN_TELEMETRY_BACKPRESSURE"
+
+#: Env var overriding the bounded queue depth.
+QUEUE_MAXSIZE_ENV: Final[str] = "BERNSTEIN_TELEMETRY_QUEUE_MAXSIZE"
+
+#: Default queue depth. Sized so a burst of lifecycle events does not block
+#: the orchestrator under the default ``drop`` policy.
+DEFAULT_QUEUE_MAXSIZE: Final[int] = 256
+
+#: Maximum time the ``queue`` policy will block a producer before giving up
+#: and dropping the event. Keeps a stalled backend from wedging a run.
+QUEUE_BLOCK_SECONDS: Final[float] = 1.0
+
+#: Per-request HTTP timeout for the Sentry store endpoint.
+TIMEOUT_SECONDS: Final[float] = 5.0
+
+#: Bound on the background worker join during shutdown flush.
+FLUSH_DEADLINE_SECONDS: Final[float] = 5.0
+
+#: Sentry client identifier sent in the auth header. Operators see this in
+#: the GlitchTip UI so they can tell Bernstein-shipped events apart.
+SENTRY_CLIENT: Final[str] = "bernstein-sidechannel/1"
+
+#: Sentry store-protocol version. ``7`` is the long-standing default that
+#: GlitchTip and Sentry both accept.
+SENTRY_PROTOCOL_VERSION: Final[str] = "7"
+
+
+class Backpressure(StrEnum):
+    """Behaviour when the bounded queue is full."""
+
+    DROP = "drop"
+    QUEUE = "queue"
+
+
+class EventLevel(StrEnum):
+    """Sentry severity levels accepted by the store protocol."""
+
+    FATAL = "fatal"
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+    DEBUG = "debug"
+
+
+# ---------------------------------------------------------------------------
+# DSN parsing
+# ---------------------------------------------------------------------------
+
+
+class DsnError(ValueError):
+    """Raised when ``BERNSTEIN_TELEMETRY_DSN`` cannot be parsed."""
+
+
+@dataclass(frozen=True, slots=True)
+class Dsn:
+    """A parsed Sentry-compatible DSN.
+
+    A DSN has the shape ``<scheme>://<public_key>@<host>[:<port>]/<project_id>``.
+    The store endpoint derived from it is
+    ``<scheme>://<host>[:<port>]/api/<project_id>/store/``.
+    """
+
+    scheme: str
+    public_key: str
+    host: str
+    project_id: str
+    port: int | None = None
+
+    @property
+    def netloc(self) -> str:
+        """Return ``host`` or ``host:port`` for URL composition."""
+        if self.port is None:
+            return self.host
+        return f"{self.host}:{self.port}"
+
+    @property
+    def store_url(self) -> str:
+        """Return the Sentry store endpoint for this DSN."""
+        return f"{self.scheme}://{self.netloc}/api/{self.project_id}/store/"
+
+    def auth_header(self, *, now: float | None = None) -> str:
+        """Return the ``X-Sentry-Auth`` header value for this DSN."""
+        ts = now if now is not None else time.time()
+        parts = [
+            f"sentry_version={SENTRY_PROTOCOL_VERSION}",
+            f"sentry_client={SENTRY_CLIENT}",
+            f"sentry_timestamp={ts:.0f}",
+            f"sentry_key={self.public_key}",
+        ]
+        return "Sentry " + ", ".join(parts)
+
+
+def parse_dsn(raw: str) -> Dsn:
+    """Parse a Sentry-compatible DSN string.
+
+    Raises:
+        DsnError: if the DSN is empty, has an unsupported scheme, or is
+            missing the public key, host, or project id.
+    """
+    if not raw or not raw.strip():
+        raise DsnError("DSN is empty")
+    parsed = urlparse(raw.strip())
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise DsnError(f"DSN scheme must be http or https, got {scheme!r}")
+    if not parsed.username:
+        raise DsnError("DSN is missing the public key (user component)")
+    if not parsed.hostname:
+        raise DsnError("DSN is missing the host")
+    project_id = parsed.path.strip("/")
+    if not project_id:
+        raise DsnError("DSN is missing the project id (path component)")
+    return Dsn(
+        scheme=scheme,
+        public_key=parsed.username,
+        host=parsed.hostname,
+        project_id=project_id,
+        port=parsed.port,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event envelope
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SideChannelEvent:
+    """A single side-channel event.
+
+    Required fields per the contract: ``category``, ``message``,
+    ``level``. ``tags`` and ``extra`` are optional structured context.
+    The ``event_id`` and ``timestamp`` are filled in automatically when
+    omitted so callers only supply the meaningful fields.
+    """
+
+    category: str
+    message: str
+    level: EventLevel = EventLevel.INFO
+    tags: dict[str, str] = field(default_factory=dict[str, str])
+    extra: dict[str, Any] = field(default_factory=dict[str, Any])
+    event_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    timestamp: str = field(default_factory=lambda: datetime.now(tz=UTC).isoformat())
+
+    def to_payload(self) -> dict[str, Any]:
+        """Render the Sentry store-protocol body for this event.
+
+        ``logger`` carries the emitter category (``lineage``, ``cost``,
+        ``run``, ``tracker``, ...) so operators can filter one stream by
+        source in the GlitchTip UI. The ``bernstein.category`` tag carries
+        the same value for tag-based search.
+        """
+        tags = dict(self.tags)
+        tags.setdefault("bernstein.category", self.category)
+        return {
+            "event_id": self.event_id,
+            "timestamp": self.timestamp,
+            "platform": "python",
+            "level": self.level.value,
+            "logger": f"bernstein.{self.category}",
+            "message": self.message,
+            "tags": tags,
+            "extra": dict(self.extra),
+            "sdk": {"name": "bernstein.sidechannel", "version": "1"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+class _HttpTransport:
+    """Posts a single rendered event to the Sentry store endpoint.
+
+    Kept behind a tiny interface so tests can inject a fake without any
+    network. Failures are surfaced as ``False`` rather than raised; the
+    sink translates that into a dropped event and a debug log.
+    """
+
+    def __init__(self, dsn: Dsn) -> None:
+        self._dsn = dsn
+
+    def send(self, payload: Mapping[str, Any]) -> bool:
+        try:
+            import httpx
+        except ImportError:
+            _LOG.debug("sidechannel: httpx not installed; event dropped")
+            return False
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "X-Sentry-Auth": self._dsn.auth_header(),
+        }
+        try:
+            resp = httpx.post(
+                self._dsn.store_url,
+                content=body,
+                headers=headers,
+                timeout=TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            _LOG.debug("sidechannel: POST failed (suppressed): %s", exc)
+            return False
+        ok = 200 <= resp.status_code < 300
+        if not ok:
+            _LOG.debug("sidechannel: store returned HTTP %s", resp.status_code)
+        return ok
+
+
+# ---------------------------------------------------------------------------
+# Sinks
+# ---------------------------------------------------------------------------
+
+
+class NullSideChannel:
+    """Sink used when no DSN is configured. Drops every event."""
+
+    enabled: bool = False
+
+    def emit(self, event: SideChannelEvent) -> bool:
+        return False
+
+    def flush(self, deadline_seconds: float = FLUSH_DEADLINE_SECONDS) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class SideChannel:
+    """Bounded, fail-closed side-channel sink.
+
+    Events are rendered and handed to a background worker thread that
+    posts them to the Sentry store endpoint. The hand-off is the only
+    backpressure point: under ``drop`` a full queue discards the newest
+    event; under ``queue`` the producer blocks for up to
+    :data:`QUEUE_BLOCK_SECONDS` before giving up.
+    """
+
+    enabled: bool = True
+
+    def __init__(
+        self,
+        dsn: Dsn,
+        *,
+        backpressure: Backpressure = Backpressure.DROP,
+        maxsize: int = DEFAULT_QUEUE_MAXSIZE,
+        transport: _HttpTransport | Any | None = None,
+    ) -> None:
+        self._dsn = dsn
+        self._backpressure = backpressure
+        self._transport = transport if transport is not None else _HttpTransport(dsn)
+        self._queue: queue.Queue[SideChannelEvent | None] = queue.Queue(maxsize=max(1, maxsize))
+        self._dropped = 0
+        self._sent = 0
+        self._lock = threading.Lock()
+        self._worker = threading.Thread(
+            target=self._run,
+            name="bernstein-sidechannel",
+            daemon=True,
+        )
+        self._worker.start()
+
+    @property
+    def dropped(self) -> int:
+        """Number of events dropped under backpressure since construction."""
+        with self._lock:
+            return self._dropped
+
+    @property
+    def sent(self) -> int:
+        """Number of events accepted by the transport since construction."""
+        with self._lock:
+            return self._sent
+
+    def emit(self, event: SideChannelEvent) -> bool:
+        """Enqueue ``event`` for delivery.
+
+        Returns ``True`` when the event was accepted into the queue,
+        ``False`` when it was dropped under backpressure. Never raises.
+        """
+        try:
+            if self._backpressure is Backpressure.QUEUE:
+                self._queue.put(event, block=True, timeout=QUEUE_BLOCK_SECONDS)
+            else:
+                self._queue.put_nowait(event)
+            return True
+        except queue.Full:
+            with self._lock:
+                self._dropped += 1
+            _LOG.debug("sidechannel: queue full; event dropped (%s)", event.category)
+            return False
+        except Exception as exc:
+            _LOG.debug("sidechannel: emit failed (suppressed): %s", exc)
+            return False
+
+    def _run(self) -> None:
+        while True:
+            item = self._queue.get()
+            try:
+                if item is None:
+                    return
+                self._deliver(item)
+            finally:
+                self._queue.task_done()
+
+    def _deliver(self, event: SideChannelEvent) -> None:
+        try:
+            ok = self._transport.send(event.to_payload())
+        except Exception as exc:
+            _LOG.debug("sidechannel: delivery failed (suppressed): %s", exc)
+            return
+        if ok:
+            with self._lock:
+                self._sent += 1
+
+    def flush(self, deadline_seconds: float = FLUSH_DEADLINE_SECONDS) -> None:
+        """Best-effort drain of the queue, bounded by ``deadline_seconds``."""
+        deadline = time.monotonic() + deadline_seconds
+        while not self._queue.empty() and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+    def close(self) -> None:
+        """Signal the worker to stop and join it within the flush deadline."""
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            # Best-effort: drop one queued event to make room for the stop
+            # sentinel so close() never blocks forever.
+            with contextlib.suppress(queue.Empty, queue.Full):
+                self._queue.get_nowait()
+                self._queue.put_nowait(None)
+        self._worker.join(timeout=FLUSH_DEADLINE_SECONDS)
+
+
+SideChannelSink = SideChannel | NullSideChannel
+
+
+# ---------------------------------------------------------------------------
+# Configuration resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_backpressure(env: Mapping[str, str]) -> Backpressure:
+    raw = (env.get(BACKPRESSURE_ENV) or "").strip().lower()
+    if raw == Backpressure.QUEUE.value:
+        return Backpressure.QUEUE
+    return Backpressure.DROP
+
+
+def _resolve_maxsize(env: Mapping[str, str]) -> int:
+    raw = (env.get(QUEUE_MAXSIZE_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_QUEUE_MAXSIZE
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_QUEUE_MAXSIZE
+    return value if value > 0 else DEFAULT_QUEUE_MAXSIZE
+
+
+def build_sidechannel(
+    *,
+    env: Mapping[str, str] | None = None,
+    transport: _HttpTransport | Any | None = None,
+) -> SideChannelSink:
+    """Build a side-channel sink from the environment.
+
+    Returns a :class:`NullSideChannel` when no DSN is configured or the
+    DSN cannot be parsed, so the boundary is fail-closed at construction
+    time. Otherwise returns a live :class:`SideChannel`.
+    """
+    real_env = env if env is not None else os.environ
+    raw = real_env.get(DSN_ENV)
+    if not raw:
+        return NullSideChannel()
+    try:
+        dsn = parse_dsn(raw)
+    except DsnError as exc:
+        _LOG.warning("sidechannel: invalid %s, telemetry disabled: %s", DSN_ENV, exc)
+        return NullSideChannel()
+    return SideChannel(
+        dsn,
+        backpressure=_resolve_backpressure(real_env),
+        maxsize=_resolve_maxsize(real_env),
+        transport=transport,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Process-wide default
+# ---------------------------------------------------------------------------
+
+_default_sink: SideChannelSink | None = None
+_default_lock = threading.Lock()
+
+
+def get_sidechannel() -> SideChannelSink:
+    """Return the process-wide default side-channel sink."""
+    global _default_sink
+    with _default_lock:
+        if _default_sink is None:
+            _default_sink = build_sidechannel()
+        return _default_sink
+
+
+def reset_sidechannel() -> None:
+    """Drop the cached default sink. Used by tests and reconfiguration."""
+    global _default_sink
+    with _default_lock:
+        if _default_sink is not None:
+            _default_sink.close()
+        _default_sink = None
+
+
+def emit(
+    category: str,
+    message: str,
+    *,
+    level: EventLevel = EventLevel.INFO,
+    tags: dict[str, str] | None = None,
+    extra: dict[str, Any] | None = None,
+    sink: SideChannelSink | None = None,
+) -> bool:
+    """Emit a side-channel event through the default sink.
+
+    This is the single entry point existing emitters route through. It is
+    fail-closed: any error is swallowed and reported as ``False``.
+    """
+    try:
+        target = sink if sink is not None else get_sidechannel()
+        event = SideChannelEvent(
+            category=category,
+            message=message,
+            level=level,
+            tags=dict(tags or {}),
+            extra=dict(extra or {}),
+        )
+        return target.emit(event)
+    except Exception as exc:
+        _LOG.debug("sidechannel: emit helper failed (suppressed): %s", exc)
+        return False
+
+
+__all__ = [
+    "BACKPRESSURE_ENV",
+    "DEFAULT_QUEUE_MAXSIZE",
+    "DSN_ENV",
+    "FLUSH_DEADLINE_SECONDS",
+    "QUEUE_MAXSIZE_ENV",
+    "Backpressure",
+    "Dsn",
+    "DsnError",
+    "EventLevel",
+    "NullSideChannel",
+    "SideChannel",
+    "SideChannelEvent",
+    "SideChannelSink",
+    "build_sidechannel",
+    "emit",
+    "get_sidechannel",
+    "parse_dsn",
+    "reset_sidechannel",
+]

--- a/tests/unit/observability/test_sidechannel.py
+++ b/tests/unit/observability/test_sidechannel.py
@@ -1,0 +1,352 @@
+"""Unit and end-to-end tests for the portable side-channel telemetry module.
+
+Coverage:
+
+* DSN parsing: well-formed DSNs, store-url derivation, auth header shape,
+  and every rejection path.
+* Event rendering: required fields, default category tag, logger naming.
+* Backpressure: ``drop`` discards the newest event on a full queue;
+  ``queue`` blocks then gives up; the dropped counter tracks losses.
+* Fail-closed boundary: a raising transport never propagates; an invalid
+  DSN yields a NullSideChannel and emits nothing.
+* End-to-end: emit a synthetic event and assert the (fake) backend
+  received it via the Sentry store protocol body.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from bernstein.core.observability import sidechannel
+from bernstein.core.observability.sidechannel import (
+    Backpressure,
+    Dsn,
+    DsnError,
+    EventLevel,
+    NullSideChannel,
+    SideChannel,
+    SideChannelEvent,
+    build_sidechannel,
+    parse_dsn,
+)
+
+VALID_DSN = "https://abc123@glitchtip.example.com/42"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTransport:
+    """Captures every rendered payload; reports configurable success."""
+
+    def __init__(self, *, ok: bool = True) -> None:
+        self.ok = ok
+        self.sent: list[dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self._delivered = threading.Event()
+
+    def send(self, payload: dict[str, Any]) -> bool:
+        with self._lock:
+            self.sent.append(dict(payload))
+        self._delivered.set()
+        return self.ok
+
+    def wait(self, timeout: float = 2.0) -> bool:
+        return self._delivered.wait(timeout)
+
+
+class _RaisingTransport:
+    """Always raises to exercise the fail-closed delivery path."""
+
+    def send(self, payload: dict[str, Any]) -> bool:
+        raise RuntimeError("backend exploded")
+
+
+# ---------------------------------------------------------------------------
+# DSN parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_dsn_wellformed() -> None:
+    dsn = parse_dsn(VALID_DSN)
+    assert dsn == Dsn(
+        scheme="https",
+        public_key="abc123",
+        host="glitchtip.example.com",
+        project_id="42",
+        port=None,
+    )
+
+
+def test_parse_dsn_with_port() -> None:
+    dsn = parse_dsn("http://key@localhost:8000/7")
+    assert dsn.port == 8000
+    assert dsn.netloc == "localhost:8000"
+    assert dsn.store_url == "http://localhost:8000/api/7/store/"
+
+
+def test_store_url_derivation() -> None:
+    assert parse_dsn(VALID_DSN).store_url == "https://glitchtip.example.com/api/42/store/"
+
+
+def test_auth_header_shape() -> None:
+    header = parse_dsn(VALID_DSN).auth_header(now=1700000000.0)
+    assert header.startswith("Sentry ")
+    assert "sentry_version=7" in header
+    assert "sentry_key=abc123" in header
+    assert "sentry_timestamp=1700000000" in header
+    assert "sentry_client=bernstein-sidechannel/1" in header
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "ftp://key@host/1",
+        "https://host/1",  # no public key
+        "https://key@/1",  # no host
+        "https://key@host/",  # no project id
+        "https://key@host",  # no project id
+    ],
+)
+def test_parse_dsn_rejects_malformed(raw: str) -> None:
+    with pytest.raises(DsnError):
+        parse_dsn(raw)
+
+
+# ---------------------------------------------------------------------------
+# Event rendering
+# ---------------------------------------------------------------------------
+
+
+def test_event_payload_required_fields() -> None:
+    event = SideChannelEvent(category="cost", message="budget exceeded", level=EventLevel.WARNING)
+    payload = event.to_payload()
+    assert payload["message"] == "budget exceeded"
+    assert payload["level"] == "warning"
+    assert payload["logger"] == "bernstein.cost"
+    assert payload["platform"] == "python"
+    assert payload["event_id"] == event.event_id
+    assert payload["timestamp"] == event.timestamp
+
+
+def test_event_payload_default_category_tag() -> None:
+    payload = SideChannelEvent(category="run", message="started").to_payload()
+    assert payload["tags"]["bernstein.category"] == "run"
+
+
+def test_event_payload_preserves_explicit_tags_and_extra() -> None:
+    event = SideChannelEvent(
+        category="tracker",
+        message="webhook delivered",
+        tags={"tracker": "linear"},
+        extra={"status": 200},
+    )
+    payload = event.to_payload()
+    assert payload["tags"]["tracker"] == "linear"
+    assert payload["tags"]["bernstein.category"] == "tracker"
+    assert payload["extra"]["status"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Build / configuration
+# ---------------------------------------------------------------------------
+
+
+def test_build_sidechannel_no_dsn_is_null() -> None:
+    sink = build_sidechannel(env={})
+    assert isinstance(sink, NullSideChannel)
+    assert sink.enabled is False
+    assert sink.emit(SideChannelEvent(category="x", message="y")) is False
+
+
+def test_build_sidechannel_invalid_dsn_is_null() -> None:
+    sink = build_sidechannel(env={sidechannel.DSN_ENV: "not-a-dsn"})
+    assert isinstance(sink, NullSideChannel)
+
+
+def test_build_sidechannel_valid_dsn_is_live() -> None:
+    transport = _RecordingTransport()
+    sink = build_sidechannel(env={sidechannel.DSN_ENV: VALID_DSN}, transport=transport)
+    try:
+        assert isinstance(sink, SideChannel)
+        assert sink.enabled is True
+    finally:
+        sink.close()
+
+
+def test_build_sidechannel_reads_backpressure_env() -> None:
+    transport = _RecordingTransport()
+    sink = build_sidechannel(
+        env={sidechannel.DSN_ENV: VALID_DSN, sidechannel.BACKPRESSURE_ENV: "queue"},
+        transport=transport,
+    )
+    try:
+        assert isinstance(sink, SideChannel)
+        assert sink._backpressure is Backpressure.QUEUE
+    finally:
+        sink.close()
+
+
+# ---------------------------------------------------------------------------
+# Backpressure
+# ---------------------------------------------------------------------------
+
+
+def _blocking_transport_sink(policy: Backpressure, maxsize: int) -> tuple[SideChannel, threading.Event]:
+    """Build a sink whose transport blocks until released, to fill the queue."""
+    release = threading.Event()
+
+    class _Blocking:
+        def send(self, payload: dict[str, Any]) -> bool:
+            release.wait(2.0)
+            return True
+
+    sink = SideChannel(
+        parse_dsn(VALID_DSN),
+        backpressure=policy,
+        maxsize=maxsize,
+        transport=_Blocking(),
+    )
+    return sink, release
+
+
+def test_drop_policy_discards_when_full() -> None:
+    sink, release = _blocking_transport_sink(Backpressure.DROP, maxsize=1)
+    try:
+        # First event is pulled by the worker and blocks in transport.
+        # Fill the single queue slot, then overflow it.
+        accepted = [sink.emit(SideChannelEvent(category="c", message=str(i))) for i in range(8)]
+        assert any(accepted)  # at least the first slots are accepted
+        assert not all(accepted)  # overflow is dropped
+        assert sink.dropped >= 1
+    finally:
+        release.set()
+        sink.close()
+
+
+def test_queue_policy_blocks_then_gives_up() -> None:
+    sink, release = _blocking_transport_sink(Backpressure.QUEUE, maxsize=1)
+    try:
+        for i in range(3):
+            sink.emit(SideChannelEvent(category="c", message=str(i)))
+        # Fill the queue; the next emit blocks up to QUEUE_BLOCK_SECONDS then drops.
+        start = time.monotonic()
+        sink.emit(SideChannelEvent(category="c", message="overflow"))
+        elapsed = time.monotonic() - start
+        # Either it slotted in fast or it waited near the block budget; never raises.
+        assert elapsed < sidechannel.QUEUE_BLOCK_SECONDS + 1.0
+    finally:
+        release.set()
+        sink.close()
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed boundary
+# ---------------------------------------------------------------------------
+
+
+def test_raising_transport_never_propagates() -> None:
+    sink = SideChannel(parse_dsn(VALID_DSN), transport=_RaisingTransport())
+    try:
+        assert sink.emit(SideChannelEvent(category="c", message="m")) is True
+        sink.flush()
+        # Delivery raised internally but was swallowed; nothing counted as sent.
+        assert sink.sent == 0
+    finally:
+        sink.close()
+
+
+def test_emit_helper_uses_injected_sink() -> None:
+    transport = _RecordingTransport()
+    sink = SideChannel(parse_dsn(VALID_DSN), transport=transport)
+    try:
+        assert sidechannel.emit("run", "lifecycle", sink=sink) is True
+    finally:
+        sink.close()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: emit then assert the backend received it
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_backend_receives_event() -> None:
+    transport = _RecordingTransport()
+    sink = build_sidechannel(env={sidechannel.DSN_ENV: VALID_DSN}, transport=transport)
+    assert isinstance(sink, SideChannel)
+    try:
+        emitted = sidechannel.emit(
+            "probe",
+            "synthetic verification event",
+            level=EventLevel.INFO,
+            tags={"synthetic": "true"},
+            extra={"probe": True},
+            sink=sink,
+        )
+        assert emitted is True
+        sink.flush()
+        assert transport.wait(2.0), "background worker did not deliver the event"
+    finally:
+        sink.close()
+
+    assert len(transport.sent) == 1
+    received = transport.sent[0]
+    assert received["message"] == "synthetic verification event"
+    assert received["logger"] == "bernstein.probe"
+    assert received["tags"]["synthetic"] == "true"
+    assert received["tags"]["bernstein.category"] == "probe"
+    assert received["extra"]["probe"] is True
+    assert sink.sent == 1
+
+
+def test_default_sink_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(sidechannel.DSN_ENV, VALID_DSN)
+    sidechannel.reset_sidechannel()
+    try:
+        sink = sidechannel.get_sidechannel()
+        assert isinstance(sink, SideChannel)
+        # Same instance returned across calls.
+        assert sidechannel.get_sidechannel() is sink
+    finally:
+        sidechannel.reset_sidechannel()
+
+
+def test_default_sink_null_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(sidechannel.DSN_ENV, raising=False)
+    sidechannel.reset_sidechannel()
+    try:
+        assert isinstance(sidechannel.get_sidechannel(), NullSideChannel)
+    finally:
+        sidechannel.reset_sidechannel()
+
+
+def test_close_does_not_hang_on_full_queue() -> None:
+    sink, release = _blocking_transport_sink(Backpressure.DROP, maxsize=1)
+    # Fill the queue while the worker is blocked, then close: must return.
+    for i in range(4):
+        sink.emit(SideChannelEvent(category="c", message=str(i)))
+    release.set()
+    sink.close()  # should not raise or hang
+    assert not sink._worker.is_alive()
+
+
+def test_queue_full_exception_path_counts_drop() -> None:
+    # Directly exercise the Full branch deterministically.
+    sink = SideChannel(parse_dsn(VALID_DSN), transport=_RecordingTransport())
+    try:
+        sink._queue = queue.Queue(maxsize=1)
+        sink._queue.put_nowait(SideChannelEvent(category="c", message="seed"))
+        accepted = sink.emit(SideChannelEvent(category="c", message="overflow"))
+        assert accepted is False
+        assert sink.dropped == 1
+    finally:
+        sink.close()

--- a/tests/unit/telemetry/test_cli_command.py
+++ b/tests/unit/telemetry/test_cli_command.py
@@ -82,3 +82,39 @@ def test_status_overridden_by_env_off(
     _code, output = _invoke(["status", "--home", str(tmp_home)])
     assert "source: do_not_track" in output
     assert "enabled: false" in output
+
+
+def test_probe_without_dsn_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.observability import sidechannel
+
+    monkeypatch.delenv(sidechannel.DSN_ENV, raising=False)
+    code, output = _invoke(["probe"])
+    assert code == 0
+    assert "is not set" in output
+    assert "nothing emitted" in output
+
+
+def test_probe_with_dsn_emits_synthetic_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.observability import sidechannel
+
+    sent: list[dict[str, object]] = []
+
+    class _Transport:
+        def send(self, payload: dict[str, object]) -> bool:
+            sent.append(payload)
+            return True
+
+    monkeypatch.setenv(sidechannel.DSN_ENV, "https://k@host/1")
+
+    real_build = sidechannel.build_sidechannel
+    monkeypatch.setattr(
+        sidechannel,
+        "build_sidechannel",
+        lambda **kw: real_build(transport=_Transport(), **kw),
+    )
+
+    code, output = _invoke(["probe", "--message", "hello probe"])
+    assert code == 0
+    assert "queued for delivery" in output
+    assert sent and sent[0]["message"] == "hello probe"
+    assert sent[0]["logger"] == "bernstein.probe"

--- a/tests/unit/test_lineage_alert.py
+++ b/tests/unit/test_lineage_alert.py
@@ -11,9 +11,11 @@ from typing import Any
 import pytest
 
 from bernstein.core.observability.lineage_alert import (
+    FanoutAlertSink,
     LineageAlertSink,
     LineageTamperEvent,
     NullAlertSink,
+    SideChannelAlertSink,
     WebhookAlertSink,
     sink_from_config,
 )
@@ -139,14 +141,88 @@ class TestSinkFromConfig:
         assert isinstance(sink, NullAlertSink)
         assert sink.emit(_event())  # null sink swallows successfully
 
-    def test_missing_url_returns_null(self) -> None:
+    def test_missing_url_mirrors_side_channel(self) -> None:
+        # No webhook URL but side-channel mirroring is on by default, so the
+        # operator's single stream still receives tamper events.
         sink = sink_from_config(enabled=True, webhook_url=None)
+        assert isinstance(sink, SideChannelAlertSink)
+
+    def test_missing_url_no_mirror_returns_null(self) -> None:
+        sink = sink_from_config(enabled=True, webhook_url=None, mirror_side_channel=False)
         assert isinstance(sink, NullAlertSink)
 
-    def test_full_config_returns_webhook(self) -> None:
+    def test_full_config_fans_out_webhook_and_side_channel(self) -> None:
         sink = sink_from_config(enabled=True, webhook_url="http://siem.example/hec")
+        assert isinstance(sink, FanoutAlertSink)
+
+    def test_webhook_only_when_mirror_disabled(self) -> None:
+        sink = sink_from_config(
+            enabled=True,
+            webhook_url="http://siem.example/hec",
+            mirror_side_channel=False,
+        )
         assert isinstance(sink, WebhookAlertSink)
         assert sink.url == "http://siem.example/hec"
+
+    def test_invalid_url_falls_back_to_side_channel(self) -> None:
+        # A bad scheme is skipped, not fatal; the side-channel mirror remains.
+        sink = sink_from_config(enabled=True, webhook_url="ftp://nope")
+        assert isinstance(sink, SideChannelAlertSink)
+
+
+class TestSideChannelAlertSink:
+    def test_emit_no_dsn_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core.observability import sidechannel
+
+        monkeypatch.delenv(sidechannel.DSN_ENV, raising=False)
+        sidechannel.reset_sidechannel()
+        try:
+            # No DSN configured: routes to NullSideChannel, returns False, never raises.
+            assert SideChannelAlertSink().emit(_event()) is False
+        finally:
+            sidechannel.reset_sidechannel()
+
+    def test_emit_with_dsn_routes_event(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core.observability import sidechannel
+
+        sent: list[dict[str, Any]] = []
+
+        class _Transport:
+            def send(self, payload: dict[str, Any]) -> bool:
+                sent.append(payload)
+                return True
+
+        sink = sidechannel.build_sidechannel(
+            env={sidechannel.DSN_ENV: "https://k@host/1"},
+            transport=_Transport(),
+        )
+        monkeypatch.setattr(sidechannel, "get_sidechannel", lambda: sink)
+        try:
+            assert SideChannelAlertSink().emit(_event()) is True
+            sink.flush()
+        finally:
+            sink.close()
+        assert sent and sent[0]["logger"] == "bernstein.lineage"
+        assert sent[0]["tags"]["run_id"] == "run-1"
+
+
+class TestFanoutAlertSink:
+    def test_one_failing_sink_does_not_stop_others(self) -> None:
+        delivered: list[str] = []
+
+        class _Good:
+            def emit(self, event: LineageTamperEvent) -> bool:
+                delivered.append(event.run_id)
+                return True
+
+        class _Bad:
+            def emit(self, event: LineageTamperEvent) -> bool:
+                raise RuntimeError("sink down")
+
+        fan = FanoutAlertSink([_Bad(), _Good()])
+        result = fan.emit(_event())
+        assert result is False  # one sink failed
+        assert delivered == ["run-1"]  # the healthy sink still delivered
 
 
 class TestLineageTamperEvent:


### PR DESCRIPTION
## Summary

- Add `core/observability/sidechannel.py`: a single, host-agnostic side channel that ships Bernstein's observability stream regardless of which host launched the run. One env var (`BERNSTEIN_TELEMETRY_DSN`, Sentry-compatible), one wire format (Sentry store protocol, GlitchTip-compatible), one default backend.
- Bounded, fail-closed sink with a background worker and explicit backpressure: `drop` the newest event (default) or `queue` (block the producer briefly). Missing or invalid DSN yields a no-op sink; no exception crosses the boundary into a run.
- Route existing emitters through it: the import-time error sink now reads the portable DSN (`GLITCHTIP_DSN` kept as a fallback), and lineage tamper alerts mirror onto the side channel alongside the optional SIEM webhook.
- Add `bernstein telemetry probe` to emit a synthetic event so operators can verify the backend received the stream.
- Document the contract, required/optional fields, backpressure behaviour, and per-host install in `docs/observability/side-channel.md` (wired into mkdocs nav).

## Acceptance criteria

- [x] Contract documented in `docs/observability/side-channel.md` (env var, required + optional fields, backpressure drop vs queue).
- [x] Emitters route through a single `core/observability/sidechannel.py`.
- [x] `bernstein telemetry probe` subcommand emits a synthetic event.
- [x] End-to-end test emits a synthetic event and asserts the backend received it.
- [x] Per-host install docs (shell/CI, MCP-style host config, Docker/Compose).

## Test plan

- [x] `pytest tests/unit/observability tests/unit/telemetry tests/unit/test_lineage_alert.py` (227 passed)
- [x] `ruff check` + `ruff format` clean on changed files
- [x] `pyright` clean on changed src files
- [x] `lint-imports` contracts kept (core does not import cli)
- [x] Manual smoke: `bernstein telemetry probe` with no DSN, invalid DSN, and a valid DSN all behave fail-closed

Closes #1672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bernstein telemetry probe` CLI command to test telemetry connectivity and configuration.
  * Telemetry alerts now automatically mirror to side-channel observability backend.

* **Documentation**
  * Added comprehensive guide for side-channel telemetry setup, configuration, and behavior.

* **Chores**
  * Updated telemetry initialization to support `BERNSTEIN_TELEMETRY_DSN` environment variable with `GLITCHTIP_DSN` fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->