### PR TITLE
style(bridges): inline single-use result in cloudflare sandbox

### DIFF
--- a/src/bernstein/bridges/cloudflare_sandbox.py
+++ b/src/bernstein/bridges/cloudflare_sandbox.py
@@ -459,8 +459,7 @@ class CloudflareSandboxBridge(RuntimeBridge):
             )
 
         data = resp.json()
-        result = data.get("result", data)
-        return result.get("files", [])
+        return data.get("result", data).get("files", [])
 
     def _api_url(self, path: str) -> str:
         """Build full Cloudflare sandbox API URL.


### PR DESCRIPTION
FURB184 leftover at `src/bernstein/bridges/cloudflare_sandbox.py:463` that the parallel refurb-zero sweep partition did not cover. Single fluent-chain rewrite. Behaviour preserved (still one `resp.json()` call).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal API response parsing logic for improved code efficiency.

---

*Note: This release contains internal code improvements with no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->