### PR TITLE
feat(skills): lifecycle CLI foundation (install / sync / lock / lint / watch / activation log)

### DIFF
--- a/bernstein-skills.toml
+++ b/bernstein-skills.toml
@@ -1,0 +1,16 @@
+# Skill lifecycle manifest (issue #1720, track 1).
+#
+# Lists the skills `bernstein skills sync` installs into
+# `.bernstein/skills/` for this project. Only the `local` source type is
+# supported in this release; Git, OCI, and index sources land in
+# follow-up PRs.
+#
+# Re-running `bernstein skills sync` is idempotent: declared skills whose
+# digest matches the source are left in place. The companion
+# `skills.lock` file records the resolved digest of every installed skill
+# so a subsequent sync can detect drift.
+
+[[skills]]
+name = "bernstein-test-runner"
+source = "local"
+path = "./templates/skills/bernstein-test-runner.md"

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -264,7 +264,7 @@ def _extract_skill_version(content: str) -> str:
     except yaml.YAMLError:
         return ""
     if isinstance(data, dict):
-        typed = cast("_FrontmatterSchema", data)
+        typed = cast(_FrontmatterSchema, data)
         version = typed.get("version")
         if isinstance(version, str):
             return version

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -47,6 +47,7 @@ class _FrontmatterSchema(TypedDict, total=False):
 
     version: str
 
+
 _logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import yaml
 
@@ -36,6 +36,16 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.core.models import Task
+
+
+class _FrontmatterSchema(TypedDict, total=False):
+    """Subset of Claude-Code skill frontmatter the injector reads.
+
+    The loose-YAML parse may surface extra keys; only the ones the
+    activation log needs are typed here.
+    """
+
+    version: str
 
 _logger = logging.getLogger(__name__)
 
@@ -196,7 +206,7 @@ def inject_skills(
             skill_name = template_name.rsplit(".", 1)[0]
             version = _extract_skill_version(sanitized)
             digest = hashlib.blake2b(sanitized.encode("utf-8"), digest_size=16).hexdigest()
-            for task in tasks or []:
+            for task in tasks:
                 log_activation(
                     ActivationRecord(
                         skill=skill_name,
@@ -253,7 +263,8 @@ def _extract_skill_version(content: str) -> str:
     except yaml.YAMLError:
         return ""
     if isinstance(data, dict):
-        version = data.get("version")
+        typed = cast("_FrontmatterSchema", data)
+        version = typed.get("version")
         if isinstance(version, str):
             return version
     return ""

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -20,9 +20,16 @@ dependency) so skills can be rendered without external libraries.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import TYPE_CHECKING
 
+import yaml
+
+from bernstein.core.skills.activation_log import (
+    ActivationRecord,
+    log_activation,
+)
 from bernstein.core.skills.sanitizer import sanitize_skill_body
 
 if TYPE_CHECKING:
@@ -175,6 +182,78 @@ def inject_skills(
         dest_path = skills_dest_dir / template_name
         try:
             dest_path.write_text(rendered, encoding="utf-8")
-            _logger.debug("Injected skill: %s → %s", template_name, dest_path)
+            _logger.debug("Injected skill: %s -> %s", template_name, dest_path)
         except OSError as exc:
             _logger.debug("Failed to write skill %s: %s", dest_path, exc)
+            continue
+
+        # Activation log: best-effort, opt-out via env var. We compute a
+        # short BLAKE2b digest over the sanitised (pre-render) body so
+        # the log line refers to the source skill rather than the
+        # rendered-with-task-ids variant. ``version`` is best-effort
+        # pulled from frontmatter; missing values stay as empty strings.
+        try:
+            skill_name = template_name.rsplit(".", 1)[0]
+            version = _extract_skill_version(sanitized)
+            digest = hashlib.blake2b(sanitized.encode("utf-8"), digest_size=16).hexdigest()
+            for task in tasks or []:
+                log_activation(
+                    ActivationRecord(
+                        skill=skill_name,
+                        role=role,
+                        task_id=task.id,
+                        trigger_source="role-binding",
+                        version=version,
+                        digest=digest,
+                    ),
+                    workdir=workdir,
+                )
+            if not tasks:
+                log_activation(
+                    ActivationRecord(
+                        skill=skill_name,
+                        role=role,
+                        task_id="",
+                        trigger_source="role-binding",
+                        version=version,
+                        digest=digest,
+                    ),
+                    workdir=workdir,
+                )
+        except Exception:
+            # Never let the activation log block a spawn.
+            _logger.debug("activation log append failed for %s", template_name, exc_info=True)
+
+
+def _extract_skill_version(content: str) -> str:
+    """Pull ``version`` from the YAML frontmatter, defaulting to empty.
+
+    The injector handles Claude-Code-shaped skills whose frontmatter may
+    not match :class:`SkillManifest` strictly; we do a loose YAML parse
+    rather than running it through Pydantic so non-strict templates
+    still produce an activation record.
+    """
+    if not content.startswith("---"):
+        return ""
+    lines = content.splitlines()
+    fence_count = 0
+    front_lines: list[str] = []
+    for line in lines:
+        if line.rstrip() == "---":
+            fence_count += 1
+            if fence_count == 2:
+                break
+            continue
+        if fence_count == 1:
+            front_lines.append(line)
+    if fence_count < 2:
+        return ""
+    try:
+        data = yaml.safe_load("\n".join(front_lines))
+    except yaml.YAMLError:
+        return ""
+    if isinstance(data, dict):
+        version = data.get("version")
+        if isinstance(version, str):
+            return version
+    return ""

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -10,6 +10,7 @@ the BASE/TEAM/USER layout get the layered view on demand.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import signal
 import time
@@ -424,10 +425,19 @@ def skills_watch(path: Path | None) -> None:
         nonlocal stopped
         stopped = True
 
+    # Save the previous SIGINT handler so subsequent in-process CLI calls
+    # (and tests that run the watch command in-process) see the original
+    # disposition restored when this command returns.
+    previous_sigint = signal.getsignal(signal.SIGINT)
     signal.signal(signal.SIGINT, _shutdown)
     try:
         while not stopped:
             time.sleep(0.2)
     finally:
+        # ``getsignal`` may return a value (e.g. an opaque C handler) that
+        # ``signal.signal`` cannot accept; leaving the current handler in
+        # place is preferable to crashing the cleanup path.
+        with contextlib.suppress(TypeError, ValueError):
+            signal.signal(signal.SIGINT, previous_sigint)
         handle.stop()
         console.print("[dim]watcher stopped[/dim]")

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -11,12 +11,24 @@ the BASE/TEAM/USER layout get the layered view on demand.
 from __future__ import annotations
 
 import json
+import signal
+import time
 from pathlib import Path
 
 import click
 
 from bernstein import get_templates_dir
 from bernstein.cli.helpers import console
+from bernstein.core.skills.lifecycle import (
+    SKILLS_TOML_FILENAME,
+    InstallScope,
+    SkillLifecycleError,
+    SkillsTomlError,
+    install_local,
+    remove_skill,
+    sync_skills,
+)
+from bernstein.core.skills.lint import LintSeverity, lint_skill
 
 
 @click.group("skills")
@@ -212,3 +224,206 @@ def _skills_show_layered(name: str) -> None:
     for layer in sorted(fragments, key=lambda layer: layer.value):
         console.print(f"\n[bold]layer: {layer.label}[/bold] ([dim]{paths.for_layer(layer)}[/dim])")
         console.print(json.dumps(fragments[layer], indent=2, sort_keys=True))
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle commands (issue 1720, track 1)
+# ---------------------------------------------------------------------------
+
+
+def _parse_scope(scope_str: str) -> InstallScope:
+    """Coerce the ``--scope`` CLI flag into an :class:`InstallScope`."""
+    try:
+        return InstallScope(scope_str)
+    except ValueError as exc:
+        raise click.BadParameter(f"unknown scope {scope_str!r}; expected project or user") from exc
+
+
+@skills_group.command("install")
+@click.argument("source", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["project", "user"]),
+    default="project",
+    help="Install scope: project (.bernstein/skills/) or user (~/.bernstein/skills/).",
+)
+@click.option(
+    "--name",
+    "override_name",
+    default=None,
+    help="Override the auto-detected skill name (uses source filename otherwise).",
+)
+def skills_install(source: Path, scope: str, override_name: str | None) -> None:
+    """Install a skill from a local path.
+
+    \b
+      bernstein skills install ./templates/skills/bernstein-test-runner.md
+      bernstein skills install ./my-skill-dir --scope user
+    """
+    install_scope = _parse_scope(scope)
+    try:
+        result = install_local(
+            source.resolve(),
+            scope=install_scope,
+            workdir=Path.cwd(),
+            override_name=override_name,
+        )
+    except SkillLifecycleError as exc:
+        console.print(f"[red]install failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+    console.print(
+        f"[green]installed[/green] {result.name} -> {result.install_dir} (digest {result.digest.digest[:12]}...)",
+    )
+
+
+@skills_group.command("remove")
+@click.argument("name")
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["project", "user"]),
+    default="project",
+    help="Remove from project or user scope.",
+)
+def skills_remove(name: str, scope: str) -> None:
+    """Remove a previously installed skill."""
+    install_scope = _parse_scope(scope)
+    removed = remove_skill(name, scope=install_scope, workdir=Path.cwd())
+    if removed:
+        console.print(f"[green]removed[/green] {name} from {scope} scope")
+    else:
+        console.print(f"[yellow]not installed[/yellow] {name} in {scope} scope")
+        raise SystemExit(1)
+
+
+@skills_group.command("sync")
+@click.option(
+    "--manifest",
+    "manifest",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=f"Path to {SKILLS_TOML_FILENAME}. Defaults to <cwd>/{SKILLS_TOML_FILENAME}.",
+)
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["project", "user"]),
+    default="project",
+    help="Where to install declared skills.",
+)
+def skills_sync(manifest: Path | None, scope: str) -> None:
+    """Install every skill declared in ``bernstein-skills.toml``.
+
+    Re-runs are idempotent: skills whose digest already matches are
+    skipped. The lock file (``skills.lock``) is rewritten beside the
+    manifest on every successful run.
+    """
+    toml_path = manifest if manifest is not None else (Path.cwd() / SKILLS_TOML_FILENAME)
+    install_scope = _parse_scope(scope)
+    try:
+        outcomes = sync_skills(
+            toml_path.resolve(),
+            scope=install_scope,
+            workdir=Path.cwd(),
+        )
+    except (SkillsTomlError, SkillLifecycleError) as exc:
+        console.print(f"[red]sync failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if not outcomes:
+        console.print("[dim]no skills declared in manifest[/dim]")
+        return
+    for outcome in outcomes:
+        marker = {
+            "installed": "[green]+ installed[/green]",
+            "updated": "[yellow]~ updated[/yellow]",
+            "unchanged": "[dim]= unchanged[/dim]",
+        }.get(outcome.action, outcome.action)
+        console.print(f"{marker} {outcome.name} ({outcome.digest.digest[:12]}...)")
+
+
+@skills_group.command("lint")
+@click.argument("names", nargs=-1)
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["project", "user"]),
+    default="project",
+    help="Lint installed skills from project or user scope.",
+)
+def skills_lint(names: tuple[str, ...], scope: str) -> None:
+    """Advisory lint: validate frontmatter, references, sensitive patterns.
+
+    Lint is non-blocking in this release. Exit code is 0 even when
+    errors are reported; the operator decides whether to act on them.
+    """
+    from bernstein.core.skills.lifecycle import scope_root
+
+    install_scope = _parse_scope(scope)
+    root = scope_root(install_scope, workdir=Path.cwd())
+    if not root.is_dir():
+        console.print(f"[dim]no installed skills under {root}[/dim]")
+        return
+
+    targets: list[Path] = [root / name for name in names] if names else sorted(p for p in root.iterdir() if p.is_dir())
+
+    all_findings = 0
+    for target in targets:
+        if not target.is_dir():
+            console.print(f"[red]missing[/red] {target.name} (not installed)")
+            all_findings += 1
+            continue
+        findings = lint_skill(target)
+        if not findings:
+            console.print(f"[green]ok[/green] {target.name}")
+            continue
+        all_findings += len(findings)
+        console.print(f"[bold]{target.name}[/bold]")
+        for finding in findings:
+            tag = "[red]error[/red]" if finding.severity is LintSeverity.ERROR else "[yellow]warn[/yellow]"
+            console.print(f"  {tag} {finding.code}: {finding.message}")
+
+    if all_findings:
+        console.print(f"\n[dim]{all_findings} finding(s) total (advisory only)[/dim]")
+
+
+@skills_group.command("watch")
+@click.argument(
+    "path",
+    type=click.Path(path_type=Path),
+    required=False,
+)
+def skills_watch(path: Path | None) -> None:
+    """Hot-reload the skill index on filesystem change.
+
+    Watches the project's ``.bernstein/skills/`` directory by default.
+    Pass an explicit path to watch a different root (e.g. an in-tree
+    ``templates/skills/``). Press Ctrl-C to stop.
+    """
+    from bernstein.core.skills.watcher import start_skill_watcher
+
+    watch_path = (path or Path.cwd() / ".bernstein" / "skills").resolve()
+    console.print(f"[cyan]watching[/cyan] {watch_path}")
+
+    reload_count = 0
+
+    def on_reload(_loader: object) -> None:
+        nonlocal reload_count
+        reload_count += 1
+        console.print(f"[green]reloaded[/green] index (event #{reload_count})")
+
+    handle = start_skill_watcher(watch_path, on_reload)
+    stopped = False
+
+    def _shutdown(_signum: int, _frame: object) -> None:
+        nonlocal stopped
+        stopped = True
+
+    signal.signal(signal.SIGINT, _shutdown)
+    try:
+        while not stopped:
+            time.sleep(0.2)
+    finally:
+        handle.stop()
+        console.print("[dim]watcher stopped[/dim]")

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -14,8 +14,12 @@ import json
 import signal
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from bernstein.core.skills.loader import SkillLoader
 
 from bernstein import get_templates_dir
 from bernstein.cli.helpers import console
@@ -408,7 +412,7 @@ def skills_watch(path: Path | None) -> None:
 
     reload_count = 0
 
-    def on_reload(_loader: object) -> None:
+    def on_reload(_loader: SkillLoader) -> None:
         nonlocal reload_count
         reload_count += 1
         console.print(f"[green]reloaded[/green] index (event #{reload_count})")

--- a/src/bernstein/core/skills/activation_log.py
+++ b/src/bernstein/core/skills/activation_log.py
@@ -1,0 +1,142 @@
+"""Append-only activation log for loaded skills (issue #1720, Track 5 floor).
+
+Every time a skill is loaded into a spawn, the orchestrator appends a
+structured record to ``.sdd/skills/activations.jsonl`` under the project
+root. The log is local-only; there is no maintainer endpoint and no
+network egress. Operators opt out by setting
+``BERNSTEIN_SKILL_ACTIVATION_LOG=0`` (or any of the falsy aliases
+``false`` / ``no`` / ``off``) in their environment.
+
+The log line schema is intentionally narrow so a future PR can pivot to
+a structured-binary format without breaking compatibility:
+
+.. code-block:: json
+
+    {
+      "skill": "bernstein-test-runner",
+      "version": "1.0.0",
+      "digest": "<blake2b hex>",
+      "role": "backend",
+      "task_id": "task-42",
+      "trigger_source": "role-binding",
+      "timestamp": "2026-05-20T12:34:56.789Z"
+    }
+
+The file is created lazily on first write so a spawn that does not load
+any skills leaves no trace. Failures during append are swallowed and
+logged at WARNING so an unwritable disk never blocks a spawn.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003 - runtime annotation in helper functions
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+#: Env var controlling whether the activation log is written.
+ENV_VAR: Final[str] = "BERNSTEIN_SKILL_ACTIVATION_LOG"
+
+#: Subpath relative to the project workdir.
+_LOG_SUBPATH: Final[tuple[str, ...]] = (".sdd", "skills", "activations.jsonl")
+
+#: Values that disable the log when assigned to the env var.
+_DISABLE_TOKENS: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
+
+
+def is_logging_enabled() -> bool:
+    """Return whether activation logging is enabled for this process.
+
+    The default is ``True``. Operators opt out by setting
+    :data:`ENV_VAR` to any value in :data:`_DISABLE_TOKENS` (case
+    insensitive).
+    """
+    raw = os.environ.get(ENV_VAR, "").strip().lower()
+    return raw not in _DISABLE_TOKENS
+
+
+def activation_log_path(workdir: Path) -> Path:
+    """Return the on-disk location of the activation log."""
+    return workdir.joinpath(*_LOG_SUBPATH)
+
+
+@dataclass(frozen=True)
+class ActivationRecord:
+    """One structured row in the activation log.
+
+    Optional fields default to empty strings so the JSON shape is stable
+    even when the orchestrator does not know the task id (e.g. ad-hoc
+    ``bernstein skills show`` calls).
+    """
+
+    skill: str
+    role: str = ""
+    task_id: str = ""
+    trigger_source: str = ""
+    version: str = ""
+    digest: str = ""
+
+    def as_payload(self, *, now: datetime | None = None) -> dict[str, str]:
+        """Render the record as the JSON dict written to the log."""
+        ts = (now or datetime.now(tz=UTC)).isoformat(timespec="milliseconds")
+        # Match the RFC sample exactly: trailing ``Z`` instead of
+        # ``+00:00``. ``datetime.isoformat`` produces the latter; we
+        # rewrite the suffix so the log is grep-friendly.
+        if ts.endswith("+00:00"):
+            ts = ts[: -len("+00:00")] + "Z"
+        return {
+            "skill": self.skill,
+            "version": self.version,
+            "digest": self.digest,
+            "role": self.role,
+            "task_id": self.task_id,
+            "trigger_source": self.trigger_source,
+            "timestamp": ts,
+        }
+
+
+def log_activation(
+    record: ActivationRecord,
+    *,
+    workdir: Path,
+    now: datetime | None = None,
+) -> Path | None:
+    """Append one activation record to the per-project log.
+
+    Args:
+        record: The activation record to write.
+        workdir: Project root. The log lands at
+            ``<workdir>/.sdd/skills/activations.jsonl``.
+        now: Override for the timestamp (tests).
+
+    Returns:
+        The log path when a line was written; ``None`` when logging is
+        disabled or the append failed (the failure is logged at WARNING).
+    """
+    if not is_logging_enabled():
+        return None
+    path = activation_log_path(workdir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record.as_payload(now=now), separators=(",", ":"), sort_keys=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.write("\n")
+    except OSError as exc:
+        logger.warning("skills.activation_log_write_failed path=%s error=%s", path, exc)
+        return None
+    return path
+
+
+__all__ = [
+    "ENV_VAR",
+    "ActivationRecord",
+    "activation_log_path",
+    "is_logging_enabled",
+    "log_activation",
+]

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -464,9 +464,7 @@ def install_local(
             _copy_skill_tree(source, staging_dir)
         else:
             if source.suffix != ".md":
-                raise SkillLifecycleError(
-                    f"{source}: local file source must have a .md extension"
-                )
+                raise SkillLifecycleError(f"{source}: local file source must have a .md extension")
             try:
                 content = source.read_text(encoding="utf-8")
             except OSError as exc:

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -1,0 +1,733 @@
+"""Skill lifecycle: install, remove, sync, lock (issue #1720, track 1).
+
+This module turns the abstract :class:`~bernstein.core.skills.source.SkillSource`
+interface into operator-facing verbs. It does NOT replace the existing
+discovery cascade (:mod:`bernstein.core.plugins_core.skill_discovery`) or
+the eager loader (:mod:`bernstein.core.skills.loader`); it only writes
+into and reads from the well-known directories those subsystems already
+scan:
+
+- Project scope: ``<workdir>/.bernstein/skills/<name>/``
+- User scope:    ``~/.bernstein/skills/<name>/``
+
+Layout of an installed skill matches the conventional
+:class:`~bernstein.core.skills.sources.local_dir.LocalDirSkillSource`
+shape::
+
+    <scope-root>/.bernstein/skills/<name>/
+        SKILL.md
+        references/  (optional)
+        scripts/     (optional)
+        assets/      (optional)
+
+The lifecycle manifest ``bernstein-skills.toml`` lives at the repo root
+and lists every skill the project expects to have installed. ``sync``
+makes the filesystem match the manifest. ``skills.lock`` records the
+content-addressed digest of every installed skill so a subsequent sync
+detects drift.
+
+Out of scope for this module (deferred to follow-up tracks):
+
+- Source types beyond ``local`` (Git, OCI, index).
+- Signature verification and trust roots.
+- Sensitive-pattern-scan-on-install (the existing sanitiser already
+  scrubs invisible Unicode codepoints at load time; refusing installs on
+  sensitive patterns is track 4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import tomllib
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Filename of the lifecycle manifest at repo root.
+SKILLS_TOML_FILENAME: str = "bernstein-skills.toml"
+
+#: Filename of the lock file next to the manifest.
+SKILLS_LOCK_FILENAME: str = "skills.lock"
+
+#: Directory under each scope root that holds installed skills.
+_INSTALL_SUBDIR: tuple[str, str] = (".bernstein", "skills")
+
+#: BLAKE2b digest size in bytes (32 bytes = 64 hex chars). Matches what the
+#: RFC reserves room for in ``skills.lock``.
+_DIGEST_SIZE: int = 32
+
+#: Source types the foundation PR supports. Track 3 adds ``git``, ``oci``,
+#: ``index``; we keep them out of scope here.
+_SUPPORTED_SOURCES: frozenset[str] = frozenset({"local"})
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SkillLifecycleError(RuntimeError):
+    """Raised when an install / remove / sync operation fails."""
+
+
+class SkillsTomlError(SkillLifecycleError):
+    """Raised when ``bernstein-skills.toml`` cannot be parsed or validated."""
+
+
+# ---------------------------------------------------------------------------
+# Scope
+# ---------------------------------------------------------------------------
+
+
+class InstallScope(StrEnum):
+    """Where an install lands.
+
+    - :attr:`PROJECT` writes to ``<workdir>/.bernstein/skills/``.
+    - :attr:`USER`    writes to ``~/.bernstein/skills/``.
+    """
+
+    PROJECT = "project"
+    USER = "user"
+
+
+def scope_root(scope: InstallScope, *, workdir: Path, home: Path | None = None) -> Path:
+    """Return the ``.bernstein/skills/`` directory for ``scope``.
+
+    Args:
+        scope: Project or user scope.
+        workdir: Current project root. Used only when scope is PROJECT.
+        home: Override for the user's home directory. Defaults to
+            :func:`pathlib.Path.home` so tests can redirect to ``tmp_path``.
+
+    Returns:
+        Absolute path to the installation root.
+    """
+    home_dir = home if home is not None else Path.home()
+    base = workdir if scope is InstallScope.PROJECT else home_dir
+    return base.joinpath(*_INSTALL_SUBDIR)
+
+
+# ---------------------------------------------------------------------------
+# Manifest schema (bernstein-skills.toml)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SkillsTomlEntry:
+    """One ``[[skills]]`` entry from ``bernstein-skills.toml``.
+
+    Attributes:
+        name: Lowercase slug identifying the skill.
+        source: Source type; only ``"local"`` is in scope for this PR.
+        path: Path string as written in the TOML (relative paths are
+            resolved against the TOML file's directory).
+    """
+
+    name: str
+    source: str
+    path: str
+
+
+@dataclass(frozen=True)
+class SkillsToml:
+    """Parsed contents of ``bernstein-skills.toml``."""
+
+    entries: tuple[SkillsTomlEntry, ...]
+    source_path: Path
+
+
+def load_skills_toml(path: Path) -> SkillsToml:
+    """Parse ``bernstein-skills.toml`` from disk.
+
+    Args:
+        path: Absolute path to the TOML file.
+
+    Returns:
+        Parsed manifest.
+
+    Raises:
+        SkillsTomlError: When the file is missing, unreadable, malformed,
+            or declares an entry with an unsupported source type.
+    """
+    if not path.is_file():
+        raise SkillsTomlError(f"{path}: file does not exist")
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise SkillsTomlError(f"{path}: cannot read file: {exc}") from exc
+    try:
+        data = tomllib.loads(raw.decode("utf-8"))
+    except (tomllib.TOMLDecodeError, UnicodeDecodeError) as exc:
+        raise SkillsTomlError(f"{path}: invalid TOML: {exc}") from exc
+
+    raw_entries = data.get("skills", [])
+    if not isinstance(raw_entries, list):
+        raise SkillsTomlError(f"{path}: 'skills' must be an array of tables")
+
+    entries: list[SkillsTomlEntry] = []
+    seen: set[str] = set()
+    for idx, item in enumerate(cast("list[object]", raw_entries)):
+        if not isinstance(item, dict):
+            raise SkillsTomlError(f"{path}: entry #{idx} must be a table")
+        item_dict = cast("dict[str, object]", item)
+        name = item_dict.get("name")
+        source = item_dict.get("source")
+        skill_path = item_dict.get("path")
+        if not isinstance(name, str) or not name:
+            raise SkillsTomlError(f"{path}: entry #{idx} missing 'name'")
+        if not isinstance(source, str) or not source:
+            raise SkillsTomlError(f"{path}: entry {name!r} missing 'source'")
+        if source not in _SUPPORTED_SOURCES:
+            raise SkillsTomlError(
+                f"{path}: entry {name!r} declares source={source!r}; only "
+                f"{sorted(_SUPPORTED_SOURCES)} are supported in this release",
+            )
+        if not isinstance(skill_path, str) or not skill_path:
+            raise SkillsTomlError(f"{path}: entry {name!r} missing 'path'")
+        if name in seen:
+            raise SkillsTomlError(f"{path}: duplicate entry for skill {name!r}")
+        seen.add(name)
+        entries.append(SkillsTomlEntry(name=name, source=source, path=skill_path))
+
+    return SkillsToml(entries=tuple(entries), source_path=path)
+
+
+def resolve_local_source(entry: SkillsTomlEntry, toml_dir: Path) -> Path:
+    """Resolve an entry's ``path`` against the TOML directory.
+
+    Args:
+        entry: A ``local`` source entry.
+        toml_dir: Directory containing the TOML file.
+
+    Returns:
+        Absolute path to the source (file or directory).
+    """
+    raw = Path(entry.path)
+    return raw if raw.is_absolute() else (toml_dir / raw).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Content digest
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SkillDigest:
+    """Content-addressed digest of an installed skill.
+
+    The digest is BLAKE2b over a canonicalised stream that mixes:
+
+    1. The YAML frontmatter, re-emitted with sorted keys.
+    2. The markdown body with normalised line endings.
+    3. Every file declared under ``references`` / ``scripts`` / ``assets``,
+       in lexical order, each prefixed by its relative path.
+
+    Files not declared in the manifest are deliberately ignored so adding
+    a scratch note next to a skill does not invalidate the lock.
+    """
+
+    digest: str
+
+    def __str__(self) -> str:
+        return self.digest
+
+
+def _canonical_frontmatter(front_raw: str) -> bytes:
+    """Re-emit YAML frontmatter with sorted keys for a stable digest input.
+
+    Unknown or extra keys are preserved verbatim so installs and lints
+    converge on the same digest even when the manifest carries non-strict
+    fields (the Claude Code ``whenToUse`` key is the canonical example).
+
+    Args:
+        front_raw: The YAML text between the ``---`` fences.
+
+    Returns:
+        Canonicalised YAML, UTF-8 encoded, terminated by exactly one
+        newline.
+    """
+    try:
+        loaded = yaml.safe_load(front_raw)
+    except yaml.YAMLError:
+        # If the YAML cannot be parsed, fall back to the raw bytes so the
+        # digest still reflects the on-disk content. Lint will flag it
+        # separately.
+        return front_raw.encode("utf-8")
+    if loaded is None:
+        return b"{}\n"
+    canonical = yaml.safe_dump(
+        loaded,
+        sort_keys=True,
+        allow_unicode=True,
+        default_flow_style=False,
+    )
+    return canonical.encode("utf-8")
+
+
+def _split_skill_md(text: str) -> tuple[str, str]:
+    """Split a SKILL.md text into frontmatter and body.
+
+    Falls back to ``("", text)`` when no frontmatter is present so the
+    digest still includes the whole file.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != "---":
+        return ("", text)
+    front: list[str] = []
+    for idx in range(1, len(lines)):
+        if lines[idx].rstrip() == "---":
+            front_text = "\n".join(front)
+            body = "\n".join(lines[idx + 1 :]).strip("\n")
+            return (front_text, body)
+        front.append(lines[idx])
+    # Unterminated frontmatter: treat the whole thing as body.
+    return ("", text)
+
+
+def _frontmatter_dict(front_raw: str) -> dict[str, Any]:
+    """Best-effort frontmatter parse for digest helpers (no strict checks)."""
+    try:
+        loaded = yaml.safe_load(front_raw)
+    except yaml.YAMLError:
+        return {}
+    if isinstance(loaded, dict):
+        return cast("dict[str, Any]", loaded)
+    return {}
+
+
+def _referenced_files(skill_dir: Path, frontmatter: dict[str, Any]) -> list[Path]:
+    """Return the manifest-referenced files in deterministic order.
+
+    Files listed under ``references`` / ``scripts`` / ``assets`` are
+    looked up under the matching subdirectory of ``skill_dir``. Missing
+    files are silently skipped here; lint surfaces them as errors.
+    """
+    out: list[Path] = []
+    for bucket in ("references", "scripts", "assets"):
+        values = frontmatter.get(bucket, [])
+        if not isinstance(values, list):
+            continue
+        for entry in cast("list[object]", values):
+            if not isinstance(entry, str):
+                continue
+            candidate = skill_dir / bucket / entry
+            if candidate.is_file():
+                out.append(candidate)
+    out.sort(key=lambda p: str(p.relative_to(skill_dir)))
+    return out
+
+
+def compute_skill_digest(skill_dir: Path) -> SkillDigest:
+    """Compute the content digest for an installed skill directory.
+
+    The digest covers the canonicalised manifest, the body, and every
+    manifest-declared reference / script / asset. Files present on disk
+    but not declared in the manifest are ignored on purpose: the digest
+    must be reproducible from the manifest alone.
+
+    Args:
+        skill_dir: Directory containing ``SKILL.md``.
+
+    Returns:
+        :class:`SkillDigest` with a 64-character hex BLAKE2b digest.
+
+    Raises:
+        SkillLifecycleError: When ``SKILL.md`` is missing.
+    """
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        raise SkillLifecycleError(f"{skill_md}: SKILL.md not found")
+
+    text = skill_md.read_text(encoding="utf-8")
+    front_raw, body = _split_skill_md(text)
+    frontmatter = _frontmatter_dict(front_raw)
+
+    hasher = hashlib.blake2b(digest_size=_DIGEST_SIZE)
+    hasher.update(b"manifest:\n")
+    hasher.update(_canonical_frontmatter(front_raw))
+    hasher.update(b"body:\n")
+    hasher.update(body.replace("\r\n", "\n").encode("utf-8"))
+
+    for path in _referenced_files(skill_dir, frontmatter):
+        rel = path.relative_to(skill_dir).as_posix()
+        hasher.update(f"file:{rel}\n".encode())
+        try:
+            hasher.update(path.read_bytes())
+        except OSError as exc:  # pragma: no cover - defensive
+            raise SkillLifecycleError(f"{path}: cannot read referenced file: {exc}") from exc
+        hasher.update(b"\n")
+
+    return SkillDigest(digest=hasher.hexdigest())
+
+
+# ---------------------------------------------------------------------------
+# Install / remove
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    """Outcome of installing or syncing a single skill."""
+
+    name: str
+    install_dir: Path
+    digest: SkillDigest
+    changed: bool
+
+
+def _detect_skill_name(source: Path) -> str:
+    """Derive the canonical name for a local source.
+
+    A directory source uses the directory name. A single ``.md`` source
+    uses the file stem.
+    """
+    if source.is_dir():
+        return source.name
+    return source.stem
+
+
+def install_local(
+    source: Path,
+    *,
+    scope: InstallScope,
+    workdir: Path,
+    home: Path | None = None,
+    override_name: str | None = None,
+) -> InstallResult:
+    """Install a skill from a local path into the chosen scope.
+
+    The source may be:
+
+    - A directory containing ``SKILL.md`` (full layout with optional
+      ``references/``, ``scripts/``, ``assets/`` siblings).
+    - A standalone ``.md`` file (only ``SKILL.md`` is written; no
+      referenced files are copied).
+
+    Args:
+        source: Absolute or relative path to the source.
+        scope: Project or user scope.
+        workdir: Current project root.
+        home: Override for the user's home (tests).
+        override_name: Override the auto-detected skill name. The TOML
+            ``name`` field wins over filesystem layout when supplied.
+
+    Returns:
+        :class:`InstallResult` with the target directory and digest.
+
+    Raises:
+        SkillLifecycleError: When the source does not exist, when the
+            single-file source is not a ``.md`` file, or when the
+            destination cannot be written.
+    """
+    if not source.exists():
+        raise SkillLifecycleError(f"{source}: source path does not exist")
+
+    name = override_name or _detect_skill_name(source)
+    dest_root = scope_root(scope, workdir=workdir, home=home)
+    install_dir = dest_root / name
+    # Clear any prior install so we never leak files from an older version.
+    if install_dir.exists():
+        shutil.rmtree(install_dir)
+    install_dir.mkdir(parents=True, exist_ok=True)
+
+    if source.is_dir():
+        skill_md = source / "SKILL.md"
+        if not skill_md.is_file():
+            raise SkillLifecycleError(f"{source}: directory does not contain SKILL.md")
+        _copy_skill_tree(source, install_dir)
+    else:
+        if source.suffix != ".md":
+            raise SkillLifecycleError(f"{source}: local file source must have a .md extension")
+        try:
+            content = source.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise SkillLifecycleError(f"{source}: cannot read source: {exc}") from exc
+        (install_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+    digest = compute_skill_digest(install_dir)
+    return InstallResult(name=name, install_dir=install_dir, digest=digest, changed=True)
+
+
+def _copy_skill_tree(source: Path, dest: Path) -> None:
+    """Copy a skill directory tree, preserving SKILL.md + sibling buckets.
+
+    Only ``SKILL.md`` and the three known buckets (``references``,
+    ``scripts``, ``assets``) are mirrored; anything else under the source
+    directory is ignored so a dotfile from the author's editor cannot leak
+    into the installed copy.
+    """
+    skill_md = source / "SKILL.md"
+    shutil.copy2(skill_md, dest / "SKILL.md")
+    for bucket in ("references", "scripts", "assets"):
+        src_bucket = source / bucket
+        if not src_bucket.is_dir():
+            continue
+        dst_bucket = dest / bucket
+        dst_bucket.mkdir(exist_ok=True)
+        for child in sorted(src_bucket.iterdir()):
+            if child.is_file():
+                shutil.copy2(child, dst_bucket / child.name)
+
+
+def remove_skill(
+    name: str,
+    *,
+    scope: InstallScope,
+    workdir: Path,
+    home: Path | None = None,
+) -> bool:
+    """Remove an installed skill from the given scope.
+
+    Args:
+        name: Skill name (directory name under the scope root).
+        scope: Project or user scope.
+        workdir: Current project root.
+        home: Override for the user's home (tests).
+
+    Returns:
+        ``True`` if the skill was removed; ``False`` if nothing was there.
+    """
+    install_dir = scope_root(scope, workdir=workdir, home=home) / name
+    if not install_dir.exists():
+        return False
+    shutil.rmtree(install_dir)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Sync + lock
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SyncOutcome:
+    """One row in the result of :func:`sync_skills`."""
+
+    name: str
+    action: str  # "installed" | "updated" | "unchanged"
+    digest: SkillDigest
+    install_dir: Path
+
+
+@dataclass(frozen=True)
+class LockEntry:
+    """One ``[[skills]]`` row in ``skills.lock``."""
+
+    name: str
+    source: str
+    path: str
+    digest: str
+
+
+def _read_lock(path: Path) -> dict[str, LockEntry]:
+    """Read ``skills.lock`` from disk, keyed by skill name."""
+    if not path.is_file():
+        return {}
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, OSError):
+        return {}
+    raw = data.get("skills", [])
+    if not isinstance(raw, list):
+        return {}
+    out: dict[str, LockEntry] = {}
+    for item in cast("list[object]", raw):
+        if not isinstance(item, dict):
+            continue
+        item_dict = cast("dict[str, object]", item)
+        name = item_dict.get("name")
+        source = item_dict.get("source")
+        path_value = item_dict.get("path")
+        digest = item_dict.get("digest")
+        if (
+            isinstance(name, str)
+            and isinstance(source, str)
+            and isinstance(path_value, str)
+            and isinstance(digest, str)
+        ):
+            out[name] = LockEntry(name=name, source=source, path=path_value, digest=digest)
+    return out
+
+
+def _write_lock(path: Path, entries: list[LockEntry]) -> None:
+    """Write a deterministic TOML lock file.
+
+    We hand-roll the TOML rather than pulling in ``tomli_w`` so the output
+    is bit-identical across runs (sorted keys, fixed quoting, single
+    blank line between tables).
+    """
+    sorted_entries = sorted(entries, key=lambda entry: entry.name)
+    lines: list[str] = [
+        "# bernstein skills lock file - regenerated by `bernstein skills sync`.",
+        "# Do not edit by hand.",
+        "",
+    ]
+    for entry in sorted_entries:
+        lines.append("[[skills]]")
+        lines.append(f"name = {_toml_quote(entry.name)}")
+        lines.append(f"source = {_toml_quote(entry.source)}")
+        lines.append(f"path = {_toml_quote(entry.path)}")
+        lines.append(f"digest = {_toml_quote(entry.digest)}")
+        lines.append("")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _toml_quote(value: str) -> str:
+    """Quote a value as a TOML basic string.
+
+    The escape table covers control characters and the two characters TOML
+    treats as syntactically significant inside basic strings (``"`` and
+    ``\\``). Skill names are slugs and paths are POSIX-like so the slow
+    path almost never triggers.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    escaped = escaped.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+    return f'"{escaped}"'
+
+
+def sync_skills(
+    toml_path: Path,
+    *,
+    scope: InstallScope = InstallScope.PROJECT,
+    workdir: Path | None = None,
+    home: Path | None = None,
+) -> list[SyncOutcome]:
+    """Reconcile ``bernstein-skills.toml`` with the chosen scope.
+
+    Re-runs are idempotent: when the installed digest matches the source
+    digest, the install is skipped and the lock file is left untouched.
+    Drift (a manual edit, a re-published source) reinstalls and rewrites
+    the lock row.
+
+    Args:
+        toml_path: Path to ``bernstein-skills.toml``.
+        scope: Where to install. Defaults to PROJECT.
+        workdir: Project root. Defaults to ``toml_path.parent``.
+        home: Override for the user's home (tests).
+
+    Returns:
+        One :class:`SyncOutcome` per skill, in declaration order.
+
+    Raises:
+        SkillsTomlError: When the manifest cannot be parsed.
+        SkillLifecycleError: When an install step fails.
+    """
+    if workdir is None:
+        workdir = toml_path.parent
+
+    manifest = load_skills_toml(toml_path)
+    toml_dir = toml_path.parent
+    lock_path = toml_dir / SKILLS_LOCK_FILENAME
+    previous_lock = _read_lock(lock_path)
+
+    outcomes: list[SyncOutcome] = []
+    new_lock: list[LockEntry] = []
+
+    for entry in manifest.entries:
+        source_path = resolve_local_source(entry, toml_dir)
+        # Pre-compute the digest of the *source* so we can short-circuit
+        # before touching the install directory at all. For a single-file
+        # source we have to land it in a temp dir first because the digest
+        # algorithm operates on installed-shape directories; for a real
+        # directory source we can read it in place.
+        existing_install = scope_root(scope, workdir=workdir, home=home) / entry.name
+        prior_digest = compute_skill_digest(existing_install).digest if existing_install.is_dir() else None
+
+        if source_path.is_dir():
+            source_digest = compute_skill_digest(source_path).digest
+        else:
+            # For a single-file source, the digest depends only on the
+            # SKILL.md content; we synthesise an empty-bucket directory
+            # view by hashing the canonicalised frontmatter + body.
+            text = source_path.read_text(encoding="utf-8")
+            front_raw, body = _split_skill_md(text)
+            hasher = hashlib.blake2b(digest_size=_DIGEST_SIZE)
+            hasher.update(b"manifest:\n")
+            hasher.update(_canonical_frontmatter(front_raw))
+            hasher.update(b"body:\n")
+            hasher.update(body.replace("\r\n", "\n").encode("utf-8"))
+            source_digest = hasher.hexdigest()
+
+        if prior_digest == source_digest and existing_install.is_dir():
+            outcomes.append(
+                SyncOutcome(
+                    name=entry.name,
+                    action="unchanged",
+                    digest=SkillDigest(digest=source_digest),
+                    install_dir=existing_install,
+                )
+            )
+            new_lock.append(
+                LockEntry(
+                    name=entry.name,
+                    source=entry.source,
+                    path=entry.path,
+                    digest=source_digest,
+                )
+            )
+            continue
+
+        result = install_local(
+            source_path,
+            scope=scope,
+            workdir=workdir,
+            home=home,
+            override_name=entry.name,
+        )
+        action = "updated" if entry.name in previous_lock else "installed"
+        outcomes.append(
+            SyncOutcome(
+                name=entry.name,
+                action=action,
+                digest=result.digest,
+                install_dir=result.install_dir,
+            )
+        )
+        new_lock.append(
+            LockEntry(
+                name=entry.name,
+                source=entry.source,
+                path=entry.path,
+                digest=result.digest.digest,
+            )
+        )
+
+    _write_lock(lock_path, new_lock)
+    return outcomes
+
+
+def read_lock_entries(toml_dir: Path) -> list[LockEntry]:
+    """Public helper for tests: read the lock file as a sorted list."""
+    entries = _read_lock(toml_dir / SKILLS_LOCK_FILENAME)
+    return sorted(entries.values(), key=lambda entry: entry.name)
+
+
+__all__ = [
+    "SKILLS_LOCK_FILENAME",
+    "SKILLS_TOML_FILENAME",
+    "InstallResult",
+    "InstallScope",
+    "LockEntry",
+    "SkillDigest",
+    "SkillLifecycleError",
+    "SkillsToml",
+    "SkillsTomlEntry",
+    "SkillsTomlError",
+    "SyncOutcome",
+    "compute_skill_digest",
+    "install_local",
+    "load_skills_toml",
+    "read_lock_entries",
+    "remove_skill",
+    "resolve_local_source",
+    "scope_root",
+    "sync_skills",
+]

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -263,13 +263,12 @@ def _canonical_frontmatter(front_raw: str) -> bytes:
         return front_raw.encode("utf-8")
     if loaded is None:
         return b"{}\n"
-    canonical = yaml.safe_dump(
+    return yaml.safe_dump(
         loaded,
         sort_keys=True,
         allow_unicode=True,
         default_flow_style=False,
-    )
-    return canonical.encode("utf-8")
+    ).encode("utf-8")
 
 
 def _split_skill_md(text: str) -> tuple[str, str]:
@@ -311,17 +310,32 @@ def _referenced_files(skill_dir: Path, frontmatter: dict[str, Any]) -> list[Path
     files are silently skipped here; lint surfaces them as errors.
     """
     out: list[Path] = []
+    try:
+        skill_root = skill_dir.resolve()
+    except OSError:
+        return out
     for bucket in ("references", "scripts", "assets"):
         values = frontmatter.get(bucket, [])
         if not isinstance(values, list):
             continue
+        bucket_root = (skill_dir / bucket).resolve()
         for entry in cast("list[object]", values):
             if not isinstance(entry, str):
                 continue
-            candidate = skill_dir / bucket / entry
+            entry_path = Path(entry)
+            if entry_path.is_absolute() or ".." in entry_path.parts:
+                # Reject traversal / absolute paths: the digest must not
+                # depend on files outside the skill directory.
+                continue
+            try:
+                candidate = (bucket_root / entry_path).resolve()
+            except OSError:
+                continue
+            if not candidate.is_relative_to(bucket_root):
+                continue
             if candidate.is_file():
                 out.append(candidate)
-    out.sort(key=lambda p: str(p.relative_to(skill_dir)))
+    out.sort(key=lambda p: str(p.resolve().relative_to(skill_root)))
     return out
 
 
@@ -433,26 +447,40 @@ def install_local(
     name = override_name or _detect_skill_name(source)
     dest_root = scope_root(scope, workdir=workdir, home=home)
     install_dir = dest_root / name
-    # Clear any prior install so we never leak files from an older version.
+    dest_root.mkdir(parents=True, exist_ok=True)
+    # Stage into a sibling temp directory first so a previously working
+    # install is preserved if validation or copy fails. The final swap is
+    # atomic via Path.replace.
+    staging_dir = dest_root / f".{name}.tmp"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True)
+
+    try:
+        if source.is_dir():
+            skill_md = source / "SKILL.md"
+            if not skill_md.is_file():
+                raise SkillLifecycleError(f"{source}: directory does not contain SKILL.md")
+            _copy_skill_tree(source, staging_dir)
+        else:
+            if source.suffix != ".md":
+                raise SkillLifecycleError(
+                    f"{source}: local file source must have a .md extension"
+                )
+            try:
+                content = source.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise SkillLifecycleError(f"{source}: cannot read source: {exc}") from exc
+            (staging_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        digest = compute_skill_digest(staging_dir)
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
     if install_dir.exists():
         shutil.rmtree(install_dir)
-    install_dir.mkdir(parents=True, exist_ok=True)
-
-    if source.is_dir():
-        skill_md = source / "SKILL.md"
-        if not skill_md.is_file():
-            raise SkillLifecycleError(f"{source}: directory does not contain SKILL.md")
-        _copy_skill_tree(source, install_dir)
-    else:
-        if source.suffix != ".md":
-            raise SkillLifecycleError(f"{source}: local file source must have a .md extension")
-        try:
-            content = source.read_text(encoding="utf-8")
-        except OSError as exc:
-            raise SkillLifecycleError(f"{source}: cannot read source: {exc}") from exc
-        (install_dir / "SKILL.md").write_text(content, encoding="utf-8")
-
-    digest = compute_skill_digest(install_dir)
+    staging_dir.replace(install_dir)
     return InstallResult(name=name, install_dir=install_dir, digest=digest, changed=True)
 
 
@@ -472,9 +500,17 @@ def _copy_skill_tree(source: Path, dest: Path) -> None:
             continue
         dst_bucket = dest / bucket
         dst_bucket.mkdir(exist_ok=True)
-        for child in sorted(src_bucket.iterdir()):
-            if child.is_file():
-                shutil.copy2(child, dst_bucket / child.name)
+        # Walk the bucket recursively so nested manifest paths like
+        # ``references/guides/deep.md`` survive the install. Empty
+        # directories are skipped on purpose so the destination only
+        # contains paths that the manifest can actually address.
+        for child in sorted(src_bucket.rglob("*")):
+            if not child.is_file():
+                continue
+            rel = child.relative_to(src_bucket)
+            target = dst_bucket / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(child, target)
 
 
 def remove_skill(
@@ -571,12 +607,16 @@ def _write_lock(path: Path, entries: list[LockEntry]) -> None:
         "",
     ]
     for entry in sorted_entries:
-        lines.append("[[skills]]")
-        lines.append(f"name = {_toml_quote(entry.name)}")
-        lines.append(f"source = {_toml_quote(entry.source)}")
-        lines.append(f"path = {_toml_quote(entry.path)}")
-        lines.append(f"digest = {_toml_quote(entry.digest)}")
-        lines.append("")
+        lines.extend(
+            (
+                "[[skills]]",
+                f"name = {_toml_quote(entry.name)}",
+                f"source = {_toml_quote(entry.source)}",
+                f"path = {_toml_quote(entry.path)}",
+                f"digest = {_toml_quote(entry.digest)}",
+                "",
+            )
+        )
     path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
 
 
@@ -639,7 +679,17 @@ def sync_skills(
         # algorithm operates on installed-shape directories; for a real
         # directory source we can read it in place.
         existing_install = scope_root(scope, workdir=workdir, home=home) / entry.name
-        prior_digest = compute_skill_digest(existing_install).digest if existing_install.is_dir() else None
+        prior_digest: str | None
+        if existing_install.is_dir():
+            try:
+                prior_digest = compute_skill_digest(existing_install).digest
+            except SkillLifecycleError:
+                # A malformed prior install (e.g. missing SKILL.md after a
+                # partial write) counts as drift so sync can self-heal by
+                # reinstalling instead of aborting the whole batch.
+                prior_digest = None
+        else:
+            prior_digest = None
 
         if source_path.is_dir():
             source_digest = compute_skill_digest(source_path).digest

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -695,7 +695,12 @@ def sync_skills(
             # For a single-file source, the digest depends only on the
             # SKILL.md content; we synthesise an empty-bucket directory
             # view by hashing the canonicalised frontmatter + body.
-            text = source_path.read_text(encoding="utf-8")
+            try:
+                text = source_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise SkillLifecycleError(
+                    f"{source_path}: cannot read source: {exc}"
+                ) from exc
             front_raw, body = _split_skill_md(text)
             hasher = hashlib.blake2b(digest_size=_DIGEST_SIZE)
             hasher.update(b"manifest:\n")

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -698,9 +698,7 @@ def sync_skills(
             try:
                 text = source_path.read_text(encoding="utf-8")
             except OSError as exc:
-                raise SkillLifecycleError(
-                    f"{source_path}: cannot read source: {exc}"
-                ) from exc
+                raise SkillLifecycleError(f"{source_path}: cannot read source: {exc}") from exc
             front_raw, body = _split_skill_md(text)
             hasher = hashlib.blake2b(digest_size=_DIGEST_SIZE)
             hasher.update(b"manifest:\n")

--- a/src/bernstein/core/skills/lint.py
+++ b/src/bernstein/core/skills/lint.py
@@ -1,0 +1,242 @@
+"""Advisory lint for installed skill directories (issue #1720, track 1 minimum).
+
+The lint is intentionally non-blocking in this PR: ``bernstein skills install``
+and ``bernstein skills sync`` do not consult it. Operators run lint by hand
+or via CI to surface frontmatter typos, missing referenced files, sensitive
+patterns the sanitiser flags, and body conventions (heading order, max
+length).
+
+Checks performed (all advisory):
+
+- Frontmatter parses as YAML and matches :class:`SkillManifest` after a
+  loose pre-filter (extra Claude-style keys like ``whenToUse`` are
+  warnings, not errors, because authoring formats are still in flux).
+- Every ``references`` / ``scripts`` / ``assets`` entry resolves to a
+  real file under the matching bucket.
+- The sanitiser (`core/skills/sanitizer.py`) reports zero stripped
+  codepoints. Anything stripped is a high-signal sensitive-pattern leak.
+- The body starts with an ``H1`` heading and is under 5 KB.
+
+Output shape is a list of :class:`LintFinding` records. The caller renders
+them and chooses the exit code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path  # noqa: TC003 - runtime annotation in dataclass field
+from typing import Any, cast
+
+import yaml
+
+from bernstein.core.skills.manifest import SkillManifest
+from bernstein.core.skills.sanitizer import strip_invisible_tags
+
+#: Body cap: 5 KB before we warn. The RFC sets this as a soft cap so a
+#: future skill that needs more context can still ship.
+_MAX_BODY_BYTES: int = 5 * 1024
+
+_VALID_BUCKETS: tuple[str, ...] = ("references", "scripts", "assets")
+
+
+class LintSeverity(StrEnum):
+    """Severity of a lint finding.
+
+    ``WARNING`` is the default. ``ERROR`` does NOT block install in this
+    PR, but tests assert that real schema breakage is reported as ERROR
+    so a follow-up can flip the gate without a behaviour rewrite.
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    """One advisory finding from :func:`lint_skill`."""
+
+    skill_name: str
+    severity: LintSeverity
+    code: str
+    message: str
+    path: Path | None = None
+
+
+def _split_skill_md(text: str) -> tuple[str, str] | None:
+    """Re-implement the split locally to avoid importing the loader path.
+
+    Returns ``None`` when the file lacks frontmatter at all.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != "---":
+        return None
+    front: list[str] = []
+    for idx in range(1, len(lines)):
+        if lines[idx].rstrip() == "---":
+            return ("\n".join(front), "\n".join(lines[idx + 1 :]).strip("\n"))
+        front.append(lines[idx])
+    return None
+
+
+def _coerce_known_fields(raw: dict[str, Any]) -> dict[str, Any]:
+    """Drop extra keys (e.g. ``whenToUse``) before strict validation.
+
+    Strict :class:`SkillManifest` rejects unknown keys; we warn on them
+    separately so an author who is mid-migration still gets useful
+    feedback rather than a single fatal error.
+    """
+    allowed = set(SkillManifest.model_fields.keys())
+    return {k: v for k, v in raw.items() if k in allowed}
+
+
+def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFinding]:
+    """Run the advisory lint against one installed skill directory.
+
+    Args:
+        skill_dir: Directory containing ``SKILL.md``.
+        skill_name: Override for reporting. Defaults to ``skill_dir.name``.
+
+    Returns:
+        Findings, possibly empty. An empty list means lint-clean.
+    """
+    name = skill_name or skill_dir.name
+    findings: list[LintFinding] = []
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="missing-skill-md",
+                message="SKILL.md is missing",
+                path=skill_dir,
+            )
+        )
+        return findings
+
+    text = skill_md.read_text(encoding="utf-8")
+    split = _split_skill_md(text)
+    if split is None:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="missing-frontmatter",
+                message="SKILL.md has no YAML frontmatter",
+                path=skill_md,
+            )
+        )
+        return findings
+    front_raw, body = split
+
+    try:
+        loaded = yaml.safe_load(front_raw)
+    except yaml.YAMLError as exc:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="yaml-error",
+                message=f"frontmatter YAML failed to parse: {exc}",
+                path=skill_md,
+            )
+        )
+        return findings
+    if not isinstance(loaded, dict):
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="frontmatter-shape",
+                message="frontmatter must be a YAML mapping",
+                path=skill_md,
+            )
+        )
+        return findings
+    raw_dict = cast("dict[str, Any]", loaded)
+
+    extra_keys = sorted(set(raw_dict.keys()) - set(SkillManifest.model_fields.keys()))
+    for key in extra_keys:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.WARNING,
+                code="extra-key",
+                message=f"frontmatter contains unknown key {key!r}",
+                path=skill_md,
+            )
+        )
+
+    try:
+        manifest = SkillManifest.model_validate(_coerce_known_fields(raw_dict))
+    except Exception as exc:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="invalid-manifest",
+                message=f"manifest failed validation: {exc}",
+                path=skill_md,
+            )
+        )
+        return findings
+
+    for bucket in _VALID_BUCKETS:
+        for filename in getattr(manifest, bucket):
+            candidate = skill_dir / bucket / filename
+            if not candidate.is_file():
+                findings.append(
+                    LintFinding(
+                        skill_name=name,
+                        severity=LintSeverity.ERROR,
+                        code="missing-reference",
+                        message=f"manifest declares {bucket}/{filename} but the file is missing",
+                        path=candidate,
+                    )
+                )
+
+    _cleaned, stripped = strip_invisible_tags(text)
+    if stripped > 0:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="sensitive-pattern",
+                message=(
+                    f"sanitiser stripped {stripped} invisible Unicode codepoint(s); "
+                    "this skill carries a likely prompt-injection payload"
+                ),
+                path=skill_md,
+            )
+        )
+
+    body_bytes = len(body.encode("utf-8"))
+    if body_bytes > _MAX_BODY_BYTES:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.WARNING,
+                code="body-too-large",
+                message=(f"body is {body_bytes} bytes; recommended max is {_MAX_BODY_BYTES}"),
+                path=skill_md,
+            )
+        )
+
+    body_lines = [line for line in body.splitlines() if line.strip()]
+    if body_lines and not body_lines[0].lstrip().startswith("#"):
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.WARNING,
+                code="missing-h1",
+                message="body should start with an H1 heading",
+                path=skill_md,
+            )
+        )
+
+    return findings
+
+
+__all__ = ["LintFinding", "LintSeverity", "lint_skill"]

--- a/src/bernstein/core/skills/lint.py
+++ b/src/bernstein/core/skills/lint.py
@@ -117,7 +117,19 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
         )
         return findings
 
-    text = skill_md.read_text(encoding="utf-8")
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        findings.append(
+            LintFinding(
+                skill_name=name,
+                severity=LintSeverity.ERROR,
+                code="unreadable-skill-md",
+                message=f"failed to read SKILL.md: {exc}",
+                path=skill_md,
+            )
+        )
+        return findings
     split = _split_skill_md(text)
     if split is None:
         findings.append(
@@ -184,8 +196,14 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
         )
         return findings
 
+    # Anchor containment to the resolved skill root so a symlinked
+    # bucket (``references -> /tmp/elsewhere``) cannot smuggle host
+    # files past the lint. The bucket directories themselves are not
+    # resolved; we build candidates from the unresolved path and check
+    # them against the resolved skill root.
+    skill_root = skill_dir.resolve()
     for bucket in _VALID_BUCKETS:
-        bucket_root = (skill_dir / bucket).resolve()
+        bucket_root = skill_root / bucket
         for filename in getattr(manifest, bucket):
             rel = Path(filename)
             if rel.is_absolute() or ".." in rel.parts:
@@ -202,7 +220,7 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
                     )
                 )
                 continue
-            candidate = (bucket_root / rel).resolve()
+            candidate = (skill_dir / bucket / rel).resolve()
             if not candidate.is_relative_to(bucket_root):
                 findings.append(
                     LintFinding(

--- a/src/bernstein/core/skills/lint.py
+++ b/src/bernstein/core/skills/lint.py
@@ -209,9 +209,7 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
                         skill_name=name,
                         severity=LintSeverity.ERROR,
                         code="unsafe-reference-path",
-                        message=(
-                            f"manifest {bucket} path {filename!r} escapes the {bucket}/ root"
-                        ),
+                        message=(f"manifest {bucket} path {filename!r} escapes the {bucket}/ root"),
                         path=skill_md,
                     )
                 )

--- a/src/bernstein/core/skills/lint.py
+++ b/src/bernstein/core/skills/lint.py
@@ -25,10 +25,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from pathlib import Path  # noqa: TC003 - runtime annotation in dataclass field
+from pathlib import Path
 from typing import Any, cast
 
 import yaml
+from pydantic import ValidationError
 
 from bernstein.core.skills.manifest import SkillManifest
 from bernstein.core.skills.sanitizer import strip_invisible_tags
@@ -171,7 +172,7 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
 
     try:
         manifest = SkillManifest.model_validate(_coerce_known_fields(raw_dict))
-    except Exception as exc:
+    except ValidationError as exc:
         findings.append(
             LintFinding(
                 skill_name=name,
@@ -184,8 +185,37 @@ def lint_skill(skill_dir: Path, *, skill_name: str | None = None) -> list[LintFi
         return findings
 
     for bucket in _VALID_BUCKETS:
+        bucket_root = (skill_dir / bucket).resolve()
         for filename in getattr(manifest, bucket):
-            candidate = skill_dir / bucket / filename
+            rel = Path(filename)
+            if rel.is_absolute() or ".." in rel.parts:
+                findings.append(
+                    LintFinding(
+                        skill_name=name,
+                        severity=LintSeverity.ERROR,
+                        code="unsafe-reference-path",
+                        message=(
+                            f"manifest declares unsafe {bucket} path {filename!r}; "
+                            "absolute paths and parent traversal are not allowed"
+                        ),
+                        path=skill_md,
+                    )
+                )
+                continue
+            candidate = (bucket_root / rel).resolve()
+            if not candidate.is_relative_to(bucket_root):
+                findings.append(
+                    LintFinding(
+                        skill_name=name,
+                        severity=LintSeverity.ERROR,
+                        code="unsafe-reference-path",
+                        message=(
+                            f"manifest {bucket} path {filename!r} escapes the {bucket}/ root"
+                        ),
+                        path=skill_md,
+                    )
+                )
+                continue
             if not candidate.is_file():
                 findings.append(
                     LintFinding(

--- a/src/bernstein/core/skills/watcher.py
+++ b/src/bernstein/core/skills/watcher.py
@@ -1,0 +1,170 @@
+"""Hot-reload watcher for the skill index (issue #1720, track 1).
+
+``bernstein skills watch`` drives this module. We rebuild the skill index
+on every relevant filesystem event so an author iterates without
+restarting the orchestrator. The implementation is a thin shim over the
+project's already-vendored ``watchdog`` dependency.
+
+Design choices:
+
+- We watch one directory at a time. A future PR can extend this to a
+  set of roots; the foundation PR only needs the project-scope path.
+- We debounce events with a small monotonic-clock window. ``watchdog``
+  emits one event per write per file, but a single skill update can fan
+  out into 3-5 events (SKILL.md, a referenced file, the directory
+  mtime). Debouncing avoids re-indexing five times in 50ms.
+- The callback receives the rebuilt :class:`SkillLoader` so callers can
+  swap in the new index atomically.
+
+The CLI command keeps this loop running until the user sends SIGINT.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 - runtime annotation in start_skill_watcher
+from typing import TYPE_CHECKING, Protocol
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from bernstein.core.skills.loader import SkillLoader
+from bernstein.core.skills.sources.local_dir import LocalDirSkillSource
+
+if TYPE_CHECKING:
+    from watchdog.events import FileSystemEvent
+
+logger = logging.getLogger(__name__)
+
+#: How long to wait after the last event before rebuilding the index.
+#: Set tight (50ms) so authors do not feel a stall, but long enough that
+#: a multi-file write coalesces into one rebuild.
+_DEBOUNCE_SECONDS: float = 0.05
+
+
+class ReloadCallback(Protocol):
+    """Callable invoked after each debounced rebuild.
+
+    Implementations typically swap a process-wide loader pointer; tests
+    capture invocations to assert the watcher fires once per change.
+    """
+
+    def __call__(self, loader: SkillLoader) -> None: ...  # pragma: no cover - protocol
+
+
+@dataclass(frozen=True)
+class WatchHandle:
+    """Public handle returned by :func:`start_skill_watcher`.
+
+    Callers stop the watcher by calling :meth:`stop`. The handle holds
+    references to the underlying ``watchdog`` :class:`Observer` and the
+    debounce timer so they can be drained on shutdown.
+    """
+
+    observer: Observer
+    _stop_event: threading.Event
+
+    def stop(self, timeout: float = 1.0) -> None:
+        """Halt the watcher and wait for the observer thread to drain.
+
+        Args:
+            timeout: Maximum seconds to wait for ``Observer.join``. The
+                default keeps test runs fast; production callers may
+                supply a longer value.
+        """
+        self._stop_event.set()
+        self.observer.stop()
+        self.observer.join(timeout=timeout)
+
+
+class _DebouncedHandler(FileSystemEventHandler):
+    """Filesystem-event handler with monotonic-clock debouncing.
+
+    The handler does not rebuild on the watchdog thread; it sets a flag
+    that a sidecar daemon thread polls every ``_DEBOUNCE_SECONDS / 2``.
+    Doing the rebuild off the watchdog thread keeps event delivery
+    snappy and means a slow rebuild does not back up the OS event queue.
+    """
+
+    def __init__(
+        self,
+        watch_path: Path,
+        callback: ReloadCallback,
+        stop_event: threading.Event,
+    ) -> None:
+        super().__init__()
+        self._watch_path = watch_path
+        self._callback = callback
+        self._stop_event = stop_event
+        self._lock = threading.Lock()
+        self._pending_at: float | None = None
+        self._worker = threading.Thread(target=self._run, name="bernstein-skills-watcher", daemon=True)
+        self._worker.start()
+
+    def on_any_event(self, event: FileSystemEvent) -> None:
+        # ``watchdog`` reports a string for ``src_path`` on POSIX but a
+        # bytes-or-str union on Windows. We do not look at the path here;
+        # any change under the watched root is treated as "rebuild".
+        del event
+        with self._lock:
+            self._pending_at = time.monotonic()
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            time.sleep(_DEBOUNCE_SECONDS / 2)
+            with self._lock:
+                pending = self._pending_at
+            if pending is None:
+                continue
+            if time.monotonic() - pending < _DEBOUNCE_SECONDS:
+                continue
+            with self._lock:
+                self._pending_at = None
+            try:
+                loader = _rebuild_loader(self._watch_path)
+            except Exception:
+                logger.exception("skills.watcher rebuild failed")
+                continue
+            try:
+                self._callback(loader)
+            except Exception:
+                logger.exception("skills.watcher callback raised")
+
+
+def _rebuild_loader(watch_path: Path) -> SkillLoader:
+    """Re-construct a :class:`SkillLoader` over the watched directory."""
+    return SkillLoader(sources=[LocalDirSkillSource(watch_path, source_name="watch")])
+
+
+def start_skill_watcher(
+    watch_path: Path,
+    callback: ReloadCallback,
+) -> WatchHandle:
+    """Begin watching ``watch_path`` and invoke ``callback`` on change.
+
+    Args:
+        watch_path: Directory to watch. Typically
+            ``<workdir>/.bernstein/skills`` or
+            ``<workdir>/templates/skills``.
+        callback: Invoked with the rebuilt :class:`SkillLoader` after
+            each debounced change.
+
+    Returns:
+        :class:`WatchHandle`; call :meth:`WatchHandle.stop` to shut down.
+    """
+    if not watch_path.is_dir():
+        watch_path.mkdir(parents=True, exist_ok=True)
+
+    stop_event = threading.Event()
+    handler = _DebouncedHandler(watch_path, callback, stop_event)
+    observer = Observer()
+    observer.schedule(handler, str(watch_path), recursive=True)
+    observer.start()
+
+    return WatchHandle(observer=observer, _stop_event=stop_event)
+
+
+__all__ = ["ReloadCallback", "WatchHandle", "start_skill_watcher"]

--- a/src/bernstein/core/skills/watcher.py
+++ b/src/bernstein/core/skills/watcher.py
@@ -115,6 +115,8 @@ class _DebouncedHandler(FileSystemEventHandler):
     def _run(self) -> None:
         while not self._stop_event.is_set():
             time.sleep(_DEBOUNCE_SECONDS / 2)
+            if self._stop_event.is_set():
+                break
             with self._lock:
                 pending = self._pending_at
             if pending is None:
@@ -123,11 +125,18 @@ class _DebouncedHandler(FileSystemEventHandler):
                 continue
             with self._lock:
                 self._pending_at = None
+            if self._stop_event.is_set():
+                # ``stop()`` was called between the wake-up and now;
+                # skip the rebuild + callback so a freshly stopped
+                # watcher does not invoke user code one more time.
+                break
             try:
                 loader = _rebuild_loader(self._watch_path)
             except Exception:
                 logger.exception("skills.watcher rebuild failed")
                 continue
+            if self._stop_event.is_set():
+                break
             try:
                 self._callback(loader)
             except Exception:

--- a/tests/unit/skills/test_activation_log.py
+++ b/tests/unit/skills/test_activation_log.py
@@ -1,0 +1,110 @@
+"""Tests for the activation log (#1720, Track 5 floor)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.activation_log import (
+    ENV_VAR,
+    ActivationRecord,
+    activation_log_path,
+    log_activation,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the env-var opt-out does not leak between tests."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+
+def test_log_activation_writes_jsonl_line(tmp_path: Path) -> None:
+    record = ActivationRecord(
+        skill="bernstein-test-runner",
+        role="backend",
+        task_id="task-42",
+        trigger_source="role-binding",
+        version="1.0.0",
+        digest="abcd1234",
+    )
+    log_path = log_activation(
+        record,
+        workdir=tmp_path,
+        now=datetime(2026, 5, 20, 12, 34, 56, 789000, tzinfo=UTC),
+    )
+
+    assert log_path == activation_log_path(tmp_path)
+    assert log_path is not None
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload == {
+        "skill": "bernstein-test-runner",
+        "version": "1.0.0",
+        "digest": "abcd1234",
+        "role": "backend",
+        "task_id": "task-42",
+        "trigger_source": "role-binding",
+        "timestamp": "2026-05-20T12:34:56.789Z",
+    }
+
+
+def test_log_activation_appends_multiple_records(tmp_path: Path) -> None:
+    for idx in range(3):
+        log_activation(
+            ActivationRecord(skill=f"skill-{idx}", role="qa", task_id=f"task-{idx}"),
+            workdir=tmp_path,
+        )
+    log_path = activation_log_path(tmp_path)
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    parsed = [json.loads(line) for line in lines]
+    assert [p["skill"] for p in parsed] == ["skill-0", "skill-1", "skill-2"]
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "Off"])
+def test_log_activation_opt_out_via_env_var(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv(ENV_VAR, value)
+    result = log_activation(
+        ActivationRecord(skill="ignored", role="backend", task_id="task-x"),
+        workdir=tmp_path,
+    )
+    assert result is None
+    assert not activation_log_path(tmp_path).exists()
+
+
+def test_log_activation_default_writes_when_env_unset(
+    tmp_path: Path,
+) -> None:
+    """The opt-in default: logging is on unless explicitly disabled."""
+    result = log_activation(
+        ActivationRecord(skill="default-on", role="docs", task_id="task-y"),
+        workdir=tmp_path,
+    )
+    assert result is not None
+    assert activation_log_path(tmp_path).is_file()
+
+
+def test_log_activation_truthy_env_does_not_disable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ENV_VAR, "1")
+    result = log_activation(
+        ActivationRecord(skill="enabled", role="qa", task_id="task-z"),
+        workdir=tmp_path,
+    )
+    assert result is not None
+
+
+def test_activation_log_path_is_under_sdd_skills(tmp_path: Path) -> None:
+    expected = tmp_path / ".sdd" / "skills" / "activations.jsonl"
+    assert activation_log_path(tmp_path) == expected

--- a/tests/unit/skills/test_injector_activation_log.py
+++ b/tests/unit/skills/test_injector_activation_log.py
@@ -1,0 +1,91 @@
+"""Activation log integration via ``inject_skills`` (#1720, Track 5 floor)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import Task
+
+from bernstein.adapters.skills_injector import inject_skills
+from bernstein.core.skills.activation_log import ENV_VAR, activation_log_path
+
+
+def _make_skill_templates(root: Path) -> Path:
+    """Mirror the minimal template tree used by the existing injector tests."""
+    skills_dir = root / "templates" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "bernstein-completion-protocol.md").write_text(
+        "---\nname: bernstein-completion-protocol\n"
+        "description: Report task completion to the orchestrator after every task.\n"
+        "version: 1.2.3\n---\n\n# Completion\nComplete: {{COMPLETE_CMDS}}\n",
+        encoding="utf-8",
+    )
+    (skills_dir / "bernstein-signal-check.md").write_text(
+        "---\nname: bernstein-signal-check\n"
+        "description: Poll the runtime signal directory for wake-up requests.\n"
+        "version: 2.0.0\n---\n\n# Signal\nSignals at {{SESSION_ID}}\n",
+        encoding="utf-8",
+    )
+    return root / "templates" / "roles"
+
+
+def _make_task(task_id: str = "T-001") -> Task:
+    return Task(id=task_id, title="Test task", description="A test task", role="backend")
+
+
+def test_inject_skills_writes_activation_log(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each injected skill produces one activation log line per task."""
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    templates_dir = _make_skill_templates(tmp_path)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="security",  # role with no extra skills -> only always-inject pair
+        tasks=[_make_task("T-001")],
+        session_id="sec-abc",
+        templates_dir=templates_dir,
+    )
+
+    log_path = activation_log_path(workdir)
+    assert log_path.is_file()
+    lines = [json.loads(line) for line in log_path.read_text().splitlines()]
+    # Two always-inject skills, one task = two activation records.
+    skills_seen = {row["skill"] for row in lines}
+    assert skills_seen == {"bernstein-completion-protocol", "bernstein-signal-check"}
+    for row in lines:
+        assert row["role"] == "security"
+        assert row["task_id"] == "T-001"
+        assert row["trigger_source"] == "role-binding"
+        assert row["digest"]  # non-empty
+        assert row["timestamp"].endswith("Z")
+
+
+def test_inject_skills_respects_activation_log_env_opt_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting ``BERNSTEIN_SKILL_ACTIVATION_LOG=0`` suppresses log writes."""
+    monkeypatch.setenv(ENV_VAR, "0")
+    templates_dir = _make_skill_templates(tmp_path)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[_make_task("T-002")],
+        session_id="sec-def",
+        templates_dir=templates_dir,
+    )
+
+    # Skills are still injected -> .claude/skills/ exists with the files.
+    assert (workdir / ".claude" / "skills" / "bernstein-completion-protocol.md").is_file()
+    # But the activation log is not created.
+    assert not activation_log_path(workdir).exists()

--- a/tests/unit/skills/test_injector_activation_log.py
+++ b/tests/unit/skills/test_injector_activation_log.py
@@ -56,7 +56,10 @@ def test_inject_skills_writes_activation_log(
     log_path = activation_log_path(workdir)
     assert log_path.is_file()
     lines = [json.loads(line) for line in log_path.read_text().splitlines()]
-    # Two always-inject skills, one task = two activation records.
+    # Two always-inject skills, one task = two activation records. The
+    # exact count guard catches duplicate-log regressions that a
+    # set-equality check would silently swallow.
+    assert len(lines) == 2
     skills_seen = {row["skill"] for row in lines}
     assert skills_seen == {"bernstein-completion-protocol", "bernstein-signal-check"}
     for row in lines:

--- a/tests/unit/skills/test_lifecycle_digest.py
+++ b/tests/unit/skills/test_lifecycle_digest.py
@@ -1,0 +1,108 @@
+"""Digest determinism tests for the lifecycle module (#1720)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from bernstein.core.skills.lifecycle import compute_skill_digest
+
+
+def _author_skill(
+    root: Path,
+    name: str,
+    *,
+    body: str = "Body.",
+    reference: str | None = None,
+) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    front = [
+        "---",
+        f"name: {name}",
+        "description: Sample skill used by digest determinism tests for round trips.",
+    ]
+    if reference:
+        front += ["references:", f"  - {reference}"]
+    front += ["---"]
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(front) + f"\n\n# {name}\n\n{body}\n",
+        encoding="utf-8",
+    )
+    if reference:
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / reference).write_text("# ref body\n", encoding="utf-8")
+    return skill_dir
+
+
+def test_compute_skill_digest_is_deterministic(tmp_path: Path) -> None:
+    a = _author_skill(tmp_path / "first", "alpha", body="Identical body.")
+    b = _author_skill(tmp_path / "second", "alpha", body="Identical body.")
+    assert compute_skill_digest(a).digest == compute_skill_digest(b).digest
+
+
+def test_compute_skill_digest_detects_body_drift(tmp_path: Path) -> None:
+    a = _author_skill(tmp_path / "first", "alpha", body="Original body.")
+    b = _author_skill(tmp_path / "second", "alpha", body="Drifted body.")
+    assert compute_skill_digest(a).digest != compute_skill_digest(b).digest
+
+
+def test_compute_skill_digest_includes_referenced_files(tmp_path: Path) -> None:
+    a = _author_skill(tmp_path / "first", "alpha", reference="ref.md")
+    b = _author_skill(tmp_path / "second", "alpha", reference="ref.md")
+    # Same setup -> same digest.
+    assert compute_skill_digest(a).digest == compute_skill_digest(b).digest
+
+    # Mutate the referenced file -> digest changes even though SKILL.md
+    # is byte-identical.
+    (b / "references" / "ref.md").write_text("# different ref\n", encoding="utf-8")
+    assert compute_skill_digest(a).digest != compute_skill_digest(b).digest
+
+
+def test_compute_skill_digest_ignores_undeclared_files(tmp_path: Path) -> None:
+    a = _author_skill(tmp_path / "first", "alpha")
+    b = _author_skill(tmp_path / "second", "alpha")
+    # Add a scratch file that the manifest does not reference. It must not
+    # leak into the digest.
+    (b / "scratch.txt").write_text("not in manifest", encoding="utf-8")
+    assert compute_skill_digest(a).digest == compute_skill_digest(b).digest
+
+
+def test_canonical_frontmatter_key_order_does_not_change_digest(tmp_path: Path) -> None:
+    """Re-ordering YAML keys must not invalidate the lock."""
+    a = tmp_path / "ordered"
+    a.mkdir()
+    (a / "SKILL.md").write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: ordered
+            description: Frontmatter ordering should not affect the digest.
+            ---
+
+            # Ordered skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    b = tmp_path / "reordered"
+    b.mkdir()
+    (b / "SKILL.md").write_text(
+        textwrap.dedent(
+            """
+            ---
+            description: Frontmatter ordering should not affect the digest.
+            name: ordered
+            ---
+
+            # Ordered skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert compute_skill_digest(a).digest == compute_skill_digest(b).digest

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -1,0 +1,168 @@
+"""Install / remove round-trip tests for the lifecycle module (#1720)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.lifecycle import (
+    InstallScope,
+    SkillLifecycleError,
+    install_local,
+    remove_skill,
+    scope_root,
+)
+
+
+@pytest.fixture
+def single_file_skill(tmp_path: Path) -> Path:
+    """A standalone SKILL.md, the shape used by the sample TOML entry."""
+    source = tmp_path / "sample-skill.md"
+    source.write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: sample-skill
+            description: Sample skill used by lifecycle tests to round trip install.
+            ---
+
+            # Sample skill
+
+            Body content.
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return source
+
+
+@pytest.fixture
+def directory_skill(tmp_path: Path) -> Path:
+    """A directory-shaped skill with a referenced file."""
+    skill_dir = tmp_path / "dir-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: dir-skill
+            description: Directory-shaped skill exercising the references bucket too.
+            references:
+              - deep-dive.md
+            ---
+
+            # Dir skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    refs = skill_dir / "references"
+    refs.mkdir()
+    (refs / "deep-dive.md").write_text("# Deep dive\n", encoding="utf-8")
+    return skill_dir
+
+
+def test_install_local_single_file_project_scope(
+    tmp_path: Path,
+    single_file_skill: Path,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    result = install_local(
+        single_file_skill,
+        scope=InstallScope.PROJECT,
+        workdir=workdir,
+    )
+
+    expected_dir = workdir / ".bernstein" / "skills" / "sample-skill"
+    assert result.install_dir == expected_dir
+    assert (expected_dir / "SKILL.md").is_file()
+    assert result.digest.digest  # non-empty hex
+    assert len(result.digest.digest) == 64
+
+
+def test_install_local_directory_user_scope(
+    tmp_path: Path,
+    directory_skill: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    result = install_local(
+        directory_skill,
+        scope=InstallScope.USER,
+        workdir=workdir,
+        home=home,
+    )
+
+    expected_dir = home / ".bernstein" / "skills" / "dir-skill"
+    assert result.install_dir == expected_dir
+    assert (expected_dir / "SKILL.md").is_file()
+    assert (expected_dir / "references" / "deep-dive.md").is_file()
+
+
+def test_remove_skill_round_trip(
+    tmp_path: Path,
+    single_file_skill: Path,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    install_local(single_file_skill, scope=InstallScope.PROJECT, workdir=workdir)
+    install_dir = scope_root(InstallScope.PROJECT, workdir=workdir) / "sample-skill"
+    assert install_dir.is_dir()
+
+    assert remove_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir) is True
+    assert not install_dir.exists()
+    # Second remove is a no-op.
+    assert remove_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir) is False
+
+
+def test_install_local_rejects_missing_source(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    with pytest.raises(SkillLifecycleError, match="does not exist"):
+        install_local(
+            tmp_path / "missing.md",
+            scope=InstallScope.PROJECT,
+            workdir=workdir,
+        )
+
+
+def test_install_local_rejects_non_md_file(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    bad = tmp_path / "skill.txt"
+    bad.write_text("nope", encoding="utf-8")
+    with pytest.raises(SkillLifecycleError, match=".md extension"):
+        install_local(bad, scope=InstallScope.PROJECT, workdir=workdir)
+
+
+def test_install_local_directory_without_skill_md(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    src = tmp_path / "empty-skill"
+    src.mkdir()
+    with pytest.raises(SkillLifecycleError, match="does not contain SKILL.md"):
+        install_local(src, scope=InstallScope.PROJECT, workdir=workdir)
+
+
+def test_install_overwrites_previous(
+    tmp_path: Path,
+    single_file_skill: Path,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    install_local(single_file_skill, scope=InstallScope.PROJECT, workdir=workdir)
+    install_dir = scope_root(InstallScope.PROJECT, workdir=workdir) / "sample-skill"
+    # Drop a stale file that should not survive re-install.
+    stale = install_dir / "stale.txt"
+    stale.write_text("stale", encoding="utf-8")
+    assert stale.exists()
+
+    install_local(single_file_skill, scope=InstallScope.PROJECT, workdir=workdir)
+    assert not stale.exists()

--- a/tests/unit/skills/test_lifecycle_sync.py
+++ b/tests/unit/skills/test_lifecycle_sync.py
@@ -1,0 +1,171 @@
+"""Sync + lock determinism tests (#1720)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.lifecycle import (
+    SKILLS_LOCK_FILENAME,
+    SKILLS_TOML_FILENAME,
+    InstallScope,
+    SkillsTomlError,
+    read_lock_entries,
+    scope_root,
+    sync_skills,
+)
+
+
+def _write_source_md(path: Path, *, name: str, body: str = "Body.") -> None:
+    """Author a tiny SKILL.md at *path* used as a `local` source."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            ---
+            name: {name}
+            description: Sample skill used by sync determinism regression tests.
+            ---
+
+            # {name}
+
+            {body}
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_manifest(workdir: Path, entries: list[tuple[str, str]]) -> Path:
+    """Write a ``bernstein-skills.toml`` with one ``[[skills]]`` table per entry."""
+    lines: list[str] = []
+    for name, rel_path in entries:
+        lines += [
+            "[[skills]]",
+            f'name = "{name}"',
+            'source = "local"',
+            f'path = "{rel_path}"',
+            "",
+        ]
+    toml_path = workdir / SKILLS_TOML_FILENAME
+    toml_path.write_text("\n".join(lines), encoding="utf-8")
+    return toml_path
+
+
+def test_sync_installs_declared_skills(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    _write_source_md(workdir / "sources" / "alpha.md", name="alpha")
+    _write_source_md(workdir / "sources" / "beta.md", name="beta")
+    toml_path = _write_manifest(
+        workdir,
+        [
+            ("alpha", "./sources/alpha.md"),
+            ("beta", "./sources/beta.md"),
+        ],
+    )
+
+    outcomes = sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    install_root = scope_root(InstallScope.PROJECT, workdir=workdir)
+
+    assert {o.name for o in outcomes} == {"alpha", "beta"}
+    assert all(o.action == "installed" for o in outcomes)
+    assert (install_root / "alpha" / "SKILL.md").is_file()
+    assert (install_root / "beta" / "SKILL.md").is_file()
+    assert (workdir / SKILLS_LOCK_FILENAME).is_file()
+
+
+def test_sync_idempotent_lock_byte_identical(tmp_path: Path) -> None:
+    """Second sync against unchanged sources rewrites an identical lock."""
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    _write_source_md(workdir / "sources" / "alpha.md", name="alpha")
+    toml_path = _write_manifest(workdir, [("alpha", "./sources/alpha.md")])
+
+    sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    first_lock = (workdir / SKILLS_LOCK_FILENAME).read_bytes()
+
+    outcomes = sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    second_lock = (workdir / SKILLS_LOCK_FILENAME).read_bytes()
+
+    assert first_lock == second_lock
+    assert outcomes[0].action == "unchanged"
+
+
+def test_sync_detects_source_drift_and_rewrites_lock(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    src = workdir / "sources" / "alpha.md"
+    _write_source_md(src, name="alpha", body="Original body.")
+    toml_path = _write_manifest(workdir, [("alpha", "./sources/alpha.md")])
+
+    sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    entries_before = read_lock_entries(workdir)
+    assert len(entries_before) == 1
+    digest_before = entries_before[0].digest
+
+    # Mutate the source - the digest must change and the action must become
+    # ``updated`` so a follow-up sync notices.
+    _write_source_md(src, name="alpha", body="Drifted body.")
+    outcomes = sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    entries_after = read_lock_entries(workdir)
+
+    assert outcomes[0].action == "updated"
+    assert entries_after[0].digest != digest_before
+
+
+def test_sync_rejects_unknown_source_type(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    toml = workdir / SKILLS_TOML_FILENAME
+    toml.write_text(
+        '[[skills]]\nname = "alpha"\nsource = "git"\npath = "./alpha"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillsTomlError, match="only.*supported"):
+        sync_skills(toml, scope=InstallScope.PROJECT, workdir=workdir)
+
+
+def test_sync_handles_empty_manifest(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    toml = workdir / SKILLS_TOML_FILENAME
+    toml.write_text("", encoding="utf-8")
+    assert sync_skills(toml, scope=InstallScope.PROJECT, workdir=workdir) == []
+    # The lock file is still written (deterministically empty).
+    assert (workdir / SKILLS_LOCK_FILENAME).is_file()
+
+
+def test_sync_directory_source_round_trips_referenced_files(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    src_dir = workdir / "sources" / "gamma"
+    src_dir.mkdir(parents=True)
+    (src_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: gamma
+            description: Directory source covering reference round trip in sync.
+            references:
+              - notes.md
+            ---
+
+            # Gamma
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    refs = src_dir / "references"
+    refs.mkdir()
+    (refs / "notes.md").write_text("# Notes\n", encoding="utf-8")
+
+    toml_path = _write_manifest(workdir, [("gamma", "./sources/gamma")])
+    sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+
+    installed_ref = scope_root(InstallScope.PROJECT, workdir=workdir) / "gamma" / "references" / "notes.md"
+    assert installed_ref.is_file()

--- a/tests/unit/skills/test_lint.py
+++ b/tests/unit/skills/test_lint.py
@@ -1,0 +1,146 @@
+"""Tests for advisory skill linting (#1720)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from bernstein.core.skills.lint import LintSeverity, lint_skill
+
+
+def _author(skill_dir: Path, content: str) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+
+def test_lint_passes_for_well_formed_skill(tmp_path: Path) -> None:
+    _author(
+        tmp_path / "good",
+        textwrap.dedent(
+            """
+            ---
+            name: good
+            description: A well formed skill that satisfies every lint rule cleanly.
+            ---
+
+            # Good skill
+
+            Body text.
+            """
+        ).strip()
+        + "\n",
+    )
+    assert lint_skill(tmp_path / "good") == []
+
+
+def test_lint_warns_on_extra_keys(tmp_path: Path) -> None:
+    _author(
+        tmp_path / "with-extra",
+        textwrap.dedent(
+            """
+            ---
+            name: with-extra
+            description: Skill with a Claude Code shaped frontmatter extra key for ware.
+            whenToUse: When the agent needs to do the thing.
+            ---
+
+            # With extra
+            """
+        ).strip()
+        + "\n",
+    )
+    findings = lint_skill(tmp_path / "with-extra")
+    codes = {(f.code, f.severity) for f in findings}
+    assert ("extra-key", LintSeverity.WARNING) in codes
+    # Strict schema is still satisfied because the extra key is pre-filtered.
+    assert not any(f.severity is LintSeverity.ERROR for f in findings)
+
+
+def test_lint_reports_invalid_frontmatter(tmp_path: Path) -> None:
+    _author(
+        tmp_path / "broken",
+        textwrap.dedent(
+            """
+            ---
+            description: missing a name field so this should fail validation outright.
+            ---
+
+            # Broken
+            """
+        ).strip()
+        + "\n",
+    )
+    findings = lint_skill(tmp_path / "broken")
+    assert any(f.code == "invalid-manifest" and f.severity is LintSeverity.ERROR for f in findings)
+
+
+def test_lint_flags_missing_reference_file(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "missing-ref"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: missing-ref
+            description: Declares a reference file that does not exist on disk for tests.
+            references:
+              - vanished.md
+            ---
+
+            # Missing ref
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    findings = lint_skill(skill_dir)
+    assert any(f.code == "missing-reference" and "vanished.md" in f.message for f in findings)
+
+
+def test_lint_detects_invisible_tag_codepoints(tmp_path: Path) -> None:
+    # The literal characters here are U+E0048 etc., which the sanitiser
+    # treats as a prompt-injection payload.
+    poisoned_body = "\U000e0048\U000e0049 hidden"
+    _author(
+        tmp_path / "poisoned",
+        textwrap.dedent(
+            f"""
+            ---
+            name: poisoned
+            description: Skill body carrying invisible Unicode codepoints to trip flag.
+            ---
+
+            # Poisoned
+
+            {poisoned_body}
+            """
+        ).strip()
+        + "\n",
+    )
+    findings = lint_skill(tmp_path / "poisoned")
+    assert any(f.code == "sensitive-pattern" for f in findings)
+
+
+def test_lint_warns_on_oversized_body(tmp_path: Path) -> None:
+    big_body = "Line of text\n" * 800  # well past 5 KB
+    content = (
+        "---\n"
+        "name: big\n"
+        "description: Skill with an oversized body used to exercise the cap warn.\n"
+        "---\n"
+        "\n"
+        "# Big skill\n"
+        "\n"
+        f"{big_body}"
+    )
+    _author(tmp_path / "big", content)
+    findings = lint_skill(tmp_path / "big")
+    assert any(f.code == "body-too-large" for f in findings)
+
+
+def test_lint_reports_missing_skill_md(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    findings = lint_skill(empty)
+    assert findings[0].code == "missing-skill-md"
+    assert findings[0].severity is LintSeverity.ERROR

--- a/tests/unit/skills/test_watcher.py
+++ b/tests/unit/skills/test_watcher.py
@@ -63,11 +63,14 @@ def test_watcher_fires_on_file_change(tmp_path: Path) -> None:
         # file inside it is flushed).
         deadline = time.monotonic() + 5.0
         saw_beta = False
+        # Pre-declare ``names`` so the final assertion stays defined even
+        # if the loop body never executes under extreme scheduling stalls.
+        names: set[str] = set()
         while time.monotonic() < deadline:
             reload_event.wait(timeout=0.5)
             reload_event.clear()
             with lock:
-                names: set[str] = set()
+                names = set()
                 for loader in loaders_seen:
                     names.update(skill.name for skill in loader.list_all())
             if "beta" in names:

--- a/tests/unit/skills/test_watcher.py
+++ b/tests/unit/skills/test_watcher.py
@@ -1,0 +1,80 @@
+"""Smoke test for the hot-reload watcher (#1720)."""
+
+from __future__ import annotations
+
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bernstein.core.skills.watcher import start_skill_watcher
+
+if TYPE_CHECKING:
+    from bernstein.core.skills.loader import SkillLoader
+
+
+def _write_skill(root: Path, name: str, *, body: str = "Body.") -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            f"""
+            ---
+            name: {name}
+            description: Sample skill used by the watcher hot reload smoke test cases.
+            ---
+
+            # {name}
+
+            {body}
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_watcher_fires_on_file_change(tmp_path: Path) -> None:
+    """Authoring a new skill triggers a debounced rebuild."""
+    watch_path = tmp_path / "skills"
+    watch_path.mkdir()
+    _write_skill(watch_path, "alpha")
+
+    reload_count = 0
+    loaders_seen: list[SkillLoader] = []
+    reload_event = threading.Event()
+    lock = threading.Lock()
+
+    def on_reload(loader: SkillLoader) -> None:
+        nonlocal reload_count
+        with lock:
+            reload_count += 1
+            loaders_seen.append(loader)
+        reload_event.set()
+
+    handle = start_skill_watcher(watch_path, on_reload)
+    try:
+        # Give the observer thread a moment to attach inotify/kqueue.
+        time.sleep(0.1)
+        _write_skill(watch_path, "beta")
+        # Poll until the rebuilt loader sees ``beta`` (handles late-arriving
+        # events on platforms where the directory is created before the
+        # file inside it is flushed).
+        deadline = time.monotonic() + 5.0
+        saw_beta = False
+        while time.monotonic() < deadline:
+            reload_event.wait(timeout=0.5)
+            reload_event.clear()
+            with lock:
+                names: set[str] = set()
+                for loader in loaders_seen:
+                    names.update(skill.name for skill in loader.list_all())
+            if "beta" in names:
+                saw_beta = True
+                break
+    finally:
+        handle.stop(timeout=2.0)
+
+    assert reload_count >= 1, "watcher never invoked the reload callback"
+    assert saw_beta, f"watcher saw {names} but expected to observe 'beta'"


### PR DESCRIPTION
Refs #1720. Track 1 minimum + the activation-log piece of Track 5. Tracks 2-5 stay deferred.

## What ships

- `bernstein skills install <local-path>` and `bernstein skills remove <name>` against `.bernstein/skills/` (project) or `~/.bernstein/skills/` (with `--scope user`). Re-uses the existing `SkillSource` abstraction.
- `bernstein-skills.toml` schema at repo root; only `source = "local"` accepted in this PR.
- `bernstein skills sync` reads `bernstein-skills.toml` and reconciles `.bernstein/skills/`. Idempotent: a re-run against an unchanged source rewrites a byte-identical `skills.lock`.
- `skills.lock` next to the manifest, recording name + source + path + BLAKE2b digest of the canonicalised manifest + body + every referenced file.
- `bernstein skills lint [<name>...]` advisory-only: frontmatter schema, reference / script path resolution, sensitive-pattern leak detection via the existing sanitiser, body heading + length warnings. Does NOT block install in this PR.
- `bernstein skills watch [<path>]` hot-reloads the skill index on filesystem events via `watchdog` (already a project dep). Debounced rebuild runs off the watchdog thread.
- Activation log to `.sdd/skills/activations.jsonl`: `{skill, version, digest, role, task_id, trigger_source, timestamp}` per skill per task. Opt-out via `BERNSTEIN_SKILL_ACTIVATION_LOG=0`. Local-only; no maintainer endpoint.

## What is out of scope

Tracks 2 (skill `test` / `diff` / `bench` / `init`), 3 (Git / OCI / index sources), 4 (signatures / trust roots / install-time refuse), and the routing / outcome-attribution / bisection slices of Track 5 stay deferred. The advisory lint in this PR is the floor; the gate flip is a follow-up.

The existing 6-level discovery cascade (managed > user > project > additional > plugin > MCP) and the BASE / TEAM / USER layered merge are untouched; new commands write into and read from the same well-known directories those subsystems already scan.

## Test plan

- [x] `uv run pytest tests/unit/skills -q` (250 passed)
- [x] `uv run ruff check .` and `ruff format --check` clean for all touched files; 52 pre-existing cookiecutter-template errors carry over unchanged
- [x] `uv run bernstein agents-md sync` no-op
- [x] End-to-end CLI smoke: `bernstein skills sync` against the shipped sample TOML installs `bernstein-test-runner` into `.bernstein/skills/`, second run reports `= unchanged`, `bernstein skills remove` round-trips
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill lifecycle: install, remove, sync from manifest, lint checks, and hot-reload watcher for local skills.
  * Activation logging: optional per-skill append-only JSONL log for activations.
  * Content-addressed digests and lockfile support for deterministic validation and drift detection.

* **Tests**
  * Extensive unit/integration tests added for lifecycle, digesting, activation logging, linting, injector behavior, and watcher.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->