### PR TITLE
docs(readme): remove unregistered CII Best Practices badge placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Multi-agent CLI orchestration with an HMAC-signed audit chain, signed agent card
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776ab?logo=python&logoColor=white)](https://python.org)
 [![License](https://img.shields.io/github/license/sipyourdrink-ltd/bernstein)](LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sipyourdrink-ltd/bernstein/badge)](https://scorecard.dev/viewer/?uri=github.com/sipyourdrink-ltd/bernstein)
-<!-- TODO(operator): register at bestpractices.dev, replace <PROJECT_ID> -->
-[![CII Best Practices](https://www.bestpractices.dev/projects/<PROJECT_ID>/badge)](https://www.bestpractices.dev/projects/<PROJECT_ID>)
 [![CodeQL](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml)
 [![MseeP.ai](https://img.shields.io/badge/MseeP.ai-verified-2496ed)](https://mseep.ai/app/chernistry-bernstein)
 [![CodeTrendy](https://img.shields.io/badge/CodeTrendy-listed-FBBF24)](https://codetrendy.com/listing/bernstein)


### PR DESCRIPTION
## Summary

The README badge row contained a CII Best Practices badge whose URL had a literal `<PROJECT_ID>` placeholder, returning HTTP 404 and rendering broken on the GitHub project home. Remove the badge and its accompanying TODO comment until the project is registered at bestpractices.dev.

OpenSSF Scorecard badge already sits in the same row and covers the supply-chain rigour signal, so no information is lost.

## Acceptance criteria

- `grep '<PROJECT_ID>' README.md` returns no matches.
- The CII Best Practices badge image URL in README.md returns HTTP 200 (or the badge is removed entirely). -> removed.
- The TODO(operator) comment immediately above the badge is also removed once resolved. -> removed.

## Test plan

- [x] `grep '<PROJECT_ID>' README.md` -> no matches.
- [x] `grep 'bestpractices' README.md` -> no matches.
- [x] `grep 'TODO(operator)' README.md` (in badge section) -> no matches.
- [x] Diff is exactly two lines removed, no other change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed invalid badge reference from project README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->