### PR TITLE
fix(ci): main-red - antigravity adapter posture + MCP meter envelope

### DIFF
--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -7,13 +7,24 @@ the same model set and the same ``--output-format`` semantics.
 Enterprise customers retain the legacy binary via paid API keys.
 
 The adapter is dual-binary aware. At spawn time it discovers which
-binary is on ``PATH`` using a deterministic cascade:
+binary is on ``PATH`` using a deterministic cascade defined by
+``_DISCOVERY_CASCADE``:
 
-1. The operator override ``BERNSTEIN_GEMINI_BINARY`` wins when set.
+1. The operator override ``BERNSTEIN_GEMINI_BINARY`` wins when set
+   (and must resolve on ``PATH``, regardless of ``strict`` mode).
 2. Otherwise ``antigravity`` is preferred.
 3. The legacy ``gemini`` binary is used as a fallback.
-4. If neither resolves, the adapter raises
-   :class:`BinaryNotInstalledError`.
+4. If neither resolves, behavior depends on the ``strict`` flag
+   passed to :func:`resolve_google_cli_binary`:
+
+   - ``strict=True`` (used by ``bernstein adapters check`` / doctor):
+     the adapter raises :class:`BinaryNotInstalledError`.
+   - ``strict=False`` (default, used by :meth:`GeminiAdapter.spawn`):
+     the resolver returns the first cascade entry as a fallback,
+     letting downstream :func:`subprocess.Popen` raise the natural
+     ``FileNotFoundError`` on actual invocation. This matches the
+     codex / aider adapter posture and keeps tests that mock
+     ``subprocess`` from tripping on eager discovery.
 
 The adapter contract (flags, env-isolation allow-list, sandbox
 profile, rate-limit meter, network policy) is unchanged: only the

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -78,6 +78,7 @@ def resolve_google_cli_binary(
     *,
     which: Any = None,
     env: dict[str, str] | None = None,
+    strict: bool = False,
 ) -> str:
     """Resolve the Google CLI binary to invoke for this adapter.
 
@@ -87,15 +88,27 @@ def resolve_google_cli_binary(
             real filesystem.
         env: Environment mapping to consult for
             :data:`BINARY_ENV_VAR`. Defaults to :data:`os.environ`.
+        strict: When ``True`` (e.g. from ``bernstein adapters check``)
+            raise :class:`BinaryNotInstalledError` if no cascade entry
+            resolves. When ``False`` (default, used by :meth:`spawn`)
+            return the first cascade entry as a fallback so the
+            downstream :func:`subprocess.Popen` raises the natural
+            ``FileNotFoundError`` if the binary is genuinely missing.
+            This matches the behaviour of the other adapters
+            (codex, aider) and keeps tests that mock subprocess from
+            tripping on eager discovery.
 
     Returns:
         The binary name to invoke. Operator override (when set and
         non-empty) wins. Otherwise the first cascade entry that
-        resolves on ``PATH`` is returned.
+        resolves on ``PATH`` is returned, or the first cascade entry
+        as a fallback when ``strict=False``.
 
     Raises:
-        BinaryNotInstalledError: When neither the override nor any
-            cascade entry resolves.
+        BinaryNotInstalledError: When ``strict=True`` and neither the
+            override nor any cascade entry resolves, OR when the
+            override is set but missing on ``PATH`` (regardless of
+            ``strict``, since this is operator error).
     """
     source_env = env if env is not None else os.environ
     # Resolve ``shutil.which`` at call time so tests that patch
@@ -114,12 +127,17 @@ def resolve_google_cli_binary(
         if resolver(candidate) is not None:
             return candidate
 
-    raise BinaryNotInstalledError(
-        "Neither 'antigravity' nor 'gemini' was found on PATH. "
-        "Install the Antigravity CLI (per docs/adapters/antigravity.md), "
-        "or set "
-        f"{BINARY_ENV_VAR}=<path-or-name> to override discovery."
-    )
+    if strict:
+        raise BinaryNotInstalledError(
+            "Neither 'antigravity' nor 'gemini' was found on PATH. "
+            "Install the Antigravity CLI (per docs/adapters/antigravity.md), "
+            "or set "
+            f"{BINARY_ENV_VAR}=<path-or-name> to override discovery."
+        )
+    # Non-strict mode: return the first cascade entry as a fallback so
+    # the call site (typically subprocess.Popen) surfaces the missing
+    # binary as a natural FileNotFoundError it can already handle.
+    return _DISCOVERY_CASCADE[0]
 
 
 class GeminiAdapter(CLIAdapter):

--- a/tests/fixtures/mcp_fake_lab.py
+++ b/tests/fixtures/mcp_fake_lab.py
@@ -282,7 +282,22 @@ class McpFakeLab:
             result = await mcp.call_tool(tool_name, args)
 
         # FastMCP returns a list of lists of content objects
-        return result[0][0].text  # type: ignore[index]
+        text: str = result[0][0].text  # type: ignore[index]
+        # Strip the MCP cost-meter envelope (#1696) so tests assert
+        # the tool's inner contract, not the cross-cutting meter. The
+        # envelope shape is {"result": <payload>, "_meter": {...}}.
+        # Tests that want to inspect the envelope itself can opt out
+        # via the dedicated MCP cost-meter test suite.
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return text
+        if isinstance(parsed, dict) and "_meter" in parsed and "result" in parsed:
+            inner = parsed["result"]
+            if isinstance(inner, str):
+                return inner
+            return json.dumps(inner)
+        return text
 
     # ------------------------------------------------------------------
     # Inspection helpers

--- a/tests/golden/gemini_adapter.yaml
+++ b/tests/golden/gemini_adapter.yaml
@@ -5,7 +5,10 @@ steps:
     model: "gemini-2.5-pro"
     expected_pid: 2345
     inner_argv:
-      - "gemini"
+      # Discovery cascade (see #1740) now prefers `antigravity` over the
+      # legacy `gemini`. In CI neither is installed, so non-strict
+      # discovery returns the first cascade entry (`antigravity`).
+      - "antigravity"
       - "-p"
       - "fix the bug in main.py"
       - "-m"

--- a/tests/unit/test_adapter_conformance.py
+++ b/tests/unit/test_adapter_conformance.py
@@ -501,10 +501,17 @@ def test_golden_transcripts_all_pass(tmp_path: Path) -> None:
         pytest.skip("No golden transcripts found")
 
     harness = ConformanceHarness()
-    # Patch subprocess at the base level for all adapters
-    with patch("bernstein.adapters.codex.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]):
-        with patch("bernstein.adapters.generic.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]):
-            report = harness.run_all(transcripts, workdir=tmp_path)
+    # Patch subprocess at the base level for the adapters the harness
+    # actually drives. Gemini joined the patched set in #1740 when the
+    # discovery cascade started returning ``antigravity`` as the
+    # non-strict default, which subprocess.Popen would otherwise try
+    # to spawn for real in CI where neither binary is installed.
+    with (
+        patch("bernstein.adapters.codex.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]),
+        patch("bernstein.adapters.generic.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]),
+        patch("bernstein.adapters.gemini.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]),
+    ):
+        report = harness.run_all(transcripts, workdir=tmp_path)
 
     failed = report.regressions
     assert not failed, f"Golden transcript conformance FAILED: {failed}"

--- a/tests/unit/test_adapter_conformance.py
+++ b/tests/unit/test_adapter_conformance.py
@@ -8,6 +8,7 @@ to prove the harness catches regressions.
 from __future__ import annotations
 
 import json
+from itertools import count
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -506,10 +507,13 @@ def test_golden_transcripts_all_pass(tmp_path: Path) -> None:
     # discovery cascade started returning ``antigravity`` as the
     # non-strict default, which subprocess.Popen would otherwise try
     # to spawn for real in CI where neither binary is installed.
+    # Use unbounded iterators so the test stays stable as transcript
+    # coverage grows: a fixed-length list would raise ``StopIteration``
+    # once the harness needed more than 100 Popen invocations.
     with (
-        patch("bernstein.adapters.codex.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]),
-        patch("bernstein.adapters.generic.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]),
-        patch("bernstein.adapters.gemini.subprocess.Popen", side_effect=[_make_popen(i) for i in range(100)]),
+        patch("bernstein.adapters.codex.subprocess.Popen", side_effect=(_make_popen(i) for i in count())),
+        patch("bernstein.adapters.generic.subprocess.Popen", side_effect=(_make_popen(i) for i in count())),
+        patch("bernstein.adapters.gemini.subprocess.Popen", side_effect=(_make_popen(i) for i in count())),
     ):
         report = harness.run_all(transcripts, workdir=tmp_path)
 

--- a/tests/unit/test_adapter_gemini.py
+++ b/tests/unit/test_adapter_gemini.py
@@ -418,13 +418,25 @@ class TestBinaryDiscoveryCascade:
         with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
             assert resolve_google_cli_binary(which=only_legacy) == LEGACY_GEMINI_BINARY
 
-    def test_neither_raises_binary_not_installed(self) -> None:
-        """When neither resolves the operator gets a typed error."""
+    def test_neither_raises_binary_not_installed_in_strict_mode(self) -> None:
+        """Strict mode (used by ``adapters check``) raises a typed error
+        when neither cascade entry resolves. The spawn path uses the
+        non-strict default and lets ``subprocess.Popen`` raise.
+        """
         with (
             patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
             pytest.raises(BinaryNotInstalledError, match="antigravity"),
         ):
-            resolve_google_cli_binary(which=lambda _name: None)
+            resolve_google_cli_binary(which=lambda _name: None, strict=True)
+
+    def test_neither_returns_default_in_non_strict_mode(self) -> None:
+        """Non-strict mode returns the first cascade entry as fallback
+        so ``subprocess.Popen`` raises the natural ``FileNotFoundError``
+        instead of the resolver raising eagerly. Matches the codex /
+        aider adapter posture.
+        """
+        with patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True):
+            assert resolve_google_cli_binary(which=lambda _name: None) == ANTIGRAVITY_BINARY
 
     def test_env_override_wins_over_cascade(self) -> None:
         """``BERNSTEIN_GEMINI_BINARY`` short-circuits the cascade."""
@@ -436,12 +448,12 @@ class TestBinaryDiscoveryCascade:
             assert resolve_google_cli_binary(which=both_present) == "vendor-cli"
 
     def test_env_override_missing_binary_raises(self) -> None:
-        """An override that does not resolve is a hard error."""
+        """An override that does not resolve is a hard error regardless of strict."""
         with (
             patch.dict("os.environ", {"PATH": "/usr/bin", BINARY_ENV_VAR: "vendor-cli"}, clear=True),
             pytest.raises(BinaryNotInstalledError, match=BINARY_ENV_VAR),
         ):
-            resolve_google_cli_binary(which=lambda _name: None)
+            resolve_google_cli_binary(which=lambda _name: None, strict=False)
 
     def test_empty_env_override_falls_through_to_cascade(self) -> None:
         """A blank override behaves as if unset (no surprise pinning)."""

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -221,7 +221,11 @@ class TestGeminiAdapterSpawn:
             )
         cmd = popen.call_args.args[0]
         inner = _inner_cmd(cmd)
-        assert inner[0] == "gemini"
+        # Discovery prefers ``antigravity`` (the new canonical binary)
+        # and falls back to ``gemini`` when the former is missing on
+        # PATH. In CI neither is installed, so non-strict discovery
+        # returns the first cascade entry. See #1740.
+        assert inner[0] in {"antigravity", "gemini"}
 
     def test_model_flag(self, tmp_path: Path) -> None:
         adapter = GeminiAdapter()

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -12,7 +12,7 @@ import pytest
 from bernstein.core.models import ModelConfig
 
 from bernstein.adapters.codex import CodexAdapter
-from bernstein.adapters.gemini import GeminiAdapter
+from bernstein.adapters.gemini import ANTIGRAVITY_BINARY, GeminiAdapter
 from bernstein.adapters.generic import GenericAdapter
 from bernstein.adapters.qwen import QwenAdapter
 
@@ -212,7 +212,17 @@ class TestGeminiAdapterSpawn:
     def test_wrapped_with_worker(self, tmp_path: Path) -> None:
         adapter = GeminiAdapter()
         proc_mock = _make_popen_mock(pid=201)
-        with patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen:
+        # Pin env + resolver so this assertion is deterministic across
+        # CI / local hosts regardless of host PATH or a stray
+        # ``BERNSTEIN_GEMINI_BINARY`` override. Discovery prefers
+        # ``antigravity`` (the new canonical binary) and falls back to
+        # ``gemini``; with both resolver lookups returning ``None`` the
+        # non-strict cascade returns the first entry. See #1740.
+        with (
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            patch("bernstein.adapters.gemini.shutil.which", side_effect=lambda _name: None),
+            patch("bernstein.adapters.gemini.subprocess.Popen", return_value=proc_mock) as popen,
+        ):
             adapter.spawn(
                 prompt="hello",
                 workdir=tmp_path,
@@ -221,11 +231,7 @@ class TestGeminiAdapterSpawn:
             )
         cmd = popen.call_args.args[0]
         inner = _inner_cmd(cmd)
-        # Discovery prefers ``antigravity`` (the new canonical binary)
-        # and falls back to ``gemini`` when the former is missing on
-        # PATH. In CI neither is installed, so non-strict discovery
-        # returns the first cascade entry. See #1740.
-        assert inner[0] in {"antigravity", "gemini"}
+        assert inner[0] == ANTIGRAVITY_BINARY
 
     def test_model_flag(self, tmp_path: Path) -> None:
         adapter = GeminiAdapter()

--- a/tests/unit/test_mcp_fake_lab.py
+++ b/tests/unit/test_mcp_fake_lab.py
@@ -33,9 +33,16 @@ class TestBernsteinRun:
 
     @pytest.mark.asyncio
     async def test_run_returns_task_id(self, lab: McpFakeLab) -> None:
-        """bernstein_run returns a JSON string containing a task_id."""
+        """bernstein_run returns a JSON string containing a task_id.
+
+        The MCP cost-meter envelope (#1696) wraps the raw payload under
+        a ``result`` key when the meter is enabled (the default).
+        Unwrap before asserting the inner shape.
+        """
         text = await lab.call_tool("bernstein_run", {"goal": "Build auth"})
         data = json.loads(text)
+        if isinstance(data, dict) and "_meter" in data:
+            data = data["result"]
         assert "task_id" in data
         assert data["task_id"].startswith("fake-")
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -408,6 +408,7 @@ async def test_crash_protection_bernstein_status() -> None:
     if isinstance(parsed, dict) and "_meter" in parsed:
         parsed = parsed["result"]
     assert "error" in parsed
+    assert "hint" in parsed
 
 
 @pytest.mark.asyncio
@@ -430,6 +431,7 @@ async def test_crash_protection_bernstein_tasks() -> None:
     if isinstance(parsed, dict) and "_meter" in parsed:
         parsed = parsed["result"]
     assert "error" in parsed
+    assert "hint" in parsed
 
 
 @pytest.mark.asyncio
@@ -452,6 +454,7 @@ async def test_crash_protection_bernstein_cost() -> None:
     if isinstance(parsed, dict) and "_meter" in parsed:
         parsed = parsed["result"]
     assert "error" in parsed
+    assert "hint" in parsed
 
 
 @pytest.mark.asyncio
@@ -474,6 +477,7 @@ async def test_crash_protection_bernstein_approve() -> None:
     if isinstance(parsed, dict) and "_meter" in parsed:
         parsed = parsed["result"]
     assert "error" in parsed
+    assert "hint" in parsed
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -319,13 +319,20 @@ async def test_bernstein_approve_completes_task() -> None:
 
 @pytest.mark.asyncio
 async def test_bernstein_health_always_succeeds() -> None:
-    """bernstein_health always returns {"status": "ok"} without contacting server."""
+    """bernstein_health always returns {"status": "ok"} without contacting server.
+
+    The MCP cost-meter envelope (#1696) wraps the raw tool payload under
+    a ``result`` key when the meter is enabled (the default). Unwrap
+    before asserting the inner shape.
+    """
     from bernstein.mcp.server import create_mcp_server
 
     mcp = create_mcp_server(server_url="http://localhost:8052")
     result = await mcp.call_tool("bernstein_health", {})
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert parsed == {"status": "ok"}
 
 
@@ -375,6 +382,8 @@ async def test_crash_protection_bernstein_run() -> None:
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert "error" in parsed
     assert "hint" in parsed
 
@@ -396,6 +405,8 @@ async def test_crash_protection_bernstein_status() -> None:
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert "error" in parsed
 
 
@@ -416,6 +427,8 @@ async def test_crash_protection_bernstein_tasks() -> None:
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert "error" in parsed
 
 
@@ -436,6 +449,8 @@ async def test_crash_protection_bernstein_cost() -> None:
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert "error" in parsed
 
 
@@ -456,6 +471,8 @@ async def test_crash_protection_bernstein_approve() -> None:
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert "error" in parsed
 
 
@@ -476,6 +493,8 @@ async def test_crash_protection_bernstein_stop() -> None:
 
     text = result[0][0].text  # type: ignore[index]
     parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
     assert "error" in parsed
     assert parsed["hint"] == "Could not write shutdown signal"
 


### PR DESCRIPTION
Two clusters hit main after the antigravity adapter merge (#1741) and the MCP cost-meter envelope rollout (#1696):

### 1. Gemini adapter: discovery now lazy by default

The new `resolve_google_cli_binary()` raised `BinaryNotInstalledError` up front when neither `antigravity` nor `gemini` was on PATH. CI runs without either binary installed, so every test that constructed `GeminiAdapter` crashed before subprocess was reached. Match the codex / aider posture: non-strict discovery returns the first cascade entry as a fallback; `subprocess.Popen` then raises the natural `FileNotFoundError` on actual invocation. Strict mode stays for the `adapters check` / doctor surface.

New test `test_neither_returns_default_in_non_strict_mode` pins the posture so a future refurb cannot quietly re-introduce the eager raise.

### 2. MCP cost-meter envelope: tests unwrap

#1696 wraps tool responses under `{result, _meter}` when the meter is enabled (default). `McpFakeLab.call_tool` now unwraps the envelope by default so `test_mcp_fake_lab` tests stay focused on the inner contract, and four `test_crash_protection_*` tests + `test_bernstein_health_always_succeeds` apply the same unwrap.

Local pytest sweep across all affected suites: **754 passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable strict/non-strict binary discovery behavior to allow a graceful fallback or explicit error when external tools aren't found.
  * MCP responses may include a cost-meter envelope; tooling now unwraps this envelope for normal processing.

* **Tests**
  * Updated fixtures and unit tests to cover the new discovery modes and cost-meter envelope handling; made adapter spawn tests deterministic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: nit-batch reason=helper extraction tracked for follow-up; current inline unwrap blocks ship as-is to keep the main-red revert minimal -->
