### PR TITLE
fix(api): reject invalid scope/complexity with 422 instead of 500

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -32,6 +32,7 @@ alwaysApply: false
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -319,10 +320,13 @@ alwaysApply: false
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -950,10 +950,17 @@ jobs:
         # `--no-deps` is safe: the exported file is fully pinned and the
         # transitive closure is resolved by `uv.lock`. `--disable-pip`
         # avoids spinning up a sub-venv just to run `pip install`.
-        run: uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps
+        #
+        # `--ignore-vuln PYSEC-2025-183` (CVE-2025-45768): disputed advisory
+        # against pyjwt that affects all released versions (introduced at 0,
+        # no fix version published) and is pulled in transitively via `mcp`.
+        # The maintainer disputes it because the key length is chosen by the
+        # calling application, not the library. There is nothing to upgrade
+        # to, so it is ignored with the rationale recorded here.
+        run: uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
       - name: Dev deps (advisory)
         continue-on-error: true
-        run: uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps
+        run: uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
 
   beartype:
     # Runtime type-check enforcement via beartype.claw. Imports the

--- a/.goosehints
+++ b/.goosehints
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from bernstein.core.bulletin import MessageType  # noqa: TC001 - Pydantic needs at runtime
 from bernstein.core.task_store import ProgressEntry  # noqa: TC001 - Pydantic needs at runtime
@@ -64,6 +64,26 @@ def _enforce_dict_size(value: dict[str, Any] | None, *, field_name: str) -> dict
     return value
 
 
+def _ensure_task_enum(value: str, field_name: str) -> str:
+    """Reject scope/complexity values outside their Task enum at the API boundary.
+
+    These fields stay typed as ``str`` for backward compatibility, so without
+    this check an out-of-range value (e.g. ``""``) passes pydantic and then
+    raises ``ValueError`` deep in the task store when ``Scope(value)`` /
+    ``Complexity(value)`` is constructed, surfacing as an unhandled 500.
+    Raising here turns that into a 422.
+    """
+    from bernstein.core.tasks.models import Complexity, Scope
+
+    enum_cls = Scope if field_name == "scope" else Complexity
+    try:
+        enum_cls(value)
+    except ValueError:
+        valid = ", ".join(m.value for m in enum_cls)
+        raise ValueError(f"{field_name} must be one of: {valid}") from None
+    return value
+
+
 class TaskCreate(BaseModel):
     """Body for POST /tasks."""
 
@@ -106,6 +126,11 @@ class TaskCreate(BaseModel):
     max_output_tokens: int | None = None  # Per-task output-token cap (escalated on retry)
     meta_messages: list[str] | None = Field(default=None, max_length=_MAX_LIST_LEN)
 
+    @field_validator("scope", "complexity")
+    @classmethod
+    def _validate_scope_complexity(cls, value: str, info: ValidationInfo) -> str:
+        return _ensure_task_enum(value, info.field_name or "")
+
     # cap serialized size of dict-of-any fields to block deeply-nested
     # or very wide payloads from wedging the server at pydantic-validation time.
     def model_post_init(self, _context: Any) -> None:
@@ -140,6 +165,11 @@ class TaskSelfCreate(BaseModel):
     estimated_minutes: int | None = None
     depends_on: list[str] = Field(default_factory=list)
     owned_files: list[str] = Field(default_factory=list)
+
+    @field_validator("scope", "complexity")
+    @classmethod
+    def _validate_scope_complexity(cls, value: str, info: ValidationInfo) -> str:
+        return _ensure_task_enum(value, info.field_name or "")
 
 
 class WebhookTaskCreate(TaskCreate):

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -155,6 +155,32 @@ def test_task_create_happy_path_still_works() -> None:
 
 
 # ---------------------------------------------------------------------------
+# scope / complexity enum validation at the API boundary (reject -> 422)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["scope", "complexity"])
+@pytest.mark.parametrize("bad", ["", "MEDIUM", "huge", "n/a"])
+def test_task_create_rejects_invalid_scope_complexity(field: str, bad: str) -> None:
+    """Out-of-range scope/complexity is rejected by pydantic, not deferred to a 500.
+
+    Empty / wrong-case / unknown values used to pass validation and then raise
+    ValueError when ``Scope(value)`` / ``Complexity(value)`` ran in the store.
+    """
+    with pytest.raises(ValidationError):
+        TaskCreate(title="ok", description="ok", **{field: bad})
+
+
+@pytest.mark.parametrize("scope", ["small", "medium", "large"])
+@pytest.mark.parametrize("complexity", ["low", "medium", "high"])
+def test_task_create_accepts_valid_scope_complexity(scope: str, complexity: str) -> None:
+    """Every valid enum value is still accepted."""
+    t = TaskCreate(title="ok", description="ok", scope=scope, complexity=complexity)
+    assert t.scope == scope
+    assert t.complexity == complexity
+
+
+# ---------------------------------------------------------------------------
 # ContentLengthMiddleware: oversized Content-Length header -> 413
 # ---------------------------------------------------------------------------
 
@@ -354,3 +380,39 @@ def test_post_tasks_small_payload_still_works(_app_with_auth_disabled) -> None:
     status, body = asyncio.run(_run())
     assert status == 201, body
     assert body["title"] == "ok"
+
+
+def test_post_tasks_empty_complexity_returns_422_not_500(_app_with_auth_disabled) -> None:
+    """POST /tasks with complexity="" must 422, never 500 (regression).
+
+    Schemathesis fuzzing surfaced an unhandled 500 here: the empty string
+    passed pydantic and then raised ValueError in the task store.
+    """
+    transport = ASGITransport(app=_app_with_auth_disabled)
+    import asyncio
+
+    async def _run() -> int:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/tasks",
+                json={"title": "x", "description": "x", "complexity": ""},
+            )
+            return resp.status_code
+
+    assert asyncio.run(_run()) == 422
+
+
+def test_post_tasks_batch_invalid_scope_returns_422_not_500(_app_with_auth_disabled) -> None:
+    """POST /tasks/batch with an invalid scope must 422, never 500 (regression)."""
+    transport = ASGITransport(app=_app_with_auth_disabled)
+    import asyncio
+
+    async def _run() -> int:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/tasks/batch",
+                json={"tasks": [{"title": "x", "description": "x", "scope": "nope"}]},
+            )
+            return resp.status_code
+
+    assert asyncio.run(_run()) == 422


### PR DESCRIPTION
## Summary

Main is red on three independent checks. This PR fixes all three so one merge restores green:

1. **Schemathesis smoke (intermittent 500).** `TaskCreate.scope` / `complexity` (and `TaskSelfCreate`) were plain `str`. An empty or out-of-range value passed pydantic, then raised `ValueError` when the store built `Scope(value)` / `Complexity(value)` at `task_store_core.py:857` / `:1016`, surfacing as a 500 on `POST /tasks` and `POST /tasks/batch`. Schemathesis flagged it only on runs that happened to fuzz an invalid value, so it looked flaky. Fixed with boundary `field_validator`s that return 422; fields stay `str` (backward compatible).
2. **pip-audit (deps).** Ignore PYSEC-2025-183 (CVE-2025-45768), a disputed pyjwt advisory with no fix version, pulled in transitively via `mcp`. Rationale recorded inline in `ci.yml`.
3. **docs-drift / Repo hygiene.** The interop module landed without regenerating agent-context files. Ran `agents-md sync` to refresh AGENTS.md, CLAUDE.md, CONVENTIONS.md, .goosehints, and the cursor module map.

Supersedes #1695 (pip-audit + spelling; spelling already on main) and #1701 (agents-md sync).

## Tests

- Unit: invalid scope/complexity (`""`, wrong case, unknown) rejected; all valid enum values accepted.
- End-to-end: `POST /tasks` `complexity=""` and `POST /tasks/batch` invalid `scope` both return 422, never 500.
- `scripts/check_docs_drift.py --strict` reports no drift.