### PR TITLE
chore(security): resolve SonarQube TLS and credential findings (tracker #1785)

### DIFF
--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -64,7 +64,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "audit": "bernstein.core.security.audit",
     "audit_export": "bernstein.core.security.audit_export",
     "audit_integrity": "bernstein.core.security.audit_integrity",
-    "auth": "bernstein.core.security.auth",
+    "auth": "bernstein.core.security.auth",  # NOSONAR python:S6418 - module redirect entry, not a credential.
     "auth_middleware": "bernstein.core.security.auth_middleware",
     "auth_rate_limiter": "bernstein.core.security.auth_rate_limiter",
     "auto_approve": "bernstein.core.security.auto_approve",

--- a/src/bernstein/core/protocols/cluster/cluster_tls.py
+++ b/src/bernstein/core/protocols/cluster/cluster_tls.py
@@ -173,14 +173,16 @@ def build_httpx_client_kwargs(cfg: TLSConfig | None) -> dict[str, Any]:
         return {}
     cfg.validate_paths()
     if cfg.verify_mode == "disabled":
-        ctx = ssl.create_default_context()
+        # Opt-in plaintext-verify path: only when operator sets verify_mode="disabled" (default is "required").
+        ctx = ssl.create_default_context()  # NOSONAR python:S5527 - opt-in verify_mode="disabled" only.
         ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         ctx.set_ciphers(_CIPHER_ALLOWLIST)
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        ctx.check_hostname = False  # NOSONAR python:S5527 - hostname check off only on opt-in disabled mode.
+        ctx.verify_mode = ssl.CERT_NONE  # NOSONAR python:S4830 - peer-cert check skipped only on opt-in disabled mode.
         ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
         return {"verify": ctx}
-    ctx = ssl.create_default_context(cafile=str(_resolve(cfg.ca_file)))
+    # Secure path (default/optional): create_default_context keeps check_hostname=True and verifies cfg.ca_file.
+    ctx = ssl.create_default_context(cafile=str(_resolve(cfg.ca_file)))  # NOSONAR python:S5527
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.set_ciphers(_CIPHER_ALLOWLIST)
     ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))

--- a/src/bernstein/eval/pentest_scorer.py
+++ b/src/bernstein/eval/pentest_scorer.py
@@ -118,7 +118,7 @@ _VULN_ALIASES: dict[str, str] = {
     "hardcoded_secret": "hardcoded_secret",
     "hardcoded-secret": "hardcoded_secret",
     "hard_coded_secret": "hardcoded_secret",
-    "secret": "hardcoded_secret",
+    "secret": "hardcoded_secret",  # NOSONAR python:S6418 - vulnerability-category alias key, not a credential value.
     "leaked_credential": "hardcoded_secret",
     "credential_in_source": "hardcoded_secret",
     # Command injection


### PR DESCRIPTION
## Summary

Resolves five SECURITY-sensitive SonarQube findings from tracker #1785. Each was reviewed against the actual code; all five are either false positives or intentional, documented opt-in configuration, so they are annotated with `# NOSONAR python:S<rule>` and a technical reason. No runtime behavior changes.

| Rule | Location | Disposition |
|---|---|---|
| python:S5527 x3, python:S4830 | `cluster_tls.py` (`build_httpx_client_kwargs`) | Opt-in `verify_mode="disabled"` branch only; default is `"required"` |
| python:S6418 | `core/__init__.py` | `"auth"` key in `_REDIRECT_MAP` module-redirection table, not a credential |
| python:S6418 | `eval/pentest_scorer.py` | `"secret"` key in `_VULN_ALIASES` category map, not a credential value |

### TLS findings (cluster_tls.py)

`build_httpx_client_kwargs` builds the worker-side httpx context. The `CERT_NONE` / `check_hostname=False` branch executes **only** when an operator explicitly sets `verify_mode="disabled"`. The default is `"required"` (full mTLS) and the default/`"optional"` path keeps `check_hostname=True` and verifies the configured CA bundle. Forcing verification on the disabled branch would break the documented staged-rollout mode and its existing tests. Annotated as false positives with per-line technical reasons; the secure path is also annotated since the same function contains the opt-in branch.

### Credential findings (S6418)

Both flagged strings are dictionary keys that pattern-match credential terms but hold no secrets:
- `core/__init__.py`: `"auth"` maps an old module name to its new dotted path in the backward-compat redirection table.
- `eval/pentest_scorer.py`: `"secret"` maps a free-form vulnerability term to the canonical `hardcoded_secret` category in the pentest-eval scorer's alias table.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src` clean (pre-existing py3.14 parse error in unrelated `gradients.py` only)
- [x] `uv run pytest tests/unit -k "cluster_tls or tls or pentest_scorer"` passes (TLS 46, pentest_scorer 52)
- [x] No behavior change: `test_build_httpx_client_kwargs_disabled` still asserts `CERT_NONE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal code quality suppression comments across multiple modules to enhance code analysis configurations.
  * Refactored SSL/TLS context handling with improved inline documentation while maintaining existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->