### PR TITLE
fix(chat): make Discord/Slack stub bridges raise on handler registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable project changes are tracked here (code + docs).
 - `bernstein doctor --substrate` reports which detected hosts have Bernstein registered, which do not, and which are stale (canonical command/args differ from the recorded entry) (#1676).
 - Operator docs at `docs/substrate/{cursor,continue,cline,zed,aider}.md` cover install, verification, and uninstall per host (#1676).
 
+### Changed
+
+- `DiscordBridge.on_command` / `on_button` and `SlackBridge.on_command` / `on_button` now raise `NotImplementedError` at registration time instead of silently dropping the handler. Callers that wire handlers up front against the unimplemented drivers will see the failure immediately rather than at the first network call.
+
 ## [2.5.0] - Interoperability surfaces, host portability, deterministic replay
 
 22 commits since v2.4.0. Full notes: [`docs/release-notes/v2.5.0.md`](docs/release-notes/v2.5.0.md).

--- a/src/bernstein/core/chat/drivers/discord.py
+++ b/src/bernstein/core/chat/drivers/discord.py
@@ -4,10 +4,10 @@ Conforms to :class:`~bernstein.core.chat.bridge.BridgeProtocol` so that
 wiring code, tests, and the CLI can treat every driver uniformly today
 while the real implementation lands in a follow-up.
 
-All network-touching methods raise :class:`NotImplementedError` with a
-pointer to the follow-up ticket. In-memory registration methods
-(``on_command`` / ``on_button``) are no-ops so a caller that wires
-handlers up front does not explode -- they simply have no effect.
+Every method, including the registration entry points
+(``on_command`` / ``on_button``), raises :class:`NotImplementedError`
+with a pointer to the follow-up ticket. Failing fast at wire-up keeps
+operators from believing their handlers are live against a stub.
 """
 
 from __future__ import annotations
@@ -50,7 +50,9 @@ class DiscordBridge(BridgeProtocol):
         raise NotImplementedError(DISCORD_STUB_MESSAGE)
 
     def on_command(self, name: str, handler: CommandHandler) -> None:
-        """No-op: command registrations are silently discarded."""
+        """Reject registrations until the real driver lands."""
+        raise NotImplementedError(DISCORD_STUB_MESSAGE)
 
     def on_button(self, handler: ButtonHandler) -> None:
-        """No-op: button handler registrations are silently discarded."""
+        """Reject registrations until the real driver lands."""
+        raise NotImplementedError(DISCORD_STUB_MESSAGE)

--- a/src/bernstein/core/chat/drivers/slack.py
+++ b/src/bernstein/core/chat/drivers/slack.py
@@ -3,6 +3,11 @@
 Conforms to :class:`~bernstein.core.chat.bridge.BridgeProtocol` so the
 rest of the chat surface stays uniform until the real driver lands in
 a follow-up.
+
+Every method, including the registration entry points
+(``on_command`` / ``on_button``), raises :class:`NotImplementedError`
+with a pointer to the follow-up ticket. Failing fast at wire-up keeps
+operators from believing their handlers are live against a stub.
 """
 
 from __future__ import annotations
@@ -45,7 +50,9 @@ class SlackBridge(BridgeProtocol):
         raise NotImplementedError(SLACK_STUB_MESSAGE)
 
     def on_command(self, name: str, handler: CommandHandler) -> None:
-        """No-op: command registrations are silently discarded."""
+        """Reject registrations until the real driver lands."""
+        raise NotImplementedError(SLACK_STUB_MESSAGE)
 
     def on_button(self, handler: ButtonHandler) -> None:
-        """No-op: button handler registrations are silently discarded."""
+        """Reject registrations until the real driver lands."""
+        raise NotImplementedError(SLACK_STUB_MESSAGE)

--- a/tests/unit/test_chat_drivers.py
+++ b/tests/unit/test_chat_drivers.py
@@ -160,11 +160,36 @@ def test_slack_start_raises_stub_message() -> None:
     assert "op-001b" in str(excinfo.value)
 
 
-def test_stub_registrations_are_noops() -> None:
-    """Registering handlers on stubs is a silent no-op."""
+def test_discord_on_command_raises_stub_message() -> None:
+    """Wiring a Discord handler must fail fast, not silently drop."""
     bridge = DiscordBridge()
-    bridge.on_command("run", lambda _m: _async_noop())  # type: ignore[misc,arg-type]
-    bridge.on_button(lambda _t, _a, _d: _async_noop())  # type: ignore[misc,arg-type]
+    with pytest.raises(NotImplementedError) as excinfo:
+        bridge.on_command("run", lambda _m: _async_noop())  # type: ignore[misc,arg-type]
+    assert DISCORD_STUB_MESSAGE in str(excinfo.value)
+
+
+def test_discord_on_button_raises_stub_message() -> None:
+    """Wiring a Discord button handler must fail fast, not silently drop."""
+    bridge = DiscordBridge()
+    with pytest.raises(NotImplementedError) as excinfo:
+        bridge.on_button(lambda _t, _a, _d: _async_noop())  # type: ignore[misc,arg-type]
+    assert DISCORD_STUB_MESSAGE in str(excinfo.value)
+
+
+def test_slack_on_command_raises_stub_message() -> None:
+    """Wiring a Slack handler must fail fast, not silently drop."""
+    bridge = SlackBridge()
+    with pytest.raises(NotImplementedError) as excinfo:
+        bridge.on_command("run", lambda _m: _async_noop())  # type: ignore[misc,arg-type]
+    assert SLACK_STUB_MESSAGE in str(excinfo.value)
+
+
+def test_slack_on_button_raises_stub_message() -> None:
+    """Wiring a Slack button handler must fail fast, not silently drop."""
+    bridge = SlackBridge()
+    with pytest.raises(NotImplementedError) as excinfo:
+        bridge.on_button(lambda _t, _a, _d: _async_noop())  # type: ignore[misc,arg-type]
+    assert SLACK_STUB_MESSAGE in str(excinfo.value)
 
 
 async def _async_noop() -> None:  # NOSONAR — async-signature required by protocol / fixture


### PR DESCRIPTION
## Summary

- `DiscordBridge.on_command` / `on_button` and `SlackBridge.on_command` / `on_button` now raise `NotImplementedError` at registration time instead of returning silently. Every other method on these stub drivers (`start`, `send_message`, `edit_message`, `push_approval`) already raises with the same stub message; the registration entry points were the lone gap.
- Callers wiring handlers up front against the unimplemented drivers now get an immediate, debuggable signal instead of discovering the gap at the first network call.
- Docstrings updated, existing "registrations are silent no-op" tests flipped to assert the raise, CHANGELOG entry under Unreleased documents the behaviour change.

## Test plan

- [x] `uv run pytest tests/unit/test_chat_drivers.py` passes (11 tests, including 4 new regression cases covering Discord/Slack x on_command/on_button raising the stub message)
- [x] `uv run ruff check` and `ruff format --check` clean on touched files
- [x] mypy diff clean on touched files (pre-existing project-wide errors unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord and Slack driver stubs now explicitly reject handler registrations with informative error messages instead of silently ignoring them. This provides clearer feedback when attempting to register event handlers on stub implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->