### PR TITLE
fix(skills): refurb cleanups in catalog + lineage gate (cluster B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Highest-value commands; full list in [docs/operations/commands.md](docs/operatio
 | `bernstein backlog claim --role reviewer` | Atomically claims one eligible row from `.sdd/runtime/task-backlog.json` for external workers. |
 | `bernstein chat serve --platform=telegram\|discord\|slack` | Drive runs from chat with `/run`, `/status`, `/approve`, `/reject`. |
 | `bernstein workflow run <name>` | Run a YAML workflow manifest. |
+| `bernstein schedule add\|list\|run` | Manage operator-registered recurring schedules; `schedule audit` walks persisted fire receipts to prove the sequence is replayable. |
 
 ### retrieval & caching: what's actually under the hood
 

--- a/src/bernstein/cli/commands/skills_catalog_cmd.py
+++ b/src/bernstein/cli/commands/skills_catalog_cmd.py
@@ -147,8 +147,7 @@ def list_cmd(scope: str) -> None:
     """List catalog entries currently installed via the lockfile."""
     from rich.table import Table
 
-    service = _build_service(scope)
-    rows = service.list_installed()
+    rows = _build_service(scope).list_installed()
     if not rows:
         console.print("[dim]No skills installed via catalog.[/dim]")
         return
@@ -206,8 +205,7 @@ def search_cmd(query: str, refresh: bool, scope: str) -> None:
 )
 def info_cmd(entry_id: str, refresh: bool, scope: str) -> None:
     """Show full info for a single catalog entry."""
-    service = _build_service(scope)
-    entry = service.info(entry_id, force_refresh=refresh)
+    entry = _build_service(scope).info(entry_id, force_refresh=refresh)
     if entry is None:
         raise click.ClickException(f"Catalog entry {entry_id!r} not found")
 
@@ -363,8 +361,7 @@ def uninstall_cmd(entry_id: str, scope: str) -> None:
 )
 def sync_cmd(scope: str) -> None:
     """Detect lockfile vs on-disk drift."""
-    service = _build_service(scope)
-    drift = service.sync()
+    drift = _build_service(scope).sync()
     if not drift:
         console.print("[green]no drift detected[/green]")
         return
@@ -381,8 +378,7 @@ def sync_cmd(scope: str) -> None:
 )
 def status_cmd(scope: str) -> None:
     """Show cache + lockfile state for ``skills catalog``."""
-    service = _build_service(scope)
-    status = service.status()
+    status = _build_service(scope).status()
     console.print("[bold cyan]Skill catalog status[/bold cyan]")
     console.print(f"Cache:                {status.cache_path}")
     console.print(f"Last fetch:           {status.last_fetch_at or 'never'}")

--- a/src/bernstein/core/lineage/gate.py
+++ b/src/bernstein/core/lineage/gate.py
@@ -237,13 +237,14 @@ def check_skill_lockfile(
         return GateResult(ok=False, failures=["skill catalog lockfile module is missing"])
 
     state = read_state(lockfile_path)
-    failures: list[str] = []
-    for row in state.catalog:
-        if row.manifest_sha256 not in known_good_manifest_shas:
-            failures.append(
-                f"{row.id}: lockfile manifest_sha256 {row.manifest_sha256[:12]}... "
-                "is not present in the audit chain's known-good set",
-            )
+    failures: list[str] = [
+        (
+            f"{row.id}: lockfile manifest_sha256 {row.manifest_sha256[:12]}... "
+            "is not present in the audit chain's known-good set"
+        )
+        for row in state.catalog
+        if row.manifest_sha256 not in known_good_manifest_shas
+    ]
     return GateResult(ok=not failures, failures=failures)
 
 

--- a/src/bernstein/core/skills/catalog/audit.py
+++ b/src/bernstein/core/skills/catalog/audit.py
@@ -94,8 +94,7 @@ def compute_manifest_sha256(manifest_url: str, payload: dict[str, Any]) -> str:
     swaps the upstream while keeping the URL is caught.
     """
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    hasher = hashlib.sha256()
-    hasher.update(manifest_url.encode("utf-8"))
+    hasher = hashlib.sha256(manifest_url.encode("utf-8"))
     hasher.update(b"\n")
     hasher.update(canonical)
     return hasher.hexdigest()

--- a/src/bernstein/core/skills/catalog/service.py
+++ b/src/bernstein/core/skills/catalog/service.py
@@ -155,7 +155,7 @@ class SkillCatalogService:
         plugin_installer: InstallerCallable | None = None,
         preloaded_catalog: SkillCatalog | None = None,
     ) -> None:
-        if fetcher is None and preloaded_catalog is None:
+        if fetcher is preloaded_catalog is None:
             raise ValueError("either fetcher or preloaded_catalog must be supplied")
         self._fetcher = fetcher
         self._auditor = auditor or SkillCatalogAuditor()
@@ -368,13 +368,11 @@ class SkillCatalogService:
         force_refresh: bool = False,
     ) -> UpgradeOutcome:
         """Upgrade a single installed catalog entry."""
-        state = read_state(self.lockfile_path)
-        prior = state.find_catalog(entry_id)
+        prior = read_state(self.lockfile_path).find_catalog(entry_id)
         if prior is None:
             raise SkillCatalogError(f"{entry_id!r} is not installed")
 
-        catalog = self.browse(force_refresh=force_refresh)
-        upstream = catalog.find(entry_id)
+        upstream = self.browse(force_refresh=force_refresh).find(entry_id)
         if upstream is None:
             return UpgradeOutcome(
                 entry_id=entry_id,

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -239,6 +239,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "desktop-register",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "supervisor",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "schedule",
     }
 )
 


### PR DESCRIPTION
## Summary
Sweeps 11 refurb warnings flagged by GitHub code scanning across the skill
catalog CLI surface, catalog service, audit hasher, and the lineage gate.
All fixes are mechanical idiom updates; no behaviour change.

## Alerts cleared

| Alert | File:line | Rule | Fix |
|---|---|---|---|
| #2475 | `skills_catalog_cmd.py:151` | FURB184 | Inline `_build_service(scope).list_installed()` |
| #2476 | `skills_catalog_cmd.py:210` | FURB184 | Inline `_build_service(scope).info(...)` |
| #2477 | `skills_catalog_cmd.py:367` | FURB184 | Inline `_build_service(scope).sync()` |
| #2478 | `skills_catalog_cmd.py:385` | FURB184 | Inline `_build_service(scope).status()` |
| #2479 | `lineage/gate.py:240` | FURB138 | Build `failures` via list comprehension |
| #2480 | `catalog/audit.py:97` | FURB182 | Pass first chunk into `hashlib.sha256(...)` constructor |
| #2481 | `catalog/audit.py:97` | FURB182 | Same fix clears the cascaded warning |
| #2482 | `catalog/audit.py:97` | FURB182 | Same fix clears the cascaded warning |
| #2483 | `catalog/service.py:158` | FURB124 | `fetcher is preloaded_catalog is None` chain |
| #2484 | `catalog/service.py:372` | FURB184 | Chain `read_state(...).find_catalog(entry_id)` |
| #2485 | `catalog/service.py:377` | FURB184 | Chain `self.browse(...).find(entry_id)` |

## Test plan
- [x] `uv run pytest tests/unit/ -q --no-cov --timeout=120 -k "catalog or skills_catalog or lineage_gate or skills_catalog_cmd"` -> 213 passed
- [x] `uv run ruff check . --fix && uv run ruff format .` -> clean, no changes
- [x] `uv tool run refurb src/bernstein/cli/commands/skills_catalog_cmd.py src/bernstein/core/skills/catalog/service.py src/bernstein/core/skills/catalog/audit.py src/bernstein/core/lineage/gate.py` -> empty output (all 11 cleared)
- [x] `uv run pyright` on the four touched files -> only a pre-existing `list[Unknown]` warning on `GateResult.failures` at gate.py:40, unrelated to this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to CLI, validation, hashing, and service initialization for more consistent behavior.

* **Documentation**
  * Added documentation for the `schedule` command and its audit/run/list subcommands.

* **Tests**
  * Updated test documentation allowlist to include the `schedule` command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->