### PR TITLE
fix(tests): disable watchdog threads in gemini adapter suite

### DIFF
--- a/tests/unit/test_adapter_gemini.py
+++ b/tests/unit/test_adapter_gemini.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 # can be hit, surfacing as "RuntimeError: can't start new thread" on an
 # otherwise-trivial test. Disable the watchdog suite-wide, matching the
 # other adapter test modules (rovo, auggie, clm, ralphex).
-pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")  # suite-wide guard, see module docstring
 
 # Parametrisation surface: both supported binary names. Every spawn-side
 # test runs against both so a regression in either path is caught.

--- a/tests/unit/test_adapter_gemini.py
+++ b/tests/unit/test_adapter_gemini.py
@@ -30,6 +30,13 @@ from bernstein.adapters.gemini import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+# Every spawn() call below arms a watchdog Timer thread by default. Under
+# the isolated test runner's high process concurrency the OS thread ceiling
+# can be hit, surfacing as "RuntimeError: can't start new thread" on an
+# otherwise-trivial test. Disable the watchdog suite-wide, matching the
+# other adapter test modules (rovo, auggie, clm, ralphex).
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
 # Parametrisation surface: both supported binary names. Every spawn-side
 # test runs against both so a regression in either path is caught.
 ALL_BINARIES = (ANTIGRAVITY_BINARY, LEGACY_GEMINI_BINARY)

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.5.1"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

The gemini adapter spawn tests each arm a watchdog Timer thread by default. Under the isolated test runner's high process concurrency the OS thread ceiling is occasionally hit, surfacing as `RuntimeError: can't start new thread` on an otherwise-trivial test (`test_logs_debug_when_no_api_key_present`).

This is non-deterministic: it depends on how many sibling processes hold threads at that instant, so it passes on a lightly-loaded PR runner and fails on a fully-loaded main matrix run. That is exactly why it slipped past PR CI and surfaced on main.

## Fix

Apply the existing `no_watchdog_threads` fixture suite-wide via `pytestmark`, matching the other adapter test modules (rovo, auggie, clm, ralphex) that already guard against this. The watchdog adds no value to these unit tests; they assert command construction and log output, not timeout behaviour.

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_gemini.py -q` -> 48 passed
- [x] `uv run ruff check tests/unit/test_adapter_gemini.py` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test-suite reliability by applying a test-suite level change that disables background watchdog timer threads during runs. This prevents OS thread exhaustion and reduces flaky failures under high parallel/concurrent test execution, especially in CI and isolated environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->