### PR TITLE
fix(sweep): narrow over-broad guard entry that failed sonar-sweep dry-run

### DIFF
--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -137,18 +137,13 @@ _LIFECYCLE_NOTE = (
     "next sync."
 )
 
-# Public-artefact guard for the rendered body. We reuse the sweeper's
-# disallowed-phrase word list but drop its bare-hyphen entry (a hyphen is
+# Public-artefact guard for the rendered body. The sweeper's
+# disallowed-phrase word list is the single source of truth; it forbids the
+# two long-dash code points (0x2014 / 0x2013) while leaving the plain hyphen
 # legitimate in markdown tables, list bullets, and rule ids like
-# ``python:S3776``). The real typographic risk is the two long-dash code
-# points (0x2014 and 0x2013), which we add back explicitly as escapes.
-# The set mirrors the project text-hygiene phrase list for the terms a
-# Sonar rule label could plausibly contain.
-_TRACKER_FORBIDDEN: tuple[str, ...] = (
-    *(s for s in _SWEEPER_FORBIDDEN if s != "-"),
-    chr(0x2014),  # long dash, code point 0x2014
-    chr(0x2013),  # short dash, code point 0x2013
-)
+# ``python:S3776``. The set mirrors the project text-hygiene phrase list for
+# the terms a Sonar rule label could plausibly contain.
+_TRACKER_FORBIDDEN: tuple[str, ...] = _SWEEPER_FORBIDDEN
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/sweep_sonar_findings.py
+++ b/scripts/sweep_sonar_findings.py
@@ -339,7 +339,8 @@ FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
     "ai search",
     "aio probe",
     "umami",
-    "-",  # em-dash forbidden by Bernstein hard constraints
+    "\u2014",  # U+2014; generated prose stays ASCII-punctuation only
+    "\u2013",  # U+2013; generated prose stays ASCII-punctuation only
 )
 
 


### PR DESCRIPTION
## Summary
- `FORBIDDEN_SUBSTRINGS` in `scripts/sweep_sonar_findings.py` carried a single-character entry that matched ordinary hyphenated prose. Generated `## Why` blurbs (text with words like `env-var`) tripped `_assert_no_forbidden`, so `bernstein doctor sonar-sweep --dry-run` exited 1 and `tests/unit/sweep/test_doctor_sonar_sweep_cli.py` failed.
- Replaced the over-broad entry with the specific typographic dash code points the guard was meant to catch.
- `scripts/render_sonar_tracker.py` reused that list with a now-redundant filter plus manual re-add; collapsed to a single source of truth.

## Test plan
- [x] `pytest tests/unit/sweep/test_doctor_sonar_sweep_cli.py` (2 passed)
- [x] `pytest tests/unit -k "sonar_tracker or sweep_sonar or render_sonar or doctor_sonar_sweep"` (31 passed)
- [x] `ruff check` + `ruff format --check` clean on both files
- [x] runtime: hyphenated prose passes the guard, typographic dashes still caught

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved text validation consistency by aligning character filtering rules across output generation and rendering processes. Additional special dash characters are now properly restricted in generated content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->