### PR TITLE
fix(security): fail-fast on lineage.kms_adapter=hsm without integration

### DIFF
--- a/docs/compliance/eu-residency-customer-setup.md
+++ b/docs/compliance/eu-residency-customer-setup.md
@@ -95,7 +95,7 @@ data_residency:
   enforce_strict: true                # any region drift = abort
 lineage:
   customer_signing_enabled: true
-  kms_adapter: env                    # or 'file' / 'hsm'
+  kms_adapter: env                    # or 'file' / 'hsm' (see note below)
   kms_adapter_env_var: LINEAGE_SIGNING_KEY
   regulatory_class_default: production_detection_rule
 network_policy:
@@ -110,6 +110,13 @@ The combination matters:
   rather than warning.
 - `network_policy.profile: airgap` -- the runtime socket guard
   blocks any unintended outbound dial.
+- `kms_adapter: hsm` is only viable when a customer-provided
+  `HSMKMSAdapter` subclass (PKCS#11 / Cloud-KMS) is on the classpath.
+  Without one, the orchestrator aborts at config-load time. For
+  non-production smoke tests, set `BERNSTEIN_ALLOW_HSM_STUB=1` to opt
+  in to the documentation stub explicitly. See
+  [regulatory-lineage.md](regulatory-lineage.md) for the integration
+  shape.
 
 ### 3. Verify the deployment with `bernstein doctor airgap`
 

--- a/docs/compliance/regulatory-lineage.md
+++ b/docs/compliance/regulatory-lineage.md
@@ -111,6 +111,24 @@ protocol and injected into `LineageWriter(..., signer=...)`. The
 file-key reference implementation ships in core; HSM / KMS adapters
 are operator-provided.
 
+#### `kms_adapter: hsm` requires a real integration
+
+Setting `lineage.customer_signing.kms_adapter: hsm` in `bernstein.yaml`
+does **not** ship a working PKCS#11 / Cloud-KMS client. The base
+`HSMKMSAdapter` in `bernstein.core.security.lineage_kms` is a
+documentation stub: every `sign()` call raises `NotImplementedError`.
+To use the `hsm` selector in production, ship a subclass that
+overrides both `sign()` and `public_key_jwk()`, import it before the
+orchestrator loads its config, and the dispatcher picks it up
+automatically.
+
+If a subclass is not on the classpath, `kms_adapter_from_config` raises
+`LineageSignerError` at config-load time -- so a misconfigured
+`bernstein.yaml` surfaces immediately rather than crashing on the first
+audit-emit / lineage-sign call. For non-production smoke tests where
+the silent-stub behaviour is acceptable, set
+`BERNSTEIN_ALLOW_HSM_STUB=1` to opt in to the stub explicitly.
+
 ## Verifying a chain
 
 A customer auditor with only the public key and the WAL files runs:

--- a/src/bernstein/core/security/lineage_kms.py
+++ b/src/bernstein/core/security/lineage_kms.py
@@ -397,8 +397,14 @@ def kms_adapter_from_config(
 
     * ``"file"`` -- :class:`FileBasedKMSAdapter` (requires ``key_path``).
     * ``"env"``  -- :class:`EnvBasedKMSAdapter` (requires ``env_var``).
-    * ``"hsm"``  -- :class:`HSMKMSAdapter` (requires ``token_uri``;
-      raises ``NotImplementedError`` on every operation in this build).
+    * ``"hsm"``  -- HSM-backed adapter (requires ``token_uri``). The
+      dispatcher prefers a concrete :class:`HSMKMSAdapter` subclass on
+      the classpath that overrides both ``sign`` and ``public_key_jwk``.
+      Falling back to the bare stub is gated behind
+      ``BERNSTEIN_ALLOW_HSM_STUB=1`` -- a misconfigured ``hsm`` adapter
+      without either a subclass or the opt-in flag raises
+      :class:`LineageSignerError` at config-load time rather than
+      crashing on the first ``sign()`` call inside the orchestrator.
 
     Returns ``None`` when ``enabled=False`` or no kind is configured,
     so callers can disable signing without removing the config block.
@@ -417,10 +423,70 @@ def kms_adapter_from_config(
     if resolved == "hsm":
         if not token_uri:
             raise LineageSignerError("lineage.kms_adapter=hsm requires lineage.kms_adapter_token_uri")
+        # Fail-fast at construction so a misconfigured `kms_adapter: hsm`
+        # surfaces at config-load time -- not at the first audit-emit /
+        # lineage-sign call deep inside the orchestrator loop. The base
+        # ``HSMKMSAdapter`` is a documentation stub; a real integration
+        # is delivered as a subclass that overrides ``sign`` and
+        # ``public_key_jwk``.
+        subclass = _resolve_hsm_subclass()
+        if subclass is not None:
+            return subclass(token_uri, kid=kid)
+        if not _hsm_stub_opt_in():
+            raise LineageSignerError(
+                "lineage.kms_adapter=hsm resolves to HSMKMSAdapter, which is a "
+                "documentation stub that raises NotImplementedError on sign(). "
+                "Either (a) import a subclass that overrides sign() and "
+                "public_key_jwk() before config load (see "
+                "bernstein.core.security.lineage_kms module docstring for the "
+                "PKCS#11 / Cloud-KMS integration shape), or (b) set "
+                "BERNSTEIN_ALLOW_HSM_STUB=1 to opt in to the stub for "
+                "non-production smoke tests.",
+            )
         return HSMKMSAdapter(token_uri, kid=kid)
     raise LineageSignerError(
         f"unsupported lineage.kms_adapter={kind!r} (expected 'file', 'env', or 'hsm')",
     )
+
+
+def _hsm_stub_opt_in() -> bool:
+    """Return ``True`` when the operator explicitly opted into the stub.
+
+    The opt-in flag exists so a non-production smoke test can still
+    boot with ``kms_adapter: hsm`` (and crash at the first sign call,
+    matching pre-fix behaviour) without a real HSM subclass on the
+    classpath. Any truthy value (``1``, ``true``, ``yes``, ``on``,
+    case-insensitive) counts as opted in.
+    """
+    raw = os.environ.get("BERNSTEIN_ALLOW_HSM_STUB", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _resolve_hsm_subclass() -> type[HSMKMSAdapter] | None:
+    """Return the concrete ``HSMKMSAdapter`` subclass to use, if any.
+
+    A customer integration ships as a subclass of :class:`HSMKMSAdapter`
+    that overrides :meth:`sign` and :meth:`public_key_jwk`. If exactly
+    one such subclass has been imported by the time config dispatch
+    runs, return it -- the dispatcher will instantiate it instead of
+    the stub. Multiple subclasses are an ambiguity the operator must
+    resolve (we raise to avoid silently picking the wrong vendor).
+    """
+    subclasses = [
+        sc
+        for sc in HSMKMSAdapter.__subclasses__()
+        if sc.sign is not HSMKMSAdapter.sign and sc.public_key_jwk is not HSMKMSAdapter.public_key_jwk
+    ]
+    if not subclasses:
+        return None
+    if len(subclasses) > 1:
+        names = ", ".join(sorted(sc.__qualname__ for sc in subclasses))
+        raise LineageSignerError(
+            f"lineage.kms_adapter=hsm resolved to multiple HSMKMSAdapter "
+            f"subclasses ({names}); only one HSM integration may be imported "
+            f"at a time.",
+        )
+    return subclasses[0]
 
 
 __all__ = [

--- a/tests/unit/test_lineage_kms_adapters.py
+++ b/tests/unit/test_lineage_kms_adapters.py
@@ -297,7 +297,13 @@ class TestConfigDispatch:
         )
         assert isinstance(adapter, EnvBasedKMSAdapter)
 
-    def test_hsm_kind_returns_stub(self) -> None:
+    def test_hsm_kind_returns_stub_with_opt_in(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # With the opt-in env var set, the stub builds at config time
+        # -- pre-fix behaviour preserved for non-production smoke tests.
+        monkeypatch.setenv("BERNSTEIN_ALLOW_HSM_STUB", "1")
         adapter = kms_adapter_from_config(
             enabled=True,
             kind="hsm",
@@ -341,7 +347,11 @@ class TestConfigDispatch:
         )
         assert isinstance(signer, EnvBasedKMSAdapter)
 
-    def test_signer_from_config_phase2_hsm(self) -> None:
+    def test_signer_from_config_phase2_hsm(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BERNSTEIN_ALLOW_HSM_STUB", "1")
         signer = signer_from_config(
             enabled=True,
             kms_adapter="hsm",
@@ -362,3 +372,187 @@ class TestConfigDispatch:
         # FileBasedKMSAdapter) so the lineage writer continues to walk
         # the original code path. Both implement LineageSigner.
         assert isinstance(signer, LineageSigner)
+
+
+# ---------------------------------------------------------------------------
+# HSM stub fail-fast at config dispatch (regression for the silent-stub bug)
+# ---------------------------------------------------------------------------
+
+
+class TestHsmStubFailFastDispatch:
+    """``kms_adapter='hsm'`` fails at config-load when no subclass is wired.
+
+    Pre-fix, ``kms_adapter_from_config`` returned the bare
+    :class:`HSMKMSAdapter` whose ``sign()`` is a documentation stub.
+    A customer setting ``lineage.customer_signing.kms_adapter: hsm``
+    therefore booted cleanly and only crashed at the first audit-emit /
+    lineage-sign call, far away from the config-load context.
+    """
+
+    def test_default_hsm_dispatch_raises_with_docstring_pointer(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Default path (no opt-in, no subclass): hard fail at config time.
+        monkeypatch.delenv("BERNSTEIN_ALLOW_HSM_STUB", raising=False)
+        with pytest.raises(LineageSignerError) as exc_info:
+            kms_adapter_from_config(
+                enabled=True,
+                kind="hsm",
+                token_uri="pkcs11:token=stub",
+            )
+        message = str(exc_info.value)
+        # The message must steer the operator to the override path the
+        # module docstring documents.
+        assert "documentation stub" in message
+        assert "sign()" in message
+        assert "BERNSTEIN_ALLOW_HSM_STUB" in message
+
+    def test_opt_in_env_var_allows_stub(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The opt-in path preserves pre-fix behaviour for smoke tests.
+        monkeypatch.setenv("BERNSTEIN_ALLOW_HSM_STUB", "1")
+        adapter = kms_adapter_from_config(
+            enabled=True,
+            kind="hsm",
+            token_uri="pkcs11:token=stub",
+        )
+        assert isinstance(adapter, HSMKMSAdapter)
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "Yes", "on"])
+    def test_opt_in_accepts_common_truthy_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        truthy: str,
+    ) -> None:
+        monkeypatch.setenv("BERNSTEIN_ALLOW_HSM_STUB", truthy)
+        adapter = kms_adapter_from_config(
+            enabled=True,
+            kind="hsm",
+            token_uri="pkcs11:token=stub",
+        )
+        assert isinstance(adapter, HSMKMSAdapter)
+
+    @pytest.mark.parametrize("falsey", ["0", "false", "no", "off", "", "  "])
+    def test_opt_in_rejects_falsey_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        falsey: str,
+    ) -> None:
+        monkeypatch.setenv("BERNSTEIN_ALLOW_HSM_STUB", falsey)
+        with pytest.raises(LineageSignerError, match="BERNSTEIN_ALLOW_HSM_STUB"):
+            kms_adapter_from_config(
+                enabled=True,
+                kind="hsm",
+                token_uri="pkcs11:token=stub",
+            )
+
+    def test_subclass_with_overrides_is_used_without_opt_in(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A real customer integration ships as a subclass that overrides
+        # both methods. When such a subclass is on the classpath, the
+        # dispatcher must pick it up without requiring the opt-in flag.
+        monkeypatch.delenv("BERNSTEIN_ALLOW_HSM_STUB", raising=False)
+
+        class _RealHsm(HSMKMSAdapter):
+            def sign(self, payload: bytes) -> bytes:  # type: ignore[override]
+                del payload
+                return b"\x00" * 64
+
+            def public_key_jwk(self) -> dict[str, str]:  # type: ignore[override]
+                return {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "alg": "EdDSA",
+                    "x": "stub",
+                }
+
+        try:
+            adapter = kms_adapter_from_config(
+                enabled=True,
+                kind="hsm",
+                token_uri="pkcs11:token=t1",
+            )
+            assert isinstance(adapter, _RealHsm)
+            # Real sign returns 64 bytes (no longer raises).
+            assert len(adapter.sign(b"x")) == 64
+        finally:
+            # __subclasses__ is a process-wide registry; ensure the
+            # weakref entry from this local class is cleared before the
+            # next test runs by dropping our reference and forcing the
+            # garbage collector to sweep it.
+            del _RealHsm
+            import gc
+
+            gc.collect()
+
+    def test_subclass_partial_override_ignored(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A subclass that forgets to override one of the two required
+        # methods must NOT be treated as a real integration -- the
+        # dispatcher falls through to the fail-fast path.
+        monkeypatch.delenv("BERNSTEIN_ALLOW_HSM_STUB", raising=False)
+
+        class _HalfBaked(HSMKMSAdapter):
+            def sign(self, payload: bytes) -> bytes:  # type: ignore[override]
+                del payload
+                return b"\x00" * 64
+
+            # public_key_jwk left as the stub -> incomplete integration.
+
+        try:
+            with pytest.raises(LineageSignerError, match="documentation stub"):
+                kms_adapter_from_config(
+                    enabled=True,
+                    kind="hsm",
+                    token_uri="pkcs11:token=t1",
+                )
+        finally:
+            del _HalfBaked
+            import gc
+
+            gc.collect()
+
+    def test_multiple_subclasses_raises_ambiguity(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Two competing HSM integrations on the classpath is an operator
+        # error we surface at config time rather than silently picking one.
+        monkeypatch.delenv("BERNSTEIN_ALLOW_HSM_STUB", raising=False)
+
+        class _VendorAHsm(HSMKMSAdapter):
+            def sign(self, payload: bytes) -> bytes:  # type: ignore[override]
+                del payload
+                return b"a" * 64
+
+            def public_key_jwk(self) -> dict[str, str]:  # type: ignore[override]
+                return {"kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "x": "a"}
+
+        class _VendorBHsm(HSMKMSAdapter):
+            def sign(self, payload: bytes) -> bytes:  # type: ignore[override]
+                del payload
+                return b"b" * 64
+
+            def public_key_jwk(self) -> dict[str, str]:  # type: ignore[override]
+                return {"kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "x": "b"}
+
+        try:
+            with pytest.raises(LineageSignerError, match="multiple HSMKMSAdapter"):
+                kms_adapter_from_config(
+                    enabled=True,
+                    kind="hsm",
+                    token_uri="pkcs11:token=t1",
+                )
+        finally:
+            del _VendorAHsm
+            del _VendorBHsm
+            import gc
+
+            gc.collect()


### PR DESCRIPTION
## Summary

`kms_adapter_from_config(kind=\"hsm\")` returned the bare `HSMKMSAdapter`
documentation stub on every call. A customer setting
`lineage.customer_signing.kms_adapter: hsm` in `bernstein.yaml` therefore
booted cleanly and only crashed at the first audit-emit / lineage-sign
call -- far away from the config-load context that produced the broken
signer.

Dispatch now prefers a customer-provided `HSMKMSAdapter` subclass on the
classpath that overrides both `sign()` and `public_key_jwk()`. Without
either a subclass or an explicit opt-in (`BERNSTEIN_ALLOW_HSM_STUB=1`),
config-load raises `LineageSignerError` with a docstring-aligned message
pointing the operator at the override contract. Mirrors the fail-fast
pattern already used by `Ed25519FileKeySigner.from_path` and the other
adapter branches.

No behaviour change for `kms_adapter='file'` or `'env'`.

## Test plan

- [x] `uv run pytest tests/unit/test_lineage_kms_adapters.py` (51 passed)
- [x] `uv run pytest tests/unit/security/` (247 passed)
- [x] `uv run ruff check src/bernstein/core/security/lineage_kms.py tests/unit/test_lineage_kms_adapters.py` (clean)
- [x] `uv run ruff format --check` (clean for changed files)
- [x] `uv run mypy src/bernstein/core/security/lineage_kms.py` (no new errors; pre-existing `binascii` attr-defined on baseline)
- [x] Docs updated: `docs/compliance/regulatory-lineage.md` HSM section + `docs/compliance/eu-residency-customer-setup.md` config block

## Migration note

Operators relying on the silent-stub behaviour for non-production smoke
tests must now set `BERNSTEIN_ALLOW_HSM_STUB=1`. Production deployments
that intended `kms_adapter: hsm` to be a real integration but never
shipped a subclass will now see the failure at config load instead of
at the first sign call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated EU residency and regulatory compliance documentation with enhanced guidance on HSM adapter setup and configuration requirements.

* **New Features**
  * Implemented HSM adapter validation at configuration load time to provide fail-fast error reporting.
  * Added environment variable support for non-production smoke testing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->