### PR TITLE
feat(ci): nightly real-run canary for end-to-end runtime coverage

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -1,0 +1,86 @@
+name: Nightly real-run canary
+
+# Executes a real end-to-end Bernstein orchestration against the
+# deterministic stub adapter so integration-level runtime breaks become
+# visible on a schedule instead of waiting for a user to hit them. PR CI
+# only runs unit / property / contract tests plus an install-smoke that
+# checks `--version` / `--help`; nothing there actually spawns a worker,
+# creates a git worktree, appends to the audit chain, or emits a lineage
+# receipt. `scripts/canary_real_run.py` drives those genuinely-runtime
+# paths with no LLM API key and no network egress.
+#
+# ADVISORY, NOT REQUIRED. This workflow reports red on a schedule; it is
+# deliberately NOT in the `CI gate` required-check list and NOT in branch
+# protection, so a canary failure never blocks a PR merge. A future
+# operator decision can promote it to a required check (see
+# docs/operations/nightly-canary.md).
+#
+# On any flow failure the script emits a structured event tagged
+# `environment=canary` to the operator's error sink via the existing
+# observability client. The DSN comes only from `secrets.GLITCHTIP_DSN`
+# (no hostname is hardcoded here); with the secret unset the client is a
+# no-op, mirroring the rest of the observability boundary. The
+# GlitchTip-to-eval ingester then turns the captured event into a P1
+# regression eval case automatically.
+
+on:
+  schedule:
+    # 05:41 UTC daily. Off-peak and off-pattern from the 06:17 Sonar
+    # sweeper and the 06:23 GlitchTip ingester so the three jobs do not
+    # contend for runners or interleave their PRs.
+    - cron: '41 5 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Real-run canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install uv and project deps
+        run: |
+          pip install --quiet uv
+          uv sync --group dev
+
+      - name: Configure git identity for worktree flow
+        run: |
+          # The worktree flow runs `git worktree add` / `commit` inside a
+          # throwaway repo it creates; CI runners ship no global identity.
+          git config --global user.email "canary@users.noreply.github.com"
+          git config --global user.name "Bernstein Canary"
+
+      - name: Run real-run canary
+        env:
+          # Indirection only: the DSN never appears in this file. With the
+          # secret unset the observability client is a no-op, so a missing
+          # DSN keeps the canary green on its own merits rather than failing
+          # on telemetry wiring.
+          BERNSTEIN_TELEMETRY_DSN: ${{ secrets.GLITCHTIP_DSN }}
+          # Block-on-full so a slow sink does not silently drop the one
+          # failure event the ingester needs; bounded internally to ~1s.
+          BERNSTEIN_TELEMETRY_BACKPRESSURE: queue
+        run: |
+          uv run python scripts/canary_real_run.py --verbose

--- a/docs/operations/nightly-canary.md
+++ b/docs/operations/nightly-canary.md
@@ -1,0 +1,106 @@
+# Nightly real-run canary
+
+Audience: operators who rely on agents + CI and never run the program by
+hand. This canary executes a real end-to-end orchestration on a schedule
+so integration-level runtime breaks surface before a user hits them.
+
+Companion to [`ci.md`](./ci.md) (the PR gate) and
+[`glitchtip-ingester.md`](./glitchtip-ingester.md) (where a canary
+failure ends up).
+
+## TL;DR
+
+| Fact | Value |
+|------|-------|
+| Workflow | `.github/workflows/nightly-canary.yml` |
+| Script | `scripts/canary_real_run.py` |
+| Schedule | `41 5 * * *` (05:41 UTC daily) + manual `workflow_dispatch` |
+| Posture | ADVISORY -- reports red, does NOT block merges |
+| Cost | none (deterministic stub adapter, no LLM key, no network egress) |
+| On failure | emits one `environment=canary` event to the error sink, exits non-zero |
+| Feeds | the GlitchTip-to-eval ingester -> a P1 regression eval case |
+
+## Why it exists
+
+PR CI runs unit / property / contract tests plus an install-smoke that
+checks `--version` / `--help`. None of that **executes** a real flow, so
+a break in genuinely-runtime plumbing -- a worker subprocess spawn, a
+`git worktree` round-trip, an audit-chain append, a lineage receipt --
+stays invisible until a user trips it. The canary closes that gap.
+
+## What it runs
+
+Three representative real-runtime flows, each in a temp dir it owns and
+tears down. These are the paths the unit suite mocks:
+
+| Flow | Real path exercised |
+|------|---------------------|
+| `subprocess_spawn` | `MockAgentAdapter.spawn()` forks a real `subprocess.Popen`; the canary reaps it and asserts a clean exit + a written log |
+| `git_worktree` | `WorktreeManager.create()` runs a real `git worktree add`; `.cleanup()` runs `git worktree remove`; the canary asserts no leftover worktree |
+| `audit_and_lineage` | real HMAC-chained `AuditChainStore` append + `verify()`, then a real Ed25519-signed `LineageRecorder` receipt re-verified through `lineage.gate.check` (the auditor's own gate) |
+
+Each flow runs independently: one failure does not stop the others, so a
+single run surfaces every broken surface, not just the first.
+
+## Env it needs
+
+| Variable | Source | Effect if unset |
+|----------|--------|-----------------|
+| `BERNSTEIN_TELEMETRY_DSN` | `secrets.GLITCHTIP_DSN` (workflow indirection) | telemetry client is a no-op; canary still runs and still red/green on its own merits |
+| `BERNSTEIN_TELEMETRY_BACKPRESSURE` | set to `queue` in the workflow | block-on-full (bounded ~1s) so the one failure event is not dropped |
+
+No backend hostname is hardcoded anywhere. The DSN reaches the script
+only through the secret; the script uses the existing observability
+client (`error_capture.capture_exception`) and invents no new emitter.
+
+## How to read a canary failure
+
+1. Open the red **Nightly real-run canary** run. The failing flow logs
+   `canary flow '<name>' failed: <exc>` with a full traceback.
+2. The same failure is captured as one error event with these fields:
+
+   | Field | Meaning |
+   |-------|---------|
+   | `logger` | `bernstein.canary` |
+   | `tags.environment` | `canary` |
+   | `tags.flow` | which flow broke (`subprocess_spawn` / `git_worktree` / `audit_and_lineage`) |
+   | `tags.exc_type` | exception class name |
+   | `tags.top_frame` | `file:line` of the failing frame |
+   | `extra.exc_value` | one-line exception message |
+
+3. Reproduce locally with no secrets needed:
+
+   ```
+   uv run python scripts/canary_real_run.py --verbose
+   ```
+
+   Exit `0` = all flows green; exit `1` = at least one flow failed.
+
+## How it feeds the GlitchTip ingester
+
+```
+canary flow raises
+   -> error_capture.capture_exception(category="canary", tags={environment: canary, ...})
+   -> side channel POSTs a Sentry-protocol event to the GlitchTip DSN
+   -> GlitchTip groups it into an issue (exception type + top frame + environment tag)
+   -> scripts/scrape_glitchtip_events.py (06:23 ingester) reads it
+   -> IncidentSynthesizer writes a P1 regression eval case
+      under src/bernstein/eval/cases/incidents/ (env_canary tag)
+```
+
+The `environment=canary` tag keeps canary noise out of the production
+error stream and lets the synthesised case be recognised as canary-origin.
+
+## How to promote it to a required check later
+
+This workflow is advisory by design. To make a canary failure block
+merges (an explicit operator decision, not a default):
+
+1. Confirm the canary is stable over several scheduled runs (no flakes).
+2. Add **Real-run canary** to branch protection's required-status-check
+   list for `main`.
+3. Optionally add it to the `CI gate` aggregation so the gate stub waits
+   on it.
+
+Until then it is a smoke alarm, not a gate: it tells you something broke
+without holding up unrelated work.

--- a/scripts/canary_real_run.py
+++ b/scripts/canary_real_run.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Nightly real-run canary for end-to-end runtime coverage.
+
+PR CI exercises unit / property / contract tests and an install-smoke that
+checks ``--version`` / ``--help``. None of that actually *executes* a real
+end-to-end orchestration flow, so integration-level runtime breaks -- a real
+subprocess spawn, a real ``git worktree`` round-trip, a real audit-chain
+append-then-verify, a real lineage receipt -- stay invisible until a user
+hits them. This script closes that gap: it drives a small, representative
+set of genuinely-runtime paths against the deterministic stub adapter, with
+no LLM API key and no network egress, and turns any failure into a
+structured telemetry event so the GlitchTip-to-eval ingester can synthesise
+a regression case automatically.
+
+Design
+------
+* **Deterministic stub only.** The spawn flow uses
+  :class:`bernstein.adapters.mock.MockAgentAdapter`, which forks a real
+  subprocess running a self-contained python script -- no provider call,
+  no key, no cost.
+* **Real runtime, not mocks.** Each flow exercises a path the unit suite
+  patches out: an actual ``subprocess.Popen`` + reap, an actual
+  ``git worktree add`` / ``git worktree remove``, an actual HMAC-chained
+  audit append + verify, and an actual Ed25519-signed lineage receipt that
+  is re-verified through the same gate an auditor would use.
+* **Fail-loud, report-rich.** On any flow exception the runner records a
+  telemetry event tagged ``environment=canary`` carrying the flow name,
+  exception type, and the failing top frame -- exactly the fields the
+  ingester (``scripts/scrape_glitchtip_events.py`` ->
+  :class:`bernstein.eval.incident_synthesizer.GlitchTipIncident`) reads to
+  build a minimal reproduction prompt. The process then exits non-zero so
+  the scheduled workflow goes red.
+* **No leaks.** Every flow runs inside a temporary directory it owns and
+  tears down, and the worktree flow removes its worktree + branch before
+  returning, even on failure.
+
+The emitter is the existing observability client
+(:func:`bernstein.core.observability.error_capture.capture_exception`); this
+script invents no new transport. With no ``BERNSTEIN_TELEMETRY_DSN``
+configured the client is a no-op, mirroring the rest of the observability
+boundary, so a missing DSN never makes the canary itself fail.
+
+This module is intentionally *not* collected by the main pytest run -- it is
+a scheduled job kept out of PR CI so it does not slow merges. Its seams are
+unit-tested in ``tests/unit/test_canary_real_run.py`` with stub flows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+logger = logging.getLogger("bernstein.canary")
+
+#: Telemetry category for every canary event. Becomes ``logger=bernstein.canary``
+#: in the GlitchTip UI so an operator can filter the canary stream.
+CANARY_CATEGORY = "canary"
+
+#: Sentry-protocol ``environment`` tag. The ingester reads this to mark the
+#: synthesised eval case ``env_canary``; it also keeps canary noise out of the
+#: production error stream.
+CANARY_ENVIRONMENT = "canary"
+
+#: A short, deterministic goal the spawn flow hands the stub adapter. The mock
+#: adapter pattern-matches the prompt to a scripted fix; this string maps to its
+#: ``broken_test`` branch, which is a pure no-op on an empty workdir (it logs and
+#: exits 0), so the flow stays a clean spawn-and-reap with no real edits.
+CANARY_GOAL = "Run the canary smoke task: verify the broken test harness spawns and exits cleanly."
+
+#: Hard cap on how long the stub subprocess may run before we treat the spawn as
+#: hung. The mock adapter sleeps ~2s of simulated work; 60s is generous slack.
+SPAWN_REAP_TIMEOUT_S = 60
+
+
+class EmitFn(Protocol):
+    """Signature of the failure emitter the runner depends on.
+
+    Decoupled behind a Protocol so the unit tests can inject a recorder and
+    so the default (``error_capture.capture_exception``) is the only place
+    that touches the real telemetry boundary.
+    """
+
+    def __call__(
+        self,
+        exc: BaseException,
+        *,
+        flow: str,
+        tags: dict[str, str],
+        extra: dict[str, Any],
+    ) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Default emitter -- routes through the existing observability client
+# ---------------------------------------------------------------------------
+
+
+def _default_emit(
+    exc: BaseException,
+    *,
+    flow: str,
+    tags: dict[str, str],
+    extra: dict[str, Any],
+) -> None:
+    """Forward a canary failure to the operator-managed error sink.
+
+    Reuses :func:`bernstein.core.observability.error_capture.capture_exception`,
+    which fans out to ``sentry-sdk`` (when initialised) and the dependency-free
+    side channel. Both are fail-closed and no-op without a DSN, so this never
+    raises and never makes a failing canary worse.
+    """
+    from bernstein.core.observability import error_capture
+
+    with contextlib.suppress(Exception):
+        error_capture.capture_exception(
+            exc,
+            category=CANARY_CATEGORY,
+            tags=tags,
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Failure context extraction
+# ---------------------------------------------------------------------------
+
+
+def _top_frame(exc: BaseException) -> str:
+    """Return ``file:line`` of the deepest frame in *exc*'s traceback.
+
+    The ingester surfaces this as the "Top in-app frame" in the synthesised
+    prompt, so an operator can jump straight to the failing call site.
+    Returns ``"<unknown>"`` when no traceback is attached.
+    """
+    tb = exc.__traceback__
+    if tb is None:
+        return "<unknown>"
+    frames = traceback.extract_tb(tb)
+    if not frames:
+        return "<unknown>"
+    last = frames[-1]
+    filename = os.path.basename(last.filename) or last.filename
+    return f"{filename}:{last.lineno}"
+
+
+def _build_event_context(flow: str, exc: BaseException) -> tuple[dict[str, str], dict[str, Any]]:
+    """Build the ``(tags, extra)`` payload for a single flow failure.
+
+    Tags carry the cheap, searchable fields the ingester reads
+    (``environment``, ``flow``, ``exc_type``, ``top_frame``); extra carries
+    the richer context (one-line value, trimmed traceback) for the prompt.
+    """
+    exc_type = type(exc).__name__
+    top = _top_frame(exc)
+    tags: dict[str, str] = {
+        "environment": CANARY_ENVIRONMENT,
+        "flow": flow,
+        "exc_type": exc_type,
+        "top_frame": top,
+    }
+    extra: dict[str, Any] = {
+        "flow": flow,
+        "exc_type": exc_type,
+        "exc_value": str(exc),
+        "top_frame": top,
+    }
+    return tags, extra
+
+
+# ---------------------------------------------------------------------------
+# Flow 1: real subprocess spawn via the deterministic stub adapter
+# ---------------------------------------------------------------------------
+
+
+def flow_subprocess_spawn(*, workdir: Path) -> int:
+    """Spawn a worker through the stub adapter and reap it -- a real subprocess.
+
+    Drives :class:`bernstein.adapters.mock.MockAgentAdapter`, which forks an
+    actual ``subprocess.Popen`` running a self-contained python worker, then
+    waits for it to exit. This is the path unit tests mock out wholesale: the
+    real ``Popen`` argv assembly, env isolation, log file creation, and the
+    ``proc.wait()`` reap.
+
+    Args:
+        workdir: A scratch directory the spawned worker treats as its repo
+            root. The caller owns its lifecycle.
+
+    Returns:
+        The reaped exit code of the worker process (``0`` on success).
+
+    Raises:
+        AssertionError: if the worker exits non-zero or writes no log.
+        TimeoutError: if the worker does not exit within the reap timeout.
+    """
+    from bernstein.adapters.mock import MockAgentAdapter
+
+    # Import from the concrete module rather than the ``bernstein.core.models``
+    # back-compat alias: the alias is served by a meta_path redirect finder
+    # that static analysers cannot follow, so the concrete path keeps this
+    # script type-clean when checked outside the package's pyright root.
+    from bernstein.core.tasks.models import ModelConfig
+
+    (workdir / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+
+    adapter = MockAgentAdapter()
+    session_id = f"canary-{uuid.uuid4().hex[:12]}"
+    result = adapter.spawn(
+        prompt=CANARY_GOAL,
+        workdir=workdir,
+        # The stub adapter ignores the model config; supply a valid one so
+        # the contract is honoured without selecting any real provider.
+        model_config=ModelConfig(model="sonnet", effort="medium"),
+        session_id=session_id,
+    )
+
+    proc = getattr(result, "proc", None)
+    if proc is None:  # pragma: no cover - mock always wires proc
+        raise AssertionError("stub adapter returned no live process handle")
+
+    # Cancel the adapter's own timeout watchdog once we own the reap, so a
+    # late watchdog cannot kill an unrelated PID after we return.
+    timer = getattr(result, "timeout_timer", None)
+    try:
+        try:
+            code = int(proc.wait(timeout=SPAWN_REAP_TIMEOUT_S))
+        except subprocess.TimeoutExpired as exc:
+            with contextlib.suppress(Exception):
+                proc.kill()
+            raise TimeoutError(f"stub worker {session_id} did not exit within {SPAWN_REAP_TIMEOUT_S}s") from exc
+    finally:
+        if timer is not None:
+            with contextlib.suppress(Exception):
+                timer.cancel()
+
+    if code != 0:
+        raise AssertionError(f"stub worker exited {code}, expected 0")
+    if not result.log_path.exists():
+        raise AssertionError(f"stub worker wrote no log at {result.log_path}")
+    logger.info("spawn flow ok: session=%s exit=%d", session_id, code)
+    return code
+
+
+# ---------------------------------------------------------------------------
+# Flow 2: real git worktree create + teardown
+# ---------------------------------------------------------------------------
+
+
+def flow_git_worktree(*, repo_root: Path) -> None:
+    """Create a real git worktree, confirm it exists, then tear it down.
+
+    Drives :class:`bernstein.core.git.worktree.WorktreeManager`, exercising
+    the actual ``git worktree add`` / ``git worktree remove`` plumbing the
+    orchestrator uses for per-task isolation -- a path the unit suite stubs.
+    The worktree is always removed before returning, including on failure, so
+    the canary never leaks a worktree or branch into the repo.
+
+    Args:
+        repo_root: An initialised git repository to host the worktree.
+
+    Raises:
+        AssertionError: if the worktree directory is not created, or if it is
+            still present after cleanup.
+    """
+    from bernstein.core.git.worktree import WorktreeManager
+
+    # Disable salvage-push: this is a throwaway worktree, and a push attempt
+    # against a bare local repo would be noise. Salvage-on-cleanup is harmless
+    # but pointless here, so turn it off to keep the teardown fast and quiet.
+    manager = WorktreeManager(repo_root, salvage_on_cleanup=False, salvage_push=False)
+    session_id = f"canary-{uuid.uuid4().hex[:12]}"
+    try:
+        created = manager.create(session_id)
+        if not created.is_dir():
+            raise AssertionError(f"git worktree add did not create {created}")
+    finally:
+        manager.cleanup(session_id)
+
+    # If create() had raised, the exception would have propagated through the
+    # finally and we would not be here; reaching this line means a worktree
+    # was created and cleanup() has run, so the leak check is unconditional.
+    if created.exists():
+        raise AssertionError(f"git worktree {created} survived cleanup -- leak")
+    logger.info("worktree flow ok: session=%s", session_id)
+
+
+# ---------------------------------------------------------------------------
+# Flow 3: real audit-chain append + verify, real signed lineage receipt
+# ---------------------------------------------------------------------------
+
+
+def flow_audit_and_lineage(*, state_dir: Path) -> None:
+    """Append HMAC-chained audit events + a signed lineage receipt, then verify.
+
+    Two genuinely-runtime verification paths in one flow:
+
+    * **Audit chain.** Append two events to
+      :class:`bernstein.core.security.audit_chain.AuditChainStore` (real HMAC
+      key creation + chaining) and assert ``verify()`` reports an intact
+      chain.
+    * **Lineage receipt.** Record a real artefact write through
+      :class:`bernstein.core.lineage.recorder.LineageRecorder` (content hash,
+      operator HMAC envelope, Ed25519 detached JWS) and re-verify the emitted
+      receipt through :func:`bernstein.core.lineage.gate.check` -- the same
+      gate an offline auditor runs. A well-formed receipt is the success
+      condition; an unverifiable one raises and becomes a telemetry event.
+
+    Args:
+        state_dir: A scratch directory the flow owns; audit logs, the lineage
+            store, and the agent card all live beneath it.
+
+    Raises:
+        AssertionError: if the audit chain or the lineage receipt fails to
+            verify.
+    """
+    import json
+
+    from bernstein.core.lineage.gate import check as lineage_check
+    from bernstein.core.lineage.identity import AgentCard, generate_keypair
+    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.store import LineageStore
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+    # -- audit chain ------------------------------------------------------
+    audit_dir = state_dir / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    chain = AuditChainStore(audit_dir)
+    chain.log(
+        event_type="canary.heartbeat",
+        actor="canary",
+        resource_type="canary",
+        resource_id="seq-1",
+        details={"step": 1},
+    )
+    chain.log_with_prev_digest(
+        event_type="canary.heartbeat",
+        actor="canary",
+        resource_type="canary",
+        resource_id="seq-2",
+        details={"step": 2},
+    )
+    ok, failures = chain.verify()
+    if not ok:
+        raise AssertionError(f"audit chain failed to verify: {failures}")
+
+    # -- lineage receipt --------------------------------------------------
+    operator_key = b"canary-operator-hmac-key-not-a-secret"
+    priv_pem, pub_pem = generate_keypair()
+    agent_id = "agent:canary"
+    kid = "canary-kid"
+    card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=pub_pem)
+
+    cards_dir = state_dir / "agents"
+    card_dir = cards_dir / agent_id
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": card.protocol_version,
+                "agent_id": agent_id,
+                "kid": kid,
+                "public_key_pem": pub_pem,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = LineageStore(state_dir / "lineage")
+    recorder = LineageRecorder(store, operator_hmac_key=operator_key)
+    entry_hash = recorder.record_write(
+        artefact_path="canary/output.txt",
+        new_content=b"canary artefact bytes",
+        agent_id=agent_id,
+        agent_card=card,
+        private_key_pem=priv_pem,
+        tool_call_id="canary-tool-call",
+        span_id="canary-span",
+    )
+    if not entry_hash.startswith("sha256:"):
+        raise AssertionError(f"lineage recorder returned malformed hash: {entry_hash!r}")
+
+    result = lineage_check(
+        store.log_path,
+        cards_dir,
+        operator_secret=operator_key,
+    )
+    if not result.ok:
+        raise AssertionError(f"lineage receipt failed to verify: {result.failures}")
+    logger.info("audit+lineage flow ok: entry=%s", entry_hash)
+
+
+# ---------------------------------------------------------------------------
+# Flow registry + runner
+# ---------------------------------------------------------------------------
+
+
+def default_flows() -> dict[str, Callable[[], None]]:
+    """Return the shipped canary flows as a name -> zero-arg callable map.
+
+    Each flow allocates and tears down its own temp directory (or git repo),
+    so the registry callables take no arguments and leave nothing behind. The
+    set is deliberately small -- one representative path per runtime surface
+    (subprocess, worktree, audit+lineage) -- to keep the canary fast and
+    debuggable rather than an exhaustive integration suite.
+    """
+    return {
+        "subprocess_spawn": _spawn_flow_self_contained,
+        "git_worktree": _worktree_flow_self_contained,
+        "audit_and_lineage": _audit_lineage_flow_self_contained,
+    }
+
+
+def _spawn_flow_self_contained() -> None:
+    """Run :func:`flow_subprocess_spawn` inside an owned temp dir."""
+    tmp = Path(tempfile.mkdtemp(prefix="bernstein-canary-spawn-"))
+    try:
+        flow_subprocess_spawn(workdir=tmp)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _worktree_flow_self_contained() -> None:
+    """Run :func:`flow_git_worktree` inside an owned, freshly-init'd git repo."""
+    tmp = Path(tempfile.mkdtemp(prefix="bernstein-canary-worktree-"))
+    try:
+        _git_init(tmp)
+        flow_git_worktree(repo_root=tmp)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _audit_lineage_flow_self_contained() -> None:
+    """Run :func:`flow_audit_and_lineage` inside an owned temp dir."""
+    tmp = Path(tempfile.mkdtemp(prefix="bernstein-canary-audit-"))
+    try:
+        flow_audit_and_lineage(state_dir=tmp)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _git_init(repo: Path) -> None:
+    """Initialise a minimal git repo with one commit (worktree precondition)."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "canary@example.com"], cwd=str(repo), check=True)
+    subprocess.run(["git", "config", "user.name", "Bernstein Canary"], cwd=str(repo), check=True)
+    (repo / "README.md").write_text("# canary\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "canary init"], cwd=str(repo), check=True, capture_output=True)
+
+
+def run_canary(
+    *,
+    flows: Mapping[str, Callable[[], None]] | None = None,
+    emit: EmitFn | None = None,
+) -> int:
+    """Run every flow; report failures via telemetry; return a process exit code.
+
+    Each flow runs independently: a failure in one does not stop the others,
+    so a single canary run surfaces *every* broken surface rather than just
+    the first. Every failure produces exactly one telemetry event carrying
+    the flow name, exception type, top frame, and ``environment=canary``.
+
+    Args:
+        flows: Override the flow registry (used by tests). Defaults to
+            :func:`default_flows`.
+        emit: Override the failure emitter (used by tests). Defaults to
+            :func:`_default_emit`, which routes through the existing
+            observability client.
+
+    Returns:
+        ``0`` when every flow passed; ``1`` when one or more failed.
+    """
+    selected = flows if flows is not None else default_flows()
+    emitter = emit if emit is not None else _default_emit
+
+    failures = 0
+    for name, fn in selected.items():
+        try:
+            fn()
+        except Exception as exc:
+            failures += 1
+            logger.error("canary flow %r failed: %s", name, exc, exc_info=True)
+            tags, extra = _build_event_context(name, exc)
+            with contextlib.suppress(Exception):
+                emitter(exc, flow=name, tags=tags, extra=extra)
+        else:
+            logger.info("canary flow %r passed", name)
+
+    if failures:
+        logger.error("canary: %d/%d flow(s) failed", failures, len(selected))
+        return 1
+    logger.info("canary: all %d flow(s) passed", len(selected))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Parses args, configures logging, runs the canary."""
+    parser = argparse.ArgumentParser(description="Bernstein nightly real-run canary.")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Emit DEBUG-level logs for each flow.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    return run_canary()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_canary_real_run.py
+++ b/tests/unit/test_canary_real_run.py
@@ -1,0 +1,269 @@
+"""Unit tests for the nightly real-run canary's flow-selection and failure-emission.
+
+The canary script (``scripts/canary_real_run.py``) drives a handful of
+genuinely-runtime orchestration paths against the deterministic stub
+adapter so a scheduled CI job catches integration-level breaks that the
+mocked unit suite cannot see. These tests pin the two behaviours the
+workflow depends on, *without* any network or real telemetry DSN:
+
+* the success path runs every registered flow and returns exit code 0;
+* an injected flow failure returns a non-zero exit code, emits exactly
+  one telemetry event carrying enough context for the GlitchTip-to-eval
+  ingester to synthesise a regression case (flow name, exception type,
+  top frame, ``environment=canary``), and leaves no worktree / temp-dir
+  behind.
+
+The canary itself is deliberately *not* collected by the main pytest
+run (it is a scheduled job); these unit tests exercise its seams with
+stub flows so PR CI stays fast.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "canary_real_run.py"
+
+
+def _load_canary() -> ModuleType:
+    """Import ``scripts/canary_real_run.py`` as a module by file path.
+
+    The script lives outside the importable package, so it is loaded via
+    an explicit spec rather than a normal import. The module is cached in
+    ``sys.modules`` under a private name so repeated loads are cheap.
+    """
+    mod_name = "_canary_real_run_under_test"
+    cached = sys.modules.get(mod_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def canary() -> ModuleType:
+    return _load_canary()
+
+
+class _RecordingEmitter:
+    """Capture telemetry emissions instead of touching any DSN."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        exc: BaseException,
+        *,
+        flow: str,
+        tags: dict[str, str],
+        extra: dict[str, Any],
+    ) -> None:
+        self.calls.append(
+            {
+                "exc": exc,
+                "flow": flow,
+                "tags": dict(tags),
+                "extra": dict(extra),
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Flow registry
+# ---------------------------------------------------------------------------
+
+
+def test_default_flow_registry_is_small_and_named(canary: ModuleType) -> None:
+    """The shipped registry stays focused (1-3 representative flows)."""
+    flows = canary.default_flows()
+    assert 1 <= len(flows) <= 3
+    # Each entry is a name -> zero-arg callable.
+    for name, fn in flows.items():
+        assert isinstance(name, str) and name
+        assert callable(fn)
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_run_canary_success_returns_zero_and_emits_nothing(canary: ModuleType) -> None:
+    """All flows passing -> exit 0, no telemetry events."""
+    emitter = _RecordingEmitter()
+    ran: list[str] = []
+
+    def _ok_a() -> None:
+        ran.append("a")
+
+    def _ok_b() -> None:
+        ran.append("b")
+
+    rc = canary.run_canary(
+        flows={"alpha": _ok_a, "beta": _ok_b},
+        emit=emitter,
+    )
+
+    assert rc == 0
+    assert sorted(ran) == ["a", "b"]
+    assert emitter.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Failure path
+# ---------------------------------------------------------------------------
+
+
+def test_run_canary_failure_returns_nonzero_and_emits_one_event(canary: ModuleType) -> None:
+    """An injected failure -> non-zero exit and exactly one shaped event."""
+    emitter = _RecordingEmitter()
+
+    def _boom() -> None:
+        raise RuntimeError("synthetic canary break")
+
+    rc = canary.run_canary(flows={"explode": _boom}, emit=emitter)
+
+    assert rc != 0
+    assert len(emitter.calls) == 1
+    call = emitter.calls[0]
+    assert call["flow"] == "explode"
+    assert isinstance(call["exc"], RuntimeError)
+    # The ingester reads these to synthesise a case: environment, flow,
+    # exception type, and a top frame must all be present.
+    tags = call["tags"]
+    assert tags["environment"] == "canary"
+    assert tags["flow"] == "explode"
+    assert tags["exc_type"] == "RuntimeError"
+    assert tags["top_frame"]  # non-empty file:line of the failing frame
+    extra = call["extra"]
+    assert "synthetic canary break" in str(extra.get("exc_value", ""))
+
+
+def test_run_canary_runs_all_flows_even_after_a_failure(canary: ModuleType) -> None:
+    """One failing flow does not stop the others; every break is reported."""
+    emitter = _RecordingEmitter()
+    ran: list[str] = []
+
+    def _ok() -> None:
+        ran.append("ok")
+
+    def _boom() -> None:
+        raise ValueError("second-flow break")
+
+    rc = canary.run_canary(
+        flows={"good": _ok, "bad": _boom},
+        emit=emitter,
+    )
+
+    assert rc != 0
+    assert "ok" in ran  # the healthy flow still ran
+    assert len(emitter.calls) == 1
+    assert emitter.calls[0]["flow"] == "bad"
+    assert emitter.calls[0]["tags"]["exc_type"] == "ValueError"
+
+
+def test_default_emit_is_resolved_when_not_injected(canary: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no ``emit`` argument the canary routes through error_capture.
+
+    The default emitter must be the existing observability client, never a
+    bespoke emitter. We assert it forwards a real exception and the
+    ``environment=canary`` tag through ``error_capture.capture_exception``.
+    """
+    from bernstein.core.observability import error_capture
+
+    calls: list[dict[str, Any]] = []
+
+    def _fake_capture(
+        exc: BaseException,
+        *,
+        category: str,
+        tags: dict[str, str] | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        calls.append({"exc": exc, "category": category, "tags": dict(tags or {}), "extra": dict(extra or {})})
+
+    monkeypatch.setattr(error_capture, "capture_exception", _fake_capture)
+
+    def _boom() -> None:
+        raise RuntimeError("default-path break")
+
+    rc = canary.run_canary(flows={"explode": _boom})
+
+    assert rc != 0
+    assert len(calls) == 1
+    assert calls[0]["category"] == "canary"
+    assert calls[0]["tags"]["environment"] == "canary"
+    assert calls[0]["tags"]["flow"] == "explode"
+    assert isinstance(calls[0]["exc"], RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# No-leak guarantee for the real flows
+# ---------------------------------------------------------------------------
+
+
+def _count_worktrees(repo_root: Path) -> int:
+    import subprocess
+
+    out = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=str(repo_root),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    # Each worktree entry begins with a "worktree <path>" line.
+    return sum(1 for line in out.splitlines() if line.startswith("worktree "))
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path: Path) -> Iterator[Path]:
+    import subprocess
+
+    repo = tmp_path / "canary_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "canary@example.com"], cwd=str(repo), check=True)
+    subprocess.run(["git", "config", "user.name", "Canary"], cwd=str(repo), check=True)
+    (repo / "README.md").write_text("# canary\n")
+    subprocess.run(["git", "add", "README.md"], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo), check=True, capture_output=True)
+    yield repo
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="git worktree flow uses POSIX semantics")
+def test_worktree_flow_creates_and_tears_down_without_leak(canary: ModuleType, temp_git_repo: Path) -> None:
+    """The real git-worktree flow leaves the repo with no extra worktrees."""
+    before = _count_worktrees(temp_git_repo)
+    canary.flow_git_worktree(repo_root=temp_git_repo)
+    after = _count_worktrees(temp_git_repo)
+    assert after == before, "git-worktree flow leaked a worktree"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="subprocess spawn flow uses POSIX semantics")
+def test_subprocess_spawn_flow_runs_real_process(canary: ModuleType, tmp_path: Path) -> None:
+    """The spawn flow drives a real subprocess and observes a clean exit."""
+    # Should not raise; returns the reaped exit code (0 for the stub adapter).
+    code = canary.flow_subprocess_spawn(workdir=tmp_path)
+    assert code == 0
+
+
+def test_audit_and_lineage_flow_verifies_chain(canary: ModuleType, tmp_path: Path) -> None:
+    """The audit + lineage flow appends, then verifies, real signed records."""
+    # Should not raise; a tampered or unverifiable chain would surface as
+    # an exception that the runner converts into a telemetry event.
+    canary.flow_audit_and_lineage(state_dir=tmp_path)


### PR DESCRIPTION
## Gap this closes

PR CI runs unit / property / contract tests plus an install-smoke that only checks `--version` / `--help`. Nothing in CI actually **executes** a real end-to-end orchestration flow, so integration-level runtime breaks stay invisible until a user hits them:

- a real worker subprocess spawn + reap
- a real `git worktree` create + teardown
- a real HMAC-chained audit append + verify
- a real Ed25519-signed lineage receipt + verify

These are exactly the paths the unit suite mocks out. This adds a scheduled canary that drives them for real.

## What it adds

| File | Purpose |
|------|---------|
| `scripts/canary_real_run.py` | Drives 3 representative real-runtime flows against the deterministic stub adapter (no LLM key, no network egress, no cost). Exits non-zero on failure; cleans up every temp dir and worktree. |
| `.github/workflows/nightly-canary.yml` | Schedule `41 5 * * *` (off-peak, off-pattern from the 06:17 and 06:23 jobs) + `workflow_dispatch`. harden-runner (audit), `contents: read`, 15-min timeout. |
| `tests/unit/test_canary_real_run.py` | Unit-tests the flow-selection + failure-emission seams with stub flows (success exits 0; injected failure exits non-zero + emits exactly one shaped event; no worktree leak). |
| `docs/operations/nightly-canary.md` | Operator guide: what it runs, env it needs, how to read a failure, ingester linkage, how to promote to a required check later. |

The three flows:

| Flow | Real path exercised |
|------|---------------------|
| `subprocess_spawn` | `MockAgentAdapter.spawn()` forks a real `subprocess.Popen`; canary reaps it and asserts clean exit + written log |
| `git_worktree` | `WorktreeManager.create()` runs real `git worktree add`; `.cleanup()` runs `git worktree remove`; asserts no leftover worktree |
| `audit_and_lineage` | real `AuditChainStore` append + `verify()`, then a real `LineageRecorder` receipt re-verified through `lineage.gate.check` (the auditor's own gate) |

## Advisory, not required

This workflow reports red on a schedule. It is deliberately **NOT** in the `CI gate` required-check list and **NOT** in branch protection, so a canary failure never blocks a PR merge. A future operator decision can promote it (steps in the doc). Until then it is a smoke alarm, not a gate.

## Telemetry / ingester linkage

On any flow failure the canary emits one structured event through the existing observability client (`error_capture.capture_exception`, no new emitter), tagged `environment=canary` and carrying the flow name, exception type, and failing top frame. The DSN reaches the script only through `secrets.GLITCHTIP_DSN` (no hostname hardcoded anywhere); with the secret unset the client is a no-op, mirroring the existing observability soft-fail posture. The GlitchTip-to-eval ingester (`scripts/scrape_glitchtip_events.py` -> `IncidentSynthesizer`) then turns the captured event into a P1 regression eval case automatically.

The canary stays out of the main pytest run (`testpaths = ["tests"]`; it lives in `scripts/`) so it does not slow PR CI.

## Test plan

- [x] `uv run pytest tests/unit/test_canary_real_run.py -q --no-cov --timeout=120` -> 8 passed
- [x] `uv run python scripts/canary_real_run.py` -> exit 0, all 3 flows pass
- [x] failure path verified end-to-end through the real default emitter: exit 1, exactly one `environment=canary` event with `exc_type` / `flow` / `top_frame`
- [x] worktree flow leaves no leftover worktree (asserted via `git worktree list`)
- [x] `ruff check` + `ruff format --check` clean; `actionlint` + `zizmor` clean on the new workflow
- [x] no-hardcoded-infra guard passes (`tests/unit/observability/test_no_hardcoded_infra.py`)
- [x] docs-drift `--strict` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a nightly real-run canary system that automatically executes critical end-to-end workflows on a daily schedule to ensure system reliability and catch regressions through deterministic testing of core operations.
  * Added comprehensive documentation describing the canary process, its test flows, environment configuration, failure logging, telemetry integration, local reproduction steps, and promotion pathway.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->