### PR TITLE
chore(docs): sync AGENTS.md mirrors after rapid feature merge burst

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -231,6 +231,7 @@ alwaysApply: false
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
 | `judge.py`                | LLM judge — evaluate code quality of agent-produced changes |
 | `metrics.py`              | Custom eval metrics — each metric is a dataclass with a compute method |
+| `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |

--- a/.goosehints
+++ b/.goosehints
@@ -232,6 +232,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
 | `judge.py`                | LLM judge — evaluate code quality of agent-produced changes |
 | `metrics.py`              | Custom eval metrics — each metric is a dataclass with a compute method |
+| `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
 | `judge.py`                | LLM judge — evaluate code quality of agent-produced changes |
 | `metrics.py`              | Custom eval metrics — each metric is a dataclass with a compute method |
+| `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
 | `judge.py`                | LLM judge — evaluate code quality of agent-produced changes |
 | `metrics.py`              | Custom eval metrics — each metric is a dataclass with a compute method |
+| `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -232,6 +232,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
 | `judge.py`                | LLM judge — evaluate code quality of agent-produced changes |
 | `metrics.py`              | Custom eval metrics — each metric is a dataclass with a compute method |
+| `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |


### PR DESCRIPTION
## Summary

- Regenerate the AGENTS.md / CLAUDE.md / CONVENTIONS.md / .goosehints / .cursor/rules mirror docs.
- Restores parity between the canonical AGENTS.md and the per-tool mirrors after PRs #1749 through #1754 added new modules without running the sync step.

## Why

Repo hygiene check on main is failing the AGENTS.md cross-CLI sync drift gate. The drift accumulated when six feature PRs auto-merged in a tight window and none of them ran `bernstein agents-md sync` as part of their docs duty. This change runs the sync once and commits the regenerated mirrors.

## Test plan

- [x] `bernstein agents-md sync` reports 13 files written across 5 targets
- [x] `git diff --stat` shows mirror-only changes; no source edits
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal module documentation and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->