### PR TITLE
style(autofix): clear 3 refurb alerts in tier3.py

### DIFF
--- a/src/bernstein/core/autofix/tier3.py
+++ b/src/bernstein/core/autofix/tier3.py
@@ -272,7 +272,7 @@ class Tier3Config:
         :data:`ENV_OPENROUTER_BASE_URL` then :data:`ENV_OPENAI_BASE_URL`;
         the shipped wheel never bakes a default hostname.
         """
-        source: dict[str, str] = dict(os.environ) if env is None else dict(env)
+        source: dict[str, str] = os.environ.copy() if env is None else dict(env)
         self_drive = source.get(ENV_SELF_DRIVE, "").strip().lower()
         promote = source.get(ENV_PROMOTE_FROM_SHADOW, "").strip() == "1"
         base_url = source.get(ENV_OPENROUTER_BASE_URL, "").strip() or source.get(ENV_OPENAI_BASE_URL, "").strip()
@@ -513,8 +513,7 @@ def extract_paths_from_unified_diff(diff: str) -> tuple[str, ...]:
                 # Rename: both sides must pass the cordon so a
                 # cordoned file cannot be moved out of the cordon (and
                 # a follow-up patch then bypasses the check).
-                paths.append(pending_old)
-                paths.append(new_path)
+                paths.extend((pending_old, new_path))
             else:
                 # Addition or in-place modification: the old and new
                 # paths agree (or the old side is absent), so a single
@@ -789,7 +788,7 @@ class Tier3Runner:
             )
 
         assert self.recurrence_tracker is not None  # populated in __post_init__
-        now_ts = float(self.clock())
+        now_ts = self.clock()
 
         # 4. recurrence detection - same class + nodeid fixed too often.
         if self.recurrence_tracker.should_escalate(


### PR DESCRIPTION
Three safe rewrites in `tier3.py`: FURB123 → `os.environ.copy()`, FURB113 → `paths.extend((...))`, FURB123 → drop redundant `float()` around already-float `self.clock()`. Sibling alerts dismissed with technical justification (stale + readability nit + `yaml.safe_load` false positive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code paths for improved performance and maintainability in configuration and timestamp handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->