### PR TITLE
chore(docs): sync agent-context files for the interop module

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -32,6 +32,7 @@ alwaysApply: false
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -319,10 +320,13 @@ alwaysApply: false
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/.goosehints
+++ b/.goosehints
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -33,6 +33,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
 | `identity/`             | Install-rev identity module — passive, operator-decodable install fingerprint |
 | `integrations/`         | Integrations sub-package |
+| `interop/`              | Cross-organisation interoperability surfaces |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
 | `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
@@ -320,10 +321,13 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `capability.py`       | Runtime capability cards for the Bernstein MCP server |
+| `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
+| `streaming.py`        | In-flight tool-call tracking with cancellation and partial-result preservation |
 | `resources/`          | MCP resource registrars for Bernstein |
 | `tool_schemas/`       | tool_schemas/ sub-package |
 


### PR DESCRIPTION
## Summary

The `core/interop/` package landed without regenerating the agent-context files, so the `docs-drift` gate on main fails (`AGENTS.md`, `CLAUDE.md`, `CONVENTIONS.md`, `.goosehints`, `.cursor/rules/module-map.mdc` all drift).

Ran `bernstein agents-md sync` to refresh them. `scripts/check_docs_drift.py --strict` now reports no drift.

## Files

- `AGENTS.md`, `CLAUDE.md`, `CONVENTIONS.md`, `.goosehints`, `.cursor/rules/module-map.mdc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module documentation and indexing to reflect structural changes in the core orchestration and MCP server modules. No user-facing functionality affected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->