### PR TITLE
fix(observability): remove operator infrastructure defaults from shipped package

### DIFF
--- a/src/bernstein/cli/commands/doctor/glitchtip.py
+++ b/src/bernstein/cli/commands/doctor/glitchtip.py
@@ -363,7 +363,8 @@ def glitchtip_cmd(as_json: bool, top_n: int, skip_baseline: bool) -> None:
     Reads:
       - BERNSTEIN_GLITCHTIP_TOKEN  (API token, required for non-trivial output)
       - BERNSTEIN_GLITCHTIP_DSN    (runtime DSN, informational only here)
-      - BERNSTEIN_GLITCHTIP_BASE_URL (optional override, default: errors.bernstein.run)
+      - BERNSTEIN_GLITCHTIP_BASE_URL (API base URL; e.g. https://glitchtip.example.com.
+        No default host: derived from the DSN host when unset, else soft-fails)
       - BERNSTEIN_GLITCHTIP_ORG    (optional override, default: bernstein)
 
     \b

--- a/src/bernstein/core/observability/glitchtip_insights.py
+++ b/src/bernstein/core/observability/glitchtip_insights.py
@@ -35,17 +35,34 @@ if TYPE_CHECKING:
 #: orchestrator process write credentials.
 ENV_GLITCHTIP_TOKEN = "BERNSTEIN_GLITCHTIP_TOKEN"
 
-#: Environment variable carrying the optional override for the base
-#: URL. Defaults to the public bernstein.run endpoint so a typical
-#: operator only needs to export the token.
+#: Environment variable carrying the base URL of the GlitchTip API.
+#: There is no hardcoded default host: the package ships with no
+#: observability backend wired. The base URL is resolved from this
+#: variable, or derived from the host of the runtime DSN
+#: (``BERNSTEIN_GLITCHTIP_DSN`` / ``BERNSTEIN_TELEMETRY_DSN`` /
+#: ``GLITCHTIP_DSN``). When neither is set, the feature soft-fails with
+#: a clear "not configured" reason. An illustrative value would be
+#: ``https://glitchtip.example.com``.
 ENV_GLITCHTIP_BASE_URL = "BERNSTEIN_GLITCHTIP_BASE_URL"
 
+#: Environment variable carrying the runtime DSN. When the base URL is
+#: not given explicitly, the host of this DSN is used to derive it so an
+#: operator who already wired the DSN does not have to repeat the host.
+ENV_GLITCHTIP_DSN = "BERNSTEIN_GLITCHTIP_DSN"
+
+#: Fallback DSN variables, in precedence order, used to derive the base
+#: URL when neither the base-URL nor the primary DSN variable is set.
+DSN_ENV_FALLBACKS: tuple[str, ...] = (
+    ENV_GLITCHTIP_DSN,
+    "BERNSTEIN_TELEMETRY_DSN",
+    "GLITCHTIP_DSN",
+)
+
 #: Environment variable carrying the GlitchTip organisation slug. Most
-#: operators run a single org, so the default matches the bernstein.run
-#: deployment.
+#: deployments run a single org, so the slug defaults to ``bernstein``;
+#: this is a project name, not a host, and reaches no network on its own.
 ENV_GLITCHTIP_ORG = "BERNSTEIN_GLITCHTIP_ORG"
 
-DEFAULT_BASE_URL = "https://errors.bernstein.run"
 DEFAULT_ORG_SLUG = "bernstein"
 
 #: Severity labels used by the Sentry-protocol API. Anything outside this
@@ -96,20 +113,63 @@ class InsightsResult:
         return payload
 
 
+def _base_url_from_dsn(dsn: str) -> str | None:
+    """Derive the API base URL from a Sentry-protocol DSN.
+
+    A DSN looks like ``https://<public_key>@<host>[:<port>]/<project_id>``.
+    The API base URL is ``<scheme>://<host>[:<port>]``. Returns ``None``
+    when the DSN cannot be parsed into a usable scheme and host.
+    """
+    from urllib.parse import urlsplit
+
+    try:
+        parts = urlsplit(dsn.strip())
+    except ValueError:
+        return None
+    if not parts.scheme or not parts.hostname:
+        return None
+    host = parts.hostname
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return f"{parts.scheme}://{host}"
+
+
+def _resolve_base_url(source: dict[str, str]) -> str | None:
+    """Resolve the base URL from env, or derive it from a DSN host.
+
+    Precedence: explicit ``BERNSTEIN_GLITCHTIP_BASE_URL`` first, then the
+    host of the first DSN variable that is set. Returns ``None`` when the
+    base URL cannot be determined: there is no hardcoded fallback host, so
+    the caller soft-fails rather than reaching any specific server.
+    """
+    explicit = source.get(ENV_GLITCHTIP_BASE_URL)
+    if explicit:
+        return explicit.rstrip("/")
+    for var in DSN_ENV_FALLBACKS:
+        dsn = source.get(var)
+        if dsn:
+            derived = _base_url_from_dsn(dsn)
+            if derived:
+                return derived.rstrip("/")
+    return None
+
+
 def _read_env(
     env: dict[str, str] | None,
-) -> tuple[str | None, str, str]:
-    """Resolve token, base URL, and org slug from env with defaults.
+) -> tuple[str | None, str | None, str]:
+    """Resolve token, base URL, and org slug from env.
 
-    A ``None`` ``env`` argument means read ``os.environ``. The token is
-    returned verbatim (``None`` when missing) so the caller can soft-fail
-    with a precise reason string.
+    A ``None`` ``env`` argument means read ``os.environ``. The token and
+    base URL are returned verbatim (``None`` when they cannot be
+    resolved) so the caller can soft-fail with a precise reason string.
+    There is no hardcoded default host: the base URL must come from
+    ``BERNSTEIN_GLITCHTIP_BASE_URL`` or be derived from a DSN host.
     """
     source = env if env is not None else dict(os.environ)
     token = source.get(ENV_GLITCHTIP_TOKEN) or None
-    base_url = source.get(ENV_GLITCHTIP_BASE_URL) or DEFAULT_BASE_URL
+    base_url = _resolve_base_url(source)
     org_slug = source.get(ENV_GLITCHTIP_ORG) or DEFAULT_ORG_SLUG
-    return token, base_url.rstrip("/"), org_slug
+    return token, base_url, org_slug
 
 
 def _coerce_issue(raw: Any) -> GlitchTipIssue | None:
@@ -258,7 +318,16 @@ def fetch_insights(
         return InsightsResult(
             ok=False,
             reason=f"{ENV_GLITCHTIP_TOKEN} not set; cannot query GlitchTip API",
-            base_url=base_url,
+            base_url=base_url or "",
+            org_slug=org_slug,
+        )
+    if not base_url:
+        return InsightsResult(
+            ok=False,
+            reason=(
+                f"{ENV_GLITCHTIP_BASE_URL} not set and no DSN host available; GlitchTip insights are not configured"
+            ),
+            base_url="",
             org_slug=org_slug,
         )
 

--- a/src/bernstein/core/observability/sonar.py
+++ b/src/bernstein/core/observability/sonar.py
@@ -18,7 +18,7 @@ Design notes
   deltas without paging through Sonar history.
 
 Env vars (matching the CI contract):
-  - ``SONAR_HOST_URL``: e.g. ``https://sonar.bernstein.run``
+  - ``SONAR_HOST_URL``: e.g. ``https://sonar.example.com``
   - ``SONAR_TOKEN``: a user token with ``Browse`` permission on the project
   - ``SONAR_PROJECT_KEY``: optional, defaults to ``bernstein``
 """

--- a/src/bernstein/core/telemetry/client.py
+++ b/src/bernstein/core/telemetry/client.py
@@ -42,7 +42,13 @@ from bernstein.core.telemetry.events import (
 
 _LOG = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT: Final[str] = "https://telemetry.bernstein.run/v1/events"
+# Illustrative placeholder only. The shipped package hardcodes no real
+# telemetry host: an operator who opts into telemetry must point it at
+# their own receiver via ``BERNSTEIN_TELEMETRY_ENDPOINT``. The placeholder
+# host does not resolve, so an opted-in install with no endpoint set sends
+# events nowhere (the POST failure is swallowed) rather than to any
+# specific server.
+DEFAULT_ENDPOINT: Final[str] = "https://telemetry.example.com/v1/events"
 ENDPOINT_ENV: Final[str] = "BERNSTEIN_TELEMETRY_ENDPOINT"
 TIMEOUT_SECONDS: Final[float] = 3.0
 FLUSH_DEADLINE_SECONDS: Final[float] = 5.0

--- a/tests/unit/cli/doctor/test_glitchtip.py
+++ b/tests/unit/cli/doctor/test_glitchtip.py
@@ -27,9 +27,9 @@ from bernstein.cli.commands.doctor.glitchtip import (
     write_baseline,
 )
 from bernstein.core.observability.glitchtip_insights import (
-    DEFAULT_BASE_URL,
     DEFAULT_ORG_SLUG,
     ENV_GLITCHTIP_BASE_URL,
+    ENV_GLITCHTIP_DSN,
     ENV_GLITCHTIP_ORG,
     ENV_GLITCHTIP_TOKEN,
     KNOWN_LEVELS,
@@ -40,6 +40,10 @@ from bernstein.core.observability.glitchtip_insights import (
     summarise_severity,
     top_unresolved,
 )
+
+# Illustrative base URL used across the suite. The package ships with no
+# hardcoded host; tests must supply one explicitly or via a DSN.
+_TEST_BASE_URL = "https://glitchtip.example.com"
 
 # ---------------------------------------------------------------------------
 # Stub HTTP getter
@@ -64,7 +68,7 @@ def _issue_row(
         "userCount": "0",
         "firstSeen": first_seen,
         "lastSeen": first_seen,
-        "permalink": f"https://errors.bernstein.run/bernstein/issues/{short_id}",
+        "permalink": f"https://glitchtip.example.com/bernstein/issues/{short_id}",
     }
 
 
@@ -98,8 +102,47 @@ def test_fetch_insights_soft_fails_when_token_missing() -> None:
     assert called["n"] == 0
     assert not result.ok
     assert ENV_GLITCHTIP_TOKEN in result.reason
-    assert result.base_url == DEFAULT_BASE_URL
+    # No hardcoded host: base_url is empty until configured.
+    assert result.base_url == ""
     assert result.org_slug == DEFAULT_ORG_SLUG
+
+
+def test_fetch_insights_soft_fails_when_base_url_unresolved() -> None:
+    """A token but no base URL or DSN host -> ok=False; no HTTP call.
+
+    Guards the privacy contract: with no base URL configured the feature
+    must never fall back to any specific host.
+    """
+    called = {"n": 0}
+
+    def _getter(*_args: Any, **_kwargs: Any) -> tuple[int, Any]:
+        called["n"] += 1
+        return 200, []
+
+    result = fetch_insights(env={ENV_GLITCHTIP_TOKEN: "tok"}, http_get=_getter)
+
+    assert called["n"] == 0
+    assert not result.ok
+    assert result.base_url == ""
+    assert ENV_GLITCHTIP_BASE_URL in result.reason
+
+
+def test_fetch_insights_derives_base_url_from_dsn_host() -> None:
+    """When no base URL is set, the host is derived from the DSN."""
+    captured: dict[str, str] = {}
+
+    def _getter(url: str, token: str, timeout: float) -> tuple[int, Any]:
+        captured["url"] = url
+        return 200, []
+
+    fetch_insights(
+        env={
+            ENV_GLITCHTIP_TOKEN: "tok",
+            ENV_GLITCHTIP_DSN: "https://pub_key@glitchtip.example.com/42",
+        },
+        http_get=_getter,
+    )
+    assert captured["url"].startswith("https://glitchtip.example.com/api/0/organizations/bernstein/issues/")
 
 
 def test_fetch_insights_populates_from_24h_payload() -> None:
@@ -110,7 +153,7 @@ def test_fetch_insights_populates_from_24h_payload() -> None:
         _issue_row("C", level="error", status="resolved", count=99),
     ]
     result = fetch_insights(
-        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        env={ENV_GLITCHTIP_TOKEN: "tok", ENV_GLITCHTIP_BASE_URL: _TEST_BASE_URL},
         http_get=_make_getter(payload),
     )
 
@@ -131,7 +174,7 @@ def test_fetch_insights_handles_non_2xx() -> None:
         return 503, None
 
     result = fetch_insights(
-        env={ENV_GLITCHTIP_TOKEN: "tok"},
+        env={ENV_GLITCHTIP_TOKEN: "tok", ENV_GLITCHTIP_BASE_URL: _TEST_BASE_URL},
         http_get=_getter,
     )
     assert not result.ok
@@ -377,6 +420,7 @@ def test_cli_renders_table_when_wired(monkeypatch: Any, tmp_path: Path) -> None:
     """A live-style fetch returns issue counts and writes the baseline."""
 
     monkeypatch.setenv(ENV_GLITCHTIP_TOKEN, "tok")
+    monkeypatch.setenv(ENV_GLITCHTIP_BASE_URL, _TEST_BASE_URL)
     monkeypatch.setenv("BERNSTEIN_GLITCHTIP_BASELINE", str(tmp_path / "baseline.json"))
 
     payload_24h = [_issue_row("Q", level="error", count=4)]

--- a/tests/unit/cli/doctor/test_glitchtip.py
+++ b/tests/unit/cli/doctor/test_glitchtip.py
@@ -68,7 +68,7 @@ def _issue_row(
         "userCount": "0",
         "firstSeen": first_seen,
         "lastSeen": first_seen,
-        "permalink": f"https://glitchtip.example.com/bernstein/issues/{short_id}",
+        "permalink": f"{_TEST_BASE_URL}/bernstein/issues/{short_id}",
     }
 
 

--- a/tests/unit/observability/test_no_hardcoded_infra.py
+++ b/tests/unit/observability/test_no_hardcoded_infra.py
@@ -1,0 +1,61 @@
+"""Regression guard: the shipped package hardcodes no specific observability host.
+
+Observability integrations (error reporting, code-quality scan, SBOM,
+telemetry) are deployment-time concerns. The package must be fully
+functional with no observability backend configured and must never
+default to any one host. This test scans the importable ``bernstein``
+package source for forbidden host literals, the known fixed IP, and the
+known DSN public-key id, and asserts zero matches so a default host can
+never silently reappear.
+
+Illustrative placeholders (``*.example.com``) are explicitly allowed:
+they do not resolve and ship no real backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import bernstein
+
+# Forbidden substrings. These are concrete observability backend hosts,
+# the fixed server IP, and the DSN public-key id. None of these may be
+# baked into the shipped package as a literal. Public product-schema
+# identifiers (for example ``https://bernstein.run/schema/...``) are not
+# backend hosts and are intentionally not listed here.
+FORBIDDEN: tuple[str, ...] = (
+    "errors.bernstein.run",
+    "sonar.bernstein.run",
+    "dt.bernstein.run",
+    "dependency-track.bernstein.run",
+    "telemetry.bernstein.run",
+    "analytics.bernstein.run",
+    "135.125.243.120",
+    "798d55a9",
+)
+
+
+def _package_root() -> Path:
+    """Return the on-disk root of the importable ``bernstein`` package."""
+    pkg_file = Path(bernstein.__file__).resolve()
+    return pkg_file.parent
+
+
+def test_no_hardcoded_observability_infra() -> None:
+    """No forbidden backend host / IP / DSN id appears in package source."""
+    root = _package_root()
+    offenders: list[str] = []
+
+    for path in root.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for needle in FORBIDDEN:
+            if needle in text:
+                offenders.append(f"{path}: contains {needle!r}")
+
+    assert not offenders, (
+        "Operator-private observability infrastructure must not be "
+        "hardcoded in the shipped package. Offending references:\n  " + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

Observability integrations (error reporting, code-quality scan, SBOM, telemetry) are deployment-time configuration. The shipped package must be fully functional with no observability backend configured and must never default to any specific host. This change removes hardcoded default hostnames, requires the base URL to come from env or the DSN, and adds a regression test.

## Changes

- `core/observability/glitchtip_insights.py`: remove the hardcoded base-URL default. The base URL is now resolved from `BERNSTEIN_GLITCHTIP_BASE_URL` or derived from the host of the runtime DSN. When neither is set, the insights feature soft-fails with a clear "not configured" message instead of reaching any fixed host.
- `core/telemetry/client.py`: replace the hardcoded default endpoint with an illustrative `example.com` placeholder that does not resolve, so an opted-in install with no endpoint configured sends events nowhere rather than to any specific host.
- Docstrings: use neutral example hosts (`glitchtip.example.com`, `sonar.example.com`) instead of concrete deployment hosts.
- Add `tests/unit/observability/test_no_hardcoded_infra.py`: scans the importable package source and asserts zero hardcoded backend hosts so this cannot regress.

Backends remain configurable at deployment time via environment variables; nothing about the operator-side CI wiring changes.

## Test plan

- [x] `pytest tests/unit/cli/doctor/test_glitchtip.py` (28 passed)
- [x] `pytest tests/unit/observability/ tests/unit/telemetry/ tests/unit/doctor/ tests/unit/cli/doctor/` (349 passed)
- [x] `bernstein --version` and `bernstein doctor` run with zero observability env vars set and reach no fixed host
- [x] `bernstein doctor glitchtip` soft-fails cleanly (exit 0) when unconfigured
- [x] new regression test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed hardcoded GlitchTip API base URL; now requires explicit environment variable or DSN host configuration
  * Removed hardcoded telemetry endpoint; now requires `BERNSTEIN_TELEMETRY_ENDPOINT` environment variable for event delivery
  * Updated configuration documentation with example placeholder values

* **Tests**
  * Added regression test to prevent hardcoded infrastructure hostnames in package

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->