### PR TITLE
test(mcp-client): fix spelling gate on stream chunk fixture

### DIFF
--- a/tests/unit/mcp/test_client_hardened.py
+++ b/tests/unit/mcp/test_client_hardened.py
@@ -234,13 +234,13 @@ class TestRetryWithContinuation:
         stream = _Stream(
             [
                 # attempt 0: emit a checkpoint then drop
-                [StreamChunk(text="hel", checkpoint_token="cp-1"), StreamChunk(dropped=True)],
+                [StreamChunk(text="part-one ", checkpoint_token="cp-1"), StreamChunk(dropped=True)],
                 # attempt 1 (resumed): finish
-                [StreamChunk(text="lo", final=True)],
+                [StreamChunk(text="part-two", final=True)],
             ]
         )
         result = await connected_session.call_tool_streaming("stream", {}, stream_factory=stream.factory)
-        assert result.content == "hello"
+        assert result.content == "part-one part-two"
         # Second attempt resumed from the checkpoint token.
         assert stream.attempts[0][0] is None
         assert stream.attempts[1][0] == "cp-1"


### PR DESCRIPTION
## Summary

Follow-up to #1692. The hardened MCP client test used the partial chunk
strings `"hel"` / `"lo"` to simulate a mid-stream split; the typos gate
flags `"hel"`. Switch to `part-one` / `part-two` so the spelling check is
green on main. No behaviour change.

## Test plan

- [x] `typos tests/unit/mcp/test_client_hardened.py` clean
- [x] `pytest tests/unit/mcp/test_client_hardened.py` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated unit test for streamed retry with checkpoint resumption to reflect new streamed outputs: the initial attempt now yields "part-one " before dropping and the resumed attempt yields "part-two".
  * Final assertion updated to expect "part-one part-two" to verify correct concatenation on resume.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->