### PR TITLE
fix(supervisor): refurb cleanups in supervisor and chat drivers (cluster D-2)

### DIFF
--- a/src/bernstein/cli/commands/supervisor_cmd.py
+++ b/src/bernstein/cli/commands/supervisor_cmd.py
@@ -125,7 +125,7 @@ def _render_status_table(console: Console, snapshot: SupervisorSnapshot) -> None
             hb = f"{int(row.last_heartbeat_age_s)}s"
         stuck_label = "STUCK" if row.is_stuck else "ok"
         table.add_row(
-            f"{row.worker_id}",
+            str(row.worker_id),
             row.role or "-",
             row.task_id or "-",
             hb,

--- a/src/bernstein/core/chat/drivers/discord.py
+++ b/src/bernstein/core/chat/drivers/discord.py
@@ -299,11 +299,11 @@ class DiscordBridge(BridgeProtocol):
 
     def approved_tool_call_hashes(self) -> set[str]:
         """Return a snapshot of every tool-call hash that has been approved."""
-        return set(self._approved_tool_call_hashes)
+        return self._approved_tool_call_hashes.copy()
 
     def partition_assignments(self) -> dict[str, str]:
         """Return ``tool_call_hash -> partition_id`` for every approved call."""
-        return dict(self._approved_partition_for)
+        return self._approved_partition_for.copy()
 
     def public_key_pem(self) -> bytes:
         """Return the install's Ed25519 public key (PEM, SubjectPublicKeyInfo)."""

--- a/src/bernstein/core/chat/drivers/slack.py
+++ b/src/bernstein/core/chat/drivers/slack.py
@@ -266,7 +266,7 @@ class SlackBridge(BridgeProtocol):
 
     def approved_tool_call_hashes(self) -> set[str]:
         """Return a snapshot of every tool-call hash that has been approved."""
-        return set(self._approved_tool_call_hashes)
+        return self._approved_tool_call_hashes.copy()
 
     def public_key_pem(self) -> bytes:
         """Return the install's Ed25519 public key (PEM, SubjectPublicKeyInfo)."""

--- a/src/bernstein/core/orchestration/supervisor_aggregator.py
+++ b/src/bernstein/core/orchestration/supervisor_aggregator.py
@@ -132,8 +132,7 @@ def load_agents_snapshot(workdir: Path) -> list[dict[str, Any]]:
         return []
     if not isinstance(payload_any, dict):
         return []
-    payload = cast(dict[str, Any], payload_any)
-    raw = payload.get("agents")
+    raw = cast(dict[str, Any], payload_any).get("agents")
     if not isinstance(raw, list):
         return []
     raw_list = cast(list[Any], raw)
@@ -353,15 +352,14 @@ def aggregator_snapshot(
 
         # Audit slice for the deterministic recommended action: failures
         # already classified for this session.
-        slice_entries: list[dict[str, Any]] = []
-        for record in load_recent_failures(workdir, session_id):
-            slice_entries.append(
-                {
-                    "event_type": str(record.get("kind", "")),
-                    "session_id": session_id,
-                    "details": record,
-                }
-            )
+        slice_entries: list[dict[str, Any]] = [
+            {
+                "event_type": str(record.get("kind", "")),
+                "session_id": session_id,
+                "details": record,
+            }
+            for record in load_recent_failures(workdir, session_id)
+        ]
 
         action = recommend_action(
             stall_reason if is_stuck else StallReason.UNKNOWN,

--- a/src/bernstein/core/orchestration/supervisor_receipt.py
+++ b/src/bernstein/core/orchestration/supervisor_receipt.py
@@ -332,7 +332,7 @@ def _count_recent_failures(audit_entries: tuple[dict[str, Any], ...] | list[dict
     failures = 0
     for entry in audit_entries:
         event_type = str(entry.get("event_type", "")).lower()
-        if event_type.endswith(".failed") or event_type.endswith(".error") or event_type.endswith(".errored"):
+        if event_type.endswith((".failed", ".error", ".errored")):
             failures += 1
     return failures
 


### PR DESCRIPTION
## Summary

Root-cause fixes for 6 code-scanning (refurb) alerts across the supervisor surface and the Slack/Discord chat drivers. Mechanical cleanups, no behaviour change.

| Alert | File:line | Rule | Fix |
|-------|-----------|------|-----|
| #2454 | `core/orchestration/supervisor_receipt.py:335` | FURB102 | collapse chained `endswith()` into single tuple-arg `endswith((...))` |
| #2455 | `core/orchestration/supervisor_receipt.py:335` | FURB102 | (same line, second arm) |
| #2452 | `core/orchestration/supervisor_aggregator.py:136` | FURB184 | inline the `cast` into the `.get()` chain |
| #2453 | `core/orchestration/supervisor_aggregator.py:356` | FURB138 | list comprehension instead of append loop |
| #2451 | `cli/commands/supervisor_cmd.py:128` | FURB183 | `str(row.worker_id)` instead of `f"{row.worker_id}"` |
| #2466 | `core/chat/drivers/discord.py:302` | FURB123 | `set.copy()` instead of re-wrapping in `set()` |
| #2467 | `core/chat/drivers/discord.py:306` | FURB123 | `dict.copy()` instead of re-wrapping in `dict()` |
| #2450 | `core/chat/drivers/slack.py:269` | FURB123 | `set.copy()` instead of re-wrapping in `set()` |

The `.copy()` swaps are safe: the backing fields are concrete `set[str]` / `dict[str, str]`, so `.copy()` returns the same type and the public method signatures (`-> set[str]` / `-> dict[str, str]`) are unchanged. The returned object is still a fresh snapshot, so callers cannot mutate internal state.

## Test plan

- [x] `uv run --with refurb refurb` on the 5 files: 0 findings
- [x] `uv run ruff check .` and `ruff format --check`: clean
- [x] `uv run pyright` on touched files: 0 errors
- [x] `uv run pytest tests/unit/ -k "supervisor or slack_driver or discord_driver"`: pass (no regressions vs base)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code patterns for consistency and performance across multiple modules.

* **Tests**
  * Updated documentation coverage tracking to include the schedule command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->