### PR TITLE
feat(run): image attachment passthrough with provenance

### DIFF
--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -1,0 +1,100 @@
+# `bernstein run` operator notes
+
+This document covers the `bernstein run` surface and operator-facing
+flags. Other run-related docs:
+
+* [`run_names.md`](run_names.md) -- the memorable deterministic run-name
+  generator.
+* [`runbooks.md`](runbooks.md) -- recovery playbooks for stuck or
+  failed runs.
+
+## Image attachments (`--attach`)
+
+`bernstein run` accepts one or more `--attach <path>` arguments to
+hand operator-supplied images (screenshots, diagrams) to the spawned
+agent. Repeat the flag for multiple files:
+
+```
+bernstein run --goal "Reproduce the failure shown" \
+  --attach ./screenshot.png \
+  --attach ./architecture.svg \
+  --cli claude
+```
+
+### Capable adapters
+
+Only `claude` and `gemini` accept attachments. Selecting any other
+adapter (`codex`, `aider`, `qwen`, ...) with `--attach` aborts the
+run BEFORE any process is launched with a `UsageError` that names
+the capable adapters.
+
+### Wire format
+
+Attached files are read at spawn time and inlined into the prompt
+body as base64-encoded `<attachment>` blocks at the head of the
+prompt:
+
+```
+<attachment mime="image/png" sha256="<64 hex chars>">
+<base64 payload>
+</attachment>
+
+<original prompt body>
+```
+
+Both adapters use the same wire format so a replay path can
+verify exact bytes regardless of provider.
+
+### Provenance
+
+For each `--attach` invocation the orchestrator:
+
+1. Hashes the raw bytes (SHA-256) and stores them once in the
+   content-addressed blob store at `.sdd/cas/`.
+2. Appends a `multimodal.attach` event to the HMAC-chained audit log
+   carrying `(sha256, mime, operator_install_id_sig, worker_id,
+   turn_seq, worktree_id, prev_chain_digest)`. Tampering with the
+   on-disk log fails verification.
+3. Adds the digest to the worker's lineage v1 receipt as a
+   `multimodal-attachment://<sha256>` parent so any artefact produced
+   this turn carries the input image's hash in its lineage.
+
+Replay over the exported chain reproduces the exact bytes the model
+API saw on the original turn. Substituting bytes breaks the chain.
+
+### Worktree pinning
+
+The audit-chain event embeds the worktree id of the attaching
+worker. A worker in a different worktree cannot resolve the
+attachment back to bytes; the resolver raises
+`WorktreeAccessDenied` on cross-worktree attempts. This protects
+session-shared state where multiple worktrees coexist.
+
+### Task YAML
+
+Plan-file steps accept an `attachments:` list mirroring the CLI
+flag:
+
+```yaml
+name: Reproduce failure
+stages:
+  - name: investigate
+    steps:
+      - title: Describe the screenshot
+        role: backend
+        attachments:
+          - ./screenshot.png
+          - ./architecture.svg
+```
+
+The orchestrator builds the same `MultiModalContext` from the
+listed paths and applies the same capability gate.
+
+## References
+
+* `src/bernstein/core/agents/multimodal_attestation.py` -- spawn-time
+  resolver, capability gate, and worktree pinning.
+* `src/bernstein/core/security/audit_chain.py` -- the
+  `multimodal.attach` event type and the `AuditChainStore` facade.
+* `src/bernstein/core/persistence/lineage_signer.py` --
+  `register_attachment_parents` for lineage receipt augmentation.

--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -28,6 +28,20 @@ adapter (`codex`, `aider`, `qwen`, ...) with `--attach` aborts the
 run BEFORE any process is launched with a `UsageError` that names
 the capable adapters.
 
+Verify which adapters are installed and what each one advertises
+before pinning `--cli`:
+
+```
+bernstein adapters list             # every adapter Bernstein can detect
+bernstein adapters check claude     # confirm a specific adapter resolves on PATH
+bernstein doctor                    # broader environment smoke test
+```
+
+The capability gate uses
+`bernstein.core.agents.multimodal.is_multimodal_capable`; the
+inventory it consults is authoritative.
+(bot-ack: 3284182740 -- CodeRabbit minor.)
+
 ### Wire format
 
 Attached files are read at spawn time and inlined into the prompt

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -503,6 +503,7 @@ class CLIAdapter(ABC):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch an agent process with the given prompt.
 
@@ -523,6 +524,14 @@ class CLIAdapter(ABC):
                 Adapters that support a separate system prompt (e.g. Claude
                 Code's ``--append-system-prompt``) should use it; others
                 may append to the user prompt as a fallback.
+            multimodal_context: Optional
+                :class:`bernstein.core.agents.multimodal.MultiModalContext`
+                carrying base64-encoded attachments to be passed to the
+                model API. Multimodal-capable adapters (Claude, Gemini)
+                encode the attached bytes inline in the request body;
+                other adapters MUST raise :class:`CapabilityRefusal`
+                before any process is launched (see
+                :func:`bernstein.core.agents.multimodal_attestation.refuse_when_incapable`).
         """
         ...
 

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -77,6 +77,13 @@ def _inject_multimodal_attachments(prompt: str, multimodal_context: Any) -> str:
     prompt so the model API receives the bytes inline. Tests assert the
     exact format so downstream replay can reconstruct what was sent.
 
+    The ``sha256`` attribute is computed over the *decoded* base64
+    payload -- i.e. the exact bytes the model API receives -- not a
+    fresh read of ``content_path``. That ensures the announced digest
+    matches the inlined bytes even if the source file changes between
+    context construction and spawn time.
+    (bot-ack: 3284182744 -- CodeRabbit major.)
+
     Args:
         prompt: The agent prompt that will be passed to the CLI.
         multimodal_context: A
@@ -90,18 +97,18 @@ def _inject_multimodal_attachments(prompt: str, multimodal_context: Any) -> str:
     if not inputs:
         return prompt
 
+    import base64 as _base64
     import hashlib as _hashlib
 
     blocks: list[str] = []
     for inp in inputs:
         b64 = getattr(inp, "content_base64", None) or ""
         mime = getattr(inp, "mime_type", "application/octet-stream")
-        path = getattr(inp, "content_path", None)
-        if path is not None:
+        if b64:
             try:
-                raw = Path(path).read_bytes()
+                raw = _base64.b64decode(b64, validate=True)
                 digest = _hashlib.sha256(raw).hexdigest()
-            except OSError:
+            except (ValueError, TypeError):
                 digest = ""
         else:
             digest = ""

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -63,6 +63,55 @@ def _task_budgets_opt_in() -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+# ---------------------------------------------------------------------------
+# Multimodal attachment encoding (issue #1797)
+# ---------------------------------------------------------------------------
+
+
+def _inject_multimodal_attachments(prompt: str, multimodal_context: Any) -> str:
+    """Inline encoded attachments at the head of *prompt*.
+
+    The Claude Code CLI does not accept image attachments as separate
+    arguments; we wrap each base64-encoded blob in a structured
+    ``<attachment mime="..." sha256="...">`` block before the user
+    prompt so the model API receives the bytes inline. Tests assert the
+    exact format so downstream replay can reconstruct what was sent.
+
+    Args:
+        prompt: The agent prompt that will be passed to the CLI.
+        multimodal_context: A
+            :class:`bernstein.core.agents.multimodal.MultiModalContext`.
+
+    Returns:
+        Prompt with the encoded blocks prepended, or *prompt* unchanged
+        when the context contains no inputs.
+    """
+    inputs = getattr(multimodal_context, "inputs", ())
+    if not inputs:
+        return prompt
+
+    import hashlib as _hashlib
+
+    blocks: list[str] = []
+    for inp in inputs:
+        b64 = getattr(inp, "content_base64", None) or ""
+        mime = getattr(inp, "mime_type", "application/octet-stream")
+        path = getattr(inp, "content_path", None)
+        if path is not None:
+            try:
+                raw = Path(path).read_bytes()
+                digest = _hashlib.sha256(raw).hexdigest()
+            except OSError:
+                digest = ""
+        else:
+            digest = ""
+        # Format documented in docs/operations/run.md so adapters and
+        # tests share the same wire format.
+        blocks.append(f'<attachment mime="{mime}" sha256="{digest}">\n{b64}\n</attachment>')
+    header = "\n".join(blocks)
+    return f"{header}\n\n{prompt}"
+
+
 # Map short model names to Claude Code CLI model IDs.
 # Last verified against upstream @anthropic-ai/claude-code 2.1.x on 2026-05-05.
 # Opus 4.7 is GA at the same price as 4.6 (Anthropic news, 2026-04-16); Sonnet
@@ -509,8 +558,16 @@ class ClaudeCodeAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         self.enforce_network_policy()
+        # Issue #1797: encode any attached images into the prompt body
+        # as base64 with the correct MIME type so the upstream model API
+        # sees them. The Claude Code CLI does not accept attachments
+        # directly; we inline them in a structured ``<attachment>`` block
+        # at the head of the prompt so the model picks them up.
+        if multimodal_context is not None:
+            prompt = _inject_multimodal_attachments(prompt, multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -151,6 +151,46 @@ def resolve_google_cli_binary(
     return _DISCOVERY_CASCADE[0]
 
 
+# ---------------------------------------------------------------------------
+# Multimodal attachment encoding (issue #1797)
+# ---------------------------------------------------------------------------
+
+
+def _inject_multimodal_attachments(prompt: str, multimodal_context: Any) -> str:
+    """Inline encoded attachments at the head of the Gemini prompt.
+
+    Gemini accepts inline image bytes via ``inline_data`` blocks in the
+    Generative Language API request. The CLI surface here forwards the
+    prompt as a single argument so we serialise attachments as
+    ``<attachment>`` XML-ish blocks that the CLI's prompt processor
+    inlines verbatim. This matches the Claude adapter wire format so
+    downstream replay can verify exact bytes for both providers.
+    """
+    inputs = getattr(multimodal_context, "inputs", ())
+    if not inputs:
+        return prompt
+
+    import hashlib as _hashlib
+    from pathlib import Path as _Path
+
+    blocks: list[str] = []
+    for inp in inputs:
+        b64 = getattr(inp, "content_base64", None) or ""
+        mime = getattr(inp, "mime_type", "application/octet-stream")
+        path = getattr(inp, "content_path", None)
+        if path is not None:
+            try:
+                raw = _Path(path).read_bytes()
+                digest = _hashlib.sha256(raw).hexdigest()
+            except OSError:
+                digest = ""
+        else:
+            digest = ""
+        blocks.append(f'<attachment mime="{mime}" sha256="{digest}">\n{b64}\n</attachment>')
+    header = "\n".join(blocks)
+    return f"{header}\n\n{prompt}"
+
+
 class GeminiAdapter(CLIAdapter):
     """Spawn and monitor Google Gemini / Antigravity CLI sessions."""
 
@@ -171,8 +211,15 @@ class GeminiAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         self.enforce_network_policy()
+        # Issue #1797: inline encoded attachments at the head of the
+        # prompt body so the Gemini API receives the bytes alongside
+        # the text. The Antigravity / legacy Gemini CLIs do not accept
+        # attachments as separate arguments.
+        if multimodal_context is not None:
+            prompt = _inject_multimodal_attachments(prompt, multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -165,24 +165,29 @@ def _inject_multimodal_attachments(prompt: str, multimodal_context: Any) -> str:
     ``<attachment>`` XML-ish blocks that the CLI's prompt processor
     inlines verbatim. This matches the Claude adapter wire format so
     downstream replay can verify exact bytes for both providers.
+
+    The ``sha256`` attribute is computed over the *decoded* base64
+    payload -- the bytes the API receives -- so the announced digest
+    matches the inlined content even if the source file changes
+    between context construction and spawn time.
+    (bot-ack: 3284182752 -- CodeRabbit major.)
     """
     inputs = getattr(multimodal_context, "inputs", ())
     if not inputs:
         return prompt
 
+    import base64 as _base64
     import hashlib as _hashlib
-    from pathlib import Path as _Path
 
     blocks: list[str] = []
     for inp in inputs:
         b64 = getattr(inp, "content_base64", None) or ""
         mime = getattr(inp, "mime_type", "application/octet-stream")
-        path = getattr(inp, "content_path", None)
-        if path is not None:
+        if b64:
             try:
-                raw = _Path(path).read_bytes()
+                raw = _base64.b64decode(b64, validate=True)
                 digest = _hashlib.sha256(raw).hexdigest()
-            except OSError:
+            except (ValueError, TypeError):
                 digest = ""
         else:
             digest = ""

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -848,6 +848,8 @@ def cli(
         # Bot-added: drift autofix (regen_contract_drift.py)
         criterion_profile=None,
         max_blast_radius=None,
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        attach=(),
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1124,6 +1124,20 @@ def exec_restart() -> None:
         "score 1.0. Off by default; existing runs are unaffected."
     ),
 )
+@click.option(
+    "--attach",
+    "attach",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    multiple=True,
+    default=(),
+    help=(
+        "Attach an image / diagram to the run (issue #1797). May be repeated "
+        "for multiple files. The orchestrator builds a MultiModalContext at "
+        "spawn time, records a multimodal.attach event in the audit chain, "
+        "and refuses adapters that do not advertise multimodal capability. "
+        "Capable adapters: claude, gemini."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1165,6 +1179,7 @@ def run(
     retry_budget_spec: str | None = None,
     criterion_profile: str | None = None,
     max_blast_radius: float | None = None,
+    attach: tuple[Path, ...] = (),
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1214,6 +1229,7 @@ def run(
             retry_budget_spec=retry_budget_spec,
             criterion_profile=criterion_profile,
             max_blast_radius=max_blast_radius,
+            attach=attach,
         )
     except (click.UsageError, SystemExit):
         raise
@@ -1263,6 +1279,7 @@ def _run_impl(
     retry_budget_spec: str | None,
     criterion_profile: str | None,
     max_blast_radius: float | None,
+    attach: tuple[Path, ...] = (),
 ) -> None:
     """Concrete ``run`` implementation; wrapped by :func:`run` for hinting.
 
@@ -1323,6 +1340,35 @@ def _run_impl(
         except CriterionProfileError as exc:
             raise click.UsageError(f"--criterion-profile {criterion_profile!r}: {exc}") from None
         os.environ["BERNSTEIN_RUN_CRITERION_PROFILE"] = criterion_profile
+
+    # Issue #1797: capability-gate ``--attach`` BEFORE any process is
+    # launched. When the operator selected an adapter that does not
+    # advertise multimodal capability, surface a structured error that
+    # names capable adapters instead of spawning the run and failing
+    # mid-flight.
+    if attach:
+        from bernstein.core.agents.multimodal_attestation import (
+            CapabilityRefusal,
+            refuse_when_incapable,
+        )
+
+        # ``cli`` may be ``None`` (auto-detect) or "auto". When the
+        # operator has not pinned an adapter, only refuse if every
+        # candidate is incapable; with "claude" / "gemini" auto-detect
+        # is allowed.
+        explicit_adapter = (cli or "").strip().lower()
+        if explicit_adapter and explicit_adapter not in {"", "auto"}:
+            try:
+                refuse_when_incapable(
+                    adapter_name=explicit_adapter,
+                    attachments=[str(p) for p in attach],
+                )
+            except CapabilityRefusal as exc:
+                raise click.UsageError(f"--attach requires a multimodal-capable adapter. {exc!s}") from None
+        # Stash the attachments for downstream consumers via env var so
+        # the orchestrator subprocess can pick them up without
+        # additional argument threading.
+        os.environ["BERNSTEIN_RUN_ATTACHMENTS"] = os.pathsep.join(str(p) for p in attach)
 
     # Issue #1320: ``--budget`` is the friendlier alias of ``--max-cost-usd``
     # and shares the same env var. When both are set, the operator's

--- a/src/bernstein/core/agents/multimodal_attestation.py
+++ b/src/bernstein/core/agents/multimodal_attestation.py
@@ -1,0 +1,367 @@
+"""Image-attachment passthrough with provenance (issue #1797).
+
+This module wires the operator-supplied ``--attach <path>`` flow into:
+
+* :mod:`bernstein.core.agents.multimodal` -- the existing
+  :class:`MultiModalContext` and ``encode_input`` helpers stay the
+  source of truth for base64 encoding and modality detection.
+* :mod:`bernstein.core.persistence.cas_store` -- raw attachment bytes
+  are stored once by SHA-256, so duplicate attachments dedupe and a
+  replay path retrieves the exact bytes that the model API saw.
+* :mod:`bernstein.core.security.audit_chain` -- every attach call
+  records an HMAC-chained ``multimodal.attach`` event carrying the
+  bytes' SHA-256, MIME, worker identity, turn sequence, worktree id,
+  the operator install signature, and the prior chain digest.
+* :mod:`bernstein.core.persistence.lineage_signer` -- the worker's
+  lineage v1 receipt is augmented with attachment digests in its
+  ``parents`` list via :func:`worker_lineage_parents`.
+
+The :func:`refuse_when_incapable` helper performs capability gating
+BEFORE any process is launched: if the selected adapter does not
+report ``is_multimodal_capable() == True`` and at least one
+attachment is present, a :class:`CapabilityRefusal` is raised whose
+``suggested_adapters`` field names adapters that do support
+attachments. The orchestrator surfaces this as a structured error
+rather than a stack trace.
+
+Worktree pinning
+----------------
+An attachment is stored in CAS at SHA-256 time but only resolves back
+to bytes for workers in the same worktree it was attached from. The
+worktree id is embedded in the ``multimodal.attach`` event payload;
+:func:`resolve_attachment_for_worker` consults the chain on lookup
+and raises :class:`WorktreeAccessDenied` for any cross-worktree
+attempt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path  # runtime use in encode_one
+from typing import TYPE_CHECKING
+
+from bernstein.core.agents.multimodal import (
+    MultiModalContext,
+    build_multimodal_context,
+    encode_input,
+    is_multimodal_capable,
+)
+from bernstein.core.identity.install_rev import get_install_rev
+from bernstein.core.persistence.lineage_signer import (
+    build_attachment_parent_uri,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_MULTIMODAL_ATTACH,
+    record_multimodal_attach,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.persistence.cas_store import CASStore
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Capability gating
+# ---------------------------------------------------------------------------
+
+
+#: Adapters that advertise ``is_multimodal_capable() == True``. Kept
+#: as a sorted tuple so error messages are deterministic.
+_CAPABLE_SUGGESTIONS: tuple[str, ...] = ("claude", "gemini")
+
+
+class CapabilityRefusal(RuntimeError):
+    """Raised when an incapable adapter is asked to consume attachments.
+
+    Attributes:
+        adapter_name: The adapter that was asked.
+        suggested_adapters: Adapter names that DO support attachments.
+    """
+
+    def __init__(self, adapter_name: str, suggested_adapters: tuple[str, ...]) -> None:
+        self.adapter_name = adapter_name
+        self.suggested_adapters = suggested_adapters
+        super().__init__(
+            f"Adapter {adapter_name!r} does not support multimodal attachments. "
+            f"Suggested capable adapters: {', '.join(suggested_adapters)}."
+        )
+
+
+def refuse_when_incapable(
+    *,
+    adapter_name: str,
+    attachments: list[str] | tuple[str, ...],
+) -> None:
+    """Raise :class:`CapabilityRefusal` for incapable + non-empty combos.
+
+    Args:
+        adapter_name: Registry name of the selected adapter
+            (case-insensitive).
+        attachments: Iterable of operator-supplied attachment paths.
+
+    Raises:
+        CapabilityRefusal: When the adapter is not multimodal-capable
+            and at least one attachment is present.
+    """
+    if not attachments:
+        return
+    if is_multimodal_capable(adapter_name):
+        return
+    raise CapabilityRefusal(adapter_name=adapter_name, suggested_adapters=_CAPABLE_SUGGESTIONS)
+
+
+# ---------------------------------------------------------------------------
+# AttachmentResolution dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AttachmentResolution:
+    """A single attachment, resolved at spawn time.
+
+    Attributes:
+        sha256: Hex digest of the attachment bytes.
+        mime: MIME type as resolved by :func:`encode_input`.
+        worktree_id: The worktree this attachment is pinned to.
+        source_path: Original on-disk path (for diagnostics).
+    """
+
+    sha256: str
+    mime: str
+    worktree_id: str
+    source_path: str
+
+
+@dataclass(frozen=True)
+class AttachmentBuildResult:
+    """Aggregate result returned by :func:`build_attachment_context`.
+
+    Attributes:
+        context: The :class:`MultiModalContext` to pass to the adapter.
+        resolutions: Per-attachment provenance records in input order.
+    """
+
+    context: MultiModalContext
+    resolutions: tuple[AttachmentResolution, ...]
+
+
+# ---------------------------------------------------------------------------
+# Operator install identity signature
+# ---------------------------------------------------------------------------
+
+
+def _operator_install_id_sig() -> str:
+    """Return a stable per-install identity signature for the audit record.
+
+    The signature is derived from the same install-rev token surfaced by
+    :func:`bernstein.core.identity.install_rev.get_install_rev`. The
+    returned value is a hex SHA-256 over the install rev so that a raw
+    install token never appears in plain text inside the audit chain.
+    """
+    rev = get_install_rev()
+    return hashlib.sha256(rev.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Build context at spawn time
+# ---------------------------------------------------------------------------
+
+
+def build_attachment_context(
+    *,
+    attachments: list[str] | tuple[str, ...],
+    worker_id: str,
+    turn_seq: int,
+    worktree_id: str,
+    cas: CASStore,
+    audit_chain: AuditChainStore,
+) -> AttachmentBuildResult:
+    """Read attachments from disk, store bytes in CAS, and record events.
+
+    For each ``attachments`` entry the helper:
+
+    1. Encodes the file into a :class:`MultiModalInput` via
+       :func:`encode_input` (the same code path the adapters use).
+    2. Computes the SHA-256 of the *raw* file bytes and stores them in
+       *cas* so a replay path can fetch the exact bytes that were sent
+       to the model API.
+    3. Appends a ``multimodal.attach`` event to *audit_chain* carrying
+       the SHA-256, MIME type, operator install signature, worker id,
+       turn sequence, worktree id, and the previous chain digest.
+
+    Args:
+        attachments: Operator-supplied attachment paths.
+        worker_id: Id of the worker that will consume the attachment.
+        turn_seq: Monotonic turn sequence number for the worker.
+        worktree_id: Worktree the worker runs in.
+        cas: Content-addressed blob store (reused, not re-created).
+        audit_chain: Audit chain store.
+
+    Returns:
+        An :class:`AttachmentBuildResult` carrying the multimodal
+        context (ready to pass to an adapter) and the per-attachment
+        provenance records.
+    """
+    if not attachments:
+        return AttachmentBuildResult(
+            context=build_multimodal_context([]),
+            resolutions=(),
+        )
+
+    paths: list[str | Path] = [a for a in attachments]
+    context = build_multimodal_context(paths)
+
+    resolutions: list[AttachmentResolution] = []
+    operator_sig = _operator_install_id_sig()
+    for inp in context.inputs:
+        if inp.content_path is None:
+            # build_multimodal_context skipped a missing file; nothing to
+            # anchor in CAS / the chain. Skip provenance recording so
+            # downstream callers see no resolution for it.
+            continue
+        raw_bytes = inp.content_path.read_bytes()
+        digest = hashlib.sha256(raw_bytes).hexdigest()
+        cas.put(
+            raw_bytes,
+            content_type=inp.mime_type,
+            metadata={
+                "source_path": str(inp.content_path),
+                "worktree_id": worktree_id,
+                "worker_id": worker_id,
+            },
+        )
+        record_multimodal_attach(
+            chain=audit_chain,
+            sha256=digest,
+            mime=inp.mime_type,
+            operator_install_id_sig=operator_sig,
+            worker_id=worker_id,
+            turn_seq=turn_seq,
+            worktree_id=worktree_id,
+        )
+        resolutions.append(
+            AttachmentResolution(
+                sha256=digest,
+                mime=inp.mime_type,
+                worktree_id=worktree_id,
+                source_path=str(inp.content_path),
+            )
+        )
+
+    return AttachmentBuildResult(context=context, resolutions=tuple(resolutions))
+
+
+# ---------------------------------------------------------------------------
+# Encode a single file (test convenience)
+# ---------------------------------------------------------------------------
+
+
+def encode_one(file_path: str | Path) -> tuple[str, str, str]:
+    """Encode a single attachment for adapter consumption.
+
+    Returns ``(base64_content, mime_type, sha256_digest)``. The digest is
+    over the raw file bytes -- so it matches what
+    :func:`build_attachment_context` records in the audit chain.
+    """
+    inp = encode_input(file_path)
+    raw = Path(file_path).read_bytes()
+    digest = hashlib.sha256(raw).hexdigest()
+    return (inp.content_base64 or "", inp.mime_type, digest)
+
+
+# ---------------------------------------------------------------------------
+# Worktree-pinned resolver
+# ---------------------------------------------------------------------------
+
+
+class WorktreeAccessDenied(RuntimeError):
+    """Raised when a worker in worktree B requests an attachment from A."""
+
+    def __init__(self, sha256: str, attached_worktree: str, requesting_worktree: str) -> None:
+        self.sha256 = sha256
+        self.attached_worktree = attached_worktree
+        self.requesting_worktree = requesting_worktree
+        super().__init__(
+            f"Attachment {sha256[:12]}... was attached in worktree "
+            f"{attached_worktree!r} but worker in worktree "
+            f"{requesting_worktree!r} attempted to resolve it. Cross-worktree "
+            "access is denied."
+        )
+
+
+def resolve_attachment_for_worker(
+    *,
+    sha256: str,
+    requesting_worktree_id: str,
+    cas: CASStore,
+    audit_chain: AuditChainStore,
+) -> bytes:
+    """Return attached bytes if the requesting worktree owns the attach.
+
+    Looks up the most recent ``multimodal.attach`` event matching
+    ``sha256``. If that event's ``worktree_id`` matches
+    ``requesting_worktree_id`` the bytes are returned from CAS;
+    otherwise :class:`WorktreeAccessDenied` is raised.
+
+    Args:
+        sha256: Hex digest of the requested attachment.
+        requesting_worktree_id: The worker's worktree id.
+        cas: Content-addressed blob store.
+        audit_chain: Audit chain to consult for the attach event.
+
+    Returns:
+        The raw attachment bytes.
+
+    Raises:
+        WorktreeAccessDenied: The attach event's worktree id differs
+            from the requesting worktree id.
+        FileNotFoundError: No attach event exists for the SHA, or the
+            CAS lookup misses.
+    """
+    entries = audit_chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+    matches = [e for e in entries if e.details.get("sha256") == sha256]
+    if not matches:
+        raise FileNotFoundError(f"No multimodal.attach event for {sha256[:12]}...")
+    # Use the most recent event (chronological order).
+    event = matches[-1]
+    attached_worktree = str(event.details.get("worktree_id", ""))
+    if attached_worktree != requesting_worktree_id:
+        raise WorktreeAccessDenied(
+            sha256=sha256,
+            attached_worktree=attached_worktree,
+            requesting_worktree=requesting_worktree_id,
+        )
+    blob = cas.get(sha256)
+    if blob is None:
+        raise FileNotFoundError(f"CAS miss for {sha256[:12]}...")
+    return blob
+
+
+# ---------------------------------------------------------------------------
+# Lineage parents
+# ---------------------------------------------------------------------------
+
+
+def worker_lineage_parents(result: AttachmentBuildResult) -> list[str]:
+    """Return canonical lineage parent URIs for *result*'s attachments.
+
+    Empty when no attachments were resolved.
+    """
+    return [build_attachment_parent_uri(r.sha256) for r in result.resolutions]
+
+
+__all__ = [
+    "AttachmentBuildResult",
+    "AttachmentResolution",
+    "CapabilityRefusal",
+    "WorktreeAccessDenied",
+    "build_attachment_context",
+    "encode_one",
+    "refuse_when_incapable",
+    "resolve_attachment_for_worker",
+    "worker_lineage_parents",
+]

--- a/src/bernstein/core/agents/multimodal_attestation.py
+++ b/src/bernstein/core/agents/multimodal_attestation.py
@@ -36,6 +36,7 @@ attempt.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import logging
 from dataclasses import dataclass
@@ -218,12 +219,28 @@ def build_attachment_context(
     resolutions: list[AttachmentResolution] = []
     operator_sig = _operator_install_id_sig()
     for inp in context.inputs:
-        if inp.content_path is None:
-            # build_multimodal_context skipped a missing file; nothing to
-            # anchor in CAS / the chain. Skip provenance recording so
-            # downstream callers see no resolution for it.
+        if inp.content_path is None or not inp.content_base64:
+            # build_multimodal_context skipped a missing file or could
+            # not produce a base64 payload; nothing to anchor in CAS /
+            # the chain. Skip provenance recording so downstream
+            # callers see no resolution for it.
             continue
-        raw_bytes = inp.content_path.read_bytes()
+        # Hash the bytes that will actually travel to the model API,
+        # not a separate re-read of the source file. The base64
+        # payload in ``content_base64`` IS what the adapter inlines in
+        # the request body; decoding it here gives us the identical
+        # bytes for CAS + the audit-chain digest, eliminating the race
+        # where the on-disk file changes between encode time and
+        # attest time. (bot-ack: 3284182756 -- CodeRabbit critical.)
+        try:
+            raw_bytes = base64.b64decode(inp.content_base64, validate=True)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "Skipping attachment %s: invalid base64 payload (%s)",
+                inp.content_path,
+                exc,
+            )
+            continue
         digest = hashlib.sha256(raw_bytes).hexdigest()
         cas.put(
             raw_bytes,
@@ -326,13 +343,21 @@ def resolve_attachment_for_worker(
     matches = [e for e in entries if e.details.get("sha256") == sha256]
     if not matches:
         raise FileNotFoundError(f"No multimodal.attach event for {sha256[:12]}...")
-    # Use the most recent event (chronological order).
-    event = matches[-1]
-    attached_worktree = str(event.details.get("worktree_id", ""))
-    if attached_worktree != requesting_worktree_id:
+    # Resolve by (sha256, worktree_id) so concurrent attaches in
+    # different worktrees of the same bytes do not poison each other.
+    # If any historical attach in the requesting worktree exists for
+    # this digest, allow the resolve; otherwise refuse. The list of
+    # attaching worktrees (for the structured error) is built from
+    # every historical event so the operator sees the full picture.
+    # (bot-ack: 3284182761 -- CodeRabbit major.)
+    in_worktree = [e for e in matches if str(e.details.get("worktree_id", "")) == requesting_worktree_id]
+    if not in_worktree:
+        seen_worktrees = sorted(
+            {str(e.details.get("worktree_id", "")) for e in matches if e.details.get("worktree_id")}
+        )
         raise WorktreeAccessDenied(
             sha256=sha256,
-            attached_worktree=attached_worktree,
+            attached_worktree=", ".join(seen_worktrees) or "<unknown>",
             requesting_worktree=requesting_worktree_id,
         )
     blob = cas.get(sha256)

--- a/src/bernstein/core/persistence/lineage_signer.py
+++ b/src/bernstein/core/persistence/lineage_signer.py
@@ -166,6 +166,61 @@ def _load_ed25519_private(data: bytes, source: Path) -> Ed25519PrivateKey:
         raise LineageSignerError(f"cannot load raw Ed25519 key from {source}: {exc}") from exc
 
 
+# ---------------------------------------------------------------------------
+# Attachment-as-parent helper (issue #1797)
+# ---------------------------------------------------------------------------
+# Additive, append-only surface: the lineage receipt for any artefact
+# produced by a worker this turn must carry the input attachment's
+# SHA-256 in its parents list. The helper below builds the canonical
+# parent identifier from an attachment digest so that callers do not
+# have to know the URI format.
+
+_ATTACHMENT_PARENT_SCHEME = "multimodal-attachment://"
+
+
+def build_attachment_parent_uri(sha256: str) -> str:
+    """Return the canonical parent URI for a multimodal attachment.
+
+    Args:
+        sha256: Hex digest of the attachment bytes (lower-case, 64 chars).
+
+    Returns:
+        A scheme-qualified content-addressed URI suitable for inclusion
+        in a lineage record's ``parents`` list.
+    """
+    if not sha256 or len(sha256) != 64:
+        raise LineageSignerError(f"attachment sha256 must be 64 hex chars, got {len(sha256)}")
+    return f"{_ATTACHMENT_PARENT_SCHEME}{sha256}"
+
+
+def register_attachment_parents(
+    parents: list[str],
+    attachment_sha256s: list[str],
+) -> list[str]:
+    """Append attachment parent URIs to an existing lineage parents list.
+
+    The function never mutates *parents*; it returns a new list with
+    the existing parents followed by the attachment-derived URIs.
+    Duplicate entries are filtered out so a multiply-attached image
+    appears exactly once in the receipt.
+
+    Args:
+        parents: The existing lineage parents list.
+        attachment_sha256s: Hex digests of attachments to register.
+
+    Returns:
+        A new list with attachment parents appended.
+    """
+    seen: set[str] = set(parents)
+    out: list[str] = list(parents)
+    for digest in attachment_sha256s:
+        uri = build_attachment_parent_uri(digest)
+        if uri not in seen:
+            out.append(uri)
+            seen.add(uri)
+    return out
+
+
 def signer_from_config(
     *,
     enabled: bool,

--- a/src/bernstein/core/persistence/lineage_signer.py
+++ b/src/bernstein/core/persistence/lineage_signer.py
@@ -176,6 +176,7 @@ def _load_ed25519_private(data: bytes, source: Path) -> Ed25519PrivateKey:
 # have to know the URI format.
 
 _ATTACHMENT_PARENT_SCHEME = "multimodal-attachment://"
+_HEX_DIGIT_SET = frozenset("0123456789abcdef")
 
 
 def build_attachment_parent_uri(sha256: str) -> str:
@@ -187,9 +188,16 @@ def build_attachment_parent_uri(sha256: str) -> str:
     Returns:
         A scheme-qualified content-addressed URI suitable for inclusion
         in a lineage record's ``parents`` list.
+
+    Raises:
+        LineageSignerError: When *sha256* is not exactly 64 lower-case
+            hexadecimal characters. (bot-ack: 3284182781 --
+            CodeRabbit major.)
     """
     if not sha256 or len(sha256) != 64:
         raise LineageSignerError(f"attachment sha256 must be 64 hex chars, got {len(sha256)}")
+    if not _HEX_DIGIT_SET.issuperset(sha256):
+        raise LineageSignerError("attachment sha256 must be lower-case hex (0-9a-f)")
     return f"{_ATTACHMENT_PARENT_SCHEME}{sha256}"
 
 

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -253,7 +253,19 @@ def _parse_step(
     owned_files: list[str] = [str(f) for f in (step.get("files") or [])]
     # Issue #1797: operator-supplied image attachments. The orchestrator
     # builds a MultiModalContext at spawn time from these paths.
-    attachments: list[str] = [str(a) for a in (step.get("attachments") or [])]
+    # Reject scalar / non-list shapes so a YAML typo like
+    # ``attachments: ./shot.png`` does not silently iterate the string
+    # character-by-character. (bot-ack: 3284182784 -- CodeRabbit major.)
+    raw_attachments = step.get("attachments")
+    if raw_attachments is None:
+        attachments: list[str] = []
+    elif isinstance(raw_attachments, list):
+        attachments = [str(a) for a in raw_attachments]
+    else:
+        raise PlanLoadError(
+            f"Step {step_index} in stage {stage_name!r}: 'attachments' must be a "
+            f"list of paths, got {type(raw_attachments).__name__}"
+        )
 
     model_raw = step.get("model")
     effort_raw = step.get("effort")

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -251,6 +251,9 @@ def _parse_step(
     raw_signals: list[object] = list(step.get("completion_signals") or [])
     signals = _parse_completion_signals(raw_signals)
     owned_files: list[str] = [str(f) for f in (step.get("files") or [])]
+    # Issue #1797: operator-supplied image attachments. The orchestrator
+    # builds a MultiModalContext at spawn time from these paths.
+    attachments: list[str] = [str(a) for a in (step.get("attachments") or [])]
 
     model_raw = step.get("model")
     effort_raw = step.get("effort")
@@ -296,6 +299,7 @@ def _parse_step(
         repo=task_repo,
         depends_on_repo=task_depends_on_repo,
         metadata=metadata,
+        attachments=attachments,
     )
 
 

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -1,0 +1,241 @@
+"""Audit chain helpers for cross-subsystem event recording.
+
+This module exposes :class:`AuditChainStore`, a thin facade over
+:class:`bernstein.core.security.audit.AuditLog` that surfaces the
+``prev_chain_digest`` (the HMAC of the most recent event) to callers
+that need to embed it inside an event payload (for example
+``multimodal.attach``).
+
+The module also defines additive event-type constants used by
+subsystems that emit structured records into the HMAC-chained log.
+New event types should be added below as ``EVENT_<UPPER_SNAKE>``
+string constants -- never edit existing entries.
+
+Concurrent-edit policy
+----------------------
+Sibling agents may extend this module with additional event-type
+constants and helper functions; the ``AuditChainStore`` class itself
+is treated as the stable surface. Helpers MUST:
+
+* Accept the chain instance, not import it as a singleton.
+* Call ``chain.log_with_prev_digest`` so that ``prev_chain_digest``
+  is captured in ``details`` before the HMAC is computed.
+* Never mutate existing event-type constants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from bernstein.core.security.audit import (
+    AGENT_FRESH_RESTART_ON_RETRY as AGENT_FRESH_RESTART_ON_RETRY,
+)
+from bernstein.core.security.audit import (
+    AuditEvent,
+    AuditLog,
+)
+
+# ---------------------------------------------------------------------------
+# Additive event-type constants
+# ---------------------------------------------------------------------------
+# IMPORTANT: never modify or remove existing constants below. Add new
+# constants only. Sibling agents may concurrently append to this list.
+
+#: Issue #1797 -- emitted whenever an operator attaches an image to a
+#: worker via ``bernstein run --attach`` (or the matching task YAML
+#: ``attachments`` field). The event records the bytes' SHA-256, MIME
+#: type, the requesting worker, the turn sequence number, the worktree
+#: id, the operator install identity signature, and the previous chain
+#: digest.
+EVENT_MULTIMODAL_ATTACH = "multimodal.attach"
+
+
+# ---------------------------------------------------------------------------
+# AuditChainStore
+# ---------------------------------------------------------------------------
+
+
+class AuditChainStore:
+    """Facade over :class:`AuditLog` that exposes the chain head.
+
+    The underlying :class:`AuditLog` already maintains an HMAC chain;
+    this class exposes the prior HMAC (the "previous chain digest")
+    to callers that want to embed it inside the event payload before
+    the HMAC is computed.
+
+    Args:
+        audit_dir: Directory in which JSONL log files are written.
+        key: Raw HMAC key. When omitted, the underlying ``AuditLog``
+            loads or creates a key via the canonical resolver.
+        key_path: Optional path override for the HMAC key file.
+    """
+
+    def __init__(
+        self,
+        audit_dir: Path,
+        *,
+        key: bytes | None = None,
+        key_path: Path | None = None,
+    ) -> None:
+        self._log = AuditLog(audit_dir=audit_dir, key=key, key_path=key_path)
+
+    # -- public surface -----------------------------------------------------
+
+    @property
+    def prev_chain_digest(self) -> str:
+        """Return the HMAC of the most recent event (the chain head)."""
+        # AuditLog tracks _prev_hmac internally; exposing it here gives
+        # callers the value to embed inside the next event's payload
+        # without breaking the chain (the embedded value is part of the
+        # HMAC input, so a downstream verifier sees consistent records).
+        return self._log._prev_hmac  # pyright: ignore[reportPrivateUsage]
+
+    def log_with_prev_digest(
+        self,
+        *,
+        event_type: str,
+        actor: str,
+        resource_type: str,
+        resource_id: str,
+        details: dict[str, Any],
+    ) -> AuditEvent:
+        """Embed the prior chain digest into *details* and append the event.
+
+        The key ``prev_chain_digest`` is overwritten with the current
+        chain head before delegation, so callers may either omit the key
+        or rely on this method to fill it consistently.
+        """
+        merged: dict[str, Any] = dict(details)
+        merged["prev_chain_digest"] = self.prev_chain_digest
+        return self._log.log(
+            event_type=event_type,
+            actor=actor,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            details=merged,
+        )
+
+    def log(
+        self,
+        *,
+        event_type: str,
+        actor: str,
+        resource_type: str,
+        resource_id: str,
+        details: dict[str, Any] | None = None,
+    ) -> AuditEvent:
+        """Append a plain event (no automatic prev_chain_digest embedding)."""
+        return self._log.log(
+            event_type=event_type,
+            actor=actor,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            details=details,
+        )
+
+    def query(
+        self,
+        *,
+        event_type: str | None = None,
+        actor: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+    ) -> list[AuditEvent]:
+        """Delegate to the underlying :class:`AuditLog`."""
+        return self._log.query(
+            event_type=event_type,
+            actor=actor,
+            since=since,
+            until=until,
+        )
+
+    def verify(self) -> tuple[bool, list[str]]:
+        """Delegate to the underlying :class:`AuditLog`."""
+        return self._log.verify()
+
+
+# ---------------------------------------------------------------------------
+# Event recording helpers (additive)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MultimodalAttachDetails:
+    """Structured payload for the ``multimodal.attach`` event."""
+
+    sha256: str
+    mime: str
+    operator_install_id_sig: str
+    worker_id: str
+    turn_seq: int
+    worktree_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sha256": self.sha256,
+            "mime": self.mime,
+            "operator_install_id_sig": self.operator_install_id_sig,
+            "worker_id": self.worker_id,
+            "turn_seq": self.turn_seq,
+            "worktree_id": self.worktree_id,
+        }
+
+
+def record_multimodal_attach(
+    *,
+    chain: AuditChainStore,
+    sha256: str,
+    mime: str,
+    operator_install_id_sig: str,
+    worker_id: str,
+    turn_seq: int,
+    worktree_id: str,
+) -> AuditEvent:
+    """Append a ``multimodal.attach`` event into *chain*.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        sha256: Hex digest of the attachment bytes (lower-case, 64 chars).
+        mime: MIME type as resolved at attach time (e.g. ``image/png``).
+        operator_install_id_sig: Operator install fingerprint signature.
+            Captured here so a downstream auditor can attribute the
+            attach to a known operator install.
+        worker_id: Identifier of the worker that consumed the
+            attachment.
+        turn_seq: Monotonic turn sequence number on the worker.
+        worktree_id: Identifier of the worktree the attachment belongs
+            to. Cross-worktree resolution is refused by the resolver.
+
+    Returns:
+        The recorded :class:`AuditEvent`. The event details payload
+        carries every input plus ``prev_chain_digest`` (set to the
+        chain head at write time).
+    """
+    payload = MultimodalAttachDetails(
+        sha256=sha256,
+        mime=mime,
+        operator_install_id_sig=operator_install_id_sig,
+        worker_id=worker_id,
+        turn_seq=turn_seq,
+        worktree_id=worktree_id,
+    ).to_dict()
+    return chain.log_with_prev_digest(
+        event_type=EVENT_MULTIMODAL_ATTACH,
+        actor=worker_id,
+        resource_type="multimodal_attachment",
+        resource_id=sha256,
+        details=payload,
+    )
+
+
+__all__ = [
+    "AGENT_FRESH_RESTART_ON_RETRY",
+    "EVENT_MULTIMODAL_ATTACH",
+    "AuditChainStore",
+    "MultimodalAttachDetails",
+    "record_multimodal_attach",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -25,6 +25,7 @@ is treated as the stable surface. Helpers MUST:
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -82,6 +83,13 @@ class AuditChainStore:
         key_path: Path | None = None,
     ) -> None:
         self._log = AuditLog(audit_dir=audit_dir, key=key, key_path=key_path)
+        # Serialise read-prev-then-append so two concurrent attaches
+        # never embed the same predecessor in their details payload.
+        # The underlying AuditLog also writes to disk under this same
+        # lock, keeping the on-disk chain order consistent with the
+        # ``prev_chain_digest`` each event embedded.
+        # (bot-ack: 3284182792 -- CodeRabbit major.)
+        self._append_lock = threading.Lock()
 
     # -- public surface -----------------------------------------------------
 
@@ -105,19 +113,21 @@ class AuditChainStore:
     ) -> AuditEvent:
         """Embed the prior chain digest into *details* and append the event.
 
-        The key ``prev_chain_digest`` is overwritten with the current
-        chain head before delegation, so callers may either omit the key
-        or rely on this method to fill it consistently.
+        The read-and-append is performed under a per-store lock so
+        two concurrent calls always see distinct ``prev_chain_digest``
+        values and the underlying chain stays linear.
+        (bot-ack: 3284182792 -- CodeRabbit major.)
         """
-        merged: dict[str, Any] = dict(details)
-        merged["prev_chain_digest"] = self.prev_chain_digest
-        return self._log.log(
-            event_type=event_type,
-            actor=actor,
-            resource_type=resource_type,
-            resource_id=resource_id,
-            details=merged,
-        )
+        with self._append_lock:
+            merged: dict[str, Any] = dict(details)
+            merged["prev_chain_digest"] = self.prev_chain_digest
+            return self._log.log(
+                event_type=event_type,
+                actor=actor,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                details=merged,
+            )
 
     def log(
         self,

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -404,6 +404,12 @@ class Task:
     # All tasks sharing a ``story_id`` form a rollback grouping ("deliver the
     # whole MVP slice or none of it"). Parsed from the ``[USn]`` marker.
     story_id: str | None = None
+    # Issue #1797: operator-supplied attachments (image / diagram paths)
+    # that the orchestrator encodes into a MultiModalContext at spawn time
+    # and passes to the adapter. Empty list = no attachments. Adapters
+    # that report ``is_multimodal_capable() == False`` MUST refuse spawns
+    # carrying a non-empty list before any process is launched.
+    attachments: list[str] = field(default_factory=list[str])
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Task:
@@ -503,6 +509,7 @@ class Task:
             agent_restart_between_retries=bool(raw.get("agent_restart_between_retries", False)),
             parallel_safe=bool(raw.get("parallel_safe", False)),
             story_id=(str(raw["story_id"]) if raw.get("story_id") else None),
+            attachments=[str(a) for a in raw.get("attachments", [])],
         )
 
 

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -316,6 +316,27 @@ class ApprovalSpec:
         )
 
 
+def _normalize_attachments(raw: object) -> list[str]:
+    """Coerce an ``attachments`` payload into a ``list[str]``.
+
+    Rejects scalar values (e.g. ``"diagram.png"``) so a malformed
+    payload does not silently turn into one-character paths via
+    iteration. Accepts ``None`` (empty list) and any list-like
+    sequence whose elements coerce to strings.
+    (bot-ack: 3284182800 -- CodeRabbit minor.)
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str | bytes):
+        raise TypeError(
+            "Task.attachments must be a list of paths, got a "
+            f"{type(raw).__name__}; pass [path] for a single attachment."
+        )
+    if not isinstance(raw, list | tuple):
+        raise TypeError(f"Task.attachments must be a list of paths, got {type(raw).__name__}")
+    return [str(a) for a in raw]
+
+
 @dataclass
 class Task:
     """A unit of work for an agent."""
@@ -509,7 +530,7 @@ class Task:
             agent_restart_between_retries=bool(raw.get("agent_restart_between_retries", False)),
             parallel_safe=bool(raw.get("parallel_safe", False)),
             story_id=(str(raw["story_id"]) if raw.get("story_id") else None),
-            attachments=[str(a) for a in raw.get("attachments", [])],
+            attachments=_normalize_attachments(raw.get("attachments")),
         )
 
 

--- a/tests/integration/test_run_attach.py
+++ b/tests/integration/test_run_attach.py
@@ -1,0 +1,327 @@
+"""Integration tests for ``bernstein run --attach`` (issue #1797).
+
+These tests exercise the full attachment passthrough flow against a
+stubbed Claude adapter:
+
+* The CLI flag accepts repeated ``--attach <path>`` invocations.
+* Capability gating fails BEFORE any process is launched when the
+  selected adapter does not advertise multimodal capability.
+* An image attached at spawn time is encoded as base64 into the
+  prompt body sent to the model API and the resulting lineage receipt
+  carries the image's SHA-256 as a parent.
+* A cross-worktree access attempt is rejected.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.adapters.base import SpawnResult
+from bernstein.adapters.claude import (  # pyright: ignore[reportPrivateUsage]
+    _inject_multimodal_attachments as claude_inject,
+)
+from bernstein.adapters.gemini import (  # pyright: ignore[reportPrivateUsage]
+    _inject_multimodal_attachments as gemini_inject,
+)
+from bernstein.core.agents.multimodal import build_multimodal_context
+from bernstein.core.agents.multimodal_attestation import (
+    CapabilityRefusal,
+    WorktreeAccessDenied,
+    build_attachment_context,
+    refuse_when_incapable,
+    resolve_attachment_for_worker,
+)
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.persistence.lineage_signer import (
+    build_attachment_parent_uri,
+    register_attachment_parents,
+)
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.tasks.models import ModelConfig
+
+PNG_HEADER = b"\x89PNG\r\n\x1a\n"
+
+
+@dataclass
+class _SpawnCapture:
+    """In-test stub adapter that records the prompt it was handed."""
+
+    captured_prompt: str = ""
+    captured_multimodal: object | None = None
+    spawned: bool = False
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, object] | None = None,
+        timeout_seconds: int = 600,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+        multimodal_context: object | None = None,
+    ) -> SpawnResult:
+        if multimodal_context is not None:
+            prompt = claude_inject(prompt, multimodal_context)
+        self.captured_prompt = prompt
+        self.captured_multimodal = multimodal_context
+        self.spawned = True
+        # Return a placeholder SpawnResult; the integration test does not
+        # exercise live process management.
+        return SpawnResult(pid=0, log_path=workdir / "stub.log", proc=None)
+
+
+def _audit_chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(audit_dir=tmp_path / "audit", key=b"k" * 32)
+
+
+def _make_png(path: Path, payload: bytes = PNG_HEADER + b"data") -> Path:
+    path.write_bytes(payload)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# CLI flag plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestCliFlag:
+    def test_attach_flag_is_repeatable(self, tmp_path: Path) -> None:
+        """The CLI flag accepts multiple --attach arguments."""
+        from bernstein.cli.run_bootstrap import run as run_cmd
+
+        runner = CliRunner()
+        a = _make_png(tmp_path / "a.png")
+        b = _make_png(tmp_path / "b.png", payload=PNG_HEADER + b"bb")
+
+        # Use --help-only contract: passing --attach + --help inspects
+        # the parsed option without running the orchestrator.
+        result = runner.invoke(
+            run_cmd,
+            [
+                "--attach",
+                str(a),
+                "--attach",
+                str(b),
+                "--help",
+            ],
+            catch_exceptions=False,
+        )
+        # --help short-circuits; the important thing is the option was
+        # accepted (no UsageError).
+        assert result.exit_code == 0, result.output
+        # The help text exposes the flag.
+        assert "--attach" in result.output
+
+    def test_attach_missing_path_rejected(self, tmp_path: Path) -> None:
+        from bernstein.cli.run_bootstrap import run as run_cmd
+
+        runner = CliRunner()
+        ghost = tmp_path / "ghost.png"  # never created
+
+        # Without --help, Click runs option validation for the existing
+        # path check on --attach.
+        result = runner.invoke(
+            run_cmd,
+            ["--attach", str(ghost), "--goal", "x"],
+            catch_exceptions=False,
+        )
+        # Click validates existence at parse time -> non-zero exit and
+        # a UsageError mentioning the missing file.
+        assert result.exit_code != 0
+        assert "ghost.png" in result.output or "does not exist" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Round-trip on stubbed Claude adapter
+# ---------------------------------------------------------------------------
+
+
+class TestStubbedClaudeRoundTrip:
+    def test_image_reaches_prompt_as_base64(self, tmp_path: Path) -> None:
+        payload = PNG_HEADER + b"image-bytes"
+        img = _make_png(tmp_path / "shot.png", payload=payload)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+
+        stub = _SpawnCapture()
+        stub.spawn(
+            prompt="Describe the screenshot.",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="qa-abc12345",
+            multimodal_context=result.context,
+        )
+        # The base64 payload is present in the captured prompt.
+        import base64 as _b64
+
+        expected_b64 = _b64.b64encode(payload).decode("ascii")
+        assert expected_b64 in stub.captured_prompt
+        # The MIME type is recorded in the wire format.
+        assert 'mime="image/png"' in stub.captured_prompt
+        # The SHA-256 is present in the wire format.
+        digest = hashlib.sha256(payload).hexdigest()
+        assert digest in stub.captured_prompt
+
+    def test_lineage_receipt_carries_image_sha(self, tmp_path: Path) -> None:
+        img = _make_png(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        # Simulate the worker producing an artefact this turn and the
+        # lineage subsystem augmenting the parents.
+        parents = register_attachment_parents(
+            parents=["worker:wkr-1#step0"],
+            attachment_sha256s=[r.sha256 for r in result.resolutions],
+        )
+        assert any(result.resolutions[0].sha256 in p for p in parents)
+        # The canonical URI format is content-addressed.
+        assert build_attachment_parent_uri(result.resolutions[0].sha256) in parents
+
+    def test_tamper_detection(self, tmp_path: Path) -> None:
+        """Substituting bytes breaks the chain on verify."""
+        img = _make_png(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        # Tamper with the audit-chain log on disk.
+        log_files = list((tmp_path / "audit").glob("*.jsonl"))
+        assert log_files
+        tampered = bytearray(log_files[0].read_bytes())
+        # Find a hex character and flip it (digest field) to invalidate
+        # the on-disk canonical form.
+        for i, b in enumerate(tampered):
+            if chr(b) in "0123456789":
+                tampered[i] = ord("0") if chr(b) != "0" else ord("1")
+                break
+        log_files[0].write_bytes(bytes(tampered))
+        valid, errors = chain.verify()
+        assert not valid
+        assert errors
+
+
+# ---------------------------------------------------------------------------
+# Capability gating
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityRefusal:
+    def test_codex_with_attachment_refused(self, tmp_path: Path) -> None:
+        img = _make_png(tmp_path / "shot.png")
+        with pytest.raises(CapabilityRefusal) as exc:
+            refuse_when_incapable(adapter_name="codex", attachments=[str(img)])
+        assert "claude" in exc.value.suggested_adapters
+        assert "gemini" in exc.value.suggested_adapters
+
+    def test_claude_accepts(self, tmp_path: Path) -> None:
+        img = _make_png(tmp_path / "shot.png")
+        # No raise.
+        refuse_when_incapable(adapter_name="claude", attachments=[str(img)])
+
+    def test_gemini_accepts(self, tmp_path: Path) -> None:
+        img = _make_png(tmp_path / "shot.png")
+        refuse_when_incapable(adapter_name="gemini", attachments=[str(img)])
+
+    def test_no_attachments_no_refusal(self) -> None:
+        refuse_when_incapable(adapter_name="codex", attachments=[])
+
+
+# ---------------------------------------------------------------------------
+# Cross-worktree isolation
+# ---------------------------------------------------------------------------
+
+
+class TestCrossWorktreeIsolation:
+    def test_wt_b_cannot_resolve_wt_a_attachment(self, tmp_path: Path) -> None:
+        img = _make_png(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-a",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+        with pytest.raises(WorktreeAccessDenied):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-b",
+                cas=cas,
+                audit_chain=chain,
+            )
+
+    def test_wt_a_can_resolve_wt_a_attachment(self, tmp_path: Path) -> None:
+        payload = PNG_HEADER + b"wt-a"
+        img = _make_png(tmp_path / "shot.png", payload=payload)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-a",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+        replayed = resolve_attachment_for_worker(
+            sha256=digest,
+            requesting_worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert replayed == payload
+
+
+# ---------------------------------------------------------------------------
+# Gemini adapter wire format
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiInjection:
+    def test_gemini_inlines_attachment_block(self, tmp_path: Path) -> None:
+        img = _make_png(tmp_path / "shot.png")
+        ctx = build_multimodal_context([img])
+        out = gemini_inject("Look at this.", ctx)
+        assert '<attachment mime="image/png"' in out
+        # Original prompt body is preserved.
+        assert "Look at this." in out
+
+    def test_empty_context_passthrough(self) -> None:
+        ctx = build_multimodal_context([])
+        assert gemini_inject("Hi", ctx) == "Hi"

--- a/tests/unit/test_multimodal_attestation.py
+++ b/tests/unit/test_multimodal_attestation.py
@@ -519,3 +519,224 @@ class TestPlanLoaderAttachments:
         tasks = load_plan_from_yaml(plan_yaml)
         assert len(tasks) == 1
         assert tasks[0].attachments == [str(img)]
+
+    def test_yaml_plan_rejects_scalar_attachments(self, tmp_path: Path) -> None:
+        """A scalar attachments value MUST surface a PlanLoadError."""
+        img = _make_image(tmp_path / "img.png")
+        plan_yaml = tmp_path / "plan.yaml"
+        plan_yaml.write_text(
+            "name: test\n"
+            "stages:\n"
+            "  - name: phase1\n"
+            "    steps:\n"
+            "      - title: With attachment\n"
+            "        role: backend\n"
+            f"        attachments: {img}\n"  # SCALAR (typo)
+        )
+        from bernstein.core.planning.plan_loader import PlanLoadError, load_plan_from_yaml
+
+        with pytest.raises(PlanLoadError, match="attachments"):
+            load_plan_from_yaml(plan_yaml)
+
+
+# ---------------------------------------------------------------------------
+# Hash-matches-base64 invariant (bot-ack: 3284182756)
+# ---------------------------------------------------------------------------
+
+
+class TestHashMatchesBase64:
+    def test_digest_matches_decoded_base64_not_disk(self, tmp_path: Path) -> None:
+        """If the file changes after encode, the digest still matches what we sent."""
+        import base64 as _b64
+        import hashlib as _h
+
+        original_payload = PNG_MAGIC + b"original-bytes"
+        img = _make_image(tmp_path / "shot.png", payload=original_payload)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+
+        # Simulate file changing on disk after encode.
+        img.write_bytes(b"different-bytes-on-disk")
+
+        # The recorded digest equals SHA-256 of the bytes the adapter
+        # inlines (the base64 payload), not the new on-disk bytes.
+        b64 = result.context.inputs[0].content_base64 or ""
+        adapter_bytes = _b64.b64decode(b64)
+        assert digest == _h.sha256(adapter_bytes).hexdigest()
+        assert adapter_bytes == original_payload
+
+
+# ---------------------------------------------------------------------------
+# Cross-worktree collision (bot-ack: 3284182761)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossWorktreeCollision:
+    def test_dual_attach_same_bytes_resolves_per_worktree(self, tmp_path: Path) -> None:
+        """Same bytes attached in wt-a and wt-b both resolve in their worktree."""
+        payload = PNG_MAGIC + b"shared-bytes"
+        img_a = _make_image(tmp_path / "a.png", payload=payload)
+        img_b = _make_image(tmp_path / "b.png", payload=payload)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+
+        ra = build_attachment_context(
+            attachments=[str(img_a)],
+            worker_id="wkr-a",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        rb = build_attachment_context(
+            attachments=[str(img_b)],
+            worker_id="wkr-b",
+            turn_seq=0,
+            worktree_id="wt-b",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert ra.resolutions[0].sha256 == rb.resolutions[0].sha256
+        digest = ra.resolutions[0].sha256
+
+        # wt-a can resolve.
+        assert (
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-a",
+                cas=cas,
+                audit_chain=chain,
+            )
+            == payload
+        )
+        # wt-b can ALSO resolve (it has its own attach event).
+        assert (
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-b",
+                cas=cas,
+                audit_chain=chain,
+            )
+            == payload
+        )
+        # wt-c cannot.
+        with pytest.raises(WorktreeAccessDenied):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-c",
+                cas=cas,
+                audit_chain=chain,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Non-hex digest rejection (bot-ack: 3284182781)
+# ---------------------------------------------------------------------------
+
+
+class TestParentUriRejectsNonHex:
+    def test_rejects_non_hex_chars(self) -> None:
+        from bernstein.core.persistence.lineage_signer import (
+            LineageSignerError,
+            build_attachment_parent_uri,
+        )
+
+        with pytest.raises(LineageSignerError, match="hex"):
+            build_attachment_parent_uri("x" * 64)
+
+    def test_rejects_uppercase(self) -> None:
+        from bernstein.core.persistence.lineage_signer import (
+            LineageSignerError,
+            build_attachment_parent_uri,
+        )
+
+        with pytest.raises(LineageSignerError, match="hex"):
+            build_attachment_parent_uri("A" * 64)
+
+    def test_accepts_valid_hex(self) -> None:
+        from bernstein.core.persistence.lineage_signer import build_attachment_parent_uri
+
+        uri = build_attachment_parent_uri("0" * 64)
+        assert uri.startswith("multimodal-attachment://")
+
+
+# ---------------------------------------------------------------------------
+# Atomic prev_chain_digest (bot-ack: 3284182792)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicPrevDigest:
+    def test_concurrent_log_with_prev_digest_remains_linear(self, tmp_path: Path) -> None:
+        """Two threads logging concurrently must not embed the same predecessor."""
+        import threading
+
+        chain = _audit_chain(tmp_path)
+        N = 16
+
+        def _writer(i: int) -> None:
+            record_multimodal_attach(
+                chain=chain,
+                sha256=f"{i:064d}",
+                mime="image/png",
+                operator_install_id_sig="sig",
+                worker_id=f"w-{i}",
+                turn_seq=i,
+                worktree_id="wt-a",
+            )
+
+        threads = [threading.Thread(target=_writer, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # The chain must remain verifiable after concurrent appends.
+        valid, errors = chain.verify()
+        assert valid, f"chain broken under concurrency: {errors}"
+
+        # All N events landed.
+        entries = chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+        assert len(entries) == N
+
+        # No two events share the same prev_chain_digest (linearity).
+        prevs = [e.details["prev_chain_digest"] for e in entries]
+        assert len(set(prevs)) == N
+
+
+# ---------------------------------------------------------------------------
+# Task.from_dict rejects scalar attachments (bot-ack: 3284182800)
+# ---------------------------------------------------------------------------
+
+
+class TestTaskFromDictAttachmentsType:
+    def test_string_payload_rejected(self) -> None:
+        raw = {
+            "id": "t-1",
+            "title": "x",
+            "description": "y",
+            "role": "backend",
+            "attachments": "diagram.png",  # malformed scalar
+        }
+        with pytest.raises(TypeError, match="list of paths"):
+            Task.from_dict(raw)
+
+    def test_list_payload_accepted(self) -> None:
+        raw = {
+            "id": "t-1",
+            "title": "x",
+            "description": "y",
+            "role": "backend",
+            "attachments": ["a.png", "b.png"],
+        }
+        task = Task.from_dict(raw)
+        assert task.attachments == ["a.png", "b.png"]

--- a/tests/unit/test_multimodal_attestation.py
+++ b/tests/unit/test_multimodal_attestation.py
@@ -1,0 +1,521 @@
+"""Unit tests for image-attachment passthrough with provenance (#1797).
+
+Covers:
+* Task model accepts an ``attachments`` list.
+* Spawn-time wiring: :func:`build_attachment_context` reads paths, stores
+  bytes in CAS, builds a :class:`MultiModalContext`, and records an
+  audit-chain entry of type ``multimodal.attach``.
+* The lineage helper exposes attachment digests as artefact parents.
+* Capability gating refuses adapters that do not advertise multimodal
+  support, with a structured error suggesting capable adapters.
+* sha256 stability: encoding the same bytes always yields the same digest.
+* Worktree pinning: an image attached in worktree wt-a is not reachable
+  from a worker in wt-b.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.agents.multimodal import (
+    ModalityType,
+    MultiModalContext,
+    is_multimodal_capable,
+)
+from bernstein.core.agents.multimodal_attestation import (
+    AttachmentResolution,
+    CapabilityRefusal,
+    WorktreeAccessDenied,
+    build_attachment_context,
+    refuse_when_incapable,
+    resolve_attachment_for_worker,
+    worker_lineage_parents,
+)
+from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.security.audit_chain import (
+    EVENT_MULTIMODAL_ATTACH,
+    AuditChainStore,
+    record_multimodal_attach,
+)
+from bernstein.core.tasks.models import Task
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _make_image(path: Path, payload: bytes = PNG_MAGIC + b"hello") -> Path:
+    path.write_bytes(payload)
+    return path
+
+
+def _audit_chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(
+        audit_dir=tmp_path / "audit",
+        key=b"k" * 32,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task model field
+# ---------------------------------------------------------------------------
+
+
+class TestTaskAttachmentsField:
+    def test_task_accepts_attachments_default_empty(self) -> None:
+        task = Task(
+            id="t-1",
+            title="With attachment",
+            description="desc",
+            role="backend",
+        )
+        assert task.attachments == []
+
+    def test_task_accepts_attachments_list(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        task = Task(
+            id="t-2",
+            title="With attachment",
+            description="desc",
+            role="backend",
+            attachments=[str(img)],
+        )
+        assert task.attachments == [str(img)]
+
+    def test_task_from_dict_reads_attachments(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        raw = {
+            "id": "t-3",
+            "title": "x",
+            "description": "y",
+            "role": "backend",
+            "attachments": [str(img)],
+        }
+        task = Task.from_dict(raw)
+        assert task.attachments == [str(img)]
+
+
+# ---------------------------------------------------------------------------
+# Capability gating
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityGating:
+    def test_capable_adapter_passes(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        # No exception raised.
+        refuse_when_incapable(adapter_name="claude", attachments=[str(img)])
+
+    def test_incapable_adapter_refused(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        with pytest.raises(CapabilityRefusal) as exc:
+            refuse_when_incapable(adapter_name="codex", attachments=[str(img)])
+        assert "codex" in str(exc.value).lower()
+        # Error suggests adapters that DO support attachments.
+        assert exc.value.suggested_adapters
+        assert all(is_multimodal_capable(a) for a in exc.value.suggested_adapters)
+
+    def test_no_attachments_no_refusal(self) -> None:
+        # An incapable adapter is fine when no attachments are present.
+        refuse_when_incapable(adapter_name="codex", attachments=[])
+
+
+# ---------------------------------------------------------------------------
+# sha256 stability
+# ---------------------------------------------------------------------------
+
+
+class TestSha256Stability:
+    def test_same_bytes_same_digest(self, tmp_path: Path) -> None:
+        img1 = _make_image(tmp_path / "a.png", payload=b"identical")
+        img2 = _make_image(tmp_path / "b.png", payload=b"identical")
+        chain1 = _audit_chain(tmp_path / "x1")
+        chain2 = _audit_chain(tmp_path / "x2")
+        cas1 = CASStore(tmp_path / "cas1")
+        cas2 = CASStore(tmp_path / "cas2")
+
+        ctx1 = build_attachment_context(
+            attachments=[str(img1)],
+            worker_id="wkr-1",
+            turn_seq=1,
+            worktree_id="wt-a",
+            cas=cas1,
+            audit_chain=chain1,
+        )
+        ctx2 = build_attachment_context(
+            attachments=[str(img2)],
+            worker_id="wkr-2",
+            turn_seq=1,
+            worktree_id="wt-b",
+            cas=cas2,
+            audit_chain=chain2,
+        )
+        assert ctx1.resolutions[0].sha256 == ctx2.resolutions[0].sha256
+
+
+# ---------------------------------------------------------------------------
+# build_attachment_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAttachmentContext:
+    def test_returns_multimodal_context(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert isinstance(result.context, MultiModalContext)
+        assert result.context.primary_modality == ModalityType.IMAGE
+        assert len(result.context.inputs) == 1
+        assert result.context.inputs[0].mime_type == "image/png"
+
+    def test_records_audit_chain_entry(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=7,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        # Find the multimodal.attach event in the chain.
+        entries = chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+        assert len(entries) == 1
+        details = entries[0].details
+        assert details["sha256"] == result.resolutions[0].sha256
+        assert details["mime"] == "image/png"
+        assert details["worker_id"] == "wkr-1"
+        assert details["turn_seq"] == 7
+        assert details["worktree_id"] == "wt-a"
+        # operator_install_id_sig is recorded (non-empty string).
+        assert details["operator_install_id_sig"]
+        assert details["prev_chain_digest"]
+
+    def test_stores_bytes_in_cas(self, tmp_path: Path) -> None:
+        payload = PNG_MAGIC + b"unique-bytes"
+        img = _make_image(tmp_path / "shot.png", payload=payload)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+        assert cas.has(digest)
+        assert cas.get(digest) == payload
+
+    def test_multiple_attachments(self, tmp_path: Path) -> None:
+        i1 = _make_image(tmp_path / "a.png", payload=b"a" * 16)
+        i2 = _make_image(tmp_path / "b.png", payload=b"b" * 16)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(i1), str(i2)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert len(result.resolutions) == 2
+        entries = chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+        assert len(entries) == 2
+
+    def test_audit_chain_valid_after_attach(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        valid, errors = chain.verify()
+        assert valid, f"chain integrity broken: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Lineage parent inclusion
+# ---------------------------------------------------------------------------
+
+
+class TestLineageParents:
+    def test_resolutions_become_lineage_parents(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        parents = worker_lineage_parents(result)
+        assert len(parents) == 1
+        # Lineage parent identifiers are content-addressed.
+        assert result.resolutions[0].sha256 in parents[0]
+
+    def test_no_attachments_no_parents(self, tmp_path: Path) -> None:
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert worker_lineage_parents(result) == []
+
+
+# ---------------------------------------------------------------------------
+# Worktree pinning
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreePinning:
+    def test_same_worktree_can_resolve(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+        # Same worktree id can resolve the attachment back to bytes.
+        bytes_back = resolve_attachment_for_worker(
+            sha256=digest,
+            requesting_worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert bytes_back == img.read_bytes()
+
+    def test_cross_worktree_rejected(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+        with pytest.raises(WorktreeAccessDenied):
+            resolve_attachment_for_worker(
+                sha256=digest,
+                requesting_worktree_id="wt-b",
+                cas=cas,
+                audit_chain=chain,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Replay & tamper detection
+# ---------------------------------------------------------------------------
+
+
+class TestReplayAndTamper:
+    def test_replay_reproduces_exact_bytes(self, tmp_path: Path) -> None:
+        payload = PNG_MAGIC + b"exact-replay-bytes"
+        img = _make_image(tmp_path / "shot.png", payload=payload)
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        digest = result.resolutions[0].sha256
+        replayed = resolve_attachment_for_worker(
+            sha256=digest,
+            requesting_worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        assert replayed == payload
+
+    def test_tamper_breaks_verification(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        # Tamper with the audit chain log on disk.
+        log_files = list((tmp_path / "audit").glob("*.jsonl"))
+        assert log_files
+        raw = log_files[0].read_bytes()
+        # Flip one byte inside the JSON payload (not the trailing newline).
+        # The first '{' is at offset 0; flip a hex character somewhere in
+        # the middle of the line so the JSON still parses but the canonical
+        # form drifts.
+        tampered = bytearray(raw)
+        # Find a digit / letter to flip in the payload.
+        for i, b in enumerate(tampered):
+            if chr(b).isalnum() and i > 0 and tampered[i - 1] != ord('"'):
+                tampered[i] = ord("a") if chr(b) != "a" else ord("b")
+                break
+        log_files[0].write_bytes(bytes(tampered))
+        valid, errors = chain.verify()
+        assert not valid
+        assert errors
+
+
+# ---------------------------------------------------------------------------
+# record_multimodal_attach helper
+# ---------------------------------------------------------------------------
+
+
+class TestRecordMultimodalAttach:
+    def test_records_event_with_required_fields(self, tmp_path: Path) -> None:
+        chain = _audit_chain(tmp_path)
+        event = record_multimodal_attach(
+            chain=chain,
+            sha256="a" * 64,
+            mime="image/png",
+            operator_install_id_sig="install-sig-abc",
+            worker_id="wkr-1",
+            turn_seq=3,
+            worktree_id="wt-a",
+        )
+        assert event.event_type == EVENT_MULTIMODAL_ATTACH
+        assert event.details["sha256"] == "a" * 64
+        assert event.details["mime"] == "image/png"
+        assert event.details["worker_id"] == "wkr-1"
+        assert event.details["turn_seq"] == 3
+        assert event.details["worktree_id"] == "wt-a"
+        assert event.details["operator_install_id_sig"] == "install-sig-abc"
+        # prev_chain_digest comes from the underlying chain (genesis for first
+        # event).
+        assert event.details["prev_chain_digest"]
+
+    def test_chain_continues_across_attaches(self, tmp_path: Path) -> None:
+        chain = _audit_chain(tmp_path)
+        e1 = record_multimodal_attach(
+            chain=chain,
+            sha256="a" * 64,
+            mime="image/png",
+            operator_install_id_sig="sig",
+            worker_id="w",
+            turn_seq=0,
+            worktree_id="wt-a",
+        )
+        e2 = record_multimodal_attach(
+            chain=chain,
+            sha256="b" * 64,
+            mime="image/jpeg",
+            operator_install_id_sig="sig",
+            worker_id="w",
+            turn_seq=1,
+            worktree_id="wt-a",
+        )
+        assert e2.details["prev_chain_digest"] == e1.hmac
+
+    def test_query_filters_event_type(self, tmp_path: Path) -> None:
+        chain = _audit_chain(tmp_path)
+        # Mix in an unrelated event.
+        chain.log(
+            event_type="task.transition",
+            actor="orchestrator",
+            resource_type="task",
+            resource_id="t-1",
+        )
+        record_multimodal_attach(
+            chain=chain,
+            sha256="a" * 64,
+            mime="image/png",
+            operator_install_id_sig="sig",
+            worker_id="w",
+            turn_seq=0,
+            worktree_id="wt-a",
+        )
+        attaches = chain.query(event_type=EVENT_MULTIMODAL_ATTACH)
+        assert len(attaches) == 1
+        assert attaches[0].details["sha256"] == "a" * 64
+
+
+# ---------------------------------------------------------------------------
+# AttachmentResolution dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentResolution:
+    def test_resolution_carries_digest_and_mime(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "shot.png")
+        chain = _audit_chain(tmp_path)
+        cas = CASStore(tmp_path / "cas")
+        result = build_attachment_context(
+            attachments=[str(img)],
+            worker_id="wkr-1",
+            turn_seq=0,
+            worktree_id="wt-a",
+            cas=cas,
+            audit_chain=chain,
+        )
+        r = result.resolutions[0]
+        assert isinstance(r, AttachmentResolution)
+        assert len(r.sha256) == 64
+        assert r.mime == "image/png"
+        assert r.worktree_id == "wt-a"
+
+
+# ---------------------------------------------------------------------------
+# YAML plan loader integration
+# ---------------------------------------------------------------------------
+
+
+class TestPlanLoaderAttachments:
+    def test_yaml_plan_attachments_propagate(self, tmp_path: Path) -> None:
+        img = _make_image(tmp_path / "img.png")
+        plan_yaml = tmp_path / "plan.yaml"
+        plan_yaml.write_text(
+            "name: test\n"
+            "stages:\n"
+            "  - name: phase1\n"
+            "    steps:\n"
+            "      - title: With attachment\n"
+            "        role: backend\n"
+            f"        attachments: ['{img}']\n"
+        )
+        from bernstein.core.planning.plan_loader import load_plan_from_yaml
+
+        tasks = load_plan_from_yaml(plan_yaml)
+        assert len(tasks) == 1
+        assert tasks[0].attachments == [str(img)]


### PR DESCRIPTION
## Summary

- Adds `--attach <path>` (repeatable) to `bernstein run`. Capability gate refuses non-multimodal adapters BEFORE spawning.
- Implements the provenance contract for #1797: each attach records an HMAC-chained `multimodal.attach` event (sha256, mime, install_id_sig, worker_id, turn_seq, prev_chain_digest, worktree_id); bytes stored once in CAS; lineage v1 receipt parents carry the attachment digest.
- Worktree pinning enforced at resolve time.

Closes #1797.

## Files touched

- New: `src/bernstein/core/agents/multimodal_attestation.py`
- New: `src/bernstein/core/security/audit_chain.py`
- New: `tests/unit/test_multimodal_attestation.py` (23 cases)
- New: `tests/integration/test_run_attach.py` (round-trip + CLI flag)
- New: `docs/operations/run.md`
- Modified: `src/bernstein/core/tasks/models.py` (Task.attachments field + from_dict)
- Modified: `src/bernstein/core/planning/plan_loader.py` (YAML attachments key)
- Modified: `src/bernstein/cli/run_bootstrap.py` (--attach option + capability gate)
- Modified: `src/bernstein/adapters/base.py` (multimodal_context= keyword on spawn)
- Modified: `src/bernstein/adapters/claude.py` (base64 wire format)
- Modified: `src/bernstein/adapters/gemini.py` (base64 wire format)
- Modified: `src/bernstein/core/persistence/lineage_signer.py` (attachment-as-parent helper)

## Acceptance criteria

- [x] `bernstein run "<prompt>" --attach ./shot.png` succeeds end to end against the Claude and Gemini adapters; the attached image reaches the model API request body as base64 with the correct MIME type.
- [x] Each `--attach` invocation records an audit-chain entry containing (sha256(image), mime, operator_install_id_sig, worker_id, turn_seq, prev_chain_digest); replay reproduces the exact bytes sent to the model API on the original turn.
- [x] The worker's lineage v1 receipt for any artefact produced this turn carries the input image's sha256 in its parents; tamper with the bytes and the chain fails verification.
- [x] An image attached to a worker in worktree wt-a is unreachable from wt-b workers in the same session; the chain entry encodes the worktree id and the resolver enforces the boundary.
- [x] Task YAML accepts an attachments list field; the orchestrator builds a MultiModalContext at spawn time from the listed paths and passes it to the adapter.
- [x] Spawning with `--attach` on an adapter where `is_multimodal_capable` returns False fails with a clear error before any process is launched; the error suggests adapters that support attachments.
- [x] Tests cover spawn-time wiring (unit), round-trip on a stubbed Claude adapter (integration), audit-chain entry shape, lineage parent inclusion, cross-worktree isolation, and capability-gating refusal.

## Test plan

- [x] `uv run pytest tests/unit/test_multimodal.py tests/unit/test_multimodal_attestation.py tests/integration/test_run_attach.py` -- 101 passed.
- [x] `uv run pytest tests/unit/ -k "multimodal or attach"` -- 90 passed.
- [x] `uv run pytest tests/unit/ -k "task_model or models or plan_loader or cas_store or lineage_signer"` -- 250 passed.
- [x] `uv run pytest tests/unit/ -k "adapter and (claude or gemini)"` -- 299 passed, 5 skipped.
- [x] `uv run pytest tests/unit/test_audit_dsse.py tests/unit/test_audit_chain_byteflip_regression.py tests/unit/test_audit_export.py` -- 32 passed.
- [x] `uv run ruff check . --fix && uv run ruff format .` -- clean.
- [x] `uv run pyright src/bernstein/core/agents/multimodal_attestation.py src/bernstein/core/security/audit_chain.py src/bernstein/core/persistence/lineage_signer.py` -- 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI --attach to pass files to multimodal-capable adapters (Claude, Gemini); attachments are base64-inlined into prompts with SHA‑256 digests, recorded as lineage parents, and rejected early for incapable adapters.
  * Worktree-pinned attachment resolution enforcing cross-worktree denial and replay-safe provenance.

* **Documentation**
  * Operator guide for the run --attach workflow, attachment wire format, provenance, and adapter compatibility.

* **Tests**
  * Comprehensive integration and unit tests covering CLI, adapter injection, provenance, audit-chain, and cross-worktree isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->