### PR TITLE
docs(release): add v2.5.0 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable project changes are tracked here (code + docs).
 
+## [2.5.0] - Interoperability surfaces, host portability, deterministic replay
+
+22 commits since v2.4.0. Full notes: [`docs/release-notes/v2.5.0.md`](docs/release-notes/v2.5.0.md).
+
+### Added
+
+- A2A capability cards as a first-class interop primitive: `bernstein interop a2a card` / `verify`, signature plus expiry plus trusted-issuer verification on consume, and the signed lineage chain carried through the A2A envelope with a cross-organisation boundary marker (#1698).
+- Hardened MCP client: capability-card validation before each tool call, retry-with-continuation on dropped streams, streamed-output cancellation, per-server cost metering, and schema-violation containment that degrades a misbehaving server instead of failing the run (#1692).
+- MCP server protocol-surface gaps closed to match the hardened client (#1696).
+- Tiered MCP tool exposure behind a context-budget knob (#1685).
+- `bernstein desktop-register --host <name>` installs Bernstein into Claude Desktop and Claude Code via a per-host adapter (#1697).
+- Portable side-channel telemetry behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN`, plus `bernstein telemetry probe` for backend verification (#1691).
+- Deterministic session-id binding for replay isolation (#1684).
+- Supervisor respawn budget with park-on-exhaustion (#1683).
+- Versioned migrations module for on-disk state (#1689).
+- Memorable deterministic run names in user-facing surfaces (#1682, #1626).
+- Per-adapter strategy enums for resume, dangerous-mode, and event channel (#1690).
+- Permission-rule prefilter on lifecycle hooks before spawn (#1680).
+- Strict structured-output schemas with a user-field blacklist (#1681).
+- Consensus scoring with detected-by provenance on review findings (#1686).
+- Tiered, cost-tuned memory compaction (#1687).
+
+### Changed
+
+- Runtime `python:3.13-slim` Docker digest bumped to `e544a7f`, staying on the pinned 3.13 line (#1699).
+
+### Fixed
+
+- `TaskCreate` / `TaskSelfCreate` validate `scope` and `complexity` at the request boundary and return `422` for empty or out-of-range values, instead of raising `ValueError` in the task store and surfacing an unhandled `500` on `POST /tasks` and `POST /tasks/batch` (#1700).
+- Shipped package no longer hardcodes operator-private infrastructure hosts as defaults; observability and telemetry backends soft-fail or no-op when unset, with a regression test asserting zero operator-private host, IP, or DSN matches in `src/` (#1694).
+- Dependency audit ignores the disputed, fix-less pyjwt advisory PYSEC-2025-183 (CVE-2025-45768), pulled in transitively via `mcp`, with the rationale recorded inline (#1695).
+- Agent-context files (`AGENTS.md`, `CLAUDE.md`, `CONVENTIONS.md`, `.goosehints`, cursor module map) re-synced for the `interop` and `substrate` modules; duplicate spell-check allow-list key removed; MCP client test fixture no longer relies on a spell-check allow-list entry (#1701, #1702, #1693).
+
 ## [2.4.0] - Observability surfaces, single-writer run state, declarative planning gates
 
 33 commits since v2.3.1. Full notes: [`docs/release-notes/v2.4.0.md`](docs/release-notes/v2.4.0.md).

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -1,0 +1,54 @@
+# v2.5.0 - Interoperability surfaces, host portability, deterministic replay
+
+**Release date:** 2026-05-20
+**Commits since v2.4.0:** 22
+
+## Highlights
+
+- A2A capability cards land as a first-class interop primitive: `bernstein interop a2a card` mints a signed manifest (identity, advertised tools, supported policies, public key, expiry), `consume_peer_card` verifies signature, expiry, and trusted-issuer set before delegating, and the existing signed lineage chain rides through the A2A envelope so a delegated run stays auditable across an organisation boundary.
+- The MCP client now treats upstream servers as untrusted and brittle: capability-card validation before each tool call, retry-with-continuation on dropped streams, streamed-output cancellation without leaks, per-server cost metering, and schema-violation containment that marks a misbehaving server degraded instead of taking the run down.
+- Bernstein can register itself into the hosts operators already run: `bernstein desktop-register --host claude-desktop` (and `claude-code`) writes the host-specific manifest entry so the orchestrator's tools and routes are available without manual wiring.
+- Side-channel telemetry is portable across hosts behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN`, and the shipped package no longer carries any operator-private host defaults: every observability and telemetry backend soft-fails or no-ops when its env vars are unset, so a fresh install never reaches an operator's private infrastructure.
+- Replay isolation is now deterministic: session ids are bound deterministically so a replayed run reproduces its own event stream, on-disk state has a versioned migrations module, and runs surface memorable deterministic names in user-facing output instead of opaque ids.
+- The API rejects invalid `scope` / `complexity` at the request boundary with `422` instead of constructing the enum deep in the task store and surfacing an unhandled `500`, closing an intermittent fuzzer-found crash on `POST /tasks` and `POST /tasks/batch`.
+
+## What ships
+
+### Interoperability
+
+- **A2A capability cards plus lineage interop** (#1698). `bernstein interop a2a card --output card.json` mints a detached-JWS-signed capability card over a JCS-canonicalised body (identity, advertised tools, policies for cost cap / redaction tier / sandbox profile, public key, expiry). `consume_peer_card` verifies the signature, rejects expired cards, checks the trusted-issuer fingerprint, and fail-closes on a policy gate. A `bernstein.lineage_v2` envelope field wraps the existing HMAC lineage chain; the receiver appends a cross-organisation boundary marker so tampering in transit is detectable. `bernstein interop a2a verify --card card.json` confirms a peer card. Docs at `docs/interop/a2a.md`.
+- **Hardened MCP client** (#1692). Capability-card validation before issuing a tool call (`MCPCapabilityMissing` on mismatch, logged with the manifest digest), retry-with-continuation from the server's last-checkpoint token with idempotency-key fall-back and a configurable retry cap, in-flight streamed-output cancellation that preserves partial output, a per-server-per-task cost meter wired into `core/cost/`, and schema-violation containment that marks a server degraded for the rest of the task and surfaces the fault through the tracker contract. Docs at `docs/mcp/client.md`.
+- **MCP server protocol-surface gaps closed** (#1696). Fills the remaining gaps in the MCP server's exposed protocol surface so the server side matches the hardened client's expectations.
+- **Tiered MCP tool exposure** (#1685). A context-budget knob exposes MCP tools in tiers, so a large upstream tool catalogue does not blow the context budget on every call.
+- **Substrate desktop-register** (#1697). `bernstein desktop-register --host <name>` performs the host-specific install (config-file path, manifest entry, restart hint) for Claude Desktop and Claude Code, with a small per-host adapter translating Bernstein's surface into the host's plugin spec. Rejects `--list` combined with `--host`. Docs under `docs/substrate/`.
+
+### Host portability and privacy
+
+- **Portable side-channel telemetry** (#1691). Consolidates the telemetry emitters behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN` so the same env var, wire format, and default backend work on every host. Adds `bernstein telemetry probe` to emit a synthetic event for backend verification. Docs at `docs/observability/side-channel.md`.
+- **Operator infrastructure defaults removed from the package** (#1694). The shipped package no longer hardcodes any operator-private host as a default (no `errors`/`sonar`/`telemetry`/`dt` host defaults baked into `src/`). Backends read their host from the env or the DSN host and otherwise soft-fail or no-op, so a fresh install never reaches private infrastructure. A `tests/unit/observability/test_no_hardcoded_infra.py` regression asserts zero operator-private host, IP, or DSN matches in `src/`.
+
+### Reliability and determinism
+
+- **Deterministic session-id binding for replay isolation** (#1684). Session ids are bound deterministically so a replayed run reproduces its own isolated event stream rather than colliding with or leaking into another session's state.
+- **Supervisor respawn budget with park-on-exhaustion** (#1683). The supervisor enforces a bounded respawn budget and parks an agent once the budget is exhausted instead of looping respawns indefinitely.
+- **Versioned migrations for on-disk state** (#1689). A versioned migrations module brings on-disk state under explicit, ordered schema migrations so an older state directory upgrades predictably.
+- **Memorable deterministic run names** (#1682, #1626). User-facing surfaces show a deterministic memorable name for each run instead of an opaque id, derived deterministically so the same run always renders the same name.
+- **Per-adapter strategy enums** (#1690). Resume behaviour, dangerous-mode handling, and event-channel selection move to explicit per-adapter strategy enums instead of scattered ad-hoc flags.
+
+### Safety
+
+- **Permission-rule prefilter on hooks before spawn** (#1680). Permission rules are evaluated as a prefilter on lifecycle hooks before an agent is spawned, so a denied action is caught ahead of process launch.
+- **Strict structured-output schemas with user-field blacklist** (#1681). Adapter structured-output schemas are tightened and a user-field blacklist prevents caller-supplied fields from overriding orchestrator-controlled output.
+- **Boundary validation for scope and complexity** (#1700). `TaskCreate` / `TaskSelfCreate` validate `scope` and `complexity` against their enums at the request boundary, returning `422` for empty or out-of-range values instead of raising `ValueError` deep in the task store and surfacing a `500`. Fields stay typed as `str` for backward compatibility. Unit and end-to-end tests cover the `POST /tasks` and `POST /tasks/batch` paths.
+- **Disputed pyjwt advisory ignored with rationale** (#1695). The dependency audit ignores PYSEC-2025-183 (CVE-2025-45768), a disputed pyjwt advisory with no published fix version, pulled in transitively via `mcp`. The rationale is recorded inline in the workflow.
+
+### Quality and memory
+
+- **Consensus scoring with detected-by provenance** (#1686). Review findings carry detected-by provenance and a consensus score, so a finding flagged by multiple reviewers is weighted distinctly from a single-reviewer signal.
+- **Tiered memory compaction** (#1687). Memory compaction runs in cost-tuned tiers so older context is compacted at a strategy matched to its retrieval value.
+
+### Maintenance
+
+- **Runtime image digest bump** (#1699). Updates the `python:3.13-slim` Docker digest to `e544a7f`, staying on the pinned 3.13 line.
+- **Agent-context files kept in sync** (#1701, #1702). `agents-md sync` regenerates `AGENTS.md`, `CLAUDE.md`, `CONVENTIONS.md`, `.goosehints`, and the cursor module map for the new `interop` and `substrate` modules, and the duplicate spell-check allow-list key is removed.
+- **Spell-check fixture cleanup** (#1693). The MCP client test fixture avoids the truncated stream-chunk string that tripped the spell checker, rather than relying on an allow-list entry.


### PR DESCRIPTION
## Summary

Curated changelog and release notes for the 22 commits merged since v2.4.0, grouped by theme:

- **Interoperability** - A2A capability cards + lineage interop (#1698), hardened MCP client (#1692), MCP server protocol-surface gaps (#1696), tiered MCP tool exposure (#1685), substrate desktop-register (#1697).
- **Host portability and privacy** - portable side-channel telemetry (#1691), operator-infrastructure defaults removed from the shipped package (#1694).
- **Deterministic replay** - session-id binding (#1684), supervisor respawn budget (#1683), versioned state migrations (#1689), memorable run names (#1682), per-adapter strategy enums (#1690).
- **Safety** - permission-rule prefilter (#1680), structured-output schemas (#1681), scope/complexity 422 boundary validation (#1700), disputed pyjwt advisory ignore (#1695).
- **Quality and memory** - consensus scoring with provenance (#1686), tiered memory compaction (#1687).

Adds `docs/release-notes/v2.5.0.md` and a `[2.5.0]` CHANGELOG section. The version bump itself is left to the minor-release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A2A capability cards and lineage support
  * Desktop registration
  * Deterministic replay sessions

* **Improvements**
  * Enhanced MCP interoperability
  * Portable telemetry and privacy controls
  * Stricter safety validation
  * Performance and reliability enhancements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->