### PR TITLE
feat(mcp-client): hardened MCP client with capability cards and retry-with-continuation

### DIFF
--- a/docs/mcp/client.md
+++ b/docs/mcp/client.md
@@ -1,0 +1,155 @@
+# Hardened MCP client
+
+Bernstein consumes external MCP servers during orchestrator runs. The client
+treats every upstream server as untrusted, brittle, and rate-limited: real
+servers return malformed responses, hang mid-stream, demand re-auth on token
+expiry, expose tools the client has no schema for, and occasionally misreport
+their capability manifest. The client survives every one of these without
+taking the orchestrator down.
+
+The implementation lives in
+`src/bernstein/core/protocols/mcp/mcp_client.py`
+(`MCPClientSession`, `MCPClientManager`) and
+`src/bernstein/core/cost/mcp_server_cost.py` (`MCPServerCostMeter`).
+
+## Hardening features at a glance
+
+| Feature | Entry point | Failure it contains |
+|---------|-------------|---------------------|
+| Capability-card validation | `call_tool` / `call_tool_streaming` | Server advertises a tool it cannot serve, or a caller asks for an undeclared tool. |
+| Retry-with-continuation | `call_tool_streaming` | A streamed tool call drops mid-stream. |
+| Streamed-output cancellation | `StreamedToolCall.cancel` | A long call must be aborted without leaking the request; partial output is kept. |
+| Per-server cost-meter | `MCPServerCostMeter` | MCP spend must be attributed and capped per server per task. |
+| Schema-violation containment | every call path | Invalid JSON or missing fields; the server is quarantined for the task. |
+
+## Capability-card validation
+
+Before issuing a tool call the client verifies the tool is declared in the
+server's manifest (the tool list discovered at `connect` time, cached on the
+session). A mismatch raises `MCPCapabilityMissing`, logged with the manifest
+digest so the rejection can be correlated against the exact manifest the
+client validated against.
+
+```python
+session = MCPClientSession(RemoteServerConfig(name="github", url="https://..."))
+await session.connect()           # discovers + digests the manifest
+await session.call_tool("create_issue", {...})   # ok: declared
+await session.call_tool("rm_minus_rf", {...})     # raises MCPCapabilityMissing
+```
+
+`MCPCapabilityMissing` subclasses `MCPToolNotFoundError`, so callers that
+already catch the broader not-found error keep working; callers that want the
+manifest-digest context catch the subclass. The manifest digest is exposed on
+`session.manifest_digest` (a SHA-256 hex string). Validation can be disabled
+per server with `RemoteServerConfig(validate_capabilities=False)`.
+
+## Retry-with-continuation
+
+`call_tool_streaming` survives mid-stream drops. Chunks are produced by a
+`stream_factory` callable invoked with `(resumption_token, idempotency_key)`:
+
+- On the first attempt the resumption token is `None`.
+- If the stream drops and the server emitted a checkpoint token, the client
+  resumes from that token (`StreamChunk.checkpoint_token`).
+- If the server does not support resumption, the client replays the whole
+  call carrying the same idempotency key so the server can deduplicate.
+
+Retries are bounded by `RemoteServerConfig.max_continuation_retries`. When
+they are exhausted the client raises `MCPStreamDropped` and marks the server
+degraded.
+
+```python
+def stream_factory(resume_from, idempotency_key):
+    # resume_from is the last checkpoint token, or None on first attempt.
+    return transport.open_stream(resume_from=resume_from, idem=idempotency_key)
+
+result = await session.call_tool_streaming("long_query", {...}, stream_factory=stream_factory)
+```
+
+A `StreamChunk` carries `text`, an optional `checkpoint_token`, a `final`
+flag, and a `dropped` flag. A stream that ends without a `final` chunk is
+treated as a drop so the client retries rather than silently truncating.
+
+## Streamed-output cancellation
+
+Pass a caller-owned `StreamedToolCall` handle to `call_tool_streaming` and
+call `handle.cancel()` from another task. The consuming loop observes the flag
+at the next chunk boundary, stops without leaking the underlying request, and
+preserves the text seen so far on `handle.partial_content`. The returned
+`ToolCallResult.metadata["cancelled"]` is `True` and `content` holds the
+partial output.
+
+```python
+handle = StreamedToolCall(server_name="github", tool_name="long_query")
+task = asyncio.create_task(
+    session.call_tool_streaming("long_query", {...}, stream_factory=f, handle=handle)
+)
+handle.cancel()              # cooperative; partial output is preserved
+result = await task
+assert result.metadata["cancelled"] is True
+```
+
+## Per-server cost-meter
+
+`MCPServerCostMeter` accumulates MCP spend per `(task_id, server_name)` pair
+and wires into the existing `core/cost/` subsystem. Construct the meter with
+an optional `SpendLedger`; metered calls are then also flushed into that
+ledger tagged with the server name (`tags.extra["mcp_server"]`) under the
+synthetic model label `mcp-server`, so the normal cost rollups
+(`ledger.totals_by("task")`) include MCP spend.
+
+```python
+from bernstein.core.cost.mcp_server_cost import MCPServerCostMeter
+from bernstein.core.cost.spend_ledger import SpendLedger
+
+meter = MCPServerCostMeter(ledger=SpendLedger(path=...))
+manager = MCPClientManager(cost_meter=meter, task_id="task-42")
+await manager.connect(config)
+await manager.call_tool("github", "search", {...}, cost_usd=0.02)
+
+manager.server_cost("github")   # 0.02
+manager.task_cost()             # total across all servers for task-42
+```
+
+Negative costs are clamped to zero so a misreporting server cannot corrupt
+the rolling totals. A ledger failure is logged and swallowed: accounting
+never takes the client down.
+
+## Schema-violation containment
+
+Malformed responses are caught and surfaced as `MCPSchemaViolation`. This
+covers invalid JSON, a non-object JSON-RPC envelope, a non-object `result`
+field, a `tools/list` entry missing its `name`, and a malformed tool-result
+`content` block. On any of these the client:
+
+1. Marks the server degraded for the rest of the task
+   (`session.is_degraded`, `session.degraded_reason`).
+2. Surfaces the failure through the metrics tracker (`MCPMetricsCollector`):
+   the call is recorded as an error and the server availability is flipped.
+3. Raises the typed `MCPSchemaViolation` rather than leaking a raw decode
+   exception.
+
+`MCPClientManager.degraded_servers()` lists every server currently
+quarantined for the task. Degradation is sticky for the task: the first
+reason is retained and the flag is not cleared by later successful calls.
+
+## Wiring metrics and cost into the manager
+
+`MCPClientManager` threads a shared cost meter, a metrics collector, and a
+`task_id` into every session it opens:
+
+```python
+manager = MCPClientManager(
+    cost_meter=MCPServerCostMeter(ledger=ledger),
+    metrics=MCPMetricsCollector(),
+    task_id="task-42",
+)
+```
+
+## Tests
+
+`tests/unit/mcp/test_client_hardened.py` exercises every acceptance path with
+a scriptable in-memory fake server (`FakeMCPServer`): capability validation,
+checkpoint resume, full retry with idempotency key, retry exhaustion,
+cancellation, cost accumulation and ledger flush, and each schema-violation
+shape. The legacy surface remains covered by `tests/unit/test_mcp_client.py`.

--- a/src/bernstein/core/cost/__init__.py
+++ b/src/bernstein/core/cost/__init__.py
@@ -3,6 +3,15 @@
 from bernstein.core.cost.cost import *  # noqa: F403
 from bernstein.core.cost.cost import _MODEL_COST_USD_PER_1K as _MODEL_COST_USD_PER_1K
 from bernstein.core.cost.cost import _model_cost as _model_cost
+from bernstein.core.cost.mcp_server_cost import (
+    MCP_LEDGER_MODEL as MCP_LEDGER_MODEL,
+)
+from bernstein.core.cost.mcp_server_cost import (
+    MCPServerCostMeter as MCPServerCostMeter,
+)
+from bernstein.core.cost.mcp_server_cost import (
+    ServerCostRecord as ServerCostRecord,
+)
 from bernstein.core.cost.retry_budget import (
     Criterion as Criterion,
 )

--- a/src/bernstein/core/cost/mcp_server_cost.py
+++ b/src/bernstein/core/cost/mcp_server_cost.py
@@ -1,0 +1,173 @@
+"""Per-server MCP cost meter (issue #1673).
+
+The hardened MCP client treats every upstream server as billable: a remote
+tool call may incur a metered cost (the server's own LLM spend, an egress
+fee, a per-call price). Bernstein accumulates that spend per server per task
+so the orchestrator can attribute, cap, and report it alongside its own LLM
+spend.
+
+This module is a thin accumulation layer that sits in front of the existing
+:class:`~bernstein.core.cost.spend_ledger.SpendLedger`. It keeps an
+in-memory rolling total per ``(task_id, server_name)`` pair and, when a
+ledger is wired in, flushes each metered call into it tagged with the server
+name so the regular cost rollups (``totals_by("task")`` etc.) include MCP
+spend.
+
+The meter never raises on a missing ledger; it degrades to in-memory
+accounting so a misconfigured cost subsystem cannot take the orchestrator
+down (the same brittleness contract the rest of the hardened client follows).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.cost.spend_ledger import SpendLedger
+
+logger = logging.getLogger(__name__)
+
+# Synthetic model label used when flushing MCP spend into the LLM-shaped
+# ledger. Keeps MCP rows distinguishable from real model spend in rollups.
+MCP_LEDGER_MODEL = "mcp-server"
+
+
+@dataclass(frozen=True)
+class ServerCostRecord:
+    """A single metered MCP tool call.
+
+    Attributes:
+        task_id: Task the call was made on behalf of.
+        server_name: Remote MCP server that billed the call.
+        tool_name: Tool invoked.
+        cost_usd: Cost attributed to the call (clamped to >= 0).
+        calls: Number of underlying calls this record represents (>= 1).
+    """
+
+    task_id: str
+    server_name: str
+    tool_name: str
+    cost_usd: float
+    calls: int = 1
+
+
+@dataclass
+class MCPServerCostMeter:
+    """Accumulate MCP spend per server per task.
+
+    The meter is process-local and thread-safe. Wire a
+    :class:`~bernstein.core.cost.spend_ledger.SpendLedger` in via ``ledger``
+    to also flush each metered call into the shared ledger; leave it ``None``
+    for pure in-memory accounting (tests, dry-runs).
+
+    Args:
+        ledger: Optional shared spend ledger to flush metered calls into.
+        feature_label: Feature label stamped onto flushed ledger rows.
+    """
+
+    ledger: SpendLedger | None = None
+    feature_label: str = "mcp-client"
+
+    # task_id -> server_name -> accumulated USD
+    _by_task_server: dict[str, dict[str, float]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(float)),
+        init=False,
+        repr=False,
+    )
+    # task_id -> server_name -> call count
+    _calls_by_task_server: dict[str, dict[str, int]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(int)),
+        init=False,
+        repr=False,
+    )
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    def record(
+        self,
+        *,
+        task_id: str,
+        server_name: str,
+        tool_name: str,
+        cost_usd: float,
+    ) -> ServerCostRecord:
+        """Record one metered MCP tool call.
+
+        Negative costs are clamped to zero so a misreporting server cannot
+        corrupt the rolling totals. When a ledger is wired in, the call is
+        also flushed there tagged with the server name; a ledger failure is
+        logged and swallowed so accounting never takes the client down.
+
+        Args:
+            task_id: Task the call belongs to (``""`` -> ``"unknown"``).
+            server_name: Remote server that billed the call.
+            tool_name: Tool that was invoked.
+            cost_usd: Cost to attribute. Clamped to ``>= 0``.
+
+        Returns:
+            The :class:`ServerCostRecord` that was accumulated.
+        """
+        cost = max(0.0, cost_usd)
+        task = task_id or "unknown"
+        with self._lock:
+            self._by_task_server[task][server_name] += cost
+            self._calls_by_task_server[task][server_name] += 1
+
+        self._flush_to_ledger(task_id=task, server_name=server_name, cost_usd=cost)
+        return ServerCostRecord(
+            task_id=task,
+            server_name=server_name,
+            tool_name=tool_name,
+            cost_usd=cost,
+        )
+
+    def cost_for(self, task_id: str, server_name: str) -> float:
+        """Return accumulated USD for one ``(task, server)`` pair."""
+        task = task_id or "unknown"
+        with self._lock:
+            return self._by_task_server.get(task, {}).get(server_name, 0.0)
+
+    def task_total(self, task_id: str) -> float:
+        """Return total MCP spend across all servers for ``task_id``."""
+        task = task_id or "unknown"
+        with self._lock:
+            return sum(self._by_task_server.get(task, {}).values())
+
+    def server_breakdown(self, task_id: str) -> dict[str, float]:
+        """Return a ``{server_name: usd}`` map for ``task_id`` (copy)."""
+        task = task_id or "unknown"
+        with self._lock:
+            return dict(self._by_task_server.get(task, {}))
+
+    def call_count(self, task_id: str, server_name: str) -> int:
+        """Return number of metered calls for one ``(task, server)`` pair."""
+        task = task_id or "unknown"
+        with self._lock:
+            return self._calls_by_task_server.get(task, {}).get(server_name, 0)
+
+    def _flush_to_ledger(self, *, task_id: str, server_name: str, cost_usd: float) -> None:
+        """Flush one metered call into the shared spend ledger, if wired."""
+        if self.ledger is None or cost_usd <= 0.0:
+            return
+        try:
+            from bernstein.core.cost.spend_ledger import CallTags
+
+            self.ledger.record(
+                tags=CallTags(
+                    task_id=task_id,
+                    feature_label=self.feature_label,
+                    extra={"mcp_server": server_name},
+                ),
+                model=MCP_LEDGER_MODEL,
+                cost_usd=cost_usd,
+            )
+        except Exception as exc:
+            logger.warning(
+                "MCPServerCostMeter: failed to flush %.6f USD for server '%s' into ledger: %s",
+                cost_usd,
+                server_name,
+                exc,
+            )

--- a/src/bernstein/core/protocols/mcp/mcp_client.py
+++ b/src/bernstein/core/protocols/mcp/mcp_client.py
@@ -2,22 +2,50 @@
 
 Connects to remote MCP servers via streamable HTTP transport,
 discovers available tools, and calls them on behalf of Bernstein agents.
+
+Upstream MCP servers are treated as untrusted, brittle, and rate-limited
+(issue #1673). The client hardens every tool call against the failure modes
+real servers exhibit:
+
+* **Capability-card validation** -- before issuing a tool call the client
+  verifies the tool is declared in the server's manifest (or runtime
+  capability card). A mismatch raises :class:`MCPCapabilityMissing`, logged
+  with the manifest digest.
+* **Retry-with-continuation** -- if a streamed tool call drops mid-stream the
+  client resumes from the server's last-checkpoint token. Servers that do not
+  advertise resumption fall back to a full retry carrying an idempotency key.
+* **Streamed-output cancellation** -- an in-flight call can be cancelled
+  without leaking the underlying request; partial output is preserved.
+* **Per-server cost-meter** -- metered calls accumulate into the shared
+  :mod:`bernstein.core.cost` subsystem, attributed per server per task.
+* **Schema-violation containment** -- malformed responses are caught, logged,
+  surfaced through the metrics tracker, and the server is marked degraded for
+  the remainder of the task.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from bernstein.core.cost.mcp_server_cost import MCPServerCostMeter
+    from bernstein.core.protocols.mcp.mcp_metrics import MCPMetricsCollector
 
 logger = logging.getLogger(__name__)
 
 _CONTENT_TYPE_JSON = "application/json"
+_CONTENT_TYPE_SSE = "text/event-stream"
 
 
 @dataclass(frozen=True)
@@ -34,6 +62,11 @@ class RemoteServerConfig:
         oauth_client_secret: OAuth client secret when auth_type is ``"oauth"``.
         timeout_seconds: Request timeout in seconds.
         retry_limit: Maximum number of retries for failed requests.
+        max_continuation_retries: Maximum retry-with-continuation attempts
+            for a streamed tool call that drops mid-stream (issue #1673).
+        validate_capabilities: When True, every tool call is checked against
+            the discovered manifest before dispatch; a mismatch raises
+            :class:`MCPCapabilityMissing`.
     """
 
     name: str
@@ -45,6 +78,8 @@ class RemoteServerConfig:
     oauth_client_secret: str = ""
     timeout_seconds: int = 30
     retry_limit: int = 3
+    max_continuation_retries: int = 3
+    validate_capabilities: bool = True
 
 
 @dataclass(frozen=True)
@@ -95,6 +130,115 @@ class MCPToolNotFoundError(MCPClientError):
     """Raised when a requested tool is not found on the server."""
 
 
+class MCPCapabilityMissing(MCPToolNotFoundError):
+    """Raised when a tool is not declared in the server's capability card.
+
+    Capability-card validation (issue #1673, AC1) runs before every tool
+    call. When the requested tool is absent from the discovered manifest the
+    client refuses to dispatch and raises this error rather than trusting an
+    undeclared capability. The manifest digest is logged so the mismatch can
+    be correlated against the manifest the client validated against.
+
+    Subclasses :class:`MCPToolNotFoundError` because an undeclared capability
+    is, semantically, a tool that is not available; callers catching the
+    broader error keep working while callers that want the manifest-digest
+    context catch this subclass.
+    """
+
+
+class MCPSchemaViolation(MCPClientError):
+    """Raised when a server response is structurally malformed.
+
+    Covers invalid JSON, a missing JSON-RPC envelope, and tool results that
+    omit required fields. The client contains the violation, marks the server
+    degraded for the rest of the task (issue #1673, AC5), and surfaces it via
+    the metrics tracker.
+    """
+
+
+class MCPStreamDropped(MCPClientError):
+    """Raised internally when a streamed tool call drops mid-stream.
+
+    Drives retry-with-continuation (issue #1673, AC2). Carries the last
+    checkpoint token the server emitted, if any, so the client can request a
+    resume rather than replaying the whole call.
+
+    Attributes:
+        resumption_token: Last-checkpoint token from the server, or ``None``
+            when the server does not support resumption.
+        partial_content: Text accumulated before the drop.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        resumption_token: str | None = None,
+        partial_content: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.resumption_token = resumption_token
+        self.partial_content = partial_content
+
+
+@dataclass(frozen=True)
+class StreamChunk:
+    """One chunk of a streamed tool-call response (issue #1673).
+
+    Attributes:
+        text: Text payload of the chunk (appended to partial output).
+        checkpoint_token: Server-issued resumption token, if this chunk
+            advances the last-checkpoint. ``None`` leaves the token unchanged.
+        final: Whether this chunk completes the stream.
+        dropped: Whether the transport signalled a mid-stream drop. Drives
+            retry-with-continuation.
+    """
+
+    text: str = ""
+    checkpoint_token: str | None = None
+    final: bool = False
+    dropped: bool = False
+
+
+@dataclass
+class StreamedToolCall:
+    """Handle on an in-flight streamed tool call (issue #1673, AC3).
+
+    Accumulates streamed chunks and exposes a cooperative ``cancel`` that
+    stops consuming the stream without leaking the underlying request. The
+    text seen before cancellation is preserved on :attr:`partial_content`.
+
+    Attributes:
+        server_name: Server the call is running against.
+        tool_name: Tool being invoked.
+        partial_content: Text accumulated so far (preserved on cancel).
+        cancelled: Whether the call has been cancelled.
+        resumption_token: Last checkpoint token observed, if any.
+    """
+
+    server_name: str
+    tool_name: str
+    partial_content: str = ""
+    cancelled: bool = False
+    resumption_token: str | None = None
+    _cancel_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+
+    def cancel(self) -> None:
+        """Request cancellation of the in-flight call.
+
+        Idempotent and safe to call from another task. The consuming loop
+        observes the flag at the next chunk boundary, stops, and preserves
+        :attr:`partial_content`.
+        """
+        self.cancelled = True
+        self._cancel_event.set()
+
+    @property
+    def is_cancel_requested(self) -> bool:
+        """Whether cancellation has been requested."""
+        return self._cancel_event.is_set()
+
+
 class MCPClientSession:
     """Active session with a remote MCP server.
 
@@ -105,13 +249,27 @@ class MCPClientSession:
         config: Configuration for the remote server.
     """
 
-    def __init__(self, config: RemoteServerConfig) -> None:
+    def __init__(
+        self,
+        config: RemoteServerConfig,
+        *,
+        cost_meter: MCPServerCostMeter | None = None,
+        metrics: MCPMetricsCollector | None = None,
+        task_id: str = "",
+    ) -> None:
         self._config = config
         self._session_id: str = str(uuid.uuid4())
         self._mcp_session_id: str | None = None
         self._tools: list[RemoteTool] = []
         self._initialized: bool = False
         self._request_id: int = 0
+        # Hardening state (issue #1673).
+        self._manifest_digest: str = ""
+        self._degraded: bool = False
+        self._degraded_reason: str = ""
+        self._cost_meter = cost_meter
+        self._metrics = metrics
+        self._task_id = task_id
 
     @property
     def server_name(self) -> str:
@@ -127,6 +285,34 @@ class MCPClientSession:
     def is_connected(self) -> bool:
         """Whether the session has been initialized."""
         return self._initialized
+
+    @property
+    def manifest_digest(self) -> str:
+        """SHA-256 digest of the last discovered tool manifest."""
+        return self._manifest_digest
+
+    @property
+    def is_degraded(self) -> bool:
+        """Whether the server has been marked degraded for this task."""
+        return self._degraded
+
+    @property
+    def degraded_reason(self) -> str:
+        """Human-readable reason the server was marked degraded."""
+        return self._degraded_reason
+
+    def mark_degraded(self, reason: str) -> None:
+        """Mark the server degraded for the rest of the task (AC5).
+
+        Idempotent: the first reason is retained. Surfaced through the
+        metrics tracker when one is wired in.
+        """
+        if not self._degraded:
+            self._degraded = True
+            self._degraded_reason = reason
+            logger.warning("MCP server '%s' marked degraded: %s", self._config.name, reason)
+            if self._metrics is not None:
+                self._metrics.record_availability(self._config.name, alive=False)
 
     async def connect(self) -> None:
         """Initialize MCP session with remote server.
@@ -177,61 +363,326 @@ class MCPClientSession:
         Raises:
             MCPClientError: If the request fails.
         """
-        raw_tools = (await self._send_jsonrpc("tools/list")).get("tools", [])
+        result = await self._send_jsonrpc("tools/list")
+        raw_tools = result.get("tools", [])
+        if not isinstance(raw_tools, list):
+            self.mark_degraded("tools/list returned a non-list 'tools' field")
+            raise MCPSchemaViolation(f"Server '{self._config.name}' returned a malformed tools/list payload")
+        tools_list = cast("list[Any]", raw_tools)
 
         self._tools = []
-        for tool_data in raw_tools:
+        for entry in tools_list:
+            if not isinstance(entry, dict) or not entry.get("name"):
+                self.mark_degraded("tools/list entry missing required 'name' field")
+                raise MCPSchemaViolation(f"Server '{self._config.name}' returned a tool entry without a name")
+            tool_data = cast("dict[str, Any]", entry)
+            input_schema = tool_data.get("inputSchema", {})
             tool = RemoteTool(
-                name=tool_data.get("name", ""),
-                description=tool_data.get("description", ""),
+                name=str(tool_data.get("name", "")),
+                description=str(tool_data.get("description", "")),
                 server_name=self._config.name,
-                input_schema=tool_data.get("inputSchema", {}),
+                input_schema=cast("dict[str, Any]", input_schema) if isinstance(input_schema, dict) else {},
             )
             self._tools.append(tool)
 
+        self._manifest_digest = self._compute_manifest_digest(tools_list)
         logger.info(
-            "Discovered %d tools from server '%s'",
+            "Discovered %d tools from server '%s' (manifest digest %s)",
             len(self._tools),
             self._config.name,
+            self._manifest_digest[:12],
         )
         return self._tools.copy()
 
-    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> ToolCallResult:
-        """Call a tool on the remote server.
+    @staticmethod
+    def _compute_manifest_digest(raw_tools: list[Any]) -> str:
+        """Return a stable SHA-256 digest of the tool manifest.
+
+        Used to correlate capability mismatches (AC1) with the exact
+        manifest the client validated against.
+        """
+        canonical = json.dumps(raw_tools, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def _validate_capability(self, tool_name: str) -> None:
+        """Verify ``tool_name`` is declared in the server's capability card.
+
+        Raises:
+            MCPCapabilityMissing: When the tool is absent from the discovered
+                manifest and capability validation is enabled.
+        """
+        if not self._config.validate_capabilities:
+            return
+        known_names = {t.name for t in self._tools}
+        if known_names and tool_name not in known_names:
+            logger.warning(
+                "Capability mismatch on server '%s': tool '%s' not in manifest (digest %s); available=%s",
+                self._config.name,
+                tool_name,
+                self._manifest_digest[:12] or "<none>",
+                sorted(known_names),
+            )
+            raise MCPCapabilityMissing(
+                f"Tool '{tool_name}' not found in the capability card of "
+                f"server '{self._config.name}' (manifest digest "
+                f"{self._manifest_digest[:12] or '<none>'})"
+            )
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        cost_usd: float = 0.0,
+    ) -> ToolCallResult:
+        """Call a tool on the remote server with full hardening (issue #1673).
+
+        Runs capability-card validation before dispatch, contains
+        schema-violating responses (marking the server degraded), records a
+        per-server cost-meter entry, and surfaces latency / error to the
+        metrics tracker.
 
         Args:
             tool_name: Name of the tool to call.
             arguments: Arguments to pass to the tool.
+            cost_usd: Metered cost to attribute to this call (default 0).
 
         Returns:
             Result of the tool call.
 
         Raises:
+            MCPCapabilityMissing: If the tool is not in the capability card.
             MCPToolNotFoundError: If the tool is not found on this server.
+            MCPSchemaViolation: If the response is structurally malformed.
             MCPClientError: If the call fails.
         """
-        # Verify tool exists
+        self._validate_capability(tool_name)
+
+        # ``known_names`` is empty before discovery; once tools are known a
+        # missing entry that passed capability validation (validation off)
+        # is still a hard not-found error.
         known_names = {t.name for t in self._tools}
         if known_names and tool_name not in known_names:
             raise MCPToolNotFoundError(
                 f"Tool '{tool_name}' not found on server '{self._config.name}'. Available: {sorted(known_names)}"
             )
 
-        result = await self._send_jsonrpc(
-            "tools/call",
-            {"name": tool_name, "arguments": arguments},
-        )
+        started = time.monotonic()
+        errored = False
+        try:
+            result = await self._send_jsonrpc(
+                "tools/call",
+                {"name": tool_name, "arguments": arguments},
+            )
+            tool_result = self._parse_tool_result(result, tool_name)
+            errored = tool_result.is_error
+            return tool_result
+        except MCPSchemaViolation:
+            errored = True
+            raise
+        except MCPClientError:
+            errored = True
+            raise
+        finally:
+            self._record_call_telemetry(
+                tool_name=tool_name,
+                latency_ms=(time.monotonic() - started) * 1000.0,
+                errored=errored,
+                cost_usd=cost_usd,
+            )
 
-        # Parse MCP tool result content
+    def _parse_tool_result(self, result: dict[str, Any], tool_name: str) -> ToolCallResult:
+        """Parse a ``tools/call`` result, containing schema violations (AC5).
+
+        ``result`` is already a JSON object (``_send_jsonrpc`` rejects a
+        non-object ``result`` field). This method additionally guards the
+        ``content`` block shape.
+
+        Raises:
+            MCPSchemaViolation: When the ``content`` block is structurally
+                malformed. The server is marked degraded before the error
+                propagates.
+        """
         content_parts = result.get("content", [])
-        text_parts = [
-            part.get("text", "") for part in content_parts if isinstance(part, dict) and part.get("type") == "text"
+        if not isinstance(content_parts, list):
+            self.mark_degraded(f"tools/call for '{tool_name}' returned non-list content")
+            raise MCPSchemaViolation(f"Server '{self._config.name}' returned malformed content for tool '{tool_name}'")
+        parts = cast("list[Any]", content_parts)
+        text_parts: list[str] = [
+            str(cast("dict[str, Any]", part).get("text", ""))
+            for part in parts
+            if isinstance(part, dict) and part.get("type") == "text"
         ]
-
         return ToolCallResult(
             content="\n".join(text_parts) if text_parts else json.dumps(result),
             is_error=bool(result.get("isError", False)),
             metadata={"server": self._config.name, "tool": tool_name},
+        )
+
+    def _record_call_telemetry(
+        self,
+        *,
+        tool_name: str,
+        latency_ms: float,
+        errored: bool,
+        cost_usd: float,
+    ) -> None:
+        """Feed latency / error / cost into the metrics + cost subsystems."""
+        if self._metrics is not None:
+            self._metrics.record_call(
+                self._config.name,
+                tool_name,
+                latency_ms,
+                error=errored,
+            )
+        if self._cost_meter is not None and cost_usd > 0.0:
+            self._cost_meter.record(
+                task_id=self._task_id,
+                server_name=self._config.name,
+                tool_name=tool_name,
+                cost_usd=cost_usd,
+            )
+
+    # ------------------------------------------------------------------
+    # Streamed tool calls with cancellation + retry-with-continuation
+    # (issue #1673, AC2 + AC3)
+    # ------------------------------------------------------------------
+
+    async def call_tool_streaming(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        stream_factory: Callable[[str | None, str], AsyncIterator[StreamChunk]],
+        handle: StreamedToolCall | None = None,
+        cost_usd: float = 0.0,
+    ) -> ToolCallResult:
+        """Call a tool over a stream, surviving mid-stream drops (AC2 + AC3).
+
+        Chunks are produced by ``stream_factory``, which is invoked with
+        ``(resumption_token, idempotency_key)``. On the first attempt the
+        resumption token is ``None``; if the stream drops and the server
+        emitted a checkpoint token the client resumes from it, otherwise it
+        replays the whole call carrying the same idempotency key so the
+        server can dedupe. Retries are bounded by
+        ``config.max_continuation_retries``.
+
+        Cancellation: pass a :class:`StreamedToolCall` ``handle`` and call
+        ``handle.cancel()`` from another task. The consuming loop stops at the
+        next chunk boundary; partial output is preserved on the handle and
+        returned.
+
+        Args:
+            tool_name: Name of the tool to call.
+            arguments: Arguments to pass to the tool.
+            stream_factory: Factory yielding :class:`StreamChunk` objects.
+            handle: Optional caller-owned handle for cancellation / inspection.
+            cost_usd: Metered cost to attribute to this call.
+
+        Returns:
+            The accumulated tool result. ``metadata['cancelled']`` is ``True``
+            when the call was cancelled mid-stream.
+
+        Raises:
+            MCPCapabilityMissing: If the tool is not in the capability card.
+            MCPStreamDropped: If retries are exhausted before completion.
+        """
+        self._validate_capability(tool_name)
+        call = handle if handle is not None else StreamedToolCall(self._config.name, tool_name)
+        idempotency_key = str(uuid.uuid4())
+
+        started = time.monotonic()
+        errored = False
+        try:
+            attempts = self._config.max_continuation_retries + 1
+            for attempt in range(attempts):
+                resume_from = call.resumption_token
+                try:
+                    completed = await self._consume_stream(
+                        call=call,
+                        stream=stream_factory(resume_from, idempotency_key),
+                    )
+                except MCPStreamDropped as drop:
+                    call.resumption_token = drop.resumption_token or call.resumption_token
+                    if attempt >= attempts - 1:
+                        errored = True
+                        self.mark_degraded(f"streamed tool '{tool_name}' dropped and retries exhausted")
+                        raise
+                    logger.warning(
+                        "Streamed tool '%s' on '%s' dropped (attempt %d/%d); resuming %s",
+                        tool_name,
+                        self._config.name,
+                        attempt + 1,
+                        attempts,
+                        "from checkpoint" if call.resumption_token else "with full retry",
+                    )
+                    continue
+
+                if call.is_cancel_requested:
+                    return ToolCallResult(
+                        content=call.partial_content,
+                        is_error=False,
+                        metadata={"server": self._config.name, "tool": tool_name, "cancelled": True},
+                    )
+                if completed:
+                    return ToolCallResult(
+                        content=call.partial_content,
+                        is_error=False,
+                        metadata={"server": self._config.name, "tool": tool_name, "cancelled": False},
+                    )
+            # Loop exhausted without completion or drop signal.
+            errored = True
+            raise MCPStreamDropped(
+                f"Streamed tool '{tool_name}' on '{self._config.name}' did not complete",
+                resumption_token=call.resumption_token,
+                partial_content=call.partial_content,
+            )
+        finally:
+            self._record_call_telemetry(
+                tool_name=tool_name,
+                latency_ms=(time.monotonic() - started) * 1000.0,
+                errored=errored,
+                cost_usd=cost_usd,
+            )
+
+    async def _consume_stream(
+        self,
+        *,
+        call: StreamedToolCall,
+        stream: AsyncIterator[StreamChunk],
+    ) -> bool:
+        """Consume a chunk stream into ``call``; return True when it completed.
+
+        Honours cooperative cancellation, tracks the latest checkpoint token,
+        and raises :class:`MCPStreamDropped` if the stream signals a drop.
+        """
+        async for chunk in stream:
+            if call.is_cancel_requested:
+                logger.info(
+                    "Streamed tool '%s' on '%s' cancelled; %d chars preserved",
+                    call.tool_name,
+                    self._config.name,
+                    len(call.partial_content),
+                )
+                return False
+            if chunk.checkpoint_token is not None:
+                call.resumption_token = chunk.checkpoint_token
+            if chunk.dropped:
+                raise MCPStreamDropped(
+                    f"Stream for tool '{call.tool_name}' dropped mid-stream",
+                    resumption_token=call.resumption_token,
+                    partial_content=call.partial_content,
+                )
+            if chunk.text:
+                call.partial_content += chunk.text
+            if chunk.final:
+                return True
+        # Stream ended without a final marker -> treat as a drop so the
+        # caller can retry-with-continuation rather than silently truncating.
+        raise MCPStreamDropped(
+            f"Stream for tool '{call.tool_name}' ended without a final chunk",
+            resumption_token=call.resumption_token,
+            partial_content=call.partial_content,
         )
 
     async def close(self) -> None:
@@ -294,15 +745,37 @@ class MCPClientSession:
                 if session_id:
                     self._mcp_session_id = session_id
 
-                data = response.json()
-                if "error" in data:
-                    error = data["error"]
+                # Schema-violation containment (AC5): invalid JSON or a
+                # missing JSON-RPC envelope is a malformed response. Mark the
+                # server degraded and surface a typed error rather than
+                # leaking a raw decode exception.
+                try:
+                    data: Any = response.json()
+                except (json.JSONDecodeError, ValueError) as exc:
+                    self.mark_degraded(f"{method} returned invalid JSON")
+                    raise MCPSchemaViolation(
+                        f"Server '{self._config.name}' returned invalid JSON for '{method}': {exc}"
+                    ) from exc
+                if not isinstance(data, dict):
+                    self.mark_degraded(f"{method} returned a non-object JSON-RPC envelope")
+                    raise MCPSchemaViolation(
+                        f"Server '{self._config.name}' returned a non-object JSON-RPC envelope for '{method}'"
+                    )
+                envelope = cast("dict[str, Any]", data)
+                if "error" in envelope:
+                    error = cast("dict[str, Any]", envelope["error"])
                     raise MCPClientError(
                         f"JSON-RPC error from '{self._config.name}': "
                         f"[{error.get('code', '?')}] {error.get('message', 'Unknown')}"
                     )
 
-                return dict(data.get("result", {}))
+                result = envelope.get("result", {})
+                if not isinstance(result, dict):
+                    self.mark_degraded(f"{method} returned a non-object 'result' field")
+                    raise MCPSchemaViolation(
+                        f"Server '{self._config.name}' returned a non-object 'result' for '{method}'"
+                    )
+                return cast("dict[str, Any]", result)
 
             except MCPClientError:
                 raise
@@ -386,15 +859,37 @@ class MCPClientManager:
 
     Provides a unified interface for connecting to, discovering tools from,
     and calling tools on multiple remote MCP servers.
+
+    Args:
+        cost_meter: Optional per-server cost meter (issue #1673, AC4) shared
+            across every session this manager opens. Metered tool calls are
+            attributed per server per ``task_id``.
+        metrics: Optional metrics collector that receives per-call latency /
+            error and degraded-server availability events (AC5).
+        task_id: Task identifier stamped onto cost-meter entries.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        cost_meter: MCPServerCostMeter | None = None,
+        metrics: MCPMetricsCollector | None = None,
+        task_id: str = "",
+    ) -> None:
         self._sessions: dict[str, MCPClientSession] = {}
+        self._cost_meter = cost_meter
+        self._metrics = metrics
+        self._task_id = task_id
 
     @property
     def sessions(self) -> dict[str, MCPClientSession]:
         """Active sessions by server name (copy)."""
         return self._sessions.copy()
+
+    @property
+    def cost_meter(self) -> MCPServerCostMeter | None:
+        """The shared per-server cost meter, if wired in."""
+        return self._cost_meter
 
     async def connect(self, config: RemoteServerConfig) -> MCPClientSession:
         """Connect to a remote MCP server.
@@ -416,7 +911,12 @@ class MCPClientManager:
         if config.name in self._sessions:
             await self._sessions[config.name].close()
 
-        session = MCPClientSession(config)
+        session = MCPClientSession(
+            config,
+            cost_meter=self._cost_meter,
+            metrics=self._metrics,
+            task_id=self._task_id,
+        )
         await session.connect()
         self._sessions[config.name] = session
         return session
@@ -471,13 +971,21 @@ class MCPClientManager:
                 all_tools.extend(tools)
         return all_tools
 
-    async def call_tool(self, server_name: str, tool_name: str, arguments: dict[str, Any]) -> ToolCallResult:
+    async def call_tool(
+        self,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        cost_usd: float = 0.0,
+    ) -> ToolCallResult:
         """Call a tool on a specific server.
 
         Args:
             server_name: Name of the server hosting the tool.
             tool_name: Name of the tool to call.
             arguments: Arguments to pass to the tool.
+            cost_usd: Metered cost to attribute to this call.
 
         Returns:
             Result of the tool call.
@@ -485,12 +993,59 @@ class MCPClientManager:
         Raises:
             MCPClientError: If the server is not connected or the call fails.
         """
+        session = self._require_session(server_name)
+        return await session.call_tool(tool_name, arguments, cost_usd=cost_usd)
+
+    async def call_tool_streaming(
+        self,
+        server_name: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        stream_factory: Callable[[str | None, str], AsyncIterator[StreamChunk]],
+        handle: StreamedToolCall | None = None,
+        cost_usd: float = 0.0,
+    ) -> ToolCallResult:
+        """Stream a tool call on a specific server (issue #1673, AC2 + AC3).
+
+        Delegates to :meth:`MCPClientSession.call_tool_streaming`.
+
+        Raises:
+            MCPClientError: If the server is not connected or the call fails.
+        """
+        session = self._require_session(server_name)
+        return await session.call_tool_streaming(
+            tool_name,
+            arguments,
+            stream_factory=stream_factory,
+            handle=handle,
+            cost_usd=cost_usd,
+        )
+
+    def _require_session(self, server_name: str) -> MCPClientSession:
+        """Return the active session for ``server_name`` or raise."""
         session = self._sessions.get(server_name)
         if session is None:
             raise MCPClientError(
                 f"No active session for server '{server_name}'. Connected: {sorted(self._sessions.keys())}"
             )
-        return await session.call_tool(tool_name, arguments)
+        return session
+
+    def server_cost(self, server_name: str) -> float:
+        """Return accumulated MCP spend for ``server_name`` on this task (AC4)."""
+        if self._cost_meter is None:
+            return 0.0
+        return self._cost_meter.cost_for(self._task_id, server_name)
+
+    def task_cost(self) -> float:
+        """Return total MCP spend across all servers for this task (AC4)."""
+        if self._cost_meter is None:
+            return 0.0
+        return self._cost_meter.task_total(self._task_id)
+
+    def degraded_servers(self) -> list[str]:
+        """Return names of servers currently marked degraded (AC5)."""
+        return sorted(name for name, s in self._sessions.items() if s.is_degraded)
 
     async def close_all(self) -> None:
         """Close all active sessions."""

--- a/tests/unit/mcp/test_client_hardened.py
+++ b/tests/unit/mcp/test_client_hardened.py
@@ -1,0 +1,469 @@
+"""Tests for the hardened MCP client (issue #1673).
+
+Covers each acceptance-criteria path with a fake MCP server:
+
+* AC1 capability-card validation -> ``MCPCapabilityMissing`` on mismatch.
+* AC2 retry-with-continuation on a streamed-tool-call drop (resume from a
+  checkpoint token, or full retry with an idempotency key).
+* AC3 streamed-output cancellation with partial output preserved.
+* AC4 per-server cost-meter accumulation wired into ``core/cost``.
+* AC5 schema-violation containment (invalid JSON / missing fields) marking
+  the server degraded for the rest of the task.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from bernstein.core.cost.mcp_server_cost import MCPServerCostMeter
+from bernstein.core.protocols.mcp.mcp_client import (
+    MCPCapabilityMissing,
+    MCPClientManager,
+    MCPClientSession,
+    MCPSchemaViolation,
+    MCPStreamDropped,
+    MCPToolNotFoundError,
+    RemoteServerConfig,
+    RemoteTool,
+    StreamChunk,
+    StreamedToolCall,
+)
+from bernstein.core.protocols.mcp.mcp_metrics import MCPMetricsCollector
+
+_FAKE_REQUEST = httpx.Request("POST", "https://fake")
+
+
+# ---------------------------------------------------------------------------
+# Fake MCP server
+# ---------------------------------------------------------------------------
+
+
+class FakeMCPServer:
+    """Scriptable in-memory MCP server for client tests.
+
+    Each ``handle`` call inspects the JSON-RPC method and returns a canned
+    ``httpx.Response``. Behaviour is configured per instance so individual
+    tests can simulate malformed payloads, auth state, and tool catalogues.
+    """
+
+    def __init__(
+        self,
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        tool_result: dict[str, Any] | None = None,
+        raw_body: str | None = None,
+        non_object_body: bool = False,
+    ) -> None:
+        self.tools = tools if tools is not None else [{"name": "echo", "description": "Echo", "inputSchema": {}}]
+        self.tool_result = (
+            tool_result
+            if tool_result is not None
+            else {
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": False,
+            }
+        )
+        self.raw_body = raw_body
+        self.non_object_body = non_object_body
+        self.calls: list[str] = []
+
+    def _envelope(self, request_id: int, result: dict[str, Any]) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": request_id, "result": result},
+            headers={"content-type": "application/json", "mcp-session-id": "sess-fake"},
+            request=_FAKE_REQUEST,
+        )
+
+    async def handle(self, url: str, *, json: Any, headers: Any, **kwargs: Any) -> httpx.Response:
+        method = json.get("method", "")
+        self.calls.append(method)
+        request_id = json.get("id", 1)
+        if method == "initialize":
+            return self._envelope(request_id, {"serverInfo": {"name": "fake"}})
+        if method == "notifications/initialized":
+            return httpx.Response(200, headers={}, request=_FAKE_REQUEST)
+        if method == "tools/list":
+            return self._envelope(request_id, {"tools": self.tools})
+        if method == "tools/call":
+            if self.raw_body is not None:
+                return httpx.Response(
+                    200,
+                    content=self.raw_body,
+                    headers={"content-type": "application/json"},
+                    request=_FAKE_REQUEST,
+                )
+            if self.non_object_body:
+                return httpx.Response(
+                    200,
+                    json={"jsonrpc": "2.0", "id": request_id, "result": ["not", "an", "object"]},
+                    headers={"content-type": "application/json"},
+                    request=_FAKE_REQUEST,
+                )
+            return self._envelope(request_id, self.tool_result)
+        return httpx.Response(200, json={}, headers={}, request=_FAKE_REQUEST)
+
+
+def _patched_client(server: FakeMCPServer, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``httpx.AsyncClient`` so POSTs hit ``server.handle``."""
+
+    class _Client:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *args: Any) -> bool:
+            return False
+
+        async def post(self, url: str, *, json: Any, headers: Any, **kwargs: Any) -> httpx.Response:
+            return await server.handle(url, json=json, headers=headers, **kwargs)
+
+    monkeypatch.setattr("bernstein.core.protocols.mcp.mcp_client.httpx.AsyncClient", _Client)
+
+
+@pytest.fixture
+def config() -> RemoteServerConfig:
+    return RemoteServerConfig(name="fake", url="https://fake/mcp", retry_limit=1)
+
+
+# ---------------------------------------------------------------------------
+# AC1: capability-card validation
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityValidation:
+    @pytest.mark.asyncio
+    async def test_known_tool_passes(self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        server = FakeMCPServer(tools=[{"name": "echo", "description": "", "inputSchema": {}}])
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        await session.connect()
+        result = await session.call_tool("echo", {"x": 1})
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_undeclared_tool_raises_capability_missing(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = FakeMCPServer(tools=[{"name": "echo", "description": "", "inputSchema": {}}])
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        await session.connect()
+        with pytest.raises(MCPCapabilityMissing, match="capability card"):
+            await session.call_tool("undeclared", {})
+        # No tools/call should have reached the server.
+        assert "tools/call" not in server.calls
+
+    @pytest.mark.asyncio
+    async def test_capability_missing_is_tool_not_found_subclass(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = FakeMCPServer(tools=[{"name": "echo", "description": "", "inputSchema": {}}])
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        await session.connect()
+        with pytest.raises(MCPToolNotFoundError):
+            await session.call_tool("undeclared", {})
+
+    @pytest.mark.asyncio
+    async def test_validation_can_be_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = RemoteServerConfig(name="fake", url="https://fake/mcp", retry_limit=1, validate_capabilities=False)
+        server = FakeMCPServer(tools=[])  # empty manifest
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(cfg)
+        await session.connect()
+        # Empty manifest + validation off -> call dispatches.
+        result = await session.call_tool("anything", {})
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_manifest_digest_is_stable(self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        server = FakeMCPServer(tools=[{"name": "echo", "description": "", "inputSchema": {}}])
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        await session.connect()
+        digest = session.manifest_digest
+        assert len(digest) == 64  # sha256 hex
+        await session.list_tools()
+        assert session.manifest_digest == digest  # unchanged manifest -> same digest
+
+
+# ---------------------------------------------------------------------------
+# AC2: retry-with-continuation
+# ---------------------------------------------------------------------------
+
+
+class _Stream:
+    """Records the (resume_token, idempotency_key) of each attempt."""
+
+    def __init__(self, scripts: list[list[StreamChunk]]) -> None:
+        self._scripts = scripts
+        self.attempts: list[tuple[str | None, str]] = []
+
+    def factory(self, resume: str | None, idem: str) -> AsyncIterator[StreamChunk]:
+        attempt_index = len(self.attempts)
+        self.attempts.append((resume, idem))
+        chunks = self._scripts[min(attempt_index, len(self._scripts) - 1)]
+
+        async def _gen() -> AsyncIterator[StreamChunk]:
+            for c in chunks:
+                yield c
+
+        return _gen()
+
+
+@pytest_asyncio.fixture
+async def connected_session(config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch) -> MCPClientSession:
+    server = FakeMCPServer(tools=[{"name": "stream", "description": "", "inputSchema": {}}])
+    _patched_client(server, monkeypatch)
+    session = MCPClientSession(config)
+    await session.connect()
+    return session
+
+
+class TestRetryWithContinuation:
+    @pytest.mark.asyncio
+    async def test_resume_from_checkpoint(self, connected_session: MCPClientSession) -> None:
+        stream = _Stream(
+            [
+                # attempt 0: emit a checkpoint then drop
+                [StreamChunk(text="hel", checkpoint_token="cp-1"), StreamChunk(dropped=True)],
+                # attempt 1 (resumed): finish
+                [StreamChunk(text="lo", final=True)],
+            ]
+        )
+        result = await connected_session.call_tool_streaming("stream", {}, stream_factory=stream.factory)
+        assert result.content == "hello"
+        # Second attempt resumed from the checkpoint token.
+        assert stream.attempts[0][0] is None
+        assert stream.attempts[1][0] == "cp-1"
+
+    @pytest.mark.asyncio
+    async def test_full_retry_with_idempotency_key(self, connected_session: MCPClientSession) -> None:
+        stream = _Stream(
+            [
+                # attempt 0: no checkpoint, just a drop
+                [StreamChunk(text="partial"), StreamChunk(dropped=True)],
+                # attempt 1: full replay completes
+                [StreamChunk(text="done", final=True)],
+            ]
+        )
+        result = await connected_session.call_tool_streaming("stream", {}, stream_factory=stream.factory)
+        assert result.content == "partialdone"
+        # No checkpoint -> resume token stays None; idempotency key is stable.
+        assert stream.attempts[1][0] is None
+        assert stream.attempts[0][1] == stream.attempts[1][1]
+
+    @pytest.mark.asyncio
+    async def test_retries_exhausted_raises_and_degrades(self, connected_session: MCPClientSession) -> None:
+        cfg = RemoteServerConfig(name="fake", url="https://fake/mcp", retry_limit=1, max_continuation_retries=1)
+        connected_session._config = cfg  # tighten retries for the test
+        stream = _Stream([[StreamChunk(dropped=True)]])  # always drops
+        with pytest.raises(MCPStreamDropped):
+            await connected_session.call_tool_streaming("stream", {}, stream_factory=stream.factory)
+        assert connected_session.is_degraded
+        # initial attempt + 1 continuation
+        assert len(stream.attempts) == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_without_final_is_treated_as_drop(self, connected_session: MCPClientSession) -> None:
+        stream = _Stream(
+            [
+                [StreamChunk(text="a")],  # ends without final -> drop
+                [StreamChunk(text="b", final=True)],
+            ]
+        )
+        result = await connected_session.call_tool_streaming("stream", {}, stream_factory=stream.factory)
+        assert result.content == "ab"
+
+
+# ---------------------------------------------------------------------------
+# AC3: streamed-output cancellation
+# ---------------------------------------------------------------------------
+
+
+class TestStreamCancellation:
+    @pytest.mark.asyncio
+    async def test_cancel_preserves_partial(self, connected_session: MCPClientSession) -> None:
+        handle = StreamedToolCall(server_name="fake", tool_name="stream")
+
+        def factory(resume: str | None, idem: str) -> AsyncIterator[StreamChunk]:
+            async def _gen() -> AsyncIterator[StreamChunk]:
+                yield StreamChunk(text="first")
+                handle.cancel()  # cancel mid-stream
+                yield StreamChunk(text="second-should-be-dropped", final=True)
+
+            return _gen()
+
+        result = await connected_session.call_tool_streaming("stream", {}, stream_factory=factory, handle=handle)
+        assert result.metadata["cancelled"] is True
+        assert result.content == "first"
+        assert handle.partial_content == "first"
+        assert "second" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_cancel_flag_idempotent(self) -> None:
+        handle = StreamedToolCall(server_name="s", tool_name="t")
+        handle.cancel()
+        handle.cancel()
+        assert handle.cancelled is True
+        assert handle.is_cancel_requested is True
+
+
+# ---------------------------------------------------------------------------
+# AC4: per-server cost-meter
+# ---------------------------------------------------------------------------
+
+
+class TestCostMeter:
+    @pytest.mark.asyncio
+    async def test_cost_accumulates_per_server_per_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        meter = MCPServerCostMeter()
+        manager = MCPClientManager(cost_meter=meter, task_id="task-1")
+        server = FakeMCPServer(tools=[{"name": "echo", "description": "", "inputSchema": {}}])
+        _patched_client(server, monkeypatch)
+        await manager.connect(RemoteServerConfig(name="fake", url="https://fake/mcp", retry_limit=1))
+
+        await manager.call_tool("fake", "echo", {}, cost_usd=0.02)
+        await manager.call_tool("fake", "echo", {}, cost_usd=0.03)
+
+        assert manager.server_cost("fake") == pytest.approx(0.05)
+        assert manager.task_cost() == pytest.approx(0.05)
+        assert meter.call_count("task-1", "fake") == 2
+
+    def test_negative_cost_clamped(self) -> None:
+        meter = MCPServerCostMeter()
+        rec = meter.record(task_id="t", server_name="s", tool_name="x", cost_usd=-5.0)
+        assert rec.cost_usd == 0.0
+        assert meter.task_total("t") == 0.0
+
+    def test_flush_to_ledger(self, tmp_path: Any) -> None:
+        from bernstein.core.cost.spend_ledger import SpendLedger
+
+        ledger = SpendLedger(path=tmp_path / "ledger.jsonl", run_id="run-x")
+        meter = MCPServerCostMeter(ledger=ledger)
+        meter.record(task_id="task-1", server_name="github", tool_name="search", cost_usd=0.10)
+        assert ledger.status().spent_usd == pytest.approx(0.10)
+        assert ledger.totals_by("task").get("task-1") == pytest.approx(0.10)
+
+    def test_server_breakdown(self) -> None:
+        meter = MCPServerCostMeter()
+        meter.record(task_id="t", server_name="a", tool_name="x", cost_usd=0.01)
+        meter.record(task_id="t", server_name="b", tool_name="y", cost_usd=0.02)
+        breakdown = meter.server_breakdown("t")
+        assert breakdown == {"a": pytest.approx(0.01), "b": pytest.approx(0.02)}
+
+
+# ---------------------------------------------------------------------------
+# AC5: schema-violation containment
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaViolationContainment:
+    @pytest.mark.asyncio
+    async def test_invalid_json_marks_degraded(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = FakeMCPServer(
+            tools=[{"name": "echo", "description": "", "inputSchema": {}}],
+            raw_body="this is not json",
+        )
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        await session.connect()
+        with pytest.raises(MCPSchemaViolation, match="invalid JSON"):
+            await session.call_tool("echo", {})
+        assert session.is_degraded
+        assert "invalid JSON" in session.degraded_reason
+
+    @pytest.mark.asyncio
+    async def test_missing_fields_marks_degraded(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = FakeMCPServer(
+            tools=[{"name": "echo", "description": "", "inputSchema": {}}],
+            non_object_body=True,
+        )
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        await session.connect()
+        with pytest.raises(MCPSchemaViolation):
+            await session.call_tool("echo", {})
+        assert session.is_degraded
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_entry_in_manifest(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        server = FakeMCPServer(tools=[{"description": "missing name"}])
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config)
+        with pytest.raises(MCPSchemaViolation):
+            await session.connect()
+        assert session.is_degraded
+
+    @pytest.mark.asyncio
+    async def test_degraded_surfaces_via_metrics(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        metrics = MCPMetricsCollector()
+        server = FakeMCPServer(
+            tools=[{"name": "echo", "description": "", "inputSchema": {}}],
+            raw_body="nope",
+        )
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config, metrics=metrics)
+        await session.connect()
+        with pytest.raises(MCPSchemaViolation):
+            await session.call_tool("echo", {})
+        summary = metrics.summary("fake")
+        assert summary is not None
+        # The malformed call was recorded as an error on the metrics tracker.
+        assert summary["error_count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_manager_lists_degraded_servers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager = MCPClientManager()
+        server = FakeMCPServer(
+            tools=[{"name": "echo", "description": "", "inputSchema": {}}],
+            raw_body="bad",
+        )
+        _patched_client(server, monkeypatch)
+        await manager.connect(RemoteServerConfig(name="fake", url="https://fake/mcp", retry_limit=1))
+        with pytest.raises(MCPSchemaViolation):
+            await manager.call_tool("fake", "echo", {})
+        assert manager.degraded_servers() == ["fake"]
+
+
+# ---------------------------------------------------------------------------
+# Telemetry on the happy path
+# ---------------------------------------------------------------------------
+
+
+class TestTelemetry:
+    @pytest.mark.asyncio
+    async def test_successful_call_records_metrics(
+        self, config: RemoteServerConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        metrics = MCPMetricsCollector()
+        server = FakeMCPServer(tools=[{"name": "echo", "description": "", "inputSchema": {}}])
+        _patched_client(server, monkeypatch)
+        session = MCPClientSession(config, metrics=metrics)
+        await session.connect()
+        await session.call_tool("echo", {})
+        summary = metrics.summary("fake")
+        assert summary is not None
+        assert summary["total_calls"] == 1
+        assert summary["error_count"] == 0
+
+    def test_remote_tool_unchanged(self) -> None:
+        # Guard against accidental signature drift of the public dataclass.
+        tool = RemoteTool(name="t", description="d", server_name="s")
+        assert tool.input_schema == {}


### PR DESCRIPTION
## Summary

Hardens the MCP client that consumes external servers during orchestrator
runs. Upstream servers are treated as untrusted, brittle, and rate-limited.

- Capability-card validation before every tool call; mismatch raises
  `MCPCapabilityMissing`, logged with the manifest digest.
- Retry-with-continuation on a streamed-tool-call drop: resume from the
  server checkpoint token, or full retry with an idempotency key when the
  server has no resumption support. Bounded by `max_continuation_retries`.
- Streamed-output cancellation that preserves partial output without leaking
  the underlying request.
- Per-server cost-meter (`MCPServerCostMeter`) accumulating spend per server
  per task, flushing into the existing `core/cost` spend ledger.
- Schema-violation containment: malformed responses are caught, surfaced
  through the metrics tracker, and the server is marked degraded for the rest
  of the task.

## Files

- `src/bernstein/core/protocols/mcp/mcp_client.py` - hardened session/manager.
- `src/bernstein/core/cost/mcp_server_cost.py` - per-server cost meter (new).
- `src/bernstein/core/cost/__init__.py` - export the cost meter.
- `tests/unit/mcp/test_client_hardened.py` - fake-server coverage (new).
- `docs/mcp/client.md` - client docs (new).

## Test plan

- [x] `pytest tests/unit/mcp tests/unit/test_mcp_client.py tests/unit/cost` (104 passed)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `pyright` on changed source: net fewer strict errors than baseline

Closes #1673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-server cost tracking with automatic ledger integration
  * Tool capability validation against server manifests
  * Streaming tool calls with retry and cooperative cancellation
  * Server degradation detection and tracking

* **Documentation**
  * Hardened MCP client implementation guide with validation and resilience features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->