### PR TITLE
fix(workflows): reject interactive node at load time with #1110 reference

### DIFF
--- a/src/bernstein/core/workflows/workflow_spec.py
+++ b/src/bernstein/core/workflows/workflow_spec.py
@@ -115,8 +115,13 @@ class WorkflowNode(BaseModel):
         fresh_context: When ``True``, agent-typed nodes get a fresh
             session per iteration (no carryover).  Ignored for command-
             typed nodes.
-        interactive: Stub for human-approval gates.  When ``True`` the
-            runner raises ``NotImplementedError`` referencing #1110.
+        interactive: Stub for human-approval gates.  Manifests with this
+            set to ``True`` are rejected at load time with a ``ValueError``
+            referencing #1110 so the failure surfaces before any upstream
+            node runs.  The runner keeps a defence-in-depth
+            ``NotImplementedError`` for out-of-band loaders.  Once the
+            approval gate ships in #1110 this validator relaxes to a
+            permissive pass-through.
         timeout_seconds: Per-iteration wall clock cap.
     """
 
@@ -168,6 +173,23 @@ class WorkflowNode(BaseModel):
             raise ValueError(f"node {self.id!r} sets 'agent'; 'prompt' is required")
         if self.id in set(self.depends_on):
             raise ValueError(f"node {self.id!r} cannot depend on itself")
+        return self
+
+    @model_validator(mode="after")
+    def _check_interactive_unsupported(self) -> WorkflowNode:
+        """Reject ``interactive: true`` until #1110 ships the approval gate.
+
+        Without this guard, manifests with an interactive node parse cleanly,
+        the DAG validates, and the runner aborts mid-run only after upstream
+        nodes have already produced state (filesystem side-effects, agent
+        spawns).  Failing at load time means manifest authors learn at lint
+        time instead of after partial execution.  This validator relaxes to
+        a permissive pass-through once #1110 lands.
+        """
+        if self.interactive:
+            raise ValueError(
+                f"node {self.id!r} sets unsupported field 'interactive: true'; approval gates ship in #1110",
+            )
         return self
 
     @property

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -281,10 +281,13 @@ nodes:
 # ---------------------------------------------------------------------------
 
 
-def test_interactive_node_raises_not_implemented_with_ticket(runner_workdir: Path) -> None:
-    """`interactive: true` is a stub that points at #1110."""
-    spec = _spec_from(
-        """
+def test_interactive_node_rejected_at_load_time(runner_workdir: Path) -> None:
+    """`interactive: true` fails fast at load time with #1110 reference."""
+    from bernstein.core.workflows.workflow_spec import WorkflowSpecError
+
+    with pytest.raises(WorkflowSpecError, match="#1110"):
+        _spec_from(
+            """
 name: needs-approval
 description: "Has a human gate"
 version: "1.0.0"
@@ -293,6 +296,35 @@ nodes:
     command: "true"
     interactive: true
 """
+        )
+
+
+def test_interactive_node_defence_in_depth_in_runner(runner_workdir: Path) -> None:
+    """The runner keeps a defence-in-depth `NotImplementedError` for out-of-band loaders.
+
+    A caller that bypasses :func:`load_workflow_spec_from_text` (e.g. via
+    ``model_construct``) must still trip the runner's stub instead of running
+    an unsupported node.
+    """
+    from bernstein.core.workflows.workflow_spec import WorkflowNode
+
+    # ``model_construct`` skips validators, simulating an out-of-band loader.
+    gate_node = WorkflowNode.model_construct(
+        id="gate",
+        depends_on=[],
+        command="true",
+        agent=None,
+        prompt=None,
+        loop=None,
+        fresh_context=False,
+        interactive=True,
+        timeout_seconds=1800,
+    )
+    spec = WorkflowSpec.model_construct(
+        name="needs-approval",
+        description="Has a human gate",
+        version="1.0.0",
+        nodes=[gate_node],
     )
     runner = _build_runner(workdir=runner_workdir)
     with pytest.raises(NotImplementedError, match="#1110"):

--- a/tests/unit/test_workflow_spec.py
+++ b/tests/unit/test_workflow_spec.py
@@ -210,6 +210,54 @@ nodes:
         load_workflow_spec_from_text(text)
 
 
+def test_rejects_interactive_node_at_load_time() -> None:
+    """``interactive: true`` is stubbed until #1110 ships, so it must fail at load.
+
+    Without this gate, manifests parse cleanly and only crash mid-run after
+    upstream nodes have already produced state. The validator collapses the
+    failure to the load step so authors learn at lint / load time instead of
+    after side-effects have landed.
+    """
+    text = """
+name: needs-approval
+description: "Has an approval gate"
+version: "1.0.0"
+nodes:
+  - id: research
+    agent: manager
+    prompt: "Research {goal}"
+  - id: approve
+    depends_on: [research]
+    agent: manager
+    prompt: "Approve the brief"
+    interactive: true
+"""
+    with pytest.raises(WorkflowSpecError, match="#1110") as exc_info:
+        load_workflow_spec_from_text(text)
+    assert "interactive" in str(exc_info.value)
+    assert "approve" in str(exc_info.value)
+
+
+def test_accepts_interactive_false_default() -> None:
+    """Existing valid workflows (no ``interactive: true``) parse identically."""
+    text = """
+name: no-gate
+description: "No interactive gate"
+version: "1.0.0"
+nodes:
+  - id: research
+    agent: manager
+    prompt: "Research {goal}"
+    interactive: false
+  - id: ship
+    depends_on: [research]
+    command: "echo done"
+"""
+    spec = load_workflow_spec_from_text(text)
+    assert spec.nodes[0].interactive is False
+    assert spec.nodes[1].interactive is False
+
+
 # ---------------------------------------------------------------------------
 # Validation: id and version shapes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A workflow manifest carrying `interactive: true` previously parsed cleanly through `WorkflowSpec.model_validate(...)`, passed topological validation, then crashed mid-run with `NotImplementedError` only after upstream nodes had already produced filesystem side-effects and spawned agents.

This adds a `model_validator(mode="after")` on `WorkflowNode` that raises a `ValueError` referencing #1110 so the failure surfaces at lint / load time instead of after partial execution. The runner keeps its defence-in-depth `NotImplementedError` so out-of-band loaders that bypass validation (e.g. via `model_construct`) still trip the stub instead of running an unsupported node. Once the approval gate ships in #1110 the validator relaxes to a permissive pass-through.

## Changes

- `src/bernstein/core/workflows/workflow_spec.py`: new `_check_interactive_unsupported` validator on `WorkflowNode` + updated docstring.
- `tests/unit/test_workflow_spec.py`: regression covering load-time rejection (positive case) plus an `interactive: false` round-trip (negative case).
- `tests/integration/test_workflow_runner.py`: split the existing interactive test into (a) load-time rejection and (b) defence-in-depth via `model_construct` to bypass validation.

## Test plan

- [x] `uv run pytest tests/unit/test_workflow_spec.py tests/integration/test_workflow_runner.py tests/unit/test_workflow.py tests/unit/test_approval_workflow.py tests/unit/test_workflow_importer.py` — 96 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/bernstein/core/workflows/` — no new errors (10 pre-existing, identical to main)