### PR TITLE
fix(privacy): scrub operator hostnames from docs and PR-comment surfaces

### DIFF
--- a/.github/workflows/glitchtip-insights.yml
+++ b/.github/workflows/glitchtip-insights.yml
@@ -20,9 +20,9 @@ on:
         required: false
         default: "bernstein"
       base_url:
-        description: "GlitchTip base URL (default: https://errors.bernstein.run)"
+        description: "GlitchTip base URL (e.g. https://errors.example.com). Defaults to vars.GLITCHTIP_BASE_URL."
         required: false
-        default: "https://errors.bernstein.run"
+        default: ""
 
 permissions:
   contents: read
@@ -34,7 +34,7 @@ concurrency:
 
 env:
   GLITCHTIP_API_TOKEN: ${{ secrets.GLITCHTIP_API_TOKEN }}
-  GLITCHTIP_BASE_URL: ${{ github.event.inputs.base_url || 'https://errors.bernstein.run' }}
+  GLITCHTIP_BASE_URL: ${{ github.event.inputs.base_url || vars.GLITCHTIP_BASE_URL }}
   GLITCHTIP_ORG: ${{ github.event.inputs.org_slug || 'bernstein' }}
   GLITCHTIP_LABEL: glitchtip-alert
 

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      DT_API_URL: ${{ vars.DT_API_URL || 'https://dt.bernstein.run' }}
+      DT_API_URL: ${{ vars.DT_API_URL }}
       DT_API_KEY: ${{ secrets.DT_API_KEY }}
     steps:
       - name: Checkout

--- a/.github/workflows/sonar-pr-comment.yml
+++ b/.github/workflows/sonar-pr-comment.yml
@@ -86,20 +86,18 @@ jobs:
           VULNS: ${{ steps.query.outputs.vulnerabilities }}
           HOTSPOTS: ${{ steps.query.outputs.security_hotspots }}
           COVERAGE: ${{ steps.query.outputs.coverage }}
-          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
         with:
           script: |
             const marker = '<!-- sonar-pr-comment:smells -->';
             const prNumber = Number(process.env.PR_NUMBER);
             const status = process.env.SONAR_STATUS || '';
-            const host = (process.env.SONAR_HOST_URL || '').replace(/\/$/, '');
 
             const lines = [
               marker,
               '## Sonar insights (advisory, no merge-block)',
               '',
               status === '200'
-                ? `Snapshot of \`bernstein\` on ${host}/dashboard?id=bernstein:`
+                ? 'Snapshot of `bernstein` on the configured Sonar instance:'
                 : `Sonar query returned status ${status || 'unknown'}; this is advisory only.`,
               '',
               '| Metric | Value |',

--- a/docs/observability/sonar.md
+++ b/docs/observability/sonar.md
@@ -20,7 +20,7 @@ The doctor reads two env vars (identical to the CI contract):
 
 | Env var | Purpose | Example |
 |---|---|---|
-| `SONAR_HOST_URL` | Sonar server base URL | `https://sonar.bernstein.run` |
+| `SONAR_HOST_URL` | Sonar server base URL | `https://sonar.example.com` |
 | `SONAR_TOKEN` | User token with `Browse` permission on the project | (45 chars) |
 | `SONAR_PROJECT_KEY` | Optional. Defaults to `bernstein`. | `bernstein` |
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -32,7 +32,7 @@ The `.github/workflows/sbom-upload.yml` workflow:
 * triggers on `push` to `main` and on `release: published`,
 * generates a CycloneDX SBOM via `cyclonedx-bom`,
 * uploads the SBOM to a Dependency-Track instance addressed by
-  `DT_API_URL` (default `https://dt.bernstein.run`) using the
+  `DT_API_URL` (required, no default; e.g. `https://dt.example.com`) using the
   `DT_API_KEY` secret.
 
 The upload step is gated on both `DT_API_URL` and `DT_API_KEY` being

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -18,7 +18,7 @@ The honest disclaimer: if a host changes its plugin spec, the per-host adapter b
 
 ## I removed my private infrastructure from the shipped package
 
-This one was a real silent bug, not a feature. The shipped wheel had `errors.bernstein.run` baked in as the GlitchTip DSN default, and `telemetry.bernstein.run` baked in as the telemetry endpoint default. Both backends soft-fail when their env vars are unset, so the package never actually reached out without consent. But the hostnames were sitting there as defaults, which is the kind of thing that turns into a real leak the day someone wires a config they did not read.
+This one was a real silent bug, not a feature. The shipped wheel had two private observability hostnames baked in as defaults for the GlitchTip DSN and the telemetry endpoint. Both backends soft-fail when their env vars are unset, so the package never actually reached out without consent. But the hostnames were sitting there as defaults, which is the kind of thing that turns into a real leak the day someone wires a config they did not read.
 
 #1694 strips those defaults. `tests/unit/observability/test_no_hardcoded_infra.py` asserts zero operator-private host, IP, or DSN matches in `src/` and will fail the build if a future change reintroduces one. Telemetry side-channel is now portable across hosts behind one Sentry-compatible `BERNSTEIN_TELEMETRY_DSN` (#1691) so each operator runs against their own backend, not mine.
 

--- a/tests/unit/observability/test_no_hardcoded_infra.py
+++ b/tests/unit/observability/test_no_hardcoded_infra.py
@@ -59,3 +59,52 @@ def test_no_hardcoded_observability_infra() -> None:
         "Operator-private observability infrastructure must not be "
         "hardcoded in the shipped package. Offending references:\n  " + "\n  ".join(offenders)
     )
+
+
+def _repo_root() -> Path:
+    """Return the repository root (parent of ``src/`` and ``docs/``)."""
+    return _package_root().parent.parent
+
+
+def test_no_hardcoded_observability_infra_in_public_artefacts() -> None:
+    """Docs and PR-comment-producing workflows must not leak operator-private hosts.
+
+    The shipped package is already covered by the test above. This
+    extends the same guard to the publishable surface: ``docs/`` (which
+    renders on the project site) and ``.github/workflows/`` files that
+    render strings into PR comments, GitHub issue bodies, or check-run
+    output. A leak in any of these surfaces shows the operator's private
+    observability hostnames to anyone reading a PR or visiting docs, so
+    they are scrubbed and replaced with ``*.example.com`` placeholders
+    or with operator-configured ``vars.*`` references.
+    """
+    repo = _repo_root()
+    surfaces = [
+        repo / "docs",
+        repo / ".github" / "workflows",
+    ]
+    offenders: list[str] = []
+
+    for surface in surfaces:
+        if not surface.exists():
+            continue
+        for path in surface.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in {".md", ".mdx", ".yml", ".yaml", ".rst", ".txt"}:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for needle in FORBIDDEN:
+                if needle in text:
+                    offenders.append(f"{path}: contains {needle!r}")
+
+    assert not offenders, (
+        "Operator-private observability infrastructure must not appear in "
+        "docs/ or in workflow files that render strings into PR comments "
+        "or issue bodies. Use *.example.com placeholders in docs and "
+        "operator-configured vars.* references in workflows. Offenders:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

#1694 scrubbed the shipped package. Three public surfaces still leaked the operator-private observability hostnames into reader-visible artefacts:

- `docs/observability/sonar.md` and `docs/operations/observability.md` worked examples
- `docs/release-notes/v2.5.0.md` historical paragraph (ironic re-leak)
- `.github/workflows/sonar-pr-comment.yml` PR-comment template (`Snapshot on <host>/dashboard`)
- `.github/workflows/glitchtip-insights.yml` workflow-dispatch default + env fallback
- `.github/workflows/sbom-upload.yml` `DT_API_URL` fallback

After this PR, docs use `*.example.com` placeholders. The PR-comment template drops the host. The two workflows read from `vars.*` with no hardcoded fallback so a fork sees no host at all.

## Regression coverage

Extends `tests/unit/observability/test_no_hardcoded_infra.py` with a second test that scans `docs/` and `.github/workflows/` for the same forbidden substrings. Both tests pass locally.

`grep` across `src/`, `docs/`, `.github/` for the forbidden hosts now returns zero matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflows now support configurable URLs via GitHub Actions variables instead of using hardcoded defaults, allowing customization of infrastructure endpoints.

* **Documentation**
  * Updated configuration examples to use generic placeholder URLs.
  * Clarified SBOM upload requires explicit configuration with no automatic fallback.

* **Tests**
  * Added regression test to prevent infrastructure endpoints from appearing in public repository artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->