### PR TITLE
fix(tests): sync EXPECTED_CHILD_SECRETS with GLITCHTIP_DSN forwards

### DIFF
--- a/tests/unit/test_post_ci_dispatcher_yaml.py
+++ b/tests/unit/test_post_ci_dispatcher_yaml.py
@@ -39,8 +39,8 @@ CHILDREN = (
 EXPECTED_CHILD_SECRETS: dict[str, frozenset[str]] = {
     "telegram-notify": frozenset({"TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"}),
     "auto-release": frozenset({"TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"}),
-    "auto-heal": frozenset({"TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"}),
-    "bernstein-ci-fix": frozenset({"GEMINI_API_KEY"}),
+    "auto-heal": frozenset({"TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "GLITCHTIP_DSN"}),
+    "bernstein-ci-fix": frozenset({"GEMINI_API_KEY", "GLITCHTIP_DSN"}),
     "bisect-on-red": frozenset(),
 }
 


### PR DESCRIPTION
## Summary
- post-ci-dispatcher.yml forwards GLITCHTIP_DSN to the auto-heal and bernstein-ci-fix children (added during the GlitchTip wiring landed in v2.6.0) so each child can emit telemetry on its own failure.
- The matching EXPECTED_CHILD_SECRETS fixture in tests/unit/test_post_ci_dispatcher_yaml.py was not updated when those forwards landed, so test_dispatcher_calls_each_child[auto-heal] tripped on the macOS test matrix cell after recursive test discovery widened the gated set.
- Update the two stale frozensets to match the workflow.

## Test plan
- [x] pytest tests/unit/test_post_ci_dispatcher_yaml.py (16 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CI/CD workflow test assertions to reflect expanded secret forwarding: two workflows now include an additional secret for error tracking in their expected configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->