### PR TITLE
test(adapters): pin gemini binary resolver in golden replay

### DIFF
--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -319,6 +319,20 @@ class TestGoldenReplay:
         if hasattr(adapter_module, "build_filtered_env"):
             monkeypatch.setattr(adapter_module, "build_filtered_env", _spy)
 
+        # Gemini adapter consults `shutil.which` to pick between the
+        # `antigravity` and `gemini` binaries (#1740 cascade). On hosts
+        # where only one happens to be installed, the recorded golden
+        # would drift from the actual argv. Pin the resolver to "neither
+        # installed" so non-strict discovery returns the first cascade
+        # entry deterministically across local + CI runs. Scoped to the
+        # gemini adapter to avoid leaking into other tests' subprocess
+        # lookups (shutil is a shared module).
+        if adapter_cls.__module__ == "bernstein.adapters.gemini":
+            monkeypatch.setattr(
+                "bernstein.adapters.gemini.resolve_google_cli_binary",
+                lambda **_kw: "antigravity",
+            )
+
         default_role = str(transcript.get("session_role") or "replay")
         for step_idx, step in enumerate(transcript.get("steps", [])):
             prompt = str(step["prompt"])


### PR DESCRIPTION
## Summary

- Golden replay test for `GeminiAdapter` was env-fragile: on hosts where only `gemini` (or only `antigravity`) is installed, `shutil.which` finds the real binary and the recorded golden argv diverges from the actual argv.
- Pin `resolve_google_cli_binary` to the first cascade entry inside the test so the golden behaves identically on local dev hosts and CI runners.
- Scope: only the gemini case is touched; other adapter goldens unchanged.

## Why

`tests/unit/test_adapter_contract.py::TestGoldenReplay::test_replay_matches_recorded_argv[gemini_adapter]` failed locally on a host that has `gemini` on PATH but not `antigravity`. The golden hardcodes the "neither installed" cascade outcome (`antigravity` as first entry) which is the only stable shape across machines. Pinning the resolver makes the test environment-independent.

## Test plan

- [x] `pytest tests/unit/test_adapter_contract.py::TestGoldenReplay -x -q` passes locally with `gemini` on PATH
- [x] `pytest tests/unit/test_adapter_contract.py tests/unit/test_adapter_gemini.py tests/unit/test_adapter_non_claude.py tests/unit/test_adapter_conformance.py` — 682 passed locally
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for adapter stability during replays. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->