### PR TITLE
fix(deps): ignore disputed pyjwt CVE and fix spelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -950,10 +950,17 @@ jobs:
         # `--no-deps` is safe: the exported file is fully pinned and the
         # transitive closure is resolved by `uv.lock`. `--disable-pip`
         # avoids spinning up a sub-venv just to run `pip install`.
-        run: uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps
+        #
+        # `--ignore-vuln PYSEC-2025-183` (CVE-2025-45768): disputed advisory
+        # against pyjwt that affects all released versions (introduced at 0,
+        # no fix version published) and is pulled in transitively via `mcp`.
+        # The maintainer disputes it because the key length is chosen by the
+        # calling application, not the library. There is nothing to upgrade
+        # to, so it is ignored with the rationale recorded here.
+        run: uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
       - name: Dev deps (advisory)
         continue-on-error: true
-        run: uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps
+        run: uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
 
   beartype:
     # Runtime type-check enforcement via beartype.claw. Imports the

--- a/typos.toml
+++ b/typos.toml
@@ -24,6 +24,7 @@ RTO = "RTO"          # Recovery Time Objective (compliance/DR, acronym)
 mis = "mis"          # false positive on partial words
 fo = "fo"            # fo = fan_out (test_complexity_correlation.py)
 thr = "thr"          # thr = threshold (scripts/mutmut_critical.py)
+hel = "hel"          # truncated stream chunk "hel" + "lo" = "hello" (test_client_hardened.py)
 Aktive = "Aktive"    # correct German word for "Active" (i18n.py)
 
 # Technical terms used consistently in the codebase


### PR DESCRIPTION
## Summary

Fixes the two red checks on `main` HEAD `20552518`.

### Spelling (typos)
- `tests/unit/mcp/test_client_hardened.py` uses an intentionally truncated stream chunk `"hel"` (it is reassembled as `"hel" + "lo" = "hello"` and asserted in the same test).
- This is test data, not a misspelling, so `hel` is added to the `typos.toml` allowlist alongside the existing truncated-fixture entries.

### pip-audit (deps)
- The strict production audit flags `pyjwt 2.12.1` for `PYSEC-2025-183` (`CVE-2025-45768`).
- The advisory affects every released version (`introduced: 0`, no fix version) and is disputed by the maintainer: the weak-key concern is the calling application's choice of key length, not a library defect. `pyjwt` arrives transitively via `mcp`, and `2.12.1` is already the latest release, so there is nothing to upgrade to.
- The strict and advisory pip-audit steps now pass `--ignore-vuln PYSEC-2025-183`, with the rationale documented inline.

## Test plan
- [x] `uvx typos` exits 0
- [x] `uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183` reports no vulnerabilities (1 ignored)
- [x] `ci.yml` parses as valid YAML