### PR TITLE
test(tasks): cover dark paths in lifecycle FSM, store, models, planning

### DIFF
--- a/tests/unit/planning/test_lifecycle_queries.py
+++ b/tests/unit/planning/test_lifecycle_queries.py
@@ -1,0 +1,170 @@
+"""Behavioral tests for PlanLifecycle queries and slug edge cases.
+
+The existing planning/lifecycle suite focuses on archive transitions, hooks,
+audit, and slug collisions. This file fills the query-helper and slug-edge
+gaps: bucket creation, ``list_plans`` / ``find`` / ``bucket``, the non-dir
+root guard, ``default_lifecycle``, and ``_slugify`` collapse/truncation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.planning.lifecycle import (
+    PlanArchiveError,
+    PlanLifecycle,
+    PlanState,
+    _slugify,
+    default_lifecycle,
+    is_archived_filename,
+)
+
+# ---------------------------------------------------------------------------
+# _slugify edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_slugify_normalizes_to_dash_lowercase() -> None:
+    assert _slugify("My Cool Plan!") == "my-cool-plan"
+
+
+def test_slugify_empty_collapses_to_plan() -> None:
+    assert _slugify("   ") == "plan"
+
+
+def test_slugify_symbols_only_collapses_to_plan() -> None:
+    assert _slugify("!!!@@@###") == "plan"
+
+
+def test_slugify_truncates_to_max_length() -> None:
+    result = _slugify("x" * 100)
+    assert len(result) == 60
+    assert result == "x" * 60
+
+
+def test_slugify_strips_trailing_dashes() -> None:
+    assert _slugify("plan---") == "plan"
+
+
+# ---------------------------------------------------------------------------
+# is_archived_filename
+# ---------------------------------------------------------------------------
+
+
+def test_is_archived_filename_accepts_dated_hash_form() -> None:
+    assert is_archived_filename("2026-05-22-my-plan-a1b2c3.yaml") is True
+
+
+def test_is_archived_filename_rejects_plain_name() -> None:
+    assert is_archived_filename("my-plan.yaml") is False
+
+
+# ---------------------------------------------------------------------------
+# PlanLifecycle construction + buckets
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_creates_three_buckets(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    # The constructor creates all three buckets as a side effect.
+    assert (lc.root / "active").is_dir()
+    assert (lc.root / "completed").is_dir()
+    assert (lc.root / "blocked").is_dir()
+
+
+def test_lifecycle_bucket_maps_state_to_directory(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    assert lc.bucket(PlanState.ACTIVE).name == "active"
+    assert lc.bucket(PlanState.COMPLETED).name == "completed"
+    assert lc.bucket(PlanState.BLOCKED).name == "blocked"
+
+
+def test_lifecycle_rejects_non_directory_root(tmp_path: Path) -> None:
+    afile = tmp_path / "afile"
+    afile.write_text("not a dir")
+    with pytest.raises(PlanArchiveError, match="not a directory"):
+        PlanLifecycle(afile)
+
+
+# ---------------------------------------------------------------------------
+# list_plans / find
+# ---------------------------------------------------------------------------
+
+
+def test_list_plans_empty_when_no_files(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    assert lc.list_plans() == []
+
+
+def test_list_plans_finds_active_plan(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    (tmp_path / "plans" / "active" / "p1.yaml").write_text("name: p1\n")
+    plans = lc.list_plans()
+    assert len(plans) == 1
+    assert plans[0].plan_id == "p1"
+    assert plans[0].state is PlanState.ACTIVE
+
+
+def test_list_plans_filtered_by_state(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    (tmp_path / "plans" / "active" / "p1.yaml").write_text("name: p1\n")
+    (tmp_path / "plans" / "completed" / "p2.yaml").write_text("name: p2\n")
+    active = lc.list_plans(PlanState.ACTIVE)
+    assert [p.plan_id for p in active] == ["p1"]
+
+
+def test_list_plans_sorted_alphabetically(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    for name in ("zebra", "alpha", "mike"):
+        (tmp_path / "plans" / "active" / f"{name}.yaml").write_text("x: 1\n")
+    ids = [p.plan_id for p in lc.list_plans(PlanState.ACTIVE)]
+    assert ids == ["alpha", "mike", "zebra"]
+
+
+def test_find_locates_plan_across_buckets(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    (tmp_path / "plans" / "blocked" / "stuck.yaml").write_text("name: stuck\n")
+    found = lc.find("stuck")
+    assert found is not None
+    assert found.state is PlanState.BLOCKED
+    assert found.plan_id == "stuck"
+
+
+def test_find_returns_none_for_missing(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    assert lc.find("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# backfill_unmanaged
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_moves_loose_yaml_into_active(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    (tmp_path / "plans" / "loose.yaml").write_text("name: loose\n")
+    migrated = lc.backfill_unmanaged()
+    assert len(migrated) == 1
+    assert (tmp_path / "plans" / "active" / "loose.yaml").exists()
+    assert not (tmp_path / "plans" / "loose.yaml").exists()
+
+
+def test_backfill_is_idempotent(tmp_path: Path) -> None:
+    lc = PlanLifecycle(tmp_path / "plans")
+    (tmp_path / "plans" / "loose.yaml").write_text("name: loose\n")
+    lc.backfill_unmanaged()
+    # Second run finds nothing loose to move.
+    assert lc.backfill_unmanaged() == []
+
+
+# ---------------------------------------------------------------------------
+# default_lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_default_lifecycle_roots_under_plans(tmp_path: Path) -> None:
+    lc = default_lifecycle(tmp_path)
+    assert lc.root.name == "plans"
+    assert lc.root.is_dir()

--- a/tests/unit/tasks/test_backlog_parser_dag.py
+++ b/tests/unit/tasks/test_backlog_parser_dag.py
@@ -1,0 +1,236 @@
+"""Behavioral tests for the backlog DAG checkbox parser and priority scaling.
+
+The existing ``test_backlog_parser`` suite covers YAML frontmatter and the
+markdown ``**Field:**`` form. This file targets the previously-untested
+surfaces: the ``- [ ] [Txxx] [P] [USn] desc -> deps`` task-line grammar,
+priority-scale normalisation (0-4 ticket scale -> 1-3 internal scale), and
+scope/complexity clamping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.tasks.backlog_parser import (
+    ParsedBacklogTask,
+    _parse_complexity,
+    _parse_priority,
+    _parse_scope,
+    parse_backlog_path,
+    parse_backlog_text,
+    parse_task_line,
+    parse_task_lines,
+)
+
+# ---------------------------------------------------------------------------
+# parse_task_line - the DAG checkbox grammar
+# ---------------------------------------------------------------------------
+
+
+def test_parse_task_line_full_grammar() -> None:
+    parsed = parse_task_line("- [ ] [T001] [P] [US1] Add YAML loader -> T000")
+    assert parsed is not None
+    assert parsed.task_id == "T001"
+    assert parsed.parallel_safe is True
+    assert parsed.story_id == "US1"
+    assert parsed.description == "Add YAML loader"
+    assert parsed.depends_on == ("T000",)
+
+
+def test_parse_task_line_minimal_id_only() -> None:
+    parsed = parse_task_line("- [ ] [T002] Just a task")
+    assert parsed is not None
+    assert parsed.task_id == "T002"
+    assert parsed.parallel_safe is False
+    assert parsed.story_id is None
+    assert parsed.depends_on == ()
+    assert parsed.description == "Just a task"
+
+
+def test_parse_task_line_checked_box_still_parses() -> None:
+    parsed = parse_task_line("- [x] [T003] Completed item")
+    assert parsed is not None
+    assert parsed.task_id == "T003"
+    assert parsed.description == "Completed item"
+
+
+def test_parse_task_line_star_bullet_accepted() -> None:
+    parsed = parse_task_line("* [ ] [T004] Star bullet")
+    assert parsed is not None
+    assert parsed.task_id == "T004"
+
+
+def test_parse_task_line_multiple_dependencies() -> None:
+    parsed = parse_task_line("- [ ] [T005] Build it -> T001, T002, T003")
+    assert parsed is not None
+    assert parsed.depends_on == ("T001", "T002", "T003")
+    assert parsed.description == "Build it"
+
+
+def test_parse_task_line_unicode_arrow_dependency() -> None:
+    parsed = parse_task_line("- [ ] [T006] Wire it → T001")
+    assert parsed is not None
+    assert parsed.depends_on == ("T001",)
+    assert parsed.description == "Wire it"
+
+
+def test_parse_task_line_story_id_is_uppercased() -> None:
+    parsed = parse_task_line("- [ ] [T007] [us2] lowercase story marker")
+    assert parsed is not None
+    assert parsed.story_id == "US2"
+
+
+def test_parse_task_line_markers_in_any_order() -> None:
+    parsed = parse_task_line("- [ ] [US3] [P] [T008] reordered markers")
+    assert parsed is not None
+    assert parsed.task_id == "T008"
+    assert parsed.parallel_safe is True
+    assert parsed.story_id == "US3"
+
+
+def test_parse_task_line_prose_returns_none() -> None:
+    assert parse_task_line("This is just a paragraph of prose.") is None
+
+
+def test_parse_task_line_checkbox_without_task_id_returns_none() -> None:
+    # A checkbox line that lacks a [Txxx] marker is not a DAG task row.
+    assert parse_task_line("- [ ] just some description, no id") is None
+
+
+def test_parse_task_line_blank_returns_none() -> None:
+    assert parse_task_line("    ") is None
+
+
+def test_parse_task_line_unknown_marker_stops_consumption() -> None:
+    # An unrecognised bracket token (e.g. [WIP]) stops marker parsing; the
+    # token then becomes part of the description text.
+    parsed = parse_task_line("- [ ] [T009] [WIP] still going")
+    assert parsed is not None
+    assert parsed.task_id == "T009"
+    assert parsed.description == "[WIP] still going"
+
+
+# ---------------------------------------------------------------------------
+# parse_task_lines - whole-document parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_task_lines_skips_non_task_rows() -> None:
+    doc = """# My Plan
+
+Some intro prose.
+
+- [ ] [T001] First task
+- [ ] [T002] Second task -> T001
+- not a checkbox
+- [ ] no id here
+"""
+    rows = parse_task_lines(doc)
+    assert [r.task_id for r in rows] == ["T001", "T002"]
+    assert rows[1].depends_on == ("T001",)
+
+
+def test_parse_task_lines_empty_document_returns_empty_list() -> None:
+    assert parse_task_lines("") == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_priority - 0-4 ticket scale collapses to 1-3 internal scale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (0, 1),  # p0 critical -> 1
+        (1, 1),  # p1 -> 1
+        (2, 2),  # p2 normal -> 2
+        (3, 3),  # p3 -> 3
+        (4, 3),  # p4 future -> 3
+        ("p0", 1),
+        ("p4", 3),
+        ("priority: 2", 2),
+    ],
+)
+def test_parse_priority_scale_collapse(raw: object, expected: int) -> None:
+    assert _parse_priority(raw) == expected
+
+
+def test_parse_priority_non_numeric_defaults_to_two() -> None:
+    assert _parse_priority("high") == 2
+
+
+# ---------------------------------------------------------------------------
+# _parse_scope / _parse_complexity - clamp to known vocabulary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("small", "small"),
+        ("MEDIUM", "medium"),
+        ("  Large ", "large"),
+        ("enormous", "medium"),  # unknown -> default
+        ("", "medium"),
+    ],
+)
+def test_parse_scope_clamps_to_known(raw: str, expected: str) -> None:
+    assert _parse_scope(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("low", "low"),
+        ("HIGH", "high"),
+        (" Medium ", "medium"),
+        ("extreme", "medium"),  # unknown -> default
+        ("", "medium"),
+    ],
+)
+def test_parse_complexity_clamps_to_known(raw: str, expected: str) -> None:
+    assert _parse_complexity(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# parse_backlog_text / parse_backlog_path - whole-file dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_parse_backlog_text_empty_returns_none() -> None:
+    assert parse_backlog_text("f.md", "   \n\n  ") is None
+
+
+def test_parse_backlog_path_missing_file_returns_none(tmp_path: Path) -> None:
+    assert parse_backlog_path(tmp_path / "does-not-exist.md") is None
+
+
+def test_parse_backlog_text_markdown_priority_uses_scale_collapse() -> None:
+    content = "# Title\n\n**Role:** backend\n**Priority:** 0\n**Scope:** large\n"
+    parsed = parse_backlog_text("t.md", content)
+    assert parsed is not None
+    assert parsed.priority == 1  # p0 -> 1
+    assert parsed.scope == "large"
+    assert parsed.role == "backend"
+
+
+def test_parse_backlog_text_yaml_frontmatter_priority_collapse() -> None:
+    content = "---\ntitle: Do thing\nrole: qa\npriority: 4\n---\nBody text.\n"
+    parsed = parse_backlog_text("t.md", content)
+    assert parsed is not None
+    assert isinstance(parsed, ParsedBacklogTask)
+    assert parsed.priority == 3  # p4 -> 3
+    assert parsed.role == "qa"
+
+
+def test_parse_backlog_path_reads_yaml_from_disk(tmp_path: Path) -> None:
+    f = tmp_path / "ticket.md"
+    f.write_text("---\ntitle: From disk\nrole: docs\n---\nDetailed body.\n", encoding="utf-8")
+    parsed = parse_backlog_path(f)
+    assert parsed is not None
+    assert parsed.title == "From disk"
+    assert parsed.role == "docs"
+    assert parsed.source_file == "ticket.md"

--- a/tests/unit/tasks/test_lifecycle_fsm.py
+++ b/tests/unit/tasks/test_lifecycle_fsm.py
@@ -1,0 +1,383 @@
+"""Behavioral tests for the lifecycle FSM kernel (``core/tasks/lifecycle.py``).
+
+Covers ``transition_task`` / ``transition_agent`` legal and illegal moves,
+terminal-state derivation, guard application, the LifecycleEvent payload,
+listener dispatch, idempotency-token handling, and HMAC audit-chain emission.
+
+Idempotency is tracked in a module-global LRU set, so every test that uses a
+``transition_id`` generates a fresh ``uuid4`` to avoid cross-test pollution.
+The audit-log slot is also module-global; the ``audit_capture`` fixture
+restores it to ``None`` after each use.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks import lifecycle as lc
+from bernstein.core.tasks.lifecycle import (
+    AGENT_TRANSITIONS,
+    TASK_TRANSITIONS,
+    TERMINAL_TASK_STATUSES,
+    DuplicateTransitionError,
+    IllegalTransitionError,
+    add_listener,
+    remove_listener,
+    transition_agent,
+    transition_task,
+)
+from bernstein.core.tasks.models import (
+    AbortReason,
+    AgentSession,
+    Task,
+    TaskStatus,
+    TransitionReason,
+)
+
+
+def _task(status: TaskStatus = TaskStatus.OPEN) -> Task:
+    return Task(id="t-fsm", title="T", description="D", role="backend", status=status)
+
+
+def _agent(status: str = "starting") -> AgentSession:
+    return AgentSession(id="a-fsm", role="backend", status=status)  # type: ignore[arg-type]
+
+
+class _FakeAudit:
+    """Minimal audit-log double that records ``log()`` keyword payloads."""
+
+    def __init__(self) -> None:
+        self.entries: list[dict[str, Any]] = []
+
+    def log(self, **kwargs: Any) -> None:
+        self.entries.append(kwargs)
+
+
+@pytest.fixture
+def audit_capture() -> Iterator[_FakeAudit]:
+    """Wire a fake audit log into the module global and restore afterwards."""
+    fake = _FakeAudit()
+    lc.set_audit_log(fake)
+    try:
+        yield fake
+    finally:
+        lc.set_audit_log(None)
+
+
+# ---------------------------------------------------------------------------
+# Legal task transitions
+# ---------------------------------------------------------------------------
+
+
+def test_legal_transition_mutates_status_and_returns_event() -> None:
+    task = _task(TaskStatus.OPEN)
+    event = transition_task(task, TaskStatus.CLAIMED, actor="store", reason="claimed it")
+    assert task.status is TaskStatus.CLAIMED
+    assert event.entity_type == "task"
+    assert event.entity_id == "t-fsm"
+    assert event.from_status == "open"
+    assert event.to_status == "claimed"
+    assert event.actor == "store"
+    assert event.reason == "claimed it"
+
+
+@pytest.mark.parametrize(
+    ("frm", "to"),
+    [
+        (TaskStatus.PLANNED, TaskStatus.OPEN),
+        (TaskStatus.OPEN, TaskStatus.WAITING_FOR_SUBTASKS),
+        (TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS),
+        (TaskStatus.IN_PROGRESS, TaskStatus.DONE),
+        (TaskStatus.DONE, TaskStatus.CLOSED),
+        (TaskStatus.FAILED, TaskStatus.OPEN),  # retry
+        (TaskStatus.BLOCKED, TaskStatus.OPEN),
+        (TaskStatus.ORPHANED, TaskStatus.OPEN),  # crash recovery
+        (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.DONE),
+        (TaskStatus.IN_PROGRESS, TaskStatus.ABANDONED),  # abandon primitive
+        (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.OPEN),  # requeue downstream
+    ],
+)
+def test_documented_legal_transitions_apply(frm: TaskStatus, to: TaskStatus) -> None:
+    task = _task(frm)
+    transition_task(task, to)
+    assert task.status is to
+
+
+# ---------------------------------------------------------------------------
+# Illegal task transitions
+# ---------------------------------------------------------------------------
+
+
+def test_illegal_transition_raises_and_leaves_status_unchanged() -> None:
+    task = _task(TaskStatus.DONE)
+    with pytest.raises(IllegalTransitionError) as exc_info:
+        transition_task(task, TaskStatus.CLAIMED)
+    assert exc_info.value.from_status == "done"
+    assert exc_info.value.to_status == "claimed"
+    assert exc_info.value.entity_type == "task"
+    # The FSM must not mutate on a rejected transition.
+    assert task.status is TaskStatus.DONE
+
+
+@pytest.mark.parametrize(
+    ("frm", "to"),
+    [
+        (TaskStatus.OPEN, TaskStatus.IN_PROGRESS),  # must claim first
+        (TaskStatus.OPEN, TaskStatus.DONE),  # cannot complete unclaimed
+        (TaskStatus.CLOSED, TaskStatus.OPEN),  # closed is terminal
+        (TaskStatus.CANCELLED, TaskStatus.OPEN),  # cancelled is terminal
+        (TaskStatus.DONE, TaskStatus.IN_PROGRESS),
+    ],
+)
+def test_documented_illegal_transitions_rejected(frm: TaskStatus, to: TaskStatus) -> None:
+    task = _task(frm)
+    with pytest.raises(IllegalTransitionError):
+        transition_task(task, to)
+
+
+def test_same_status_self_loop_is_illegal() -> None:
+    # No (X, X) entries exist in the table, so a no-op transition is rejected.
+    task = _task(TaskStatus.OPEN)
+    with pytest.raises(IllegalTransitionError):
+        transition_task(task, TaskStatus.OPEN)
+
+
+# ---------------------------------------------------------------------------
+# Terminal-state derivation
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_statuses_have_no_outbound_transitions() -> None:
+    outbound_sources = {frm for (frm, _to) in TASK_TRANSITIONS}
+    for terminal in TERMINAL_TASK_STATUSES:
+        assert terminal not in outbound_sources
+
+
+def test_closed_and_cancelled_are_terminal() -> None:
+    assert TaskStatus.CLOSED in TERMINAL_TASK_STATUSES
+    assert TaskStatus.CANCELLED in TERMINAL_TASK_STATUSES
+
+
+def test_open_is_not_terminal() -> None:
+    assert TaskStatus.OPEN not in TERMINAL_TASK_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# transition_reason on the event
+# ---------------------------------------------------------------------------
+
+
+def test_transition_reason_is_carried_on_event() -> None:
+    task = _task(TaskStatus.IN_PROGRESS)
+    event = transition_task(task, TaskStatus.DONE, transition_reason=TransitionReason.COMPLETED)
+    assert event.transition_reason is TransitionReason.COMPLETED
+
+
+def test_transition_reason_omitted_is_none_on_event() -> None:
+    task = _task(TaskStatus.IN_PROGRESS)
+    event = transition_task(task, TaskStatus.DONE)
+    assert event.transition_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tokens
+# ---------------------------------------------------------------------------
+
+
+def test_unique_transition_id_is_accepted() -> None:
+    task = _task(TaskStatus.OPEN)
+    event = transition_task(task, TaskStatus.CLAIMED, transition_id=uuid.uuid4().hex)
+    assert event.to_status == "claimed"
+
+
+def test_duplicate_transition_id_raises_and_does_not_mutate() -> None:
+    tid = uuid.uuid4().hex
+    first = _task(TaskStatus.OPEN)
+    transition_task(first, TaskStatus.CLAIMED, transition_id=tid)
+
+    second = _task(TaskStatus.OPEN)
+    with pytest.raises(DuplicateTransitionError) as exc_info:
+        transition_task(second, TaskStatus.CLAIMED, transition_id=tid)
+    assert exc_info.value.transition_id == tid
+    assert second.status is TaskStatus.OPEN
+
+
+def test_no_transition_id_is_never_deduplicated() -> None:
+    # Two separate transitions without ids must both succeed.
+    a = _task(TaskStatus.OPEN)
+    b = _task(TaskStatus.OPEN)
+    transition_task(a, TaskStatus.CLAIMED)
+    transition_task(b, TaskStatus.CLAIMED)
+    assert a.status is TaskStatus.CLAIMED
+    assert b.status is TaskStatus.CLAIMED
+
+
+# ---------------------------------------------------------------------------
+# Listener dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_listener_receives_event_on_transition() -> None:
+    captured: list[Any] = []
+    cb = captured.append
+    add_listener(cb)
+    try:
+        task = _task(TaskStatus.OPEN)
+        transition_task(task, TaskStatus.CANCELLED, actor="op")
+    finally:
+        remove_listener(cb)
+    assert len(captured) == 1
+    assert captured[0].to_status == "cancelled"
+    assert captured[0].actor == "op"
+
+
+def test_listener_exception_does_not_break_transition() -> None:
+    def boom(_event: Any) -> None:
+        raise RuntimeError("listener failure")
+
+    add_listener(boom)
+    try:
+        task = _task(TaskStatus.OPEN)
+        # Listener raises, but the transition still completes.
+        transition_task(task, TaskStatus.CLAIMED)
+    finally:
+        remove_listener(boom)
+    assert task.status is TaskStatus.CLAIMED
+
+
+def test_remove_listener_unknown_callback_is_silent() -> None:
+    # Removing a callback that was never registered must not raise.
+    remove_listener(lambda _e: None)
+
+
+# ---------------------------------------------------------------------------
+# Audit-chain emission
+# ---------------------------------------------------------------------------
+
+
+def test_task_transition_emits_audit_entry(audit_capture: _FakeAudit) -> None:
+    task = _task(TaskStatus.OPEN)
+    transition_task(
+        task,
+        TaskStatus.CLAIMED,
+        actor="store",
+        reason="claim",
+        transition_reason=TransitionReason.RETRY,
+    )
+    assert len(audit_capture.entries) == 1
+    entry = audit_capture.entries[0]
+    assert entry["event_type"] == "task.transition"
+    assert entry["resource_type"] == "task"
+    assert entry["resource_id"] == "t-fsm"
+    details = entry["details"]
+    assert details["action"] == "open->claimed"
+    assert details["from_status"] == "open"
+    assert details["to_status"] == "claimed"
+    assert details["transition_reason"] == "retry"
+
+
+def test_audit_entry_input_and_output_hashes_differ(audit_capture: _FakeAudit) -> None:
+    task = _task(TaskStatus.OPEN)
+    transition_task(task, TaskStatus.CLAIMED)
+    details = audit_capture.entries[0]["details"]
+    # The state before and after the transition hash to different values.
+    assert details["input_hash"] != details["output_hash"]
+    assert len(details["input_hash"]) == 64  # sha256 hex digest
+
+
+def test_illegal_transition_emits_no_audit_entry(audit_capture: _FakeAudit) -> None:
+    task = _task(TaskStatus.DONE)
+    with pytest.raises(IllegalTransitionError):
+        transition_task(task, TaskStatus.CLAIMED)
+    assert audit_capture.entries == []
+
+
+# ---------------------------------------------------------------------------
+# Agent transitions
+# ---------------------------------------------------------------------------
+
+
+def test_agent_legal_transition_sets_status_and_reason() -> None:
+    agent = _agent("starting")
+    event = transition_agent(agent, "working", transition_reason=TransitionReason.COMPLETED)
+    assert agent.status == "working"
+    assert agent.transition_reason is TransitionReason.COMPLETED
+    assert event.entity_type == "agent"
+    assert event.to_status == "working"
+
+
+def test_agent_illegal_transition_raises() -> None:
+    agent = _agent("dead")  # dead is terminal for agents
+    with pytest.raises(IllegalTransitionError) as exc_info:
+        transition_agent(agent, "working")
+    assert exc_info.value.from_status == "dead"
+    assert exc_info.value.to_status == "working"
+    assert agent.status == "dead"
+
+
+def test_agent_death_records_abort_fields() -> None:
+    agent = _agent("working")
+    transition_agent(
+        agent,
+        "dead",
+        abort_reason=AbortReason.TIMEOUT,
+        abort_detail="exceeded wall clock",
+        finish_reason="killed",
+    )
+    assert agent.status == "dead"
+    assert agent.abort_reason is AbortReason.TIMEOUT
+    assert agent.abort_detail == "exceeded wall clock"
+    assert agent.finish_reason == "killed"
+
+
+def test_agent_duplicate_transition_id_rejected() -> None:
+    tid = uuid.uuid4().hex
+    a1 = _agent("starting")
+    transition_agent(a1, "working", transition_id=tid)
+    a2 = _agent("starting")
+    with pytest.raises(DuplicateTransitionError):
+        transition_agent(a2, "working", transition_id=tid)
+    assert a2.status == "starting"
+
+
+def test_agent_transition_emits_audit_entry(audit_capture: _FakeAudit) -> None:
+    agent = _agent("working")
+    transition_agent(
+        agent,
+        "dead",
+        actor="supervisor",
+        abort_reason=AbortReason.OOM,
+        abort_detail="out of memory",
+    )
+    assert len(audit_capture.entries) == 1
+    entry = audit_capture.entries[0]
+    assert entry["event_type"] == "agent.transition"
+    assert entry["details"]["action"] == "working->dead"
+    assert entry["details"]["abort_reason"] == "oom"
+    assert entry["details"]["abort_detail"] == "out of memory"
+
+
+@pytest.mark.parametrize(
+    ("frm", "to"),
+    [
+        ("starting", "working"),
+        ("starting", "dead"),
+        ("working", "idle"),
+        ("working", "dead"),
+        ("idle", "working"),
+        ("idle", "dead"),
+    ],
+)
+def test_documented_agent_transitions_are_legal(frm: str, to: str) -> None:
+    agent = _agent(frm)
+    transition_agent(agent, to)  # type: ignore[arg-type]
+    assert agent.status == to
+
+
+def test_agent_transition_table_has_no_self_loops() -> None:
+    for frm, to in AGENT_TRANSITIONS:
+        assert frm != to

--- a/tests/unit/tasks/test_lifecycle_fsm.py
+++ b/tests/unit/tasks/test_lifecycle_fsm.py
@@ -59,13 +59,19 @@ class _FakeAudit:
 
 @pytest.fixture
 def audit_capture() -> Iterator[_FakeAudit]:
-    """Wire a fake audit log into the module global and restore afterwards."""
+    """Wire a fake audit log into the module global and restore afterwards.
+
+    Captures whatever logger was installed before the test and reinstates it
+    in teardown so randomly-ordered ``tests/unit/**`` runs never clobber
+    preconfigured global state.
+    """
+    prev = lc.get_audit_log()
     fake = _FakeAudit()
     lc.set_audit_log(fake)
     try:
         yield fake
     finally:
-        lc.set_audit_log(None)
+        lc.set_audit_log(prev)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tasks/test_lifecycle_helpers.py
+++ b/tests/unit/tasks/test_lifecycle_helpers.py
@@ -1,0 +1,390 @@
+"""Behavioral tests for pure helper logic in ``task_lifecycle``.
+
+These cover the retry-escalation ladder, dynamic retry limits, batch timeout
+bucketing, file-overlap detection, path inference, decomposition gating, and
+llm-judge routing. All functions under test are pure (no orchestrator, no I/O)
+so each assertion checks a concrete returned value.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from bernstein.core.tasks.models import (
+    AgentSession,
+    CompletionSignal,
+    Complexity,
+    Scope,
+    Task,
+)
+from bernstein.core.tasks.task_lifecycle import (
+    _batch_timeout_seconds,
+    _bump_effort,
+    _choose_retry_escalation,
+    _dynamic_retry_limit,
+    _escalate_model,
+    _has_llm_judge_signal,
+    check_file_overlap,
+    infer_affected_paths,
+    should_auto_decompose,
+)
+
+
+def _task(**overrides: object) -> Task:
+    base: dict[str, object] = {
+        "id": "t-1",
+        "title": "Title",
+        "description": "Description",
+        "role": "backend",
+    }
+    base.update(overrides)
+    return Task(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _bump_effort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [
+        ("low", "medium"),
+        ("medium", "high"),
+        ("high", "max"),
+        ("max", "max"),  # capped at top
+    ],
+)
+def test_bump_effort_walks_ladder(current: str, expected: str) -> None:
+    assert _bump_effort(current) == expected
+
+
+def test_bump_effort_unknown_value_starts_at_high_position() -> None:
+    # Unknown effort defaults to index 2 ("high"), so the next is "max".
+    assert _bump_effort("totally-unknown") == "max"
+
+
+# ---------------------------------------------------------------------------
+# _escalate_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("current", "expected"),
+    [
+        ("haiku", "sonnet"),
+        ("sonnet", "opus"),
+        ("opus", "opus"),  # capped at top
+    ],
+)
+def test_escalate_model_walks_ladder(current: str, expected: str) -> None:
+    assert _escalate_model(current) == expected
+
+
+def test_escalate_model_matches_substring_case_insensitive() -> None:
+    # A fully-qualified model id containing "sonnet" maps to the sonnet rung.
+    assert _escalate_model("claude-3-5-SONNET-latest") == "opus"
+
+
+def test_escalate_model_unknown_defaults_to_sonnet_position() -> None:
+    # No ladder match -> default index 1 (sonnet) -> escalate to opus.
+    assert _escalate_model("gpt-5-mini") == "opus"
+
+
+# ---------------------------------------------------------------------------
+# _choose_retry_escalation
+# ---------------------------------------------------------------------------
+
+
+def test_retry_escalation_max_turns_bumps_effort_keeps_model() -> None:
+    task = _task(terminal_reason="error_max_turns")
+    assert _choose_retry_escalation(task, 1, "sonnet", "medium") == ("sonnet", "high")
+
+
+def test_retry_escalation_max_turns_keeps_effort_when_already_max() -> None:
+    task = _task(terminal_reason="error_max_turns")
+    assert _choose_retry_escalation(task, 1, "sonnet", "max") == ("sonnet", "max")
+
+
+def test_retry_escalation_budget_forces_max_effort() -> None:
+    task = _task(terminal_reason="error_max_budget_usd")
+    assert _choose_retry_escalation(task, 1, "haiku", "low") == ("haiku", "max")
+
+
+def test_retry_escalation_model_error_keeps_both() -> None:
+    task = _task(terminal_reason="model_error")
+    assert _choose_retry_escalation(task, 3, "sonnet", "medium") == ("sonnet", "medium")
+
+
+def test_retry_escalation_blocking_limit_jumps_to_opus_max() -> None:
+    task = _task(terminal_reason="blocking_limit")
+    assert _choose_retry_escalation(task, 1, "haiku", "low") == ("opus", "max")
+
+
+def test_retry_escalation_large_scope_jumps_to_opus_max() -> None:
+    task = _task(scope=Scope.LARGE)
+    assert _choose_retry_escalation(task, 1, "sonnet", "low") == ("opus", "max")
+
+
+@pytest.mark.parametrize("role", ["architect", "security"])
+def test_retry_escalation_high_value_roles_jump_to_opus_max(role: str) -> None:
+    task = _task(role=role)
+    assert _choose_retry_escalation(task, 1, "sonnet", "low") == ("opus", "max")
+
+
+def test_retry_escalation_past_deadline_jumps_to_opus_max() -> None:
+    task = _task(deadline=time.time() - 100)
+    assert _choose_retry_escalation(task, 1, "sonnet", "low") == ("opus", "max")
+
+
+def test_retry_escalation_first_retry_bumps_effort_only() -> None:
+    task = _task()
+    assert _choose_retry_escalation(task, 1, "sonnet", "low") == ("sonnet", "medium")
+
+
+def test_retry_escalation_second_retry_escalates_model_resets_effort_high() -> None:
+    task = _task()
+    assert _choose_retry_escalation(task, 2, "haiku", "low") == ("sonnet", "high")
+
+
+def test_retry_escalation_terminal_reason_takes_precedence_over_scope() -> None:
+    # blocking_limit short-circuits before the LARGE-scope branch is reached;
+    # both would produce ("opus", "max") here, so use model_error to prove it.
+    task = _task(scope=Scope.LARGE, terminal_reason="model_error")
+    # model_error returns current model/effort unchanged, NOT opus/max from scope.
+    assert _choose_retry_escalation(task, 1, "haiku", "low") == ("haiku", "low")
+
+
+# ---------------------------------------------------------------------------
+# _dynamic_retry_limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "Connection timeout after 30s",
+        "HTTP 503 Service Unavailable",
+        "rate limit exceeded",
+        "429 Too Many Requests",
+        "API overloaded, retry later",
+        "transient network error",
+    ],
+)
+def test_dynamic_retry_limit_transient_markers_return_three(reason: str) -> None:
+    # Transient failures get a generous retry budget regardless of the default.
+    assert _dynamic_retry_limit(reason, default_max=0) == 3
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "SyntaxError: invalid syntax",
+        "syntax error in module",
+        "fatal: could not read from remote",
+    ],
+)
+def test_dynamic_retry_limit_fatal_markers_return_zero(reason: str) -> None:
+    # Fatal failures are non-retryable even when the default allows retries.
+    assert _dynamic_retry_limit(reason, default_max=5) == 0
+
+
+def test_dynamic_retry_limit_unknown_reason_uses_default() -> None:
+    assert _dynamic_retry_limit("some unfamiliar failure", default_max=7) == 7
+
+
+def test_dynamic_retry_limit_transient_beats_default_higher() -> None:
+    # Even if default is higher than 3, a transient marker clamps to 3.
+    assert _dynamic_retry_limit("connection refused", default_max=9) == 3
+
+
+# ---------------------------------------------------------------------------
+# _batch_timeout_seconds
+# ---------------------------------------------------------------------------
+
+
+def test_batch_timeout_small_scope_is_15_minutes() -> None:
+    batch = [_task(scope=Scope.SMALL)]
+    assert _batch_timeout_seconds(batch) == 900
+
+
+def test_batch_timeout_medium_scope_is_30_minutes() -> None:
+    batch = [_task(scope=Scope.MEDIUM)]
+    assert _batch_timeout_seconds(batch) == 1800
+
+
+def test_batch_timeout_takes_max_bucket_across_batch() -> None:
+    batch = [_task(scope=Scope.SMALL), _task(scope=Scope.MEDIUM)]
+    assert _batch_timeout_seconds(batch) == 1800
+
+
+def test_batch_timeout_xl_role_promotes_to_xl_timeout() -> None:
+    # An XL role (architect/security/manager) forces the xl bucket.
+    batch = [_task(scope=Scope.SMALL, role="architect")]
+    assert _batch_timeout_seconds(batch) == 7200
+
+
+def test_batch_timeout_large_high_complexity_promotes_to_xl() -> None:
+    batch = [_task(scope=Scope.LARGE, complexity=Complexity.HIGH)]
+    assert _batch_timeout_seconds(batch) == 7200
+
+
+def test_batch_timeout_large_low_complexity_stays_large_bucket() -> None:
+    batch = [_task(scope=Scope.LARGE, complexity=Complexity.LOW)]
+    assert _batch_timeout_seconds(batch) == 3600
+
+
+# ---------------------------------------------------------------------------
+# infer_affected_paths
+# ---------------------------------------------------------------------------
+
+
+def test_infer_affected_paths_extracts_explicit_src_and_test_paths() -> None:
+    task = _task(
+        title="Fix src/bernstein/core/foo.py",
+        description="Also touch tests/unit/test_bar.py please",
+    )
+    assert infer_affected_paths(task) == {
+        "src/bernstein/core/foo.py",
+        "tests/unit/test_bar.py",
+    }
+
+
+def test_infer_affected_paths_empty_when_no_paths_mentioned() -> None:
+    task = _task(title="Refactor the planner", description="No file paths here.")
+    assert infer_affected_paths(task) == set()
+
+
+def test_infer_affected_paths_does_not_double_count_qualified_path() -> None:
+    # The bare-name resolver skips a name already present as a full path.
+    task = _task(title="Edit src/bernstein/core/defaults.py", description="defaults.py")
+    paths = infer_affected_paths(task)
+    assert "src/bernstein/core/defaults.py" in paths
+    # The bare "defaults.py" must not add a second, different entry.
+    assert all(p.endswith("defaults.py") for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# check_file_overlap
+# ---------------------------------------------------------------------------
+
+
+def _agent(agent_id: str, status: str = "working") -> AgentSession:
+    sess = AgentSession(id=agent_id, role="backend")
+    sess.status = status  # type: ignore[assignment]
+    return sess
+
+
+def test_check_file_overlap_detects_conflict_with_live_agent() -> None:
+    task = _task(owned_files=["src/a.py"])
+    ownership = {"src/a.py": "agent-1"}
+    agents = {"agent-1": _agent("agent-1", "working")}
+    assert check_file_overlap([task], ownership, agents) is True
+
+
+def test_check_file_overlap_ignores_dead_agent_ownership() -> None:
+    task = _task(owned_files=["src/a.py"])
+    ownership = {"src/a.py": "agent-1"}
+    agents = {"agent-1": _agent("agent-1", "dead")}
+    assert check_file_overlap([task], ownership, agents) is False
+
+
+def test_check_file_overlap_no_conflict_when_files_disjoint() -> None:
+    task = _task(owned_files=["src/b.py"])
+    ownership = {"src/a.py": "agent-1"}
+    agents = {"agent-1": _agent("agent-1", "working")}
+    assert check_file_overlap([task], ownership, agents) is False
+
+
+def test_check_file_overlap_missing_owner_session_is_not_conflict() -> None:
+    # File owned by an agent that is no longer in the agents dict -> no conflict.
+    task = _task(owned_files=["src/a.py"])
+    ownership = {"src/a.py": "ghost-agent"}
+    agents: dict[str, AgentSession] = {}
+    assert check_file_overlap([task], ownership, agents) is False
+
+
+def test_check_file_overlap_uses_inferred_paths_from_text() -> None:
+    # No explicit owned_files, but the description names a file owned by a live agent.
+    task = _task(description="please edit src/bernstein/core/foo.py")
+    ownership = {"src/bernstein/core/foo.py": "agent-1"}
+    agents = {"agent-1": _agent("agent-1", "working")}
+    assert check_file_overlap([task], ownership, agents) is True
+
+
+# ---------------------------------------------------------------------------
+# should_auto_decompose
+# ---------------------------------------------------------------------------
+
+
+def test_should_auto_decompose_disabled_without_force_parallel() -> None:
+    task = _task(scope=Scope.LARGE)
+    assert should_auto_decompose(task, set(), force_parallel=False) is False
+
+
+def test_should_auto_decompose_large_scope_when_forced() -> None:
+    task = _task(scope=Scope.LARGE)
+    assert should_auto_decompose(task, set(), force_parallel=True) is True
+
+
+def test_should_auto_decompose_small_scope_no_retries_is_false() -> None:
+    task = _task(scope=Scope.SMALL, retry_count=0)
+    assert should_auto_decompose(task, set(), force_parallel=True) is False
+
+
+def test_should_auto_decompose_two_retries_triggers() -> None:
+    task = _task(scope=Scope.SMALL, retry_count=2)
+    assert should_auto_decompose(task, set(), force_parallel=True) is True
+
+
+def test_should_auto_decompose_skips_already_decomposed() -> None:
+    task = _task(id="dt-1", scope=Scope.LARGE)
+    assert should_auto_decompose(task, {"dt-1"}, force_parallel=True) is False
+
+
+def test_should_auto_decompose_skips_decompose_prefixed_title() -> None:
+    task = _task(scope=Scope.LARGE, title="[DECOMPOSE] subtask body")
+    assert should_auto_decompose(task, set(), force_parallel=True) is False
+
+
+def test_should_auto_decompose_reads_legacy_retry_prefix_when_count_zero() -> None:
+    # Pre-migration tasks carry "[RETRY N]" in the title with retry_count==0.
+    task = _task(scope=Scope.SMALL, retry_count=0, title="[RETRY 2] do the thing")
+    assert should_auto_decompose(task, set(), force_parallel=True) is True
+
+
+def test_should_auto_decompose_legacy_retry_one_is_not_enough() -> None:
+    task = _task(scope=Scope.SMALL, retry_count=0, title="[RETRY 1] do the thing")
+    assert should_auto_decompose(task, set(), force_parallel=True) is False
+
+
+# ---------------------------------------------------------------------------
+# _has_llm_judge_signal
+# ---------------------------------------------------------------------------
+
+
+def test_has_llm_judge_signal_true_when_present() -> None:
+    task = _task(completion_signals=[CompletionSignal(type="llm_judge", value="review")])
+    assert _has_llm_judge_signal(task) is True
+
+
+def test_has_llm_judge_signal_false_for_other_signal_types() -> None:
+    task = _task(completion_signals=[CompletionSignal(type="path_exists", value="x")])
+    assert _has_llm_judge_signal(task) is False
+
+
+def test_has_llm_judge_signal_false_when_no_signals() -> None:
+    task = _task(completion_signals=[])
+    assert _has_llm_judge_signal(task) is False
+
+
+def test_has_llm_judge_signal_true_when_mixed_with_others() -> None:
+    task = _task(
+        completion_signals=[
+            CompletionSignal(type="path_exists", value="x"),
+            CompletionSignal(type="llm_judge", value="review"),
+        ]
+    )
+    assert _has_llm_judge_signal(task) is True

--- a/tests/unit/tasks/test_lifecycle_orch_helpers.py
+++ b/tests/unit/tasks/test_lifecycle_orch_helpers.py
@@ -1,0 +1,150 @@
+"""Behavioral tests for orchestrator-facing helpers in ``task_lifecycle``.
+
+``evict_degraded_sessions`` is exercised against a duck-typed orchestrator
+stub (detector / agents / recovery store / signal manager). The permission
+helper is tested for its retry-decision logic and degraded (no-hint) path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from bernstein.core.tasks.models import AgentSession
+from bernstein.core.tasks.task_lifecycle import (
+    evict_degraded_sessions,
+    handle_permission_denied_error,
+)
+
+
+class _Checkpoint:
+    def __init__(self) -> None:
+        self.task_ids = ["t1", "t2"]
+        self.recovery_context = "recover me"
+        self.consecutive_rejects = 3
+        self.verdict_count = 3
+
+
+class _Detector:
+    def __init__(self, degraded: list[str]) -> None:
+        self._degraded = degraded
+        self.cleared: list[str] = []
+        self.raise_on_checkpoint = False
+
+    def degraded_sessions(self) -> list[str]:
+        return list(self._degraded)
+
+    def checkpoint(self, _session: Any) -> _Checkpoint:
+        if self.raise_on_checkpoint:
+            raise RuntimeError("checkpoint failed")
+        return _Checkpoint()
+
+    def clear(self, session_id: str) -> None:
+        self.cleared.append(session_id)
+
+
+class _SignalMgr:
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str, str]] = []
+
+    def write_shutdown(self, session_id: str, *, reason: str = "", task_title: str = "") -> None:
+        self.writes.append((session_id, reason, task_title))
+
+
+def _agent(status: str = "working") -> AgentSession:
+    return AgentSession(id="sess-1", role="backend", status=status)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# evict_degraded_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_evict_returns_empty_when_detector_disabled() -> None:
+    orch = SimpleNamespace(_context_degradation=None)
+    assert evict_degraded_sessions(orch) == []
+
+
+def test_evict_checkpoints_alive_session_and_signals_shutdown() -> None:
+    detector = _Detector(["sess-1"])
+    signal_mgr = _SignalMgr()
+    recovery: dict[str, str] = {}
+    orch = SimpleNamespace(
+        _context_degradation=detector,
+        _agents={"sess-1": _agent("working")},
+        _context_recovery=recovery,
+        _signal_mgr=signal_mgr,
+    )
+    evicted = evict_degraded_sessions(orch)
+    assert evicted == ["sess-1"]
+    # Recovery context stashed for every task the session owned.
+    assert recovery["t1"] == "recover me"
+    assert recovery["t2"] == "recover me"
+    # SHUTDOWN signal written with the degradation reason.
+    assert signal_mgr.writes == [("sess-1", "context_degradation", "t1, t2")]
+    # Detector state cleared after eviction.
+    assert detector.cleared == ["sess-1"]
+
+
+def test_evict_skips_dead_session_but_clears_tracking() -> None:
+    detector = _Detector(["sess-1"])
+    orch = SimpleNamespace(
+        _context_degradation=detector,
+        _agents={"sess-1": _agent("dead")},
+        _context_recovery={},
+        _signal_mgr=_SignalMgr(),
+    )
+    assert evict_degraded_sessions(orch) == []
+    assert detector.cleared == ["sess-1"]
+
+
+def test_evict_skips_missing_session_but_clears_tracking() -> None:
+    detector = _Detector(["sess-1"])
+    orch = SimpleNamespace(
+        _context_degradation=detector,
+        _agents={},  # session no longer present
+        _context_recovery={},
+        _signal_mgr=_SignalMgr(),
+    )
+    assert evict_degraded_sessions(orch) == []
+    assert detector.cleared == ["sess-1"]
+
+
+def test_evict_clears_tracking_when_checkpoint_raises() -> None:
+    detector = _Detector(["sess-1"])
+    detector.raise_on_checkpoint = True
+    orch = SimpleNamespace(
+        _context_degradation=detector,
+        _agents={"sess-1": _agent("working")},
+        _context_recovery={},
+        _signal_mgr=_SignalMgr(),
+    )
+    # A checkpoint failure must not evict, but must clear tracking state.
+    assert evict_degraded_sessions(orch) == []
+    assert detector.cleared == ["sess-1"]
+
+
+# ---------------------------------------------------------------------------
+# handle_permission_denied_error
+# ---------------------------------------------------------------------------
+
+
+def test_permission_denied_with_hint_allows_retry_under_limit() -> None:
+    result = handle_permission_denied_error("Permission denied for Edit tool", "t1", "backend", 0)
+    assert result["permission_denied"] is True
+    assert result["hint"] is not None
+    assert result["should_retry"] is True
+    assert result["max_retries"] == 2
+
+
+def test_permission_denied_with_hint_blocks_retry_at_limit() -> None:
+    result = handle_permission_denied_error("Permission denied for Edit tool", "t1", "backend", 2)
+    assert result["should_retry"] is False
+
+
+def test_permission_denied_without_hint_does_not_retry() -> None:
+    # A message with no recognised hint pattern routes to the no-hint branch.
+    result = handle_permission_denied_error("totally unrecognised failure text", "t1", "backend", 0)
+    assert result["permission_denied"] is True
+    assert result["hint"] is None
+    assert result["should_retry"] is False

--- a/tests/unit/tasks/test_models_serialization.py
+++ b/tests/unit/tasks/test_models_serialization.py
@@ -1,0 +1,336 @@
+"""Behavioral tests for task-model validation and serialization round-trips.
+
+Covers the previously-untested logic paths in ``core/tasks/models.py``:
+``Task.from_dict`` coercions, ``_normalize_attachments`` guards,
+``ApprovalSpec`` validation, the cost-model and plan round-trips, and the
+small predicate helpers (``ProgressSnapshot.is_same_progress``,
+``NodeInfo.is_alive``, ``ClusterConfig.cluster_url_scheme``,
+``OrchestratorConfig.__post_init__``).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from bernstein.core.tasks.models import (
+    AgentCostSummary,
+    ApprovalSpec,
+    ClusterConfig,
+    ModelCostBreakdown,
+    NodeInfo,
+    OrchestratorConfig,
+    PlanStatus,
+    ProgressSnapshot,
+    RunCostProjection,
+    RunCostReport,
+    Scope,
+    Task,
+    TaskCostEstimate,
+    TaskPlan,
+    TaskStatus,
+    TaskType,
+    _normalize_attachments,
+)
+
+# ---------------------------------------------------------------------------
+# Task.from_dict
+# ---------------------------------------------------------------------------
+
+
+def test_task_from_dict_minimal_applies_defaults() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend"})
+    assert task.status is TaskStatus.OPEN
+    assert task.scope is Scope.MEDIUM
+    assert task.priority == 2
+    assert task.task_type is TaskType.STANDARD
+    assert task.estimated_minutes == 30
+
+
+def test_task_from_dict_invalid_task_type_falls_back_to_standard() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "task_type": "bogus"})
+    assert task.task_type is TaskType.STANDARD
+
+
+def test_task_from_dict_batch_eligible_none_preserved() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "batch_eligible": None})
+    assert task.batch_eligible is None
+
+
+def test_task_from_dict_batch_eligible_truthy_coerced_to_bool() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "batch_eligible": 1})
+    assert task.batch_eligible is True
+
+
+def test_task_from_dict_empty_tenant_id_defaults() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "tenant_id": ""})
+    assert task.tenant_id == "default"
+
+
+def test_task_from_dict_falsy_story_id_becomes_none() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "story_id": ""})
+    assert task.story_id is None
+
+
+def test_task_from_dict_truthy_story_id_kept_as_string() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "story_id": 5})
+    assert task.story_id == "5"
+
+
+def test_task_from_dict_skips_malformed_completion_signal() -> None:
+    task = Task.from_dict(
+        {
+            "id": "x",
+            "title": "T",
+            "description": "D",
+            "role": "backend",
+            "completion_signals": [
+                {"type": "path_exists", "value": "out.txt"},
+                {"type": "path_exists"},  # missing value -> skipped
+            ],
+        }
+    )
+    assert len(task.completion_signals) == 1
+    assert task.completion_signals[0].value == "out.txt"
+
+
+def test_task_from_dict_best_of_n_coercion() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "best_of_n": "3"})
+    assert task.best_of_n == 3
+
+
+def test_task_from_dict_best_of_n_none_preserved() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "best_of_n": None})
+    assert task.best_of_n is None
+
+
+def test_task_from_dict_status_round_trips_from_enum_value() -> None:
+    task = Task.from_dict({"id": "x", "title": "T", "description": "D", "role": "backend", "status": "blocked"})
+    assert task.status is TaskStatus.BLOCKED
+
+
+def test_task_from_dict_parses_approval_spec() -> None:
+    task = Task.from_dict(
+        {
+            "id": "x",
+            "title": "T",
+            "description": "D",
+            "role": "backend",
+            "approval_spec": {"prompt": "approve?", "timeout_seconds": 60, "default_action": "approve"},
+        }
+    )
+    assert task.approval_spec is not None
+    assert task.approval_spec.prompt == "approve?"
+    assert task.approval_spec.default_action == "approve"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_attachments
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_attachments_none_returns_empty() -> None:
+    assert _normalize_attachments(None) == []
+
+
+def test_normalize_attachments_coerces_list_elements_to_str() -> None:
+    assert _normalize_attachments(["a.png", 1]) == ["a.png", "1"]
+
+
+def test_normalize_attachments_tuple_accepted() -> None:
+    assert _normalize_attachments(("a.png", "b.png")) == ["a.png", "b.png"]
+
+
+def test_normalize_attachments_rejects_bare_string() -> None:
+    with pytest.raises(TypeError, match="list of paths"):
+        _normalize_attachments("diagram.png")
+
+
+def test_normalize_attachments_rejects_scalar() -> None:
+    with pytest.raises(TypeError, match="list of paths"):
+        _normalize_attachments(123)
+
+
+# ---------------------------------------------------------------------------
+# ApprovalSpec
+# ---------------------------------------------------------------------------
+
+
+def test_approval_spec_empty_prompt_raises() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        ApprovalSpec(prompt="   ")
+
+
+def test_approval_spec_non_positive_timeout_raises() -> None:
+    with pytest.raises(ValueError, match="> 0"):
+        ApprovalSpec(prompt="ok", timeout_seconds=0)
+
+
+def test_approval_spec_defaults() -> None:
+    spec = ApprovalSpec(prompt="proceed?")
+    assert spec.timeout_seconds == 86_400
+    assert spec.default_action == "reject"
+
+
+def test_approval_spec_round_trip() -> None:
+    spec = ApprovalSpec(prompt="proceed?", timeout_seconds=120, default_action="approve")
+    assert ApprovalSpec.from_dict(spec.to_dict()) == spec
+
+
+def test_approval_spec_from_dict_rejects_bad_action() -> None:
+    with pytest.raises(ValueError, match="reject\\|approve\\|fail"):
+        ApprovalSpec.from_dict({"prompt": "ok", "default_action": "maybe"})
+
+
+# ---------------------------------------------------------------------------
+# ProgressSnapshot.is_same_progress
+# ---------------------------------------------------------------------------
+
+
+def test_progress_snapshot_same_ignores_timestamp_and_file() -> None:
+    a = ProgressSnapshot(timestamp=1.0, files_changed=3, tests_passing=10, errors=0, last_file="a.py")
+    b = ProgressSnapshot(timestamp=2.0, files_changed=3, tests_passing=10, errors=0, last_file="b.py")
+    assert a.is_same_progress(b) is True
+
+
+def test_progress_snapshot_different_when_files_changed_differs() -> None:
+    a = ProgressSnapshot(timestamp=1.0, files_changed=3)
+    b = ProgressSnapshot(timestamp=1.0, files_changed=4)
+    assert a.is_same_progress(b) is False
+
+
+def test_progress_snapshot_different_when_errors_differ() -> None:
+    a = ProgressSnapshot(timestamp=1.0, files_changed=3, errors=0)
+    b = ProgressSnapshot(timestamp=1.0, files_changed=3, errors=1)
+    assert a.is_same_progress(b) is False
+
+
+# ---------------------------------------------------------------------------
+# NodeInfo.is_alive
+# ---------------------------------------------------------------------------
+
+
+def test_node_is_alive_recent_heartbeat() -> None:
+    node = NodeInfo(last_heartbeat=time.time())
+    assert node.is_alive() is True
+
+
+def test_node_is_alive_stale_beyond_timeout() -> None:
+    node = NodeInfo(last_heartbeat=time.time() - 100)
+    assert node.is_alive(timeout_s=60.0) is False
+
+
+def test_node_is_alive_within_extended_timeout() -> None:
+    node = NodeInfo(last_heartbeat=time.time() - 100)
+    assert node.is_alive(timeout_s=200.0) is True
+
+
+# ---------------------------------------------------------------------------
+# ClusterConfig.cluster_url_scheme
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_url_scheme_http_without_tls() -> None:
+    assert ClusterConfig().cluster_url_scheme == "http"
+
+
+# ---------------------------------------------------------------------------
+# OrchestratorConfig.__post_init__
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_config_dict_approval_parsed_into_workflow() -> None:
+    cfg = OrchestratorConfig(approval={"enabled": False, "high_risk": "pr"})  # type: ignore[arg-type]
+    assert cfg.approval == "workflow"
+    assert cfg.approval_workflow.enabled is False
+    assert cfg.approval_workflow.high_risk == "pr"
+
+
+def test_orchestrator_config_string_approval_unchanged() -> None:
+    cfg = OrchestratorConfig(approval="auto")
+    assert cfg.approval == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Cost-model and plan round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_model_cost_breakdown_round_trip() -> None:
+    mcb = ModelCostBreakdown(
+        model="opus",
+        total_cost_usd=1.5,
+        total_tokens=1000,
+        invocation_count=3,
+        input_tokens=600,
+        output_tokens=400,
+        cache_read_tokens=50,
+        cache_write_tokens=25,
+    )
+    assert ModelCostBreakdown.from_dict(mcb.to_dict()) == mcb
+
+
+def test_task_plan_round_trip_preserves_estimates_and_status() -> None:
+    plan = TaskPlan(
+        id="p1",
+        goal="ship it",
+        task_estimates=[TaskCostEstimate(task_id="t1", title="Title", role="backend", risk_reasons=["complex"])],
+        total_estimated_cost_usd=1.25,
+        total_estimated_minutes=45,
+        high_risk_tasks=["t1"],
+        status=PlanStatus.APPROVED,
+        decided_at=5.0,
+        decision_reason="looks fine",
+    )
+    restored = TaskPlan.from_dict(plan.to_dict())
+    assert restored.id == "p1"
+    assert restored.status is PlanStatus.APPROVED
+    assert len(restored.task_estimates) == 1
+    assert restored.task_estimates[0].risk_reasons == ["complex"]
+    assert restored.high_risk_tasks == ["t1"]
+    assert restored.decision_reason == "looks fine"
+
+
+def test_run_cost_report_round_trip_with_projection() -> None:
+    report = RunCostReport(
+        run_id="r1",
+        total_spent_usd=2.0,
+        budget_usd=10.0,
+        per_agent=[AgentCostSummary(agent_id="a1", total_cost_usd=2.0, task_count=1, model_breakdown={"opus": 2.0})],
+        per_model=[ModelCostBreakdown(model="opus", total_cost_usd=2.0, total_tokens=100, invocation_count=1)],
+        projection=RunCostProjection(
+            run_id="r1",
+            tasks_done=1,
+            tasks_remaining=1,
+            current_cost_usd=2.0,
+            projected_total_usd=4.0,
+            avg_cost_per_task_usd=2.0,
+            budget_usd=10.0,
+            within_budget=True,
+            confidence=0.5,
+        ),
+        timestamp=9.0,
+        cache_savings_usd=0.5,
+    )
+    restored = RunCostReport.from_dict(report.to_dict())
+    assert restored.run_id == "r1"
+    assert restored.total_spent_usd == 2.0
+    assert restored.projection is not None
+    assert restored.projection.projected_total_usd == 4.0
+    assert restored.per_agent[0].agent_id == "a1"
+    assert restored.cache_savings_usd == 0.5
+
+
+def test_run_cost_report_round_trip_without_projection() -> None:
+    report = RunCostReport(
+        run_id="r2",
+        total_spent_usd=0.0,
+        budget_usd=0.0,
+        per_agent=[],
+        per_model=[],
+        projection=None,
+    )
+    restored = RunCostReport.from_dict(report.to_dict())
+    assert restored.projection is None
+    assert restored.per_agent == []

--- a/tests/unit/tasks/test_models_serialization.py
+++ b/tests/unit/tasks/test_models_serialization.py
@@ -315,11 +315,11 @@ def test_run_cost_report_round_trip_with_projection() -> None:
     )
     restored = RunCostReport.from_dict(report.to_dict())
     assert restored.run_id == "r1"
-    assert restored.total_spent_usd == 2.0
+    assert restored.total_spent_usd == pytest.approx(2.0)
     assert restored.projection is not None
-    assert restored.projection.projected_total_usd == 4.0
+    assert restored.projection.projected_total_usd == pytest.approx(4.0)
     assert restored.per_agent[0].agent_id == "a1"
-    assert restored.cache_savings_usd == 0.5
+    assert restored.cache_savings_usd == pytest.approx(0.5)
 
 
 def test_run_cost_report_round_trip_without_projection() -> None:

--- a/tests/unit/tasks/test_spawn_bridge.py
+++ b/tests/unit/tasks/test_spawn_bridge.py
@@ -1,0 +1,234 @@
+"""Behavioral tests for ``task_spawn_bridge`` conflict + decomposition wiring.
+
+These exercise the HTTP-backed task-creation helpers with a stubbed
+``httpx.Client`` so the POST body shape, priority bump, success-path return
+value, side-effect mutation, and HTTP-error degradation are all observable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+
+from bernstein.core.tasks.models import Scope, Task
+from bernstein.core.tasks.task_spawn_bridge import (
+    auto_decompose_task,
+    create_conflict_resolution_task,
+    should_auto_decompose,
+)
+
+
+def _task(**overrides: object) -> Task:
+    base: dict[str, object] = {
+        "id": "abc123",
+        "title": "Big task",
+        "description": "A large body of work",
+        "role": "backend",
+        "priority": 2,
+    }
+    base.update(overrides)
+    return Task(**base)  # type: ignore[arg-type]
+
+
+def _ok_client(returned_id: str) -> MagicMock:
+    client = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"id": returned_id}
+    resp.raise_for_status.return_value = None
+    client.post.return_value = resp
+    return client
+
+
+def _last_post_body(client: MagicMock) -> dict[str, Any]:
+    _, kwargs = client.post.call_args
+    return kwargs["json"]
+
+
+# ---------------------------------------------------------------------------
+# should_auto_decompose (separate copy living in the bridge module)
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_should_auto_decompose_requires_force_parallel() -> None:
+    assert should_auto_decompose(_task(scope=Scope.LARGE), set(), force_parallel=False) is False
+
+
+def test_bridge_should_auto_decompose_large_when_forced() -> None:
+    assert should_auto_decompose(_task(scope=Scope.LARGE), set(), force_parallel=True) is True
+
+
+def test_bridge_should_auto_decompose_legacy_retry_prefix() -> None:
+    task = _task(scope=Scope.SMALL, retry_count=0, title="[RETRY 3] redo")
+    assert should_auto_decompose(task, set(), force_parallel=True) is True
+
+
+def test_bridge_should_auto_decompose_skips_decompose_prefix() -> None:
+    task = _task(scope=Scope.LARGE, title="[DECOMPOSE] already planning")
+    assert should_auto_decompose(task, set(), force_parallel=True) is False
+
+
+# ---------------------------------------------------------------------------
+# create_conflict_resolution_task
+# ---------------------------------------------------------------------------
+
+
+def test_create_conflict_task_posts_resolver_body_and_returns_id() -> None:
+    client = _ok_client("resolver-9")
+    rid = create_conflict_resolution_task(
+        _task(),
+        ["src/a.py", "src/b.py"],
+        client=client,
+        server_url="http://srv",
+        session_id="sess-1",
+    )
+    assert rid == "resolver-9"
+    url_args, _ = client.post.call_args
+    assert url_args[0] == "http://srv/tasks"
+    body = _last_post_body(client)
+    assert body["role"] == "resolver"
+    assert body["title"] == "[CONFLICT] Big task"
+    assert body["owned_files"] == ["src/a.py", "src/b.py"]
+
+
+def test_create_conflict_task_bumps_priority_one_step() -> None:
+    client = _ok_client("r1")
+    create_conflict_resolution_task(
+        _task(priority=3),
+        ["src/a.py"],
+        client=client,
+        server_url="http://srv",
+        session_id="s",
+    )
+    assert _last_post_body(client)["priority"] == 2  # 3 -> 2
+
+
+def test_create_conflict_task_priority_floor_is_one() -> None:
+    client = _ok_client("r1")
+    create_conflict_resolution_task(
+        _task(priority=1),
+        ["src/a.py"],
+        client=client,
+        server_url="http://srv",
+        session_id="s",
+    )
+    assert _last_post_body(client)["priority"] == 1  # max(1, 1-1) == 1
+
+
+def test_create_conflict_task_embeds_files_in_description() -> None:
+    client = _ok_client("r1")
+    create_conflict_resolution_task(
+        _task(),
+        ["src/x.py", "src/y.py"],
+        client=client,
+        server_url="http://srv",
+        session_id="s",
+    )
+    desc = _last_post_body(client)["description"]
+    assert "- src/x.py" in desc
+    assert "- src/y.py" in desc
+
+
+def test_create_conflict_task_returns_none_on_http_error() -> None:
+    client = MagicMock()
+    client.post.side_effect = httpx.HTTPError("connection reset")
+    rid = create_conflict_resolution_task(
+        _task(),
+        ["src/a.py"],
+        client=client,
+        server_url="http://srv",
+        session_id="s",
+    )
+    assert rid is None
+
+
+def test_create_conflict_task_defaults_missing_id_to_question_mark() -> None:
+    client = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {}  # server omitted "id"
+    resp.raise_for_status.return_value = None
+    client.post.return_value = resp
+    rid = create_conflict_resolution_task(
+        _task(),
+        ["src/a.py"],
+        client=client,
+        server_url="http://srv",
+        session_id="s",
+    )
+    assert rid == "?"
+
+
+# ---------------------------------------------------------------------------
+# auto_decompose_task (no-workdir planner fallback path)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_decompose_creates_planner_task_without_workdir() -> None:
+    client = _ok_client("planner-1")
+    seen: set[str] = set()
+    auto_decompose_task(
+        _task(),
+        client=client,
+        server_url="http://srv",
+        decomposed_task_ids=seen,
+        workdir=None,
+    )
+    body = _last_post_body(client)
+    assert body["role"] == "manager"
+    assert body["title"] == "[DECOMPOSE] Big task"
+    assert body["model"] == "haiku"
+    assert body["effort"] == "high"
+
+
+def test_auto_decompose_marks_task_decomposed_on_success() -> None:
+    client = _ok_client("planner-1")
+    seen: set[str] = set()
+    auto_decompose_task(
+        _task(id="task-77"),
+        client=client,
+        server_url="http://srv",
+        decomposed_task_ids=seen,
+        workdir=None,
+    )
+    assert "task-77" in seen
+
+
+def test_auto_decompose_bumps_planner_priority() -> None:
+    client = _ok_client("planner-1")
+    auto_decompose_task(
+        _task(priority=3),
+        client=client,
+        server_url="http://srv",
+        decomposed_task_ids=set(),
+        workdir=None,
+    )
+    assert _last_post_body(client)["priority"] == 2  # 3 -> 2
+
+
+def test_auto_decompose_embeds_subtask_marker_in_description() -> None:
+    client = _ok_client("planner-1")
+    auto_decompose_task(
+        _task(id="parent-5"),
+        client=client,
+        server_url="http://srv",
+        decomposed_task_ids=set(),
+        workdir=None,
+    )
+    desc = _last_post_body(client)["description"]
+    assert "[subtask of parent-5]" in desc
+
+
+def test_auto_decompose_http_error_does_not_mark_decomposed() -> None:
+    client = MagicMock()
+    client.post.side_effect = httpx.HTTPError("503")
+    seen: set[str] = set()
+    auto_decompose_task(
+        _task(id="task-err"),
+        client=client,
+        server_url="http://srv",
+        decomposed_task_ids=seen,
+        workdir=None,
+    )
+    # The failed POST must not record the task as decomposed.
+    assert "task-err" not in seen

--- a/tests/unit/tasks/test_splitter_edges.py
+++ b/tests/unit/tasks/test_splitter_edges.py
@@ -1,0 +1,110 @@
+"""Edge-case tests for ``TaskSplitter.split`` beyond the existing happy path.
+
+The shipped suite covers ``should_split`` and the nominal split. These add the
+out-of-range guard, LARGE-scope clamping, the parent-task-id wiring, and the
+wait-for-subtasks parking call, all observable through a stubbed httpx client.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bernstein.core.tasks.models import Complexity, Scope, Task
+from bernstein.core.tasks.task_splitter import TaskSplitter
+
+
+def _parent(**overrides: object) -> Task:
+    base: dict[str, object] = {
+        "id": "parent-1",
+        "title": "Parent",
+        "description": "short",
+        "role": "backend",
+        "estimated_minutes": 90,
+    }
+    base.update(overrides)
+    return Task(**base)  # type: ignore[arg-type]
+
+
+def _subtask(idx: int, scope: Scope = Scope.SMALL) -> Task:
+    return Task(
+        id=f"s{idx}",
+        title=f"Sub {idx}",
+        description=f"do {idx}",
+        role="backend",
+        scope=scope,
+        complexity=Complexity.MEDIUM,
+        estimated_minutes=20,
+        owned_files=[f"f{idx}.py"],
+    )
+
+
+class _Decomposer:
+    def __init__(self, subtasks: list[Task]) -> None:
+        self._subtasks = subtasks
+
+    def decompose_sync(self, task: Task, *, min_subtasks: int = 2, max_subtasks: int = 5) -> list[Task]:
+        return self._subtasks
+
+
+def _ok_client() -> MagicMock:
+    client = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"id": "created"}
+    resp.raise_for_status.return_value = None
+    client.post.return_value = resp
+    return client
+
+
+def _task_posts(client: MagicMock) -> list[dict[str, object]]:
+    return [call.kwargs["json"] for call in client.post.call_args_list if call.args[0].endswith("/tasks")]
+
+
+def test_split_rejects_too_few_subtasks() -> None:
+    splitter = TaskSplitter(client=MagicMock(), server_url="http://srv")
+    with pytest.raises(ValueError, match="expected 2-5"):
+        splitter.split(_parent(), _Decomposer([_subtask(1)]))
+
+
+def test_split_rejects_too_many_subtasks() -> None:
+    splitter = TaskSplitter(client=MagicMock(), server_url="http://srv")
+    too_many = [_subtask(i) for i in range(6)]
+    with pytest.raises(ValueError, match="expected 2-5"):
+        splitter.split(_parent(), _Decomposer(too_many))
+
+
+def test_split_clamps_large_subtask_scope_to_small() -> None:
+    client = _ok_client()
+    splitter = TaskSplitter(client=client, server_url="http://srv")
+    splitter.split(_parent(), _Decomposer([_subtask(1, Scope.LARGE), _subtask(2, Scope.MEDIUM)]))
+    bodies = _task_posts(client)
+    assert bodies[0]["scope"] == "small"  # LARGE clamped down
+    assert bodies[1]["scope"] == "medium"  # MEDIUM preserved
+
+
+def test_split_sets_parent_task_id_on_each_subtask() -> None:
+    client = _ok_client()
+    splitter = TaskSplitter(client=client, server_url="http://srv")
+    splitter.split(_parent(id="P9"), _Decomposer([_subtask(1), _subtask(2)]))
+    for body in _task_posts(client):
+        assert body["parent_task_id"] == "P9"
+
+
+def test_split_returns_created_ids_and_parks_parent() -> None:
+    client = _ok_client()
+    splitter = TaskSplitter(client=client, server_url="http://srv")
+    created = splitter.split(_parent(id="P9"), _Decomposer([_subtask(1), _subtask(2)]))
+    assert created == ["created", "created"]
+    wait_calls = [c for c in client.post.call_args_list if "wait-for-subtasks" in c.args[0]]
+    assert len(wait_calls) == 1
+    assert wait_calls[0].kwargs["json"]["subtask_count"] == 2
+
+
+def test_split_caps_estimated_minutes_at_sixty() -> None:
+    client = _ok_client()
+    splitter = TaskSplitter(client=client, server_url="http://srv")
+    big = _subtask(1)
+    big.estimated_minutes = 999
+    splitter.split(_parent(), _Decomposer([big, _subtask(2)]))
+    assert _task_posts(client)[0]["estimated_minutes"] == 60

--- a/tests/unit/tasks/test_store_core_mutations.py
+++ b/tests/unit/tasks/test_store_core_mutations.py
@@ -1,0 +1,282 @@
+"""Behavioral tests for TaskStore mutation transitions and progress tracking.
+
+Covers ``block`` (FSM precondition + KeyError), ``fail``, ``wait_for_subtasks``,
+``claim_by_id`` optimistic-locking / role-locking / not-open guards,
+``force_claim`` requeue + terminal guard, ``add_progress``, and the snapshot
+ring buffer (``add_snapshot`` / ``get_snapshots``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.lifecycle import IllegalTransitionError
+from bernstein.core.tasks.models import TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+
+
+def _req(**overrides: Any) -> Any:
+    base: dict[str, Any] = {
+        "title": "T",
+        "description": "D",
+        "role": "backend",
+        "priority": 2,
+        "scope": "medium",
+        "complexity": "medium",
+        "estimated_minutes": 30,
+        "depends_on": [],
+        "owned_files": [],
+        "cell_id": None,
+        "task_type": "standard",
+        "upgrade_details": None,
+        "model": None,
+        "effort": None,
+        "batch_eligible": False,
+        "completion_signals": [],
+        "slack_context": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _store(tmp_path: Path) -> TaskStore:
+    return TaskStore(tmp_path / "runtime" / "tasks.jsonl", archive_path=tmp_path / "archive" / "tasks.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_block_open_task_is_illegal_transition(tmp_path: Path) -> None:
+    # OPEN -> BLOCKED is not in the FSM table; block must be reached from
+    # a claimed/in-progress state.
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    with pytest.raises(IllegalTransitionError):
+        await store.block(task.id, "needs human")
+
+
+@pytest.mark.anyio
+async def test_block_claimed_task_succeeds(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    await store.claim_by_id(task.id)
+    blocked = await store.block(task.id, "needs human input")
+    assert blocked.status is TaskStatus.BLOCKED
+    assert blocked.result_summary == "needs human input"
+
+
+@pytest.mark.anyio
+async def test_block_unknown_task_raises_keyerror(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        await store.block("ghost", "x")
+
+
+# ---------------------------------------------------------------------------
+# fail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_fail_moves_to_failed_and_stamps_completion(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    failed = await store.fail(task.id, "compilation error")
+    assert failed.status is TaskStatus.FAILED
+    assert failed.result_summary == "compilation error"
+    assert failed.completed_at is not None
+
+
+@pytest.mark.anyio
+async def test_fail_unknown_task_raises_keyerror(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        await store.fail("ghost", "x")
+
+
+# ---------------------------------------------------------------------------
+# wait_for_subtasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_wait_for_subtasks_sets_waiting_status_and_timestamp(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    waiting = await store.wait_for_subtasks(task.id, 3)
+    assert waiting.status is TaskStatus.WAITING_FOR_SUBTASKS
+    assert waiting.subtask_wait_started_at is not None
+    assert "3 subtasks" in (waiting.result_summary or "")
+
+
+# ---------------------------------------------------------------------------
+# claim_by_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_success_bumps_version(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    version_before = task.version
+    claimed = await store.claim_by_id(task.id, version_before)
+    assert claimed.status is TaskStatus.CLAIMED
+    assert claimed.version == version_before + 1
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_version_conflict_raises(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    with pytest.raises(ValueError, match="Version conflict"):
+        await store.claim_by_id(task.id, expected_version=999)
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_role_mismatch_raises(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req(role="backend"))
+    with pytest.raises(ValueError, match="role mismatch"):
+        await store.claim_by_id(task.id, agent_role="qa")
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_already_claimed_raises(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    await store.claim_by_id(task.id)
+    with pytest.raises(ValueError, match="not open"):
+        await store.claim_by_id(task.id)
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_records_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    claimed = await store.claim_by_id(task.id, claimed_by_session="coord-1")
+    assert claimed.claimed_by_session == "coord-1"
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_unknown_raises_keyerror(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        await store.claim_by_id("ghost")
+
+
+# ---------------------------------------------------------------------------
+# force_claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_force_claim_open_task_sets_priority_zero(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req(priority=3))
+    forced = await store.force_claim(task.id)
+    assert forced.status is TaskStatus.OPEN
+    assert forced.priority == 0
+
+
+@pytest.mark.anyio
+async def test_force_claim_requeues_claimed_task(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    await store.claim_by_id(task.id, claimed_by_session="coord-1")
+    forced = await store.force_claim(task.id)
+    assert forced.status is TaskStatus.OPEN
+    assert forced.priority == 0
+    assert forced.claimed_by_session is None
+    assert forced.claimed_at is None
+
+
+@pytest.mark.anyio
+async def test_force_claim_terminal_task_raises(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    await store.fail(task.id, "broke")
+    with pytest.raises(ValueError, match="terminal state"):
+        await store.force_claim(task.id)
+
+
+# ---------------------------------------------------------------------------
+# add_progress
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_progress_appends_entry(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    updated = await store.add_progress(task.id, "halfway there", 50)
+    assert len(updated.progress_log) == 1
+    assert updated.progress_log[0]["message"] == "halfway there"
+    assert updated.progress_log[0]["percent"] == 50
+
+
+@pytest.mark.anyio
+async def test_add_progress_accumulates_entries(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    await store.add_progress(task.id, "step 1", 25)
+    updated = await store.add_progress(task.id, "step 2", 50)
+    assert len(updated.progress_log) == 2
+
+
+@pytest.mark.anyio
+async def test_add_progress_unknown_task_raises_keyerror(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        await store.add_progress("ghost", "x", 10)
+
+
+# ---------------------------------------------------------------------------
+# add_snapshot / get_snapshots ring buffer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_snapshot_returns_snapshot_and_stores_it(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    snap = store.add_snapshot(task.id, files_changed=2, tests_passing=5, errors=0, last_file="a.py")
+    assert snap.files_changed == 2
+    stored = store.get_snapshots(task.id)
+    assert len(stored) == 1
+    assert stored[0].last_file == "a.py"
+
+
+@pytest.mark.anyio
+async def test_get_snapshots_returns_in_order(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    store.add_snapshot(task.id, files_changed=1, tests_passing=0, errors=0, last_file="a.py")
+    store.add_snapshot(task.id, files_changed=3, tests_passing=0, errors=0, last_file="b.py")
+    snaps = store.get_snapshots(task.id)
+    assert [s.files_changed for s in snaps] == [1, 3]
+
+
+@pytest.mark.anyio
+async def test_snapshot_ring_buffer_keeps_last_ten(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    for i in range(15):
+        store.add_snapshot(task.id, files_changed=i, tests_passing=0, errors=0, last_file=f"f{i}.py")
+    snaps = store.get_snapshots(task.id)
+    assert len(snaps) == 10
+    # The oldest five (0-4) are evicted; the buffer holds 5..14.
+    assert snaps[0].files_changed == 5
+    assert snaps[-1].files_changed == 14
+
+
+@pytest.mark.anyio
+async def test_get_snapshots_unknown_task_returns_empty(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    assert store.get_snapshots("ghost") == []

--- a/tests/unit/tasks/test_store_core_queries.py
+++ b/tests/unit/tasks/test_store_core_queries.py
@@ -271,4 +271,6 @@ async def test_replay_then_recover_requeues_stale_claim(tmp_path: Path) -> None:
     assert replayed is not None
     assert replayed.status is TaskStatus.CLAIMED
     assert fresh.recover_stale_claimed_tasks() == 1
-    assert fresh.get_task(task.id).status is TaskStatus.OPEN  # type: ignore[union-attr]
+    recovered_after_reset = fresh.get_task(task.id)
+    assert recovered_after_reset is not None
+    assert recovered_after_reset.status is TaskStatus.OPEN

--- a/tests/unit/tasks/test_store_core_queries.py
+++ b/tests/unit/tasks/test_store_core_queries.py
@@ -1,0 +1,274 @@
+"""Behavioral tests for TaskStore query/recovery surfaces and cycle detection.
+
+Targets gaps in ``core/tasks/task_store_core.py``: the static cycle detector,
+``list_tasks`` filtering and pagination, ``count_by_status``,
+``count_subtasks``, ``get_task``, ``prioritize``, ``cancel``,
+``recover_stale_claimed_tasks``, and a JSONL persistence round-trip via
+``replay_jsonl``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+
+
+def _req(**overrides: Any) -> Any:
+    base: dict[str, Any] = {
+        "title": "T",
+        "description": "D",
+        "role": "backend",
+        "priority": 2,
+        "scope": "medium",
+        "complexity": "medium",
+        "estimated_minutes": 30,
+        "depends_on": [],
+        "owned_files": [],
+        "cell_id": None,
+        "task_type": "standard",
+        "upgrade_details": None,
+        "model": None,
+        "effort": None,
+        "batch_eligible": False,
+        "completion_signals": [],
+        "slack_context": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _store(tmp_path: Path) -> TaskStore:
+    return TaskStore(tmp_path / "runtime" / "tasks.jsonl", archive_path=tmp_path / "archive" / "tasks.jsonl")
+
+
+def _bare_task(task_id: str, deps: list[str] | None = None) -> Task:
+    return Task(id=task_id, title="T", description="D", role="backend", depends_on=deps or [])
+
+
+# ---------------------------------------------------------------------------
+# _detect_cycle (static, pure)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_cycle_returns_none_for_acyclic_graph() -> None:
+    tasks = {"a": _bare_task("a"), "b": _bare_task("b", ["a"])}
+    new = _bare_task("c", ["b"])
+    assert TaskStore._detect_cycle(tasks, new) is None
+
+
+def test_detect_cycle_flags_self_dependency() -> None:
+    new = _bare_task("d", ["d"])
+    cycle = TaskStore._detect_cycle({}, new)
+    assert cycle is not None
+    assert cycle[0] == cycle[-1] == "d"
+
+
+def test_detect_cycle_flags_indirect_cycle() -> None:
+    # a -> x already exists; inserting x -> a closes the loop.
+    tasks = {"a": _bare_task("a", ["x"])}
+    new = _bare_task("x", ["a"])
+    cycle = TaskStore._detect_cycle(tasks, new)
+    assert cycle is not None
+    assert cycle[0] == cycle[-1]  # cycle path is closed
+
+
+# ---------------------------------------------------------------------------
+# list_tasks filtering and pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_tasks_filters_by_cell(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    await store.create(_req(cell_id="cellA"))
+    await store.create(_req(cell_id="cellB"))
+    assert len(store.list_tasks(cell_id="cellA")) == 1
+
+
+@pytest.mark.anyio
+async def test_list_tasks_filters_by_tenant(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    await store.create(_req(tenant_id="tenant-x"))
+    await store.create(_req(tenant_id="tenant-y"))
+    matches = store.list_tasks(tenant_id="tenant-x")
+    assert len(matches) == 1
+    assert matches[0].tenant_id == "tenant-x"
+
+
+@pytest.mark.anyio
+async def test_list_tasks_invalid_status_returns_empty(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    await store.create(_req())
+    assert store.list_tasks(status="not-a-status") == []
+
+
+@pytest.mark.anyio
+async def test_list_tasks_status_open_excludes_unsatisfied_deps(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    dep = await store.create(_req(title="dep"))
+    # A task whose dependency is not yet DONE is not "open" for claiming.
+    await store.create(_req(title="downstream", depends_on=[dep.id]))
+    open_now = store.list_tasks(status="open")
+    titles = {t.title for t in open_now}
+    assert "dep" in titles
+    assert "downstream" not in titles
+
+
+@pytest.mark.anyio
+async def test_list_tasks_pagination_limit_and_offset(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    for i in range(5):
+        await store.create(_req(title=f"task-{i}"))
+    assert len(store.list_tasks(limit=2)) == 2
+    assert len(store.list_tasks(offset=3)) == 2
+    assert len(store.list_tasks(offset=1, limit=2)) == 2
+
+
+# ---------------------------------------------------------------------------
+# count_by_status / count_subtasks / get_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_count_by_status_tracks_totals(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    await store.create(_req())
+    t2 = await store.create(_req())
+    await store.cancel(t2.id, "drop")
+    counts = store.count_by_status()
+    assert counts["open"] == 1
+    assert counts["cancelled"] == 1
+    assert counts["total"] == 2
+
+
+@pytest.mark.anyio
+async def test_count_subtasks_counts_direct_children(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    parent = await store.create(_req(title="parent"))
+    await store.create(_req(title="c1", parent_task_id=parent.id))
+    await store.create(_req(title="c2", parent_task_id=parent.id))
+    assert store.count_subtasks(parent.id) == 2
+
+
+@pytest.mark.anyio
+async def test_count_subtasks_zero_for_childless_parent(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    lone = await store.create(_req())
+    assert store.count_subtasks(lone.id) == 0
+
+
+@pytest.mark.anyio
+async def test_get_task_returns_none_for_unknown_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    assert store.get_task("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# prioritize / cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_prioritize_sets_priority_zero_and_bumps_version(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req(priority=2))
+    original_version = task.version
+    updated = await store.prioritize(task.id)
+    assert updated.priority == 0
+    assert updated.version == original_version + 1
+
+
+@pytest.mark.anyio
+async def test_prioritize_unknown_task_raises_keyerror(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(KeyError):
+        await store.prioritize("ghost")
+
+
+@pytest.mark.anyio
+async def test_cancel_moves_task_to_cancelled(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    cancelled = await store.cancel(task.id, "no longer needed")
+    assert cancelled.status is TaskStatus.CANCELLED
+    assert cancelled.result_summary is not None
+
+
+# ---------------------------------------------------------------------------
+# recover_stale_claimed_tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_recover_stale_resets_claimed_to_open(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    claimed = await store.claim_next("backend")
+    assert claimed is not None
+    assert claimed.status is TaskStatus.CLAIMED
+
+    reset = store.recover_stale_claimed_tasks()
+    assert reset == 1
+    recovered = store.get_task(task.id)
+    assert recovered is not None
+    assert recovered.status is TaskStatus.OPEN
+    assert recovered.claimed_by_session is None
+    assert recovered.claimed_at is None
+
+
+@pytest.mark.anyio
+async def test_recover_stale_noop_when_nothing_claimed(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    await store.create(_req())
+    assert store.recover_stale_claimed_tasks() == 0
+
+
+# ---------------------------------------------------------------------------
+# JSONL persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_replay_jsonl_reconstructs_tasks_from_log(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    t1 = await store.create(_req(title="alpha", role="qa"))
+    t2 = await store.create(_req(title="beta"))
+    await store.cancel(t2.id, "drop")
+    await store.flush_buffer()
+
+    # A fresh store replaying the same JSONL log must rebuild identical state.
+    fresh = _store(tmp_path)
+    fresh.replay_jsonl()
+    assert len(fresh.list_tasks()) == 2
+    replayed_t1 = fresh.get_task(t1.id)
+    assert replayed_t1 is not None
+    assert replayed_t1.title == "alpha"
+    assert replayed_t1.role == "qa"
+    replayed_t2 = fresh.get_task(t2.id)
+    assert replayed_t2 is not None
+    assert replayed_t2.status is TaskStatus.CANCELLED
+
+
+@pytest.mark.anyio
+async def test_replay_then_recover_requeues_stale_claim(tmp_path: Path) -> None:
+    # Simulate a server kill: create + claim, then a fresh store replays and
+    # recovers the orphaned claim back to OPEN.
+    store = _store(tmp_path)
+    task = await store.create(_req())
+    await store.claim_next("backend")
+    await store.flush_buffer()
+
+    fresh = _store(tmp_path)
+    fresh.replay_jsonl()
+    # The replayed task is CLAIMED with no live agent.
+    replayed = fresh.get_task(task.id)
+    assert replayed is not None
+    assert replayed.status is TaskStatus.CLAIMED
+    assert fresh.recover_stale_claimed_tasks() == 1
+    assert fresh.get_task(task.id).status is TaskStatus.OPEN  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

Test-only PR. Adds 266 behavioral test cases (219 functions across 10 files)
for the tasks and planning subsystems. Every assertion checks a real
observable; no trivially-true assertions, no `src/` edits.

## Coverage before -> after

Measured over a fixed focused test set (`--cov=src/bernstein/core/tasks
--cov=src/bernstein/core/planning`, branch coverage):

| File | Before | After |
|---|---|---|
| `tasks/lifecycle.py` (FSM kernel) | 73% | **95%** |
| `tasks/models.py` | 91% | **99%** |
| `tasks/task_lifecycle.py` | 49% | **55%** |
| `tasks/task_store_core.py` | 71% | **77%** |
| `tasks/task_spawn_bridge.py` | 12% | **69%** |
| `tasks/backlog_parser.py` | 84% | **89%** |
| `tasks/task_splitter.py` | 92% | **95%** |
| `planning/lifecycle.py` | 82% | **85%** |
| **TOTAL (tasks + planning)** | **44%** | **47%** |

## What is covered

- **Lifecycle FSM kernel**: legal + illegal transitions (parametrised over the
  documented transition table), terminal-state derivation, guard application,
  the `LifecycleEvent` payload, listener dispatch + listener-exception
  isolation, idempotency-token de-duplication, and HMAC audit-chain emission
  for both task and agent transitions.
- **task_store_core**: static cycle detection, `list_tasks` filtering
  (cell/tenant/status) + open-dependency exclusion + pagination,
  `count_by_status` / `count_subtasks`, `block`/`fail`/`wait_for_subtasks`,
  `claim_by_id` optimistic-locking + role-locking + not-open guards,
  `force_claim` requeue + terminal guard, `add_progress`, the snapshot ring
  buffer, JSONL persistence round-trip, and stale-claim recovery.
- **task_spawn_bridge**: conflict-resolution and auto-decompose POST body
  shape, priority bumps, side-effect mutation, and HTTP-error degradation.
- **models**: `Task.from_dict` coercions, `_normalize_attachments` guards,
  `ApprovalSpec` validation, cost-model and plan serialization round-trips,
  and the small predicate helpers (`is_same_progress`, `is_alive`,
  `cluster_url_scheme`, `OrchestratorConfig.__post_init__`).
- **backlog_parser**: the `[Txxx] [P] [USn] desc -> deps` DAG grammar,
  0-4 -> 1-3 priority-scale collapse, scope/complexity clamping.
- **task_splitter** edge cases and **planning lifecycle** query helpers + slug
  edge cases.

## Bugs surfaced

None. All asserted behavior matches the existing implementation.

## Test plan

- [x] `uv run pytest tests/unit/tasks tests/unit/planning -q --no-cov --timeout=120` green (350 passed)
- [x] `uv run pytest <new files> -q --no-cov` green (266 passed)
- [x] `uv run ruff check .` clean on new files; `uv run ruff format` clean
- [x] Coverage re-measured before/after (table above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for plan lifecycle management, state transitions, and model serialization.
  * Added comprehensive test suites for backlog parsing, task decomposition, and conflict resolution.
  * Introduced tests for task store operations including mutations, queries, and recovery.
  * Enhanced orchestrator helper test coverage for session management and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->