### PR TITLE
docs(observability): per-host telemetry DSN snippets + live HTTP backend test

### DIFF
--- a/docs/substrate/aider.md
+++ b/docs/substrate/aider.md
@@ -42,6 +42,26 @@ mcp-servers:
 `command` is the Python interpreter that runs Bernstein (resolved at
 registration time). Unrelated keys are preserved verbatim.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) into your own GlitchTip project when a wrapper launches
+Bernstein from Aider, export `BERNSTEIN_TELEMETRY_DSN` in the wrapper's
+environment before invoking Bernstein:
+
+```bash
+export BERNSTEIN_TELEMETRY_DSN="https://<public_key>@<host>/<project_id>"
+python -m bernstein.mcp
+```
+
+Or add an equivalent `env` block in your custom launch script. Aider's own
+YAML config does not carry env vars for sub-processes, so the DSN must be
+set wherever the wrapper actually launches Bernstein. The same env-var
+name and wire format are honoured by every host (see
+[docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after relaunching.
+
 ## Verify
 
 ```bash

--- a/docs/substrate/claude-code.md
+++ b/docs/substrate/claude-code.md
@@ -46,6 +46,33 @@ are preserved verbatim.
 
 Reopen the project in Claude Code so it reloads `.mcp.json`.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) from Claude Code into your own GlitchTip project, add an
+`env` block to the `bernstein` entry with `BERNSTEIN_TELEMETRY_DSN` set to a
+Sentry-compatible DSN:
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+The same env-var name and wire format are honoured by every host
+(see [docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after reopening the
+project.
+
 ## Verify
 
 ```bash

--- a/docs/substrate/claude-desktop.md
+++ b/docs/substrate/claude-desktop.md
@@ -45,6 +45,32 @@ verbatim.
 
 Restart Claude Desktop after registering so it reloads its config.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) from Claude Desktop into your own GlitchTip project, add an
+`env` block to the `bernstein` entry with `BERNSTEIN_TELEMETRY_DSN` set to a
+Sentry-compatible DSN:
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+The same env-var name and wire format are honoured by every host
+(see [docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after restarting the host.
+
 ## Verify
 
 ```bash

--- a/docs/substrate/cline.md
+++ b/docs/substrate/cline.md
@@ -46,6 +46,32 @@ verbatim.
 
 Reload the VS Code window so Cline picks up the new MCP server.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) from Cline into your own GlitchTip project, add an `env`
+block to the `bernstein` entry with `BERNSTEIN_TELEMETRY_DSN` set to a
+Sentry-compatible DSN:
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+The same env-var name and wire format are honoured by every host
+(see [docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after reloading VS Code.
+
 ## Verify
 
 ```bash

--- a/docs/substrate/continue.md
+++ b/docs/substrate/continue.md
@@ -45,6 +45,33 @@ registration time). Unrelated keys (models, slash commands, etc.) in
 
 Restart your editor so Continue reloads `~/.continue/config.json`.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) from Continue into your own GlitchTip project, add an
+`env` block to the `bernstein` entry with `BERNSTEIN_TELEMETRY_DSN` set to
+a Sentry-compatible DSN:
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+The same env-var name and wire format are honoured by every host
+(see [docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after restarting the
+editor.
+
 ## Verify
 
 ```bash

--- a/docs/substrate/cursor.md
+++ b/docs/substrate/cursor.md
@@ -44,6 +44,32 @@ verbatim.
 
 Restart Cursor (or reload the MCP servers panel) so it reloads the config.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) from Cursor into your own GlitchTip project, add an `env`
+block to the `bernstein` entry with `BERNSTEIN_TELEMETRY_DSN` set to a
+Sentry-compatible DSN:
+
+```json
+{
+  "mcpServers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+The same env-var name and wire format are honoured by every host
+(see [docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after restarting the host.
+
 ## Verify
 
 ```bash

--- a/docs/substrate/zed.md
+++ b/docs/substrate/zed.md
@@ -43,6 +43,32 @@ in `settings.json` are preserved verbatim.
 
 Restart Zed after registering so it reloads its settings.
 
+## Telemetry DSN
+
+To route Bernstein's side-channel telemetry (lineage, cost, run lifecycle,
+tracker events) from Zed into your own GlitchTip project, add an `env`
+block to the `bernstein` entry with `BERNSTEIN_TELEMETRY_DSN` set to a
+Sentry-compatible DSN:
+
+```json
+{
+  "context_servers": {
+    "bernstein": {
+      "command": "/path/to/python",
+      "args": ["-m", "bernstein.mcp"],
+      "env": {
+        "BERNSTEIN_TELEMETRY_DSN": "https://<public_key>@<host>/<project_id>"
+      }
+    }
+  }
+}
+```
+
+The same env-var name and wire format are honoured by every host
+(see [docs/observability/side-channel.md](../observability/side-channel.md)),
+so operators running several hosts in parallel can point them all at one
+project. Verify with `bernstein telemetry probe` after restarting Zed.
+
 ## Verify
 
 ```bash

--- a/tests/unit/observability/test_sidechannel.py
+++ b/tests/unit/observability/test_sidechannel.py
@@ -350,3 +350,91 @@ def test_queue_full_exception_path_counts_drop() -> None:
         assert sink.dropped == 1
     finally:
         sink.close()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against a real localhost HTTP backend (Sentry store protocol)
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_real_http_backend_receives_event() -> None:
+    """Drive the live HTTP transport against a localhost stand-in for the
+    Sentry store endpoint.
+
+    GlitchTip and any Sentry-compatible backend ingest the same store
+    payload over HTTP. By spinning up a tiny ``http.server`` on a random
+    local port and pointing a DSN at it, we exercise the entire pipeline
+    (build sink, render payload, POST via httpx, parse store URL and auth
+    header) without depending on a hosted backend in CI. The assertion
+    below confirms what the backend would have received.
+    """
+    import http.server
+    import socketserver
+    import threading as _th
+
+    received: list[dict[str, Any]] = []
+    received_headers: list[dict[str, str]] = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            body = self.rfile.read(length) if length else b""
+            try:
+                import json as _json
+
+                received.append(_json.loads(body.decode("utf-8")))
+            except Exception:  # pragma: no cover - defensive
+                received.append({"_raw": body.decode("utf-8", "replace")})
+            received_headers.append({k: v for k, v in self.headers.items()})
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+        def log_message(self, *_args: object) -> None:
+            # Silence the test server; it would otherwise spam stderr.
+            return
+
+    with socketserver.TCPServer(("127.0.0.1", 0), _Handler) as server:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        thread = _th.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            dsn = f"http://localkey@{host}:{port}/9"
+            sink = build_sidechannel(env={sidechannel.DSN_ENV: dsn})
+            assert isinstance(sink, SideChannel)
+            try:
+                accepted = sidechannel.emit(
+                    "probe",
+                    "live-http synthetic event",
+                    level=EventLevel.INFO,
+                    tags={"synthetic": "true"},
+                    extra={"probe": True},
+                    sink=sink,
+                )
+                assert accepted is True
+                # Wait for the worker to drain (bounded).
+                deadline = time.monotonic() + 5.0
+                while not received and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                sink.flush()
+            finally:
+                sink.close()
+        finally:
+            server.shutdown()
+            thread.join(timeout=2.0)
+
+    assert received, "live HTTP backend did not receive any event"
+    payload = received[0]
+    assert payload["message"] == "live-http synthetic event"
+    assert payload["logger"] == "bernstein.probe"
+    assert payload["platform"] == "python"
+    assert payload["level"] == EventLevel.INFO.value
+    assert payload["tags"]["bernstein.category"] == "probe"
+    assert payload["tags"]["synthetic"] == "true"
+    assert payload["extra"]["probe"] is True
+    auth = received_headers[0].get("X-Sentry-Auth", "")
+    assert auth.startswith("Sentry "), auth
+    assert "sentry_key=localkey" in auth
+    assert "sentry_version=7" in auth


### PR DESCRIPTION
## Summary

- Adds a `## Telemetry DSN` section to each per-host substrate guide (claude-desktop, claude-code, cursor, cline, continue, zed, aider) showing how to wire `BERNSTEIN_TELEMETRY_DSN` through the host's env block so operators running multiple hosts in parallel can point them all at one GlitchTip project.
- Adds a localhost HTTP-server-backed test for the side-channel transport that exercises the full pipeline (`httpx` POST, Sentry store URL, `X-Sentry-Auth` header) and asserts the rendered Sentry-protocol payload, closing the regression coverage gap for the wire format without depending on a hosted backend.
- Closes the per-host install documentation gap for the side-channel telemetry contract documented in `docs/observability/side-channel.md`.

Refs #1672.

## Test plan

- [x] `uv run pytest tests/unit/observability/test_sidechannel.py tests/unit/telemetry/test_cli_command.py` (43 passed)
- [x] `uv run ruff check tests/unit/observability/test_sidechannel.py docs/substrate/`
- [x] `uv run ruff format --check tests/unit/observability/test_sidechannel.py`
- [x] `uv run python scripts/check_docs_drift.py` (clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added telemetry configuration guidance across all supported AI coding platforms (Aider, Claude Code, Claude Desktop, Cline, Continue, Cursor, Zed).
  * Instructions include routing side-channel telemetry to GlitchTip projects and verification steps.

* **Tests**
  * Added integration test for telemetry functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->