### PR TITLE
fix(docs): drop orphan section from docs-drift playbook

### DIFF
--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -108,13 +108,6 @@ Source of truth for this group is `src/bernstein/gui/` (FastAPI + SPA), `web/`
 | `troubleshooting.md` | `src/bernstein/gui/cli.py` (`_check_gui_extras`), static-assets gating | Error-message change in the extras check | `manual-prose` |
 | `mobile.md` | `web/` responsive breakpoints | Layout breakpoint change | `manual-prose` |
 
-### `docs/architecture/orchestration-approaches.md` and `docs/adapters/openai-agents-comparison.md`
-
-| Doc | Source of truth | Drift signal | Remediation |
-|-----|-----------------|--------------|-------------|
-| `architecture/orchestration-approaches.md` | None | Manual refresh by operator | `static` |
-| `adapters/openai-agents-comparison.md` | None | Manual refresh by operator | `static` |
-
 ### `docs/sdd/`
 
 | Doc | Source of truth | Drift signal | Remediation |


### PR DESCRIPTION
## Summary

Drop the orphan section header from `docs/playbooks/docs-drift.md` that combined two paths in its title (`docs/architecture/orchestration-approaches.md and docs/adapters/openai-agents-comparison.md`). The two rows under it were `static` remediation; removing the section entirely keeps the same on-disk coverage while fixing the drift parser's path resolution.

## Test plan

- [x] `uv run python scripts/check_docs_drift.py --strict` returns exit 0 with 'No drift detected.'
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated entries from the docs drift playbook inventory table.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->