### PR TITLE
feat(substrate): desktop-register for Claude Desktop and Claude Code

### DIFF
--- a/docs/substrate/claude-code.md
+++ b/docs/substrate/claude-code.md
@@ -1,0 +1,78 @@
+# Register Bernstein in Claude Code
+
+Claude Code auto-discovers MCP servers from a project-local `.mcp.json`
+file. `bernstein desktop-register --host claude-code` merges a `bernstein`
+entry into that file in the current working directory, so any Claude Code
+session opened in the project can call Bernstein's tools.
+
+The write is idempotent and backup-first: the existing `.mcp.json` is
+copied to a timestamped `.bak` sibling before any mutating write, and
+re-running the command when the entry is already correct performs no
+write.
+
+## Config path
+
+| Scope | Path |
+|-------|------|
+| Project (current directory) | `./.mcp.json` |
+
+Because the scope is project-local, run the command from the repository
+root you want Bernstein registered in. `bernstein desktop-register --list`
+prints the resolved path for the current directory.
+
+## Install
+
+```bash
+cd /path/to/your/project
+bernstein desktop-register --host claude-code
+```
+
+This writes (merging into any existing `mcpServers` map):
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"]
+    }
+  }
+}
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated servers and top-level keys in `.mcp.json`
+are preserved verbatim.
+
+Reopen the project in Claude Code so it reloads `.mcp.json`.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `claude-code` row should show `Registered: yes` when run from the same
+directory. In a Claude Code session opened on the project, the Bernstein
+tools appear in the available MCP tools.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Open `./.mcp.json` and delete the `bernstein` key under `mcpServers`, or
+remove the whole file if Bernstein was the only entry. A backup of the
+pre-registration state is available as the `.mcp.json.*.bak` sibling
+created during install.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A `.mcp.json` that is not valid JSON is left untouched and the command
+  reports an error rather than overwriting it.
+- `bernstein init` may also write `.claude/mcp.json` for orchestration
+  auto-discovery; the two mechanisms are independent and can coexist.

--- a/docs/substrate/claude-desktop.md
+++ b/docs/substrate/claude-desktop.md
@@ -1,0 +1,75 @@
+# Register Bernstein in Claude Desktop
+
+Claude Desktop auto-discovers MCP servers from a single JSON config file.
+`bernstein desktop-register --host claude-desktop` merges a `bernstein`
+entry into that file so every Claude Desktop session can call Bernstein's
+tools without manual editing.
+
+The write is idempotent and backup-first: the existing config is copied to
+a timestamped `.bak` sibling before any mutating write, and re-running the
+command when the entry is already correct performs no write.
+
+## Config path per OS
+
+| OS | Path |
+|----|------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Linux | `$XDG_CONFIG_HOME/Claude/claude_desktop_config.json` (falls back to `~/.config/Claude/...`) |
+
+Run `bernstein desktop-register --list` to print the resolved path on your
+machine.
+
+## Install
+
+```bash
+bernstein desktop-register --host claude-desktop
+```
+
+This writes (merging into any existing `mcpServers` map):
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"]
+    }
+  }
+}
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated servers and top-level keys are preserved
+verbatim.
+
+Restart Claude Desktop after registering so it reloads its config.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `claude-desktop` row should show `Registered: yes`. In Claude Desktop,
+the Bernstein tools appear in the MCP tool list once the app has
+restarted.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Bernstein does not own the host config, so removal is a manual edit: open
+the config file shown by `--list` and delete the `bernstein` key under
+`mcpServers`. A backup of the pre-registration state is available as the
+`*.bak` sibling created during install. Restart Claude Desktop afterwards.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A config file that is not valid JSON is left untouched and the command
+  reports an error rather than overwriting it.

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -49,6 +49,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "delegate_cmd": "bernstein.cli.commands.delegate_cmd",
     "dep_impact_cmd": "bernstein.cli.commands.dep_impact_cmd",
     "diff_cmd": "bernstein.cli.commands.diff_cmd",
+    "desktop_register_cmd": "bernstein.cli.commands.desktop_register_cmd",
     "disaster_recovery_cmd": "bernstein.cli.commands.disaster_recovery_cmd",
     "doctor_cmd": "bernstein.cli.commands.doctor_cmd",
     "drain_screen": "bernstein.cli.display.drain_screen",

--- a/src/bernstein/cli/commands/desktop_register_cmd.py
+++ b/src/bernstein/cli/commands/desktop_register_cmd.py
@@ -1,0 +1,140 @@
+"""``bernstein desktop-register`` -- register Bernstein into host apps.
+
+Registers Bernstein's MCP server into a host application's config so the
+host auto-discovers Bernstein's tools without manual wiring. Two hosts are
+supported today (Claude Desktop, Claude Code); the rest are listed as
+stubbed via ``--list`` so the surface is discoverable.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.substrate.host_registry import (
+    HOST_REGISTRY,
+    HostStatus,
+    known_host_names,
+)
+from bernstein.core.substrate.register import is_registered, register_host
+
+
+def _list_payload() -> list[dict[str, object]]:
+    """Build the per-host status rows used by ``--list`` (table and JSON)."""
+    rows: list[dict[str, object]] = []
+    for name in known_host_names():
+        host = HOST_REGISTRY[name]
+        path = host.config_path()
+        registered = is_registered(host, path=path) if host.supported else False
+        rows.append(
+            {
+                "host": host.name,
+                "display_name": host.display_name,
+                "status": host.status.value,
+                "scope": host.scope,
+                "config_path": str(path) if path is not None else None,
+                "registered": registered,
+                "notes": host.notes,
+            }
+        )
+    return rows
+
+
+def _render_list(*, as_json: bool) -> None:
+    rows = _list_payload()
+    if as_json:
+        console.print_json(_json.dumps({"hosts": rows}))
+        return
+
+    table = Table(title="Bernstein substrate hosts", show_lines=False)
+    table.add_column("Host", style="cyan", no_wrap=True)
+    table.add_column("Status")
+    table.add_column("Registered")
+    table.add_column("Config path", overflow="fold")
+
+    for row in rows:
+        if row["status"] == HostStatus.SUPPORTED.value:
+            status_cell = "[green]supported[/green]"
+            reg_cell = "[green]yes[/green]" if row["registered"] else "[yellow]no[/yellow]"
+        else:
+            status_cell = "[dim]stubbed[/dim]"
+            reg_cell = "[dim]-[/dim]"
+        path = row["config_path"] or "[dim](n/a on this OS)[/dim]"
+        table.add_row(str(row["host"]), status_cell, reg_cell, str(path))
+
+    console.print(table)
+    console.print("\n[dim]Supported hosts can be registered with[/dim] bernstein desktop-register --host <name>")
+
+
+@click.command("desktop-register")
+@click.option("--host", "host_name", default=None, help="Host to register Bernstein into (e.g. claude-desktop).")
+@click.option(
+    "--list",
+    "do_list",
+    is_flag=True,
+    default=False,
+    help="List supported/stubbed hosts and registration state.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def desktop_register_cmd(host_name: str | None, do_list: bool, as_json: bool) -> None:
+    """Register Bernstein's MCP server into a host application.
+
+    \b
+    Examples:
+      bernstein desktop-register --list
+      bernstein desktop-register --host claude-desktop
+      bernstein desktop-register --host claude-code
+    """
+    if do_list or host_name is None:
+        if host_name is None and not do_list:
+            console.print("[yellow]Specify --host <name> or --list.[/yellow]\n")
+        _render_list(as_json=as_json)
+        if host_name is None and not do_list:
+            raise SystemExit(2)
+        return
+
+    host = HOST_REGISTRY.get(host_name)
+    if host is None:
+        valid = ", ".join(known_host_names())
+        raise click.BadParameter(f"unknown host {host_name!r}; known hosts: {valid}", param_hint="--host")
+
+    if not host.supported:
+        console.print(
+            f"[yellow]Host '{host.display_name}' is not yet supported for registration.[/yellow]\n"
+            f"[dim]{host.notes}[/dim]"
+        )
+        raise SystemExit(1)
+
+    result = register_host(host)
+
+    if as_json:
+        console.print_json(
+            _json.dumps(
+                {
+                    "host": result.host,
+                    "action": result.action,
+                    "config_path": str(result.config_path),
+                    "backup_path": str(result.backup_path) if result.backup_path else None,
+                }
+            )
+        )
+        return
+
+    if result.action == "already_registered":
+        console.print(f"[green]Bernstein is already registered in {host.display_name}.[/green]")
+        console.print(f"[dim]Config:[/dim] {result.config_path}")
+        return
+
+    verb = "Updated" if result.action == "updated" else "Registered"
+    console.print(f"[green]{verb} Bernstein in {host.display_name}.[/green]")
+    console.print(f"[dim]Config:[/dim] {result.config_path}")
+    if result.backup_path:
+        console.print(f"[dim]Backup:[/dim] {result.backup_path}")
+    if host.notes:
+        console.print(f"[cyan]Next:[/cyan] {host.notes}")
+
+
+__all__ = ["desktop_register_cmd"]

--- a/src/bernstein/cli/commands/desktop_register_cmd.py
+++ b/src/bernstein/cli/commands/desktop_register_cmd.py
@@ -88,6 +88,9 @@ def desktop_register_cmd(host_name: str | None, do_list: bool, as_json: bool) ->
       bernstein desktop-register --host claude-desktop
       bernstein desktop-register --host claude-code
     """
+    if do_list and host_name is not None:
+        raise click.UsageError("Use either --list or --host <name>, not both.")
+
     if do_list or host_name is None:
         if host_name is None and not do_list:
             console.print("[yellow]Specify --host <name> or --list.[/yellow]\n")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -62,6 +62,7 @@ from bernstein.cli.commands.citation_cmd import quality_group as citation_qualit
 from bernstein.cli.commands.consensus_cmd import consensus_group
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
+from bernstein.cli.commands.desktop_register_cmd import desktop_register_cmd
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.integrations_cmd import integrations_group
@@ -1035,6 +1036,7 @@ cli.add_command(citation_quality_group, "quality")
 cli.add_command(dry_run_cmd, "dry-run")
 cli.add_command(explain_help_cmd, "explain")
 cli.add_command(config_path_cmd, "config-path")
+cli.add_command(desktop_register_cmd, "desktop-register")
 cli.add_command(init_wizard_cmd, "init-wizard")
 cli.add_command(aliases_cmd, "aliases")
 cli.add_command(debug_cmd, "debug-bundle")

--- a/src/bernstein/core/substrate/__init__.py
+++ b/src/bernstein/core/substrate/__init__.py
@@ -1,0 +1,31 @@
+"""Substrate: register Bernstein into host applications (MCP servers, etc.).
+
+A "host" is an application an operator already runs (Claude Desktop,
+Claude Code, Cursor, ...) that auto-discovers MCP servers via its own
+config file. This package describes each host (``host_registry``) and
+performs idempotent, backup-first registration writes.
+
+Bernstein is a guest in the host's config: registration merges a single
+``bernstein`` entry into the host's ``mcpServers`` map and never clobbers
+unrelated keys.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.substrate.host_registry import (
+    HOST_REGISTRY,
+    HostSpec,
+    HostStatus,
+    bernstein_server_entry,
+    get_host,
+    known_host_names,
+)
+
+__all__ = [
+    "HOST_REGISTRY",
+    "HostSpec",
+    "HostStatus",
+    "bernstein_server_entry",
+    "get_host",
+    "known_host_names",
+]

--- a/src/bernstein/core/substrate/__init__.py
+++ b/src/bernstein/core/substrate/__init__.py
@@ -20,12 +20,20 @@ from bernstein.core.substrate.host_registry import (
     get_host,
     known_host_names,
 )
+from bernstein.core.substrate.register import (
+    RegisterResult,
+    is_registered,
+    register_host,
+)
 
 __all__ = [
     "HOST_REGISTRY",
     "HostSpec",
     "HostStatus",
+    "RegisterResult",
     "bernstein_server_entry",
     "get_host",
+    "is_registered",
     "known_host_names",
+    "register_host",
 ]

--- a/src/bernstein/core/substrate/host_registry.py
+++ b/src/bernstein/core/substrate/host_registry.py
@@ -1,0 +1,243 @@
+"""Registry of host applications that can auto-discover Bernstein's MCP server.
+
+Each :class:`HostSpec` records how to locate a host's MCP config file per
+OS and whether registration is implemented yet. Two hosts are fully
+supported (``claude-desktop``, ``claude-code``); the rest are stubbed so
+the surface is discoverable without claiming behaviour that does not exist.
+
+Path resolution is intentionally pure (no filesystem writes here) so it is
+trivially testable. Actual config merges live in
+:mod:`bernstein.core.substrate.register`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+#: Key under ``mcpServers`` that Bernstein owns in any host config.
+SERVER_ID = "bernstein"
+
+
+class HostStatus(StrEnum):
+    """Whether ``desktop-register`` can write a host's config today."""
+
+    SUPPORTED = "supported"
+    STUBBED = "stubbed"
+
+
+# ---------------------------------------------------------------------------
+# Per-OS config path resolution
+# ---------------------------------------------------------------------------
+
+
+def _platform_key() -> str:
+    """Return one of ``macos`` / ``linux`` / ``windows`` for the current OS."""
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform.startswith("win"):
+        return "windows"
+    return "linux"
+
+
+def _home() -> Path:
+    """Resolve the user home directory (override via ``HOME`` for tests)."""
+    return Path(os.environ.get("HOME") or Path.home())
+
+
+def _xdg_config_home() -> Path:
+    """Resolve ``$XDG_CONFIG_HOME`` with the documented fallback."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    return Path(xdg).expanduser() if xdg else _home() / ".config"
+
+
+def _windows_appdata() -> Path:
+    """Resolve ``%APPDATA%`` with a sensible fallback."""
+    appdata = os.environ.get("APPDATA")
+    return Path(appdata) if appdata else _home() / "AppData" / "Roaming"
+
+
+# Path templates per host, keyed by platform. Resolved lazily so an OS we do
+# not run on never has its env vars dereferenced.
+
+
+def _claude_desktop_path() -> Path:
+    plat = _platform_key()
+    if plat == "macos":
+        return _home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    if plat == "windows":
+        return _windows_appdata() / "Claude" / "claude_desktop_config.json"
+    # Linux is community-supported by Claude Desktop; XDG location.
+    return _xdg_config_home() / "Claude" / "claude_desktop_config.json"
+
+
+def _claude_code_path() -> Path:
+    # Claude Code reads a project-local ``.mcp.json`` from the working dir.
+    return Path.cwd() / ".mcp.json"
+
+
+# ---------------------------------------------------------------------------
+# Host specification
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HostSpec:
+    """Describe one host application and where its MCP config lives.
+
+    Attributes:
+        name: Stable CLI identifier (e.g. ``claude-desktop``).
+        display_name: Human-friendly name for tables and docs.
+        status: Whether registration is implemented or stubbed.
+        config_key: Top-level key holding the server map in the host config.
+        scope: ``user`` (global config in home dir) or ``project`` (cwd).
+        notes: One-line operator note (restart hint or stub reason).
+        _path_resolver: Internal callable returning the config path.
+    """
+
+    name: str
+    display_name: str
+    status: HostStatus
+    config_key: str = "mcpServers"
+    scope: str = "user"
+    notes: str = ""
+    _path_resolver: object = field(default=None, repr=False, compare=False)
+
+    @property
+    def supported(self) -> bool:
+        """True when ``desktop-register`` can write this host today."""
+        return self.status is HostStatus.SUPPORTED
+
+    def config_path(self) -> Path | None:
+        """Resolve the host's MCP config path for the current OS.
+
+        Returns ``None`` for stubbed hosts whose path is not yet wired up.
+        """
+        resolver = self._path_resolver
+        if resolver is None:
+            return None
+        return resolver()  # type: ignore[operator]
+
+
+def bernstein_server_entry() -> dict[str, object]:
+    """Return the canonical ``mcpServers`` entry that launches Bernstein.
+
+    Mirrors the entry written by orchestration bootstrap so a manually
+    registered host behaves identically to an auto-discovered project.
+    """
+    return {
+        "command": sys.executable,
+        "args": ["-m", "bernstein.mcp"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+
+def _stub(name: str, display: str, path_resolver: object, notes: str, scope: str = "user") -> HostSpec:
+    return HostSpec(
+        name=name,
+        display_name=display,
+        status=HostStatus.STUBBED,
+        scope=scope,
+        notes=notes,
+        _path_resolver=path_resolver,
+    )
+
+
+HOST_REGISTRY: dict[str, HostSpec] = {
+    "claude-desktop": HostSpec(
+        name="claude-desktop",
+        display_name="Claude Desktop",
+        status=HostStatus.SUPPORTED,
+        scope="user",
+        notes="Restart Claude Desktop after registering.",
+        _path_resolver=_claude_desktop_path,
+    ),
+    "claude-code": HostSpec(
+        name="claude-code",
+        display_name="Claude Code",
+        status=HostStatus.SUPPORTED,
+        scope="project",
+        notes="Writes .mcp.json in the current directory; reopen the project.",
+        _path_resolver=_claude_code_path,
+    ),
+    "cursor": _stub(
+        "cursor",
+        "Cursor",
+        lambda: _home() / ".cursor" / "mcp.json",
+        "Not yet implemented; would merge into ~/.cursor/mcp.json.",
+    ),
+    "continue": _stub(
+        "continue",
+        "Continue",
+        lambda: _home() / ".continue" / "config.json",
+        "Not yet implemented; Continue uses its own mcpServers schema.",
+    ),
+    "cline": _stub(
+        "cline",
+        "Cline",
+        lambda: _home() / ".cline" / "mcp_settings.json",
+        "Not yet implemented; VS Code extension settings vary by install.",
+    ),
+    "zed": _stub(
+        "zed",
+        "Zed",
+        lambda: _xdg_config_home() / "zed" / "settings.json",
+        "Not yet implemented; Zed nests servers under context_servers.",
+        scope="user",
+    ),
+    "aider": _stub(
+        "aider",
+        "Aider",
+        lambda: _home() / ".aider.conf.yml",
+        "Not yet implemented; Aider config is YAML, not mcpServers JSON.",
+    ),
+    "codex": _stub(
+        "codex",
+        "Codex",
+        lambda: _home() / ".codex" / "config.toml",
+        "Not yet implemented; Codex config is TOML.",
+    ),
+    "gemini": _stub(
+        "gemini",
+        "Gemini CLI",
+        lambda: _home() / ".gemini" / "settings.json",
+        "Not yet implemented; would merge into ~/.gemini/settings.json.",
+    ),
+}
+
+
+def known_host_names() -> list[str]:
+    """Return host identifiers in a stable, alphabetised order."""
+    return sorted(HOST_REGISTRY)
+
+
+def get_host(name: str) -> HostSpec:
+    """Look up a host by name.
+
+    Raises:
+        KeyError: When ``name`` is not a known host. The message lists the
+            valid identifiers so the caller can surface a helpful error.
+    """
+    try:
+        return HOST_REGISTRY[name]
+    except KeyError as exc:
+        valid = ", ".join(known_host_names())
+        raise KeyError(f"unknown host {name!r}; known hosts: {valid}") from exc
+
+
+__all__ = [
+    "HOST_REGISTRY",
+    "SERVER_ID",
+    "HostSpec",
+    "HostStatus",
+    "bernstein_server_entry",
+    "get_host",
+    "known_host_names",
+]

--- a/src/bernstein/core/substrate/register.py
+++ b/src/bernstein/core/substrate/register.py
@@ -47,17 +47,18 @@ class RegisterResult:
 
 
 def _load_config(path: Path) -> dict[str, Any]:
-    """Read an existing JSON host config, tolerating absence/garbage.
+    """Read an existing JSON host config, tolerating absence.
 
-    A missing or unparseable file yields an empty dict so registration can
-    bootstrap a fresh config without discarding a valid one.
+    A missing file yields an empty dict so registration can bootstrap a
+    fresh config. An unreadable or invalid file raises ``ValueError`` so a
+    mutating write never clobbers existing-but-unreadable state.
     """
     if not path.exists():
         return {}
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError:
-        return {}
+    except OSError as exc:
+        raise ValueError(f"existing config at {path} is not readable; refusing to overwrite") from exc
     if not text.strip():
         return {}
     try:
@@ -71,7 +72,7 @@ def _load_config(path: Path) -> dict[str, Any]:
 
 def _backup(path: Path, *, now: datetime | None = None) -> Path:
     """Copy ``path`` to a timestamped ``.bak`` sibling and return its path."""
-    stamp = (now or datetime.now(tz=UTC)).strftime("%Y%m%d%H%M%S")
+    stamp = (now or datetime.now(tz=UTC)).strftime("%Y%m%d%H%M%S%f")
     backup = path.with_name(f"{path.name}.{stamp}.bak")
     shutil.copy2(path, backup)
     return backup
@@ -118,7 +119,7 @@ def register_host(
 
     config = _load_config(target)
     raw_servers = config.get(host.config_key)
-    servers: dict[str, Any] = dict(cast("dict[str, Any]", raw_servers)) if isinstance(raw_servers, dict) else {}
+    servers: dict[str, Any] = cast("dict[str, Any]", raw_servers).copy() if isinstance(raw_servers, dict) else {}
 
     desired = bernstein_server_entry()
     existing_entry: Any = servers.get(SERVER_ID)

--- a/src/bernstein/core/substrate/register.py
+++ b/src/bernstein/core/substrate/register.py
@@ -1,0 +1,150 @@
+"""Idempotent, backup-first registration of Bernstein into a host config.
+
+The write contract:
+
+* Merge a single ``bernstein`` entry into the host's server map; never
+  touch unrelated keys (acceptance criterion: never clobber existing
+  config).
+* Back up the existing config file before the first mutating write.
+* Be idempotent: re-registering an already-correct entry reports
+  ``already_registered`` and performs no write (and creates no backup).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.substrate.host_registry import (
+    SERVER_ID,
+    HostSpec,
+    bernstein_server_entry,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RegisterResult:
+    """Outcome of a registration attempt.
+
+    Attributes:
+        host: Host identifier.
+        config_path: Path that was (or would be) written.
+        action: ``registered`` | ``updated`` | ``already_registered``.
+        backup_path: Path of the backup taken, or ``None`` when no write
+            occurred or the config file did not previously exist.
+    """
+
+    host: str
+    config_path: Path
+    action: str
+    backup_path: Path | None
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    """Read an existing JSON host config, tolerating absence/garbage.
+
+    A missing or unparseable file yields an empty dict so registration can
+    bootstrap a fresh config without discarding a valid one.
+    """
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    if not text.strip():
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"existing config at {path} is not valid JSON; refusing to overwrite") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"existing config at {path} is not a JSON object; refusing to overwrite")
+    return cast("dict[str, Any]", data)
+
+
+def _backup(path: Path, *, now: datetime | None = None) -> Path:
+    """Copy ``path`` to a timestamped ``.bak`` sibling and return its path."""
+    stamp = (now or datetime.now(tz=UTC)).strftime("%Y%m%d%H%M%S")
+    backup = path.with_name(f"{path.name}.{stamp}.bak")
+    shutil.copy2(path, backup)
+    return backup
+
+
+def is_registered(host: HostSpec, *, path: Path | None = None) -> bool:
+    """Return True when the host config already has the Bernstein entry."""
+    target = path or host.config_path()
+    if target is None:
+        return False
+    config = _load_config(target)
+    servers = config.get(host.config_key)
+    if not isinstance(servers, dict):
+        return False
+    return SERVER_ID in servers
+
+
+def register_host(
+    host: HostSpec,
+    *,
+    path: Path | None = None,
+    now: datetime | None = None,
+) -> RegisterResult:
+    """Merge Bernstein's MCP entry into ``host``'s config, idempotently.
+
+    Args:
+        host: Target host spec (must be supported).
+        path: Override the resolved config path (testing).
+        now: Override the wall clock for backup naming (testing).
+
+    Returns:
+        A :class:`RegisterResult` describing the action taken.
+
+    Raises:
+        ValueError: When the host is stubbed, has no resolvable path, or
+            the existing config file is not a JSON object.
+    """
+    if not host.supported:
+        raise ValueError(f"host {host.name!r} is not yet supported for registration")
+
+    target = path or host.config_path()
+    if target is None:
+        raise ValueError(f"host {host.name!r} has no resolvable config path on this OS")
+
+    config = _load_config(target)
+    raw_servers = config.get(host.config_key)
+    servers: dict[str, Any] = dict(cast("dict[str, Any]", raw_servers)) if isinstance(raw_servers, dict) else {}
+
+    desired = bernstein_server_entry()
+    existing_entry: Any = servers.get(SERVER_ID)
+
+    if existing_entry == desired:
+        return RegisterResult(host.name, target, "already_registered", None)
+
+    action = "updated" if SERVER_ID in servers else "registered"
+
+    backup_path: Path | None = None
+    if target.exists():
+        backup_path = _backup(target, now=now)
+
+    servers[SERVER_ID] = desired
+    config[host.config_key] = servers
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(target)
+
+    return RegisterResult(host.name, target, action, backup_path)
+
+
+__all__ = [
+    "RegisterResult",
+    "is_registered",
+    "register_host",
+]

--- a/tests/unit/substrate/__init__.py
+++ b/tests/unit/substrate/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for bernstein.core.substrate."""

--- a/tests/unit/substrate/test_desktop_register_cmd.py
+++ b/tests/unit/substrate/test_desktop_register_cmd.py
@@ -37,16 +37,22 @@ def test_register_claude_desktop_via_cli(tmp_path, monkeypatch) -> None:
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
+    # Pin the config-path resolution under HOME so the assertion is
+    # deterministic regardless of the runner's ambient environment.
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
 
     result = CliRunner().invoke(desktop_register_cmd, ["--host", "claude-desktop", "--json"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["action"] == "registered"
 
-    cfg = home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
-    if not cfg.exists():
-        # Non-macOS CI resolves to the XDG path instead.
-        cfg = home / ".config" / "Claude" / "claude_desktop_config.json"
+    candidates = [
+        home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json",
+        home / ".config" / "Claude" / "claude_desktop_config.json",
+    ]
+    cfg = next((p for p in candidates if p.exists()), None)
+    assert cfg is not None, "expected desktop-register to write a Claude Desktop config file"
     data = json.loads(cfg.read_text())
     assert SERVER_ID in data["mcpServers"]
 

--- a/tests/unit/substrate/test_desktop_register_cmd.py
+++ b/tests/unit/substrate/test_desktop_register_cmd.py
@@ -1,0 +1,72 @@
+"""Tests for the ``bernstein desktop-register`` CLI command."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.desktop_register_cmd import desktop_register_cmd
+from bernstein.core.substrate.host_registry import SERVER_ID
+
+
+def test_list_shows_supported_and_stubbed() -> None:
+    """``--list`` shows both supported hosts and at least one stub."""
+    result = CliRunner().invoke(desktop_register_cmd, ["--list"])
+    assert result.exit_code == 0, result.output
+    assert "claude-desktop" in result.output
+    assert "claude-code" in result.output
+    assert "supported" in result.output
+    assert "stubbed" in result.output
+
+
+def test_list_json_is_parseable() -> None:
+    """``--list --json`` emits parseable JSON with the documented schema."""
+    result = CliRunner().invoke(desktop_register_cmd, ["--list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    by_name = {row["host"]: row for row in payload["hosts"]}
+    assert by_name["claude-desktop"]["status"] == "supported"
+    assert by_name["cursor"]["status"] == "stubbed"
+    for row in payload["hosts"]:
+        assert {"host", "status", "scope", "config_path", "registered", "notes"} <= row.keys()
+
+
+def test_register_claude_desktop_via_cli(tmp_path, monkeypatch) -> None:
+    """``--host claude-desktop`` writes the entry into the resolved config."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "claude-desktop", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["action"] == "registered"
+
+    cfg = home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+    if not cfg.exists():
+        # Non-macOS CI resolves to the XDG path instead.
+        cfg = home / ".config" / "Claude" / "claude_desktop_config.json"
+    data = json.loads(cfg.read_text())
+    assert SERVER_ID in data["mcpServers"]
+
+
+def test_register_unknown_host_errors() -> None:
+    """An unknown ``--host`` is a usage error listing valid hosts."""
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "bogus"])
+    assert result.exit_code != 0
+    assert "unknown host" in result.output
+
+
+def test_register_stubbed_host_exits_nonzero() -> None:
+    """A stubbed host reports not-implemented and exits non-zero."""
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "cursor"])
+    assert result.exit_code == 1
+    assert "not yet supported" in result.output
+
+
+def test_no_args_prints_hint_and_exits_two() -> None:
+    """Bare invocation nudges toward --host/--list and exits with code 2."""
+    result = CliRunner().invoke(desktop_register_cmd, [])
+    assert result.exit_code == 2
+    assert "--host" in result.output

--- a/tests/unit/substrate/test_host_registry.py
+++ b/tests/unit/substrate/test_host_registry.py
@@ -1,0 +1,138 @@
+"""Tests for the substrate host registry and registration writes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.substrate.host_registry import (
+    HOST_REGISTRY,
+    SERVER_ID,
+    HostStatus,
+    bernstein_server_entry,
+    get_host,
+    known_host_names,
+)
+from bernstein.core.substrate.register import (
+    RegisterResult,
+    is_registered,
+    register_host,
+)
+
+
+def test_two_hosts_supported_rest_stubbed() -> None:
+    """Exactly the two MVP hosts are supported; everything else is stubbed."""
+    supported = {n for n, h in HOST_REGISTRY.items() if h.status is HostStatus.SUPPORTED}
+    assert supported == {"claude-desktop", "claude-code"}
+    stubbed = {n for n, h in HOST_REGISTRY.items() if h.status is HostStatus.STUBBED}
+    assert {"cursor", "continue", "cline", "zed", "aider", "codex", "gemini"} <= stubbed
+
+
+def test_known_host_names_sorted() -> None:
+    """``known_host_names`` returns a stable alphabetised list."""
+    names = known_host_names()
+    assert names == sorted(names)
+    assert "claude-desktop" in names
+
+
+def test_get_host_unknown_raises_with_valid_list() -> None:
+    """Unknown host lookups raise KeyError naming the valid hosts."""
+    with pytest.raises(KeyError) as exc:
+        get_host("not-a-host")
+    assert "claude-desktop" in str(exc.value)
+
+
+def test_bernstein_server_entry_shape() -> None:
+    """The server entry launches the bundled MCP module."""
+    entry = bernstein_server_entry()
+    assert entry["args"] == ["-m", "bernstein.mcp"]
+    assert isinstance(entry["command"], str)
+
+
+def test_stubbed_host_register_rejected() -> None:
+    """Registering a stubbed host raises rather than silently no-op."""
+    cursor = get_host("cursor")
+    assert not cursor.supported
+    with pytest.raises(ValueError, match="not yet supported"):
+        register_host(cursor)
+
+
+# ---------------------------------------------------------------------------
+# Registration writes (filesystem mocked via tmp_path)
+# ---------------------------------------------------------------------------
+
+
+def test_register_claude_desktop_creates_entry(tmp_path) -> None:
+    """Registering Claude Desktop writes a bernstein mcpServers entry."""
+    cfg = tmp_path / "claude_desktop_config.json"
+    host = get_host("claude-desktop")
+
+    result = register_host(host, path=cfg)
+
+    assert isinstance(result, RegisterResult)
+    assert result.action == "registered"
+    assert result.backup_path is None  # no prior file -> no backup
+    data = json.loads(cfg.read_text())
+    assert data["mcpServers"][SERVER_ID] == bernstein_server_entry()
+
+
+def test_register_idempotent_no_rewrite(tmp_path) -> None:
+    """Re-registering an identical entry reports already_registered, no backup."""
+    cfg = tmp_path / "claude_desktop_config.json"
+    host = get_host("claude-desktop")
+    register_host(host, path=cfg)
+
+    again = register_host(host, path=cfg)
+    assert again.action == "already_registered"
+    assert again.backup_path is None
+    # No stray backup files were created on the idempotent path.
+    assert list(tmp_path.glob("*.bak")) == []
+
+
+def test_register_backs_up_existing_config(tmp_path) -> None:
+    """An existing config is backed up before a mutating write."""
+    cfg = tmp_path / "claude_desktop_config.json"
+    cfg.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}, "theme": "dark"}))
+    host = get_host("claude-desktop")
+
+    result = register_host(host, path=cfg)
+
+    assert result.backup_path is not None
+    assert result.backup_path.exists()
+    # Backup preserves the pre-write content.
+    backed = json.loads(result.backup_path.read_text())
+    assert backed["theme"] == "dark"
+    assert "bernstein" not in backed["mcpServers"]
+
+
+def test_register_never_clobbers_unrelated_keys(tmp_path) -> None:
+    """Merge preserves unrelated servers and top-level keys."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"mcpServers": {"other": {"command": "x"}}, "globalShortcut": "Cmd+K"}))
+    host = get_host("claude-desktop")
+
+    register_host(host, path=cfg)
+
+    data = json.loads(cfg.read_text())
+    assert data["globalShortcut"] == "Cmd+K"
+    assert data["mcpServers"]["other"] == {"command": "x"}
+    assert SERVER_ID in data["mcpServers"]
+
+
+def test_register_invalid_json_refuses(tmp_path) -> None:
+    """A non-JSON existing config is not overwritten silently."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{not valid json")
+    host = get_host("claude-desktop")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        register_host(host, path=cfg)
+
+
+def test_is_registered_reflects_state(tmp_path) -> None:
+    """``is_registered`` is False before and True after a write."""
+    cfg = tmp_path / "config.json"
+    host = get_host("claude-desktop")
+    assert is_registered(host, path=cfg) is False
+    register_host(host, path=cfg)
+    assert is_registered(host, path=cfg) is True

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -235,6 +235,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "run-lookup",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "interop",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "desktop-register",
     }
 )
 


### PR DESCRIPTION
## Summary

Adds `bernstein desktop-register` to register Bernstein's MCP server into a
host application's config file, so the host auto-discovers Bernstein's tools
without manual editing. This is a partial landing of the priority-host work:
2 of N hosts are fully supported, the rest are stubbed and discoverable.

- `bernstein desktop-register --host <name>` merges a `bernstein` entry into
  the host's `mcpServers` map. Idempotent and backup-first: existing config is
  copied to a timestamped `.bak` before any mutating write, and re-registering
  an already-correct entry performs no write. Unrelated keys are never
  clobbered; a non-JSON config is refused rather than overwritten.
- `bernstein desktop-register --list` (and `--list --json`) shows which hosts
  are supported vs stubbed, each host's resolved config path per OS, and
  whether Bernstein is currently registered.
- Implementation: `src/bernstein/core/substrate/host_registry.py` (per-OS path
  resolution + `HOST_REGISTRY`), `src/bernstein/core/substrate/register.py`
  (merge/backup writes), `src/bernstein/cli/commands/desktop_register_cmd.py`.

## Hosts landed vs deferred

| Host | Status | Config path |
|------|--------|-------------|
| Claude Desktop | supported | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS); Windows/Linux documented |
| Claude Code | supported | project-local `./.mcp.json` |
| Cursor | stubbed | `~/.cursor/mcp.json` |
| Continue | stubbed | `~/.continue/config.json` |
| Cline | stubbed | `~/.cline/mcp_settings.json` |
| Zed | stubbed | `~/.config/zed/settings.json` |
| Aider | stubbed | `~/.aider.conf.yml` |
| Codex | stubbed | `~/.codex/config.toml` |
| Gemini CLI | stubbed | `~/.gemini/settings.json` |

Stubbed hosts return a clear "not yet supported" message and exit non-zero;
their config paths are recorded in `HOST_REGISTRY` so the surface is
discoverable. Implementing each is a follow-up (several use non-JSON config
formats, e.g. Aider YAML, Codex TOML).

## Docs

- `docs/substrate/claude-desktop.md` (install / verify / uninstall, per-OS path)
- `docs/substrate/claude-code.md` (install / verify / uninstall)

## Test plan

- [x] `tests/unit/substrate/` (17 tests): register Claude Desktop with mocked
      fs, idempotent re-register (no write, no stray backup), `--list`,
      backup-created, never-clobber unrelated keys, invalid-JSON refused,
      unknown-host error, stubbed-host rejected, CLI JSON output.
- [x] `ruff check` and `ruff format --check` clean on new files.
- [x] `pyright` clean (0 errors) on new modules.

Refs #1676 (partial -- 2 of N hosts; remaining hosts deferred as above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bernstein desktop-register` command to register Bernstein MCP server with Claude Desktop and Claude Code applications, including list and JSON output options.

* **Documentation**
  * Added guides for registering Bernstein with Claude Desktop and Claude Code, covering installation, verification, and uninstall procedures.

* **Tests**
  * Added comprehensive test coverage for the new desktop registration functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- bot-ack: nit-batch-skipped -->
_Informational CodeRabbit refactor suggestions (typed-dict schemas, constant centralization) batched as nits; deferred as follow-up. All must-address findings fixed in commit adb5e6f4._
