### PR TITLE
feat(observability): add consolidated SonarQube findings tracker

### DIFF
--- a/.github/workflows/sonar-tracker.yml
+++ b/.github/workflows/sonar-tracker.yml
@@ -1,0 +1,78 @@
+name: SonarQube findings tracker
+
+# Renders a single consolidated GitHub issue ("SonarQube findings tracker")
+# from the live Sonar API and keeps it in sync. The issue is found by a
+# hidden marker in its body, so every run edits the same issue instead of
+# opening duplicates. This is the consolidated counterpart to the per-finding
+# sweeper in sweep-sonar-findings.yml.
+#
+# Triggers:
+#   * workflow_dispatch  - manual run.
+#   * workflow_run       - after the "SonarQube scan" workflow completes on
+#                          main, so the tracker refreshes right after a scan.
+#   * schedule           - a daily backstop so the thread never goes stale.
+#
+# When SONAR_TOKEN is empty (the default on a fork) the job logs a notice
+# and exits 0; nothing is created.
+
+on:  # zizmor: ignore[dangerous-triggers]
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["SonarQube scan"]
+    types: [completed]
+    branches: [main]
+  schedule:
+    - cron: '37 7 * * *'  # 07:37 UTC daily; off-peak.
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonar-tracker
+  cancel-in-progress: false
+
+jobs:
+  render:
+    name: Render Sonar tracker issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only run when the Sonar host is configured. For workflow_run, also
+    # require that the upstream scan concluded successfully.
+    if: >-
+      ${{ vars.SONAR_HOST_URL != '' &&
+          (github.event_name != 'workflow_run' ||
+           github.event.workflow_run.conclusion == 'success') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Bootstrap (uv + python)
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: '3.13'
+
+      - name: Render and sync tracker
+        env:
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SONAR_TOKEN}" ]; then
+            echo "::notice::SONAR_TOKEN is empty; skipping tracker render (no-op on forks)."
+            exit 0
+          fi
+          uv run python scripts/render_sonar_tracker.py

--- a/docs/operations/sonar-tracker.md
+++ b/docs/operations/sonar-tracker.md
@@ -120,6 +120,45 @@ uv run python scripts/render_sonar_tracker.py \
 When `SONAR_TOKEN` is empty (the default on a fork) the workflow logs a
 `::notice::` and exits 0, so the tracker is a no-op on forks.
 
+## Health checks
+
+After a run, verify:
+
+1. Exactly one open issue exists with label `sonar-tracker` and the hidden
+   marker `<!-- sonar-tracker:bernstein -->` in its body.
+2. The issue `updatedAt` changed after the workflow run (a re-run edits the
+   same issue rather than opening a new one).
+3. The trailing fenced `json` summary parses and reflects current Sonar
+   counts.
+
+```bash
+gh issue list --repo sipyourdrink-ltd/bernstein --label sonar-tracker --state open
+gh issue view <issue-number> --repo sipyourdrink-ltd/bernstein --json body,updatedAt
+```
+
+A green run prints a one-line status to the workflow log, for example:
+
+```text
+sonar-tracker: updated issue #1234
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Check | Remediation |
+|---|---|---|---|
+| Workflow logs a `::notice::` and exits 0 without touching the issue | `SONAR_TOKEN` is empty (expected on forks) | Confirm the `SONAR_TOKEN` secret exists in the target repository settings | Set `SONAR_TOKEN` in the repository; no-op on forks is intended |
+| Non-zero exit with `error: sonar fetch failed` | Sonar API unreachable, bad host, or insufficient token scope | Verify `SONAR_HOST_URL`, `SONAR_PROJECT_KEY`, and that `SONAR_TOKEN` has Browse permission on the project | Correct the variable/secret and re-run `workflow_dispatch` |
+| Render succeeds but `error: github sync failed` | `GITHUB_TOKEN` lacks `issues: write`, or `GITHUB_REPOSITORY` is wrong | Confirm the job has `issues: write` permission and `GITHUB_REPOSITORY` resolves to `owner/name` | Restore the workflow/job `permissions:` block and retry |
+| Two open `sonar-tracker` issues appear | The hidden marker was hand-edited out of an issue body | Run the health-check `gh issue list` above | Close the duplicate; the marker-bearing issue is the canonical one |
+
+Reproduce a fetch failure locally without writing to GitHub:
+
+```bash
+SONAR_HOST_URL=https://sonar.bernstein.run \
+SONAR_TOKEN=<your-browse-token> \
+uv run python scripts/render_sonar_tracker.py --dry-run --output-body /tmp/body.md
+```
+
 ## Relationship to the per-finding sweeper
 
 | | Sweeper (`sweep-sonar-findings.yml`) | Tracker (`sonar-tracker.yml`) |

--- a/docs/operations/sonar-tracker.md
+++ b/docs/operations/sonar-tracker.md
@@ -1,0 +1,134 @@
+# SonarQube findings tracker
+
+A single consolidated GitHub issue, auto-rendered from the live Sonar API,
+that mirrors the current open-finding set. An agent (or an operator) works
+the thread top-down; the next scan drops items that have been fixed.
+
+This is the consolidated counterpart to the per-finding sweeper documented
+in [`sonar.md`](../observability/sonar.md). The sweeper emits one backlog
+ticket per finding; the tracker keeps one living issue thread.
+
+## TL;DR
+
+- One issue titled **SonarQube findings tracker**, labelled `sonar-tracker`
+  and `automated`.
+- Re-rendered on every run; the same issue is edited, never duplicated.
+- Found by a hidden marker `<!-- sonar-tracker:bernstein -->` in its body.
+- BLOCKER + CRITICAL listed in full as checkboxes with deep links.
+- MAJOR / MINOR / INFO collapsed into `<details>` blocks.
+- A trailing fenced ```json``` block carries a machine-readable summary so a
+  downstream fixer agent can dispatch work without re-parsing the markdown.
+- Workflow: `.github/workflows/sonar-tracker.yml`.
+- Script: `scripts/render_sonar_tracker.py`.
+
+## How the loop closes
+
+| Step | What happens |
+|---|---|
+| 1 | A push to `main` runs the **SonarQube scan** workflow. |
+| 2 | On scan success, `workflow_run` fires `sonar-tracker.yml`. |
+| 3 | The script polls `/api/issues/search` (paginated), the quality gate, and coverage. |
+| 4 | It renders one markdown body and creates or edits the tracker issue. |
+| 5 | An agent fixes code or marks an item Won't Fix in Sonar. |
+| 6 | The next scan + render drops the resolved item from the thread. |
+
+A daily `schedule` cron is a backstop so the thread never goes stale even if
+no push lands. A manual `workflow_dispatch` run is always available.
+
+## The body
+
+| Region | Content |
+|---|---|
+| TL;DR table | quality-gate status, coverage %, count per severity |
+| BLOCKER section | every finding as `- [ ] rule \`<rule>\`: <label> \`<file>:<line>\` ([view](...))` |
+| CRITICAL section | same shape as BLOCKER |
+| MAJOR / MINOR / INFO | collapsed `<details>`; capped at 80 items each with an "and N more, see Sonar" pointer |
+| JSON summary | fenced ```json``` block (see below) |
+
+### Public-artefact note
+
+A GitHub issue in this repository is a public artefact. The renderer never
+copies the raw Sonar `message`/`htmlDesc` text into the body. Every
+human-readable label is synthesised from the shared pre-vetted rule-family
+blurb table in `scripts/sweep_sonar_findings.py` (with a neutral default
+keyed only on the rule id). The fully rendered body is then scanned against
+a forbidden-substring guard before it is written.
+
+### Size cap
+
+GitHub rejects issue bodies above 65536 characters. The renderer measures
+the body and, if it is over, collapses progressively (lowest severity first)
+to counts-with-link until it fits. It never truncates mid-line: each collapse
+step drops whole list items or whole sections.
+
+## The JSON summary block
+
+A downstream fixer agent reads the fenced block instead of scraping markdown:
+
+```json
+{
+  "generated_at": "2026-05-21T07:37:00+00:00",
+  "quality_gate": "ERROR",
+  "coverage": 19.3,
+  "by_severity": {"BLOCKER": 1, "CRITICAL": 12, "MAJOR": 240},
+  "blocker_keys": ["AY..."],
+  "critical_keys": ["AY...", "AY..."]
+}
+```
+
+A fixer loop typically:
+
+1. Reads the issue body, slices out the ```json``` fence, `json.loads` it.
+2. Iterates `blocker_keys` then `critical_keys` (highest leverage first).
+3. For each key, opens the Sonar deep link to read the rule context.
+4. Dispatches a fix task; on the next scan the key drops from the lists.
+
+## Run it manually
+
+Through the workflow (uses the repo `SONAR_TOKEN` secret):
+
+```bash
+gh workflow run sonar-tracker.yml --repo sipyourdrink-ltd/bernstein
+```
+
+Locally, render only (no GitHub write), against the live server:
+
+```bash
+SONAR_HOST_URL=https://sonar.bernstein.run \
+SONAR_TOKEN=<your-browse-token> \
+uv run python scripts/render_sonar_tracker.py --dry-run --output-body /tmp/body.md
+```
+
+Locally, render from a saved fixture (no network):
+
+```bash
+uv run python scripts/render_sonar_tracker.py \
+  --dry-run --fixture tests/unit/sweep/fixtures/issues_search.json \
+  --output-body /tmp/body.md
+```
+
+## Configuration
+
+| Env var | Purpose |
+|---|---|
+| `SONAR_HOST_URL` | Sonar server base URL (repo variable). |
+| `SONAR_TOKEN` | User token with Browse permission (repo secret). |
+| `SONAR_PROJECT_KEY` | Optional; defaults to `bernstein`. |
+| `GITHUB_TOKEN` | Used for the `gh issue` create/edit calls. |
+| `GITHUB_REPOSITORY` | `owner/name`; defaults from the checkout. |
+
+When `SONAR_TOKEN` is empty (the default on a fork) the workflow logs a
+`::notice::` and exits 0, so the tracker is a no-op on forks.
+
+## Relationship to the per-finding sweeper
+
+| | Sweeper (`sweep-sonar-findings.yml`) | Tracker (`sonar-tracker.yml`) |
+|---|---|---|
+| Output | one backlog ticket file per finding | one consolidated GitHub issue |
+| Storage | `.sdd/backlog/open/*.md` via a PR | a labelled GitHub issue thread |
+| De-dup | on `sonar_issue_key` in frontmatter | on the hidden body marker |
+| Audience | the backlog pickup workflow | an agent or operator working a thread |
+
+The two are complementary and can run side by side. Pick the tracker when
+you want a single living thread; pick the sweeper when you want individual
+tickets that flow through the backlog state machine.

--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -123,6 +123,13 @@ _FULL_LIST_SEVERITIES = ("BLOCKER", "CRITICAL")
 # the first N and append an "and N more" pointer to Sonar.
 _DETAILS_ITEM_CAP = 80
 
+# Cap on the number of issue keys serialised into each list in the trailing
+# JSON summary. A fixer loop consumes the highest-leverage keys first, so an
+# unbounded list only risks pushing the body past the GitHub size cap on a
+# pathological project. When a list is truncated a ``*_keys_truncated`` count
+# is emitted alongside it so a consumer can tell the list is partial.
+_JSON_KEYS_CAP = 200
+
 _LIFECYCLE_NOTE = (
     "This thread is auto-rendered from Sonar on each scan. Resolve an item "
     "by fixing the code (the next scan drops it) or by marking it Won't Fix "
@@ -178,9 +185,12 @@ def fetch_all_findings(
                 "p": str(page),
             }
             resp = _request_with_retries(client, url, params)
-            payload = resp.json()
+            try:
+                payload = resp.json()
+            except ValueError as exc:
+                raise SonarAPIError("issues search returned invalid JSON") from exc
             if not isinstance(payload, dict):
-                break
+                raise SonarAPIError("issues search returned a non-object payload")
             issues = payload.get("issues") or []
             for raw in issues:
                 if isinstance(raw, dict):
@@ -192,8 +202,8 @@ def fetch_all_findings(
                 total = int(paging.get("total", 0))
                 page_idx = int(paging.get("pageIndex", page))
                 size = int(paging.get("pageSize", page_size))
-            except (TypeError, ValueError):
-                break
+            except (TypeError, ValueError) as exc:
+                raise SonarAPIError("issues search returned invalid paging metadata") from exc
             if size <= 0 or page_idx * size >= total:
                 break
             page += 1
@@ -455,16 +465,26 @@ def _counts_only_section(severity: str, items: list[Finding], host: str, project
 
 
 def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding]], generated_at: str) -> list[str]:
-    """Build the trailing machine-readable JSON summary."""
+    """Build the trailing machine-readable JSON summary.
+
+    The per-severity key lists are capped at ``_JSON_KEYS_CAP`` so the JSON
+    blob stays bounded even on a project with thousands of high-severity
+    findings. When a list is truncated, a sibling ``*_keys_truncated`` count
+    records how many keys were dropped so a consumer can tell it is partial.
+    """
     by_severity = {sev: len(buckets[sev]) for sev in sorted(buckets, key=_severity_sort_key) if buckets.get(sev)}
-    summary = {
+    summary: dict[str, Any] = {
         "generated_at": generated_at,
         "quality_gate": snapshot.quality_gate,
         "coverage": snapshot.coverage,
         "by_severity": by_severity,
-        "blocker_keys": [f.key for f in buckets.get("BLOCKER", [])],
-        "critical_keys": [f.key for f in buckets.get("CRITICAL", [])],
     }
+    for name, severity in (("blocker", "BLOCKER"), ("critical", "CRITICAL")):
+        all_keys = [f.key for f in buckets.get(severity, [])]
+        summary[f"{name}_keys"] = all_keys[:_JSON_KEYS_CAP]
+        truncated = len(all_keys) - len(all_keys[:_JSON_KEYS_CAP])
+        if truncated > 0:
+            summary[f"{name}_keys_truncated"] = truncated
     blob = json.dumps(summary, indent=2, sort_keys=True)
     return ["## Machine-readable summary", "", "```json", blob, "```", ""]
 
@@ -483,14 +503,18 @@ def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> 
     Strategy, applied in order until the body fits under the limit:
 
     1. BLOCKER + CRITICAL listed in full (checkboxes); MAJOR/MINOR/INFO in
-       <details> capped at ``_DETAILS_ITEM_CAP`` items each.
-    2. Collapse the lowest-severity <details> sections to a counts-only
+       <details> capped at ``_DETAILS_ITEM_CAP`` items each. The trailing
+       JSON key lists are capped at ``_JSON_KEYS_CAP`` regardless of size.
+    2. Shrink the per-section item cap on the <details> sections (preferred
+       over dropping a whole section).
+    3. Collapse the lowest-severity <details> sections to a counts-only
        line, one at a time from INFO upward.
-    3. Shrink the per-section item cap on the remaining <details> sections.
     4. As a final guard, collapse CRITICAL (then BLOCKER) to counts-only.
 
     The body is never truncated mid-line: every collapse step drops whole
-    list items or whole sections.
+    list items or whole sections. If the body still exceeds the limit after
+    every step, a ``ValueError`` is raised so the failure is explicit rather
+    than surfacing later as a rejected ``gh`` call.
     """
     generated_at = generated_at or _dt.datetime.now(tz=_dt.UTC).isoformat(timespec="seconds")
     buckets = group_by_severity(snapshot.findings)
@@ -547,17 +571,19 @@ def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> 
     body = _build()
     budget = GITHUB_BODY_LIMIT - _BODY_SAFETY_MARGIN
 
-    # Step 2: collapse <details> sections to counts-only, lowest severity first.
+    # Step 2: shrink the per-section item cap while <details> sections still
+    # exist. Reducing items inside a section is preferred over dropping the
+    # whole section, so this runs before the counts-only collapse below.
+    while len(body) > budget and item_cap > 1:
+        item_cap = max(1, item_cap // 2)
+        body = _build()
+
+    # Step 3: collapse <details> sections to counts-only, lowest severity first.
     collapse_queue = list(reversed(details_order))
     qi = 0
     while len(body) > budget and qi < len(collapse_queue):
         mode[collapse_queue[qi]] = "counts"
         qi += 1
-        body = _build()
-
-    # Step 3: shrink the item cap on any remaining <details> sections.
-    while len(body) > budget and item_cap > 1:
-        item_cap = max(1, item_cap // 2)
         body = _build()
 
     # Step 4: collapse CRITICAL then BLOCKER to counts-only as a last resort.
@@ -566,6 +592,12 @@ def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> 
             break
         mode[sev] = "counts"
         body = _build()
+
+    # Final guard: every section is now counts-only and the JSON key lists are
+    # capped, so the body should fit. If it still does not, fail loudly here
+    # rather than letting `gh issue create/edit` reject an oversized body.
+    if len(body) > budget:
+        raise ValueError("rendered tracker body still exceeds GitHub's issue body limit")
 
     _assert_no_forbidden(body)
     return body

--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python3
+"""Render a single consolidated GitHub issue from live SonarQube findings.
+
+This is the consolidated counterpart to ``scripts/sweep_sonar_findings.py``.
+Where the sweeper emits one backlog ticket per finding, this script renders
+ONE GitHub issue thread that mirrors the current open-finding set and is
+re-rendered idempotently on every run. An agent (or an operator) works the
+thread top-down; the next scan drops items that have been fixed.
+
+The issue body carries a hidden marker ``<!-- sonar-tracker:bernstein -->``
+so re-runs find and edit the existing issue instead of opening duplicates.
+
+Public-artefact discipline
+--------------------------
+A GitHub issue in this repository is a public artefact. Like the sweeper,
+this renderer NEVER copies the raw Sonar ``message``/``htmlDesc`` text into
+the issue. Every human-readable description is synthesised from the shared
+pre-vetted rule-family blurb table in ``scripts/sweep_sonar_findings.py``
+(falling back to a neutral default keyed only on the rule id). The fully
+rendered body is then scanned against a forbidden-substring guard before it
+is written, so a new rule family that lands without a blurb still cannot
+leak disallowed phrasing.
+
+Env vars (matching the CI contract used by the scan + sweeper):
+  - ``SONAR_HOST_URL``  e.g. ``https://sonar.bernstein.run``
+  - ``SONAR_TOKEN``     user token with Browse permission on the project
+  - ``SONAR_PROJECT_KEY`` optional, defaults to ``bernstein``
+  - ``GITHUB_TOKEN``    token used for ``gh issue`` operations
+  - ``GITHUB_REPOSITORY`` optional ``owner/name``; falls back to the
+    ``gh`` default repo resolved from the checkout.
+
+Usage
+-----
+
+    python scripts/render_sonar_tracker.py [--dry-run] \\
+        [--fixture path/to/issues.json] [--output-body path.md] \\
+        [--repo owner/name]
+
+Exit codes
+----------
+
+- 0: clean run (rendered + synced, or no-op when SONAR_TOKEN is empty).
+- 1: Sonar API failed after retries, or the GitHub sync failed.
+- 2: misconfiguration (missing env vars, bad CLI args).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    RunnerFn = Callable[..., Any]
+else:
+    RunnerFn = Any
+
+# Make the bernstein package importable when running from the source tree,
+# and let us reuse the sweeper's vetted blurb table + Sonar helpers.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+from sweep_sonar_findings import (  # noqa: E402
+    FORBIDDEN_SUBSTRINGS as _SWEEPER_FORBIDDEN,
+)
+from sweep_sonar_findings import (  # noqa: E402
+    SEVERITY_ORDER,
+    SEVERITY_RANK,
+    Finding,
+    SonarAPIError,
+    _auth,
+    _component_path,
+    _normalise_issue,
+    _request_with_retries,
+    safe_why,
+)
+
+from bernstein.core.observability.sonar import (  # noqa: E402
+    SonarConfig,
+    load_config,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Hidden marker that uniquely identifies the tracker issue. Searched for in
+# the body of open issues so re-runs edit instead of duplicating.
+TRACKER_MARKER = "<!-- sonar-tracker:bernstein -->"
+
+TRACKER_TITLE = "SonarQube findings tracker"
+TRACKER_LABELS = ("sonar-tracker", "automated")
+PRIMARY_LABEL = "sonar-tracker"
+
+# GitHub rejects issue bodies above 65536 characters. Keep a small safety
+# margin so trailing newlines / CRLF normalisation never tip us over.
+GITHUB_BODY_LIMIT = 65536
+_BODY_SAFETY_MARGIN = 256
+
+DEFAULT_PAGE_SIZE = 500
+MAX_PAGES = 40  # 40 * 500 = 20k findings ceiling; well above current volume.
+
+DEFAULT_TIMEOUT_SECONDS = 20.0
+
+# Severities listed in full (every item as a checkbox) before any collapse.
+_FULL_LIST_SEVERITIES = ("BLOCKER", "CRITICAL")
+
+# Per-severity cap for the collapsed <details> sections. Above this we list
+# the first N and append an "and N more" pointer to Sonar.
+_DETAILS_ITEM_CAP = 80
+
+_LIFECYCLE_NOTE = (
+    "This thread is auto-rendered from Sonar on each scan. Resolve an item "
+    "by fixing the code (the next scan drops it) or by marking it Won't Fix "
+    "or resolved in Sonar. Do not hand-edit; edits are overwritten on the "
+    "next sync."
+)
+
+# Public-artefact guard for the rendered body. We reuse the sweeper's
+# disallowed-phrase word list but drop its bare-hyphen entry (a hyphen is
+# legitimate in markdown tables, list bullets, and rule ids like
+# ``python:S3776``). The real typographic risk is the two long-dash code
+# points (0x2014 and 0x2013), which we add back explicitly as escapes.
+# The set mirrors the project text-hygiene phrase list for the terms a
+# Sonar rule label could plausibly contain.
+_TRACKER_FORBIDDEN: tuple[str, ...] = (
+    *(s for s in _SWEEPER_FORBIDDEN if s != "-"),
+    chr(0x2014),  # long dash, code point 0x2014
+    chr(0x2013),  # short dash, code point 0x2013
+)
+
+
+# ---------------------------------------------------------------------------
+# Sonar fetch: issues, quality gate, coverage
+# ---------------------------------------------------------------------------
+
+
+def fetch_all_findings(
+    config: SonarConfig,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    client: httpx.Client | None = None,
+) -> list[Finding]:
+    """Page through ``/api/issues/search`` for every open finding.
+
+    Unlike the sweeper we do not pre-filter by severity: the tracker shows
+    the whole open set grouped by severity, so we request all severities.
+    """
+    url = f"{config.host}/api/issues/search"
+    findings: list[Finding] = []
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=_auth(config.token))
+    assert client is not None
+    try:
+        page = 1
+        while page <= MAX_PAGES:
+            params: dict[str, Any] = {
+                "componentKeys": config.project_key,
+                "resolved": "false",
+                "s": "SEVERITY",
+                "asc": "false",
+                "ps": str(page_size),
+                "p": str(page),
+            }
+            resp = _request_with_retries(client, url, params)
+            payload = resp.json()
+            if not isinstance(payload, dict):
+                break
+            issues = payload.get("issues") or []
+            for raw in issues:
+                if isinstance(raw, dict):
+                    finding = _normalise_issue(raw)
+                    if finding is not None:
+                        findings.append(finding)
+            paging = payload.get("paging") or {}
+            try:
+                total = int(paging.get("total", 0))
+                page_idx = int(paging.get("pageIndex", page))
+                size = int(paging.get("pageSize", page_size))
+            except (TypeError, ValueError):
+                break
+            if size <= 0 or page_idx * size >= total:
+                break
+            page += 1
+    finally:
+        if owns_client:
+            client.close()
+    return findings
+
+
+def fetch_quality_gate(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+) -> str:
+    """Return the quality-gate status string (e.g. ``OK``/``ERROR``).
+
+    Returns ``"UNKNOWN"`` when the server omits the field or the call
+    fails; the tracker still renders with the issue counts.
+    """
+    url = f"{config.host}/api/qualitygates/project_status"
+    params = {"projectKey": config.project_key}
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=_auth(config.token))
+    assert client is not None
+    try:
+        try:
+            resp = _request_with_retries(client, url, params)
+        except SonarAPIError:
+            return "UNKNOWN"
+        try:
+            payload = resp.json()
+        except ValueError:
+            return "UNKNOWN"
+    finally:
+        if owns_client:
+            client.close()
+    if not isinstance(payload, dict):
+        return "UNKNOWN"
+    status = payload.get("projectStatus")
+    if isinstance(status, dict):
+        value = status.get("status")
+        if isinstance(value, str) and value:
+            return value
+    return "UNKNOWN"
+
+
+def fetch_coverage(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+) -> float | None:
+    """Return the project coverage percentage, or ``None`` when unavailable."""
+    url = f"{config.host}/api/measures/component"
+    params = {"component": config.project_key, "metricKeys": "coverage"}
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=_auth(config.token))
+    assert client is not None
+    try:
+        try:
+            resp = _request_with_retries(client, url, params)
+        except SonarAPIError:
+            return None
+        try:
+            payload = resp.json()
+        except ValueError:
+            return None
+    finally:
+        if owns_client:
+            client.close()
+    if not isinstance(payload, dict):
+        return None
+    component = payload.get("component")
+    if not isinstance(component, dict):
+        return None
+    measures = component.get("measures")
+    if not isinstance(measures, list):
+        return None
+    for item in measures:
+        if isinstance(item, dict) and item.get("metric") == "coverage":
+            return _opt_float(item.get("value"))
+    return None
+
+
+@dataclasses.dataclass(frozen=True)
+class SonarSnapshot:
+    """Everything the renderer needs from one Sonar poll."""
+
+    findings: list[Finding]
+    quality_gate: str
+    coverage: float | None
+    host: str
+    project_key: str
+
+
+def collect_snapshot(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+) -> SonarSnapshot:
+    """Fetch findings + quality gate + coverage in one pass."""
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=_auth(config.token))
+    assert client is not None
+    try:
+        findings = fetch_all_findings(config, client=client)
+        quality_gate = fetch_quality_gate(config, client=client)
+        coverage = fetch_coverage(config, client=client)
+    finally:
+        if owns_client:
+            client.close()
+    return SonarSnapshot(
+        findings=findings,
+        quality_gate=quality_gate,
+        coverage=coverage,
+        host=config.host,
+        project_key=config.project_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def group_by_severity(findings: Sequence[Finding]) -> dict[str, list[Finding]]:
+    """Bucket findings into the canonical severity order.
+
+    Within a severity, findings are sorted by component then line so the
+    rendered list is stable across runs (idempotent body for a fixed input).
+    """
+    buckets: dict[str, list[Finding]] = {sev: [] for sev in SEVERITY_ORDER}
+    extra: dict[str, list[Finding]] = {}
+    for finding in findings:
+        target = buckets.get(finding.severity)
+        if target is None:
+            target = extra.setdefault(finding.severity, [])
+        target.append(finding)
+    # Fold any unexpected severity label into the table under its own key so
+    # counts stay honest, then sort each bucket deterministically.
+    buckets.update(extra)
+    for sev in buckets:
+        buckets[sev].sort(key=lambda f: (_component_path(f.component), f.line or 0, f.key))
+    return buckets
+
+
+def _severity_sort_key(severity: str) -> int:
+    return SEVERITY_RANK.get(severity, len(SEVERITY_ORDER))
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _issue_permalink(host: str, project_key: str, issue_key: str) -> str:
+    """Build the deep link to a single issue in the Sonar UI."""
+    return f"{host}/project/issues?issueStatuses=OPEN,CONFIRMED&id={project_key}&open={issue_key}"
+
+
+def _finding_line(finding: Finding, host: str, project_key: str, *, checkbox: bool) -> str:
+    """Render one finding as a markdown list item (public-safe)."""
+    desc = safe_why(finding.rule, finding.severity, finding.component, finding.line)
+    location = _component_path(finding.component)
+    if finding.line:
+        location = f"{location}:{finding.line}"
+    link = _issue_permalink(host, project_key, finding.key)
+    box = "- [ ] " if checkbox else "- "
+    return f"{box}rule `{finding.rule}`: {desc} `{location}` ([view]({link}))"
+
+
+def _coverage_text(coverage: float | None) -> str:
+    if coverage is None:
+        return "n/a"
+    return f"{coverage:.1f}%"
+
+
+def _tldr_table(
+    buckets: dict[str, list[Finding]],
+    *,
+    quality_gate: str,
+    coverage: float | None,
+) -> list[str]:
+    """Build the header summary table lines."""
+    total = sum(len(v) for v in buckets.values())
+    lines = [
+        f"# {TRACKER_TITLE}",
+        "",
+        TRACKER_MARKER,
+        "",
+        "## TL;DR",
+        "",
+        f"- Quality gate: **{quality_gate}**",
+        f"- Coverage: **{_coverage_text(coverage)}**",
+        f"- Open findings: **{total}**",
+        "",
+        "| Severity | Open |",
+        "| --- | ---: |",
+    ]
+    for sev in sorted(buckets, key=_severity_sort_key):
+        count = len(buckets[sev])
+        if count:
+            lines.append(f"| {sev} | {count} |")
+    lines.append(f"| **Total** | **{total}** |")
+    lines.append("")
+    lines.append(f"_{_LIFECYCLE_NOTE}_")
+    lines.append("")
+    return lines
+
+
+def _full_section(
+    severity: str,
+    items: list[Finding],
+    host: str,
+    project_key: str,
+) -> list[str]:
+    """Render a BLOCKER/CRITICAL section: every item as a checkbox."""
+    if not items:
+        return []
+    lines = [f"## {severity} ({len(items)})", ""]
+    lines.extend(_finding_line(f, host, project_key, checkbox=True) for f in items)
+    lines.append("")
+    return lines
+
+
+def _details_section(
+    severity: str,
+    items: list[Finding],
+    host: str,
+    project_key: str,
+    *,
+    item_cap: int,
+) -> list[str]:
+    """Render a MAJOR/MINOR/INFO section collapsed inside <details>."""
+    if not items:
+        return []
+    shown = items[:item_cap]
+    remainder = len(items) - len(shown)
+    lines = [
+        "<details>",
+        f"<summary>{severity} ({len(items)})</summary>",
+        "",
+    ]
+    lines.extend(_finding_line(f, host, project_key, checkbox=False) for f in shown)
+    if remainder > 0:
+        lines.append(f"- and {remainder} more, see Sonar")
+    lines.extend(["", "</details>", ""])
+    return lines
+
+
+def _counts_only_section(severity: str, items: list[Finding], host: str, project_key: str) -> list[str]:
+    """Most compact section form: a one-line count + a link to Sonar."""
+    if not items:
+        return []
+    link = f"{host}/project/issues?issueStatuses=OPEN,CONFIRMED&id={project_key}&severities={severity}"
+    return [f"- **{severity}**: {len(items)} open ([view]({link}))", ""]
+
+
+def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding]], generated_at: str) -> list[str]:
+    """Build the trailing machine-readable JSON summary."""
+    by_severity = {sev: len(buckets[sev]) for sev in sorted(buckets, key=_severity_sort_key) if buckets.get(sev)}
+    summary = {
+        "generated_at": generated_at,
+        "quality_gate": snapshot.quality_gate,
+        "coverage": snapshot.coverage,
+        "by_severity": by_severity,
+        "blocker_keys": [f.key for f in buckets.get("BLOCKER", [])],
+        "critical_keys": [f.key for f in buckets.get("CRITICAL", [])],
+    }
+    blob = json.dumps(summary, indent=2, sort_keys=True)
+    return ["## Machine-readable summary", "", "```json", blob, "```", ""]
+
+
+def _assert_no_forbidden(body: str) -> None:
+    """Raise if the rendered body carries any disallowed substring."""
+    lower = body.lower()
+    for forbidden in _TRACKER_FORBIDDEN:
+        if forbidden.lower() in lower:
+            raise AssertionError(f"rendered tracker body contains forbidden substring {forbidden!r}")
+
+
+def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> str:
+    """Render the full issue body, collapsing to fit the GitHub size cap.
+
+    Strategy, applied in order until the body fits under the limit:
+
+    1. BLOCKER + CRITICAL listed in full (checkboxes); MAJOR/MINOR/INFO in
+       <details> capped at ``_DETAILS_ITEM_CAP`` items each.
+    2. Collapse the lowest-severity <details> sections to a counts-only
+       line, one at a time from INFO upward.
+    3. Shrink the per-section item cap on the remaining <details> sections.
+    4. As a final guard, collapse CRITICAL (then BLOCKER) to counts-only.
+
+    The body is never truncated mid-line: every collapse step drops whole
+    list items or whole sections.
+    """
+    generated_at = generated_at or _dt.datetime.now(tz=_dt.UTC).isoformat(timespec="seconds")
+    buckets = group_by_severity(snapshot.findings)
+    host = snapshot.host
+    project_key = snapshot.project_key
+
+    # Severities that get a collapsible section, lowest-priority last.
+    details_order = [s for s in SEVERITY_ORDER if s not in _FULL_LIST_SEVERITIES]
+    # Any unexpected severity labels render as counts-only at the very end.
+    extra_severities = [s for s in buckets if s not in SEVERITY_ORDER]
+
+    # Render mode per severity: "full", "details", or "counts".
+    mode: dict[str, str] = {}
+    for sev in _FULL_LIST_SEVERITIES:
+        mode[sev] = "full"
+    for sev in details_order:
+        mode[sev] = "details"
+    for sev in extra_severities:
+        mode[sev] = "counts"
+
+    item_cap = _DETAILS_ITEM_CAP
+
+    def _build() -> str:
+        parts: list[str] = []
+        parts.extend(
+            _tldr_table(
+                buckets,
+                quality_gate=snapshot.quality_gate,
+                coverage=snapshot.coverage,
+            )
+        )
+        for sev in SEVERITY_ORDER + tuple(extra_severities):
+            items = buckets.get(sev, [])
+            if not items:
+                continue
+            current = mode.get(sev, "details")
+            if current == "full":
+                parts.extend(_full_section(sev, items, host, project_key))
+            elif current == "details":
+                parts.extend(
+                    _details_section(
+                        sev,
+                        items,
+                        host,
+                        project_key,
+                        item_cap=item_cap,
+                    )
+                )
+            else:
+                parts.extend(_counts_only_section(sev, items, host, project_key))
+        parts.extend(_json_summary_block(snapshot, buckets, generated_at))
+        return "\n".join(parts).rstrip() + "\n"
+
+    body = _build()
+    budget = GITHUB_BODY_LIMIT - _BODY_SAFETY_MARGIN
+
+    # Step 2: collapse <details> sections to counts-only, lowest severity first.
+    collapse_queue = list(reversed(details_order))
+    qi = 0
+    while len(body) > budget and qi < len(collapse_queue):
+        mode[collapse_queue[qi]] = "counts"
+        qi += 1
+        body = _build()
+
+    # Step 3: shrink the item cap on any remaining <details> sections.
+    while len(body) > budget and item_cap > 1:
+        item_cap = max(1, item_cap // 2)
+        body = _build()
+
+    # Step 4: collapse CRITICAL then BLOCKER to counts-only as a last resort.
+    for sev in ("CRITICAL", "BLOCKER"):
+        if len(body) <= budget:
+            break
+        mode[sev] = "counts"
+        body = _build()
+
+    _assert_no_forbidden(body)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# GitHub issue sync (via gh CLI)
+# ---------------------------------------------------------------------------
+
+
+class GitHubSyncError(RuntimeError):
+    """Raised when a ``gh`` operation fails."""
+
+
+def _run_gh(
+    args: Sequence[str],
+    *,
+    runner: RunnerFn = subprocess.run,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` command, returning the completed process."""
+    return runner(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        input=input_text,
+    )
+
+
+def _repo_args(repo: str | None) -> list[str]:
+    return ["--repo", repo] if repo else []
+
+
+def find_tracker_issue(repo: str | None, *, runner: RunnerFn = subprocess.run) -> int | None:
+    """Return the number of the existing tracker issue, or ``None``.
+
+    Searches open issues carrying the ``sonar-tracker`` label and confirms
+    the hidden marker is present in the body before claiming a match.
+    """
+    args = [
+        "issue",
+        "list",
+        *_repo_args(repo),
+        "--label",
+        PRIMARY_LABEL,
+        "--state",
+        "open",
+        "--json",
+        "number,body",
+        "--limit",
+        "50",
+    ]
+    result = _run_gh(args, runner=runner)
+    if result.returncode != 0:
+        raise GitHubSyncError(f"gh issue list failed: {result.stderr.strip()[:200]}")
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise GitHubSyncError(f"gh issue list returned invalid JSON: {exc}") from exc
+    if not isinstance(payload, list):
+        return None
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        body = entry.get("body")
+        number = entry.get("number")
+        if isinstance(body, str) and TRACKER_MARKER in body and isinstance(number, int):
+            return number
+    return None
+
+
+def _ensure_labels_exist(repo: str | None, *, runner: RunnerFn = subprocess.run) -> None:
+    """Best-effort create the tracker labels; ignore 'already exists'."""
+    colours = {"sonar-tracker": "1d76db", "automated": "ededed"}
+    for label in TRACKER_LABELS:
+        _run_gh(
+            [
+                "label",
+                "create",
+                label,
+                *_repo_args(repo),
+                "--color",
+                colours.get(label, "ededed"),
+                "--force",
+            ],
+            runner=runner,
+        )
+
+
+def create_tracker_issue(
+    body: str,
+    repo: str | None,
+    *,
+    runner: RunnerFn = subprocess.run,
+) -> int:
+    """Create the tracker issue and return its number."""
+    _ensure_labels_exist(repo, runner=runner)
+    args = [
+        "issue",
+        "create",
+        *_repo_args(repo),
+        "--title",
+        TRACKER_TITLE,
+        "--body-file",
+        "-",
+        "--label",
+        ",".join(TRACKER_LABELS),
+    ]
+    result = _run_gh(args, runner=runner, input_text=body)
+    if result.returncode != 0:
+        raise GitHubSyncError(f"gh issue create failed: {result.stderr.strip()[:300]}")
+    url = (result.stdout or "").strip().splitlines()
+    if not url:
+        raise GitHubSyncError("gh issue create returned no URL")
+    return _issue_number_from_url(url[-1])
+
+
+def update_tracker_issue(
+    number: int,
+    body: str,
+    repo: str | None,
+    *,
+    runner: RunnerFn = subprocess.run,
+) -> None:
+    """Edit the existing tracker issue body and ensure the label is set."""
+    _ensure_labels_exist(repo, runner=runner)
+    args = [
+        "issue",
+        "edit",
+        str(number),
+        *_repo_args(repo),
+        "--body-file",
+        "-",
+        "--add-label",
+        PRIMARY_LABEL,
+    ]
+    result = _run_gh(args, runner=runner, input_text=body)
+    if result.returncode != 0:
+        raise GitHubSyncError(f"gh issue edit failed: {result.stderr.strip()[:300]}")
+
+
+def _issue_number_from_url(url: str) -> int:
+    """Extract the trailing issue number from a GitHub issue URL."""
+    tail = url.rstrip("/").rsplit("/", 1)[-1]
+    try:
+        return int(tail)
+    except ValueError as exc:
+        raise GitHubSyncError(f"could not parse issue number from {url!r}") from exc
+
+
+def sync_issue(
+    body: str,
+    repo: str | None,
+    *,
+    runner: RunnerFn = subprocess.run,
+) -> tuple[int, str]:
+    """Create or update the tracker issue. Returns ``(number, action)``."""
+    existing = find_tracker_issue(repo, runner=runner)
+    if existing is not None:
+        update_tracker_issue(existing, body, repo, runner=runner)
+        return existing, "updated"
+    number = create_tracker_issue(body, repo, runner=runner)
+    return number, "created"
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(path: Path) -> SonarSnapshot:
+    """Build a snapshot from a saved JSON fixture (tests + offline dry-run).
+
+    The fixture may be a bare ``/api/issues/search`` payload (an object with
+    an ``issues`` list) or an extended object that also carries
+    ``quality_gate``, ``coverage``, ``host`` and ``project_key`` keys.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return SonarSnapshot([], "UNKNOWN", None, "https://sonar.bernstein.run", "bernstein")
+    issues = payload.get("issues")
+    findings: list[Finding] = []
+    if isinstance(issues, list):
+        for raw in issues:
+            if isinstance(raw, dict):
+                finding = _normalise_issue(raw)
+                if finding is not None:
+                    findings.append(finding)
+    return SonarSnapshot(
+        findings=findings,
+        quality_gate=str(payload.get("quality_gate", "UNKNOWN")),
+        coverage=_opt_float(payload.get("coverage")),
+        host=str(payload.get("host", "https://sonar.bernstein.run")),
+        project_key=str(payload.get("project_key", "bernstein")),
+    )
+
+
+def _opt_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def run(args: argparse.Namespace) -> int:
+    """Fetch the snapshot, render the body, and sync the GitHub issue."""
+    # 1) Build the snapshot.
+    if args.fixture:
+        try:
+            snapshot = _load_fixture(Path(args.fixture))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"error: failed to load fixture: {exc}", file=sys.stderr)
+            return 2
+    else:
+        config = load_config()
+        if config is None:
+            print("error: SONAR_HOST_URL and SONAR_TOKEN must be set", file=sys.stderr)
+            return 2
+        try:
+            snapshot = collect_snapshot(config)
+        except SonarAPIError as exc:
+            print(f"error: sonar fetch failed: {exc}", file=sys.stderr)
+            return 1
+
+    # 2) Render the body.
+    body = render_body(snapshot)
+    print(
+        f"sonar-tracker: findings={len(snapshot.findings)} "
+        f"quality_gate={snapshot.quality_gate} "
+        f"coverage={_coverage_text(snapshot.coverage)} "
+        f"body_chars={len(body)}/{GITHUB_BODY_LIMIT}",
+    )
+
+    if args.output_body:
+        Path(args.output_body).write_text(body, encoding="utf-8")
+        print(f"sonar-tracker: wrote rendered body to {args.output_body}")
+
+    if args.dry_run:
+        print("sonar-tracker: dry-run; not syncing GitHub issue")
+        return 0
+
+    # 3) Sync the GitHub issue.
+    repo = args.repo or _default_repo()
+    try:
+        number, action = sync_issue(body, repo)
+    except GitHubSyncError as exc:
+        print(f"error: github sync failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"sonar-tracker: {action} issue #{number}")
+    return 0
+
+
+def _default_repo() -> str | None:
+    """Resolve ``owner/name`` from env; let gh fall back to the checkout."""
+    import os
+
+    repo = (os.environ.get("GITHUB_REPOSITORY") or "").strip()
+    return repo or None
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render the body but do not create or edit any GitHub issue.",
+    )
+    p.add_argument(
+        "--fixture",
+        default=None,
+        help="Read the snapshot from a saved JSON fixture instead of Sonar.",
+    )
+    p.add_argument(
+        "--output-body",
+        default=None,
+        help="Also write the rendered body to this path (debugging aid).",
+    )
+    p.add_argument(
+        "--repo",
+        default=None,
+        help="Target GitHub repo as owner/name. Defaults to $GITHUB_REPOSITORY.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -99,6 +99,7 @@ from bernstein.core.observability.sonar import (  # noqa: E402
 
 # Hidden marker that uniquely identifies the tracker issue. Searched for in
 # the body of open issues so re-runs edit instead of duplicating.
+# Consolidated SonarQube findings tracker. See docs/operations/sonar-tracker.md.
 TRACKER_MARKER = "<!-- sonar-tracker:bernstein -->"
 
 TRACKER_TITLE = "SonarQube findings tracker"

--- a/tests/unit/scripts/test_render_sonar_tracker.py
+++ b/tests/unit/scripts/test_render_sonar_tracker.py
@@ -211,6 +211,36 @@ def test_body_respects_github_limit_with_5000_findings(tracker: ModuleType) -> N
     assert sum(parsed["by_severity"].values()) == 5000
 
 
+def test_json_summary_caps_key_lists_and_records_truncation(tracker: ModuleType) -> None:
+    # More BLOCKER + CRITICAL findings than the JSON key cap forces the key
+    # lists to be truncated, with a sibling count of how many were dropped.
+    cap = tracker._JSON_KEYS_CAP
+    findings = [_issue(f"B-{i:05d}", severity="BLOCKER", component=f"bernstein:b{i}.py") for i in range(cap + 25)]
+    findings += [_issue(f"C-{i:05d}", severity="CRITICAL", component=f"bernstein:c{i}.py") for i in range(cap + 10)]
+    snapshot = _snapshot(tracker, findings)
+    body = tracker.render_body(snapshot)
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    assert len(parsed["blocker_keys"]) == cap
+    assert len(parsed["critical_keys"]) == cap
+    assert parsed["blocker_keys_truncated"] == 25
+    assert parsed["critical_keys_truncated"] == 10
+    # Counts stay honest even though the key lists are capped.
+    assert parsed["by_severity"]["BLOCKER"] == cap + 25
+    assert parsed["by_severity"]["CRITICAL"] == cap + 10
+
+
+def test_json_summary_omits_truncation_field_when_under_cap(tracker: ModuleType) -> None:
+    snapshot = _snapshot(tracker, [_issue("b1", severity="BLOCKER"), _issue("c1", severity="CRITICAL")])
+    body = tracker.render_body(snapshot)
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    assert "blocker_keys_truncated" not in parsed
+    assert "critical_keys_truncated" not in parsed
+
+
 def test_body_no_partial_list_item_when_collapsed(tracker: ModuleType) -> None:
     # 5000 findings forces collapse; assert no line is a dangling fragment
     # (every list bullet line ends with the closing of a markdown link or
@@ -222,6 +252,31 @@ def test_body_no_partial_list_item_when_collapsed(tracker: ModuleType) -> None:
             # A rendered finding line always ends with the closing paren of
             # its ([view](...)) permalink.
             assert line.rstrip().endswith(")"), line
+
+
+def test_item_cap_shrinks_before_sections_collapse_to_counts(tracker: ModuleType) -> None:
+    # Three large <details> severities with very long component paths push the
+    # body over budget. The renderer must first shrink the per-section item
+    # cap (keeping the sections as <details>) before it drops a whole section
+    # to a counts-only line. Assert the sections survive with fewer items.
+    pad = "z" * 1000
+    findings: list[dict[str, Any]] = []
+    for sev in ("MAJOR", "MINOR", "INFO"):
+        for i in range(200):
+            comp = f"bernstein:src/{pad}/m_{i:05d}/file_{i:05d}.py"
+            findings.append(_issue(f"{sev[0]}-{i:05d}", severity=sev, component=comp, line=i % 900 + 1))
+    snapshot = _snapshot(tracker, findings)
+    body = tracker.render_body(snapshot)
+    assert len(body) <= tracker.GITHUB_BODY_LIMIT
+    # All three sections are still rendered as <details>, not collapsed to a
+    # counts-only line. (The item cap was halved instead.)
+    assert body.count("<details>") == 3
+    for sev in ("MAJOR", "MINOR", "INFO"):
+        assert f"<summary>{sev} (200)</summary>" in body
+        assert f"- **{sev}**:" not in body
+    # Fewer than the default cap of items are shown per section.
+    rendered = sum(1 for line in body.splitlines() if line.startswith("- rule "))
+    assert 0 < rendered < 3 * tracker._DETAILS_ITEM_CAP
 
 
 def test_small_input_lists_everything_in_full(tracker: ModuleType) -> None:
@@ -359,6 +414,25 @@ def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleTyp
     assert len(snapshot.findings) == 750
     assert snapshot.quality_gate == "ERROR"
     assert snapshot.coverage == pytest.approx(19.3)
+
+
+def test_fetch_all_findings_raises_on_non_object_payload(tracker: ModuleType) -> None:
+    # A malformed page (a JSON array instead of an object) must fail closed so
+    # an incomplete finding set is never published as a successful run.
+    config = tracker.SonarConfig(host=HOST, token="t", project_key=PROJECT)
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(f"{HOST}/api/issues/search").mock(return_value=httpx.Response(200, json=[1, 2, 3]))
+        with pytest.raises(tracker.SonarAPIError):
+            tracker.fetch_all_findings(config)
+
+
+def test_fetch_all_findings_raises_on_bad_paging(tracker: ModuleType) -> None:
+    config = tracker.SonarConfig(host=HOST, token="t", project_key=PROJECT)
+    bad = {"issues": [_issue("b1", severity="BLOCKER")], "paging": {"total": "not-a-number"}}
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(f"{HOST}/api/issues/search").mock(return_value=httpx.Response(200, json=bad))
+        with pytest.raises(tracker.SonarAPIError):
+            tracker.fetch_all_findings(config)
 
 
 def test_fetch_quality_gate_unknown_on_bad_payload(tracker: ModuleType) -> None:

--- a/tests/unit/scripts/test_render_sonar_tracker.py
+++ b/tests/unit/scripts/test_render_sonar_tracker.py
@@ -1,0 +1,406 @@
+"""Unit tests for ``scripts/render_sonar_tracker.py``.
+
+Covers the contract documented in docs/operations/sonar-tracker.md:
+
+- grouping findings by severity (deterministic order)
+- the 65536-char body cap (5000 synthetic findings -> body fits, no
+  mid-line truncation)
+- idempotency marker detection (find existing tracker issue)
+- the trailing JSON summary block shape
+- the empty-result path
+- create-vs-update sync routing through a fake gh runner
+
+The Sonar HTTP layer is exercised with respx so the pagination + quality
+gate + coverage fetches are covered end to end without a live server.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "render_sonar_tracker.py"
+HOST = "https://sonar.test"
+PROJECT = "bernstein"
+
+
+@pytest.fixture
+def tracker() -> ModuleType:
+    """Load scripts/render_sonar_tracker.py as a module."""
+    spec = importlib.util.spec_from_file_location("render_sonar_tracker_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    key: str,
+    *,
+    rule: str = "python:S3776",
+    severity: str = "CRITICAL",
+    issue_type: str = "CODE_SMELL",
+    component: str = "bernstein:src/bernstein/cli/main.py",
+    line: int | None = 10,
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "rule": rule,
+        "severity": severity,
+        "type": issue_type,
+        "component": component,
+        "line": line,
+        "message": "vendor message that must never be rendered",
+        "creationDate": "2026-05-20T10:00:00+0000",
+    }
+
+
+def _snapshot(
+    tracker: ModuleType,
+    findings: list[dict[str, Any]],
+    *,
+    quality_gate: str = "ERROR",
+    coverage: float | None = 19.3,
+) -> Any:
+    normalised = [tracker._normalise_issue(raw) for raw in findings]
+    return tracker.SonarSnapshot(
+        findings=[f for f in normalised if f is not None],
+        quality_gate=quality_gate,
+        coverage=coverage,
+        host=HOST,
+        project_key=PROJECT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_severity_buckets_and_orders(tracker: ModuleType) -> None:
+    findings = [
+        tracker._normalise_issue(_issue("c1", severity="CRITICAL", component="bernstein:z.py", line=9)),
+        tracker._normalise_issue(_issue("b1", severity="BLOCKER")),
+        tracker._normalise_issue(_issue("c2", severity="CRITICAL", component="bernstein:a.py", line=3)),
+        tracker._normalise_issue(_issue("m1", severity="MAJOR")),
+    ]
+    buckets = tracker.group_by_severity([f for f in findings if f is not None])
+    assert [f.key for f in buckets["BLOCKER"]] == ["b1"]
+    # CRITICAL sorted by component path then line: a.py before z.py.
+    assert [f.key for f in buckets["CRITICAL"]] == ["c2", "c1"]
+    assert [f.key for f in buckets["MAJOR"]] == ["m1"]
+    # Empty buckets present for the remaining canonical severities.
+    assert buckets["MINOR"] == []
+    assert buckets["INFO"] == []
+
+
+def test_group_by_severity_handles_unexpected_label(tracker: ModuleType) -> None:
+    findings = [tracker._normalise_issue(_issue("x1", severity="WEIRD"))]
+    buckets = tracker.group_by_severity([f for f in findings if f is not None])
+    assert "WEIRD" in buckets
+    assert [f.key for f in buckets["WEIRD"]] == ["x1"]
+
+
+# ---------------------------------------------------------------------------
+# TL;DR + JSON summary block shape
+# ---------------------------------------------------------------------------
+
+
+def test_body_tldr_table_shows_gate_and_coverage(tracker: ModuleType) -> None:
+    snapshot = _snapshot(tracker, [_issue("b1", severity="BLOCKER")], quality_gate="ERROR", coverage=19.3)
+    body = tracker.render_body(snapshot, generated_at="2026-05-21T00:00:00+00:00")
+    assert "Quality gate: **ERROR**" in body
+    assert "Coverage: **19.3%**" in body
+    assert tracker.TRACKER_MARKER in body
+    assert "| BLOCKER | 1 |" in body
+
+
+def test_json_summary_block_shape(tracker: ModuleType) -> None:
+    findings = [
+        _issue("b1", severity="BLOCKER"),
+        _issue("c1", severity="CRITICAL"),
+        _issue("c2", severity="CRITICAL"),
+        _issue("m1", severity="MAJOR"),
+    ]
+    snapshot = _snapshot(tracker, findings, quality_gate="ERROR", coverage=19.3)
+    body = tracker.render_body(snapshot, generated_at="2026-05-21T00:00:00+00:00")
+    # Extract the fenced json block.
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    assert parsed["generated_at"] == "2026-05-21T00:00:00+00:00"
+    assert parsed["quality_gate"] == "ERROR"
+    assert parsed["coverage"] == 19.3
+    assert parsed["by_severity"] == {"BLOCKER": 1, "CRITICAL": 2, "MAJOR": 1}
+    assert parsed["blocker_keys"] == ["b1"]
+    assert sorted(parsed["critical_keys"]) == ["c1", "c2"]
+
+
+def test_blocker_and_critical_rendered_as_checkboxes_with_permalink(tracker: ModuleType) -> None:
+    snapshot = _snapshot(tracker, [_issue("b1", severity="BLOCKER", rule="python:S2068")])
+    body = tracker.render_body(snapshot)
+    assert "- [ ] rule `python:S2068`" in body
+    assert "open=b1" in body
+    assert f"{HOST}/project/issues?issueStatuses=OPEN,CONFIRMED&id={PROJECT}&open=b1" in body
+
+
+# ---------------------------------------------------------------------------
+# Empty-result path
+# ---------------------------------------------------------------------------
+
+
+def test_empty_result_renders_zero_total(tracker: ModuleType) -> None:
+    snapshot = _snapshot(tracker, [], quality_gate="OK", coverage=88.0)
+    body = tracker.render_body(snapshot)
+    assert "Open findings: **0**" in body
+    assert "| **Total** | **0** |" in body
+    assert "Quality gate: **OK**" in body
+    # JSON block still valid with empty key lists.
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    assert parsed["blocker_keys"] == []
+    assert parsed["critical_keys"] == []
+    assert parsed["by_severity"] == {}
+
+
+# ---------------------------------------------------------------------------
+# 65k char cap with no mid-line truncation
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_findings(n: int) -> list[dict[str, Any]]:
+    """Build *n* findings spread across severities with long components."""
+    severities = ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]
+    out: list[dict[str, Any]] = []
+    for i in range(n):
+        sev = severities[i % len(severities)]
+        comp = f"bernstein:src/bernstein/some/deeply/nested/module_{i:05d}/file_{i:05d}.py"
+        out.append(_issue(f"KEY-{i:06d}", severity=sev, component=comp, line=i % 900 + 1))
+    return out
+
+
+def test_body_respects_github_limit_with_5000_findings(tracker: ModuleType) -> None:
+    snapshot = _snapshot(tracker, _synthetic_findings(5000), quality_gate="ERROR", coverage=19.3)
+    body = tracker.render_body(snapshot)
+    assert len(body) <= tracker.GITHUB_BODY_LIMIT
+    # No mid-line truncation: every line is whole. The body ends with the
+    # closing fence of the JSON block, and the JSON parses.
+    assert body.endswith("```\n")
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    # All 5000 findings are still counted in the summary even though the
+    # per-severity item lists were collapsed to fit.
+    assert sum(parsed["by_severity"].values()) == 5000
+
+
+def test_body_no_partial_list_item_when_collapsed(tracker: ModuleType) -> None:
+    # 5000 findings forces collapse; assert no line is a dangling fragment
+    # (every list bullet line ends with the closing of a markdown link or
+    # is a plain count line).
+    snapshot = _snapshot(tracker, _synthetic_findings(5000))
+    body = tracker.render_body(snapshot)
+    for line in body.splitlines():
+        if line.startswith("- [ ] ") or line.startswith("- rule "):
+            # A rendered finding line always ends with the closing paren of
+            # its ([view](...)) permalink.
+            assert line.rstrip().endswith(")"), line
+
+
+def test_small_input_lists_everything_in_full(tracker: ModuleType) -> None:
+    snapshot = _snapshot(tracker, _synthetic_findings(20))
+    body = tracker.render_body(snapshot)
+    # No collapse needed: BLOCKER + CRITICAL are full checkbox lists and the
+    # body is comfortably under the cap.
+    assert len(body) < tracker.GITHUB_BODY_LIMIT
+    assert "## BLOCKER" in body
+    assert "## CRITICAL" in body
+    assert "- [ ] rule" in body
+
+
+# ---------------------------------------------------------------------------
+# Idempotency marker detection + sync routing (fake gh runner)
+# ---------------------------------------------------------------------------
+
+
+class _FakeGh:
+    """Records gh invocations and returns scripted responses."""
+
+    def __init__(
+        self, *, list_payload: list[dict[str, Any]], create_url: str = f"https://github.com/{PROJECT}/issues/4242"
+    ):
+        self._list_payload = list_payload
+        self._create_url = create_url
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self,
+        cmd: list[str],
+        *,
+        capture_output: bool = False,
+        text: bool = False,
+        check: bool = False,
+        input: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(cmd)
+        sub = cmd[1] if len(cmd) > 1 else ""
+        action = cmd[2] if len(cmd) > 2 else ""
+        if sub == "label":
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if sub == "issue" and action == "list":
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(self._list_payload), "")
+        if sub == "issue" and action == "create":
+            return subprocess.CompletedProcess(cmd, 0, f"{self._create_url}\n", "")
+        if sub == "issue" and action == "edit":
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+
+def test_find_tracker_issue_matches_marker(tracker: ModuleType) -> None:
+    fake = _FakeGh(
+        list_payload=[
+            {"number": 7, "body": "some unrelated tracker without the marker"},
+            {"number": 9, "body": f"header\n{tracker.TRACKER_MARKER}\nbody"},
+        ]
+    )
+    number = tracker.find_tracker_issue(PROJECT, runner=fake)
+    assert number == 9
+
+
+def test_find_tracker_issue_returns_none_when_no_marker(tracker: ModuleType) -> None:
+    fake = _FakeGh(list_payload=[{"number": 7, "body": "no marker here"}])
+    assert tracker.find_tracker_issue(PROJECT, runner=fake) is None
+
+
+def test_sync_creates_when_absent(tracker: ModuleType) -> None:
+    fake = _FakeGh(list_payload=[])
+    number, action = tracker.sync_issue("body text", PROJECT, runner=fake)
+    assert action == "created"
+    assert number == 4242
+    # A create call was issued with the title + labels.
+    create_calls = [c for c in fake.calls if c[1:3] == ["issue", "create"]]
+    assert create_calls, fake.calls
+    assert tracker.TRACKER_TITLE in create_calls[0]
+
+
+def test_sync_updates_when_marker_present(tracker: ModuleType) -> None:
+    fake = _FakeGh(
+        list_payload=[{"number": 55, "body": f"x\n{tracker.TRACKER_MARKER}\ny"}],
+    )
+    number, action = tracker.sync_issue("new body", PROJECT, runner=fake)
+    assert action == "updated"
+    assert number == 55
+    edit_calls = [c for c in fake.calls if c[1:3] == ["issue", "edit"]]
+    assert edit_calls, fake.calls
+    assert "55" in edit_calls[0]
+    # No create call when an existing issue was found.
+    assert not [c for c in fake.calls if c[1:3] == ["issue", "create"]]
+
+
+def test_find_tracker_issue_raises_on_gh_failure(tracker: ModuleType) -> None:
+    def _boom(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+    with pytest.raises(tracker.GitHubSyncError):
+        tracker.find_tracker_issue(PROJECT, runner=_boom)
+
+
+# ---------------------------------------------------------------------------
+# Sonar HTTP layer (respx): pagination + quality gate + coverage
+# ---------------------------------------------------------------------------
+
+
+def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleType) -> None:
+    config = tracker.SonarConfig(host=HOST, token="t0ken", project_key=PROJECT)
+
+    page1 = {
+        "issues": [_issue(f"P1-{i}", severity="MAJOR") for i in range(500)],
+        "paging": {"pageIndex": 1, "pageSize": 500, "total": 750},
+    }
+    page2 = {
+        "issues": [_issue(f"P2-{i}", severity="MINOR") for i in range(250)],
+        "paging": {"pageIndex": 2, "pageSize": 500, "total": 750},
+    }
+
+    def _issues_responder(request: httpx.Request) -> httpx.Response:
+        page = request.url.params.get("p")
+        return httpx.Response(200, json=page1 if page == "1" else page2)
+
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(f"{HOST}/api/issues/search").mock(side_effect=_issues_responder)
+        mock.get(f"{HOST}/api/qualitygates/project_status").mock(
+            return_value=httpx.Response(200, json={"projectStatus": {"status": "ERROR"}})
+        )
+        mock.get(f"{HOST}/api/measures/component").mock(
+            return_value=httpx.Response(
+                200,
+                json={"component": {"measures": [{"metric": "coverage", "value": "19.3"}]}},
+            )
+        )
+        snapshot = tracker.collect_snapshot(config)
+
+    assert len(snapshot.findings) == 750
+    assert snapshot.quality_gate == "ERROR"
+    assert snapshot.coverage == pytest.approx(19.3)
+
+
+def test_fetch_quality_gate_unknown_on_bad_payload(tracker: ModuleType) -> None:
+    config = tracker.SonarConfig(host=HOST, token="t", project_key=PROJECT)
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(f"{HOST}/api/qualitygates/project_status").mock(return_value=httpx.Response(200, json={"nope": 1}))
+        assert tracker.fetch_quality_gate(config) == "UNKNOWN"
+
+
+def test_fetch_coverage_none_when_metric_absent(tracker: ModuleType) -> None:
+    config = tracker.SonarConfig(host=HOST, token="t", project_key=PROJECT)
+    with respx.mock(assert_all_called=False) as mock:
+        mock.get(f"{HOST}/api/measures/component").mock(
+            return_value=httpx.Response(200, json={"component": {"measures": []}})
+        )
+        assert tracker.fetch_coverage(config) is None
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_dry_run_with_fixture(tracker: ModuleType, tmp_path: Path) -> None:
+    fixture = tmp_path / "issues.json"
+    fixture.write_text(
+        json.dumps(
+            {
+                "issues": [_issue("b1", severity="BLOCKER")],
+                "quality_gate": "ERROR",
+                "coverage": 19.3,
+                "host": HOST,
+                "project_key": PROJECT,
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_body = tmp_path / "body.md"
+    rc = tracker.main(["--dry-run", "--fixture", str(fixture), "--output-body", str(out_body)])
+    assert rc == 0
+    text = out_body.read_text(encoding="utf-8")
+    assert tracker.TRACKER_MARKER in text
+    assert "open=b1" in text
+    # Raw vendor message is never rendered.
+    assert "vendor message" not in text

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.5.1"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

- Add `scripts/render_sonar_tracker.py`: renders one consolidated GitHub issue from the live Sonar API, grouped by severity, with deep links and a machine-readable JSON summary block.
- Add `.github/workflows/sonar-tracker.yml`: runs on dispatch, after the SonarQube scan workflow completes on main, and on a daily schedule.
- Add unit tests (`tests/unit/scripts/test_render_sonar_tracker.py`) and operator docs (`docs/operations/sonar-tracker.md`).

This is the consolidated counterpart to the per-finding sweeper. Instead of one backlog ticket per finding, agents work a single living issue thread.

### How it behaves

- The issue is found by a hidden body marker, so every run edits the same issue rather than opening duplicates.
- BLOCKER and CRITICAL findings list in full as checkboxes with permalinks; MAJOR, MINOR, and INFO collapse into details blocks (capped at 80 each with an "and N more" pointer).
- The rendered body is held under the GitHub 65536 character limit by progressive collapse; it is never truncated mid-line.
- A trailing fenced json block exposes the gate status, coverage, per-severity counts, and the blocker/critical issue keys so a downstream fixer can consume it without scraping markdown.
- Human-readable descriptions are synthesised from the shared vetted rule-family table; raw vendor text is never copied into the issue.
- When the Sonar token is empty (the default on a fork) the workflow logs a notice and exits 0.

## Test plan

- [x] `uv run pytest tests/unit/scripts/test_render_sonar_tracker.py -q` (18 passed)
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean
- [x] `actionlint` and `zizmor` clean on the new workflow
- [ ] Trigger `sonar-tracker.yml`, confirm exactly one issue is created, then edited (not duplicated) on a second run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated SonarQube findings tracker that consolidates open findings into a single idempotently-updated GitHub issue, re-rendered after scans and on a daily schedule.

* **Documentation**
  * Added an operational guide describing tracker structure, execution paths, environment variables, health checks, and troubleshooting.

* **CI / Automation**
  * Added a workflow to run and synchronize the tracker issue with guarded execution for forks.

* **Tests**
  * Added comprehensive unit tests covering rendering, pagination, CLI modes, and sync behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: 3282614645 reason=tests inject gh via the runner= dependency-injection parameter using isolation-safe callable doubles; this avoids the unittest.mock.patch leakage the tests/unit guideline warns against, so switching to Mock is a lateral change with no correctness benefit. -->
