### PR TITLE
feat(eval): ingest CI-failure post-mortems into regression cases

### DIFF
--- a/docs/eval/incident-synthesis.md
+++ b/docs/eval/incident-synthesis.md
@@ -1,11 +1,13 @@
 # Incident-to-eval synthesis
 
-Bernstein already captures incidents in three places: the dead-letter
-queue, orchestrator postmortems, and the flaky-test detector. Until
-this feature, those records stayed where they were created and never
+Bernstein already captures incidents in four places: the dead-letter
+queue, orchestrator postmortems, the flaky-test detector, and
+CI-failure postmortems mined from merged pull requests. Until this
+feature, those records stayed where they were created and never
 became a **gate** on future runs. The same prompt-injection /
 token-runaway / adapter-timeout patterns surfaced as repeat incidents
-weeks apart.
+weeks apart, and CI regressions that the human author had to fix up
+across 2+ commits never made it into the eval corpus at all.
 
 `incident_synthesizer` ingests each incident, redacts secrets,
 extracts the smallest reproducible trigger, and emits a YAML eval
@@ -33,11 +35,45 @@ bernstein eval sync-incidents --dry-run
 
 The synthesiser:
 
-1. Reads dead-letter queue + postmortem artefacts.
+1. Reads dead-letter queue, orchestrator postmortem artefacts, and
+   CI-failure postmortems under `.sdd/reports/ci_postmortems/`.
 2. Strips secrets via `core/security/sanitize.py`.
 3. Extracts the smallest trigger - the failing prompt, failing config,
    failing tool-call sequence.
-4. Writes one YAML per incident, idempotent by content hash.
+4. Writes one YAML per incident, idempotent by content hash *and*
+   `source_incident` key.
+
+### CI-failure postmortems
+
+The companion `scripts/scrape_ci_postmortems.py` walks merged pull
+requests from the last 30 days via the `gh` CLI. A PR qualifies as a
+post-mortem when its commit list shows a feature commit followed by
+**two or more fix-up commits**. The fix-up regex (see
+`FIXUP_SUBJECT_RE` in the script) matches conventional-commit
+prefixes like `fix(ci):`, `fix(tests):`, `fix(lint):`, `fix(types):`,
+`fixup!`, `squash!`, and the plain-prefix variants `fix ci:` /
+`fix tests:` / `fix typing:`. The first commit of the PR is always
+treated as the original feature commit and never counted as a fix-up.
+
+Each qualifying PR becomes one JSON record under
+`.sdd/reports/ci_postmortems/pr-<PR#>-<short-sha>.json`. The next
+`bernstein eval sync-incidents` run promotes that record into a
+P1 (warn-only) regression case keyed on
+`ci-postmortem:<PR#>:<commit-sha>`. Re-running either the scraper or
+the synthesizer is a no-op once the case exists on disk.
+
+Run the scraper on a daily cron (or after every release):
+
+```bash
+python scripts/scrape_ci_postmortems.py \
+    --repo sipyourdrink-ltd/bernstein \
+    --since-days 30 \
+    --out .sdd/reports/ci_postmortems
+```
+
+When the `gh` CLI is missing or unauthenticated the scraper logs a
+notice and exits 0 - downstream integration tests skip rather than
+fail.
 
 Sample emitted case:
 
@@ -84,7 +120,8 @@ Metrics:
 
 - Source: `src/bernstein/eval/incident_synthesizer.py`
 - Inputs: `core/tasks/dead_letter_queue.py`,
-  `core/observability/postmortem.py`
+  `core/observability/postmortem.py`,
+  `scripts/scrape_ci_postmortems.py`
 - Quality gate: `core/quality/gate_pipeline.py`
 - CLI: `bernstein eval sync-incidents`
-- PR #1001
+- PR #1001 (initial), #1793 (CI-failure postmortem ingestion)

--- a/scripts/scrape_ci_postmortems.py
+++ b/scripts/scrape_ci_postmortems.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python
+"""Mine recently merged PRs for CI-failure post-mortems.
+
+A merged pull request is treated as a CI-failure post-mortem when its
+commit list shows a feature commit followed by 2+ fix-up commits. Each
+such PR becomes one JSON record matching the ``CIFailurePostmortem``
+schema in ``bernstein.eval.incident_synthesizer``.
+
+Pipeline
+--------
+1. Use the ``gh`` CLI to list PRs merged in the last 30 days against
+   the default branch.
+2. For each PR, pull its commit subjects (oldest first).
+3. Apply the fix-up regex (see :data:`FIXUP_SUBJECT_RE`) to every
+   commit after the first. A PR qualifies when at least 2 of those
+   trailing commits match.
+4. Emit one JSON file per qualifying PR under
+   ``.sdd/reports/ci_postmortems/pr-<PR#>-<short-sha>.json``.
+5. Skip writing when a record for the same ``(pr_number, commit_sha)``
+   already exists on disk or when an emitted YAML case already
+   references the same source-incident key. This makes re-runs
+   idempotent.
+
+Fix-up commit heuristic
+-----------------------
+We deliberately keep the regex narrow so an honest fix-up author is
+detected and unrelated commits are not swept in. A commit subject is
+treated as a fix-up when it matches one of:
+
+* ``fix(ci): ...`` / ``fix(tests): ...`` / ``fix(test): ...``
+* ``fix(lint): ...`` / ``fix(types): ...`` / ``fix(typing): ...``
+* ``fixup! ...`` / ``!fixup ...`` / ``squash! ...``
+* Plain prefix ``fix ci:`` / ``fix tests:`` / ``fix lint:``
+
+Operators that want a broader heuristic should adjust
+:data:`FIXUP_SUBJECT_RE` here rather than override per-run. The
+exact regex is operator-judgement territory: keep it explicit and
+reviewed in this script.
+
+Graceful degradation
+--------------------
+The scraper depends on the ``gh`` CLI. When ``gh`` is missing the
+script writes a clear notice and exits 0; downstream integration
+tests skip rather than fail. The same fallback fires when ``gh`` is
+present but unauthenticated.
+
+Usage::
+
+    python scripts/scrape_ci_postmortems.py \\
+        --repo sipyourdrink-ltd/bernstein \\
+        --since-days 30 \\
+        --out .sdd/reports/ci_postmortems
+
+A ``--dry-run`` flag prints the JSON records to stdout without
+touching the filesystem.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+# The scraper is intentionally importable without the bernstein package
+# installed - that lets it run from a stale wheelhouse or air-gapped
+# host. We *do* re-use the dataclass when bernstein is available so the
+# scraper and the synthesizer never drift.
+try:
+    from bernstein.eval.incident_synthesizer import CIFailurePostmortem
+except Exception:  # pragma: no cover - import fallback for air-gap
+    CIFailurePostmortem = None  # type: ignore[assignment,misc]
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger("scrape_ci_postmortems")
+
+# Fix-up subject heuristic. Update only with reviewer eyes on the diff;
+# it is the operator-judgement seam called out in the issue.
+FIXUP_SUBJECT_RE: re.Pattern[str] = re.compile(
+    r"""
+    ^(?:
+        fix\((?:ci|tests?|lint|types?|typing|format|formatting|coverage)\)\s*:
+        | fixup!\s+
+        | !fixup\s+
+        | squash!\s+
+        | fix\s+(?:ci|tests?|lint|typing|types)\s*:
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# A PR qualifies when at least this many of its trailing (post-feature)
+# commits are fix-up commits.
+MIN_FIXUP_COMMITS: int = 2
+
+# Common CI-failure error-line markers we surface verbatim. Conservative
+# on purpose - the prompt readers only need a representative line.
+_ERROR_LINE_HINTS: tuple[str, ...] = (
+    "FAILED ",
+    "AssertionError",
+    "ruff check failed",
+    "pyright",
+    "mypy:",
+    "E   ",
+    "Error:",
+    "error:",
+)
+
+
+def _gh_available() -> bool:
+    """Return True when the ``gh`` CLI is on PATH and authenticated."""
+    if shutil.which("gh") is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["gh", "auth", "status"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def _gh_json(args: list[str]) -> Any:
+    """Run a ``gh`` subcommand returning JSON; raise on failure."""
+    proc = subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        msg = f"gh {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}"
+        raise RuntimeError(msg)
+    if not proc.stdout.strip():
+        return []
+    return json.loads(proc.stdout)
+
+
+def list_merged_prs(repo: str, since_days: int) -> list[dict[str, Any]]:
+    """Return PRs merged in the last ``since_days`` days against the default branch."""
+    args = [
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--limit",
+        "300",
+        "--json",
+        "number,title,mergeCommit,mergedAt,headRefName",
+    ]
+    raw = _gh_json(args)
+    if not isinstance(raw, list):
+        return []
+    cutoff: float | None = None
+    if since_days > 0:
+        import datetime as _dt
+
+        cutoff_dt = _dt.datetime.now(tz=_dt.UTC) - _dt.timedelta(days=since_days)
+        cutoff = cutoff_dt.timestamp()
+
+    fresh: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        if cutoff is not None:
+            merged_at = item.get("mergedAt") or ""
+            ts = _parse_iso(merged_at)
+            if ts is None or ts < cutoff:
+                continue
+        fresh.append(item)
+    return fresh
+
+
+def _parse_iso(value: str) -> float | None:
+    if not value:
+        return None
+    try:
+        import datetime as _dt
+
+        # Accept both ``Z`` and offset suffixes.
+        clean = value.replace("Z", "+00:00")
+        return _dt.datetime.fromisoformat(clean).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def list_pr_commits(repo: str, pr_number: int) -> list[str]:
+    """Return commit subjects for a PR, oldest first."""
+    args = [
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "commits",
+    ]
+    raw = _gh_json(args)
+    if not isinstance(raw, dict):
+        return []
+    commits = raw.get("commits") or []
+    subjects: list[str] = []
+    for c in commits:
+        if not isinstance(c, dict):
+            continue
+        # gh exposes the full message under ``messageHeadline`` (first
+        # line) plus ``messageBody``. We only need the headline.
+        subject = c.get("messageHeadline") or ""
+        if isinstance(subject, str) and subject.strip():
+            subjects.append(subject.strip())
+    return subjects
+
+
+def detect_fixup_commits(subjects: Iterable[str]) -> list[str]:
+    """Apply the fix-up regex to every commit *after* the first.
+
+    The first commit in a PR is treated as the original feature commit
+    and never counted as a fix-up. Returns the list of qualifying
+    subjects in input order.
+    """
+    out: list[str] = []
+    for i, subj in enumerate(subjects):
+        if i == 0:
+            continue
+        if FIXUP_SUBJECT_RE.match(subj):
+            out.append(subj)
+    return out
+
+
+def _pick_error_line(text: str) -> str:
+    """Pull a short representative error line from a free-form blob."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if any(hint in stripped for hint in _ERROR_LINE_HINTS):
+            return stripped
+    return ""
+
+
+def synthesize_record(
+    pr: dict[str, Any],
+    commits: list[str],
+    fixups: list[str],
+) -> dict[str, Any] | None:
+    """Return a JSON-serialisable record or ``None`` when the PR does not qualify."""
+    if len(fixups) < MIN_FIXUP_COMMITS:
+        return None
+    pr_number = pr.get("number")
+    if not isinstance(pr_number, int):
+        return None
+    merge_commit = pr.get("mergeCommit") or {}
+    commit_sha = ""
+    if isinstance(merge_commit, dict):
+        commit_sha = str(merge_commit.get("oid") or "")
+    if not commit_sha:
+        return None
+
+    failing_test = _guess_failing_test(fixups)
+    error_line = _pick_error_line("\n".join(fixups))
+
+    record: dict[str, Any] = {
+        "pr_number": pr_number,
+        "commit_sha": commit_sha,
+        "failing_test": failing_test,
+        "error_line": error_line,
+        "fixup_commits": fixups,
+    }
+    if CIFailurePostmortem is not None:
+        # Round-trip through the dataclass to ensure the scraper and
+        # synthesizer never drift on field names.
+        pm = CIFailurePostmortem(
+            pr_number=pr_number,
+            commit_sha=commit_sha,
+            failing_test=failing_test,
+            error_line=error_line,
+            fixup_commits=tuple(fixups),
+        )
+        record = asdict(pm)
+        # ``asdict`` returns a tuple for ``fixup_commits``; JSON expects a list.
+        record["fixup_commits"] = list(record["fixup_commits"])
+    return record
+
+
+_TEST_HINT_RE: re.Pattern[str] = re.compile(
+    r"(?P<path>tests?/[A-Za-z0-9_/\-]+\.py(?:::[\w\[\].\-]+)*)",
+)
+_LINT_HINT_RE: re.Pattern[str] = re.compile(
+    r"\b(ruff|pyright|mypy|black|isort|coverage|pre[\-_]commit)\b",
+    re.IGNORECASE,
+)
+
+
+def _guess_failing_test(fixups: list[str]) -> str:
+    """Try to extract a failing-test identifier from fix-up subjects."""
+    joined = " ".join(fixups)
+    m = _TEST_HINT_RE.search(joined)
+    if m:
+        return m.group("path")
+    m = _LINT_HINT_RE.search(joined)
+    if m:
+        return m.group(1).lower()
+    return ""
+
+
+def existing_keys(out_dir: Path, cases_dir: Path | None) -> set[str]:
+    """Return ``ci-postmortem:<pr>:<sha>`` keys already on disk.
+
+    Two sources are merged:
+
+    * The scraper's own ``out_dir`` (so re-running the script is a
+      pure no-op).
+    * Emitted YAML cases under ``cases_dir`` (so a previous synth pass
+      that has already promoted a record into a YAML case is also
+      treated as covered).
+    """
+    keys: set[str] = set()
+    if out_dir.is_dir():
+        for path in out_dir.glob("*.json"):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            pr_n = raw.get("pr_number") if isinstance(raw, dict) else None
+            sha = raw.get("commit_sha") if isinstance(raw, dict) else None
+            if isinstance(pr_n, int) and isinstance(sha, str) and sha:
+                keys.add(f"ci-postmortem:{pr_n}:{sha}")
+    if cases_dir and cases_dir.is_dir():
+        for path in cases_dir.glob("inc-*.yaml"):
+            try:
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    if line.startswith("source_incident:"):
+                        raw_val = line.split(":", 1)[1].strip()
+                        if len(raw_val) >= 2 and raw_val[0] == '"' and raw_val[-1] == '"':
+                            raw_val = raw_val[1:-1]
+                        if raw_val.startswith("ci-postmortem:"):
+                            keys.add(raw_val)
+                        break
+            except OSError:
+                continue
+    return keys
+
+
+def emit_record(record: dict[str, Any], out_dir: Path) -> Path:
+    """Write a record under ``out_dir`` and return the path."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    short = str(record["commit_sha"])[:12]
+    path = out_dir / f"pr-{record['pr_number']}-{short}.json"
+    path.write_text(json.dumps(record, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def run(
+    *,
+    repo: str,
+    since_days: int,
+    out_dir: Path,
+    cases_dir: Path | None,
+    dry_run: bool,
+    pr_data: list[dict[str, Any]] | None = None,
+    commits_loader: Any = None,
+) -> int:
+    """Drive one scrape pass. Returns the number of records emitted."""
+    if pr_data is None:
+        if not _gh_available():
+            logger.warning("gh CLI unavailable or unauthenticated; scraper exits 0 with no output")
+            return 0
+        pr_data = list_merged_prs(repo, since_days)
+
+    loader = commits_loader or (lambda pr_num: list_pr_commits(repo, pr_num))
+    seen = existing_keys(out_dir, cases_dir)
+    emitted = 0
+    for pr in pr_data:
+        pr_number = pr.get("number")
+        if not isinstance(pr_number, int):
+            continue
+        try:
+            subjects = loader(pr_number)
+        except Exception as exc:
+            logger.warning("could not load commits for PR #%s: %s", pr_number, exc)
+            continue
+        fixups = detect_fixup_commits(subjects)
+        record = synthesize_record(pr, subjects, fixups)
+        if record is None:
+            continue
+        key = f"ci-postmortem:{record['pr_number']}:{record['commit_sha']}"
+        if key in seen:
+            continue
+        if dry_run:
+            print(json.dumps(record, sort_keys=True))
+        else:
+            path = emit_record(record, out_dir)
+            logger.info("emitted %s", path)
+        seen.add(key)
+        emitted += 1
+    return emitted
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--repo",
+        default="sipyourdrink-ltd/bernstein",
+        help="``owner/repo`` slug passed to ``gh``.",
+    )
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=30,
+        help="Look back N days when listing merged PRs (default: 30).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(".sdd/reports/ci_postmortems"),
+        help="Output directory for emitted JSON records.",
+    )
+    parser.add_argument(
+        "--cases-dir",
+        type=Path,
+        default=Path("src/bernstein/eval/cases/incidents"),
+        help="Existing YAML cases dir (consulted for dedup only).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print records to stdout instead of writing files.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Verbose logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+    count = run(
+        repo=args.repo,
+        since_days=args.since_days,
+        out_dir=args.out,
+        cases_dir=args.cases_dir,
+        dry_run=args.dry_run,
+    )
+    logger.info("scraper finished; %d new postmortem record(s)", count)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    sys.exit(main())

--- a/src/bernstein/eval/incident_synthesizer.py
+++ b/src/bernstein/eval/incident_synthesizer.py
@@ -1,21 +1,23 @@
 """Convert dead-letter and post-mortem incidents into regression eval cases.
 
 Implements the *incident-to-eval-synthesis* pattern. Each terminally
-failed task or orchestrator post-mortem becomes one minimal,
-reproducible eval case under ``src/bernstein/eval/cases/incidents/``.
-The next agent must pass these cases or the quality gate blocks merge.
+failed task, orchestrator post-mortem, or CI-failure post-mortem
+becomes one minimal, reproducible eval case under
+``src/bernstein/eval/cases/incidents/``. The next agent must pass
+these cases or the quality gate blocks merge.
 
 Pipeline
 --------
-1. **Read** new incidents from the dead-letter queue and post-mortem
-   reports.
+1. **Read** new incidents from the dead-letter queue, post-mortem
+   reports, and CI-failure post-mortems scraped from merged PRs.
 2. **Minimise** the trigger - keep only the smallest prompt / config /
    tool sequence that would reproduce the failure. Long tracebacks are
    collapsed to their first useful frames.
 3. **Redact** with the existing PII / secret scanner. If a finding
    cannot be redacted safely the case is dropped.
-4. **De-duplicate** by stable content hash so re-running the synthesiser
-   over the same DLQ does not produce duplicate cases.
+4. **De-duplicate** by stable content hash and source-incident key so
+   re-running the synthesiser over the same DLQ does not produce
+   duplicate cases.
 5. **Emit** YAML files with ``id``, ``severity``, ``prompt``,
    ``expected_outcome`` and ``source_incident`` fields.
 
@@ -24,6 +26,15 @@ Severity routing follows the ticket convention:
 * ``P0`` - security / data-loss / prompt-injection. Blocks merge.
 * ``P1`` - correctness / orchestration regressions. Warn-only.
 * ``P2`` - flaky / transient. Warn-only.
+
+CI-failure post-mortems
+-----------------------
+A merged PR that needed 2+ fix-up commits between the original feature
+commit and merge is treated as a CI-failure post-mortem. The scraper
+in ``scripts/scrape_ci_postmortems.py`` emits one record per such PR;
+``IncidentSynthesizer.synthesize_from_ci_postmortem`` converts it to
+a P1 (warn-only) regression case keyed on
+``ci-postmortem:<PR#>:<commit-sha>``.
 
 The CLI (``bernstein eval sync-incidents``) and the
 ``run_incident_eval_gate`` function below are the two entry points.
@@ -49,6 +60,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "CIFailurePostmortem",
     "IncidentEvalCase",
     "IncidentSyncResult",
     "IncidentSynthesizer",
@@ -124,6 +136,38 @@ class IncidentEvalCase:
         return d
 
 
+@dataclass(frozen=True, slots=True)
+class CIFailurePostmortem:
+    """A CI-failure post-mortem mined from a merged pull request.
+
+    A merged PR is treated as a post-mortem when it needed 2+ fix-up
+    commits between the original feature commit and merge. Each such
+    PR yields exactly one ``CIFailurePostmortem`` instance, which the
+    synthesizer turns into a P1 regression eval case.
+
+    Attributes:
+        pr_number: Pull-request number on the host repository.
+        commit_sha: The merge commit (or last fix-up) SHA. Used together
+            with ``pr_number`` as the dedup key.
+        failing_test: Identifier of the CI check / test that failed,
+            e.g. ``"pytest::tests/unit/eval/test_foo.py::test_bar"`` or
+            ``"ruff"``. Empty string if unknown.
+        error_line: Single representative line lifted from the failing
+            CI log. Empty string if unavailable.
+        fixup_commits: Subjects of the fix-up commits, in chronological
+            order. At least two entries are required for the PR to
+            qualify as a post-mortem; the synthesizer accepts any
+            non-empty tuple to stay decoupled from the scraper's exact
+            threshold.
+    """
+
+    pr_number: int
+    commit_sha: str
+    failing_test: str = ""
+    error_line: str = ""
+    fixup_commits: tuple[str, ...] = ()
+
+
 @dataclass(slots=True)
 class IncidentSyncResult:
     """Outcome of one synthesiser pass.
@@ -175,13 +219,15 @@ class IncidentSynthesizer:
         Returns:
             Aggregated :class:`IncidentSyncResult`.
         """
-        existing_ids = self._load_existing_ids()
+        existing_ids, existing_sources = self._load_existing_state()
         result = IncidentSyncResult(dry_run=dry_run)
 
         for case in self._iter_dlq_cases():
-            self._emit(case, existing_ids, result, dry_run=dry_run)
+            self._emit(case, existing_ids, existing_sources, result, dry_run=dry_run)
         for case in self._iter_postmortem_cases():
-            self._emit(case, existing_ids, result, dry_run=dry_run)
+            self._emit(case, existing_ids, existing_sources, result, dry_run=dry_run)
+        for case in self._iter_ci_postmortem_cases():
+            self._emit(case, existing_ids, existing_sources, result, dry_run=dry_run)
         return result
 
     def synthesize_from_dlq_entry(self, entry: DLQEntry) -> IncidentEvalCase | None:
@@ -190,14 +236,50 @@ class IncidentSynthesizer:
         Returns ``None`` when redaction fails. Pure function - does not
         touch the filesystem.
         """
-        return self._case_from_dlq(entry)
+        return self._synthesize_eval_case(entry)
+
+    def synthesize_from_ci_postmortem(self, pm: CIFailurePostmortem) -> IncidentEvalCase | None:
+        """Build a single eval case from a CI-failure post-mortem.
+
+        Returns ``None`` when redaction fails or the post-mortem is
+        empty. Pure function - does not touch the filesystem.
+        """
+        return self._synthesize_eval_case(pm)
+
+    def _synthesize_eval_case(
+        self,
+        incident: object,
+        *,
+        source_path: Path | None = None,
+    ) -> IncidentEvalCase | None:
+        """Dispatch on the incident shape and produce a single eval case.
+
+        This is the single seam every input type flows through. New
+        incident shapes plug in here. ``incident`` is typed as
+        :class:`object` so any of the supported variants
+        (:class:`DLQEntry`, :class:`CIFailurePostmortem`, or the
+        raw post-mortem ``dict[str, Any]``) can be passed without
+        pyright complaining about overlapping isinstance branches.
+        """
+        if isinstance(incident, DLQEntry):
+            return self._case_from_dlq(incident)
+        if isinstance(incident, CIFailurePostmortem):
+            return self._case_from_ci_postmortem(incident)
+        if isinstance(incident, dict):
+            if source_path is None:
+                msg = "post-mortem dicts require a source_path"
+                raise ValueError(msg)
+            raw_dict: dict[str, Any] = dict(incident)  # type: ignore[arg-type]
+            return self._case_from_postmortem(raw_dict, source_path=source_path)
+        msg = f"unsupported incident type: {type(incident).__name__}"
+        raise TypeError(msg)
 
     # ------------------------------------------------------------------ readers
 
     def _iter_dlq_cases(self) -> Iterable[IncidentEvalCase]:
         dlq = DeadLetterQueue(self._sdd)
         for entry in dlq.list_entries(limit=10_000):
-            case = self._case_from_dlq(entry)
+            case = self._synthesize_eval_case(entry)
             if case is not None:
                 yield case
 
@@ -213,7 +295,31 @@ class IncidentSynthesizer:
                 continue
             if not isinstance(raw, dict):
                 continue
-            case = self._case_from_postmortem(raw, source_path=path)
+            case = self._synthesize_eval_case(raw, source_path=path)
+            if case is not None:
+                yield case
+
+    def _iter_ci_postmortem_cases(self) -> Iterable[IncidentEvalCase]:
+        """Yield cases from JSON records emitted by ``scrape_ci_postmortems``.
+
+        Records live under ``.sdd/reports/ci_postmortems/*.json``. Each
+        file is one record matching the :class:`CIFailurePostmortem`
+        schema. Records lacking the required ``pr_number`` /
+        ``commit_sha`` fields are skipped.
+        """
+        ci_dir = self._sdd / "reports" / "ci_postmortems"
+        if not ci_dir.is_dir():
+            return
+        for path in sorted(ci_dir.glob("*.json")):
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug("skipping unreadable ci postmortem %s: %s", path, exc)
+                continue
+            pm = _ci_postmortem_from_dict(raw)
+            if pm is None:
+                continue
+            case = self._synthesize_eval_case(pm)
             if case is not None:
                 yield case
 
@@ -281,20 +387,53 @@ class IncidentSynthesizer:
             created_at=time.time(),
         )
 
+    def _case_from_ci_postmortem(self, pm: CIFailurePostmortem) -> IncidentEvalCase | None:
+        if not pm.fixup_commits:
+            return None
+        if not pm.commit_sha:
+            return None
+
+        source = f"ci-postmortem:{pm.pr_number}:{pm.commit_sha}"
+        tags: set[str] = {"ci_failure", "regression"}
+        if pm.failing_test:
+            tags.add("test_failure")
+        # P1 per AC: regression, warn-only.
+        severity: Severity = "P1"
+
+        prompt_raw = _build_prompt_from_ci_postmortem(pm)
+        prompt = _redact(prompt_raw)
+        if prompt is None:
+            return None
+
+        outcome = _expected_outcome_for(severity, "ci_failure")
+        case_id = _content_id(prompt, severity, source)
+        return IncidentEvalCase(
+            id=case_id,
+            severity=severity,
+            prompt=prompt,
+            expected_outcome=outcome,
+            source_incident=source,
+            tags=tuple(sorted(tags)),
+            owner="ci-fixer",
+            created_at=time.time(),
+        )
+
     # ------------------------------------------------------------------ writer
 
     def _emit(
         self,
         case: IncidentEvalCase,
         existing_ids: set[str],
+        existing_sources: set[str],
         result: IncidentSyncResult,
         *,
         dry_run: bool,
     ) -> None:
-        if case.id in existing_ids:
+        if case.id in existing_ids or case.source_incident in existing_sources:
             result.skipped_duplicates += 1
             return
         existing_ids.add(case.id)
+        existing_sources.add(case.source_incident)
         result.created.append(case)
         if dry_run:
             return
@@ -314,10 +453,23 @@ class IncidentSynthesizer:
         path.write_text(body, encoding="utf-8")
         logger.info("incident eval case written: %s (%s)", path, case.severity)
 
-    def _load_existing_ids(self) -> set[str]:
+    def _load_existing_state(self) -> tuple[set[str], set[str]]:
+        """Return ``(case_ids, source_incident_keys)`` already on disk.
+
+        Source-incident keys give the scraper a second dedup axis: the
+        same fix-up PR re-scanned must not produce a new case even if
+        the redaction subtly shifts the content hash.
+        """
         if not self._cases_dir.is_dir():
-            return set()
-        return {p.stem for p in self._cases_dir.glob("inc-*.yaml")}
+            return set(), set()
+        ids: set[str] = set()
+        sources: set[str] = set()
+        for p in self._cases_dir.glob("inc-*.yaml"):
+            ids.add(p.stem)
+            src = _source_incident_from_yaml(p)
+            if src:
+                sources.add(src)
+        return ids, sources
 
 
 # ---------------------------------------------------------------------------
@@ -424,6 +576,53 @@ def _build_prompt_from_postmortem(run_id: str, factors: list[str], snippets: lis
     if len(body) > _MAX_PROMPT_LEN:
         body = body[:_MAX_PROMPT_LEN] + "..."
     return body
+
+
+def _build_prompt_from_ci_postmortem(pm: CIFailurePostmortem) -> str:
+    parts: list[str] = [
+        f"Reproduce and resolve the CI-failure regression from PR #{pm.pr_number}.",
+    ]
+    if pm.failing_test:
+        parts.append(f"Failing check: {pm.failing_test}")
+    if pm.error_line:
+        snippet = pm.error_line.strip()
+        if len(snippet) > _MAX_ERROR_LEN:
+            snippet = snippet[:_MAX_ERROR_LEN] + "..."
+        parts.append(f"Representative error line: {snippet}")
+    if pm.fixup_commits:
+        parts.append("Fix-up commits the human author needed before the PR went green:")
+        for subject in pm.fixup_commits[:8]:
+            parts.append(f"- {subject[:200]}")
+    body = "\n".join(parts)
+    if len(body) > _MAX_PROMPT_LEN:
+        body = body[:_MAX_PROMPT_LEN] + "..."
+    return body
+
+
+def _ci_postmortem_from_dict(raw: object) -> CIFailurePostmortem | None:
+    """Parse a JSON record emitted by ``scrape_ci_postmortems``.
+
+    Returns ``None`` for malformed records.
+    """
+    if not isinstance(raw, dict):
+        return None
+    data: dict[str, Any] = raw  # type: ignore[assignment]
+    pr_number: Any = data.get("pr_number")
+    commit_sha: Any = data.get("commit_sha")
+    if not isinstance(pr_number, int) or not isinstance(commit_sha, str) or not commit_sha:
+        return None
+    fixups_raw_any: Any = data.get("fixup_commits") or []
+    fixups_iter: list[Any] = list(fixups_raw_any) if isinstance(fixups_raw_any, list) else []  # type: ignore[arg-type]
+    fixups: tuple[str, ...] = tuple(str(c) for c in fixups_iter if c)
+    failing_test_raw: Any = data.get("failing_test") or ""
+    error_line_raw: Any = data.get("error_line") or ""
+    return CIFailurePostmortem(
+        pr_number=pr_number,
+        commit_sha=commit_sha,
+        failing_test=str(failing_test_raw),
+        error_line=str(error_line_raw),
+        fixup_commits=fixups,
+    )
 
 
 def _collapse_traceback(text: str) -> str:
@@ -538,6 +737,25 @@ def _severity_from_yaml(path: Path) -> str:
         for line in path.read_text(encoding="utf-8").splitlines():
             if line.startswith("severity:"):
                 return line.split(":", 1)[1].strip()
+    except OSError:
+        return ""
+    return ""
+
+
+def _source_incident_from_yaml(path: Path) -> str:
+    """Extract ``source_incident`` from a previously written eval-case YAML.
+
+    Quoted scalars from :func:`_yaml_scalar` are unquoted so the
+    returned value matches what the synthesizer would re-emit. Returns
+    ``""`` when the field is absent or the file is unreadable.
+    """
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("source_incident:"):
+                raw = line.split(":", 1)[1].strip()
+                if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+                    raw = raw[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+                return raw
     except OSError:
         return ""
     return ""

--- a/tests/unit/eval/test_incident_synthesizer.py
+++ b/tests/unit/eval/test_incident_synthesizer.py
@@ -1,0 +1,498 @@
+"""Tests for CI-failure post-mortem ingestion.
+
+The original DLQ / postmortem coverage lives in
+``tests/unit/test_incident_synthesizer.py``. This file focuses on the
+new ``CIFailurePostmortem`` shape and the
+``scripts/scrape_ci_postmortems`` helpers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.eval.incident_synthesizer import (
+    CIFailurePostmortem,
+    IncidentSynthesizer,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _load_scraper() -> Any:
+    """Load ``scripts/scrape_ci_postmortems`` once per session.
+
+    The scripts directory is not a package, so we import by path.
+    """
+    if "scrape_ci_postmortems" in sys.modules:
+        return sys.modules["scrape_ci_postmortems"]
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "scrape_ci_postmortems.py"
+    spec = importlib.util.spec_from_file_location("scrape_ci_postmortems", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["scrape_ci_postmortems"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SCRAPER = _load_scraper()
+
+
+# ---------------------------------------------------------------------------
+# CIFailurePostmortem dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestCIFailurePostmortemDataclass:
+    def test_required_fields_and_defaults(self) -> None:
+        pm = CIFailurePostmortem(pr_number=1, commit_sha="abc")
+        assert pm.pr_number == 1
+        assert pm.commit_sha == "abc"
+        assert pm.failing_test == ""
+        assert pm.error_line == ""
+        assert pm.fixup_commits == ()
+
+    def test_is_hashable_and_frozen(self) -> None:
+        import dataclasses
+
+        pm = CIFailurePostmortem(pr_number=2, commit_sha="def")
+        # Frozen dataclasses must be hashable.
+        assert hash(pm) == hash(pm)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            pm.pr_number = 3  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Synthesizer dispatch on CIFailurePostmortem
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeFromCiPostmortem:
+    def test_one_postmortem_produces_one_case(self, tmp_path: Path) -> None:
+        pm = CIFailurePostmortem(
+            pr_number=1793,
+            commit_sha="0123456789abcdef" * 2,
+            failing_test="tests/unit/eval/test_widget.py::test_foo",
+            error_line="AssertionError: expected 1 got 2",
+            fixup_commits=(
+                "fix(ci): retry flaky network harness",
+                "fix(tests): widen widget expected output",
+            ),
+        )
+        synth = IncidentSynthesizer(tmp_path)
+        case = synth.synthesize_from_ci_postmortem(pm)
+        assert case is not None
+        assert case.severity == "P1"
+        assert case.source_incident == f"ci-postmortem:{pm.pr_number}:{pm.commit_sha}"
+        assert case.owner == "ci-fixer"
+        assert "ci_failure" in case.tags
+        assert "regression" in case.tags
+        assert "test_failure" in case.tags
+        # The fix-up commit subjects must be visible in the synthesised prompt
+        # so the candidate agent has the breadcrumb to reproduce the regression.
+        assert "fix(ci): retry flaky network harness" in case.prompt
+        assert "tests/unit/eval/test_widget.py" in case.prompt
+        assert "AssertionError" in case.prompt
+
+    def test_empty_fixups_skipped(self, tmp_path: Path) -> None:
+        pm = CIFailurePostmortem(pr_number=99, commit_sha="aaaa", fixup_commits=())
+        synth = IncidentSynthesizer(tmp_path)
+        assert synth.synthesize_from_ci_postmortem(pm) is None
+
+    def test_missing_sha_skipped(self, tmp_path: Path) -> None:
+        pm = CIFailurePostmortem(
+            pr_number=99,
+            commit_sha="",
+            fixup_commits=("fix(ci): a", "fix(tests): b"),
+        )
+        synth = IncidentSynthesizer(tmp_path)
+        assert synth.synthesize_from_ci_postmortem(pm) is None
+
+    def test_dispatch_via_internal_seam(self, tmp_path: Path) -> None:
+        pm = CIFailurePostmortem(
+            pr_number=1,
+            commit_sha="abc",
+            fixup_commits=("fix(ci): a", "fix(tests): b"),
+        )
+        synth = IncidentSynthesizer(tmp_path)
+        # _synthesize_eval_case is the single dispatch seam called by
+        # both public methods and the iterators.
+        case = synth._synthesize_eval_case(pm)
+        assert case is not None
+        assert case.severity == "P1"
+
+
+# ---------------------------------------------------------------------------
+# JSON record ingestion via sync()
+# ---------------------------------------------------------------------------
+
+
+def _write_record(workdir: Path, record: dict[str, Any]) -> Path:
+    ci_dir = workdir / ".sdd" / "reports" / "ci_postmortems"
+    ci_dir.mkdir(parents=True, exist_ok=True)
+    path = ci_dir / f"pr-{record['pr_number']}-{record['commit_sha'][:12]}.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+class TestSyncIngestsCiPostmortems:
+    def test_sync_emits_yaml_case(self, tmp_path: Path) -> None:
+        _write_record(
+            tmp_path,
+            {
+                "pr_number": 100,
+                "commit_sha": "deadbeefcafe1234",
+                "failing_test": "ruff",
+                "error_line": "ruff check failed in tests/unit/test_foo.py",
+                "fixup_commits": ["fix(ci): a", "fix(lint): b"],
+            },
+        )
+        synth = IncidentSynthesizer(tmp_path)
+        result = synth.sync()
+        assert len(result.created) == 1
+        case = result.created[0]
+        assert case.source_incident == "ci-postmortem:100:deadbeefcafe1234"
+        assert case.severity == "P1"
+
+        cases_dir = tmp_path / "src" / "bernstein" / "eval" / "cases" / "incidents"
+        files = list(cases_dir.glob("inc-*.yaml"))
+        assert len(files) == 1
+        body = files[0].read_text(encoding="utf-8")
+        assert "source_incident:" in body
+        assert "ci-postmortem:100:deadbeefcafe1234" in body
+        assert "severity: P1" in body
+
+    def test_sync_is_idempotent_for_ci_postmortems(self, tmp_path: Path) -> None:
+        _write_record(
+            tmp_path,
+            {
+                "pr_number": 101,
+                "commit_sha": "feedfacecafef00d",
+                "failing_test": "",
+                "error_line": "",
+                "fixup_commits": ["fix(ci): a", "fix(tests): b"],
+            },
+        )
+        synth = IncidentSynthesizer(tmp_path)
+        first = synth.sync()
+        second = synth.sync()
+        assert len(first.created) == 1
+        assert len(second.created) == 0
+        assert second.skipped_duplicates >= 1
+
+    def test_malformed_records_skipped(self, tmp_path: Path) -> None:
+        ci_dir = tmp_path / ".sdd" / "reports" / "ci_postmortems"
+        ci_dir.mkdir(parents=True, exist_ok=True)
+        (ci_dir / "bad.json").write_text("{not json", encoding="utf-8")
+        (ci_dir / "wrong.json").write_text(json.dumps({"pr_number": "not-an-int"}), encoding="utf-8")
+        synth = IncidentSynthesizer(tmp_path)
+        result = synth.sync()
+        assert len(result.created) == 0
+
+
+# ---------------------------------------------------------------------------
+# scrape_ci_postmortems heuristics + idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestFixupCommitDetection:
+    """Pin down the fix-up commit regex behaviour.
+
+    A fix-up commit is one of:
+      - ``fix(ci):`` / ``fix(tests):`` / ``fix(lint):`` / ``fix(types):``
+        / ``fix(typing):`` / ``fix(format):`` / ``fix(coverage):``
+      - ``fixup!`` / ``!fixup`` / ``squash!``
+      - ``fix ci:`` / ``fix tests:`` / ``fix lint:`` / ``fix typing:``
+
+    The first commit of a PR is treated as the *original feature commit*
+    and is never counted as a fix-up regardless of its subject.
+    """
+
+    def test_first_commit_never_counted(self) -> None:
+        subjects = [
+            "fix(ci): set up matrix",
+            "feat: real work",
+        ]
+        # Even though the first subject matches the regex, it is the
+        # 'original feature commit' slot by position.
+        assert SCRAPER.detect_fixup_commits(subjects) == []
+
+    def test_obvious_ci_fixup_detected(self) -> None:
+        subjects = [
+            "feat(eval): wire new judge",
+            "fix(ci): bump runner image",
+        ]
+        assert SCRAPER.detect_fixup_commits(subjects) == ["fix(ci): bump runner image"]
+
+    def test_full_pattern_set(self) -> None:
+        subjects = [
+            "feat: introduce widget",
+            "fix(ci): rerun smoke",
+            "fix(tests): adjust fixture",
+            "fix(lint): satisfy ruff",
+            "fix(types): mypy override",
+            "fixup! widget defaults",
+            "squash! prior",
+            "!fixup typo",
+            "fix ci: cache npm",
+            "fix tests: fixture order",
+            "fix typing: stub return",
+        ]
+        detected = SCRAPER.detect_fixup_commits(subjects)
+        # All 10 trailing subjects must match.
+        assert len(detected) == 10
+
+    def test_unrelated_commits_not_detected(self) -> None:
+        subjects = [
+            "feat: introduce widget",
+            "docs: improve readme",
+            "refactor: split helper",
+            "chore: bump dep",
+            "feat: another feature",
+        ]
+        assert SCRAPER.detect_fixup_commits(subjects) == []
+
+
+class TestSynthesizeRecord:
+    def test_single_fixup_does_not_qualify(self) -> None:
+        pr = {"number": 1, "mergeCommit": {"oid": "abc123"}}
+        record = SCRAPER.synthesize_record(pr, ["feat: x", "fix(ci): one"], ["fix(ci): one"])
+        # MIN_FIXUP_COMMITS = 2, so a single fixup does not qualify.
+        assert record is None
+
+    def test_two_fixups_qualify(self) -> None:
+        pr = {"number": 42, "mergeCommit": {"oid": "abc123def456"}}
+        subjects = ["feat: x", "fix(ci): one", "fix(tests): two"]
+        fixups = SCRAPER.detect_fixup_commits(subjects)
+        record = SCRAPER.synthesize_record(pr, subjects, fixups)
+        assert record is not None
+        assert record["pr_number"] == 42
+        assert record["commit_sha"] == "abc123def456"
+        assert record["fixup_commits"] == ["fix(ci): one", "fix(tests): two"]
+
+    def test_missing_merge_commit_skipped(self) -> None:
+        pr: dict[str, Any] = {"number": 7, "mergeCommit": None}
+        record = SCRAPER.synthesize_record(pr, ["a", "b"], ["fix(ci): b"])
+        assert record is None
+
+
+class TestScraperRun:
+    """End-to-end behaviour of ``scrape_ci_postmortems.run`` with a fake gh."""
+
+    def _make_loader(self, mapping: dict[int, list[str]]) -> Callable[[int], list[str]]:
+        def loader(pr_num: int) -> list[str]:
+            return mapping.get(pr_num, [])
+
+        return loader
+
+    def test_one_fixup_pr_becomes_one_record(self, tmp_path: Path) -> None:
+        pr_data = [
+            {
+                "number": 500,
+                "mergeCommit": {"oid": "merge-sha-500"},
+                "mergedAt": "",
+            },
+        ]
+        commits = {
+            500: [
+                "feat(eval): add foo",
+                "fix(ci): pin runner image",
+                "fix(tests): widen expected output",
+            ],
+        }
+        out_dir = tmp_path / "ci_postmortems"
+        emitted = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=None,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=self._make_loader(commits),
+        )
+        assert emitted == 1
+        files = list(out_dir.glob("*.json"))
+        assert len(files) == 1
+        record = json.loads(files[0].read_text(encoding="utf-8"))
+        assert record["pr_number"] == 500
+        assert record["commit_sha"] == "merge-sha-500"
+        assert record["fixup_commits"] == [
+            "fix(ci): pin runner image",
+            "fix(tests): widen expected output",
+        ]
+
+    def test_rerun_is_idempotent(self, tmp_path: Path) -> None:
+        pr_data = [
+            {"number": 501, "mergeCommit": {"oid": "sha-501"}, "mergedAt": ""},
+        ]
+        commits = {
+            501: [
+                "feat: thing",
+                "fix(ci): a",
+                "fix(tests): b",
+            ],
+        }
+        out_dir = tmp_path / "ci_postmortems"
+        loader = self._make_loader(commits)
+        first = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=None,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=loader,
+        )
+        second = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=None,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=loader,
+        )
+        assert first == 1
+        assert second == 0
+        assert len(list(out_dir.glob("*.json"))) == 1
+
+    def test_no_fixups_produces_zero_records(self, tmp_path: Path) -> None:
+        pr_data = [
+            {"number": 600, "mergeCommit": {"oid": "sha-600"}, "mergedAt": ""},
+            {"number": 601, "mergeCommit": {"oid": "sha-601"}, "mergedAt": ""},
+        ]
+        commits = {
+            600: ["feat: a"],
+            601: ["feat: b", "docs: c", "chore: d"],
+        }
+        out_dir = tmp_path / "ci_postmortems"
+        emitted = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=None,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=self._make_loader(commits),
+        )
+        assert emitted == 0
+        assert not out_dir.exists() or not list(out_dir.glob("*.json"))
+
+    def test_multi_pr_mixed_qualification(self, tmp_path: Path) -> None:
+        pr_data = [
+            {"number": 700, "mergeCommit": {"oid": "sha-700"}, "mergedAt": ""},
+            {"number": 701, "mergeCommit": {"oid": "sha-701"}, "mergedAt": ""},
+            {"number": 702, "mergeCommit": {"oid": "sha-702"}, "mergedAt": ""},
+        ]
+        commits = {
+            700: ["feat: a", "fix(ci): x", "fix(tests): y"],  # qualifies
+            701: ["feat: b", "fix(ci): only one"],  # does not qualify (< MIN_FIXUP_COMMITS)
+            702: ["feat: c", "fix(lint): u", "fix(types): v", "fix(coverage): w"],  # qualifies
+        }
+        out_dir = tmp_path / "ci_postmortems"
+        emitted = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=None,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=self._make_loader(commits),
+        )
+        assert emitted == 2
+        files = sorted(p.name for p in out_dir.glob("*.json"))
+        assert any("700" in f for f in files)
+        assert any("702" in f for f in files)
+        assert not any("701" in f for f in files)
+
+    def test_dedup_against_existing_yaml_case(self, tmp_path: Path) -> None:
+        # Seed a YAML case that already references the same source_incident
+        # key so the scraper recognises the postmortem as already promoted.
+        cases_dir = tmp_path / "cases" / "incidents"
+        cases_dir.mkdir(parents=True, exist_ok=True)
+        (cases_dir / "inc-deadbeefcafe.yaml").write_text(
+            "id: inc-deadbeefcafe\n"
+            "severity: P1\n"
+            'source_incident: "ci-postmortem:800:sha-800"\n'
+            "owner: ci-fixer\n"
+            "tags: []\n"
+            "prompt: |\n"
+            "  Reproduce and resolve the CI-failure regression from PR #800.\n",
+            encoding="utf-8",
+        )
+
+        pr_data = [
+            {"number": 800, "mergeCommit": {"oid": "sha-800"}, "mergedAt": ""},
+        ]
+        commits = {800: ["feat: a", "fix(ci): x", "fix(tests): y"]}
+        out_dir = tmp_path / "ci_postmortems"
+        emitted = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=cases_dir,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=self._make_loader(commits),
+        )
+        assert emitted == 0
+
+    def test_gh_unavailable_exits_zero(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(SCRAPER, "_gh_available", lambda: False)
+        # When pr_data is None the scraper goes through _gh_available.
+        emitted = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=30,
+            out_dir=tmp_path / "ci_postmortems",
+            cases_dir=None,
+            dry_run=False,
+        )
+        assert emitted == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-module: scraper -> synthesizer end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndFlow:
+    def test_scraper_output_drives_synthesizer(self, tmp_path: Path) -> None:
+        """A record emitted by the scraper must be ingested by ``sync()``."""
+        pr_data = [
+            {"number": 900, "mergeCommit": {"oid": "sha-900-long"}, "mergedAt": ""},
+        ]
+        commits = {
+            900: [
+                "feat(eval): new harness",
+                "fix(ci): bump action",
+                "fix(tests): repair fixture",
+            ],
+        }
+        out_dir = tmp_path / ".sdd" / "reports" / "ci_postmortems"
+        emitted = SCRAPER.run(
+            repo="dummy/repo",
+            since_days=0,
+            out_dir=out_dir,
+            cases_dir=None,
+            dry_run=False,
+            pr_data=pr_data,
+            commits_loader=lambda pr_num: commits[pr_num],
+        )
+        assert emitted == 1
+        synth = IncidentSynthesizer(tmp_path)
+        result = synth.sync()
+        assert len(result.created) == 1
+        case = result.created[0]
+        assert case.source_incident.startswith("ci-postmortem:900:")
+        assert case.severity == "P1"
+        # Re-run is a pure no-op end-to-end.
+        again = synth.sync()
+        assert len(again.created) == 0
+        assert again.skipped_duplicates >= 1


### PR DESCRIPTION
Closes #1793.

## Summary

- Add `CIFailurePostmortem` dataclass and route every incident shape (DLQ entry, post-mortem JSON, CI-failure post-mortem) through a single `_synthesize_eval_case` dispatcher in `src/bernstein/eval/incident_synthesizer.py`.
- Add `scripts/scrape_ci_postmortems.py` that walks merged PRs from the last 30 days via the `gh` CLI, detects 2+ fix-up commit patterns, and emits one JSON record per qualifying PR under `.sdd/reports/ci_postmortems/`. The synthesizer then promotes each record into a P1 (warn-only) regression case keyed on `ci-postmortem:<PR#>:<commit-sha>`.
- Tests in `tests/unit/eval/test_incident_synthesizer.py` cover the dataclass, the dispatcher, the JSON-record sync path, the fix-up regex, scraper qualification thresholds, idempotency, and dedup against existing YAML cases.

## Fix-up commit heuristic (operator-judgement decision)

The first commit in a PR is treated as the original feature commit and never counted as a fix-up. A trailing commit qualifies when its subject matches `FIXUP_SUBJECT_RE`:

- `fix(ci):`, `fix(tests):`, `fix(test):`, `fix(lint):`, `fix(types):`, `fix(typing):`, `fix(format):`, `fix(coverage):`
- `fixup!`, `!fixup`, `squash!`
- Plain prefix `fix ci:`, `fix tests:`, `fix lint:`, `fix typing:`, `fix types:`

A PR qualifies for ingestion when at least 2 trailing commits match (`MIN_FIXUP_COMMITS = 2`).

## Files touched

- `src/bernstein/eval/incident_synthesizer.py`
- `scripts/scrape_ci_postmortems.py` (new)
- `tests/unit/eval/test_incident_synthesizer.py` (new)
- `docs/eval/incident-synthesis.md`

## Acceptance criteria

- [x] New `CIFailurePostmortem` dataclass with `pr_number`, `commit_sha`, `failing_test`, `error_line`, `fixup_commits` fields
- [x] `_synthesize_eval_case` dispatches on input type and produces a valid `IncidentEvalCase` from a `CIFailurePostmortem`
- [x] New `scripts/scrape_ci_postmortems.py` walks merged PRs from the last 30 days via `gh`, detects 2+ fix-up commits, emits one JSON record per detection
- [x] Emitted YAML eval-case carries `source_incident: ci-postmortem:<PR#>:<commit-sha>` and `tier: P1` (regression, warn-only by default)
- [x] Dedup: re-running the scraper does not duplicate cases already in `src/bernstein/eval/cases/incidents/`. Key on `(pr_number, commit_sha)`
- [x] Tests: one fix-up commit becomes one case (positive); multi-commit pattern behaviour documented and tested; re-run idempotency; empty input produces zero cases
- [x] `gh` unavailable graceful degradation - scraper exits 0 with notice

## Test plan

- [x] `uv run pytest tests/unit/eval/ -q --no-cov --timeout=120` - 88 passed
- [x] `uv run pytest tests/unit/test_incident_synthesizer.py tests/unit/eval/ -q --no-cov --timeout=120` - 136 passed (no regression on existing DLQ / post-mortem coverage)
- [x] `uv run ruff check . && uv run ruff format .` - clean
- [x] `uv run pyright src/bernstein/eval/incident_synthesizer.py` - 15 errors, equal to pre-existing baseline (no net regression)
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incident synthesis now ingests CI-failure postmortems from merged pull requests as a fourth incident source alongside dead-letter queues, orchestrator postmortems, and flaky-test detection.
  * Automatically extracts minimal reproducible triggers from CI failures and promotes them as eval gates on future CI runs.
  * Adds idempotent scraping and deduplication to prevent duplicate incident processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->