### PR TITLE
feat(interop): A2A capability cards plus lineage chain interop

### DIFF
--- a/docs/interop/a2a.md
+++ b/docs/interop/a2a.md
@@ -1,0 +1,219 @@
+# A2A capability cards and lineage interop
+
+This page covers the cross-organisation A2A surface: signed **capability
+cards** that one orchestrator publishes so a peer can decide whether to
+delegate to it, and the **lineage chain wrapper** that carries a signed
+Bernstein lineage chain through the A2A evidence envelope so a delegated run
+stays auditable across an organisational boundary.
+
+If you only have time for one paragraph: a capability card is a JCS-canonical
+JSON body (RFC 8785) signed as a detached JWS (RFC 7515 A.5) with an Ed25519
+key (RFC 8037 / EdDSA). It declares the issuer's identity, advertised tools,
+enforced policies (cost cap, redaction tier, sandbox profile), the public key
+that verifies it, and an expiry. A consumer fetches the card, verifies the
+signature against a trusted-issuer set, and proceeds only if the advertised
+policies meet its required policies. The lineage wrapper reuses the existing
+`core/lineage/tracker_audit.py` HMAC chain.
+
+This is distinct from the A2A v1.0 *agent card* served at
+`/.well-known/agent.json` (see [A2A v1.0 signed agent
+cards](../architecture/a2a.md)). The agent card describes wire formats and
+auth schemes for protocol discovery; the capability card described here is a
+delegation-trust manifest.
+
+---
+
+## Capability card fields
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Card schema version (currently `"1"`). |
+| `issuer` | Stable issuer id (organisation / orchestrator). |
+| `name`, `description` | Human-readable issuer identity. |
+| `advertised_tools[]` | Tool names the issuer exposes for delegation. |
+| `policies.cost_cap_usd` | Maximum spend the issuer accepts per sub-task. |
+| `policies.redaction_tier` | Redaction tier applied before artefacts leave the boundary. |
+| `policies.sandbox_profile` | Sandbox profile delegated work runs under. |
+| `public_key_pem` | SPKI PEM Ed25519 public key that verifies the signature. |
+| `kid` | Key identifier carried in the JWS protected header. |
+| `created_at`, `expires_at` | Issue and expiry timestamps (Unix seconds). |
+
+The signature is a detached compact JWS (`header..signature`, empty payload)
+over the JCS canonicalisation of the body, with the protected-header `typ`
+set to `a2a-capability+jws` so it can never be confused with the
+`agent-card+jws` identity-card context.
+
+---
+
+## Issue side
+
+Generate a signed capability card for the local orchestrator:
+
+```bash
+bernstein interop a2a card \
+  --issuer acme \
+  --name "Acme Orchestrator" \
+  --tool task_orchestration \
+  --tool code_review \
+  --cost-cap-usd 10 \
+  --redaction-tier standard \
+  --sandbox-profile container \
+  --ttl-seconds 86400 \
+  --output card.json
+```
+
+When no `--private-key` is supplied a fresh Ed25519 keypair is minted and the
+private key is written to `card.json.key.pem` with `0600` permissions so the
+operator can re-issue without changing identity. Pass `--private-key
+card.json.key.pem` on a later run to keep the same key fingerprint.
+
+The command prints the card's key **fingerprint** (`sha256:...`). Share that
+fingerprint with peers out of band so they can pin you in their
+trusted-issuer set.
+
+---
+
+## Consume side
+
+Before delegating a sub-task to a peer, Bernstein:
+
+1. fetches the peer's capability card;
+2. verifies the detached JWS and rejects expired cards;
+3. confirms the card's signing-key fingerprint is in the operator's
+   trusted-issuer set;
+4. proceeds only if the card's advertised policies meet the operator's
+   required policies.
+
+Programmatically:
+
+```python
+from bernstein.core.interop import (
+    SignedCapabilityCard,
+    PolicyRequirements,
+    consume_peer_card,
+)
+from bernstein.core.interop.a2a_consume import PeerCardRejected
+
+signed = SignedCapabilityCard.from_json(peer_card_json)
+requirements = PolicyRequirements(
+    max_cost_cap_usd=10.0,
+    min_redaction_tier="standard",
+    min_sandbox_profile="container",
+)
+try:
+    consume_peer_card(
+        signed,
+        trusted_issuer_fingerprints={"sha256:..."},
+        requirements=requirements,
+    )
+except PeerCardRejected as exc:
+    # exc.reason is one of: signature, untrusted_issuer, policy
+    raise
+```
+
+The policy gate is conservative and fails closed:
+
+| Policy | Rule |
+|---|---|
+| Cost cap | Peer's advertised cap must be at or below the operator ceiling. |
+| Redaction tier | Peer's tier must rank at or above the required tier. |
+| Sandbox profile | Peer's profile must rank at or above the required profile. |
+
+Tier and profile ordering (weakest to strongest):
+
+- Redaction: `none < basic < standard < strict`
+- Sandbox: `none < process < container < microvm`
+
+An unranked custom value on either side fails the gate.
+
+---
+
+## CLI verify
+
+Confirm a peer card is valid (signature plus, optionally, trust and policy):
+
+```bash
+# signature + expiry only
+bernstein interop a2a verify --card peer-card.json
+
+# also require the key be trusted and policies meet requirements
+bernstein interop a2a verify \
+  --card peer-card.json \
+  --trusted-fingerprint sha256:... \
+  --require-cost-cap-usd 10 \
+  --require-redaction-tier standard \
+  --require-sandbox-profile container
+```
+
+The command exits `0` when the card passes every requested check and `1`
+otherwise, printing the specific reasons it failed. Add `--json` at the top
+level (`bernstein --json interop a2a verify ...`) for machine-readable output.
+
+---
+
+## Lineage chain interop
+
+When a Bernstein run delegates work to a peer over A2A, the run's signed
+lineage chain travels inside the A2A evidence envelope under the
+`bernstein.lineage_v2` field. The receiving side appends the delegated work
+to its **own** chain with a cross-org boundary marker, so an auditor can see
+exactly where one organisation's chain hands off to another.
+
+The wrapper reuses the existing HMAC chain in
+`core/lineage/tracker_audit.py`. No new signing primitive is introduced: the
+boundary entry the receiver records is a normal signed tracker-audit entry
+(`tracker_name = "a2a-cross-org-boundary"`) and verifies under the receiver's
+operator HMAC key via the existing `bernstein lineage tracker-audit verify`.
+
+Envelope payload shape (the value of `bernstein.lineage_v2`):
+
+```json
+{
+  "schema_version": 1,
+  "source_issuer": "acme",
+  "chain_digest": "sha256:...",
+  "entries": [ { "...tracker-audit entry..." } ]
+}
+```
+
+`chain_digest` binds the carried entries and their order. The receiver
+recomputes the digest on parse and rejects an envelope whose digest does not
+match, so the chain cannot be tampered with in transit. The boundary marker
+the receiver appends records `source_issuer` and `source_chain_digest`, so
+the receiver's own chain is cryptographically bound to the exact source chain
+it received.
+
+Programmatically:
+
+```python
+from bernstein.core.interop import (
+    wrap_lineage_chain,
+    LineageEnvelope,
+    append_cross_org_segment,
+)
+from bernstein.core.lineage.tracker_audit import TrackerActor, TrackerAuditLog
+
+# Sender: wrap the local chain into an envelope field.
+envelope = wrap_lineage_chain(sender_log, source_issuer="acme")
+payload = envelope.to_envelope_field()  # splice into the A2A envelope
+
+# Receiver: extract, then append a boundary marker to its own chain.
+envelope = LineageEnvelope.from_envelope_field(received_payload)
+actor = TrackerActor(session_id="r1", role="reviewer", model="...")
+append_cross_org_segment(receiver_log, envelope, actor=actor, ticket_id="RECV-9")
+```
+
+---
+
+## Trust model and limits
+
+- The card carries its own public key, but carrying the key is **not**
+  trust. A verifier must independently confirm the key fingerprint is in the
+  operator's trusted-issuer set, which `consume_peer_card` enforces.
+- Expiry is enforced at the verifier. A stale card is rejected even when its
+  signature is otherwise valid, so a card cannot be replayed past its
+  window.
+- Fingerprints are computed over the raw Ed25519 public-key bytes, so they
+  are stable across PEM whitespace differences.
+- This surface does not replace the intra-org tracker handoff bus, and it
+  does not bridge between MCP, ACP, and A2A.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
       - Artifact storage: architecture/storage.md
       - Skill packs: architecture/skills.md
       - A2A v1.0 signed agent cards: architecture/a2a.md
+      - A2A capability cards and lineage interop: interop/a2a.md
       - Design notes: architecture/DESIGN.md
       - Glossary: reference/GLOSSARY.md
       - AST-aware reviewer chunks: concepts/ast-aware-chunking.md

--- a/src/bernstein/cli/commands/interop_cmd.py
+++ b/src/bernstein/cli/commands/interop_cmd.py
@@ -1,0 +1,250 @@
+"""CLI surface for cross-organisation A2A interop.
+
+Exposes the capability-card primitives as operator commands:
+
+* ``bernstein interop a2a card --output card.json`` issues a signed
+  capability card for the local orchestrator (identity, advertised tools,
+  supported policies, public key, expiry).
+* ``bernstein interop a2a verify --card card.json`` confirms a peer card is
+  cryptographically valid and (optionally) meets the operator's required
+  policies.
+
+The signing key is generated fresh on ``card`` unless ``--private-key`` is
+supplied; the private key is written next to the card (``<output>.key.pem``)
+with ``0600`` permissions so the operator can re-issue without minting a new
+identity. The card itself carries only the public key.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import (
+    console,
+    is_json,
+    print_error,
+    print_json,
+    print_success,
+)
+from bernstein.core.interop.a2a_card import (
+    CardPolicies,
+    SignedCapabilityCard,
+    card_public_key_fingerprint,
+    issue_capability_card,
+    verify_capability_card,
+)
+from bernstein.core.interop.a2a_consume import (
+    PolicyRequirements,
+    policies_meet_requirements,
+)
+
+
+@click.group("interop")
+def interop_group() -> None:
+    """Cross-organisation agent interoperability surfaces."""
+
+
+@interop_group.group("a2a")
+def a2a_group() -> None:
+    """A2A capability cards: issue and verify signed manifests.
+
+    \b
+    Examples:
+      bernstein interop a2a card --issuer acme --output card.json
+      bernstein interop a2a verify --card card.json
+    """
+
+
+@a2a_group.command("card")
+@click.option("--issuer", required=True, help="Stable issuer id (organisation / orchestrator).")
+@click.option("--name", default="bernstein-orchestrator", show_default=True, help="Human-readable issuer name.")
+@click.option(
+    "--description",
+    default="Bernstein multi-agent orchestration system",
+    show_default=True,
+    help="What the issuer does.",
+)
+@click.option(
+    "--tool",
+    "tools",
+    multiple=True,
+    help="Advertised tool name (repeatable). Defaults to a minimal set when omitted.",
+)
+@click.option("--cost-cap-usd", type=float, default=10.0, show_default=True, help="Advertised cost cap (USD).")
+@click.option("--redaction-tier", default="standard", show_default=True, help="Advertised redaction tier.")
+@click.option("--sandbox-profile", default="container", show_default=True, help="Advertised sandbox profile.")
+@click.option(
+    "--ttl-seconds",
+    type=int,
+    default=86400,
+    show_default=True,
+    help="Card validity window in seconds (0 disables expiry).",
+)
+@click.option(
+    "--private-key",
+    "private_key_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Existing PKCS#8 Ed25519 PEM private key to sign with. Generated when omitted.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path("card.json"),
+    show_default=True,
+    help="Where to write the signed capability card JSON.",
+)
+def card(
+    issuer: str,
+    name: str,
+    description: str,
+    tools: tuple[str, ...],
+    cost_cap_usd: float,
+    redaction_tier: str,
+    sandbox_profile: str,
+    ttl_seconds: int,
+    private_key_path: Path | None,
+    output_path: Path,
+) -> None:
+    """Issue a signed A2A capability card for the local orchestrator."""
+    advertised_tools = list(tools) or ["task_orchestration", "code_review"]
+    policies = CardPolicies(
+        cost_cap_usd=cost_cap_usd,
+        redaction_tier=redaction_tier,
+        sandbox_profile=sandbox_profile,
+    )
+
+    private_key_pem = private_key_path.read_bytes() if private_key_path is not None else None
+
+    signed, used_private_key = issue_capability_card(
+        issuer=issuer,
+        name=name,
+        description=description,
+        advertised_tools=advertised_tools,
+        policies=policies,
+        private_key_pem=private_key_pem,
+        ttl_seconds=ttl_seconds,
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(signed.to_json())
+
+    fingerprint = card_public_key_fingerprint(signed.card.public_key_pem)
+
+    # Persist the freshly generated private key so the operator can re-issue.
+    key_path: Path | None = None
+    if private_key_path is None:
+        key_path = output_path.with_suffix(output_path.suffix + ".key.pem")
+        key_path.write_bytes(used_private_key)
+        os.chmod(key_path, 0o600)
+
+    if is_json():
+        print_json(
+            {
+                "output": str(output_path),
+                "issuer": issuer,
+                "kid": signed.card.kid,
+                "fingerprint": fingerprint,
+                "expires_at": signed.card.expires_at,
+                "private_key": str(key_path) if key_path else None,
+            }
+        )
+        return
+
+    print_success(f"Capability card written to {output_path}")
+    console.print(f"  issuer: [bold]{issuer}[/bold]  kid: {signed.card.kid}")
+    console.print(f"  fingerprint: {fingerprint}")
+    if key_path is not None:
+        console.print(f"  private key (keep safe, 0600): {key_path}")
+
+
+@a2a_group.command("verify")
+@click.option(
+    "--card",
+    "card_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the signed capability card JSON to verify.",
+)
+@click.option(
+    "--trusted-fingerprint",
+    "trusted_fingerprints",
+    multiple=True,
+    help="Trusted issuer key fingerprint (repeatable). When supplied the card key must match one.",
+)
+@click.option("--require-cost-cap-usd", type=float, default=None, help="Reject cards advertising a higher cost cap.")
+@click.option("--require-redaction-tier", default=None, help="Reject cards with a weaker redaction tier.")
+@click.option("--require-sandbox-profile", default=None, help="Reject cards with a weaker sandbox profile.")
+def verify(
+    card_path: Path,
+    trusted_fingerprints: tuple[str, ...],
+    require_cost_cap_usd: float | None,
+    require_redaction_tier: str | None,
+    require_sandbox_profile: str | None,
+) -> None:
+    """Verify a peer capability card; exit non-zero when it is not valid."""
+    try:
+        signed = SignedCapabilityCard.from_json(card_path.read_text())
+    except (ValueError, json.JSONDecodeError) as exc:
+        _fail(f"could not parse capability card: {exc}")
+        return
+
+    failures: list[str] = []
+
+    if not verify_capability_card(signed, check_expiry=True):
+        failures.append("signature is invalid or the card has expired")
+
+    fingerprint = card_public_key_fingerprint(signed.card.public_key_pem)
+    if trusted_fingerprints and fingerprint not in set(trusted_fingerprints):
+        failures.append(f"key fingerprint {fingerprint} is not in the trusted-issuer set")
+
+    if require_cost_cap_usd is not None or require_redaction_tier is not None or require_sandbox_profile is not None:
+        requirements = PolicyRequirements(
+            max_cost_cap_usd=require_cost_cap_usd if require_cost_cap_usd is not None else float("inf"),
+            min_redaction_tier=require_redaction_tier or "none",
+            min_sandbox_profile=require_sandbox_profile or "none",
+        )
+        verdict = policies_meet_requirements(signed.card.policies, requirements)
+        failures.extend(verdict.failures)
+
+    if failures:
+        if is_json():
+            print_json({"ok": False, "fingerprint": fingerprint, "failures": failures})
+        else:
+            print_error(f"Capability card {card_path} is NOT valid:")
+            for reason in failures:
+                console.print(f"  - {reason}")
+        sys.exit(1)
+
+    if is_json():
+        print_json(
+            {
+                "ok": True,
+                "issuer": signed.card.issuer,
+                "kid": signed.card.kid,
+                "fingerprint": fingerprint,
+                "expires_at": signed.card.expires_at,
+            }
+        )
+        return
+    print_success(f"Capability card {card_path} is valid")
+    console.print(f"  issuer: [bold]{signed.card.issuer}[/bold]  kid: {signed.card.kid}")
+    console.print(f"  fingerprint: {fingerprint}")
+
+
+def _fail(message: str) -> None:
+    """Print an error (JSON-aware) and exit non-zero."""
+    if is_json():
+        print_json({"ok": False, "error": message})
+    else:
+        print_error(message)
+    sys.exit(1)
+
+
+__all__ = ["a2a_group", "card", "interop_group", "verify"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1058,6 +1058,11 @@ from bernstein.cli.commands.acp_cmd import acp_group  # noqa: E402
 
 cli.add_command(acp_group, "acp")
 
+# Cross-organisation A2A interop: signed capability cards + lineage interop.
+from bernstein.cli.commands.interop_cmd import interop_group  # noqa: E402
+
+cli.add_command(interop_group, "interop")
+
 # release/1.9: outbound notification drivers (Telegram, Slack, Discord, Email, Webhook, Shell).
 from bernstein.cli.commands.notify_cmd import notify_group  # noqa: E402
 

--- a/src/bernstein/core/interop/__init__.py
+++ b/src/bernstein/core/interop/__init__.py
@@ -1,0 +1,59 @@
+"""Cross-organisation interoperability surfaces.
+
+This package holds the A2A (agent-to-agent) capability-card primitives and
+the lineage-chain wrapper that lets a Bernstein run delegated to a peer
+agent stay auditable across an organisational boundary.
+
+Submodules:
+
+* :mod:`bernstein.core.interop.a2a_card` -- issue, sign, and verify a
+  capability card describing the local orchestrator (identity, advertised
+  tools, supported policies, public key, expiry).
+* :mod:`bernstein.core.interop.a2a_consume` -- fetch a peer card, verify it
+  against a trusted-issuer set, and gate delegation on whether the peer's
+  advertised policies meet the operator's required policies.
+* :mod:`bernstein.core.interop.a2a_lineage` -- wrap a signed Bernstein
+  lineage chain into an A2A envelope payload and append a cross-org
+  boundary marker on the receiving side, reusing the existing
+  :mod:`bernstein.core.lineage.tracker_audit` HMAC chain.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.interop.a2a_card import (
+    CapabilityCard,
+    CardPolicies,
+    SignedCapabilityCard,
+    issue_capability_card,
+    verify_capability_card,
+)
+from bernstein.core.interop.a2a_consume import (
+    PolicyRequirements,
+    PolicyVerdict,
+    consume_peer_card,
+    policies_meet_requirements,
+)
+from bernstein.core.interop.a2a_lineage import (
+    CROSS_ORG_BOUNDARY_MARKER,
+    LINEAGE_ENVELOPE_FIELD,
+    LineageEnvelope,
+    append_cross_org_segment,
+    wrap_lineage_chain,
+)
+
+__all__ = [
+    "CROSS_ORG_BOUNDARY_MARKER",
+    "LINEAGE_ENVELOPE_FIELD",
+    "CapabilityCard",
+    "CardPolicies",
+    "LineageEnvelope",
+    "PolicyRequirements",
+    "PolicyVerdict",
+    "SignedCapabilityCard",
+    "append_cross_org_segment",
+    "consume_peer_card",
+    "issue_capability_card",
+    "policies_meet_requirements",
+    "verify_capability_card",
+    "wrap_lineage_chain",
+]

--- a/src/bernstein/core/interop/a2a_card.py
+++ b/src/bernstein/core/interop/a2a_card.py
@@ -1,0 +1,464 @@
+"""A2A capability cards: a signed manifest of what an orchestrator can do.
+
+A capability card is the first-class A2A primitive a peer fetches before it
+delegates work: it describes the issuer's identity, the tools the
+orchestrator advertises, the policies it enforces (cost cap, redaction tier,
+sandbox profile), the public key a verifier uses to check the signature, and
+an expiry past which the card must not be trusted.
+
+The signature reuses the existing Ed25519 / detached-JWS / JCS machinery in
+:mod:`bernstein.core.security.agent_card_signer` so a capability card is
+verifiable with the same primitives Bernstein already ships for A2A v1.0
+agent cards. The card body is JCS-canonical JSON (RFC 8785); the signature
+is a detached JWS (RFC 7515 A.5) over those bytes, signed with Ed25519
+(RFC 8037 / EdDSA). The card carries its own public key (SPKI PEM) so a
+verifier can recompute the signing input and check the signature without a
+side channel, while still cross-checking the embedded key against a
+trusted-issuer set.
+
+Design notes:
+
+* The card body is signed with the ``typ`` header ``a2a-capability+jws`` so
+  a signature minted for a different JWS context (for instance the
+  ``agent-card+jws`` identity card) cannot be replayed as a capability card.
+* ``expires_at`` is a Unix timestamp; :func:`verify_capability_card` rejects
+  an expired card by default. Expiry is enforced at the verifier so a stale
+  card cannot be replayed even if the signature is otherwise valid.
+* The public key the card carries is the SPKI PEM of the signing key. The
+  verifier confirms the signature against that key AND confirms the key's
+  fingerprint is in the operator's trusted-issuer set; carrying the key in
+  the card alone is not sufficient trust.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from bernstein.core.security.agent_card_signer import (
+    canonicalize_jcs,
+    generate_ed25519_keypair,
+)
+
+__all__ = [
+    "CAPABILITY_CARD_TYP",
+    "DEFAULT_CARD_TTL_SECONDS",
+    "CapabilityCard",
+    "CardPolicies",
+    "SignedCapabilityCard",
+    "card_public_key_fingerprint",
+    "issue_capability_card",
+    "verify_capability_card",
+]
+
+#: JWS ``typ`` header for a capability-card signature. Distinct from the
+#: identity card's ``agent-card+jws`` so the two signature contexts never
+#: cross.
+CAPABILITY_CARD_TYP: str = "a2a-capability+jws"
+
+#: A2A capability-card schema version. Bumping requires a parallel reader.
+CAPABILITY_CARD_VERSION: str = "1"
+
+#: Default validity window for an issued card (24h). Operators override per
+#: issue call; verifiers always enforce whatever ``expires_at`` the card
+#: carries.
+DEFAULT_CARD_TTL_SECONDS: int = 24 * 60 * 60
+
+
+def _b64url(data: bytes) -> str:
+    """Base64-url-encode without padding (RFC 7515 2)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Base64-url-decode, restoring padding."""
+    pad = -len(data) % 4
+    return base64.urlsafe_b64decode(data + ("=" * pad))
+
+
+@dataclass(frozen=True)
+class CardPolicies:
+    """Policies a capability card advertises to peers.
+
+    Attributes:
+        cost_cap_usd: The maximum spend (USD) the issuer will accept for a
+            delegated sub-task. A consumer requiring a lower-or-equal cap is
+            satisfied; an issuer advertising a *higher* cap is acceptable
+            because the consumer can still bound its own spend, but a
+            consumer that needs a hard ceiling treats the issuer's cap as
+            the maximum it can be charged. See
+            :func:`bernstein.core.interop.a2a_consume.policies_meet_requirements`
+            for the exact comparison semantics.
+        redaction_tier: Named redaction tier the issuer applies to
+            artefacts before they leave its boundary (for instance
+            ``none``, ``standard``, ``strict``). Higher tiers redact more.
+        sandbox_profile: Named sandbox profile the issuer runs delegated
+            work under (for instance ``none``, ``container``, ``microvm``).
+    """
+
+    cost_cap_usd: float
+    redaction_tier: str
+    sandbox_profile: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible dict of the policies."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CardPolicies:
+        """Rebuild from a JSON-compatible dict, validating field shapes."""
+        cls.validate(data)
+        return cls(
+            cost_cap_usd=float(data["cost_cap_usd"]),
+            redaction_tier=str(data["redaction_tier"]),
+            sandbox_profile=str(data["sandbox_profile"]),
+        )
+
+    @staticmethod
+    def validate(data: dict[str, Any]) -> None:
+        """Raise ``ValueError`` if ``data`` is not a valid policy block."""
+        cost = data.get("cost_cap_usd")
+        if not isinstance(cost, (int, float)) or isinstance(cost, bool):
+            raise ValueError("CardPolicies 'cost_cap_usd' must be a number")
+        if float(cost) < 0:
+            raise ValueError("CardPolicies 'cost_cap_usd' must be non-negative")
+        for key in ("redaction_tier", "sandbox_profile"):
+            value = data.get(key)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"CardPolicies '{key}' must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class CapabilityCard:
+    """The unsigned body of an A2A capability card.
+
+    This is the JCS-canonicalised payload the detached JWS attests to. The
+    field set is the manifest a peer reads before delegating: who the issuer
+    is, what tools it advertises, what policies it enforces, the public key
+    that verifies the signature, and when the card expires.
+
+    Attributes:
+        schema_version: Card schema version (see
+            :data:`CAPABILITY_CARD_VERSION`).
+        issuer: Stable identifier of the issuing orchestrator / organisation.
+        name: Human-readable issuer name.
+        description: What the issuer does.
+        advertised_tools: Tool names the issuer exposes for delegation.
+        policies: The :class:`CardPolicies` block.
+        public_key_pem: SPKI PEM of the Ed25519 public key that verifies the
+            card's signature. Decoded as ASCII text in the JSON body.
+        kid: Key identifier carried in the JWS protected header.
+        created_at: Unix timestamp the card was issued.
+        expires_at: Unix timestamp past which the card must not be trusted.
+    """
+
+    schema_version: str
+    issuer: str
+    name: str
+    description: str
+    advertised_tools: list[str]
+    policies: CardPolicies
+    public_key_pem: str
+    kid: str
+    created_at: float
+    expires_at: float
+
+    def to_body(self) -> dict[str, Any]:
+        """Return the canonical body dict the signature is computed over.
+
+        Lists are copied and ``policies`` is flattened to a plain dict so
+        the JCS canonicalisation is stable and side-effect free.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "issuer": self.issuer,
+            "name": self.name,
+            "description": self.description,
+            "advertised_tools": list(self.advertised_tools),
+            "policies": self.policies.to_dict(),
+            "public_key_pem": self.public_key_pem,
+            "kid": self.kid,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+        }
+
+    def is_expired(self, *, now: float | None = None) -> bool:
+        """Return ``True`` when the card's ``expires_at`` is in the past."""
+        ref = time.time() if now is None else now
+        return self.expires_at > 0 and ref > self.expires_at
+
+    @classmethod
+    def from_body(cls, data: dict[str, Any]) -> CapabilityCard:
+        """Rebuild a card body from a JSON-compatible dict.
+
+        Raises:
+            ValueError: If required fields are missing or malformed.
+        """
+        cls.validate_body(data)
+        return cls(
+            schema_version=str(data["schema_version"]),
+            issuer=str(data["issuer"]),
+            name=str(data["name"]),
+            description=str(data.get("description", "")),
+            advertised_tools=[str(t) for t in data["advertised_tools"]],
+            policies=CardPolicies.from_dict(data["policies"]),
+            public_key_pem=str(data["public_key_pem"]),
+            kid=str(data["kid"]),
+            created_at=float(data["created_at"]),
+            expires_at=float(data["expires_at"]),
+        )
+
+    @staticmethod
+    def validate_body(data: dict[str, Any]) -> None:
+        """Raise ``ValueError`` if ``data`` is not a valid card body."""
+        for key in ("schema_version", "issuer", "name", "public_key_pem", "kid"):
+            value = data.get(key)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"CapabilityCard '{key}' must be a non-empty string")
+        tools = data.get("advertised_tools")
+        if not isinstance(tools, list) or any(not isinstance(t, str) for t in tools):
+            raise ValueError("CapabilityCard 'advertised_tools' must be a list of strings")
+        policies = data.get("policies")
+        if not isinstance(policies, dict):
+            raise ValueError("CapabilityCard 'policies' must be an object")
+        CardPolicies.validate(policies)
+        for key in ("created_at", "expires_at"):
+            value = data.get(key)
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ValueError(f"CapabilityCard '{key}' must be a number")
+
+
+@dataclass(frozen=True)
+class SignedCapabilityCard:
+    """A capability card body plus its detached JWS signature.
+
+    This is the on-the-wire artefact written by ``bernstein interop a2a
+    card`` and read by ``bernstein interop a2a verify``. The ``card`` and
+    ``signature`` are kept separate so a verifier recomputes the signing
+    input from the JCS-canonical body it received (RFC 7515 A.5 detached
+    content) rather than trusting any inlined payload.
+    """
+
+    card: CapabilityCard
+    #: Detached compact JWS string ``header..signature`` (empty payload).
+    signature: str
+    #: Algorithm name (always ``EdDSA`` here).
+    alg: str = "EdDSA"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the JSON document persisted to disk / sent on wire."""
+        return {
+            "card": self.card.to_body(),
+            "signature": self.signature,
+            "alg": self.alg,
+        }
+
+    def to_json(self, *, indent: int | None = 2) -> str:
+        """Render the signed card as a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SignedCapabilityCard:
+        """Rebuild a signed card from a parsed JSON document.
+
+        Raises:
+            ValueError: If the document is missing required keys.
+        """
+        if not isinstance(data, dict):
+            raise ValueError("signed capability card must be a JSON object")
+        body = data.get("card")
+        if not isinstance(body, dict):
+            raise ValueError("signed capability card missing 'card' body")
+        signature = data.get("signature")
+        if not isinstance(signature, str) or not signature:
+            raise ValueError("signed capability card missing 'signature'")
+        return cls(
+            card=CapabilityCard.from_body(body),
+            signature=signature,
+            alg=str(data.get("alg", "EdDSA")),
+        )
+
+    @classmethod
+    def from_json(cls, text: str) -> SignedCapabilityCard:
+        """Parse a signed card from a JSON string."""
+        return cls.from_dict(json.loads(text))
+
+
+def card_public_key_fingerprint(public_key_pem: str | bytes) -> str:
+    """Return a stable ``sha256:`` fingerprint of an SPKI PEM public key.
+
+    The fingerprint is computed over the raw 32-byte Ed25519 public key (the
+    SPKI inner bytes), so it is independent of PEM whitespace or line
+    wrapping. Used as the trusted-issuer identifier: an operator pins the
+    fingerprints it trusts, and the verifier confirms the card's embedded
+    key is one of them.
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    pem_bytes = public_key_pem.encode("ascii") if isinstance(public_key_pem, str) else public_key_pem
+    raw = serialization.load_pem_public_key(pem_bytes).public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    )
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def issue_capability_card(
+    *,
+    issuer: str,
+    name: str,
+    description: str,
+    advertised_tools: list[str],
+    policies: CardPolicies,
+    private_key_pem: bytes | None = None,
+    public_key_pem: bytes | None = None,
+    kid: str | None = None,
+    ttl_seconds: int = DEFAULT_CARD_TTL_SECONDS,
+    now: float | None = None,
+) -> tuple[SignedCapabilityCard, bytes]:
+    """Issue and sign a capability card for the local orchestrator.
+
+    When no keypair is supplied a fresh Ed25519 keypair is generated; the
+    private key is returned so the caller can persist it for re-issuance.
+    The card carries the public key so any verifier can recompute the
+    signing input.
+
+    Args:
+        issuer: Stable issuer identifier (organisation / orchestrator id).
+        name: Human-readable issuer name.
+        description: What the issuer does.
+        advertised_tools: Tool names exposed for delegation.
+        policies: The :class:`CardPolicies` the issuer enforces.
+        private_key_pem: Optional PKCS#8 PEM Ed25519 private key. Generated
+            when omitted.
+        public_key_pem: Optional SPKI PEM public key matching
+            ``private_key_pem``. Derived from the private key when omitted.
+        kid: Optional key identifier for the JWS header. Defaults to
+            ``a2a-{issuer}``.
+        ttl_seconds: Validity window in seconds (0 disables expiry, which
+            verifiers treat as never-expiring -- discouraged).
+        now: Optional override for the issue timestamp (testing).
+
+    Returns:
+        ``(signed_card, private_key_pem)`` -- the signed card plus the
+        private key (freshly generated or echoed back) so the caller owns
+        the material needed to re-issue.
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    if private_key_pem is None:
+        private_key_pem, derived_public = generate_ed25519_keypair()
+        public_key_pem = derived_public
+    elif public_key_pem is None:
+        private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+        public_key_pem = private_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+    issued_at = time.time() if now is None else now
+    expires_at = issued_at + ttl_seconds if ttl_seconds > 0 else 0.0
+    resolved_kid = kid or f"a2a-{issuer}"
+
+    card = CapabilityCard(
+        schema_version=CAPABILITY_CARD_VERSION,
+        issuer=issuer,
+        name=name,
+        description=description,
+        advertised_tools=list(advertised_tools),
+        policies=policies,
+        public_key_pem=public_key_pem.decode("ascii"),
+        kid=resolved_kid,
+        created_at=issued_at,
+        expires_at=expires_at,
+    )
+
+    signature = _sign_card_body(card, private_key_pem, kid=resolved_kid)
+    return SignedCapabilityCard(card=card, signature=signature), private_key_pem
+
+
+def _sign_card_body(card: CapabilityCard, private_key_pem: bytes, *, kid: str) -> str:
+    """Return the detached JWS over the card body's JCS bytes."""
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    header = {"alg": "EdDSA", "typ": CAPABILITY_CARD_TYP, "kid": kid}
+    header_b64 = _b64url(canonicalize_jcs(header))
+    body_b64 = _b64url(canonicalize_jcs(card.to_body()))
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    signature = private_key.sign(signing_input)
+    return f"{header_b64}..{_b64url(signature)}"
+
+
+def verify_capability_card(
+    signed: SignedCapabilityCard,
+    *,
+    check_expiry: bool = True,
+    now: float | None = None,
+) -> bool:
+    """Verify a signed capability card against the public key it carries.
+
+    Confirms the detached JWS is well-formed, uses ``EdDSA`` with the
+    capability-card ``typ``, and verifies against the SPKI public key the
+    card body declares. When ``check_expiry`` is set (the default) an
+    expired card is rejected.
+
+    This function checks cryptographic validity and expiry only. Confirming
+    the card's key is *trusted* (in the operator's trusted-issuer set) is
+    the caller's responsibility -- see
+    :func:`bernstein.core.interop.a2a_consume.consume_peer_card`.
+
+    Returns:
+        ``True`` iff the signature is valid and (when requested) the card is
+        not expired. Never raises on malformed network input.
+    """
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    if signed.alg != "EdDSA":
+        return False
+
+    parts = signed.signature.split(".")
+    if len(parts) != 3:
+        return False
+    header_b64, payload_b64, sig_b64 = parts
+    if payload_b64:
+        # Not a detached signature -- refuse rather than silently accept.
+        return False
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+    except (ValueError, json.JSONDecodeError):
+        return False
+    if not isinstance(header, dict):
+        return False
+    if header.get("alg") != "EdDSA" or header.get("typ") != CAPABILITY_CARD_TYP:
+        return False
+
+    if check_expiry and signed.card.is_expired(now=now):
+        return False
+
+    try:
+        public_key = serialization.load_pem_public_key(signed.card.public_key_pem.encode("ascii"))
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(public_key, Ed25519PublicKey):
+        # The card declares EdDSA; a non-Ed25519 key cannot have signed it.
+        return False
+
+    body_b64 = _b64url(canonicalize_jcs(signed.card.to_body()))
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    try:
+        sig = _b64url_decode(sig_b64)
+    except ValueError:
+        return False
+    try:
+        public_key.verify(sig, signing_input)
+    except InvalidSignature:
+        return False
+    return True

--- a/src/bernstein/core/interop/a2a_consume.py
+++ b/src/bernstein/core/interop/a2a_consume.py
@@ -1,0 +1,250 @@
+"""Consume side: fetch a peer capability card, verify, gate on policy.
+
+Before delegating a sub-task to a peer agent over A2A, Bernstein:
+
+1. fetches the peer's capability card (from a local artefact or an HTTP
+   ``.well-known`` endpoint);
+2. verifies the card's detached JWS and rejects expired cards
+   (:func:`bernstein.core.interop.a2a_card.verify_capability_card`);
+3. confirms the card's signing key fingerprint is in the operator's
+   trusted-issuer set;
+4. proceeds only if the card's advertised policies meet the operator's
+   required policies (cost cap, sandbox profile, redaction tier).
+
+The policy gate is conservative: a peer must advertise a cost cap at or
+below the operator's ceiling, a sandbox profile at least as strong as the
+operator requires, and a redaction tier at least as strong as the operator
+requires. Unknown ordinal values fail closed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.interop.a2a_card import (
+    SignedCapabilityCard,
+    card_public_key_fingerprint,
+    verify_capability_card,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    import httpx
+
+    from bernstein.core.interop.a2a_card import CardPolicies
+
+__all__ = [
+    "REDACTION_TIER_ORDER",
+    "SANDBOX_PROFILE_ORDER",
+    "PolicyRequirements",
+    "PolicyVerdict",
+    "consume_peer_card",
+    "fetch_peer_card_http",
+    "policies_meet_requirements",
+]
+
+#: Ordering of redaction tiers from weakest to strongest. A peer satisfies a
+#: requirement when its tier is at the required rank or higher. Operators
+#: extend this map for custom tiers; an unranked tier fails the gate closed.
+REDACTION_TIER_ORDER: dict[str, int] = {
+    "none": 0,
+    "basic": 1,
+    "standard": 2,
+    "strict": 3,
+}
+
+#: Ordering of sandbox profiles from weakest to strongest, same semantics as
+#: :data:`REDACTION_TIER_ORDER`.
+SANDBOX_PROFILE_ORDER: dict[str, int] = {
+    "none": 0,
+    "process": 1,
+    "container": 2,
+    "microvm": 3,
+}
+
+#: Default peer path for a published capability card.
+PEER_CARD_PATH = "/.well-known/a2a-capability-card.json"
+
+
+@dataclass(frozen=True)
+class PolicyRequirements:
+    """Operator-required policies a peer card must meet to be trusted.
+
+    Attributes:
+        max_cost_cap_usd: The highest cost cap the operator will accept from
+            a peer. A peer advertising a cap at or below this is acceptable;
+            a peer advertising a higher cap is rejected because the operator
+            cannot guarantee the spend ceiling it requires.
+        min_redaction_tier: The weakest redaction tier the operator will
+            accept. The peer's tier must rank at or above this in
+            :data:`REDACTION_TIER_ORDER`.
+        min_sandbox_profile: The weakest sandbox profile the operator will
+            accept. The peer's profile must rank at or above this in
+            :data:`SANDBOX_PROFILE_ORDER`.
+    """
+
+    max_cost_cap_usd: float
+    min_redaction_tier: str
+    min_sandbox_profile: str
+
+
+@dataclass(frozen=True)
+class PolicyVerdict:
+    """Outcome of a policy-requirements check against a peer card."""
+
+    ok: bool
+    failures: list[str] = field(default_factory=list)
+
+
+def _rank(order: Mapping[str, int], value: str) -> int | None:
+    """Return the ordinal rank of ``value`` in ``order`` or ``None``."""
+    return order.get(value)
+
+
+def policies_meet_requirements(
+    policies: CardPolicies,
+    requirements: PolicyRequirements,
+) -> PolicyVerdict:
+    """Return whether ``policies`` satisfy ``requirements`` (fail-closed).
+
+    Each failure is reported with a human-readable reason so callers can
+    surface exactly which constraint blocked the delegation. Unknown
+    redaction tiers or sandbox profiles on either side fail the check.
+    """
+    failures: list[str] = []
+
+    if policies.cost_cap_usd > requirements.max_cost_cap_usd:
+        failures.append(
+            f"cost cap: peer advertises {policies.cost_cap_usd} USD, operator ceiling is "
+            f"{requirements.max_cost_cap_usd} USD"
+        )
+
+    peer_redaction = _rank(REDACTION_TIER_ORDER, policies.redaction_tier)
+    req_redaction = _rank(REDACTION_TIER_ORDER, requirements.min_redaction_tier)
+    if peer_redaction is None:
+        failures.append(f"redaction tier: peer tier {policies.redaction_tier!r} is not a known tier")
+    elif req_redaction is None:
+        failures.append(f"redaction tier: required tier {requirements.min_redaction_tier!r} is not a known tier")
+    elif peer_redaction < req_redaction:
+        failures.append(
+            f"redaction tier: peer tier {policies.redaction_tier!r} is weaker than required "
+            f"{requirements.min_redaction_tier!r}"
+        )
+
+    peer_sandbox = _rank(SANDBOX_PROFILE_ORDER, policies.sandbox_profile)
+    req_sandbox = _rank(SANDBOX_PROFILE_ORDER, requirements.min_sandbox_profile)
+    if peer_sandbox is None:
+        failures.append(f"sandbox profile: peer profile {policies.sandbox_profile!r} is not a known profile")
+    elif req_sandbox is None:
+        failures.append(
+            f"sandbox profile: required profile {requirements.min_sandbox_profile!r} is not a known profile"
+        )
+    elif peer_sandbox < req_sandbox:
+        failures.append(
+            f"sandbox profile: peer profile {policies.sandbox_profile!r} is weaker than required "
+            f"{requirements.min_sandbox_profile!r}"
+        )
+
+    return PolicyVerdict(ok=not failures, failures=failures)
+
+
+class PeerCardRejected(RuntimeError):
+    """Raised when a peer card cannot be trusted for delegation.
+
+    Attributes:
+        reason: Machine-readable reason code (``signature``,
+            ``untrusted_issuer``, ``policy``).
+        detail: Human-readable explanation.
+    """
+
+    def __init__(self, reason: str, detail: str) -> None:
+        super().__init__(f"peer card rejected ({reason}): {detail}")
+        self.reason = reason
+        self.detail = detail
+
+
+def consume_peer_card(
+    signed: SignedCapabilityCard,
+    *,
+    trusted_issuer_fingerprints: Iterable[str],
+    requirements: PolicyRequirements,
+    now: float | None = None,
+) -> PolicyVerdict:
+    """Verify, trust-check, and policy-gate a peer capability card.
+
+    The full consume-side gate from the acceptance criteria: a peer card is
+    accepted only when its signature verifies, it is unexpired, its signing
+    key is in the trusted-issuer set, and its advertised policies meet the
+    operator's requirements.
+
+    Args:
+        signed: The peer's signed capability card.
+        trusted_issuer_fingerprints: ``sha256:`` fingerprints (see
+            :func:`bernstein.core.interop.a2a_card.card_public_key_fingerprint`)
+            of issuer keys the operator trusts.
+        requirements: The operator's required policies.
+        now: Optional timestamp override for expiry checks (testing).
+
+    Returns:
+        The :class:`PolicyVerdict` from the policy gate when every prior
+        check passes.
+
+    Raises:
+        PeerCardRejected: If the signature is invalid/expired, the issuer is
+            untrusted, or the policy gate fails. The exception's ``reason``
+            distinguishes the three cases.
+    """
+    if not verify_capability_card(signed, check_expiry=True, now=now):
+        raise PeerCardRejected("signature", "card signature is invalid or the card has expired")
+
+    trusted = set(trusted_issuer_fingerprints)
+    fingerprint = card_public_key_fingerprint(signed.card.public_key_pem)
+    if fingerprint not in trusted:
+        raise PeerCardRejected(
+            "untrusted_issuer",
+            f"card key fingerprint {fingerprint} is not in the trusted-issuer set",
+        )
+
+    verdict = policies_meet_requirements(signed.card.policies, requirements)
+    if not verdict.ok:
+        raise PeerCardRejected("policy", "; ".join(verdict.failures))
+    return verdict
+
+
+async def fetch_peer_card_http(
+    endpoint: str,
+    *,
+    path: str = PEER_CARD_PATH,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+) -> SignedCapabilityCard:
+    """Fetch a peer's published capability card over HTTP.
+
+    Performs a GET to ``{endpoint}{path}`` and parses the JSON body into a
+    :class:`SignedCapabilityCard`. This only fetches and parses; the caller
+    passes the result to :func:`consume_peer_card` to verify and gate it.
+
+    Args:
+        endpoint: Peer base URL.
+        path: Card path on the peer (defaults to the well-known path).
+        client: Optional preconfigured ``httpx.AsyncClient``.
+        timeout: Request timeout in seconds when no client is supplied.
+
+    Returns:
+        The parsed (but not yet verified) signed card.
+    """
+    import httpx
+
+    url = f"{endpoint.rstrip('/')}{path}"
+    owns_client = client is None
+    ac = client or httpx.AsyncClient(timeout=timeout)
+    try:
+        response = await ac.get(url)
+        response.raise_for_status()
+        data: Any = response.json()
+    finally:
+        if owns_client:
+            await ac.aclose()
+    return SignedCapabilityCard.from_dict(data)

--- a/src/bernstein/core/interop/a2a_lineage.py
+++ b/src/bernstein/core/interop/a2a_lineage.py
@@ -1,0 +1,244 @@
+"""Lineage chain interop: carry a signed Bernstein chain through A2A.
+
+When a Bernstein run delegates work to a peer agent over A2A, the run's
+signed lineage chain travels inside the A2A evidence envelope under the
+``bernstein.lineage_v2`` field. The receiving side appends the delegated
+work to its *own* chain with a cross-org boundary marker so an auditor can
+see exactly where one organisation's chain hands off to another.
+
+This module reuses the existing HMAC chain in
+:mod:`bernstein.core.lineage.tracker_audit`: the envelope payload is the
+canonical bytes of the source chain's tracker-audit entries plus a chain
+digest, and the receiving side records the handoff as a normal signed entry
+(``action="comment"``) whose body is the cross-org boundary marker. No new
+signing primitive is introduced -- the boundary entry is verifiable by the
+receiver's existing ``bernstein lineage tracker-audit verify``.
+
+Envelope shape (the value of ``bernstein.lineage_v2``)::
+
+    {
+      "schema_version": 1,
+      "source_issuer": "<issuer id from the sender's capability card>",
+      "chain_digest": "sha256:...",        # over the canonical entry bytes
+      "entries": [ <tracker-audit entry dict>, ... ]
+    }
+
+The ``chain_digest`` lets the receiver bind the boundary entry it appends to
+the exact source chain it received: the digest is recorded in the boundary
+marker, so tampering with the carried chain after the fact is detectable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.tracker_audit import (
+    TrackerActor,
+    entry_from_payload,
+    entry_to_body,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.core.lineage.tracker_audit import (
+        TrackerAuditEntry,
+        TrackerAuditLog,
+    )
+
+__all__ = [
+    "CROSS_ORG_BOUNDARY_MARKER",
+    "LINEAGE_ENVELOPE_FIELD",
+    "LINEAGE_ENVELOPE_SCHEMA_VERSION",
+    "LineageEnvelope",
+    "append_cross_org_segment",
+    "chain_digest",
+    "wrap_lineage_chain",
+]
+
+#: A2A envelope field that carries the signed Bernstein lineage chain.
+LINEAGE_ENVELOPE_FIELD: str = "bernstein.lineage_v2"
+
+#: Marker recorded in the boundary entry's tracker name so the cross-org
+#: handoff is greppable in an audit export.
+CROSS_ORG_BOUNDARY_MARKER: str = "a2a-cross-org-boundary"
+
+#: Envelope schema version. Bumping requires a parallel reader.
+LINEAGE_ENVELOPE_SCHEMA_VERSION: int = 1
+
+
+def _canonical(payload: dict[str, Any]) -> bytes:
+    """Return stable JCS-style bytes for ``payload``."""
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True, ensure_ascii=False).encode("utf-8")
+
+
+def chain_digest(entries: Sequence[TrackerAuditEntry]) -> str:
+    """Return a ``sha256:`` digest over the canonical bytes of ``entries``.
+
+    The digest is computed over the newline-joined JCS canonicalisation of
+    each entry body, in order, so it binds both the entry contents and their
+    sequence. Two chains with the same entries in a different order produce
+    different digests.
+    """
+    hasher = hashlib.sha256()
+    for entry in entries:
+        hasher.update(_canonical(entry_to_body(entry)))
+        hasher.update(b"\n")
+    return "sha256:" + hasher.hexdigest()
+
+
+@dataclass(frozen=True)
+class LineageEnvelope:
+    """The ``bernstein.lineage_v2`` payload carried in an A2A envelope.
+
+    Attributes:
+        source_issuer: Issuer id from the sender's capability card.
+        chain_digest: ``sha256:`` digest over the carried entries.
+        entries: The source chain's tracker-audit entries.
+        schema_version: Envelope schema version.
+    """
+
+    source_issuer: str
+    chain_digest: str
+    entries: list[TrackerAuditEntry] = field(default_factory=list)
+    schema_version: int = LINEAGE_ENVELOPE_SCHEMA_VERSION
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the JSON-compatible envelope payload."""
+        return {
+            "schema_version": self.schema_version,
+            "source_issuer": self.source_issuer,
+            "chain_digest": self.chain_digest,
+            "entries": [entry_to_body(entry) for entry in self.entries],
+        }
+
+    def to_envelope_field(self) -> dict[str, dict[str, Any]]:
+        """Return ``{LINEAGE_ENVELOPE_FIELD: payload}`` for splicing in."""
+        return {LINEAGE_ENVELOPE_FIELD: self.to_payload()}
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> LineageEnvelope:
+        """Rebuild an envelope from a parsed payload.
+
+        Raises:
+            ValueError: If required keys are missing or malformed.
+        """
+        if not isinstance(payload, dict):
+            raise ValueError("lineage envelope payload must be an object")
+        source_issuer = payload.get("source_issuer")
+        digest = payload.get("chain_digest")
+        raw_entries = payload.get("entries")
+        if not isinstance(source_issuer, str) or not source_issuer:
+            raise ValueError("lineage envelope missing 'source_issuer'")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise ValueError("lineage envelope missing valid 'chain_digest'")
+        if not isinstance(raw_entries, list):
+            raise ValueError("lineage envelope 'entries' must be a list")
+        entries = [entry_from_payload(item) for item in raw_entries]
+        recomputed = chain_digest(entries)
+        if recomputed != digest:
+            raise ValueError(f"lineage envelope chain_digest mismatch (carried {digest}, recomputed {recomputed})")
+        return cls(
+            source_issuer=source_issuer,
+            chain_digest=digest,
+            entries=entries,
+            schema_version=int(payload.get("schema_version", LINEAGE_ENVELOPE_SCHEMA_VERSION)),
+        )
+
+    @classmethod
+    def from_envelope_field(cls, envelope: dict[str, Any]) -> LineageEnvelope:
+        """Extract and rebuild the envelope from a full A2A envelope dict.
+
+        Raises:
+            ValueError: If the ``bernstein.lineage_v2`` field is absent.
+        """
+        payload = envelope.get(LINEAGE_ENVELOPE_FIELD)
+        if not isinstance(payload, dict):
+            raise ValueError(f"A2A envelope missing '{LINEAGE_ENVELOPE_FIELD}' field")
+        return cls.from_payload(payload)
+
+
+def wrap_lineage_chain(
+    log: TrackerAuditLog,
+    *,
+    source_issuer: str,
+    tracker_name: str | None = None,
+    ticket_id: str | None = None,
+) -> LineageEnvelope:
+    """Read a signed chain from ``log`` and wrap it in an A2A envelope.
+
+    Args:
+        log: The source :class:`TrackerAuditLog` to read entries from.
+        source_issuer: Issuer id from the sender's capability card; recorded
+            so the receiver can attribute the carried chain.
+        tracker_name: Optional filter to wrap only one tracker's entries.
+        ticket_id: Optional filter to wrap only one ticket's entries.
+
+    Returns:
+        A :class:`LineageEnvelope` ready to splice into an A2A payload via
+        :meth:`LineageEnvelope.to_envelope_field`.
+    """
+    if tracker_name is not None or ticket_id is not None:
+        entries = log.filter(tracker_name=tracker_name, ticket_id=ticket_id)
+    else:
+        entries = log.read()
+    return LineageEnvelope(
+        source_issuer=source_issuer,
+        chain_digest=chain_digest(entries),
+        entries=list(entries),
+    )
+
+
+def append_cross_org_segment(
+    receiver_log: TrackerAuditLog,
+    envelope: LineageEnvelope,
+    *,
+    actor: TrackerActor,
+    ticket_id: str,
+    lifecycle_event_id: str | None = None,
+) -> TrackerAuditEntry:
+    """Append a cross-org boundary marker to the receiver's own chain.
+
+    The receiving side records the handoff as a normal signed tracker-audit
+    entry whose body captures the source issuer and the carried chain's
+    digest. The entry's ``tracker_name`` is :data:`CROSS_ORG_BOUNDARY_MARKER`
+    so the boundary is greppable, and its ``output_blob`` is the canonical
+    envelope payload so the receiver's chain binds the exact bytes received.
+    The entry is signed and chained by the receiver's existing
+    :class:`TrackerAuditLog`, so it verifies under the receiver's operator
+    HMAC key with no new primitive.
+
+    Args:
+        receiver_log: The receiver's :class:`TrackerAuditLog`.
+        envelope: The lineage envelope extracted from the A2A payload.
+        actor: The receiving actor (session/role/model) recording the entry.
+        ticket_id: The receiver-side ticket the delegated work attaches to.
+        lifecycle_event_id: Optional lifecycle correlation id.
+
+    Returns:
+        The appended, signed :class:`TrackerAuditEntry` boundary marker.
+    """
+    marker_body = _canonical(
+        {
+            "marker": CROSS_ORG_BOUNDARY_MARKER,
+            "source_issuer": envelope.source_issuer,
+            "source_chain_digest": envelope.chain_digest,
+            "source_entry_count": len(envelope.entries),
+        }
+    )
+
+    payload_bytes = _canonical(envelope.to_payload())
+
+    result = receiver_log.append(
+        tracker_name=CROSS_ORG_BOUNDARY_MARKER,
+        ticket_id=ticket_id,
+        action="comment",
+        actor=actor,
+        input_prompt=marker_body,
+        output_blob=payload_bytes,
+        lifecycle_event_id=lifecycle_event_id,
+    )
+    return result.entry

--- a/src/bernstein/core/lineage/tracker_audit.py
+++ b/src/bernstein/core/lineage/tracker_audit.py
@@ -539,6 +539,27 @@ def _entry_from_payload(payload: dict[str, Any]) -> TrackerAuditEntry:
     )
 
 
+def entry_to_body(entry: TrackerAuditEntry) -> dict[str, Any]:
+    """Return ``entry`` as a plain dict ready for JCS canonicalisation.
+
+    Public wrapper over the internal serialiser so cross-module callers
+    (for instance the A2A lineage envelope) can read an entry's wire body
+    without reaching into module privates.
+    """
+
+    return _entry_body(entry)
+
+
+def entry_from_payload(payload: dict[str, Any]) -> TrackerAuditEntry:
+    """Reconstruct a :class:`TrackerAuditEntry` from a parsed JSON dict.
+
+    Public wrapper over the internal parser. Validates the entry shape via
+    the dataclass ``__post_init__`` invariants on construction.
+    """
+
+    return _entry_from_payload(payload)
+
+
 # ---------------------------------------------------------------------------
 # Tracker contract integration
 # ---------------------------------------------------------------------------
@@ -744,5 +765,7 @@ __all__ = [
     "compute_signature",
     "content_hash",
     "emit_audit_entry",
+    "entry_from_payload",
+    "entry_to_body",
     "wrap_adapter",
 ]

--- a/tests/unit/interop/__init__.py
+++ b/tests/unit/interop/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for cross-organisation A2A interop."""

--- a/tests/unit/interop/test_a2a_card_issue.py
+++ b/tests/unit/interop/test_a2a_card_issue.py
@@ -1,0 +1,178 @@
+"""Tests for issuing and signing A2A capability cards (AC 1)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.interop.a2a_card import (
+    CAPABILITY_CARD_TYP,
+    CapabilityCard,
+    CardPolicies,
+    SignedCapabilityCard,
+    card_public_key_fingerprint,
+    issue_capability_card,
+    verify_capability_card,
+)
+
+
+def _policies() -> CardPolicies:
+    return CardPolicies(cost_cap_usd=10.0, redaction_tier="standard", sandbox_profile="container")
+
+
+def test_issue_card_carries_required_fields() -> None:
+    signed, private_key = issue_capability_card(
+        issuer="acme",
+        name="Acme Orchestrator",
+        description="does things",
+        advertised_tools=["task_orchestration", "code_review"],
+        policies=_policies(),
+        ttl_seconds=3600,
+        now=1_000.0,
+    )
+    card = signed.card
+    assert card.issuer == "acme"
+    assert card.name == "Acme Orchestrator"
+    assert card.advertised_tools == ["task_orchestration", "code_review"]
+    assert card.policies.cost_cap_usd == 10.0
+    assert card.policies.redaction_tier == "standard"
+    assert card.policies.sandbox_profile == "container"
+    # public key for verification is carried, expiry is set.
+    assert "BEGIN PUBLIC KEY" in card.public_key_pem
+    assert card.created_at == 1_000.0
+    assert card.expires_at == 1_000.0 + 3600
+    # the private key is returned so the operator can re-issue.
+    assert b"BEGIN PRIVATE KEY" in private_key
+
+
+def test_issued_card_verifies() -> None:
+    signed, _ = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d",
+        advertised_tools=["t"],
+        policies=_policies(),
+        ttl_seconds=3600,
+    )
+    assert verify_capability_card(signed) is True
+
+
+def test_signature_uses_capability_card_typ() -> None:
+    signed, _ = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d",
+        advertised_tools=["t"],
+        policies=_policies(),
+    )
+    header_b64 = signed.signature.split(".")[0]
+    import base64
+
+    pad = -len(header_b64) % 4
+    header = json.loads(base64.urlsafe_b64decode(header_b64 + "=" * pad))
+    assert header["typ"] == CAPABILITY_CARD_TYP
+    assert header["alg"] == "EdDSA"
+
+
+def test_tampered_body_fails_verification() -> None:
+    import dataclasses
+
+    signed, _ = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d",
+        advertised_tools=["t"],
+        policies=_policies(),
+        ttl_seconds=3600,
+    )
+    tampered = dataclasses.replace(signed, card=dataclasses.replace(signed.card, issuer="evil"))
+    assert verify_capability_card(tampered) is False
+
+
+def test_expired_card_rejected_by_default() -> None:
+    signed, _ = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d",
+        advertised_tools=["t"],
+        policies=_policies(),
+        ttl_seconds=3600,
+        now=1_000.0,
+    )
+    # now well past expiry.
+    assert verify_capability_card(signed, now=1_000.0 + 99_999) is False
+    # signature itself stays valid when expiry is not checked.
+    assert verify_capability_card(signed, check_expiry=False, now=1_000.0 + 99_999) is True
+
+
+def test_card_json_round_trips() -> None:
+    signed, _ = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d",
+        advertised_tools=["a", "b"],
+        policies=_policies(),
+        ttl_seconds=3600,
+    )
+    text = signed.to_json()
+    reloaded = SignedCapabilityCard.from_json(text)
+    assert reloaded.card.to_body() == signed.card.to_body()
+    assert reloaded.signature == signed.signature
+    # round-trip preserves cryptographic validity.
+    assert verify_capability_card(reloaded) is True
+
+
+def test_fingerprint_is_stable_for_same_key() -> None:
+    signed, private_key = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d",
+        advertised_tools=["t"],
+        policies=_policies(),
+    )
+    fp1 = card_public_key_fingerprint(signed.card.public_key_pem)
+    # re-issuing with the same private key keeps the same fingerprint.
+    signed2, _ = issue_capability_card(
+        issuer="acme",
+        name="Acme",
+        description="d2",
+        advertised_tools=["t"],
+        policies=_policies(),
+        private_key_pem=private_key,
+    )
+    fp2 = card_public_key_fingerprint(signed2.card.public_key_pem)
+    assert fp1 == fp2 == fp1
+    assert fp1.startswith("sha256:")
+
+
+def test_fresh_key_per_issue_when_unspecified() -> None:
+    s1, _ = issue_capability_card(issuer="a", name="a", description="d", advertised_tools=[], policies=_policies())
+    s2, _ = issue_capability_card(issuer="a", name="a", description="d", advertised_tools=[], policies=_policies())
+    assert card_public_key_fingerprint(s1.card.public_key_pem) != card_public_key_fingerprint(s2.card.public_key_pem)
+
+
+@pytest.mark.parametrize(
+    "bad_body",
+    [
+        {"schema_version": ""},
+        {"advertised_tools": "not-a-list"},
+        {"policies": {"cost_cap_usd": -1, "redaction_tier": "x", "sandbox_profile": "y"}},
+    ],
+)
+def test_invalid_body_rejected(bad_body: dict[str, object]) -> None:
+    base = {
+        "schema_version": "1",
+        "issuer": "acme",
+        "name": "Acme",
+        "description": "d",
+        "advertised_tools": ["t"],
+        "policies": {"cost_cap_usd": 1.0, "redaction_tier": "standard", "sandbox_profile": "container"},
+        "public_key_pem": "x",
+        "kid": "k",
+        "created_at": 1.0,
+        "expires_at": 2.0,
+    }
+    base.update(bad_body)
+    with pytest.raises(ValueError):
+        CapabilityCard.from_body(base)

--- a/tests/unit/interop/test_a2a_consume.py
+++ b/tests/unit/interop/test_a2a_consume.py
@@ -1,0 +1,120 @@
+"""Tests for the consume side: verify + trust + policy gate (AC 2)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from bernstein.core.interop.a2a_card import (
+    CardPolicies,
+    card_public_key_fingerprint,
+    issue_capability_card,
+)
+from bernstein.core.interop.a2a_consume import (
+    PeerCardRejected,
+    PolicyRequirements,
+    consume_peer_card,
+    policies_meet_requirements,
+)
+
+
+def _signed(policies: CardPolicies, *, ttl_seconds: int = 3600):
+    return issue_capability_card(
+        issuer="peer",
+        name="Peer",
+        description="d",
+        advertised_tools=["t"],
+        policies=policies,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def test_policy_gate_accepts_compliant_peer() -> None:
+    policies = CardPolicies(cost_cap_usd=5.0, redaction_tier="strict", sandbox_profile="microvm")
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    verdict = policies_meet_requirements(policies, req)
+    assert verdict.ok is True
+    assert verdict.failures == []
+
+
+def test_policy_gate_rejects_high_cost_cap() -> None:
+    policies = CardPolicies(cost_cap_usd=50.0, redaction_tier="strict", sandbox_profile="microvm")
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    verdict = policies_meet_requirements(policies, req)
+    assert verdict.ok is False
+    assert any("cost cap" in f for f in verdict.failures)
+
+
+def test_policy_gate_rejects_weaker_sandbox_and_redaction() -> None:
+    policies = CardPolicies(cost_cap_usd=1.0, redaction_tier="basic", sandbox_profile="process")
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="strict", min_sandbox_profile="microvm")
+    verdict = policies_meet_requirements(policies, req)
+    assert verdict.ok is False
+    assert any("redaction" in f for f in verdict.failures)
+    assert any("sandbox" in f for f in verdict.failures)
+
+
+def test_unknown_ordinal_fails_closed() -> None:
+    policies = CardPolicies(cost_cap_usd=1.0, redaction_tier="bespoke", sandbox_profile="container")
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    verdict = policies_meet_requirements(policies, req)
+    assert verdict.ok is False
+    assert any("not a known tier" in f for f in verdict.failures)
+
+
+def test_consume_accepts_trusted_compliant_peer() -> None:
+    policies = CardPolicies(cost_cap_usd=5.0, redaction_tier="strict", sandbox_profile="microvm")
+    signed, _ = _signed(policies)
+    fp = card_public_key_fingerprint(signed.card.public_key_pem)
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    verdict = consume_peer_card(signed, trusted_issuer_fingerprints=[fp], requirements=req)
+    assert verdict.ok is True
+
+
+def test_consume_rejects_untrusted_issuer() -> None:
+    policies = CardPolicies(cost_cap_usd=5.0, redaction_tier="strict", sandbox_profile="microvm")
+    signed, _ = _signed(policies)
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    with pytest.raises(PeerCardRejected) as exc:
+        consume_peer_card(signed, trusted_issuer_fingerprints=["sha256:not-this-one"], requirements=req)
+    assert exc.value.reason == "untrusted_issuer"
+
+
+def test_consume_rejects_bad_signature() -> None:
+    policies = CardPolicies(cost_cap_usd=5.0, redaction_tier="strict", sandbox_profile="microvm")
+    signed, _ = _signed(policies)
+    fp = card_public_key_fingerprint(signed.card.public_key_pem)
+    tampered = dataclasses.replace(signed, card=dataclasses.replace(signed.card, issuer="evil"))
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    with pytest.raises(PeerCardRejected) as exc:
+        consume_peer_card(tampered, trusted_issuer_fingerprints=[fp], requirements=req)
+    assert exc.value.reason == "signature"
+
+
+def test_consume_rejects_policy_violation() -> None:
+    policies = CardPolicies(cost_cap_usd=50.0, redaction_tier="basic", sandbox_profile="process")
+    signed, _ = _signed(policies)
+    fp = card_public_key_fingerprint(signed.card.public_key_pem)
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="strict", min_sandbox_profile="microvm")
+    with pytest.raises(PeerCardRejected) as exc:
+        consume_peer_card(signed, trusted_issuer_fingerprints=[fp], requirements=req)
+    assert exc.value.reason == "policy"
+
+
+def test_consume_rejects_expired_card() -> None:
+    policies = CardPolicies(cost_cap_usd=1.0, redaction_tier="strict", sandbox_profile="microvm")
+    signed, _ = issue_capability_card(
+        issuer="peer",
+        name="Peer",
+        description="d",
+        advertised_tools=["t"],
+        policies=policies,
+        ttl_seconds=3600,
+        now=1_000.0,
+    )
+    fp = card_public_key_fingerprint(signed.card.public_key_pem)
+    req = PolicyRequirements(max_cost_cap_usd=10.0, min_redaction_tier="standard", min_sandbox_profile="container")
+    with pytest.raises(PeerCardRejected) as exc:
+        consume_peer_card(signed, trusted_issuer_fingerprints=[fp], requirements=req, now=1_000.0 + 99_999)
+    assert exc.value.reason == "signature"

--- a/tests/unit/interop/test_a2a_lineage_wrap.py
+++ b/tests/unit/interop/test_a2a_lineage_wrap.py
@@ -1,0 +1,125 @@
+"""Tests for the lineage chain wrapper through the A2A envelope (AC 3)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.interop.a2a_lineage import (
+    CROSS_ORG_BOUNDARY_MARKER,
+    LINEAGE_ENVELOPE_FIELD,
+    LineageEnvelope,
+    append_cross_org_segment,
+    chain_digest,
+    wrap_lineage_chain,
+)
+from bernstein.core.lineage.tracker_audit import TrackerActor, TrackerAuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def actor() -> TrackerActor:
+    return TrackerActor(session_id="s1", role="backend", model="m")
+
+
+def _seed_source(path: Path, actor: TrackerActor) -> TrackerAuditLog:
+    log = TrackerAuditLog(path, hmac_key=b"sender-operator-secret")
+    log.append(
+        tracker_name="jira", ticket_id="PROJ-1", action="claim", actor=actor, input_prompt=b"p", output_blob=b"o"
+    )
+    log.append(
+        tracker_name="jira", ticket_id="PROJ-1", action="comment", actor=actor, input_prompt=b"p2", output_blob=b"o2"
+    )
+    return log
+
+
+def test_wrap_carries_signed_chain_under_envelope_field(tmp_path: Path, actor: TrackerActor) -> None:
+    src = _seed_source(tmp_path / "src.jsonl", actor)
+    envelope = wrap_lineage_chain(src, source_issuer="acme")
+    field = envelope.to_envelope_field()
+    assert LINEAGE_ENVELOPE_FIELD in field
+    payload = field[LINEAGE_ENVELOPE_FIELD]
+    assert payload["source_issuer"] == "acme"
+    assert len(payload["entries"]) == 2
+    assert payload["chain_digest"].startswith("sha256:")
+
+
+def test_envelope_round_trips_through_json(tmp_path: Path, actor: TrackerActor) -> None:
+    src = _seed_source(tmp_path / "src.jsonl", actor)
+    envelope = wrap_lineage_chain(src, source_issuer="acme")
+    wire = json.loads(json.dumps(envelope.to_envelope_field()))
+    rebuilt = LineageEnvelope.from_envelope_field(wire)
+    assert rebuilt.chain_digest == envelope.chain_digest
+    assert chain_digest(rebuilt.entries) == envelope.chain_digest
+
+
+def test_tampered_carried_chain_is_detected(tmp_path: Path, actor: TrackerActor) -> None:
+    src = _seed_source(tmp_path / "src.jsonl", actor)
+    envelope = wrap_lineage_chain(src, source_issuer="acme")
+    payload = json.loads(json.dumps(envelope.to_payload()))
+    payload["entries"][0]["ticket_id"] = "EVIL"
+    with pytest.raises(ValueError, match="chain_digest mismatch"):
+        LineageEnvelope.from_payload(payload)
+
+
+def test_missing_envelope_field_raises(actor: TrackerActor) -> None:
+    with pytest.raises(ValueError, match=LINEAGE_ENVELOPE_FIELD):
+        LineageEnvelope.from_envelope_field({"some_other_field": {}})
+
+
+def test_receiver_appends_boundary_marker(tmp_path: Path, actor: TrackerActor) -> None:
+    src = _seed_source(tmp_path / "src.jsonl", actor)
+    envelope = wrap_lineage_chain(src, source_issuer="acme")
+
+    receiver = TrackerAuditLog(tmp_path / "recv.jsonl", hmac_key=b"receiver-operator-secret")
+    receiver_actor = TrackerActor(session_id="r1", role="reviewer", model="m")
+    entry = append_cross_org_segment(receiver, envelope, actor=receiver_actor, ticket_id="RECV-9")
+
+    assert entry.tracker_name == CROSS_ORG_BOUNDARY_MARKER
+    assert entry.ticket_id == "RECV-9"
+    assert entry.action == "comment"
+    assert entry.actor == receiver_actor
+    # the boundary marker content is content-addressed; recompute the same
+    # hash from the marker body to confirm the entry binds the source chain.
+    from bernstein.core.lineage.tracker_audit import content_hash
+
+    expected_marker = json.dumps(
+        {
+            "marker": CROSS_ORG_BOUNDARY_MARKER,
+            "source_issuer": envelope.source_issuer,
+            "source_chain_digest": envelope.chain_digest,
+            "source_entry_count": len(envelope.entries),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    assert entry.input_prompt_hash == content_hash(expected_marker)
+
+
+def test_receiver_chain_verifies_after_append(tmp_path: Path, actor: TrackerActor) -> None:
+    src = _seed_source(tmp_path / "src.jsonl", actor)
+    envelope = wrap_lineage_chain(src, source_issuer="acme")
+
+    receiver_key = b"receiver-operator-secret"
+    receiver = TrackerAuditLog(tmp_path / "recv.jsonl", hmac_key=receiver_key)
+    receiver_actor = TrackerActor(session_id="r1", role="reviewer", model="m")
+    append_cross_org_segment(receiver, envelope, actor=receiver_actor, ticket_id="RECV-9")
+
+    # the receiver's existing verify path validates the boundary entry with
+    # no new primitive.
+    result = receiver.verify()
+    assert result.ok is True
+    assert result.entry_count == 1
+
+
+def test_wrap_filters_by_ticket(tmp_path: Path, actor: TrackerActor) -> None:
+    log = TrackerAuditLog(tmp_path / "src.jsonl", hmac_key=b"k")
+    log.append(tracker_name="jira", ticket_id="A-1", action="claim", actor=actor, input_prompt=b"p", output_blob=b"o")
+    log.append(tracker_name="jira", ticket_id="B-2", action="claim", actor=actor, input_prompt=b"p", output_blob=b"o")
+    envelope = wrap_lineage_chain(log, source_issuer="acme", ticket_id="A-1")
+    assert len(envelope.entries) == 1
+    assert envelope.entries[0].ticket_id == "A-1"

--- a/tests/unit/interop/test_a2a_verify_cli.py
+++ b/tests/unit/interop/test_a2a_verify_cli.py
@@ -1,0 +1,133 @@
+"""Tests for ``bernstein interop a2a card|verify`` (AC 1, 4)."""
+
+from __future__ import annotations
+
+import json
+import stat
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.interop_cmd import interop_group
+from bernstein.core.interop.a2a_card import SignedCapabilityCard, card_public_key_fingerprint
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _issue(runner: CliRunner, tmp_path: Path, *extra: str) -> Path:
+    out = tmp_path / "card.json"
+    result = runner.invoke(
+        interop_group,
+        ["a2a", "card", "--issuer", "acme", "--output", str(out), "--ttl-seconds", "3600", *extra],
+    )
+    assert result.exit_code == 0, result.output
+    return out
+
+
+def test_card_command_writes_signed_card(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = _issue(runner, tmp_path, "--tool", "task_orchestration", "--tool", "code_review")
+    assert out.exists()
+    signed = SignedCapabilityCard.from_json(out.read_text())
+    assert signed.card.issuer == "acme"
+    assert signed.card.advertised_tools == ["task_orchestration", "code_review"]
+    assert "BEGIN PUBLIC KEY" in signed.card.public_key_pem
+
+
+def test_card_command_persists_private_key_0600(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = _issue(runner, tmp_path)
+    key_path = out.with_suffix(out.suffix + ".key.pem")
+    assert key_path.exists()
+    mode = stat.S_IMODE(key_path.stat().st_mode)
+    assert mode == 0o600
+    assert b"BEGIN PRIVATE KEY" in key_path.read_bytes()
+
+
+def test_verify_command_accepts_valid_card(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = _issue(runner, tmp_path)
+    result = runner.invoke(interop_group, ["a2a", "verify", "--card", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "is valid" in result.output
+
+
+def test_verify_command_rejects_tampered_card(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = _issue(runner, tmp_path)
+    doc = json.loads(out.read_text())
+    doc["card"]["issuer"] = "evil"
+    out.write_text(json.dumps(doc))
+    result = runner.invoke(interop_group, ["a2a", "verify", "--card", str(out)])
+    assert result.exit_code == 1
+    assert "NOT valid" in result.output
+
+
+def test_verify_command_enforces_trusted_fingerprint(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = _issue(runner, tmp_path)
+    signed = SignedCapabilityCard.from_json(out.read_text())
+    good_fp = card_public_key_fingerprint(signed.card.public_key_pem)
+
+    # wrong fingerprint -> rejected.
+    bad = runner.invoke(interop_group, ["a2a", "verify", "--card", str(out), "--trusted-fingerprint", "sha256:nope"])
+    assert bad.exit_code == 1
+    assert "trusted-issuer set" in bad.output
+
+    # correct fingerprint -> accepted.
+    ok = runner.invoke(interop_group, ["a2a", "verify", "--card", str(out), "--trusted-fingerprint", good_fp])
+    assert ok.exit_code == 0, ok.output
+
+
+def test_verify_command_enforces_policy_requirements(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = _issue(runner, tmp_path, "--cost-cap-usd", "50", "--redaction-tier", "basic", "--sandbox-profile", "process")
+    result = runner.invoke(
+        interop_group,
+        [
+            "a2a",
+            "verify",
+            "--card",
+            str(out),
+            "--require-cost-cap-usd",
+            "10",
+            "--require-redaction-tier",
+            "strict",
+            "--require-sandbox-profile",
+            "microvm",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "cost cap" in result.output
+    assert "redaction" in result.output
+    assert "sandbox" in result.output
+
+
+def test_card_command_accepts_existing_private_key(tmp_path: Path) -> None:
+    runner = CliRunner()
+    first = _issue(runner, tmp_path)
+    key_path = first.with_suffix(first.suffix + ".key.pem")
+    first_fp = card_public_key_fingerprint(SignedCapabilityCard.from_json(first.read_text()).card.public_key_pem)
+
+    second = tmp_path / "card2.json"
+    result = runner.invoke(
+        interop_group,
+        [
+            "a2a",
+            "card",
+            "--issuer",
+            "acme",
+            "--output",
+            str(second),
+            "--private-key",
+            str(key_path),
+            "--ttl-seconds",
+            "3600",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    second_fp = card_public_key_fingerprint(SignedCapabilityCard.from_json(second.read_text()).card.public_key_pem)
+    assert first_fp == second_fp
+    # supplying a key should not write a new one next to the second card.
+    assert not second.with_suffix(second.suffix + ".key.pem").exists()

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -233,6 +233,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "spec",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "run-lookup",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "interop",
     }
 )
 

--- a/typos.toml
+++ b/typos.toml
@@ -22,6 +22,7 @@ ehr = "ehr"          # Electronic Health Record (HIPAA compliance)
 rto = "rto"          # Recovery Time Objective (compliance/DR)
 RTO = "RTO"          # Recovery Time Objective (compliance/DR, acronym)
 mis = "mis"          # false positive on partial words
+hel = "hel"          # truncated stream-chunk fixture "hel"+"lo" (test_client_hardened.py)
 fo = "fo"            # fo = fan_out (test_complexity_correlation.py)
 thr = "thr"          # thr = threshold (scripts/mutmut_critical.py)
 Aktive = "Aktive"    # correct German word for "Active" (i18n.py)


### PR DESCRIPTION
## Summary

- Add a signed A2A capability card primitive: `bernstein interop a2a card --output card.json` mints a card carrying identity, advertised tools, supported policies (cost cap, redaction tier, sandbox profile), public key, and expiry. The card body is JCS-canonical JSON signed as a detached JWS with Ed25519, reusing the existing `agent_card_signer` primitives.
- Add the consume-side gate: fetch a peer card, verify the signature against a trusted-issuer fingerprint set, reject expired cards, and proceed only if advertised policies meet operator requirements (fail-closed ordinal comparison for redaction tier and sandbox profile).
- Add lineage-chain interop: wrap a signed tracker-audit chain into the A2A envelope under `bernstein.lineage_v2`; the receiving side appends a cross-org boundary marker to its own chain, reusing `core/lineage/tracker_audit.py` HMAC chain with no new signing primitive. The carried chain digest is recomputed on parse so in-transit tampering is detectable.
- Add `bernstein interop a2a verify --card card.json` (signature plus optional trusted-fingerprint and policy checks; exits non-zero on failure).
- Docs at `docs/interop/a2a.md`; new module under `src/bernstein/core/interop/`.

## Test plan

- [x] `pytest tests/unit/interop/` (34 tests: issue, consume, verify CLI, lineage wrap)
- [x] `pytest tests/unit/lineage/test_tracker_audit.py` and `tests/unit/test_a2a.py` unaffected
- [x] `ruff check` and `ruff format --check` clean on touched files
- [x] `lint-imports` contracts kept (core does not import cli)
- [x] CLI smoke: `interop a2a card` then `verify` round-trip, private key written 0600

Closes #1675