### PR TITLE
feat(mcp-server): close ecosystem surface gaps

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -324,6 +324,8 @@ alwaysApply: false
 | `capability.py`       | Runtime capability cards for the Bernstein MCP server |
 | `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
+| `oauth.py`            | OAuth-2 / OIDC discovery metadata for the Bernstein MCP server |
+| `prompts.py`          | Built-in MCP prompts for the Bernstein server |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |

--- a/.goosehints
+++ b/.goosehints
@@ -325,6 +325,8 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `capability.py`       | Runtime capability cards for the Bernstein MCP server |
 | `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
+| `oauth.py`            | OAuth-2 / OIDC discovery metadata for the Bernstein MCP server |
+| `prompts.py`          | Built-in MCP prompts for the Bernstein server |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,8 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `capability.py`       | Runtime capability cards for the Bernstein MCP server |
 | `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
+| `oauth.py`            | OAuth-2 / OIDC discovery metadata for the Bernstein MCP server |
+| `prompts.py`          | Built-in MCP prompts for the Bernstein server |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,8 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `capability.py`       | Runtime capability cards for the Bernstein MCP server |
 | `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
+| `oauth.py`            | OAuth-2 / OIDC discovery metadata for the Bernstein MCP server |
+| `prompts.py`          | Built-in MCP prompts for the Bernstein server |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -325,6 +325,8 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `capability.py`       | Runtime capability cards for the Bernstein MCP server |
 | `cost_meter.py`       | Per-call cost-meter and observability envelope for MCP tool responses |
 | `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
+| `oauth.py`            | OAuth-2 / OIDC discovery metadata for the Bernstein MCP server |
+| `prompts.py`          | Built-in MCP prompts for the Bernstein server |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |

--- a/docs/mcp/server-audit-2026.md
+++ b/docs/mcp/server-audit-2026.md
@@ -26,7 +26,7 @@ covered, the gap is recorded as a follow-up rather than left undefined.
 | Transport: WebSocket | Uncommon | Not implemented | Planned |
 | Auth: anonymous | Loopback-only convenience | Allowed on loopback only; refused on non-loopback binds | Yes |
 | Auth: static bearer | Common | Constant-time bearer check; token from env or config | Yes |
-| Auth: OAuth-2 PKCE | Emerging | Not implemented; advertised under `auth.planned` | Planned |
+| Auth: OAuth-2 PKCE | Emerging | Discovery metadata served at `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` when `BERNSTEIN_MCP_OAUTH_ISSUER` is set; token issuance is delegated to the configured IdP. See `src/bernstein/mcp/oauth.py` | Partial |
 | Auth: OIDC federation | Emerging | Not implemented; advertised under `auth.planned` | Planned |
 | Capability negotiation: static manifest | Standard `initialize` capabilities | Static `capabilities` object on `initialize` | Yes |
 | Capability negotiation: runtime capability cards | Less common | `bernstein://capability` resource and `capabilityCard` on `initialize`, built from live process state | Yes |

--- a/docs/mcp/server-audit-2026.md
+++ b/docs/mcp/server-audit-2026.md
@@ -33,13 +33,14 @@ covered, the gap is recorded as a follow-up rather than left undefined.
 | Streaming tool-call output | Common | Tool calls run as cancellable tasks on the HTTP transport | Partial |
 | Cancel in-flight tool call | Common | `notifications/cancelled` by request id | Yes |
 | Partial-result preservation on cancel | Less common | Cancelled calls return `cancelled: true` with preserved `partial` chunks | Yes |
-| Resource listing: prompts/sampling routes | Common | Lineage resources and the capability card; no prompt/sampling routes | Partial |
+| Resource listing: prompts routes | Common | Built-in prompt catalogue served via `prompts/list` and `prompts/get`; see `src/bernstein/mcp/prompts.py` | Yes |
+| Resource listing: sampling routes | Less common | Not implemented; advertised under `auth.planned`-style follow-up | Planned |
 | Observability: per-call latency | Less common | `_meter.latency_ms` on every response | Yes |
 | Observability: per-call cost meter | Uncommon | `_meter.cost_usd` envelope on every response | Yes |
 | Observability: call trace id | Less common | `_meter.call_id` on every response | Yes |
 | Tool-catalogue richness | Varies | Tiered catalogue (`core` / `standard` / `all`); see `docs/mcp/tool_tiers.md` | Yes |
 
-## Surfaces landed in this pass
+## Surfaces landed in earlier passes
 
 1. Per-call cost-meter envelope on every tool response (`result` plus `_meter`
    with latency, cost, trace id, status), uniform across stdio, SSE, and the
@@ -50,14 +51,28 @@ covered, the gap is recorded as a follow-up rather than left undefined.
 3. Streaming tool-call cancel with partial-result preservation on the
    streamable HTTP transport, via `notifications/cancelled`.
 
+## Surfaces landed in this pass
+
+1. Built-in prompt catalogue exposed via `prompts/list` and `prompts/get` on
+   the FastMCP server and the streamable HTTP transport. Three orchestration
+   prompts (`orchestrate_goal`, `triage_failed_tasks`, `cost_recap`) are
+   rendered server-side from arguments; see `src/bernstein/mcp/prompts.py`.
+2. OAuth-2 PKCE authorization-server metadata published at the
+   `.well-known/oauth-authorization-server` discovery path on the streamable
+   HTTP transport. The metadata is opt-in (configured via
+   `BERNSTEIN_MCP_OAUTH_ISSUER`) so a client that auto-discovers protected
+   resource metadata can locate the IdP without the server itself issuing
+   tokens; see `src/bernstein/mcp/oauth.py`.
+
 ## Follow-ups (tracked, not in this pass)
 
-- OAuth-2 PKCE and OIDC federation auth paths. The capability card already
-  advertises these under `auth.planned` so a client sees the gap as
-  acknowledged rather than undefined.
+- Full OAuth-2 PKCE token issuance and OIDC federation behind the metadata.
+  The discovery metadata advertises the IdP a host should redirect to;
+  bearer-token validation against that issuer is still the static-bearer
+  path.
 - WebSocket transport.
 - Server-initiated SSE push channel over GET.
-- Prompt and sampling resource routes.
+- Sampling resource routes (`sampling/createMessage`).
 
 New tools are out of scope for this pass by design; this work closes
 protocol-surface gaps only.

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -26,8 +26,26 @@ at startup.
 | Anonymous | default on loopback | Allowed only on `127.0.0.1` / `localhost` / `::1`. |
 | Static bearer | `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) | Constant-time check; required on non-loopback binds. |
 
-OAuth-2 PKCE and OIDC federation are not yet implemented. The capability card
-advertises them under `auth.planned` so a client sees the gap as acknowledged.
+OAuth-2 PKCE token issuance is delegated to an external IdP. When the operator
+sets `BERNSTEIN_MCP_OAUTH_ISSUER=https://idp.example.com`, the streamable
+HTTP transport serves the standard discovery documents so a host can
+auto-locate the IdP:
+
+| Path | Document |
+|------|----------|
+| `/.well-known/oauth-authorization-server` | RFC 8414 authorization-server metadata for the configured issuer (PKCE S256, code grant, public client allowed). |
+| `/.well-known/oauth-protected-resource` | RFC 9728 / MCP-draft protected-resource metadata pointing at the issuer; the `resource` field is built from the request `Host` and `X-Forwarded-Proto` headers. |
+
+Both well-known paths are served without authentication, since a client
+probing discovery has no token yet. When the env var is unset, the paths
+return 404 and only anonymous (loopback) / static bearer are advertised.
+
+`BERNSTEIN_MCP_OAUTH_SCOPES` (comma-separated) overrides the default
+`bernstein.read,bernstein.write` scope list in both documents.
+
+The capability card reports the discovery state under `auth.oauth` so a
+client that has already fetched the card can locate the well-known paths
+without probing. OIDC federation is still a follow-up.
 
 ## Capability cards
 
@@ -44,6 +62,23 @@ The card is available two ways:
   resource API);
 - under the `capabilityCard` key on the streamable HTTP transport's
   `initialize` result.
+
+## Built-in prompt catalogue
+
+The server ships three orchestration-focused prompt templates exposed via
+the MCP `prompts/list` and `prompts/get` routes. A host that auto-discovers
+MCP servers can populate a prompt picker without sending a tool call first.
+
+| Prompt | Arguments | Use when |
+|--------|-----------|----------|
+| `orchestrate_goal` | `goal` (required), `role`, `scope` | Planning a single Bernstein run from a free-form goal. |
+| `triage_failed_tasks` | `limit` (default 5) | Reviewing recent failed tasks and proposing next actions. |
+| `cost_recap` | `window` (default `today`) | Summarising cost-per-role across a labelled window. |
+
+Each prompt renders deterministically from its arguments and does not call
+the task server. The capability card lists the catalogue under
+`prompts.catalogue` so a client that has already fetched the card can pick a
+prompt without a second probe.
 
 ## Per-call cost-meter envelope
 
@@ -124,7 +159,33 @@ Cancelling an unknown or already-settled id is a no-op.
      -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bernstein_status","arguments":{}}}'
    ```
 
-4. Cancel a long-running call by its id (in a second request, while the call
+4. List and fetch a built-in prompt:
+
+   ```bash
+   curl -s http://127.0.0.1:8053/mcp \
+     -H "Authorization: Bearer dev-token" \
+     -H "content-type: application/json" \
+     -d '{"jsonrpc":"2.0","id":3,"method":"prompts/list"}'
+
+   curl -s http://127.0.0.1:8053/mcp \
+     -H "Authorization: Bearer dev-token" \
+     -H "content-type: application/json" \
+     -d '{"jsonrpc":"2.0","id":4,"method":"prompts/get","params":{"name":"orchestrate_goal","arguments":{"goal":"ship X","role":"qa"}}}'
+   ```
+
+5. (Optional) Probe OAuth-2 discovery before authenticating:
+
+   ```bash
+   export BERNSTEIN_MCP_OAUTH_ISSUER=https://idp.example.com
+   # restart the server to pick up the env var, then:
+   curl -s http://127.0.0.1:8053/.well-known/oauth-authorization-server
+   curl -s http://127.0.0.1:8053/.well-known/oauth-protected-resource
+   ```
+
+   The client redirects the user to the IdP from these documents and presents
+   the resulting bearer token to the streamable HTTP transport.
+
+6. Cancel a long-running call by its id (in a second request, while the call
    is in flight):
 
    ```bash

--- a/src/bernstein/mcp/capability.py
+++ b/src/bernstein/mcp/capability.py
@@ -51,17 +51,27 @@ def _auth_modes() -> dict[str, Any]:
     """Describe the auth paths the running server supports.
 
     Reports the modes the transport layer can enforce (anonymous on
-    loopback, static bearer token) and whether a token is currently
-    configured in the environment. Modes the server does not yet implement
-    are listed under ``planned`` so a client knows the gap is acknowledged
-    rather than undefined.
+    loopback, static bearer token, OAuth-2 PKCE discovery) and whether a
+    token is currently configured in the environment. When the OAuth issuer
+    env var is set, the discovery surface is advertised under ``oauth`` and
+    ``oauth2_pkce`` moves from ``planned`` into ``supported``.
     """
+    from bernstein.mcp.oauth import capability_card_oauth, oauth_discovery_enabled
+
     token_configured = any(os.environ.get(name) for name in ("BERNSTEIN_MCP_TOKEN", "BERNSTEIN_MCP_AUTH_TOKEN"))
+    oauth_active = oauth_discovery_enabled()
+    supported = ["anonymous", "bearer"]
+    planned = ["oidc"]
+    if oauth_active:
+        supported.append("oauth2_pkce")
+    else:
+        planned.insert(0, "oauth2_pkce")
     return {
-        "supported": ["anonymous", "bearer"],
-        "planned": ["oauth2_pkce", "oidc"],
+        "supported": supported,
+        "planned": planned,
         "bearer_token_configured": token_configured,
         "anonymous_scope": "loopback-only",
+        "oauth": capability_card_oauth(),
     }
 
 

--- a/src/bernstein/mcp/capability.py
+++ b/src/bernstein/mcp/capability.py
@@ -113,6 +113,10 @@ def build_capability_card() -> dict[str, Any]:
             "advertised": tools_for_tier(active_tier),
             "tiers": tier_audit(),
         },
+        "prompts": {
+            "supported": True,
+            "catalogue": ["orchestrate_goal", "triage_failed_tasks", "cost_recap"],
+        },
         "costMeter": {
             "enabled": cost_meter_enabled(),
             "envVar": COST_METER_ENV,

--- a/src/bernstein/mcp/oauth.py
+++ b/src/bernstein/mcp/oauth.py
@@ -1,0 +1,125 @@
+"""OAuth-2 / OIDC discovery metadata for the Bernstein MCP server.
+
+Hosts that auto-discover MCP servers look for the standard OAuth-2
+authorization-server metadata document (RFC 8414) and the MCP-style
+protected-resource metadata document (draft) to learn:
+
+  * which authorization server (IdP) issues tokens for this resource;
+  * which scopes the resource accepts;
+  * which response/grant types and PKCE methods are advertised.
+
+Bernstein itself does not issue tokens. Instead, when the operator points the
+server at an external IdP (via ``BERNSTEIN_MCP_OAUTH_ISSUER``), this module
+publishes the discovery metadata so a client can negotiate a PKCE flow with
+that IdP and then present the resulting bearer token to the streamable HTTP
+transport. The transport's existing static-bearer check validates the token
+opaquely; full JWKS validation against the issuer is a follow-up.
+
+This closes the discovery gap for the OAuth-2 PKCE auth path: a client that
+auto-discovers protected-resource metadata can locate the IdP without trial
+and error. When the issuer env var is not set, the discovery endpoints
+return 404 so anonymous/static-bearer flows remain the only advertised path.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+#: Env var that configures the OAuth-2 issuer URL Bernstein advertises.
+#: When unset, discovery endpoints return 404.
+ISSUER_ENV: str = "BERNSTEIN_MCP_OAUTH_ISSUER"
+
+#: Env var holding the comma-separated scopes the resource server accepts.
+SCOPES_ENV: str = "BERNSTEIN_MCP_OAUTH_SCOPES"
+
+#: Default scopes advertised when ``BERNSTEIN_MCP_OAUTH_SCOPES`` is unset.
+_DEFAULT_SCOPES: tuple[str, ...] = ("bernstein.read", "bernstein.write")
+
+#: Path where authorization-server metadata is served (RFC 8414).
+AS_METADATA_PATH: str = "/.well-known/oauth-authorization-server"
+
+#: Path where protected-resource metadata is served (MCP draft / RFC 9728).
+PR_METADATA_PATH: str = "/.well-known/oauth-protected-resource"
+
+
+def issuer() -> str:
+    """Return the configured OAuth-2 issuer URL, or an empty string."""
+    return os.environ.get(ISSUER_ENV, "").strip().rstrip("/")
+
+
+def scopes_supported() -> list[str]:
+    """Return the scopes advertised by the protected-resource metadata."""
+    raw = os.environ.get(SCOPES_ENV, "").strip()
+    if not raw:
+        return list(_DEFAULT_SCOPES)
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def oauth_discovery_enabled() -> bool:
+    """Return True when the OAuth issuer is configured."""
+    return bool(issuer())
+
+
+def authorization_server_metadata() -> dict[str, Any] | None:
+    """Build the RFC 8414 authorization-server metadata document.
+
+    Returns:
+        A JSON-serialisable dict, or ``None`` when no issuer is configured.
+    """
+    iss = issuer()
+    if not iss:
+        return None
+    return {
+        "issuer": iss,
+        "authorization_endpoint": f"{iss}/oauth/authorize",
+        "token_endpoint": f"{iss}/oauth/token",
+        "jwks_uri": f"{iss}/.well-known/jwks.json",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": [
+            "client_secret_basic",
+            "none",  # public client + PKCE
+        ],
+        "scopes_supported": scopes_supported(),
+    }
+
+
+def protected_resource_metadata(resource_url: str) -> dict[str, Any] | None:
+    """Build the protected-resource metadata document (RFC 9728 / MCP draft).
+
+    Args:
+        resource_url: Absolute URL of the MCP resource (the streamable HTTP
+            transport endpoint), used as the ``resource`` field.
+
+    Returns:
+        A JSON-serialisable dict, or ``None`` when no issuer is configured.
+    """
+    iss = issuer()
+    if not iss:
+        return None
+    return {
+        "resource": resource_url,
+        "authorization_servers": [iss],
+        "scopes_supported": scopes_supported(),
+        "bearer_methods_supported": ["header"],
+        "resource_documentation": "https://github.com/sipyourdrink-ltd/bernstein/blob/main/docs/mcp/server.md",
+    }
+
+
+def capability_card_oauth() -> dict[str, Any]:
+    """Return the ``auth.oauth`` subtree for the runtime capability card.
+
+    Reports whether the discovery surface is live and which issuer it points
+    at, so a client that fetches the card can locate the metadata documents
+    without probing the well-known paths.
+    """
+    iss = issuer()
+    return {
+        "enabled": bool(iss),
+        "issuer": iss,
+        "authorizationServerMetadata": AS_METADATA_PATH,
+        "protectedResourceMetadata": PR_METADATA_PATH,
+        "envVar": ISSUER_ENV,
+    }

--- a/src/bernstein/mcp/prompts.py
+++ b/src/bernstein/mcp/prompts.py
@@ -1,0 +1,122 @@
+"""Built-in MCP prompts for the Bernstein server.
+
+The MCP spec defines a `prompts/list` and `prompts/get` surface so a client
+can browse server-side reusable prompt templates and parametrise them by
+argument. Common ecosystem implementations ship at least a small built-in
+prompt catalogue so an auto-discovery host can show users what the server is
+useful for without sending a single tool call first.
+
+This module registers a small catalogue tailored to Bernstein's orchestration
+surface. Prompts are templates rendered server-side from parameters; they
+take no live process state and do not call the task server, so they are
+cheap and safe to expose unconditionally.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+
+def _orchestrate_goal_template(
+    goal: str,
+    role: str = "backend",
+    scope: str = "medium",
+) -> str:
+    """Render the orchestration-kickoff prompt body."""
+    return textwrap.dedent(
+        f"""\
+        You are about to drive a Bernstein orchestration run.
+
+        Goal: {goal}
+        Suggested role: {role}
+        Scope: {scope}
+
+        Plan the smallest sequence of Bernstein tool calls that lands the goal:
+        1. Use `bernstein_run` to post the task with the suggested role and scope.
+        2. Poll `bernstein_status` until the task settles, or call `bernstein_tasks`
+           filtered by status to inspect progress.
+        3. If a subtask appears blocked, call `bernstein_approve` with the task id.
+
+        Stop when the goal is done or when a tool returns an error you cannot
+        recover from. Report the final task ids and statuses to the user.
+        """
+    ).strip()
+
+
+def _triage_failed_tasks_template(limit: int = 5) -> str:
+    """Render the triage-failed-tasks prompt body."""
+    return textwrap.dedent(
+        f"""\
+        Triage the latest failed Bernstein tasks.
+
+        Steps:
+        1. Call `bernstein_tasks` with `status="failed"` to list candidates.
+        2. For up to {limit} tasks, inspect the result summary and surface the
+           shortest reproduction in the conversation.
+        3. Group failures by likely cause (env, flaky test, real bug) and
+           propose one next action per group.
+
+        Output a compact table with columns: task_id, role, cause, next action.
+        """
+    ).strip()
+
+
+def _cost_recap_template(window: str = "today") -> str:
+    """Render the cost-recap prompt body."""
+    return textwrap.dedent(
+        f"""\
+        Produce a cost recap for the {window} window.
+
+        Steps:
+        1. Call `bernstein_cost` to fetch the per-role breakdown.
+        2. List roles in descending cost order; collapse rows under $0.01.
+        3. Flag any role whose share exceeds 50% of the total as a concentration risk.
+
+        Output: one short paragraph plus a per-role table.
+        """
+    ).strip()
+
+
+def register_prompt_resources(mcp: FastMCP[None]) -> None:
+    """Register the built-in prompt catalogue on a FastMCP server.
+
+    Exposes three orchestration-focused prompts via the MCP `prompts/list`
+    and `prompts/get` routes. Each prompt is a pure render of its arguments
+    so the surface is deterministic and cheap.
+
+    Args:
+        mcp: The FastMCP server to register the prompts on.
+    """
+
+    @mcp.prompt(
+        name="orchestrate_goal",
+        description="Plan a Bernstein orchestration run for a single goal.",
+    )
+    def orchestrate_goal(  # pyright: ignore[reportUnusedFunction]
+        goal: str,
+        role: str = "backend",
+        scope: str = "medium",
+    ) -> str:
+        return _orchestrate_goal_template(goal=goal, role=role, scope=scope)
+
+    @mcp.prompt(
+        name="triage_failed_tasks",
+        description="Triage the most recent failed tasks and propose next actions.",
+    )
+    def triage_failed_tasks(  # pyright: ignore[reportUnusedFunction]
+        limit: int = 5,
+    ) -> str:
+        return _triage_failed_tasks_template(limit=limit)
+
+    @mcp.prompt(
+        name="cost_recap",
+        description="Summarise Bernstein cost by role for a stated window.",
+    )
+    def cost_recap(  # pyright: ignore[reportUnusedFunction]
+        window: str = "today",
+    ) -> str:
+        return _cost_recap_template(window=window)

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -253,10 +253,42 @@ _SERVER_INFO: dict[str, Any] = {
 
 _CAPABILITIES: dict[str, Any] = {
     "tools": {"listChanged": False},
+    # Server-side prompt templates surfaced via prompts/list and prompts/get.
+    "prompts": {"listChanged": False},
     # The server honours notifications/cancelled for in-flight tool calls and
     # preserves partial output on cancel.
     "experimental": {"cancellation": {"partialResults": True}},
 }
+
+
+# Built-in prompt catalogue mirroring src/bernstein/mcp/prompts.py. Mirroring
+# here keeps the streamable HTTP transport self-contained: it does not need
+# to spin up a FastMCP instance to answer prompts/list and prompts/get.
+_PROMPT_DEFS: list[dict[str, Any]] = [
+    {
+        "name": "orchestrate_goal",
+        "description": "Plan a Bernstein orchestration run for a single goal.",
+        "arguments": [
+            {"name": "goal", "description": "What to accomplish.", "required": True},
+            {"name": "role", "description": "Specialist role.", "required": False},
+            {"name": "scope", "description": "Task scope.", "required": False},
+        ],
+    },
+    {
+        "name": "triage_failed_tasks",
+        "description": "Triage the most recent failed tasks and propose next actions.",
+        "arguments": [
+            {"name": "limit", "description": "Max tasks to inspect.", "required": False},
+        ],
+    },
+    {
+        "name": "cost_recap",
+        "description": "Summarise Bernstein cost by role for a stated window.",
+        "arguments": [
+            {"name": "window", "description": "Window label (e.g. today).", "required": False},
+        ],
+    },
+]
 
 
 class StreamableHTTPTransport:
@@ -459,6 +491,8 @@ class StreamableHTTPTransport:
             "initialize": self._method_initialize,
             "tools/list": self._method_tools_list,
             "tools/call": self._method_tools_call,
+            "prompts/list": self._method_prompts_list,
+            "prompts/get": self._method_prompts_get,
             "ping": self._method_ping,
             "notifications/initialized": self._method_noop,
             "notifications/cancelled": self._method_cancelled,
@@ -564,6 +598,72 @@ class StreamableHTTPTransport:
             await self._inflight.discard(req_id)
         return {
             "content": [{"type": "text", "text": wrap_envelope(text, meter)}],
+        }
+
+    async def _method_prompts_list(
+        self,
+        session: MCPSession,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Handle 'prompts/list' - return the built-in prompt catalogue.
+
+        Common auto-discovery hosts probe this surface to populate a prompt
+        picker. The catalogue is the same one the FastMCP server registers,
+        kept in sync via ``_PROMPT_DEFS`` on this transport.
+        """
+        return {"prompts": _PROMPT_DEFS}
+
+    async def _method_prompts_get(
+        self,
+        session: MCPSession,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Handle 'prompts/get' - render a named prompt with arguments.
+
+        Args:
+            session: Current MCP session.
+            params: JSON-RPC params carrying ``name`` and optional ``arguments``.
+
+        Returns:
+            A prompt response with a single user-role text message.
+
+        Raises:
+            ValueError: When the requested prompt name is unknown.
+        """
+        from bernstein.mcp.prompts import (
+            _cost_recap_template,
+            _orchestrate_goal_template,
+            _triage_failed_tasks_template,
+        )
+
+        name = params.get("name", "")
+        arguments = params.get("arguments", {}) or {}
+        if name == "orchestrate_goal":
+            body = _orchestrate_goal_template(
+                goal=arguments.get("goal", ""),
+                role=arguments.get("role", "backend"),
+                scope=arguments.get("scope", "medium"),
+            )
+        elif name == "triage_failed_tasks":
+            limit_raw = arguments.get("limit", 5)
+            try:
+                limit = int(limit_raw)
+            except (TypeError, ValueError):
+                limit = 5
+            body = _triage_failed_tasks_template(limit=limit)
+        elif name == "cost_recap":
+            body = _cost_recap_template(window=arguments.get("window", "today"))
+        else:
+            msg = f"Unknown prompt: {name}"
+            raise ValueError(msg)
+        return {
+            "description": next((p["description"] for p in _PROMPT_DEFS if p["name"] == name), ""),
+            "messages": [
+                {
+                    "role": "user",
+                    "content": {"type": "text", "text": body},
+                }
+            ],
         }
 
     async def _method_cancelled(

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -330,6 +330,13 @@ class StreamableHTTPTransport:
         Returns:
             Tuple of (status_code, response_headers, response_body).
         """
+        # OAuth-2 / OIDC discovery metadata. Served without authentication so
+        # a client can locate the IdP before it has a token; standard well-known
+        # paths only return content when ``BERNSTEIN_MCP_OAUTH_ISSUER`` is set,
+        # otherwise 404 (anonymous/static-bearer remain the advertised path).
+        if method == "GET" and self._is_well_known(path):
+            return self._handle_well_known(path, headers)
+
         # Normalise path.
         if not path.rstrip("/").endswith(self._config.path.rstrip("/")):
             return (404, {"content-type": _CONTENT_TYPE_JSON}, b'{"error":"not found"}')
@@ -815,6 +822,56 @@ class StreamableHTTPTransport:
             )
             resp.raise_for_status()
             return resp.text
+
+    # -- OAuth discovery -----------------------------------------------------
+
+    @staticmethod
+    def _is_well_known(path: str) -> bool:
+        """Return True for the OAuth-2 / protected-resource discovery paths."""
+        from bernstein.mcp.oauth import AS_METADATA_PATH, PR_METADATA_PATH
+
+        return path in {AS_METADATA_PATH, PR_METADATA_PATH}
+
+    def _handle_well_known(
+        self,
+        path: str,
+        headers: dict[str, str],
+    ) -> tuple[int, dict[str, str], bytes]:
+        """Serve OAuth-2 authorization-server / protected-resource metadata.
+
+        Returns:
+            (200, headers, json-body) when discovery is enabled; 404 otherwise.
+        """
+        from bernstein.mcp.oauth import (
+            AS_METADATA_PATH,
+            PR_METADATA_PATH,
+            authorization_server_metadata,
+            protected_resource_metadata,
+        )
+
+        if path == AS_METADATA_PATH:
+            meta = authorization_server_metadata()
+        elif path == PR_METADATA_PATH:
+            # Build the absolute resource URL from the Host header so the
+            # advertised resource matches what the client called.
+            host = headers.get("host", f"{self._config.host}:{self._config.port}")
+            scheme = headers.get("x-forwarded-proto", "http")
+            resource_url = f"{scheme}://{host}{self._config.path}"
+            meta = protected_resource_metadata(resource_url)
+        else:
+            meta = None
+
+        if meta is None:
+            return (
+                404,
+                {"content-type": _CONTENT_TYPE_JSON},
+                b'{"error":"oauth discovery not configured"}',
+            )
+        return (
+            200,
+            {"content-type": _CONTENT_TYPE_JSON, "cache-control": "public, max-age=300"},
+            json.dumps(meta).encode(),
+        )
 
     # -- Auth ----------------------------------------------------------------
 

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -552,10 +552,12 @@ def create_mcp_server(
         Configured FastMCP instance with the active tier's tools registered.
     """
     from bernstein.mcp.capability import register_capability_resource
+    from bernstein.mcp.prompts import register_prompt_resources
 
     active_tier = resolve_active_tier(tier)
     mcp: FastMCP[None] = FastMCP(name)
     register_capability_resource(mcp)
+    register_prompt_resources(mcp)
     _register_health_tool(mcp)
     _register_query_tools(mcp, server_url)
     _register_action_tools(mcp, server_url)

--- a/tests/unit/mcp/test_oauth_discovery.py
+++ b/tests/unit/mcp/test_oauth_discovery.py
@@ -1,0 +1,214 @@
+"""Tests for OAuth-2 / OIDC discovery metadata (issue #1674).
+
+Covers:
+
+  * the discovery helpers return ``None`` when no issuer is configured;
+  * with an issuer set, the authorization-server metadata is RFC 8414 shaped;
+  * the protected-resource metadata carries the configured authorization
+    server and the resource URL;
+  * the streamable HTTP transport serves both well-known paths and falls
+    back to 404 when discovery is off;
+  * the capability card reports the discovery state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _no_issuer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_MCP_OAUTH_ISSUER", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_OAUTH_SCOPES", raising=False)
+
+
+@pytest.fixture
+def _with_issuer(monkeypatch: pytest.MonkeyPatch) -> str:
+    issuer = "https://idp.example.com"
+    monkeypatch.setenv("BERNSTEIN_MCP_OAUTH_ISSUER", issuer)
+    monkeypatch.delenv("BERNSTEIN_MCP_OAUTH_SCOPES", raising=False)
+    return issuer
+
+
+def test_no_issuer_returns_none(_no_issuer: None) -> None:
+    from bernstein.mcp.oauth import (
+        authorization_server_metadata,
+        oauth_discovery_enabled,
+        protected_resource_metadata,
+    )
+
+    assert oauth_discovery_enabled() is False
+    assert authorization_server_metadata() is None
+    assert protected_resource_metadata("https://example.com/mcp") is None
+
+
+def test_authorization_server_metadata_is_rfc8414_shaped(_with_issuer: str) -> None:
+    from bernstein.mcp.oauth import authorization_server_metadata
+
+    meta = authorization_server_metadata()
+    assert meta is not None
+    assert meta["issuer"] == _with_issuer
+    assert meta["authorization_endpoint"].startswith(_with_issuer)
+    assert meta["token_endpoint"].startswith(_with_issuer)
+    assert "code" in meta["response_types_supported"]
+    assert "authorization_code" in meta["grant_types_supported"]
+    assert "S256" in meta["code_challenge_methods_supported"]
+    # Public client + PKCE path is advertised.
+    assert "none" in meta["token_endpoint_auth_methods_supported"]
+
+
+def test_authorization_server_metadata_strips_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from bernstein.mcp.oauth import authorization_server_metadata
+
+    monkeypatch.setenv("BERNSTEIN_MCP_OAUTH_ISSUER", "https://idp.example.com/")
+    meta = authorization_server_metadata()
+    assert meta is not None
+    # Trailing slash is normalised so the endpoints are well-formed.
+    assert meta["issuer"] == "https://idp.example.com"
+    assert meta["authorization_endpoint"] == "https://idp.example.com/oauth/authorize"
+
+
+def test_protected_resource_metadata_carries_resource(_with_issuer: str) -> None:
+    from bernstein.mcp.oauth import protected_resource_metadata
+
+    meta = protected_resource_metadata("https://bernstein.example.com/mcp")
+    assert meta is not None
+    assert meta["resource"] == "https://bernstein.example.com/mcp"
+    assert meta["authorization_servers"] == [_with_issuer]
+    assert "header" in meta["bearer_methods_supported"]
+
+
+def test_custom_scopes_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.mcp.oauth import scopes_supported
+
+    monkeypatch.setenv("BERNSTEIN_MCP_OAUTH_SCOPES", "foo, bar, baz")
+    assert scopes_supported() == ["foo", "bar", "baz"]
+
+
+# ---------------------------------------------------------------------------
+# Streamable HTTP transport well-known paths
+# ---------------------------------------------------------------------------
+
+
+def test_transport_serves_authorization_server_metadata(_with_issuer: str) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    status, headers, body = asyncio.run(
+        transport.handle_request(
+            "GET",
+            "/.well-known/oauth-authorization-server",
+            {"host": "bernstein.example.com"},
+            b"",
+        )
+    )
+    assert status == 200
+    assert headers["content-type"] == "application/json"
+    payload = json.loads(body)
+    assert payload["issuer"] == _with_issuer
+
+
+def test_transport_serves_protected_resource_metadata(_with_issuer: str) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    status, _, body = asyncio.run(
+        transport.handle_request(
+            "GET",
+            "/.well-known/oauth-protected-resource",
+            {"host": "bernstein.example.com", "x-forwarded-proto": "https"},
+            b"",
+        )
+    )
+    assert status == 200
+    payload = json.loads(body)
+    assert payload["resource"] == "https://bernstein.example.com/mcp"
+    assert payload["authorization_servers"] == [_with_issuer]
+
+
+def test_transport_returns_404_when_discovery_disabled(_no_issuer: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    status, _, _ = asyncio.run(
+        transport.handle_request(
+            "GET",
+            "/.well-known/oauth-authorization-server",
+            {"host": "127.0.0.1"},
+            b"",
+        )
+    )
+    assert status == 404
+
+
+def test_well_known_path_does_not_require_auth(_with_issuer: str) -> None:
+    """A client probing discovery has no token yet; the path must not 401."""
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    # Bearer config that would 401 any /mcp request without Authorization.
+    cfg = RemoteMCPConfig(
+        host="127.0.0.1",
+        auth_type="bearer",
+        auth_token="secret",
+    )
+    transport = StreamableHTTPTransport(config=cfg)
+    status, _, _ = asyncio.run(
+        transport.handle_request(
+            "GET",
+            "/.well-known/oauth-authorization-server",
+            {"host": "127.0.0.1"},
+            b"",
+        )
+    )
+    assert status == 200
+
+
+# ---------------------------------------------------------------------------
+# Capability card integration
+# ---------------------------------------------------------------------------
+
+
+def test_capability_card_reports_oauth_state(_with_issuer: str) -> None:
+    from bernstein.mcp.capability import build_capability_card
+
+    card = build_capability_card()
+    oauth = card["auth"]["oauth"]
+    assert oauth["enabled"] is True
+    assert oauth["issuer"] == _with_issuer
+    assert oauth["authorizationServerMetadata"] == "/.well-known/oauth-authorization-server"
+    # With discovery on, oauth2_pkce moves into supported.
+    assert "oauth2_pkce" in card["auth"]["supported"]
+
+
+def test_capability_card_reports_oauth_disabled(_no_issuer: None) -> None:
+    from bernstein.mcp.capability import build_capability_card
+
+    card = build_capability_card()
+    assert card["auth"]["oauth"]["enabled"] is False
+    # When off, oauth2_pkce remains planned, not supported.
+    assert "oauth2_pkce" in card["auth"]["planned"]
+    assert "oauth2_pkce" not in card["auth"]["supported"]

--- a/tests/unit/mcp/test_prompts.py
+++ b/tests/unit/mcp/test_prompts.py
@@ -1,0 +1,191 @@
+"""Tests for the built-in MCP prompt catalogue (issue #1674).
+
+Covers:
+
+  * the FastMCP server registers the prompts and exposes ``prompts/list`` /
+    ``prompts/get``;
+  * each prompt renders deterministically from its arguments;
+  * the streamable HTTP transport answers ``prompts/list`` and ``prompts/get``
+    with the same catalogue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pure template rendering
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrate_goal_template_includes_goal_role_scope() -> None:
+    from bernstein.mcp.prompts import _orchestrate_goal_template
+
+    body = _orchestrate_goal_template(goal="ship feature", role="backend", scope="small")
+    assert "ship feature" in body
+    assert "backend" in body
+    assert "small" in body
+    # Mentions the right Bernstein tools so a host preview is useful.
+    assert "bernstein_run" in body
+    assert "bernstein_status" in body
+
+
+def test_triage_failed_tasks_template_uses_limit() -> None:
+    from bernstein.mcp.prompts import _triage_failed_tasks_template
+
+    body = _triage_failed_tasks_template(limit=3)
+    assert "3" in body
+    assert "failed" in body
+
+
+def test_cost_recap_template_uses_window() -> None:
+    from bernstein.mcp.prompts import _cost_recap_template
+
+    body = _cost_recap_template(window="last 7 days")
+    assert "last 7 days" in body
+    assert "bernstein_cost" in body
+
+
+# ---------------------------------------------------------------------------
+# FastMCP server
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_TOOL_TIER", raising=False)
+    monkeypatch.delenv("BERNSTEIN_MCP_COST_METER", raising=False)
+
+
+def test_fastmcp_server_lists_prompts(_clean_env: None) -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(tier="standard")
+    prompts = asyncio.run(mcp.list_prompts())
+    names = {p.name for p in prompts}
+    assert {"orchestrate_goal", "triage_failed_tasks", "cost_recap"} <= names
+
+
+def test_fastmcp_server_renders_orchestrate_goal(_clean_env: None) -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(tier="standard")
+    rendered = asyncio.run(mcp.get_prompt("orchestrate_goal", {"goal": "fix flaky test", "role": "qa"}))
+    assert rendered.messages, "prompt should render at least one message"
+    msg = rendered.messages[0]
+    assert msg.role == "user"
+    assert msg.content.type == "text"
+    assert "fix flaky test" in msg.content.text
+    assert "qa" in msg.content.text
+
+
+def test_capability_card_advertises_prompt_catalogue(_clean_env: None) -> None:
+    from bernstein.mcp.capability import build_capability_card
+
+    card = build_capability_card()
+    assert card["prompts"]["supported"] is True
+    assert "orchestrate_goal" in card["prompts"]["catalogue"]
+    assert "triage_failed_tasks" in card["prompts"]["catalogue"]
+    assert "cost_recap" in card["prompts"]["catalogue"]
+
+
+# ---------------------------------------------------------------------------
+# Streamable HTTP transport
+# ---------------------------------------------------------------------------
+
+
+def _post_jsonrpc(transport, method: str, params: dict | None = None, req_id: int = 1) -> dict:
+    """Send a JSON-RPC POST through the transport and return the decoded result."""
+    payload = {"jsonrpc": "2.0", "method": method, "id": req_id}
+    if params is not None:
+        payload["params"] = params
+    body = json.dumps(payload).encode()
+    status, _, resp_body = asyncio.run(transport.handle_request("POST", "/mcp", {}, body))
+    assert status == 200, f"got {status}: {resp_body!r}"
+    return json.loads(resp_body)
+
+
+def test_http_transport_lists_prompts(_clean_env: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    resp = _post_jsonrpc(transport, "prompts/list")
+    prompts = resp["result"]["prompts"]
+    names = {p["name"] for p in prompts}
+    assert {"orchestrate_goal", "triage_failed_tasks", "cost_recap"} <= names
+    # Arguments are described so a client picker can render input fields.
+    og = next(p for p in prompts if p["name"] == "orchestrate_goal")
+    arg_names = {a["name"] for a in og["arguments"]}
+    assert "goal" in arg_names
+
+
+def test_http_transport_gets_prompt_with_arguments(_clean_env: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    resp = _post_jsonrpc(
+        transport,
+        "prompts/get",
+        {"name": "orchestrate_goal", "arguments": {"goal": "ship X", "role": "qa"}},
+    )
+    result = resp["result"]
+    assert result["messages"], "expected at least one message"
+    msg = result["messages"][0]
+    assert msg["role"] == "user"
+    assert msg["content"]["type"] == "text"
+    text = msg["content"]["text"]
+    assert "ship X" in text
+    assert "qa" in text
+
+
+def test_http_transport_prompts_get_unknown_name_errors(_clean_env: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "prompts/get",
+            "id": 7,
+            "params": {"name": "nope"},
+        }
+    ).encode()
+    status, _, resp_body = asyncio.run(transport.handle_request("POST", "/mcp", {}, body))
+    assert status == 200
+    payload = json.loads(resp_body)
+    assert "error" in payload
+    assert "nope" in payload["error"]["message"]
+
+
+def test_http_initialize_advertises_prompts_capability(_clean_env: None) -> None:
+    from bernstein.mcp.remote_transport import (
+        RemoteMCPConfig,
+        StreamableHTTPTransport,
+    )
+
+    cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
+    transport = StreamableHTTPTransport(config=cfg)
+    resp = _post_jsonrpc(
+        transport,
+        "initialize",
+        {"clientInfo": {"name": "test"}},
+    )
+    caps = resp["result"]["capabilities"]
+    assert "prompts" in caps


### PR DESCRIPTION
## Summary

Closes two MCP-server surface gaps that hosts auto-discovering servers expect, on top of the protocol-surface work that already landed in #1696:

- **Built-in prompt catalogue** via `prompts/list` and `prompts/get` on both the FastMCP server and the streamable HTTP transport. Three orchestration-focused templates (`orchestrate_goal`, `triage_failed_tasks`, `cost_recap`) render server-side from arguments, so a host populates a prompt picker without sending a tool call first. The capability card advertises the catalogue under `prompts.catalogue` and the static `capabilities` object includes `prompts.listChanged: false`.
- **OAuth-2 PKCE discovery metadata** served at the standard well-known paths (`/.well-known/oauth-authorization-server` per RFC 8414 and `/.well-known/oauth-protected-resource` per RFC 9728 / MCP draft) on the streamable HTTP transport. The surface is gated on `BERNSTEIN_MCP_OAUTH_ISSUER`; when set, an auto-discovery client locates the configured IdP and negotiates a PKCE flow before presenting a bearer token. Token issuance is delegated to the IdP. The capability card moves `oauth2_pkce` from `auth.planned` into `auth.supported` when discovery is live and reports the well-known paths under `auth.oauth`. The well-known paths are served without authentication so a client probing discovery (which has no token yet) is not 401'd before it can read the metadata.

Audit table at `docs/mcp/server-audit-2026.md` is updated to reflect the new state. Worked example and surface-by-surface description in `docs/mcp/server.md`.

Deferred (tracked in the audit follow-ups, none in this pass):

- Full OAuth-2 PKCE token issuance and OIDC federation behind the discovery metadata.
- WebSocket transport.
- Server-initiated SSE push channel over GET.
- Sampling resource routes (`sampling/createMessage`).

Closes #1674

## Test plan

- [x] `uv run pytest tests/unit/mcp -q` (110 passed)
- [x] `uv run ruff check . && uv run ruff format .`
- [ ] `uv run pytest tests/unit -q` (no regressions)
- [ ] CI green