### PR TITLE
fix(persistence): refurb cleanups in replay journal + lineage signer + eval (cluster C)

### DIFF
--- a/src/bernstein/core/persistence/journal.py
+++ b/src/bernstein/core/persistence/journal.py
@@ -206,7 +206,7 @@ class JournalEntry:
             "tool_result": self.tool_result,
             "step_hash": self.step_hash,
             "ts": self.ts,
-            "blob_refs": list(self.blob_refs),
+            "blob_refs": self.blob_refs.copy(),
         }
 
     @classmethod

--- a/src/bernstein/core/persistence/journal_export.py
+++ b/src/bernstein/core/persistence/journal_export.py
@@ -91,7 +91,7 @@ class ReceiptManifest:
             "steps": self.steps,
             "bernstein_version": self.bernstein_version,
             "created_at": self.created_at,
-            "blob_digests": list(self.blob_digests),
+            "blob_digests": self.blob_digests.copy(),
             "format_version": self.format_version,
         }
         return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -105,7 +105,7 @@ class ReceiptManifest:
                 "steps": self.steps,
                 "bernstein_version": self.bernstein_version,
                 "created_at": self.created_at,
-                "blob_digests": list(self.blob_digests),
+                "blob_digests": self.blob_digests.copy(),
                 "format_version": self.format_version,
             },
             sort_keys=True,
@@ -472,6 +472,7 @@ def open_receipt(receipt_path: Path):  # type: ignore[no-untyped-def]
 __all__ = [
     "MANIFEST_NAME",
     "ExportResult",
+    "JournalError",
     "ReceiptError",
     "ReceiptManifest",
     "ReceiptVerificationResult",
@@ -479,7 +480,3 @@ __all__ = [
     "open_receipt",
     "verify_receipt",
 ]
-
-
-# Re-export so callers don't need a separate journal import for the symbol.
-JournalError = JournalError

--- a/src/bernstein/core/persistence/journal_publish.py
+++ b/src/bernstein/core/persistence/journal_publish.py
@@ -133,7 +133,7 @@ def _redact_value(value: Any) -> Any:
 
 def _redact_row(row: dict[str, Any], policy: RedactionPolicy) -> dict[str, Any]:
     """Return a copy of *row* with redaction policy applied."""
-    redacted = dict(row)
+    redacted = row.copy()
     for field_name in policy.redact_fields:
         if field_name in redacted:
             redacted[field_name] = _redact_value(redacted[field_name])

--- a/src/bernstein/core/persistence/lineage_signer.py
+++ b/src/bernstein/core/persistence/lineage_signer.py
@@ -220,7 +220,7 @@ def register_attachment_parents(
         A new list with attachment parents appended.
     """
     seen: set[str] = set(parents)
-    out: list[str] = list(parents)
+    out: list[str] = parents.copy()
     for digest in attachment_sha256s:
         uri = build_attachment_parent_uri(digest)
         if uri not in seen:

--- a/src/bernstein/eval/incident_synthesizer.py
+++ b/src/bernstein/eval/incident_synthesizer.py
@@ -753,7 +753,7 @@ def _source_incident_from_yaml(path: Path) -> str:
         for line in path.read_text(encoding="utf-8").splitlines():
             if line.startswith("source_incident:"):
                 raw = line.split(":", 1)[1].strip()
-                if len(raw) >= 2 and raw[0] == '"' and raw[-1] == '"':
+                if len(raw) >= 2 and raw[0] == '"' == raw[-1]:
                     raw = raw[1:-1].replace('\\"', '"').replace("\\\\", "\\")
                 return raw
     except OSError:

--- a/tests/unit/test_journal_chain.py
+++ b/tests/unit/test_journal_chain.py
@@ -454,7 +454,7 @@ class TestLayout:
         # Single bucket file by default.
         files = list(agent_dir.glob("*.jsonl"))
         assert len(files) == 1
-        # File mode is owner-writeable; on POSIX must not be group/world-writable.
+        # File mode is owner-writable; on POSIX must not be group/world-writable.
         if os.name == "posix":
             mode = files[0].stat().st_mode & 0o777
             assert (mode & 0o022) == 0, f"unsafe mode {oct(mode)}"

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -239,6 +239,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "desktop-register",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "supervisor",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "schedule",
     }
 )
 


### PR DESCRIPTION
## Summary

Address 7 refurb alerts across 5 files in the replay journal, lineage signer, and eval subsystems.

## Alerts cleared

| Alert | File:line | Rule | Fix |
|---|---|---|---|
| #2468 | `src/bernstein/core/persistence/journal.py:209` | FURB123 | `list(self.blob_refs)` -> `self.blob_refs.copy()` |
| #2469 | `src/bernstein/core/persistence/journal_export.py:94` | FURB123 | `list(self.blob_digests)` -> `self.blob_digests.copy()` |
| #2470 | `src/bernstein/core/persistence/journal_export.py:108` | FURB123 | `list(self.blob_digests)` -> `self.blob_digests.copy()` |
| #2471 | `src/bernstein/core/persistence/journal_export.py:485` | FURB160 | drop redundant `JournalError = JournalError` self-assignment; add `JournalError` to `__all__` so the re-export stays explicit for callers |
| #2472 | `src/bernstein/core/persistence/journal_publish.py:136` | FURB123 | `dict(row)` -> `row.copy()` |
| #2473 | `src/bernstein/core/persistence/lineage_signer.py:223` | FURB123 | `list(parents)` -> `parents.copy()` |
| #2465 | `src/bernstein/eval/incident_synthesizer.py:756` | FURB124 | collapse `raw[0] == '"' and raw[-1] == '"'` into chained `raw[0] == '"' == raw[-1]` |

## Behaviour

Unchanged. Each `.copy()` produces the same shallow-copy semantics as the explicit `list(...)` / `dict(...)` constructor. The chained comparison evaluates identically for two-character bounds. The `JournalError` re-export remains available via the top-of-file import; adding it to `__all__` documents the public surface explicitly.

## Test plan

- [x] `uv run refurb` on the 5 touched files is clean.
- [x] `uv run pytest tests/unit/ -q --no-cov --timeout=120 -k "journal or lineage_signer or incident_synthesizer"` - 104 tests pass.
- [x] `uv run ruff check . --fix && uv run ruff format .` - all checks passed, no formatting drift.
- [x] `uv run pyright` on the 5 touched files - error count unchanged versus `origin/main` baseline (53/53; all pre-existing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of quoted strings in YAML parsing.

* **Documentation**
  * Added schedule command to documented CLI commands list.

* **Refactor**
  * Updated internal list copying methods across persistence modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->