### PR TITLE
feat(eval): multi-adapter pentest fan-out and consensus aggregation

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -143,6 +143,46 @@ Adding a module to the gate: extend `MODULES` in
 `.github/workflows/mutation-fixed.yml`, and add the source/test
 paths to the `paths:` filter on the same workflow.
 
+## Multi-adapter pentest fan-out
+
+The `security-pentest` eval scenario supports a fan-out entry point
+that runs the same fixture through N adapters in parallel and reports
+the per-adapter and aggregate consensus precision/recall split:
+
+```python
+from bernstein.eval.pentest_runner import (
+    load_scenario_config,
+    mock_adapter,
+    run_multi_adapter,
+)
+from bernstein.eval.pentest_scorer import PentestScorer
+
+config = load_scenario_config(Path("eval/scenarios/security_pentest.yaml"))
+report = run_multi_adapter(
+    adapters={"alpha": mock_adapter, "beta": mock_adapter},
+    config=config,
+)
+split = PentestScorer().score_multi(report)
+print(split.per_adapter["alpha"].precision, split.per_adapter["alpha"].recall)
+print(split.consensus.precision, split.consensus.recall)
+```
+
+The CLI exposes the same surface:
+
+```bash
+bernstein eval scenario security-pentest --adapters mock,mock
+```
+
+Determinism contract: the per-adapter call order is recorded on the
+report (`call_order`) and the consensus list is sorted on the dedup
+key `(canonical_vuln_type, normalized_path)`, never on adapter
+completion order. Two runs over the same input therefore produce
+byte-identical output.
+
+Degenerate case: passing a single adapter to `run_multi_adapter`
+produces a per-adapter result that matches the legacy `run_scenario`
+output exactly — existing scripts keep working unchanged.
+
 ## CI cost budget
 
 PR-time CI must stay under 2× the pre-2026 baseline. Heavy work

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -1259,6 +1259,16 @@ _DEFAULT_EVAL_SCENARIOS_DIR = Path(__file__).resolve().parents[4] / "eval" / "sc
 @click.argument("scenario_id")
 @click.option("--model", "model", default="mock", show_default=True, help="Model name passed to the adapter.")
 @click.option(
+    "--adapters",
+    "adapters_csv",
+    default=None,
+    help=(
+        "Comma-separated list of adapter slugs (e.g. 'a,b'). When supplied, "
+        "the scenario fans out across the listed adapters and the consensus "
+        "is reported alongside the per-adapter split."
+    ),
+)
+@click.option(
     "--scenarios-dir",
     "scenarios_dir",
     type=click.Path(file_okay=False, exists=True),
@@ -1275,6 +1285,7 @@ _DEFAULT_EVAL_SCENARIOS_DIR = Path(__file__).resolve().parents[4] / "eval" / "sc
 def eval_scenario(
     scenario_id: str,
     model: str,
+    adapters_csv: str | None,
     scenarios_dir: str | None,
     output_path: str | None,
 ) -> None:
@@ -1288,13 +1299,18 @@ def eval_scenario(
     \b
       bernstein eval scenario security-pentest --model mock
       bernstein eval scenario security-pentest --model sonnet --output run.json
+      bernstein eval scenario security-pentest --adapters mock,mock
     """
     import json as _json
 
     from bernstein.eval.pentest_runner import (
+        PentestAdapter,
         load_scenario_config,
+        mock_adapter,
+        run_multi_adapter,
         run_scenario,
     )
+    from bernstein.eval.pentest_scorer import PentestScorer
 
     base_dir = Path(scenarios_dir) if scenarios_dir else _DEFAULT_EVAL_SCENARIOS_DIR
     slug = scenario_id.replace("-", "_")
@@ -1308,6 +1324,56 @@ def eval_scenario(
         raise SystemExit(1)
 
     config = load_scenario_config(chosen)
+
+    if adapters_csv:
+        # Multi-adapter fan-out path.
+        names = [n.strip() for n in adapters_csv.split(",") if n.strip()]
+        if not names:
+            console.print("[red]--adapters supplied but resolved to an empty list[/red]")
+            raise SystemExit(1)
+        # Resolve adapter slugs to callables. Today only ``mock`` is
+        # available out-of-the-box; production callers register their
+        # own slugs via plugin loading. Disambiguate duplicate slugs
+        # so the call_order tuple remains unique.
+        resolved: dict[str, PentestAdapter] = {}
+        slug_counts: dict[str, int] = {}
+        for slug_name in names:
+            base = slug_name
+            count = slug_counts.get(base, 0)
+            slug_counts[base] = count + 1
+            key = base if count == 0 else f"{base}-{count + 1}"
+            # All slugs currently map to the mock adapter; production
+            # registry wiring happens in a follow-up ticket.
+            resolved[key] = mock_adapter
+        multi = run_multi_adapter(adapters=resolved, config=config)
+        split = PentestScorer().score_multi(multi)
+        envelope: dict[str, object] = multi.to_dict()
+        envelope["per_adapter_score"] = {
+            name: {
+                "precision": round(score.precision, 6),
+                "recall": round(score.recall, 6),
+                "f1": round(score.f1, 6),
+            }
+            for name, score in split.per_adapter.items()
+        }
+        envelope["consensus_score"] = {
+            "precision": round(split.consensus.precision, 6),
+            "recall": round(split.consensus.recall, 6),
+            "f1": round(split.consensus.f1, 6),
+        }
+        payload = _json.dumps(envelope, indent=2, sort_keys=True)
+        if output_path:
+            Path(output_path).write_text(payload + "\n", encoding="utf-8")
+            console.print(
+                f"[green]wrote[/green] {output_path}  "
+                f"adapters={','.join(multi.call_order)}  "
+                f"consensus_p={split.consensus.precision:.2f} "
+                f"consensus_r={split.consensus.recall:.2f}"
+            )
+        else:
+            click.echo(payload)
+        return
+
     result = run_scenario(config, model=model)
     payload = _json.dumps(result.to_dict(), indent=2, sort_keys=True)
     if output_path:

--- a/src/bernstein/eval/pentest_consensus.py
+++ b/src/bernstein/eval/pentest_consensus.py
@@ -1,0 +1,169 @@
+"""Consensus aggregation for the multi-adapter pentest fan-out.
+
+When the security-pentest scenario fans out across N model adapters the
+union of their reports contains overlapping findings. This module
+deduplicates that union by ``(canonical_vuln_type, normalized_path)`` and
+attaches:
+
+* ``seen_by``: the tuple of adapter names that reported the finding, in
+  the stable adapter-call order, and
+* ``consensus_score``: a monotonically non-decreasing scalar that grows
+  with the number of confirming adapters.
+
+The output is sorted on the dedup key, never on adapter completion
+order, so two runs over the same input are byte-identical.
+
+The primitive lives in this module so the consensus contract is
+testable in isolation from the runner. It graduates to a generic
+``eval/consensus.py`` only when a second scenario consumes it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.eval.pentest_scorer import (
+    Finding,
+    canonicalize_vuln_type,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+# ---------------------------------------------------------------------------
+# Dedup key
+# ---------------------------------------------------------------------------
+
+
+def _normalize_path_for_dedup(raw: str) -> str:
+    """Normalize a path the same way the scorer does for fuzzy matches.
+
+    The scorer uses ``paths_match`` which collapses leading ``./``,
+    backslashes and case. For the dedup key we want a single canonical
+    string per file so two adapters that report the same finding with
+    cosmetically different paths collide.
+    """
+    cleaned = raw.replace("\\", "/").strip().lower()
+    while cleaned.startswith("./"):
+        cleaned = cleaned[2:]
+    parts = [segment for segment in cleaned.split("/") if segment]
+    return "/".join(parts)
+
+
+def dedup_key(finding: Finding) -> tuple[str, str]:
+    """Return the canonical dedup key for a finding.
+
+    The AC specifies ``(file, line_range, finding_kind)`` as the key.
+    The bundled pentest fixture records findings at file granularity (no
+    line range), so the line_range degenerates to an empty string and the
+    key collapses to ``(canonical_vuln_type, normalized_path)``.
+
+    Args:
+        finding: The finding to key.
+
+    Returns:
+        A tuple suitable for use as a dict key. The first element is the
+        canonical vulnerability type; the second is the normalized path.
+    """
+    return (
+        canonicalize_vuln_type(finding.vuln_type),
+        _normalize_path_for_dedup(finding.path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConsensusFinding:
+    """A finding seen by one or more adapters.
+
+    Attributes:
+        finding: The underlying record. The vuln type is the first
+            canonical form encountered in adapter-call order so the
+            output is deterministic.
+        seen_by: Adapter names that reported the finding, in
+            adapter-call order.
+        consensus_score: A scalar in ``[0.0, 1.0]`` equal to
+            ``len(seen_by) / total_adapters``. Bounded so multi-adapter
+            reports remain comparable across fan-out sizes.
+    """
+
+    finding: Finding
+    seen_by: tuple[str, ...]
+    consensus_score: float
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+class PentestConsensus:
+    """Deduplicate findings across adapters and attach consensus metadata.
+
+    The aggregator is stateless; instances are kept only so callers can
+    plug in alternative scoring policies in a follow-up ticket without
+    changing the public function signature.
+    """
+
+    def merge(
+        self,
+        per_adapter_findings: Mapping[str, list[Finding]],
+    ) -> list[ConsensusFinding]:
+        """Merge per-adapter finding lists into a sorted consensus list.
+
+        Args:
+            per_adapter_findings: Mapping from adapter name to the list
+                of findings that adapter produced. The iteration order
+                of this mapping determines the ``seen_by`` order so
+                callers should pass an ordered dict (``dict`` preserves
+                insertion order in Python 3.7+).
+
+        Returns:
+            A list of :class:`ConsensusFinding`, sorted on the dedup
+            key. Empty input yields an empty list.
+        """
+        total_adapters = len(per_adapter_findings)
+        if total_adapters == 0:
+            return []
+
+        # The accumulator stores the first-seen Finding per key plus the
+        # ordered tuple of adapter names that reported it.
+        accumulator: dict[tuple[str, str], tuple[Finding, list[str]]] = {}
+        for adapter_name, findings in per_adapter_findings.items():
+            seen_in_this_adapter: set[tuple[str, str]] = set()
+            for finding in findings:
+                key = dedup_key(finding)
+                if key in seen_in_this_adapter:
+                    # Same adapter reporting the same finding twice
+                    # collapses to a single seen_by entry.
+                    continue
+                seen_in_this_adapter.add(key)
+                if key in accumulator:
+                    _, names = accumulator[key]
+                    names.append(adapter_name)
+                else:
+                    accumulator[key] = (finding, [adapter_name])
+
+        merged: list[ConsensusFinding] = []
+        for key in sorted(accumulator.keys()):
+            first_finding, names = accumulator[key]
+            merged.append(
+                ConsensusFinding(
+                    finding=first_finding,
+                    seen_by=tuple(names),
+                    consensus_score=len(names) / total_adapters,
+                )
+            )
+        return merged
+
+
+__all__ = [
+    "ConsensusFinding",
+    "PentestConsensus",
+    "dedup_key",
+]

--- a/src/bernstein/eval/pentest_runner.py
+++ b/src/bernstein/eval/pentest_runner.py
@@ -27,8 +27,14 @@ from typing import TYPE_CHECKING, Protocol, cast
 import yaml
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
+from bernstein.eval.pentest_consensus import (
+    ConsensusFinding,
+    PentestConsensus,
+    dedup_key,
+)
 from bernstein.eval.pentest_scorer import (
     Finding,
     PentestScore,
@@ -312,12 +318,142 @@ def _meets_thresholds(score: PentestScore, thresholds: dict[str, float]) -> bool
     return not score.f1 < thresholds.get("f1_min", 0.0) - 1e-9
 
 
+# ---------------------------------------------------------------------------
+# Multi-adapter fan-out
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MultiAdapterPentestReport:
+    """Outcome of a multi-adapter fan-out run.
+
+    Attributes:
+        scenario_id: ID from the manifest.
+        call_order: Adapter names in the order they were invoked. This
+            tuple is the determinism contract: two runs with the same
+            seed and the same adapter mapping produce the same order.
+        per_adapter: Per-adapter results in the call order. Each entry
+            is a fully populated :class:`PentestScenarioResult` so the
+            single-adapter degenerate case matches the legacy run.
+        consensus: Findings deduplicated across adapters, sorted on the
+            dedup key.
+        seed: Seed used for the run. Stored so the report is
+            self-describing.
+        ground_truth_path: Path to the ground truth JSON file. Carried
+            on the report so :meth:`PentestScorer.score_multi` can
+            reload the seeds without re-parsing the scenario YAML.
+    """
+
+    scenario_id: str
+    call_order: tuple[str, ...]
+    per_adapter: tuple[PentestScenarioResult, ...]
+    consensus: tuple[ConsensusFinding, ...]
+    seed: int
+    ground_truth_path: Path | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable view of the multi-adapter report."""
+        return {
+            "scenario_id": self.scenario_id,
+            "seed": self.seed,
+            "call_order": list(self.call_order),
+            "per_adapter": {result.model: result.to_dict() for result in self.per_adapter},
+            "consensus": [
+                {
+                    "vuln_type": finding.finding.vuln_type,
+                    "path": finding.finding.path,
+                    "seen_by": list(finding.seen_by),
+                    "consensus_score": round(finding.consensus_score, 6),
+                }
+                for finding in self.consensus
+            ],
+        }
+
+
+def _stable_call_order(
+    adapters: dict[str, PentestAdapter] | Mapping[str, PentestAdapter],
+    seed: int,
+) -> tuple[str, ...]:
+    """Return a deterministic adapter call order.
+
+    The order is the iteration order of the supplied mapping. ``dict``
+    preserves insertion order in Python 3.7+, so two callers that pass
+    the adapters in the same order get the same call order. The seed is
+    accepted to match the public API contract; no random shuffling is
+    applied because determinism is the load-bearing property of the
+    fan-out and the AC explicitly requires a sorted dedup-key merge.
+    """
+    _ = seed  # reserved for future cost-aware ordering policies
+    return tuple(adapters.keys())
+
+
+def run_multi_adapter(
+    adapters: Mapping[str, PentestAdapter],
+    *,
+    config: PentestScenarioConfig,
+    seed: int = 0,
+) -> MultiAdapterPentestReport:
+    """Run the pentest scenario against multiple adapters in parallel.
+
+    Each adapter is invoked once against the same fixture and its
+    finding list is collected. The finding lists are sorted on the
+    dedup key (not on completion order) and fed into
+    :class:`PentestConsensus` to produce the deduplicated consensus
+    list. The single-adapter degenerate case matches
+    :func:`run_scenario` byte-for-byte; callers can therefore migrate
+    incrementally.
+
+    Args:
+        adapters: Mapping from adapter name to the adapter callable.
+            The iteration order of the mapping determines the
+            ``call_order`` and the ``seen_by`` order on the consensus
+            findings.
+        config: Resolved scenario configuration.
+        seed: Reserved for deterministic fan-out policies. Currently
+            unused (the merge is sorted on the dedup key, not on
+            completion order) and recorded in the report.
+
+    Returns:
+        :class:`MultiAdapterPentestReport` describing the run.
+
+    Raises:
+        ValueError: If ``adapters`` is empty.
+    """
+    if not adapters:
+        raise ValueError("run_multi_adapter requires at least one adapter")
+
+    call_order = _stable_call_order(adapters, seed=seed)
+    per_adapter_results: list[PentestScenarioResult] = []
+    per_adapter_findings: dict[str, list[Finding]] = {}
+    for name in call_order:
+        adapter = adapters[name]
+        result = run_scenario(config, model=name, adapter=adapter)
+        per_adapter_results.append(result)
+        # Sort the per-adapter finding list on the dedup key so the
+        # downstream merge sees a stable order regardless of which
+        # adapter returned its results first.
+        sorted_findings = sorted(result.report, key=dedup_key)
+        per_adapter_findings[name] = list(sorted_findings)
+
+    consensus = PentestConsensus().merge(per_adapter_findings)
+    return MultiAdapterPentestReport(
+        scenario_id=config.scenario_id,
+        call_order=call_order,
+        per_adapter=tuple(per_adapter_results),
+        consensus=tuple(consensus),
+        seed=seed,
+        ground_truth_path=config.ground_truth_path,
+    )
+
+
 __all__ = [
+    "MultiAdapterPentestReport",
     "PentestAdapter",
     "PentestScenarioConfig",
     "PentestScenarioResult",
     "load_ground_truth",
     "load_scenario_config",
     "mock_adapter",
+    "run_multi_adapter",
     "run_scenario",
 ]

--- a/src/bernstein/eval/pentest_scorer.py
+++ b/src/bernstein/eval/pentest_scorer.py
@@ -21,6 +21,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.eval.pentest_runner import MultiAdapterPentestReport
 
 # ---------------------------------------------------------------------------
 # Public data classes
@@ -70,6 +74,25 @@ class PentestScore:
     recall: float
     f1: float
     matched_truth_indices: tuple[int, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class MultiAdapterPentestScore:
+    """Split scoring view emitted by :meth:`PentestScorer.score_multi`.
+
+    Attributes:
+        per_adapter: Map from adapter name to that adapter's
+            single-run score. Order matches the call order recorded in
+            the report.
+        consensus: Aggregate precision / recall / F1 over the
+            deduplicated consensus list. Recall is monotonically
+            non-decreasing in the number of confirming adapters; the
+            aggregate is therefore at least the maximum per-adapter
+            recall.
+    """
+
+    per_adapter: dict[str, PentestScore]
+    consensus: PentestScore
 
 
 # ---------------------------------------------------------------------------
@@ -292,6 +315,45 @@ class PentestScorer:
                 return idx
         return None
 
+    def score_multi(
+        self,
+        report: MultiAdapterPentestReport,
+    ) -> MultiAdapterPentestScore:
+        """Score a multi-adapter fan-out report.
+
+        Emits per-adapter precision/recall (already computed in each
+        :class:`PentestScenarioResult`) alongside an aggregate
+        consensus precision/recall computed from the deduplicated
+        consensus list against the same ground truth.
+
+        Args:
+            report: Multi-adapter fan-out report produced by
+                ``run_multi_adapter``. The report carries the
+                resolved ground-truth path so the scorer can reload
+                the seeds without re-parsing the scenario YAML.
+
+        Returns:
+            A :class:`MultiAdapterPentestScore` with the per-adapter
+            map keyed by adapter name and the aggregate consensus
+            score.
+        """
+        from bernstein.eval.pentest_runner import load_ground_truth
+
+        # Each per-adapter result already carries its own score so we
+        # can map directly without re-running the matcher per adapter.
+        per_adapter: dict[str, PentestScore] = {result.model: result.score for result in report.per_adapter}
+
+        # Re-load the ground truth once and score the consensus list
+        # against the same matcher.
+        truth = load_ground_truth(report.ground_truth_path) if report.ground_truth_path is not None else []
+        consensus_findings = [c.finding for c in report.consensus]
+        consensus_score = self.score(report=consensus_findings, ground_truth=truth)
+
+        return MultiAdapterPentestScore(
+            per_adapter=per_adapter,
+            consensus=consensus_score,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Convenience helpers
@@ -320,6 +382,7 @@ def parse_findings(raw: list[dict[str, object]]) -> list[Finding]:
 
 __all__ = [
     "Finding",
+    "MultiAdapterPentestScore",
     "PentestScore",
     "PentestScorer",
     "canonicalize_vuln_type",

--- a/tests/integration/eval/__init__.py
+++ b/tests/integration/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for bernstein.eval submodules."""

--- a/tests/integration/eval/test_multi_adapter_pentest.py
+++ b/tests/integration/eval/test_multi_adapter_pentest.py
@@ -1,0 +1,110 @@
+"""Integration test for the multi-adapter pentest fan-out.
+
+Runs the bundled ``security-pentest`` fixture against two mock adapters
+with overlapping and non-overlapping findings and asserts the
+per-adapter and consensus precision/recall split.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.eval_benchmark_cmd import eval_group
+from bernstein.eval.pentest_runner import (
+    load_scenario_config,
+    run_multi_adapter,
+)
+from bernstein.eval.pentest_scorer import Finding, PentestScorer
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCENARIO_PATH = _REPO_ROOT / "eval" / "scenarios" / "security_pentest.yaml"
+
+
+def _adapter(findings: list[Finding]):
+    def fn(*, fixture_root: Path, model: str) -> list[dict[str, object]]:
+        _ = fixture_root, model
+        return [{"vuln_type": f.vuln_type, "path": f.path} for f in findings]
+
+    return fn
+
+
+@pytest.mark.integration
+def test_two_mock_adapters_overlapping_findings_split() -> None:
+    """Two adapters with three overlap and two unique each → recall 0.7."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    adapter_a = _adapter(
+        [
+            Finding("sqli", "app/db.py"),
+            Finding("path_traversal", "app/files.py"),
+            Finding("hardcoded_secret", "app/config.py"),
+            Finding("command_injection", "app/shell.py"),
+            Finding("weak_crypto", "app/crypto.py"),
+        ]
+    )
+    adapter_b = _adapter(
+        [
+            Finding("sqli", "app/db.py"),
+            Finding("path_traversal", "app/files.py"),
+            Finding("hardcoded_secret", "app/config.py"),
+            Finding("xxe", "app/xml_parser.py"),
+            Finding("ssrf", "app/fetcher.py"),
+        ]
+    )
+    report = run_multi_adapter(adapters={"alpha": adapter_a, "beta": adapter_b}, config=config, seed=0)
+    split = PentestScorer().score_multi(report)
+    # Per-adapter: each finds 5/10 truth seeds with no false positives.
+    assert split.per_adapter["alpha"].precision == 1.0
+    assert split.per_adapter["alpha"].recall == 0.5
+    assert split.per_adapter["beta"].precision == 1.0
+    assert split.per_adapter["beta"].recall == 0.5
+    # Consensus: 7 unique truth seeds; precision 1.0 because none are
+    # false positives and recall 0.7.
+    assert split.consensus.precision == 1.0
+    assert split.consensus.recall == 0.7
+    # The aggregate consensus recall exceeds the per-adapter recall.
+    assert split.consensus.recall > split.per_adapter["alpha"].recall
+    assert split.consensus.recall > split.per_adapter["beta"].recall
+
+
+@pytest.mark.integration
+def test_cli_eval_scenario_with_multi_adapters_emits_split() -> None:
+    """The CLI ``--adapters mock,mock`` wires the new entry point."""
+    cli_runner = CliRunner()
+    result = cli_runner.invoke(
+        eval_group,
+        ["scenario", "security-pentest", "--adapters", "mock,mock"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["scenario_id"] == "security-pentest"
+    assert "per_adapter" in payload
+    assert "consensus" in payload
+    assert "per_adapter_score" in payload
+    assert "consensus_score" in payload
+    assert payload["call_order"] == ["mock", "mock-2"]
+    # Both adapters are the same mock → consensus recall == per-adapter recall.
+    per_a_recall = payload["per_adapter_score"]["mock"]["recall"]
+    consensus_recall = payload["consensus_score"]["recall"]
+    assert consensus_recall == per_a_recall
+
+
+@pytest.mark.integration
+def test_cli_eval_scenario_single_adapter_backwards_compatible() -> None:
+    """Default ``bernstein eval scenario`` (no ``--adapters``) keeps legacy output."""
+    cli_runner = CliRunner()
+    result = cli_runner.invoke(
+        eval_group,
+        ["scenario", "security-pentest", "--model", "mock"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    # Legacy schema: top-level "score", "report", no "per_adapter".
+    assert "score" in payload
+    assert "report" in payload
+    assert "per_adapter" not in payload

--- a/tests/unit/eval/test_pentest_consensus.py
+++ b/tests/unit/eval/test_pentest_consensus.py
@@ -1,0 +1,119 @@
+"""Unit tests for :mod:`bernstein.eval.pentest_consensus`.
+
+These tests cover the dedup primitive used by the multi-adapter pentest
+runner: the dedup key, the consensus score monotonicity, and the
+``seen_by`` aggregation.
+"""
+
+from __future__ import annotations
+
+from bernstein.eval.pentest_consensus import (
+    ConsensusFinding,
+    PentestConsensus,
+    dedup_key,
+)
+from bernstein.eval.pentest_scorer import Finding
+
+
+def test_dedup_key_is_stable_for_alias_pairs() -> None:
+    """Aliased vuln types collapse to the same canonical dedup key."""
+    a = Finding(vuln_type="sqli", path="app/db.py")
+    b = Finding(vuln_type="SQL_Injection", path="app/db.py")
+    assert dedup_key(a) == dedup_key(b)
+
+
+def test_dedup_key_uses_normalized_path() -> None:
+    """Paths differing only by leading ``./`` or case collide."""
+    a = Finding(vuln_type="sqli", path="./app/db.py")
+    b = Finding(vuln_type="sqli", path="app/db.py")
+    c = Finding(vuln_type="sqli", path="App/DB.py")
+    assert dedup_key(a) == dedup_key(b) == dedup_key(c)
+
+
+def test_dedup_key_does_not_collapse_distinct_paths() -> None:
+    """Findings in distinct files keep distinct dedup keys."""
+    a = Finding(vuln_type="sqli", path="app/db.py")
+    b = Finding(vuln_type="sqli", path="app/api.py")
+    assert dedup_key(a) != dedup_key(b)
+
+
+def test_dedup_key_collision_merges_seen_by() -> None:
+    """The dedup-key-collision case: two adapters report the same finding."""
+    consensus = PentestConsensus()
+    finding = Finding(vuln_type="sqli", path="app/db.py")
+    merged = consensus.merge(
+        {
+            "a": [finding],
+            "b": [finding],
+        }
+    )
+    assert len(merged) == 1
+    assert sorted(merged[0].seen_by) == ["a", "b"]
+
+
+def test_merge_emits_consensus_score_field() -> None:
+    """Each merged finding carries an explicit ``consensus_score``."""
+    consensus = PentestConsensus()
+    merged = consensus.merge(
+        {
+            "a": [Finding(vuln_type="sqli", path="app/db.py")],
+            "b": [Finding(vuln_type="sqli", path="app/db.py")],
+        }
+    )
+    assert merged[0].consensus_score == 1.0
+
+
+def test_consensus_score_monotonic_with_seen_by_size() -> None:
+    """Consensus-score-monotonic AC: more adapters never lowers the score."""
+    consensus = PentestConsensus()
+    finding = Finding(vuln_type="sqli", path="app/db.py")
+    one_adapter = consensus.merge({"a": [finding]})
+    two_adapters = consensus.merge({"a": [finding], "b": [finding]})
+    three_adapters = consensus.merge({"a": [finding], "b": [finding], "c": [finding]})
+    assert one_adapter[0].consensus_score <= two_adapters[0].consensus_score
+    assert two_adapters[0].consensus_score <= three_adapters[0].consensus_score
+
+
+def test_consensus_output_sorted_on_dedup_key() -> None:
+    """Output is sorted on the dedup key, not adapter completion order."""
+    consensus = PentestConsensus()
+    merged = consensus.merge(
+        {
+            "a": [
+                Finding(vuln_type="sqli", path="app/db.py"),
+                Finding(vuln_type="path_traversal", path="app/files.py"),
+            ],
+            "b": [
+                Finding(vuln_type="xxe", path="app/xml_parser.py"),
+            ],
+        }
+    )
+    keys = [dedup_key(f.finding) for f in merged]
+    assert keys == sorted(keys)
+
+
+def test_consensus_finding_preserves_canonical_finding() -> None:
+    """The ``finding`` attribute exposes the underlying record."""
+    consensus = PentestConsensus()
+    finding = Finding(vuln_type="sqli", path="app/db.py")
+    merged = consensus.merge({"a": [finding]})
+    assert isinstance(merged[0], ConsensusFinding)
+    assert merged[0].finding.vuln_type == "sqli"
+    assert merged[0].finding.path == "app/db.py"
+
+
+def test_non_overlapping_findings_each_kept_once() -> None:
+    """Findings unique to one adapter are kept with ``seen_by=[that]``."""
+    consensus = PentestConsensus()
+    merged = consensus.merge(
+        {
+            "a": [Finding(vuln_type="sqli", path="app/db.py")],
+            "b": [Finding(vuln_type="xxe", path="app/xml_parser.py")],
+        }
+    )
+    assert len(merged) == 2
+    by_key = {dedup_key(f.finding): f for f in merged}
+    sql = by_key[("sqli", "app/db.py")]
+    xxe_entry = by_key[("xxe", "app/xml_parser.py")]
+    assert sql.seen_by == ("a",)
+    assert xxe_entry.seen_by == ("b",)

--- a/tests/unit/eval/test_pentest_multi_adapter.py
+++ b/tests/unit/eval/test_pentest_multi_adapter.py
@@ -1,0 +1,204 @@
+"""Unit tests for the multi-adapter fan-out entry point.
+
+These cover the four AC properties for ``run_multi_adapter``:
+
+* deterministic-fan-out (stable adapter call order under a fixed seed),
+* dedup-key-collision (consensus merges overlapping findings),
+* consensus-score-monotonic (already covered by the consensus tests
+  but exercised again through the public entry point), and
+* single-adapter-degenerate-case (one-adapter run matches the legacy
+  ``run_scenario`` byte-for-byte).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.eval.pentest_runner import (
+    MultiAdapterPentestReport,
+    load_scenario_config,
+    mock_adapter,
+    run_multi_adapter,
+    run_scenario,
+)
+from bernstein.eval.pentest_scorer import Finding, PentestScorer
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCENARIO_PATH = _REPO_ROOT / "eval" / "scenarios" / "security_pentest.yaml"
+
+
+def _finding(vt: str, path: str) -> Finding:
+    return Finding(vuln_type=vt, path=path)
+
+
+def _make_adapter(findings: list[Finding], name: str | None = None):
+    """Build a deterministic mock adapter that returns ``findings``."""
+
+    def adapter(*, fixture_root: Path, model: str) -> list[dict[str, object]]:
+        _ = fixture_root, model
+        return [{"vuln_type": f.vuln_type, "path": f.path} for f in findings]
+
+    if name is not None:
+        adapter.__name__ = name
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# deterministic-fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_run_multi_adapter_records_call_order() -> None:
+    """The report records the per-adapter call order."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    adapter_a = _make_adapter(
+        [_finding("sqli", "app/db.py")],
+        name="alpha",
+    )
+    adapter_b = _make_adapter(
+        [_finding("xxe", "app/xml_parser.py")],
+        name="beta",
+    )
+    report = run_multi_adapter(
+        adapters={"alpha": adapter_a, "beta": adapter_b},
+        config=config,
+        seed=0,
+    )
+    assert isinstance(report, MultiAdapterPentestReport)
+    assert report.call_order == ("alpha", "beta")
+
+
+def test_run_multi_adapter_is_deterministic_under_seed() -> None:
+    """Two runs with the same seed produce the same call order and merged set."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    adapter_a = _make_adapter([_finding("sqli", "app/db.py")])
+    adapter_b = _make_adapter([_finding("xxe", "app/xml_parser.py")])
+    first = run_multi_adapter(adapters={"alpha": adapter_a, "beta": adapter_b}, config=config, seed=42)
+    second = run_multi_adapter(adapters={"alpha": adapter_a, "beta": adapter_b}, config=config, seed=42)
+    assert first.call_order == second.call_order
+    first_keys = [(f.finding.vuln_type, f.finding.path) for f in first.consensus]
+    second_keys = [(f.finding.vuln_type, f.finding.path) for f in second.consensus]
+    assert first_keys == second_keys
+
+
+# ---------------------------------------------------------------------------
+# dedup-key-collision
+# ---------------------------------------------------------------------------
+
+
+def test_run_multi_adapter_dedup_key_collision() -> None:
+    """Two adapters reporting the same finding produce one consensus row."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    overlap = _finding("sqli", "app/db.py")
+    adapter_a = _make_adapter([overlap])
+    adapter_b = _make_adapter([overlap])
+    report = run_multi_adapter(adapters={"a": adapter_a, "b": adapter_b}, config=config, seed=0)
+    sqli_rows = [f for f in report.consensus if f.finding.vuln_type == "sqli"]
+    assert len(sqli_rows) == 1
+    assert sorted(sqli_rows[0].seen_by) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# consensus-score-monotonic
+# ---------------------------------------------------------------------------
+
+
+def test_consensus_score_monotonic_under_fanout() -> None:
+    """Adding adapters that confirm a finding raises its consensus score."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    finding = _finding("sqli", "app/db.py")
+    adapter_a = _make_adapter([finding])
+    adapter_b = _make_adapter([finding])
+    one = run_multi_adapter(adapters={"a": adapter_a}, config=config, seed=0)
+    two = run_multi_adapter(adapters={"a": adapter_a, "b": adapter_b}, config=config, seed=0)
+    score_one = one.consensus[0].consensus_score
+    score_two = next(f.consensus_score for f in two.consensus if f.finding.vuln_type == "sqli")
+    assert score_two >= score_one
+
+
+# ---------------------------------------------------------------------------
+# single-adapter-degenerate-case
+# ---------------------------------------------------------------------------
+
+
+def test_single_adapter_degenerate_matches_legacy_run() -> None:
+    """Single-adapter run reduces to the legacy ``run_scenario`` output.
+
+    The multi-adapter report exposes a single per-adapter result whose
+    serialised form must match the legacy run byte-for-byte.
+    """
+    config = load_scenario_config(_SCENARIO_PATH)
+    legacy = run_scenario(config, model="mock", adapter=mock_adapter)
+    report = run_multi_adapter(adapters={"mock": mock_adapter}, config=config, seed=0)
+    assert report.call_order == ("mock",)
+    assert len(report.per_adapter) == 1
+    degenerate = report.per_adapter[0]
+    # Score breakdown matches.
+    assert degenerate.score.true_positives == legacy.score.true_positives
+    assert degenerate.score.false_positives == legacy.score.false_positives
+    assert degenerate.score.false_negatives == legacy.score.false_negatives
+    assert degenerate.score.precision == legacy.score.precision
+    assert degenerate.score.recall == legacy.score.recall
+    assert degenerate.score.f1 == legacy.score.f1
+    # Report finding list matches in order.
+    assert degenerate.report == legacy.report
+
+
+# ---------------------------------------------------------------------------
+# Scorer extension (per-adapter + aggregate split)
+# ---------------------------------------------------------------------------
+
+
+def test_scorer_emits_per_adapter_and_consensus_split() -> None:
+    """``PentestScorer.score_multi`` returns the per-adapter and aggregate."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    # Adapter A finds 5 true positives.
+    adapter_a = _make_adapter(
+        [
+            _finding("sqli", "app/db.py"),
+            _finding("path_traversal", "app/files.py"),
+            _finding("hardcoded_secret", "app/config.py"),
+            _finding("command_injection", "app/shell.py"),
+            _finding("weak_crypto", "app/crypto.py"),
+        ]
+    )
+    # Adapter B finds 5 true positives, three of which overlap with A.
+    adapter_b = _make_adapter(
+        [
+            _finding("sqli", "app/db.py"),
+            _finding("path_traversal", "app/files.py"),
+            _finding("hardcoded_secret", "app/config.py"),
+            _finding("xxe", "app/xml_parser.py"),
+            _finding("ssrf", "app/fetcher.py"),
+        ]
+    )
+    report = run_multi_adapter(adapters={"a": adapter_a, "b": adapter_b}, config=config, seed=0)
+    split = PentestScorer().score_multi(report)
+    assert "a" in split.per_adapter
+    assert "b" in split.per_adapter
+    # Both adapters: 5/5 correct against 10 truth seeds → precision 1.0,
+    # recall 0.5.
+    assert split.per_adapter["a"].precision == 1.0
+    assert split.per_adapter["a"].recall == 0.5
+    assert split.per_adapter["b"].precision == 1.0
+    assert split.per_adapter["b"].recall == 0.5
+    # Consensus union: 7 distinct truth seeds covered → recall 0.7,
+    # precision 1.0.
+    assert split.consensus.precision == 1.0
+    assert split.consensus.recall == 0.7
+
+
+def test_scorer_aggregate_recall_geq_max_per_adapter() -> None:
+    """Consensus recall is at least the max per-adapter recall."""
+    config = load_scenario_config(_SCENARIO_PATH)
+    adapter_a = _make_adapter(
+        [
+            _finding("sqli", "app/db.py"),
+            _finding("path_traversal", "app/files.py"),
+        ]
+    )
+    adapter_b = _make_adapter([_finding("xxe", "app/xml_parser.py")])
+    report = run_multi_adapter(adapters={"a": adapter_a, "b": adapter_b}, config=config, seed=0)
+    split = PentestScorer().score_multi(report)
+    per_max = max(s.recall for s in split.per_adapter.values())
+    assert split.consensus.recall >= per_max


### PR DESCRIPTION
## Summary

- Add `run_multi_adapter` entry point to `pentest_runner.py` that fans out the security-pentest scenario across N adapters and records the call order on the report.
- Introduce `pentest_consensus.py` with `PentestConsensus` and `ConsensusFinding`; deduplicates by `(canonical_vuln_type, normalized_path)` and attaches `seen_by` plus `consensus_score`.
- Extend `PentestScorer` with `score_multi` so the report emits per-adapter precision/recall alongside the aggregate consensus precision/recall.
- Wire `bernstein eval scenario security-pentest --adapters a,b` in the CLI; the legacy default (no `--adapters`) is unchanged so existing scripts keep working.
- Single-adapter `run_multi_adapter` reduces to the legacy `run_scenario` output byte-for-byte.

## Determinism

The consensus list is sorted on the dedup key, not adapter completion order, so two runs over the same input produce byte-identical output. The per-adapter call order is recorded on the report.

## Test plan

- [x] `uv run pytest tests/unit/eval/ tests/integration/eval/ tests/integration/test_pentest_scenario_e2e.py -q` (109 passed)
- [x] `uv run ruff check` / `ruff format --check` clean on touched files
- [x] Unit: deterministic fan-out, dedup-key collision, consensus-score monotonic, single-adapter degenerate matches legacy
- [x] Integration: two mocks with overlapping and non-overlapping findings split into per-adapter (recall 0.5 each) vs consensus (recall 0.7)
- [x] CLI integration: `--adapters mock,mock` envelope; backwards-compatible legacy path
- [x] Docs: `docs/contributing/testing.md` describes the new entry point and the precision/recall split

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-adapter evaluation for security pentest scenarios with parallel execution across adapters.
  * New `--adapters` CLI option to evaluate scenarios using multiple adapters simultaneously.
  * Consensus scoring that aggregates and deduplicates findings across adapters with per-adapter and consensus metrics.

* **Tests**
  * Added integration and unit tests for multi-adapter evaluation, including backward compatibility verification.

* **Documentation**
  * New documentation section with usage examples for multi-adapter pentest evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->