### PR TITLE
fix(ci): exclude cookiecutter templates from ruff and tolerate non-zero in autosync

### DIFF
--- a/.github/workflows/pre-merge-autosync.yml
+++ b/.github/workflows/pre-merge-autosync.yml
@@ -90,8 +90,12 @@ jobs:
 
       - name: Run ruff fix and format
         run: |
+          # Tolerate non-zero from both steps so unrelated lint failures
+          # (e.g. cookiecutter Jinja sources in templates/, intentionally
+          # vulnerable security-pentest fixtures) never abort the inline
+          # auto-amend. The reformatted files still land in the next step.
           uv run ruff check . --fix --unsafe-fixes || true
-          uv run ruff format .
+          uv run ruff format . || true
 
       - name: Detect drift
         id: drift

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,9 @@ extend-exclude = [
     # security-pentest eval scenario. Linting it makes no sense; the
     # files exist so the security role can find seeded findings.
     "tests/fixtures/eval/security_pentest/**",
+    # Cookiecutter source templates with Jinja-interpolated identifiers
+    # ({{cookiecutter.X}}) that ruff cannot parse as Python.
+    "templates/**",
 ]
 
 [tool.ruff.format]

--- a/scripts/check_data_freshness.py
+++ b/scripts/check_data_freshness.py
@@ -121,8 +121,7 @@ def main(argv: list[str] | None = None) -> int:
     if soft_hits:
         print(f"::group::data-freshness soft warning (>= {SOFT_THRESHOLD_DAYS} days)")
         for rel_path, line_no, line_text, age_days in soft_hits:
-            print(f"::warning file={rel_path},line={line_no}::"
-                  f"{age_days} days old: {line_text}")
+            print(f"::warning file={rel_path},line={line_no}::{age_days} days old: {line_text}")
         print("::endgroup::")
 
     if not soft_hits and not hard_hits:

--- a/tests/unit/observability/test_no_hardcoded_infra.py
+++ b/tests/unit/observability/test_no_hardcoded_infra.py
@@ -105,6 +105,5 @@ def test_no_hardcoded_observability_infra_in_public_artefacts() -> None:
         "Operator-private observability infrastructure must not appear in "
         "docs/ or in workflow files that render strings into PR comments "
         "or issue bodies. Use *.example.com placeholders in docs and "
-        "operator-configured vars.* references in workflows. Offenders:\n  "
-        + "\n  ".join(offenders)
+        "operator-configured vars.* references in workflows. Offenders:\n  " + "\n  ".join(offenders)
     )


### PR DESCRIPTION
## Summary

- Add `templates/**` to ruff `extend-exclude` in `pyproject.toml` so cookiecutter Jinja sources stop tripping the parser.
- Add `|| true` to the `ruff format` step in `.github/workflows/pre-merge-autosync.yml` so the inline auto-amend never aborts on unrelated lint failures.

## Why

The pre-merge autosync workflow shipped in #1756 aborted before reaching the commit/push step because `ruff format .` returned non-zero on the cookiecutter Jinja templates. Local repro on main showed four parse errors against `templates/{adapter_plugin,quality_gate_plugin}/{{cookiecutter.X}}/...`. After the exclude, `uv run ruff format .` reports 3290 files unchanged and exits 0.

## Test plan

- [x] `uv run ruff format .` clean locally after the exclude
- [x] `uv run ruff check . --fix --unsafe-fixes` clean locally after the exclude
- [ ] CI green
- [ ] Pre-merge autosync workflow on this PR reaches the commit step (a no-op since nothing drifted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to exclude template files from code analysis.
  * Improved GitHub Actions warning message formatting for data freshness checks.
  * Added clarifying comments to build workflow to improve maintainability.

* **Tests**
  * Reformatted test assertion messages for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->