### PR TITLE
fix(security): MCP OAuth metadata correctness + Tier-3 cordon misses deletions/renames

### DIFF
--- a/docs/mcp/server-audit-2026.md
+++ b/docs/mcp/server-audit-2026.md
@@ -26,7 +26,7 @@ covered, the gap is recorded as a follow-up rather than left undefined.
 | Transport: WebSocket | Uncommon | Not implemented | Planned |
 | Auth: anonymous | Loopback-only convenience | Allowed on loopback only; refused on non-loopback binds | Yes |
 | Auth: static bearer | Common | Constant-time bearer check; token from env or config | Yes |
-| Auth: OAuth-2 PKCE | Emerging | Discovery metadata served at `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` when `BERNSTEIN_MCP_OAUTH_ISSUER` is set; token issuance is delegated to the configured IdP. See `src/bernstein/mcp/oauth.py` | Partial |
+| Auth: OAuth-2 PKCE | Emerging | Protected-resource metadata (RFC 9728) served at `/.well-known/oauth-protected-resource` when `BERNSTEIN_MCP_OAUTH_ISSUER` is set; the client follows `authorization_servers[0]` to the IdP's own RFC 8414 metadata. Token issuance is delegated to the configured IdP. See `src/bernstein/mcp/oauth.py` | Partial |
 | Auth: OIDC federation | Emerging | Not implemented; advertised under `auth.planned` | Planned |
 | Capability negotiation: static manifest | Standard `initialize` capabilities | Static `capabilities` object on `initialize` | Yes |
 | Capability negotiation: runtime capability cards | Less common | `bernstein://capability` resource and `capabilityCard` on `initialize`, built from live process state | Yes |
@@ -57,12 +57,14 @@ covered, the gap is recorded as a follow-up rather than left undefined.
    the FastMCP server and the streamable HTTP transport. Three orchestration
    prompts (`orchestrate_goal`, `triage_failed_tasks`, `cost_recap`) are
    rendered server-side from arguments; see `src/bernstein/mcp/prompts.py`.
-2. OAuth-2 PKCE authorization-server metadata published at the
-   `.well-known/oauth-authorization-server` discovery path on the streamable
+2. OAuth-2 PKCE protected-resource metadata (RFC 9728) published at the
+   `.well-known/oauth-protected-resource` discovery path on the streamable
    HTTP transport. The metadata is opt-in (configured via
-   `BERNSTEIN_MCP_OAUTH_ISSUER`) so a client that auto-discovers protected
-   resource metadata can locate the IdP without the server itself issuing
-   tokens; see `src/bernstein/mcp/oauth.py`.
+   `BERNSTEIN_MCP_OAUTH_ISSUER`) so a client can locate the IdP by
+   following `authorization_servers[0]` and then fetching the IdP's own
+   RFC 8414 metadata from the IdP. Bernstein does not fabricate
+   authorization-server metadata; only the IdP can publish that
+   document. See `src/bernstein/mcp/oauth.py`.
 
 ## Follow-ups (tracked, not in this pass)
 

--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -26,25 +26,39 @@ at startup.
 | Anonymous | default on loopback | Allowed only on `127.0.0.1` / `localhost` / `::1`. |
 | Static bearer | `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) | Constant-time check; required on non-loopback binds. |
 
-OAuth-2 PKCE token issuance is delegated to an external IdP. When the operator
+OAuth-2 PKCE token issuance is delegated to an external IdP. Bernstein is
+the **resource server**: it does not host an authorization server and so
+does not publish RFC 8414 authorization-server metadata. When the operator
 sets `BERNSTEIN_MCP_OAUTH_ISSUER=https://idp.example.com`, the streamable
-HTTP transport serves the standard discovery documents so a host can
-auto-locate the IdP:
+HTTP transport serves a single discovery document so a host can locate
+the IdP:
 
 | Path | Document |
 |------|----------|
-| `/.well-known/oauth-authorization-server` | RFC 8414 authorization-server metadata for the configured issuer (PKCE S256, code grant, public client allowed). |
 | `/.well-known/oauth-protected-resource` | RFC 9728 / MCP-draft protected-resource metadata pointing at the issuer; the `resource` field is built from the request `Host` and `X-Forwarded-Proto` headers. |
 
-Both well-known paths are served without authentication, since a client
-probing discovery has no token yet. When the env var is unset, the paths
-return 404 and only anonymous (loopback) / static bearer are advertised.
+The discovery handshake is:
+
+1. Client fetches `/.well-known/oauth-protected-resource` from Bernstein.
+2. Client reads `authorization_servers[0]` (the configured issuer URL).
+3. Client fetches the IdP's own RFC 8414 metadata from the IdP, for
+   example `https://idp.example.com/.well-known/oauth-authorization-server`
+   or whatever path the IdP uses (Keycloak, Auth0, Okta all differ).
+4. Client completes the PKCE S256 authorization-code flow against the
+   IdP and presents the resulting bearer token to the streamable HTTP
+   transport.
+
+The protected-resource path is served without authentication, since a
+client probing discovery has no token yet. When the env var is unset,
+the path returns 404 and only anonymous (loopback) / static bearer are
+advertised. Bernstein never serves `/.well-known/oauth-authorization-server`;
+that document belongs to the IdP, not the resource server.
 
 `BERNSTEIN_MCP_OAUTH_SCOPES` (comma-separated) overrides the default
-`bernstein.read,bernstein.write` scope list in both documents.
+`bernstein.read,bernstein.write` scope list in the document.
 
 The capability card reports the discovery state under `auth.oauth` so a
-client that has already fetched the card can locate the well-known paths
+client that has already fetched the card can locate the well-known path
 without probing. OIDC federation is still a follow-up.
 
 ## Capability cards
@@ -178,12 +192,14 @@ Cancelling an unknown or already-settled id is a no-op.
    ```bash
    export BERNSTEIN_MCP_OAUTH_ISSUER=https://idp.example.com
    # restart the server to pick up the env var, then:
-   curl -s http://127.0.0.1:8053/.well-known/oauth-authorization-server
    curl -s http://127.0.0.1:8053/.well-known/oauth-protected-resource
    ```
 
-   The client redirects the user to the IdP from these documents and presents
-   the resulting bearer token to the streamable HTTP transport.
+   The protected-resource document points at the IdP via
+   `authorization_servers[0]`. The client then fetches the IdP's own RFC
+   8414 metadata from the IdP (its path is IdP-specific) and completes
+   the PKCE flow there, presenting the resulting bearer token to the
+   streamable HTTP transport.
 
 6. Cancel a long-running call by its id (in a second request, while the call
    is in flight):

--- a/docs/operations/autofix-tier3.md
+++ b/docs/operations/autofix-tier3.md
@@ -61,6 +61,19 @@ drops the patch, and exits without writing a diff. The cordon-zone
 question itself stays governance, not engineering - widening it
 requires an operator-approved RFC.
 
+The cordon walks every file-pair header in the unified diff, not only
+the new-side `+++ b/<path>` line:
+
+- **Deletions.** A pure deletion has `+++ /dev/null`; the old-side
+  `--- a/<path>` is the file the patch would delete and must pass the
+  cordon. Without this the patch could delete an arbitrary
+  out-of-cordon file silently.
+- **Renames.** Both the old-side `--- a/<old>` and new-side
+  `+++ b/<new>` paths must pass the cordon. A rename that moves a
+  cordoned file outside the cordon (or pulls an out-of-cordon file
+  in) is refused. The decision-log entry records both sides under
+  `touched_paths` and the offending side(s) under `rejected_paths`.
+
 ## How to read shadow captures
 
 Every Tier-3 capture writes four artefacts under `.sdd/`:

--- a/src/bernstein/core/autofix/tier3.py
+++ b/src/bernstein/core/autofix/tier3.py
@@ -453,22 +453,74 @@ def evaluate_cordon(paths: Sequence[str]) -> tuple[bool, tuple[str, ...]]:
 
 
 def extract_paths_from_unified_diff(diff: str) -> tuple[str, ...]:
-    """Pull the set of ``b/...`` paths out of a unified-diff blob.
+    """Pull every touched path out of a unified-diff blob.
 
-    Tier-3 receives a unified diff from the injected hook. We do not
-    parse the full hunk format - only the ``+++ b/<path>`` headers are
-    needed so the cordon check stays cheap and predictable.
+    Tier-3 receives a unified diff from the injected hook. We walk the
+    file-pair headers and collect every path the diff intends to touch
+    so the cordon check sees the full blast radius:
+
+    * For an addition / in-place modification, the ``+++ b/<path>``
+      header carries the new-side path.
+    * For a pure deletion, the new-side header is ``+++ /dev/null`` and
+      the old-side path is announced on the preceding ``--- a/<path>``;
+      collecting only the new side would let a Tier-3 patch delete an
+      arbitrary out-of-cordon file unchallenged.
+    * For a rename, the new-side header is ``+++ b/<new>`` but the
+      old-side ``--- a/<old>`` is a separate path that must also pass
+      the cordon, or a cordoned file could be renamed out of the
+      cordon (and a follow-up patch would then bypass the check).
+
+    Headers are processed as (old, new) pairs so the deletion / rename
+    semantics are visible. The order of returned paths preserves the
+    diff's own ordering (old before new within each pair) so the
+    decision-log entry can quote the offending paths verbatim.
     """
     paths: list[str] = []
+    pending_old: str | None = None
     for line in diff.splitlines():
-        if line.startswith("+++ b/"):
-            paths.append(line[len("+++ b/") :].strip())
-        elif line.startswith("+++ "):
-            # Defensive: malformed headers fall through and trigger a
-            # cordon violation downstream rather than silently passing.
+        if line.startswith("--- "):
+            rest = line[len("--- ") :].strip()
+            if rest.startswith("a/"):
+                pending_old = rest[len("a/") :]
+            elif rest and rest != "/dev/null":
+                # Defensive: malformed old-side header still surfaces
+                # so the cordon trips rather than silently dropping the
+                # path on the floor.
+                pending_old = rest
+            else:
+                pending_old = None
+            continue
+        if line.startswith("+++ "):
             rest = line[len("+++ ") :].strip()
-            if rest and rest != "/dev/null":
-                paths.append(rest)
+            new_path: str | None
+            if rest.startswith("b/"):
+                new_path = rest[len("b/") :]
+            elif rest == "/dev/null":
+                new_path = None
+            elif rest:
+                # Defensive: malformed new-side header still surfaces.
+                new_path = rest
+            else:
+                new_path = None
+
+            if new_path is None:
+                # Pure deletion: the new side is /dev/null. The old
+                # path must still pass the cordon, otherwise a Tier-3
+                # patch can delete arbitrary files outside the cordon.
+                if pending_old is not None:
+                    paths.append(pending_old)
+            elif pending_old is not None and pending_old != new_path:
+                # Rename: both sides must pass the cordon so a
+                # cordoned file cannot be moved out of the cordon (and
+                # a follow-up patch then bypasses the check).
+                paths.append(pending_old)
+                paths.append(new_path)
+            else:
+                # Addition or in-place modification: the old and new
+                # paths agree (or the old side is absent), so a single
+                # entry is enough.
+                paths.append(new_path)
+            pending_old = None
     return tuple(paths)
 
 

--- a/src/bernstein/mcp/oauth.py
+++ b/src/bernstein/mcp/oauth.py
@@ -1,24 +1,24 @@
 """OAuth-2 / OIDC discovery metadata for the Bernstein MCP server.
 
-Hosts that auto-discover MCP servers look for the standard OAuth-2
-authorization-server metadata document (RFC 8414) and the MCP-style
-protected-resource metadata document (draft) to learn:
+Bernstein is the **resource server**, not the authorization server. The only
+discovery document Bernstein itself can correctly publish is the
+protected-resource metadata (RFC 9728 / MCP draft) under
+``/.well-known/oauth-protected-resource``. That document points clients at
+the configured authorization server via ``authorization_servers[0]``; the
+client then fetches the AS's own RFC 8414 metadata from the AS to learn
+the per-IdP authorization, token, and JWKS endpoints (Keycloak, Auth0,
+Okta, ... all use different layouts).
 
-  * which authorization server (IdP) issues tokens for this resource;
-  * which scopes the resource accepts;
-  * which response/grant types and PKCE methods are advertised.
+An earlier revision of this module also synthesised an RFC 8414
+authorization-server metadata document under
+``/.well-known/oauth-authorization-server`` with hardcoded ``/oauth/...``
+paths under the issuer URL. That was incorrect: only the AS itself can
+publish that document, and the path layout is operator-specific. The
+fabricated metadata has been removed; clients should rely solely on the
+protected-resource metadata to locate the IdP.
 
-Bernstein itself does not issue tokens. Instead, when the operator points the
-server at an external IdP (via ``BERNSTEIN_MCP_OAUTH_ISSUER``), this module
-publishes the discovery metadata so a client can negotiate a PKCE flow with
-that IdP and then present the resulting bearer token to the streamable HTTP
-transport. The transport's existing static-bearer check validates the token
-opaquely; full JWKS validation against the issuer is a follow-up.
-
-This closes the discovery gap for the OAuth-2 PKCE auth path: a client that
-auto-discovers protected-resource metadata can locate the IdP without trial
-and error. When the issuer env var is not set, the discovery endpoints
-return 404 so anonymous/static-bearer flows remain the only advertised path.
+When the issuer env var is not set, the discovery endpoint returns 404 so
+anonymous / static-bearer flows remain the only advertised path.
 """
 
 from __future__ import annotations
@@ -35,9 +35,6 @@ SCOPES_ENV: str = "BERNSTEIN_MCP_OAUTH_SCOPES"
 
 #: Default scopes advertised when ``BERNSTEIN_MCP_OAUTH_SCOPES`` is unset.
 _DEFAULT_SCOPES: tuple[str, ...] = ("bernstein.read", "bernstein.write")
-
-#: Path where authorization-server metadata is served (RFC 8414).
-AS_METADATA_PATH: str = "/.well-known/oauth-authorization-server"
 
 #: Path where protected-resource metadata is served (MCP draft / RFC 9728).
 PR_METADATA_PATH: str = "/.well-known/oauth-protected-resource"
@@ -59,31 +56,6 @@ def scopes_supported() -> list[str]:
 def oauth_discovery_enabled() -> bool:
     """Return True when the OAuth issuer is configured."""
     return bool(issuer())
-
-
-def authorization_server_metadata() -> dict[str, Any] | None:
-    """Build the RFC 8414 authorization-server metadata document.
-
-    Returns:
-        A JSON-serialisable dict, or ``None`` when no issuer is configured.
-    """
-    iss = issuer()
-    if not iss:
-        return None
-    return {
-        "issuer": iss,
-        "authorization_endpoint": f"{iss}/oauth/authorize",
-        "token_endpoint": f"{iss}/oauth/token",
-        "jwks_uri": f"{iss}/.well-known/jwks.json",
-        "response_types_supported": ["code"],
-        "grant_types_supported": ["authorization_code", "refresh_token"],
-        "code_challenge_methods_supported": ["S256"],
-        "token_endpoint_auth_methods_supported": [
-            "client_secret_basic",
-            "none",  # public client + PKCE
-        ],
-        "scopes_supported": scopes_supported(),
-    }
 
 
 def protected_resource_metadata(resource_url: str) -> dict[str, Any] | None:
@@ -112,14 +84,16 @@ def capability_card_oauth() -> dict[str, Any]:
     """Return the ``auth.oauth`` subtree for the runtime capability card.
 
     Reports whether the discovery surface is live and which issuer it points
-    at, so a client that fetches the card can locate the metadata documents
-    without probing the well-known paths.
+    at, so a client that fetches the card can locate the protected-resource
+    metadata document without probing the well-known path. The card does
+    not advertise an authorization-server metadata path: Bernstein is the
+    resource server and the client follows ``authorization_servers[0]`` to
+    the IdP's own RFC 8414 metadata.
     """
     iss = issuer()
     return {
         "enabled": bool(iss),
         "issuer": iss,
-        "authorizationServerMetadata": AS_METADATA_PATH,
         "protectedResourceMetadata": PR_METADATA_PATH,
         "envVar": ISSUER_ENV,
     }

--- a/src/bernstein/mcp/remote_transport.py
+++ b/src/bernstein/mcp/remote_transport.py
@@ -827,31 +827,31 @@ class StreamableHTTPTransport:
 
     @staticmethod
     def _is_well_known(path: str) -> bool:
-        """Return True for the OAuth-2 / protected-resource discovery paths."""
-        from bernstein.mcp.oauth import AS_METADATA_PATH, PR_METADATA_PATH
+        """Return True for the protected-resource discovery path.
 
-        return path in {AS_METADATA_PATH, PR_METADATA_PATH}
+        Bernstein only publishes RFC 9728 protected-resource metadata; the
+        RFC 8414 authorization-server metadata is owned by the IdP itself.
+        """
+        from bernstein.mcp.oauth import PR_METADATA_PATH
+
+        return path == PR_METADATA_PATH
 
     def _handle_well_known(
         self,
         path: str,
         headers: dict[str, str],
     ) -> tuple[int, dict[str, str], bytes]:
-        """Serve OAuth-2 authorization-server / protected-resource metadata.
+        """Serve protected-resource metadata (RFC 9728 / MCP draft).
 
         Returns:
             (200, headers, json-body) when discovery is enabled; 404 otherwise.
         """
         from bernstein.mcp.oauth import (
-            AS_METADATA_PATH,
             PR_METADATA_PATH,
-            authorization_server_metadata,
             protected_resource_metadata,
         )
 
-        if path == AS_METADATA_PATH:
-            meta = authorization_server_metadata()
-        elif path == PR_METADATA_PATH:
+        if path == PR_METADATA_PATH:
             # Build the absolute resource URL from the Host header so the
             # advertised resource matches what the client called.
             host = headers.get("host", f"{self._config.host}:{self._config.port}")

--- a/tests/unit/autofix/test_tier3_shadow.py
+++ b/tests/unit/autofix/test_tier3_shadow.py
@@ -76,6 +76,37 @@ def _diff_for(path: str, body: str = "+added line") -> str:
     return f"--- a/{path}\n+++ b/{path}\n@@ -1,1 +1,2 @@\n existing line\n{body}\n"
 
 
+def _deletion_diff_for(path: str) -> str:
+    """Render a minimal unified diff that deletes ``path`` entirely.
+
+    Matches the format ``git diff`` emits for a pure deletion: the
+    new-side header is ``+++ /dev/null`` and every existing line is a
+    ``-`` deletion line.
+    """
+    return f"--- a/{path}\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-existing line\n"
+
+
+def _rename_diff(old: str, new: str) -> str:
+    """Render a minimal unified diff that renames ``old`` -> ``new``.
+
+    Matches the format ``git diff`` emits for a content-preserving
+    rename: ``rename from`` / ``rename to`` lines, then a paired
+    ``--- a/<old>`` / ``+++ b/<new>`` and a single edit hunk so the
+    file-pair headers are visible to the parser.
+    """
+    return (
+        f"diff --git a/{old} b/{new}\n"
+        "similarity index 95%\n"
+        f"rename from {old}\n"
+        f"rename to {new}\n"
+        f"--- a/{old}\n"
+        f"+++ b/{new}\n"
+        "@@ -1,1 +1,1 @@\n"
+        "-existing line\n"
+        "+edited line\n"
+    )
+
+
 def _ctx(**overrides: Any) -> FailureContext:
     base: dict[str, Any] = {
         "failed_run_id": "987654321",
@@ -301,6 +332,123 @@ def test_cordon_violation_rejected_with_decision_log_kind(tmp_path: Path) -> Non
     assert len(records) == 1
     assert records[0].kind == "cordon_violation"
     assert "src/bernstein/core/server.py" in records[0].inputs["rejected_paths"]
+
+
+def test_cordon_violation_deletion_outside_cordon(tmp_path: Path) -> None:
+    """A pure deletion outside the cordon must trip a violation.
+
+    The patch's new-side header is ``+++ /dev/null``; only the old-side
+    ``--- a/<path>`` carries the file the patch would delete. The
+    runner must surface that old-side path and reject the capture.
+    """
+    sdd = tmp_path / "sdd"
+    decision_path = tmp_path / "decisions.jsonl"
+    patch = _deletion_diff_for("src/bernstein/core/server.py")
+    hook = _RecordingRunHook(queued=[RunResult(patch=patch, model_used="x", cost_usd=0.0)])
+    runner, _ = _runner(sdd_dir=sdd, hook=hook, decision_log_path=decision_path)
+
+    outcome = runner.run(_ctx())
+
+    assert outcome.kind == "cordon_violation"
+    assert outcome.rejected_paths == ("src/bernstein/core/server.py",)
+    assert not (sdd / "autoheal" / "tier3-shadow" / "987654321.diff").exists()
+    records = dl.replay(decision_path)
+    assert len(records) == 1
+    assert records[0].kind == "cordon_violation"
+    # Decision log records the offending old-side path verbatim.
+    assert "src/bernstein/core/server.py" in records[0].inputs["rejected_paths"]
+    assert "src/bernstein/core/server.py" in records[0].inputs["touched_paths"]
+
+
+def test_cordon_violation_deletion_within_cordon_passes(tmp_path: Path) -> None:
+    """A pure deletion of a cordoned file must NOT trip a violation.
+
+    The deletion is a destructive operation, but the cordon's purpose
+    is to scope the blast radius, not to forbid deletion outright. A
+    deletion of e.g. ``typos.toml`` (cordon-allowed) should land just
+    like an addition or in-place edit.
+    """
+    sdd = tmp_path / "sdd"
+    decision_path = tmp_path / "decisions.jsonl"
+    patch = _deletion_diff_for("typos.toml")
+    hook = _RecordingRunHook(queued=[RunResult(patch=patch, model_used=DEFAULT_PRIMARY_MODEL)])
+    runner, _ = _runner(sdd_dir=sdd, hook=hook, decision_log_path=decision_path)
+
+    outcome = runner.run(_ctx())
+
+    assert outcome.kind == "shadow_captured"
+    assert outcome.rejected_paths == ()
+
+
+def test_cordon_violation_rename_out_of_cordon(tmp_path: Path) -> None:
+    """A rename that moves a cordoned file outside the cordon trips a violation.
+
+    Old side (``typos.toml``) passes the cordon; new side
+    (``src/bernstein/core/server.py``) does not. Without the rename
+    detection in ``extract_paths_from_unified_diff`` the patch would
+    have been accepted because only the new side would have been
+    inspected, then a follow-up patch could touch the renamed-out file
+    while it sits outside the cordon.
+    """
+    sdd = tmp_path / "sdd"
+    decision_path = tmp_path / "decisions.jsonl"
+    patch = _rename_diff("typos.toml", "src/bernstein/core/server.py")
+    hook = _RecordingRunHook(queued=[RunResult(patch=patch, model_used="x", cost_usd=0.0)])
+    runner, _ = _runner(sdd_dir=sdd, hook=hook, decision_log_path=decision_path)
+
+    outcome = runner.run(_ctx())
+
+    assert outcome.kind == "cordon_violation"
+    # Rejection surfaces the new-side path that left the cordon.
+    assert "src/bernstein/core/server.py" in outcome.rejected_paths
+    records = dl.replay(decision_path)
+    assert len(records) == 1
+    assert records[0].kind == "cordon_violation"
+    # Both sides of the rename are recorded under touched_paths.
+    touched = records[0].inputs["touched_paths"]
+    assert "typos.toml" in touched
+    assert "src/bernstein/core/server.py" in touched
+
+
+def test_cordon_violation_rename_into_cordon(tmp_path: Path) -> None:
+    """A rename that moves a file INTO the cordon also trips a violation.
+
+    Old side (``src/bernstein/core/server.py``) is out-of-cordon, even
+    though the new side is cordon-allowed. Without inspecting the old
+    side, a Tier-3 patch could rename an arbitrary file into the
+    cordon and then mutate it freely.
+    """
+    sdd = tmp_path / "sdd"
+    decision_path = tmp_path / "decisions.jsonl"
+    patch = _rename_diff("src/bernstein/core/server.py", "typos.toml")
+    hook = _RecordingRunHook(queued=[RunResult(patch=patch, model_used="x", cost_usd=0.0)])
+    runner, _ = _runner(sdd_dir=sdd, hook=hook, decision_log_path=decision_path)
+
+    outcome = runner.run(_ctx())
+
+    assert outcome.kind == "cordon_violation"
+    assert "src/bernstein/core/server.py" in outcome.rejected_paths
+    records = dl.replay(decision_path)
+    assert records[0].kind == "cordon_violation"
+    assert "src/bernstein/core/server.py" in records[0].inputs["rejected_paths"]
+
+
+def test_cordon_rename_within_cordon_passes(tmp_path: Path) -> None:
+    """A rename where both sides are inside the cordon must NOT trip.
+
+    Both ``typos.toml`` and ``AGENTS.md`` are cordon-allowed root
+    files; renaming one into the other is a legal Tier-3 edit.
+    """
+    sdd = tmp_path / "sdd"
+    decision_path = tmp_path / "decisions.jsonl"
+    patch = _rename_diff("typos.toml", "AGENTS.md")
+    hook = _RecordingRunHook(queued=[RunResult(patch=patch, model_used=DEFAULT_PRIMARY_MODEL)])
+    runner, _ = _runner(sdd_dir=sdd, hook=hook, decision_log_path=decision_path)
+
+    outcome = runner.run(_ctx())
+
+    assert outcome.kind == "shadow_captured"
+    assert outcome.rejected_paths == ()
 
 
 def test_cordon_violation_permits_tier3_yaml_extension(tmp_path: Path) -> None:
@@ -546,6 +694,29 @@ def test_extract_paths_from_unified_diff_multi_file() -> None:
     diff = _diff_for("typos.toml") + _diff_for("AGENTS.md", body="+ entry")
     paths = extract_paths_from_unified_diff(diff)
     assert paths == ("typos.toml", "AGENTS.md")
+
+
+def test_extract_paths_from_unified_diff_collects_deletion_old_side() -> None:
+    """A pure deletion must surface the old-side ``--- a/<path>``.
+
+    Without this the cordon sees only ``/dev/null`` on the new side and
+    a Tier-3 patch could delete an arbitrary out-of-cordon file.
+    """
+    diff = _deletion_diff_for("src/bernstein/core/server.py")
+    paths = extract_paths_from_unified_diff(diff)
+    assert paths == ("src/bernstein/core/server.py",)
+
+
+def test_extract_paths_from_unified_diff_collects_both_sides_of_rename() -> None:
+    """A rename must surface both the old-side and new-side paths.
+
+    Without the old side, a cordoned file could be renamed out of the
+    cordon (the new path passes; the old path is invisible) and a
+    follow-up patch would then bypass the cordon entirely.
+    """
+    diff = _rename_diff("typos.toml", "src/bernstein/core/server.py")
+    paths = extract_paths_from_unified_diff(diff)
+    assert paths == ("typos.toml", "src/bernstein/core/server.py")
 
 
 def test_recurrence_tracker_ignores_old_rows(tmp_path: Path) -> None:

--- a/tests/unit/mcp/test_oauth_discovery.py
+++ b/tests/unit/mcp/test_oauth_discovery.py
@@ -1,13 +1,21 @@
-"""Tests for OAuth-2 / OIDC discovery metadata (issue #1674).
+"""Tests for OAuth-2 / OIDC discovery metadata (issue #1674, #1722).
+
+Bernstein is the **resource server**, not the authorization server. The only
+discovery document it publishes is the RFC 9728 / MCP-draft protected-resource
+metadata under ``/.well-known/oauth-protected-resource``. The RFC 8414
+authorization-server metadata is owned by the IdP itself; Bernstein does not
+attempt to fabricate it and never registers
+``/.well-known/oauth-authorization-server``.
 
 Covers:
 
   * the discovery helpers return ``None`` when no issuer is configured;
-  * with an issuer set, the authorization-server metadata is RFC 8414 shaped;
-  * the protected-resource metadata carries the configured authorization
-    server and the resource URL;
-  * the streamable HTTP transport serves both well-known paths and falls
+  * with an issuer set, the protected-resource metadata carries the
+    configured authorization server and the resource URL;
+  * the streamable HTTP transport serves the PR well-known path and falls
     back to 404 when discovery is off;
+  * the AS well-known path is **not** registered (returns 404 even with an
+    issuer set);
   * the capability card reports the discovery state.
 """
 
@@ -39,42 +47,25 @@ def _with_issuer(monkeypatch: pytest.MonkeyPatch) -> str:
 
 def test_no_issuer_returns_none(_no_issuer: None) -> None:
     from bernstein.mcp.oauth import (
-        authorization_server_metadata,
         oauth_discovery_enabled,
         protected_resource_metadata,
     )
 
     assert oauth_discovery_enabled() is False
-    assert authorization_server_metadata() is None
     assert protected_resource_metadata("https://example.com/mcp") is None
 
 
-def test_authorization_server_metadata_is_rfc8414_shaped(_with_issuer: str) -> None:
-    from bernstein.mcp.oauth import authorization_server_metadata
+def test_authorization_server_metadata_helper_removed() -> None:
+    """The AS metadata builder must not exist; only the IdP can publish it."""
+    import bernstein.mcp.oauth as oauth_mod
 
-    meta = authorization_server_metadata()
-    assert meta is not None
-    assert meta["issuer"] == _with_issuer
-    assert meta["authorization_endpoint"].startswith(_with_issuer)
-    assert meta["token_endpoint"].startswith(_with_issuer)
-    assert "code" in meta["response_types_supported"]
-    assert "authorization_code" in meta["grant_types_supported"]
-    assert "S256" in meta["code_challenge_methods_supported"]
-    # Public client + PKCE path is advertised.
-    assert "none" in meta["token_endpoint_auth_methods_supported"]
-
-
-def test_authorization_server_metadata_strips_trailing_slash(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from bernstein.mcp.oauth import authorization_server_metadata
-
-    monkeypatch.setenv("BERNSTEIN_MCP_OAUTH_ISSUER", "https://idp.example.com/")
-    meta = authorization_server_metadata()
-    assert meta is not None
-    # Trailing slash is normalised so the endpoints are well-formed.
-    assert meta["issuer"] == "https://idp.example.com"
-    assert meta["authorization_endpoint"] == "https://idp.example.com/oauth/authorize"
+    assert not hasattr(oauth_mod, "authorization_server_metadata"), (
+        "authorization_server_metadata was removed: Bernstein is the resource "
+        "server and only the IdP can publish RFC 8414 metadata"
+    )
+    assert not hasattr(oauth_mod, "AS_METADATA_PATH"), (
+        "AS_METADATA_PATH was removed alongside authorization_server_metadata"
+    )
 
 
 def test_protected_resource_metadata_carries_resource(_with_issuer: str) -> None:
@@ -85,6 +76,18 @@ def test_protected_resource_metadata_carries_resource(_with_issuer: str) -> None
     assert meta["resource"] == "https://bernstein.example.com/mcp"
     assert meta["authorization_servers"] == [_with_issuer]
     assert "header" in meta["bearer_methods_supported"]
+
+
+def test_protected_resource_metadata_strips_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A trailing slash on the issuer URL must be normalised."""
+    from bernstein.mcp.oauth import protected_resource_metadata
+
+    monkeypatch.setenv("BERNSTEIN_MCP_OAUTH_ISSUER", "https://idp.example.com/")
+    meta = protected_resource_metadata("https://bernstein.example.com/mcp")
+    assert meta is not None
+    assert meta["authorization_servers"] == ["https://idp.example.com"]
 
 
 def test_custom_scopes_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -99,7 +102,16 @@ def test_custom_scopes_env(monkeypatch: pytest.MonkeyPatch) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_transport_serves_authorization_server_metadata(_with_issuer: str) -> None:
+def test_transport_does_not_register_authorization_server_endpoint(
+    _with_issuer: str,
+) -> None:
+    """The transport must not advertise an authorization-server endpoint.
+
+    Bernstein cannot guess the IdP's path layout, so the AS well-known path
+    is never served, even when an issuer is configured. Clients learn the
+    AS endpoints from the IdP's own RFC 8414 metadata, which they reach by
+    following ``authorization_servers[0]`` from the PR metadata.
+    """
     from bernstein.mcp.remote_transport import (
         RemoteMCPConfig,
         StreamableHTTPTransport,
@@ -107,7 +119,7 @@ def test_transport_serves_authorization_server_metadata(_with_issuer: str) -> No
 
     cfg = RemoteMCPConfig(host="127.0.0.1", auth_type="none")
     transport = StreamableHTTPTransport(config=cfg)
-    status, headers, body = asyncio.run(
+    status, _, _ = asyncio.run(
         transport.handle_request(
             "GET",
             "/.well-known/oauth-authorization-server",
@@ -115,10 +127,8 @@ def test_transport_serves_authorization_server_metadata(_with_issuer: str) -> No
             b"",
         )
     )
-    assert status == 200
-    assert headers["content-type"] == "application/json"
-    payload = json.loads(body)
-    assert payload["issuer"] == _with_issuer
+    # Not registered: the path falls through to the standard 404 handler.
+    assert status == 404
 
 
 def test_transport_serves_protected_resource_metadata(_with_issuer: str) -> None:
@@ -143,7 +153,9 @@ def test_transport_serves_protected_resource_metadata(_with_issuer: str) -> None
     assert payload["authorization_servers"] == [_with_issuer]
 
 
-def test_transport_returns_404_when_discovery_disabled(_no_issuer: None) -> None:
+def test_transport_returns_404_for_protected_resource_when_discovery_disabled(
+    _no_issuer: None,
+) -> None:
     from bernstein.mcp.remote_transport import (
         RemoteMCPConfig,
         StreamableHTTPTransport,
@@ -154,7 +166,7 @@ def test_transport_returns_404_when_discovery_disabled(_no_issuer: None) -> None
     status, _, _ = asyncio.run(
         transport.handle_request(
             "GET",
-            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
             {"host": "127.0.0.1"},
             b"",
         )
@@ -162,7 +174,7 @@ def test_transport_returns_404_when_discovery_disabled(_no_issuer: None) -> None
     assert status == 404
 
 
-def test_well_known_path_does_not_require_auth(_with_issuer: str) -> None:
+def test_protected_resource_path_does_not_require_auth(_with_issuer: str) -> None:
     """A client probing discovery has no token yet; the path must not 401."""
     from bernstein.mcp.remote_transport import (
         RemoteMCPConfig,
@@ -179,7 +191,7 @@ def test_well_known_path_does_not_require_auth(_with_issuer: str) -> None:
     status, _, _ = asyncio.run(
         transport.handle_request(
             "GET",
-            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
             {"host": "127.0.0.1"},
             b"",
         )
@@ -199,7 +211,9 @@ def test_capability_card_reports_oauth_state(_with_issuer: str) -> None:
     oauth = card["auth"]["oauth"]
     assert oauth["enabled"] is True
     assert oauth["issuer"] == _with_issuer
-    assert oauth["authorizationServerMetadata"] == "/.well-known/oauth-authorization-server"
+    assert oauth["protectedResourceMetadata"] == "/.well-known/oauth-protected-resource"
+    # The AS metadata path is no longer advertised.
+    assert "authorizationServerMetadata" not in oauth
     # With discovery on, oauth2_pkce moves into supported.
     assert "oauth2_pkce" in card["auth"]["supported"]
 


### PR DESCRIPTION
## Summary

Two correctness fixes on recently-merged security surfaces.

### 1. MCP `oauth.py` no longer fabricates authorization-server metadata

`src/bernstein/mcp/oauth.py` previously synthesised an RFC 8414 authorization-server metadata document under `/.well-known/oauth-authorization-server` with hardcoded `${iss}/oauth/authorize`, `${iss}/oauth/token`, `${iss}/.well-known/jwks.json` paths. Bernstein is the resource server, not the AS; only the IdP can publish that document, and the per-IdP path layout (Keycloak, Auth0, Okta, ...) is operator-specific.

- Drop `authorization_server_metadata()` and the `AS_METADATA_PATH` constant.
- Drop the `/.well-known/oauth-authorization-server` route from the streamable HTTP transport (path now returns 404 even with an issuer configured).
- Update `capability_card_oauth()` to advertise only the protected-resource path.
- Keep `protected_resource_metadata()` (RFC 9728); clients reach the IdP via `authorization_servers[0]` and fetch the IdP's own RFC 8414 metadata from the IdP.
- Update `docs/mcp/server.md` and `docs/mcp/server-audit-2026.md` to document the new discovery handshake.

### 2. Tier-3 cordon walks deletions and renames

`extract_paths_from_unified_diff` in `src/bernstein/core/autofix/tier3.py` collected only new-side `+++ b/<path>` headers. A pure deletion has `+++ /dev/null` and announces the file on the old-side `--- a/<path>` only, so the parser surfaced nothing - a Tier-3 patch could delete an arbitrary out-of-cordon file unchallenged. A rename announced both sides separately, but the old-side was ignored, so a cordoned file could be renamed outside the cordon and a follow-up patch would then bypass the check.

- Walk file-pair headers as (old, new) tuples; collect old-side on deletion, both sides on rename, single entry on addition or in-place edit.
- The decision-log entry's `touched_paths` and `rejected_paths` now carry the offending old-side path verbatim on `cordon_violation`.
- Regression tests in `tests/unit/autofix/test_tier3_shadow.py` cover: deletion outside cordon trips a violation; deletion inside cordon allowed; rename out of cordon trips a violation (and the decision-log records both sides); rename into cordon trips a violation; rename within cordon allowed; parser-level unit tests for deletion and rename header pairs.
- Update `docs/operations/autofix-tier3.md` to document that the cordon walks deletions and renames.

Tier-3 is shadow-mode by default today (#1715), so this is not exploitable yet; the cordon is the load-bearing safety check before any future promotion-from-shadow.

Closes #1722.

## Test plan

- [x] `uv run pytest tests/unit/mcp/test_oauth_discovery.py -q` (11 passed)
- [x] `uv run pytest tests/unit/autofix/test_tier3_shadow.py -q` (27 passed; 7 new)
- [x] `uv run pytest tests/unit/mcp tests/unit/autofix -q` (284 passed)
- [x] `uv run ruff check src/` and `uv run ruff format --check src/` (clean)
- [ ] Full `tests/unit` suite via CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth 2.0 PKCE discovery behavior; Bernstein now serves only protected-resource metadata, delegating token issuance to the configured identity provider.
  * Updated worked examples and authentication flow documentation.

* **Bug Fixes**
  * Improved auto-heal cordon validation to correctly identify all affected files during deletions and renames, preventing out-of-cordon violations.

* **Tests**
  * Added test coverage for deletion and rename scenarios in cordon validation.
  * Updated OAuth discovery tests to reflect simplified metadata serving behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->