### PR TITLE
fix(ci): main-red - git_context Path join + mcp_cmd test expectation

### DIFF
--- a/src/bernstein/core/git/git_context.py
+++ b/src/bernstein/core/git/git_context.py
@@ -42,7 +42,11 @@ def _run_git(args: list[str], cwd: Path, *, timeout: int = 10) -> str | None:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     except (subprocess.TimeoutExpired, OSError) as exc:
-        args_str = " ".join(args)
+        # Defensive str() per element: callers pass Path objects in the
+        # argv list (see git log --follow -- <file_path>), and " ".join
+        # raises TypeError on a Path. subprocess.run itself accepts
+        # PathLike entries, so only this debug-log path needs the cast.
+        args_str = " ".join(str(a) for a in args)
         logger.debug("git %s failed: %s", args_str, exc)
     return None
 

--- a/tests/unit/test_mcp_cmd.py
+++ b/tests/unit/test_mcp_cmd.py
@@ -56,7 +56,7 @@ def test_mcp_command_http_mode_runs_sse_server() -> None:
         result = runner.invoke(mcp_server, ["--transport", "http", "--host", "0.0.0.0", "--port", "9999"])
 
     assert result.exit_code == 0
-    mock_sse.assert_called_once_with(server_url="http://localhost:8052", host="0.0.0.0", port=9999)
+    mock_sse.assert_called_once_with(server_url="http://localhost:8052", host="0.0.0.0", port=9999, tier=None)
 
 
 def test_mcp_list_shows_bundled_marketplace_entries() -> None:


### PR DESCRIPTION
Two test failures on main HEAD (`e9ae24b2`):

1. `_run_git` raised `TypeError: sequence item 6: expected str instance, PosixPath found` in the OSError debug-log path. Callers like `git log --follow -- <file_path>` pass Path objects in the argv list. Cast per-element with `str()` in the debug log only - this is the same recurring regression after refurb passes.

2. `test_mcp_command_http_mode_runs_sse_server` asserted `run_sse` was called without `tier=None`. #1715 added the kwarg; the test was not updated.

Local pytest: 3 git tests + the mcp_cmd test all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential error when git operations involve path-like objects in debug logging.

* **Tests**
  * Updated test assertions for HTTP-mode server validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->