### PR TITLE
fix(security): redact sensitive logging + refurb cleanups (cluster A)

### DIFF
--- a/src/bernstein/core/security/always_allow.py
+++ b/src/bernstein/core/security/always_allow.py
@@ -291,7 +291,12 @@ def _verify_manifest(workdir: Path, rules_path: Path) -> None:
             "load agent-supplied always-allow rules."
         )
         _record_tamper_event(workdir, rules_path, reason)
-        logger.error(reason)  # lgtm[py/clear-text-logging-sensitive-data] - file paths only, no credential material
+        # Log a generic safety message; the full path-bearing reason is in
+        # .sdd/metrics/guardrails.jsonl for operator forensic review.
+        logger.error(
+            "Always-allow rules rejected: agent-writable rules file has no "
+            "orchestrator manifest. See .sdd/metrics/guardrails.jsonl for details."
+        )
         raise AlwaysAllowTamperError(reason)
 
     try:
@@ -299,7 +304,12 @@ def _verify_manifest(workdir: Path, rules_path: Path) -> None:
     except (OSError, json.JSONDecodeError) as exc:
         reason = f"Always-allow manifest at {manifest_path} is unreadable: {type(exc).__name__}"
         _record_tamper_event(workdir, rules_path, reason)
-        logger.error(reason)  # lgtm[py/clear-text-logging-sensitive-data] - file path + exception type only
+        # Log a generic safety message; the full path-bearing reason is in
+        # .sdd/metrics/guardrails.jsonl for operator forensic review.
+        logger.error(
+            "Always-allow manifest unreadable (%s). See .sdd/metrics/guardrails.jsonl for details.",
+            type(exc).__name__,
+        )
         raise AlwaysAllowTamperError(f"Always-allow manifest at {manifest_path} is unreadable: {exc}") from exc
 
     expected_digest = str(manifest.get("sha256", "")).lower()

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -119,7 +119,7 @@ class AuditChainStore:
         (bot-ack: 3284182792 -- CodeRabbit major.)
         """
         with self._append_lock:
-            merged: dict[str, Any] = dict(details)
+            merged: dict[str, Any] = details.copy()
             merged["prev_chain_digest"] = self.prev_chain_digest
             return self._log.log(
                 event_type=event_type,

--- a/src/bernstein/core/security/jwt_tokens.py
+++ b/src/bernstein/core/security/jwt_tokens.py
@@ -155,8 +155,7 @@ class JWTManager:
             raise ValueError("Invalid token header") from exc
         if not isinstance(header_obj, dict):
             raise ValueError("Invalid token header")
-        header_dict = cast("dict[str, Any]", header_obj)
-        alg_obj: object = header_dict.get("alg")
+        alg_obj: object = cast("dict[str, Any]", header_obj).get("alg")
         # Reject unsigned tokens explicitly - even if the configured
         # algorithm somehow matched, "none" means no signature was applied.
         if not isinstance(alg_obj, str) or alg_obj.lower() == "none":

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -565,7 +565,7 @@ def _capture_dead_letter(entry: Any, *, original_error: str) -> None:
             extra={
                 "title": entry.title,
                 "retry_count": entry.retry_count,
-                "original_error": (original_error or "")[:800],
+                "original_error": original_error[:800],
             },
         )
     except Exception as exc:  # pragma: no cover - defensive

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -239,6 +239,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "desktop-register",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "supervisor",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "schedule",
     }
 )
 


### PR DESCRIPTION
## Summary

Closes #2446 #2447 (CodeQL `py/clear-text-logging-sensitive-data`, HIGH). Also fixes three refurb findings in the same cluster.

| Alert | File:Line | Fix |
|-------|-----------|-----|
| #2446 (CodeQL HIGH) | `src/bernstein/core/security/always_allow.py:294` | `logger.error(reason)` embedded env-var-derived paths (`rules_path`, `manifest_path`). Switched to a static safety message; full path-bearing reason still goes to `.sdd/metrics/guardrails.jsonl` via `_record_tamper_event` for operator forensic review. |
| #2447 (CodeQL HIGH) | `src/bernstein/core/security/always_allow.py:302` | Same site, same strategy: static log line + pointer to the metrics file. Identical treatment to #2446. |
| FURB123 | `src/bernstein/core/security/audit_chain.py:122` | `dict(details)` -> `details.copy()` for an already-typed `dict[str, Any]` input. |
| FURB143 | `src/bernstein/core/tasks/task_lifecycle.py:568` | Dropped the redundant `or ""` since `original_error` is typed `str`. |
| FURB184 | `src/bernstein/core/security/jwt_tokens.py:159` | Chained the `cast()` and `.get()` call; the intermediate `header_dict` had no other users. |

## Redaction strategy (both HIGH sites)

CodeQL traced the `BERNSTEIN_ALWAYS_ALLOW_PATH` env value through `rules_path` -> `reason` -> `logger.error(reason)` and classified the resolved path as sensitive. The fix:

- Application log line is now a static safety message naming the failure category (missing manifest / unreadable manifest) plus a pointer to `.sdd/metrics/guardrails.jsonl`.
- The full path-bearing `reason` is still forwarded to `_record_tamper_event`, which writes it (with sha256 digests pre-redacted) to `.sdd/metrics/guardrails.jsonl` for forensic review.
- The raised `AlwaysAllowTamperError` still carries the full reason for callers that catch and re-emit it through orchestrator-side channels.

Net effect: operators keep full debuggability via the metrics file; the application-log stream no longer carries the env-derived path.

## Verification

- `uv run pytest tests/unit/ -q --no-cov --timeout=120 -k "always_allow or audit_chain or task_lifecycle or jwt_tokens or agent_identity_jwt or jwt_refresh"` -> 145 passed
- `uv run ruff check .` -> All checks passed
- `uv run ruff format .` -> 1 file reformatted (always_allow.py whitespace only)
- `uv run refurb` on the four files -> the three targeted findings cleared (FURB186 at task_lifecycle:1328 was out of scope and untouched)
- `uv run pyright` -> no new errors near the edited lines (255 pre-existing baseline errors unchanged)

## Test plan

- [x] Targeted unit tests pass (145/145)
- [x] Ruff check + format clean
- [x] Refurb findings cleared at the three cited lines
- [ ] CodeQL re-run confirms #2446 and #2447 resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `schedule` CLI command for managing scheduled operations.

* **Security & Stability**
  * Enhanced error logging in security operations to emit generic, operator-friendly messages.
  * Improved error handling in task lifecycle telemetry for better diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->