### PR TITLE
style: clear refurb code-scanning alerts outside core package

### DIFF
--- a/src/bernstein/adapters/claude_stream_parser.py
+++ b/src/bernstein/adapters/claude_stream_parser.py
@@ -286,9 +286,7 @@ class ClaudeStreamParser:
         message_raw = msg.get("message", {})
         if not isinstance(message_raw, dict):
             return []
-        message = cast(_CAST_DICT_STR_ANY, message_raw)
-
-        content_raw = message.get("content", [])
+        content_raw = cast(_CAST_DICT_STR_ANY, message_raw).get("content", [])
         if not isinstance(content_raw, list):
             return []
 

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -199,7 +199,7 @@ class ConformanceReport:
         return {
             "passed": self.passed,
             "regressions": self.regressions,
-            "missing_terminal_signal": list(self.missing_terminal_signal),
+            "missing_terminal_signal": self.missing_terminal_signal.copy(),
             "results": [r.to_dict() for r in self.results],
         }
 

--- a/src/bernstein/adapters/q_dev.py
+++ b/src/bernstein/adapters/q_dev.py
@@ -257,8 +257,7 @@ def _has_q_login_cache() -> bool:
         xdg_data = os.environ.get("XDG_DATA_HOME")
         if xdg_data:
             candidates.append(Path(xdg_data) / "amazon-q")
-        candidates.append(home / ".local" / "share" / "amazon-q")
         # macOS users sometimes end up with the legacy ~/.amazon-q layout.
-        candidates.append(home / ".amazon-q")
+        candidates.extend((home / ".local" / "share" / "amazon-q", home / ".amazon-q"))
 
     return any(p.exists() for p in candidates)

--- a/src/bernstein/adapters/strict_schema.py
+++ b/src/bernstein/adapters/strict_schema.py
@@ -234,7 +234,7 @@ def assert_schema_sealed(schema: Mapping[str, Any]) -> None:
                 msg = f"object node at {location} does not seal additionalProperties"
                 raise ValueError(msg)
             for key, value in mapping.items():
-                _walk(value, f"{path}/{key}" if path else str(key))
+                _walk(value, f"{path}/{key}" if path else key)
         elif isinstance(node, list):
             items = cast("list[Any]", node)
             for index, item in enumerate(items):

--- a/src/bernstein/benchmark/comparative.py
+++ b/src/bernstein/benchmark/comparative.py
@@ -470,14 +470,17 @@ class ComparativeBenchmark:
             Markdown string with per-task and summary comparison tables.
         """
         lines: list[str] = []
-        lines.append("# Comparative Benchmark Report")
-        lines.append("")
+        lines.extend(("# Comparative Benchmark Report", ""))
 
         # Per-task results table
-        lines.append("## Per-Task Results")
-        lines.append("")
-        lines.append("| Task ID | Mode | Wall Time (s) | Cost (USD) | Tokens | Success | Verified |")
-        lines.append("|---------|------|---------------|------------|--------|---------|----------|")
+        lines.extend(
+            (
+                "## Per-Task Results",
+                "",
+                "| Task ID | Mode | Wall Time (s) | Cost (USD) | Tokens | Success | Verified |",
+                "|---------|------|---------------|------------|--------|---------|----------|",
+            )
+        )
 
         for r in sorted(report.results, key=lambda x: (x.task_id, x.mode)):
             success_mark = "Yes" if r.success else "No"

--- a/src/bernstein/bridges/cloudflare_sandbox.py
+++ b/src/bernstein/bridges/cloudflare_sandbox.py
@@ -459,8 +459,7 @@ class CloudflareSandboxBridge(RuntimeBridge):
             )
 
         data = resp.json()
-        result = data.get("result", data)
-        files: list[str] = result.get("files", [])
+        files: list[str] = data.get("result", data).get("files", [])
         return files
 
     def _api_url(self, path: str) -> str:

--- a/src/bernstein/cli/commands/_lineage_conflict_helpers.py
+++ b/src/bernstein/cli/commands/_lineage_conflict_helpers.py
@@ -16,10 +16,18 @@ from typing import TYPE_CHECKING
 
 from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
 from bernstein.core.lineage.merge import (
-    AgentPolicy,
-    FirstWriterPolicy,
-    HumanPolicy,
-    LineageConflict,
+    AgentPolicy as AgentPolicy,
+)
+from bernstein.core.lineage.merge import (
+    FirstWriterPolicy as FirstWriterPolicy,
+)
+from bernstein.core.lineage.merge import (
+    HumanPolicy as HumanPolicy,
+)
+from bernstein.core.lineage.merge import (
+    LineageConflict as LineageConflict,
+)
+from bernstein.core.lineage.merge import (
     MergePolicy,
     resolve_policy,
 )
@@ -185,10 +193,3 @@ def resolve_one(
             matching candidate).
     """
     return policy.resolve(fork, by_hash)
-
-
-# Re-exports so the CLI command module does not need to import twice.
-HumanPolicy = HumanPolicy
-FirstWriterPolicy = FirstWriterPolicy
-AgentPolicy = AgentPolicy
-LineageConflict = LineageConflict

--- a/src/bernstein/cli/commands/_lineage_v1_helpers.py
+++ b/src/bernstein/cli/commands/_lineage_v1_helpers.py
@@ -62,8 +62,7 @@ def reindex(log_path: Path) -> int:
         out = by_artefact_root / shard / (digest + ".jsonl")
         out.parent.mkdir(parents=True, exist_ok=True)
         with out.open("w") as f:
-            for e in group:
-                f.write(json.dumps(_asdict(e), sort_keys=True) + "\n")
+            f.writelines(json.dumps(_asdict(e), sort_keys=True) + "\n" for e in group)
         # Tips
         tip_data = tips.get(path, {"open": [entry_hash(group[-1])], "merged": []})
         tips_out = tips_root / (digest + ".json")

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -1358,7 +1358,7 @@ def _parse_filename_date(name: str) -> date | None:
     """Return the date encoded in ``YYYY-MM-DD.jsonl`` or ``None``."""
     from datetime import datetime
 
-    stem = name[: -len(".jsonl")] if name.endswith(".jsonl") else name
+    stem = name.removesuffix(".jsonl")
     try:
         return datetime.strptime(stem, "%Y-%m-%d").date()
     except ValueError:

--- a/src/bernstein/cli/commands/bundle_cmd.py
+++ b/src/bernstein/cli/commands/bundle_cmd.py
@@ -43,7 +43,7 @@ def bundle_group() -> None:
 @click.option(
     "--workdir",
     type=click.Path(file_okay=False, exists=True, path_type=Path),
-    default=Path("."),
+    default=Path(),
     help="Project root directory containing .sdd/ (default: current).",
 )
 @click.option(

--- a/src/bernstein/cli/commands/doctor/backends.py
+++ b/src/bernstein/cli/commands/doctor/backends.py
@@ -159,7 +159,7 @@ def probe_sonar(env: dict[str, str] | None = None) -> BackendReport:
     back to a quality-gate fetch if that is unavailable.
     """
 
-    env = env or dict(os.environ)
+    env = env or os.environ.copy()
     host = (env.get("SONAR_HOST_URL") or "").strip()
     token = (env.get("SONAR_TOKEN") or "").strip()
     if not host or not token:
@@ -307,7 +307,7 @@ def probe_glitchtip(env: dict[str, str] | None = None) -> BackendReport:
     ``bernstein doctor glitchtip``.
     """
 
-    env = env or dict(os.environ)
+    env = env or os.environ.copy()
     token = (env.get("BERNSTEIN_GLITCHTIP_TOKEN") or "").strip()
     if not token:
         return BackendReport(
@@ -393,7 +393,7 @@ def probe_dt(env: dict[str, str] | None = None) -> BackendReport:
     from env. Soft-fails if not configured.
     """
 
-    env = env or dict(os.environ)
+    env = env or os.environ.copy()
     url = (env.get("DTRACK_URL") or "").strip()
     token = (env.get("DTRACK_TOKEN") or "").strip()
     project = (env.get("DTRACK_PROJECT") or "").strip()
@@ -435,21 +435,20 @@ def probe_dt(env: dict[str, str] | None = None) -> BackendReport:
         overall = ProbeStatus.FAIL
     elif counts["high"] > 0:
         overall = ProbeStatus.WARN
-    rows: list[MetricRow] = []
-    for sev, value in counts.items():
-        rows.append(
-            MetricRow(
-                name=f"{sev}_vulns",
-                value=str(value),
-                numeric=float(value),
-                threshold="0" if sev in ("critical", "high") else "",
-                threshold_status=_classify(
-                    float(value),
-                    warn_above=1 if sev in ("critical", "high", "medium") else None,
-                    fail_above=1 if sev == "critical" else 5 if sev == "high" else None,
-                ),
-            )
+    rows: list[MetricRow] = [
+        MetricRow(
+            name=f"{sev}_vulns",
+            value=str(value),
+            numeric=float(value),
+            threshold="0" if sev in ("critical", "high") else "",
+            threshold_status=_classify(
+                float(value),
+                warn_above=1 if sev in ("critical", "high", "medium") else None,
+                fail_above=1 if sev == "critical" else 5 if sev == "high" else None,
+            ),
         )
+        for sev, value in counts.items()
+    ]
     return BackendReport(
         backend="dt",
         status=overall,
@@ -466,7 +465,7 @@ def probe_code_scanning(env: dict[str, str] | None = None) -> BackendReport:
     either is missing.
     """
 
-    env = env or dict(os.environ)
+    env = env or os.environ.copy()
     token = (env.get("GITHUB_TOKEN") or "").strip()
     repo = (env.get("GITHUB_REPOSITORY") or "").strip()
     if not token or not repo:

--- a/src/bernstein/cli/commands/doctor/glitchtip.py
+++ b/src/bernstein/cli/commands/doctor/glitchtip.py
@@ -295,7 +295,7 @@ def suggest_nudge_line(
     operator sees a single concise line at the end of the diagnostic
     report rather than another full table.
     """
-    source = env if env is not None else dict(os.environ)
+    source = env if env is not None else os.environ.copy()
     if not source.get(ENV_GLITCHTIP_TOKEN):
         return None
 
@@ -372,7 +372,7 @@ def glitchtip_cmd(as_json: bool, top_n: int, skip_baseline: bool) -> None:
       bernstein doctor glitchtip --json
       bernstein doctor glitchtip --top-n 10
     """
-    env = dict(os.environ)
+    env = os.environ.copy()
     has_token = bool(env.get(ENV_GLITCHTIP_TOKEN))
     has_dsn = bool(env.get(ENV_GLITCHTIP_DSN))
 

--- a/src/bernstein/cli/commands/doctor/observe.py
+++ b/src/bernstein/cli/commands/doctor/observe.py
@@ -129,7 +129,7 @@ def observe_cmd(as_json: bool, watch: bool, interval: int, no_persist: bool) -> 
       bernstein doctor observe --watch --interval 30
     """
 
-    interval = max(1, int(interval))
+    interval = max(1, interval)
     persist = not no_persist
 
     def _one_pass() -> int:

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -922,9 +922,7 @@ def eval_report() -> None:
 
     workdir = Path()
     state_dir = workdir / ".sdd"
-    harness = EvalHarness(state_dir=state_dir, repo_root=workdir)
-
-    prev = harness.load_previous_run()
+    prev = EvalHarness(state_dir=state_dir, repo_root=workdir).load_previous_run()
     if not prev:
         console.print(_NO_EVAL_RUNS_MSG)
         raise SystemExit(1)

--- a/src/bernstein/cli/commands/logs_group_cmd.py
+++ b/src/bernstein/cli/commands/logs_group_cmd.py
@@ -188,9 +188,8 @@ def logs_search(
     from bernstein.core.log_search import LogSearchIndex
 
     workdir_path = Path(workdir).resolve()
-    index = LogSearchIndex(workdir_path)
 
-    result = index.search(
+    result = LogSearchIndex(workdir_path).search(
         query,
         time_range=time_range,
         agent_role=agent_role,

--- a/src/bernstein/cli/commands/plan_generate_cmd.py
+++ b/src/bernstein/cli/commands/plan_generate_cmd.py
@@ -176,8 +176,7 @@ def _extract_yaml(raw: str) -> str:
     raw = raw.strip()
     # Strip ```yaml ... ``` fences
     raw = re.sub(r"^```(?:yaml)?\s*\n", "", raw, flags=re.MULTILINE)
-    raw = re.sub(r"\n```\s*$", "", raw, flags=re.MULTILINE)
-    return raw.strip()
+    return re.sub(r"\n```\s*$", "", raw, flags=re.MULTILINE).strip()
 
 
 _COST_PER_STEP = 0.08  # rough USD per agent step (medium complexity, sonnet)

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -161,13 +161,7 @@ def verify_cmd(
       bernstein verify --memory-audit             Audit lesson memory provenance
       bernstein verify --formal <task-id>         Run Z3/Lean4 property checks
     """
-    if (
-        wheelhouse_path is None
-        and wal_run_id is None
-        and determinism_run_id is None
-        and not memory_audit
-        and formal_task_id is None
-    ):
+    if wheelhouse_path is wal_run_id is determinism_run_id is None and not memory_audit and formal_task_id is None:
         console.print(
             "[dim]Use <wheelhouse-path>, --wal-integrity <run-id>, --determinism <run-id>, "
             "--memory-audit, or --formal <task-id>.[/dim]"

--- a/src/bernstein/cli/display/image_renderer.py
+++ b/src/bernstein/cli/display/image_renderer.py
@@ -244,8 +244,7 @@ class HalfBlockRenderer(BaseRenderer):
 
     def render(self, img: Image.Image, width: int, height: int) -> str:
         pixel_h = height * 2  # two pixel rows per character row
-        img = img.convert("RGB").resize((width, pixel_h), Image.Resampling.LANCZOS)
-        pixels = img.load()
+        pixels = img.convert("RGB").resize((width, pixel_h), Image.Resampling.LANCZOS).load()
         if pixels is None:  # pragma: no cover
             return ""
 

--- a/src/bernstein/cli/plan/plan_explain.py
+++ b/src/bernstein/cli/plan/plan_explain.py
@@ -243,8 +243,7 @@ def format_plan_explanation(plan_data: dict[str, Any]) -> str:
     cp_suffix = "s" if summary.critical_path_length != 1 else ""
     lines.append(f"  Critical path:   {summary.critical_path_length} stage{cp_suffix}")
     low, high = summary.estimated_cost_range
-    lines.append(f"  Estimated cost:  ${low:.2f}-${high:.2f}")
-    lines.append("")
+    lines.extend((f"  Estimated cost:  ${low:.2f}-${high:.2f}", ""))
 
     # Explanation paragraph
     lines.append(explanation)

--- a/src/bernstein/cli/run.py
+++ b/src/bernstein/cli/run.py
@@ -166,12 +166,14 @@ def create_live_dashboard(
         cost_panel.render(total_cost_usd, elapsed_seconds),
     ]
 
-    # Progress bar inside a small panel
+    # Progress bar inside a small panel, then the log panel
     progress_text = progress.render(summary)
-    renderables.append(Panel(progress_text, title="Progress", border_style="cyan"))
-
-    # Log panel
-    renderables.append(_build_log_panel(log_lines or []))
+    renderables.extend(
+        (
+            Panel(progress_text, title="Progress", border_style="cyan"),
+            _build_log_panel(log_lines or []),
+        )
+    )
 
     return Group(*renderables)
 

--- a/src/bernstein/eval/pentest_runner.py
+++ b/src/bernstein/eval/pentest_runner.py
@@ -79,8 +79,7 @@ def mock_adapter(*, fixture_root: Path, model: str) -> list[dict[str, object]]:
     raw_payload: object = json.loads(truth_path.read_text(encoding="utf-8"))
     if not isinstance(raw_payload, dict):
         return []
-    payload: dict[str, object] = cast("dict[str, object]", raw_payload)
-    findings_obj = payload.get("findings", [])
+    findings_obj = cast("dict[str, object]", raw_payload).get("findings", [])
     if not isinstance(findings_obj, list):
         return []
     findings_list: list[object] = cast("list[object]", findings_obj)
@@ -223,8 +222,7 @@ def _parse_thresholds(raw_scoring: object) -> dict[str, float]:
     """Extract numeric ``thresholds`` from a YAML ``scoring`` block."""
     if not isinstance(raw_scoring, dict):
         return {}
-    scoring: dict[str, object] = cast("dict[str, object]", raw_scoring)
-    raw_thresholds = scoring.get("thresholds")
+    raw_thresholds = cast("dict[str, object]", raw_scoring).get("thresholds")
     if not isinstance(raw_thresholds, dict):
         return {}
     thresholds_obj: dict[str, object] = cast("dict[str, object]", raw_thresholds)
@@ -241,8 +239,7 @@ def _parse_max_duration(raw_limits: object) -> int:
     """Extract ``max_duration_seconds`` from a YAML ``limits`` block."""
     if not isinstance(raw_limits, dict):
         return 60
-    limits: dict[str, object] = cast("dict[str, object]", raw_limits)
-    raw_value = limits.get("max_duration_seconds", 60)
+    raw_value = cast("dict[str, object]", raw_limits).get("max_duration_seconds", 60)
     try:
         return int(str(raw_value))
     except (TypeError, ValueError):
@@ -254,8 +251,7 @@ def load_ground_truth(ground_truth_path: Path) -> list[Finding]:
     raw_payload: object = json.loads(ground_truth_path.read_text(encoding="utf-8"))
     if not isinstance(raw_payload, dict):
         return []
-    payload: dict[str, object] = cast("dict[str, object]", raw_payload)
-    findings_raw_obj = payload.get("findings", [])
+    findings_raw_obj = cast("dict[str, object]", raw_payload).get("findings", [])
     if not isinstance(findings_raw_obj, list):
         return []
     findings_list: list[object] = cast("list[object]", findings_raw_obj)

--- a/src/bernstein/eval/scenario_runner.py
+++ b/src/bernstein/eval/scenario_runner.py
@@ -233,8 +233,7 @@ def _as_dict(raw: object) -> dict[str, object]:
 
 def _parse_setup_section(raw: dict[str, object]) -> ScenarioSetup:
     """Parse the ``setup`` section of a scenario YAML."""
-    setup_dict = _as_dict(raw.get("setup") or {})
-    setup_cmd: object = setup_dict.get("command")
+    setup_cmd: object = _as_dict(raw.get("setup") or {}).get("command")
     return ScenarioSetup(command=str(setup_cmd) if setup_cmd is not None else None)
 
 

--- a/src/bernstein/evolution/report.py
+++ b/src/bernstein/evolution/report.py
@@ -354,19 +354,20 @@ class EvolutionReport:
         lines: list[str] = []
         now = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M UTC")
 
-        lines.append("# Bernstein Evolution Report")
-        lines.append(f"\n_Generated {now}_\n")
+        lines.extend(("# Bernstein Evolution Report", f"\n_Generated {now}_\n"))
 
         # Summary section
-        lines.append("## Summary\n")
-        lines.append("| Metric | Value |")
-        lines.append("|--------|-------|")
-        lines.append(f"| Total cycles | {self.total_cycles} |")
-        lines.append(f"| Tasks completed | {self.total_tasks_completed} |")
-        lines.append(f"| Tasks failed | {self.total_tasks_failed} |")
-        lines.append(f"| Commits made | {self.total_commits} |")
-        lines.append(
-            f"| Tests (first -> last) | {self.first_tests_passed} -> {self.last_tests_passed} (+{self.test_delta}) |"
+        lines.extend(
+            (
+                "## Summary\n",
+                "| Metric | Value |",
+                "|--------|-------|",
+                f"| Total cycles | {self.total_cycles} |",
+                f"| Tasks completed | {self.total_tasks_completed} |",
+                f"| Tasks failed | {self.total_tasks_failed} |",
+                f"| Commits made | {self.total_commits} |",
+                f"| Tests (first -> last) | {self.first_tests_passed} -> {self.last_tests_passed} (+{self.test_delta}) |",
+            )
         )
         if self.experiments:
             lines.extend(
@@ -379,13 +380,16 @@ class EvolutionReport:
             )
 
         # Trajectory sparkline
-        lines.append("\n## Test Count Trajectory\n")
-        lines.append(f"```\n{self._tests_sparkline()}\n```")
+        lines.extend(("\n## Test Count Trajectory\n", f"```\n{self._tests_sparkline()}\n```"))
 
         # Cycle breakdown
-        lines.append("\n## Cycle Breakdown\n")
-        lines.append("| # | Time (UTC) | Focus | Tasks ✓ | Tasks ✗ | Tests | Success% | Commits | Duration |")
-        lines.append("|---|-----------|-------|---------|---------|-------|----------|---------|----------|")
+        lines.extend(
+            (
+                "\n## Cycle Breakdown\n",
+                "| # | Time (UTC) | Focus | Tasks ✓ | Tasks ✗ | Tests | Success% | Commits | Duration |",
+                "|---|-----------|-------|---------|---------|-------|----------|---------|----------|",
+            )
+        )
 
         for i, c in enumerate(self.cycles):
             dt = datetime.fromtimestamp(c.timestamp, tz=UTC)

--- a/src/bernstein/github_app/mapper.py
+++ b/src/bernstein/github_app/mapper.py
@@ -376,8 +376,7 @@ def trigger_label_to_task(event: WebhookEvent) -> dict[str, Any] | None:
     if event.action != "labeled":
         return None
 
-    label: dict[str, Any] = event.payload.get("label", {})
-    label_name = label.get("name", "").lower()
+    label_name = event.payload.get("label", {}).get("name", "").lower()
 
     if label_name not in TRIGGER_LABELS:
         return None
@@ -439,8 +438,7 @@ def label_to_action(event: WebhookEvent) -> dict[str, Any] | None:
     if event.action != "labeled":
         return None
 
-    label: dict[str, Any] = event.payload.get("label", {})
-    label_name = label.get("name", "").lower()
+    label_name = event.payload.get("label", {}).get("name", "").lower()
 
     if label_name != "evolve-candidate":
         return None

--- a/src/bernstein/github_app/webhooks.py
+++ b/src/bernstein/github_app/webhooks.py
@@ -80,15 +80,13 @@ def parse_webhook(headers: dict[str, str], body: bytes) -> WebhookEvent:
     action = payload.get("action", "")
 
     # Extract repo full name — different location for push vs other events
-    repo: dict[str, Any] = payload.get("repository", {})
-    repo_full_name = repo.get("full_name", "")
+    repo_full_name = payload.get("repository", {}).get("full_name", "")
     if not repo_full_name:
         msg = "Missing repository.full_name in payload"
         raise ValueError(msg)
 
     # Extract sender
-    sender_obj: dict[str, Any] = payload.get("sender", {})
-    sender = sender_obj.get("login", "unknown")
+    sender = payload.get("sender", {}).get("login", "unknown")
 
     from bernstein.core.sanitize import sanitize_log
 

--- a/src/bernstein/gitlab_app/mapper.py
+++ b/src/bernstein/gitlab_app/mapper.py
@@ -256,8 +256,7 @@ def pipeline_to_tasks(
         fetch_and_parse_failures,
     )
 
-    project: dict[str, Any] = event.payload.get("project", {})
-    project_id = project.get("id", "")
+    project_id = event.payload.get("project", {}).get("id", "")
 
     failures = fetch_and_parse_failures(
         project_id=project_id,

--- a/src/bernstein/mcp/cost_meter.py
+++ b/src/bernstein/mcp/cost_meter.py
@@ -90,7 +90,7 @@ class CallMeter:
 
     def add_cost(self, usd: float) -> None:
         """Accumulate an estimated USD cost for this call."""
-        self.cost_usd += float(usd)
+        self.cost_usd += usd
 
     def finalise(self) -> None:
         """Record the elapsed wall-clock latency for this call in millis."""

--- a/src/bernstein/plugins/manager.py
+++ b/src/bernstein/plugins/manager.py
@@ -235,7 +235,7 @@ class CommandHook:
         home_dir: BernsteinHome = BernsteinHome.default()
 
         return {
-            "PLUGIN_ROOT": self._plugin_root if self._plugin_root else "",
+            "PLUGIN_ROOT": self._plugin_root,
             "DATA_DIR": str(hooks_dir.parent),
             "HOOKS_DIR": str(hooks_dir),
             "WORK_DIR": str(Path.cwd()),

--- a/src/bernstein/sdd/validator.py
+++ b/src/bernstein/sdd/validator.py
@@ -302,17 +302,15 @@ def _issue_from_error(err: jsonschema.ValidationError) -> ValidationIssue:
 
 
 def _missing_recommended(metadata: Mapping[str, Any], keys: tuple[str, ...]) -> list[ValidationIssue]:
-    out: list[ValidationIssue] = []
-    for key in keys:
-        if key not in metadata:
-            out.append(
-                ValidationIssue(
-                    message=f"recommended key missing: {key}",
-                    path=(key,),
-                    code="recommended_missing",
-                )
-            )
-    return out
+    return [
+        ValidationIssue(
+            message=f"recommended key missing: {key}",
+            path=(key,),
+            code="recommended_missing",
+        )
+        for key in keys
+        if key not in metadata
+    ]
 
 
 def validate_ticket_metadata(

--- a/src/bernstein/tui/away_summary.py
+++ b/src/bernstein/tui/away_summary.py
@@ -211,14 +211,16 @@ def format_away_report(summary: AwaySummary) -> str:
     lines: list[str] = []
     lines.extend(("", "  [bold cyan]-- Since You Were Away --[/bold cyan]", ""))
 
-    # Duration
+    # Duration and task summary
     dur_h = summary.duration_s / 3600
     dur_m = (summary.duration_s % 3600) / 60
     dur_s = summary.duration_s % 60
-    lines.append(f"  [dim]Duration: {int(dur_h)}h {int(dur_m)}m {int(dur_s)}s[/dim]")
-
-    # Tasks
-    lines.append(f"  [green]{summary.completed_tasks} [/green]tasks completed")
+    lines.extend(
+        (
+            f"  [dim]Duration: {int(dur_h)}h {int(dur_m)}m {int(dur_s)}s[/dim]",
+            f"  [green]{summary.completed_tasks} [/green]tasks completed",
+        )
+    )
     if summary.failed_tasks:
         lines.append(f"  [red]{summary.failed_tasks} [/red]tasks failed")
 


### PR DESCRIPTION
## Summary

Behavior-preserving refurb rewrites across the non-core subpackages (adapters, benchmark, bridges, cli, eval, evolution, github_app, gitlab_app, mcp, plugins, sdd, tui) to clear refurb code-scanning alerts. 30 files touched; 48 alerts cleared, 1 deliberately skipped.

## Rule families

| Rule | Count | What changed |
|---|---|---|
| FURB110 + FURB143 | 1 | Drop redundant ternary, then redundant `or ""` on always-str field. |
| FURB113 | 10 | Collapse runs of single-arg `.append()` into one `.extend((...))`. |
| FURB122 | 1 | Replace explicit `for ... f.write(...)` with `f.writelines(...)` generator. |
| FURB123 | 10 | Drop redundant `int()`/`float()`/`str()`/`list()` wraps on values already of the target type; use `os.environ.copy()` instead of `dict(os.environ)`. |
| FURB124 | 2 | Chain consecutive `x is None` comparisons (`a is None and b is None and c is None` -> `a is b is c is None`). |
| FURB138 | 2 | Convert pure accumulation `for`-loops to list comprehensions. |
| FURB153 | 1 | `Path()` instead of `Path(".")`. |
| FURB160 | 4 | Drop redundant `X = X` self-assignment block; use explicit `import X as X` re-exports instead. |
| FURB184 | 16 | Inline single-use typed intermediates into the immediately following chained access; inline single-use constructor setup lines. |
| FURB188 | 1 | `name.removesuffix(".jsonl")` instead of slice + `endswith` ternary. |

## Skipped (kept open as an alert)

- `src/bernstein/cli/commands/doctor/backends.py:135` (FURB159): `f"{diff:+.2f}".rstrip("0").rstrip(".")` is **not** equivalent to `f"{diff:+.2f}".rstrip(".0")`. With `+.2f` formatting, values like `+10.00` produce `"+10"` vs `"+1"` respectively. Skipped to preserve behavior.

## Scope

- Excludes `src/bernstein/core/` (sibling cleanup).
- No public API changes; no test changes.

## Test plan

- [x] `uv run ruff check` clean on all 30 changed files.
- [x] `uv run ruff format --check` clean on all 30 changed files.
- [x] `uv run refurb` on non-core scope shows only the deliberately-skipped FURB159 alert remaining.
- [x] Targeted unit tests pass: `tests/unit/{eval,lineage,doctor,cost,mcp,adapters}` (640 passing locally).
- [ ] Full `tests/unit` suite in CI.
- [ ] Code-scanning re-run after merge confirms cleared alerts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Q login cache detection by checking additional legacy macOS locations.

* **Refactor**
  * Improved code quality and maintainability throughout the codebase with simplified variable assignments, consolidated list operations, and streamlined data extraction logic. Changes include refactored markdown generation, environment variable handling, and schema validation.

* **Style**
  * Adjusted cost display formatting in plan explanations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->