### PR TITLE
chore(release): v2.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.5.0"
+version = "2.5.1"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

Manual patch bump catching up the 5 fix PRs that have landed on main since v2.5.0 without triggering an automatic patch release. The auto pipeline has been broken since cbc95847 (#1715) due to the dispatcher startup failure traced in #1730.

## Fixes included

- #1705 - fix(security): resolve CodeQL / Semgrep / workflow code-scanning alerts
- #1713 - fix(observability): repair Sonar workflow_run skip and verify GlitchTip CLI path
- #1718 - fix(privacy): scrub operator hostnames from docs and PR-comment surfaces
- #1726 - fix(routes): replace blocking subprocess.run + narrow bare except clauses
- #1727 - fix(api): pagination cap + claim_batch TOCTOU + list_tasks single-pass filter

## After merge

Tag `v2.5.1` + GH release will be cut following the same pattern as v2.5.0 (manual tag, publish.yml fires on tag push).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project version bumped to 2.5.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->