### PR TITLE
fix(observability): unblock glitchtip insights, capture cli exceptions, drop dead sonar config

### DIFF
--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Capture observe snapshot
         id: capture
+        continue-on-error: true  # `doctor observe` returns 1 on Sonar WARN; snapshot still valid.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/glitchtip-insights.yml
+++ b/.github/workflows/glitchtip-insights.yml
@@ -9,6 +9,13 @@ name: glitchtip-insights
 # configured so a fresh fork stays green until the operator wires the
 # token. The token is minted by the operator in GlitchTip and stored as
 # a repo secret named GLITCHTIP_API_TOKEN.
+#
+# Required repository configuration:
+#   * secret  GLITCHTIP_API_TOKEN  -- Bearer token for the GlitchTip API.
+#   * var     GLITCHTIP_BASE_URL   -- Base URL of the GlitchTip instance
+#                                     (e.g. https://errors.example.com).
+# Both are optional; the workflow short-circuits with a notice when
+# either is empty so forks stay green until the operator wires them.
 
 on:
   schedule:
@@ -44,13 +51,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Check token presence
+      - name: Check token + base URL presence
         id: check_token
         env:
           TOKEN_PRESENT: ${{ secrets.GLITCHTIP_API_TOKEN != '' }}
+          BASE_URL_PRESENT: ${{ env.GLITCHTIP_BASE_URL != '' }}
         run: |
           if [ "${TOKEN_PRESENT}" != "true" ]; then
-            echo "GLITCHTIP_API_TOKEN is not configured; skipping sweep."
+            echo "::notice::GLITCHTIP_API_TOKEN is not configured; skipping sweep."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "${BASE_URL_PRESENT}" != "true" ]; then
+            echo "::notice::GLITCHTIP_BASE_URL is not configured; skipping sweep."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,20 +1,17 @@
 name: SonarQube scan
 
-# Runs after a push to main, after the main CI workflow completes
-# successfully, or on manual dispatch.
+# Runs after a push to main or on manual dispatch.
 #
-# Why three triggers? Under the normal rapid-merge cadence on main,
-# ci.yml's branch-scoped `cancel-in-progress: true` (see ci.yml lines
-# 112-135) almost never lets a main CI run reach a `success`
-# conclusion: each new merge cancels the prior in-flight run. As a
-# result the historical `workflow_run` listener fired but the job-level
-# `if: workflow_run.conclusion == 'success'` short-circuited to
-# `skipped` on every recent run. The fix is to also trigger directly
-# on `push: branches: [main]` so the Sonar surface stays fresh
-# regardless of which upstream CI run was the last to actually finish.
-# The `workflow_run` arm is kept because it provides a free coverage
-# artifact when the upstream did finish; the `push` arm runs a thin
-# fallback coverage pass when there is no usable upstream artifact.
+# Historically a third `workflow_run` arm chained off the main `CI`
+# workflow's `completed` event, but ci.yml's branch-scoped
+# `cancel-in-progress: true` (ci.yml lines 112-135) almost never lets a
+# main CI run reach a `success` conclusion under the normal rapid-merge
+# cadence: each new merge cancels the prior in-flight run, so the
+# job-level `if: workflow_run.conclusion == 'success'` short-circuited
+# to `skipped` on every recent run (0/19 successful in the last 50
+# observed). The `push: branches: [main]` trigger keeps the Sonar
+# surface fresh on its own; the `push` arm runs a thin fallback
+# coverage pass when there is no usable upstream coverage artifact.
 on:
   push:
     branches: [main]
@@ -23,10 +20,6 @@ on:
       - '**/*.md'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'
-  workflow_run:
-    workflows: ['CI']
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -42,16 +35,12 @@ jobs:
     name: SonarQube scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Run when:
-    # - Triggered manually, or
-    # - Direct push to main (independent of upstream CI conclusion), or
-    # - The upstream CI run succeeded on main.
-    # SONAR_HOST_URL must be configured as a repo variable in every case.
+    # Run on direct push to main or manual dispatch.
+    # SONAR_HOST_URL must be configured as a repo variable.
     if: >-
       ${{ vars.SONAR_HOST_URL != '' &&
           (github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'push' ||
-           github.event.workflow_run.conclusion == 'success') }}
+           github.event_name == 'push') }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
@@ -62,20 +51,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
-          # Sonar needs full git history for accurate blame. When
-          # triggered by workflow_run, check out the SHA that CI ran
-          # against so the scan reflects that exact commit.
+          # Sonar needs full git history for accurate blame.
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
-
-      - name: Download coverage artifact (workflow_run)
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-        with:
-          name: coverage-report
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # When triggered manually we have no upstream run-id, so resolve the
       # most recent successful CI run on main and pull its coverage-report
@@ -212,13 +191,16 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
         with:
+          # `sonar.projectKey` and `sonar.projectName` come from
+          # `sonar-project.properties`. The overrides below cover values
+          # the workflow needs to differ from the file (e.g. broader
+          # python.version matrix, top-level `src/` for full-tree scans,
+          # workflow-run SHA pinning).
           args: >
-            -Dsonar.projectKey=bernstein
-            -Dsonar.projectName=Bernstein
             -Dsonar.python.version=3.12,3.13
             -Dsonar.sources=src
             -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.exclusions=src/bernstein/_default_templates/**,src/bernstein/grpc_gen/**
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha || github.sha }}
+            -Dsonar.scm.revision=${{ github.sha }}
             -Dsonar.ws.timeout=600

--- a/docs/operations/glitchtip-setup.md
+++ b/docs/operations/glitchtip-setup.md
@@ -16,24 +16,33 @@ event verification.
 | 1 | Create an organization + project in the GlitchTip UI |
 | 2 | Copy the project DSN (`Settings -> Projects -> <name> -> Client Keys`) |
 | 3 | Store the DSN in the deploy environment (GH secret, systemd unit, container env) |
-| 4 | Export `GLITCHTIP_DSN=<dsn>` into every Bernstein process |
+| 4 | Export `BERNSTEIN_TELEMETRY_DSN=<dsn>` into every Bernstein process |
 | 5 | Trigger a controlled error and confirm the issue lands in the UI |
 
-## Env var
+## Env vars
 
-The Bernstein CLI reads exactly one env var at startup:
+The Bernstein CLI reads its DSN from a small, ordered set of env vars at
+startup:
 
 ```text
-GLITCHTIP_DSN=https://<public-key>@<host>/<project-id>
+BERNSTEIN_TELEMETRY_DSN=https://<public-key>@<host>/<project-id>   # canonical
+GLITCHTIP_DSN=https://<public-key>@<host>/<project-id>             # legacy alias
 ```
 
-Defined in `src/bernstein/cli/main.py::_init_error_telemetry`.  When the
-var is unset or empty, the helper is a no-op and `sentry-sdk` is never
-imported -- minimal installs pay zero overhead.
+Resolved in `src/bernstein/cli/main.py::_init_error_telemetry`. The
+canonical name is `BERNSTEIN_TELEMETRY_DSN`: a host-agnostic,
+project-specific variable documented in
+`docs/observability/side-channel.md`. `GLITCHTIP_DSN` is honoured as a
+deprecated fallback for deployments wired before the rename; new
+deployments should use `BERNSTEIN_TELEMETRY_DSN`.
 
-`SENTRY_DSN` is **not** read.  Bernstein deliberately uses a
-project-specific env var to keep operator-managed error sinks distinct
-from any third-party Sentry wiring an embedded library might do.
+When neither var is set, the helper is a no-op and `sentry-sdk` is never
+imported. Minimal installs pay zero overhead.
+
+The plain `SENTRY_DSN` is **not** read. Bernstein deliberately uses a
+project-specific env var so an operator-managed error sink stays
+distinct from any third-party Sentry wiring an embedded library might
+do.
 
 ## Provisioning a project
 
@@ -41,35 +50,59 @@ from any third-party Sentry wiring an embedded library might do.
 2. `Organization -> New Project`, pick **Python** as the platform.
 3. Open the project's **Client Keys (DSN)** page and copy the public DSN.
    Format: `https://<32-hex-public-key>@<host>/<numeric-project-id>`.
-4. Store the DSN as the `GLITCHTIP_DSN` secret in every deploy surface
-   that runs Bernstein:
+4. Store the DSN as the `BERNSTEIN_TELEMETRY_DSN` secret in every deploy
+   surface that runs Bernstein:
 
    * GitHub Actions: `Settings -> Secrets and variables -> Actions ->
-     New repository secret`, name `GLITCHTIP_DSN`.  The
+     New repository secret`, name `BERNSTEIN_TELEMETRY_DSN`. The
      `bernstein-deploy.yml` workflow passes it through to the deploy
      target.
    * systemd: drop into the unit's `EnvironmentFile=` or via
-     `Environment=GLITCHTIP_DSN=...`.
-   * Container: pass via `--env GLITCHTIP_DSN=...` or compose `env_file`.
-   * Local operator workstation: `export GLITCHTIP_DSN=...` in the
-     shell that runs `bernstein`.
+     `Environment=BERNSTEIN_TELEMETRY_DSN=...`.
+   * Container: pass via `--env BERNSTEIN_TELEMETRY_DSN=...` or compose
+     `env_file`.
+   * Local operator workstation: `export BERNSTEIN_TELEMETRY_DSN=...` in
+     the shell that runs `bernstein`.
+
+## Workflow vars (CI insights sweep)
+
+The `.github/workflows/glitchtip-insights.yml` workflow performs a daily
+sweep of fatal-level GlitchTip issues and mirrors them as GitHub issues.
+It needs two pieces of configuration on the repository:
+
+| Kind | Name | Purpose |
+|------|------|---------|
+| secret | `GLITCHTIP_API_TOKEN` | Bearer token for the GlitchTip API |
+| var    | `GLITCHTIP_BASE_URL`  | Base URL of the GlitchTip instance, e.g. `https://errors.example.com` |
+
+Both are optional: the workflow short-circuits with a notice when
+either is empty so forks stay green until the operator wires them.
+Set the variable under `Settings -> Secrets and variables -> Actions ->
+Variables -> New repository variable`.
 
 ## Verifying events flow
 
 After exporting the DSN, run a controlled capture to confirm ingestion:
 
 ```bash
-export GLITCHTIP_DSN='https://<public-key>@<host>/<project-id>'
+export BERNSTEIN_TELEMETRY_DSN='https://<public-key>@<host>/<project-id>'
 python -c "
-import os, bernstein.cli.main  # triggers _init_error_telemetry
+import bernstein.cli.main  # triggers _init_error_telemetry
 import sentry_sdk
 sentry_sdk.capture_message('bernstein glitchtip smoke', level='info')
 sentry_sdk.flush(timeout=5)
 "
 ```
 
-Then open the GlitchTip UI -> Issues for the project.  The
+Then open the GlitchTip UI -> Issues for the project. The
 `bernstein glitchtip smoke` issue should appear within a few seconds.
+
+To verify CLI-side exception capture, the first-run guard at
+`src/bernstein/cli/first_run_guard.py::handle_first_run_exception` calls
+`sentry_sdk.capture_exception` explicitly before converting a top-level
+exception into a Rich hint panel. The default `sys.excepthook` never
+sees these exceptions, so the explicit call is required to keep
+GlitchTip in the loop.
 
 To verify via the API (auth token from `Profile -> Auth Tokens`):
 
@@ -85,7 +118,7 @@ GlitchTip lets the operator add/revoke client keys without re-provisioning
 the project.  To rotate:
 
 1. `Project Settings -> Client Keys -> New Client Key`.
-2. Update `GLITCHTIP_DSN` in every deploy surface listed above.
+2. Update `BERNSTEIN_TELEMETRY_DSN` in every deploy surface listed above.
 3. Restart Bernstein processes so they pick up the new DSN at import time.
 4. Revoke the old key once traffic on it has stopped.
 
@@ -93,7 +126,8 @@ the project.  To rotate:
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
-| No events in UI | Env var not exported in the process | Confirm with `printenv GLITCHTIP_DSN` inside the running process namespace |
+| No events in UI | Env var not exported in the process | Confirm with `printenv BERNSTEIN_TELEMETRY_DSN` inside the running process namespace |
 | `ImportError` swallowed silently | `sentry-sdk` not installed | Reinstall with the extra: `pip install 'bernstein[observability]'` |
 | `429 Too Many Requests` from sink | Per-project throttle in GlitchTip | Raise `eventThrottleRate` on the project, or bound `before_send` |
 | DSN works locally, not on VPS | Egress firewall blocks the GlitchTip host | Whitelist the sink host in the VPS egress policy |
+| Workflow `glitchtip-insights` skipped with notice | `GLITCHTIP_BASE_URL` var or `GLITCHTIP_API_TOKEN` secret not set | Configure both on the repository as described above |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,16 +1,10 @@
-sonar.organization=chernistry
-sonar.projectKey=chernistry_bernstein
+sonar.projectKey=bernstein
 sonar.projectName=Bernstein
 
-# NOTE: The `chernistry` SonarCloud org is on the free public-projects plan
-# (~191k LOC soft cap). Main-branch analyses are currently rejected by the
-# compute engine ("maximum allowed lines limit") so the project has no stored
-# baseline and zero issues are reported, even though PR-scoped scans still
-# pass on the diff. Resolution requires admin action (plan upgrade, re-home
-# the project under the `sipyourdrink-ltd` org, or further `sonar.sources`
-# shrinkage) and cannot be fixed from the codebase alone. See
-# `.sdd/backlog/closed/2026-05-07-sonar-manual-review.md` for evidence and
-# the recommended path (option 2: re-home).
+# The previous SonarCloud-hosted project (`chernistry_bernstein` under the
+# `chernistry` org) is decommissioned. Analysis now runs against a
+# self-hosted SonarQube instance configured via `vars.SONAR_HOST_URL` and
+# `secrets.SONAR_TOKEN` in the `sonar-scan.yml` workflow.
 
 # -------------------------------------------------------------------------
 # Scope

--- a/src/bernstein/cli/first_run_guard.py
+++ b/src/bernstein/cli/first_run_guard.py
@@ -69,6 +69,35 @@ def _context_from_exception(exc: BaseException) -> HintContext:
     return ctx
 
 
+def _capture_to_telemetry_sink(exc: BaseException) -> None:
+    """Forward ``exc`` to the operator-managed error sink, if one is wired.
+
+    This is the explicit-capture counterpart to ``sys.excepthook``: the
+    default hook never fires for exceptions caught by the CLI's
+    first-run barrier, so without this call no event reaches GlitchTip
+    even though the SDK is initialised. The function is a no-op when:
+
+    * ``sentry-sdk`` is not installed (minimal install without the
+      ``observability`` extra), or
+    * the SDK was never initialised (operator has not exported a DSN).
+
+    Telemetry is best-effort and must not crash the CLI's exit path:
+    any error raised by the SDK is swallowed.
+    """
+    try:
+        import sentry_sdk  # type: ignore[import-not-found]
+    except ImportError:
+        return
+    try:
+        client = sentry_sdk.get_client()
+        if not client.is_active():
+            return
+        sentry_sdk.capture_exception(exc)
+    except Exception:
+        # Best-effort: a misbehaving SDK must never block the exit path.
+        return
+
+
 def handle_first_run_exception(
     exc: BaseException,
     *,
@@ -99,6 +128,12 @@ def handle_first_run_exception(
     # overwrite the operator's chosen exit code with a categorised one.
     if isinstance(exc, SystemExit):
         raise exc
+
+    # Forward to GlitchTip / Sentry-compatible sink before the pretty
+    # print. The default ``sys.excepthook`` never sees this exception
+    # because we are about to convert it into a SystemExit, so explicit
+    # capture is required to keep the error sink in the loop.
+    _capture_to_telemetry_sink(exc)
 
     category = categorize_exception(exc)
     ctx = _context_from_exception(exc)

--- a/tests/unit/cli/test_first_run_guard_capture.py
+++ b/tests/unit/cli/test_first_run_guard_capture.py
@@ -1,0 +1,173 @@
+"""Tests for explicit ``sentry_sdk.capture_exception`` wiring in the CLI barrier.
+
+The first-run guard converts top-level exceptions into a Rich hint panel
+plus a ``SystemExit``. Because the conversion swallows the original
+exception, the default ``sys.excepthook`` never fires for these paths
+and the configured GlitchTip / Sentry-compatible sink would otherwise
+miss every CLI crash.
+
+These tests pin the explicit ``sentry_sdk.capture_exception`` call so
+the wire-up cannot regress silently.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import click
+import pytest
+
+from bernstein.cli import first_run_guard
+
+
+class _FakeClient:
+    """Stand-in for ``sentry_sdk.get_client()``.
+
+    Exposes ``is_active`` so the guard can short-circuit when no DSN
+    was configured.
+    """
+
+    def __init__(self, *, active: bool) -> None:
+        self._active = active
+
+    def is_active(self) -> bool:
+        return self._active
+
+
+def _install_fake_sentry(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    active: bool,
+) -> SimpleNamespace:
+    """Install a fake ``sentry_sdk`` module and return a recorder.
+
+    The recorder counts ``capture_exception`` invocations and stores
+    each captured exception so tests can assert on them.
+    """
+    captured: list[BaseException] = []
+
+    def _capture(exc: BaseException) -> None:
+        captured.append(exc)
+
+    fake = ModuleType("sentry_sdk")
+    fake.get_client = lambda: _FakeClient(active=active)  # type: ignore[attr-defined]
+    fake.capture_exception = _capture  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+    return SimpleNamespace(captured=captured)
+
+
+def test_capture_exception_called_once_on_unhandled_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unhandled CLI exception triggers exactly one capture call."""
+    recorder = _install_fake_sentry(monkeypatch, active=True)
+
+    boom = RuntimeError("simulated CLI failure")
+
+    # Silence the Rich hint render so the test stays quiet; the only
+    # behaviour under test here is the capture call.
+    monkeypatch.setattr(
+        first_run_guard,
+        "render_hint",
+        lambda *args, **kwargs: None,
+    )
+
+    with pytest.raises(SystemExit):
+        first_run_guard.handle_first_run_exception(boom)
+
+    assert len(recorder.captured) == 1
+    assert recorder.captured[0] is boom
+
+
+def test_capture_skipped_when_sdk_inactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No capture call when the SDK is installed but never initialised."""
+    recorder = _install_fake_sentry(monkeypatch, active=False)
+
+    monkeypatch.setattr(
+        first_run_guard,
+        "render_hint",
+        lambda *args, **kwargs: None,
+    )
+
+    with pytest.raises(SystemExit):
+        first_run_guard.handle_first_run_exception(RuntimeError("boom"))
+
+    assert recorder.captured == []
+
+
+def test_capture_skipped_when_sdk_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The guard is a no-op when ``sentry-sdk`` is not importable."""
+    # Force ``import sentry_sdk`` to raise ImportError.
+    monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+
+    monkeypatch.setattr(
+        first_run_guard,
+        "render_hint",
+        lambda *args, **kwargs: None,
+    )
+
+    # Must not raise anything other than the expected SystemExit.
+    with pytest.raises(SystemExit):
+        first_run_guard.handle_first_run_exception(RuntimeError("boom"))
+
+
+def test_capture_failures_do_not_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A misbehaving SDK must not block the CLI exit path."""
+
+    def _explode(_: BaseException) -> None:
+        raise RuntimeError("sentry sdk is on fire")
+
+    fake = ModuleType("sentry_sdk")
+    fake.get_client = lambda: _FakeClient(active=True)  # type: ignore[attr-defined]
+    fake.capture_exception = _explode  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+
+    monkeypatch.setattr(
+        first_run_guard,
+        "render_hint",
+        lambda *args, **kwargs: None,
+    )
+
+    # The capture explosion is swallowed; SystemExit still bubbles up
+    # so the categorised exit code reaches the operator.
+    with pytest.raises(SystemExit):
+        first_run_guard.handle_first_run_exception(RuntimeError("boom"))
+
+
+def test_usage_error_skips_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``click.UsageError`` is re-raised before any capture happens."""
+    recorder = _install_fake_sentry(monkeypatch, active=True)
+
+    monkeypatch.setattr(
+        first_run_guard,
+        "render_hint",
+        lambda *args, **kwargs: None,
+    )
+
+    with pytest.raises(click.UsageError):
+        first_run_guard.handle_first_run_exception(click.UsageError("nope"))
+
+    assert recorder.captured == []
+
+
+def test_system_exit_skips_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit ``SystemExit`` from inner code is honoured verbatim."""
+    recorder = _install_fake_sentry(monkeypatch, active=True)
+
+    monkeypatch.setattr(
+        first_run_guard,
+        "render_hint",
+        lambda *args, **kwargs: None,
+    )
+
+    with pytest.raises(SystemExit):
+        first_run_guard.handle_first_run_exception(SystemExit(42))
+
+    assert recorder.captured == []


### PR DESCRIPTION
## Summary

Six mechanical observability quick-wins bundled as one hygiene pass.

* `glitchtip-insights.yml`: gate the curl step on both `GLITCHTIP_API_TOKEN` secret and `GLITCHTIP_BASE_URL` var. Failing run on missing base URL (curl exit 3) now short-circuits with a notice. Workflow header documents both pieces of repo config.
* `docs-observability-snapshot.yml`: tolerate the documented non-zero exit from `bernstein doctor observe` on Sonar WARN by adding `continue-on-error` to the capture step. Matches the PR-summary workflow.
* `sonar-project.properties`: drop the decommissioned SonarCloud project key + organisation; settle on `sonar.projectKey=bernstein` now that scans run against the self-hosted SonarQube. Removes the now-redundant `-Dsonar.projectKey` override in the scan workflow.
* `sonar-scan.yml`: remove the `workflow_run` trigger arm and its conditional steps. The upstream CI run almost never reaches `success` under the rapid-merge cadence (cancel-in-progress concurrency), so the listener short-circuited to `skipped` on every recent run (0/19 in the last 50 observed). `push` + `workflow_dispatch` cover the remaining cases.
* `first_run_guard.py`: explicit `sentry_sdk.capture_exception` inside the CLI exception barrier, guarded by `sentry_sdk.get_client().is_active()`. The default `sys.excepthook` never sees exceptions caught by this barrier (they convert into `SystemExit`), so without the explicit call the configured GlitchTip sink misses every CLI crash. Unit test pins the wire-up.
* `docs/operations/glitchtip-setup.md`: lead with the canonical `BERNSTEIN_TELEMETRY_DSN` env var and mark `GLITCHTIP_DSN` as a legacy alias. Document the `GLITCHTIP_BASE_URL` workflow var requirement and add a troubleshooting row.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_first_run_guard_capture.py tests/integration/test_errcat_cli.py tests/unit/cli/doctor/test_observe.py tests/unit/cli/doctor/test_glitchtip.py` -- 67 passed
- [x] `uv run ruff check .` -- all checks passed
- [x] `uv run ruff format --check .` -- clean
- [x] `actionlint` on the three touched workflows -- clean
- [x] `uv run python -m bernstein --help` -- imports without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GlitchTip setup guide to standardize on `BERNSTEIN_TELEMETRY_DSN` environment variable for telemetry configuration, with guidance for provisioning and rotation.

* **Bug Fixes**
  * Improved CI workflow error handling and configuration validation to prevent misconfiguration issues in deployments.

* **Tests**
  * Added tests for telemetry exception capture in error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->