### PR TITLE
fix(ci): post-CI dispatcher startup_failure - grant per-job permissions to reusable-workflow calls

### DIFF
--- a/.github/workflows/post-ci-dispatcher.yml
+++ b/.github/workflows/post-ci-dispatcher.yml
@@ -35,6 +35,19 @@ concurrency:
   group: post-ci-dispatcher-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
+# Workflow-level permissions stay minimal. Each reusable child below
+# declares its own per-job `permissions:` block scoped to the union of
+# the scopes that the called workflow's jobs request. A reusable
+# workflow inherits the *calling job's* GITHUB_TOKEN permissions, and
+# the GitHub Actions validator rejects the call at workflow_run boot
+# (zero check_runs, conclusion: startup_failure) when the caller grants
+# less than any callee job requests. The repo default for GITHUB_TOKEN
+# is `read` only, so an empty `permissions: {}` at this level grants
+# nothing and every callee with a `contents: write` /
+# `pull-requests: write` / `issues: write` / `attestations: write` /
+# `id-token: write` job failed the call before any job was scheduled.
+# That was the cause of the silent startup_failure on every dispatcher
+# run since the consolidation merged.
 permissions: {}
 
 jobs:
@@ -100,6 +113,10 @@ jobs:
       needs.meta.outputs.conclusion != 'success' &&
       needs.meta.outputs.conclusion != 'skipped' &&
       needs.meta.outputs.conclusion != 'neutral'
+    # Union of permissions the called workflow's jobs request.
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/telegram-notify.yml
     # Pass only the secrets this child actually reads. Avoids the
     # `secrets: inherit` blanket pass that zizmor flags as
@@ -119,6 +136,12 @@ jobs:
     name: Auto-release
     needs: meta
     if: needs.meta.outputs.head_branch == 'main'
+    # Union of permissions the called workflow's jobs request: it tags
+    # the release commit (contents:write) and opens / closes the
+    # auto-release-skipped issue (issues:write).
+    permissions:
+      contents: write
+      issues: write
     uses: ./.github/workflows/auto-release.yml
     # auto-release only needs Telegram credentials for its alert job.
     # GITHUB_TOKEN is provided automatically to reusable workflows.
@@ -142,6 +165,17 @@ jobs:
       !startsWith(needs.meta.outputs.display_title, 'fix(ci-heal-v2):') &&
       !startsWith(needs.meta.outputs.display_title, 'fix(ci-heal):') &&
       needs.meta.outputs.actor_login != 'github-actions[bot]'
+    # Union of permissions the called workflow's jobs request: it pushes
+    # heal branches and opens heal PRs (contents:write,
+    # pull-requests:write), attests provenance on the heal commit
+    # (attestations:write, id-token:write), and reads upstream CI run
+    # metadata (actions:read).
+    permissions:
+      contents: write
+      pull-requests: write
+      attestations: write
+      id-token: write
+      actions: read
     uses: ./.github/workflows/auto-heal.yml
     # auto-heal optionally pings Telegram on heal outcomes. GITHUB_TOKEN
     # is auto-provided. Both Telegram secrets are declared `required:
@@ -175,6 +209,15 @@ jobs:
         needs.auto-heal.outputs.heal_outcome == '' ||
         needs.auto-heal.outputs.heal_outcome == 'skipped_no_jobs' ||
         needs.auto-heal.outputs.heal_outcome == 'failed_validation')
+    # Union of permissions the called workflow's jobs request: it pushes
+    # auto-heal branches and opens auto-heal PRs (contents:write,
+    # pull-requests:write), opens fallback ci-fix issues (issues:write),
+    # and reads upstream CI run + PR metadata (actions:read).
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
     uses: ./.github/workflows/bernstein-ci-fix.yml
     # bernstein-ci-fix uses GEMINI_API_KEY for the LLM triage agent.
     # GITHUB_TOKEN is auto-provided. GEMINI_API_KEY is declared
@@ -182,19 +225,14 @@ jobs:
     # on a non-empty value rather than failing the whole reusable call.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      # NOTE: OPENROUTER_API_KEY_FREE was previously passed here for the
-      # Tier-3 shadow-mode escalation (#1715). When the operator has NOT
-      # defined that repo secret, the `secrets.OPENROUTER_API_KEY_FREE`
-      # reference fails the reusable-workflow startup with
-      # `startup_failure` (GitHub Actions resolves the secrets block at
-      # workflow_call start, before the called workflow's own
-      # `required: false` declaration applies). That broke the entire
-      # post-CI dispatcher chain (auto-release, auto-heal, bisect)
-      # silently from cbc95847 onward.
-      #
-      # Restore the pass once OPENROUTER_API_KEY_FREE is defined on the
-      # repo. Until then, the Tier-3 job inside bernstein-ci-fix degrades
-      # to flag_off / skipped, which is the documented default behaviour.
+      # OPENROUTER_API_KEY_FREE: ${{ secrets.OPENROUTER_API_KEY_FREE }}
+      # Re-enable the pass once OPENROUTER_API_KEY_FREE is defined on
+      # the repo. The Tier-3 shadow-mode job (#1715) gates on
+      # vars.BERNSTEIN_CI_SELF_DRIVE == 'tier3' (default off) so leaving
+      # the pass commented while the operator has not defined the secret
+      # is the documented graceful-degrade posture: Tier-3 records a
+      # flag_off / skipped outcome and the rest of the dispatcher chain
+      # continues to run.
     with:
       head_sha: ${{ needs.meta.outputs.head_sha }}
       head_branch: ${{ needs.meta.outputs.head_branch }}
@@ -208,6 +246,14 @@ jobs:
     if: >-
       needs.meta.outputs.conclusion == 'failure' &&
       needs.meta.outputs.head_branch == 'main'
+    # Union of permissions the called workflow's jobs request: it reads
+    # the failing commit's git history (contents:read) and posts the
+    # culprit comment on the suspected PR plus opens a bisect-on-red
+    # issue (pull-requests:write, issues:write).
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     uses: ./.github/workflows/bisect-on-red.yml
     # bisect-on-red reads only inputs and GITHUB_TOKEN (auto-provided).
     # No repository secrets are forwarded, replacing the prior


### PR DESCRIPTION
## Symptom

Every Post-CI dispatcher run since the consolidation merged returns `startup_failure` with zero check_runs, zero jobs, and an empty `timing.billable` payload. The pattern is consistent across 175 of 175 historical runs (no successes in the entire workflow history). The first startup_failure run was 2026-05-19T12:26:56Z on commit `278404f7` (PR #1507, the consolidation itself).

## Root cause

The dispatcher declared `permissions: {}` at workflow level and did not set per-job `permissions:` on the five `uses:` jobs that call reusable workflows. The repo default for `GITHUB_TOKEN` is `read` only (`gh api repos/.../actions/permissions/workflow` returns `default_workflow_permissions: read`).

When a job calls a reusable workflow whose own jobs request `contents: write`, `pull-requests: write`, `issues: write`, `attestations: write`, or `id-token: write`, the Actions validator checks the requested permissions against the caller's grant at workflow_run boot. If the caller grants less than any callee job requests, the call is rejected with `conclusion: startup_failure` before any check_run is allocated. That is the exact signature this dispatcher has produced for its entire history.

Evidence (per child workflow's job-level `permissions:` blocks, all on main today):

| Callee | Requested by callee jobs |
|---|---|
| auto-heal | `contents:write`, `pull-requests:write`, `attestations:write`, `id-token:write`, `actions:read` |
| auto-release | `contents:write`, `issues:write` |
| bernstein-ci-fix | `contents:write`, `pull-requests:write`, `issues:write`, `actions:read` |
| telegram-notify | `contents:read`, `actions:read` |
| bisect-on-red | `contents:read`, `pull-requests:write`, `issues:write` |

The dispatcher granted none of these.

## Why #1730 did not fix it

#1730 dropped the `secrets.OPENROUTER_API_KEY_FREE` pass on the assumption that an undefined-secret reference inside a `workflow_call` `secrets:` block caused the boot failure. Two reasons that theory is wrong:

1. The first startup_failure run was 2026-05-19T12:26:56Z on the dispatcher's introducing commit `278404f7` (#1507). OPENROUTER was wired in 2026-05-20T11:36Z (#1715 / `cbc95847`), one day later. The dispatcher was already failing before OPENROUTER ever appeared.
2. Empty `secrets.X` references resolve to empty string at run time, not to startup_failure. The boot validator does not reject a missing `secrets.X` when the called workflow declares the secret `required: false`, which `OPENROUTER_API_KEY_FREE` does on `bernstein-ci-fix.yml`.

#1730's drop is harmless and remains in place (the secret is not defined on the repo so the Tier-3 job gates off via `vars.BERNSTEIN_CI_SELF_DRIVE`, default off, regardless).

## What this PR changes

Each of the five `uses:` jobs in `post-ci-dispatcher.yml` now declares the strict union of the scopes its callee jobs request. Workflow-level `permissions: {}` stays empty so the dispatcher's own `meta` job continues to run with `contents: read` only and zizmor's `excessive-permissions` audit stays clean.

The OPENROUTER comment block from #1730 is replaced with a single-line commented-out pass plus a brief note documenting the graceful-degrade posture.

## Verification after merge

The next CI completion on main triggers post-ci-dispatcher. The resulting run should have:

- `conclusion: success` (or downstream-child `failure` on actual failures, never `startup_failure`).
- non-empty `jobs` array on the run.
- non-empty `timing.billable` payload.

Repeat for the next five CI completions on main to confirm the dispatcher chain is durable.

## Out of scope

- Tier-3 OpenRouter shadow-mode wire-up itself (#1715). The dispatcher works whether or not `OPENROUTER_API_KEY_FREE` is defined on the repo.
- The reusable-workflow consolidation pattern (#1507) stays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by implementing explicit permission scoping for automated workflows to improve build reliability and reduce potential security risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->