### PR TITLE
docs(release): rewrite v2.5.0 notes in narrative voice

### DIFF
--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -1,54 +1,45 @@
-# v2.5.0 - Interoperability surfaces, host portability, deterministic replay
+## A note on the voice
 
-**Release date:** 2026-05-20
-**Commits since v2.4.0:** 22
+v2.4.0 was about observability surfaces, running the four backends through one umbrella so a code-scanning regression or a coverage drop surfaces in the same table as a GlitchTip spike. v2.5.0 is the next question over: now that the orchestrator can see itself, can the hosts an operator already runs see it too. And can it stop quietly phoning home to my private infrastructure when it does.
 
-## Highlights
+## Interop, finally
 
-- A2A capability cards land as a first-class interop primitive: `bernstein interop a2a card` mints a signed manifest (identity, advertised tools, supported policies, public key, expiry), `consume_peer_card` verifies signature, expiry, and trusted-issuer set before delegating, and the existing signed lineage chain rides through the A2A envelope so a delegated run stays auditable across an organisation boundary.
-- The MCP client now treats upstream servers as untrusted and brittle: capability-card validation before each tool call, retry-with-continuation on dropped streams, streamed-output cancellation without leaks, per-server cost metering, and schema-violation containment that marks a misbehaving server degraded instead of taking the run down.
-- Bernstein can register itself into the hosts operators already run: `bernstein desktop-register --host claude-desktop` (and `claude-code`) writes the host-specific manifest entry so the orchestrator's tools and routes are available without manual wiring.
-- Side-channel telemetry is portable across hosts behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN`, and the shipped package no longer carries any operator-private host defaults: every observability and telemetry backend soft-fails or no-ops when its env vars are unset, so a fresh install never reaches an operator's private infrastructure.
-- Replay isolation is now deterministic: session ids are bound deterministically so a replayed run reproduces its own event stream, on-disk state has a versioned migrations module, and runs surface memorable deterministic names in user-facing output instead of opaque ids.
-- The API rejects invalid `scope` / `complexity` at the request boundary with `422` instead of constructing the enum deep in the task store and surfacing an unhandled `500`, closing an intermittent fuzzer-found crash on `POST /tasks` and `POST /tasks/batch`.
+The piece that kept blocking me on multi-host runs was the lack of a real handshake. Claude Desktop is one process, Claude Code is another, both can spawn agents, neither knew what the other had already decided. I shipped A2A capability cards (#1698): one process mints a signed manifest of what it can do, the other consumes it, verifies the signature against a trusted-issuer set, and refuses to delegate when the advertised policies do not meet the operator's required policies. The lineage chain rides through the same envelope so the audit trail does not break at the organisation boundary.
 
-## What ships
+The MCP client got the matching upgrade (#1692). Upstream servers will return malformed responses, hang mid-stream, demand re-auth, lie about their capability manifest. The client now treats every upstream as untrusted: capability-card validation before a tool call, retry-with-continuation on dropped streams, in-flight cancellation that preserves partial output, per-server cost metering, schema-violation containment that marks a misbehaving server degraded for the rest of the task. None of this is exotic; it is the brittle-real-world posture that the larger MCP ecosystem will end up needing.
 
-### Interoperability
+The MCP server side got prompt-catalogue plus OAuth-2 PKCE discovery metadata (#1696, #1709), so auto-discovering hosts that expect a real RFC 8414 / RFC 9728 surface stop skipping us.
 
-- **A2A capability cards plus lineage interop** (#1698). `bernstein interop a2a card --output card.json` mints a detached-JWS-signed capability card over a JCS-canonicalised body (identity, advertised tools, policies for cost cap / redaction tier / sandbox profile, public key, expiry). `consume_peer_card` verifies the signature, rejects expired cards, checks the trusted-issuer fingerprint, and fail-closes on a policy gate. A `bernstein.lineage_v2` envelope field wraps the existing HMAC lineage chain; the receiver appends a cross-organisation boundary marker so tampering in transit is detectable. `bernstein interop a2a verify --card card.json` confirms a peer card. Docs at `docs/interop/a2a.md`.
-- **Hardened MCP client** (#1692). Capability-card validation before issuing a tool call (`MCPCapabilityMissing` on mismatch, logged with the manifest digest), retry-with-continuation from the server's last-checkpoint token with idempotency-key fall-back and a configurable retry cap, in-flight streamed-output cancellation that preserves partial output, a per-server-per-task cost meter wired into `core/cost/`, and schema-violation containment that marks a server degraded for the rest of the task and surfaces the fault through the tracker contract. Docs at `docs/mcp/client.md`.
-- **MCP server protocol-surface gaps closed** (#1696). Fills the remaining gaps in the MCP server's exposed protocol surface so the server side matches the hardened client's expectations.
-- **Tiered MCP tool exposure** (#1685). A context-budget knob exposes MCP tools in tiers, so a large upstream tool catalogue does not blow the context budget on every call.
-- **Substrate desktop-register** (#1697). `bernstein desktop-register --host <name>` performs the host-specific install (config-file path, manifest entry, restart hint) for Claude Desktop and Claude Code, with a small per-host adapter translating Bernstein's surface into the host's plugin spec. Rejects `--list` combined with `--host`. Docs under `docs/substrate/`.
+## bernstein desktop-register
 
-### Host portability and privacy
+`bernstein desktop-register --host <name>` (#1697, then #1708 added five more hosts) writes the host-specific config entry for Claude Desktop, Claude Code, Cursor, Continue, Cline, Zed, and Aider. One command. The orchestrator is a guest in the host's settings file; we ship the plugin, the host renders it. `bernstein doctor --substrate` reports which hosts have us registered, which do not, and which have a stale registration.
 
-- **Portable side-channel telemetry** (#1691). Consolidates the telemetry emitters behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN` so the same env var, wire format, and default backend work on every host. Adds `bernstein telemetry probe` to emit a synthetic event for backend verification. Docs at `docs/observability/side-channel.md`.
-- **Operator infrastructure defaults removed from the package** (#1694). The shipped package no longer hardcodes any operator-private host as a default (no `errors`/`sonar`/`telemetry`/`dt` host defaults baked into `src/`). Backends read their host from the env or the DSN host and otherwise soft-fail or no-op, so a fresh install never reaches private infrastructure. A `tests/unit/observability/test_no_hardcoded_infra.py` regression asserts zero operator-private host, IP, or DSN matches in `src/`.
+The honest disclaimer: if a host changes its plugin spec, the per-host adapter breaks. Each adapter is small enough that a host-spec change is a one-day fix, not a re-architecture.
 
-### Reliability and determinism
+## I removed my private infrastructure from the shipped package
 
-- **Deterministic session-id binding for replay isolation** (#1684). Session ids are bound deterministically so a replayed run reproduces its own isolated event stream rather than colliding with or leaking into another session's state.
-- **Supervisor respawn budget with park-on-exhaustion** (#1683). The supervisor enforces a bounded respawn budget and parks an agent once the budget is exhausted instead of looping respawns indefinitely.
-- **Versioned migrations for on-disk state** (#1689). A versioned migrations module brings on-disk state under explicit, ordered schema migrations so an older state directory upgrades predictably.
-- **Memorable deterministic run names** (#1682, #1626). User-facing surfaces show a deterministic memorable name for each run instead of an opaque id, derived deterministically so the same run always renders the same name.
-- **Per-adapter strategy enums** (#1690). Resume behaviour, dangerous-mode handling, and event-channel selection move to explicit per-adapter strategy enums instead of scattered ad-hoc flags.
+This one was a real silent bug, not a feature. The shipped wheel had `errors.bernstein.run` baked in as the GlitchTip DSN default, and `telemetry.bernstein.run` baked in as the telemetry endpoint default. Both backends soft-fail when their env vars are unset, so the package never actually reached out without consent. But the hostnames were sitting there as defaults, which is the kind of thing that turns into a real leak the day someone wires a config they did not read.
 
-### Safety
+#1694 strips those defaults. `tests/unit/observability/test_no_hardcoded_infra.py` asserts zero operator-private host, IP, or DSN matches in `src/` and will fail the build if a future change reintroduces one. Telemetry side-channel is now portable across hosts behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN` (#1691) so each operator runs against their own backend, not mine.
 
-- **Permission-rule prefilter on hooks before spawn** (#1680). Permission rules are evaluated as a prefilter on lifecycle hooks before an agent is spawned, so a denied action is caught ahead of process launch.
-- **Strict structured-output schemas with user-field blacklist** (#1681). Adapter structured-output schemas are tightened and a user-field blacklist prevents caller-supplied fields from overriding orchestrator-controlled output.
-- **Boundary validation for scope and complexity** (#1700). `TaskCreate` / `TaskSelfCreate` validate `scope` and `complexity` against their enums at the request boundary, returning `422` for empty or out-of-range values instead of raising `ValueError` deep in the task store and surfacing a `500`. Fields stay typed as `str` for backward compatibility. Unit and end-to-end tests cover the `POST /tasks` and `POST /tasks/batch` paths.
-- **Disputed pyjwt advisory ignored with rationale** (#1695). The dependency audit ignores PYSEC-2025-183 (CVE-2025-45768), a disputed pyjwt advisory with no published fix version, pulled in transitively via `mcp`. The rationale is recorded inline in the workflow.
+## Deterministic replay
 
-### Quality and memory
+Three small things compounded. Session ids are bound deterministically (#1684) so a replayed run reproduces its own event stream without colliding with a sibling. The supervisor enforces a bounded respawn budget and parks an agent when the budget is exhausted (#1683), instead of looping respawns indefinitely. On-disk state has a versioned migrations module (#1689) so an older `.sdd/` upgrades predictably. Plus the cosmetic-but-real win: runs surface a memorable deterministic name (#1682) in user-facing output, so the operator can refer to "the brisk-sparrow run" instead of memorising a UUID.
 
-- **Consensus scoring with detected-by provenance** (#1686). Review findings carry detected-by provenance and a consensus score, so a finding flagged by multiple reviewers is weighted distinctly from a single-reviewer signal.
-- **Tiered memory compaction** (#1687). Memory compaction runs in cost-tuned tiers so older context is compacted at a strategy matched to its retrieval value.
+## The API stops returning 500 on a fuzzer-found bug
 
-### Maintenance
+The `TaskCreate.scope` and `complexity` fields were typed as plain `str` with only a length cap. An empty or out-of-range value passed pydantic and then raised `ValueError` deep in the task store when the enum was constructed, surfacing as an unhandled 500 on `POST /tasks` and `POST /tasks/batch`. Schemathesis kept flagging it intermittently and everyone kept rerunning it as a flake. It was not a flake. #1700 validates at the request boundary and returns 422.
 
-- **Runtime image digest bump** (#1699). Updates the `python:3.13-slim` Docker digest to `e544a7f`, staying on the pinned 3.13 line.
-- **Agent-context files kept in sync** (#1701, #1702). `agents-md sync` regenerates `AGENTS.md`, `CLAUDE.md`, `CONVENTIONS.md`, `.goosehints`, and the cursor module map for the new `interop` and `substrate` modules, and the duplicate spell-check allow-list key is removed.
-- **Spell-check fixture cleanup** (#1693). The MCP client test fixture avoids the truncated stream-chunk string that tripped the spell checker, rather than relying on an allow-list entry.
+## What I am not claiming
+
+The two new transports are functional but not load-tested at adversarial scale; the OAuth-2 PKCE discovery surface ships metadata, full token issuance and OIDC federation are deferred to a follow-up. The substrate adapters cover seven hosts; Codex and Gemini CLI are stubbed by design until their respective plugin specs stabilise. The A2A integration honours the protocol as specified at the time of pickup and will need maintenance as the spec evolves.
+
+## Try it
+
+```bash
+pipx install --upgrade bernstein
+bernstein interop a2a card --output card.json
+bernstein desktop-register --host cursor
+```
+
+Full per-PR notes in `docs/release-notes/v2.5.0.md`. Source: https://github.com/sipyourdrink-ltd/bernstein (Apache-2.0). 22 commits since v2.4.0.


### PR DESCRIPTION
Match the v2.1.0 / v2.2.0 register that drifted out of the v2.4.0 + v2.5.0 first-cut notes (bullet stuffing). First-person, headline-only, honest disclaimer section. The GH release body is already updated; this brings the in-repo file in sync.