### PR TITLE
chore: bump to 2.6.0

### DIFF
--- a/docs/release-notes/v2.6.0.md
+++ b/docs/release-notes/v2.6.0.md
@@ -1,0 +1,40 @@
+# v2.6.0
+
+Released 2026-05-21.
+
+## Features
+
+- Multi-adapter pentest fan-out: `bernstein eval pentest --adapters a,b,c` now runs the same scenario across multiple adapters and aggregates consensus on the dedup key `(canonical_vuln_type, normalized_path)`. New `PentestScorer.score_multi` returns per-adapter and aggregate scores; single-adapter behaviour stays byte-identical. (#1754)
+- SOTA merge-gate stack: pre-merge autosync regenerates AGENTS.md mirrors + ruff format on PR branches; main-red-guard blocks PR merges while main CI is red; nightly drift sweep opens a PR if mirror or format drift accumulates overnight; CI workflow now also responds to `merge_group:` events so a native merge queue can run the existing suite against the combined branch. Operator runbook at `docs/operations/merge-gate.md`. (#1756)
+- Per-row source-adapter provenance for the memory subsystem: `SQLiteMemoryStore` now carries an optional `source_adapter` column, supports `add_many` plus `query(read_only_from_adapters=[...])`, and uses additive NULL-backfill migration so existing rows still surface from default reads. (#1759)
+- Static-analysis sweeper for Sonar findings: `bernstein doctor sonar-sweep --dry-run` walks `/api/issues/search` and emits backlog tickets to `.sdd/backlog/open/` keyed on the Sonar issue id. Phase-1 rollout config: BLOCKER severity only, cap 10 per day, GH-issue creation off until the operator graduates the workflow. (#1763)
+- PR text-hygiene gate scans PR title / body / branch / commit messages against the deny-list configured in `vars.PR_TEXT_HYGIENE_DENYLIST` repo variable; opt-in via the repo settings page. (#1765 / #1766)
+
+## Fixes
+
+- Post-CI dispatcher no longer crashes with `startup_failure`; per-job permissions are now declared explicitly on each reusable-workflow call. (#1746)
+- Gemini adapter golden replay test is environment-independent (`shutil.which` mock pins the resolver), so the recorded argv matches across hosts whether `gemini` or `antigravity` is installed. (#1748)
+- Discord and Slack stub bridges now raise `NotImplementedError` at handler-registration time instead of silently dropping the callback. (#1751)
+- `bernstein audit export --standard` only accepts `ai-act`; the `dora` and `finos-aigf` placeholders were removed until their clause mappings are reviewed. (#1752)
+- HSM lineage kind fails fast at config-load when no real `HSMKMSAdapter` subclass is on the classpath; opt-in to the stub via `BERNSTEIN_ALLOW_HSM_STUB=1` for smoke tests. (#1753)
+- Workflow loader rejects `interactive: true` nodes at config-load instead of crashing mid-run (closes #1110). (#1760)
+- GlitchTip-insights workflow guards against an empty `GLITCHTIP_BASE_URL` repo variable; observe-snapshot tolerates the `bernstein doctor observe` exit code on Sonar WARN. Top-level CLI exception barrier explicitly captures unhandled exceptions to the configured telemetry sink. Dead `workflow_run` trigger and dead SonarCloud project key dropped from the sonar-scan workflow. (#1762)
+- Ruff `extend-exclude` now skips `templates/**`, so cookiecutter Jinja sources no longer break the pre-merge autosync workflow. (#1758)
+- Pre-merge autosync sources its deny-list from `vars.PR_TEXT_HYGIENE_DENYLIST`; when the variable is unset the script logs a notice and exits 0. (#1766)
+- `pentest_runner.run_multi_adapter` uses `sorted_findings.copy()` instead of `list(sorted_findings)` (closes FURB123 alert #2443). (#1776)
+- Dependabot config: the github-actions ecosystem block dropped `semver-major-days` from `cooldown` (not a supported property for that ecosystem). Trufflehog gate now only fails on verified secrets; the unknown bucket was dominated by test-fixture connection strings. (#1776)
+
+## Internals and docs hygiene
+
+- Dropped the unused `bernstein.benchmark.head_to_head` module and its test from the wheel. (#1767)
+- Reorganized the docs tree: ecosystem comparison memos, migration guides, the competitive audit, and the strategic plan now live under `docs/_internal/`. The two genuinely public pages (adapter-selection comparison, orchestration-approaches architecture note) moved into existing public nav sections. (#1768)
+- Front-page Comparison section, FAQ entry, JSON-LD metadata blocks, sitemap entries, and eleven stale README translations were dropped or refreshed. (#1769)
+- Punctuation across markdown / yaml / html / typescript / python is now ASCII hyphen only. AGENTS.md mirror set regenerated. (#1771 / #1776 / #1777)
+- Docs-drift playbook inventory matches the new on-disk layout. (#1770)
+
+## Operator follow-ups
+
+- Set `vars.PR_TEXT_HYGIENE_DENYLIST` in repo settings to activate the PR text-hygiene gate (currently no-op when unset).
+- Set `BERNSTEIN_AUTOSYNC_TOKEN` repo secret to a fine-grained PAT or GitHub App token with `contents:write` so pre-merge autosync amends trigger downstream CI re-runs without manual empty commits.
+- Pin additional checks (`Repo hygiene`, `docs-drift / Run drift check`, `main-red-guard`, multi-OS Test matrix jobs) to the required-check list per `docs/operations/merge-gate.md`.
+- Schedule the Sonar sweeper graduation (BLOCKER -> CRITICAL -> all severities) per `docs/operations/sonar-sweeper.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.5.1"
+version = "2.6.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Minor bump for the four feat commits since v2.5.1:

- feat(eval) multi-adapter pentest fan-out (#1754)
- feat(ci) SOTA merge-gate stack (#1756)
- feat(memory) per-row source-adapter provenance (#1759)
- feat(backlog) static-analysis sweeper for sonar findings (#1763)

Plus ten fix commits and the docs / hygiene cycle around them.

## Release notes

`docs/release-notes/v2.6.0.md` is included in this PR.

After merge: `auto-release.yml` fires on the green post-CI dispatcher, tags `v2.6.0`, creates the GitHub Release, and triggers `publish.yml` (PyPI) and `publish-docker.yml` (GHCR).

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` clean
- [x] pyproject.toml version is the only source-code change
- [ ] CI green
- [ ] auto-release tags v2.6.0 within 10 min of merge
- [ ] PyPI shows bernstein-2.6.0; GHCR has the v2.6.0 tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v2.6.0 describing new capabilities: multi-adapter pentest scoring, merge-gate autosync/CI improvements, optional memory-subsystem provenance, Sonar findings sweeper, and a PR text-hygiene gate. Also lists fixes across adapters, workflows, exporters and config loading, plus docs reorganization and content hygiene updates.

* **Chores**
  * Bumped package version to v2.6.0 and included operator follow-up steps for enabling gates and scheduling sweeper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->