### PR TITLE
fix(schedule): refurb cleanups in schedule subsystem (cluster D-1)

### DIFF
--- a/src/bernstein/cli/commands/schedule_cmd.py
+++ b/src/bernstein/cli/commands/schedule_cmd.py
@@ -146,8 +146,7 @@ def schedule_add(
 def schedule_list(as_json: bool) -> None:
     """List all registered schedules."""
     sdd = _sdd_dir()
-    store = ScheduleStore(sdd)
-    schedules = store.list()
+    schedules = ScheduleStore(sdd).list()
 
     if as_json:
         click.echo(
@@ -339,9 +338,7 @@ def schedule_doctor(as_json: bool) -> None:
     """
     sdd = _sdd_dir()
     store = ScheduleStore(sdd)
-    supervisor = ScheduleSupervisor(store, lambda _evt: None, None)
-
-    status = supervisor.status()
+    status = ScheduleSupervisor(store, lambda _evt: None, None).status()
     payload = {
         "alive": status.alive,
         "last_tick_at": status.last_tick_at,

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -247,7 +247,7 @@ class ScheduleSupervisor:
         self._store = store
         self._dispatch = dispatch
         self._chain = _AuditChainAdapter(audit_writer) if audit_writer is not None else None
-        self._catch_up_limit = max(1, int(catch_up_limit))
+        self._catch_up_limit = max(1, catch_up_limit)
         self._receipts_dir = store.directory.parent / "schedule_receipts"
         self._receipts_dir.mkdir(parents=True, exist_ok=True)
         self._last_tick_at = 0.0

--- a/src/bernstein/core/planning/schedule_store.py
+++ b/src/bernstein/core/planning/schedule_store.py
@@ -71,7 +71,7 @@ class Schedule:
     misfire_policy: MisfirePolicy = "skip"
     created_at: float = 0.0
     last_fire_at: float = 0.0
-    extra: dict[str, Any] = field(default_factory=lambda: {})
+    extra: dict[str, Any] = field(default_factory=dict[str, Any])
 
 
 class CronParseError(ValueError):
@@ -170,8 +170,7 @@ def _expand_field(spec: str, lo: int, hi: int, names: dict[str, int] | None = No
                 continue
             start, end = value, hi
 
-        for v in range(start, end + 1, step):
-            result.add(v)
+        result.update(range(start, end + 1, step))
 
     if not result:
         raise CronParseError(f"empty cron field expansion: {spec!r}")
@@ -407,7 +406,7 @@ class ScheduleStore:
             scenario_id=schedule.scenario_id,
             misfire_policy=schedule.misfire_policy,
             created_at=schedule.created_at,
-            last_fire_at=float(fire_time),
+            last_fire_at=fire_time,
             extra=dict(schedule.extra),
         )
         self._write(updated)

--- a/src/bernstein/core/trigger_sources/schedule.py
+++ b/src/bernstein/core/trigger_sources/schedule.py
@@ -47,7 +47,7 @@ def normalize_schedule_fire(
     metadata: dict[str, Any] = {
         "source_type": "schedule",
         "schedule_id": schedule_id,
-        "fire_time": float(fire_time),
+        "fire_time": fire_time,
         "misfire_policy": misfire_policy,
     }
     if scenario_id:
@@ -66,10 +66,10 @@ def normalize_schedule_fire(
 
     return TriggerEvent(
         source="schedule",
-        timestamp=float(fire_time),
+        timestamp=fire_time,
         raw_payload={
             "schedule_id": schedule_id,
-            "fire_time": float(fire_time),
+            "fire_time": fire_time,
             "goal": goal,
             "scenario_id": scenario_id,
             "projection_hash": projection_hash,


### PR DESCRIPTION
## Summary

Root-cause fixes for 6 code-scanning (refurb) alerts in the schedule subsystem. Mechanical cleanups, no behaviour change.

| Alert | File:line | Rule | Fix |
|-------|-----------|------|-----|
| #2462 | `core/trigger_sources/schedule.py:50` | FURB123 | drop `float()` cast on `fire_time` (already `float`) |
| #2463 | `core/trigger_sources/schedule.py:69` | FURB123 | drop `float()` cast on `fire_time` |
| #2464 | `core/trigger_sources/schedule.py:72` | FURB123 | drop `float()` cast on `fire_time` |
| #2459 | `core/planning/schedule_store.py:74` | FURB111 | `default_factory=dict[str, Any]` instead of `lambda: {}` |
| #2460 | `core/planning/schedule_store.py:173` | FURB142 | `result.update(range(...))` instead of `for v in range(...): result.add(v)` |
| #2461 | `core/planning/schedule_store.py:410` | FURB123 | drop `float()` cast on already-`float` `fire_time` |
| #2456 | `cli/commands/schedule_cmd.py:150` | FURB184 | chain `ScheduleStore(sdd).list()` |
| #2457 | `cli/commands/schedule_cmd.py:344` | FURB184 | chain `ScheduleSupervisor(...).status()` |
| #2458 | `core/orchestration/schedule_supervisor.py:250` | FURB123 | drop `int()` cast on already-`int` `catch_up_limit` |

The `default_factory=dict[str, Any]` form (mirroring the existing pattern in `supervisor_aggregator.py`) preserves the parameterised type so pyright stays clean; plain `dict` would have dropped the type parameter.

## Test plan

- [x] `uv run --with refurb refurb` on the 4 files: 0 findings
- [x] `uv run ruff check .` and `ruff format --check`: clean
- [x] `uv run pyright` on touched files: 0 errors
- [x] `uv run pytest tests/unit/ -k "schedule or supervisor"`: schedule suites pass (no regressions vs base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal scheduling command execution and cron field expansion logic.
  * Improved fire time handling in trigger event processing.

* **Documentation**
  * Updated documentation coverage to include schedule command references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->