### PR TITLE
feat(adapters): dual-binary discovery for antigravity / gemini migration

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -106,7 +106,7 @@ alwaysApply: false
 | `droid.py`                 | Droid (Factory AI) CLI adapter |
 | `env_isolation.py`         | Environment variable isolation for spawned agents |
 | `forge.py`                 | Forge CLI adapter |
-| `gemini.py`                | Google Gemini CLI adapter |
+| `gemini.py`                | Google Gemini / Antigravity CLI adapter |
 | `generic.py`               | Generic CLI adapter for arbitrary coding agent CLIs |
 | `goose.py`                 | Goose CLI adapter for Bernstein |
 | `gptme.py`                 | gptme CLI adapter |

--- a/.goosehints
+++ b/.goosehints
@@ -107,7 +107,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `droid.py`                 | Droid (Factory AI) CLI adapter |
 | `env_isolation.py`         | Environment variable isolation for spawned agents |
 | `forge.py`                 | Forge CLI adapter |
-| `gemini.py`                | Google Gemini CLI adapter |
+| `gemini.py`                | Google Gemini / Antigravity CLI adapter |
 | `generic.py`               | Generic CLI adapter for arbitrary coding agent CLIs |
 | `goose.py`                 | Goose CLI adapter for Bernstein |
 | `gptme.py`                 | gptme CLI adapter |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `droid.py`                 | Droid (Factory AI) CLI adapter |
 | `env_isolation.py`         | Environment variable isolation for spawned agents |
 | `forge.py`                 | Forge CLI adapter |
-| `gemini.py`                | Google Gemini CLI adapter |
+| `gemini.py`                | Google Gemini / Antigravity CLI adapter |
 | `generic.py`               | Generic CLI adapter for arbitrary coding agent CLIs |
 | `goose.py`                 | Goose CLI adapter for Bernstein |
 | `gptme.py`                 | gptme CLI adapter |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `droid.py`                 | Droid (Factory AI) CLI adapter |
 | `env_isolation.py`         | Environment variable isolation for spawned agents |
 | `forge.py`                 | Forge CLI adapter |
-| `gemini.py`                | Google Gemini CLI adapter |
+| `gemini.py`                | Google Gemini / Antigravity CLI adapter |
 | `generic.py`               | Generic CLI adapter for arbitrary coding agent CLIs |
 | `goose.py`                 | Goose CLI adapter for Bernstein |
 | `gptme.py`                 | gptme CLI adapter |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -107,7 +107,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `droid.py`                 | Droid (Factory AI) CLI adapter |
 | `env_isolation.py`         | Environment variable isolation for spawned agents |
 | `forge.py`                 | Forge CLI adapter |
-| `gemini.py`                | Google Gemini CLI adapter |
+| `gemini.py`                | Google Gemini / Antigravity CLI adapter |
 | `generic.py`               | Generic CLI adapter for arbitrary coding agent CLIs |
 | `goose.py`                 | Goose CLI adapter for Bernstein |
 | `gptme.py`                 | gptme CLI adapter |

--- a/docs/adapters/antigravity.md
+++ b/docs/adapters/antigravity.md
@@ -1,0 +1,154 @@
+# `antigravity` / `gemini` adapter - Google CLI (dual-binary)
+
+Bernstein's adapter for the Google CLI. The upstream CLI is changing
+binary names ahead of a deprecation date: the legacy `gemini` binary
+stops serving free / AI Pro / Ultra subscribers on **2026-06-18**, and
+the replacement `antigravity` binary carries the same model set and
+the same `--output-format` semantics forward. Enterprise customers on
+Standard or Enterprise licenses retain the legacy binary via paid
+Gemini Enterprise Agent Platform API keys.
+
+The adapter is **dual-binary aware**. At spawn time it discovers which
+binary is on `PATH` and uses whichever the operator has installed. The
+adapter contract (flags passed, env-isolation allow-list, sandbox
+profile, network policy, rate-limit meter) is identical on either
+binary; only the discovered binary name and the discovery step differ.
+
+The same adapter is registered under two registry keys:
+
+* `gemini` - back-compat for existing routines and operator muscle
+  memory.
+* `antigravity` - so `bernstein adapters check antigravity` and
+  `bernstein run --cli antigravity ...` work the moment the new binary
+  is on `PATH`.
+
+---
+
+## Discovery cascade
+
+The cascade is deterministic and runs every time the adapter spawns:
+
+1. **Operator override.** If `BERNSTEIN_GEMINI_BINARY` is set and
+   non-empty, that binary is used. If it does not resolve on `PATH`
+   the adapter raises `BinaryNotInstalledError` and exits.
+2. **Prefer the new binary.** `antigravity` is checked next. If it
+   resolves on `PATH`, it is used.
+3. **Fall back to the legacy binary.** `gemini` is checked. If it
+   resolves on `PATH`, it is used (operator on the transition path
+   who has not migrated yet, or an Enterprise license holder).
+4. **Hard error.** If none of the above resolves, the adapter raises
+   `BinaryNotInstalledError` with a message naming both expected
+   binaries and the override env var.
+
+The cascade is implemented in
+`bernstein.adapters.gemini.resolve_google_cli_binary` and is covered
+by `tests/unit/test_adapter_gemini.py::TestBinaryDiscoveryCascade`.
+
+---
+
+## Install paths
+
+### `antigravity` (recommended; required for free / Pro / Ultra after
+2026-06-18)
+
+The Antigravity CLI is a Go binary distributed via an upstream
+installer. Follow the official transition notice for the current
+install command for your platform:
+
+* Transition notice:
+  <https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/>
+
+After installing, run `antigravity auth` to populate the system
+keyring; on a headless / SSH host the CLI falls back to a URL flow.
+
+> **Operator note.** Bernstein does not ship any installer URL inside
+> the package. Operators install the binary from the upstream
+> installer of their choice and Bernstein discovers whatever is on
+> `PATH`.
+
+### `gemini` (legacy; Enterprise-only after 2026-06-18)
+
+```bash
+npm install -g @google/gemini-cli
+gemini auth
+```
+
+The legacy binary keeps working for operators on Enterprise licenses
+with paid Gemini Enterprise Agent Platform API keys. Free / AI Pro /
+Ultra subscribers should migrate to `antigravity` before 2026-06-18.
+
+---
+
+## Operator override
+
+For non-default install paths (vendored binary, pre-release build,
+shadow install under a custom name) set `BERNSTEIN_GEMINI_BINARY`:
+
+```bash
+export BERNSTEIN_GEMINI_BINARY=/opt/google/antigravity/bin/antigravity
+bernstein adapters check antigravity
+```
+
+The override accepts either an absolute path or a bare binary name
+that resolves on `PATH`. Blank / whitespace-only values are treated
+as unset.
+
+---
+
+## Verifying the install
+
+```bash
+# Confirm the binary is discoverable.
+bernstein adapters check antigravity
+
+# When only the legacy binary is on PATH this still reports useful
+# information for the operator, even though the registry key is the
+# new name.
+bernstein adapters check gemini
+```
+
+A passing row shows the binary path, the captured `--version` line,
+and `conformance: ok` (meaning `--help` advertised every flag the
+adapter relies on: `-p`, `-m`, `--output-format`, `--yolo`).
+
+---
+
+## Models
+
+The model set is identical on either binary:
+
+| Model | Notes |
+|---|---|
+| `gemini-3.1-pro` | Highest reasoning. |
+| `gemini-3-flash` | Default in the Gemini app, Pro-grade reasoning at Flash speed. |
+| `gemini-3.1-flash-lite` | Cheapest tier. |
+
+No Anthropic models are available through this binary. Operators who
+want Claude continue using the existing `claude` adapter.
+
+---
+
+## What is not changing
+
+* The adapter passes the same command line on either binary:
+  `-p`, `-m`, `--output-format`, `--yolo`.
+* The env-isolation allow-list still scopes the spawned process to
+  `GOOGLE_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_CLOUD_PROJECT`,
+  `GOOGLE_APPLICATION_CREDENTIALS`.
+* The rate-limit meter still labels upstream pressure under
+  `google_generative_language`.
+* The strategy declaration in
+  `bernstein.adapters._contract.STRATEGY_MATRIX` is identical for both
+  registry keys: `resume=UNSUPPORTED`,
+  `dangerous_mode=CLI_FLAG`, `event_channel=STREAM_JSON`.
+
+---
+
+## Migration checklist
+
+1. Install `antigravity` from the upstream installer.
+2. Run `antigravity auth` to populate the system keyring.
+3. Run `bernstein adapters check antigravity` and confirm the row
+   reports the binary path and `conformance: ok`.
+4. Optionally uninstall the legacy `gemini` binary. The adapter
+   handles either ordering.

--- a/docs/adapters/gemini.md
+++ b/docs/adapters/gemini.md
@@ -1,0 +1,6 @@
+# `gemini` adapter
+
+The `gemini` adapter is dual-binary aware. The upstream CLI is changing
+binary names ahead of a 2026-06-18 deprecation: see
+[`antigravity.md`](antigravity.md) for install paths, the discovery
+cascade, and the operator override.

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -500,6 +500,15 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
         dangerous_mode=DangerousModeStrategy.CLI_FLAG,
         event_channel=EventChannel.STREAM_JSON,
     ),
+    # Antigravity is the upstream rename of the Gemini CLI binary
+    # (transition deadline 2026-06-18 for free / Pro / Ultra). Same
+    # strategy on every axis - it is the same adapter, only the
+    # discovered binary name differs.
+    "antigravity": AdapterStrategy(
+        resume=ResumeStrategy.UNSUPPORTED,
+        dangerous_mode=DangerousModeStrategy.CLI_FLAG,
+        event_channel=EventChannel.STREAM_JSON,
+    ),
     # CLI-flag dangerous mode, text-signal channel, fresh-session resume.
     "cline": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
     "charm": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -76,7 +76,7 @@ class BinaryNotInstalledError(SpawnError):
 
 def resolve_google_cli_binary(
     *,
-    which: Any = shutil.which,
+    which: Any = None,
     env: dict[str, str] | None = None,
 ) -> str:
     """Resolve the Google CLI binary to invoke for this adapter.
@@ -98,9 +98,12 @@ def resolve_google_cli_binary(
             cascade entry resolves.
     """
     source_env = env if env is not None else os.environ
+    # Resolve ``shutil.which`` at call time so tests that patch
+    # ``bernstein.adapters.gemini.shutil.which`` see the swap.
+    resolver = which if which is not None else shutil.which
     override = (source_env.get(BINARY_ENV_VAR) or "").strip()
     if override:
-        if which(override) is None:
+        if resolver(override) is None:
             raise BinaryNotInstalledError(
                 f"{BINARY_ENV_VAR}={override!r} but {override!r} is not on PATH. "
                 f"Unset {BINARY_ENV_VAR} to fall back to discovery, or install the binary."
@@ -108,7 +111,7 @@ def resolve_google_cli_binary(
         return override
 
     for candidate in _DISCOVERY_CASCADE:
-        if which(candidate) is not None:
+        if resolver(candidate) is not None:
             return candidate
 
     raise BinaryNotInstalledError(
@@ -263,8 +266,8 @@ class GeminiAdapter(CLIAdapter):
 __all__ = [
     "ANTIGRAVITY_BINARY",
     "BINARY_ENV_VAR",
+    "LEGACY_GEMINI_BINARY",
     "BinaryNotInstalledError",
     "GeminiAdapter",
-    "LEGACY_GEMINI_BINARY",
     "resolve_google_cli_binary",
 ]

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -1,31 +1,126 @@
-"""Google Gemini CLI adapter.
+"""Google Gemini / Antigravity CLI adapter.
 
-Last verified against upstream @google/gemini-cli 0.40.x on 2026-05-05.
-Install: ``npm install -g @google/gemini-cli``.  Recommended models:
-``gemini-3.1-pro`` (highest reasoning), ``gemini-3-flash`` (default in the
-Gemini app, Pro-grade reasoning at Flash speed), or ``gemini-3.1-flash-lite``
-for the cheapest tier.
+The upstream CLI is changing binary names ahead of a deprecation date:
+the legacy ``gemini`` binary stops serving free / AI Pro / Ultra
+subscribers on 2026-06-18; the replacement ``antigravity`` binary uses
+the same model set and the same ``--output-format`` semantics.
+Enterprise customers retain the legacy binary via paid API keys.
+
+The adapter is dual-binary aware. At spawn time it discovers which
+binary is on ``PATH`` using a deterministic cascade:
+
+1. The operator override ``BERNSTEIN_GEMINI_BINARY`` wins when set.
+2. Otherwise ``antigravity`` is preferred.
+3. The legacy ``gemini`` binary is used as a fallback.
+4. If neither resolves, the adapter raises
+   :class:`BinaryNotInstalledError`.
+
+The adapter contract (flags, env-isolation allow-list, sandbox
+profile, rate-limit meter, network policy) is unchanged: only the
+binary name and the discovery step differ.
+
+Recommended models (identical on both binaries):
+``gemini-3.1-pro`` (highest reasoning), ``gemini-3-flash`` (default in
+the Gemini app, Pro-grade reasoning at Flash speed), or
+``gemini-3.1-flash-lite`` for the cheapest tier.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.base import (
+    DEFAULT_TIMEOUT_SECONDS,
+    CLIAdapter,
+    SpawnError,
+    SpawnResult,
+    build_worker_cmd,
+)
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
 
 logger = logging.getLogger(__name__)
 
+#: Operator override env var for the binary name. Takes precedence over
+#: the cascade so operators on a non-default install path do not have to
+#: rely on ``PATH`` ordering.
+BINARY_ENV_VAR: str = "BERNSTEIN_GEMINI_BINARY"
+
+#: Replacement binary shipped by the upstream CLI rename.
+ANTIGRAVITY_BINARY: str = "antigravity"
+
+#: Legacy binary name, retained for operators still on the deprecated
+#: install path or on a paid Enterprise license.
+LEGACY_GEMINI_BINARY: str = "gemini"
+
+#: Discovery cascade in priority order. ``antigravity`` first; the
+#: legacy binary as fallback.
+_DISCOVERY_CASCADE: tuple[str, ...] = (ANTIGRAVITY_BINARY, LEGACY_GEMINI_BINARY)
+
+
+class BinaryNotInstalledError(SpawnError):
+    """Raised when neither ``antigravity`` nor ``gemini`` resolves on ``PATH``.
+
+    The message lists both expected binaries and the override env var so
+    the operator-facing error is self-explanatory without consulting the
+    docs.
+    """
+
+
+def resolve_google_cli_binary(
+    *,
+    which: Any = shutil.which,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Resolve the Google CLI binary to invoke for this adapter.
+
+    Args:
+        which: Callable matching :func:`shutil.which`. Tests override
+            this to simulate ``PATH`` contents without touching the
+            real filesystem.
+        env: Environment mapping to consult for
+            :data:`BINARY_ENV_VAR`. Defaults to :data:`os.environ`.
+
+    Returns:
+        The binary name to invoke. Operator override (when set and
+        non-empty) wins. Otherwise the first cascade entry that
+        resolves on ``PATH`` is returned.
+
+    Raises:
+        BinaryNotInstalledError: When neither the override nor any
+            cascade entry resolves.
+    """
+    source_env = env if env is not None else os.environ
+    override = (source_env.get(BINARY_ENV_VAR) or "").strip()
+    if override:
+        if which(override) is None:
+            raise BinaryNotInstalledError(
+                f"{BINARY_ENV_VAR}={override!r} but {override!r} is not on PATH. "
+                f"Unset {BINARY_ENV_VAR} to fall back to discovery, or install the binary."
+            )
+        return override
+
+    for candidate in _DISCOVERY_CASCADE:
+        if which(candidate) is not None:
+            return candidate
+
+    raise BinaryNotInstalledError(
+        "Neither 'antigravity' nor 'gemini' was found on PATH. "
+        "Install the Antigravity CLI (per docs/adapters/antigravity.md), "
+        "or set "
+        f"{BINARY_ENV_VAR}=<path-or-name> to override discovery."
+    )
+
 
 class GeminiAdapter(CLIAdapter):
-    """Spawn and monitor Google Gemini CLI sessions."""
+    """Spawn and monitor Google Gemini / Antigravity CLI sessions."""
 
     external_endpoints = (("generativelanguage.googleapis.com", 443),)
     # Google Generative Language returns HTTP 429 with status
@@ -51,11 +146,14 @@ class GeminiAdapter(CLIAdapter):
 
         api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
         if not api_key:
-            # Gemini CLI supports OAuth auth without API keys — this is just informational
+            # Both binaries support keyring / OAuth auth without API
+            # keys - this is just informational.
             logger.debug("GeminiAdapter: no GOOGLE_API_KEY/GEMINI_API_KEY set (using OAuth)")
 
+        binary = resolve_google_cli_binary()
+
         cmd = [
-            "gemini",
+            binary,
             "-p",
             prompt,
             "-m",
@@ -100,12 +198,13 @@ class GeminiAdapter(CLIAdapter):
                 )
             except FileNotFoundError as exc:
                 raise RuntimeError(
-                    "gemini not found in PATH. Install it with: npm install -g @google/gemini-cli"
+                    f"{binary} not found in PATH. Install the Antigravity CLI "
+                    "or the legacy Gemini CLI; see docs/adapters/antigravity.md."
                 ) from exc
             except PermissionError as exc:
-                raise RuntimeError(f"Permission denied executing gemini: {exc}") from exc
+                raise RuntimeError(f"Permission denied executing {binary}: {exc}") from exc
 
-        self._probe_fast_exit(proc, log_path, provider_name="gemini")
+        self._probe_fast_exit(proc, log_path, provider_name=binary)
 
         result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
         if timeout_seconds > 0:
@@ -159,3 +258,13 @@ class GeminiAdapter(CLIAdapter):
             rate_limit=rate_limit,
             is_active=True,
         )
+
+
+__all__ = [
+    "ANTIGRAVITY_BINARY",
+    "BINARY_ENV_VAR",
+    "BinaryNotInstalledError",
+    "GeminiAdapter",
+    "LEGACY_GEMINI_BINARY",
+    "resolve_google_cli_binary",
+]

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -79,6 +79,11 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "devin_terminal": DevinTerminalAdapter,
     "droid": DroidAdapter,
     "forge": ForgeAdapter,
+    # The Google CLI ships under two binary names during the 2026-06-18
+    # transition. Both registry keys resolve to the same dual-binary aware
+    # adapter; the adapter discovers ``antigravity`` first on PATH and falls
+    # back to ``gemini`` (or honours BERNSTEIN_GEMINI_BINARY) at spawn time.
+    "antigravity": GeminiAdapter,
     "gemini": GeminiAdapter,
     "generic": GenericAdapter,
     "goose": GooseAdapter,

--- a/templates/capabilities/adapters.yaml
+++ b/templates/capabilities/adapters.yaml
@@ -17,6 +17,8 @@ tools:
     capabilities: [private_data, external_comm]
   - name: adapter.cloudflare_agents
     capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.antigravity
+    capabilities: [private_data, untrusted_input, external_comm]
   - name: adapter.codex
     capabilities: [private_data, untrusted_input, external_comm]
   - name: adapter.cody

--- a/tests/contract/contracts/antigravity.yaml
+++ b/tests/contract/contracts/antigravity.yaml
@@ -1,0 +1,25 @@
+# Contract for the Google Antigravity CLI (adapter: antigravity).
+#
+# Antigravity is the upstream rename of the Gemini CLI binary. The legacy
+# ``gemini`` binary stops serving free / AI Pro / Ultra subscribers on
+# 2026-06-18; ``antigravity`` carries the same model set and the same
+# ``--output-format`` semantics forward. The flags below mirror
+# ``gemini.yaml`` because the adapter passes the same command line.
+adapter: antigravity
+binary: antigravity
+install:
+  method: shell
+  spec: "antigravity (Go binary; install via the upstream installer documented in docs/adapters/antigravity.md)"
+auth:
+  required_for_help: false
+  required_for_models: false
+  secret_env: "GEMINI_API_KEY"
+required_flags:
+  - "-p"
+  - "-m"
+  - "--output-format"
+  - "--yolo"
+required_subcommands: []
+expected_models:
+  command: []
+  required_present: []

--- a/tests/unit/test_adapter_gemini.py
+++ b/tests/unit/test_adapter_gemini.py
@@ -1,4 +1,12 @@
-"""Unit tests for GeminiAdapter spawn/kill/is_alive."""
+"""Unit tests for GeminiAdapter spawn/kill/is_alive.
+
+Every spawn test is parametrised over both supported binary names
+(``antigravity`` and ``gemini``) so the suite proves the adapter's
+discovery cascade works against either binary. A dedicated
+``TestBinaryDiscoveryCascade`` block exercises the cascade itself:
+both binaries present, only legacy, neither (raises
+:class:`BinaryNotInstalledError`), and the operator override.
+"""
 
 from __future__ import annotations
 
@@ -10,10 +18,22 @@ from unittest.mock import MagicMock, patch
 import pytest
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
-from bernstein.adapters.gemini import GeminiAdapter
+from bernstein.adapters.gemini import (
+    ANTIGRAVITY_BINARY,
+    BINARY_ENV_VAR,
+    LEGACY_GEMINI_BINARY,
+    BinaryNotInstalledError,
+    GeminiAdapter,
+    resolve_google_cli_binary,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+# Parametrisation surface: both supported binary names. Every spawn-side
+# test runs against both so a regression in either path is caught.
+ALL_BINARIES = (ANTIGRAVITY_BINARY, LEGACY_GEMINI_BINARY)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -33,18 +53,31 @@ def _inner_cmd(full_cmd: list[str]) -> list[str]:
     return full_cmd[sep + 1 :]
 
 
+def _which_only(binary: str) -> object:
+    """Return a ``shutil.which`` stub that resolves only ``binary``."""
+
+    def stub(name: str) -> str | None:
+        return f"/usr/local/bin/{name}" if name == binary else None
+
+    return stub
+
+
 # ---------------------------------------------------------------------------
-# GeminiAdapter.spawn() — command construction
+# GeminiAdapter.spawn() - command construction, parametrised on binary name
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("binary", ALL_BINARIES)
 class TestGeminiAdapterSpawn:
-    """GeminiAdapter.spawn() builds correct command."""
+    """GeminiAdapter.spawn() builds correct command on each supported binary."""
 
-    def test_wrapped_with_worker(self, tmp_path: Path) -> None:
+    def test_wrapped_with_worker(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=100)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="fix the bug",
                 workdir=tmp_path,
@@ -55,12 +88,15 @@ class TestGeminiAdapterSpawn:
         assert cmd[0] == sys.executable
         assert cmd[1:3] == ["-m", "bernstein.core.orchestration.worker"]
         inner = _inner_cmd(cmd)
-        assert inner[0] == "gemini"
+        assert inner[0] == binary
 
-    def test_model_flag_passthrough(self, tmp_path: Path) -> None:
+    def test_model_flag_passthrough(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=101)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -71,10 +107,13 @@ class TestGeminiAdapterSpawn:
         assert "-m" in inner
         assert inner[inner.index("-m") + 1] == "gemini-3-flash"
 
-    def test_output_format_json_flag(self, tmp_path: Path) -> None:
+    def test_output_format_json_flag(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=102)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -85,10 +124,13 @@ class TestGeminiAdapterSpawn:
         assert "--output-format" in inner
         assert inner[inner.index("--output-format") + 1] == "json"
 
-    def test_prompt_flag_used(self, tmp_path: Path) -> None:
+    def test_prompt_flag_used(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=103)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="my-unique-prompt",
                 workdir=tmp_path,
@@ -99,10 +141,13 @@ class TestGeminiAdapterSpawn:
         assert "-p" in inner
         assert inner[inner.index("-p") + 1] == "my-unique-prompt"
 
-    def test_yolo_flag_present(self, tmp_path: Path) -> None:
+    def test_yolo_flag_present(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=108)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -112,10 +157,13 @@ class TestGeminiAdapterSpawn:
         inner = _inner_cmd(popen.call_args.args[0])
         assert "--yolo" in inner
 
-    def test_creates_log_dir(self, tmp_path: Path) -> None:
+    def test_creates_log_dir(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=104)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock):
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock),
+        ):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -124,10 +172,13 @@ class TestGeminiAdapterSpawn:
             )
         assert (tmp_path / ".sdd" / "runtime").is_dir()
 
-    def test_spawn_result_pid(self, tmp_path: Path) -> None:
+    def test_spawn_result_pid(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=105)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock):
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock),
+        ):
             result = adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -136,10 +187,13 @@ class TestGeminiAdapterSpawn:
             )
         assert result.pid == 105
 
-    def test_log_path_uses_session_id(self, tmp_path: Path) -> None:
+    def test_log_path_uses_session_id(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=106)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock):
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock),
+        ):
             result = adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -148,10 +202,13 @@ class TestGeminiAdapterSpawn:
             )
         assert result.log_path.name == "my-gemini-session.log"
 
-    def test_start_new_session_enabled(self, tmp_path: Path) -> None:
+    def test_start_new_session_enabled(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=107)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -163,14 +220,15 @@ class TestGeminiAdapterSpawn:
 
 
 # ---------------------------------------------------------------------------
-# spawn() — env isolation
+# spawn() - env isolation, parametrised on binary name
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("binary", ALL_BINARIES)
 class TestGeminiEnvIsolation:
     """spawn() passes only Google-specific keys to subprocess."""
 
-    def test_env_contains_google_keys(self, tmp_path: Path) -> None:
+    def test_env_contains_google_keys(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=200)
         with (
@@ -180,6 +238,7 @@ class TestGeminiEnvIsolation:
                 {"GOOGLE_API_KEY": "AIza-test", "GOOGLE_CLOUD_PROJECT": "my-proj", "PATH": "/usr/bin"},
                 clear=True,
             ),
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
         ):
             adapter.spawn(
                 prompt="hello",
@@ -191,7 +250,7 @@ class TestGeminiEnvIsolation:
         assert "GOOGLE_API_KEY" in env
         assert env["GOOGLE_API_KEY"] == "AIza-test"
 
-    def test_env_excludes_unrelated_keys(self, tmp_path: Path) -> None:
+    def test_env_excludes_unrelated_keys(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=201)
         with (
@@ -207,6 +266,7 @@ class TestGeminiEnvIsolation:
                 },
                 clear=True,
             ),
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
         ):
             adapter.spawn(
                 prompt="hello",
@@ -219,12 +279,13 @@ class TestGeminiEnvIsolation:
         assert "OPENAI_API_KEY" not in env
         assert "DATABASE_URL" not in env
 
-    def test_env_includes_path(self, tmp_path: Path) -> None:
+    def test_env_includes_path(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=202)
         with (
             patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
             patch.dict("os.environ", {"PATH": "/usr/bin", "GOOGLE_API_KEY": "AIza-x"}, clear=True),
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
         ):
             adapter.spawn(
                 prompt="hello",
@@ -247,14 +308,16 @@ class TestGeminiAdapterName:
 
 
 # ---------------------------------------------------------------------------
-# Missing binary / PermissionError
+# Missing binary / PermissionError, parametrised on binary name
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize("binary", ALL_BINARIES)
 class TestGeminiSpawnMissingBinary:
-    def test_file_not_found_raises_runtime_error(self, tmp_path: Path) -> None:
+    def test_file_not_found_raises_runtime_error(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
             patch(
                 "bernstein.adapters.gemini.subprocess.Popen",
                 side_effect=FileNotFoundError("No such file"),
@@ -268,9 +331,10 @@ class TestGeminiSpawnMissingBinary:
                 session_id="missing",
             )
 
-    def test_permission_error_raises_runtime_error(self, tmp_path: Path) -> None:
+    def test_permission_error_raises_runtime_error(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         with (
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
             patch(
                 "bernstein.adapters.gemini.subprocess.Popen",
                 side_effect=PermissionError("Permission denied"),
@@ -285,13 +349,20 @@ class TestGeminiSpawnMissingBinary:
             )
 
 
+@pytest.mark.parametrize("binary", ALL_BINARIES)
 class TestGeminiWarnings:
-    def test_logs_debug_when_no_api_key_present(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    def test_logs_debug_when_no_api_key_present(
+        self,
+        tmp_path: Path,
+        binary: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=301)
         with (
             patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock),
             patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
             caplog.at_level("DEBUG"),
         ):
             adapter.spawn(
@@ -302,12 +373,13 @@ class TestGeminiWarnings:
             )
         assert "no GOOGLE_API_KEY/GEMINI_API_KEY set" in caplog.text
 
-    def test_populates_gemini_api_key_from_google_key(self, tmp_path: Path) -> None:
+    def test_populates_gemini_api_key_from_google_key(self, tmp_path: Path, binary: str) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=302)
         with (
             patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
             patch.dict("os.environ", {"GOOGLE_API_KEY": "AIza-test", "PATH": "/usr/bin"}, clear=True),
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=_which_only(binary)),
         ):
             adapter.spawn(
                 prompt="hello",
@@ -321,7 +393,68 @@ class TestGeminiWarnings:
 
 
 # ---------------------------------------------------------------------------
-# is_alive() and kill() — inherited from CLIAdapter base
+# Binary discovery cascade (issue #1740)
+# ---------------------------------------------------------------------------
+
+
+class TestBinaryDiscoveryCascade:
+    """Cover the four discovery outcomes the adapter contract promises."""
+
+    def test_antigravity_wins_when_both_present(self) -> None:
+        """When both binaries resolve, ``antigravity`` is preferred."""
+
+        def both_present(name: str) -> str | None:
+            return f"/usr/local/bin/{name}" if name in {ANTIGRAVITY_BINARY, LEGACY_GEMINI_BINARY} else None
+
+        with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
+            assert resolve_google_cli_binary(which=both_present) == ANTIGRAVITY_BINARY
+
+    def test_legacy_wins_when_only_legacy_present(self) -> None:
+        """When only the legacy binary resolves, the cascade falls back."""
+
+        def only_legacy(name: str) -> str | None:
+            return "/usr/local/bin/gemini" if name == LEGACY_GEMINI_BINARY else None
+
+        with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
+            assert resolve_google_cli_binary(which=only_legacy) == LEGACY_GEMINI_BINARY
+
+    def test_neither_raises_binary_not_installed(self) -> None:
+        """When neither resolves the operator gets a typed error."""
+        with (
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            pytest.raises(BinaryNotInstalledError, match="antigravity"),
+        ):
+            resolve_google_cli_binary(which=lambda _name: None)
+
+    def test_env_override_wins_over_cascade(self) -> None:
+        """``BERNSTEIN_GEMINI_BINARY`` short-circuits the cascade."""
+
+        def both_present(name: str) -> str | None:
+            return f"/usr/local/bin/{name}" if name in {"antigravity", "gemini", "vendor-cli"} else None
+
+        with patch.dict("os.environ", {"PATH": "/usr/bin", BINARY_ENV_VAR: "vendor-cli"}, clear=True):
+            assert resolve_google_cli_binary(which=both_present) == "vendor-cli"
+
+    def test_env_override_missing_binary_raises(self) -> None:
+        """An override that does not resolve is a hard error."""
+        with (
+            patch.dict("os.environ", {"PATH": "/usr/bin", BINARY_ENV_VAR: "vendor-cli"}, clear=True),
+            pytest.raises(BinaryNotInstalledError, match=BINARY_ENV_VAR),
+        ):
+            resolve_google_cli_binary(which=lambda _name: None)
+
+    def test_empty_env_override_falls_through_to_cascade(self) -> None:
+        """A blank override behaves as if unset (no surprise pinning)."""
+
+        def only_antigravity(name: str) -> str | None:
+            return "/usr/local/bin/antigravity" if name == ANTIGRAVITY_BINARY else None
+
+        with patch.dict("os.environ", {"PATH": "/usr/bin", BINARY_ENV_VAR: "   "}, clear=True):
+            assert resolve_google_cli_binary(which=only_antigravity) == ANTIGRAVITY_BINARY
+
+
+# ---------------------------------------------------------------------------
+# is_alive() and kill() - inherited from CLIAdapter base
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_adapter_timeouts.py
+++ b/tests/unit/test_adapter_timeouts.py
@@ -204,7 +204,15 @@ class TestAllAdaptersHaveTimeout:
         self._assert_has_timer(CursorAdapter, "bernstein.adapters.cursor.subprocess.Popen", tmp_path)
 
     def test_gemini_has_timer(self, tmp_path: Path) -> None:
-        self._assert_has_timer(GeminiAdapter, "bernstein.adapters.gemini.subprocess.Popen", tmp_path)
+        # GeminiAdapter discovers the binary via shutil.which at spawn time
+        # (dual-binary cascade for the 2026-06-18 transition). Pin the
+        # resolver here so the test passes on a CI runner that has neither
+        # ``antigravity`` nor ``gemini`` installed.
+        with patch(
+            "bernstein.adapters.gemini.shutil.which",
+            side_effect=lambda name: f"/usr/local/bin/{name}" if name in {"antigravity", "gemini"} else None,
+        ):
+            self._assert_has_timer(GeminiAdapter, "bernstein.adapters.gemini.subprocess.Popen", tmp_path)
 
     def test_generic_has_timer(self, tmp_path: Path) -> None:
         self._assert_has_timer(


### PR DESCRIPTION
## Summary

The upstream Google CLI is changing binary names ahead of a 2026-06-18 deprecation date for free / AI Pro / Ultra subscribers (Enterprise customers retain the legacy binary via paid API keys). The adapter is now dual-binary aware and discovers the binary at spawn time using a deterministic cascade.

The adapter contract is unchanged: same flags, same env-isolation allow-list, same sandbox profile, same network policy, same rate-limit meter. Only the binary name and the discovery step differ.

## Discovery cascade

1. `BERNSTEIN_GEMINI_BINARY` override wins when set.
2. `antigravity` is preferred.
3. `gemini` is the fallback.
4. `BinaryNotInstalledError` when neither resolves.

Implemented in `bernstein.adapters.gemini.resolve_google_cli_binary`.

## Acceptance criteria

- [x] `bernstein adapters check antigravity` reports `installed: true, capabilities: <list>` when the new binary is on PATH (verified locally; reports `version_string: 1.107.0`).
- [x] Same call reports the legacy binary when only `gemini` is on PATH (registry registers both keys against the same adapter; legacy row continues to report `conformance: ok` locally).
- [x] `tests/unit/test_adapter_gemini.py` parametrised on the binary name (every spawn-side test runs against both `antigravity` and `gemini`).
- [x] Adapter capability matrix regenerated: `templates/capabilities/adapters.yaml` carries a new `adapter.antigravity` row mirroring `adapter.gemini`, and `STRATEGY_MATRIX` in `_contract.py` declares the same strategy on every axis.
- [x] Tests under `tests/unit/test_adapter_gemini.py` cover the discovery cascade: both binaries present (antigravity wins), only legacy (legacy wins), neither (`BinaryNotInstalledError`), env-var override (set, set-but-missing, blank-falls-through).
- [x] Docs at `docs/adapters/antigravity.md` cover both install paths and the migration deadline; `docs/adapters/gemini.md` carries a one-line back-link.

## Out of scope (per the issue)

- Antigravity plugin authoring (Skills / Hooks / Subagents porting).
- Anthropic model access via Google (not available through this binary).
- Renaming `gemini.py` to a vendor-neutral path.

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_gemini.py -q` (47 passed)
- [x] `uv run pytest tests/unit/adapters/ tests/unit/test_adapter_gemini.py tests/unit/test_adapter_timeouts.py tests/unit/test_adapter_registry.py tests/unit/test_capability_matrix.py -q` (326 passed)
- [x] `uv run pytest tests/unit/cli/ -q` (198 passed, 1 skipped)
- [x] `uv run ruff check` on changed Python files (clean)
- [x] `uv run bernstein adapters check antigravity --format json` returns a populated row with the binary path and capabilities

Closes #1740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for `antigravity` CLI binary with automatic discovery preferring `antigravity` over legacy `gemini`.
  * Environment variable override (`BERNSTEIN_GEMINI_BINARY`) for explicit binary selection.
  * Improved error messaging when required binaries are unavailable.

* **Documentation**
  * Added comprehensive adapter documentation for both Antigravity and Gemini CLI binaries.

* **Tests**
  * Expanded test coverage to validate functionality across both supported CLI binary variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->