### PR TITLE
feat(backlog): static-analysis sweeper for sonar findings

### DIFF
--- a/.github/workflows/sweep-sonar-findings.yml
+++ b/.github/workflows/sweep-sonar-findings.yml
@@ -1,0 +1,180 @@
+name: Sonar findings sweeper
+
+# Imports open static-analysis findings into the .sdd/backlog/ as
+# Markdown ticket files. The job runs as a PR that an operator reviews
+# and merges; it never pushes straight to main.
+#
+# The cron trigger ships disabled-by-default. Flip ENABLE_CRON to "1"
+# (in the workflow file, not at run time) only after a clean
+# workflow_dispatch smoke run. This keeps the first-day blast radius
+# bounded to a manual invocation while the rule-family blurb table
+# settles.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'  # 06:17 UTC daily; off-peak.
+  workflow_dispatch:
+    inputs:
+      severity_min:
+        description: Minimum severity to include
+        required: false
+        default: BLOCKER
+        type: choice
+        options:
+          - BLOCKER
+          - CRITICAL
+          - MAJOR
+          - MINOR
+          - INFO
+      max_per_day:
+        description: Cap on tickets emitted in this run
+        required: false
+        default: '10'
+      dry_run:
+        description: When true, only print the would-be tickets
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sweep-sonar-findings
+  cancel-in-progress: false
+
+env:
+  # Phase-1 default knobs. The cron trigger is gated by ENABLE_CRON
+  # below so that a scheduled run is a no-op until the operator
+  # explicitly opts in via a follow-up PR that flips this value. Job
+  # 'if:' cannot read env directly, so the gate runs as the first
+  # step of the job (see "Gate cron trigger" below).
+  ENABLE_CRON: '0'
+
+jobs:
+  sweep:
+    name: Sweep Sonar findings
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: >-
+      ${{ vars.SONAR_HOST_URL != '' &&
+          (github.event_name == 'workflow_dispatch' ||
+           github.event_name == 'schedule') }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Gate cron trigger
+        id: gate
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "${ENABLE_CRON}" != "1" ]; then
+            echo "Cron trigger fired but ENABLE_CRON is '0'; exiting cleanly."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Harden runner
+        if: steps.gate.outputs.skip != 'true'
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install uv and project deps
+        if: steps.gate.outputs.skip != 'true'
+        run: |
+          pip install --quiet uv
+          uv sync --group dev
+
+      - name: Run sweeper
+        if: steps.gate.outputs.skip != 'true'
+        id: sweep
+        env:
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+          SEVERITY_MIN: ${{ inputs.severity_min || 'BLOCKER' }}
+          MAX_PER_DAY: ${{ inputs.max_per_day || '10' }}
+          DRY_RUN_INPUT: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .sdd/backlog/open
+          args=(
+            "--severity-min" "${SEVERITY_MIN}"
+            "--max-per-day" "${MAX_PER_DAY}"
+            "--out-dir" ".sdd/backlog/open"
+          )
+          if [ "${DRY_RUN_INPUT}" = "true" ]; then
+            args+=("--dry-run")
+          fi
+          uv run python scripts/sweep_sonar_findings.py "${args[@]}"
+
+      - name: Detect new ticket files
+        if: steps.gate.outputs.skip != 'true'
+        id: detect
+        run: |
+          set -euo pipefail
+          # `git status --porcelain` lists every change. We only consider
+          # files under .sdd/backlog/open/ to keep the PR scope tight.
+          changed=$(git status --porcelain -- .sdd/backlog/open/ | wc -l | tr -d ' ')
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+          if [ "${changed}" = "0" ]; then
+            echo "No new tickets emitted; will skip PR creation."
+          else
+            echo "${changed} new ticket file(s) to commit."
+          fi
+
+      - name: Open PR with new tickets
+        if: >-
+          steps.gate.outputs.skip != 'true' &&
+          steps.detect.outputs.changed != '0' &&
+          inputs.dry_run != 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: sonar-sweep/${{ github.run_id }}
+          delete-branch: true
+          add-paths: |
+            .sdd/backlog/open/
+          commit-message: |
+            chore(backlog): import sonar findings
+          title: 'chore(backlog): import sonar findings'
+          body: |
+            Automated import of open static-analysis findings as backlog
+            ticket files under `.sdd/backlog/open/`. Generated by
+            `.github/workflows/sweep-sonar-findings.yml`.
+
+            Each emitted ticket carries the upstream issue key in its
+            frontmatter (`sonar_issue_key`) so re-runs are idempotent;
+            the same finding will not produce a second ticket.
+
+            Severity filter: `${{ inputs.severity_min || 'BLOCKER' }}`.
+            Per-run cap: `${{ inputs.max_per_day || '10' }}`.
+
+            Review the emitted `## Why` bodies. They are synthesised from
+            a pre-vetted rule-family blurb table inside the sweeper; the
+            raw upstream message is never copied verbatim. If a new rule
+            family appears with the default fallback blurb, add a row to
+            `RULE_FAMILY_BLURBS` in `scripts/sweep_sonar_findings.py`
+            before merging this PR.
+          labels: |
+            backlog
+            static-analysis
+            chore

--- a/docs/operations/sonar-sweeper.md
+++ b/docs/operations/sonar-sweeper.md
@@ -1,0 +1,147 @@
+# Sonar findings sweeper
+
+Imports open static-analysis findings into `.sdd/backlog/open/` as
+Markdown ticket files. Re-runs are idempotent: each ticket carries the
+upstream issue key in its frontmatter (`sonar_issue_key`) so the same
+finding will never produce a second ticket.
+
+## TL;DR
+
+| What | Where |
+|------|-------|
+| Script | `scripts/sweep_sonar_findings.py` |
+| Workflow | `.github/workflows/sweep-sonar-findings.yml` (cron dormant by default) |
+| CLI entry point | `bernstein doctor sonar-sweep` |
+| Output | `.sdd/backlog/open/<YYYY-MM-DD>-<type>-<slug>.md` |
+| Phase 1 defaults | `BLOCKER` only, 10/day cap, GH-issue creation off |
+
+## Env vars
+
+| Env var | Purpose | Required? |
+|---|---|---|
+| `SONAR_HOST_URL` | Sonar server base URL. | yes (unless `--fixture` used) |
+| `SONAR_TOKEN` | User token with `Browse` permission on the project. | yes (unless `--fixture` used) |
+| `SONAR_PROJECT_KEY` | Project key. | optional (defaults to `bernstein`) |
+| `GH_TOKEN` | GitHub token. | only with `--create-gh-issues` |
+
+These match the existing `bernstein doctor sonar` env contract.
+
+## Local invocation
+
+```
+# Dry-run against the live Sonar server (no files written).
+SONAR_HOST_URL=... SONAR_TOKEN=... \
+  uv run bernstein doctor sonar-sweep --dry-run
+
+# Dry-run against a saved fixture (no network at all).
+uv run bernstein doctor sonar-sweep \
+  --dry-run \
+  --fixture tests/unit/sweep/fixtures/issues_search.json
+
+# Real emission, phase-1 defaults.
+SONAR_HOST_URL=... SONAR_TOKEN=... \
+  uv run bernstein doctor sonar-sweep \
+  --severity-min BLOCKER \
+  --max-per-day 10 \
+  --out-dir .sdd/backlog/open
+```
+
+The script can also be called directly:
+
+```
+uv run python scripts/sweep_sonar_findings.py --help
+```
+
+## CI invocation
+
+The workflow at `.github/workflows/sweep-sonar-findings.yml` ships with:
+
+- `schedule: cron: '17 6 * * *'` (06:17 UTC daily).
+- `workflow_dispatch` with `severity_min`, `max_per_day`, `dry_run`
+  inputs so an operator can force a one-off run.
+
+The cron trigger is gated behind an `ENABLE_CRON` workflow-level env
+var that defaults to `'0'`. Scheduled runs no-op while the gate is off.
+Flip `ENABLE_CRON` to `'1'` in a follow-up PR after a clean
+`workflow_dispatch` smoke run.
+
+When new tickets appear, the job opens a PR with branch
+`sonar-sweep/<run-id>` and a title `chore(backlog): import sonar
+findings`. The PR is review-only; no auto-merge.
+
+## How de-dup works
+
+1. The sweeper walks `.sdd/backlog/{open,claimed,closed,done,deferred}`.
+2. It parses every `*.md`'s YAML frontmatter and collects:
+   - The set of `sonar_issue_key` values across all states.
+   - The set of `(sonar_rule, sonar_component, sonar_line)` triples for
+     tickets in an open-ish state (`open`, `claimed`, `in_progress`,
+     `blocked`).
+3. For every incoming finding:
+   - Skip if its `key` is in the first set.
+   - Skip if its `(rule, component, line)` triple is in the second set
+     (handles Sonar key churn after a refactor).
+
+The exclusive-create open mode (`O_EXCL`) inside the emitter handles
+the rare case where two concurrent runs race past the de-dup step.
+
+## How `## Why` bodies stay safe
+
+The script never copies the raw Sonar `message` or `htmlDesc` into the
+ticket. The `## Why` body is synthesised from a pre-vetted rule-family
+table in `scripts/sweep_sonar_findings.py`:
+
+```python
+RULE_FAMILY_BLURBS: tuple[tuple[str, str, str], ...] = (
+    ("python:S3776", "cognitive-complexity", "Cognitive complexity exceeds..."),
+    ...
+)
+DEFAULT_BLURB = "Static-analysis finding flagged under rule key {rule_key}..."
+```
+
+A unit test (`test_safe_why_no_forbidden_substrings`) asserts that no
+blurb contains any string from `FORBIDDEN_SUBSTRINGS`, which includes
+em-dash, "marketing", "funnel", "premortem", and the rest of the
+project's public-artefact discipline list.
+
+### Extending the blurb table
+
+1. Find the rule key in the Sonar UI (e.g. `python:S5754`).
+2. Pick a short category slug (`broad-except`, `hardcoded-credential`,
+   etc).
+3. Write a one or two sentence engineering-hygiene blurb. No marketing
+   language, no vendor terms beyond "static-analysis".
+4. Add the tuple to `RULE_FAMILY_BLURBS`.
+5. Run `uv run pytest tests/unit/sweep/ -q` to confirm the
+   forbidden-substring guard still passes.
+
+## Phase rollout
+
+| Phase | Severity floor | Cap/day | GH issues | Cron |
+|---|---|---|---|---|
+| 1 (week 1) | `BLOCKER` | 10 | off | off |
+| 2 (week 2-3) | `BLOCKER`+`CRITICAL` | 20 | off | on |
+| 3 (week 4+) | adds `MAJOR` | 30 | P0 only | on |
+
+Phase transitions are operator-driven: update the workflow's input
+defaults and flip `ENABLE_CRON` in a follow-up PR.
+
+## Retracting a ticket
+
+If a sweep-emitted ticket should not have been raised:
+
+1. Delete the file from `.sdd/backlog/open/`.
+2. Add the finding's `sonar_issue_key` to `.sdd/backlog/closed/` as a
+   one-line stub with `status: closed_miss`. The dedup walker reads the
+   `closed/` folder so the finding will not be re-imported.
+
+## Tests
+
+```
+uv run pytest tests/unit/sweep/ -q
+```
+
+The suite covers de-dup (by key and by rule/component/line), idempotent
+double-run, severity filter, per-day cap, the rule-family blurb
+forbidden-substring guard, exclusive-create file emission, and the HTTP
+retry on 5xx/429.

--- a/scripts/sweep_sonar_findings.py
+++ b/scripts/sweep_sonar_findings.py
@@ -1,0 +1,1106 @@
+#!/usr/bin/env python3
+"""Static-analysis sweeper: turn open Sonar findings into backlog tickets.
+
+Walks the project's Sonar findings via ``/api/issues/search`` and emits
+one backlog ticket per new finding into ``.sdd/backlog/open/``. De-dup is
+keyed on the Sonar stable issue ``key`` field (stored in the ticket
+frontmatter as ``sonar_issue_key``), so re-runs are idempotent.
+
+This script intentionally **never** consumes the raw Sonar ``message``
+or ``htmlDesc`` text in the ticket body. Every public-facing string is
+synthesised from a pre-vetted rule-family blurb table so the emitted
+ticket reads as ordinary engineering hygiene regardless of what the
+upstream vendor prose contains.
+
+Usage
+-----
+
+    python scripts/sweep_sonar_findings.py \\
+        --severity-min BLOCKER \\
+        --max-per-day 10 \\
+        --out-dir .sdd/backlog/open \\
+        [--dry-run] [--create-gh-issues] [--fixture path/to/issues.json]
+
+Exit codes
+----------
+
+- 0: clean run (may have emitted zero or more tickets).
+- 1: Sonar API failed after retries; no partial tickets emitted.
+- 2: misconfiguration (missing env vars, bad CLI args).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import random
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator, Sequence
+
+    SleepFn = Callable[[float], None]
+    RunnerFn = Callable[..., Any]
+else:
+    SleepFn = Any
+    RunnerFn = Any
+
+# Make the bernstein package importable when running from the source tree.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from bernstein.core.observability.sonar import (  # noqa: E402
+    SonarConfig,
+    load_config,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_OUT_DIR = Path(".sdd/backlog/open")
+DEFAULT_BACKLOG_ROOTS: tuple[Path, ...] = (
+    Path(".sdd/backlog/open"),
+    Path(".sdd/backlog/claimed"),
+    Path(".sdd/backlog/closed"),
+    Path(".sdd/backlog/done"),
+    Path(".sdd/backlog/deferred"),
+)
+
+SEVERITY_ORDER: tuple[str, ...] = ("BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO")
+SEVERITY_RANK: dict[str, int] = {sev: idx for idx, sev in enumerate(SEVERITY_ORDER)}
+
+# Priority is the project's P0/P1/P2 enum (see docs/sdd/ticket_schema.md).
+SEVERITY_TO_PRIORITY: dict[str, str] = {
+    "BLOCKER": "P0",
+    "CRITICAL": "P1",
+    "MAJOR": "P2",
+    "MINOR": "P2",
+    "INFO": "P2",
+}
+
+# Effort defaults: most static-analysis findings are small, one or two
+# files worth of refactor. Override via the rule-family table when a
+# given rule family is known to span more.
+DEFAULT_EFFORT = "S"
+
+# Ticket "type" tag mapping (informational; the validator only checks
+# top-level required keys).
+SONAR_TYPE_TO_TICKET_TYPE: dict[str, str] = {
+    "BUG": "fix",
+    "VULNERABILITY": "fix",
+    "CODE_SMELL": "refactor",
+    "SECURITY_HOTSPOT": "fix",
+}
+
+DEFAULT_PAGE_SIZE = 500
+MAX_PAGES = 20
+
+DEFAULT_TIMEOUT_SECONDS = 15.0
+RETRY_ATTEMPTS = 3
+_BACKOFF_BASE_SECONDS = 2.0
+_BACKOFF_JITTER_FRACTION = 0.25
+
+
+# ---------------------------------------------------------------------------
+# Rule-family blurb table (public-safe ## Why bodies)
+#
+# Every blurb is reviewed at code-review time. New rule keys land as PRs
+# that add a row here. The raw Sonar message/htmlDesc is NEVER substituted
+# in: vendor prose can carry phrasing the project's public-artefact
+# discipline disallows.
+# ---------------------------------------------------------------------------
+
+
+# (rule-prefix, category-slug, blurb)
+RULE_FAMILY_BLURBS: tuple[tuple[str, str, str], ...] = (
+    (
+        "python:S3776",
+        "cognitive-complexity",
+        (
+            "Cognitive complexity exceeds the per-function cap configured in "
+            "the static-analysis rules. Split the function into smaller helpers "
+            "so each one stays readable and unit-testable in isolation."
+        ),
+    ),
+    (
+        "python:S1192",
+        "duplicated-strings",
+        (
+            "Repeated string literal should be extracted to a module-level "
+            "constant so it has a single source of truth and is searchable."
+        ),
+    ),
+    (
+        "python:S5754",
+        "broad-except",
+        (
+            "Broad exception clause hides specific failure modes. Narrow the "
+            "except clause to the exact exception types the caller is meant to "
+            "handle."
+        ),
+    ),
+    (
+        "python:S1481",
+        "unused-local",
+        (
+            "Local variable is declared but never read. Remove it so the "
+            "function reads cleanly and any future maintainer is not misled."
+        ),
+    ),
+    (
+        "python:S107",
+        "long-parameter-list",
+        (
+            "Function parameter count exceeds the per-function cap. Group "
+            "related parameters into a dataclass or keyword-only block."
+        ),
+    ),
+    (
+        "python:S1186",
+        "empty-function",
+        (
+            "Function body is empty. Either implement the function or remove "
+            "it so the callable surface matches the project's documented API."
+        ),
+    ),
+    (
+        "python:S125",
+        "commented-out-code",
+        (
+            "Commented-out code block should be removed; version control "
+            "preserves history and stale comments mislead future readers."
+        ),
+    ),
+    (
+        "python:S1066",
+        "collapsible-if",
+        ("Nested if statement can be merged with its parent so the branching reads as a single condition."),
+    ),
+    (
+        "python:S1854",
+        "useless-assignment",
+        (
+            "Value assigned to a local is overwritten before it is read. "
+            "Remove the dead assignment so the data flow reads cleanly."
+        ),
+    ),
+    (
+        "python:S5806",
+        "redefined-builtin",
+        (
+            "Local name shadows a Python builtin. Rename the local so the "
+            "builtin remains accessible inside the function."
+        ),
+    ),
+    (
+        "python:S1226",
+        "reassigned-parameter",
+        (
+            "Function parameter is reassigned inside the body. Introduce a "
+            "local variable so the original argument value stays visible."
+        ),
+    ),
+    (
+        "python:S1172",
+        "unused-parameter",
+        (
+            "Function parameter is declared but never used. Remove it or "
+            "rename it with a leading underscore to mark it intentional."
+        ),
+    ),
+    (
+        "python:S5547",
+        "weak-cryptography",
+        (
+            "Cryptographic primitive is below the project's configured "
+            "strength baseline. Replace with a primitive that meets the "
+            "documented baseline."
+        ),
+    ),
+    (
+        "python:S2068",
+        "hardcoded-credential",
+        (
+            "Hard-coded credential literal must not ship in source. Move the "
+            "value to an env-var or the project's secrets store."
+        ),
+    ),
+    (
+        "python:S5443",
+        "tempfile-permissions",
+        (
+            "Temporary file or directory is created with permissive default "
+            "permissions. Restrict the mode so the file is not readable by "
+            "other local users."
+        ),
+    ),
+    (
+        "python:S4423",
+        "weak-tls",
+        (
+            "TLS configuration accepts a protocol version below the project's "
+            "configured baseline. Restrict the configured protocol set."
+        ),
+    ),
+    (
+        "python:S5659",
+        "jwt-without-strong-validation",
+        (
+            "JWT verification path accepts a weak signature algorithm. Pin "
+            "the accepted algorithm set to the documented baseline."
+        ),
+    ),
+    (
+        "python:S3457",
+        "format-string-mismatch",
+        (
+            "Format string and its arguments do not line up. Align the "
+            "placeholders with the actual values so the formatted output is "
+            "correct at runtime."
+        ),
+    ),
+    (
+        "python:S1117",
+        "shadowed-name",
+        ("Local name shadows an outer-scope name. Rename the inner local so both scopes stay readable."),
+    ),
+    (
+        "python:S1542",
+        "function-naming",
+        (
+            "Function name does not match the project's naming convention. "
+            "Rename so the symbol matches the configured lint rule."
+        ),
+    ),
+    # Bug families
+    (
+        "python:S2589",
+        "always-true-condition",
+        (
+            "Condition always evaluates the same way and the dependent branch "
+            "is dead code. Remove or fix the condition so the branch reflects "
+            "actual runtime behaviour."
+        ),
+    ),
+    (
+        "python:S5806",
+        "unreachable-code",
+        ("Block of code is unreachable. Delete it so future readers do not spend time on dead branches."),
+    ),
+    (
+        "python:S930",
+        "wrong-argument-count",
+        (
+            "Function call passes the wrong number of arguments. Update the "
+            "call site so it matches the callee's signature."
+        ),
+    ),
+)
+
+
+DEFAULT_BLURB = (
+    "Static-analysis finding flagged under rule key {rule_key}. Resolve so "
+    "the file conforms to the project's configured maintainability rules."
+)
+
+
+# Strings that must never appear in any emitted ## Why. Belt-and-braces.
+FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
+    "audience",
+    "funnel",
+    "adoption",
+    "conversion",
+    "retention",
+    "buyer",
+    "monetisation",
+    "monetization",
+    "roi",
+    "brand",
+    "moat",
+    "competitor",
+    "competitive",
+    "flywheel",
+    "marketing",
+    "scenario prognos",
+    "premortem",
+    "ai search",
+    "aio probe",
+    "umami",
+    "—",  # em-dash forbidden by Bernstein hard constraints
+)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    """One Sonar finding, normalised."""
+
+    key: str
+    rule: str
+    severity: str
+    type: str
+    component: str
+    line: int | None
+    creation_date: str  # ISO-8601 timestamp string, used only for sorting.
+
+    @property
+    def severity_rank(self) -> int:
+        return SEVERITY_RANK.get(self.severity, len(SEVERITY_ORDER))
+
+
+# ---------------------------------------------------------------------------
+# Sanitisation
+# ---------------------------------------------------------------------------
+
+
+def safe_why(rule_key: str, severity: str, component: str, line: int | None) -> str:
+    """Return a public-safe ``## Why`` body for a Sonar finding.
+
+    Uses only the rule key to look up a pre-vetted blurb from
+    ``RULE_FAMILY_BLURBS`` or the ``DEFAULT_BLURB`` fallback. Never
+    consumes the raw Sonar ``message`` or ``htmlDesc``.
+    """
+    del severity, component, line  # accepted for signature stability
+    blurb = DEFAULT_BLURB.format(rule_key=rule_key)
+    for prefix, _category, text in RULE_FAMILY_BLURBS:
+        if rule_key == prefix or rule_key.startswith(prefix + ":"):
+            blurb = text
+            break
+    return blurb
+
+
+def _assert_no_forbidden(text: str, context: str = "") -> None:
+    """Raise AssertionError if ``text`` contains any forbidden substring."""
+    lower = text.lower()
+    for forbidden in FORBIDDEN_SUBSTRINGS:
+        if forbidden.lower() in lower:
+            raise AssertionError(
+                f"emitted text in {context!r} contains forbidden substring {forbidden!r}: {text[:120]!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Backlog walker and de-dup index
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_DELIM = "---"
+
+
+def _parse_frontmatter(path: Path) -> dict[str, Any] | None:
+    """Parse YAML frontmatter from a Markdown ticket. Returns ``None`` on error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not text.startswith(_FRONTMATTER_DELIM):
+        return None
+    parts = text.split(_FRONTMATTER_DELIM, 2)
+    if len(parts) < 3:
+        return None
+    raw = parts[1]
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def _walk_yaml_tickets(roots: Iterable[Path]) -> Iterator[tuple[Path, dict[str, Any]]]:
+    """Yield ``(path, frontmatter)`` for every parseable ticket under ``roots``."""
+    for root in roots:
+        if not root.exists() or not root.is_dir():
+            continue
+        for path in sorted(root.glob("*.md")):
+            fm = _parse_frontmatter(path)
+            if fm is None:
+                continue
+            yield path, fm
+        for path in sorted(root.glob("*.yaml")):
+            fm = None
+            try:
+                fm = yaml.safe_load(path.read_text(encoding="utf-8"))
+            except (OSError, yaml.YAMLError):
+                fm = None
+            if isinstance(fm, dict):
+                yield path, fm
+
+
+@dataclasses.dataclass(frozen=True)
+class DedupIndex:
+    """Pre-computed lookups so the sweeper can decide skip-or-emit fast."""
+
+    keys: frozenset[str]
+    open_rule_component_line: frozenset[tuple[str, str, int | None]]
+
+
+_OPEN_STATES: frozenset[str] = frozenset({"open", "claimed", "in_progress", "blocked"})
+
+
+def build_dedup_index(roots: Iterable[Path]) -> DedupIndex:
+    """Walk backlog folders and build the key + rule/component/line indices."""
+    keys: set[str] = set()
+    rcl: set[tuple[str, str, int | None]] = set()
+    for _path, fm in _walk_yaml_tickets(roots):
+        key = fm.get("sonar_issue_key")
+        if isinstance(key, str) and key:
+            keys.add(key)
+        status = fm.get("status")
+        rule = fm.get("sonar_rule")
+        comp = fm.get("sonar_component")
+        line = fm.get("sonar_line")
+        if (
+            isinstance(status, str)
+            and status in _OPEN_STATES
+            and isinstance(rule, str)
+            and isinstance(comp, str)
+            and (line is None or isinstance(line, int))
+        ):
+            rcl.add((rule, comp, line))
+    return DedupIndex(keys=frozenset(keys), open_rule_component_line=frozenset(rcl))
+
+
+# ---------------------------------------------------------------------------
+# Sonar API client
+# ---------------------------------------------------------------------------
+
+
+def _auth(token: str) -> tuple[str, str]:
+    """Sonar HTTP basic auth: token as username, empty password."""
+    return token, ""
+
+
+def _jitter_sleep(base: float) -> None:
+    """Sleep ``base`` seconds with +/- 25 percent jitter."""
+    if base <= 0:
+        return
+    delta = base * _BACKOFF_JITTER_FRACTION
+    time.sleep(base + random.uniform(-delta, delta))
+
+
+class SonarAPIError(RuntimeError):
+    """Raised when the Sonar API fails after the configured retries."""
+
+
+def _request_with_retries(
+    client: httpx.Client,
+    url: str,
+    params: dict[str, Any],
+    *,
+    sleep_fn: SleepFn = _jitter_sleep,
+) -> httpx.Response:
+    """GET with exponential backoff on 5xx and Retry-After-aware 429 retry."""
+    last_exc: Exception | None = None
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        try:
+            resp = client.get(url, params=params)
+        except httpx.HTTPError as exc:
+            last_exc = exc
+            if attempt == RETRY_ATTEMPTS:
+                raise SonarAPIError(f"Sonar request failed: {exc}") from exc
+            sleep_fn(_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)))
+            continue
+        if 200 <= resp.status_code < 300:
+            return resp
+        if resp.status_code == 429:
+            retry_after = resp.headers.get("Retry-After")
+            wait = 1.0
+            if retry_after is not None:
+                try:
+                    wait = float(retry_after)
+                except ValueError:
+                    wait = 1.0
+            sleep_fn(wait)
+            # 429 gets exactly one retry (per design); fall through on next loop.
+            continue
+        if 500 <= resp.status_code < 600:
+            if attempt == RETRY_ATTEMPTS:
+                raise SonarAPIError(f"Sonar returned {resp.status_code} after {attempt} attempts")
+            sleep_fn(_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)))
+            continue
+        raise SonarAPIError(f"Sonar returned {resp.status_code}: {resp.text[:200]}")
+    if last_exc is not None:
+        raise SonarAPIError(f"Sonar request failed: {last_exc}") from last_exc
+    raise SonarAPIError("Sonar request failed after retries")
+
+
+def fetch_findings(
+    config: SonarConfig,
+    *,
+    severities: Sequence[str],
+    page_size: int = DEFAULT_PAGE_SIZE,
+    client: httpx.Client | None = None,
+    sleep_fn: SleepFn = _jitter_sleep,
+) -> list[Finding]:
+    """Page through ``/api/issues/search`` and return all open findings."""
+    url = f"{config.host}/api/issues/search"
+    findings: list[Finding] = []
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=_auth(config.token))
+    assert client is not None
+    try:
+        page = 1
+        while page <= MAX_PAGES:
+            params: dict[str, Any] = {
+                "componentKeys": config.project_key,
+                "resolved": "false",
+                "severities": ",".join(severities),
+                "types": "CODE_SMELL,BUG,VULNERABILITY",
+                "s": "CREATION_DATE",
+                "asc": "false",
+                "ps": str(page_size),
+                "p": str(page),
+            }
+            resp = _request_with_retries(client, url, params, sleep_fn=sleep_fn)
+            payload = resp.json()
+            if not isinstance(payload, dict):
+                break
+            issues = payload.get("issues") or []
+            for raw in issues:
+                if not isinstance(raw, dict):
+                    continue
+                finding = _normalise_issue(raw)
+                if finding is not None:
+                    findings.append(finding)
+            paging = payload.get("paging") or {}
+            try:
+                total = int(paging.get("total", 0))
+                page_idx = int(paging.get("pageIndex", page))
+                size = int(paging.get("pageSize", page_size))
+            except (TypeError, ValueError):
+                break
+            if size <= 0 or page_idx * size >= total:
+                break
+            page += 1
+    finally:
+        if owns_client:
+            client.close()
+    return findings
+
+
+def _normalise_issue(raw: dict[str, Any]) -> Finding | None:
+    """Coerce one raw Sonar issue dict into a :class:`Finding`."""
+    key = raw.get("key")
+    rule = raw.get("rule")
+    severity = raw.get("severity")
+    issue_type = raw.get("type")
+    component = raw.get("component")
+    line = raw.get("line")
+    creation = raw.get("creationDate") or ""
+    if not (
+        isinstance(key, str)
+        and key
+        and isinstance(rule, str)
+        and isinstance(severity, str)
+        and isinstance(issue_type, str)
+        and isinstance(component, str)
+    ):
+        return None
+    if line is not None and not isinstance(line, int):
+        try:
+            line = int(line)
+        except (TypeError, ValueError):
+            line = None
+    if not isinstance(creation, str):
+        creation = ""
+    return Finding(
+        key=key,
+        rule=rule,
+        severity=severity,
+        type=issue_type,
+        component=component,
+        line=line,
+        creation_date=creation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ticket emission
+# ---------------------------------------------------------------------------
+
+
+_SLUG_INVALID = re.compile(r"[^a-z0-9-]+")
+
+
+def _slugify(text: str, *, max_len: int = 60) -> str:
+    """Reduce ``text`` to a kebab slug fit for filenames and ticket ids."""
+    lower = text.lower().replace("_", "-").replace("/", "-").replace(":", "-")
+    cleaned = _SLUG_INVALID.sub("-", lower)
+    collapsed = re.sub(r"-+", "-", cleaned).strip("-")
+    return collapsed[:max_len].strip("-")
+
+
+def _component_tail(component: str) -> str:
+    """Return the file-name portion of a Sonar component key."""
+    # component looks like "bernstein:src/bernstein/core/agents/spawn_supervisor.py"
+    if ":" in component:
+        _, _, tail = component.partition(":")
+    else:
+        tail = component
+    return Path(tail).name or component
+
+
+def _ticket_filename(finding: Finding, day: str) -> str:
+    ticket_type = SONAR_TYPE_TO_TICKET_TYPE.get(finding.type, "refactor")
+    tail = _component_tail(finding.component)
+    line_suffix = f"-{finding.line}" if finding.line else ""
+    slug_input = f"{finding.rule}-{tail}{line_suffix}"
+    slug = _slugify(slug_input, max_len=60)
+    return f"{day}-{ticket_type}-{slug}.md"
+
+
+def _ticket_id(finding: Finding, day: str) -> str:
+    ticket_type = SONAR_TYPE_TO_TICKET_TYPE.get(finding.type, "refactor")
+    tail = _component_tail(finding.component)
+    line_suffix = f"-{finding.line}" if finding.line else ""
+    slug_input = f"{ticket_type}-{day}-{finding.rule}-{tail}{line_suffix}"
+    slug = _slugify(slug_input, max_len=80)
+    # Ensure starts with [a-z0-9] per schema pattern.
+    if not slug or not slug[0].isalnum():
+        slug = f"sonar-{slug}".strip("-")
+    return slug
+
+
+def _ticket_title(finding: Finding) -> str:
+    ticket_type = SONAR_TYPE_TO_TICKET_TYPE.get(finding.type, "refactor")
+    tail = _component_tail(finding.component)
+    location = tail
+    if finding.line:
+        location = f"{tail}:{finding.line}"
+    return f"{ticket_type}(static-analysis): address {finding.rule} in {location}"
+
+
+def _component_path(component: str) -> str:
+    """Strip the project prefix from a Sonar component key."""
+    if ":" in component:
+        _, _, tail = component.partition(":")
+        return tail
+    return component
+
+
+def _format_frontmatter(data: dict[str, Any]) -> str:
+    """YAML-dump frontmatter with stable key order."""
+    # PyYAML's default flow style is fine, but we want plain ASCII output
+    # and a stable order (insertion order preserved by dict in 3.12+).
+    text = yaml.safe_dump(
+        data,
+        sort_keys=False,
+        default_flow_style=False,
+        allow_unicode=False,
+        width=1000,
+    )
+    return text
+
+
+def render_ticket(finding: Finding, *, day: str) -> str:
+    """Build the full Markdown body for one ticket."""
+    ticket_type = SONAR_TYPE_TO_TICKET_TYPE.get(finding.type, "refactor")
+    priority = SEVERITY_TO_PRIORITY.get(finding.severity, "P2")
+    title = _ticket_title(finding)
+    component_path = _component_path(finding.component)
+
+    why = safe_why(finding.rule, finding.severity, finding.component, finding.line)
+    _assert_no_forbidden(why, context=f"safe_why({finding.rule})")
+    _assert_no_forbidden(title, context="ticket title")
+
+    location_text = component_path
+    if finding.line:
+        location_text = f"{component_path}:{finding.line}"
+
+    tldr = (
+        f"Static-analysis rule `{finding.rule}` is open in `{location_text}`. "
+        f"Resolve so the file matches the project's configured rule set on "
+        f"the next scan."
+    )
+    _assert_no_forbidden(tldr, context="TL;DR")
+
+    ac_lines = [
+        (f"The finding at `{location_text}` is resolved on the next static-analysis scan."),
+        (
+            "Behaviour is preserved: existing unit tests covering the touched "
+            "code path continue to pass without modification."
+        ),
+        (
+            "Any new helpers or constants introduced carry docstrings and "
+            "explicit type hints matching the surrounding module."
+        ),
+        (
+            f"The static-analysis issue with key `{finding.key}` is absent "
+            f"from the next scan output for this rule and component."
+        ),
+    ]
+    for ac in ac_lines:
+        _assert_no_forbidden(ac, context="acceptance criterion")
+
+    fm: dict[str, Any] = {
+        "id": _ticket_id(finding, day),
+        "created": day,
+        "status": "open",
+        "priority": priority,
+        "effort": DEFAULT_EFFORT,
+        "title": title,
+        "type": ticket_type,
+        "tags": ["static-analysis", "quality", finding.severity.lower()],
+        "acceptance_criteria": ac_lines,
+        "sonar_issue_key": finding.key,
+        "sonar_rule": finding.rule,
+        "sonar_component": component_path,
+        "sonar_line": finding.line if finding.line is not None else None,
+        "sonar_severity": finding.severity,
+        "sonar_type": finding.type,
+    }
+
+    fm_text = _format_frontmatter(fm)
+    body_lines = [
+        f"# {title}",
+        "",
+        "## TL;DR",
+        "",
+        tldr,
+        "",
+        "## Why",
+        "",
+        why,
+        "",
+        "## Acceptance criteria",
+        "",
+    ]
+    for idx, ac in enumerate(ac_lines, start=1):
+        body_lines.append(f"{idx}. {ac}")
+    body_lines.extend(
+        [
+            "",
+            "## Out of scope",
+            "",
+            (f"- Other rule findings in the same file that are not flagged by `{finding.rule}`."),
+            "- Changing the configured rule itself.",
+            "",
+            (
+                f"<!-- sonar-finding-imported: {finding.key} "
+                f"{_dt.datetime.now(tz=_dt.UTC).isoformat(timespec='seconds')} -->"
+            ),
+            "",
+        ]
+    )
+
+    body = "\n".join(body_lines)
+    _assert_no_forbidden(body, context="ticket body")
+    return f"---\n{fm_text}---\n\n{body}"
+
+
+def emit_ticket(
+    finding: Finding,
+    out_dir: Path,
+    *,
+    day: str,
+    dry_run: bool = False,
+) -> tuple[Path, str, bool]:
+    """Write the ticket file, returning ``(path, body, wrote)``.
+
+    Uses exclusive-create open so two concurrent runs cannot clobber each
+    other; the loser logs a skip and continues.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    filename = _ticket_filename(finding, day)
+    path = out_dir / filename
+    body = render_ticket(finding, day=day)
+    if dry_run:
+        return path, body, False
+    try:
+        with path.open("x", encoding="utf-8") as fh:
+            fh.write(body)
+    except FileExistsError:
+        return path, body, False
+    return path, body, True
+
+
+# ---------------------------------------------------------------------------
+# Severity filter and per-day cap
+# ---------------------------------------------------------------------------
+
+
+def filter_by_severity(findings: Iterable[Finding], severity_min: str) -> list[Finding]:
+    """Keep only findings at ``severity_min`` or higher."""
+    min_rank = SEVERITY_RANK.get(severity_min.upper(), 0)
+    return [f for f in findings if f.severity_rank <= min_rank]
+
+
+def cap_per_day(findings: Sequence[Finding], cap: int) -> list[Finding]:
+    """Sort by ``(severity_rank, creation_date desc)`` and apply the cap."""
+    ordered = sorted(
+        findings,
+        key=lambda f: (f.severity_rank, -_creation_sort_key(f.creation_date)),
+    )
+    if cap <= 0:
+        return list(ordered)
+    return list(ordered[:cap])
+
+
+def _creation_sort_key(text: str) -> float:
+    """Return an epoch-ish float for the timestamp (newest first when negated)."""
+    if not text:
+        return 0.0
+    # Sonar timestamps look like '2026-05-20T08:14:02+0000'. Trim the colon-less
+    # offset format so fromisoformat accepts it on 3.12+ (3.11 needs the fix).
+    norm = text
+    if len(norm) >= 5 and (norm[-5] == "+" or norm[-5] == "-") and norm[-3] != ":":
+        norm = f"{norm[:-2]}:{norm[-2:]}"
+    try:
+        return _dt.datetime.fromisoformat(norm).timestamp()
+    except ValueError:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# GH-issue creation (opt-in)
+# ---------------------------------------------------------------------------
+
+
+def maybe_create_gh_issue(
+    ticket_path: Path,
+    title: str,
+    *,
+    enable: bool,
+    priority: str,
+    runner: RunnerFn = subprocess.run,
+) -> str | None:
+    """Optionally create a GH issue and return its URL or ``None``."""
+    if not enable:
+        return None
+    if priority != "P0":
+        # Only the highest-priority bucket auto-promotes; everything else
+        # stays file-only until an operator picks it up by hand.
+        return None
+    if not ticket_path.exists():
+        return None
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--title",
+        title,
+        "--body-file",
+        str(ticket_path),
+    ]
+    try:
+        result = runner(cmd, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    url = (result.stdout or "").strip().splitlines()
+    if not url:
+        return None
+    return url[-1]
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _today_utc() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).strftime("%Y-%m-%d")
+
+
+def _load_fixture(path: Path) -> list[Finding]:
+    """Load Sonar findings from a saved JSON fixture (for tests and dry-run)."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    issues = payload.get("issues") if isinstance(payload, dict) else None
+    if not isinstance(issues, list):
+        return []
+    out: list[Finding] = []
+    for raw in issues:
+        if isinstance(raw, dict):
+            f = _normalise_issue(raw)
+            if f is not None:
+                out.append(f)
+    return out
+
+
+def run_sweep(args: argparse.Namespace) -> int:
+    """End-to-end sweep: fetch, filter, cap, dedup, emit."""
+    out_dir = Path(args.out_dir)
+    backlog_roots: tuple[Path, ...]
+    if args.backlog_root:
+        # When a single root is given (used in tests), still walk all sub-states
+        # if they exist next to it.
+        root = Path(args.backlog_root)
+        backlog_roots = (
+            root / "open",
+            root / "claimed",
+            root / "closed",
+            root / "done",
+            root / "deferred",
+        )
+    else:
+        backlog_roots = DEFAULT_BACKLOG_ROOTS
+
+    day = args.day or _today_utc()
+
+    # Load findings: fixture path bypasses network entirely.
+    if args.fixture:
+        try:
+            findings = _load_fixture(Path(args.fixture))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"error: failed to load fixture: {exc}", file=sys.stderr)
+            return 2
+    else:
+        config = load_config()
+        if config is None:
+            print(
+                "error: SONAR_HOST_URL and SONAR_TOKEN must be set",
+                file=sys.stderr,
+            )
+            return 2
+        severities = _selected_severities(args.severity_min)
+        try:
+            findings = fetch_findings(config, severities=severities)
+        except SonarAPIError as exc:
+            print(f"error: sonar fetch failed: {exc}", file=sys.stderr)
+            return 1
+
+    filtered = filter_by_severity(findings, args.severity_min)
+
+    # Build the dedup index after we have the candidate set so we can also
+    # report on the (rule, component, line) fallback.
+    index = build_dedup_index(backlog_roots)
+
+    deduped: list[Finding] = []
+    for f in filtered:
+        if f.key in index.keys:
+            continue
+        if (f.rule, _component_path(f.component), f.line) in index.open_rule_component_line:
+            continue
+        deduped.append(f)
+
+    capped = cap_per_day(deduped, args.max_per_day)
+
+    emitted: list[tuple[Path, Finding]] = []
+    skipped_existing = 0
+    for f in capped:
+        path, body, wrote = emit_ticket(f, out_dir, day=day, dry_run=args.dry_run)
+        if args.dry_run:
+            print(f"would-emit {path}")
+            emitted.append((path, f))
+            continue
+        if not wrote:
+            print(f"skipped (file already exists) {path}")
+            skipped_existing += 1
+            continue
+        emitted.append((path, f))
+        if args.create_gh_issues:
+            priority = SEVERITY_TO_PRIORITY.get(f.severity, "P2")
+            url = maybe_create_gh_issue(
+                path,
+                _ticket_title(f),
+                enable=True,
+                priority=priority,
+            )
+            if url:
+                _append_gh_trailer(path, url)
+        del body  # already written
+
+    print(
+        f"sonar-sweep: fetched={len(findings)} filtered={len(filtered)} "
+        f"deduped={len(deduped)} capped={len(capped)} emitted={len(emitted)} "
+        f"skipped_existing={skipped_existing} dry_run={args.dry_run}"
+    )
+    return 0
+
+
+def _selected_severities(severity_min: str) -> list[str]:
+    """Translate ``--severity-min`` to the Sonar API ``severities`` list."""
+    rank = SEVERITY_RANK.get(severity_min.upper(), 0)
+    return [sev for sev in SEVERITY_ORDER if SEVERITY_RANK[sev] <= rank]
+
+
+def _append_gh_trailer(path: Path, url: str) -> None:
+    """Append a ``gh-issue-created`` HTML comment trailer to the ticket file."""
+    now = _dt.datetime.now(tz=_dt.UTC).isoformat(timespec="seconds")
+    trailer = f"<!-- gh-issue-created: {url} {now} -->\n"
+    try:
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(trailer)
+    except OSError:
+        return
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--severity-min",
+        default="BLOCKER",
+        choices=list(SEVERITY_ORDER),
+        help="Minimum severity to include (default: BLOCKER).",
+    )
+    p.add_argument(
+        "--max-per-day",
+        type=int,
+        default=10,
+        help="Maximum tickets to emit in this run (default: 10).",
+    )
+    p.add_argument(
+        "--out-dir",
+        default=str(DEFAULT_OUT_DIR),
+        help="Output directory for ticket files.",
+    )
+    p.add_argument(
+        "--backlog-root",
+        default=None,
+        help=(
+            "Root that contains open/, claimed/, closed/, done/, deferred/ "
+            "subfolders. When set, overrides the default .sdd/backlog/* roots. "
+            "Used by tests to isolate against tmp dirs."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print would-be ticket paths without writing files.",
+    )
+    p.add_argument(
+        "--create-gh-issues",
+        action="store_true",
+        help="For P0 tickets, also call `gh issue create` and trailer the file.",
+    )
+    p.add_argument(
+        "--fixture",
+        default=None,
+        help=("Read findings from a saved JSON fixture instead of calling Sonar. Useful for local dry-runs and tests."),
+    )
+    p.add_argument(
+        "--day",
+        default=None,
+        help="Override the UTC day used in filenames and ticket ids (YYYY-MM-DD).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return run_sweep(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -961,6 +961,96 @@ from bernstein.cli.commands.doctor.glitchtip import (  # noqa: E402
 _register_doctor_glitchtip(doctor)
 
 
+@doctor.command("sonar-sweep")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the would-be ticket paths without writing files.",
+)
+@click.option(
+    "--severity-min",
+    "severity_min",
+    default="BLOCKER",
+    show_default=True,
+    type=click.Choice(["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]),
+    help="Minimum severity to include.",
+)
+@click.option(
+    "--max-per-day",
+    "max_per_day",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Cap on the number of tickets emitted in this run.",
+)
+@click.option(
+    "--out-dir",
+    "out_dir",
+    default=".sdd/backlog/open",
+    show_default=True,
+    help="Directory to write emitted ticket files into.",
+)
+@click.option(
+    "--fixture",
+    default=None,
+    help="Use a saved JSON fixture instead of calling Sonar (for local dry-runs).",
+)
+def doctor_sonar_sweep_cmd(
+    dry_run: bool,
+    severity_min: str,
+    max_per_day: int,
+    out_dir: str,
+    fixture: str | None,
+) -> None:
+    """Turn open static-analysis findings into backlog tickets.
+
+    \b
+    Reads ``SONAR_HOST_URL`` and ``SONAR_TOKEN`` from the environment,
+    fetches the open findings, applies de-dup against existing tickets
+    under ``.sdd/backlog/*``, and writes one Markdown ticket per new
+    finding into the configured output directory.
+
+    \b
+    With ``--dry-run`` the command lists the would-be file paths without
+    writing them. With ``--fixture`` it loads findings from a saved JSON
+    blob instead of calling the Sonar API at all -- useful for local
+    smoke tests.
+    """
+    # The sweeper lives under ``scripts/`` so the wheel stays slim. We
+    # import it lazily from the source tree.
+    from pathlib import Path as _Path
+
+    repo_root = _Path(__file__).resolve().parents[4]
+    scripts_dir = repo_root / "scripts"
+    import sys as _sys
+
+    if str(scripts_dir) not in _sys.path:
+        _sys.path.insert(0, str(scripts_dir))
+    try:
+        from sweep_sonar_findings import (
+            main as _sweep_main,  # type: ignore[import-not-found]
+        )
+    except ImportError as exc:
+        click.echo(f"error: cannot import sweeper: {exc}", err=True)
+        raise SystemExit(2) from exc
+
+    argv: list[str] = [
+        "--severity-min",
+        severity_min,
+        "--max-per-day",
+        str(max_per_day),
+        "--out-dir",
+        out_dir,
+    ]
+    if dry_run:
+        argv.append("--dry-run")
+    if fixture:
+        argv.extend(["--fixture", fixture])
+
+    raise SystemExit(int(_sweep_main(argv)))
+
+
 # ---------------------------------------------------------------------------
 # recap
 # ---------------------------------------------------------------------------

--- a/tests/unit/sweep/conftest.py
+++ b/tests/unit/sweep/conftest.py
@@ -1,0 +1,39 @@
+"""Shared pytest fixtures for the Sonar findings sweeper tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# Make the script importable as a module without touching pyproject.toml.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture
+def issues_search_fixture_path() -> Path:
+    """Path to the canonical issues_search.json fixture."""
+    return _FIXTURE_DIR / "issues_search.json"
+
+
+@pytest.fixture
+def issues_search_payload(issues_search_fixture_path: Path) -> dict:
+    """Parsed payload of the canonical issues_search.json fixture."""
+    return json.loads(issues_search_fixture_path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def sweep_workspace(tmp_path: Path) -> Iterator[Path]:
+    """A temp directory with empty open/claimed/closed/done/deferred subdirs."""
+    for sub in ("open", "claimed", "closed", "done", "deferred"):
+        (tmp_path / sub).mkdir()
+    yield tmp_path

--- a/tests/unit/sweep/fixtures/issues_search.json
+++ b/tests/unit/sweep/fixtures/issues_search.json
@@ -1,0 +1,73 @@
+{
+  "total": 6,
+  "p": 1,
+  "ps": 500,
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 6
+  },
+  "issues": [
+    {
+      "key": "FINDING-BLOCKER-001",
+      "rule": "python:S2068",
+      "severity": "BLOCKER",
+      "type": "VULNERABILITY",
+      "component": "bernstein:src/bernstein/core/agents/secrets_loader.py",
+      "line": 42,
+      "message": "Vendor message that is ignored by the sweeper.",
+      "creationDate": "2026-05-20T10:00:00+0000"
+    },
+    {
+      "key": "FINDING-CRITICAL-001",
+      "rule": "python:S3776",
+      "severity": "CRITICAL",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/agents/spawn_supervisor.py",
+      "line": 230,
+      "message": "Refactor this function to reduce its Cognitive Complexity.",
+      "creationDate": "2026-05-20T09:00:00+0000"
+    },
+    {
+      "key": "FINDING-CRITICAL-002",
+      "rule": "python:S1192",
+      "severity": "CRITICAL",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/main.py",
+      "line": 17,
+      "message": "Extract the duplicated literal.",
+      "creationDate": "2026-05-20T08:30:00+0000"
+    },
+    {
+      "key": "FINDING-MAJOR-001",
+      "rule": "python:S1481",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/helpers.py",
+      "line": 88,
+      "message": "Remove the unused local.",
+      "creationDate": "2026-05-20T07:00:00+0000"
+    },
+    {
+      "key": "FINDING-MINOR-001",
+      "rule": "python:S125",
+      "severity": "MINOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/orchestration/queue.py",
+      "line": 5,
+      "message": "Remove commented-out code.",
+      "creationDate": "2026-05-20T06:00:00+0000"
+    },
+    {
+      "key": "FINDING-BUG-001",
+      "rule": "python:S2589",
+      "severity": "CRITICAL",
+      "type": "BUG",
+      "component": "bernstein:src/bernstein/core/observability/metrics.py",
+      "line": null,
+      "message": "Condition always evaluates the same way.",
+      "creationDate": "2026-05-20T05:00:00+0000"
+    }
+  ],
+  "components": []
+}

--- a/tests/unit/sweep/test_doctor_sonar_sweep_cli.py
+++ b/tests/unit/sweep/test_doctor_sonar_sweep_cli.py
@@ -1,0 +1,46 @@
+"""Smoke test for ``bernstein doctor sonar-sweep`` CLI wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import doctor
+
+_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "issues_search.json"
+
+
+def test_doctor_sonar_sweep_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(doctor, ["sonar-sweep", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "static-analysis" in result.output.lower()
+    assert "--dry-run" in result.output
+    assert "--severity-min" in result.output
+    assert "--max-per-day" in result.output
+
+
+def test_doctor_sonar_sweep_dry_run_with_fixture(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out_dir = tmp_path / "open"
+    result = runner.invoke(
+        doctor,
+        [
+            "sonar-sweep",
+            "--dry-run",
+            "--severity-min",
+            "BLOCKER",
+            "--max-per-day",
+            "5",
+            "--out-dir",
+            str(out_dir),
+            "--fixture",
+            str(_FIXTURE),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Dry-run never writes anything.
+    if out_dir.exists():
+        assert list(out_dir.glob("*.md")) == []
+    assert "would-emit" in result.output

--- a/tests/unit/sweep/test_sonar_findings.py
+++ b/tests/unit/sweep/test_sonar_findings.py
@@ -1,0 +1,640 @@
+"""Unit tests for ``scripts/sweep_sonar_findings.py``.
+
+Covers de-dup, severity filter, per-day cap, idempotence, the public-safe
+``## Why`` table, exclusive-create emission, and HTTP retry semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import yaml
+from sweep_sonar_findings import (  # type: ignore[import-not-found]
+    DEFAULT_BLURB,
+    FORBIDDEN_SUBSTRINGS,
+    RULE_FAMILY_BLURBS,
+    SEVERITY_TO_PRIORITY,
+    Finding,
+    SonarAPIError,
+    _component_path,
+    _request_with_retries,
+    build_dedup_index,
+    emit_ticket,
+    fetch_findings,
+    main,
+    maybe_create_gh_issue,
+    safe_why,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_ticket(
+    dir_: Path,
+    *,
+    name: str,
+    sonar_issue_key: str | None = None,
+    sonar_rule: str | None = None,
+    sonar_component: str | None = None,
+    sonar_line: int | None = None,
+    status: str = "open",
+) -> Path:
+    fm: dict[str, Any] = {
+        "id": name.replace(".md", ""),
+        "created": "2026-05-20",
+        "status": status,
+        "priority": "P1",
+        "effort": "S",
+    }
+    if sonar_issue_key is not None:
+        fm["sonar_issue_key"] = sonar_issue_key
+    if sonar_rule is not None:
+        fm["sonar_rule"] = sonar_rule
+    if sonar_component is not None:
+        fm["sonar_component"] = sonar_component
+    if sonar_line is not None:
+        fm["sonar_line"] = sonar_line
+    body = "---\n" + yaml.safe_dump(fm, sort_keys=False) + "---\n\n# body\n"
+    path = dir_ / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _args(
+    *,
+    fixture: Path,
+    out_dir: Path,
+    backlog_root: Path,
+    severity_min: str = "MINOR",
+    max_per_day: int = 100,
+    dry_run: bool = False,
+    create_gh_issues: bool = False,
+    day: str = "2026-05-21",
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        severity_min=severity_min,
+        max_per_day=max_per_day,
+        out_dir=str(out_dir),
+        backlog_root=str(backlog_root),
+        dry_run=dry_run,
+        create_gh_issues=create_gh_issues,
+        fixture=str(fixture),
+        day=day,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. backlog walker / de-dup
+# ---------------------------------------------------------------------------
+
+
+def test_parses_existing_frontmatter_for_dedup(sweep_workspace: Path) -> None:
+    _write_ticket(
+        sweep_workspace / "open",
+        name="2026-05-19-fix-a.md",
+        sonar_issue_key="KEY1",
+    )
+    _write_ticket(
+        sweep_workspace / "done",
+        name="2026-05-18-fix-b.md",
+        sonar_issue_key="KEY2",
+        status="closed_hit",
+    )
+    roots = [
+        sweep_workspace / "open",
+        sweep_workspace / "claimed",
+        sweep_workspace / "closed",
+        sweep_workspace / "done",
+        sweep_workspace / "deferred",
+    ]
+    index = build_dedup_index(roots)
+    assert index.keys == frozenset({"KEY1", "KEY2"})
+
+
+def test_skips_dup_by_key(
+    sweep_workspace: Path,
+    issues_search_fixture_path: Path,
+    tmp_path: Path,
+) -> None:
+    out_dir = sweep_workspace / "open"
+    _write_ticket(out_dir, name="existing.md", sonar_issue_key="FINDING-BLOCKER-001")
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "BLOCKER",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    new = [p for p in out_dir.glob("2026-05-21-*.md")]
+    assert new == []
+
+
+def test_skips_dup_by_rule_component_line(
+    sweep_workspace: Path,
+    issues_search_fixture_path: Path,
+) -> None:
+    out_dir = sweep_workspace / "open"
+    # Existing open ticket with the same (rule, component, line) but a stale key.
+    _write_ticket(
+        out_dir,
+        name="2026-05-15-refactor-stale.md",
+        sonar_issue_key="STALE-KEY-NOT-MATCHING",
+        sonar_rule="python:S3776",
+        sonar_component="src/bernstein/core/agents/spawn_supervisor.py",
+        sonar_line=230,
+    )
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "CRITICAL",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    # The FINDING-CRITICAL-001 finding matches the stale ticket's (rule, component, line)
+    # and must be skipped. Other findings can still be emitted.
+    emitted_files = list(out_dir.glob("2026-05-21-*.md"))
+    for path in emitted_files:
+        fm = yaml.safe_load(path.read_text().split("---")[1])
+        assert fm["sonar_issue_key"] != "FINDING-CRITICAL-001"
+
+
+# ---------------------------------------------------------------------------
+# 4. idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_double_run(
+    sweep_workspace: Path,
+    issues_search_fixture_path: Path,
+) -> None:
+    out_dir = sweep_workspace / "open"
+    rc1 = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MINOR",
+            "--max-per-day",
+            "100",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc1 == 0
+    first_count = len(list(out_dir.glob("2026-05-21-*.md")))
+    assert first_count > 0
+    rc2 = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MINOR",
+            "--max-per-day",
+            "100",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc2 == 0
+    second_count = len(list(out_dir.glob("2026-05-21-*.md")))
+    assert second_count == first_count
+
+
+# ---------------------------------------------------------------------------
+# 5 + 6. per-day cap and severity filter
+# ---------------------------------------------------------------------------
+
+
+def test_per_day_cap(
+    sweep_workspace: Path,
+    issues_search_fixture_path: Path,
+) -> None:
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MINOR",
+            "--max-per-day",
+            "2",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    files = sorted(out_dir.glob("2026-05-21-*.md"))
+    assert len(files) == 2
+    # The two highest-rank findings should win: 1 BLOCKER, then 1 of the CRITICALs.
+    parsed = [yaml.safe_load(p.read_text().split("---")[1]) for p in files]
+    severities = sorted(p["sonar_severity"] for p in parsed)
+    assert "BLOCKER" in severities
+    assert "CRITICAL" in severities
+
+
+def test_severity_filter(
+    sweep_workspace: Path,
+    issues_search_fixture_path: Path,
+) -> None:
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "CRITICAL",
+            "--max-per-day",
+            "100",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    files = list(out_dir.glob("2026-05-21-*.md"))
+    severities = []
+    for f in files:
+        fm = yaml.safe_load(f.read_text().split("---")[1])
+        severities.append(fm["sonar_severity"])
+    assert all(s in ("BLOCKER", "CRITICAL") for s in severities)
+    assert "MAJOR" not in severities
+    assert "MINOR" not in severities
+
+
+# ---------------------------------------------------------------------------
+# 7 + 8 + 9. safe_why behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_safe_why_known_rule() -> None:
+    text = safe_why("python:S3776", "CRITICAL", "x", 1)
+    assert "cognitive complexity" in text.lower()
+
+
+def test_safe_why_unknown_rule_fallback() -> None:
+    text = safe_why("python:S99999", "MINOR", "x", None)
+    assert "python:S99999" in text
+    assert "static-analysis" in text.lower()
+
+
+def test_safe_why_no_forbidden_substrings() -> None:
+    for prefix, _category, blurb in RULE_FAMILY_BLURBS:
+        for forbidden in FORBIDDEN_SUBSTRINGS:
+            assert forbidden.lower() not in blurb.lower(), (
+                f"blurb for {prefix} contains forbidden substring {forbidden!r}"
+            )
+    for forbidden in FORBIDDEN_SUBSTRINGS:
+        assert forbidden.lower() not in DEFAULT_BLURB.lower(), (
+            f"DEFAULT_BLURB contains forbidden substring {forbidden!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10 + 14 + 15. ticket emission
+# ---------------------------------------------------------------------------
+
+
+def test_filename_collision_uses_exclusive_create(tmp_path: Path) -> None:
+    finding = Finding(
+        key="K1",
+        rule="python:S3776",
+        severity="CRITICAL",
+        type="CODE_SMELL",
+        component="bernstein:src/foo.py",
+        line=10,
+        creation_date="2026-05-20T08:00:00+0000",
+    )
+    out_dir = tmp_path / "open"
+    out_dir.mkdir()
+    # Pre-populate the exact filename the emitter would pick.
+    path, _body1, wrote1 = emit_ticket(finding, out_dir, day="2026-05-21")
+    assert wrote1 is True
+    assert path.exists()
+    # Second emit should hit the exclusive-create branch and NOT overwrite.
+    pre_text = path.read_text()
+    path2, _body2, wrote2 = emit_ticket(finding, out_dir, day="2026-05-21")
+    assert path2 == path
+    assert wrote2 is False
+    assert path.read_text() == pre_text
+
+
+def test_emitted_frontmatter_contract(tmp_path: Path) -> None:
+    finding = Finding(
+        key="K2",
+        rule="python:S1192",
+        severity="MAJOR",
+        type="CODE_SMELL",
+        component="bernstein:src/bar.py",
+        line=20,
+        creation_date="2026-05-20T08:00:00+0000",
+    )
+    out_dir = tmp_path / "open"
+    out_dir.mkdir()
+    path, _body, wrote = emit_ticket(finding, out_dir, day="2026-05-21")
+    assert wrote is True
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    parts = text.split("---", 2)
+    fm = yaml.safe_load(parts[1])
+    for required in ("id", "created", "status", "priority", "effort"):
+        assert required in fm, f"missing required key: {required}"
+    for sweep_key in (
+        "sonar_issue_key",
+        "sonar_rule",
+        "sonar_component",
+        "sonar_severity",
+        "sonar_type",
+    ):
+        assert sweep_key in fm, f"missing sweep key: {sweep_key}"
+    assert fm["sonar_issue_key"] == "K2"
+    assert fm["sonar_rule"] == "python:S1192"
+
+
+def test_ticket_body_is_ascii_safe(tmp_path: Path) -> None:
+    finding = Finding(
+        key="K3",
+        rule="python:S3776",
+        severity="BLOCKER",
+        type="CODE_SMELL",
+        component="bernstein:src/baz.py",
+        line=30,
+        creation_date="2026-05-20T08:00:00+0000",
+    )
+    out_dir = tmp_path / "open"
+    out_dir.mkdir()
+    path, _body, wrote = emit_ticket(finding, out_dir, day="2026-05-21")
+    assert wrote is True
+    text = path.read_text(encoding="utf-8")
+    # Reject em-dash and curly quotes per Bernstein hard constraints.
+    # Use chr() so this test source itself stays ASCII-only.
+    em_dash = chr(0x2014)
+    left_single = chr(0x2018)
+    right_single = chr(0x2019)
+    left_double = chr(0x201C)
+    right_double = chr(0x201D)
+    assert em_dash not in text
+    assert left_single not in text and right_single not in text
+    assert left_double not in text and right_double not in text
+
+
+# ---------------------------------------------------------------------------
+# 11 + 12 + 13. HTTP client retry semantics
+# ---------------------------------------------------------------------------
+
+
+def _stub_sleep_calls() -> tuple[list[float], Any]:
+    calls: list[float] = []
+
+    def _sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    return calls, _sleep
+
+
+def test_5xx_retry_then_success() -> None:
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return httpx.Response(503, text="busy")
+        return httpx.Response(200, json={"issues": [], "paging": {"pageIndex": 1, "pageSize": 500, "total": 0}})
+
+    transport = httpx.MockTransport(handler)
+    sleeps, sleep_fn = _stub_sleep_calls()
+    with httpx.Client(transport=transport) as client:
+        resp = _request_with_retries(client, "https://sonar.example.com/api/issues/search", {}, sleep_fn=sleep_fn)
+    assert resp.status_code == 200
+    assert calls["count"] == 3
+    assert len(sleeps) == 2  # two backoff sleeps before the third (successful) try
+
+
+def test_5xx_final_failure_exits_one() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="still busy")
+
+    transport = httpx.MockTransport(handler)
+    _, sleep_fn = _stub_sleep_calls()
+    with httpx.Client(transport=transport) as client:
+        with pytest.raises(SonarAPIError):
+            _request_with_retries(
+                client,
+                "https://sonar.example.com/api/issues/search",
+                {},
+                sleep_fn=sleep_fn,
+            )
+
+
+def test_429_respects_retry_after() -> None:
+    seq = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seq["n"] += 1
+        if seq["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "3"})
+        return httpx.Response(
+            200,
+            json={
+                "issues": [],
+                "paging": {"pageIndex": 1, "pageSize": 500, "total": 0},
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    sleeps, sleep_fn = _stub_sleep_calls()
+    with httpx.Client(transport=transport) as client:
+        resp = _request_with_retries(
+            client,
+            "https://sonar.example.com/api/issues/search",
+            {},
+            sleep_fn=sleep_fn,
+        )
+    assert resp.status_code == 200
+    assert sleeps == [3.0]
+
+
+# ---------------------------------------------------------------------------
+# fetch_findings paging integration
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_findings_paginates() -> None:
+    page1 = {
+        "issues": [
+            {
+                "key": "k1",
+                "rule": "python:S1481",
+                "severity": "MAJOR",
+                "type": "CODE_SMELL",
+                "component": "bernstein:src/x.py",
+                "line": 1,
+                "creationDate": "2026-05-20T01:00:00+0000",
+            }
+        ],
+        "paging": {"pageIndex": 1, "pageSize": 1, "total": 2},
+    }
+    page2 = {
+        "issues": [
+            {
+                "key": "k2",
+                "rule": "python:S1481",
+                "severity": "MAJOR",
+                "type": "CODE_SMELL",
+                "component": "bernstein:src/y.py",
+                "line": 2,
+                "creationDate": "2026-05-20T02:00:00+0000",
+            }
+        ],
+        "paging": {"pageIndex": 2, "pageSize": 1, "total": 2},
+    }
+
+    seen_pages: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = dict(request.url.params).get("p", "1")
+        seen_pages.append(page)
+        if page == "1":
+            return httpx.Response(200, json=page1)
+        return httpx.Response(200, json=page2)
+
+    from sweep_sonar_findings import SonarConfig  # type: ignore[import-not-found]
+
+    cfg = SonarConfig(host="https://sonar.example.com", token="t", project_key="bernstein")
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        findings = fetch_findings(
+            cfg,
+            severities=["MAJOR"],
+            page_size=1,
+            client=client,
+            sleep_fn=lambda _x: None,
+        )
+    assert [f.key for f in findings] == ["k1", "k2"]
+    assert seen_pages == ["1", "2"]
+
+
+# ---------------------------------------------------------------------------
+# Dry-run does not write
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_writes_no_files(
+    sweep_workspace: Path,
+    issues_search_fixture_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MINOR",
+            "--dry-run",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    assert list(out_dir.glob("2026-05-21-*.md")) == []
+    captured = capsys.readouterr()
+    assert "would-emit" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# GH issue creation gating
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_create_gh_issue_skips_when_disabled(tmp_path: Path) -> None:
+    path = tmp_path / "t.md"
+    path.write_text("body")
+    assert maybe_create_gh_issue(path, "title", enable=False, priority="P0") is None
+
+
+def test_maybe_create_gh_issue_skips_non_p0(tmp_path: Path) -> None:
+    path = tmp_path / "t.md"
+    path.write_text("body")
+    assert maybe_create_gh_issue(path, "title", enable=True, priority="P1") is None
+
+
+def test_maybe_create_gh_issue_calls_runner(tmp_path: Path) -> None:
+    path = tmp_path / "t.md"
+    path.write_text("body")
+    captured: dict[str, Any] = {}
+
+    class _R:
+        def __init__(self, rc: int, out: str) -> None:
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = ""
+
+    def fake_runner(cmd: list[str], **kwargs: Any) -> _R:
+        captured["cmd"] = cmd
+        return _R(0, "https://github.com/org/repo/issues/42\n")
+
+    url = maybe_create_gh_issue(path, "title", enable=True, priority="P0", runner=fake_runner)
+    assert url == "https://github.com/org/repo/issues/42"
+    assert captured["cmd"][:3] == ["gh", "issue", "create"]
+
+
+# ---------------------------------------------------------------------------
+# Component path stripping
+# ---------------------------------------------------------------------------
+
+
+def test_component_path_strips_project_prefix() -> None:
+    assert _component_path("bernstein:src/foo/bar.py") == "src/foo/bar.py"
+    assert _component_path("src/foo/bar.py") == "src/foo/bar.py"
+
+
+# ---------------------------------------------------------------------------
+# Severity to priority mapping
+# ---------------------------------------------------------------------------
+
+
+def test_severity_to_priority_mapping() -> None:
+    assert SEVERITY_TO_PRIORITY["BLOCKER"] == "P0"
+    assert SEVERITY_TO_PRIORITY["CRITICAL"] == "P1"
+    assert SEVERITY_TO_PRIORITY["MAJOR"] == "P2"

--- a/tests/unit/sweep/test_sweep_sonar_workflow_yaml.py
+++ b/tests/unit/sweep/test_sweep_sonar_workflow_yaml.py
@@ -1,0 +1,81 @@
+"""Workflow YAML smoke test.
+
+The Sonar findings sweep workflow ships with the cron trigger present
+but gated behind ``ENABLE_CRON='0'``. This test pins the gate so
+operators cannot accidentally enable the daily cron without flipping
+the well-known env var inside the workflow file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "sweep-sonar-findings.yml"
+
+
+def _load_workflow() -> dict:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(text)
+    assert isinstance(parsed, dict), "workflow must parse as a YAML mapping"
+    return parsed
+
+
+def test_workflow_has_cron_and_dispatch() -> None:
+    parsed = _load_workflow()
+    # PyYAML parses the literal `on:` key as the boolean True.
+    on = parsed.get(True) if True in parsed else parsed["on"]
+    assert isinstance(on, dict)
+    assert "schedule" in on
+    schedule = on["schedule"]
+    assert isinstance(schedule, list) and schedule
+    crons = [item.get("cron") for item in schedule]
+    assert "17 6 * * *" in crons
+    assert "workflow_dispatch" in on
+
+
+def test_workflow_cron_is_gated_off_by_default() -> None:
+    parsed = _load_workflow()
+    env = parsed.get("env") or {}
+    # The gate env var must default to '0' (string). Operators flip it
+    # to '1' in a follow-up PR after a clean smoke run.
+    assert env.get("ENABLE_CRON") == "0"
+
+
+def test_workflow_has_concurrency_group() -> None:
+    parsed = _load_workflow()
+    concurrency = parsed.get("concurrency") or {}
+    assert concurrency.get("group") == "sweep-sonar-findings"
+    assert concurrency.get("cancel-in-progress") is False
+
+
+def test_workflow_pins_action_shas() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    # Every `uses:` line must use a 40-char SHA pin, never a floating tag.
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uses:"):
+            continue
+        ref = stripped.removeprefix("uses:").strip()
+        # actions/checkout@<sha> # vN.N.N -- split off the SHA.
+        if "@" not in ref:
+            raise AssertionError(f"uses line missing '@<sha>': {line!r}")
+        _name, _, after = ref.partition("@")
+        sha = after.split()[0]
+        assert len(sha) == 40 and all(c in "0123456789abcdef" for c in sha), (
+            f"uses line not pinned to a 40-char SHA: {line!r}"
+        )
+
+
+def test_workflow_has_harden_runner() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "step-security/harden-runner@" in text
+
+
+def test_workflow_top_level_permissions_are_narrow() -> None:
+    parsed = _load_workflow()
+    perms = parsed.get("permissions")
+    assert perms == {"contents": "read"}, (
+        "Top-level permissions must default to read-only; the sweep job grants its own write scopes."
+    )


### PR DESCRIPTION
## Summary

- New `scripts/sweep_sonar_findings.py` walks open Sonar findings via `/api/issues/search` and emits one backlog ticket per new finding into `.sdd/backlog/open/`. Re-runs are idempotent on the upstream `key` field, stored in ticket frontmatter as `sonar_issue_key`.
- New `bernstein doctor sonar-sweep` CLI surface for local dry-runs and fixture-driven smoke tests, including a `--fixture` flag that bypasses the network entirely.
- New `.github/workflows/sweep-sonar-findings.yml` with daily cron at 06:17 UTC plus `workflow_dispatch`. The cron trigger ships dormant: an `ENABLE_CRON` workflow-level env var defaults to `'0'` so scheduled runs no-op until an operator flips it in a follow-up PR after a clean smoke run.

## Idempotence

- Primary dedup key: `sonar_issue_key` from ticket frontmatter, walked across `open/`, `claimed/`, `closed/`, `done/`, `deferred/`.
- Fallback dedup: `(rule, component, line)` triple for tickets still in an open-ish state, so upstream key churn after a refactor does not re-import the same finding.
- Exclusive-create file open (`open("x")`) protects against a concurrent-run race past the dedup step.

## Public-safe `## Why` bodies

The script never copies the raw Sonar `message` or `htmlDesc` into a ticket. Every `## Why` body is built from a pre-vetted `RULE_FAMILY_BLURBS` table plus a `DEFAULT_BLURB` fallback that interpolates only the rule key. A unit test (`test_safe_why_no_forbidden_substrings`) asserts that no blurb contains any string from `FORBIDDEN_SUBSTRINGS`. Extending the table is documented under `docs/operations/sonar-sweeper.md`.

## Phase-1 defaults

`BLOCKER` only, 10 tickets/day cap, GH-issue creation off, cron dormant. The phase rollout table lives in the operator doc.

## Network failure mode

- 5xx: 3-attempt exponential backoff (2/4/8s with +/-25% jitter). Persistent failure exits 1 with a single log line; no partial tickets emitted.
- 429: respects `Retry-After`, single retry.

## Test plan

- [x] `uv run pytest tests/unit/sweep/ -q` (30 tests pass).
- [x] `uv run ruff check scripts/sweep_sonar_findings.py tests/unit/sweep/ src/bernstein/cli/commands/advanced_cmd.py` (clean).
- [x] `uv run ruff format --check ...` (clean).
- [x] `actionlint .github/workflows/sweep-sonar-findings.yml` (clean).
- [x] Adjacent suites unaffected: `tests/unit/cli/doctor/test_sonar.py` and `tests/unit/observability/` all green.
- [x] CLI smoke: `bernstein doctor sonar-sweep --dry-run --fixture tests/unit/sweep/fixtures/issues_search.json` prints `would-emit` lines and writes nothing.

## Operator follow-ups (not in this PR)

1. Configure `SONAR_PROJECT_KEY` repo var (the existing `SONAR_HOST_URL` + `SONAR_TOKEN` already cover the rest of the contract).
2. Trigger `workflow_dispatch` with `dry_run: true` once to smoke-test the workflow end-to-end.
3. Flip `ENABLE_CRON` from `'0'` to `'1'` in a follow-up PR after the smoke run looks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated workflow that sweeps SonarQube findings and creates tickets in the backlog daily or on-demand.
  * Added CLI command to run the sweeper locally with configurable severity filters and per-day caps.

* **Documentation**
  * Added documentation describing the sweep process, configuration, and deduplication behavior.

* **Tests**
  * Added comprehensive test suite covering workflow validation, sweeper functionality, and CLI integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->