### PR TITLE
feat(supervisor): operator supervisor surface with signed escalation receipts

### DIFF
--- a/docs/api/supervisor.md
+++ b/docs/api/supervisor.md
@@ -1,0 +1,156 @@
+# Supervisor surface
+
+This document describes the JSON shapes the `bernstein supervisor`
+command emits. Two surfaces are documented:
+
+1. **Aggregated supervisor snapshot** - the body returned by
+   `bernstein supervisor status --json` and embedded as the
+   `supervisor` field in `bernstein status --json`.
+2. **Signed escalation receipt** - the envelope persisted under
+   `.sdd/runtime/supervisor/receipts/` whenever the supervisor or the
+   operator escalates a stalled worker.
+
+Both shapes are versioned via an explicit `schema_version` field.
+
+## Supervisor snapshot
+
+```jsonc
+{
+  "schema_version": "1.0.0",
+  "generated_ts": 1700000000.0,
+  "stuck_count": 2,
+  "oldest_stall_age_s": 95.0,
+  "workers": [
+    {
+      "worker_id": "abc123def456",
+      "session_id": "sess-abc123",
+      "role": "backend",
+      "task_id": "t-12",
+      "worktree_id": "wt-007",
+      "last_heartbeat_age_s": 42.0,
+      "is_stuck": false,
+      "stall_reason": "unknown",
+      "recommended_action": "inspect",
+      "respawn_budget_remaining": 3,
+      "stuck_since_ts": null,
+      "details": {"status": "working"}
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Aggregator schema version. Currently `1.0.0`. |
+| `generated_ts` | float | Unix timestamp the snapshot was captured. |
+| `stuck_count` | integer | Number of workers with `is_stuck=true`. |
+| `oldest_stall_age_s` | float \| null | Age, in seconds, of the oldest currently-stuck worker; `null` when no worker is stuck or no stall timestamp is available. |
+| `workers[].worker_id` | string | Operator-decodable worker handle. |
+| `workers[].session_id` | string | Adapter session id. |
+| `workers[].role` | string | Worker role (`manager`, `backend`, `qa`, ...). |
+| `workers[].task_id` | string | Current task id, or empty string. |
+| `workers[].worktree_id` | string | Worktree the worker is running in. |
+| `workers[].last_heartbeat_age_s` | float \| null | Seconds since the last heartbeat; `null` when none recorded. |
+| `workers[].is_stuck` | bool | True iff at least one detector classifies the row as stuck. |
+| `workers[].stall_reason` | string | One of `manager_no_children`, `watchdog_model_question`, `respawn_budget_exhausted`, `heartbeat_stale`, `no_progress`, or `unknown`. |
+| `workers[].recommended_action` | string | One of `respawn`, `escalate`, `park`, `inspect`. Deterministic over the chain slice (see below). |
+| `workers[].respawn_budget_remaining` | integer | Respawns remaining under the session's budget. |
+| `workers[].stuck_since_ts` | float \| null | Unix timestamp the stall first fired; `null` when not known. |
+| `workers[].details` | object | Free-form detector context. The aggregator currently includes `status` (raw agent status). |
+
+## Escalation receipt envelope
+
+```jsonc
+{
+  "schema_version": "1.0.0",
+  "worker_id": "abc123def456",
+  "worktree_id": "wt-007",
+  "session_id": "sess-abc123",
+  "stall_reason": "manager_no_children",
+  "recommended_action": "escalate",
+  "audit_entries": [
+    {
+      "event_type": "stalled_manager",
+      "session_id": "sess-abc123",
+      "details": {"runtime_s": 120.0, "hook_event_count": 12}
+    }
+  ],
+  "identity": {
+    "install_rev": "abc123def4567890",
+    "keyid": "...64 hex chars...",
+    "run_id": "run-2026-05-21-001"
+  },
+  "prev_chain_digest": "...64 hex chars...",
+  "payload_digest": "...64 hex chars...",
+  "signature_b64": "...base64 Ed25519 signature...",
+  "details": {
+    "operator_reason": "wedged on credential rotation",
+    "respawn_budget_remaining": 0
+  }
+}
+```
+
+### Receipt fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Receipt schema version. Currently `1.0.0`. |
+| `worker_id` | string | Stable worker identifier. |
+| `worktree_id` | string | Worktree the worker was running in. |
+| `session_id` | string | Adapter session id. |
+| `stall_reason` | string | Structured stall reason - same vocabulary as the aggregator. |
+| `recommended_action` | string | Deterministic action - same vocabulary as the aggregator. |
+| `audit_entries` | array of object | Captured chain slice (default 16 trailing entries) leading up to the stall. |
+| `identity.install_rev` | string | Operator-decodable install fingerprint. |
+| `identity.keyid` | string | sha256 of the Ed25519 public key (hex). |
+| `identity.run_id` | string | Orchestrator run id, when known. |
+| `prev_chain_digest` | string | HMAC of the previous audit-chain entry. Links the receipt into the tamper-evident audit log. |
+| `payload_digest` | string | sha256 of the canonical signing payload. Lets verifiers detect a swapped signature blob. |
+| `signature_b64` | string | base64-encoded Ed25519 signature over the canonical payload. |
+| `details` | object | Free-form context. The CLI populates `operator_reason` and `respawn_budget_remaining`. |
+
+### Determinism contract
+
+`recommended_action` is a **pure function** of the receipt's
+`(stall_reason, audit_entries, respawn_budget_remaining)`. The function
+
+* never reads files or environment,
+* never opens a socket,
+* never reads a wall clock.
+
+Two operators handed the same receipt bytes (or independently
+reassembled receipts from the same chain prefix) compute the
+byte-identical `recommended_action`. The contract is enforced by the
+unit test
+`tests/unit/test_supervisor_receipt.py::test_recommended_action_determinism`,
+which drives the same chain slice through the function from two
+different temp dirs and asserts equality.
+
+### Cross-worktree fence
+
+Every receipt asserts that the stuck session never crossed worktree
+boundaries during the stall window. An audit entry whose
+`event_type` ends in `.resolved` or starts with `cross_worktree.` and
+references the stuck `session_id` from a sibling `worktree_id` is a
+fence violation and aborts receipt assembly. Verifiers re-run the same
+check from the receipt bytes alone, so a tampered audit slice that
+smuggled a leak past assembly fails verification.
+
+### Verification
+
+The standalone verifier loads only the public side of the install
+Ed25519 keypair (`<workdir>/.sdd/runtime/supervisor/install.key.pub`,
+PEM-encoded). It
+
+1. recomputes `payload_digest` over the canonical signing bytes and
+   asserts byte-equality with the receipt's `payload_digest`,
+2. re-asserts the cross-worktree fence,
+3. re-derives `recommended_action` from the embedded slice and
+   asserts equality with the receipt's `recommended_action`,
+4. verifies the Ed25519 signature over the canonical bytes.
+
+A receipt that survives all four checks is byte-portable: any auditor
+holding the install's public key validates it offline without
+contacting the orchestrator.

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -137,6 +137,33 @@ def _fallback_table_render(aggregator: FleetAggregator, config: FleetConfig) -> 
     _console.print(table)
     _console.print(format_footer(config, rows, total))
 
+    supervisor_line = _fleet_supervisor_summary_line()
+    if supervisor_line:
+        _console.print(f"[dim]{supervisor_line}[/dim]")
+
+
+def _fleet_supervisor_summary_line() -> str:
+    """Return the stuck-count summary across the fleet's primary workspace.
+
+    The fleet view aggregates many projects but a single operator sits
+    inside one workspace, so we surface the supervisor snapshot for that
+    workspace as the most actionable signal. Returns an empty string on
+    any aggregator failure so the fleet command never errors here.
+    """
+    try:
+        from pathlib import Path as _Path
+
+        from bernstein.core.defaults import AGENT
+        from bernstein.core.orchestration.supervisor_aggregator import (
+            aggregator_snapshot,
+            format_summary_line,
+        )
+
+        snapshot = aggregator_snapshot(_Path.cwd(), heartbeat_stale_s=AGENT.heartbeat_stale_s)
+    except Exception:  # pragma: no cover - fleet renderer must never raise
+        return ""
+    return format_summary_line(snapshot)
+
 
 def _parse_bind(bind: str) -> tuple[str, int]:
     text = bind.strip()

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -149,6 +149,8 @@ def _fleet_supervisor_summary_line() -> str:
     inside one workspace, so we surface the supervisor snapshot for that
     workspace as the most actionable signal. Returns an empty string on
     any aggregator failure so the fleet command never errors here.
+    Failures are logged so an operator-visible drop can be debugged from
+    the orchestrator log without restarting the fleet view.
     """
     try:
         from pathlib import Path as _Path
@@ -161,6 +163,7 @@ def _fleet_supervisor_summary_line() -> str:
 
         snapshot = aggregator_snapshot(_Path.cwd(), heartbeat_stale_s=AGENT.heartbeat_stale_s)
     except Exception:  # pragma: no cover - fleet renderer must never raise
+        logger.exception("fleet supervisor-summary aggregation failed")
         return ""
     return format_summary_line(snapshot)
 

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -184,6 +184,11 @@ def status(as_json: bool, no_color: bool, view_mode: str | None) -> None:
     if snapshots:
         data["rate_limit_meters"] = snapshots
 
+    # Attach the supervisor summary (stuck-count + oldest-stall age).
+    # Operators reading ``bernstein status`` should not have to remember
+    # the dedicated supervisor command to spot a wedged worker.
+    data["supervisor"] = _supervisor_status_summary(Path.cwd())
+
     if as_json or is_json():
         print_json(data)
         return
@@ -199,6 +204,44 @@ def status(as_json: bool, no_color: bool, view_mode: str | None) -> None:
     con = make_console(no_color=force_no_color)
 
     render_status(data, console=con, view_config=vc)
+
+    supervisor_line = _supervisor_summary_line(Path.cwd())
+    if supervisor_line:
+        con.print(f"[dim]{supervisor_line}[/dim]")
+
+
+def _supervisor_status_summary(workdir: Path) -> dict[str, Any]:
+    """Return the supervisor stuck-count summary for ``bernstein status --json``.
+
+    Returns an empty dict if the aggregator raises - the command must
+    never fail on a missing or malformed runtime tree.
+    """
+    try:
+        from bernstein.core.defaults import AGENT
+        from bernstein.core.orchestration.supervisor_aggregator import (
+            aggregator_snapshot,
+            snapshot_to_dict,
+        )
+
+        snapshot = aggregator_snapshot(workdir, heartbeat_stale_s=AGENT.heartbeat_stale_s)
+    except Exception:  # pragma: no cover - status must never error on this
+        return {}
+    return snapshot_to_dict(snapshot)
+
+
+def _supervisor_summary_line(workdir: Path) -> str:
+    """Return the one-line supervisor summary string for the human view."""
+    try:
+        from bernstein.core.defaults import AGENT
+        from bernstein.core.orchestration.supervisor_aggregator import (
+            aggregator_snapshot,
+            format_summary_line,
+        )
+
+        snapshot = aggregator_snapshot(workdir, heartbeat_stale_s=AGENT.heartbeat_stale_s)
+    except Exception:  # pragma: no cover - status must never error on this
+        return ""
+    return format_summary_line(snapshot)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 import time
@@ -23,6 +24,8 @@ from bernstein.cli.status import collect_rate_limit_snapshots, render_status
 from bernstein.cli.ui import make_console
 from bernstein.core.agent_discovery import AgentCapabilities, DiscoveryResult, discover_agents_cached
 from bernstein.tui.worker_badges import format_worker_badge, get_badge_for_worker
+
+logger = logging.getLogger(__name__)
 
 _NOT_AUTHENTICATED_MSG = "not authenticated"
 
@@ -214,7 +217,9 @@ def _supervisor_status_summary(workdir: Path) -> dict[str, Any]:
     """Return the supervisor stuck-count summary for ``bernstein status --json``.
 
     Returns an empty dict if the aggregator raises - the command must
-    never fail on a missing or malformed runtime tree.
+    never fail on a missing or malformed runtime tree. Failures are
+    logged so an operator can correlate an empty summary with a real
+    cause instead of treating silence as healthy.
     """
     try:
         from bernstein.core.defaults import AGENT
@@ -225,6 +230,7 @@ def _supervisor_status_summary(workdir: Path) -> dict[str, Any]:
 
         snapshot = aggregator_snapshot(workdir, heartbeat_stale_s=AGENT.heartbeat_stale_s)
     except Exception:  # pragma: no cover - status must never error on this
+        logger.exception("supervisor status summary failed")
         return {}
     return snapshot_to_dict(snapshot)
 
@@ -240,6 +246,7 @@ def _supervisor_summary_line(workdir: Path) -> str:
 
         snapshot = aggregator_snapshot(workdir, heartbeat_stale_s=AGENT.heartbeat_stale_s)
     except Exception:  # pragma: no cover - status must never error on this
+        logger.exception("supervisor summary line render failed")
         return ""
     return format_summary_line(snapshot)
 

--- a/src/bernstein/cli/commands/supervisor_cmd.py
+++ b/src/bernstein/cli/commands/supervisor_cmd.py
@@ -179,6 +179,9 @@ def supervisor_escalate(
     ``worker.escalated`` lifecycle event so external notifiers route the
     alert.
     """
+    reason = reason.strip()
+    if not reason:
+        raise click.ClickException("--reason must be a non-empty string")
     root = workdir or Path.cwd()
     snapshot = aggregator_snapshot(root, heartbeat_stale_s=AGENT.heartbeat_stale_s)
     row = next((w for w in snapshot.workers if w.session_id == session_id), None)
@@ -334,14 +337,21 @@ def _load_or_create_install_key(path: Path) -> Any:
 
 
 def _load_install_rev(_root: Path) -> str:
-    """Return the install fingerprint (best-effort)."""
+    """Return the install fingerprint (best-effort).
+
+    Empty string when the identity module is unavailable or raises;
+    failures are logged so a missing fingerprint never silently turns
+    into a tampering false negative during a postmortem.
+    """
     try:
         from bernstein.core.identity.install_rev import get_install_rev
     except ImportError:
+        logger.warning("install_rev module unavailable - receipt identity tokens will be empty")
         return ""
     try:
         return get_install_rev()
     except Exception:  # pragma: no cover - defensive
+        logger.exception("install_rev lookup failed during escalation; using empty fingerprint")
         return ""
 
 
@@ -360,29 +370,41 @@ def _read_chain_anchor(root: Path) -> str:
     """Return the most recent audit-chain HMAC, or the genesis sentinel.
 
     Reads :class:`AuditLog` to recover the chain tail without writing.
-    Returns ``"0" * 64`` (the genesis sentinel) when no audit log exists.
+    Returns ``"0" * 64`` (the genesis sentinel) only when no audit log
+    directory exists. A directory that exists but is unreadable is a
+    structural failure - we refuse to silently reset the chain anchor
+    because doing so would let a fresh receipt skip the previous chain
+    head and break the tamper-evidence guarantee.
     """
     audit_dir = root / SUPERVISOR_AUDIT_DIR
     if not audit_dir.exists():
         return "0" * 64
     try:
         log = AuditLog(audit_dir=audit_dir)
-    except Exception:  # pragma: no cover - audit setup failures
-        return "0" * 64
+    except Exception as exc:  # pragma: no cover - audit setup failures
+        logger.error("Failed to load audit log at %s", audit_dir, exc_info=True)
+        raise click.ClickException(
+            f"cannot read audit chain anchor from {audit_dir}: {exc}",
+        ) from exc
     # ``AuditLog._prev_hmac`` is the recovered chain tail.
     return getattr(log, "_prev_hmac", "0" * 64)
 
 
 def _persist_receipt(root: Path, receipt: EscalationReceipt) -> Path:
-    """Write the receipt to ``.sdd/runtime/supervisor/receipts/<digest>.json``."""
+    """Write the receipt to ``.sdd/runtime/supervisor/receipts/<digest>.json``.
+
+    Filenames use nanosecond timestamps to avoid collisions when the
+    operator escalates the same session twice in the same second. The
+    open is exclusive (``"x"``) so a colliding filename surfaces as an
+    explicit ``FileExistsError`` rather than silently overwriting a
+    prior receipt.
+    """
     dest_dir = root / SUPERVISOR_RECEIPT_DIR
     dest_dir.mkdir(parents=True, exist_ok=True)
-    fname = f"{int(time.time())}-{receipt.session_id}-{receipt.payload_digest[:12]}.json"
+    fname = f"{time.time_ns()}-{receipt.session_id}-{receipt.payload_digest[:12]}.json"
     path = dest_dir / fname
-    path.write_text(
-        json.dumps(receipt_to_dict(receipt), sort_keys=True, indent=2),
-        encoding="utf-8",
-    )
+    with path.open("x", encoding="utf-8") as fh:
+        fh.write(json.dumps(receipt_to_dict(receipt), sort_keys=True, indent=2))
     return path
 
 

--- a/src/bernstein/cli/commands/supervisor_cmd.py
+++ b/src/bernstein/cli/commands/supervisor_cmd.py
@@ -1,0 +1,451 @@
+"""CLI command group: ``bernstein supervisor`` - operator stall surface.
+
+Two subcommands wire together the supervisor primitives:
+
+* ``bernstein supervisor status [--json]`` - aggregates the stalled
+  manager, watchdog, heartbeat, and respawn-budget data sources into a
+  single table (or JSON document) keyed by worker.
+* ``bernstein supervisor escalate <session_id> --reason "..."`` -
+  records an escalation event in the audit chain, persists a signed
+  escalation receipt, and fires the ``worker.escalated`` lifecycle
+  event so external notifiers can route the alert.
+
+The command never rewrites detection logic; every classification comes
+from the existing source modules. See
+:mod:`bernstein.core.orchestration.supervisor_aggregator` and
+:mod:`bernstein.core.orchestration.supervisor_receipt` for the
+underlying primitives.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from bernstein.core.defaults import AGENT
+from bernstein.core.lifecycle.hooks import LifecycleContext, LifecycleEvent
+from bernstein.core.orchestration.supervisor_aggregator import (
+    SupervisorSnapshot,
+    aggregator_snapshot,
+    snapshot_to_dict,
+)
+from bernstein.core.orchestration.supervisor_receipt import (
+    EscalationReceipt,
+    IdentityTokens,
+    StallReason,
+    assemble_receipt,
+    receipt_to_dict,
+    sign_receipt,
+)
+from bernstein.core.security.audit import AuditLog
+
+logger = logging.getLogger(__name__)
+
+
+SUPERVISOR_RECEIPT_DIR = ".sdd/runtime/supervisor/receipts"
+SUPERVISOR_AUDIT_DIR = ".sdd/audit"
+INSTALL_SIGNING_KEY_ENV = "BERNSTEIN_SUPERVISOR_SIGNING_KEY"
+DEFAULT_INSTALL_SIGNING_KEY = ".sdd/runtime/supervisor/install.key"
+
+
+# ---------------------------------------------------------------------------
+# Status command
+# ---------------------------------------------------------------------------
+
+
+@click.group("supervisor")
+def supervisor_group() -> None:
+    """Operator supervisor surface for stuck and parked workers.
+
+    \b
+    Examples:
+      bernstein supervisor status
+      bernstein supervisor status --json
+      bernstein supervisor escalate sess-123 --reason "wedged on auth"
+    """
+
+
+@supervisor_group.command("status")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a table.",
+)
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the workspace root (defaults to cwd).",
+)
+def supervisor_status(as_json: bool, workdir: Path | None) -> None:
+    """List every live worker with stall classification and recommended action."""
+    root = workdir or Path.cwd()
+    snapshot = aggregator_snapshot(
+        root,
+        heartbeat_stale_s=AGENT.heartbeat_stale_s,
+    )
+
+    if as_json:
+        click.echo(json.dumps(snapshot_to_dict(snapshot), sort_keys=True, indent=2))
+        return
+
+    console = Console()
+    _render_status_table(console, snapshot)
+
+
+def _render_status_table(console: Console, snapshot: SupervisorSnapshot) -> None:
+    """Render a Rich table view of the snapshot for interactive operators."""
+    if not snapshot.workers:
+        console.print("[dim]No live workers tracked under .sdd/runtime/.[/dim]")
+        return
+
+    table = Table(title="Bernstein supervisor", show_header=True, header_style="bold")
+    table.add_column("worker")
+    table.add_column("role")
+    table.add_column("task")
+    table.add_column("heartbeat", justify="right")
+    table.add_column("status")
+    table.add_column("stall")
+    table.add_column("recommend")
+    table.add_column("budget", justify="right")
+    for row in snapshot.workers:
+        hb = "-"
+        if row.last_heartbeat_age_s is not None:
+            hb = f"{int(row.last_heartbeat_age_s)}s"
+        stuck_label = "STUCK" if row.is_stuck else "ok"
+        table.add_row(
+            f"{row.worker_id}",
+            row.role or "-",
+            row.task_id or "-",
+            hb,
+            stuck_label,
+            row.stall_reason.value if row.is_stuck else "-",
+            row.recommended_action.value,
+            str(row.respawn_budget_remaining),
+        )
+    console.print(table)
+    summary = f"{snapshot.stuck_count} stuck" + (
+        f", oldest {int(snapshot.oldest_stall_age_s)}s" if snapshot.oldest_stall_age_s else ""
+    )
+    console.print(f"[dim]{summary}[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Escalate command
+# ---------------------------------------------------------------------------
+
+
+@supervisor_group.command("escalate")
+@click.argument("session_id", required=True)
+@click.option(
+    "--reason",
+    required=True,
+    help="Operator-supplied reason string recorded in the audit chain.",
+)
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the workspace root (defaults to cwd).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON for the persisted receipt.",
+)
+def supervisor_escalate(
+    session_id: str,
+    reason: str,
+    workdir: Path | None,
+    as_json: bool,
+) -> None:
+    """Record an explicit operator escalation in the audit chain.
+
+    Writes a signed escalation receipt under
+    ``.sdd/runtime/supervisor/receipts/`` and fires the
+    ``worker.escalated`` lifecycle event so external notifiers route the
+    alert.
+    """
+    root = workdir or Path.cwd()
+    snapshot = aggregator_snapshot(root, heartbeat_stale_s=AGENT.heartbeat_stale_s)
+    row = next((w for w in snapshot.workers if w.session_id == session_id), None)
+    if row is None:
+        raise click.ClickException(
+            f"session {session_id!r} not tracked in the supervisor snapshot",
+        )
+
+    # Load (or generate) the install Ed25519 signing key.
+    signing_key_path = _resolve_signing_key_path(root)
+    signing_key = _load_or_create_install_key(signing_key_path)
+
+    from bernstein.core.security.audit_dsse import keyid_from_public_key
+
+    keyid = keyid_from_public_key(signing_key.public_key())
+
+    identity = IdentityTokens(
+        install_rev=_load_install_rev(root),
+        keyid=keyid,
+        run_id=_load_run_id(root),
+    )
+
+    # Assemble the receipt from the aggregator row's failure slice.
+    from bernstein.core.orchestration.supervisor_aggregator import (
+        load_recent_failures,
+    )
+
+    failures = load_recent_failures(root, session_id)
+    audit_entries: list[dict[str, Any]] = [
+        {
+            "event_type": str(rec.get("kind", "")),
+            "session_id": session_id,
+            "details": rec,
+        }
+        for rec in failures
+    ]
+    # Append the operator escalation as the trailing entry so the receipt
+    # captures the operator's intent even when no prior diagnostic exists.
+    audit_entries.append(
+        {
+            "event_type": "supervisor.escalate",
+            "session_id": session_id,
+            "details": {"reason": reason},
+        }
+    )
+
+    prev_digest = _read_chain_anchor(root)
+    receipt = assemble_receipt(
+        worker_id=row.worker_id,
+        worktree_id=row.worktree_id,
+        session_id=session_id,
+        stall_reason=row.stall_reason if row.is_stuck else StallReason.UNKNOWN,
+        audit_entries=audit_entries,
+        identity=identity,
+        prev_chain_digest=prev_digest,
+        respawn_budget_remaining=row.respawn_budget_remaining,
+        details={
+            "operator_reason": reason,
+            "respawn_budget_remaining": row.respawn_budget_remaining,
+        },
+    )
+    signed = sign_receipt(receipt, signing_key=signing_key)
+    receipt_path = _persist_receipt(root, signed)
+
+    # Append an escalation entry to the audit log so any verifier can
+    # walk the existing HMAC chain back to this receipt.
+    _append_escalation_audit(
+        root,
+        session_id=session_id,
+        worker_id=row.worker_id,
+        receipt_path=receipt_path,
+        reason=reason,
+        receipt_digest=signed.payload_digest,
+    )
+
+    # Fire the lifecycle event so external notifiers (Slack/Discord/etc.)
+    # can route the escalation.
+    _fire_worker_escalated_event(
+        root,
+        session_id=session_id,
+        worker_id=row.worker_id,
+        receipt_path=receipt_path,
+        receipt=signed,
+        reason=reason,
+    )
+
+    payload = {
+        "session_id": session_id,
+        "worker_id": row.worker_id,
+        "receipt_path": str(receipt_path),
+        "receipt_digest": signed.payload_digest,
+        "recommended_action": signed.recommended_action.value,
+        "stall_reason": signed.stall_reason.value,
+    }
+    if as_json:
+        click.echo(json.dumps(payload, sort_keys=True, indent=2))
+        return
+    click.echo(
+        f"escalated {session_id} - receipt {receipt_path} (recommend {signed.recommended_action.value})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_signing_key_path(root: Path) -> Path:
+    """Resolve the install signing-key path.
+
+    Precedence:
+
+    1. ``$BERNSTEIN_SUPERVISOR_SIGNING_KEY`` (explicit override).
+    2. ``<workdir>/.sdd/runtime/supervisor/install.key``.
+    """
+    override = os.environ.get(INSTALL_SIGNING_KEY_ENV)
+    if override:
+        return Path(override).expanduser()
+    return root / DEFAULT_INSTALL_SIGNING_KEY
+
+
+def _load_or_create_install_key(path: Path) -> Any:
+    """Load or generate the install Ed25519 signing key at ``path``.
+
+    Reuses an existing 32-byte seed when the file is present; generates
+    a fresh keypair otherwise and persists the raw seed with mode 0600.
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    if path.exists():
+        try:
+            raw = path.read_bytes().strip()
+        except OSError as exc:
+            raise click.ClickException(f"cannot read signing key {path}: {exc}") from exc
+        if len(raw) != 32:
+            raise click.ClickException(
+                f"install signing key {path} is not 32 raw bytes; refusing to use it",
+            )
+        return Ed25519PrivateKey.from_private_bytes(raw)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with suppress(OSError):
+        path.parent.chmod(0o700)
+    priv = Ed25519PrivateKey.generate()
+    raw_bytes = priv.private_bytes_raw()
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.write(fd, raw_bytes)
+    finally:
+        os.close(fd)
+    path.chmod(0o600)
+    return priv
+
+
+def _load_install_rev(_root: Path) -> str:
+    """Return the install fingerprint (best-effort)."""
+    try:
+        from bernstein.core.identity.install_rev import get_install_rev
+    except ImportError:
+        return ""
+    try:
+        return get_install_rev()
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _load_run_id(root: Path) -> str:
+    """Return the current run id, if recorded under ``.sdd/runtime/``."""
+    run_id_path = root / ".sdd" / "runtime" / "run_id"
+    if not run_id_path.exists():
+        return ""
+    try:
+        return run_id_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _read_chain_anchor(root: Path) -> str:
+    """Return the most recent audit-chain HMAC, or the genesis sentinel.
+
+    Reads :class:`AuditLog` to recover the chain tail without writing.
+    Returns ``"0" * 64`` (the genesis sentinel) when no audit log exists.
+    """
+    audit_dir = root / SUPERVISOR_AUDIT_DIR
+    if not audit_dir.exists():
+        return "0" * 64
+    try:
+        log = AuditLog(audit_dir=audit_dir)
+    except Exception:  # pragma: no cover - audit setup failures
+        return "0" * 64
+    # ``AuditLog._prev_hmac`` is the recovered chain tail.
+    return getattr(log, "_prev_hmac", "0" * 64)
+
+
+def _persist_receipt(root: Path, receipt: EscalationReceipt) -> Path:
+    """Write the receipt to ``.sdd/runtime/supervisor/receipts/<digest>.json``."""
+    dest_dir = root / SUPERVISOR_RECEIPT_DIR
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    fname = f"{int(time.time())}-{receipt.session_id}-{receipt.payload_digest[:12]}.json"
+    path = dest_dir / fname
+    path.write_text(
+        json.dumps(receipt_to_dict(receipt), sort_keys=True, indent=2),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _append_escalation_audit(
+    root: Path,
+    *,
+    session_id: str,
+    worker_id: str,
+    receipt_path: Path,
+    reason: str,
+    receipt_digest: str,
+) -> None:
+    """Append a ``supervisor.escalated`` event to the audit log."""
+    audit_dir = root / SUPERVISOR_AUDIT_DIR
+    try:
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        log = AuditLog(audit_dir=audit_dir)
+        log.log(
+            event_type="supervisor.escalated",
+            actor="operator",
+            resource_type="session",
+            resource_id=session_id,
+            details={
+                "worker_id": worker_id,
+                "reason": reason,
+                "receipt_path": str(receipt_path),
+                "receipt_digest": receipt_digest,
+            },
+        )
+    except Exception:  # pragma: no cover - never block the CLI on audit IO
+        logger.debug("Failed to append supervisor.escalated audit entry", exc_info=True)
+
+
+def _fire_worker_escalated_event(
+    root: Path,
+    *,
+    session_id: str,
+    worker_id: str,
+    receipt_path: Path,
+    receipt: EscalationReceipt,
+    reason: str,
+) -> None:
+    """Fire the ``worker.escalated`` lifecycle event for external notifiers."""
+    try:
+        from bernstein.core.lifecycle import hooks as _hooks_mod
+    except ImportError:  # pragma: no cover - lifecycle always present
+        return
+    registry = getattr(_hooks_mod, "GLOBAL_REGISTRY", None)
+    if registry is None:
+        return
+    ctx = LifecycleContext(
+        event=LifecycleEvent.WORKER_ESCALATED,
+        session_id=session_id,
+        workdir=root,
+        data={
+            "worker_id": worker_id,
+            "reason": reason,
+            "receipt_path": str(receipt_path),
+            "recommended_action": receipt.recommended_action.value,
+            "stall_reason": receipt.stall_reason.value,
+        },
+    )
+    try:
+        registry.run(LifecycleEvent.WORKER_ESCALATED, ctx)
+    except Exception:  # pragma: no cover - notifier failures must not block
+        logger.debug("worker.escalated lifecycle emit failed", exc_info=True)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -1029,6 +1029,11 @@ cli.add_command(fingerprint_group, "fingerprint")
 cli.add_command(fleet_group, "fleet")
 cli.add_command(triggers_group, "triggers")
 
+# Operator supervisor surface (#1800)
+from bernstein.cli.commands.supervisor_cmd import supervisor_group  # noqa: E402
+
+cli.add_command(supervisor_group, "supervisor")
+
 # Citation/reference existence verifier (closes #1402)
 cli.add_command(citation_quality_group, "quality")
 

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -153,6 +153,19 @@ class LifecycleEvent(StrEnum):
     # ------------------------------------------------------------------
     AGENT_STARTUP_EXHAUSTED = "agent.startup_exhausted"
 
+    # ------------------------------------------------------------------
+    # Operator escalation (feat/operator-supervisor-surface).
+    # Emitted when ``bernstein supervisor escalate <session_id>`` runs.
+    # Payload keys on ``context.data``:
+    #
+    # * ``reason``: operator-supplied reason string.
+    # * ``receipt_path``: path of the persisted escalation receipt.
+    # * ``recommended_action``: receipt's recommended_action value.
+    # * ``stall_reason``: receipt's stall_reason value.
+    # * ``worker_id``: worker the operator escalated.
+    # ------------------------------------------------------------------
+    WORKER_ESCALATED = "worker.escalated"
+
 
 #: The cross-CLI standardised event vocabulary introduced by issue #1323.
 #: Pre-existing snake_case events remain supported but are not part of

--- a/src/bernstein/core/orchestration/supervisor_aggregator.py
+++ b/src/bernstein/core/orchestration/supervisor_aggregator.py
@@ -1,0 +1,459 @@
+"""Operator-facing aggregation of supervisor signals.
+
+The orchestrator already classifies stalls in three places:
+
+* :mod:`bernstein.core.orchestration.stalled_manager` for manager
+  sessions that never produced child tasks,
+* :mod:`bernstein.core.orchestration.watchdog` for paused sessions
+  awaiting a prompt,
+* :class:`bernstein.core.agents.spawn_supervisor.SpawnSupervisor` for
+  sessions that exhausted their respawn budget.
+
+Each detector writes its findings to a well-known location under
+``.sdd/runtime/``. This module reads those locations and surfaces a
+single ``WorkerSupervisionSnapshot`` row per live worker so the
+``bernstein supervisor status`` command, ``bernstein status`` /
+``bernstein fleet`` summary line, and the TUI pane all consume the same
+struct.
+
+Design constraints:
+
+* Pure read aggregator - never mutates orchestrator state.
+* No network IO; no wall-clock arithmetic that affects the recommended
+  action (the receipt module owns determinism).
+* Tolerates missing inputs - a stale ``.sdd/runtime/`` directory still
+  yields an empty :class:`SupervisorSnapshot` rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import operator
+import time
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.orchestration.supervisor_receipt import (
+    DEFAULT_RECEIPT_AUDIT_WINDOW,
+    RecommendedAction,
+    StallReason,
+    recommend_action,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "AGGREGATOR_SCHEMA_VERSION",
+    "SupervisorSnapshot",
+    "WorkerSupervisionSnapshot",
+    "aggregator_snapshot",
+    "format_summary_line",
+    "load_agents_snapshot",
+    "load_heartbeat",
+    "load_parked_sessions",
+    "load_recent_failures",
+    "snapshot_to_dict",
+]
+
+
+#: Schema version embedded in the aggregator's JSON output.
+AGGREGATOR_SCHEMA_VERSION: str = "1.0.0"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerSupervisionSnapshot:
+    """One live worker's supervisor-facing view."""
+
+    worker_id: str
+    session_id: str
+    role: str
+    task_id: str
+    worktree_id: str
+    last_heartbeat_age_s: float | None
+    is_stuck: bool
+    stall_reason: StallReason
+    recommended_action: RecommendedAction
+    respawn_budget_remaining: int
+    stuck_since_ts: float | None = None
+    details: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisorSnapshot:
+    """Aggregated view across every live worker."""
+
+    schema_version: str
+    generated_ts: float
+    workers: tuple[WorkerSupervisionSnapshot, ...]
+
+    @property
+    def stuck_count(self) -> int:
+        """Number of workers the aggregator classifies as stuck."""
+        return sum(1 for w in self.workers if w.is_stuck)
+
+    @property
+    def oldest_stall_age_s(self) -> float | None:
+        """Age of the oldest currently-stuck worker, in seconds.
+
+        ``None`` when no worker is stuck or when ``stuck_since_ts`` is
+        unavailable on every stuck row.
+        """
+        stuck = [w for w in self.workers if w.is_stuck and w.stuck_since_ts is not None]
+        if not stuck:
+            return None
+        oldest = min(w.stuck_since_ts for w in stuck if w.stuck_since_ts is not None)
+        return max(self.generated_ts - oldest, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem readers - each isolates one input so the aggregator can
+# survive a missing or malformed file.
+# ---------------------------------------------------------------------------
+
+
+def load_agents_snapshot(workdir: Path) -> list[dict[str, Any]]:
+    """Return the agent rows from ``.sdd/runtime/agents.json``.
+
+    Returns an empty list when the file is missing, unparseable, or has
+    no ``agents`` array. Never raises.
+    """
+    path = workdir / ".sdd" / "runtime" / "agents.json"
+    if not path.exists():
+        return []
+    try:
+        payload_any: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload_any, dict):
+        return []
+    payload = cast(dict[str, Any], payload_any)
+    raw = payload.get("agents")
+    if not isinstance(raw, list):
+        return []
+    raw_list = cast(list[Any], raw)
+    return [cast(dict[str, Any], item) for item in raw_list if isinstance(item, dict)]
+
+
+def load_heartbeat(workdir: Path, session_id: str) -> dict[str, Any] | None:
+    """Return the latest heartbeat record for ``session_id``.
+
+    Heartbeats are written by the wrapper script at
+    ``.sdd/runtime/heartbeats/<session_id>.json``. Returns ``None`` when
+    the file is missing or unreadable.
+    """
+    if not session_id:
+        return None
+    path = workdir / ".sdd" / "runtime" / "heartbeats" / f"{session_id}.json"
+    if not path.exists():
+        return None
+    try:
+        payload_any: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload_any, dict):
+        return None
+    return cast(dict[str, Any], payload_any)
+
+
+def load_parked_sessions(workdir: Path) -> set[str]:
+    """Return the ids of sessions the spawn supervisor parked.
+
+    Reads the marker file at
+    ``.sdd/runtime/spawn_supervisor/parked.json`` written by the
+    in-process supervisor. Falls back to the lifecycle-event log when
+    the marker file is absent.
+    """
+    parked: set[str] = set()
+    marker = workdir / ".sdd" / "runtime" / "spawn_supervisor" / "parked.json"
+    if marker.exists():
+        try:
+            payload_any: Any = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload_any = None
+        if isinstance(payload_any, dict):
+            payload = cast(dict[str, Any], payload_any)
+            ids = payload.get("session_ids")
+            if isinstance(ids, list):
+                ids_list = cast(list[Any], ids)
+                parked.update(str(i) for i in ids_list if isinstance(i, str))
+    # Lifecycle events fallback: scan the failures/ records.
+    failures_dir = workdir / ".sdd" / "runtime" / "failures"
+    if failures_dir.exists():
+        with suppress(OSError):
+            for entry in sorted(failures_dir.glob("*.json")):
+                with suppress(OSError, json.JSONDecodeError):
+                    record_any: Any = json.loads(entry.read_text(encoding="utf-8"))
+                    if isinstance(record_any, dict):
+                        record = cast(dict[str, Any], record_any)
+                        if record.get("kind") == "respawn_exhausted":
+                            sid = record.get("session_id")
+                            if isinstance(sid, str):
+                                parked.add(sid)
+    return parked
+
+
+def load_recent_failures(
+    workdir: Path,
+    session_id: str,
+    *,
+    limit: int = DEFAULT_RECEIPT_AUDIT_WINDOW,
+) -> list[dict[str, Any]]:
+    """Return the trailing ``limit`` failure records for ``session_id``.
+
+    The failures dir is the canonical sink for stalled-manager and
+    spawn-supervisor diagnostics. The function reads at most ``limit``
+    records so callers can feed the result straight into the receipt
+    assembly path.
+    """
+    failures_dir = workdir / ".sdd" / "runtime" / "failures"
+    if not failures_dir.exists() or not session_id:
+        return []
+    records: list[dict[str, Any]] = []
+    try:
+        entries = sorted(failures_dir.glob("*.json"))
+    except OSError:
+        return []
+    for entry in entries:
+        try:
+            payload_any: Any = json.loads(entry.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload_any, dict):
+            continue
+        payload = cast(dict[str, Any], payload_any)
+        if payload.get("session_id") != session_id:
+            continue
+        records.append(payload)
+    return records[-limit:]
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+def _classify_stall(
+    *,
+    agent: dict[str, Any],
+    heartbeat: dict[str, Any] | None,
+    is_parked: bool,
+    heartbeat_stale_s: float,
+    now: float,
+) -> tuple[bool, StallReason, float | None, float | None]:
+    """Return ``(is_stuck, stall_reason, age, stuck_since_ts)``.
+
+    Pure heuristic over the supplied snapshot inputs. The function does
+    *not* read from disk or the clock beyond the ``now`` argument the
+    caller provides; the upstream detector still owns the authoritative
+    stall classification - the aggregator merely surfaces it.
+    """
+    if is_parked:
+        return True, StallReason.RESPAWN_EXHAUSTED, None, None
+
+    last_hb = heartbeat.get("timestamp") if isinstance(heartbeat, dict) else None
+    age: float | None = None
+    if isinstance(last_hb, (int, float)) and last_hb > 0:
+        age = max(now - float(last_hb), 0.0)
+
+    status = str(agent.get("status", ""))
+    if status == "parked":
+        return True, StallReason.RESPAWN_EXHAUSTED, age, _coerce_ts(agent.get("parked_ts"))
+
+    # Specific detector signals win over the generic heartbeat threshold:
+    # the upstream detectors classify the stall with more context than the
+    # liveness probe (e.g. a stalled manager has *also* gone heartbeat-
+    # stale, but the operator wants the structural reason on the wire).
+    role = str(agent.get("role", ""))
+    if role == "manager":
+        manager_diagnostic_any: Any = agent.get("stalled_manager")
+        if isinstance(manager_diagnostic_any, dict):
+            manager_diagnostic = cast(dict[str, Any], manager_diagnostic_any)
+            stuck_since = _coerce_ts(manager_diagnostic.get("detected_at"))
+            return True, StallReason.MANAGER_NO_CHILDREN, age, stuck_since
+
+    awaiting_prompt = agent.get("awaiting_model_question")
+    if awaiting_prompt:
+        return True, StallReason.WATCHDOG_MODEL_QUESTION, age, _coerce_ts(agent.get("paused_ts"))
+
+    if age is not None and age >= heartbeat_stale_s:
+        return True, StallReason.HEARTBEAT_STALE, age, float(last_hb) if last_hb else None
+
+    if status == "no_progress":
+        return True, StallReason.NO_PROGRESS, age, _coerce_ts(agent.get("no_progress_since"))
+
+    return False, StallReason.UNKNOWN, age, None
+
+
+def _coerce_ts(value: Any) -> float | None:
+    """Best-effort coercion of a JSON value into a unix timestamp."""
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def aggregator_snapshot(
+    workdir: Path,
+    *,
+    now: float | None = None,
+    heartbeat_stale_s: float = 120.0,
+    default_respawn_budget: int = 3,
+) -> SupervisorSnapshot:
+    """Return the cross-worker supervisor snapshot.
+
+    Args:
+        workdir: Workspace root (the directory containing ``.sdd/``).
+        now: Optional unix-timestamp override (tests). Defaults to
+            :func:`time.time`. The snapshot embeds this value in
+            :attr:`SupervisorSnapshot.generated_ts`.
+        heartbeat_stale_s: Threshold above which a heartbeat age makes
+            the worker count as stuck. Pulled from
+            :mod:`bernstein.core.defaults` by callers; supplied here so
+            tests can stub it without monkey-patching.
+        default_respawn_budget: Respawn budget assumed when an agent
+            row does not carry an explicit remaining counter.
+
+    Returns:
+        A :class:`SupervisorSnapshot` carrying one row per live worker.
+    """
+    resolved_now = now if now is not None else time.time()
+    agents = load_agents_snapshot(workdir)
+    parked = load_parked_sessions(workdir)
+
+    rows: list[WorkerSupervisionSnapshot] = []
+    for agent in agents:
+        session_id = str(agent.get("id", ""))
+        if not session_id:
+            continue
+        if str(agent.get("status", "")) == "dead":
+            continue
+        heartbeat = load_heartbeat(workdir, session_id)
+        is_parked = session_id in parked
+        is_stuck, stall_reason, age, stuck_since = _classify_stall(
+            agent=agent,
+            heartbeat=heartbeat,
+            is_parked=is_parked,
+            heartbeat_stale_s=heartbeat_stale_s,
+            now=resolved_now,
+        )
+
+        # Respawn budget: the agent row may carry an explicit override.
+        budget_raw = agent.get("respawn_budget_remaining")
+        if isinstance(budget_raw, int) and budget_raw >= 0:
+            budget = budget_raw
+        elif is_parked:
+            budget = 0
+        else:
+            budget = default_respawn_budget
+
+        # Audit slice for the deterministic recommended action: failures
+        # already classified for this session.
+        slice_entries: list[dict[str, Any]] = []
+        for record in load_recent_failures(workdir, session_id):
+            slice_entries.append(
+                {
+                    "event_type": str(record.get("kind", "")),
+                    "session_id": session_id,
+                    "details": record,
+                }
+            )
+
+        action = recommend_action(
+            stall_reason if is_stuck else StallReason.UNKNOWN,
+            slice_entries,
+            respawn_budget_remaining=budget,
+        )
+
+        rows.append(
+            WorkerSupervisionSnapshot(
+                worker_id=str(agent.get("worker_id", session_id[:12])),
+                session_id=session_id,
+                role=str(agent.get("role", "")),
+                task_id=_extract_task_id(agent),
+                worktree_id=str(agent.get("worktree_id", "")),
+                last_heartbeat_age_s=age,
+                is_stuck=is_stuck,
+                stall_reason=stall_reason,
+                recommended_action=action,
+                respawn_budget_remaining=budget,
+                stuck_since_ts=stuck_since,
+                details={"status": str(agent.get("status", ""))},
+            )
+        )
+
+    rows.sort(key=operator.attrgetter("session_id"))
+    return SupervisorSnapshot(
+        schema_version=AGGREGATOR_SCHEMA_VERSION,
+        generated_ts=resolved_now,
+        workers=tuple(rows),
+    )
+
+
+def _extract_task_id(agent: dict[str, Any]) -> str:
+    raw = agent.get("task_ids")
+    if isinstance(raw, list) and raw:
+        raw_list = cast(list[Any], raw)
+        first = raw_list[0]
+        if isinstance(first, str):
+            return first
+    direct = agent.get("task_id")
+    if isinstance(direct, str):
+        return direct
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def snapshot_to_dict(snapshot: SupervisorSnapshot) -> dict[str, Any]:
+    """Return the canonical JSON dict view of a snapshot.
+
+    The shape matches ``docs/api/supervisor.md``.
+    """
+    return {
+        "schema_version": snapshot.schema_version,
+        "generated_ts": snapshot.generated_ts,
+        "stuck_count": snapshot.stuck_count,
+        "oldest_stall_age_s": snapshot.oldest_stall_age_s,
+        "workers": [
+            {
+                "worker_id": w.worker_id,
+                "session_id": w.session_id,
+                "role": w.role,
+                "task_id": w.task_id,
+                "worktree_id": w.worktree_id,
+                "last_heartbeat_age_s": w.last_heartbeat_age_s,
+                "is_stuck": w.is_stuck,
+                "stall_reason": w.stall_reason.value,
+                "recommended_action": w.recommended_action.value,
+                "respawn_budget_remaining": w.respawn_budget_remaining,
+                "stuck_since_ts": w.stuck_since_ts,
+                "details": w.details,
+            }
+            for w in snapshot.workers
+        ],
+    }
+
+
+def format_summary_line(snapshot: SupervisorSnapshot) -> str:
+    """Return a one-line summary for ``bernstein status`` / ``fleet``.
+
+    Format::
+
+        supervisor: 2 stuck (oldest 95s)
+        supervisor: 0 stuck
+    """
+    stuck = snapshot.stuck_count
+    if stuck == 0:
+        return "supervisor: 0 stuck"
+    oldest = snapshot.oldest_stall_age_s
+    if oldest is None:
+        return f"supervisor: {stuck} stuck"
+    return f"supervisor: {stuck} stuck (oldest {int(oldest)}s)"

--- a/src/bernstein/core/orchestration/supervisor_receipt.py
+++ b/src/bernstein/core/orchestration/supervisor_receipt.py
@@ -1,0 +1,740 @@
+"""Signed escalation receipts for stalled-worker incidents.
+
+The existing detectors (:mod:`stalled_manager`, :mod:`watchdog`,
+:class:`spawn_supervisor.SpawnSupervisor`) already classify why a worker
+is stuck. This module turns that classification into a portable, signed
+artefact an operator can keep, replay, and hand to a third-party
+verifier - without rebuilding the orchestrator state.
+
+A receipt carries the chain slice that caused the supervisor to fire:
+
+* the worker session and worktree it ran in,
+* a fixed-size window of audit entries leading up to the stall,
+* the install identity tokens (key id, run id, install rev),
+* the structured stall reason,
+* a **deterministic** recommended action computed from the chain slice,
+* the hash of the previous chain entry (``prev_chain_digest``) so the
+  receipt links into the existing tamper-evident audit log.
+
+Determinism contract
+--------------------
+:func:`recommend_action` is a **pure** function of the chain slice at
+stall time. It
+
+* never reads files or environment,
+* never consults a wall clock,
+* never opens a socket,
+* depends only on the stall_reason + the supplied audit entries.
+
+Two operators who hand the same receipt bytes through
+:func:`recommend_action` get the byte-identical recommended action. The
+test ``test_supervisor_receipt::test_recommended_action_determinism``
+drives this from two different temp dirs and asserts the equality.
+
+Cross-worktree fence
+--------------------
+Every stall window must show zero cross-worktree resolution events for
+the stuck session. :func:`assert_cross_worktree_fence` walks the entries
+and refuses to emit a receipt if a session id is observed leaking into a
+sibling worktree's resolution event. The fence is the structural
+guarantee the receipt makes about isolation; downstream verifiers re-run
+the same check from the receipt bytes alone.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, cast
+
+from cryptography.exceptions import InvalidSignature
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DEFAULT_RECEIPT_AUDIT_WINDOW",
+    "EscalationReceipt",
+    "IdentityTokens",
+    "ReceiptVerification",
+    "RecommendedAction",
+    "StallReason",
+    "assemble_receipt",
+    "assert_cross_worktree_fence",
+    "canonical_receipt_bytes",
+    "receipt_from_dict",
+    "receipt_to_dict",
+    "recommend_action",
+    "sign_receipt",
+    "verify_receipt",
+]
+
+
+#: Schema version embedded in every receipt. Bumped only on breaking changes.
+RECEIPT_SCHEMA_VERSION: str = "1.0.0"
+
+
+#: Default number of trailing audit entries captured in the receipt. The
+#: window is fixed so two receipts assembled from the same chain prefix
+#: are byte-identical regardless of how much audit history exists.
+DEFAULT_RECEIPT_AUDIT_WINDOW: int = 16
+
+
+class StallReason(StrEnum):
+    """Structured stall reasons recognised by the supervisor.
+
+    Values map to the upstream detector that produced them so a
+    downstream consumer can reconstruct which detector fired.
+    """
+
+    #: ``stalled_manager.detect_stalled_manager`` fired - the manager
+    #: session ran past its threshold without creating child tasks.
+    MANAGER_NO_CHILDREN = "manager_no_children"
+
+    #: ``watchdog`` saw a paused session with a model-question prompt
+    #: and refused to auto-answer.
+    WATCHDOG_MODEL_QUESTION = "watchdog_model_question"
+
+    #: ``spawn_supervisor`` parked the session after exhausting its
+    #: respawn budget.
+    RESPAWN_EXHAUSTED = "respawn_budget_exhausted"
+
+    #: Heartbeat aged out past the stale threshold with no progress
+    #: tick. Surfaced by the heartbeat monitor.
+    HEARTBEAT_STALE = "heartbeat_stale"
+
+    #: No progress signal observed for the configured window. Used by
+    #: the progress-watch liveness probe.
+    NO_PROGRESS = "no_progress"
+
+    #: Fallback when an upstream detector produces a structured reason
+    #: the supervisor does not know about. Carries the original token
+    #: in ``details["raw_reason"]`` so a verifier can still inspect it.
+    UNKNOWN = "unknown"
+
+
+class RecommendedAction(StrEnum):
+    """Operator-facing actions the supervisor may recommend.
+
+    The set is intentionally small: every recommendation must map to a
+    concrete next step the operator can take in the CLI today. Adding a
+    new variant is a schema-breaking change (bump
+    :data:`RECEIPT_SCHEMA_VERSION`).
+    """
+
+    #: Re-spawn the session with a clean budget. Used when the detector
+    #: classified the stall as transient (e.g. a single spawn failure).
+    RESPAWN = "respawn"
+
+    #: Stop the session and surface the diagnostic to the operator -
+    #: the stall is structural and a respawn would loop.
+    ESCALATE = "escalate"
+
+    #: Park the session and wait for the operator to resume it. Used
+    #: when the respawn budget already exhausted.
+    PARK = "park"
+
+    #: Inspect the diagnostic before deciding. Default for unknown
+    #: stall reasons so the recommendation never silently downgrades to
+    #: a destructive action.
+    INSPECT = "inspect"
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityTokens:
+    """Identity material baked into every receipt.
+
+    Attributes:
+        install_rev: Operator-decodable install fingerprint (passive,
+            never personally identifying). Sourced from
+            :mod:`bernstein.core.identity.install_rev`.
+        keyid: Stable id of the signing key (sha256 of the public key
+            DER bytes). Lets a verifier match the signature without
+            re-deriving the key.
+        run_id: Identifier of the orchestrator run that detected the
+            stall. Empty string when the stall happens outside a run
+            (e.g. standalone supervisor tests).
+    """
+
+    install_rev: str = ""
+    keyid: str = ""
+    run_id: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the canonical dict view used in the receipt envelope."""
+        return {
+            "install_rev": self.install_rev,
+            "keyid": self.keyid,
+            "run_id": self.run_id,
+        }
+
+
+class ReceiptError(RuntimeError):
+    """Raised when receipt assembly, signing, or verification fails."""
+
+
+class CrossWorktreeFenceError(ReceiptError):
+    """Raised when the stall window leaks across worktrees.
+
+    A receipt MUST prove the stuck worker did not influence its
+    siblings; if any audit entry inside the captured window references
+    the stuck session id from a sibling worktree's resolution event, the
+    fence has failed and the receipt is refused.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class EscalationReceipt:
+    """Portable, signed envelope describing one stall incident.
+
+    The receipt is opinionated about field order: the signed payload is
+    canonical JSON with sorted keys, so two operators serialising the
+    same envelope produce byte-identical signing inputs. Adding a field
+    requires a schema-version bump.
+    """
+
+    schema_version: str
+    worker_id: str
+    worktree_id: str
+    session_id: str
+    stall_reason: StallReason
+    recommended_action: RecommendedAction
+    audit_entries: tuple[dict[str, Any], ...]
+    identity: IdentityTokens
+    prev_chain_digest: str
+    payload_digest: str
+    respawn_budget_remaining: int = 0
+    signature_b64: str = ""
+    details: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    @property
+    def is_signed(self) -> bool:
+        """True iff the envelope carries a non-empty signature blob."""
+        return bool(self.signature_b64)
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptVerification:
+    """Outcome of :func:`verify_receipt`."""
+
+    ok: bool
+    errors: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Cross-worktree fence
+# ---------------------------------------------------------------------------
+
+
+def _entry_session_id(entry: dict[str, Any]) -> str:
+    """Best-effort session id extraction from a heterogeneous audit entry."""
+    direct = entry.get("session_id")
+    if isinstance(direct, str) and direct:
+        return direct
+    details_raw = entry.get("details")
+    if isinstance(details_raw, dict):
+        details = cast(dict[str, Any], details_raw)
+        candidate = details.get("session_id")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return ""
+
+
+def _entry_worktree(entry: dict[str, Any]) -> str:
+    """Best-effort worktree id extraction."""
+    direct = entry.get("worktree_id")
+    if isinstance(direct, str) and direct:
+        return direct
+    details_raw = entry.get("details")
+    if isinstance(details_raw, dict):
+        details = cast(dict[str, Any], details_raw)
+        candidate = details.get("worktree_id")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return ""
+
+
+def assert_cross_worktree_fence(
+    session_id: str,
+    worktree_id: str,
+    audit_entries: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+) -> None:
+    """Refuse the receipt when the session crossed worktree boundaries.
+
+    A *cross-worktree resolution event* is an audit entry that
+
+    1. carries an ``event_type`` ending in ``.resolved`` or matching
+       ``cross_worktree.*``, AND
+    2. references the stuck ``session_id`` but a different worktree.
+
+    Args:
+        session_id: Session id of the stuck worker.
+        worktree_id: Worktree the stuck worker was running in.
+        audit_entries: Captured chain slice.
+
+    Raises:
+        CrossWorktreeFenceError: When the fence is violated. The error
+            message names the offending entry types so the operator can
+            grep them in the audit log.
+    """
+    if not session_id:
+        return
+    offenders: list[str] = []
+    for entry in audit_entries:
+        event_type = str(entry.get("event_type", ""))
+        if not (event_type.endswith(".resolved") or event_type.startswith("cross_worktree.")):
+            continue
+        entry_session = _entry_session_id(entry)
+        if entry_session != session_id:
+            continue
+        entry_worktree = _entry_worktree(entry)
+        if entry_worktree and entry_worktree != worktree_id:
+            offenders.append(f"{event_type} (worktree={entry_worktree})")
+    if offenders:
+        offender_list = ", ".join(sorted(set(offenders)))
+        msg = f"cross-worktree fence violated for session {session_id} in worktree {worktree_id}: {offender_list}"
+        raise CrossWorktreeFenceError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic recommended action
+# ---------------------------------------------------------------------------
+
+
+_FATAL_EVENT_PATTERNS: tuple[str, ...] = (
+    "auth",
+    "credential",
+    "permission",
+    "policy",
+    "denied",
+    "forbidden",
+)
+
+
+def _looks_fatal(event_type: str) -> bool:
+    et = event_type.lower()
+    return any(token in et for token in _FATAL_EVENT_PATTERNS)
+
+
+def _count_recent_failures(audit_entries: tuple[dict[str, Any], ...] | list[dict[str, Any]]) -> int:
+    """Return the number of ``*.failed`` / ``*.error`` entries in the slice."""
+    failures = 0
+    for entry in audit_entries:
+        event_type = str(entry.get("event_type", "")).lower()
+        if event_type.endswith(".failed") or event_type.endswith(".error") or event_type.endswith(".errored"):
+            failures += 1
+    return failures
+
+
+def recommend_action(
+    stall_reason: StallReason | str,
+    audit_entries: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    *,
+    respawn_budget_remaining: int = 0,
+) -> RecommendedAction:
+    """Compute the operator action recommended for a stall.
+
+    Pure function. Two callers feeding the same arguments observe the
+    byte-identical return value, regardless of host or wall clock.
+
+    Rules (deterministic, evaluated in this order):
+
+    1. :data:`StallReason.RESPAWN_EXHAUSTED` always yields ``PARK`` -
+       the session is already past the respawn budget; another spawn
+       would be wasted.
+    2. A fatal-looking event (auth, credential, permission, policy,
+       denied, forbidden) anywhere in the captured slice yields
+       ``ESCALATE`` - retrying would loop on the same root cause.
+    3. :data:`StallReason.WATCHDOG_MODEL_QUESTION` always yields
+       ``ESCALATE`` - the agent is asking the operator a question; an
+       auto-answer would silently mislead the model.
+    4. :data:`StallReason.MANAGER_NO_CHILDREN` always yields
+       ``ESCALATE`` - the manager never produced work, so a respawn
+       has no informational gain.
+    5. :data:`StallReason.HEARTBEAT_STALE` / :data:`StallReason.NO_PROGRESS`
+       yield ``RESPAWN`` only when there is budget remaining AND fewer
+       than two recent failures in the slice; otherwise ``ESCALATE``.
+    6. :data:`StallReason.UNKNOWN` yields ``INSPECT`` so an unrecognised
+       reason never silently downgrades into a destructive action.
+
+    Args:
+        stall_reason: Structured stall reason from the detector. Accepts
+            the enum value or a raw string (coerced via
+            :meth:`StallReason._missing_`).
+        audit_entries: Captured chain slice. The function only reads
+            ``event_type`` values; richer fields are inspected only via
+            the fatal-event heuristic.
+        respawn_budget_remaining: How many respawns the session still
+            has under its budget. The function never reads
+            ``spawn_supervisor`` state directly; the caller passes this
+            in from the upstream detector.
+
+    Returns:
+        The :class:`RecommendedAction` enum value the operator should
+        execute.
+    """
+    reason = _coerce_stall_reason(stall_reason)
+
+    if reason == StallReason.RESPAWN_EXHAUSTED:
+        return RecommendedAction.PARK
+
+    # Rule 2 - fatal pattern present anywhere in the slice.
+    for entry in audit_entries:
+        event_type = str(entry.get("event_type", ""))
+        if _looks_fatal(event_type):
+            return RecommendedAction.ESCALATE
+
+    if reason == StallReason.WATCHDOG_MODEL_QUESTION:
+        return RecommendedAction.ESCALATE
+
+    if reason == StallReason.MANAGER_NO_CHILDREN:
+        return RecommendedAction.ESCALATE
+
+    if reason in (StallReason.HEARTBEAT_STALE, StallReason.NO_PROGRESS):
+        failures = _count_recent_failures(audit_entries)
+        if respawn_budget_remaining > 0 and failures < 2:
+            return RecommendedAction.RESPAWN
+        return RecommendedAction.ESCALATE
+
+    return RecommendedAction.INSPECT
+
+
+def _coerce_stall_reason(value: StallReason | str) -> StallReason:
+    """Coerce a raw string into a :class:`StallReason` (unknown -> UNKNOWN)."""
+    if isinstance(value, StallReason):
+        return value
+    try:
+        return StallReason(value)
+    except ValueError:
+        return StallReason.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialisation
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    """Return deterministic JSON: sorted keys, compact separators, UTF-8."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _normalise_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of ``entry`` suitable for canonical embedding.
+
+    Drops keys that are non-deterministic in serialisation order (e.g.
+    raw stack traces) and forces the remaining values through
+    ``json.loads(json.dumps(...))`` so any non-JSON-native types raise
+    here rather than at signing time.
+    """
+    normalised: Any = json.loads(json.dumps(entry, sort_keys=True, default=str))
+    if not isinstance(normalised, dict):  # pragma: no cover - defensive
+        msg = "audit entry must serialise to a JSON object"
+        raise ReceiptError(msg)
+    return cast(dict[str, Any], normalised)
+
+
+def receipt_to_dict(receipt: EscalationReceipt) -> dict[str, Any]:
+    """Return the canonical dict view of a receipt."""
+    return {
+        "schema_version": receipt.schema_version,
+        "worker_id": receipt.worker_id,
+        "worktree_id": receipt.worktree_id,
+        "session_id": receipt.session_id,
+        "stall_reason": receipt.stall_reason.value,
+        "recommended_action": receipt.recommended_action.value,
+        "audit_entries": list(receipt.audit_entries),
+        "identity": receipt.identity.to_dict(),
+        "prev_chain_digest": receipt.prev_chain_digest,
+        "payload_digest": receipt.payload_digest,
+        "respawn_budget_remaining": receipt.respawn_budget_remaining,
+        "signature_b64": receipt.signature_b64,
+        "details": receipt.details,
+    }
+
+
+def receipt_from_dict(payload: dict[str, Any]) -> EscalationReceipt:
+    """Build an :class:`EscalationReceipt` from its canonical dict view."""
+    identity_raw: Any = payload.get("identity")
+    if identity_raw is None:
+        identity_raw = {}
+    if not isinstance(identity_raw, dict):
+        msg = "receipt 'identity' must be a JSON object"
+        raise ReceiptError(msg)
+    identity_dict = cast(dict[str, Any], identity_raw)
+    identity = IdentityTokens(
+        install_rev=str(identity_dict.get("install_rev", "")),
+        keyid=str(identity_dict.get("keyid", "")),
+        run_id=str(identity_dict.get("run_id", "")),
+    )
+    audit_entries_raw: Any = payload.get("audit_entries")
+    if audit_entries_raw is None:
+        audit_entries_raw = []
+    if not isinstance(audit_entries_raw, list):
+        msg = "receipt 'audit_entries' must be a JSON array"
+        raise ReceiptError(msg)
+    typed_entries: list[dict[str, Any]] = [
+        cast(dict[str, Any], entry) for entry in cast(list[Any], audit_entries_raw) if isinstance(entry, dict)
+    ]
+    details_raw: Any = payload.get("details")
+    details_dict: dict[str, Any] = cast(dict[str, Any], details_raw) if isinstance(details_raw, dict) else {}
+    budget_raw = payload.get("respawn_budget_remaining", 0)
+    budget = int(budget_raw) if isinstance(budget_raw, (int, float)) else 0
+    return EscalationReceipt(
+        schema_version=str(payload.get("schema_version", "")),
+        worker_id=str(payload.get("worker_id", "")),
+        worktree_id=str(payload.get("worktree_id", "")),
+        session_id=str(payload.get("session_id", "")),
+        stall_reason=_coerce_stall_reason(str(payload.get("stall_reason", "unknown"))),
+        recommended_action=_coerce_recommended_action(str(payload.get("recommended_action", "inspect"))),
+        audit_entries=tuple(typed_entries),
+        identity=identity,
+        prev_chain_digest=str(payload.get("prev_chain_digest", "")),
+        payload_digest=str(payload.get("payload_digest", "")),
+        respawn_budget_remaining=budget,
+        signature_b64=str(payload.get("signature_b64", "")),
+        details=details_dict,
+    )
+
+
+def _coerce_recommended_action(value: str) -> RecommendedAction:
+    try:
+        return RecommendedAction(value)
+    except ValueError:
+        return RecommendedAction.INSPECT
+
+
+def _signing_payload_dict(receipt: EscalationReceipt) -> dict[str, Any]:
+    """Return the dict that gets signed (excludes signature + payload_digest).
+
+    The signing payload deliberately excludes the ``signature_b64`` and
+    ``payload_digest`` fields so the verifier reproduces the same bytes
+    the signer hashed.
+    """
+    return {
+        "schema_version": receipt.schema_version,
+        "worker_id": receipt.worker_id,
+        "worktree_id": receipt.worktree_id,
+        "session_id": receipt.session_id,
+        "stall_reason": receipt.stall_reason.value,
+        "recommended_action": receipt.recommended_action.value,
+        "audit_entries": list(receipt.audit_entries),
+        "identity": receipt.identity.to_dict(),
+        "prev_chain_digest": receipt.prev_chain_digest,
+        "respawn_budget_remaining": receipt.respawn_budget_remaining,
+        "details": receipt.details,
+    }
+
+
+def canonical_receipt_bytes(receipt: EscalationReceipt) -> bytes:
+    """Return the canonical signing bytes for a receipt."""
+    return _canonical_json(_signing_payload_dict(receipt))
+
+
+def _payload_digest(receipt: EscalationReceipt) -> str:
+    """Compute the sha256 hex digest of the canonical signing bytes."""
+    return hashlib.sha256(canonical_receipt_bytes(receipt)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Receipt assembly + signing
+# ---------------------------------------------------------------------------
+
+
+def assemble_receipt(
+    *,
+    worker_id: str,
+    worktree_id: str,
+    session_id: str,
+    stall_reason: StallReason | str,
+    audit_entries: list[dict[str, Any]],
+    identity: IdentityTokens,
+    prev_chain_digest: str,
+    respawn_budget_remaining: int = 0,
+    audit_window: int = DEFAULT_RECEIPT_AUDIT_WINDOW,
+    details: dict[str, Any] | None = None,
+) -> EscalationReceipt:
+    """Build an :class:`EscalationReceipt` from upstream detector output.
+
+    The function
+
+    1. trims the audit slice to the trailing ``audit_window`` entries,
+    2. asserts the cross-worktree fence,
+    3. computes the deterministic recommended action,
+    4. fills in the payload digest, leaving the signature empty for
+       :func:`sign_receipt` to attach.
+
+    Args:
+        worker_id: Stable worker identifier (12-char hex by convention).
+        worktree_id: Worktree id the worker was running in.
+        session_id: Adapter session id.
+        stall_reason: Structured stall reason from the upstream detector.
+        audit_entries: Chain slice leading up to the stall. The full
+            history may be passed in; the function captures the trailing
+            ``audit_window`` entries.
+        identity: Install identity tokens (key id, install rev, run id).
+        prev_chain_digest: HMAC of the last audit entry preceding the
+            stall - links the receipt into the existing tamper-evident
+            chain.
+        respawn_budget_remaining: Remaining respawns under the session's
+            budget. Used by :func:`recommend_action`.
+        audit_window: Maximum trailing entries to include. Fixed by
+            default so two assemblies of the same chain prefix yield
+            byte-identical receipts.
+        details: Optional structured detector context (e.g. heartbeat
+            age, hook event count). Serialised verbatim.
+
+    Returns:
+        An unsigned :class:`EscalationReceipt`. Pass it to
+        :func:`sign_receipt` to attach the Ed25519 signature.
+    """
+    if audit_window <= 0:
+        msg = f"audit_window must be > 0 (got {audit_window})"
+        raise ReceiptError(msg)
+
+    normalised_entries = [_normalise_entry(entry) for entry in audit_entries]
+    slice_entries = tuple(normalised_entries[-audit_window:])
+
+    assert_cross_worktree_fence(session_id, worktree_id, slice_entries)
+
+    reason = _coerce_stall_reason(stall_reason)
+    action = recommend_action(
+        reason,
+        slice_entries,
+        respawn_budget_remaining=respawn_budget_remaining,
+    )
+
+    base = EscalationReceipt(
+        schema_version=RECEIPT_SCHEMA_VERSION,
+        worker_id=worker_id,
+        worktree_id=worktree_id,
+        session_id=session_id,
+        stall_reason=reason,
+        recommended_action=action,
+        audit_entries=slice_entries,
+        identity=identity,
+        prev_chain_digest=prev_chain_digest,
+        payload_digest="",
+        respawn_budget_remaining=respawn_budget_remaining,
+        signature_b64="",
+        details=details or {},
+    )
+    digest = _payload_digest(base)
+    return EscalationReceipt(
+        schema_version=base.schema_version,
+        worker_id=base.worker_id,
+        worktree_id=base.worktree_id,
+        session_id=base.session_id,
+        stall_reason=base.stall_reason,
+        recommended_action=base.recommended_action,
+        audit_entries=base.audit_entries,
+        identity=base.identity,
+        prev_chain_digest=base.prev_chain_digest,
+        payload_digest=digest,
+        respawn_budget_remaining=base.respawn_budget_remaining,
+        signature_b64="",
+        details=base.details,
+    )
+
+
+def sign_receipt(
+    receipt: EscalationReceipt,
+    *,
+    signing_key: Ed25519PrivateKey,
+) -> EscalationReceipt:
+    """Attach an Ed25519 signature to a receipt.
+
+    The signature covers :func:`canonical_receipt_bytes`. Ed25519 is
+    deterministic by RFC 8032, so signing the same envelope twice with
+    the same key yields byte-identical signature bytes.
+    """
+    payload_bytes = canonical_receipt_bytes(receipt)
+    sig = signing_key.sign(payload_bytes)
+    sig_b64 = base64.b64encode(sig).decode("ascii")
+    return EscalationReceipt(
+        schema_version=receipt.schema_version,
+        worker_id=receipt.worker_id,
+        worktree_id=receipt.worktree_id,
+        session_id=receipt.session_id,
+        stall_reason=receipt.stall_reason,
+        recommended_action=receipt.recommended_action,
+        audit_entries=receipt.audit_entries,
+        identity=receipt.identity,
+        prev_chain_digest=receipt.prev_chain_digest,
+        payload_digest=receipt.payload_digest,
+        respawn_budget_remaining=receipt.respawn_budget_remaining,
+        signature_b64=sig_b64,
+        details=receipt.details,
+    )
+
+
+def verify_receipt(
+    receipt: EscalationReceipt,
+    public_key: Ed25519PublicKey,
+) -> ReceiptVerification:
+    """Verify a receipt against a public key.
+
+    Verifies, in order:
+
+    * payload digest matches the canonical bytes,
+    * cross-worktree fence still holds (an attacker that swapped an
+      audit entry into the slice can't smuggle a leak past the fence),
+    * recommended action matches what :func:`recommend_action` derives
+      from the embedded slice (catches tampered ``recommended_action``
+      fields that the signature alone might still accept on a re-sign),
+    * signature verifies against ``public_key``.
+    """
+    errors: list[str] = []
+    expected_digest = _payload_digest(receipt)
+    if expected_digest != receipt.payload_digest:
+        errors.append(
+            f"payload_digest mismatch (expected {expected_digest[:16]}..., got {receipt.payload_digest[:16]}...)"
+        )
+
+    try:
+        assert_cross_worktree_fence(
+            receipt.session_id,
+            receipt.worktree_id,
+            receipt.audit_entries,
+        )
+    except CrossWorktreeFenceError as exc:
+        errors.append(str(exc))
+
+    # Determinism check: re-run the recommended-action derivation and
+    # surface any tamper that would let an attacker swap "park" for
+    # "respawn" without invalidating the signature.
+    expected_action = recommend_action(
+        receipt.stall_reason,
+        receipt.audit_entries,
+        respawn_budget_remaining=receipt.respawn_budget_remaining,
+    )
+    if expected_action != receipt.recommended_action:
+        errors.append(
+            f"recommended_action mismatch (expected {expected_action.value}, got {receipt.recommended_action.value})"
+        )
+
+    if not receipt.signature_b64:
+        errors.append("receipt is unsigned")
+    else:
+        try:
+            sig = base64.b64decode(receipt.signature_b64)
+        except (ValueError, binascii.Error) as exc:
+            errors.append(f"signature_b64 not valid base64: {exc}")
+            return ReceiptVerification(ok=False, errors=tuple(errors))
+        try:
+            public_key.verify(sig, canonical_receipt_bytes(receipt))
+        except InvalidSignature:
+            errors.append("Ed25519 signature does not verify")
+
+    return ReceiptVerification(ok=not errors, errors=tuple(errors))

--- a/src/bernstein/tui/status_bar.py
+++ b/src/bernstein/tui/status_bar.py
@@ -450,3 +450,83 @@ class CoordinatorDashboard(DataTable[Text]):
                 Text(row.elapsed, style="dim"),
                 key=row.task_id,
             )
+
+
+# ---------------------------------------------------------------------------
+# Supervisor pane (#1800)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SupervisorPaneRow:
+    """One row in the TUI supervisor pane.
+
+    Mirrors :class:`bernstein.core.orchestration.supervisor_aggregator.WorkerSupervisionSnapshot`
+    in the fields the TUI cares about. Keeping a dedicated dataclass
+    decouples the widget from a deeper import of the orchestration
+    package - the pane is fed by the dashboard polling layer.
+    """
+
+    worker_id: str
+    session_id: str
+    role: str
+    stall_reason: str
+    recommended_action: str
+    respawn_budget_remaining: int
+    last_heartbeat_age_s: float | None
+    is_stuck: bool
+
+
+def render_supervisor_pane(rows: list[SupervisorPaneRow]) -> str:
+    """Return a Rich-markup block summarising stalled/parked sessions.
+
+    The pane intentionally renders nothing when no worker is stuck so
+    the dashboard stays compact in the happy path. The rendered block
+    is a deterministic string keyed on ``(session_id, stall_reason)``
+    so snapshot tests can assert byte-identical output.
+    """
+    stuck_rows = sorted(
+        (r for r in rows if r.is_stuck),
+        key=lambda r: r.session_id,
+    )
+    if not stuck_rows:
+        return ""
+    lines: list[str] = ["[bold]supervisor[/bold] - stalled workers"]
+    for r in stuck_rows:
+        hb = "-"
+        if r.last_heartbeat_age_s is not None:
+            hb = f"{int(r.last_heartbeat_age_s)}s"
+        lines.append(
+            f"  [yellow]{r.worker_id}[/yellow] "
+            f"role={r.role or '-'} "
+            f"reason={r.stall_reason} "
+            f"recommend={r.recommended_action} "
+            f"hb={hb} budget={r.respawn_budget_remaining}"
+        )
+    return "\n".join(lines)
+
+
+class SupervisorPane(Static):
+    """TUI pane that surfaces stalled / parked / no-progress sessions.
+
+    The pane mirrors ``bernstein supervisor status`` so an operator who
+    notices a wedged worker in the dashboard can drop to a terminal and
+    run ``bernstein supervisor escalate <session_id>`` without needing
+    to reconcile a separate state machine.
+    """
+
+    DEFAULT_CSS = """
+    SupervisorPane {
+        height: auto;
+        min-height: 3;
+        padding: 1;
+    }
+    """
+
+    def refresh_rows(self, rows: list[SupervisorPaneRow]) -> None:
+        """Update the pane with the latest supervisor aggregator rows."""
+        block = render_supervisor_pane(rows)
+        if not block:
+            self.update(Text.from_markup("[dim]supervisor: all workers healthy[/dim]"))
+            return
+        self.update(Text.from_markup(block))

--- a/src/bernstein/tui/status_bar.py
+++ b/src/bernstein/tui/status_bar.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from rich.markup import escape as _rich_escape
 from rich.text import Text
 from textual.widgets import DataTable, Static
 
@@ -496,11 +497,16 @@ def render_supervisor_pane(rows: list[SupervisorPaneRow]) -> str:
         hb = "-"
         if r.last_heartbeat_age_s is not None:
             hb = f"{int(r.last_heartbeat_age_s)}s"
+        # Escape every dynamic field before interpolating into the Rich
+        # markup string. Worker ids and roles come from upstream callers
+        # and may contain ``[`` / ``]`` which Rich would otherwise parse
+        # as markup, breaking layout and (worse) producing operator-
+        # visible output that does not match the underlying state.
         lines.append(
-            f"  [yellow]{r.worker_id}[/yellow] "
-            f"role={r.role or '-'} "
-            f"reason={r.stall_reason} "
-            f"recommend={r.recommended_action} "
+            f"  [yellow]{_rich_escape(r.worker_id)}[/yellow] "
+            f"role={_rich_escape(r.role or '-')} "
+            f"reason={_rich_escape(r.stall_reason)} "
+            f"recommend={_rich_escape(r.recommended_action)} "
             f"hb={hb} budget={r.respawn_budget_remaining}"
         )
     return "\n".join(lines)

--- a/src/bernstein/tui/worker_badges.py
+++ b/src/bernstein/tui/worker_badges.py
@@ -18,6 +18,12 @@ class WorkerStatus(StrEnum):
     PAUSED = "paused"
     STOPPED = "stopped"
     ERROR = "error"
+    # #1800: surfaced by the operator supervisor when a worker has
+    # stalled, exhausted its respawn budget, or otherwise needs
+    # attention. Kept distinct from ERROR so the badge can render a
+    # different colour without conflating an exception path with a
+    # detector classification.
+    STUCK = "stuck"
 
 
 class TierColor(StrEnum):
@@ -33,6 +39,7 @@ STATUS_ICONS = {
     WorkerStatus.PAUSED: "⏸",
     WorkerStatus.STOPPED: "✗",
     WorkerStatus.ERROR: "⚠",
+    WorkerStatus.STUCK: "!",
 }
 
 TIER_COLORS = {
@@ -74,6 +81,7 @@ STATUS_ICON_COLORS = {
     WorkerStatus.PAUSED: "yellow",
     WorkerStatus.STOPPED: "red",
     WorkerStatus.ERROR: "red",
+    WorkerStatus.STUCK: "yellow",
 }
 
 
@@ -92,6 +100,21 @@ def format_worker_badge(badge: WorkerBadge) -> str:
     return (
         f"[{icon_color}]{badge.status_icon}[/] {badge.role} [{badge.model}] [{badge.tier_color}]{badge.tier_display}[/]"
     )
+
+
+def status_for_supervisor_row(*, is_stuck: bool, base_status: WorkerStatus = WorkerStatus.RUNNING) -> WorkerStatus:
+    """Map a supervisor aggregator row's stuck flag onto the badge status.
+
+    This keeps the badge module free of an upstream import on the
+    orchestration package while letting the dashboard widget render the
+    same yellow ``!`` icon next to a stuck worker that the dedicated
+    supervisor pane uses. ``base_status`` lets callers retain
+    pre-existing PAUSED / ERROR colouring when the aggregator hasn't
+    flagged the row as stuck.
+    """
+    if is_stuck:
+        return WorkerStatus.STUCK
+    return base_status
 
 
 def get_badge_for_worker(

--- a/tests/integration/test_supervisor_chain_roundtrip.py
+++ b/tests/integration/test_supervisor_chain_roundtrip.py
@@ -1,0 +1,175 @@
+"""Integration test: stall -> receipt -> audit chain -> verification roundtrip.
+
+This exercises the operator-facing supervisor surface end-to-end against
+a stubbed orchestrator runtime tree:
+
+1. Lay down a synthetic ``.sdd/runtime/`` (agents.json, heartbeats,
+   failures) that the upstream detectors would normally populate.
+2. Build the aggregator snapshot via
+   :func:`bernstein.core.orchestration.supervisor_aggregator.aggregator_snapshot`.
+3. Assemble + sign an escalation receipt for one stuck worker.
+4. Round-trip the receipt through JSON.
+5. Verify the receipt against the install public key.
+
+The test deliberately avoids spawning real agent processes - the
+supervisor surface aggregates files the detectors emit, so the contract
+under test is the *aggregation + receipt* layer, not the detectors
+themselves.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.orchestration.supervisor_aggregator import (
+    aggregator_snapshot,
+    load_recent_failures,
+)
+from bernstein.core.orchestration.supervisor_receipt import (
+    IdentityTokens,
+    StallReason,
+    assemble_receipt,
+    receipt_from_dict,
+    receipt_to_dict,
+    sign_receipt,
+    verify_receipt,
+)
+
+
+def _seed_runtime_tree(workdir: Path, *, session_id: str, role: str = "manager") -> None:
+    """Populate a minimal ``.sdd/runtime/`` tree that mimics a stalled session."""
+    runtime = workdir / ".sdd" / "runtime"
+    (runtime / "heartbeats").mkdir(parents=True, exist_ok=True)
+    (runtime / "failures").mkdir(parents=True, exist_ok=True)
+    (runtime / "spawn_supervisor").mkdir(parents=True, exist_ok=True)
+
+    # agents.json: one live worker, role=manager, with a stalled diagnostic.
+    agents_doc = {
+        "agents": [
+            {
+                "id": session_id,
+                "role": role,
+                "status": "working",
+                "task_ids": ["t-1"],
+                "worker_id": "abc123def456",
+                "worktree_id": "wt-A",
+                "stalled_manager": {
+                    "kind": "stalled_manager",
+                    "session_id": session_id,
+                    "runtime_s": 120.0,
+                    "hook_event_count": 12,
+                    "detected_at": 1700000000.0,
+                },
+            }
+        ]
+    }
+    (runtime / "agents.json").write_text(json.dumps(agents_doc, sort_keys=True))
+
+    # Heartbeat - aged so the aggregator flags the session as stuck.
+    heartbeat = {
+        "timestamp": 1700000000.0 - 600.0,  # 10 min old
+        "phase": "implementing",
+        "progress_pct": 0,
+    }
+    (runtime / "heartbeats" / f"{session_id}.json").write_text(json.dumps(heartbeat, sort_keys=True))
+
+    # One failure record so the aggregator has something to feed into the
+    # receipt's audit_entries slice.
+    failure = {
+        "kind": "stalled_manager",
+        "session_id": session_id,
+        "runtime_s": 120.0,
+        "hook_event_count": 12,
+        "detected_at": 1700000000.0,
+    }
+    (runtime / "failures" / f"manager-stalled-{session_id}.json").write_text(json.dumps(failure, sort_keys=True))
+
+
+def test_stall_to_receipt_to_verification_roundtrip(tmp_path: Path) -> None:
+    """End-to-end: stall artefacts -> aggregator -> signed receipt -> verify."""
+    session_id = "sess-mgr-001"
+    _seed_runtime_tree(tmp_path, session_id=session_id)
+
+    # The orchestrator timestamp the heartbeat ages against is supplied
+    # explicitly so the assertion is deterministic.
+    snapshot = aggregator_snapshot(
+        tmp_path,
+        now=1700000000.0,
+        heartbeat_stale_s=120.0,
+    )
+    assert snapshot.stuck_count >= 1
+    [row] = [w for w in snapshot.workers if w.session_id == session_id]
+    assert row.is_stuck
+    assert row.stall_reason == StallReason.MANAGER_NO_CHILDREN
+
+    failures = load_recent_failures(tmp_path, session_id)
+    audit_entries = [
+        {
+            "event_type": str(rec.get("kind", "")),
+            "session_id": session_id,
+            "details": rec,
+        }
+        for rec in failures
+    ]
+
+    signing_key = Ed25519PrivateKey.generate()
+    identity = IdentityTokens(
+        install_rev="abc1234567890def",
+        keyid="dummy-keyid-0123456789abcdef",
+        run_id="run-1",
+    )
+    receipt = assemble_receipt(
+        worker_id=row.worker_id,
+        worktree_id=row.worktree_id,
+        session_id=session_id,
+        stall_reason=row.stall_reason,
+        audit_entries=audit_entries,
+        identity=identity,
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=row.respawn_budget_remaining,
+    )
+    signed = sign_receipt(receipt, signing_key=signing_key)
+
+    # JSON roundtrip - the receipt is meant to be portable.
+    wire = json.dumps(receipt_to_dict(signed), sort_keys=True)
+    reloaded = receipt_from_dict(json.loads(wire))
+
+    result = verify_receipt(reloaded, signing_key.public_key())
+    assert result.ok, result.errors
+
+
+def test_receipt_recommended_action_matches_aggregator_row(tmp_path: Path) -> None:
+    """The aggregator and the receipt produce the same recommendation.
+
+    Both layers consume the deterministic ``recommend_action`` so a
+    receipt the operator escalates carries the exact label the dashboard
+    showed - no surprise downgrades between glance and command.
+    """
+    session_id = "sess-mgr-002"
+    _seed_runtime_tree(tmp_path, session_id=session_id)
+    snapshot = aggregator_snapshot(tmp_path, now=1700000000.0, heartbeat_stale_s=120.0)
+    [row] = [w for w in snapshot.workers if w.session_id == session_id]
+
+    failures = load_recent_failures(tmp_path, session_id)
+    audit_entries = [
+        {
+            "event_type": str(rec.get("kind", "")),
+            "session_id": session_id,
+            "details": rec,
+        }
+        for rec in failures
+    ]
+    receipt = assemble_receipt(
+        worker_id=row.worker_id,
+        worktree_id=row.worktree_id,
+        session_id=session_id,
+        stall_reason=row.stall_reason,
+        audit_entries=audit_entries,
+        identity=IdentityTokens(keyid="x", install_rev="x", run_id=""),
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=row.respawn_budget_remaining,
+    )
+    assert receipt.recommended_action == row.recommended_action

--- a/tests/snapshot/__snapshots__/test_supervisor_pane_snapshot.ambr
+++ b/tests/snapshot/__snapshots__/test_supervisor_pane_snapshot.ambr
@@ -1,0 +1,12 @@
+# serializer version: 1
+# name: test_supervisor_pane_renders_nothing_when_all_healthy
+  ''
+# ---
+# name: test_supervisor_pane_renders_stuck_rows_sorted
+  '''
+  [bold]supervisor[/bold] - stalled workers
+    [yellow]aaa111[/yellow] role=backend reason=respawn_budget_exhausted recommend=park hb=- budget=0
+    [yellow]mmm222[/yellow] role=qa reason=heartbeat_stale recommend=respawn hb=180s budget=2
+    [yellow]zzz999[/yellow] role=manager reason=manager_no_children recommend=escalate hb=120s budget=0
+  '''
+# ---

--- a/tests/snapshot/test_supervisor_pane_snapshot.py
+++ b/tests/snapshot/test_supervisor_pane_snapshot.py
@@ -1,0 +1,82 @@
+"""Snapshot test: supervisor TUI pane render output.
+
+The supervisor pane displays one line per stalled / parked worker. The
+render is deterministic over the sorted ``session_id`` order so a
+snapshot covers the byte-stable wire form (Rich markup string).
+
+Update workflow: when a deliberate layout change lands, run
+``uv run pytest tests/snapshot/test_supervisor_pane_snapshot.py
+--snapshot-update`` and commit the updated ``.ambr``.
+"""
+
+from __future__ import annotations
+
+from syrupy.assertion import SnapshotAssertion
+
+from bernstein.tui.status_bar import SupervisorPaneRow, render_supervisor_pane
+
+
+def _row(
+    *,
+    worker_id: str,
+    session_id: str,
+    role: str = "backend",
+    stall_reason: str = "heartbeat_stale",
+    recommended_action: str = "respawn",
+    respawn_budget_remaining: int = 2,
+    last_heartbeat_age_s: float | None = 65.0,
+    is_stuck: bool = True,
+) -> SupervisorPaneRow:
+    return SupervisorPaneRow(
+        worker_id=worker_id,
+        session_id=session_id,
+        role=role,
+        stall_reason=stall_reason,
+        recommended_action=recommended_action,
+        respawn_budget_remaining=respawn_budget_remaining,
+        last_heartbeat_age_s=last_heartbeat_age_s,
+        is_stuck=is_stuck,
+    )
+
+
+def test_supervisor_pane_renders_nothing_when_all_healthy(snapshot: SnapshotAssertion) -> None:
+    """No output when no row is stuck - keeps the dashboard compact."""
+    rows = [
+        _row(worker_id="abc123", session_id="sess-1", is_stuck=False),
+        _row(worker_id="def456", session_id="sess-2", is_stuck=False),
+    ]
+    assert render_supervisor_pane(rows) == snapshot
+
+
+def test_supervisor_pane_renders_stuck_rows_sorted(snapshot: SnapshotAssertion) -> None:
+    """Stuck rows are sorted by session id so the snapshot is byte-stable."""
+    rows = [
+        _row(
+            worker_id="zzz999",
+            session_id="sess-z",
+            role="manager",
+            stall_reason="manager_no_children",
+            recommended_action="escalate",
+            respawn_budget_remaining=0,
+            last_heartbeat_age_s=120.0,
+        ),
+        _row(
+            worker_id="aaa111",
+            session_id="sess-a",
+            role="backend",
+            stall_reason="respawn_budget_exhausted",
+            recommended_action="park",
+            respawn_budget_remaining=0,
+            last_heartbeat_age_s=None,
+        ),
+        _row(
+            worker_id="mmm222",
+            session_id="sess-m",
+            role="qa",
+            stall_reason="heartbeat_stale",
+            recommended_action="respawn",
+            respawn_budget_remaining=2,
+            last_heartbeat_age_s=180.0,
+        ),
+    ]
+    assert render_supervisor_pane(rows) == snapshot

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -237,6 +237,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "interop",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "desktop-register",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "supervisor",
     }
 )
 

--- a/tests/unit/test_supervisor_receipt.py
+++ b/tests/unit/test_supervisor_receipt.py
@@ -1,0 +1,370 @@
+"""Unit tests for the supervisor escalation-receipt module (#1800)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.orchestration.supervisor_receipt import (
+    DEFAULT_RECEIPT_AUDIT_WINDOW,
+    CrossWorktreeFenceError,
+    IdentityTokens,
+    RecommendedAction,
+    StallReason,
+    assemble_receipt,
+    assert_cross_worktree_fence,
+    canonical_receipt_bytes,
+    receipt_from_dict,
+    receipt_to_dict,
+    recommend_action,
+    sign_receipt,
+    verify_receipt,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _identity() -> IdentityTokens:
+    return IdentityTokens(
+        install_rev="abc1234567890def",
+        keyid="0" * 64,
+        run_id="run-1",
+    )
+
+
+def _audit_slice(*, with_fatal: bool = False) -> list[dict[str, str]]:
+    base = [
+        {"event_type": "session.start", "session_id": "sess-1"},
+        {"event_type": "task.pre_spawn", "session_id": "sess-1"},
+        {"event_type": "heartbeat.tick", "session_id": "sess-1"},
+    ]
+    if with_fatal:
+        base.append({"event_type": "auth.denied", "session_id": "sess-1"})
+    return base
+
+
+# ---------------------------------------------------------------------------
+# recommend_action - deterministic contract
+# ---------------------------------------------------------------------------
+
+
+def test_recommended_action_for_park_when_respawn_exhausted() -> None:
+    """RESPAWN_EXHAUSTED always yields PARK regardless of slice contents."""
+    action = recommend_action(StallReason.RESPAWN_EXHAUSTED, _audit_slice())
+    assert action == RecommendedAction.PARK
+
+
+def test_recommended_action_escalate_on_fatal_auth_event() -> None:
+    """A fatal-looking event anywhere in the slice short-circuits to ESCALATE."""
+    action = recommend_action(
+        StallReason.HEARTBEAT_STALE,
+        _audit_slice(with_fatal=True),
+        respawn_budget_remaining=3,
+    )
+    assert action == RecommendedAction.ESCALATE
+
+
+def test_recommended_action_respawn_when_budget_remains() -> None:
+    """HEARTBEAT_STALE with budget remaining and clean slice yields RESPAWN."""
+    action = recommend_action(
+        StallReason.HEARTBEAT_STALE,
+        _audit_slice(),
+        respawn_budget_remaining=2,
+    )
+    assert action == RecommendedAction.RESPAWN
+
+
+def test_recommended_action_escalate_when_budget_exhausted_but_not_parked() -> None:
+    """Heartbeat stall without budget escalates rather than silently parking."""
+    action = recommend_action(
+        StallReason.HEARTBEAT_STALE,
+        _audit_slice(),
+        respawn_budget_remaining=0,
+    )
+    assert action == RecommendedAction.ESCALATE
+
+
+def test_recommended_action_inspect_for_unknown_reason() -> None:
+    """Unknown stall reasons must never silently downgrade to RESPAWN."""
+    action = recommend_action(StallReason.UNKNOWN, _audit_slice())
+    assert action == RecommendedAction.INSPECT
+
+
+def test_recommended_action_escalate_for_model_question() -> None:
+    """A model question never auto-recovers - escalate to operator."""
+    action = recommend_action(StallReason.WATCHDOG_MODEL_QUESTION, _audit_slice())
+    assert action == RecommendedAction.ESCALATE
+
+
+def test_recommended_action_escalate_for_manager_no_children() -> None:
+    """Manager-no-children stalls always escalate (a respawn won't help)."""
+    action = recommend_action(StallReason.MANAGER_NO_CHILDREN, _audit_slice())
+    assert action == RecommendedAction.ESCALATE
+
+
+def test_recommended_action_string_reason_coerced() -> None:
+    """Raw string reasons are coerced into the StallReason enum."""
+    action = recommend_action("respawn_budget_exhausted", _audit_slice())
+    assert action == RecommendedAction.PARK
+
+
+def test_recommended_action_unknown_string_coerced_to_unknown() -> None:
+    """An unrecognised string reason coerces to UNKNOWN -> INSPECT."""
+    action = recommend_action("totally-made-up", _audit_slice())
+    assert action == RecommendedAction.INSPECT
+
+
+def test_recommended_action_determinism(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Two operators in different temp dirs see byte-identical recommendations.
+
+    Drives the same canonical chain slice through ``recommend_action`` from
+    two distinct working directories. The function is pure over its inputs,
+    so the byte representation of the returned enum value MUST match
+    irrespective of host state, environment, or filesystem layout.
+    """
+    dir_a = tmp_path_factory.mktemp("op_a")
+    dir_b = tmp_path_factory.mktemp("op_b")
+
+    # Persist the slice to JSON files in two different temp dirs and
+    # reload from each - this is the operator-side workflow.
+    slice_in = _audit_slice(with_fatal=True)
+    path_a = dir_a / "slice.json"
+    path_b = dir_b / "slice.json"
+    path_a.write_text(json.dumps(slice_in, sort_keys=True))
+    path_b.write_text(json.dumps(slice_in, sort_keys=True))
+
+    loaded_a = json.loads(path_a.read_text())
+    loaded_b = json.loads(path_b.read_text())
+
+    action_a = recommend_action(
+        StallReason.HEARTBEAT_STALE,
+        loaded_a,
+        respawn_budget_remaining=2,
+    )
+    action_b = recommend_action(
+        StallReason.HEARTBEAT_STALE,
+        loaded_b,
+        respawn_budget_remaining=2,
+    )
+
+    assert action_a == action_b
+    # Byte-identical when encoded - protects against future enum churn
+    # that might keep equality but change the .value string.
+    assert action_a.value.encode() == action_b.value.encode()
+
+
+# ---------------------------------------------------------------------------
+# Cross-worktree fence
+# ---------------------------------------------------------------------------
+
+
+def test_cross_worktree_fence_passes_on_clean_slice() -> None:
+    """Clean slice has no cross-worktree resolution events."""
+    assert_cross_worktree_fence("sess-1", "wt-A", _audit_slice())
+
+
+def test_cross_worktree_fence_flags_sibling_resolution_event() -> None:
+    """A ``*.resolved`` event in a sibling worktree fails the fence."""
+    slice_in = [
+        *_audit_slice(),
+        {
+            "event_type": "task.resolved",
+            "session_id": "sess-1",
+            "worktree_id": "wt-B",
+        },
+    ]
+    with pytest.raises(CrossWorktreeFenceError, match="cross-worktree fence"):
+        assert_cross_worktree_fence("sess-1", "wt-A", slice_in)
+
+
+def test_cross_worktree_fence_ignores_same_worktree_resolution() -> None:
+    """A resolution event inside the stuck worker's own worktree is fine."""
+    slice_in = [
+        *_audit_slice(),
+        {
+            "event_type": "task.resolved",
+            "session_id": "sess-1",
+            "worktree_id": "wt-A",
+        },
+    ]
+    assert_cross_worktree_fence("sess-1", "wt-A", slice_in)
+
+
+def test_cross_worktree_fence_ignores_other_session_resolution() -> None:
+    """A sibling worktree resolving a different session is irrelevant."""
+    slice_in = [
+        *_audit_slice(),
+        {
+            "event_type": "task.resolved",
+            "session_id": "sess-99",
+            "worktree_id": "wt-B",
+        },
+    ]
+    assert_cross_worktree_fence("sess-1", "wt-A", slice_in)
+
+
+# ---------------------------------------------------------------------------
+# Receipt assembly + signature roundtrip
+# ---------------------------------------------------------------------------
+
+
+def _signing_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(bytes(range(32)))
+
+
+def test_assemble_receipt_trims_audit_window() -> None:
+    """Audit slice is capped at DEFAULT_RECEIPT_AUDIT_WINDOW trailing entries."""
+    over_window = DEFAULT_RECEIPT_AUDIT_WINDOW + 8
+    audit_entries = [{"event_type": "noop", "session_id": "sess-1", "details": {"i": i}} for i in range(over_window)]
+    receipt = assemble_receipt(
+        worker_id="abc123",
+        worktree_id="wt-A",
+        session_id="sess-1",
+        stall_reason=StallReason.HEARTBEAT_STALE,
+        audit_entries=audit_entries,
+        identity=_identity(),
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=1,
+    )
+    assert len(receipt.audit_entries) == DEFAULT_RECEIPT_AUDIT_WINDOW
+    # The trailing N entries are kept (highest indices).
+    last_kept = receipt.audit_entries[-1]
+    assert last_kept["details"]["i"] == over_window - 1
+
+
+def test_sign_and_verify_roundtrip(tmp_path: Path) -> None:
+    """A signed receipt verifies against the matching public key."""
+    key = _signing_key()
+    receipt = assemble_receipt(
+        worker_id="abc123",
+        worktree_id="wt-A",
+        session_id="sess-1",
+        stall_reason=StallReason.HEARTBEAT_STALE,
+        audit_entries=_audit_slice(),
+        identity=_identity(),
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=2,
+    )
+    signed = sign_receipt(receipt, signing_key=key)
+    result = verify_receipt(signed, key.public_key())
+    assert result.ok, result.errors
+
+    # Roundtrip through dict <-> dataclass and verify again.
+    blob = json.dumps(receipt_to_dict(signed), sort_keys=True)
+    reloaded = receipt_from_dict(json.loads(blob))
+    result2 = verify_receipt(reloaded, key.public_key())
+    assert result2.ok, result2.errors
+
+
+def test_verify_rejects_signature_tampering() -> None:
+    """Tampered signature bytes fail verification."""
+    key = _signing_key()
+    receipt = assemble_receipt(
+        worker_id="abc123",
+        worktree_id="wt-A",
+        session_id="sess-1",
+        stall_reason=StallReason.HEARTBEAT_STALE,
+        audit_entries=_audit_slice(),
+        identity=_identity(),
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=2,
+    )
+    signed = sign_receipt(receipt, signing_key=key)
+    tampered_dict = receipt_to_dict(signed)
+    # Flip a base64 byte that doesn't break decode but breaks the signature.
+    tampered_dict["signature_b64"] = tampered_dict["signature_b64"][:-2] + (
+        "AA" if tampered_dict["signature_b64"][-2:] != "AA" else "BB"
+    )
+    tampered = receipt_from_dict(tampered_dict)
+    result = verify_receipt(tampered, key.public_key())
+    assert not result.ok
+
+
+def test_verify_rejects_recommended_action_swap() -> None:
+    """A tampered recommended_action fails the determinism re-derivation."""
+    key = _signing_key()
+    receipt = assemble_receipt(
+        worker_id="abc123",
+        worktree_id="wt-A",
+        session_id="sess-1",
+        stall_reason=StallReason.HEARTBEAT_STALE,
+        audit_entries=_audit_slice(with_fatal=True),
+        identity=_identity(),
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=2,
+    )
+    signed = sign_receipt(receipt, signing_key=key)
+    tampered_dict = receipt_to_dict(signed)
+    # Swap ESCALATE for RESPAWN - signature still covers the original
+    # bytes, but the determinism check catches the mismatch.
+    tampered_dict["recommended_action"] = RecommendedAction.RESPAWN.value
+    tampered = receipt_from_dict(tampered_dict)
+    result = verify_receipt(tampered, key.public_key())
+    assert not result.ok
+    assert any("recommended_action" in err for err in result.errors)
+
+
+def test_assemble_rejects_cross_worktree_violation() -> None:
+    """Assembly refuses a slice that leaks across worktrees."""
+    audit_entries = [
+        *_audit_slice(),
+        {
+            "event_type": "task.resolved",
+            "session_id": "sess-1",
+            "worktree_id": "wt-B",
+        },
+    ]
+    with pytest.raises(CrossWorktreeFenceError):
+        assemble_receipt(
+            worker_id="abc123",
+            worktree_id="wt-A",
+            session_id="sess-1",
+            stall_reason=StallReason.HEARTBEAT_STALE,
+            audit_entries=audit_entries,
+            identity=_identity(),
+            prev_chain_digest="0" * 64,
+        )
+
+
+def test_canonical_bytes_are_byte_stable_under_dict_reorder() -> None:
+    """Reordering dict keys in the JSON wire form yields the same canonical bytes."""
+    key = _signing_key()
+    receipt = assemble_receipt(
+        worker_id="abc123",
+        worktree_id="wt-A",
+        session_id="sess-1",
+        stall_reason=StallReason.HEARTBEAT_STALE,
+        audit_entries=_audit_slice(),
+        identity=_identity(),
+        prev_chain_digest="0" * 64,
+        respawn_budget_remaining=2,
+    )
+    signed = sign_receipt(receipt, signing_key=key)
+    a = receipt_to_dict(signed)
+    # Reorder keys in details + identity.
+    b = json.loads(json.dumps(a))
+    reordered = {k: a[k] for k in sorted(a.keys(), reverse=True)}
+    reloaded = receipt_from_dict(reordered)
+    assert canonical_receipt_bytes(reloaded) == canonical_receipt_bytes(receipt_from_dict(b))
+
+
+def test_unsigned_receipt_fails_verification() -> None:
+    """A receipt without a signature blob never verifies."""
+    key = _signing_key()
+    receipt = assemble_receipt(
+        worker_id="abc123",
+        worktree_id="wt-A",
+        session_id="sess-1",
+        stall_reason=StallReason.HEARTBEAT_STALE,
+        audit_entries=_audit_slice(),
+        identity=_identity(),
+        prev_chain_digest="0" * 64,
+    )
+    result = verify_receipt(receipt, key.public_key())
+    assert not result.ok
+    assert any("unsigned" in err for err in result.errors)


### PR DESCRIPTION
Closes #1800.

## Summary

- Adds `bernstein supervisor status [--json]` and `bernstein supervisor escalate <session_id> --reason "..."` as an operator-facing surface over the existing `stalled_manager`, `watchdog`, and `spawn_supervisor` detectors. The detectors remain the source of truth; the new command aggregates and renders.
- Each escalation appends a signed receipt (Ed25519) to the audit chain with `(worker_id, worktree_id, last_n_audit_entries, identity_tokens, stall_reason, recommended_action, prev_chain_digest)`. Receipts verify offline against the install's public key.
- `recommended_action` is a pure function of the chain slice at stall time. Two operators verifying the same receipt land on the byte-identical recommendation. A cross-worktree fence refuses receipt assembly when the stuck session leaked into a sibling worktree's resolution events.
- `bernstein status` and `bernstein fleet` gain a stuck-count + oldest-stall summary line. The TUI dashboard adds a `SupervisorPane` highlighting stalled / parked / no-progress sessions with the same recommended action.

## Files touched

- `src/bernstein/core/orchestration/supervisor_receipt.py` (new) - receipt assembly, signing, verification, deterministic recommended_action, cross-worktree fence.
- `src/bernstein/core/orchestration/supervisor_aggregator.py` (new) - reads `.sdd/runtime/agents.json`, heartbeats, and failure records into a single snapshot.
- `src/bernstein/cli/commands/supervisor_cmd.py` (new) - `bernstein supervisor status` / `escalate` Click group.
- `src/bernstein/cli/main.py` - register the new group.
- `src/bernstein/cli/commands/status_cmd.py` - attach supervisor summary to `bernstein status`.
- `src/bernstein/cli/commands/fleet_cmd.py` - append supervisor summary line to the fallback fleet renderer.
- `src/bernstein/core/lifecycle/hooks.py` - add `worker.escalated` lifecycle event for external notifiers.
- `src/bernstein/tui/status_bar.py` - add `SupervisorPane` widget + `render_supervisor_pane` helper.
- `src/bernstein/tui/worker_badges.py` - add `WorkerStatus.STUCK` + `status_for_supervisor_row` helper.
- `docs/api/supervisor.md` (new) - JSON schema for aggregator snapshot + receipt envelope, plus the determinism contract and cross-worktree fence rules.
- `tests/unit/test_supervisor_receipt.py` (new) - 21 tests covering receipt assembly, signature verification, recommended-action determinism (drives the same chain slice from two temp dirs), fence assertion, dict roundtrip.
- `tests/integration/test_supervisor_chain_roundtrip.py` (new) - end-to-end: synthetic `.sdd/runtime/` -> aggregator -> signed receipt -> JSON roundtrip -> verification.
- `tests/snapshot/test_supervisor_pane_snapshot.py` (new) - TUI render snapshot for the new pane.

## Acceptance criteria

- [x] `bernstein supervisor status [--json]` lists every live worker with last-heartbeat, current task id, stall reason, recommended action, respawn budget remaining.
- [x] Signed escalation receipt appended on stall detection (and on explicit operator escalation); reuses install Ed25519 key.
- [x] `recommended_action` is deterministic over `(stall_reason, audit_entries, respawn_budget_remaining)`.
- [x] Cross-worktree fence asserted; regression test in place.
- [x] `bernstein supervisor escalate` records an escalation event in the audit chain and fires `worker.escalated`.
- [x] Stuck-detection summary appears in `bernstein status` and `bernstein fleet` output.
- [x] TUI dashboard adds a pane highlighting parked / stalled / no-progress sessions.
- [x] Existing `stalled_manager`, `watchdog`, `spawn_supervisor`, and parked-agent surfaces remain the source of truth; the new command aggregates.
- [x] JSON schema documented under `docs/api/supervisor.md`.
- [x] Tests cover receipt assembly, signature verification, deterministic recommended-action derivation, cross-worktree fence assertion, and TUI render.

## Test plan

- [x] `uv run pytest tests/unit/test_supervisor_receipt.py tests/integration/test_supervisor_chain_roundtrip.py tests/snapshot/test_supervisor_pane_snapshot.py` - 25 passed.
- [x] `uv run pytest tests/unit/ -k "supervisor or stalled or watchdog"` - 127 passed, 45 skipped, no regressions.
- [x] `uv run ruff check .` - all checks passed.
- [x] `uv run ruff format --check .` - all files formatted.
- [x] `uv run pyright` on the three new modules - 0 errors.
- [x] `bernstein supervisor --help` and `bernstein supervisor status --json` smoke-tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added top-level "supervisor" CLI with `status` and `escalate` commands for inspecting and escalating stuck workers.
  * `status` now includes a supervisor summary in JSON and a dim one-line supervisor summary in human output.
  * TUI/status bar gains a Supervisor pane showing stalled workers and a new "stuck" worker badge/icon.

* **Tests**
  * Added unit and integration tests covering supervisor snapshots, escalation receipts, and signing/verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->