### PR TITLE
feat(substrate): desktop-register for remaining priority hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable project changes are tracked here (code + docs).
 
+## [Unreleased]
+
+### Added
+
+- `bernstein desktop-register --host <name>` covers the remaining priority hosts: Cursor, Continue, Cline, Zed, and Aider, alongside the existing Claude Desktop and Claude Code adapters. JSON hosts merge into their canonical `mcpServers` map (or `context_servers` for Zed); Aider records the entry in its YAML config under `mcp-servers` for community-wrapper consumption (#1676).
+- `bernstein doctor --substrate` reports which detected hosts have Bernstein registered, which do not, and which are stale (canonical command/args differ from the recorded entry) (#1676).
+- Operator docs at `docs/substrate/{cursor,continue,cline,zed,aider}.md` cover install, verification, and uninstall per host (#1676).
+
 ## [2.5.0] - Interoperability surfaces, host portability, deterministic replay
 
 22 commits since v2.4.0. Full notes: [`docs/release-notes/v2.5.0.md`](docs/release-notes/v2.5.0.md).

--- a/docs/substrate/aider.md
+++ b/docs/substrate/aider.md
@@ -1,0 +1,75 @@
+# Register Bernstein in Aider
+
+Aider's config file lives at `~/.aider.conf.yml` and is YAML, not JSON.
+Aider does not natively load MCP servers, so this adapter is best-effort:
+`bernstein desktop-register --host aider` records a `bernstein` entry
+under an `mcp-servers` key in the YAML config. Community wrappers, custom
+launch scripts, and Aider plugins can pick that entry up to invoke
+Bernstein.
+
+The write is idempotent and backup-first: the existing config is copied to
+a timestamped `.bak` sibling before any mutating write, and re-running the
+command when the entry is already correct performs no write.
+
+## Config path
+
+| Scope | Path |
+|-------|------|
+| User (all projects) | `~/.aider.conf.yml` |
+
+Run `bernstein desktop-register --list` to print the resolved path on your
+machine.
+
+## Install
+
+```bash
+bernstein desktop-register --host aider
+```
+
+This writes (merging into any existing top-level keys):
+
+```yaml
+model: gpt-4o            # existing keys preserved
+auto-commits: false      # existing keys preserved
+mcp-servers:
+  bernstein:
+    command: /path/to/python
+    args:
+      - -m
+      - bernstein.mcp
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated keys are preserved verbatim.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `aider` row should show `Registered: yes`. Because Aider has no
+built-in MCP loader, the entry will not light up the host's UI on its own;
+use it as input to a wrapper script that launches Bernstein when Aider
+starts.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Open `~/.aider.conf.yml` and delete the `bernstein` key under
+`mcp-servers` (and the `mcp-servers` key itself if Bernstein was the only
+entry). A backup of the pre-registration state is available as the
+`*.bak` sibling created during install.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A config file that is not valid YAML is left untouched and the command
+  reports an error rather than overwriting it.
+- If a future Aider release adds first-class MCP support, this adapter
+  will move to use the new key without changing the operator workflow.

--- a/docs/substrate/cline.md
+++ b/docs/substrate/cline.md
@@ -1,0 +1,77 @@
+# Register Bernstein in Cline
+
+Cline (a VS Code extension) auto-discovers MCP servers from a
+`cline_mcp_settings.json` file inside the extension's VS Code global
+storage. `bernstein desktop-register --host cline` merges a `bernstein`
+entry into that file so every Cline session can call Bernstein's tools
+without manual editing.
+
+The write is idempotent and backup-first: the existing config is copied to
+a timestamped `.bak` sibling before any mutating write, and re-running the
+command when the entry is already correct performs no write.
+
+## Config path per OS
+
+| OS | Path |
+|----|------|
+| macOS | `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
+| Windows | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json` |
+| Linux | `$XDG_CONFIG_HOME/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` (falls back to `~/.config/Code/...`) |
+
+Run `bernstein desktop-register --list` to print the resolved path on your
+machine.
+
+## Install
+
+```bash
+bernstein desktop-register --host cline
+```
+
+This writes (merging into any existing `mcpServers` map):
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"]
+    }
+  }
+}
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated servers and top-level keys are preserved
+verbatim.
+
+Reload the VS Code window so Cline picks up the new MCP server.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `cline` row should show `Registered: yes`. In Cline, the Bernstein
+tools appear in the MCP tool list once VS Code has reloaded.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Open the config path shown by `--list` and delete the `bernstein` key
+under `mcpServers`. A backup of the pre-registration state is available
+as the `*.bak` sibling created during install. Reload VS Code afterwards.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A config file that is not valid JSON is left untouched and the command
+  reports an error rather than overwriting it.
+- VS Code Insiders and other variants store the extension data under a
+  different parent directory; in that case point the operator at the
+  canonical settings file (Cline exposes it via its UI).

--- a/docs/substrate/continue.md
+++ b/docs/substrate/continue.md
@@ -1,0 +1,77 @@
+# Register Bernstein in Continue
+
+Continue auto-discovers MCP servers from a user-global
+`~/.continue/config.json` file. `bernstein desktop-register --host continue`
+merges a `bernstein` entry into the `mcpServers` map so every Continue
+session can call Bernstein's tools without manual editing.
+
+The write is idempotent and backup-first: the existing config is copied to
+a timestamped `.bak` sibling before any mutating write, and re-running the
+command when the entry is already correct performs no write.
+
+## Config path
+
+| Scope | Path |
+|-------|------|
+| User (all projects) | `~/.continue/config.json` |
+
+Continue also reads `config.yaml` in some releases; the JSON file remains
+the canonical location for MCP server registration and is what
+`desktop-register` writes. Run `bernstein desktop-register --list` to
+print the resolved path on your machine.
+
+## Install
+
+```bash
+bernstein desktop-register --host continue
+```
+
+This writes (merging into any existing `mcpServers` map):
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"]
+    }
+  }
+}
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated keys (models, slash commands, etc.) in
+`config.json` are preserved verbatim.
+
+Restart your editor so Continue reloads `~/.continue/config.json`.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `continue` row should show `Registered: yes`. In a Continue session,
+the Bernstein tools appear in the MCP tool list once the editor has
+reloaded the config.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Open `~/.continue/config.json` and delete the `bernstein` key under
+`mcpServers`. A backup of the pre-registration state is available as the
+`*.bak` sibling created during install. Restart your editor afterwards.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A config file that is not valid JSON is left untouched and the command
+  reports an error rather than overwriting it.
+- If your installation only uses `config.yaml`, mirror the entry manually;
+  `desktop-register` writes to the JSON file by design so the merge
+  contract is identical across hosts.

--- a/docs/substrate/cursor.md
+++ b/docs/substrate/cursor.md
@@ -1,0 +1,75 @@
+# Register Bernstein in Cursor
+
+Cursor auto-discovers MCP servers from a user-global `~/.cursor/mcp.json`
+file (and an optional project-local `./.cursor/mcp.json`).
+`bernstein desktop-register --host cursor` merges a `bernstein` entry into
+the user-global file so every Cursor session can call Bernstein's tools
+without manual editing.
+
+The write is idempotent and backup-first: the existing config is copied to
+a timestamped `.bak` sibling before any mutating write, and re-running the
+command when the entry is already correct performs no write.
+
+## Config path
+
+| Scope | Path |
+|-------|------|
+| User (all projects) | `~/.cursor/mcp.json` |
+
+Run `bernstein desktop-register --list` to print the resolved path on your
+machine.
+
+## Install
+
+```bash
+bernstein desktop-register --host cursor
+```
+
+This writes (merging into any existing `mcpServers` map):
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"]
+    }
+  }
+}
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated servers and top-level keys are preserved
+verbatim.
+
+Restart Cursor (or reload the MCP servers panel) so it reloads the config.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `cursor` row should show `Registered: yes`. In Cursor, the Bernstein
+tools appear in the MCP tool list once the editor has restarted.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Open `~/.cursor/mcp.json` and delete the `bernstein` key under
+`mcpServers`. A backup of the pre-registration state is available as the
+`*.bak` sibling created during install. Restart Cursor afterwards.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A config file that is not valid JSON is left untouched and the command
+  reports an error rather than overwriting it.
+- Project-local overrides under `./.cursor/mcp.json` are not touched by
+  the user-scoped registration; edit them manually if you need a
+  per-project entry.

--- a/docs/substrate/zed.md
+++ b/docs/substrate/zed.md
@@ -1,0 +1,75 @@
+# Register Bernstein in Zed
+
+Zed reads MCP servers (which it calls "context servers") from its
+user-global settings file. `bernstein desktop-register --host zed` merges
+a `bernstein` entry under the `context_servers` key so every Zed session
+can call Bernstein's tools without manual editing.
+
+The write is idempotent and backup-first: the existing config is copied to
+a timestamped `.bak` sibling before any mutating write, and re-running the
+command when the entry is already correct performs no write.
+
+## Config path
+
+| Scope | Path |
+|-------|------|
+| User (all projects) | `$XDG_CONFIG_HOME/zed/settings.json` (falls back to `~/.config/zed/settings.json`) |
+
+Run `bernstein desktop-register --list` to print the resolved path on your
+machine.
+
+## Install
+
+```bash
+bernstein desktop-register --host zed
+```
+
+This writes (merging into any existing `context_servers` map):
+
+```json
+{
+  "context_servers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"]
+    }
+  }
+}
+```
+
+`command` is the Python interpreter that runs Bernstein (resolved at
+registration time). Unrelated keys (themes, fonts, language servers, etc.)
+in `settings.json` are preserved verbatim.
+
+Restart Zed after registering so it reloads its settings.
+
+## Verify
+
+```bash
+bernstein desktop-register --list
+```
+
+The `zed` row should show `Registered: yes`. In Zed, the Bernstein tools
+appear in the context-servers menu once the editor has restarted.
+
+For machine-readable output:
+
+```bash
+bernstein desktop-register --list --json
+```
+
+## Uninstall
+
+Open the Zed settings file shown by `--list` and delete the `bernstein`
+key under `context_servers`. A backup of the pre-registration state is
+available as the `*.bak` sibling created during install. Restart Zed
+afterwards.
+
+## Notes
+
+- Registration never deletes or rewrites entries it did not create.
+- A config file that is not valid JSON is left untouched and the command
+  reports an error rather than overwriting it.
+- Zed uses `context_servers` rather than the `mcpServers` key seen in the
+  Claude / Cursor / Continue / Cline configs; both schemas are otherwise
+  compatible.

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -282,11 +282,86 @@ def run_all_checks() -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Substrate health-check (``bernstein doctor --substrate``)
+# ---------------------------------------------------------------------------
+
+
+def _substrate_status_for(host: Any) -> dict[str, Any]:
+    """Return a doctor-style row describing one host's substrate state.
+
+    States:
+      - ``unsupported``: host is stubbed (we cannot register it yet)
+      - ``no_config_path``: host is supported but path is unavailable
+      - ``not_registered``: host config exists / could exist; no entry
+      - ``registered``: entry present and matches canonical command
+      - ``stale``: entry present but command/args differ from canonical
+    """
+    from bernstein.core.substrate import is_registered, is_stale
+
+    if not host.supported:
+        return {"host": host.name, "state": "unsupported", "config_path": None}
+    path = host.config_path()
+    if path is None:
+        return {"host": host.name, "state": "no_config_path", "config_path": None}
+    if not is_registered(host, path=path):
+        return {"host": host.name, "state": "not_registered", "config_path": str(path)}
+    if is_stale(host, path=path):
+        return {"host": host.name, "state": "stale", "config_path": str(path)}
+    return {"host": host.name, "state": "registered", "config_path": str(path)}
+
+
+def _run_substrate_checks() -> list[dict[str, Any]]:
+    """Build the substrate report for every host in the registry."""
+    from bernstein.core.substrate import HOST_REGISTRY, known_host_names
+
+    return [_substrate_status_for(HOST_REGISTRY[name]) for name in known_host_names()]
+
+
+def _render_substrate_report(rows: list[dict[str, Any]], *, as_json: bool) -> int:
+    """Render the substrate report and return the desired exit code."""
+    import json as _json
+
+    from rich.table import Table
+
+    from bernstein.cli.helpers import console
+
+    if as_json:
+        console.print_json(_json.dumps({"substrate": rows}))
+        return 0
+
+    table = Table(title="Bernstein substrate state", show_lines=False)
+    table.add_column("Host", style="cyan", no_wrap=True)
+    table.add_column("State")
+    table.add_column("Config path", overflow="fold")
+
+    palette = {
+        "registered": "[green]registered[/green]",
+        "not_registered": "[yellow]not_registered[/yellow]",
+        "stale": "[red]stale[/red]",
+        "unsupported": "[dim]unsupported[/dim]",
+        "no_config_path": "[dim]no_config_path[/dim]",
+    }
+    for row in rows:
+        path = row["config_path"] or "[dim](n/a)[/dim]"
+        table.add_row(row["host"], palette.get(row["state"], row["state"]), str(path))
+
+    console.print(table)
+    return 0
+
+
 @click.command("doctor")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 @click.option("--fix", "auto_fix", is_flag=True, default=False, help="Attempt to auto-fix issues.")
+@click.option(
+    "--substrate",
+    "substrate_only",
+    is_flag=True,
+    default=False,
+    help="Report which host applications have Bernstein registered.",
+)
 @click.pass_context
-def doctor_cmd(ctx: click.Context, as_json: bool, auto_fix: bool) -> None:
+def doctor_cmd(ctx: click.Context, as_json: bool, auto_fix: bool, substrate_only: bool) -> None:
     """Run health checks on the Bernstein installation.
 
     \b
@@ -303,10 +378,18 @@ def doctor_cmd(ctx: click.Context, as_json: bool, auto_fix: bool) -> None:
 
     \b
     Examples:
-      bernstein doctor            # print diagnostic report
-      bernstein doctor --json     # machine-readable output
-      bernstein doctor --fix      # attempt to auto-fix issues
+      bernstein doctor             # print diagnostic report
+      bernstein doctor --json      # machine-readable output
+      bernstein doctor --fix       # attempt to auto-fix issues
+      bernstein doctor --substrate # report host registration state only
     """
+    if substrate_only:
+        rows = _run_substrate_checks()
+        exit_code = _render_substrate_report(rows, as_json=as_json)
+        if exit_code:
+            raise SystemExit(exit_code)
+        return
+
     # Delegate to the existing full doctor implementation which has more checks
     from bernstein.cli.status_cmd import doctor as _doctor_impl
 

--- a/src/bernstein/core/substrate/__init__.py
+++ b/src/bernstein/core/substrate/__init__.py
@@ -1,19 +1,22 @@
 """Substrate: register Bernstein into host applications (MCP servers, etc.).
 
 A "host" is an application an operator already runs (Claude Desktop,
-Claude Code, Cursor, ...) that auto-discovers MCP servers via its own
-config file. This package describes each host (``host_registry``) and
-performs idempotent, backup-first registration writes.
+Claude Code, Cursor, Continue, Cline, Zed, Aider, ...) that auto-discovers
+MCP servers via its own config file. This package describes each host
+(``host_registry``) and performs idempotent, backup-first registration
+writes.
 
 Bernstein is a guest in the host's config: registration merges a single
-``bernstein`` entry into the host's ``mcpServers`` map and never clobbers
-unrelated keys.
+``bernstein`` entry into the host's server map (``mcpServers`` for most
+hosts, ``context_servers`` for Zed, ``mcp-servers`` for Aider) and never
+clobbers unrelated keys.
 """
 
 from __future__ import annotations
 
 from bernstein.core.substrate.host_registry import (
     HOST_REGISTRY,
+    ConfigFormat,
     HostSpec,
     HostStatus,
     bernstein_server_entry,
@@ -23,17 +26,20 @@ from bernstein.core.substrate.host_registry import (
 from bernstein.core.substrate.register import (
     RegisterResult,
     is_registered,
+    is_stale,
     register_host,
 )
 
 __all__ = [
     "HOST_REGISTRY",
+    "ConfigFormat",
     "HostSpec",
     "HostStatus",
     "RegisterResult",
     "bernstein_server_entry",
     "get_host",
     "is_registered",
+    "is_stale",
     "known_host_names",
     "register_host",
 ]

--- a/src/bernstein/core/substrate/host_registry.py
+++ b/src/bernstein/core/substrate/host_registry.py
@@ -1,9 +1,11 @@
 """Registry of host applications that can auto-discover Bernstein's MCP server.
 
-Each :class:`HostSpec` records how to locate a host's MCP config file per
-OS and whether registration is implemented yet. Two hosts are fully
-supported (``claude-desktop``, ``claude-code``); the rest are stubbed so
-the surface is discoverable without claiming behaviour that does not exist.
+Each :class:`HostSpec` records how to locate a host's config file per OS,
+which config format and key the host uses, and whether registration is
+implemented. Most priority hosts are JSON-with-``mcpServers``; Zed nests
+under ``context_servers`` and Aider uses YAML. The shape differences are
+captured declaratively so :mod:`bernstein.core.substrate.register` can
+stay format-agnostic.
 
 Path resolution is intentionally pure (no filesystem writes here) so it is
 trivially testable. Actual config merges live in
@@ -27,6 +29,17 @@ class HostStatus(StrEnum):
 
     SUPPORTED = "supported"
     STUBBED = "stubbed"
+
+
+class ConfigFormat(StrEnum):
+    """On-disk format of a host's config file.
+
+    JSON covers Claude Desktop, Claude Code, Cursor, Continue, Cline, Zed.
+    YAML covers Aider (whose ``.aider.conf.yml`` is YAML, not JSON).
+    """
+
+    JSON = "json"
+    YAML = "yaml"
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +92,51 @@ def _claude_code_path() -> Path:
     return Path.cwd() / ".mcp.json"
 
 
+def _cursor_path() -> Path:
+    # Cursor reads a user-global ``~/.cursor/mcp.json`` (and a project-local
+    # ``./.cursor/mcp.json``); we target the user-global path for parity
+    # with how Claude Desktop is registered.
+    return _home() / ".cursor" / "mcp.json"
+
+
+def _continue_path() -> Path:
+    # Continue reads ``~/.continue/config.json`` for legacy MCP server
+    # declarations. Newer Continue releases also accept ``config.yaml``;
+    # we target the JSON path because every shipped version still reads
+    # it and the merge is identical to the other JSON hosts.
+    return _home() / ".continue" / "config.json"
+
+
+def _cline_path() -> Path:
+    # Cline stores its MCP settings inside the VS Code extension global
+    # storage on every OS. The default location depends on the editor
+    # variant; we target the stable canonical name used by Cline's own
+    # docs, with an OS-specific parent.
+    plat = _platform_key()
+    vscode_user = "Code" + os.sep + "User"
+    rel = Path(vscode_user) / "globalStorage" / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json"
+    if plat == "macos":
+        return _home() / "Library" / "Application Support" / rel
+    if plat == "windows":
+        return _windows_appdata() / rel
+    return _xdg_config_home() / rel
+
+
+def _zed_path() -> Path:
+    # Zed reads ``~/.config/zed/settings.json`` on Linux and
+    # ``~/.config/zed/settings.json`` (via ``$XDG_CONFIG_HOME``) on macOS
+    # too; Windows support is community-driven and shares the path.
+    return _xdg_config_home() / "zed" / "settings.json"
+
+
+def _aider_path() -> Path:
+    # Aider reads ``~/.aider.conf.yml`` for its YAML config. Aider does
+    # not natively load MCP servers; we record the entry under an
+    # ``mcp-servers`` key so a community wrapper or operator script can
+    # consume it (see ``docs/substrate/aider.md``).
+    return _home() / ".aider.conf.yml"
+
+
 # ---------------------------------------------------------------------------
 # Host specification
 # ---------------------------------------------------------------------------
@@ -86,13 +144,16 @@ def _claude_code_path() -> Path:
 
 @dataclass(frozen=True)
 class HostSpec:
-    """Describe one host application and where its MCP config lives.
+    """Describe one host application and where its config lives.
 
     Attributes:
         name: Stable CLI identifier (e.g. ``claude-desktop``).
         display_name: Human-friendly name for tables and docs.
         status: Whether registration is implemented or stubbed.
-        config_key: Top-level key holding the server map in the host config.
+        config_key: Top-level key holding the server map in the host
+            config (``mcpServers`` for Claude/Cursor/Continue/Cline,
+            ``context_servers`` for Zed, ``mcp-servers`` for Aider).
+        config_format: ``json`` or ``yaml``.
         scope: ``user`` (global config in home dir) or ``project`` (cwd).
         notes: One-line operator note (restart hint or stub reason).
         _path_resolver: Internal callable returning the config path.
@@ -102,6 +163,7 @@ class HostSpec:
     display_name: str
     status: HostStatus
     config_key: str = "mcpServers"
+    config_format: ConfigFormat = ConfigFormat.JSON
     scope: str = "user"
     notes: str = ""
     _path_resolver: object = field(default=None, repr=False, compare=False)
@@ -112,7 +174,7 @@ class HostSpec:
         return self.status is HostStatus.SUPPORTED
 
     def config_path(self) -> Path | None:
-        """Resolve the host's MCP config path for the current OS.
+        """Resolve the host's config path for the current OS.
 
         Returns ``None`` for stubbed hosts whose path is not yet wired up.
         """
@@ -123,7 +185,7 @@ class HostSpec:
 
 
 def bernstein_server_entry() -> dict[str, object]:
-    """Return the canonical ``mcpServers`` entry that launches Bernstein.
+    """Return the canonical entry that launches Bernstein.
 
     Mirrors the entry written by orchestration bootstrap so a manually
     registered host behaves identically to an auto-discovered project.
@@ -137,17 +199,6 @@ def bernstein_server_entry() -> dict[str, object]:
 # ---------------------------------------------------------------------------
 # The registry
 # ---------------------------------------------------------------------------
-
-
-def _stub(name: str, display: str, path_resolver: object, notes: str, scope: str = "user") -> HostSpec:
-    return HostSpec(
-        name=name,
-        display_name=display,
-        status=HostStatus.STUBBED,
-        scope=scope,
-        notes=notes,
-        _path_resolver=path_resolver,
-    )
 
 
 HOST_REGISTRY: dict[str, HostSpec] = {
@@ -167,48 +218,64 @@ HOST_REGISTRY: dict[str, HostSpec] = {
         notes="Writes .mcp.json in the current directory; reopen the project.",
         _path_resolver=_claude_code_path,
     ),
-    "cursor": _stub(
-        "cursor",
-        "Cursor",
-        lambda: _home() / ".cursor" / "mcp.json",
-        "Not yet implemented; would merge into ~/.cursor/mcp.json.",
-    ),
-    "continue": _stub(
-        "continue",
-        "Continue",
-        lambda: _home() / ".continue" / "config.json",
-        "Not yet implemented; Continue uses its own mcpServers schema.",
-    ),
-    "cline": _stub(
-        "cline",
-        "Cline",
-        lambda: _home() / ".cline" / "mcp_settings.json",
-        "Not yet implemented; VS Code extension settings vary by install.",
-    ),
-    "zed": _stub(
-        "zed",
-        "Zed",
-        lambda: _xdg_config_home() / "zed" / "settings.json",
-        "Not yet implemented; Zed nests servers under context_servers.",
+    "cursor": HostSpec(
+        name="cursor",
+        display_name="Cursor",
+        status=HostStatus.SUPPORTED,
         scope="user",
+        notes="Restart Cursor or reload the MCP servers panel.",
+        _path_resolver=_cursor_path,
     ),
-    "aider": _stub(
-        "aider",
-        "Aider",
-        lambda: _home() / ".aider.conf.yml",
-        "Not yet implemented; Aider config is YAML, not mcpServers JSON.",
+    "continue": HostSpec(
+        name="continue",
+        display_name="Continue",
+        status=HostStatus.SUPPORTED,
+        scope="user",
+        notes="Restart your editor so Continue reloads ~/.continue/config.json.",
+        _path_resolver=_continue_path,
     ),
-    "codex": _stub(
-        "codex",
-        "Codex",
-        lambda: _home() / ".codex" / "config.toml",
-        "Not yet implemented; Codex config is TOML.",
+    "cline": HostSpec(
+        name="cline",
+        display_name="Cline",
+        status=HostStatus.SUPPORTED,
+        scope="user",
+        notes="Reload the VS Code window so Cline picks up the new MCP server.",
+        _path_resolver=_cline_path,
     ),
-    "gemini": _stub(
-        "gemini",
-        "Gemini CLI",
-        lambda: _home() / ".gemini" / "settings.json",
-        "Not yet implemented; would merge into ~/.gemini/settings.json.",
+    "zed": HostSpec(
+        name="zed",
+        display_name="Zed",
+        status=HostStatus.SUPPORTED,
+        config_key="context_servers",
+        scope="user",
+        notes="Restart Zed after registering; servers nest under context_servers.",
+        _path_resolver=_zed_path,
+    ),
+    "aider": HostSpec(
+        name="aider",
+        display_name="Aider",
+        status=HostStatus.SUPPORTED,
+        config_key="mcp-servers",
+        config_format=ConfigFormat.YAML,
+        scope="user",
+        notes="Aider has no native MCP loader; the entry is recorded for community wrappers.",
+        _path_resolver=_aider_path,
+    ),
+    "codex": HostSpec(
+        name="codex",
+        display_name="Codex",
+        status=HostStatus.STUBBED,
+        scope="user",
+        notes="Not yet implemented; Codex config is TOML.",
+        _path_resolver=lambda: _home() / ".codex" / "config.toml",
+    ),
+    "gemini": HostSpec(
+        name="gemini",
+        display_name="Gemini CLI",
+        status=HostStatus.STUBBED,
+        scope="user",
+        notes="Not yet implemented; would merge into ~/.gemini/settings.json.",
+        _path_resolver=lambda: _home() / ".gemini" / "settings.json",
     ),
 }
 
@@ -235,6 +302,7 @@ def get_host(name: str) -> HostSpec:
 __all__ = [
     "HOST_REGISTRY",
     "SERVER_ID",
+    "ConfigFormat",
     "HostSpec",
     "HostStatus",
     "bernstein_server_entry",

--- a/src/bernstein/core/substrate/register.py
+++ b/src/bernstein/core/substrate/register.py
@@ -8,6 +8,10 @@ The write contract:
 * Back up the existing config file before the first mutating write.
 * Be idempotent: re-registering an already-correct entry reports
   ``already_registered`` and performs no write (and creates no backup).
+
+Both JSON hosts (Claude Desktop, Claude Code, Cursor, Continue, Cline,
+Zed) and YAML hosts (Aider) share the same merge contract; the dispatch
+on :class:`ConfigFormat` keeps the per-host adapter surface declarative.
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.substrate.host_registry import (
     SERVER_ID,
+    ConfigFormat,
     HostSpec,
     bernstein_server_entry,
 )
@@ -46,15 +51,12 @@ class RegisterResult:
     backup_path: Path | None
 
 
-def _load_config(path: Path) -> dict[str, Any]:
-    """Read an existing JSON host config, tolerating absence.
+# ---------------------------------------------------------------------------
+# Format-aware load / dump
+# ---------------------------------------------------------------------------
 
-    A missing file yields an empty dict so registration can bootstrap a
-    fresh config. An unreadable or invalid file raises ``ValueError`` so a
-    mutating write never clobbers existing-but-unreadable state.
-    """
-    if not path.exists():
-        return {}
+
+def _load_json(path: Path) -> dict[str, Any]:
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
@@ -70,6 +72,56 @@ def _load_config(path: Path) -> dict[str, Any]:
     return cast("dict[str, Any]", data)
 
 
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"existing config at {path} is not readable; refusing to overwrite") from exc
+    if not text.strip():
+        return {}
+    try:
+        import yaml  # local import keeps the optional surface honest
+    except ImportError as exc:  # pragma: no cover -- yaml is a runtime dep
+        raise ValueError("PyYAML is required to register YAML-based hosts") from exc
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"existing config at {path} is not valid YAML; refusing to overwrite") from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"existing config at {path} is not a YAML mapping; refusing to overwrite")
+    return cast("dict[str, Any]", data)
+
+
+def _load_config(path: Path, fmt: ConfigFormat) -> dict[str, Any]:
+    """Read an existing host config, tolerating absence.
+
+    A missing file yields an empty dict so registration can bootstrap a
+    fresh config. An unreadable or invalid file raises ``ValueError`` so a
+    mutating write never clobbers existing-but-unreadable state.
+    """
+    if not path.exists():
+        return {}
+    if fmt is ConfigFormat.YAML:
+        return _load_yaml(path)
+    return _load_json(path)
+
+
+def _dump_config(data: dict[str, Any], fmt: ConfigFormat) -> str:
+    """Serialise ``data`` for the given on-disk format.
+
+    JSON is pretty-printed with a trailing newline (matching Claude
+    Desktop / Cursor conventions). YAML is dumped with block style and
+    sort-keys off to keep operator-edited keys in their original order.
+    """
+    if fmt is ConfigFormat.YAML:
+        import yaml
+
+        return yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+    return json.dumps(data, indent=2) + "\n"
+
+
 def _backup(path: Path, *, now: datetime | None = None) -> Path:
     """Copy ``path`` to a timestamped ``.bak`` sibling and return its path."""
     stamp = (now or datetime.now(tz=UTC)).strftime("%Y%m%d%H%M%S%f")
@@ -83,11 +135,39 @@ def is_registered(host: HostSpec, *, path: Path | None = None) -> bool:
     target = path or host.config_path()
     if target is None:
         return False
-    config = _load_config(target)
+    try:
+        config = _load_config(target, host.config_format)
+    except ValueError:
+        # Unreadable / invalid configs are not registered for our purposes.
+        return False
     servers = config.get(host.config_key)
     if not isinstance(servers, dict):
         return False
     return SERVER_ID in servers
+
+
+def is_stale(host: HostSpec, *, path: Path | None = None) -> bool:
+    """Return True when an existing entry differs from the canonical entry.
+
+    A host is stale when it has a ``bernstein`` entry but the recorded
+    command/args do not match :func:`bernstein_server_entry`. The
+    ``doctor --substrate`` reporter surfaces this so operators can re-run
+    ``desktop-register`` after upgrading Python.
+    """
+    target = path or host.config_path()
+    if target is None:
+        return False
+    try:
+        config = _load_config(target, host.config_format)
+    except ValueError:
+        return False
+    servers = config.get(host.config_key)
+    if not isinstance(servers, dict):
+        return False
+    entry = servers.get(SERVER_ID)
+    if entry is None:
+        return False
+    return entry != bernstein_server_entry()
 
 
 def register_host(
@@ -108,7 +188,7 @@ def register_host(
 
     Raises:
         ValueError: When the host is stubbed, has no resolvable path, or
-            the existing config file is not a JSON object.
+            the existing config file is not a parseable mapping.
     """
     if not host.supported:
         raise ValueError(f"host {host.name!r} is not yet supported for registration")
@@ -117,7 +197,7 @@ def register_host(
     if target is None:
         raise ValueError(f"host {host.name!r} has no resolvable config path on this OS")
 
-    config = _load_config(target)
+    config = _load_config(target, host.config_format)
     raw_servers = config.get(host.config_key)
     servers: dict[str, Any] = cast("dict[str, Any]", raw_servers).copy() if isinstance(raw_servers, dict) else {}
 
@@ -138,7 +218,7 @@ def register_host(
 
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_suffix(target.suffix + ".tmp")
-    tmp.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    tmp.write_text(_dump_config(config, host.config_format), encoding="utf-8")
     tmp.replace(target)
 
     return RegisterResult(host.name, target, action, backup_path)
@@ -147,5 +227,6 @@ def register_host(
 __all__ = [
     "RegisterResult",
     "is_registered",
+    "is_stale",
     "register_host",
 ]

--- a/tests/unit/substrate/test_desktop_register_cmd.py
+++ b/tests/unit/substrate/test_desktop_register_cmd.py
@@ -16,8 +16,9 @@ def test_list_shows_supported_and_stubbed() -> None:
     assert result.exit_code == 0, result.output
     assert "claude-desktop" in result.output
     assert "claude-code" in result.output
+    assert "cursor" in result.output
     assert "supported" in result.output
-    assert "stubbed" in result.output
+    assert "stubbed" in result.output  # codex/gemini remain stubbed
 
 
 def test_list_json_is_parseable() -> None:
@@ -27,7 +28,8 @@ def test_list_json_is_parseable() -> None:
     payload = json.loads(result.output)
     by_name = {row["host"]: row for row in payload["hosts"]}
     assert by_name["claude-desktop"]["status"] == "supported"
-    assert by_name["cursor"]["status"] == "stubbed"
+    assert by_name["cursor"]["status"] == "supported"
+    assert by_name["codex"]["status"] == "stubbed"
     for row in payload["hosts"]:
         assert {"host", "status", "scope", "config_path", "registered", "notes"} <= row.keys()
 
@@ -66,7 +68,7 @@ def test_register_unknown_host_errors() -> None:
 
 def test_register_stubbed_host_exits_nonzero() -> None:
     """A stubbed host reports not-implemented and exits non-zero."""
-    result = CliRunner().invoke(desktop_register_cmd, ["--host", "cursor"])
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "codex"])
     assert result.exit_code == 1
     assert "not yet supported" in result.output
 
@@ -76,3 +78,55 @@ def test_no_args_prints_hint_and_exits_two() -> None:
     result = CliRunner().invoke(desktop_register_cmd, [])
     assert result.exit_code == 2
     assert "--host" in result.output
+
+
+def test_register_cursor_via_cli(tmp_path, monkeypatch) -> None:
+    """``--host cursor`` writes ``~/.cursor/mcp.json``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "cursor", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["action"] == "registered"
+
+    cfg = home / ".cursor" / "mcp.json"
+    assert cfg.exists()
+    data = json.loads(cfg.read_text())
+    assert SERVER_ID in data["mcpServers"]
+
+
+def test_register_zed_via_cli(tmp_path, monkeypatch) -> None:
+    """``--host zed`` writes the entry under ``context_servers``."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "zed", "--json"])
+    assert result.exit_code == 0, result.output
+
+    cfg = home / ".config" / "zed" / "settings.json"
+    assert cfg.exists()
+    data = json.loads(cfg.read_text())
+    assert SERVER_ID in data["context_servers"]
+
+
+def test_register_aider_via_cli(tmp_path, monkeypatch) -> None:
+    """``--host aider`` writes a YAML config rather than JSON."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    result = CliRunner().invoke(desktop_register_cmd, ["--host", "aider", "--json"])
+    assert result.exit_code == 0, result.output
+
+    cfg = home / ".aider.conf.yml"
+    assert cfg.exists()
+    import yaml
+
+    data = yaml.safe_load(cfg.read_text())
+    assert SERVER_ID in data["mcp-servers"]

--- a/tests/unit/substrate/test_doctor_substrate.py
+++ b/tests/unit/substrate/test_doctor_substrate.py
@@ -1,0 +1,91 @@
+"""Tests for ``bernstein doctor --substrate``."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.doctor_cmd import (
+    _run_substrate_checks,
+    _substrate_status_for,
+    doctor_cmd,
+)
+from bernstein.core.substrate import get_host
+
+
+def test_substrate_status_for_unsupported_host() -> None:
+    """Stubbed hosts report ``unsupported``."""
+    row = _substrate_status_for(get_host("codex"))
+    assert row["host"] == "codex"
+    assert row["state"] == "unsupported"
+    assert row["config_path"] is None
+
+
+def test_substrate_status_for_supported_unregistered(tmp_path, monkeypatch) -> None:
+    """A supported host with no entry reports ``not_registered``."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    row = _substrate_status_for(get_host("cursor"))
+    assert row["state"] == "not_registered"
+    assert row["config_path"] is not None
+
+
+def test_substrate_status_for_registered(tmp_path, monkeypatch) -> None:
+    """A registered host reports ``registered``."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    from bernstein.core.substrate import register_host
+
+    register_host(get_host("cursor"))
+    row = _substrate_status_for(get_host("cursor"))
+    assert row["state"] == "registered"
+
+
+def test_substrate_status_for_stale(tmp_path, monkeypatch) -> None:
+    """A host with a divergent entry reports ``stale``."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    cfg = tmp_path / ".cursor" / "mcp.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "bernstein": {"command": "/old/python", "args": ["-m", "bernstein.mcp"]},
+                }
+            }
+        )
+    )
+
+    row = _substrate_status_for(get_host("cursor"))
+    assert row["state"] == "stale"
+
+
+def test_doctor_substrate_json_emits_every_host(tmp_path, monkeypatch) -> None:
+    """``doctor --substrate --json`` lists every known host."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = CliRunner().invoke(doctor_cmd, ["--substrate", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    hosts = {row["host"] for row in payload["substrate"]}
+    assert {"claude-desktop", "claude-code", "cursor", "continue", "cline", "zed", "aider"} <= hosts
+
+
+def test_doctor_substrate_table_renders(tmp_path, monkeypatch) -> None:
+    """The text-mode substrate report mentions known hosts."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = CliRunner().invoke(doctor_cmd, ["--substrate"])
+    assert result.exit_code == 0, result.output
+    assert "cursor" in result.output
+    assert "zed" in result.output
+
+
+def test_run_substrate_checks_returns_one_row_per_host() -> None:
+    """``_run_substrate_checks`` returns one row per host in the registry."""
+    from bernstein.core.substrate import known_host_names
+
+    rows = _run_substrate_checks()
+    assert {row["host"] for row in rows} == set(known_host_names())

--- a/tests/unit/substrate/test_host_registry.py
+++ b/tests/unit/substrate/test_host_registry.py
@@ -9,6 +9,7 @@ import pytest
 from bernstein.core.substrate.host_registry import (
     HOST_REGISTRY,
     SERVER_ID,
+    ConfigFormat,
     HostStatus,
     bernstein_server_entry,
     get_host,
@@ -17,16 +18,22 @@ from bernstein.core.substrate.host_registry import (
 from bernstein.core.substrate.register import (
     RegisterResult,
     is_registered,
+    is_stale,
     register_host,
 )
 
 
-def test_two_hosts_supported_rest_stubbed() -> None:
-    """Exactly the two MVP hosts are supported; everything else is stubbed."""
+def test_priority_hosts_supported() -> None:
+    """All priority hosts (Claude pair + Cursor/Continue/Cline/Zed/Aider) are supported."""
     supported = {n for n, h in HOST_REGISTRY.items() if h.status is HostStatus.SUPPORTED}
-    assert supported == {"claude-desktop", "claude-code"}
+    assert {"claude-desktop", "claude-code", "cursor", "continue", "cline", "zed", "aider"} <= supported
+
+
+def test_remaining_hosts_still_stubbed() -> None:
+    """Hosts not yet in the priority list remain stubbed."""
     stubbed = {n for n, h in HOST_REGISTRY.items() if h.status is HostStatus.STUBBED}
-    assert {"cursor", "continue", "cline", "zed", "aider", "codex", "gemini"} <= stubbed
+    # codex (TOML) and gemini stay stubbed pending their own packaging passes.
+    assert {"codex", "gemini"} <= stubbed
 
 
 def test_known_host_names_sorted() -> None:
@@ -52,10 +59,24 @@ def test_bernstein_server_entry_shape() -> None:
 
 def test_stubbed_host_register_rejected() -> None:
     """Registering a stubbed host raises rather than silently no-op."""
-    cursor = get_host("cursor")
-    assert not cursor.supported
+    codex = get_host("codex")
+    assert not codex.supported
     with pytest.raises(ValueError, match="not yet supported"):
-        register_host(cursor)
+        register_host(codex)
+
+
+def test_zed_uses_context_servers_key() -> None:
+    """Zed nests servers under ``context_servers``, not ``mcpServers``."""
+    zed = get_host("zed")
+    assert zed.config_key == "context_servers"
+    assert zed.config_format is ConfigFormat.JSON
+
+
+def test_aider_uses_yaml_format() -> None:
+    """Aider's config is YAML; the registry must reflect that."""
+    aider = get_host("aider")
+    assert aider.config_format is ConfigFormat.YAML
+    assert aider.config_key == "mcp-servers"
 
 
 # ---------------------------------------------------------------------------
@@ -136,3 +157,113 @@ def test_is_registered_reflects_state(tmp_path) -> None:
     assert is_registered(host, path=cfg) is False
     register_host(host, path=cfg)
     assert is_registered(host, path=cfg) is True
+
+
+# ---------------------------------------------------------------------------
+# New hosts: per-host smoke tests for the same write contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("host_name", "config_key"),
+    [
+        ("cursor", "mcpServers"),
+        ("continue", "mcpServers"),
+        ("cline", "mcpServers"),
+        ("zed", "context_servers"),
+    ],
+)
+def test_register_json_host_writes_expected_key(tmp_path, host_name, config_key) -> None:
+    """Cursor / Continue / Cline / Zed all write through the JSON path."""
+    cfg = tmp_path / f"{host_name}.json"
+    host = get_host(host_name)
+    assert host.config_format is ConfigFormat.JSON
+    assert host.config_key == config_key
+
+    result = register_host(host, path=cfg)
+
+    assert result.action == "registered"
+    data = json.loads(cfg.read_text())
+    assert data[config_key][SERVER_ID] == bernstein_server_entry()
+
+
+def test_register_zed_preserves_unrelated_top_level_keys(tmp_path) -> None:
+    """Zed config registration leaves editor settings (theme, fonts) intact."""
+    cfg = tmp_path / "settings.json"
+    cfg.write_text(json.dumps({"theme": "One Dark", "ui_font_size": 16}))
+    host = get_host("zed")
+
+    register_host(host, path=cfg)
+
+    data = json.loads(cfg.read_text())
+    assert data["theme"] == "One Dark"
+    assert data["ui_font_size"] == 16
+    assert SERVER_ID in data["context_servers"]
+
+
+def test_register_aider_writes_yaml_entry(tmp_path) -> None:
+    """Aider registration round-trips through YAML and records the entry."""
+    cfg = tmp_path / "aider.yml"
+    host = get_host("aider")
+
+    result = register_host(host, path=cfg)
+
+    assert result.action == "registered"
+    import yaml
+
+    data = yaml.safe_load(cfg.read_text())
+    assert data["mcp-servers"][SERVER_ID] == bernstein_server_entry()
+
+
+def test_register_aider_preserves_existing_yaml_keys(tmp_path) -> None:
+    """Aider registration leaves unrelated YAML keys untouched."""
+    cfg = tmp_path / "aider.yml"
+    cfg.write_text("model: gpt-4o\nauto-commits: false\n")
+    host = get_host("aider")
+
+    result = register_host(host, path=cfg)
+
+    assert result.backup_path is not None
+    import yaml
+
+    data = yaml.safe_load(cfg.read_text())
+    assert data["model"] == "gpt-4o"
+    assert data["auto-commits"] is False
+    assert SERVER_ID in data["mcp-servers"]
+
+
+def test_register_aider_idempotent(tmp_path) -> None:
+    """A second Aider registration with identical content is a no-op."""
+    cfg = tmp_path / "aider.yml"
+    host = get_host("aider")
+    register_host(host, path=cfg)
+
+    again = register_host(host, path=cfg)
+    assert again.action == "already_registered"
+    assert again.backup_path is None
+
+
+def test_register_aider_invalid_yaml_refuses(tmp_path) -> None:
+    """Aider config with a broken YAML body is left untouched."""
+    cfg = tmp_path / "aider.yml"
+    cfg.write_text("model: gpt-4o\n  badly: indented: mapping: here\n: : :\n")
+    host = get_host("aider")
+    with pytest.raises(ValueError, match="not valid YAML|not a YAML mapping"):
+        register_host(host, path=cfg)
+
+
+def test_is_stale_detects_drift(tmp_path) -> None:
+    """``is_stale`` returns True when the recorded command differs."""
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"mcpServers": {SERVER_ID: {"command": "/old/python", "args": ["-m", "bernstein.mcp"]}}}))
+    host = get_host("claude-desktop")
+    assert is_stale(host, path=cfg) is True
+
+
+def test_is_stale_false_when_absent_or_current(tmp_path) -> None:
+    """``is_stale`` is False for missing entries and for current entries."""
+    cfg = tmp_path / "config.json"
+    host = get_host("claude-desktop")
+    assert is_stale(host, path=cfg) is False  # file does not exist
+    register_host(host, path=cfg)
+    assert is_stale(host, path=cfg) is False  # entry matches canonical


### PR DESCRIPTION
Closes #1676

## Summary

Extend the per-host adapter abstraction shipped in #1697 to cover the
remaining priority hosts so an operator running any of these editors
or agents registers Bernstein with a single command, reducing manual
setup friction.

Hosts promoted from stubbed to supported:

| Host | Config path | Key | Format |
|------|-------------|-----|--------|
| Cursor | `~/.cursor/mcp.json` | `mcpServers` | JSON |
| Continue | `~/.continue/config.json` | `mcpServers` | JSON |
| Cline | VS Code `globalStorage/.../cline_mcp_settings.json` | `mcpServers` | JSON |
| Zed | `~/.config/zed/settings.json` | `context_servers` | JSON |
| Aider | `~/.aider.conf.yml` | `mcp-servers` | YAML |

The host registry now records both the config key (`mcpServers` vs
`context_servers` vs `mcp-servers`) and the config format (JSON vs
YAML), keeping the merge contract declarative. Aider has no native
MCP loader; the entry is recorded under `mcp-servers` for
community-wrapper consumers, documented in `docs/substrate/aider.md`.

Stretch goal shipped: `bernstein doctor --substrate` reports
`registered` / `not_registered` / `stale` / `unsupported` /
`no_config_path` per host. Stale detection compares the recorded
command/args against the canonical entry so operators can re-run
`desktop-register` after a Python upgrade.

Codex and Gemini CLI remain stubbed pending their own packaging
passes (TOML and a separate settings schema respectively).

## Test plan

- [x] `uv run ruff check` on changed paths
- [x] `uv run ruff format --check` on changed paths
- [x] `uv run pytest tests/unit/substrate -q` (41 tests pass)
- [x] `uv run pytest tests/unit/substrate tests/unit/test_doctor_cmd.py tests/unit/test_doctor.py -q` (64 tests pass)
- [ ] Manual smoke on macOS: `bernstein desktop-register --host cursor` writes `~/.cursor/mcp.json`
- [ ] Manual smoke: `bernstein desktop-register --host zed` writes `context_servers` entry
- [ ] Manual smoke: `bernstein desktop-register --host aider` writes YAML entry under `mcp-servers`
- [ ] Manual smoke: `bernstein doctor --substrate` reports correct state for each host

## Files

- `src/bernstein/core/substrate/host_registry.py`: add `ConfigFormat` enum, per-host path resolvers, promote five hosts to `SUPPORTED`.
- `src/bernstein/core/substrate/register.py`: dispatch load/dump on `ConfigFormat`, add `is_stale`.
- `src/bernstein/core/substrate/__init__.py`: export the new surface.
- `src/bernstein/cli/commands/doctor_cmd.py`: add `--substrate` mode (table + JSON renderers).
- `docs/substrate/{cursor,continue,cline,zed,aider}.md`: per-host operator pages.
- `tests/unit/substrate/`: cover the new adapters and the doctor command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--substrate` flag to diagnostic command for checking host registration status across supported IDEs and editors.
  * Extended registration support to Aider, Cline, Continue, Cursor, and Zed.

* **Documentation**
  * Added configuration guides for registering with Aider, Cline, Continue, Cursor, and Zed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->