### PR TITLE
fix(ci): unblock post-ci dispatcher by dropping unset OPENROUTER secret pass

### DIFF
--- a/.github/workflows/post-ci-dispatcher.yml
+++ b/.github/workflows/post-ci-dispatcher.yml
@@ -182,12 +182,19 @@ jobs:
     # on a non-empty value rather than failing the whole reusable call.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      # OPENROUTER_API_KEY_FREE is optional on the called workflow; the
-      # Tier-3 shadow-mode escalation gates on the
-      # BERNSTEIN_CI_SELF_DRIVE feature flag (default off). When the
-      # repo secret is unset the called job degrades gracefully and
-      # records a flag_off / skipped outcome.
-      OPENROUTER_API_KEY_FREE: ${{ secrets.OPENROUTER_API_KEY_FREE }}
+      # NOTE: OPENROUTER_API_KEY_FREE was previously passed here for the
+      # Tier-3 shadow-mode escalation (#1715). When the operator has NOT
+      # defined that repo secret, the `secrets.OPENROUTER_API_KEY_FREE`
+      # reference fails the reusable-workflow startup with
+      # `startup_failure` (GitHub Actions resolves the secrets block at
+      # workflow_call start, before the called workflow's own
+      # `required: false` declaration applies). That broke the entire
+      # post-CI dispatcher chain (auto-release, auto-heal, bisect)
+      # silently from cbc95847 onward.
+      #
+      # Restore the pass once OPENROUTER_API_KEY_FREE is defined on the
+      # repo. Until then, the Tier-3 job inside bernstein-ci-fix degrades
+      # to flag_off / skipped, which is the documented default behaviour.
     with:
       head_sha: ${{ needs.meta.outputs.head_sha }}
       head_branch: ${{ needs.meta.outputs.head_branch }}


### PR DESCRIPTION
## Symptom

Post-CI dispatcher returns \`startup_failure\` on every run since \`cbc95847\` (#1715). 20+ consecutive failures on main. Every patch-release auto-publish path (auto-release.yml -> patch bump -> PyPI publish) has been silently dead since 2026-05-20T09:31Z. The last automatic patch release was v2.0.1 on 2026-05-17.

## Root cause

\`post-ci-dispatcher.yml\` passes \`secrets.OPENROUTER_API_KEY_FREE\` to the reusable \`bernstein-ci-fix.yml\` for Tier-3 shadow mode. The operator has not defined that secret on the repo (\`gh secret list\` shows \`GEMINI_API_KEY\`, \`TELEGRAM_BOT_TOKEN\`, \`TELEGRAM_CHAT_ID\` only). GitHub Actions resolves the \`secrets:\` block of a \`workflow_call\` at startup; an undefined secret reference fails the whole call even though the receiving side declares the secret \`required: false\`.

## Fix

Drop the OPENROUTER pass from the dispatcher with a NOTE comment so it can be restored cleanly once the secret is defined. Tier-3 already gates on the \`BERNSTEIN_CI_SELF_DRIVE\` feature flag (default off), so removing the secret pass does not change behaviour: the Tier-3 job degrades to \`flag_off / skipped\`, which is the documented default.

## After this merges

- Next CI completion on main triggers post-ci-dispatcher cleanly.
- Auto-release.yml runs, evaluates the conventional-commit history since v2.5.0, bumps to v2.5.1 (5 fix commits since v2.5.0 qualify it as a patch).
- Patch publish cadence is restored.

Operator follow-up: define OPENROUTER_API_KEY_FREE on the repo if Tier-3 shadow is to be enabled later. Then restore the pass per the NOTE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve handling of optional API credentials and graceful degradation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->