### PR TITLE
fix(compliance): drop dora and finos-aigf TODO stubs from audit export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable project changes are tracked here (code + docs).
 - `bernstein doctor --substrate` reports which detected hosts have Bernstein registered, which do not, and which are stale (canonical command/args differ from the recorded entry) (#1676).
 - Operator docs at `docs/substrate/{cursor,continue,cline,zed,aider}.md` cover install, verification, and uninstall per host (#1676).
 
+### Changed
+
+- `bernstein audit export --standard` no longer accepts `dora` or `finos-aigf`; the click choice list is `ai-act` only. The previous control maps for those two standards contained only placeholder rows (`status: "todo"`, `selector: "TODO"`) and have been removed from `SUPPORTED_STANDARDS` until their clause mappings are reviewed by subject-matter experts. Operators who pass either value now receive a clean usage error rather than a TODO-only zip (#1316).
+
 ## [2.5.0] - Interoperability surfaces, host portability, deterministic replay
 
 22 commits since v2.4.0. Full notes: [`docs/release-notes/v2.5.0.md`](docs/release-notes/v2.5.0.md).

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -269,11 +269,12 @@ def verify_hmac_cmd() -> None:
     "--standard",
     "standard",
     default=None,
-    type=click.Choice(["ai-act", "dora", "finos-aigf"]),
+    type=click.Choice(["ai-act"]),
     help=(
         "Emit a one-command compliance evidence pack mapped to the chosen "
-        "regulatory standard (issue #1316). 'ai-act' has a fleshed-out "
-        "control map; 'dora' and 'finos-aigf' ship as TODO stubs at MVP."
+        "regulatory standard (issue #1316). 'ai-act' is the only standard "
+        "with a reviewed control map at MVP; DORA and FINOS AIGF are tracked "
+        "under #1316 and will be added once their clause maps are validated."
     ),
 )
 @click.option(

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -18,10 +18,11 @@ so an auditor can re-derive the SHA-256 of the bundle and compare.
 
 The mapping from regulatory ``control_id`` to a record selector is
 declarative and lives inside this module (see ``_STANDARD_MAPS``). At
-MVP only the EU AI Act mapping is fleshed out; DORA and FINOS AIGF
-are stubbed with TODO links to the published standards so the bundle
-still emits, but the ``controls.json`` artefact carries explicit
-``status: "todo"`` markers per unmapped control.
+MVP only the EU AI Act mapping is fleshed out. DORA and FINOS AIGF
+control maps are tracked under issue #1316 and are not selectable
+until the underlying clause mappings are reviewed by subject-matter
+experts; attempting to build a pack for an unsupported standard
+raises ``ValueError``.
 
 Usage:
 
@@ -38,8 +39,8 @@ Usage:
 Out of scope for the MVP (tracked in #1316):
 
 * PDF/Markdown narrative report generation.
-* Real DORA Articles 8-15 evidence templates.
-* Real FINOS AIGF control catalogue mapping.
+* DORA Articles 8-15 evidence templates (selector not yet defined).
+* FINOS AIGF control catalogue mapping (selector not yet defined).
 """
 
 from __future__ import annotations
@@ -63,10 +64,12 @@ logger = logging.getLogger(__name__)
 SCHEMA_VERSION: str = "1.0.0"
 
 #: Supported standards at MVP. Only ``ai-act`` has a fleshed-out
-#: control map; the others ship as stubs (see ``_STANDARD_MAPS``).
-Standard = Literal["ai-act", "dora", "finos-aigf"]
+#: control map. DORA and FINOS AIGF are tracked under #1316 and will
+#: be added once their clause maps are reviewed by subject-matter
+#: experts; emitting TODO-only bundles would mislead operators.
+Standard = Literal["ai-act"]
 
-SUPPORTED_STANDARDS: tuple[str, ...] = ("ai-act", "dora", "finos-aigf")
+SUPPORTED_STANDARDS: tuple[str, ...] = ("ai-act",)
 
 #: Fixed mtime for every entry in the produced zip — required for
 #: byte-deterministic output. Zip cannot store dates before 1980.
@@ -145,46 +148,6 @@ _STANDARD_MAPS: dict[str, dict[str, Any]] = {
         "deferred": [
             "Article 43 conformity assessment paperwork (out of MVP scope)",
             "Annex IV technical documentation (handled by compliance/eu_ai_act.py)",
-        ],
-    },
-    "dora": {
-        "regulation": ("Regulation (EU) 2022/2554 (DORA) — Digital Operational Resilience Act"),
-        "controls": [
-            {
-                "control_id": "art-8",
-                "requirement": "ICT risk management framework — TODO: real evidence selector.",
-                "artefact": "audit-chain/events.jsonl",
-                "selector": "TODO",
-                "status": "todo",
-                "see_also": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32022R2554",
-            },
-            {
-                "control_id": "art-9-15",
-                "requirement": "ICT third-party risk — TODO: agent + model attribution mapping.",
-                "artefact": "audit-chain/events.jsonl",
-                "selector": "TODO",
-                "status": "todo",
-                "see_also": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32022R2554",
-            },
-        ],
-        "deferred": [
-            "Real DORA evidence template (#1316 follow-up).",
-        ],
-    },
-    "finos-aigf": {
-        "regulation": "FINOS AI Governance Framework (AIGF)",
-        "controls": [
-            {
-                "control_id": "AIGF-TODO",
-                "requirement": "FINOS AIGF control catalogue mapping — TODO.",
-                "artefact": "audit-chain/events.jsonl",
-                "selector": "TODO",
-                "status": "todo",
-                "see_also": "https://air-governance-framework.finos.org/",
-            },
-        ],
-        "deferred": [
-            "Full FINOS AIGF control-ID coverage (#1316 follow-up).",
         ],
     },
 }

--- a/tests/unit/test_evidence_pack.py
+++ b/tests/unit/test_evidence_pack.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-* Standard-map resolution (real vs TODO stub for ai-act / dora / finos-aigf).
+* Standard-map resolution (only ai-act is exposed at MVP).
 * End-to-end build: pack contains the expected zip layout and the
   per-artefact SHA-256 hashes in ``manifest.json`` agree with the
   on-disk content.
@@ -12,8 +12,8 @@ Covers:
   bound.
 * Determinism: two builds of the same input produce a byte-identical
   zip with matching ``sha256``.
-* TODO standards still emit a valid bundle but flag every control as
-  ``status == "todo"`` so an operator can see what is real.
+* Unsupported standards (dora, finos-aigf) raise ``ValueError`` rather
+  than emitting a TODO-only bundle.
 """
 
 from __future__ import annotations
@@ -120,7 +120,11 @@ def sdd_dir(tmp_path: Path) -> Path:
 
 class TestStandardMap:
     def test_supported_standards_constant(self) -> None:
-        assert set(SUPPORTED_STANDARDS) == {"ai-act", "dora", "finos-aigf"}
+        # Only ai-act ships with a reviewed control map at MVP. DORA
+        # and FINOS AIGF are tracked under #1316 and must not be
+        # selectable from the CLI until their clause mappings are
+        # validated; emitting TODO-only bundles would mislead operators.
+        assert set(SUPPORTED_STANDARDS) == {"ai-act"}
 
     def test_ai_act_has_real_controls(self) -> None:
         mapping = get_standard_map("ai-act")
@@ -131,20 +135,13 @@ class TestStandardMap:
         clause_ids = {c["control_id"] for c in controls}
         assert {"art-12(1)", "art-12(2)(a)", "art-12(3)"}.issubset(clause_ids)
 
-    def test_dora_is_todo_stub(self) -> None:
-        mapping = get_standard_map("dora")
-        assert all(c["status"] == "todo" for c in mapping["controls"])
-        # Must cite the regulation for an operator to follow up.
-        assert "DORA" in mapping["regulation"] or "2022/2554" in mapping["regulation"]
-        # Every TODO control carries a follow-up link.
-        for c in mapping["controls"]:
-            assert "see_also" in c
-
-    def test_finos_is_todo_stub(self) -> None:
-        mapping = get_standard_map("finos-aigf")
-        assert all(c["status"] == "todo" for c in mapping["controls"])
-        for c in mapping["controls"]:
-            assert "see_also" in c
+    @pytest.mark.parametrize("standard", ["dora", "finos-aigf"])
+    def test_unsupported_standards_rejected(self, standard: str) -> None:
+        # Regression for the L2 bughunt: dora / finos-aigf used to be
+        # selectable and emit a bundle whose only controls were
+        # ``status: "todo"`` rows. They must now raise instead.
+        with pytest.raises(ValueError, match="unknown standard"):
+            get_standard_map(standard)
 
     def test_unknown_standard_raises(self) -> None:
         with pytest.raises(ValueError, match="unknown standard"):
@@ -272,26 +269,55 @@ class TestDeterminism:
 
 
 # ---------------------------------------------------------------------------
-# TODO standards still emit a valid bundle
+# Regression: deferred standards must error, not emit TODO-only bundles
 # ---------------------------------------------------------------------------
 
 
-class TestStubStandards:
-    @pytest.mark.parametrize("standard", ["dora", "finos-aigf"])
-    def test_stub_emits_bundle_with_todo_controls(self, sdd_dir: Path, standard: str) -> None:
-        pack = build_evidence_pack(
-            sdd_dir=sdd_dir,
-            standard=standard,
-        )
-        assert pack.archive_path is not None
-        assert pack.controls_mapped == 0
-        assert pack.controls_todo >= 1
+class TestDeferredStandardsRejected:
+    """Regression for the L2 bughunt on issue #1316.
 
-        with zipfile.ZipFile(pack.archive_path) as zf:
-            controls = json.loads(zf.read("controls.json"))
-            assert controls["standard"] == standard
-            for c in controls["controls"]:
-                assert c["status"] == "todo"
-            # Deferred follow-ups must be captured so an operator knows
-            # the gap is documented, not hidden.
-            assert controls["deferred"]
+    Prior to the fix, ``--standard dora`` and ``--standard finos-aigf``
+    were advertised by the CLI ``click.Choice`` list and produced a zip
+    whose ``controls.json`` carried only ``status: "todo"`` /
+    ``selector: "TODO"`` rows. That is not a useful evidence pack and
+    misrepresents the project's compliance surface. Both standards now
+    raise at build time until their clause maps are reviewed.
+    """
+
+    @pytest.mark.parametrize("standard", ["dora", "finos-aigf"])
+    def test_deferred_standard_raises_at_build(self, sdd_dir: Path, standard: str) -> None:
+        with pytest.raises(ValueError, match="unknown standard"):
+            build_evidence_pack(sdd_dir=sdd_dir, standard=standard)
+
+    @pytest.mark.parametrize("standard", ["dora", "finos-aigf"])
+    def test_deferred_standard_not_in_supported_list(self, standard: str) -> None:
+        assert standard not in SUPPORTED_STANDARDS
+
+    @pytest.mark.parametrize("standard", ["dora", "finos-aigf"])
+    def test_cli_choice_rejects_deferred_standards(self, tmp_path: Path, standard: str) -> None:
+        """``bernstein audit export --standard {dora,finos-aigf}`` must error.
+
+        Asserts (a) non-zero exit code and (b) the error mentions
+        ``--standard`` so an operator understands the gate. This pins
+        the ``click.Choice`` declaration in
+        ``cli/commands/audit_cmd.py`` so the deferred standards cannot
+        be re-introduced without updating both the choice list and the
+        underlying control maps.
+        """
+        from click.testing import CliRunner
+
+        from bernstein.cli.main import cli
+
+        # ``audit export`` requires a ``.sdd`` directory to exist before
+        # it parses the flags; seed an empty one so the click parser
+        # gets the chance to reject the choice.
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["audit", "export", "--standard", standard, "--dir", str(tmp_path)],
+        )
+        assert result.exit_code != 0
+        assert "--standard" in result.output or "'--standard'" in result.output


### PR DESCRIPTION
## Summary

- `bernstein audit export --standard` previously listed `dora` and `finos-aigf` in its `click.Choice` alongside `ai-act`, but both standards shipped with placeholder control maps (`status: "todo"`, `selector: "TODO"`). Running either flag produced a zip whose `controls.json` advertised DORA / FINOS AIGF evidence while every row pointed at a TODO, which is not usable as evidence and misrepresents the surface.
- Route (1) from the bughunt: hide the deferred choices until their clause mappings are reviewed by subject-matter experts. The flag now accepts `ai-act` only; both deferred names raise `ValueError` at the build API and a clean Click usage error at the CLI.
- Module docstring, `_STANDARD_MAPS`, `SUPPORTED_STANDARDS`, the `Standard` literal, and the CLI help text are all aligned. CHANGELOG `[Unreleased] / Changed` entry documents the surface shrink and links #1316.

## Test plan

- [x] `uv run pytest tests/unit/test_evidence_pack.py` (18 passed)
- [x] `uv run pytest tests/unit/test_evidence_pack.py tests/unit/test_eu_ai_act.py tests/unit/test_compliance_engine.py` (78 passed)
- [x] `uv run pytest tests/integration/test_soc2_real_evidence.py` (7 passed)
- [x] `uv run pytest tests/unit/cli/` (216 passed, 1 skipped)
- [x] `uv run ruff check` on changed files clean; `uv run ruff format --check` clean
- [x] New regression class `TestDeferredStandardsRejected` covers (a) build-API rejection, (b) `SUPPORTED_STANDARDS` exclusion, (c) CLI non-zero exit with `--standard` mentioned in the usage error

Refs #1316.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `bernstein audit export --standard` option now supports only `ai-act`
  * DORA and FINOS AIGF standards are no longer available; attempting to use them will raise an error and exit with a message
  
* **Tests**
  * Updated test coverage to verify unsupported standards are properly rejected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->