### PR TITLE
feat(ci): coverage ratchet to drive monotonic test-coverage growth

### DIFF
--- a/.coverage-baseline.json
+++ b/.coverage-baseline.json
@@ -1,0 +1,5 @@
+{
+  "diff_coverage_floor_percent": 85,
+  "total_coverage_percent": 77.51,
+  "updated_at": "2026-05-21T22:42:39+00:00"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1059,8 +1059,19 @@ jobs:
           uv run mutmut results || true
 
   diff-coverage:
-    # diff-cover gate: lines touched in this PR must have >=80%
-    # coverage. Reuses coverage.xml uploaded by the main test job.
+    # LEVEL 1 of the coverage ratchet - diff-cover gate: lines touched in
+    # this PR must hit the committed diff-coverage floor. The floor lives
+    # in .coverage-baseline.json (key: diff_coverage_floor_percent) so it
+    # is a single source of truth that the weekly bump workflow nudges up
+    # over time (see docs/operations/coverage-ratchet.md). Reuses the
+    # coverage.xml uploaded by the main test job.
+    #
+    # ADVISORY: the diff-cover step is continue-on-error, so this job's
+    # result stays `success` even when diff coverage is below the floor.
+    # That keeps it safe to leave in the CI-gate `needs` set without
+    # wedging the merge queue. Promote it to blocking by removing the
+    # continue-on-error once coverage is healthy (documented in the ops
+    # runbook).
     name: Diff coverage gate
     needs: [test]
     runs-on: ubuntu-latest
@@ -1083,15 +1094,31 @@ jobs:
         with:
           name: coverage-report
         continue-on-error: true  # main may not have generated coverage on the PR's commit
+      - name: Resolve diff-coverage floor from baseline
+        id: floor
+        # Single source of truth: the floor the weekly bump nudges up.
+        # Falls back to 80 if the baseline file is somehow absent so a
+        # missing file never silently disables the gate.
+        run: |
+          if [ -f .coverage-baseline.json ]; then
+            floor=$(uv run python scripts/coverage_ratchet.py show-floor \
+              --baseline .coverage-baseline.json)
+          else
+            echo "::warning::.coverage-baseline.json missing; defaulting diff floor to 80"
+            floor=80
+          fi
+          echo "value=${floor}" >> "$GITHUB_OUTPUT"
+          echo "Diff-coverage floor: ${floor}%"
       - name: Run diff-cover
         continue-on-error: true  # advisory until all PRs reliably have coverage.xml
         env:
           BASE_REF: ${{ github.base_ref }}
+          FLOOR: ${{ steps.floor.outputs.value }}
         run: |
           if [ -f coverage.xml ]; then
             uv run diff-cover coverage.xml \
               --compare-branch="origin/${BASE_REF}" \
-              --fail-under=80 \
+              --fail-under="${FLOOR}" \
               --markdown-report diff-coverage.md
             cat diff-coverage.md >> "$GITHUB_STEP_SUMMARY" || true
           else

--- a/.github/workflows/coverage-ratchet-weekly.yml
+++ b/.github/workflows/coverage-ratchet-weekly.yml
@@ -1,0 +1,148 @@
+name: Coverage ratchet (weekly floor bump)
+
+# The "nudges up over time" half of the coverage ratchet. Once a week it
+# raises the LEVEL 1 diff-coverage floor (diff_coverage_floor_percent in
+# .coverage-baseline.json) by a gentle increment, capped, and opens a PR
+# for operator review. The diff-coverage gate in ci.yml reads that same
+# floor, so merging this PR tightens the per-PR coverage requirement.
+#
+# The increment is intentionally small so the floor creeps up without ever
+# becoming a wall. Cap stops it short of demanding near-total diff coverage.
+#
+# The cron trigger ships disabled-by-default. Flip ENABLE_CRON to "1" (in
+# this file, not at run time) only after a clean workflow_dispatch smoke
+# run, mirroring the sweep-sonar-findings.yml rollout. Until then a
+# scheduled fire is a clean no-op.
+
+on:
+  schedule:
+    - cron: "23 7 * * 1"  # 07:23 UTC every Monday; off-peak.
+  workflow_dispatch:
+    inputs:
+      step:
+        description: Percentage points to raise the diff-coverage floor
+        required: false
+        default: "1"
+      cap:
+        description: Hard ceiling the floor may never exceed
+        required: false
+        default: "90"
+
+concurrency:
+  group: coverage-ratchet-weekly
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  # Gated like the Sonar sweeper: a scheduled run is a no-op until an
+  # operator opts in via a follow-up PR that flips this to "1". The job
+  # `if:` cannot read env directly, so the gate is the first job step.
+  ENABLE_CRON: "0"
+
+jobs:
+  bump:
+    name: Bump diff-coverage floor and open review PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Gate cron trigger
+        id: gate
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "${ENABLE_CRON}" != "1" ]; then
+            echo "Cron trigger fired but ENABLE_CRON is '0'; exiting cleanly."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Harden runner (audit mode)
+        if: steps.gate.outputs.skip != 'true'
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        if: steps.gate.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/bootstrap
+        if: steps.gate.outputs.skip != 'true'
+
+      - name: Bump floor
+        if: steps.gate.outputs.skip != 'true'
+        id: bump
+        env:
+          STEP: ${{ inputs.step || '1' }}
+          CAP: ${{ inputs.cap || '90' }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/coverage_ratchet.py bump-floor \
+            --baseline .coverage-baseline.json \
+            --step "${STEP}" \
+            --cap "${CAP}"
+
+      - name: Detect baseline change
+        if: steps.gate.outputs.skip != 'true'
+        id: detect
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .coverage-baseline.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Floor already at cap; no PR needed."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read new floor
+        if: steps.gate.outputs.skip != 'true' && steps.detect.outputs.changed == 'true'
+        id: floor
+        run: |
+          set -euo pipefail
+          floor=$(uv run python scripts/coverage_ratchet.py show-floor \
+            --baseline .coverage-baseline.json)
+          echo "value=${floor}" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR with the bumped floor
+        if: steps.gate.outputs.skip != 'true' && steps.detect.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: coverage-ratchet/weekly-floor-${{ github.run_id }}
+          delete-branch: true
+          add-paths: |
+            .coverage-baseline.json
+          commit-message: |
+            chore(ci): raise diff-coverage floor to ${{ steps.floor.outputs.value }}%
+          title: "chore(ci): raise diff-coverage floor to ${{ steps.floor.outputs.value }}%"
+          body: |
+            Weekly nudge of the LEVEL 1 diff-coverage floor.
+
+            The diff-coverage gate in `.github/workflows/ci.yml` reads
+            `diff_coverage_floor_percent` from `.coverage-baseline.json`.
+            This PR raises that floor so every subsequent PR must cover a
+            slightly higher share of its changed lines.
+
+            New floor: **${{ steps.floor.outputs.value }}%**.
+
+            The gate stays advisory (`continue-on-error`) until an operator
+            promotes it; see `docs/operations/coverage-ratchet.md` for the
+            promotion and override procedure. If the increment is too steep
+            for the current trunk, close this PR - the floor only moves when
+            the PR merges.
+
+            Generated by `.github/workflows/coverage-ratchet-weekly.yml`.
+          labels: |
+            ci
+            chore

--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -1,0 +1,153 @@
+name: Coverage ratchet (total)
+
+# LEVEL 2 of the coverage ratchet - total-coverage monotonic gate.
+#
+# The CI coverage shard already produces a Cobertura coverage.xml on every
+# push to main and uploads it as the `coverage-report` artifact. This
+# workflow consumes that *same* artifact (no parallel coverage system) and
+# runs scripts/coverage_ratchet.py check:
+#
+#   - measured < committed baseline (beyond float tolerance): report a
+#     drop. ADVISORY - the compare step is continue-on-error and this
+#     workflow is NOT in the CI-gate required-check set, so a drop never
+#     wedges the merge queue. Promote to blocking later (see the ops
+#     runbook).
+#   - measured > baseline: the ratchet clicks - bump .coverage-baseline.json
+#     to the new high-water mark and open a PR with that one-line change.
+#   - flat: no change.
+#
+# Why a PR (not a direct push): main is protected by required status
+# checks, so a bot commit pushed straight to main would be rejected (it
+# has not passed `CI gate`). Opening a PR is the protection-safe path and
+# matches the repo convention (sonar sweeper, weekly floor bump). It also
+# makes every baseline movement a reviewable, auditable artifact - the
+# ratchet click is a PR, not a silent rewrite.
+#
+# Trigger: push to main, then resolve the freshest CI run that actually
+# uploaded a coverage-report artifact. This mirrors sonar-scan.yml: under
+# the rapid-merge cadence ci.yml's cancel-in-progress concurrency cancels
+# most main CI runs, so a `workflow_run`/`conclusion == success` trigger
+# almost never fires. Searching recent runs for the artifact (cancelled
+# runs may still have uploaded it) is the robust pattern. Keeping the
+# baseline-write here (not in ci.yml) means ci.yml's gate jobs never need
+# `contents: write`.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  # Serialise baseline writes so two back-to-back main pushes cannot race
+  # on the commit. Never cancel an in-flight bump.
+  group: coverage-ratchet
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  ratchet:
+    name: Total coverage ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Skip the merge of a baseline-bump PR this workflow opened (avoids a
+    # self-retrigger loop on its own change).
+    if: "!contains(github.event.head_commit.message, 'ratchet coverage baseline')"
+    permissions:
+      contents: write  # create the bump branch
+      pull-requests: write  # open the baseline-bump PR
+      actions: read  # list CI runs and download their coverage artifact
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/bootstrap
+
+      - name: Resolve latest CI run with a coverage artifact
+        id: ci_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Search the last 20 main CI runs for one that uploaded the
+          # coverage-report artifact. Cancelled runs can still have
+          # uploaded it if the coverage step ran before cancellation, so
+          # we do not filter by status (mirrors sonar-scan.yml).
+          found=""
+          for run_id in $(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow ci.yml \
+              --branch main \
+              --limit 20 \
+              --json databaseId \
+              --jq '.[].databaseId'); do
+            artifacts=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id/artifacts" \
+                --jq '.artifacts[].name' 2>/dev/null || true)
+            if printf '%s\n' "$artifacts" | grep -qx coverage-report; then
+              found="$run_id"
+              break
+            fi
+          done
+          if [ -n "$found" ]; then
+            echo "Found coverage-report artifact in CI run: $found"
+            echo "run_id=$found" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No recent CI run with a coverage-report artifact; skipping ratchet."
+          fi
+
+      - name: Download coverage report from the CI run
+        if: steps.ci_run.outputs.run_id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-report
+          run-id: ${{ steps.ci_run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true  # docs-only pushes skip the coverage shard
+
+      - name: Run total-coverage ratchet
+        id: ratchet
+        continue-on-error: true  # ADVISORY: a drop reports red but never blocks
+        run: |
+          if [ ! -f coverage.xml ] || [ ! -s coverage.xml ]; then
+            echo "::warning::No usable coverage.xml available; skipping coverage ratchet for this push."
+            exit 0
+          fi
+          uv run python scripts/coverage_ratchet.py check \
+            --coverage-xml coverage.xml \
+            --baseline .coverage-baseline.json
+
+      - name: Open PR with the bumped baseline
+        # Only when the ratchet actually clicked (coverage rose). The check
+        # step rewrote .coverage-baseline.json in place; open a PR with that
+        # change (main is protected, so a direct push would be rejected).
+        if: steps.ratchet.outputs.baseline_bumped == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: coverage-ratchet/baseline-${{ github.run_id }}
+          delete-branch: true
+          add-paths: |
+            .coverage-baseline.json
+          commit-message: |
+            chore(ci): ratchet coverage baseline up to ${{ steps.ratchet.outputs.measured }}%
+          title: "chore(ci): ratchet coverage baseline up to ${{ steps.ratchet.outputs.measured }}%"
+          body: |
+            Total line coverage rose on `main`, so the monotonic ratchet
+            bumped the committed high-water mark in `.coverage-baseline.json`
+            to **${{ steps.ratchet.outputs.measured }}%**.
+
+            From here, any later push whose total coverage falls below this
+            mark is flagged by the LEVEL 2 ratchet. The gate stays advisory
+            until promoted; see `docs/operations/coverage-ratchet.md`.
+
+            Generated by `.github/workflows/coverage-ratchet.yml`.
+          labels: |
+            ci
+            chore

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -25,7 +25,8 @@ locally without waiting for the cloud runner.
 | **syrupy** (snapshot)       | JSONL/audit/lineage wire-format drift                             | PR                  |
 | **Pyright strict zone**     | Untyped/implicit-Any leakage in `core/security/`, `core/protocols/cluster/` | PR                  |
 | **Vulture**                 | Dead code (unused functions/classes/vars at confidence ≥80)       | PR                  |
-| **diff-cover**              | <80% coverage on lines this PR changed                            | PR (advisory)       |
+| **diff-cover** (LEVEL 1)    | Changed lines below the committed diff-coverage floor             | PR (advisory)       |
+| **coverage ratchet** (LEVEL 2) | Total coverage dropped below the committed high-water mark      | push to main (advisory) |
 | **import-linter**           | Architecture-contract violations (cross-package imports)          | PR                  |
 | **ruff** + **typos**        | Lint, format drift, common typos                                  | PR                  |
 
@@ -74,9 +75,18 @@ uv run pyright --typecheckingmode strict \
 # Vulture
 vulture src/ vulture_whitelist.py --min-confidence 80 --exclude tests,docs
 
-# Diff-cover (after a coverage run)
+# Diff-cover (after a coverage run). The floor is the committed
+# diff_coverage_floor_percent in .coverage-baseline.json (LEVEL 1 of the
+# coverage ratchet); the weekly bump nudges it up. See
+# docs/operations/coverage-ratchet.md.
 uv run pytest tests/unit/ --cov=src/bernstein --cov-report=xml
-uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+FLOOR=$(uv run python scripts/coverage_ratchet.py show-floor --baseline .coverage-baseline.json)
+uv run diff-cover coverage.xml --compare-branch=origin/main --fail-under="$FLOOR"
+
+# Total-coverage ratchet (LEVEL 2): compare a coverage.xml total to the
+# committed high-water mark without writing unless it rose.
+uv run python scripts/coverage_ratchet.py check \
+  --coverage-xml coverage.xml --baseline .coverage-baseline.json --no-bump
 ```
 
 ## When a tool fires on you

--- a/docs/operations/coverage-ratchet.md
+++ b/docs/operations/coverage-ratchet.md
@@ -1,0 +1,237 @@
+# Coverage ratchet
+
+**Audience:** operators maintaining the Bernstein test-coverage gate.
+
+**What:** a two-level, one-way coverage gate. Coverage can only hold or
+rise; a drop is reported but (initially) does not block. The floor for
+new code nudges up over time so the dark, untested share of the codebase
+shrinks instead of growing.
+
+**Why:** only a fraction of the code is exercised by the suite today, so
+runtime bugs hide in the untested remainder. The ratchet fixes the root
+cause - new code arrives covered - and prevents backsliding without a new
+scanner.
+
+---
+
+## TL;DR
+
+| Item | Value |
+|---|---|
+| LEVEL 1 - diff floor | every PR's *changed* lines must hit a minimum diff coverage |
+| LEVEL 2 - total ratchet | total coverage may never drop below the committed high-water mark |
+| Baseline file | `.coverage-baseline.json` (repo root) |
+| Ratchet script | `scripts/coverage_ratchet.py` |
+| Posture | both ADVISORY (report red, never block) until promoted |
+| Weekly bump | `coverage-ratchet-weekly.yml` raises the diff floor; opens a review PR |
+| Promotion | remove `continue-on-error` (LEVEL 1) / add to required checks (LEVEL 2) |
+
+Both levels reuse machinery already in the repo (`diff-cover` and the CI
+coverage shard's `coverage.xml`). There is no parallel coverage system.
+
+---
+
+## The baseline file
+
+`.coverage-baseline.json` is the single source of truth. It is committed
+to the repo and updated by the ratchet, never hand-edited in normal flow.
+
+```json
+{
+  "diff_coverage_floor_percent": 85,
+  "total_coverage_percent": 77.51,
+  "updated_at": "2026-05-22T00:00:00+00:00"
+}
+```
+
+The starting diff floor is **85%** - one step above the 80% the diff-cover
+step enforced before the ratchet, so new code clears a slightly higher bar
+than the legacy default. The weekly bump continues raising it from there.
+This is an operator-tunable choice; lower it in the baseline file if 85% is
+too steep for the current trunk.
+
+| Key | Meaning | Moved by |
+|---|---|---|
+| `total_coverage_percent` | high-water mark of total line coverage on `main` | LEVEL 2 ratchet, on a rise |
+| `diff_coverage_floor_percent` | minimum diff coverage every PR must hit | weekly bump PR |
+| `updated_at` | ISO-8601 UTC timestamp of the last write | every write |
+
+`total_coverage_percent` is seeded from a real measurement of `main` (the
+full per-file isolated unit-suite coverage run, identical to the CI shard),
+not a guess, so the ratchet starts honest.
+
+Note: this measured total can differ from the figure a static-analysis
+dashboard reports. The dashboard ingests whatever `coverage.xml` the CI
+shard last uploaded, and under the rapid-merge cadence that artifact is
+frequently partial (the shard is cancelled mid-run by `cancel-in-progress`
+concurrency) - which understates coverage. The baseline here is the
+complete-run number, which is the value the ratchet must protect.
+
+---
+
+## LEVEL 1 - diff-coverage floor (per PR)
+
+Fixes the *root cause* of dark code: new code must arrive covered.
+
+- The `diff-coverage` job in `.github/workflows/ci.yml` runs
+  `diff-cover coverage.xml --fail-under=<floor>` on the lines the PR
+  changed, relative to the base branch.
+- `<floor>` is read at job time from `diff_coverage_floor_percent` in the
+  baseline (step `Resolve diff-coverage floor from baseline`), so the
+  weekly bump and the gate share one number.
+- The job reuses the `coverage.xml` the main test job uploaded as the
+  `coverage-report` artifact. No second coverage run.
+
+**Advisory mechanism.** The `Run diff-cover` step is
+`continue-on-error: true`, so the *job* result is always `success` even
+when diff coverage is below the floor. That is why the job can stay in
+the CI-gate `needs` set without ever wedging the merge queue. The shortfall
+is reported as a warning and in the step summary; it does not fail the PR.
+
+---
+
+## LEVEL 2 - total-coverage monotonic ratchet (per push to main)
+
+Prevents backsliding: total coverage may only hold or rise.
+
+Flow (`.github/workflows/coverage-ratchet.yml`, triggered on push to
+`main`):
+
+1. Resolve the freshest CI run that actually uploaded a `coverage-report`
+   artifact and download it (the same `coverage.xml` the shard produced).
+   This mirrors `sonar-scan.yml`: under the rapid-merge cadence ci.yml's
+   `cancel-in-progress` concurrency cancels most main CI runs, so a
+   `workflow_run`/`conclusion == success` trigger almost never fires;
+   searching recent runs for the artifact (cancelled runs may still carry
+   it) is the robust pattern.
+2. `scripts/coverage_ratchet.py check` parses the root `line-rate` and
+   compares it to `total_coverage_percent`:
+   - **measured < baseline** (beyond a 0.05 pp float-jitter tolerance):
+     report a drop, exit non-zero. ADVISORY - the step is
+     `continue-on-error` and the workflow is **not** in the required-check
+     set, so a drop never blocks a merge.
+   - **measured > baseline:** the ratchet *clicks* - rewrite the baseline
+     to the new high-water mark and open a PR with that one-line change.
+   - **flat:** no change.
+
+The bump is a **PR, not a direct push**: `main` is protected by required
+status checks, so a bot commit pushed straight to `main` would be rejected.
+Opening a PR is the protection-safe path and matches the repo convention
+(sonar sweeper, weekly floor bump). Every baseline movement is therefore a
+reviewable, auditable artifact rather than a silent rewrite. Merge the PR
+to record the new high-water mark.
+
+The baseline write lives in this separate workflow (not in `ci.yml`) so
+`ci.yml`'s gate jobs never need `contents: write`.
+
+### Why a missing coverage.xml is not a drop
+
+Docs-only pushes skip the coverage shard, so `coverage.xml` may be absent.
+The script treats a missing or malformed report as a **soft-skip**
+(exit 3, warning) - never as a coverage drop - so the ratchet cannot
+false-fail on a push that legitimately produced no coverage.
+
+---
+
+## The weekly bump (nudges up over time)
+
+`.github/workflows/coverage-ratchet-weekly.yml`:
+
+- Runs `scripts/coverage_ratchet.py bump-floor` once a week.
+- Raises `diff_coverage_floor_percent` by `step` (default **+1 pp**),
+  capped at `cap` (default **90%**). The increment is gentle on purpose so
+  the floor creeps up without becoming a wall.
+- Opens a PR with only the baseline change for operator review. The floor
+  moves only when that PR merges; close it to decline a given week's bump.
+- If the floor is already at the cap, the run is a clean no-op (no PR).
+
+**Cron is disabled by default.** `ENABLE_CRON` is `"0"` in the workflow
+file. A scheduled fire is a no-op until an operator flips it to `"1"` in a
+follow-up PR, after a clean `workflow_dispatch` smoke run. This mirrors the
+Sonar sweeper rollout and bounds first-day blast radius.
+
+To smoke-test: run the workflow via **Actions -> Coverage ratchet (weekly
+floor bump) -> Run workflow**. Confirm the review PR looks right, then flip
+`ENABLE_CRON` to `"1"`.
+
+---
+
+## Promoting from advisory to required
+
+Do this only once coverage is healthy enough that the gates rarely fire.
+
+### Promote LEVEL 1 (diff floor) to blocking
+
+1. In `.github/workflows/ci.yml`, remove `continue-on-error: true` from the
+   `Run diff-cover` step in the `diff-coverage` job.
+2. The job now fails when diff coverage is below the floor. It is already
+   in the CI-gate `needs` set, so the gate will then enforce it.
+3. Watch a few PRs to confirm the floor is realistic before tightening it
+   further via the weekly bump.
+
+### Promote LEVEL 2 (total ratchet) to blocking
+
+The total ratchet runs *post-merge* (on push to `main`), so it is
+structurally advisory: it cannot block a PR merge. To make a total drop
+actionable as a hard signal:
+
+1. Remove `continue-on-error: true` from the `Run total-coverage ratchet`
+   step in `coverage-ratchet.yml` so the workflow run goes red on a drop.
+2. Optionally wire the red `coverage-ratchet` workflow conclusion into the
+   trunk-health / main-red-guard surface so a post-merge coverage drop
+   raises the same alarm as a broken build.
+3. Do **not** add this workflow to branch protection's required checks - it
+   is a post-merge workflow, not a PR check, and adding it there would wedge
+   the merge queue.
+
+---
+
+## Override for a legitimate coverage-neutral refactor
+
+Sometimes a PR legitimately moves code without changing behaviour (pure
+rename, file split, dead-code deletion) and trips the diff floor or dips
+total coverage. Options, least to most invasive:
+
+| Situation | Override |
+|---|---|
+| LEVEL 1 false-positive on a PR | gate is advisory by default - no action needed; if promoted, add the missing tests or split the refactor from the behaviour change |
+| LEVEL 2 reports a drop from a *partial* CI run | when the resolved CI run was cancelled mid-shard, its `coverage.xml` understates coverage and the ratchet flags a spurious drop. This is advisory (warning only) and self-heals on the next complete run. Do **not** lower the baseline for this - it is a measurement artifact, not a real regression. Promote LEVEL 2 to blocking only once full-run artifacts are reliable. |
+| Total dips on a pure deletion | the deletion removes covered *and* uncovered lines; if the percentage genuinely dropped, add a test or accept the lower baseline by editing `total_coverage_percent` down in the same PR, with a one-line justification in the PR body |
+| Need to reset the baseline after a large legitimate change | run `scripts/coverage_ratchet.py init --coverage-xml coverage.xml --baseline .coverage-baseline.json` against a fresh measurement and commit the result |
+
+Editing `total_coverage_percent` downward is the explicit, auditable escape
+hatch: it is a committed file change, visible in review, with the
+`updated_at` stamp showing when and (via git blame) who.
+
+---
+
+## Local usage
+
+```bash
+# Compare a local coverage.xml to the baseline (does not write unless it rose).
+uv run python scripts/coverage_ratchet.py check \
+    --coverage-xml coverage.xml --baseline .coverage-baseline.json --no-bump
+
+# Print the current diff-coverage floor.
+uv run python scripts/coverage_ratchet.py show-floor --baseline .coverage-baseline.json
+
+# Re-seed the baseline from a fresh measurement.
+uv run python scripts/coverage_ratchet.py init \
+    --coverage-xml coverage.xml --baseline .coverage-baseline.json --diff-floor 80
+```
+
+Exit codes: `0` held/rose, `1` dropped (advisory), `2` misconfiguration,
+`3` missing/malformed `coverage.xml` (soft-skip).
+
+---
+
+## Files
+
+| Path | Role |
+|---|---|
+| `scripts/coverage_ratchet.py` | compare / bump / seed logic |
+| `.coverage-baseline.json` | committed baseline (high-water + floor) |
+| `.github/workflows/ci.yml` (`diff-coverage` job) | LEVEL 1 per-PR gate |
+| `.github/workflows/coverage-ratchet.yml` | LEVEL 2 post-push total ratchet |
+| `.github/workflows/coverage-ratchet-weekly.yml` | weekly floor bump PR |
+| `tests/unit/test_coverage_ratchet.py` | unit tests for the script |

--- a/scripts/coverage_ratchet.py
+++ b/scripts/coverage_ratchet.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Total-coverage monotonic ratchet for Bernstein.
+
+Two levers, both **advisory** until an operator promotes them (see
+``docs/operations/coverage-ratchet.md``):
+
+LEVEL 2 - total coverage ratchet (this script's ``check`` command).
+    Reads the line-coverage total out of the Cobertura ``coverage.xml``
+    that the CI coverage shard already produces, and compares it to the
+    committed high-water mark in ``.coverage-baseline.json``.
+
+    - measured < baseline (beyond a small float tolerance): the ratchet
+      reports a drop and exits non-zero. The CI job keeps this advisory
+      via ``continue-on-error`` so a drop never wedges the merge queue.
+    - measured > baseline: the ratchet *clicks* - it rewrites the
+      baseline to the new high-water mark and exits zero. The push-side
+      workflow commits the bumped baseline back to ``main``.
+    - measured == baseline (within tolerance): pass, no write.
+
+LEVEL 1 - diff-coverage floor (this script's ``bump-floor`` command).
+    The per-PR diff-cover gate reads its ``--fail-under`` floor from the
+    same baseline file (``diff_coverage_floor_percent``) so there is one
+    source of truth. The weekly workflow nudges that floor up by a gentle
+    increment, capped, and opens a review PR.
+
+The module is import-safe (no work at import time) so the unit tests can
+drive the pure functions directly.
+
+Usage
+-----
+
+    # LEVEL 2: compare coverage.xml total to the baseline; bump on a rise.
+    python scripts/coverage_ratchet.py check \\
+        --coverage-xml coverage.xml \\
+        --baseline .coverage-baseline.json \\
+        [--tolerance 0.05] [--no-bump]
+
+    # LEVEL 1: raise the committed diff-coverage floor by one step.
+    python scripts/coverage_ratchet.py bump-floor \\
+        --baseline .coverage-baseline.json \\
+        [--step 1] [--cap 90]
+
+    # Seed the baseline from a freshly-measured coverage.xml.
+    python scripts/coverage_ratchet.py init \\
+        --coverage-xml coverage.xml \\
+        --baseline .coverage-baseline.json \\
+        [--diff-floor 80]
+
+    # Print the current diff-coverage floor (for the CI step to consume).
+    python scripts/coverage_ratchet.py show-floor \\
+        --baseline .coverage-baseline.json
+
+Exit codes
+----------
+
+- 0: success - coverage held or rose, or a non-``check`` command ran.
+- 1: ``check`` found a coverage drop beyond tolerance (advisory in CI).
+- 2: misconfiguration - bad args, missing baseline, unreadable input.
+- 3: ``coverage.xml`` was missing or malformed (treated as soft-skip by
+     the workflow; a missing report must not be read as a drop).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as _dt
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# defusedxml is a drop-in for xml.etree.ElementTree that re-exports the
+# stdlib ``ParseError`` and additionally raises ``DefusedXmlException``
+# (a ValueError subclass) on disallowed constructs (DTDs, entity
+# expansion). The coverage report is locally produced, but parsing it
+# with the hardened parser keeps this script aligned with the repo's
+# XML-handling convention and silences bandit's B314.
+from defusedxml import ElementTree as ET
+from defusedxml.common import DefusedXmlException
+
+# Float jitter between two coverage runs of the same tree is normally
+# << 0.05 percentage points; anything inside this band is treated as
+# "flat" so noise never trips the gate or churns the baseline.
+DEFAULT_TOLERANCE: float = 0.05
+
+# LEVEL 1 weekly-bump knobs. Operator-tunable in the weekly workflow.
+DEFAULT_FLOOR_STEP: int = 1
+DEFAULT_FLOOR_CAP: int = 90
+
+# Seed value for a brand-new baseline's diff floor when none is given.
+DEFAULT_DIFF_FLOOR: int = 80
+
+
+class CoverageParseError(Exception):
+    """Raised when ``coverage.xml`` is missing, malformed, or unreadable."""
+
+
+@dataclasses.dataclass
+class Baseline:
+    """The committed coverage high-water mark and diff floor.
+
+    Attributes:
+        total_coverage_percent: Highest total line coverage observed on
+            ``main`` so far, as a percentage (0-100).
+        diff_coverage_floor_percent: Minimum diff coverage every PR's
+            changed lines must hit, as an integer percentage (0-100).
+        updated_at: ISO-8601 UTC timestamp of the last write, for audit.
+    """
+
+    total_coverage_percent: float
+    diff_coverage_floor_percent: int
+    updated_at: str | None = None
+
+
+@dataclasses.dataclass
+class Decision:
+    """Outcome of comparing measured coverage to the baseline."""
+
+    baseline_pct: float
+    measured_pct: float
+    dropped: bool
+    should_bump: bool
+    new_total_pct: float
+    exit_code: int
+
+
+def parse_total_coverage(coverage_xml: Path) -> float:
+    """Read the total line-coverage percentage from a Cobertura report.
+
+    The Cobertura ``coverage.xml`` produced by ``coverage xml`` carries a
+    ``line-rate`` attribute on the root ``<coverage>`` element as a 0-1
+    fraction; this returns it as a 0-100 percentage.
+
+    Args:
+        coverage_xml: Path to the ``coverage.xml`` file.
+
+    Returns:
+        Total line coverage as a percentage in the range [0, 100].
+
+    Raises:
+        CoverageParseError: If the file is missing, not valid XML, lacks a
+            ``line-rate`` attribute, or that attribute is not numeric.
+    """
+    if not coverage_xml.exists():
+        raise CoverageParseError(f"coverage report not found: {coverage_xml}")
+
+    try:
+        tree = ET.parse(coverage_xml)
+    except (ET.ParseError, DefusedXmlException) as exc:
+        raise CoverageParseError(f"coverage report is not valid XML: {coverage_xml}: {exc}") from exc
+
+    root = tree.getroot()
+    if root is None:
+        raise CoverageParseError(f"coverage report has no root element: {coverage_xml}")
+
+    raw = root.get("line-rate")
+    if raw is None:
+        raise CoverageParseError(f"coverage report has no root line-rate attribute: {coverage_xml}")
+
+    try:
+        fraction = float(raw)
+    except ValueError as exc:
+        raise CoverageParseError(f"coverage report line-rate is not numeric: {raw!r}") from exc
+
+    return round(fraction * 100.0, 2)
+
+
+def read_baseline(baseline_path: Path) -> Baseline:
+    """Load the committed baseline.
+
+    Args:
+        baseline_path: Path to ``.coverage-baseline.json``.
+
+    Returns:
+        The parsed :class:`Baseline`.
+
+    Raises:
+        FileNotFoundError: If the baseline file does not exist.
+        ValueError: If the baseline JSON is malformed or missing keys.
+    """
+    if not baseline_path.exists():
+        raise FileNotFoundError(f"coverage baseline not found: {baseline_path}")
+
+    try:
+        data: dict[str, Any] = json.loads(baseline_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"coverage baseline is not valid JSON: {baseline_path}: {exc}") from exc
+
+    try:
+        return Baseline(
+            total_coverage_percent=float(data["total_coverage_percent"]),
+            diff_coverage_floor_percent=int(data["diff_coverage_floor_percent"]),
+            updated_at=data.get("updated_at"),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"coverage baseline is missing or has bad keys: {baseline_path}: {exc}") from exc
+
+
+def write_baseline(baseline_path: Path, baseline: Baseline) -> None:
+    """Atomically write the baseline to disk.
+
+    Serialises to a temp file in the same directory, then ``os.replace``
+    onto the target so a crash mid-write can never leave a partial or
+    corrupt baseline (the prior committed value survives intact).
+
+    Args:
+        baseline_path: Destination ``.coverage-baseline.json`` path.
+        baseline: The :class:`Baseline` to persist.
+
+    Raises:
+        TypeError: If a field is not JSON-serialisable (the existing file,
+            if any, is left untouched because the temp file is discarded
+            before the replace).
+    """
+    payload = {
+        "total_coverage_percent": baseline.total_coverage_percent,
+        "diff_coverage_floor_percent": baseline.diff_coverage_floor_percent,
+        "updated_at": baseline.updated_at or _utc_now_iso(),
+    }
+    # Serialise first so a TypeError aborts before we touch the filesystem.
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    parent = baseline_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".coverage-baseline.", suffix=".tmp", dir=parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, baseline_path)
+    finally:
+        # If the replace already happened the temp file is gone; otherwise
+        # discard the partial temp so no turds are left behind.
+        tmp_path.unlink(missing_ok=True)
+
+
+def decide(baseline_pct: float, measured_pct: float, tolerance: float = DEFAULT_TOLERANCE) -> Decision:
+    """Compare measured coverage to the baseline high-water mark.
+
+    Args:
+        baseline_pct: Committed high-water coverage percentage.
+        measured_pct: Freshly-measured coverage percentage.
+        tolerance: Band (in percentage points) treated as "flat" to absorb
+            float jitter between runs.
+
+    Returns:
+        A :class:`Decision` describing whether coverage dropped, whether the
+        baseline should be bumped, and the process exit code to use.
+    """
+    delta = measured_pct - baseline_pct
+
+    if delta < -tolerance:
+        return Decision(
+            baseline_pct=baseline_pct,
+            measured_pct=measured_pct,
+            dropped=True,
+            should_bump=False,
+            new_total_pct=baseline_pct,
+            exit_code=1,
+        )
+
+    if delta > tolerance:
+        return Decision(
+            baseline_pct=baseline_pct,
+            measured_pct=measured_pct,
+            dropped=False,
+            should_bump=True,
+            new_total_pct=measured_pct,
+            exit_code=0,
+        )
+
+    # Within tolerance: flat. Hold the baseline, do not churn it.
+    return Decision(
+        baseline_pct=baseline_pct,
+        measured_pct=measured_pct,
+        dropped=False,
+        should_bump=False,
+        new_total_pct=baseline_pct,
+        exit_code=0,
+    )
+
+
+def next_floor(current: int, step: int = DEFAULT_FLOOR_STEP, cap: int = DEFAULT_FLOOR_CAP) -> int:
+    """Compute the next diff-coverage floor for the weekly bump.
+
+    Raises the floor by ``step`` percentage points without exceeding
+    ``cap``. A floor already at or above the cap is clamped down to the
+    cap (never raised), so a manually-edited over-cap value self-heals.
+
+    Args:
+        current: Current diff-coverage floor percentage.
+        step: Increment in percentage points (must be positive).
+        cap: Hard ceiling the floor may never exceed.
+
+    Returns:
+        The next floor, an integer in the range [current_or_lower, cap].
+
+    Raises:
+        ValueError: If ``step`` is not a positive integer.
+    """
+    if step <= 0:
+        raise ValueError(f"weekly floor step must be positive, got {step}")
+    if current >= cap:
+        return cap
+    return min(current + step, cap)
+
+
+def _utc_now_iso() -> str:
+    return _dt.datetime.now(_dt.UTC).replace(microsecond=0).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    baseline_path = Path(args.baseline)
+    try:
+        baseline = read_baseline(baseline_path)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    try:
+        measured = parse_total_coverage(Path(args.coverage_xml))
+    except CoverageParseError as exc:
+        # A missing/broken report is NOT a coverage drop. Soft-skip (exit 3)
+        # so the advisory workflow can decide to ignore rather than fail red.
+        print(f"::warning::{exc}; skipping coverage ratchet for this run")
+        return 3
+
+    decision = decide(baseline.total_coverage_percent, measured, tolerance=args.tolerance)
+
+    print(f"baseline total coverage : {baseline.total_coverage_percent:.2f}%")
+    print(f"measured total coverage : {measured:.2f}%")
+    print(f"delta                   : {measured - baseline.total_coverage_percent:+.2f} pp")
+
+    if decision.dropped:
+        print(
+            f"::warning::coverage dropped from {baseline.total_coverage_percent:.2f}% to "
+            f"{measured:.2f}% (tolerance {args.tolerance} pp). Add tests for the new/changed "
+            f"lines, or see docs/operations/coverage-ratchet.md for the coverage-neutral override."
+        )
+        _emit_github_output(coverage_dropped="true", baseline_bumped="false", measured=measured)
+        return decision.exit_code
+
+    if decision.should_bump and not args.no_bump:
+        bumped = dataclasses.replace(
+            baseline,
+            total_coverage_percent=decision.new_total_pct,
+            updated_at=_utc_now_iso(),
+        )
+        write_baseline(baseline_path, bumped)
+        print(f"ratchet click: baseline bumped to {decision.new_total_pct:.2f}%")
+        _emit_github_output(coverage_dropped="false", baseline_bumped="true", measured=measured)
+        return 0
+
+    print("coverage held at baseline; no bump.")
+    _emit_github_output(coverage_dropped="false", baseline_bumped="false", measured=measured)
+    return 0
+
+
+def _cmd_bump_floor(args: argparse.Namespace) -> int:
+    baseline_path = Path(args.baseline)
+    try:
+        baseline = read_baseline(baseline_path)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    current = baseline.diff_coverage_floor_percent
+    new_floor = next_floor(current, step=args.step, cap=args.cap)
+    if new_floor == current:
+        print(f"diff-coverage floor already at cap {args.cap}%; no bump.")
+        _emit_github_output(floor_changed="false", new_floor=new_floor)
+        return 0
+
+    bumped = dataclasses.replace(
+        baseline,
+        diff_coverage_floor_percent=new_floor,
+        updated_at=_utc_now_iso(),
+    )
+    write_baseline(baseline_path, bumped)
+    print(f"diff-coverage floor bumped: {current}% -> {new_floor}% (cap {args.cap}%)")
+    _emit_github_output(floor_changed="true", new_floor=new_floor, old_floor=current)
+    return 0
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    try:
+        measured = parse_total_coverage(Path(args.coverage_xml))
+    except CoverageParseError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 3
+
+    baseline_path = Path(args.baseline)
+    baseline = Baseline(
+        total_coverage_percent=measured,
+        diff_coverage_floor_percent=args.diff_floor,
+        updated_at=_utc_now_iso(),
+    )
+    write_baseline(baseline_path, baseline)
+    print(f"seeded baseline at {baseline_path}: total={measured:.2f}%, diff_floor={args.diff_floor}%")
+    return 0
+
+
+def _cmd_show_floor(args: argparse.Namespace) -> int:
+    baseline_path = Path(args.baseline)
+    try:
+        baseline = read_baseline(baseline_path)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+    # Bare integer on stdout so a CI step can capture it directly.
+    print(baseline.diff_coverage_floor_percent)
+    return 0
+
+
+def _emit_github_output(**pairs: object) -> None:
+    """Append key=value pairs to ``$GITHUB_OUTPUT`` when running in CI."""
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        return
+    try:
+        with open(out, "a", encoding="utf-8") as handle:
+            for key, value in pairs.items():
+                handle.write(f"{key}={value}\n")
+    except OSError:
+        # Never let an observability write break the gate.
+        pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Total-coverage monotonic ratchet")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_check = sub.add_parser("check", help="compare coverage.xml total to baseline; bump on a rise")
+    p_check.add_argument("--coverage-xml", default="coverage.xml", help="path to Cobertura coverage.xml")
+    p_check.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
+    p_check.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE, help="flat-band in pp")
+    p_check.add_argument("--no-bump", action="store_true", help="report only; never rewrite the baseline")
+    p_check.set_defaults(func=_cmd_check)
+
+    p_bump = sub.add_parser("bump-floor", help="raise the diff-coverage floor by one step (weekly)")
+    p_bump.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
+    p_bump.add_argument("--step", type=int, default=DEFAULT_FLOOR_STEP, help="increment in pp")
+    p_bump.add_argument("--cap", type=int, default=DEFAULT_FLOOR_CAP, help="hard ceiling for the floor")
+    p_bump.set_defaults(func=_cmd_bump_floor)
+
+    p_init = sub.add_parser("init", help="seed the baseline from a measured coverage.xml")
+    p_init.add_argument("--coverage-xml", default="coverage.xml", help="path to Cobertura coverage.xml")
+    p_init.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
+    p_init.add_argument("--diff-floor", type=int, default=DEFAULT_DIFF_FLOOR, help="initial diff floor pp")
+    p_init.set_defaults(func=_cmd_init)
+
+    p_show = sub.add_parser("show-floor", help="print the current diff-coverage floor")
+    p_show.add_argument("--baseline", default=".coverage-baseline.json", help="path to baseline JSON")
+    p_show.set_defaults(func=_cmd_show_floor)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = args.func
+    result = func(args)
+    return int(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_coverage_ratchet.py
+++ b/tests/unit/test_coverage_ratchet.py
@@ -1,0 +1,249 @@
+"""Unit tests for the total-coverage monotonic ratchet.
+
+Covers ``scripts/coverage_ratchet.py``:
+
+- parsing total line coverage from a Cobertura ``coverage.xml``;
+- the compare/bump decision (drop -> fail, rise -> pass + high-water bump,
+  flat -> pass + no write);
+- atomic baseline read/write (no partial file on crash);
+- the weekly diff-coverage floor increment with its cap;
+- graceful handling of a malformed / missing ``coverage.xml``.
+
+The script is import-only at module level (no side effects) so these
+tests can drive its functions directly without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+# ``scripts/`` is not an installed package, so load the module by path.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "coverage_ratchet.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("coverage_ratchet", _SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register so dataclasses / typing resolve a stable module identity.
+    sys.modules["coverage_ratchet"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ratchet = _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# coverage.xml parsing
+# --------------------------------------------------------------------------- #
+
+
+def _write_coverage_xml(path: Path, line_rate: str) -> None:
+    """Write a minimal Cobertura coverage.xml with the given root line-rate."""
+    path.write_text(
+        f'<?xml version="1.0" ?>\n'
+        f'<coverage line-rate="{line_rate}" branch-rate="0.1" version="7.0">\n'
+        f"  <packages></packages>\n"
+        f"</coverage>\n",
+        encoding="utf-8",
+    )
+
+
+def test_parse_total_coverage_reads_root_line_rate(tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, "0.1753")
+
+    pct = ratchet.parse_total_coverage(xml)
+
+    assert pct == pytest.approx(17.53, abs=0.001)
+
+
+def test_parse_total_coverage_full_coverage(tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, "1.0")
+
+    assert ratchet.parse_total_coverage(xml) == pytest.approx(100.0, abs=0.001)
+
+
+def test_parse_total_coverage_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(ratchet.CoverageParseError):
+        ratchet.parse_total_coverage(tmp_path / "does-not-exist.xml")
+
+
+def test_parse_total_coverage_malformed_xml_raises(tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    xml.write_text("<coverage line-rate=", encoding="utf-8")  # truncated, invalid
+
+    with pytest.raises(ratchet.CoverageParseError):
+        ratchet.parse_total_coverage(xml)
+
+
+def test_parse_total_coverage_missing_attribute_raises(tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    xml.write_text('<?xml version="1.0" ?>\n<coverage version="7.0"></coverage>\n', encoding="utf-8")
+
+    with pytest.raises(ratchet.CoverageParseError):
+        ratchet.parse_total_coverage(xml)
+
+
+def test_parse_total_coverage_non_numeric_attribute_raises(tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, "not-a-number")
+
+    with pytest.raises(ratchet.CoverageParseError):
+        ratchet.parse_total_coverage(xml)
+
+
+def test_parse_total_coverage_empty_tree_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A parse that yields no root element is reported, not an AttributeError."""
+    xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(xml, "0.5")
+
+    class _RootlessTree:
+        def getroot(self) -> None:
+            return None
+
+    monkeypatch.setattr(ratchet.ET, "parse", lambda _path: _RootlessTree())
+
+    with pytest.raises(ratchet.CoverageParseError):
+        ratchet.parse_total_coverage(xml)
+
+
+# --------------------------------------------------------------------------- #
+# baseline read / write
+# --------------------------------------------------------------------------- #
+
+
+def test_read_baseline_round_trips(tmp_path: Path) -> None:
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    written = ratchet.Baseline(total_coverage_percent=17.5, diff_coverage_floor_percent=80)
+    ratchet.write_baseline(baseline_path, written)
+
+    loaded = ratchet.read_baseline(baseline_path)
+
+    assert loaded.total_coverage_percent == pytest.approx(17.5)
+    assert loaded.diff_coverage_floor_percent == 80
+
+
+def test_read_baseline_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ratchet.read_baseline(tmp_path / "nope.json")
+
+
+def test_write_baseline_is_atomic_no_partial_temp_left(tmp_path: Path) -> None:
+    """A successful write leaves exactly the target file, no temp turds."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    ratchet.write_baseline(
+        baseline_path,
+        ratchet.Baseline(total_coverage_percent=20.0, diff_coverage_floor_percent=85),
+    )
+
+    siblings = list(tmp_path.iterdir())
+    assert siblings == [baseline_path], f"unexpected leftover files: {siblings}"
+    # File is valid JSON with the documented keys.
+    data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert set(data) >= {"total_coverage_percent", "diff_coverage_floor_percent"}
+
+
+def test_write_baseline_does_not_corrupt_existing_on_serialise_failure(tmp_path: Path) -> None:
+    """If serialisation blows up mid-write, the prior baseline survives."""
+    baseline_path = tmp_path / ".coverage-baseline.json"
+    good = ratchet.Baseline(total_coverage_percent=17.5, diff_coverage_floor_percent=80)
+    ratchet.write_baseline(baseline_path, good)
+    original_bytes = baseline_path.read_bytes()
+
+    class _Unserialisable:
+        pass
+
+    bad = ratchet.Baseline(
+        total_coverage_percent=_Unserialisable(),  # type: ignore[arg-type]
+        diff_coverage_floor_percent=80,
+    )
+    with pytest.raises(TypeError):
+        ratchet.write_baseline(baseline_path, bad)
+
+    # Atomic replace means the original content is untouched.
+    assert baseline_path.read_bytes() == original_bytes
+
+
+# --------------------------------------------------------------------------- #
+# compare / bump decision
+# --------------------------------------------------------------------------- #
+
+
+def test_decide_drop_fails_and_does_not_bump() -> None:
+    decision = ratchet.decide(baseline_pct=17.5, measured_pct=16.0, tolerance=0.05)
+
+    assert decision.dropped is True
+    assert decision.should_bump is False
+    assert decision.exit_code != 0
+
+
+def test_decide_rise_passes_and_bumps() -> None:
+    decision = ratchet.decide(baseline_pct=17.5, measured_pct=19.2, tolerance=0.05)
+
+    assert decision.dropped is False
+    assert decision.should_bump is True
+    assert decision.new_total_pct == pytest.approx(19.2)
+    assert decision.exit_code == 0
+
+
+def test_decide_flat_within_tolerance_passes_without_bump() -> None:
+    decision = ratchet.decide(baseline_pct=17.50, measured_pct=17.52, tolerance=0.05)
+
+    assert decision.dropped is False
+    assert decision.should_bump is False
+    assert decision.exit_code == 0
+
+
+def test_decide_tiny_drop_within_tolerance_does_not_fail() -> None:
+    """Sub-tolerance noise (float jitter between runs) must not trip the gate."""
+    decision = ratchet.decide(baseline_pct=17.50, measured_pct=17.48, tolerance=0.05)
+
+    assert decision.dropped is False
+    assert decision.exit_code == 0
+
+
+def test_decide_drop_beyond_tolerance_fails() -> None:
+    decision = ratchet.decide(baseline_pct=17.50, measured_pct=17.40, tolerance=0.05)
+
+    assert decision.dropped is True
+    assert decision.exit_code != 0
+
+
+# --------------------------------------------------------------------------- #
+# weekly diff-coverage floor increment + cap
+# --------------------------------------------------------------------------- #
+
+
+def test_weekly_bump_increments_by_step() -> None:
+    assert ratchet.next_floor(current=80, step=1, cap=90) == 81
+
+
+def test_weekly_bump_caps_at_ceiling() -> None:
+    assert ratchet.next_floor(current=90, step=1, cap=90) == 90
+
+
+def test_weekly_bump_does_not_overshoot_cap() -> None:
+    assert ratchet.next_floor(current=89, step=5, cap=90) == 90
+
+
+def test_weekly_bump_already_above_cap_clamps_down_to_cap() -> None:
+    # Defensive: a manually-edited floor above the cap is clamped, never raised.
+    assert ratchet.next_floor(current=95, step=1, cap=90) == 90
+
+
+def test_weekly_bump_rejects_non_positive_step() -> None:
+    with pytest.raises(ValueError):
+        ratchet.next_floor(current=80, step=0, cap=90)


### PR DESCRIPTION
## Summary

A two-level, **advisory-first** coverage gate that makes coverage a one-way
monotonic ratchet (it can only hold or rise) and nudges the per-PR floor up
over time. It reuses machinery already in the repo - the `diff-cover` dev
dep and the CI coverage shard's `coverage.xml` - so there is **no parallel
coverage system**.

### LEVEL 1 - per-PR diff floor (root-cause fix)
The existing `diff-coverage` job now reads its `--fail-under` floor from
`diff_coverage_floor_percent` in `.coverage-baseline.json`, making the floor
a single source of truth the weekly bump can raise. New code must arrive
covered. Stays advisory via the step's `continue-on-error`, so the job
result remains `success` and it can sit in the `CI gate` `needs` set without
ever wedging the merge queue.

### LEVEL 2 - total monotonic ratchet (anti-backslide)
`.github/workflows/coverage-ratchet.yml` runs on push to `main`, resolves
the freshest CI run that uploaded a `coverage-report` artifact (mirroring
`sonar-scan.yml`, since `cancel-in-progress` cancels most main CI runs), and
compares the total to the committed high-water mark:
- **drop** -> reports red (advisory; `continue-on-error`, not in any
  required-check set);
- **rise** -> opens a PR bumping `.coverage-baseline.json` to the new
  high-water mark (a PR, not a direct push, because `main` is protected);
- **flat** -> no change.

### Weekly bump (nudges up over time)
`.github/workflows/coverage-ratchet-weekly.yml` raises the diff floor by
**+1pp** (capped at **90%**) and opens a review PR. Cron is
disabled-by-default behind `ENABLE_CRON` until a clean manual run, mirroring
the existing sweeper rollout.

## Advisory-not-required posture
Neither level is added to the `CI gate` required-check aggregator or to
branch protection, so a red signal here can never block the merge queue. The
operator promotes them to blocking later; the runbook documents exactly how
(`docs/operations/coverage-ratchet.md`).

## Measured baseline
`.coverage-baseline.json` is seeded from a **real measurement**, not a
guess: a full per-file isolated unit-suite run over `src/bernstein`
(identical command to the CI shard) measured **77.51% line coverage**
(137,554 / 177,471 lines; `coverage report` total 75%).

Note for reviewers: this complete-run number is much higher than a
static-analysis dashboard may show. That dashboard ingests whatever
`coverage.xml` the CI shard last uploaded, and under the rapid-merge cadence
that artifact is frequently partial (the shard is cancelled mid-run), which
understates coverage. The baseline committed here is the complete-run value,
which is what the ratchet must protect. The doc and override table call out
that a partial-CI run can produce a spurious LEVEL 2 drop warning (advisory
only; self-heals on the next complete run).

## Operator-judgement calls (please confirm)
- **Starting diff floor: 85%** - one step above the 80% the diff-cover step
  enforced before this change. Tunable in the baseline file.
- **Weekly increment: +1pp, cap 90%** - gentle so the floor creeps up
  without becoming a wall. Tunable via the weekly workflow inputs.

## Test plan
- [x] `uv run pytest tests/unit/test_coverage_ratchet.py -q --no-cov` (21 passed)
- [x] `ruff check` + `ruff format --check` on the script and test (clean)
- [x] `pyright scripts/coverage_ratchet.py` (0 errors)
- [x] `actionlint` on the three workflows (clean)
- [x] `typos` on all new/changed files (clean)
- [x] CLI smoke: `init` / `check` (drop -> exit 1, rise -> exit 0 + bump, flat -> exit 0) / `bump-floor` (cap) / malformed-xml soft-skip (exit 3)
- [ ] CI green on this PR