### PR TITLE
fix(cli): harden audit-dir safety check and a2a verdict line wrapping

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -1383,12 +1383,15 @@ def _is_safe_audit_dir(audit_dir: Path) -> tuple[bool, str]:
         resolved = audit_dir.resolve()
     except OSError as exc:
         return False, f"cannot resolve {audit_dir}: {exc}"
-    # Reject tmpfs-style paths the operator almost certainly didn't mean.
-    suspicious_prefixes = ("/dev/", "/proc/", "/sys/")
+    # Reject pseudo-filesystem paths the operator almost certainly didn't
+    # mean. A symlink to /proc resolves to exactly "/proc" (no trailing
+    # slash), so we must refuse both the bare mount root and anything under
+    # it -- while still allowing lookalike siblings such as /procurement.
+    suspicious_roots = ("/dev", "/proc", "/sys")
     s = str(resolved)
-    for pref in suspicious_prefixes:
-        if s.startswith(pref):
-            return False, f"refusing to operate on {pref}* path: {resolved}"
+    for root in suspicious_roots:
+        if s == root or s.startswith(root + "/"):
+            return False, f"refusing to operate on {root}* path: {resolved}"
     return True, ""
 
 

--- a/src/bernstein/cli/commands/interop_cmd.py
+++ b/src/bernstein/cli/commands/interop_cmd.py
@@ -217,7 +217,7 @@ def verify(
         if is_json():
             print_json({"ok": False, "fingerprint": fingerprint, "failures": failures})
         else:
-            print_error(f"Capability card {card_path} is NOT valid:")
+            print_error(f"Capability card {card_path} is NOT valid:", soft_wrap=True)
             for reason in failures:
                 console.print(f"  - {reason}")
         sys.exit(1)
@@ -233,7 +233,7 @@ def verify(
             }
         )
         return
-    print_success(f"Capability card {card_path} is valid")
+    print_success(f"Capability card {card_path} is valid", soft_wrap=True)
     console.print(f"  issuer: [bold]{signed.card.issuer}[/bold]  kid: {signed.card.kid}")
     console.print(f"  fingerprint: {fingerprint}")
 

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -373,14 +373,26 @@ def output_option(fn: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def print_success(message: str) -> None:
-    """Print a success message in green with a check mark prefix."""
-    console.print(f"[green]✓[/green] {message}")
+def print_success(message: str, *, soft_wrap: bool = False) -> None:
+    """Print a success message in green with a check mark prefix.
+
+    Set ``soft_wrap=True`` for verdict lines that embed an unbounded value
+    (e.g. a filesystem path) so the human-readable verdict phrase is never
+    fragmented by terminal soft-wrapping. Without it a long path can push a
+    trailing phrase past the console width and split it across a newline,
+    breaking copy-paste and substring consumers. ``soft_wrap`` emits the
+    full text without inserting hard line breaks (the terminal still wraps
+    visually), unlike ``no_wrap`` which would crop the line to the width.
+    """
+    console.print(f"[green]✓[/green] {message}", soft_wrap=soft_wrap)
 
 
-def print_error(message: str) -> None:
-    """Print an error message in red with an x prefix."""
-    console.print(f"[red]✗[/red] {message}")
+def print_error(message: str, *, soft_wrap: bool = False) -> None:
+    """Print an error message in red with an x prefix.
+
+    See :func:`print_success` for the ``soft_wrap`` rationale.
+    """
+    console.print(f"[red]✗[/red] {message}", soft_wrap=soft_wrap)
 
 
 def print_warning(message: str) -> None:

--- a/tests/unit/cli/test_audit_archive_cmd.py
+++ b/tests/unit/cli/test_audit_archive_cmd.py
@@ -417,3 +417,48 @@ def test_archive_refuses_proc_path(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     )
     assert result.exit_code == 1, result.output
     assert "Refusing to operate" in result.output or "Refusing to archive" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _is_safe_audit_dir boundary (platform-independent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        # Exact mount roots: a symlink to /proc resolves to "/proc" with NO
+        # trailing slash, so a startswith("/proc/") check silently lets it
+        # through. These exact-root cases are the regression that landed red.
+        "/proc",
+        "/dev",
+        "/sys",
+        # Children must also be refused.
+        "/proc/self",
+        "/dev/null",
+        "/sys/kernel",
+    ],
+)
+def test_is_safe_audit_dir_refuses_pseudo_filesystems(unsafe: str) -> None:
+    from bernstein.cli.commands.audit_cmd import _is_safe_audit_dir
+
+    safe, reason = _is_safe_audit_dir(Path(unsafe))
+    assert safe is False, f"expected {unsafe} to be refused, got safe=True"
+    assert "refusing to operate" in reason.lower()
+
+
+@pytest.mark.parametrize(
+    "ok",
+    [
+        # Lookalike prefixes that merely *start* with the pseudo-fs token must
+        # NOT be refused (e.g. /procurement, /devel, /system).
+        "/procurement/audit",
+        "/devel/audit",
+        "/system/audit",
+    ],
+)
+def test_is_safe_audit_dir_allows_lookalike_prefixes(ok: str) -> None:
+    from bernstein.cli.commands.audit_cmd import _is_safe_audit_dir
+
+    safe, _reason = _is_safe_audit_dir(Path(ok))
+    assert safe is True, f"expected {ok} to be allowed, got safe=False"

--- a/tests/unit/interop/test_a2a_verify_cli.py
+++ b/tests/unit/interop/test_a2a_verify_cli.py
@@ -6,7 +6,9 @@ import json
 import stat
 from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
+from rich.console import Console
 
 from bernstein.cli.commands.interop_cmd import interop_group
 from bernstein.core.interop.a2a_card import SignedCapabilityCard, card_public_key_fingerprint
@@ -48,6 +50,37 @@ def test_card_command_persists_private_key_0600(tmp_path: Path) -> None:
 def test_verify_command_accepts_valid_card(tmp_path: Path) -> None:
     runner = CliRunner()
     out = _issue(runner, tmp_path)
+    result = runner.invoke(interop_group, ["a2a", "verify", "--card", str(out)])
+    assert result.exit_code == 0, result.output
+    assert "is valid" in result.output
+
+
+def test_verify_verdict_survives_narrow_terminal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ``is valid`` / ``is NOT valid`` verdict must never be split by
+    terminal soft-wrapping. Long resolved card paths (e.g. the runner's
+    ``/tmp/pytest-of-runner/...`` tmpdirs) used to push the verdict phrase
+    past the 80-column default of a non-TTY Rich console, wrapping it to
+    ``is \\nvalid`` and breaking machine/test consumers that scan for the
+    literal phrase.
+
+    To make the regression deterministic regardless of the tmp path length,
+    pin the console width to exactly the column where the buggy renderer
+    would break ``is`` from ``valid`` (just past the trailing ``is``). With
+    the fix in place the verdict stays atomic and ``is valid`` is present.
+    """
+    runner = CliRunner()
+    out = _issue(runner, tmp_path)
+
+    # Width chosen so "valid" is forced onto the next visual line in the
+    # buggy renderer: prefix + path + " is" fits, " valid" does not. The
+    # verify command prints the card path verbatim (no resolve_path), so we
+    # measure the exact string the user passed.
+    prefix_cells = len("X Capability card ")  # check-mark renders as 1 cell
+    forced_width = prefix_cells + len(str(out)) + len(" is")
+    narrow = Console(width=forced_width)
+    monkeypatch.setattr("bernstein.cli.helpers.console", narrow)
+    monkeypatch.setattr("bernstein.cli.commands.interop_cmd.console", narrow)
+
     result = runner.invoke(interop_group, ["a2a", "verify", "--card", str(out)])
     assert result.exit_code == 0, result.output
     assert "is valid" in result.output


### PR DESCRIPTION
## Summary

Two latent, environment-dependent test failures on `main`, both fixed at the root cause with platform-independent regression tests.

- **`_is_safe_audit_dir` boundary.** The guard used `startswith("/proc/")` / `/dev/` / `/sys/` (trailing slash). A symlink whose resolved path is exactly `/proc` (no trailing slash) slipped past, so `bernstein audit archive --audit-dir <symlink-to-/proc>` exited 0 with "Nothing to archive" instead of refusing. Now refuses the bare mount root and anything under it, while still allowing lookalike siblings like `/procurement`, `/devel`, `/system`. Surfaced via `test_archive_refuses_proc_path` (Linux-only; macOS skips, which is why it was easy to miss locally).

- **`interop a2a verify` verdict wrapping.** The verdict line interpolated an unbounded card path inline with the `is valid` / `is NOT valid` phrase. With a long resolved path (e.g. a runner's `/tmp/pytest-of-runner/...` tmpdir) the default 80-column non-TTY Rich console soft-wrapped the phrase to `is \nvalid`, so substring/test consumers scanning for `is valid` failed. Now renders the verdict with `soft_wrap=True` so the full line is emitted without hard breaks (the terminal still wraps visually). Adds an opt-in `soft_wrap` keyword to `print_success` / `print_error` (keyword-only, default `False`, backward-compatible).

## Why now

These two checks only fail when the runtime path satisfies a length/symlink boundary, so green PRs that branch off the same base can each pass while the condition still bites on the integration ref. Hardening the boundary makes both deterministic.

## Test plan

- [x] `tests/unit/interop/test_a2a_verify_cli.py::test_verify_verdict_survives_narrow_terminal` (new) - red before fix, green after
- [x] `tests/unit/cli/test_audit_archive_cmd.py::test_is_safe_audit_dir_refuses_pseudo_filesystems` + `..._allows_lookalike_prefixes` (new) - red before fix for exact roots, green after
- [x] `tests/unit/cli/ tests/unit/interop/ tests/unit/test_post_ci_dispatcher_yaml.py` - 264 passed, 1 skipped
- [x] `ruff check src/` + `ruff format --check src/` clean