### PR TITLE
feat(telemetry): foundation CLI + schema-guard + off-by-default proof

### DIFF
--- a/docs/observability/side-channel.md
+++ b/docs/observability/side-channel.md
@@ -163,3 +163,11 @@ and review every agent's activity in a single stream.
   follow-up.
 - The lineage chain itself stays in `core/lineage/`. Tamper detections are
   mirrored onto the side channel, but the chain is not re-implemented here.
+
+## Related: maintainer-share consent
+
+The side channel above is operator-controlled. A separate, additive consent
+flag (`share_with_maintainer`) is documented in
+[telemetry-share.md](./telemetry-share.md). That flag gates an opt-in path
+to a community-shared maintainer endpoint and is off by default. The two
+surfaces are independent.

--- a/docs/observability/telemetry-share.md
+++ b/docs/observability/telemetry-share.md
@@ -1,0 +1,126 @@
+# Maintainer-share telemetry (RFC #1719 foundation)
+
+Bernstein already exposes a portable, operator-controlled telemetry pipeline
+(see [side-channel.md](./side-channel.md)). That pipeline is the operator's:
+the operator picks the backend, points the DSN at it, and reviews the stream.
+
+This page documents a separate, additive consent surface: the
+`share_with_maintainer` flag introduced by the RFC #1719 foundation. The flag
+gates an opt-in path that may, after the RFC settles, ship aggregate
+reliability signal to a community-shared maintainer endpoint. No endpoint is
+defined in this PR, and no default URL is baked into the package.
+
+## TL;DR
+
+- Default state is off. With the flag unset, nothing is ever sent.
+- One TOML file controls consent:
+  `$XDG_CONFIG_HOME/bernstein/telemetry.toml` (falls back to
+  `~/.config/bernstein/telemetry.toml`).
+- Three CLI subcommands manage the surface:
+  - `bernstein telemetry enable --share-with-maintainer` to opt in.
+  - `bernstein telemetry disable` to revert.
+  - `bernstein telemetry tail [-n N]` to audit the stream offline.
+- One env var beats the file: `BERNSTEIN_TELEMETRY_SHARE=0` always disables.
+- `DO_NOT_TRACK=1` always wins, regardless of the file or any env var.
+
+## How consent flows
+
+1. Operator runs `bernstein telemetry enable --share-with-maintainer`.
+2. The CLI prints the full event schema and the redaction list. Nothing is
+   written yet.
+3. The CLI asks for confirmation. If the operator declines, the flag stays
+   unset and the path stays unreachable.
+4. On confirmation, the CLI writes `share_with_maintainer = true` to the
+   TOML file and prints the path.
+
+To revoke at any time, run `bernstein telemetry disable`. The TOML is
+rewritten with `share_with_maintainer = false` and the path goes back to
+unreachable on the next process start.
+
+## Configuration precedence
+
+The flag is resolved from the highest available signal:
+
+| Layer | Signal | Effect |
+|---|---|---|
+| 1 | `DO_NOT_TRACK=1` env var | Forces off (universal W3C opt-out). |
+| 2 | `BERNSTEIN_TELEMETRY_SHARE` env var | `0` / `false` / `no` / `off` / `""` force off; anything else forces on. |
+| 3 | TOML file `share_with_maintainer` | The persisted operator choice. |
+| 4 | Default | Off. |
+
+`bernstein telemetry status` prints the resolved value and the layer that
+won, so operators can diagnose surprising state in one command.
+
+## What gets sent
+
+The event schema is the closed taxonomy already defined in
+`src/bernstein/core/telemetry/events.py`. Field-by-field:
+
+| Event | Fields |
+|---|---|
+| `install_completed` | `os`, `py_version`, `install_method`, `bernstein_version` |
+| `first_run_started` | `time_since_install_seconds` |
+| `first_run_completed` | `ok`, `duration_ms`, `error_category` |
+| `command_invoked` | `name_only`, `bernstein_version` |
+| `daily_active` | `day_iso` (ISO-8601 UTC date) |
+
+Every event is wrapped in an envelope that adds `schema_version`,
+`install_id`, and `timestamp`. The install id is the opaque per-install
+fingerprint documented in `core/telemetry/install_id.py`.
+
+## Redaction list
+
+The schema is the redaction list: nothing outside the table above is ever
+collected. The boundary explicitly drops:
+
+- **File paths**: any path-shaped value is replaced with a stable hash before
+  it can enter a field. No raw paths are ever serialised.
+- **Agent output**: rendered text never enters the pipeline.
+- **Diff bytes**: source patches are not part of the schema.
+- **Tool-call args**: only the bare command name is emitted; arguments are
+  stripped.
+- **Prompts**: user-authored prompts never reach the boundary.
+- **Secrets**: env vars and credentials are not part of the schema.
+
+The schema is also guarded by a build-time test
+(`tests/unit/telemetry/test_event_schema_guard.py`): any new field that lacks
+either an entry in the allowlist of safe primitive fields or an explicit
+redaction entry fails the test. Field renames or removals are a major-version
+bump on the event schema; operators can pin a schema version they have
+reviewed.
+
+## Auditing the stream offline
+
+`bernstein telemetry tail` reads the in-process side-channel preview ring
+buffer and prints the most recent rendered events, one JSON object per line,
+oldest first. The buffer is populated at the boundary, so the output reflects
+what would be sent, regardless of whether the backend is reachable. Use this
+to audit the stream before deciding whether to flip the flag.
+
+```text
+$ bernstein telemetry tail -n 5
+{"event_id":"...","level":"info","logger":"bernstein.run", ...}
+```
+
+## Revoking consent
+
+Three equivalent revocations:
+
+- `bernstein telemetry disable` writes `share_with_maintainer = false`.
+- `export BERNSTEIN_TELEMETRY_SHARE=0` forces off for the current process.
+- `export DO_NOT_TRACK=1` forces off for every Bernstein process and matches
+  the universal W3C signal.
+
+The operator-controlled side channel (`BERNSTEIN_TELEMETRY_DSN`) is
+unaffected by any of the above. Operators who run their own backend never
+need to touch the share flag.
+
+## What this PR does not do
+
+- It does not define a maintainer endpoint URL.
+- It does not change the existing telemetry pipeline.
+- It does not flip the flag for any operator. The default stays off.
+
+The foundation lands so the consent surface is reviewable. The
+consent-posture decision (Option A opt-in vs B opt-out vs C nudged opt-in)
+stays in the RFC discussion at issue #1719.

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -2,10 +2,13 @@
 
 Operator-facing surface:
 
-    bernstein telemetry on        opt in, write config, generate install id
-    bernstein telemetry off       opt out, delete install id
-    bernstein telemetry status    show current state + which signal won
-    bernstein telemetry export    dump last 30 days of locally queued events
+    bernstein telemetry on              opt in (operator-controlled backend)
+    bernstein telemetry off             opt out (operator-controlled backend)
+    bernstein telemetry status          show current state + flag-source provenance
+    bernstein telemetry export          dump last 30 days of locally queued events
+    bernstein telemetry enable          opt in to share with maintainer (RFC #1719)
+    bernstein telemetry disable         revert share-with-maintainer flag
+    bernstein telemetry tail [-n N]     preview the next N events offline
 
 The output is deliberately compact and deterministic to enable snapshot
 tests against the ``status`` command.
@@ -13,6 +16,8 @@ tests against the ``status`` command.
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +36,54 @@ from bernstein.core.telemetry import (
     resolve,
     write_enabled,
 )
+from bernstein.core.telemetry.consent import (
+    consent_file_path,
+    explain_share_source,
+    resolve_share,
+    write_share_flag,
+)
+from bernstein.core.telemetry.events import (
+    CommandInvokedPayload,
+    DailyActivePayload,
+    FirstRunCompletedPayload,
+    FirstRunStartedPayload,
+    InstallCompletedPayload,
+    TelemetryEvent,
+)
+
+# Operator-visible event schema and redaction list shown before the
+# ``enable --share-with-maintainer`` flag is flipped. Both are kept here so
+# the consent surface and the schema-guard test reference the same source
+# of truth.
+SAFE_PRIMITIVE_FIELDS: frozenset[str] = frozenset(
+    {
+        # InstallCompletedPayload
+        "os",
+        "py_version",
+        "install_method",
+        "bernstein_version",
+        # FirstRunStartedPayload
+        "time_since_install_seconds",
+        # FirstRunCompletedPayload
+        "ok",
+        "duration_ms",
+        "error_category",
+        # CommandInvokedPayload
+        "name_only",
+        # DailyActivePayload
+        "day_iso",
+    }
+)
+
+
+REDACTION_RULES: dict[str, str] = {
+    "file_paths": "any path-shaped value is replaced with a stable hash",
+    "agent_output": "never collected; rendered text is dropped at the boundary",
+    "diff_bytes": "never collected; source patches are not in the schema",
+    "tool_call_args": "never collected; only the command name (no args) is emitted",
+    "prompts": "never collected; user-authored prompts never enter the pipeline",
+    "secrets": "never collected; env vars and credentials are not in the schema",
+}
 
 
 @click.group("telemetry")
@@ -82,19 +135,24 @@ def telemetry_off(home: Path | None) -> None:
 )
 def telemetry_status(home: Path | None) -> None:
     """Show current state and which precedence layer determined it."""
+    from bernstein.core.observability import sidechannel
+
     state = resolve(home=home)
+    share = resolve_share(home=home)
     install_id = read_install_id(home=home)
-    lines: list[str] = []
-    lines.extend(
-        (
-            f"enabled: {str(state.enabled).lower()}",
-            f"source: {state.source.value}",
-            f"install_id: {install_id or 'none'}",
-            f"config_file: {config_file_path(home)}",
-            f"install_id_path: {install_id_path(home)}",
-            f"queue: {queue_path(home)}",
-        )
-    )
+    dsn = os.environ.get(sidechannel.DSN_ENV) or "(unset)"
+    lines: list[str] = [
+        f"enabled: {str(state.enabled).lower()}",
+        f"source: {state.source.value}",
+        f"install_id: {install_id or 'none'}",
+        f"config_file: {config_file_path(home)}",
+        f"install_id_path: {install_id_path(home)}",
+        f"queue: {queue_path(home)}",
+        f"share_with_maintainer: {str(share.enabled).lower()}",
+        f"share_source: {share.source.value} ({explain_share_source(share.source)})",
+        f"share_config_file: {consent_file_path(home=home)}",
+        f"dsn: {dsn}",
+    ]
     click.echo("\n".join(lines))
 
 
@@ -170,6 +228,152 @@ def telemetry_probe(message: str) -> None:
         click.echo("telemetry probe: event was dropped under backpressure.")
 
 
+def _render_consent_disclosure() -> str:
+    """Render the schema + redaction disclosure shown before the flag flip.
+
+    The text is the operator-facing source of truth for the consent
+    contract. Any change to the event schema must update this disclosure
+    and the matching schema-guard test in lockstep.
+    """
+    schemas: dict[str, type[Any]] = {
+        TelemetryEvent.INSTALL_COMPLETED.value: InstallCompletedPayload,
+        TelemetryEvent.FIRST_RUN_STARTED.value: FirstRunStartedPayload,
+        TelemetryEvent.FIRST_RUN_COMPLETED.value: FirstRunCompletedPayload,
+        TelemetryEvent.COMMAND_INVOKED.value: CommandInvokedPayload,
+        TelemetryEvent.DAILY_ACTIVE.value: DailyActivePayload,
+    }
+    lines = [
+        "Event schema (RFC #1719 foundation):",
+        "",
+    ]
+    for name, cls in schemas.items():
+        fields = ", ".join(cls.__slots__) or "(no fields)"
+        lines.append(f"  - {name}: {fields}")
+    lines.extend(
+        [
+            "",
+            "Redaction rules applied at the boundary:",
+            "",
+        ]
+    )
+    for key, rule in REDACTION_RULES.items():
+        lines.append(f"  - {key}: {rule}")
+    lines.extend(
+        [
+            "",
+            "No file paths, agent output, diff bytes, tool-call args, prompts, or",
+            "secrets are collected. See docs/observability/telemetry-share.md for",
+            "the full contract, how to audit offline (bernstein telemetry tail),",
+            "and how to revoke (bernstein telemetry disable).",
+        ]
+    )
+    return "\n".join(lines)
+
+
+@telemetry_group.command("enable")
+@click.option(
+    "--share-with-maintainer",
+    "share_with_maintainer",
+    is_flag=True,
+    required=True,
+    help="Opt in to share telemetry with the project maintainer (RFC #1719).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the interactive confirmation prompt.",
+)
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the operator home directory (testing).",
+)
+def telemetry_enable(
+    share_with_maintainer: bool,
+    assume_yes: bool,
+    home: Path | None,
+) -> None:
+    """Opt in to share telemetry with the project maintainer (RFC #1719).
+
+    Prints the full event schema and redaction list, then requires
+    explicit confirmation before persisting the
+    ``share_with_maintainer = true`` flag to
+    ``$XDG_CONFIG_HOME/bernstein/telemetry.toml``.
+    """
+    if not share_with_maintainer:
+        # ``required=True`` on the click option keeps the flag mandatory,
+        # but this guard documents the invariant for readers.
+        raise click.UsageError("--share-with-maintainer is required")
+
+    click.echo(_render_consent_disclosure())
+    click.echo("")
+
+    if not assume_yes:
+        confirmed = click.confirm(
+            "Proceed and set share_with_maintainer = true?",
+            default=False,
+        )
+        if not confirmed:
+            click.echo("telemetry: no change (consent declined).")
+            return
+
+    path = write_share_flag(True, home=home)
+    click.echo(f"telemetry: share_with_maintainer = true (written to {path}).")
+    click.echo("Revert any time with `bernstein telemetry disable`.")
+
+
+@telemetry_group.command("disable")
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the operator home directory (testing).",
+)
+def telemetry_disable(home: Path | None) -> None:
+    """Revert the maintainer-share consent flag.
+
+    Writes ``share_with_maintainer = false`` to the consent TOML file. The
+    operator-controlled telemetry pipeline (``bernstein telemetry on/off``)
+    is unaffected.
+    """
+    path = write_share_flag(False, home=home)
+    click.echo(f"telemetry: share_with_maintainer = false (written to {path}).")
+
+
+@telemetry_group.command("tail")
+@click.option(
+    "-n",
+    "count",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Number of recent preview events to print.",
+)
+def telemetry_tail(count: int) -> None:
+    """Print the next N events that would be sent, offline.
+
+    Reads from the side-channel preview ring buffer. Events are rendered
+    in the same shape they would be posted in, one JSON object per line,
+    oldest-first. Use this to audit the stream before deciding whether to
+    opt in via ``bernstein telemetry enable --share-with-maintainer``.
+    """
+    from bernstein.core.observability import sidechannel
+
+    events = sidechannel.read_preview(count)
+    if not events:
+        click.echo(
+            "telemetry tail: no events buffered yet. The preview buffer fills\n"
+            "as the side-channel emit helper records events at the boundary."
+        )
+        return
+    for event in events:
+        click.echo(json.dumps(event, sort_keys=True, separators=(",", ":")))
+
+
 def explain_source(source: OptInSource) -> str:
     """Return a one-line operator-facing description of ``source``."""
     if source is OptInSource.DO_NOT_TRACK:
@@ -188,12 +392,17 @@ def register(parent: Any) -> None:
 
 
 __all__ = [
+    "REDACTION_RULES",
+    "SAFE_PRIMITIVE_FIELDS",
     "explain_source",
     "register",
+    "telemetry_disable",
+    "telemetry_enable",
     "telemetry_export",
     "telemetry_group",
     "telemetry_off",
     "telemetry_on",
     "telemetry_probe",
     "telemetry_status",
+    "telemetry_tail",
 ]

--- a/src/bernstein/core/observability/sidechannel.py
+++ b/src/bernstein/core/observability/sidechannel.py
@@ -39,6 +39,7 @@ import queue
 import threading
 import time
 import uuid
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -83,6 +84,48 @@ SENTRY_CLIENT: Final[str] = "bernstein-sidechannel/1"
 #: Sentry store-protocol version. ``7`` is the long-standing default that
 #: GlitchTip and Sentry both accept.
 SENTRY_PROTOCOL_VERSION: Final[str] = "7"
+
+#: Maximum number of events kept in the offline preview ring buffer.
+#: This buffer powers ``bernstein telemetry tail`` so operators can audit
+#: the stream offline before any network send. It is intentionally small.
+PREVIEW_BUFFER_MAXSIZE: Final[int] = 128
+
+
+_preview_buffer: deque[dict[str, Any]] = deque(maxlen=PREVIEW_BUFFER_MAXSIZE)
+_preview_lock = threading.Lock()
+
+
+def record_preview(payload: Mapping[str, Any]) -> None:
+    """Append a rendered event payload to the offline preview ring buffer.
+
+    The buffer is bounded; oldest entries are evicted automatically. It is
+    intentionally a shallow record of what ``emit`` produced before any
+    network attempt, so operators can audit the stream offline regardless
+    of whether the backend is reachable.
+    """
+    with _preview_lock:
+        _preview_buffer.append(dict(payload))
+
+
+def read_preview(n: int = 10) -> list[dict[str, Any]]:
+    """Return the most recent ``n`` rendered events from the preview buffer.
+
+    The returned list is ordered oldest-first. ``n`` is clamped to the
+    buffer's configured capacity.
+    """
+    if n <= 0:
+        return []
+    with _preview_lock:
+        snapshot = list(_preview_buffer)
+    if n >= len(snapshot):
+        return snapshot
+    return snapshot[-n:]
+
+
+def clear_preview() -> None:
+    """Drop the preview buffer. Used by tests."""
+    with _preview_lock:
+        _preview_buffer.clear()
 
 
 class Backpressure(StrEnum):
@@ -497,6 +540,11 @@ def emit(
             tags=dict(tags or {}),
             extra=dict(extra or {}),
         )
+        # Record the rendered payload in the offline preview buffer so
+        # ``bernstein telemetry tail`` can show what was queued for send,
+        # whether or not the backend was reachable.
+        with contextlib.suppress(Exception):
+            record_preview(event.to_payload())
         return target.emit(event)
     except Exception as exc:
         _LOG.debug("sidechannel: emit helper failed (suppressed): %s", exc)
@@ -508,6 +556,7 @@ __all__ = [
     "DEFAULT_QUEUE_MAXSIZE",
     "DSN_ENV",
     "FLUSH_DEADLINE_SECONDS",
+    "PREVIEW_BUFFER_MAXSIZE",
     "QUEUE_MAXSIZE_ENV",
     "Backpressure",
     "Dsn",
@@ -518,8 +567,11 @@ __all__ = [
     "SideChannelEvent",
     "SideChannelSink",
     "build_sidechannel",
+    "clear_preview",
     "emit",
     "get_sidechannel",
     "parse_dsn",
+    "read_preview",
+    "record_preview",
     "reset_sidechannel",
 ]

--- a/src/bernstein/core/telemetry/consent.py
+++ b/src/bernstein/core/telemetry/consent.py
@@ -1,0 +1,175 @@
+"""Maintainer-share consent flag (foundation for RFC #1719).
+
+This module implements the consent surface for an additive, opt-in path
+to a community-shared maintainer endpoint. It is intentionally separate
+from :mod:`bernstein.core.telemetry.config`: the existing ``enabled``
+flag governs operator-controlled backends and stays unchanged. The
+``share_with_maintainer`` flag here gates a different, additive code
+path that may be wired up in a follow-up PR after RFC #1719 settles.
+
+Invariants (tested):
+
+* Default state is off (flag missing).
+* The flag persists at
+  ``$XDG_CONFIG_HOME/bernstein/telemetry.toml`` (falling back to
+  ``~/.config/bernstein/telemetry.toml`` when ``XDG_CONFIG_HOME`` is
+  unset, per the XDG Base Directory spec).
+* Precedence (highest first): ``DO_NOT_TRACK=1`` > ``BERNSTEIN_TELEMETRY_SHARE``
+  env > TOML file > default-off. ``BERNSTEIN_TELEMETRY_SHARE=0`` always wins
+  over the TOML.
+* No maintainer endpoint URL is baked into the package. This module
+  reads and writes the flag only; consumers decide what to do with it.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Final
+
+_DO_NOT_TRACK: Final[str] = "DO_NOT_TRACK"
+_SHARE_ENV: Final[str] = "BERNSTEIN_TELEMETRY_SHARE"
+_XDG_CONFIG_HOME: Final[str] = "XDG_CONFIG_HOME"
+
+_FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off", ""})
+_TRUE_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+
+class ShareSource(StrEnum):
+    """Which precedence layer decided the current share flag value."""
+
+    DO_NOT_TRACK = "do_not_track"
+    ENV = "env"
+    FILE = "file"
+    DEFAULT = "default"
+
+
+@dataclass(frozen=True, slots=True)
+class ShareState:
+    """Resolved share flag plus the signal that determined it."""
+
+    enabled: bool
+    source: ShareSource
+
+
+def _xdg_config_home(env: dict[str, str] | None = None, home: Path | None = None) -> Path:
+    """Return ``$XDG_CONFIG_HOME`` or its XDG-spec fallback."""
+    real_env = env if env is not None else os.environ
+    raw = real_env.get(_XDG_CONFIG_HOME)
+    if raw:
+        return Path(raw)
+    base = home if home is not None else Path.home()
+    return base / ".config"
+
+
+def consent_file_path(
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Return the on-disk path of the consent TOML file."""
+    return _xdg_config_home(env=env, home=home) / "bernstein" / "telemetry.toml"
+
+
+def _load_toml(path: Path) -> dict[str, object]:
+    """Load the TOML config or return an empty dict on any error."""
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _file_share(path: Path) -> bool | None:
+    """Return the file's ``share_with_maintainer`` field, or ``None``."""
+    if not path.exists():
+        return None
+    value = _load_toml(path).get("share_with_maintainer")
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _parse_env(raw: str) -> bool:
+    """Parse a string env-var value to a bool. Unknown values count as ``True``."""
+    normalized = raw.strip().lower()
+    if normalized in _FALSE_VALUES:
+        return False
+    if normalized in _TRUE_VALUES:
+        return True
+    return True
+
+
+def resolve_share(
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> ShareState:
+    """Resolve the maintainer-share flag with full precedence."""
+    real_env = env if env is not None else os.environ.copy()
+
+    if real_env.get(_DO_NOT_TRACK) == "1":
+        return ShareState(enabled=False, source=ShareSource.DO_NOT_TRACK)
+
+    raw = real_env.get(_SHARE_ENV)
+    if raw is not None:
+        return ShareState(enabled=_parse_env(raw), source=ShareSource.ENV)
+
+    path = consent_file_path(env=real_env, home=home)
+    file_choice = _file_share(path)
+    if file_choice is not None:
+        return ShareState(enabled=file_choice, source=ShareSource.FILE)
+
+    return ShareState(enabled=False, source=ShareSource.DEFAULT)
+
+
+def is_sharing_with_maintainer(
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> bool:
+    """Shortcut for ``resolve_share(...).enabled``."""
+    return resolve_share(env=env, home=home).enabled
+
+
+def _serialize_toml(flag: bool) -> str:
+    """Render a minimal TOML body. Avoids a tomli-w dependency."""
+    value = "true" if flag else "false"
+    return (
+        f"# Bernstein telemetry consent. See docs/observability/telemetry-share.md.\nshare_with_maintainer = {value}\n"
+    )
+
+
+def write_share_flag(
+    enabled: bool,
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Persist ``share_with_maintainer`` to the consent TOML file."""
+    path = consent_file_path(env=env, home=home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_serialize_toml(enabled), encoding="utf-8")
+    return path
+
+
+def explain_share_source(source: ShareSource) -> str:
+    """Return an operator-facing one-line description of ``source``."""
+    if source is ShareSource.DO_NOT_TRACK:
+        return "DO_NOT_TRACK env var (universal opt-out)"
+    if source is ShareSource.ENV:
+        return f"{_SHARE_ENV} env var"
+    if source is ShareSource.FILE:
+        return "consent file ($XDG_CONFIG_HOME/bernstein/telemetry.toml)"
+    return "default (off)"
+
+
+__all__ = [
+    "ShareSource",
+    "ShareState",
+    "consent_file_path",
+    "explain_share_source",
+    "is_sharing_with_maintainer",
+    "resolve_share",
+    "write_share_flag",
+]

--- a/tests/unit/telemetry/test_cli_command.py
+++ b/tests/unit/telemetry/test_cli_command.py
@@ -88,6 +88,103 @@ def test_status_overridden_by_env_off(
     assert "enabled: false" in output
 
 
+def test_enable_requires_confirmation_and_writes_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enable prints schema + redaction, confirms, then writes the TOML."""
+    xdg = tmp_path / "xdg-config"
+    xdg.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("BERNSTEIN_TELEMETRY_SHARE", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        telemetry_group,
+        ["enable", "--share-with-maintainer"],
+        input="y\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Event schema" in result.output
+    assert "Redaction rules" in result.output
+    assert "share_with_maintainer = true" in result.output
+
+    toml_path = xdg / "bernstein" / "telemetry.toml"
+    assert toml_path.exists()
+    body = toml_path.read_text(encoding="utf-8")
+    assert "share_with_maintainer = true" in body
+
+
+def test_enable_declined_does_not_write_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Declining the confirmation leaves the consent file untouched."""
+    xdg = tmp_path / "xdg-config"
+    xdg.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("BERNSTEIN_TELEMETRY_SHARE", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        telemetry_group,
+        ["enable", "--share-with-maintainer"],
+        input="n\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "consent declined" in result.output
+    assert not (xdg / "bernstein" / "telemetry.toml").exists()
+
+
+def test_disable_writes_false_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disable persists share_with_maintainer = false."""
+    xdg = tmp_path / "xdg-config"
+    xdg.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("BERNSTEIN_TELEMETRY_SHARE", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, ["disable"])
+    assert result.exit_code == 0, result.output
+    toml_path = xdg / "bernstein" / "telemetry.toml"
+    assert toml_path.exists()
+    assert "share_with_maintainer = false" in toml_path.read_text(encoding="utf-8")
+
+
+def test_tail_empty_message_when_buffer_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tail prints a helpful message when no events have been buffered."""
+    from bernstein.core.observability import sidechannel
+
+    sidechannel.clear_preview()
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, ["tail"])
+    assert result.exit_code == 0, result.output
+    assert "no events buffered" in result.output
+
+
+def test_tail_prints_buffered_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tail prints the rendered events from the preview ring buffer."""
+    from bernstein.core.observability import sidechannel
+
+    sidechannel.clear_preview()
+    monkeypatch.delenv(sidechannel.DSN_ENV, raising=False)
+    # ``emit`` records the rendered payload in the preview buffer even when
+    # the sink is the Null sink, which is the operator-audit guarantee.
+    sidechannel.emit(category="run", message="first")
+    sidechannel.emit(category="run", message="second")
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, ["tail", "-n", "5"])
+    assert result.exit_code == 0, result.output
+    assert "first" in result.output
+    assert "second" in result.output
+
+
 def test_probe_without_dsn_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     from bernstein.core.observability import sidechannel
 

--- a/tests/unit/telemetry/test_cli_command.py
+++ b/tests/unit/telemetry/test_cli_command.py
@@ -70,6 +70,10 @@ def test_status_snapshot_default(tmp_home: Path) -> None:
         "config_file",
         "install_id_path",
         "queue",
+        "share_with_maintainer",
+        "share_source",
+        "share_config_file",
+        "dsn",
     ]
 
 

--- a/tests/unit/telemetry/test_event_schema_guard.py
+++ b/tests/unit/telemetry/test_event_schema_guard.py
@@ -29,7 +29,6 @@ from bernstein.cli.commands.telemetry_cmd import (
 )
 from bernstein.core.telemetry import events as events_module
 
-
 # The closed set of payload dataclasses that travel over the wire. Any new
 # event must add its payload class here so the guard sees it.
 PAYLOAD_CLASSES: tuple[type, ...] = (
@@ -76,9 +75,7 @@ def test_every_field_has_redaction_decision(payload_cls: type[Any]) -> None:
     """Every payload field must be listed as safe or carry a redaction entry."""
     field_names = [f.name for f in dataclasses.fields(payload_cls)]
     undecided: list[str] = [
-        name
-        for name in field_names
-        if name not in SAFE_PRIMITIVE_FIELDS and name not in REDACTION_RULES
+        name for name in field_names if name not in SAFE_PRIMITIVE_FIELDS and name not in REDACTION_RULES
     ]
     assert not undecided, (
         f"Payload {payload_cls.__name__} has fields without a redaction "

--- a/tests/unit/telemetry/test_event_schema_guard.py
+++ b/tests/unit/telemetry/test_event_schema_guard.py
@@ -1,0 +1,105 @@
+"""Schema-guard for the telemetry event taxonomy (RFC #1719 foundation).
+
+Every field on every payload dataclass in
+:mod:`bernstein.core.telemetry.events` must have an explicit redaction
+decision recorded somewhere reviewable. This test enforces that by
+introspecting the dataclass field sets and requiring each field to be
+either:
+
+* listed in ``SAFE_PRIMITIVE_FIELDS`` (a known-safe primitive on which a
+  reviewer has signed off), or
+* mapped in ``REDACTION_RULES`` to a written rationale describing how the
+  field is sanitised at the boundary.
+
+Adding a new field without recording a decision in one of those two places
+fails the build, so the schema cannot silently grow a field that no one
+has reviewed.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+from bernstein.cli.commands.telemetry_cmd import (
+    REDACTION_RULES,
+    SAFE_PRIMITIVE_FIELDS,
+)
+from bernstein.core.telemetry import events as events_module
+
+
+# The closed set of payload dataclasses that travel over the wire. Any new
+# event must add its payload class here so the guard sees it.
+PAYLOAD_CLASSES: tuple[type, ...] = (
+    events_module.InstallCompletedPayload,
+    events_module.FirstRunStartedPayload,
+    events_module.FirstRunCompletedPayload,
+    events_module.CommandInvokedPayload,
+    events_module.DailyActivePayload,
+)
+
+
+def _payload_classes_in_module() -> list[type]:
+    """Discover every frozen-dataclass payload defined in events.py.
+
+    We deliberately discover by introspection so a new payload class added
+    to ``events.py`` without updating ``PAYLOAD_CLASSES`` is caught.
+    """
+    found: list[type] = []
+    for name in dir(events_module):
+        obj = getattr(events_module, name)
+        if not isinstance(obj, type):
+            continue
+        if not dataclasses.is_dataclass(obj):
+            continue
+        if name.endswith("Payload"):
+            found.append(obj)
+    return found
+
+
+def test_payload_classes_match_known_set() -> None:
+    """The schema-guard's known list must cover every Payload dataclass."""
+    discovered = {cls.__name__ for cls in _payload_classes_in_module()}
+    known = {cls.__name__ for cls in PAYLOAD_CLASSES}
+    missing = discovered - known
+    assert not missing, (
+        "New event payload classes detected. Add them to PAYLOAD_CLASSES in "
+        "tests/unit/telemetry/test_event_schema_guard.py and record a "
+        f"redaction decision for their fields. Missing: {sorted(missing)}"
+    )
+
+
+@pytest.mark.parametrize("payload_cls", PAYLOAD_CLASSES, ids=lambda cls: cls.__name__)
+def test_every_field_has_redaction_decision(payload_cls: type[Any]) -> None:
+    """Every payload field must be listed as safe or carry a redaction entry."""
+    field_names = [f.name for f in dataclasses.fields(payload_cls)]
+    undecided: list[str] = [
+        name
+        for name in field_names
+        if name not in SAFE_PRIMITIVE_FIELDS and name not in REDACTION_RULES
+    ]
+    assert not undecided, (
+        f"Payload {payload_cls.__name__} has fields without a redaction "
+        f"decision: {undecided}. Either add the field to "
+        "SAFE_PRIMITIVE_FIELDS in src/bernstein/cli/commands/telemetry_cmd.py "
+        "(literal allowlist of primitives that are safe to send) or add an "
+        "explicit entry in REDACTION_RULES describing how the field is "
+        "sanitised. See docs/observability/telemetry-share.md."
+    )
+
+
+def test_safe_fields_are_known_strings() -> None:
+    """The allowlist must be a frozenset of non-empty strings."""
+    assert isinstance(SAFE_PRIMITIVE_FIELDS, frozenset)
+    assert SAFE_PRIMITIVE_FIELDS, "SAFE_PRIMITIVE_FIELDS must not be empty"
+    assert all(isinstance(name, str) and name for name in SAFE_PRIMITIVE_FIELDS)
+
+
+def test_redaction_rules_describe_real_categories() -> None:
+    """Each redaction entry must come with a non-empty rationale."""
+    assert REDACTION_RULES, "REDACTION_RULES must not be empty"
+    for key, value in REDACTION_RULES.items():
+        assert isinstance(key, str) and key
+        assert isinstance(value, str) and value

--- a/tests/unit/telemetry/test_share_off_by_default.py
+++ b/tests/unit/telemetry/test_share_off_by_default.py
@@ -1,0 +1,171 @@
+"""Presence-or-absence proof: nothing is sent without explicit share consent.
+
+This integration test asserts the package's invariant for RFC #1719:
+when ``share_with_maintainer`` is unset, the package never reaches the
+network on the maintainer-share path, regardless of whether the
+operator-controlled DSN is unset, set to a syntactically valid URL, or
+set to an explicitly bad value.
+
+The proof is two complementary checks:
+
+* ``is_sharing_with_maintainer`` returns ``False`` for every
+  configuration where the consent flag is unset.
+* The side-channel transport is intercepted with ``respx``; no request
+  passes through it across the same configurations, even when an event
+  is explicitly emitted to exercise the boundary.
+
+The existing operator-controlled telemetry (the ``BERNSTEIN_TELEMETRY_DSN``
+side channel) keeps its own behaviour: events queued for that path are
+the operator's choice. The guarantee here is specifically that the
+foundation does not silently add a maintainer-bound transmission.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.observability import sidechannel
+from bernstein.core.telemetry import consent
+
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Provide an isolated XDG config root + clean env for each scenario."""
+    xdg = tmp_path / "xdg-config"
+    xdg.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    monkeypatch.delenv("BERNSTEIN_TELEMETRY_SHARE", raising=False)
+    sidechannel.clear_preview()
+    sidechannel.reset_sidechannel()
+    yield tmp_path
+    sidechannel.reset_sidechannel()
+    sidechannel.clear_preview()
+
+
+@pytest.mark.parametrize(
+    "dsn_value",
+    [
+        None,  # no DSN at all
+        "not-a-valid-dsn",  # explicitly-bad DSN
+        "://missing-key@host/1",  # syntactically wrong DSN
+    ],
+    ids=["no_dsn", "bad_dsn_string", "bad_dsn_shape"],
+)
+def test_share_flag_off_by_default_blocks_sends(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dsn_value: str | None,
+) -> None:
+    """Without share_with_maintainer, no HTTP call is made on the share path."""
+    if dsn_value is None:
+        monkeypatch.delenv(sidechannel.DSN_ENV, raising=False)
+    else:
+        monkeypatch.setenv(sidechannel.DSN_ENV, dsn_value)
+
+    # Sanity: the resolved consent flag is off and ``DEFAULT`` is the source.
+    state = consent.resolve_share(home=isolated_home)
+    assert state.enabled is False
+    assert state.source is consent.ShareSource.DEFAULT
+    assert consent.is_sharing_with_maintainer(home=isolated_home) is False
+
+    # Intercept every outbound HTTP call. ``assert_all_mocked=True`` (the
+    # default) raises if any unmocked request escapes the test boundary, so
+    # a future regression that adds a hidden default URL fails loudly.
+    with respx.mock(assert_all_called=False) as mock:
+        # No route is registered. Any request goes to the catch-all and is
+        # recorded so we can assert zero calls.
+        catch_all = mock.route().respond(status_code=204)
+
+        # Exercise the side-channel emit boundary: with no share consent,
+        # the package must not produce a maintainer-bound request even when
+        # the operator's own DSN is broken or absent.
+        sidechannel.emit(category="run", message="presence-or-absence proof")
+
+        sink = sidechannel.get_sidechannel()
+        # Drain whatever the operator-controlled sink would do; under
+        # ``NullSideChannel`` this is a no-op. Under a parsed-but-broken
+        # DSN the worker may attempt a delivery; ``respx`` records every
+        # such attempt so we can assert below.
+        sink.flush(deadline_seconds=0.2)
+
+        # No request is permitted on the maintainer-share path. The
+        # operator-controlled DSN path may produce its own traffic when a
+        # parseable DSN is set; we constrain that path separately by
+        # routing through ``respx`` and checking that no request was
+        # actually sent because every DSN in this parametrisation is
+        # either absent or unparseable.
+        assert catch_all.called is False, (
+            f"share path leaked a request despite share_with_maintainer=False "
+            f"and DSN={dsn_value!r}; calls={catch_all.call_count}"
+        )
+
+
+def test_share_flag_off_by_default_no_consent_file_written(
+    isolated_home: Path,
+) -> None:
+    """Resolving consent must not create the TOML file as a side effect."""
+    consent.resolve_share(home=isolated_home)
+    assert not consent.consent_file_path(home=isolated_home).exists()
+
+
+def test_share_flag_explicit_env_off_overrides_file(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BERNSTEIN_TELEMETRY_SHARE=0 forces off even when the file says true."""
+    consent.write_share_flag(True, home=isolated_home)
+    monkeypatch.setenv("BERNSTEIN_TELEMETRY_SHARE", "0")
+    state = consent.resolve_share(home=isolated_home)
+    assert state.enabled is False
+    assert state.source is consent.ShareSource.ENV
+
+
+def test_share_flag_do_not_track_wins_over_everything(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DO_NOT_TRACK=1 wins over file=true and env=on."""
+    consent.write_share_flag(True, home=isolated_home)
+    monkeypatch.setenv("BERNSTEIN_TELEMETRY_SHARE", "1")
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    state = consent.resolve_share(home=isolated_home)
+    assert state.enabled is False
+    assert state.source is consent.ShareSource.DO_NOT_TRACK
+
+
+def test_share_flag_no_default_endpoint_in_consent_module() -> None:
+    """The consent module must not bake in a default maintainer URL.
+
+    The RFC explicitly forbids a hardcoded maintainer endpoint in this PR;
+    this assertion catches an accidental string literal that would defeat
+    the contract.
+    """
+    import inspect
+
+    source = inspect.getsource(consent)
+    forbidden_fragments = ("https://", "http://")
+    offenders = [fragment for fragment in forbidden_fragments if fragment in source]
+    assert not offenders, f"Consent module must not contain a default maintainer endpoint URL. Found: {offenders}"
+
+
+def test_respx_intercepts_outbound_calls_when_share_off(
+    isolated_home: Path,
+) -> None:
+    """Sanity: respx is wired up correctly and intercepts httpx calls.
+
+    Without this, the assertion above (``catch_all.called is False``) would
+    pass trivially. Keep an independent check that respx is the live
+    transport during the test so a future config drift cannot hide the
+    real signal.
+    """
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.route().respond(status_code=204)
+        with httpx.Client() as client:
+            client.post("https://example.test/canary", content=b"x")
+        assert route.called is True


### PR DESCRIPTION
## Summary

Lands the foundation for the consent surface described in RFC #1719.
Operator-controlled telemetry (the existing `BERNSTEIN_TELEMETRY_DSN`
side channel and `core/telemetry/client.py`) is unchanged. The shipped
package still hardcodes no maintainer endpoint URL.

This PR ships only the bits that hold regardless of the eventual
consent-posture choice (Option A vs B vs C). The community discussion
stays open.

## What this adds

**CLI** under `bernstein telemetry`:

- `enable --share-with-maintainer` prints the full event schema and redaction list, requires confirmation, then writes `share_with_maintainer = true` to `$XDG_CONFIG_HOME/bernstein/telemetry.toml`.
- `disable` reverts the flag.
- `status` grows new lines covering the share flag value, its source provenance, and the resolved DSN.
- `tail [-n N]` prints the most recent rendered events from a new in-process side-channel preview ring buffer, so operators can audit the stream offline before flipping the flag.

**Docs** at `docs/observability/telemetry-share.md`:

- Env-var and TOML precedence (DO_NOT_TRACK, BERNSTEIN_TELEMETRY_SHARE).
- The exact schema and redaction list.
- How to audit offline via `bernstein telemetry tail`.
- Three equivalent ways to revoke.
- Linked from `docs/observability/side-channel.md`.

**Schema guard** at `tests/unit/telemetry/test_event_schema_guard.py`:

- Introspects every Payload dataclass in `core/telemetry/events.py`.
- Fails the build if any field lacks an entry in `SAFE_PRIMITIVE_FIELDS` or `REDACTION_RULES`.
- Also fails if a new Payload class is added without registering it.

**Presence-or-absence proof** at `tests/unit/telemetry/test_share_off_by_default.py`:

- Asserts no HTTP call passes through `respx` on the maintainer-share path with `share_with_maintainer` unset, parametrised across three DSN states: unset, syntactically invalid, broken-shape.
- Covers env precedence (`BERNSTEIN_TELEMETRY_SHARE=0`, `DO_NOT_TRACK=1`).
- Independent canary inside the test confirms `respx` is the live transport so the assertion cannot pass trivially.
- Asserts the consent module contains no `https://` / `http://` literal.

## What this does not do

- Does not define a maintainer endpoint URL.
- Does not change the existing telemetry pipeline.
- Does not flip the flag for any operator. Default stays off.
- Does not pick a consent posture; that stays in the RFC discussion.

## Test plan

- [x] `uv run pytest tests/unit/telemetry/ -q`
- [x] `uv run pytest tests/unit/observability/test_no_hardcoded_infra.py -q`
- [x] `uv run pytest tests/unit/observability/test_sidechannel.py -q`
- [x] `uv run ruff check` clean on changed files
- [x] `uv run ruff format --check` clean on changed files
- [x] `uv run bernstein agents-md sync` no-op (no new top-level CLI group)
- [ ] CI green
- [ ] Manual smoke: `bernstein telemetry enable --share-with-maintainer` prints the disclosure and writes the TOML on confirm
- [ ] Manual smoke: `bernstein telemetry tail` returns helpful empty message when the preview buffer is empty

Refs #1719