### PR TITLE
feat(sweep): widen Sonar findings sweeper to cover MAJOR severity

### DIFF
--- a/.github/workflows/sweep-sonar-findings.yml
+++ b/.github/workflows/sweep-sonar-findings.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       severity_min:
-        description: Minimum severity to include
+        description: Minimum severity to include (default covers MAJOR and above)
         required: false
-        default: BLOCKER
+        default: MAJOR
         type: choice
         options:
           - BLOCKER
@@ -29,9 +29,19 @@ on:
       max_per_day:
         description: Cap on tickets emitted in this run
         required: false
-        default: '10'
+        default: '25'
       dry_run:
         description: When true, only print the would-be tickets
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      create_gh_issues:
+        description: >-
+          When true, also open a GH issue for P0+P1 tickets (BLOCKER,
+          CRITICAL, MAJOR). P2 tickets stay file-only either way.
         required: false
         default: 'false'
         type: choice
@@ -52,6 +62,25 @@ env:
   # explicitly opts in via a follow-up PR that flips this value. Job
   # 'if:' cannot read env directly, so the gate runs as the first
   # step of the job (see "Gate cron trigger" below).
+  #
+  # When ENABLE_CRON flips from '0' to '1':
+  #   - The 06:17 UTC cron starts producing a PR per run with up to
+  #     max_per_day=25 new ticket files plus, for P0+P1 (BLOCKER,
+  #     CRITICAL, MAJOR), a freshly opened GH issue per ticket.
+  #   - The PR is reviewed and merged manually; nothing pushes
+  #     straight to main.
+  #
+  # First three runs after the flip - operator checklist:
+  #   1. PR opened? Confirm peter-evans/create-pull-request actually
+  #      surfaced a branch named sonar-sweep/<run-id> and that the
+  #      diff is bounded to .sdd/backlog/open/ paths.
+  #   2. Blurb coverage? Skim each emitted ticket body for a real
+  #      "## Why" rather than the DEFAULT_BLURB fallback. Any rule
+  #      with the fallback should land a new row in RULE_FAMILY_BLURBS
+  #      in the same PR before merge.
+  #   3. GH-issue cardinality? Confirm the gh-issue trailer on each
+  #      file matches the run's emit count and that no spurious P2
+  #      tickets created a GH issue.
   ENABLE_CRON: '0'
 
 jobs:
@@ -110,9 +139,10 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-          SEVERITY_MIN: ${{ inputs.severity_min || 'BLOCKER' }}
-          MAX_PER_DAY: ${{ inputs.max_per_day || '10' }}
+          SEVERITY_MIN: ${{ inputs.severity_min || 'MAJOR' }}
+          MAX_PER_DAY: ${{ inputs.max_per_day || '25' }}
           DRY_RUN_INPUT: ${{ inputs.dry_run || 'false' }}
+          CREATE_GH_ISSUES_INPUT: ${{ inputs.create_gh_issues || 'false' }}
         run: |
           set -euo pipefail
           mkdir -p .sdd/backlog/open
@@ -123,6 +153,9 @@ jobs:
           )
           if [ "${DRY_RUN_INPUT}" = "true" ]; then
             args+=("--dry-run")
+          fi
+          if [ "${CREATE_GH_ISSUES_INPUT}" = "true" ]; then
+            args+=("--create-gh-issues")
           fi
           uv run python scripts/sweep_sonar_findings.py "${args[@]}"
 
@@ -165,8 +198,8 @@ jobs:
             frontmatter (`sonar_issue_key`) so re-runs are idempotent;
             the same finding will not produce a second ticket.
 
-            Severity filter: `${{ inputs.severity_min || 'BLOCKER' }}`.
-            Per-run cap: `${{ inputs.max_per_day || '10' }}`.
+            Severity filter: `${{ inputs.severity_min || 'MAJOR' }}`.
+            Per-run cap: `${{ inputs.max_per_day || '25' }}`.
 
             Review the emitted `## Why` bodies. They are synthesised from
             a pre-vetted rule-family blurb table inside the sweeper; the

--- a/scripts/sweep_sonar_findings.py
+++ b/scripts/sweep_sonar_findings.py
@@ -16,10 +16,15 @@ Usage
 -----
 
     python scripts/sweep_sonar_findings.py \\
-        --severity-min BLOCKER \\
-        --max-per-day 10 \\
+        --severity-min MAJOR \\
+        --max-per-day 25 \\
         --out-dir .sdd/backlog/open \\
         [--dry-run] [--create-gh-issues] [--fixture path/to/issues.json]
+
+The ``--create-gh-issues`` flag promotes both P0 and P1 tickets to a GH
+issue via ``gh issue create``. P0 covers BLOCKER findings; P1 covers
+CRITICAL and MAJOR. P2 tickets (MINOR, INFO) stay file-only so the GH
+issue feed does not get flooded by low-severity churn.
 
 Exit codes
 ----------
@@ -83,10 +88,19 @@ SEVERITY_ORDER: tuple[str, ...] = ("BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INF
 SEVERITY_RANK: dict[str, int] = {sev: idx for idx, sev in enumerate(SEVERITY_ORDER)}
 
 # Priority is the project's P0/P1/P2 enum (see docs/sdd/ticket_schema.md).
+#
+# MAJOR is intentionally promoted to P1 (was P2). Rationale: the MAJOR
+# cohort accumulates much faster than operators can hand-triage it, so
+# leaving it at P2 (file-only) means the queue grows without bound while
+# the underlying static-analysis debt compounds. Promoting MAJOR to P1
+# lets the sweeper auto-open GH issues for MAJOR findings alongside
+# BLOCKER (P0) and CRITICAL (P1), which routes them onto the same
+# tracker surface operators already monitor. MINOR and INFO stay at P2
+# so the GH-issue feed is not flooded with low-severity churn.
 SEVERITY_TO_PRIORITY: dict[str, str] = {
     "BLOCKER": "P0",
     "CRITICAL": "P1",
-    "MAJOR": "P2",
+    "MAJOR": "P1",
     "MINOR": "P2",
     "INFO": "P2",
 }
@@ -306,6 +320,93 @@ RULE_FAMILY_BLURBS: tuple[tuple[str, str, str], ...] = (
         (
             "Function call passes the wrong number of arguments. Update the "
             "call site so it matches the callee's signature."
+        ),
+    ),
+    # MAJOR-cohort additions for the widened sweeper. Each entry is
+    # framed as ordinary engineering hygiene and never reuses raw vendor
+    # prose.
+    (
+        "python:S5886",
+        "return-type-mismatch",
+        (
+            "Declared return type does not line up with the value the "
+            "function actually returns. Align the annotation with the "
+            "returned value or fix the returned value so the static type "
+            "contract holds."
+        ),
+    ),
+    (
+        "python:S5864",
+        "isinstance-non-type",
+        (
+            "isinstance call is given a second argument that is not a class "
+            "or a tuple of classes. Pass an actual class object so the "
+            "runtime check behaves as the call site reads."
+        ),
+    ),
+    (
+        "python:S3358",
+        "nested-ternary",
+        (
+            "Nested ternary expression is hard to read at the call site. "
+            "Lift the inner condition into a named local or an if-block so "
+            "the branching is explicit."
+        ),
+    ),
+    (
+        "python:S5869",
+        "regex-character-class-duplicate",
+        (
+            "Regular-expression character class contains a duplicate "
+            "element. Remove the duplicate so the regex reads cleanly and "
+            "the intent is unambiguous."
+        ),
+    ),
+    (
+        "python:S1244",
+        "float-equality",
+        (
+            "Floating-point values are compared with == or !=, which is "
+            "fragile due to rounding. Use math.isclose or compare to an "
+            "explicit tolerance instead."
+        ),
+    ),
+    (
+        "python:S5843",
+        "regex-super-linear",
+        (
+            "Regular-expression pattern is susceptible to super-linear "
+            "backtracking on adversarial input. Restructure the pattern to "
+            "use non-capturing groups, possessive quantifiers, or anchored "
+            "alternatives so worst-case matching stays linear."
+        ),
+    ),
+    (
+        "python:S1764",
+        "identical-subexpressions",
+        (
+            "Both sides of a binary operator are identical sub-expressions, "
+            "so the operator either has no effect or hides a bug. Rewrite "
+            "the expression so each side carries the intended value."
+        ),
+    ),
+    (
+        "python:S8495",
+        "typing-misuse",
+        (
+            "Generic-typing construct is used in a way the type system "
+            "cannot resolve. Update the annotation so it matches the "
+            "documented usage of the typing primitive."
+        ),
+    ),
+    (
+        "python:S3923",
+        "all-branches-identical",
+        (
+            "All branches of the conditional structure have the same "
+            "implementation, so the branching is redundant. Collapse the "
+            "structure or fix the branch bodies so each branch contributes "
+            "distinct behaviour."
         ),
     ),
 )
@@ -883,14 +984,26 @@ def maybe_create_gh_issue(
     *,
     enable: bool,
     priority: str,
-    runner: RunnerFn = subprocess.run,
+    runner: RunnerFn | None = None,
 ) -> str | None:
-    """Optionally create a GH issue and return its URL or ``None``."""
+    """Optionally create a GH issue and return its URL or ``None``.
+
+    The auto-promotion covers the P0 and P1 priority buckets. P0 maps to
+    BLOCKER severity; P1 covers CRITICAL and MAJOR. P2 (MINOR, INFO)
+    stays file-only so the GH issue feed does not flood with low
+    severity churn.
+
+    ``runner`` defaults to :func:`subprocess.run`, resolved at call time
+    so tests can monkeypatch ``subprocess.run`` on the module.
+    """
+    if runner is None:
+        runner = subprocess.run
     if not enable:
         return None
-    if priority != "P0":
-        # Only the highest-priority bucket auto-promotes; everything else
-        # stays file-only until an operator picks it up by hand.
+    if priority not in ("P0", "P1"):
+        # P0 and P1 auto-promote so MAJOR and CRITICAL findings land on
+        # the same tracker surface operators already monitor. Lower
+        # priorities stay file-only until an operator picks them up.
         return None
     if not ticket_path.exists():
         return None
@@ -1051,15 +1164,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--severity-min",
-        default="BLOCKER",
+        default="MAJOR",
         choices=list(SEVERITY_ORDER),
-        help="Minimum severity to include (default: BLOCKER).",
+        help="Minimum severity to include (default: MAJOR).",
     )
     p.add_argument(
         "--max-per-day",
         type=int,
-        default=10,
-        help="Maximum tickets to emit in this run (default: 10).",
+        default=25,
+        help="Maximum tickets to emit in this run (default: 25).",
     )
     p.add_argument(
         "--out-dir",
@@ -1083,7 +1196,10 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "--create-gh-issues",
         action="store_true",
-        help="For P0 tickets, also call `gh issue create` and trailer the file.",
+        help=(
+            "For P0 and P1 tickets (BLOCKER, CRITICAL, MAJOR), also call "
+            "`gh issue create` and trailer the file with the issue URL."
+        ),
     )
     p.add_argument(
         "--fixture",

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -971,7 +971,7 @@ _register_doctor_glitchtip(doctor)
 @click.option(
     "--severity-min",
     "severity_min",
-    default="BLOCKER",
+    default="MAJOR",
     show_default=True,
     type=click.Choice(["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]),
     help="Minimum severity to include.",
@@ -980,7 +980,7 @@ _register_doctor_glitchtip(doctor)
     "--max-per-day",
     "max_per_day",
     type=int,
-    default=10,
+    default=25,
     show_default=True,
     help="Cap on the number of tickets emitted in this run.",
 )
@@ -992,6 +992,13 @@ _register_doctor_glitchtip(doctor)
     help="Directory to write emitted ticket files into.",
 )
 @click.option(
+    "--create-gh-issues",
+    "create_gh_issues",
+    is_flag=True,
+    default=False,
+    help="For P0+P1 tickets (BLOCKER, CRITICAL, MAJOR), also open a GH issue.",
+)
+@click.option(
     "--fixture",
     default=None,
     help="Use a saved JSON fixture instead of calling Sonar (for local dry-runs).",
@@ -1001,6 +1008,7 @@ def doctor_sonar_sweep_cmd(
     severity_min: str,
     max_per_day: int,
     out_dir: str,
+    create_gh_issues: bool,
     fixture: str | None,
 ) -> None:
     """Turn open static-analysis findings into backlog tickets.
@@ -1045,6 +1053,8 @@ def doctor_sonar_sweep_cmd(
     ]
     if dry_run:
         argv.append("--dry-run")
+    if create_gh_issues:
+        argv.append("--create-gh-issues")
     if fixture:
         argv.extend(["--fixture", fixture])
 

--- a/tests/unit/sweep/conftest.py
+++ b/tests/unit/sweep/conftest.py
@@ -26,6 +26,12 @@ def issues_search_fixture_path() -> Path:
 
 
 @pytest.fixture
+def issues_search_widen_fixture_path() -> Path:
+    """Path to the widen fixture: 5 BLOCKER + 25 MAJOR + 5 MINOR."""
+    return _FIXTURE_DIR / "issues_search_widen.json"
+
+
+@pytest.fixture
 def issues_search_payload(issues_search_fixture_path: Path) -> dict:
     """Parsed payload of the canonical issues_search.json fixture."""
     return json.loads(issues_search_fixture_path.read_text(encoding="utf-8"))

--- a/tests/unit/sweep/fixtures/issues_search_widen.json
+++ b/tests/unit/sweep/fixtures/issues_search_widen.json
@@ -1,0 +1,363 @@
+{
+  "total": 35,
+  "p": 1,
+  "ps": 500,
+  "paging": {
+    "pageIndex": 1,
+    "pageSize": 500,
+    "total": 35
+  },
+  "issues": [
+    {
+      "key": "WIDEN-BLOCKER-00",
+      "rule": "python:S2068",
+      "severity": "BLOCKER",
+      "type": "VULNERABILITY",
+      "component": "bernstein:src/bernstein/core/b0.py",
+      "line": 1,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-20T10:00:00+0000"
+    },
+    {
+      "key": "WIDEN-BLOCKER-01",
+      "rule": "python:S2068",
+      "severity": "BLOCKER",
+      "type": "VULNERABILITY",
+      "component": "bernstein:src/bernstein/core/b1.py",
+      "line": 2,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-20T10:01:00+0000"
+    },
+    {
+      "key": "WIDEN-BLOCKER-02",
+      "rule": "python:S2068",
+      "severity": "BLOCKER",
+      "type": "VULNERABILITY",
+      "component": "bernstein:src/bernstein/core/b2.py",
+      "line": 3,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-20T10:02:00+0000"
+    },
+    {
+      "key": "WIDEN-BLOCKER-03",
+      "rule": "python:S2068",
+      "severity": "BLOCKER",
+      "type": "VULNERABILITY",
+      "component": "bernstein:src/bernstein/core/b3.py",
+      "line": 4,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-20T10:03:00+0000"
+    },
+    {
+      "key": "WIDEN-BLOCKER-04",
+      "rule": "python:S2068",
+      "severity": "BLOCKER",
+      "type": "VULNERABILITY",
+      "component": "bernstein:src/bernstein/core/b4.py",
+      "line": 5,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-20T10:04:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-00",
+      "rule": "python:S5886",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m0.py",
+      "line": 100,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:00:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-01",
+      "rule": "python:S5864",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m1.py",
+      "line": 101,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:01:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-02",
+      "rule": "python:S3358",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m2.py",
+      "line": 102,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:02:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-03",
+      "rule": "python:S5869",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m3.py",
+      "line": 103,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:03:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-04",
+      "rule": "python:S1244",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m4.py",
+      "line": 104,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:04:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-05",
+      "rule": "python:S5843",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m5.py",
+      "line": 105,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:05:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-06",
+      "rule": "python:S1764",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m6.py",
+      "line": 106,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:06:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-07",
+      "rule": "python:S8495",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m7.py",
+      "line": 107,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:07:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-08",
+      "rule": "python:S3923",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m8.py",
+      "line": 108,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:08:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-09",
+      "rule": "python:S1481",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m9.py",
+      "line": 109,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:09:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-10",
+      "rule": "python:S1172",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m10.py",
+      "line": 110,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:10:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-11",
+      "rule": "python:S1192",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m11.py",
+      "line": 111,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:11:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-12",
+      "rule": "python:S3776",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m12.py",
+      "line": 112,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:12:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-13",
+      "rule": "python:S125",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m13.py",
+      "line": 113,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:13:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-14",
+      "rule": "python:S107",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m14.py",
+      "line": 114,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:14:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-15",
+      "rule": "python:S1854",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m15.py",
+      "line": 115,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:15:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-16",
+      "rule": "python:S1066",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m16.py",
+      "line": 116,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:16:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-17",
+      "rule": "python:S1186",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m17.py",
+      "line": 117,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:17:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-18",
+      "rule": "python:S1117",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m18.py",
+      "line": 118,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:18:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-19",
+      "rule": "python:S1542",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m19.py",
+      "line": 119,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:19:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-20",
+      "rule": "python:S5547",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m20.py",
+      "line": 120,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:20:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-21",
+      "rule": "python:S5443",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m21.py",
+      "line": 121,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:21:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-22",
+      "rule": "python:S4423",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m22.py",
+      "line": 122,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:22:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-23",
+      "rule": "python:S5659",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m23.py",
+      "line": 123,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:23:00+0000"
+    },
+    {
+      "key": "WIDEN-MAJOR-24",
+      "rule": "python:S3457",
+      "severity": "MAJOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/cli/m24.py",
+      "line": 124,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-19T08:24:00+0000"
+    },
+    {
+      "key": "WIDEN-MINOR-00",
+      "rule": "python:S125",
+      "severity": "MINOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/n0.py",
+      "line": 200,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-18T08:00:00+0000"
+    },
+    {
+      "key": "WIDEN-MINOR-01",
+      "rule": "python:S125",
+      "severity": "MINOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/n1.py",
+      "line": 201,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-18T08:01:00+0000"
+    },
+    {
+      "key": "WIDEN-MINOR-02",
+      "rule": "python:S125",
+      "severity": "MINOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/n2.py",
+      "line": 202,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-18T08:02:00+0000"
+    },
+    {
+      "key": "WIDEN-MINOR-03",
+      "rule": "python:S125",
+      "severity": "MINOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/n3.py",
+      "line": 203,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-18T08:03:00+0000"
+    },
+    {
+      "key": "WIDEN-MINOR-04",
+      "rule": "python:S125",
+      "severity": "MINOR",
+      "type": "CODE_SMELL",
+      "component": "bernstein:src/bernstein/core/n4.py",
+      "line": 204,
+      "message": "Vendor message ignored by the sweeper.",
+      "creationDate": "2026-05-18T08:04:00+0000"
+    }
+  ],
+  "components": []
+}

--- a/tests/unit/sweep/test_sonar_findings.py
+++ b/tests/unit/sweep/test_sonar_findings.py
@@ -20,6 +20,7 @@ from sweep_sonar_findings import (  # type: ignore[import-not-found]
     SEVERITY_TO_PRIORITY,
     Finding,
     SonarAPIError,
+    _assert_no_forbidden,
     _component_path,
     _request_with_retries,
     build_dedup_index,
@@ -593,10 +594,38 @@ def test_maybe_create_gh_issue_skips_when_disabled(tmp_path: Path) -> None:
     assert maybe_create_gh_issue(path, "title", enable=False, priority="P0") is None
 
 
-def test_maybe_create_gh_issue_skips_non_p0(tmp_path: Path) -> None:
+def test_maybe_create_gh_issue_p1_now_fires(tmp_path: Path) -> None:
+    """MAJOR -> P1 promotes to a GH issue after the widening change."""
     path = tmp_path / "t.md"
     path.write_text("body")
-    assert maybe_create_gh_issue(path, "title", enable=True, priority="P1") is None
+    captured: dict[str, Any] = {}
+
+    class _R:
+        def __init__(self, rc: int, out: str) -> None:
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = ""
+
+    def fake_runner(cmd: list[str], **kwargs: Any) -> _R:
+        captured["cmd"] = cmd
+        return _R(0, "https://github.com/org/repo/issues/77\n")
+
+    url = maybe_create_gh_issue(
+        path,
+        "title",
+        enable=True,
+        priority="P1",
+        runner=fake_runner,
+    )
+    assert url == "https://github.com/org/repo/issues/77"
+    assert captured["cmd"][:3] == ["gh", "issue", "create"]
+
+
+def test_maybe_create_gh_issue_skips_p2(tmp_path: Path) -> None:
+    """P2 tickets stay file-only and never auto-promote to a GH issue."""
+    path = tmp_path / "t.md"
+    path.write_text("body")
+    assert maybe_create_gh_issue(path, "title", enable=True, priority="P2") is None
 
 
 def test_maybe_create_gh_issue_calls_runner(tmp_path: Path) -> None:
@@ -635,6 +664,297 @@ def test_component_path_strips_project_prefix() -> None:
 
 
 def test_severity_to_priority_mapping() -> None:
+    """MAJOR moves from P2 to P1 so the queue actually drains.
+
+    MAJOR findings accumulate faster than operators can hand-triage them,
+    so they now auto-promote to GH issues alongside BLOCKER (P0) and
+    CRITICAL (P1). MINOR and INFO stay at P2 (file-only).
+    """
     assert SEVERITY_TO_PRIORITY["BLOCKER"] == "P0"
     assert SEVERITY_TO_PRIORITY["CRITICAL"] == "P1"
-    assert SEVERITY_TO_PRIORITY["MAJOR"] == "P2"
+    assert SEVERITY_TO_PRIORITY["MAJOR"] == "P1"
+    assert SEVERITY_TO_PRIORITY["MINOR"] == "P2"
+    assert SEVERITY_TO_PRIORITY["INFO"] == "P2"
+
+
+# ---------------------------------------------------------------------------
+# Top-10 MAJOR rule families have vetted blurb coverage
+# ---------------------------------------------------------------------------
+
+
+def test_top_major_rules_have_blurb_coverage() -> None:
+    """The top MAJOR rule families seen in production must have a blurb.
+
+    Lifted from the open MAJOR cohort on the Sonar tracker so the next
+    sweep run does not emit `DEFAULT_BLURB` placeholders.
+    """
+    top_major_rules = [
+        "python:S5886",  # return-type mismatch
+        "python:S5864",  # isinstance with non-type-like arg
+        "python:S3358",  # nested ternary
+        "python:S5869",  # regex character-class duplicates
+        "python:S1244",  # float equality compare
+        "python:S5843",  # regex super-linear backtracking
+        "python:S1764",  # identical sub-expressions
+        "python:S8495",  # generic typing misuse
+        "python:S3923",  # all branches identical
+    ]
+    covered_prefixes = {prefix for prefix, _slug, _blurb in RULE_FAMILY_BLURBS}
+    for rule in top_major_rules:
+        assert rule in covered_prefixes, f"missing RULE_FAMILY_BLURBS entry for {rule}"
+
+
+# ---------------------------------------------------------------------------
+# Widened sweeper: MAJOR-severity scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_major_finding_emits_p1_ticket(tmp_path: Path) -> None:
+    """A MAJOR-severity finding emits a ticket whose priority is P1."""
+    finding = Finding(
+        key="MAJOR-K1",
+        rule="python:S1481",
+        severity="MAJOR",
+        type="CODE_SMELL",
+        component="bernstein:src/a.py",
+        line=5,
+        creation_date="2026-05-21T08:00:00+0000",
+    )
+    out_dir = tmp_path / "open"
+    out_dir.mkdir()
+    path, _body, wrote = emit_ticket(finding, out_dir, day="2026-05-21")
+    assert wrote is True
+    fm = yaml.safe_load(path.read_text(encoding="utf-8").split("---")[1])
+    assert fm["priority"] == "P1"
+    assert fm["sonar_severity"] == "MAJOR"
+
+
+def test_capping_picks_blocker_first_then_major_in_receipt_order(
+    sweep_workspace: Path,
+    tmp_path: Path,
+) -> None:
+    """5 BLOCKER + 25 MAJOR + 5 MINOR with cap=25 keeps 5 BLOCKER + 20 MAJOR.
+
+    The cap applies after severity sort (BLOCKER first), so all five
+    BLOCKERs land and the remainder of the cap (20 slots) goes to the
+    MAJOR cohort in receipt order (newest creation_date first).
+    """
+    issues = []
+    for idx in range(5):
+        issues.append(
+            {
+                "key": f"BLOCKER-K{idx:02d}",
+                "rule": "python:S2068",
+                "severity": "BLOCKER",
+                "type": "VULNERABILITY",
+                "component": f"bernstein:src/b{idx}.py",
+                "line": idx + 1,
+                "creationDate": f"2026-05-20T10:{idx:02d}:00+0000",
+            }
+        )
+    for idx in range(25):
+        issues.append(
+            {
+                "key": f"MAJOR-K{idx:02d}",
+                "rule": "python:S1481",
+                "severity": "MAJOR",
+                "type": "CODE_SMELL",
+                "component": f"bernstein:src/m{idx}.py",
+                "line": idx + 100,
+                "creationDate": f"2026-05-19T08:{idx:02d}:00+0000",
+            }
+        )
+    for idx in range(5):
+        issues.append(
+            {
+                "key": f"MINOR-K{idx:02d}",
+                "rule": "python:S125",
+                "severity": "MINOR",
+                "type": "CODE_SMELL",
+                "component": f"bernstein:src/n{idx}.py",
+                "line": idx + 200,
+                "creationDate": f"2026-05-18T08:{idx:02d}:00+0000",
+            }
+        )
+    payload = {
+        "paging": {"pageIndex": 1, "pageSize": 500, "total": len(issues)},
+        "issues": issues,
+    }
+    fixture = tmp_path / "issues.json"
+    fixture.write_text(__import__("json").dumps(payload), encoding="utf-8")
+
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(fixture),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MAJOR",
+            "--max-per-day",
+            "25",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    files = sorted(out_dir.glob("2026-05-21-*.md"))
+    assert len(files) == 25
+    parsed = [yaml.safe_load(p.read_text(encoding="utf-8").split("---")[1]) for p in files]
+    severities = [p["sonar_severity"] for p in parsed]
+    keys = {p["sonar_issue_key"] for p in parsed}
+    # All 5 BLOCKERs must be present (highest priority bucket).
+    assert severities.count("BLOCKER") == 5
+    assert {f"BLOCKER-K{idx:02d}" for idx in range(5)} <= keys
+    # Remaining 20 slots filled with MAJORs in newest-first receipt order:
+    # the 5 oldest MAJORs (K00-K04) are dropped by the cap, K05-K24 survive.
+    assert severities.count("MAJOR") == 20
+    assert {f"MAJOR-K{idx:02d}" for idx in range(5, 25)} <= keys
+    assert not any(f"MAJOR-K{idx:02d}" in keys for idx in range(5))
+    # Severity-min=MAJOR excludes MINOR entirely.
+    assert "MINOR" not in severities
+
+
+def test_widen_fixture_caps_at_25_and_bodies_pass_guard(
+    sweep_workspace: Path,
+    issues_search_widen_fixture_path: Path,
+) -> None:
+    """On-disk widen fixture: severity-min=MAJOR, cap=25 -> 25 clean tickets.
+
+    The fixture carries 5 BLOCKER + 25 MAJOR + 5 MINOR = 35 findings. With
+    severity-min=MAJOR the MINORs drop, leaving 30 candidates; cap=25
+    trims to 25 (5 BLOCKER + 20 MAJOR). Every emitted body must pass the
+    public-artefact guard.
+    """
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_widen_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MAJOR",
+            "--max-per-day",
+            "25",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    files = sorted(out_dir.glob("2026-05-21-*.md"))
+    assert len(files) == 25
+    parsed = [yaml.safe_load(p.read_text(encoding="utf-8").split("---")[1]) for p in files]
+    assert sum(1 for p in parsed if p["sonar_severity"] == "BLOCKER") == 5
+    assert sum(1 for p in parsed if p["sonar_severity"] == "MAJOR") == 20
+    assert not any(p["sonar_severity"] == "MINOR" for p in parsed)
+    # Every emitted ticket body passes the forbidden-substring guard.
+    for path in files:
+        _assert_no_forbidden(path.read_text(encoding="utf-8"), context=str(path))
+
+
+def test_widen_fixture_major_rules_use_vetted_blurbs(
+    sweep_workspace: Path,
+    issues_search_widen_fixture_path: Path,
+) -> None:
+    """No emitted MAJOR ticket falls back to DEFAULT_BLURB for the top rules."""
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(issues_search_widen_fixture_path),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MAJOR",
+            "--max-per-day",
+            "100",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    files = sorted(out_dir.glob("2026-05-21-*.md"))
+    fallback_marker = "Static-analysis finding flagged under rule key"
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        assert fallback_marker not in text, f"{path} used DEFAULT_BLURB fallback"
+
+
+def test_major_with_create_gh_issues_invokes_runner(
+    sweep_workspace: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MAJOR finding + --create-gh-issues -> gh CLI is invoked once.
+
+    The widening means MAJOR (P1) now opts in to GH-issue creation.
+    """
+    issues = [
+        {
+            "key": "MAJOR-K-GH",
+            "rule": "python:S1481",
+            "severity": "MAJOR",
+            "type": "CODE_SMELL",
+            "component": "bernstein:src/foo.py",
+            "line": 12,
+            "creationDate": "2026-05-20T08:00:00+0000",
+        }
+    ]
+    payload = {
+        "paging": {"pageIndex": 1, "pageSize": 500, "total": 1},
+        "issues": issues,
+    }
+    fixture = tmp_path / "issues_gh.json"
+    fixture.write_text(__import__("json").dumps(payload), encoding="utf-8")
+
+    captured: dict[str, Any] = {"calls": 0, "cmds": []}
+
+    class _R:
+        def __init__(self, rc: int, out: str) -> None:
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = ""
+
+    def fake_runner(cmd: list[str], **kwargs: Any) -> _R:
+        captured["calls"] = captured["calls"] + 1
+        captured["cmds"].append(cmd)
+        return _R(0, "https://github.com/org/repo/issues/123\n")
+
+    import sweep_sonar_findings as sweeper  # type: ignore[import-not-found]
+
+    monkeypatch.setattr(sweeper.subprocess, "run", fake_runner)
+
+    out_dir = sweep_workspace / "open"
+    rc = main(
+        argv=[
+            "--fixture",
+            str(fixture),
+            "--out-dir",
+            str(out_dir),
+            "--backlog-root",
+            str(sweep_workspace),
+            "--severity-min",
+            "MAJOR",
+            "--max-per-day",
+            "25",
+            "--create-gh-issues",
+            "--day",
+            "2026-05-21",
+        ]
+    )
+    assert rc == 0
+    assert captured["calls"] == 1
+    assert captured["cmds"][0][:3] == ["gh", "issue", "create"]
+    # The ticket file should have the GH trailer appended.
+    files = list(out_dir.glob("2026-05-21-*.md"))
+    assert len(files) == 1
+    text = files[0].read_text(encoding="utf-8")
+    assert "gh-issue-created:" in text

--- a/tests/unit/sweep/test_sweep_sonar_workflow_yaml.py
+++ b/tests/unit/sweep/test_sweep_sonar_workflow_yaml.py
@@ -79,3 +79,20 @@ def test_workflow_top_level_permissions_are_narrow() -> None:
     assert perms == {"contents": "read"}, (
         "Top-level permissions must default to read-only; the sweep job grants its own write scopes."
     )
+
+
+def test_workflow_dispatch_default_severity_is_major() -> None:
+    """Default severity input must be MAJOR after the widening change."""
+    parsed = _load_workflow()
+    on = parsed.get(True) if True in parsed else parsed["on"]
+    inputs = on["workflow_dispatch"]["inputs"]
+    assert inputs["severity_min"]["default"] == "MAJOR"
+
+
+def test_workflow_dispatch_default_max_per_day_is_25() -> None:
+    """Default per-run cap raised so the MAJOR queue drains in a sane timeline."""
+    parsed = _load_workflow()
+    on = parsed.get(True) if True in parsed else parsed["on"]
+    inputs = on["workflow_dispatch"]["inputs"]
+    # YAML may parse '25' as the string '25' or the int 25; accept either.
+    assert str(inputs["max_per_day"]["default"]) == "25"

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -239,6 +239,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "desktop-register",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "supervisor",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "schedule",
     }
 )
 


### PR DESCRIPTION
## Summary

Widens the Sonar findings sweeper so MAJOR-severity findings flow into actionable tickets (and GH issues) instead of accumulating untriaged. At the previous BLOCKER-only, 10/day setting the queue would take years to drain; this change lets the MAJOR cohort drain on a sane timeline.

## Four config changes

| Change | Before | After |
| --- | --- | --- |
| Default `severity_min` (workflow dispatch input + sweeper CLI default) | `BLOCKER` | `MAJOR` |
| Default `max_per_day` (workflow dispatch input + sweeper CLI default) | `10` | `25` |
| `SEVERITY_TO_PRIORITY` mapping for MAJOR | `P2` | `P1` (BLOCKER->P0, CRITICAL->P1, MAJOR->P1, MINOR->P2, INFO->P2) |
| `--create-gh-issues` promotion bucket | P0 only | P0 + P1 (BLOCKER, CRITICAL, MAJOR) |

MAJOR is promoted to P1 because the cohort accumulates faster than operators can hand-triage it; promoting it routes MAJOR findings onto the same tracker surface operators already monitor. MINOR and INFO stay file-only at P2 so the issue feed is not flooded with low-severity churn. Justification is captured in a comment on the mapping and in the script docstring.

## Rule-family blurb additions

Confirmed blurb coverage for the top open MAJOR rules on the tracker (#1785). Nine families lacked a vetted entry and now have one (engineering-hygiene framing, passes the existing forbidden-substring guard):

| Rule | Slug | Topic |
| --- | --- | --- |
| `python:S5886` | return-type-mismatch | declared vs returned type |
| `python:S5864` | isinstance-non-type | isinstance second arg not a class |
| `python:S3358` | nested-ternary | nested ternary readability |
| `python:S5869` | regex-character-class-duplicate | duplicate regex char-class element |
| `python:S1244` | float-equality | float == / != fragility |
| `python:S5843` | regex-super-linear | regex backtracking risk |
| `python:S1764` | identical-subexpressions | identical operands on a binary op |
| `python:S8495` | typing-misuse | generic-typing construct misuse |
| `python:S3923` | all-branches-identical | redundant conditional branches |

(`python:S1172` was already covered.)

## Cron gate unchanged

`ENABLE_CRON` stays `'0'`. A comment block above it now documents what flipping to `'1'` produces (a per-run PR of up to 25 ticket files plus a GH issue per P0/P1 ticket) and the first-three-runs operator checklist (PR scope bounded to `.sdd/backlog/open/`, blurb coverage skim, GH-issue cardinality). The `doctor sonar-sweep` CLI wrapper picks up the new defaults and a `--create-gh-issues` passthrough.

## Surface

This widening starts consuming the open findings tracked on #1785 (the Sonar findings tracker): 1 BLOCKER + the MAJOR cohort move from "file-only, hand-triaged" to "auto-emitted ticket + GH issue".

## Test plan

- [ ] `uv run pytest tests/unit/sweep/ -q --no-cov --timeout=120`
- [ ] `uv run pytest tests/unit/sweep/test_doctor_sonar_sweep_cli.py`
- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] Dry-run smoke against the live tracker's rule set passes the forbidden-substring guard for every emitted body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--create-gh-issues` flag to automatically create GitHub issues for high-priority Sonar findings.

* **Chores**
  * Updated default minimum severity filter from BLOCKER to MAJOR in Sonar findings sweep.
  * Increased default daily ticket emission cap from 10 to 25.

* **Tests**
  * Expanded test coverage for updated Sonar sweep defaults and GitHub issue creation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: 3284445351 reason=Codebase convention is monkeypatch (283 test modules use it; only 2 use unittest.mock). The existing pre-existing test in this same file (test_maybe_create_gh_issue_calls_runner) uses the explicit-runner pattern; the monkeypatch.setattr here matches the dominant standard, so switching to mock.patch.object would diverge from it. -->
<!-- bot-ack: 3284445334 reason=No test module in this repo uses TypedDict for inline fixture dicts (0 occurrences). Adding TypedDict shapes for throwaway per-test Sonar payload fixtures would be inconsistent with every other test fixture and is YAGNI; the dicts are local, asserted immediately, and never cross a public boundary. -->
