### PR TITLE
fix(observability): repair Sonar workflow_run skip and verify GlitchTip CLI path

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,12 +1,28 @@
 name: SonarQube scan
 
-# Runs after the main CI workflow completes successfully on main.
-# Reuses the coverage.xml artifact uploaded by ci.yml so we do not
-# re-run the unit suite. The unit suite takes ~25 minutes when sharded
-# per-file in CI; re-running it inline here was hitting the 30 minute
-# step timeout (the suite barely reached 5% of files within 30 minutes
-# when run as a single pytest --cov invocation).
+# Runs after a push to main, after the main CI workflow completes
+# successfully, or on manual dispatch.
+#
+# Why three triggers? Under the normal rapid-merge cadence on main,
+# ci.yml's branch-scoped `cancel-in-progress: true` (see ci.yml lines
+# 112-135) almost never lets a main CI run reach a `success`
+# conclusion: each new merge cancels the prior in-flight run. As a
+# result the historical `workflow_run` listener fired but the job-level
+# `if: workflow_run.conclusion == 'success'` short-circuited to
+# `skipped` on every recent run. The fix is to also trigger directly
+# on `push: branches: [main]` so the Sonar surface stays fresh
+# regardless of which upstream CI run was the last to actually finish.
+# The `workflow_run` arm is kept because it provides a free coverage
+# artifact when the upstream did finish; the `push` arm runs a thin
+# fallback coverage pass when there is no usable upstream artifact.
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
   workflow_run:
     workflows: ['CI']
     types: [completed]
@@ -25,13 +41,16 @@ jobs:
   scan:
     name: SonarQube scan
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Only run when:
+    timeout-minutes: 30
+    # Run when:
     # - Triggered manually, or
-    # - The upstream CI run succeeded on main and SONAR_HOST_URL is set.
+    # - Direct push to main (independent of upstream CI conclusion), or
+    # - The upstream CI run succeeded on main.
+    # SONAR_HOST_URL must be configured as a repo variable in every case.
     if: >-
       ${{ vars.SONAR_HOST_URL != '' &&
           (github.event_name == 'workflow_dispatch' ||
+           github.event_name == 'push' ||
            github.event.workflow_run.conclusion == 'success') }}
     steps:
       - name: Harden runner
@@ -95,12 +114,95 @@ jobs:
           run-id: ${{ steps.ci_run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify coverage.xml present
+      # Direct push to main: try to pull the freshest coverage-report
+      # artifact from any recent CI run on main (succeeded or cancelled),
+      # so a partial coverage snapshot still feeds Sonar even when the
+      # upstream CI run never reached `success`. This is the dominant
+      # case under the rapid-merge cadence and is the root cause of the
+      # historical "Coverage 0.0" comment on the project.
+      - name: Resolve latest CI run with coverage (push)
+        if: github.event_name == 'push'
+        id: ci_run_push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -f coverage.xml ]; then
-            echo "::warning::coverage.xml not found; Sonar scan will run without Python coverage data"
+          # Search the last 20 main CI runs for one that uploaded the
+          # `coverage-report` artifact. Cancelled runs can still have
+          # uploaded the artifact if the coverage step ran before the
+          # cancellation, so we do not filter by status here.
+          for run_id in $(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow ci.yml \
+              --branch main \
+              --limit 20 \
+              --json databaseId \
+              --jq '.[].databaseId'); do
+            if gh run view "$run_id" \
+                --repo "${{ github.repository }}" \
+                --json jobs \
+                --jq '.jobs[].name' >/dev/null 2>&1; then
+              artifacts=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id/artifacts" \
+                  --jq '.artifacts[].name' 2>/dev/null || true)
+              if printf '%s\n' "$artifacts" | grep -qx coverage-report; then
+                echo "Found coverage-report artifact in CI run: $run_id"
+                echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+                break
+              fi
+            fi
+          done
+          if [ -z "${run_id:-}" ] || ! grep -q '^run_id=' "$GITHUB_OUTPUT"; then
+            echo "::notice::No recent CI run with coverage-report artifact found; will run thin coverage fallback"
+          fi
+
+      - name: Download coverage artifact (push)
+        if: github.event_name == 'push' && steps.ci_run_push.outputs.run_id != ''
+        continue-on-error: true  # coverage is advisory; never block the scan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: coverage-report
+          run-id: ${{ steps.ci_run_push.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify coverage.xml present
+        id: coverage_check
+        run: |
+          if [ ! -f coverage.xml ] || [ ! -s coverage.xml ]; then
+            echo "::warning::coverage.xml not found or empty; will run thin coverage fallback"
+            echo "missing=true" >> "$GITHUB_OUTPUT"
           else
-            echo "coverage.xml found ($(wc -c < coverage.xml) bytes)"
+            size=$(wc -c < coverage.xml)
+            echo "coverage.xml found ($size bytes)"
+            echo "missing=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Thin coverage fallback: run a fast unit-test subset with coverage
+      # so Sonar receives a non-zero coverage signal even when no upstream
+      # artifact was usable. This is intentionally NOT the full suite
+      # (which is ~25 minutes sharded) - it runs the fastest unit modules
+      # with --no-cov-on-fail and a hard timeout so the Sonar workflow
+      # itself never becomes the slow CI path.
+      - name: Thin coverage fallback
+        if: steps.coverage_check.outputs.missing == 'true'
+        timeout-minutes: 10
+        continue-on-error: true  # coverage is advisory; never block the scan
+        run: |
+          set +e
+          if ! command -v uv >/dev/null 2>&1; then
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          uv sync --group dev --no-progress 2>&1 | tail -20 || true
+          uv run --no-progress python -m coverage run -m pytest \
+            tests/unit/observability \
+            tests/unit/cli/doctor \
+            tests/unit/telemetry \
+            -q --no-header \
+            --timeout=60 2>&1 | tail -40 || true
+          uv run --no-progress python -m coverage xml -o coverage.xml || true
+          if [ -f coverage.xml ] && [ -s coverage.xml ]; then
+            echo "Thin coverage fallback produced coverage.xml ($(wc -c < coverage.xml) bytes)"
+          else
+            echo "::warning::Thin coverage fallback did not produce coverage.xml; Sonar will scan without coverage"
           fi
 
       - name: SonarQube scan

--- a/docs/observability/glitchtip-insights.md
+++ b/docs/observability/glitchtip-insights.md
@@ -22,10 +22,16 @@ unresolved issues without leaving the terminal.
 | Env var | Purpose | Default |
 |---|---|---|
 | `BERNSTEIN_GLITCHTIP_TOKEN` | API token with org read scope. | (required for non-trivial output) |
-| `BERNSTEIN_GLITCHTIP_DSN` | Runtime DSN for event submission. | (informational here) |
-| `BERNSTEIN_GLITCHTIP_BASE_URL` | Override for the API base URL. | `https://errors.bernstein.run` |
+| `BERNSTEIN_GLITCHTIP_DSN` | Runtime DSN for event submission. | (informational here; host derives the base URL if `BERNSTEIN_GLITCHTIP_BASE_URL` is unset) |
+| `BERNSTEIN_GLITCHTIP_BASE_URL` | Override for the API base URL (for example `https://glitchtip.example.com`). | (no default; required when `BERNSTEIN_GLITCHTIP_DSN` is unset) |
 | `BERNSTEIN_GLITCHTIP_ORG` | Organisation slug. | `bernstein` |
 | `BERNSTEIN_GLITCHTIP_BASELINE` | Override for the baseline cache path. | `~/.local/share/bernstein/glitchtip-baseline.json` |
+
+The shipped package hardcodes no observability backend host. Configure
+the base URL at deployment time via `BERNSTEIN_GLITCHTIP_BASE_URL`, or
+provide `BERNSTEIN_GLITCHTIP_DSN` and the base URL will be derived from
+its host. When neither is configured, `bernstein doctor glitchtip`
+soft-fails with a clear "not configured" message and exit code 0.
 
 If `BERNSTEIN_GLITCHTIP_TOKEN` is missing, the doctor soft-fails with a
 one-line hint and exit code 0. `BERNSTEIN_GLITCHTIP_DSN` is informational

--- a/tests/unit/test_sonar_scan_workflow_yaml.py
+++ b/tests/unit/test_sonar_scan_workflow_yaml.py
@@ -1,0 +1,131 @@
+"""Structural assertions on the SonarQube scan workflow.
+
+These tests pin the contract that the Sonar scan stays reachable on
+main without depending on a successful upstream CI conclusion. The
+root cause of the historical "all sonar-scan runs return skipped" was
+the job-level ``if: workflow_run.conclusion == 'success'`` combined
+with ``ci.yml``'s ``cancel-in-progress: true`` policy on main: a
+rapid merge cadence cancels almost every CI run before it finishes,
+so the success conclusion is never observed.
+
+The tests below assert the workflow has:
+
+    * a direct ``push: branches: [main]`` trigger so the scan runs
+      independently of CI's conclusion,
+    * a fallback coverage step that activates when no upstream
+      ``coverage-report`` artifact is available,
+    * a job-level ``if`` that accepts ``push`` and ``workflow_dispatch``
+      events, not only the historical workflow_run success.
+
+The tests are cheap; they parse YAML only and do not call the GitHub
+API.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+SONAR_WF = Path(".github/workflows/sonar-scan.yml")
+
+
+@pytest.fixture(scope="module")
+def sonar_doc() -> dict[str, object]:
+    """Parse the sonar-scan workflow once per module."""
+    return yaml.safe_load(SONAR_WF.read_text(encoding="utf-8"))
+
+
+def test_sonar_scan_workflow_file_exists() -> None:
+    """The Sonar scan workflow must exist at the expected path."""
+    assert SONAR_WF.is_file(), f"Missing workflow: {SONAR_WF}"
+
+
+def test_sonar_scan_triggers_on_push_to_main(sonar_doc: dict[str, object]) -> None:
+    """Sonar scan must trigger directly on push to main.
+
+    Without this trigger the scan relied entirely on
+    ``workflow_run.conclusion == 'success'``, which under the normal
+    rapid-merge cadence almost never fires because ci.yml cancels
+    in-flight runs on each new push. The push trigger is the only
+    one that guarantees the scan reaches main on every merge.
+    """
+    on_block = sonar_doc.get(True) or sonar_doc.get("on")
+    assert isinstance(on_block, dict), f"Workflow `on:` block must be a mapping, got {type(on_block)!r}"
+    push_block = on_block.get("push")
+    assert isinstance(push_block, dict), "Sonar scan workflow must define a `push:` trigger"
+    branches = push_block.get("branches") or []
+    assert "main" in branches, "Sonar scan `push` trigger must include `main`"
+
+
+def test_sonar_scan_keeps_workflow_dispatch(sonar_doc: dict[str, object]) -> None:
+    """``workflow_dispatch`` must remain so operators can bootstrap."""
+    on_block = sonar_doc.get(True) or sonar_doc.get("on")
+    assert isinstance(on_block, dict)
+    assert "workflow_dispatch" in on_block, "Sonar scan must keep its manual dispatch trigger"
+
+
+def test_sonar_scan_job_if_accepts_push_and_dispatch(sonar_doc: dict[str, object]) -> None:
+    """The job-level `if` must accept `push` and `workflow_dispatch`.
+
+    Regression guard: an earlier version gated the job purely on
+    ``github.event.workflow_run.conclusion == 'success'``, which never
+    fires under the rapid-merge cancellation pattern.
+    """
+    jobs = sonar_doc.get("jobs")
+    assert isinstance(jobs, dict) and jobs, "Workflow must declare a `jobs:` block"
+    scan_job = jobs.get("scan")
+    assert isinstance(scan_job, dict), "Workflow must define a `scan` job"
+    job_if = scan_job.get("if", "")
+    assert isinstance(job_if, str)
+    flat = " ".join(job_if.split())
+    assert "workflow_dispatch" in flat, "Job `if` must accept workflow_dispatch events"
+    assert "'push'" in flat or '"push"' in flat or "push" in flat, (
+        "Job `if` must accept push events so a direct push to main is not gated by upstream CI conclusion"
+    )
+
+
+def test_sonar_scan_has_coverage_fallback(sonar_doc: dict[str, object]) -> None:
+    """Workflow must have a thin coverage fallback for cancelled CI runs.
+
+    When ci.yml cancels in-flight runs the ``coverage-report``
+    artifact may be missing or empty. The Sonar workflow must run a
+    thin coverage pass in that case so the project never sits at
+    Coverage=0 forever.
+    """
+    jobs = sonar_doc.get("jobs", {})
+    assert isinstance(jobs, dict)
+    scan = jobs.get("scan", {})
+    assert isinstance(scan, dict)
+    steps = scan.get("steps", [])
+    assert isinstance(steps, list) and steps, "scan job must declare steps"
+
+    step_names = [s.get("name", "") for s in steps if isinstance(s, dict)]
+    has_fallback = any("fallback" in name.lower() or "thin coverage" in name.lower() for name in step_names)
+    assert has_fallback, (
+        "Sonar scan must include a thin coverage fallback step so "
+        "Coverage stays > 0 even when the upstream CI artifact is missing. "
+        f"Found steps: {step_names!r}"
+    )
+
+
+def test_sonar_scan_references_coverage_xml_in_args(sonar_doc: dict[str, object]) -> None:
+    """The SonarQube scan step must point at coverage.xml so Sonar reads it."""
+    jobs = sonar_doc.get("jobs", {})
+    scan = jobs.get("scan", {})
+    steps = scan.get("steps", [])
+    sonar_step = next(
+        (s for s in steps if isinstance(s, dict) and "SonarSource/sonarqube-scan-action" in (s.get("uses") or "")),
+        None,
+    )
+    assert sonar_step is not None, "Workflow must invoke SonarSource/sonarqube-scan-action"
+    args = (sonar_step.get("with") or {}).get("args", "")
+    assert "sonar.python.coverage.reportPaths=coverage.xml" in args, (
+        "Sonar scan args must point at coverage.xml so Python coverage is ingested"
+    )


### PR DESCRIPTION
## Summary

Three of the observability surfaces shipped recently were partially broken in production. This consolidates the fixes.

| Fix | Symptom | File:line | Verification |
|---|---|---|---|
| Sonar scan never runs on main | `workflow_run.conclusion == 'success'` gate never fires because ci.yml's `cancel-in-progress: true` cancels almost every main CI run; 6/6 recent sonar-scan runs returned `skipped`. | `.github/workflows/sonar-scan.yml:23-49` (add `push: branches: [main]` trigger; broaden job-level `if`) | After merge, observe sonar-scan trigger directly on the merge commit (push event) instead of waiting for an upstream success that does not arrive. |
| Coverage = 0 on Sonar | Cancelled CI runs sometimes lack a usable `coverage-report` artifact. | `.github/workflows/sonar-scan.yml:128-206` (resolve artifact from any recent CI run; run a thin coverage fallback over observability / doctor / telemetry unit modules when no artifact is usable) | Coverage > 0 on the next scan; the fallback runs offline against fast unit modules and writes coverage.xml even when upstream artifacts are missing. |
| GlitchTip CLI documentation still leaked an operator hostname as a "default" | `docs/observability/glitchtip-insights.md` listed a specific operator host as the default for `BERNSTEIN_GLITCHTIP_BASE_URL`, contradicting the shipped-package contract established in #1694 (no hardcoded backend host). | `docs/observability/glitchtip-insights.md:22-39` | `bernstein doctor glitchtip` already soft-fails to exit 0 with a "not configured" message when no token / no base URL is set (verified locally with `env -i`); docs now match. |
| Regression coverage | Future PRs could re-introduce the workflow_run-only gate. | `tests/unit/test_sonar_scan_workflow_yaml.py` (new; 6 assertions, ~1s) | `uv run pytest tests/unit/test_sonar_scan_workflow_yaml.py` -> 6 passed. |

Earlier merged PR #1665 attempted to fix the same `skipped` issue via the `workflow_dispatch` path only. That path requires an operator to manually dispatch; the push trigger added here makes the scan automatic on every merge to main.

## Test plan

- [x] `uv run pytest tests/unit/cli/doctor tests/unit/observability tests/unit/telemetry tests/unit/test_sonar_scan_workflow_yaml.py` -> 292 passed
- [x] `bernstein doctor glitchtip` with no env -> exit 0, soft-fail message
- [x] `bernstein doctor glitchtip --json` with no env -> exit 0, structured `ok: false`
- [x] `bernstein doctor glitchtip --json` with token only -> exit 0, "base URL not set" reason
- [x] `uv run ruff check .` on changed files passes (pre-existing unrelated errors in cookiecutter templates remain)
- [ ] After merge: a new sonar-scan run fires on the next push to main (event=push, not workflow_run); coverage > 0 on the next PR's sticky Sonar comment.