### PR TITLE
fix(quality): resolve SonarQube S3516 and S5754 findings (tracker #1785)

### DIFF
--- a/src/bernstein/adapters/clm_tls_launcher.py
+++ b/src/bernstein/adapters/clm_tls_launcher.py
@@ -116,7 +116,10 @@ def _run_aider(argv: list[str]) -> int:
     sys.argv = [target, *rest]
     try:
         runpy.run_module("aider", run_name="__main__", alter_sys=True)
-    except SystemExit as exc:
+    # SystemExit is the expected control signal from runpy: aider calls
+    # sys.exit(), and we translate its code into our own return value
+    # rather than letting the process die mid-launcher.
+    except SystemExit as exc:  # NOSONAR python:S5754 - runpy propagates aider's sys.exit; mapped to a return code
         code = exc.code
         if isinstance(code, int):
             return code

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -582,7 +582,7 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool, suggest_docs: bool
     exit_code = 0
     try:
         ctx.invoke(_doctor_impl, as_json=as_json, auto_fix=auto_fix)
-    except SystemExit as exc:
+    except SystemExit as exc:  # NOSONAR python:S5754 - captured to add a hint, re-raised below
         exit_code = int(exc.code or 0)
 
     if not as_json:

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -318,8 +318,16 @@ def _run_substrate_checks() -> list[dict[str, Any]]:
     return [_substrate_status_for(HOST_REGISTRY[name]) for name in known_host_names()]
 
 
-def _render_substrate_report(rows: list[dict[str, Any]], *, as_json: bool) -> int:
-    """Render the substrate report and return the desired exit code."""
+def _render_substrate_report(  # NOSONAR python:S3516 - advisory surface, always exit 0 by design
+    rows: list[dict[str, Any]], *, as_json: bool
+) -> int:
+    """Render the substrate report and return the desired exit code.
+
+    The substrate report is advisory: it always returns ``0`` regardless
+    of the host states it renders. A non-zero exit code is reserved for a
+    future ``--gate`` flag and is intentionally not produced here (hence
+    the ``S3516`` invariant-return waiver).
+    """
     import json as _json
 
     from rich.table import Table

--- a/src/bernstein/cli/commands/doctor_sonar_cmd.py
+++ b/src/bernstein/cli/commands/doctor_sonar_cmd.py
@@ -170,7 +170,7 @@ def _render_json(
     console.print_json(json.dumps(payload))
 
 
-def run_doctor_sonar(
+def run_doctor_sonar(  # NOSONAR python:S3516 - advisory renderer, always exit 0 by design (see docstring)
     *,
     as_json: bool = False,
     smell_threshold: int = DEFAULT_SMELL_NUDGE,

--- a/src/bernstein/core/agents/spawner_sandbox_session.py
+++ b/src/bernstein/core/agents/spawner_sandbox_session.py
@@ -111,7 +111,10 @@ def _run_session_loop(
         except asyncio.CancelledError:
             handle.future.cancel()
             return
-        except BaseException as exc:
+        # Fail-closed: every exception (incl. KeyboardInterrupt/SystemExit)
+        # must reach the blocked caller's future, otherwise the caller's
+        # future.result() hangs forever. Narrowing here would deadlock it.
+        except BaseException as exc:  # NOSONAR python:S5754 - intentional fail-closed handoff to the blocked future
             handle.future.set_exception(exc)
             return
         handle.future.set_result(result)

--- a/src/bernstein/core/quality/quality_gate_coalescer.py
+++ b/src/bernstein/core/quality/quality_gate_coalescer.py
@@ -248,10 +248,12 @@ class QualityGateCoalescer:
                     config,
                     **queued.kwargs,
                 )
-            except BaseException as exc:
-                # Capture ANY exception (including KeyboardInterrupt/SystemExit-adjacent
-                # runtime errors from subprocess gates) so the blocked caller receives
-                # it rather than hanging forever on its event.
+            except BaseException as exc:  # NOSONAR python:S5754 - intentional fail-closed handoff to the blocked waiter
+                # Capture ANY exception (incl. KeyboardInterrupt/SystemExit-
+                # adjacent runtime errors from subprocess gates) so the blocked
+                # caller receives it via _wait_for_queued (which re-raises)
+                # rather than hanging forever on its event. Narrowing would
+                # deadlock the waiter.
                 queued.error = exc
             finally:
                 queued.event.set()

--- a/src/bernstein/core/security/url_allowlist.py
+++ b/src/bernstein/core/security/url_allowlist.py
@@ -33,13 +33,19 @@ _HTTP_AND_HTTPS: Final[frozenset[str]] = frozenset({"http", "https"})
 _LOCAL_HOSTS: Final[frozenset[str]] = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
-def ensure_http_url(
+def ensure_http_url(  # NOSONAR python:S3516 - accept path returns input unchanged; rejection is via raise
     url: str,
     *,
     allow_http: bool = False,
     source: str = "",
 ) -> str:
     """Validate that ``url`` has an http(s) scheme; return it unchanged.
+
+    This is a validate-and-passthrough guard: every accept path returns
+    the same value (the input ``url``), and rejection is signalled by
+    raising :class:`UrlSchemeError` rather than by a sentinel return.
+    That invariant return is intentional (hence the ``S3516`` waiver) and
+    must not be relaxed into an always-allow.
 
     Args:
         url: The candidate URL string.

--- a/tests/unit/security/test_url_allowlist.py
+++ b/tests/unit/security/test_url_allowlist.py
@@ -1,0 +1,97 @@
+"""Tests for :func:`bernstein.core.security.ensure_http_url`.
+
+``ensure_http_url`` is a validate-and-passthrough guard: every call site
+relies on it returning its input unchanged on accept and raising
+:class:`UrlSchemeError` on reject. The function is marked ``NOSONAR
+python:S3516`` because every accept path returns the same value (the
+input ``url``); these tests pin the *reject* paths so the suppression
+can never mask a regression that turns the guard into an always-allow.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.security.url_allowlist import UrlSchemeError, ensure_http_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/path",
+        "https://example.com",
+        "https://localhost:8052/health",
+    ],
+)
+def test_https_is_accepted_and_returned_unchanged(url: str) -> None:
+    assert ensure_http_url(url) == url
+
+
+def test_http_rejected_by_default() -> None:
+    with pytest.raises(UrlSchemeError):
+        ensure_http_url("http://example.com")
+
+
+def test_http_accepted_when_allow_http_set() -> None:
+    url = "http://example.com/webhook"
+    assert ensure_http_url(url, allow_http=True) == url
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["localhost", "127.0.0.1", "[::1]"],
+)
+def test_loopback_http_always_allowed(host: str) -> None:
+    """Plain HTTP to loopback is permitted even without ``allow_http``.
+
+    IPv6 literals must be bracketed in a URL authority so ``urlparse``
+    extracts ``::1`` as the hostname rather than mis-splitting on the
+    colons.
+    """
+    url = f"http://{host}:8052/mock"
+    assert ensure_http_url(url) == url
+
+
+def test_bind_any_host_is_not_treated_as_loopback() -> None:
+    """``0.0.0.0`` is the bind-any address, not a loopback target.
+
+    It must NOT inherit the localhost plain-HTTP exemption, otherwise a
+    routable interface could receive unencrypted traffic.
+    """
+    with pytest.raises(UrlSchemeError):
+        ensure_http_url("http://0.0.0.0:8052/x")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/payload",
+        "gopher://example.com",
+        "data:text/plain;base64,AAAA",
+        "jar:file:///tmp/x.jar",
+    ],
+)
+def test_non_http_schemes_are_rejected(url: str) -> None:
+    """The whole point of the guard: deny non-http(s) schemes.
+
+    A regression that made this an always-allow guard (returning the URL
+    for every input) would surface here as the missing ``UrlSchemeError``.
+    """
+    with pytest.raises(UrlSchemeError):
+        ensure_http_url(url, allow_http=True)
+
+
+def test_empty_url_rejected() -> None:
+    with pytest.raises(UrlSchemeError):
+        ensure_http_url("")
+
+
+def test_schemeless_url_rejected() -> None:
+    with pytest.raises(UrlSchemeError):
+        ensure_http_url("example.com/no-scheme")
+
+
+def test_error_message_includes_source_label() -> None:
+    with pytest.raises(UrlSchemeError, match="jira webhook"):
+        ensure_http_url("ftp://example.com", source="jira webhook")


### PR DESCRIPTION
## Summary

Resolves two clusters from the consolidated SonarQube findings tracker (#1785). Each flagged site was inspected and the flagged behaviour found intentional, so it is annotated with a concise rationale rather than rewritten.

### S3516 (BLOCKER) - function always returns the same value
- `core/security/url_allowlist.py` `ensure_http_url`: validate-and-passthrough guard. Every accept path returns the input unchanged; rejection is via `raise UrlSchemeError`. Inspected for an always-allow regression and confirmed it denies non-http(s) schemes.
- `cli/commands/doctor_cmd.py` `_render_substrate_report`: advisory surface, always exit 0 by design.
- `cli/commands/doctor_sonar_cmd.py` `run_doctor_sonar`: advisory renderer, always exit 0 by design (already documented in its docstring).

### S5754 (CRITICAL) - catch of generic/system exception
- `adapters/clm_tls_launcher.py`: `except SystemExit` deliberately translates the runpy-propagated aider exit code into a return value.
- `cli/commands/advanced_cmd.py`: `except SystemExit` captures the code only to print a trailing hint, then re-raises it unchanged.
- `core/agents/spawner_sandbox_session.py` and `core/quality/quality_gate_coalescer.py`: `except BaseException` is a fail-closed handoff to a blocked waiter (a `Future` / an `Event`). Narrowing to `Exception` would let a `KeyboardInterrupt`/`SystemExit` escape the handoff and deadlock the caller, so it stays broad with a documented waiver.

### Test coverage
Added `tests/unit/security/test_url_allowlist.py` pinning the reject paths of `ensure_http_url` (file/ftp/gopher/data schemes, schemeless, empty, and the `0.0.0.0` non-loopback case) so the S3516 waiver can never mask a slide into always-allow.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src` clean (sole error is a pre-existing PEP 695 parse error in the untouched `cli/display/gradients.py`)
- [x] `uv run pytest tests/unit -q -k "doctor or url_allowlist or clm or advanced or spawner_sandbox or quality_gate_coalescer"` green (one unrelated pre-existing failure in `sweep/test_doctor_sonar_sweep_cli.py` reproduces on clean main and is out of scope)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for URL validation behavior to clarify expected contract and error handling.

* **Tests**
  * Added comprehensive test coverage for URL validation, including HTTPS, HTTP, loopback, and invalid scheme handling.

* **Chores**
  * Improved code quality with clarifying comments and static analysis suppressions across exception handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->