### PR TITLE
feat(mcp): close MCP server protocol-surface gaps

### DIFF
--- a/docs/mcp/server-audit-2026.md
+++ b/docs/mcp/server-audit-2026.md
@@ -1,0 +1,63 @@
+# Bernstein MCP server surface audit (2026)
+
+This audit records the protocol surface the Bernstein MCP server exposes and
+where it stands against common MCP server implementations in the ecosystem.
+The goal is plain coverage: a host that auto-discovers MCP servers should be
+able to connect and negotiate without surprises. Where a dimension is not yet
+covered, the gap is recorded as a follow-up rather than left undefined.
+
+## Status legend
+
+| Mark | Meaning |
+|------|---------|
+| Yes | Implemented and tested. |
+| Partial | Implemented for the common path; documented limits remain. |
+| Planned | Acknowledged gap, tracked for a follow-up. |
+
+## Comparison table
+
+| Dimension | Common ecosystem baseline | Bernstein | Status |
+|-----------|---------------------------|-----------|--------|
+| Spec-rev compliance | Latest MCP spec revision | Targets spec rev `2025-03-26`, reported in the capability card and the HTTP `initialize` result | Yes |
+| Transport: stdio | Standard for local IDE integration | `bernstein mcp` (default) | Yes |
+| Transport: SSE | Common for remote/web | `bernstein mcp --transport http` (FastMCP SSE app) | Yes |
+| Transport: streamable HTTP | Increasingly common for remote | POST request/response plus session management on `/mcp` | Yes |
+| Transport: server-initiated SSE push (GET) | Optional | GET returns 501; cancellation handled over POST | Planned |
+| Transport: WebSocket | Uncommon | Not implemented | Planned |
+| Auth: anonymous | Loopback-only convenience | Allowed on loopback only; refused on non-loopback binds | Yes |
+| Auth: static bearer | Common | Constant-time bearer check; token from env or config | Yes |
+| Auth: OAuth-2 PKCE | Emerging | Not implemented; advertised under `auth.planned` | Planned |
+| Auth: OIDC federation | Emerging | Not implemented; advertised under `auth.planned` | Planned |
+| Capability negotiation: static manifest | Standard `initialize` capabilities | Static `capabilities` object on `initialize` | Yes |
+| Capability negotiation: runtime capability cards | Less common | `bernstein://capability` resource and `capabilityCard` on `initialize`, built from live process state | Yes |
+| Streaming tool-call output | Common | Tool calls run as cancellable tasks on the HTTP transport | Partial |
+| Cancel in-flight tool call | Common | `notifications/cancelled` by request id | Yes |
+| Partial-result preservation on cancel | Less common | Cancelled calls return `cancelled: true` with preserved `partial` chunks | Yes |
+| Resource listing: prompts/sampling routes | Common | Lineage resources and the capability card; no prompt/sampling routes | Partial |
+| Observability: per-call latency | Less common | `_meter.latency_ms` on every response | Yes |
+| Observability: per-call cost meter | Uncommon | `_meter.cost_usd` envelope on every response | Yes |
+| Observability: call trace id | Less common | `_meter.call_id` on every response | Yes |
+| Tool-catalogue richness | Varies | Tiered catalogue (`core` / `standard` / `all`); see `docs/mcp/tool_tiers.md` | Yes |
+
+## Surfaces landed in this pass
+
+1. Per-call cost-meter envelope on every tool response (`result` plus `_meter`
+   with latency, cost, trace id, status), uniform across stdio, SSE, and the
+   streamable HTTP transport. Opt-out via `BERNSTEIN_MCP_COST_METER`.
+2. Runtime capability cards: a `bernstein://capability` resource and the
+   `capabilityCard` field on the HTTP `initialize` result, built from live
+   process state (transports, auth modes, active tier, meter state, spec rev).
+3. Streaming tool-call cancel with partial-result preservation on the
+   streamable HTTP transport, via `notifications/cancelled`.
+
+## Follow-ups (tracked, not in this pass)
+
+- OAuth-2 PKCE and OIDC federation auth paths. The capability card already
+  advertises these under `auth.planned` so a client sees the gap as
+  acknowledged rather than undefined.
+- WebSocket transport.
+- Server-initiated SSE push channel over GET.
+- Prompt and sampling resource routes.
+
+New tools are out of scope for this pass by design; this work closes
+protocol-surface gaps only.

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -1,0 +1,138 @@
+# Bernstein MCP server
+
+Bernstein exposes its orchestration layer as MCP tools so any MCP client
+(Cursor, Claude Code, Cline, Windsurf, and others) can drive multi-agent work
+through Bernstein. This page describes the protocol surface and how to point a
+client at the server. For the per-tier tool catalogue see
+[`tool_tiers.md`](tool_tiers.md); for the full surface audit see
+[`server-audit-2026.md`](server-audit-2026.md).
+
+## Transports
+
+| Transport | Command | Use when |
+|-----------|---------|----------|
+| stdio (default) | `bernstein mcp` | Local IDE integration. |
+| SSE | `bernstein mcp --transport http` | Remote/web integration. |
+| Streamable HTTP | served on `/mcp` | Remote integration with session management and cancellation. |
+
+The streamable HTTP transport binds to loopback by default. Binding to a
+public interface requires a bearer token (see Auth) and is otherwise refused
+at startup.
+
+## Auth
+
+| Mode | How | Notes |
+|------|-----|-------|
+| Anonymous | default on loopback | Allowed only on `127.0.0.1` / `localhost` / `::1`. |
+| Static bearer | `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) | Constant-time check; required on non-loopback binds. |
+
+OAuth-2 PKCE and OIDC federation are not yet implemented. The capability card
+advertises them under `auth.planned` so a client sees the gap as acknowledged.
+
+## Capability cards
+
+Beyond the static `capabilities` object on `initialize`, the server publishes
+a runtime capability card describing how it is actually running: reachable
+transports, configured auth modes, the active tool tier, the cost-meter
+state, and the targeted spec revision. The card is built from live process
+state on each read, so it reflects the current configuration without a
+restart.
+
+The card is available two ways:
+
+- as the `bernstein://capability` MCP resource (read it with the client's
+  resource API);
+- under the `capabilityCard` key on the streamable HTTP transport's
+  `initialize` result.
+
+## Per-call cost-meter envelope
+
+Every tool response is wrapped in a uniform envelope so observability is
+consistent across transports:
+
+```json
+{
+  "result": { "status": "ok" },
+  "_meter": {
+    "tool": "bernstein_health",
+    "call_id": "b1c2...",
+    "latency_ms": 12.4,
+    "cost_usd": 0.0,
+    "ok": true,
+    "ts": "2026-05-20T10:11:12.345Z"
+  }
+}
+```
+
+`cost_usd` is best-effort: the MCP server proxies to the task server and does
+not itself spend model tokens, so the per-call figure is `0.0` unless a
+handler attaches a cost. The field exists so the envelope shape is stable.
+
+To get the bare tool payload (the historical shape), disable the meter:
+
+```bash
+export BERNSTEIN_MCP_COST_METER=0
+```
+
+## Streaming cancel with partial-result preservation
+
+On the streamable HTTP transport, each `tools/call` runs as a cancellable
+task tracked by its JSON-RPC id. A client cancels an in-flight call by sending
+a `notifications/cancelled` notification carrying that `requestId`. The
+originating call then returns the work done before the stop rather than a bare
+error:
+
+```json
+{
+  "content": [{ "type": "text", "text": "{\"status\": \"running\", ...}" }],
+  "cancelled": true,
+  "partial": ["{\"status\": \"running\", \"tool\": \"bernstein_run\"}"],
+  "_meter": { "tool": "bernstein_run", "ok": false, "...": "..." }
+}
+```
+
+`isError` is not set: a cancel is a client-initiated stop, not a tool failure.
+Cancelling an unknown or already-settled id is a no-op.
+
+## Worked example: pointing a host at the server
+
+1. Start the server over the streamable HTTP transport on loopback:
+
+   ```bash
+   export BERNSTEIN_MCP_TOKEN=dev-token
+   bernstein mcp --transport http --host 127.0.0.1 --port 8053
+   ```
+
+2. Initialize and read the capability card:
+
+   ```bash
+   curl -s http://127.0.0.1:8053/mcp \
+     -H "Authorization: Bearer dev-token" \
+     -H "content-type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"example"}}}'
+   ```
+
+   The `result.capabilityCard` shows the active tier, auth modes, and
+   transports the client can use.
+
+3. Call a tool. The response carries the cost-meter envelope:
+
+   ```bash
+   curl -s http://127.0.0.1:8053/mcp \
+     -H "Authorization: Bearer dev-token" \
+     -H "content-type: application/json" \
+     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bernstein_status","arguments":{}}}'
+   ```
+
+4. Cancel a long-running call by its id (in a second request, while the call
+   is in flight):
+
+   ```bash
+   curl -s http://127.0.0.1:8053/mcp \
+     -H "Authorization: Bearer dev-token" \
+     -H "content-type: application/json" \
+     -d '{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":2}}'
+   ```
+
+   The original call returns `cancelled: true` with its preserved `partial`
+   output.

--- a/src/bernstein/mcp/capability.py
+++ b/src/bernstein/mcp/capability.py
@@ -1,0 +1,147 @@
+"""Runtime capability cards for the Bernstein MCP server.
+
+The MCP ``initialize`` handshake advertises a small static ``capabilities``
+object (which message families the server supports). That static manifest
+does not describe the *runtime* shape an operator needs to point a client at
+the server: which transports are reachable, which auth modes are configured,
+which tool tier is active, whether the cost-meter envelope is on, and which
+spec revision the server speaks.
+
+A capability card answers those questions at request time. It is built from
+live process state (env vars, the resolved tier, the meter toggle) rather
+than a baked-in constant, so a client that fetches the card sees the server
+as it is actually running. Hosts that auto-discover MCP servers can use the
+card to decide how to connect without trial and error.
+
+The card is exposed two ways, both returning the same dict:
+
+  * over the FastMCP server as the ``bernstein://capability`` resource;
+  * on the streamable HTTP transport's ``initialize`` result under the
+    ``capabilityCard`` key, alongside the spec ``capabilities`` object.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.protocols.mcp.tool_tiers import (
+    resolve_active_tier,
+    tier_audit,
+    tools_for_tier,
+)
+from bernstein.mcp.cost_meter import COST_METER_ENV, cost_meter_enabled
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+#: MCP spec revision the Bernstein server targets. Kept in one place so the
+#: card and the HTTP ``initialize`` response cannot drift apart.
+SPEC_REVISION: str = "2025-03-26"
+
+#: Stable server version reported in the card and server info.
+SERVER_VERSION: str = "1.0.0"
+
+#: URI under which the capability card is exposed as an MCP resource.
+CAPABILITY_RESOURCE_URI: str = "bernstein://capability"
+
+
+def _auth_modes() -> dict[str, Any]:
+    """Describe the auth paths the running server supports.
+
+    Reports the modes the transport layer can enforce (anonymous on
+    loopback, static bearer token) and whether a token is currently
+    configured in the environment. Modes the server does not yet implement
+    are listed under ``planned`` so a client knows the gap is acknowledged
+    rather than undefined.
+    """
+    token_configured = any(os.environ.get(name) for name in ("BERNSTEIN_MCP_TOKEN", "BERNSTEIN_MCP_AUTH_TOKEN"))
+    return {
+        "supported": ["anonymous", "bearer"],
+        "planned": ["oauth2_pkce", "oidc"],
+        "bearer_token_configured": token_configured,
+        "anonymous_scope": "loopback-only",
+    }
+
+
+def _transports() -> list[dict[str, Any]]:
+    """Describe the transports a client can use to reach the server."""
+    return [
+        {
+            "type": "stdio",
+            "default": True,
+            "streaming": False,
+            "command": "bernstein mcp",
+        },
+        {
+            "type": "sse",
+            "default": False,
+            "streaming": True,
+            "command": "bernstein mcp --transport http",
+        },
+        {
+            "type": "http",
+            "default": False,
+            "streaming": True,
+            "path": "/mcp",
+            "cancellable": True,
+        },
+    ]
+
+
+def build_capability_card() -> dict[str, Any]:
+    """Build the runtime capability card from live process state.
+
+    The card is intentionally self-describing and stable in shape so a client
+    can consume it without a Bernstein-specific schema.
+
+    Returns:
+        A JSON-serialisable dict describing transports, auth, tool tiers, the
+        cost-meter state, and the targeted spec revision.
+    """
+    active_tier = resolve_active_tier()
+    return {
+        "name": "bernstein",
+        "version": SERVER_VERSION,
+        "specRevision": SPEC_REVISION,
+        "transports": _transports(),
+        "auth": _auth_modes(),
+        "tools": {
+            "activeTier": active_tier,
+            "tierEnvVar": "BERNSTEIN_MCP_TOOL_TIER",
+            "advertised": tools_for_tier(active_tier),
+            "tiers": tier_audit(),
+        },
+        "costMeter": {
+            "enabled": cost_meter_enabled(),
+            "envVar": COST_METER_ENV,
+            "envelopeKeys": ["result", "_meter"],
+        },
+        "observability": {
+            "perCallMeter": cost_meter_enabled(),
+            "fields": ["latency_ms", "cost_usd", "call_id", "ok", "ts"],
+        },
+    }
+
+
+def register_capability_resource(mcp: FastMCP[None]) -> None:
+    """Register the runtime capability card as an MCP resource.
+
+    Exposes the card at :data:`CAPABILITY_RESOURCE_URI` so any client can read
+    the server's live transports, auth modes, active tier, and meter state
+    without a server restart. The card is rebuilt on each read so it reflects
+    current process state.
+
+    Args:
+        mcp: The FastMCP server to register the resource on.
+    """
+
+    @mcp.resource(
+        CAPABILITY_RESOURCE_URI,
+        name="bernstein_capability",
+        description="Runtime capability card: transports, auth, tiers, meter, spec rev.",
+        mime_type="application/json",
+    )
+    def capability_card() -> str:  # pyright: ignore[reportUnusedFunction]
+        return json.dumps(build_capability_card(), sort_keys=True)

--- a/src/bernstein/mcp/cost_meter.py
+++ b/src/bernstein/mcp/cost_meter.py
@@ -1,0 +1,166 @@
+"""Per-call cost-meter and observability envelope for MCP tool responses.
+
+Every Bernstein MCP tool returns a JSON string. This module wraps that raw
+payload in a uniform envelope that carries observability metadata alongside
+the tool result:
+
+* ``result``  - the tool's original JSON payload, unchanged.
+* ``_meter``  - a per-call cost / latency / trace record.
+
+The envelope is opt-in per process via ``BERNSTEIN_MCP_COST_METER`` so an
+operator who wants the bare tool payload (the historical shape) can disable
+it without code changes. When disabled, :func:`wrap_envelope` returns the raw
+payload string untouched, so existing clients keep working.
+
+The meter record is deliberately small and self-describing so any MCP client
+can surface it without a Bernstein-specific schema:
+
+    {
+      "tool": "bernstein_status",
+      "call_id": "b1c2...",
+      "latency_ms": 12.4,
+      "cost_usd": 0.0,
+      "ok": true,
+      "ts": "2026-05-20T10:11:12.345Z"
+    }
+
+``cost_usd`` is best-effort: the MCP server proxies to the task server and
+does not itself spend model tokens, so the per-call figure is ``0.0`` unless
+a handler attaches a cost. The field exists so the envelope shape is stable
+and a future cost-attributing handler does not change the contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+#: Env var that toggles the per-call envelope. Defaults to ON; set to a
+#: falsey value to return the bare tool payload (the historical shape).
+COST_METER_ENV: str = "BERNSTEIN_MCP_COST_METER"
+
+#: Values that disable the meter when set in :data:`COST_METER_ENV`.
+_DISABLED_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def cost_meter_enabled() -> bool:
+    """Return whether the per-call envelope should wrap tool responses.
+
+    Reads :data:`COST_METER_ENV` at call time so an operator can toggle the
+    envelope without restarting (the value is consulted on each tool call).
+    Defaults to ``True`` when the var is unset or empty.
+    """
+    raw = os.environ.get(COST_METER_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in _DISABLED_VALUES
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string with a ``Z`` suffix."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class CallMeter:
+    """Mutable per-call observability record built during a tool call.
+
+    A handler obtains one via :func:`measure_call`, may attach a cost with
+    :meth:`add_cost`, and the context manager finalises latency + status on
+    exit. The finalised record is serialised into the response envelope.
+    """
+
+    tool: str
+    call_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    cost_usd: float = 0.0
+    ok: bool = True
+    error: str | None = None
+    started_at: str = field(default_factory=_utc_now_iso)
+    latency_ms: float = 0.0
+    _start_perf: float = field(default_factory=time.perf_counter, repr=False)
+
+    def add_cost(self, usd: float) -> None:
+        """Accumulate an estimated USD cost for this call."""
+        self.cost_usd += float(usd)
+
+    def finalise(self) -> None:
+        """Record the elapsed wall-clock latency for this call in millis."""
+        self.latency_ms = (time.perf_counter() - self._start_perf) * 1000.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the meter as a JSON-serialisable dict for the envelope."""
+        record: dict[str, Any] = {
+            "tool": self.tool,
+            "call_id": self.call_id,
+            "latency_ms": round(self.latency_ms, 3),
+            "cost_usd": round(self.cost_usd, 6),
+            "ok": self.ok,
+            "ts": self.started_at,
+        }
+        if self.error is not None:
+            record["error"] = self.error
+        return record
+
+
+@contextmanager
+def measure_call(tool: str) -> Iterator[CallMeter]:
+    """Context manager that times a tool call and records its outcome.
+
+    On normal exit the latency is recorded and ``ok`` stays ``True``. If the
+    block raises, ``ok`` is set ``False`` and the exception message is stored
+    on the meter before the exception propagates, so the caller can still
+    serialise a meter for a failed call.
+
+    Args:
+        tool: The MCP-advertised tool name being measured.
+
+    Yields:
+        A :class:`CallMeter` the handler may mutate (e.g. attach a cost).
+    """
+    meter = CallMeter(tool=tool)
+    try:
+        yield meter
+    except Exception as exc:
+        meter.ok = False
+        meter.error = str(exc)
+        meter.finalise()
+        raise
+    else:
+        meter.finalise()
+
+
+def wrap_envelope(payload: str, meter: CallMeter) -> str:
+    """Wrap a tool's raw JSON payload in the cost-meter envelope.
+
+    When the meter is disabled (:func:`cost_meter_enabled` is ``False``) the
+    payload is returned untouched so existing clients see the historical
+    shape. Otherwise the result is a JSON object with two keys: ``result``
+    (the parsed original payload) and ``_meter`` (the call record).
+
+    The original payload is parsed so a JSON result nests as structured data
+    rather than an escaped string; if it is not valid JSON it is carried
+    verbatim under ``result`` as a string.
+
+    Args:
+        payload: The tool handler's JSON string result.
+        meter: The finalised per-call meter.
+
+    Returns:
+        The enveloped JSON string, or ``payload`` unchanged when disabled.
+    """
+    if not cost_meter_enabled():
+        return payload
+    try:
+        parsed: Any = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        parsed = payload
+    return json.dumps({"result": parsed, "_meter": meter.to_dict()})

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -454,12 +454,21 @@ class StreamableHTTPTransport:
         session: MCPSession,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Handle 'initialize' — return server info and capabilities."""
+        """Handle 'initialize' — return server info and capabilities.
+
+        Alongside the static spec ``capabilities`` object, the result carries
+        a runtime ``capabilityCard`` describing the live transports, auth
+        modes, active tool tier, and cost-meter state so a client can decide
+        how to connect without trial and error.
+        """
+        from bernstein.mcp.capability import build_capability_card
+
         session.metadata["client_info"] = params.get("clientInfo", {})
         return {
             "protocolVersion": "2025-03-26",
             "serverInfo": _SERVER_INFO,
             "capabilities": _CAPABILITIES,
+            "capabilityCard": build_capability_card(),
         }
 
     async def _method_tools_list(

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -365,7 +365,7 @@ class StreamableHTTPTransport:
         self,
         headers: dict[str, str],
     ) -> tuple[int, dict[str, str], bytes]:
-        """Handle GET: server-initiated SSE stream endpoint (stub — 501).
+        """Handle GET: server-initiated SSE stream endpoint (stub - 501).
 
         Client-to-server streaming, cancellation, and partial-result
         preservation are handled over POST (``tools/call`` plus
@@ -472,7 +472,7 @@ class StreamableHTTPTransport:
         session: MCPSession,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Handle 'initialize' — return server info and capabilities.
+        """Handle 'initialize' - return server info and capabilities.
 
         Alongside the static spec ``capabilities`` object, the result carries
         a runtime ``capabilityCard`` describing the live transports, auth
@@ -504,7 +504,7 @@ class StreamableHTTPTransport:
         params: dict[str, Any],
         req_id: int | str | None = None,
     ) -> dict[str, Any]:
-        """Handle 'tools/call' — execute a tool and return result.
+        """Handle 'tools/call' - execute a tool and return result.
 
         The tool runs inside a cancellable task tracked by its JSON-RPC id, so
         a ``notifications/cancelled`` for that id stops the work and the
@@ -571,7 +571,7 @@ class StreamableHTTPTransport:
         session: MCPSession,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Handle 'notifications/cancelled' — stop an in-flight tool call.
+        """Handle 'notifications/cancelled' - stop an in-flight tool call.
 
         Per the MCP spec the notification carries ``requestId`` (the id of the
         ``tools/call`` to cancel). Cancelling marks the tracked call and

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -13,6 +13,7 @@ import logging
 import os
 import time
 import uuid
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -475,21 +476,36 @@ class StreamableHTTPTransport:
         session: MCPSession,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Handle 'tools/call' — execute a tool and return result."""
+        """Handle 'tools/call' — execute a tool and return result.
+
+        The tool's JSON payload is wrapped in the per-call cost-meter
+        envelope (latency, cost, trace id, status) so the remote transport
+        emits the same observable shape as the stdio/SSE server. The envelope
+        is a no-op when the meter is disabled via ``BERNSTEIN_MCP_COST_METER``.
+        """
+        from bernstein.mcp.cost_meter import measure_call, wrap_envelope
+
         tool_name = params.get("name", "")
         arguments = params.get("arguments", {})
 
+        meter_ctx = measure_call(tool_name)
+        meter = meter_ctx.__enter__()
         try:
             text = await self._execute_tool(tool_name, arguments)
         except Exception as exc:
+            # Finalise the meter for the failed call, then emit it alongside
+            # the error so observability covers failures too.
+            with suppress(Exception):
+                meter_ctx.__exit__(type(exc), exc, exc.__traceback__)
             logger.warning("Tool %s failed: %s", tool_name, exc)
+            error_payload = wrap_envelope(json.dumps({"error": str(exc)}), meter)
             return {
-                "content": [{"type": "text", "text": json.dumps({"error": str(exc)})}],
+                "content": [{"type": "text", "text": error_payload}],
                 "isError": True,
             }
-
+        meter_ctx.__exit__(None, None, None)
         return {
-            "content": [{"type": "text", "text": text}],
+            "content": [{"type": "text", "text": wrap_envelope(text, meter)}],
         }
 
     async def _method_ping(

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import httpx
 
+from bernstein.mcp.streaming import InFlightRegistry, cancelled_envelope
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_SERVER_URL = "http://127.0.0.1:8052"
@@ -251,6 +253,9 @@ _SERVER_INFO: dict[str, Any] = {
 
 _CAPABILITIES: dict[str, Any] = {
     "tools": {"listChanged": False},
+    # The server honours notifications/cancelled for in-flight tool calls and
+    # preserves partial output on cancel.
+    "experimental": {"cancellation": {"partialResults": True}},
 }
 
 
@@ -271,6 +276,7 @@ class StreamableHTTPTransport:
         self._server_url = server_url
         self._sessions: dict[str, MCPSession] = {}
         self._lock = asyncio.Lock()
+        self._inflight = InFlightRegistry()
 
     # -- public API ----------------------------------------------------------
 
@@ -359,7 +365,13 @@ class StreamableHTTPTransport:
         self,
         headers: dict[str, str],
     ) -> tuple[int, dict[str, str], bytes]:
-        """Handle GET: SSE stream endpoint (stub — returns 501)."""
+        """Handle GET: server-initiated SSE stream endpoint (stub — 501).
+
+        Client-to-server streaming, cancellation, and partial-result
+        preservation are handled over POST (``tools/call`` plus
+        ``notifications/cancelled``). A server-initiated SSE push channel is
+        not implemented, so GET still returns 501 with a pointer to POST.
+        """
         session_id = headers.get("mcp-session-id")
         if session_id and session_id not in self._sessions:
             return (
@@ -367,11 +379,11 @@ class StreamableHTTPTransport:
                 {"content-type": _CONTENT_TYPE_JSON},
                 b'{"error":"session not found"}',
             )
-        # Server-initiated SSE not yet implemented.
+        # Server-initiated SSE not implemented; cancellation is over POST.
         return (
             501,
             {"content-type": _CONTENT_TYPE_JSON},
-            b'{"error":"SSE stream not implemented - use POST for request/response"}',
+            b'{"error":"server-initiated SSE not implemented - use POST and notifications/cancelled"}',
         )
 
     async def _handle_delete(
@@ -425,7 +437,12 @@ class StreamableHTTPTransport:
             return _jsonrpc_error(_METHOD_NOT_FOUND, f"Method not found: {method}", req_id)
 
         try:
-            result = await handler(session, params)
+            # tools/call needs its JSON-RPC id so the call can be tracked for
+            # cancellation; other handlers take only (session, params).
+            if method == "tools/call":
+                result = await self._method_tools_call(session, params, req_id)
+            else:
+                result = await handler(session, params)
         except Exception as exc:
             logger.exception("Error handling method %s", method)
             if is_notification:
@@ -444,6 +461,7 @@ class StreamableHTTPTransport:
             "tools/call": self._method_tools_call,
             "ping": self._method_ping,
             "notifications/initialized": self._method_noop,
+            "notifications/cancelled": self._method_cancelled,
         }
         return handlers.get(method or "")
 
@@ -484,28 +502,57 @@ class StreamableHTTPTransport:
         self,
         session: MCPSession,
         params: dict[str, Any],
+        req_id: int | str | None = None,
     ) -> dict[str, Any]:
         """Handle 'tools/call' — execute a tool and return result.
 
-        The tool's JSON payload is wrapped in the per-call cost-meter
-        envelope (latency, cost, trace id, status) so the remote transport
-        emits the same observable shape as the stdio/SSE server. The envelope
-        is a no-op when the meter is disabled via ``BERNSTEIN_MCP_COST_METER``.
+        The tool runs inside a cancellable task tracked by its JSON-RPC id, so
+        a ``notifications/cancelled`` for that id stops the work and the
+        accumulated partial output is returned (``cancelled: true`` with the
+        preserved ``partial`` chunks) rather than discarded.
+
+        The tool's JSON payload is wrapped in the per-call cost-meter envelope
+        (latency, cost, trace id, status) so the remote transport emits the
+        same observable shape as the stdio/SSE server. The envelope is a no-op
+        when the meter is disabled via ``BERNSTEIN_MCP_COST_METER``.
         """
         from bernstein.mcp.cost_meter import measure_call, wrap_envelope
 
         tool_name = params.get("name", "")
         arguments = params.get("arguments", {})
 
+        # Untracked calls (no id) still execute, just without cancel support.
+        call = await self._inflight.register(req_id, tool_name) if req_id is not None else None
+
         meter_ctx = measure_call(tool_name)
         meter = meter_ctx.__enter__()
         try:
-            text = await self._execute_tool(tool_name, arguments)
+            if call is not None:
+                # Seed a partial chunk so a cancel mid-flight preserves the
+                # in-progress context rather than returning an empty result.
+                call.append_partial(json.dumps({"status": "running", "tool": tool_name}))
+                task: asyncio.Task[str] = asyncio.ensure_future(self._execute_tool(tool_name, arguments))
+                await self._inflight.attach_task(req_id, task)  # type: ignore[arg-type]
+                text = await task
+            else:
+                text = await self._execute_tool(tool_name, arguments)
+        except asyncio.CancelledError:
+            # Client-initiated cancel: preserve and return partial output.
+            meter_ctx.__exit__(None, None, None)
+            current = await self._inflight.get(req_id) if req_id is not None else None
+            if req_id is not None:
+                await self._inflight.discard(req_id)
+            if current is not None and current.cancelled:
+                return cancelled_envelope(current, meter.to_dict())
+            # A cancel we did not initiate (e.g. transport shutdown): re-raise.
+            raise
         except Exception as exc:
             # Finalise the meter for the failed call, then emit it alongside
             # the error so observability covers failures too.
             with suppress(Exception):
                 meter_ctx.__exit__(type(exc), exc, exc.__traceback__)
+            if req_id is not None:
+                await self._inflight.discard(req_id)
             logger.warning("Tool %s failed: %s", tool_name, exc)
             error_payload = wrap_envelope(json.dumps({"error": str(exc)}), meter)
             return {
@@ -513,9 +560,29 @@ class StreamableHTTPTransport:
                 "isError": True,
             }
         meter_ctx.__exit__(None, None, None)
+        if req_id is not None:
+            await self._inflight.discard(req_id)
         return {
             "content": [{"type": "text", "text": wrap_envelope(text, meter)}],
         }
+
+    async def _method_cancelled(
+        self,
+        session: MCPSession,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Handle 'notifications/cancelled' — stop an in-flight tool call.
+
+        Per the MCP spec the notification carries ``requestId`` (the id of the
+        ``tools/call`` to cancel). Cancelling marks the tracked call and
+        cancels its task; the originating ``tools/call`` handler then returns
+        the preserved partial output. Cancelling an unknown or already-settled
+        id is a no-op, as the spec requires.
+        """
+        request_id = params.get("requestId")
+        if request_id is not None:
+            await self._inflight.cancel(request_id)
+        return {}
 
     async def _method_ping(
         self,

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -35,6 +35,7 @@ from bernstein.core.protocols.mcp.tool_tiers import (
     resolve_active_tier,
     tool_in_tier,
 )
+from bernstein.mcp.cost_meter import measure_call, wrap_envelope
 from bernstein.mcp.input_validation import (
     ValidatedPayload,
     ValidationError,
@@ -473,6 +474,37 @@ def _lineage_mcp_default(*, default: bool) -> bool:
     return raw.strip().lower() not in {"0", "false", "no", "off", ""}
 
 
+def _apply_cost_meter(mcp: FastMCP[None]) -> None:
+    """Wrap every registered tool so its response carries a meter envelope.
+
+    Each Bernstein tool returns a JSON string. This rewraps each tool's
+    callable so the string is passed through :func:`wrap_envelope`, which
+    attaches a per-call ``_meter`` record (latency, cost, trace id, status)
+    when the meter is enabled and is a no-op otherwise. Wrapping centrally
+    here keeps every tool handler free of envelope plumbing and guarantees a
+    uniform shape across the stdio, SSE, and skill/scenario tools.
+
+    Args:
+        mcp: The FastMCP server whose tools should be metered.
+    """
+    import functools
+
+    # FastMCP exposes no public per-tool rewrap hook, so wrap each tool's
+    # callable directly via the tool manager's registry (same access pattern
+    # as _apply_tool_tier above).
+    for tool in mcp._tool_manager._tools.values():  # pyright: ignore[reportPrivateUsage]
+        original = tool.fn
+        tool_name = tool.name
+
+        @functools.wraps(original)
+        async def metered(*args: Any, __orig: Any = original, __name: str = tool_name, **kwargs: Any) -> str:
+            with measure_call(__name) as meter:
+                payload = await __orig(*args, **kwargs)
+            return wrap_envelope(payload, meter)
+
+        tool.fn = metered
+
+
 def _apply_tool_tier(mcp: FastMCP[None], active_tier: ToolTier) -> None:
     """Drop every registered tool that is outside ``active_tier``.
 
@@ -537,6 +569,7 @@ def create_mcp_server(
         register_lineage_resources(mcp, lineage_root=root, enabled=True)
 
     _apply_tool_tier(mcp, active_tier)
+    _apply_cost_meter(mcp)
     return mcp
 
 

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -551,8 +551,11 @@ def create_mcp_server(
     Returns:
         Configured FastMCP instance with the active tier's tools registered.
     """
+    from bernstein.mcp.capability import register_capability_resource
+
     active_tier = resolve_active_tier(tier)
     mcp: FastMCP[None] = FastMCP(name)
+    register_capability_resource(mcp)
     _register_health_tool(mcp)
     _register_query_tools(mcp, server_url)
     _register_action_tools(mcp, server_url)

--- a/src/bernstein/mcp/streaming.py
+++ b/src/bernstein/mcp/streaming.py
@@ -1,0 +1,137 @@
+"""In-flight tool-call tracking with cancellation and partial-result preservation.
+
+The MCP spec lets a client cancel an in-flight request by sending a
+``notifications/cancelled`` notification carrying the target ``requestId``.
+For a long-running tool call the server should stop the work *and* preserve
+whatever the handler produced before the cancel so the client is not left
+with a bare error.
+
+This module provides the small amount of state that makes that possible on
+the streamable HTTP transport:
+
+  * :class:`InFlightCall` - one cancellable tool call. It owns an
+    :class:`asyncio.Task`, a ``partial`` buffer the handler can append to as
+    it streams output, and a cancel flag.
+  * :class:`InFlightRegistry` - a per-transport map of ``requestId`` to
+    :class:`InFlightCall`, so an incoming cancel can find and stop the right
+    task and read its partial buffer.
+
+The handler signals streaming progress by appending to the call's ``partial``
+list. On cancel the registry returns the accumulated partial output rather
+than discarding it, so the response carries ``cancelled: true`` together with
+``partial``: the chunks gathered before the stop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class InFlightCall:
+    """A single cancellable in-flight tool call.
+
+    Attributes:
+        request_id: The JSON-RPC ``id`` of the originating ``tools/call``.
+        tool: The tool name being executed.
+        task: The asyncio task running the tool body, set once scheduled.
+        partial: Output chunks the handler has produced so far. Preserved and
+            returned to the client if the call is cancelled mid-flight.
+        cancelled: Set ``True`` when a cancel notification targeted this call.
+    """
+
+    request_id: int | str
+    tool: str
+    task: asyncio.Task[str] | None = None
+    partial: list[str] = field(default_factory=list[str])
+    cancelled: bool = False
+
+    def append_partial(self, chunk: str) -> None:
+        """Record a streamed output chunk for partial-result preservation."""
+        self.partial.append(chunk)
+
+    def partial_text(self) -> str:
+        """Return the accumulated partial output as a single string."""
+        return "".join(self.partial)
+
+
+class InFlightRegistry:
+    """Tracks cancellable tool calls keyed by JSON-RPC request id.
+
+    The registry is per-transport (created in the transport ``__init__``) and
+    guarded by its own lock so concurrent POSTs (a tool call and its cancel)
+    do not race on the shared map.
+    """
+
+    def __init__(self) -> None:
+        self._calls: dict[int | str, InFlightCall] = {}
+        self._lock = asyncio.Lock()
+
+    async def register(self, request_id: int | str, tool: str) -> InFlightCall:
+        """Create and store an :class:`InFlightCall` for ``request_id``."""
+        call = InFlightCall(request_id=request_id, tool=tool)
+        async with self._lock:
+            self._calls[request_id] = call
+        return call
+
+    async def attach_task(self, request_id: int | str, task: asyncio.Task[str]) -> None:
+        """Bind the running task to a previously registered call."""
+        async with self._lock:
+            call = self._calls.get(request_id)
+            if call is not None:
+                call.task = task
+
+    async def get(self, request_id: int | str) -> InFlightCall | None:
+        """Return the in-flight call for ``request_id``, if still tracked."""
+        async with self._lock:
+            return self._calls.get(request_id)
+
+    async def discard(self, request_id: int | str) -> None:
+        """Stop tracking ``request_id`` once its call has settled."""
+        async with self._lock:
+            self._calls.pop(request_id, None)
+
+    async def cancel(self, request_id: int | str) -> InFlightCall | None:
+        """Cancel the in-flight call for ``request_id``.
+
+        Marks the call cancelled and cancels its task (if scheduled). The
+        call is returned so the caller can read the preserved ``partial``
+        buffer; it is *not* discarded here because the tool-call handler is
+        responsible for emitting the partial result and then discarding.
+
+        Returns:
+            The cancelled :class:`InFlightCall`, or ``None`` when no call with
+            that id is in flight (an already-finished or unknown id).
+        """
+        async with self._lock:
+            call = self._calls.get(request_id)
+            if call is None:
+                return None
+            call.cancelled = True
+            if call.task is not None and not call.task.done():
+                call.task.cancel()
+            return call
+
+
+def cancelled_envelope(call: InFlightCall, meter_dict: dict[str, Any]) -> dict[str, Any]:
+    """Build the ``tools/call`` result body for a cancelled call.
+
+    Carries ``cancelled: true`` and the preserved ``partial`` output so the
+    client keeps the work done before the stop. ``isError`` is left ``False``:
+    a cancel is a client-initiated stop, not a tool failure.
+
+    Args:
+        call: The cancelled in-flight call holding the partial buffer.
+        meter_dict: The finalised per-call meter record to attach.
+
+    Returns:
+        A JSON-RPC ``tools/call`` result dict.
+    """
+    return {
+        "content": [{"type": "text", "text": call.partial_text()}],
+        "cancelled": True,
+        "partial": call.partial,
+        "_meter": meter_dict,
+    }

--- a/tests/unit/mcp/test_capability_card.py
+++ b/tests/unit/mcp/test_capability_card.py
@@ -1,0 +1,141 @@
+"""Tests for runtime capability cards (issue #1674).
+
+Covers:
+
+  * the card shape (transports, auth, tiers, meter, spec rev);
+  * the card reflecting live process state (active tier, meter toggle, token);
+  * the FastMCP resource exposing the card;
+  * the streamable HTTP transport emitting the card on ``initialize``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from bernstein.mcp.capability import (
+    CAPABILITY_RESOURCE_URI,
+    SPEC_REVISION,
+    build_capability_card,
+)
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_TOOL_TIER", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_COST_METER", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Card shape
+# ---------------------------------------------------------------------------
+
+
+def test_card_has_core_dimensions(_clean_env: None) -> None:
+    card = build_capability_card()
+    assert card["name"] == "bernstein"
+    assert card["specRevision"] == SPEC_REVISION
+    for key in ("transports", "auth", "tools", "costMeter", "observability"):
+        assert key in card
+
+
+def test_card_lists_all_transports(_clean_env: None) -> None:
+    card = build_capability_card()
+    types = {t["type"] for t in card["transports"]}
+    assert {"stdio", "sse", "http"} <= types
+    http = next(t for t in card["transports"] if t["type"] == "http")
+    assert http["cancellable"] is True
+    assert http["streaming"] is True
+
+
+def test_card_reports_auth_modes(_clean_env: None) -> None:
+    card = build_capability_card()
+    assert "anonymous" in card["auth"]["supported"]
+    assert "bearer" in card["auth"]["supported"]
+    assert card["auth"]["bearer_token_configured"] is False
+    # OAuth/OIDC are acknowledged-but-not-implemented, not silently missing.
+    assert "oauth2_pkce" in card["auth"]["planned"]
+
+
+def test_card_token_flag_tracks_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_TOKEN", "tok")
+    card = build_capability_card()
+    assert card["auth"]["bearer_token_configured"] is True
+
+
+# ---------------------------------------------------------------------------
+# Live state reflection
+# ---------------------------------------------------------------------------
+
+
+def test_card_reflects_active_tier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_TOOL_TIER", "core")
+    card = build_capability_card()
+    assert card["tools"]["activeTier"] == "core"
+    assert "bernstein_cost" not in card["tools"]["advertised"]
+
+
+def test_card_reflects_meter_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_COST_METER", "0")
+    card = build_capability_card()
+    assert card["costMeter"]["enabled"] is False
+    assert card["observability"]["perCallMeter"] is False
+
+
+# ---------------------------------------------------------------------------
+# FastMCP resource
+# ---------------------------------------------------------------------------
+
+
+def test_server_exposes_capability_resource(_clean_env: None) -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(tier="standard")
+    resources = asyncio.run(mcp.list_resources())
+    uris = {str(r.uri) for r in resources}
+    assert CAPABILITY_RESOURCE_URI in uris
+
+
+def test_capability_resource_returns_card(_clean_env: None) -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(tier="standard")
+    contents = asyncio.run(mcp.read_resource(CAPABILITY_RESOURCE_URI))
+    body = next(iter(contents)).content
+    card = json.loads(body)
+    assert card["name"] == "bernstein"
+    assert card["tools"]["activeTier"] == "standard"
+
+
+# ---------------------------------------------------------------------------
+# Streamable HTTP transport initialize
+# ---------------------------------------------------------------------------
+
+
+def test_http_initialize_carries_capability_card(_clean_env: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {"clientInfo": {"name": "test"}},
+        }
+    ).encode()
+    status, _, resp_body = asyncio.run(transport.handle_request("POST", "/mcp", {}, body))
+    assert status == 200
+    result = json.loads(resp_body)["result"]
+    assert "capabilityCard" in result
+    assert result["capabilityCard"]["specRevision"] == SPEC_REVISION
+    # The static spec capabilities object is still present.
+    assert "capabilities" in result

--- a/tests/unit/mcp/test_cost_meter.py
+++ b/tests/unit/mcp/test_cost_meter.py
@@ -1,0 +1,184 @@
+"""Tests for the per-call cost-meter envelope (issue #1674).
+
+Covers:
+
+  * the meter toggle (``BERNSTEIN_MCP_COST_METER``);
+  * the :func:`measure_call` context manager (latency, cost, status);
+  * :func:`wrap_envelope` shape on success, failure, and non-JSON payloads;
+  * the FastMCP server wrapping every tool response in the envelope;
+  * the streamable HTTP transport emitting the same envelope shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from bernstein.mcp.cost_meter import (
+    CallMeter,
+    cost_meter_enabled,
+    measure_call,
+    wrap_envelope,
+)
+
+
+@pytest.fixture
+def _meter_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_MCP_COST_METER", raising=False)
+
+
+@pytest.fixture
+def _meter_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_COST_METER", "0")
+
+
+# ---------------------------------------------------------------------------
+# Toggle
+# ---------------------------------------------------------------------------
+
+
+def test_meter_enabled_by_default(_meter_on: None) -> None:
+    assert cost_meter_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "OFF", "False"])
+def test_meter_disabled_by_falsey_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_COST_METER", value)
+    assert cost_meter_enabled() is False
+
+
+def test_meter_enabled_by_truthy_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_MCP_COST_METER", "1")
+    assert cost_meter_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# CallMeter / measure_call
+# ---------------------------------------------------------------------------
+
+
+def test_measure_call_records_latency_and_ok() -> None:
+    with measure_call("bernstein_status") as meter:
+        pass
+    record = meter.to_dict()
+    assert record["tool"] == "bernstein_status"
+    assert record["ok"] is True
+    assert record["latency_ms"] >= 0.0
+    assert record["cost_usd"] == 0.0
+    assert "call_id" in record
+    assert record["ts"].endswith("Z")
+
+
+def test_measure_call_records_failure_and_reraises() -> None:
+    meter_seen: CallMeter | None = None
+    with pytest.raises(ValueError, match="boom"):
+        with measure_call("bernstein_run") as meter:
+            meter_seen = meter
+            raise ValueError("boom")
+    assert meter_seen is not None
+    record = meter_seen.to_dict()
+    assert record["ok"] is False
+    assert record["error"] == "boom"
+    assert record["latency_ms"] >= 0.0
+
+
+def test_add_cost_accumulates() -> None:
+    with measure_call("x") as meter:
+        meter.add_cost(0.01)
+        meter.add_cost(0.02)
+    assert meter.to_dict()["cost_usd"] == pytest.approx(0.03)
+
+
+def test_call_ids_are_unique() -> None:
+    with measure_call("a") as m1:
+        pass
+    with measure_call("a") as m2:
+        pass
+    assert m1.call_id != m2.call_id
+
+
+# ---------------------------------------------------------------------------
+# wrap_envelope
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_envelope_nests_json_result(_meter_on: None) -> None:
+    with measure_call("bernstein_status") as meter:
+        pass
+    out = wrap_envelope('{"total": 5}', meter)
+    parsed = json.loads(out)
+    assert parsed["result"] == {"total": 5}
+    assert parsed["_meter"]["tool"] == "bernstein_status"
+
+
+def test_wrap_envelope_carries_non_json_verbatim(_meter_on: None) -> None:
+    with measure_call("x") as meter:
+        pass
+    out = wrap_envelope("not json", meter)
+    assert json.loads(out)["result"] == "not json"
+
+
+def test_wrap_envelope_passthrough_when_disabled(_meter_off: None) -> None:
+    with measure_call("x") as meter:
+        pass
+    payload = '{"total": 5}'
+    assert wrap_envelope(payload, meter) == payload
+
+
+# ---------------------------------------------------------------------------
+# FastMCP server integration
+# ---------------------------------------------------------------------------
+
+
+def _call(tool: str, args: dict | None = None) -> str:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(tier="standard")
+    result = asyncio.run(mcp.call_tool(tool, args or {}))
+    # FastMCP returns a (content, structured) tuple in recent versions, or a
+    # content list in older ones; normalise to the text payload.
+    content = result[0] if isinstance(result, tuple) else result
+    return content[0].text
+
+
+def test_server_health_response_is_enveloped(_meter_on: None) -> None:
+    parsed = json.loads(_call("bernstein_health"))
+    assert parsed["result"]["status"] == "ok"
+    assert parsed["_meter"]["tool"] == "bernstein_health"
+    assert parsed["_meter"]["ok"] is True
+
+
+def test_server_response_bare_when_disabled(_meter_off: None) -> None:
+    parsed = json.loads(_call("bernstein_health"))
+    assert parsed == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Streamable HTTP transport integration
+# ---------------------------------------------------------------------------
+
+
+def test_http_transport_health_enveloped(_meter_on: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "bernstein_health", "arguments": {}},
+        }
+    ).encode()
+    status, _, resp_body = asyncio.run(transport.handle_request("POST", "/mcp", {}, body))
+    assert status == 200
+    text = json.loads(resp_body)["result"]["content"][0]["text"]
+    parsed = json.loads(text)
+    assert parsed["result"]["status"] == "ok"
+    assert parsed["_meter"]["tool"] == "bernstein_health"

--- a/tests/unit/mcp/test_streaming_cancel.py
+++ b/tests/unit/mcp/test_streaming_cancel.py
@@ -1,0 +1,167 @@
+"""Tests for streaming tool-call cancel + partial-result preservation (#1674).
+
+Covers:
+
+  * the :class:`InFlightRegistry` lifecycle (register, attach, cancel, discard);
+  * the cancelled-result envelope shape (``cancelled``, ``partial``, ``_meter``);
+  * an end-to-end cancel through the streamable HTTP transport: a slow
+    ``tools/call`` cancelled by a concurrent ``notifications/cancelled`` returns
+    the preserved partial output rather than an error;
+  * cancelling an unknown id is a no-op;
+  * the HTTP capabilities advertise cancellation with partial results.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from bernstein.mcp.remote_transport import (
+    _CAPABILITIES,
+    RemoteMCPConfig,
+    StreamableHTTPTransport,
+)
+from bernstein.mcp.streaming import (
+    InFlightCall,
+    InFlightRegistry,
+    cancelled_envelope,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_COST_METER", raising=False)
+
+
+@pytest.fixture
+def transport(_clean_env: None) -> StreamableHTTPTransport:
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    return StreamableHTTPTransport(config=cfg, server_url="https://test:8052")
+
+
+def _request(method: str, params: dict, req_id: int) -> bytes:
+    return json.dumps({"jsonrpc": "2.0", "method": method, "id": req_id, "params": params}).encode()
+
+
+def _notification(method: str, params: dict) -> bytes:
+    return json.dumps({"jsonrpc": "2.0", "method": method, "params": params}).encode()
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+async def test_registry_register_get_discard() -> None:
+    reg = InFlightRegistry()
+    call = await reg.register(7, "bernstein_status")
+    assert call.request_id == 7
+    assert await reg.get(7) is call
+    await reg.discard(7)
+    assert await reg.get(7) is None
+
+
+async def test_registry_cancel_marks_and_cancels_task() -> None:
+    reg = InFlightRegistry()
+    await reg.register(1, "bernstein_run")
+
+    async def _slow() -> str:
+        await asyncio.sleep(10)
+        return "{}"
+
+    task: asyncio.Task[str] = asyncio.ensure_future(_slow())
+    await reg.attach_task(1, task)
+    call = await reg.cancel(1)
+    assert call is not None
+    assert call.cancelled is True
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_registry_cancel_unknown_id_is_noop() -> None:
+    reg = InFlightRegistry()
+    assert await reg.cancel("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# Cancelled envelope
+# ---------------------------------------------------------------------------
+
+
+def test_cancelled_envelope_preserves_partial() -> None:
+    call = InFlightCall(request_id=3, tool="bernstein_run")
+    call.append_partial('{"chunk": 1}')
+    call.append_partial('{"chunk": 2}')
+    env = cancelled_envelope(call, {"tool": "bernstein_run", "ok": False})
+    assert env["cancelled"] is True
+    assert env["partial"] == ['{"chunk": 1}', '{"chunk": 2}']
+    assert env.get("isError") is None
+    assert env["_meter"]["tool"] == "bernstein_run"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end cancel through the transport
+# ---------------------------------------------------------------------------
+
+
+async def test_tools_call_cancelled_returns_partial(
+    transport: StreamableHTTPTransport,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+
+    async def _slow_execute(name: str, arguments: dict) -> str:
+        started.set()
+        await asyncio.sleep(10)
+        return json.dumps({"unreached": True})
+
+    monkeypatch.setattr(transport, "_execute_tool", _slow_execute)
+
+    call_body = _request("tools/call", {"name": "bernstein_status", "arguments": {}}, req_id=42)
+    call_fut = asyncio.ensure_future(transport.handle_request("POST", "/mcp", {}, call_body))
+
+    # Wait until the slow tool is actually running, then cancel it.
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    cancel_body = _notification("notifications/cancelled", {"requestId": 42})
+    status, _, _ = await transport.handle_request("POST", "/mcp", {}, cancel_body)
+    assert status == 204  # notification -> no body
+
+    status, _, resp_body = await asyncio.wait_for(call_fut, timeout=2.0)
+    assert status == 200
+    result = json.loads(resp_body)["result"]
+    assert result["cancelled"] is True
+    # The seeded "running" partial chunk is preserved.
+    assert any("running" in chunk for chunk in result["partial"])
+    assert result.get("isError") is not True
+
+
+async def test_tools_call_not_cancelled_completes_normally(
+    transport: StreamableHTTPTransport,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fast_execute(name: str, arguments: dict) -> str:
+        return json.dumps({"total": 1})
+
+    monkeypatch.setattr(transport, "_execute_tool", _fast_execute)
+    body = _request("tools/call", {"name": "bernstein_status", "arguments": {}}, req_id=5)
+    status, _, resp_body = await transport.handle_request("POST", "/mcp", {}, body)
+    assert status == 200
+    result = json.loads(resp_body)["result"]
+    assert "cancelled" not in result
+    # The id is no longer tracked once the call settles.
+    assert await transport._inflight.get(5) is None
+
+
+# ---------------------------------------------------------------------------
+# Capabilities advertise cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_capabilities_advertise_cancellation() -> None:
+    assert _CAPABILITIES["experimental"]["cancellation"]["partialResults"] is True

--- a/tests/unit/test_mcp_remote_transport.py
+++ b/tests/unit/test_mcp_remote_transport.py
@@ -71,6 +71,19 @@ def _jsonrpc_notification(method: str, params: dict | None = None) -> bytes:
     return json.dumps(msg).encode()
 
 
+def _tool_result(text: str) -> dict:
+    """Return a tool call's result payload, unwrapping the cost-meter envelope.
+
+    Tool responses are wrapped in ``{"result": ..., "_meter": ...}`` by the
+    per-call cost meter (issue #1674). This helper returns the inner result so
+    assertions read the tool payload regardless of whether the meter is on.
+    """
+    parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        return parsed["result"]
+    return parsed
+
+
 # ---------------------------------------------------------------------------
 # RemoteMCPConfig tests
 # ---------------------------------------------------------------------------
@@ -420,7 +433,7 @@ class TestToolExecution:
         data = json.loads(resp_body)
         content = data["result"]["content"]
         assert len(content) == 1
-        assert json.loads(content[0]["text"])["status"] == "ok"
+        assert _tool_result(content[0]["text"])["status"] == "ok"
 
     @pytest.mark.anyio
     async def test_unknown_tool_returns_error(self, transport: StreamableHTTPTransport) -> None:
@@ -449,7 +462,7 @@ class TestToolExecution:
         assert status == 200
         data = json.loads(resp_body)
         text = data["result"]["content"][0]["text"]
-        assert json.loads(text)["total"] == 5
+        assert _tool_result(text)["total"] == 5
 
     @pytest.mark.anyio
     async def test_stop_tool_writes_signal(self, transport: StreamableHTTPTransport, tmp_path: object) -> None:
@@ -463,7 +476,7 @@ class TestToolExecution:
         status, _, resp_body = await transport.handle_request("POST", "/mcp", {}, body)
         assert status == 200
         data = json.loads(resp_body)
-        text = json.loads(data["result"]["content"][0]["text"])
+        text = _tool_result(data["result"]["content"][0]["text"])
         assert text["status"] == "shutdown signal sent"
         signal_file = workdir / ".sdd" / "runtime" / "signals" / "SHUTDOWN"
         assert signal_file.exists()


### PR DESCRIPTION
## Summary

Closes protocol-surface gaps on the existing Bernstein MCP server. No new
tools (separate concern); this only widens the protocol surface so a client
can negotiate and observe calls consistently across transports.

Three surfaces landed, each as its own commit:

- **Per-call cost-meter envelope** on every tool response (`result` plus
  `_meter` with latency, cost, trace id, status), uniform across stdio, SSE,
  and the streamable HTTP transport. Opt-out via `BERNSTEIN_MCP_COST_METER`.
- **Runtime capability cards** alongside the static manifest: a
  `bernstein://capability` MCP resource and a `capabilityCard` field on the
  HTTP `initialize` result, built from live process state (transports, auth
  modes, active tier, meter state, spec rev).
- **Streaming tool-call cancel with partial-result preservation** on the
  streamable HTTP transport via `notifications/cancelled`; a cancelled call
  returns its preserved `partial` output rather than discarding it.

Docs: `docs/mcp/server-audit-2026.md` (comparison table across spec rev,
transports, auth, capability negotiation, streaming/cancel, observability,
catalogue richness) and `docs/mcp/server.md` (surface description plus a
worked example of a host pointing at the server). Tests under
`tests/unit/mcp/`.

## Deferred (tracked in the audit doc, not in this pass)

- OAuth-2 PKCE and OIDC federation auth paths (advertised under
  `auth.planned` in the capability card so the gap is acknowledged).
- WebSocket transport.
- Server-initiated SSE push channel over GET.
- Prompt and sampling resource routes.

## Test plan

- [ ] `tests/unit/mcp/test_cost_meter.py` (envelope shape, toggle, server +
  HTTP integration)
- [ ] `tests/unit/mcp/test_capability_card.py` (card shape, live state,
  resource, HTTP initialize)
- [ ] `tests/unit/mcp/test_streaming_cancel.py` (registry, end-to-end cancel,
  partial preservation)
- [ ] `tests/unit/test_mcp_remote_transport.py` (existing transport suite,
  updated to read through the envelope)

Refs #1674