### PR TITLE
docs: tighten v2.6.0 release-note wording

### DIFF
--- a/docs/release-notes/v2.6.0.md
+++ b/docs/release-notes/v2.6.0.md
@@ -27,9 +27,9 @@ Released 2026-05-21.
 ## Internals and docs hygiene
 
 - Dropped the unused `bernstein.benchmark.head_to_head` module and its test from the wheel. (#1767)
-- Reorganized the docs tree: ecosystem comparison memos, migration guides, the competitive audit, and the strategic plan now live under `docs/_internal/`. The two genuinely public pages (adapter-selection comparison, orchestration-approaches architecture note) moved into existing public nav sections. (#1768)
-- Front-page Comparison section, FAQ entry, JSON-LD metadata blocks, sitemap entries, and eleven stale README translations were dropped or refreshed. (#1769)
-- Punctuation across markdown / yaml / html / typescript / python is now ASCII hyphen only. AGENTS.md mirror set regenerated. (#1771 / #1776 / #1777)
+- Reorganized the docs tree: internal working notes were consolidated under `docs/_internal/`. The two genuinely public pages (adapter-selection comparison, orchestration-approaches architecture note) moved into existing public nav sections. (#1768)
+- Front-page content, page metadata, and eleven stale README translations were dropped or refreshed. (#1769)
+- Repository-wide formatting pass across markdown, yaml, html, typescript, and python sources. AGENTS.md mirror set regenerated. (#1771 / #1776 / #1777)
 - Docs-drift playbook inventory matches the new on-disk layout. (#1770)
 
 ## Operator follow-ups


### PR DESCRIPTION
## Summary
- Generalize the three docs-hygiene bullets in `docs/release-notes/v2.6.0.md` so they describe the docs-tree reorg, front-page refresh, and repository formatting pass at the level of what changed, rather than enumerating individual internal file names.

## Test plan
- [x] No forbidden-term hits in the file
- [x] No em/en-dash glyphs in the file
- [x] Diff is wording-only (3 bullet lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v2.6.0 release notes and applied repository-wide formatting standardization to documentation files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->