### PR TITLE
fix(ci): discover unit tests recursively so subdir suites gate on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1303,7 +1303,7 @@ jobs:
 
           os.environ['COVERAGE_FILE'] = '.coverage'
           test_dir = Path('tests/unit')
-          files = sorted(test_dir.glob('test_*.py'))
+          files = sorted(test_dir.rglob('test_*.py'))
           failed = 0
           junit_parts = []
           for i, f in enumerate(files):

--- a/docs/operations/sonar-tracker.md
+++ b/docs/operations/sonar-tracker.md
@@ -91,10 +91,10 @@ Through the workflow (uses the repo `SONAR_TOKEN` secret):
 gh workflow run sonar-tracker.yml --repo sipyourdrink-ltd/bernstein
 ```
 
-Locally, render only (no GitHub write), against the live server:
+Locally, render only (no GitHub write), against your Sonar server:
 
 ```bash
-SONAR_HOST_URL=https://sonar.bernstein.run \
+SONAR_HOST_URL=https://sonar.example.com \
 SONAR_TOKEN=<your-browse-token> \
 uv run python scripts/render_sonar_tracker.py --dry-run --output-body /tmp/body.md
 ```
@@ -154,7 +154,7 @@ sonar-tracker: updated issue #1234
 Reproduce a fetch failure locally without writing to GitHub:
 
 ```bash
-SONAR_HOST_URL=https://sonar.bernstein.run \
+SONAR_HOST_URL=https://sonar.example.com \
 SONAR_TOKEN=<your-browse-token> \
 uv run python scripts/render_sonar_tracker.py --dry-run --output-body /tmp/body.md
 ```

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -32,8 +32,8 @@ def _default_workers() -> int:
 
 
 def discover_test_files(test_dir: Path, keyword: str | None = None) -> list[Path]:
-    """Find all test_*.py files, optionally filtered by keyword."""
-    files = sorted(test_dir.glob("test_*.py"))
+    """Find all test_*.py files recursively, optionally filtered by keyword."""
+    files = sorted(test_dir.rglob("test_*.py"))
     if keyword:
         files = [f for f in files if keyword in f.stem]
     return files

--- a/tests/unit/identity/test_decode_cli.py
+++ b/tests/unit/identity/test_decode_cli.py
@@ -68,7 +68,7 @@ class TestShowCmd:
         ir._reset_cache_for_tests()
 
         result = runner.invoke(identity_group, ["show"])
-        expected = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, 1)
+        expected = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, ir._version_byte())
         assert result.exit_code == 0
         assert result.stdout.strip() == expected
 
@@ -85,7 +85,7 @@ class TestDecodeCmd:
         runner: CliRunner,
     ) -> None:
         monkeypatch.setenv(ENV_SEED, TEST_SEED_HEX)
-        token = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, 1)
+        token = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, ir._version_byte())
 
         result = runner.invoke(identity_group, ["decode", token])
         assert result.exit_code == 0
@@ -123,7 +123,7 @@ class TestVerifyCmd:
         runner: CliRunner,
     ) -> None:
         monkeypatch.setenv(ENV_SEED, TEST_SEED_HEX)
-        token = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, 1)
+        token = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, ir._version_byte())
 
         result = runner.invoke(
             identity_group,
@@ -133,7 +133,7 @@ class TestVerifyCmd:
                 "--nonce",
                 TEST_NONCE.hex(),
                 "--version-major",
-                "1",
+                str(ir._version_byte()),
             ],
         )
         assert result.exit_code == 0
@@ -145,7 +145,7 @@ class TestVerifyCmd:
         runner: CliRunner,
     ) -> None:
         monkeypatch.setenv(ENV_SEED, TEST_SEED_HEX)
-        token = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, 1)
+        token = _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, ir._version_byte())
         wrong_nonce = bytes(NONCE_BYTES)  # all zeros, deterministically wrong
 
         result = runner.invoke(

--- a/tests/unit/identity/test_prompt_emit.py
+++ b/tests/unit/identity/test_prompt_emit.py
@@ -65,7 +65,7 @@ def _enable_emission(monkeypatch: pytest.MonkeyPatch, nonce_path: Path) -> str:
     nonce_path.parent.mkdir(parents=True, exist_ok=True)
     nonce_path.write_bytes(TEST_NONCE)
     ir._reset_cache_for_tests()
-    return _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, 1)
+    return _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, ir._version_byte())
 
 
 # ---------------------------------------------------------------------------
@@ -200,4 +200,4 @@ class TestPromptEmitLive:
         between = last.split("bernstein-rev:", 1)[1]
         emitted = between.removesuffix("-->").strip()
         assert emitted == expected
-        assert ir.verify_with_nonce(emitted, TEST_NONCE, version_major=1) is True
+        assert ir.verify_with_nonce(emitted, TEST_NONCE, version_major=ir._version_byte()) is True

--- a/tests/unit/identity/test_trace_emit.py
+++ b/tests/unit/identity/test_trace_emit.py
@@ -73,7 +73,7 @@ def _enable_emission(monkeypatch: pytest.MonkeyPatch, nonce_path: Path) -> str:
     nonce_path.parent.mkdir(parents=True, exist_ok=True)
     nonce_path.write_bytes(TEST_NONCE)
     ir._reset_cache_for_tests()
-    return _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, 1)
+    return _compute_token(bytes.fromhex(TEST_SEED_HEX), TEST_NONCE, ir._version_byte())
 
 
 # ---------------------------------------------------------------------------
@@ -204,4 +204,4 @@ class TestTraceEmitLive:
         emitted = json.loads(line)["_rev"]
 
         assert emitted == expected
-        assert ir.verify_with_nonce(emitted, TEST_NONCE, version_major=1) is True
+        assert ir.verify_with_nonce(emitted, TEST_NONCE, version_major=ir._version_byte()) is True

--- a/tests/unit/identity/test_yaml_emit.py
+++ b/tests/unit/identity/test_yaml_emit.py
@@ -75,7 +75,7 @@ def _enable_emission(
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(nonce)
     ir._reset_cache_for_tests()
-    return _compute_token(bytes.fromhex(TEST_SEED_HEX), nonce or TEST_NONCE, 1)
+    return _compute_token(bytes.fromhex(TEST_SEED_HEX), nonce or TEST_NONCE, ir._version_byte())
 
 
 # ---------------------------------------------------------------------------
@@ -165,7 +165,7 @@ class TestGenerateYamlEmit:
             pytest.fail("yaml output is missing the bernstein-rev comment")
 
         assert emitted == expected
-        assert ir.verify_with_nonce(emitted, TEST_NONCE, version_major=1) is True
+        assert ir.verify_with_nonce(emitted, TEST_NONCE, version_major=ir._version_byte()) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `scripts/run_tests.py` and the `ci.yml` coverage step enumerated unit tests with a non-recursive `glob("test_*.py")`, so **251 test files** under `tests/unit/<subdir>/` (identity, security, lineage, adapters, mcp, telemetry, sweep, ...) never ran in the gating Test job on push to main. Only the ~1160 top-level files gated. Both switched to `rglob`.
- Repaired the suites this surfaced (rotted while invisible):
  - `tests/unit/identity/*`: install-rev token derivation incorporates the package major version via `_version_byte()`; tests hardcoded `major=1` and broke at the 2.0 bump. Now track `_version_byte()`.
  - `docs/operations/sonar-tracker.md`: use an `example.com` placeholder host to satisfy the `no-hardcoded-infra` guard.

## Test plan
- [x] `pytest tests/unit/identity tests/unit/observability/test_no_hardcoded_infra.py` (70 passed)
- [x] discovery now finds 1411 files (was ~1160)
- [x] full isolated re-audit of all 251 subdir files (running)