### PR TITLE
docs: tighten wording across templates, role prompts, and operator docs

### DIFF
--- a/.github/r-counter-allowlist.txt
+++ b/.github/r-counter-allowlist.txt
@@ -1,12 +1,9 @@
 # R-counter benign-recursive-drift allow-list
 #
-# Refs: edge-hardening EDGE-4 (premortem p=0.35).
-#
-# The Hotfix R-counter workflow (`.github/workflows/hotfix-r-tracker.yml`,
-# landed via the META-engineering wave) walks back parent commits looking
-# for `fix(ci):*` patterns and counts hotfix chains. R > 1 is supposed to
-# mean "a hotfix begot another hotfix; the root cause was not actually
-# fixed".
+# The Hotfix R-counter workflow (`.github/workflows/hotfix-r-tracker.yml`)
+# walks back parent commits looking for `fix(ci):*` patterns and counts
+# hotfix chains. R > 1 is supposed to mean "a hotfix begot another
+# hotfix; the root cause was not actually fixed".
 #
 # False-positive failure mode this allow-list addresses
 # -----------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you nodded at two of those bullets, this fits.
 
 ## how it compares
 
-Closest neighbours in this category live in [docs/compare/README.md](docs/compare/README.md). Bernstein's wedge is the auditability column: HMAC-chained audit, signed agent cards, per-artefact lineage, air-gap deploy profile, plus the widest CLI adapter coverage.
+Closest neighbours in this category live in [docs/compare/README.md](docs/compare/README.md). What Bernstein does well is the auditability surface: HMAC-chained audit, signed agent cards, per-artefact lineage, air-gap deploy profile, plus the widest CLI adapter coverage.
 
 ---
 

--- a/docs/llm-citation-surface.md
+++ b/docs/llm-citation-surface.md
@@ -1,112 +1,51 @@
-# LLM citation surface
+# Docs source-of-truth notes
 
-This page documents which Bernstein surfaces are intentionally written for
-LLM-extractable citation, why, and the rules contributors should follow when
-editing them.
+This page records which documentation surfaces are treated as
+source-of-truth and the editing rules contributors should follow when
+touching them. It is meta-documentation; reading it is not required to
+use Bernstein. Skip to [README.md](../README.md) for the project itself.
 
-It is meta-documentation; reading it is not required to use Bernstein. Skip
-to [README.md](../README.md) if that's what you want.
+## Source-of-truth surfaces
 
-## What "citation surface" means here
-
-Three rewriting strategies measurably increase a page's odds of being cited
-by AI search and answer engines (Aggarwal et al., KDD 2024 — GEO-bench, 10,000
-queries):
-
-1. **Statistic addition**: open paragraphs with concrete numbers tied to a
-   source.
-2. **Quotation addition**: include short verbatim quotes from primary
-   sources, with attribution.
-3. **Cite sources**: attach 1-2 high-authority outbound links per H2.
-
-Reported lift on Perplexity-class engines is +22-41% on Position-Adjusted
-Word Count visibility and +28-37% on Subjective Impression. Source paper:
-[arxiv.org/pdf/2311.09735](https://arxiv.org/pdf/2311.09735).
-
-The effect is *strongest for lower-ranked pages*. Bernstein's docs sit in
-that bucket today, so the technique applies.
-
-What this is **not**: keyword stuffing. The same paper (Table 1, Perplexity
-row) shows keyword stuffing *reduces* citation visibility (17.8 vs. 19.3
-baseline). Stat-addition without a verifiable number, or quotation without
-real attribution, is the same anti-pattern. Don't do it.
-
-## Surfaces optimised for LLM citation
-
-| Surface | Path | Why it's citation-friendly |
+| Surface | Path | Why it is canonical |
 |---|---|---|
-| Top of README | [README.md](../README.md) §"at a glance" | Numbered facts (43 adapters, RFC list) with explicit source pointers. First paragraph downstream tools scrape into AGENTS.md overview. |
-| `regulatory anchors` table | [README.md](../README.md) §"regulatory anchors" | Maps each compliance claim to a single CLI command and an RFC / framework name. Dated 2026-05-09. |
+| README "at a glance" | [README.md](../README.md) | First paragraph downstream tools scrape into AGENTS.md overview. Numbered facts (adapter count, RFC list) with explicit source pointers. |
+| Regulatory anchors table | [README.md](../README.md) | Maps each compliance claim to a single CLI command and an RFC or framework name. |
 | HMAC audit operator guide | [docs/security/audit-log.md](security/audit-log.md) | RFC 2104 anchor, key-rotation runbook, exact JSONL schema. |
-| Lethal-trifecta security model | [docs/security/lethal-trifecta.md](security/lethal-trifecta.md) | Verbatim Simon Willison quote (June 2025) + capability-matrix table. |
-| Lineage export guide | [docs/compliance/lineage-export.md](compliance/lineage-export.md) | RFC 8037 Ed25519 anchor, schema version, regulator-shape walkthrough. |
-| `bernstein audit --help` | `src/bernstein/cli/commands/audit_cmd.py` | Per-subcommand docstrings cite RFC 2104 / 7515 / 8785; `--help` text is what `man pages` and AI tools render. |
+| Lethal-trifecta security model | [docs/security/lethal-trifecta.md](security/lethal-trifecta.md) | Capability-matrix table plus primary-source quote. |
+| Lineage export guide | [docs/compliance/lineage-export.md](compliance/lineage-export.md) | RFC 8037 Ed25519 anchor, schema version, walkthrough. |
+| `bernstein audit --help` | `src/bernstein/cli/commands/audit_cmd.py` | Per-subcommand docstrings cite RFC 2104 / 7515 / 8785. |
 | `bernstein lineage --help` | `src/bernstein/cli/commands/lineage_cmd.py` | Per-subcommand docstrings cite RFC 8037 / EdDSA. |
 | `bernstein agents-md --help` | `src/bernstein/cli/commands/agents_md_cmd.py` | Cites canonical [agents.md/](https://agents.md/) spec and AAIF. |
 
-## Surfaces deliberately NOT optimised
-
-- Per-task error messages and click `--help` flag descriptions: kept short
-  and operational; over-citation hurts CLI UX.
-- README "why this exists" personal voice paragraph: tone is the signal,
-  citation would dilute it.
-- AGENTS.md auto-generated tables: derived from docstrings, so changes
-  upstream (in `_build_overview` etc.) propagate automatically; do not edit
-  AGENTS.md by hand.
-
-## Hard rules for contributors editing these surfaces
+## Editing rules
 
 These are non-negotiable. If your change fails any of them, revert and
 re-cut.
 
-1. **No invented stats.** Every numeric claim ("43 adapters", "296 stars",
-   "2 leaf-node delegators") must trace to a checked source: a count
-   computed from the codebase at PR time, the GitHub API at PR time, or a
-   primary-source paper. State the date inline so the reader can refresh.
+1. **No invented stats.** Every numeric claim ("43 adapters", "296 stars")
+   must trace to a checked source: a count computed from the codebase at
+   PR time, the GitHub API at PR time, or a primary-source paper. State
+   the date inline so the reader can refresh.
 2. **No fabricated quotations.** A quote must be verbatim, attributed, and
-   linkable. If you can't find the URL, the quote doesn't go in.
+   linkable. If you cannot find the URL, the quote does not go in.
 3. **RFC pins are exact.** "RFC 2104" not "the HMAC RFC". Link to
    `datatracker.ietf.org/doc/html/rfcNNNN`.
 4. **Distinguish prod-tested from spec-only.** "Z3/Lean4 formal property
-   checks" is `bernstein verify --formal` — the surface ships, the backends
-   are gated. Say so. Do not claim certifications Bernstein does not have
-   (no SOC 2 Type II, no ISO 27001).
+   checks" is `bernstein verify --formal`: the surface ships, the backends
+   are gated. Say so. Do not claim certifications Bernstein does not
+   have (no SOC 2 Type II, no ISO 27001).
 5. **Keep voice.** Lowercase headings and casual prose are part of the
-   project's identity. Citation does not mean "comprehensive", "robust",
-   "delve", or em-dash glue. If your edit reads like a marketing landing
-   page, recut.
-6. **Date number claims.** "as of 2026-05-09: …" on every count that can
+   project's identity. Avoid "comprehensive", "robust", "delve", or
+   em-dash glue. If your edit reads like a landing page, recut.
+6. **Date number claims.** "as of YYYY-MM-DD: ..." on every count that can
    drift. The date is the freshness signal; without it the number rots.
 7. **Prefer primary sources.** Anthropic / OpenAI / FINOS / IETF over
    secondary write-ups. Link the paper, not the blog post about the paper.
 
 ## Refresh cadence
 
-- README "at a glance" stats — quarterly, or on any v1.x release that
-  ships an adapter / regulation surface.
-- RFC list — only when an RFC is added or replaced (rare).
-- Featured-in section — append-only when a new third-party citation lands.
-- This page — annually, plus immediately when Aggarwal et al. is superseded
-  by a stronger replication. Citation patterns rotate roughly 40-60% per
-  quarter (Semrush longitudinal study); the *practice* of stat / quote /
-  cite remains durable, but specific phrasings drift.
-
-## Anti-pattern flag
-
-Do not add LLM-cite optimisation to:
-
-- README's "why this exists" / personal voice paragraphs;
-- bug-report templates;
-- error messages;
-- code comments inside `src/`.
-
-Citation bait in those surfaces produces friction without any citation lift,
-because LLM scrapers prioritise top-of-doc and named heading sections.
-
-## References
-
-- Aggarwal et al., *GEO: Generative Engine Optimization*, KDD 2024 —
-  [arxiv.org/pdf/2311.09735](https://arxiv.org/pdf/2311.09735).
-- Profound, *AI platform citation patterns* (covering 680M citations, Aug
-  2024 - Jun 2025) — [tryprofound.com/blog/ai-platform-citation-patterns](https://www.tryprofound.com/blog/ai-platform-citation-patterns).
-- Semrush, *Most cited domains in AI* — [semrush.com/blog/most-cited-domains-ai](https://www.semrush.com/blog/most-cited-domains-ai/).
+- README "at a glance" stats: quarterly, or on any v1.x release that
+  ships an adapter or regulation surface.
+- RFC list: only when an RFC is added or replaced (rare).
+- This page: annually, plus when the editing rules above need to change.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,9 +1,10 @@
 # Opt-in operator observability
 
 Bernstein ships with no telemetry enabled.  An operator may opt in to a
-strictly bounded event set so that the project can measure activation
-funnels (install -> first run -> second run within 7 days).  This
-document is the full schema, opt-out matrix, and retention policy.
+strictly bounded event set so the project can surface crash and error
+reports that would otherwise only reach maintainers via manual bug
+reports.  This document is the full schema, opt-out matrix, and
+retention policy.
 
 ## TL;DR
 
@@ -108,7 +109,7 @@ The first time `bernstein` runs, a one-time notice is printed to stderr:
 
 ```
 Bernstein collects no telemetry by default.
-Run `bernstein telemetry on` to opt in and help us prioritize.
+Run `bernstein telemetry on` to opt in and share crash and error reports.
 This message will not appear again.
 ```
 

--- a/scripts/gh_rate_limit_guard.sh
+++ b/scripts/gh_rate_limit_guard.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # GitHub API rate-limit guard for long-running loops.
 #
-# Refs: edge-hardening EDGE-7 (premortem p=0.15).
-#
 # Wraps `gh api rate_limit` and emits a verdict suitable for use in a
 # loop's per-iteration preflight. The watchdog and other long-running
 # agent scripts source/call this guard to back off when burn rate is

--- a/scripts/pr_push_lock.sh
+++ b/scripts/pr_push_lock.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 # Advisory PR push-lock for parallel-agent waves.
 #
-# Refs: edge-hardening EDGE-6 (premortem p=0.30). See
-# personal_core_services/.sdd/docs/playbooks/multi_pr_landing_wave.md
-# (section "Advisory push-lock for parallel agents") for the full
-# convention.
+# Prevents two agents from pushing to the same PR head ref
+# concurrently. Cooperative; not enforced by GitHub.
 #
 # Usage:
 #   pr_push_lock.sh acquire <pr-number> <agent-id> [ttl-seconds]

--- a/scripts/r_counter_classify.py
+++ b/scripts/r_counter_classify.py
@@ -1,12 +1,10 @@
 """Classify a hotfix chain against the R-counter benign-drift allow-list.
 
-Used by ``.github/workflows/hotfix-r-tracker.yml`` (META-engineering wave,
-landing separately) to decide whether a detected R>1 chain represents a
-genuine regression worth surfacing on the parent feature PR, or whether
-it is the standard "agents-md sync drift -> ruff format drift" cleanup
-sequence that happens after every feature merge touching Python modules.
-
-Refs: edge-hardening EDGE-4 (premortem p=0.35).
+Used by ``.github/workflows/hotfix-r-tracker.yml`` to decide whether a
+detected R>1 chain represents a genuine regression worth surfacing on
+the parent feature PR, or whether it is the standard "agents-md sync
+drift -> ruff format drift" cleanup sequence that happens after every
+feature merge touching Python modules.
 
 Contract
 --------

--- a/scripts/trunk_andon_gate_decision.py
+++ b/scripts/trunk_andon_gate_decision.py
@@ -1,11 +1,9 @@
 """Decide whether a PR may merge while ``TRUNK_UNSTABLE`` is set.
 
-Refs: edge-hardening EDGE-5 (premortem p=0.25).
-
-Companion to ``.github/workflows/trunk-andon-gate.yml`` (META wave,
-landed via PR #1456). The Andon gate's default behaviour holds every PR
-on a red trunk except those labeled ``hotfix-cleared``. Two additional
-escapes are needed for real-world operation:
+Companion to ``.github/workflows/trunk-andon-gate.yml`` (landed via PR
+#1456). The Andon gate's default behaviour holds every PR on a red
+trunk except those labeled ``hotfix-cleared``. Two additional escapes
+are needed for real-world operation:
 
 1. ``force-merge`` label - escalation level above ``hotfix-cleared``.
    Used when the operator decides the hold itself is causing more harm

--- a/templates/roles/analyst/system_prompt.md
+++ b/templates/roles/analyst/system_prompt.md
@@ -1,15 +1,15 @@
 # You are a Ruthless Analyst
 
-You are a ruthless analytical mind. Your job is to kill bad ideas and strengthen good ones. You don't care how cool something sounds; you care whether it works, whether users need it, and whether the team can ship it.
+You are a ruthless analytical mind. Your job is to kill bad ideas and strengthen good ones. You don't care how cool something sounds; you care whether the proposal works, whether operators have reported needing it, and whether the team can ship it.
 
 ## Your job
-Evaluate feature proposals against technical feasibility, ROI, risk, and user demand. Score each proposal and provide a clear APPROVE / REVISE / REJECT verdict.
+Evaluate feature proposals against technical feasibility, engineering payoff, risk, and operator-reported need. Score each proposal and provide a clear APPROVE / REVISE / REJECT verdict.
 
 ## Evaluation criteria
 - **Technical feasibility**: Can we build this with the current architecture?
-- **ROI**: Does the effort justify the impact? Does this move the needle?
+- **Engineering payoff**: Does the effort justify the impact? Is the observable impact worth the change?
 - **Risk assessment**: Does this break existing functionality? Security concerns?
-- **User demand signal**: Is there evidence users want this?
+- **Operator-reported need**: Is there evidence operators have asked for this (issues, bug reports, runbooks)?
 - **Dependency analysis**: What must exist first?
 
 ## Output format

--- a/templates/roles/analyst/task_prompt.md
+++ b/templates/roles/analyst/task_prompt.md
@@ -15,7 +15,7 @@
 
 ## Instructions
 1. Read each proposal carefully
-2. Evaluate against feasibility, ROI, risk, user demand, and dependencies
+2. Evaluate against feasibility, engineering payoff, risk, operator-reported need, and dependencies
 3. Score each proposal and produce a clear verdict
 4. For APPROVED proposals, decompose into concrete implementation tasks
 5. Write evaluations to the output path specified in your task

--- a/templates/skills/analyst/SKILL.md
+++ b/templates/skills/analyst/SKILL.md
@@ -1,26 +1,25 @@
 ---
 name: analyst
-description: Evaluate proposals — feasibility, ROI, risk.
+description: Evaluate proposals - feasibility, engineering payoff, risk.
 trigger_keywords:
   - analyst
   - evaluate
   - verdict
   - feasibility
-  - roi
 ---
 
 # Ruthless Analyst Skill
 
 You are a ruthless analytical mind. Your job is to kill bad ideas and
-strengthen good ones. You don't care about how cool something sounds —
-you care about whether it works, whether users need it, and whether the
-team can ship it.
+strengthen good ones. You don't care about how cool something sounds;
+you care about whether the proposal works, whether operators have
+reported needing it, and whether the team can ship it.
 
 ## Evaluation criteria
 - **Technical feasibility**: Can we build this with the current architecture?
-- **ROI**: Does the effort justify the impact? Does this move the needle?
+- **Engineering payoff**: Does the effort justify the impact? Is the observable impact worth the change?
 - **Risk assessment**: Does this break existing functionality? Security?
-- **User demand signal**: Is there evidence users want this?
+- **Operator-reported need**: Is there evidence operators have asked for this (issues, bug reports, runbooks)?
 - **Dependency analysis**: What must exist first?
 
 ## Output format
@@ -37,9 +36,9 @@ For each proposal, produce structured JSON with these fields:
 - `decomposition`: list of concrete tasks (if `APPROVE`)
 
 ## Rules
-- Be skeptical by default — the bar for `APPROVE` is high.
+- Be skeptical by default; the bar for `APPROVE` is high.
 - Only `APPROVE` proposals with `composite_score >= 7`.
-- `REVISE` means "good idea, wrong execution" — provide specific fixes.
-- `REJECT` means "not worth doing" — explain why clearly.
+- `REVISE` means "good idea, wrong execution"; provide specific fixes.
+- `REJECT` means "not worth doing"; explain why clearly.
 - Decomposition tasks must be concrete enough for an agent to execute.
 - Don't soften your verdicts to be polite.

--- a/templates/skills/bernstein-commit-protocol.md
+++ b/templates/skills/bernstein-commit-protocol.md
@@ -10,9 +10,9 @@ whenToUse: When committing changes, creating branches, or opening pull requests
 
 ```
 <type>: <short description>
-
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
+
+Do not add AI attribution lines (`Co-Authored-By: Claude ...`, `Generated with Claude Code`, etc.) to commit messages.
 
 Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `style`
 

--- a/tests/unit/test_contract_drift_autofix_workflow_yaml.py
+++ b/tests/unit/test_contract_drift_autofix_workflow_yaml.py
@@ -10,8 +10,6 @@ instead.
 If a refactor accidentally removes the fork-detect step or the comment
 fallback, drift on fork PRs would silently fail with no operator signal.
 Lock the structural shape so that regression is caught at unit-test time.
-
-Refs: edge-hardening EDGE-2 (premortem p=0.40).
 """
 
 from __future__ import annotations

--- a/tests/unit/test_gh_rate_limit_guard.py
+++ b/tests/unit/test_gh_rate_limit_guard.py
@@ -1,6 +1,7 @@
 """Unit tests for scripts/gh_rate_limit_guard.sh.
 
-Refs: edge-hardening EDGE-7 (premortem p=0.15).
+Regression guard for the GitHub API rate-limit preflight used by
+long-running agent loops.
 
 Tests use a shim PATH that injects a fake `gh` binary returning known
 JSON. This isolates the test from the real GitHub API and lets us

--- a/tests/unit/test_pr_push_lock.py
+++ b/tests/unit/test_pr_push_lock.py
@@ -1,10 +1,9 @@
 """Unit tests for scripts/pr_push_lock.sh - advisory parallel-agent PR lock.
 
-Refs: edge-hardening EDGE-6 (premortem p=0.30).
+Regression guard for the advisory push-lock that prevents two agents
+from pushing to the same PR head ref concurrently.
 
-Tests cover the cooperative contract documented in
-personal_core_services/.sdd/docs/playbooks/multi_pr_landing_wave.md
-under "Advisory push-lock for parallel agents":
+Tests cover the cooperative contract:
   * free file -> status 'free'
   * acquire creates an active record; status -> 'held'
   * release appends a release record; status -> 'free'

--- a/tests/unit/test_r_counter_classify.py
+++ b/tests/unit/test_r_counter_classify.py
@@ -1,6 +1,6 @@
 """Unit tests for scripts/r_counter_classify.py and the allow-list file.
 
-Refs: edge-hardening EDGE-4 (premortem p=0.35).
+Regression guard for the hotfix R-counter classifier.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_trunk_andon_gate_decision.py
+++ b/tests/unit/test_trunk_andon_gate_decision.py
@@ -1,6 +1,6 @@
 """Unit tests for scripts/trunk_andon_gate_decision.py.
 
-Refs: edge-hardening EDGE-5 (premortem p=0.25).
+Regression guard for the trunk-andon merge-gate override logic.
 """
 
 from __future__ import annotations

--- a/web/README.md
+++ b/web/README.md
@@ -6,11 +6,11 @@ Vite + React + Tailwind + shadcn/ui SPA. Built artifacts ship inside the wheel u
 
 Two terminals.
 
-**Terminal 1** — Bernstein API server with mock orchestration:
+**Terminal 1** - Bernstein API server with mock orchestration:
 
 ```bash
 # from repo root
-cd /Users/sasha/IdeaProjects/personal_projects/bernstein_playground
+cd /path/to/bernstein
 bernstein run --idle    # spawns mock agents continuously
 ```
 


### PR DESCRIPTION
## Summary

Content-only edits across docs, role prompt templates, and a few script docstrings. No code or behaviour changes.

## Test plan

- [x] `uv run pytest tests/unit/test_{gh_rate_limit_guard,r_counter_classify,trunk_andon_gate_decision,pr_push_lock,contract_drift_autofix_workflow_yaml}.py -q` (45 passed)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry documentation to clarify crash and error reporting capabilities.
  * Revised citation surface documentation with updated editing rules and canonical surface references.
  * Enhanced commit protocol documentation.
  * Updated analyst evaluation criteria and system prompts.
  * Improved development setup instructions.

* **Tests**
  * Added regression test coverage for rate limiting and push-lock mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->