### PR TITLE
fix(security): resolve CodeQL/Semgrep/workflow code-scanning alerts

### DIFF
--- a/src/bernstein/bridges/r2_sync.py
+++ b/src/bernstein/bridges/r2_sync.py
@@ -522,8 +522,10 @@ class R2WorkspaceSync:
                     status_code=resp.status_code,
                 )
 
-        # Parse S3 XML response — extract <Key> elements
-        import xml.etree.ElementTree as ET
+        # Parse S3 XML response - extract <Key> elements. The body is an
+        # external HTTP response, so use defusedxml to block entity-expansion
+        # and external-entity attacks that the stdlib parser is vulnerable to.
+        import defusedxml.ElementTree as ET
 
         keys: list[str] = []
         try:

--- a/src/bernstein/core/git/git_hygiene.py
+++ b/src/bernstein/core/git/git_hygiene.py
@@ -64,7 +64,9 @@ def _rmtree_windows_safe(path: Path, max_attempts: int = 3) -> bool:
     def _onerror(func: Callable[[str], object], fpath: str, exc_info: object) -> None:
         """Handle permission errors by making file writable and retrying."""
         with contextlib.suppress(OSError):
-            os.chmod(fpath, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            # Owner-write is sufficient to let the current process delete the
+            # file; do not grant group/other write (avoids world-writable).
+            os.chmod(fpath, stat.S_IWUSR)
             func(fpath)
 
     is_windows = sys.platform == "win32"

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -520,7 +520,9 @@ def _worktree_manual_delete(cwd: Path, path: Path) -> GitResult | None:
     def _onerror(func, fpath, _exc_info):  # type: ignore[no-untyped-def]
         """Clear read-only flag and retry; ignore if still locked."""
         with suppress(OSError):
-            os.chmod(fpath, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            # Owner-write is enough for this process to delete the file;
+            # avoid granting group/other write (no world-writable bit).
+            os.chmod(fpath, stat.S_IWUSR)
             func(fpath)
 
     try:

--- a/src/bernstein/core/memory/compaction/time_based.py
+++ b/src/bernstein/core/memory/compaction/time_based.py
@@ -33,9 +33,17 @@ COST_WEIGHT: float = TIER_COST_WEIGHT[Tier.TIME_BASED]
 IDLE_THRESHOLD_SECONDS: float = defaults.COMPACTION.idle_threshold_seconds
 
 # Matches a block opening with an age tag, capturing the age and the block
-# body up to the next blank-line boundary.
+# body up to the next age-tagged boundary (or end of text).
+#
+# The body is consumed one whole line at a time via ``(?:\n(?!\[age:)[^\n]*)*``
+# where every iteration mandatorily starts with a ``\n`` and the negative
+# lookahead stops it at the next ``[age:`` boundary. Because each iteration
+# anchors on a distinct newline there is no overlapping/ambiguous split, so
+# the engine cannot backtrack exponentially (CodeQL py/redos). The original
+# lazy form ``(?:[^\n]*\n?)*?`` allowed the same offset to be reached many
+# ways, which was the source of the catastrophic backtracking.
 _AGED_BLOCK_RE = re.compile(
-    r"\[age:(\d+)\][^\n]*\n(?:[^\n]*\n?)*?(?=\n\[age:|\n*\Z)",
+    r"\[age:(\d+)\][^\n]*(?:\n(?!\[age:)[^\n]*)*",
 )
 
 

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -197,7 +197,8 @@ def _rmtree_windows_safe(path: Path, max_attempts: int = 3) -> bool:
         with contextlib.suppress(OSError):
             # Intentional: clear read-only flag on internal worktree files
             # during cleanup so shutil.rmtree can delete them (Windows).
-            os.chmod(fpath, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            # Owner-write is sufficient; do not grant group/other write.
+            os.chmod(fpath, stat.S_IWUSR)
             func(fpath)
 
     attempts = max_attempts if sys.platform == "win32" else 1

--- a/src/bernstein/core/routes/auth.py
+++ b/src/bernstein/core/routes/auth.py
@@ -264,12 +264,7 @@ def _login_success_page(display_name: str, role: str, token: str) -> HTMLRespons
     """
     safe_name = html.escape(display_name)
     safe_role = html.escape(role)
-    js_token = (
-        json.dumps(token)
-        .replace("<", "\\u003c")
-        .replace(">", "\\u003e")
-        .replace("&", "\\u0026")
-    )
+    js_token = json.dumps(token).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
     return HTMLResponse(
         content=f"""<!DOCTYPE html>
 <html><head><title>Login Successful</title></head>

--- a/src/bernstein/core/routes/auth.py
+++ b/src/bernstein/core/routes/auth.py
@@ -11,6 +11,7 @@ Provides endpoints for:
 from __future__ import annotations
 
 import html
+import json
 import logging
 import secrets
 import time
@@ -247,14 +248,36 @@ async def oidc_callback(request: Request) -> Response:
 
     user, token = result
     # Return a page that stores the token and redirects to dashboard
+    return _login_success_page(user.display_name, user.role.value, token)
+
+
+def _login_success_page(display_name: str, role: str, token: str) -> HTMLResponse:
+    """Render the post-login page that stashes the session token.
+
+    ``display_name`` and ``role`` originate from IdP-supplied claims, so
+    they are HTML-escaped before being placed in element text. ``token``
+    is embedded inside a JavaScript string literal inside a ``<script>``
+    block, so it is JSON-encoded (a safe, fully quoted JS string) and the
+    HTML-significant characters ``<``, ``>`` and ``&`` are then escaped to
+    ``\\uXXXX`` so a value containing ``</script>`` cannot break out of
+    the script element.
+    """
+    safe_name = html.escape(display_name)
+    safe_role = html.escape(role)
+    js_token = (
+        json.dumps(token)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
     return HTMLResponse(
         content=f"""<!DOCTYPE html>
 <html><head><title>Login Successful</title></head>
 <body>
-<h2>Welcome, {user.display_name}!</h2>
-<p>Role: {user.role.value} | Redirecting to dashboard...</p>
+<h2>Welcome, {safe_name}!</h2>
+<p>Role: {safe_role} | Redirecting to dashboard...</p>
 <script>
-localStorage.setItem('bernstein_token', '{token}');
+localStorage.setItem('bernstein_token', {js_token});
 window.location.href = '/dashboard';
 </script>
 </body></html>"""
@@ -294,18 +317,7 @@ async def saml_acs(request: Request) -> Response:
         )
 
     user, token = result
-    return HTMLResponse(
-        content=f"""<!DOCTYPE html>
-<html><head><title>Login Successful</title></head>
-<body>
-<h2>Welcome, {user.display_name}!</h2>
-<p>Role: {user.role.value} | Redirecting to dashboard...</p>
-<script>
-localStorage.setItem('bernstein_token', '{token}');
-window.location.href = '/dashboard';
-</script>
-</body></html>"""
-    )
+    return _login_success_page(user.display_name, user.role.value, token)
 
 
 @router.get("/saml/metadata", responses={503: {"description": "SSO authentication not configured"}})

--- a/src/bernstein/core/routes/telemetry_webhooks.py
+++ b/src/bernstein/core/routes/telemetry_webhooks.py
@@ -181,8 +181,11 @@ async def _handle_source(
 
     try:
         payload = parse_json_payload(raw_body)
-    except ValueError as exc:
-        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except ValueError:
+        # Do not echo the parser exception text back to the caller: it can
+        # leak internal structure. Log server-side, return a generic 400.
+        logger.warning("telemetry_webhooks: malformed payload for source %s", source)
+        return JSONResponse(status_code=400, content={"detail": "malformed JSON payload"})
 
     adapter = state.sources.get(source)
     if adapter is None:
@@ -193,11 +196,13 @@ async def _handle_source(
 
     try:
         event = adapter.parse(payload)
-    except Exception as exc:
+    except Exception:
+        # Full traceback is logged server-side; the response carries only a
+        # generic message so adapter internals are never exposed to callers.
         logger.exception("telemetry_webhooks: adapter raised for %s", source)
         return JSONResponse(
             status_code=400,
-            content={"detail": f"adapter {source!r} could not parse payload: {exc}"},
+            content={"detail": f"adapter {source!r} could not parse payload"},
         )
 
     record = dispatch_telemetry_event(

--- a/src/bernstein/core/routes/tracker_webhooks.py
+++ b/src/bernstein/core/routes/tracker_webhooks.py
@@ -120,7 +120,7 @@ async def tracker_webhook(adapter: str, request: Request) -> JSONResponse:
                 "Tracker webhook accepted adapter=%s id=%s ticket=%s",
                 sanitize_log(adapter),
                 sanitize_log(str(result.delivery_id)),
-                result.event.ticket.id,
+                sanitize_log(str(result.event.ticket.id)),
             )
 
     return _status_to_response(result)

--- a/src/bernstein/core/routes/tracker_webhooks.py
+++ b/src/bernstein/core/routes/tracker_webhooks.py
@@ -29,6 +29,7 @@ import logging
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.trackers.webhook_receiver import (
     ReceiveResult,
     WebhookReceiver,
@@ -110,15 +111,15 @@ async def tracker_webhook(adapter: str, request: Request) -> JSONResponse:
             except Exception as exc:  # boundary
                 logger.warning(
                     "Tracker webhook queue rejected event adapter=%s id=%s: %s",
-                    adapter,
-                    result.delivery_id,
+                    sanitize_log(adapter),
+                    sanitize_log(str(result.delivery_id)),
                     exc,
                 )
         else:
             logger.info(
                 "Tracker webhook accepted adapter=%s id=%s ticket=%s",
-                adapter,
-                result.delivery_id,
+                sanitize_log(adapter),
+                sanitize_log(str(result.delivery_id)),
                 result.event.ticket.id,
             )
 

--- a/src/bernstein/core/trackers/webhook_receiver.py
+++ b/src/bernstein/core/trackers/webhook_receiver.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from pathlib import Path
 
+from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.trackers.contract import RoutingHint, Ticket
 from bernstein.core.webhook_signatures import verify_hmac_sha256
 
@@ -320,7 +321,7 @@ class WebhookReceiver:
         try:
             event = handler.parse_event(lower_headers, payload)
         except Exception as exc:  # boundary
-            logger.debug("Parser raised for adapter=%s: %s", adapter, exc)
+            logger.debug("Parser raised for adapter=%s: %s", sanitize_log(adapter), exc)
             return ReceiveResult(status="bad_payload", delivery_id=delivery_id)
 
         # Record only after successful parse so a flaky parser does not

--- a/src/bernstein/core/trackers/webhook_receiver.py
+++ b/src/bernstein/core/trackers/webhook_receiver.py
@@ -321,7 +321,14 @@ class WebhookReceiver:
         try:
             event = handler.parse_event(lower_headers, payload)
         except Exception as exc:  # boundary
-            logger.debug("Parser raised for adapter=%s: %s", sanitize_log(adapter), exc)
+            # The exception text can echo payload fragments; sanitize so
+            # an attacker-controlled body cannot inject CR/LF into log
+            # lines via the parser-failure path.
+            logger.debug(
+                "Parser raised for adapter=%s: %s",
+                sanitize_log(adapter),
+                sanitize_log(str(exc)),
+            )
             return ReceiveResult(status="bad_payload", delivery_id=delivery_id)
 
         # Record only after successful parse so a flaky parser does not


### PR DESCRIPTION
## Summary

Triages every open non-refurb code-scanning alert (CodeQL, Semgrep, zizmor, Scorecard). 12 alerts fixed in code; 23 dismissed on the dashboard with per-alert technical justifications. Refurb (FURB*) alerts intentionally left alone (handled in parallel branches).

## Fixed in code (12 alerts)

| Rule | Count | File(s) | Fix |
|------|------:|---------|-----|
| py/use-defused-xml | 1 | bridges/r2_sync.py | Parse S3 XML LIST response via defusedxml.ElementTree (external HTTP response, was xml.etree). |
| python.django.security.injection.raw-html-format | 2 | core/routes/auth.py | OIDC + SAML success pages: html.escape() display_name/role, JSON-encode the session token with <, >, & escaped to \uXXXX so a `</script>` value cannot break out of the script block. Extracted into `_login_success_page` helper. |
| py/stack-trace-exposure | 2 | core/routes/telemetry_webhooks.py | Stop echoing the raw parser/adapter exception text in 400 responses; log server-side, return a generic message. |
| py/redos | 1 | core/memory/compaction/time_based.py | Rewrite `_AGED_BLOCK_RE` from the catastrophically-ambiguous lazy form to a non-ambiguous line-at-a-time form anchored on \n with a negative lookahead. Linear on the previous worst case (verified 40k chars in 2 ms); also correctly matches blocks the old regex silently missed. |
| python.lang.security.audit.insecure-file-permissions | 3 | core/git/git_hygiene.py, core/git/git_pr.py, core/orchestration/drain.py | rmtree `onerror` handlers were chmodding to `S_IWUSR\|S_IWGRP\|S_IWOTH` (world-writable). Owner-write alone suffices to delete; drop the group/other write bits. |
| py/log-injection | 3 | core/routes/tracker_webhooks.py, core/trackers/webhook_receiver.py | Route the attacker-controllable `adapter` path param and the header-derived `delivery_id` through `sanitize_log()` before they reach the logger, blocking CR/LF log forging. |

## Dismissed on the dashboard (23 alerts)

Each carries a specific technical justification.

| Rule | Count | Why dismissed |
|------|------:|---------------|
| pickle/avoid-pickle (fingerprint memo cache) | 3 | Process-local content-addressed disk cache: loads only files this same process wrote under a sha256 digest path. No network/user bytes reach `pickle.loads`. Corrupt entries are unlinked. |
| pickle/avoid-pickle (cache_cmd action-cache replay) | 1 | Loads local `.sdd/runtime/action_cache/` records the CLI itself wrote earlier; never ingests remote/user bytes. |
| pickle/avoid-pickle (duration_predictor model) | 2 | Model bytes are HMAC-verified via `_verify_model_hmac` before `pickle.loads` and refused on mismatch. |
| eval-detected (formal_verification) | 2 | Evaluates an operator-authored property invariant from bernstein.yaml (config DSL) with `__builtins__={}` so no builtins/imports are reachable; namespace restricted to typed Z3 vars / concrete context values. |
| dangerous-os-exec-tainted-env-args | 1 | `os.execv(sys.executable, [sys.executable, *sys.argv])` is a process self-restart. Argv is exactly what this trusted process was launched with; no shell. |
| dangerous-subprocess-use-tainted-env-args | 1 | bernstein-worker exists to spawn an adapter command supplied as an argv list by the orchestrator. `Popen` uses a list with `shell=False`; session id is regex-validated. |
| logger-credential-leak + py/clear-text-logging-sensitive-data | 2 | The broker logs only non-secret identifiers (`token_id`, `secret_name`, `task_id`, `ttl`, `reason`). `secret_name` is the lookup key (e.g. `GITHUB_TOKEN`), never the secret value. |
| avoid-insecure-deserialization (yaml) | 1 | Code uses `yaml.safe_load` (recommended safe API, never constructs arbitrary Python objects); rule fires on any 'yaml' usage. |
| raw-html-format (auth.py:223) | 1 | The interpolated `error_description` is already `html.escape()`'d before being placed in the HTML string. |
| TokenPermissionsID | 3 | Workflow defaults are read-only or `permissions: {}`. The single escalating job in each workflow needs the minimum scopes for its documented purpose (post PR check annotations, open a quarantine PR, open a sweep PR). |
| PinnedDependenciesID (setup-python @ trend-scan.yml:45) | 1 | The action is already SHA-pinned to `a309ff8b...`; alert is stale. |
| PinnedDependenciesID (pip install) | 4 | `pip install -e .` installs the project's own checked-out source; hash-pinning isn't meaningful. Dependency integrity is enforced via `uv.lock`. |
| zizmor/dangerous-triggers | 1 | The `workflow_run` trigger here runs with `contents: read + actions: read` only, `persist-credentials: false`, no untrusted PR code with write scope. Not the pwn-request pattern. |

## Verification

- `uv run ruff check src/` clean on the changed files (CI's exact ruff scope).
- `uv run ruff format --check src/` clean.
- 407 unit tests run locally across every changed surface pass (compaction tiers, formal verification, git hygiene, git PR, r2_sync, sanitize, tracker webhook receiver, auth, drain, telemetry, webhook route, conflict resolution, task lifecycle, metrics batching). Full unit suite to run in PR CI.

## Test plan

- [ ] CodeQL workflow auto-closes the 12 in-code-fixed alerts on this branch.
- [ ] Semgrep / Scorecard / zizmor re-runs surface no new findings.
- [ ] Full unit suite green in CI.
- [ ] No refurb-rule alerts touched (parallel branches handle those).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regex pattern in memory compaction to prevent catastrophic backtracking issues

* **Security**
  * Enhanced XML parsing with protection against entity-expansion and external-entity attacks
  * Improved login page security with HTML-escaping and JSON-encoding of sensitive data
  * Suppressed exception details in webhook error responses
  * Added sanitization for untrusted webhook field logging
  * Restricted file permissions during cleanup operations to owner-only write access

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->