### PR TITLE
fix(repo): turn main green - dedupe typos key and sync substrate module map

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -58,6 +58,7 @@ alwaysApply: false
 | `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
 | `tasks/`                | tasks sub-package |
 | `telemetry/`            | Opt-in operator observability for Bernstein |
 | `tokens/`               | tokens sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -59,6 +59,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
 | `tasks/`                | tasks sub-package |
 | `telemetry/`            | Opt-in operator observability for Bernstein |
 | `tokens/`               | tokens sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
 | `tasks/`                | tasks sub-package |
 | `telemetry/`            | Opt-in operator observability for Bernstein |
 | `tokens/`               | tokens sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
 | `tasks/`                | tasks sub-package |
 | `telemetry/`            | Opt-in operator observability for Bernstein |
 | `tokens/`               | tokens sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -59,6 +59,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
 | `tasks/`                | tasks sub-package |
 | `telemetry/`            | Opt-in operator observability for Bernstein |
 | `tokens/`               | tokens sub-package |

--- a/typos.toml
+++ b/typos.toml
@@ -25,7 +25,6 @@ mis = "mis"          # false positive on partial words
 hel = "hel"          # truncated stream-chunk fixture "hel"+"lo" (test_client_hardened.py)
 fo = "fo"            # fo = fan_out (test_complexity_correlation.py)
 thr = "thr"          # thr = threshold (scripts/mutmut_critical.py)
-hel = "hel"          # truncated stream chunk "hel" + "lo" = "hello" (test_client_hardened.py)
 Aktive = "Aktive"    # correct German word for "Active" (i18n.py)
 
 # Technical terms used consistently in the codebase


### PR DESCRIPTION
## Summary
- Remove the duplicate `hel` key in `typos.toml`. The merge of #1695 added a second `hel = "hel"` entry; the current typos CLI rejects the duplicate key as a fatal TOML parse error, which broke the Spelling check on main.
- Regenerate the cross-CLI module map (AGENTS.md / CLAUDE.md / CONVENTIONS.md / .goosehints / .cursor) via `bernstein agents-md sync` to add the new `substrate/` sub-package, fixing the Repo hygiene drift check.

## Test plan
- [ ] `typos --config typos.toml` exits 0 (Spelling check)
- [ ] `uv run bernstein agents-md verify --workdir .` reports all files in sync (Repo hygiene check)
- [ ] CI gate green