### PR TITLE
chore(release): v2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.4.0"
+version = "2.5.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

Bump pyproject and `uv.lock` to v2.5.0. Release notes already on main at `docs/release-notes/v2.5.0.md` (added in #1703).

**Theme**: interoperability surfaces, host portability, deterministic replay. 22 commits since v2.4.0.

Highlights:

- A2A capability cards + lineage interop (#1698)
- Hardened MCP client + protocol-surface gaps closed (#1692, #1696)
- `bernstein desktop-register` for Claude Desktop / Claude Code (#1697)
- Portable side-channel telemetry; operator-infra defaults removed from the shipped package (#1691, #1694)
- Deterministic replay: session-id binding, versioned state migrations, memorable run names (#1684, #1689, #1682)
- Boundary `422` for invalid scope / complexity instead of `500` (#1700)

After merge: tag `v2.5.0` and create the GH release pointing at `docs/release-notes/v2.5.0.md`.

## Summary by Sourcery

Release version 2.5.0 by updating project metadata and lockfile for distribution.

Build:
- Update package version in pyproject configuration to 2.5.0.
- Refresh uv.lock to align dependency lockfile with the new release version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.5.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->