### PR TITLE
fix(quality): resolve Sonar S8413 + S125 in gui mount and defaults

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -46,16 +46,16 @@ from typing import Any, Literal
 class OrchestratorDefaults:
     """Run loop, tick scheduling, drain, and convergence."""
 
-    tick_interval_s: float = 3.0  # arbitrary; tune in tuning:orchestrator
+    tick_interval_s: float = 3.0
     normal_tick_phase: int = 6  # run normal ops every N ticks
     slow_tick_phase: int = 30  # run slow ops every N ticks
 
     max_consecutive_failures: int = 10  # tick failures before abort
     max_spawn_failures: int = 3  # consecutive spawn failures → mark failed
-    spawn_backoff_base_s: float = 30.0  # arbitrary; tune in tuning:orchestrator
+    spawn_backoff_base_s: float = 30.0
     spawn_backoff_max_s: float = 300.0  # cap exponential backoff at 5 min
 
-    drain_timeout_s: float = 60.0  # arbitrary; tune in tuning:orchestrator
+    drain_timeout_s: float = 60.0
     server_failure_threshold: int = 12  # ticks of server unreachability → stop
     server_failure_warn: int = 3  # warn after N consecutive server failures
 
@@ -97,9 +97,9 @@ class AgentDefaults:
     escalation_sigkill_s: float = 150.0  # 2.5 min → hard SIGKILL
 
     # Escalation count thresholds
-    escalation_kill_count: int = 7  # arbitrary; tune in tuning:agent
-    escalation_high_count: int = 5  # arbitrary; tune in tuning:agent
-    escalation_med_count: int = 3  # arbitrary; tune in tuning:agent
+    escalation_kill_count: int = 7
+    escalation_high_count: int = 5
+    escalation_med_count: int = 3
 
     zombie_pid_max_age_s: float = 7 * 24 * 3600  # 7 days
 
@@ -195,9 +195,9 @@ class CostDefaults:
     scope_budget_usd: Mapping[str, float] = field(
         default_factory=lambda: _freeze_dict_str_float(
             {
-                "small": 2.0,  # arbitrary; tune in tuning:cost
-                "medium": 5.0,  # arbitrary; tune in tuning:cost
-                "large": 15.0,  # arbitrary; tune in tuning:cost
+                "small": 2.0,
+                "medium": 5.0,
+                "large": 15.0,
             }
         )
     )
@@ -213,11 +213,11 @@ class CostDefaults:
     effort_base_turns: Mapping[str, int] = field(
         default_factory=lambda: _freeze_dict_str_int(
             {
-                "max": 100,  # arbitrary; tune in tuning:cost
-                "high": 50,  # arbitrary; tune in tuning:cost
-                "medium": 30,  # arbitrary; tune in tuning:cost
-                "normal": 25,  # arbitrary; tune in tuning:cost
-                "low": 15,  # arbitrary; tune in tuning:cost
+                "max": 100,
+                "high": 50,
+                "medium": 30,
+                "normal": 25,
+                "low": 15,
             }
         )
     )
@@ -290,7 +290,7 @@ class ProtocolDefaults:
 
     cluster_autoscale_cooldown_s: float = 120.0  # 2 min between scale decisions
     cluster_min_nodes: int = 1  # always keep at least one node alive
-    cluster_max_nodes: int = 20  # arbitrary; tune in tuning:protocol
+    cluster_max_nodes: int = 20
     cluster_steal_threshold: int = 3  # steal work if queue >3 deeper than peer
     cluster_steal_cooldown_s: float = 10.0  # 10s between work-steal attempts
 
@@ -307,9 +307,9 @@ class PlanDefaults:
     tokens_by_scope: Mapping[str, int] = field(
         default_factory=lambda: _freeze_dict_str_int(
             {
-                "small": 30_000,  # arbitrary; tune in tuning:plan
-                "medium": 80_000,  # arbitrary; tune in tuning:plan
-                "large": 200_000,  # arbitrary; tune in tuning:plan
+                "small": 30_000,
+                "medium": 80_000,
+                "large": 200_000,
             }
         )
     )

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -57,7 +57,9 @@ BUDGET_AWARE_OPUS_MARGIN: float = 2.0
 
 
 _budget_context_state: dict[str, Any] = {
-    "budget_remaining_usd": None,  # float | None - ``None`` = unknown / disabled
+    # ``budget_remaining_usd`` holds an Optional float; the None default means
+    # the budget is unknown or budget-aware routing has been disabled.
+    "budget_remaining_usd": None,
     "enabled": True,
     "estimated_opus_cost_usd": DEFAULT_OPUS_TASK_COST_USD,
 }

--- a/src/bernstein/gui/__init__.py
+++ b/src/bernstein/gui/__init__.py
@@ -52,11 +52,13 @@ def mount(app: FastAPI) -> None:
         )
 
     # Bidirectional parity: register on BOTH the root app AND under /api/v1/.
-    # AUDIT-126's `test_every_v1_route_has_root_counterpart` asserts every
-    # versioned route has a root mirror - keeping the router prefix-less and
-    # mounting it twice satisfies both directions of the parity test.
-    router = APIRouter(tags=["gui"])
-
+    # AUDIT-126's ``test_every_v1_route_has_root_counterpart`` asserts every
+    # versioned route has a root mirror. Build two independent ``APIRouter``
+    # instances via a local factory so each mount receives its own object -
+    # FastAPI's ``include_router`` mutates per-route state on the included
+    # instance, so reusing one router for both mounts (or nesting it inside an
+    # aggregator that is then mounted) trips python:S8413.
+    #
     # NB: ``from __future__ import annotations`` (top of this file) turns every
     # return annotation into a string. FastAPI's OpenAPI builder then tries to
     # resolve ``JSONResponse`` / ``FileResponse`` as response *models* (via
@@ -65,25 +67,23 @@ def mount(app: FastAPI) -> None:
     # dropping the return annotation - keeps the endpoint's runtime behaviour
     # identical while signalling to FastAPI that the response is a Starlette
     # ``Response`` subclass that should NOT be schema-modelled.
-    @router.get("/gui-meta", response_class=JSONResponse)
-    def gui_meta():  # pyright: ignore[reportUnusedFunction]
-        return JSONResponse(
-            {
-                "version": _package_version(),
-                "commit": _git_sha(),
-                "build_time": _build_time(),
-            },
-        )
+    def _build_gui_meta_router() -> APIRouter:
+        sub_router = APIRouter(tags=["gui"])
 
-    app.include_router(router)
-    # Mirror the same routes under /api/v1 via a dedicated aggregator router
-    # rather than re-including the ``router`` instance a second time. Including
-    # one ``APIRouter`` object into two parents shares mutable per-route state;
-    # nesting it inside a fresh ``api_v1_router`` keeps the versioned surface in
-    # parity (test_gui_meta_versioned_alias) without that shared-instance reuse.
-    api_v1_router = APIRouter()
-    api_v1_router.include_router(router)
-    app.include_router(api_v1_router, prefix="/api/v1")
+        @sub_router.get("/gui-meta", response_class=JSONResponse)
+        def gui_meta():  # pyright: ignore[reportUnusedFunction]
+            return JSONResponse(
+                {
+                    "version": _package_version(),
+                    "commit": _git_sha(),
+                    "build_time": _build_time(),
+                },
+            )
+
+        return sub_router
+
+    app.include_router(_build_gui_meta_router())
+    app.include_router(_build_gui_meta_router(), prefix="/api/v1")
 
     assets_dir = STATIC_DIR / "assets"
     if assets_dir.exists():


### PR DESCRIPTION
## Summary

Phase 2 Sonar sweep, cluster 1: resolves 16 findings across 3 files.

| File                               | Rule         | Count | Fix |
|------------------------------------|--------------|-------|-----|
| src/bernstein/gui/__init__.py:86   | python:S8413 | 1 (BLOCKER) | Build two independent APIRouter instances via a local factory, replacing the shared-instance-via-aggregator pattern |
| src/bernstein/core/defaults.py     | python:S125  | 14    | Drop redundant 'arbitrary; tune in tuning:<area>' end-of-line comments (the module docstring already documents tuning) |
| src/bernstein/core/routing/router_core.py:60 | python:S125 | 1 | Rephrase the inline 'float | None - ...' annotation as a prose comment |

## Root-cause notes

- **S8413** fires when the same APIRouter object is included into a parent more than once, directly or via a nested aggregator that is itself mounted. PR #1788 nested the shared router into a fresh aggregator but the underlying object reuse remained. This PR replaces the shared router with a factory that returns a fresh APIRouter for each mount.
- **S125** misfires on the inline comments because the colon in 'tuning:orchestrator' / 'float | None' parses as commented-out Python syntax. The information is preserved (module docstring, prose comment) without that pattern.

## Test plan

- [x] uv run pytest tests/integration/test_gui_pwa_integration.py -k gui_meta (gui-meta + versioned alias parity)
- [x] uv run pytest tests/unit/test_defaults.py (frozen dataclass defaults)
- [x] uv run pytest tests/unit/test_budget_aware_routing.py (router_core budget context)
- [x] uv run ruff check + format on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified type documentation for internal state tracking.

* **Refactor**
  * Improved internal route initialization structure for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->