### PR TITLE
fix(routes): Annotated query params + dedupe gui router include (S8410/S8413)

### DIFF
--- a/src/bernstein/core/fleet/web.py
+++ b/src/bernstein/core/fleet/web.py
@@ -21,7 +21,7 @@ import logging
 import operator
 import time
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
@@ -152,13 +152,13 @@ def build_fleet_app(
 
     @app.get("/api/audit")
     async def api_audit(  # pyright: ignore[reportUnusedFunction]
-        project: str | None = Query(default=None),
-        role: str | None = Query(default=None),
-        adapter: str | None = Query(default=None),
-        outcome: str | None = Query(default=None),
-        since: float | None = Query(default=None),
-        until: float | None = Query(default=None),
-        limit: int = Query(default=200, ge=1, le=2000),
+        project: Annotated[str | None, Query()] = None,
+        role: Annotated[str | None, Query()] = None,
+        adapter: Annotated[str | None, Query()] = None,
+        outcome: Annotated[str | None, Query()] = None,
+        since: Annotated[float | None, Query()] = None,
+        until: Annotated[float | None, Query()] = None,
+        limit: Annotated[int, Query(ge=1, le=2000)] = 200,
     ) -> JSONResponse:
         rows: list[dict[str, Any]] = []
         for proj in aggregator.projects():

--- a/src/bernstein/core/observability/trace_store.py
+++ b/src/bernstein/core/observability/trace_store.py
@@ -672,18 +672,24 @@ def build_viewer_app(store: ContentAddressedTraceStore) -> Any:
 
     @app.get("/", response_class=HTMLResponse)
     def _index(
-        task: str = Query(default=""),
-        model: str = Query(default=""),
-        q: str = Query(default=""),
+        # NOSONAR python:S8410 - Annotated[..., Query()] cannot be used here:
+        # ``Query`` is imported lazily inside this function (optional viewer
+        # extra), so FastAPI's get_type_hints cannot resolve the stringized
+        # annotation under ``from __future__ import annotations``.
+        task: str = Query(default=""),  # NOSONAR python:S8410
+        model: str = Query(default=""),  # NOSONAR python:S8410
+        q: str = Query(default=""),  # NOSONAR python:S8410
     ) -> HTMLResponse:
         entries = store.search(task_id=task, model=model, text=q)
         return HTMLResponse(_render_index_html(store, entries, task=task, model=model, q=q))
 
     @app.get("/api/traces")
     def _api_index(
-        task: str = Query(default=""),
-        model: str = Query(default=""),
-        q: str = Query(default=""),
+        # NOSONAR python:S8410 - see _index above; lazy local ``Query`` import
+        # prevents the Annotated form from resolving at route registration.
+        task: str = Query(default=""),  # NOSONAR python:S8410
+        model: str = Query(default=""),  # NOSONAR python:S8410
+        q: str = Query(default=""),  # NOSONAR python:S8410
     ) -> JSONResponse:
         entries = store.search(task_id=task, model=model, text=q)
         return JSONResponse({"traces": [e.to_dict() for e in entries]})

--- a/src/bernstein/core/routes/fleet.py
+++ b/src/bernstein/core/routes/fleet.py
@@ -24,7 +24,7 @@ client-side change.
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import APIRouter, Query, Request
 
@@ -87,8 +87,8 @@ def fleet_projects(request: Request) -> dict[str, Any]:
 @router.get("/fleet/search")
 def fleet_search(
     request: Request,
-    q: str = Query(default="", description="Cross-project search query"),
-    limit: int = Query(default=50, ge=1, le=500),
+    q: Annotated[str, Query(description="Cross-project search query")] = "",
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
 ) -> dict[str, Any]:
     """Cross-project search stub for the topbar search bar.
 

--- a/src/bernstein/core/routes/session_peek.py
+++ b/src/bernstein/core/routes/session_peek.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 import html
 import re
 from pathlib import Path
-from typing import Final
+from typing import Annotated, Final
 
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -145,7 +145,7 @@ def peek_session(session_id: str, request: Request) -> JSONResponse:
 def send_to_session(
     session_id: str,
     request: Request,
-    payload: dict[str, str] = Body(default_factory=dict),  # noqa: B008
+    payload: Annotated[dict[str, str], Body(default_factory=dict)],
 ) -> JSONResponse:
     """Pipe one line of operator input into ``session_id``'s stdin.
 

--- a/src/bernstein/core/routes/task_trace.py
+++ b/src/bernstein/core/routes/task_trace.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -224,8 +224,8 @@ def _flatten_trace_events(traces: list[dict[str, Any]]) -> list[TraceTimelineEve
 def task_trace(
     request: Request,
     task_id: str,
-    limit: int = Query(default=500, ge=1, le=2000),
-    cursor: int = Query(default=0, ge=0),
+    limit: Annotated[int, Query(ge=1, le=2000)] = 500,
+    cursor: Annotated[int, Query(ge=0)] = 0,
 ) -> TraceTimelineResponse:
     """Return the timeline of trace events for *task_id*.
 

--- a/src/bernstein/gui/__init__.py
+++ b/src/bernstein/gui/__init__.py
@@ -76,7 +76,14 @@ def mount(app: FastAPI) -> None:
         )
 
     app.include_router(router)
-    app.include_router(router, prefix="/api/v1")
+    # Mirror the same routes under /api/v1 via a dedicated aggregator router
+    # rather than re-including the ``router`` instance a second time. Including
+    # one ``APIRouter`` object into two parents shares mutable per-route state;
+    # nesting it inside a fresh ``api_v1_router`` keeps the versioned surface in
+    # parity (test_gui_meta_versioned_alias) without that shared-instance reuse.
+    api_v1_router = APIRouter()
+    api_v1_router.include_router(router)
+    app.include_router(api_v1_router, prefix="/api/v1")
 
     assets_dir = STATIC_DIR / "assets"
     if assets_dir.exists():


### PR DESCRIPTION
## Summary

Resolves a cluster of SonarQube BLOCKER findings (tracker #1785).

- **python:S8410** (function call used as a default parameter value) on FastAPI route handlers: move the `Query()` / `Body()` markers into `Annotated[...]` with literal defaults. Files: `core/fleet/web.py`, `core/routes/fleet.py`, `core/routes/session_peek.py`, `core/routes/task_trace.py`. This matches the existing idiom in `core/routes/provider_latency.py` and `core/routes/predictive.py`.
- **python:S8413** on `gui/__init__.py`: the same `APIRouter` instance was included into the app twice (root + `/api/v1`). Mirror the versioned surface through a dedicated aggregator router instead, matching the `create_app` pattern in `core/server/server_app.py`. Route parity (`/gui-meta` and `/api/v1/gui-meta`) is unchanged.
- `core/observability/trace_store.py`: its viewer handlers import `fastapi` lazily inside the factory, so `get_type_hints` cannot resolve the stringized `Annotated` form under `from __future__ import annotations`. Those six lines keep the inline form with an inline `# NOSONAR python:S8410` marker plus a reason.

Behavior is preserved across all touched handlers.

## Test plan

- [x] `uv run pytest tests/unit -q -k "fleet or trace_store or session_peek or task_trace or gui"` -> 234 passed, 6 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` -> clean
- [x] `uv run mypy src` -> clean except a pre-existing py3.14 `type` statement parse error in `cli/display/gradients.py` (untouched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal API parameter type declarations across core fleet, observability, route, and GUI modules for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->