### PR TITLE
test(protocols,routing,cost): cover dark paths in a2a/acp/mcp, bandit router, cost tracker

### DIFF
--- a/tests/unit/cost/test_claude_cost_tracking.py
+++ b/tests/unit/cost/test_claude_cost_tracking.py
@@ -1,0 +1,280 @@
+"""Tests for ``claude_cost_tracking`` - parse Claude Code session output.
+
+Covers the dark paths of the session-output parser and the aggregator:
+
+* ``SessionCostData`` token totals + JSON serialisation.
+* ``parse_session_output`` across all three input shapes (stream-json
+  events, text summary lines, structured result JSON), including the
+  ``max`` accumulation semantics and comma-stripped integers.
+* ``_extract_from_json`` field precedence (cost keys, duration units,
+  cache-read / cache-write alias keys, model fill-in).
+* ``CostTrackingAggregator`` per-model rollups, dedupe-by-session, and
+  the rounded summary contract.
+
+Every assertion pins an observed numeric / structural fact so a
+behaviour change would break the test.
+"""
+
+from __future__ import annotations
+
+import json
+
+from bernstein.core.cost.claude_cost_tracking import (
+    CostTrackingAggregator,
+    SessionCostData,
+    parse_session_output,
+)
+
+
+class TestSessionCostData:
+    def test_total_tokens_sums_all_four_buckets(self) -> None:
+        data = SessionCostData(
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_tokens=3,
+            cache_write_tokens=7,
+        )
+        assert data.total_tokens == 40
+
+    def test_total_tokens_zero_by_default(self) -> None:
+        assert SessionCostData().total_tokens == 0
+
+    def test_to_dict_rounds_cost_to_six_places(self) -> None:
+        data = SessionCostData(total_cost_usd=0.123456789)
+        assert data.to_dict()["total_cost_usd"] == 0.123457
+
+    def test_to_dict_rounds_duration_to_one_place(self) -> None:
+        data = SessionCostData(duration_s=12.349)
+        assert data.to_dict()["duration_s"] == 12.3
+
+    def test_to_dict_includes_derived_total_tokens(self) -> None:
+        data = SessionCostData(input_tokens=5, output_tokens=6)
+        d = data.to_dict()
+        assert d["total_tokens"] == 11
+        assert d["input_tokens"] == 5
+        assert d["output_tokens"] == 6
+
+    def test_to_dict_is_json_serialisable(self) -> None:
+        data = SessionCostData(session_id="s1", model="sonnet", total_cost_usd=1.5)
+        # round-trips through JSON without raising
+        round_tripped = json.loads(json.dumps(data.to_dict()))
+        assert round_tripped["session_id"] == "s1"
+        assert round_tripped["model"] == "sonnet"
+
+
+class TestParseSessionOutputText:
+    def test_parses_total_cost_line(self) -> None:
+        out = "some preamble\nTotal cost: $0.42\nmore"
+        data = parse_session_output(out)
+        assert data.total_cost_usd == 0.42
+
+    def test_parses_session_cost_line_case_insensitive(self) -> None:
+        data = parse_session_output("session COST: $1.23")
+        assert data.total_cost_usd == 1.23
+
+    def test_cost_line_without_dollar_sign(self) -> None:
+        data = parse_session_output("Total cost: 0.10")
+        assert data.total_cost_usd == 0.10
+
+    def test_parses_token_line_with_commas(self) -> None:
+        data = parse_session_output("Input tokens: 12,345, Output tokens: 6,789")
+        assert data.input_tokens == 12345
+        assert data.output_tokens == 6789
+
+    def test_prompt_completion_synonyms(self) -> None:
+        data = parse_session_output("Prompt tokens: 100 ... Completion tokens: 200")
+        assert data.input_tokens == 100
+        assert data.output_tokens == 200
+
+    def test_cost_takes_running_maximum(self) -> None:
+        # Two cost lines; parser keeps the larger value.
+        out = "Total cost: $0.10\nTotal cost: $0.99\nTotal cost: $0.50"
+        data = parse_session_output(out)
+        assert data.total_cost_usd == 0.99
+
+    def test_blank_lines_skipped(self) -> None:
+        data = parse_session_output("\n\n   \nTotal cost: $0.05\n\n")
+        assert data.total_cost_usd == 0.05
+
+    def test_no_cost_data_yields_zero(self) -> None:
+        data = parse_session_output("nothing relevant here\njust prose")
+        assert data.total_cost_usd == 0.0
+        assert data.total_tokens == 0
+
+    def test_session_id_and_model_passthrough(self) -> None:
+        data = parse_session_output("", session_id="sess-9", model="opus")
+        assert data.session_id == "sess-9"
+        assert data.model == "opus"
+
+
+class TestParseSessionOutputJson:
+    def test_extracts_usage_dict_tokens(self) -> None:
+        line = json.dumps({"usage": {"input_tokens": 500, "output_tokens": 250}})
+        data = parse_session_output(line)
+        assert data.input_tokens == 500
+        assert data.output_tokens == 250
+
+    def test_extracts_cache_tokens_primary_keys(self) -> None:
+        line = json.dumps(
+            {
+                "usage": {
+                    "cache_read_input_tokens": 80,
+                    "cache_creation_input_tokens": 40,
+                }
+            }
+        )
+        data = parse_session_output(line)
+        assert data.cache_read_tokens == 80
+        assert data.cache_write_tokens == 40
+
+    def test_extracts_cache_tokens_alias_keys(self) -> None:
+        line = json.dumps({"usage": {"cache_read_tokens": 11, "cache_write_tokens": 22}})
+        data = parse_session_output(line)
+        assert data.cache_read_tokens == 11
+        assert data.cache_write_tokens == 22
+
+    def test_extracts_cost_usd_key(self) -> None:
+        data = parse_session_output(json.dumps({"cost_usd": 3.14}))
+        assert data.total_cost_usd == 3.14
+
+    def test_extracts_session_cost_key(self) -> None:
+        data = parse_session_output(json.dumps({"session_cost": 7.5}))
+        assert data.total_cost_usd == 7.5
+
+    def test_duration_ms_converted_to_seconds(self) -> None:
+        data = parse_session_output(json.dumps({"duration_ms": 4200}))
+        assert data.duration_s == 4.2
+
+    def test_duration_s_kept_as_is(self) -> None:
+        data = parse_session_output(json.dumps({"duration_s": 9.0}))
+        assert data.duration_s == 9.0
+
+    def test_elapsed_ms_converted(self) -> None:
+        data = parse_session_output(json.dumps({"elapsed_ms": 1500}))
+        assert data.duration_s == 1.5
+
+    def test_model_filled_from_json_when_unset(self) -> None:
+        data = parse_session_output(json.dumps({"model": "claude-sonnet-4"}))
+        assert data.model == "claude-sonnet-4"
+
+    def test_explicit_model_not_overwritten_by_json(self) -> None:
+        # Caller passes a model; a JSON model field must not clobber it.
+        data = parse_session_output(json.dumps({"model": "haiku"}), model="opus")
+        assert data.model == "opus"
+
+    def test_assistant_type_counts_turns(self) -> None:
+        out = "\n".join(
+            json.dumps(obj)
+            for obj in (
+                {"type": "assistant", "usage": {"input_tokens": 1, "output_tokens": 1}},
+                {"type": "assistant", "usage": {"input_tokens": 2, "output_tokens": 2}},
+                {"type": "user"},
+            )
+        )
+        data = parse_session_output(out)
+        assert data.turns == 2
+
+    def test_assistant_role_also_counts_turns(self) -> None:
+        out = json.dumps({"role": "assistant", "usage": {"input_tokens": 1, "output_tokens": 1}})
+        data = parse_session_output(out)
+        assert data.turns == 1
+
+    def test_usage_max_accumulation_across_events(self) -> None:
+        # The parser keeps the maximum seen per field, not the sum.
+        out = "\n".join(json.dumps({"usage": {"input_tokens": v, "output_tokens": v * 2}}) for v in (10, 100, 50))
+        data = parse_session_output(out)
+        assert data.input_tokens == 100
+        assert data.output_tokens == 200
+
+    def test_non_dict_json_falls_through_to_text(self) -> None:
+        # A bare JSON array is valid JSON but not a dict; the line then
+        # still gets a regex pass (which finds nothing here).
+        data = parse_session_output("[1, 2, 3]")
+        assert data.total_tokens == 0
+        assert data.total_cost_usd == 0.0
+
+    def test_mixed_json_and_text_lines(self) -> None:
+        out = "\n".join(
+            [
+                json.dumps({"usage": {"input_tokens": 300, "output_tokens": 150}}),
+                "Total cost: $2.00",
+            ]
+        )
+        data = parse_session_output(out)
+        assert data.input_tokens == 300
+        assert data.output_tokens == 150
+        assert data.total_cost_usd == 2.0
+
+    def test_invalid_cost_value_in_json_ignored(self) -> None:
+        # cost field present but non-numeric: suppressed, stays at 0.
+        data = parse_session_output(json.dumps({"cost": "not-a-number"}))
+        assert data.total_cost_usd == 0.0
+
+    def test_non_dict_usage_value_skipped(self) -> None:
+        # ``usage`` present but not a dict: the usage branch is skipped,
+        # other fields (cost) still parse.
+        data = parse_session_output(json.dumps({"usage": "oops", "cost_usd": 1.0}))
+        assert data.total_tokens == 0
+        assert data.total_cost_usd == 1.0
+
+
+class TestCostTrackingAggregator:
+    def test_record_and_total_cost(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="a", total_cost_usd=1.0))
+        agg.record_session(SessionCostData(session_id="b", total_cost_usd=2.5))
+        assert agg.total_cost_usd() == 3.5
+
+    def test_record_same_session_id_overwrites(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="x", total_cost_usd=1.0))
+        agg.record_session(SessionCostData(session_id="x", total_cost_usd=9.0))
+        # Same key replaces; total reflects only the latest record.
+        assert agg.total_cost_usd() == 9.0
+        assert len(agg.sessions) == 1
+
+    def test_total_tokens_across_sessions(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="a", input_tokens=10, output_tokens=5))
+        agg.record_session(SessionCostData(session_id="b", input_tokens=20, cache_read_tokens=2))
+        assert agg.total_tokens() == 37
+
+    def test_empty_aggregator_totals_zero(self) -> None:
+        agg = CostTrackingAggregator()
+        assert agg.total_cost_usd() == 0.0
+        assert agg.total_tokens() == 0
+
+    def test_summary_groups_by_model(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="a", model="sonnet", total_cost_usd=1.0, input_tokens=100))
+        agg.record_session(SessionCostData(session_id="b", model="sonnet", total_cost_usd=2.0, input_tokens=50))
+        agg.record_session(SessionCostData(session_id="c", model="opus", total_cost_usd=4.0, output_tokens=10))
+        summary = agg.summary()
+        assert summary["total_sessions"] == 3
+        assert summary["by_model"]["sonnet"]["sessions"] == 2
+        assert summary["by_model"]["sonnet"]["cost_usd"] == 3.0
+        assert summary["by_model"]["sonnet"]["tokens"] == 150
+        assert summary["by_model"]["opus"]["cost_usd"] == 4.0
+        assert summary["by_model"]["opus"]["sessions"] == 1
+
+    def test_summary_unknown_model_bucket(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="a", model="", total_cost_usd=1.0))
+        summary = agg.summary()
+        assert "unknown" in summary["by_model"]
+        assert summary["by_model"]["unknown"]["cost_usd"] == 1.0
+
+    def test_summary_rounds_floats(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="a", model="m", total_cost_usd=0.1234567))
+        summary = agg.summary()
+        assert summary["total_cost_usd"] == 0.123457
+        assert summary["by_model"]["m"]["cost_usd"] == 0.123457
+
+    def test_summary_total_cost_matches_sum(self) -> None:
+        agg = CostTrackingAggregator()
+        agg.record_session(SessionCostData(session_id="a", total_cost_usd=1.5))
+        agg.record_session(SessionCostData(session_id="b", total_cost_usd=2.5))
+        summary = agg.summary()
+        assert summary["total_cost_usd"] == 4.0
+        assert summary["total_tokens"] == 0

--- a/tests/unit/cost/test_cost_tracker_paths.py
+++ b/tests/unit/cost/test_cost_tracker_paths.py
@@ -1,0 +1,790 @@
+"""Behavioural tests for ``cost_tracker`` dark paths.
+
+Targets the per-run budget tracker's observable contracts:
+
+* ``estimate_cost`` with the per-1M pricing table (exact arithmetic) and
+  the blended-rate fallback for unknown models.
+* ``resolve_run_budget_usd`` layered precedence + bad-env handling.
+* ``EnvelopeConfig`` normalisation, allowlist matching, (de)serialisation.
+* ``CostTracker.record`` aggregation into ``spent_by_model`` /
+  ``spent_for_agent`` / envelope rollups; explicit-cost vs estimated.
+* ``record_cumulative`` delta-safe accounting + cost proration.
+* Envelope hard caps (``EnvelopeBudgetError``), allowlist refusal, and
+  the threshold hook firing exactly once.
+* ``status`` soft thresholds, hard-cap kill switch, unlimited budget.
+* ``agent_summaries`` / ``model_breakdowns`` ordering + token buckets.
+* ``project`` confidence ramp + within-budget flag.
+* ``cache_savings_usd`` from cache-read pricing delta.
+* ``save`` / ``load`` round-trip preserving aggregates and envelopes.
+* Usage-buffer eviction with JSONL rotation; accumulators stay exact.
+
+All numeric assertions are pinned against the real pricing tables so a
+behaviour change is caught.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.cost_tracker import (
+    DEFAULT_QUOTA_ENVELOPE,
+    EnvelopeBudgetError,
+    EnvelopeConfig,
+    TokenUsage,
+    estimate_cost,
+    resolve_run_budget_usd,
+)
+from bernstein.core.cost.cost_tracker import CostTracker as Tracker
+
+# ---------------------------------------------------------------------------
+# estimate_cost
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateCost:
+    def test_sonnet_input_one_million_tokens(self) -> None:
+        # sonnet input pricing is $3 / 1M tokens.
+        assert estimate_cost("sonnet", 1_000_000, 0) == pytest.approx(3.0)
+
+    def test_sonnet_output_one_million_tokens(self) -> None:
+        # sonnet output pricing is $15 / 1M tokens.
+        assert estimate_cost("sonnet", 0, 1_000_000) == pytest.approx(15.0)
+
+    def test_opus_input_output_combined(self) -> None:
+        # opus: input $5/1M, output $25/1M.
+        cost = estimate_cost("opus", 200_000, 100_000)
+        assert cost == pytest.approx(0.2 * 5.0 + 0.1 * 25.0)
+
+    def test_cache_read_cheaper_than_input(self) -> None:
+        # sonnet cache_read is $0.3/1M vs $3/1M input.
+        cost = estimate_cost("sonnet", 0, 0, cache_read_tokens=1_000_000)
+        assert cost == pytest.approx(0.3)
+
+    def test_cache_write_pricing(self) -> None:
+        # sonnet cache_write is $3.75/1M.
+        cost = estimate_cost("sonnet", 0, 0, cache_write_tokens=1_000_000)
+        assert cost == pytest.approx(3.75)
+
+    def test_model_name_substring_match_case_insensitive(self) -> None:
+        # "claude-sonnet-4" contains "sonnet" -> uses sonnet pricing.
+        a = estimate_cost("claude-sonnet-4-20990101", 1_000_000, 0)
+        assert a == pytest.approx(3.0)
+
+    def test_unknown_model_uses_blended_fallback(self) -> None:
+        # Totally unknown model -> safe fallback blended rate 0.005/1k.
+        cost = estimate_cost("totally-made-up-model-xyz", 1000, 0)
+        assert cost == pytest.approx(0.005)
+
+    def test_o3_uses_detailed_per_million_pricing(self) -> None:
+        # o3 is in the per-1M table (input $2/1M) so detailed pricing wins
+        # over the blended fallback: 2000 input tokens => $0.004.
+        assert estimate_cost("o3", 2000, 0) == pytest.approx(0.004)
+
+    def test_haiku_combined_input_output(self) -> None:
+        # haiku: input $1/1M, output $5/1M.
+        cost = estimate_cost("haiku", 1_000_000, 1_000_000)
+        assert cost == pytest.approx(6.0)
+
+    def test_zero_tokens_zero_cost(self) -> None:
+        assert estimate_cost("sonnet", 0, 0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# resolve_run_budget_usd
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRunBudget:
+    def test_env_var_takes_precedence(self) -> None:
+        env = {"BERNSTEIN_MAX_COST_USD": "12.5"}
+        assert resolve_run_budget_usd(run_config_value=5.0, seed_value=3.0, env=env) == 12.5
+
+    def test_run_config_over_seed(self) -> None:
+        assert resolve_run_budget_usd(run_config_value=5.0, seed_value=3.0, env={}) == 5.0
+
+    def test_seed_when_no_run_config(self) -> None:
+        assert resolve_run_budget_usd(run_config_value=None, seed_value=3.0, env={}) == 3.0
+
+    def test_default_when_nothing_set(self) -> None:
+        assert resolve_run_budget_usd(env={}, default=2.0) == 2.0
+
+    def test_invalid_env_falls_through(self) -> None:
+        env = {"BERNSTEIN_MAX_COST_USD": "not-a-float"}
+        assert resolve_run_budget_usd(run_config_value=7.0, env=env) == 7.0
+
+    def test_negative_env_normalised_to_zero(self) -> None:
+        env = {"BERNSTEIN_MAX_COST_USD": "-5"}
+        assert resolve_run_budget_usd(env=env) == 0.0
+
+    def test_blank_env_ignored(self) -> None:
+        env = {"BERNSTEIN_MAX_COST_USD": "   "}
+        assert resolve_run_budget_usd(seed_value=4.0, env=env) == 4.0
+
+    def test_nonpositive_run_config_skipped(self) -> None:
+        # run_config of 0 is not "set"; seed wins.
+        assert resolve_run_budget_usd(run_config_value=0.0, seed_value=9.0, env={}) == 9.0
+
+
+# ---------------------------------------------------------------------------
+# EnvelopeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeConfig:
+    def test_negative_budget_normalised_to_zero(self) -> None:
+        cfg = EnvelopeConfig(name="e", budget_usd=-3.0)
+        assert cfg.budget_usd == 0.0
+
+    def test_negative_hard_budget_normalised(self) -> None:
+        cfg = EnvelopeConfig(name="e", hard_budget_usd=-1.0)
+        assert cfg.hard_budget_usd == 0.0
+
+    def test_out_of_range_threshold_resets_to_default(self) -> None:
+        assert EnvelopeConfig(name="e", threshold_pct=1.5).threshold_pct == pytest.approx(0.80)
+        assert EnvelopeConfig(name="e", threshold_pct=0.0).threshold_pct == pytest.approx(0.80)
+
+    def test_valid_threshold_kept(self) -> None:
+        assert EnvelopeConfig(name="e", threshold_pct=0.5).threshold_pct == 0.5
+
+    def test_empty_allowlist_allows_any_model(self) -> None:
+        assert EnvelopeConfig(name="e").model_allowed("anything")
+
+    def test_allowlist_substring_case_insensitive(self) -> None:
+        cfg = EnvelopeConfig(name="e", model_allowlist=("sonnet",))
+        assert cfg.model_allowed("claude-SONNET-4")
+        assert not cfg.model_allowed("opus")
+
+    def test_to_dict_from_dict_round_trip(self) -> None:
+        cfg = EnvelopeConfig(name="e", budget_usd=10.0, hard_budget_usd=20.0, model_allowlist=("haiku", "sonnet"))
+        rebuilt = EnvelopeConfig.from_dict("e", cfg.to_dict())
+        assert rebuilt == cfg
+
+    def test_from_dict_coerces_allowlist_strings(self) -> None:
+        cfg = EnvelopeConfig.from_dict("e", {"model_allowlist": ["sonnet", "", "opus"]})
+        # blank entries dropped.
+        assert cfg.model_allowlist == ("sonnet", "opus")
+
+
+# ---------------------------------------------------------------------------
+# record / spent_by_model / spent_for_agent
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAggregation:
+    def test_record_uses_explicit_cost(self) -> None:
+        t = Tracker(run_id="r")
+        status = t.record("agent-a", "task-1", "sonnet", 100, 50, cost_usd=0.25)
+        assert status.spent_usd == pytest.approx(0.25)
+        assert t.spent_usd == pytest.approx(0.25)
+
+    def test_record_estimates_cost_when_omitted(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("agent-a", "task-1", "sonnet", 1_000_000, 0)
+        # sonnet input is $3/1M.
+        assert t.spent_usd == pytest.approx(3.0)
+
+    def test_spent_by_model_aggregates_per_model(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=2.0)
+        t.record("a", "t", "opus", 0, 0, cost_usd=4.0)
+        by_model = t.spent_by_model()
+        assert by_model["sonnet"] == pytest.approx(3.0)
+        assert by_model["opus"] == pytest.approx(4.0)
+
+    def test_spent_by_model_returns_copy(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        snapshot = t.spent_by_model()
+        snapshot["sonnet"] = 999.0
+        # mutating the snapshot must not change tracker state.
+        assert t.spent_by_model()["sonnet"] == pytest.approx(1.0)
+
+    def test_spent_for_agent_isolated(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("agent-a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        t.record("agent-b", "t", "sonnet", 0, 0, cost_usd=3.0)
+        assert t.spent_for_agent("agent-a") == pytest.approx(1.0)
+        assert t.spent_for_agent("agent-b") == pytest.approx(3.0)
+
+    def test_spent_for_unknown_agent_is_zero(self) -> None:
+        t = Tracker(run_id="r")
+        assert t.spent_for_agent("nope") == 0.0
+
+    def test_total_usages_recorded_counts_all(self) -> None:
+        t = Tracker(run_id="r")
+        for _ in range(5):
+            t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        assert t.total_usages_recorded == 5
+        assert len(t.usages) == 5
+
+    def test_record_attaches_role_and_feature_tags(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01, role="backend", feature_label="auth")
+        usage = t.usages[-1]
+        assert usage.cost_tags["role"] == "backend"
+        assert usage.cost_tags["feature_label"] == "auth"
+
+    def test_record_default_envelope(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 1, 1, cost_usd=0.5)
+        assert t.spent_by_envelope()[DEFAULT_QUOTA_ENVELOPE] == pytest.approx(0.5)
+        assert t.calls_by_envelope()[DEFAULT_QUOTA_ENVELOPE] == 1
+
+
+# ---------------------------------------------------------------------------
+# record_cumulative (delta-safe)
+# ---------------------------------------------------------------------------
+
+
+class TestRecordCumulative:
+    def test_first_call_records_full_total(self) -> None:
+        t = Tracker(run_id="r")
+        delta = t.record_cumulative("a", "t", "sonnet", 1000, 500, total_cost_usd=0.3)
+        assert delta == pytest.approx(0.3)
+        assert t.spent_usd == pytest.approx(0.3)
+
+    def test_second_call_records_only_delta(self) -> None:
+        t = Tracker(run_id="r")
+        t.record_cumulative("a", "t", "sonnet", 1000, 0, total_cost_usd=1.0)
+        # cumulative grows to 2000 input tokens; prorated cost.
+        delta = t.record_cumulative("a", "t", "sonnet", 2000, 0, total_cost_usd=2.0)
+        # second call prorates total_cost over the delta tokens fraction.
+        assert delta > 0.0
+        assert t.spent_usd == pytest.approx(1.0 + delta)
+
+    def test_no_new_tokens_returns_zero(self) -> None:
+        t = Tracker(run_id="r")
+        t.record_cumulative("a", "t", "sonnet", 1000, 500, total_cost_usd=1.0)
+        delta = t.record_cumulative("a", "t", "sonnet", 1000, 500, total_cost_usd=1.0)
+        assert delta == 0.0
+
+    def test_decreasing_totals_clamped_no_negative(self) -> None:
+        t = Tracker(run_id="r")
+        t.record_cumulative("a", "t", "sonnet", 5000, 2000, total_cost_usd=1.0)
+        before = t.spent_usd
+        # a smaller "total" than before means no positive delta -> no record.
+        delta = t.record_cumulative("a", "t", "sonnet", 100, 50, total_cost_usd=0.5)
+        assert delta == 0.0
+        assert t.spent_usd == pytest.approx(before)
+
+    def test_distinct_keys_tracked_separately(self) -> None:
+        t = Tracker(run_id="r")
+        t.record_cumulative("a", "t1", "sonnet", 1000, 0, total_cost_usd=1.0)
+        t.record_cumulative("a", "t2", "sonnet", 1000, 0, total_cost_usd=1.0)
+        # different task ids => two separate cumulative baselines.
+        assert t.spent_usd == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Envelope hard caps + allowlist + threshold hook
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeEnforcement:
+    def test_hard_cap_breach_raises(self) -> None:
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", hard_budget_usd=1.0)})
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=0.5, quota_envelope="sub")
+        with pytest.raises(EnvelopeBudgetError) as exc:
+            t.record("a", "t", "sonnet", 0, 0, cost_usd=0.75, quota_envelope="sub")
+        assert exc.value.envelope == "sub"
+        assert exc.value.cap_usd == pytest.approx(1.0)
+
+    def test_hard_cap_rejection_does_not_mutate_state(self) -> None:
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", hard_budget_usd=1.0)})
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=0.5, quota_envelope="sub")
+        with pytest.raises(EnvelopeBudgetError):
+            t.record("a", "t", "sonnet", 0, 0, cost_usd=5.0, quota_envelope="sub")
+        # spend stays at the pre-rejection value.
+        assert t.spent_by_envelope()["sub"] == pytest.approx(0.5)
+        assert t.spent_usd == pytest.approx(0.5)
+
+    def test_allowlist_refusal_raises(self) -> None:
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", model_allowlist=("haiku",))})
+        with pytest.raises(EnvelopeBudgetError) as exc:
+            t.record("a", "t", "opus", 0, 0, cost_usd=0.1, quota_envelope="sub")
+        assert "allowlist" in exc.value.reason
+
+    def test_threshold_hook_fires_once(self) -> None:
+        fired: list[str] = []
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=1.0, threshold_pct=0.8)})
+        t.set_envelope_threshold_hook(lambda report: fired.append(report.name))
+        # Below 80% -> no fire.
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=0.5, quota_envelope="sub")
+        assert fired == []
+        # Crosses 80% -> fires once.
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=0.4, quota_envelope="sub")
+        assert fired == ["sub"]
+        # Further spend over the watermark -> no repeat fire.
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=0.05, quota_envelope="sub")
+        assert fired == ["sub"]
+
+    def test_envelope_report_reflects_spend(self) -> None:
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=10.0, hard_budget_usd=20.0)})
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=5.0, quota_envelope="sub")
+        rep = t.envelope_report("sub")
+        assert rep.spent_usd == pytest.approx(5.0)
+        assert rep.cap_usd == pytest.approx(10.0)
+        assert rep.pct_used == pytest.approx(0.5)
+        assert rep.remaining_usd == pytest.approx(5.0)
+        assert rep.hard_remaining_usd == pytest.approx(15.0)
+        assert not rep.hard_breached
+
+    def test_envelope_reports_includes_configured_and_spent(self) -> None:
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"cfg-only": EnvelopeConfig(name="cfg-only", budget_usd=5.0)})
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0, quota_envelope="spent-only")
+        reports = t.envelope_reports()
+        # both the configured-but-unspent and the spent-but-unconfigured show.
+        assert "cfg-only" in reports
+        assert "spent-only" in reports
+        assert reports["spent-only"].spent_usd == pytest.approx(1.0)
+
+    def test_uncapped_envelope_report_infinite_remaining(self) -> None:
+        import math
+
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0, quota_envelope="free")
+        rep = t.envelope_report("free")
+        assert math.isinf(rep.remaining_usd)
+        assert rep.to_dict()["remaining_usd"] is None
+
+
+# ---------------------------------------------------------------------------
+# status thresholds + hard cap
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    def test_unlimited_budget_never_stops(self) -> None:
+        t = Tracker(run_id="r", budget_usd=0.0)
+        t.record("a", "t", "opus", 0, 0, cost_usd=1000.0)
+        status = t.status()
+        assert status.should_stop is False
+        assert status.percentage_used == 0.0
+        import math
+
+        assert math.isinf(status.remaining_usd)
+
+    def test_warn_threshold_trips(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0, warn_threshold=0.8)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=8.5)
+        status = t.status()
+        assert status.should_warn is True
+        assert status.should_stop is False
+        assert status.percentage_used == pytest.approx(0.85)
+
+    def test_hard_stop_threshold_trips(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0)
+        t.record("a", "t", "opus", 0, 0, cost_usd=10.0)
+        assert t.status().should_stop is True
+
+    def test_remaining_clamped_at_zero(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0)
+        t.record("a", "t", "opus", 0, 0, cost_usd=15.0)
+        assert t.status().remaining_usd == 0.0
+
+    def test_hard_cap_kill_switch_overrides_unlimited(self) -> None:
+        t = Tracker(run_id="r", budget_usd=0.0, hard_budget_usd=5.0)
+        t.record("a", "t", "opus", 0, 0, cost_usd=5.0)
+        status = t.status()
+        assert status.should_stop is True
+        assert status.should_warn is True
+
+    def test_can_spawn_false_after_hard_cap(self) -> None:
+        t = Tracker(run_id="r", hard_budget_usd=2.0)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=2.0)
+        assert t.can_spawn() is False
+
+    def test_can_spawn_true_under_soft_cap(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        assert t.can_spawn() is True
+
+    def test_can_spawn_envelope_hard_cap(self) -> None:
+        t = Tracker(run_id="r")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", hard_budget_usd=1.0)})
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0, quota_envelope="sub")
+        assert t.can_spawn(quota_envelope="sub") is False
+        # a different envelope is unaffected.
+        assert t.can_spawn(quota_envelope="other") is True
+
+    def test_status_to_dict_round_number(self) -> None:
+        t = Tracker(run_id="r", budget_usd=3.0)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        d = t.status().to_dict()
+        assert d["run_id"] == "r"
+        assert d["percentage_used"] == pytest.approx(0.3333, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# breakdowns + projection + cache savings
+# ---------------------------------------------------------------------------
+
+
+class TestBreakdownsAndProjection:
+    def test_agent_summaries_sorted_by_cost_desc(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("cheap", "t", "sonnet", 0, 0, cost_usd=1.0)
+        t.record("expensive", "t", "opus", 0, 0, cost_usd=9.0)
+        summaries = t.agent_summaries()
+        assert [s.agent_id for s in summaries] == ["expensive", "cheap"]
+        assert summaries[0].total_cost_usd == pytest.approx(9.0)
+        assert summaries[1].task_count == 1
+
+    def test_agent_summary_model_breakdown(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        t.record("a", "t", "opus", 0, 0, cost_usd=2.0)
+        summary = t.agent_summaries()[0]
+        assert summary.model_breakdown["sonnet"] == pytest.approx(1.0)
+        assert summary.model_breakdown["opus"] == pytest.approx(2.0)
+
+    def test_model_breakdowns_token_buckets(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 100, 50, cost_usd=1.0, cache_read_tokens=10, cache_write_tokens=5)
+        bd = t.model_breakdowns()[0]
+        assert bd.model == "sonnet"
+        assert bd.input_tokens == 100
+        assert bd.output_tokens == 50
+        assert bd.cache_read_tokens == 10
+        assert bd.cache_write_tokens == 5
+        assert bd.total_tokens == 165
+        assert bd.invocation_count == 1
+
+    def test_model_breakdowns_sorted_by_cost_desc(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "haiku", 0, 0, cost_usd=0.5)
+        t.record("a", "t", "opus", 0, 0, cost_usd=5.0)
+        models = [b.model for b in t.model_breakdowns()]
+        assert models == ["opus", "haiku"]
+
+    def test_project_no_tasks_zero_confidence(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        proj = t.project(tasks_done=0, tasks_remaining=10)
+        assert proj.confidence == 0.0
+        assert proj.avg_cost_per_task_usd == 0.0
+        assert proj.projected_total_usd == pytest.approx(1.0)
+
+    def test_project_avg_extrapolation(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=4.0)
+        proj = t.project(tasks_done=2, tasks_remaining=3)
+        # avg = 4/2 = 2; projected = 4 + 2*3 = 10.
+        assert proj.avg_cost_per_task_usd == pytest.approx(2.0)
+        assert proj.projected_total_usd == pytest.approx(10.0)
+
+    def test_project_confidence_caps_at_one(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        proj = t.project(tasks_done=10, tasks_remaining=0)
+        assert proj.confidence == 1.0
+
+    def test_project_within_budget_flag(self) -> None:
+        t = Tracker(run_id="r", budget_usd=5.0)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        # avg 1.0/task; 3 remaining -> projected 4.0 <= 5.0 budget.
+        assert t.project(tasks_done=1, tasks_remaining=3).within_budget is True
+        # 10 remaining -> projected 11.0 > 5.0.
+        assert t.project(tasks_done=1, tasks_remaining=10).within_budget is False
+
+    def test_cache_savings_from_cache_reads(self) -> None:
+        t = Tracker(run_id="r")
+        # sonnet: input $3/1M, cache_read $0.3/1M -> savings $2.7/1M.
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=0.3, cache_read_tokens=1_000_000)
+        assert t.cache_savings_usd() == pytest.approx(2.7)
+
+    def test_no_cache_reads_zero_savings(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 100, 100, cost_usd=0.1)
+        assert t.cache_savings_usd() == 0.0
+
+    def test_report_assembles_sections(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0)
+        t.record("a", "t", "sonnet", 100, 50, cost_usd=1.0)
+        t.record("b", "t", "opus", 200, 100, cost_usd=2.0)
+        report = t.report(tasks_done=2, tasks_remaining=2)
+        assert report.total_spent_usd == pytest.approx(3.0)
+        assert len(report.per_agent) == 2
+        assert len(report.per_model) == 2
+        assert report.projection is not None
+        assert report.projection.tasks_done == 2
+
+    def test_report_without_tasks_has_no_projection(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 1, 1, cost_usd=0.1)
+        assert t.report().projection is None
+
+
+# ---------------------------------------------------------------------------
+# save / load round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_save_writes_expected_path(self, tmp_path: Path) -> None:
+        t = Tracker(run_id="run-xyz", budget_usd=10.0)
+        t.record("a", "t", "sonnet", 100, 50, cost_usd=1.0)
+        out = t.save(tmp_path)
+        assert out == tmp_path / "runtime" / "costs" / "run-xyz.json"
+        assert out.exists()
+
+    def test_load_round_trip_preserves_aggregates(self, tmp_path: Path) -> None:
+        t = Tracker(run_id="run-1", budget_usd=20.0, hard_budget_usd=30.0)
+        t.record("agent-a", "t1", "sonnet", 100, 50, cost_usd=1.0)
+        t.record("agent-b", "t2", "opus", 200, 100, cost_usd=2.0)
+        t.save(tmp_path)
+
+        loaded = Tracker.load(tmp_path, "run-1")
+        assert loaded is not None
+        assert loaded.run_id == "run-1"
+        assert loaded.budget_usd == pytest.approx(20.0)
+        assert loaded.hard_budget_usd == pytest.approx(30.0)
+        assert loaded.spent_usd == pytest.approx(3.0)
+        assert loaded.spent_by_model()["sonnet"] == pytest.approx(1.0)
+        assert loaded.spent_by_model()["opus"] == pytest.approx(2.0)
+        assert loaded.spent_for_agent("agent-a") == pytest.approx(1.0)
+
+    def test_load_rebuilds_model_breakdowns(self, tmp_path: Path) -> None:
+        t = Tracker(run_id="run-2")
+        t.record("a", "t", "sonnet", 100, 50, cost_usd=1.0)
+        t.save(tmp_path)
+        loaded = Tracker.load(tmp_path, "run-2")
+        assert loaded is not None
+        # accumulators must be rebuilt so breakdowns survive reload.
+        bd = loaded.model_breakdowns()
+        assert len(bd) == 1
+        assert bd[0].input_tokens == 100
+
+    def test_load_preserves_envelope_config(self, tmp_path: Path) -> None:
+        t = Tracker(run_id="run-3")
+        t.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=5.0, hard_budget_usd=10.0)})
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=1.0, quota_envelope="sub")
+        t.save(tmp_path)
+        loaded = Tracker.load(tmp_path, "run-3")
+        assert loaded is not None
+        assert "sub" in loaded.envelopes
+        assert loaded.envelopes["sub"].budget_usd == pytest.approx(5.0)
+        assert loaded.spent_by_envelope()["sub"] == pytest.approx(1.0)
+
+    def test_load_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert Tracker.load(tmp_path, "does-not-exist") is None
+
+    def test_load_corrupt_file_returns_none(self, tmp_path: Path) -> None:
+        costs_dir = tmp_path / "runtime" / "costs"
+        costs_dir.mkdir(parents=True)
+        (costs_dir / "bad.json").write_text("{ not valid json")
+        assert Tracker.load(tmp_path, "bad") is None
+
+    def test_save_metrics_writes_report(self, tmp_path: Path) -> None:
+        t = Tracker(run_id="run-m")
+        t.record("a", "t", "sonnet", 10, 5, cost_usd=0.5)
+        out = t.save_metrics(tmp_path)
+        assert out == tmp_path / "costs_run-m.json"
+        payload = json.loads(out.read_text())
+        assert payload["run_id"] == "run-m"
+        assert payload["total_spent_usd"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# usage buffer eviction + rotation
+# ---------------------------------------------------------------------------
+
+
+class TestUsageBufferEviction:
+    def test_buffer_caps_in_memory_rows(self) -> None:
+        t = Tracker(run_id="r", usage_buffer_size=3)
+        for _ in range(5):
+            t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        # ring buffer holds at most 3 rows.
+        assert len(t.usages) == 3
+        # but the total count is exact.
+        assert t.total_usages_recorded == 5
+
+    def test_accumulators_exact_after_eviction(self) -> None:
+        t = Tracker(run_id="r", usage_buffer_size=2)
+        for _ in range(10):
+            t.record("a", "t", "sonnet", 100, 50, cost_usd=0.10)
+        # spend total survives eviction of older rows.
+        assert t.spent_usd == pytest.approx(1.0)
+        bd = t.model_breakdowns()[0]
+        assert bd.invocation_count == 10
+        assert bd.input_tokens == 1000
+
+    def test_eviction_rotates_to_jsonl(self, tmp_path: Path) -> None:
+        rotation = tmp_path / "rot"
+        t = Tracker(run_id="r", usage_buffer_size=2, rotation_dir=rotation)
+        for _ in range(5):
+            t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        rotation_file = rotation / "usages-r.jsonl"
+        assert rotation_file.exists()
+        # 5 recorded, buffer=2 -> 3 rows rotated out.
+        lines = rotation_file.read_text().strip().splitlines()
+        assert len(lines) == 3
+        first = json.loads(lines[0])
+        assert first["model"] == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage (de)serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUsage:
+    def test_to_dict_from_dict_round_trip(self) -> None:
+        usage = TokenUsage(
+            input_tokens=10,
+            output_tokens=5,
+            model="sonnet",
+            cost_usd=0.5,
+            agent_id="a",
+            task_id="t",
+            cache_read_tokens=3,
+            cache_write_tokens=2,
+            cost_tags={"role": "qa"},
+            quota_envelope="sub",
+        )
+        rebuilt = TokenUsage.from_dict(usage.to_dict())
+        assert rebuilt.input_tokens == 10
+        assert rebuilt.model == "sonnet"
+        assert rebuilt.cost_usd == pytest.approx(0.5)
+        assert rebuilt.cache_read_tokens == 3
+        assert rebuilt.cost_tags == {"role": "qa"}
+        assert rebuilt.quota_envelope == "sub"
+
+    def test_from_dict_defaults_missing_envelope(self) -> None:
+        usage = TokenUsage.from_dict(
+            {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "model": "sonnet",
+                "cost_usd": 0.1,
+                "agent_id": "a",
+                "task_id": "t",
+            }
+        )
+        assert usage.quota_envelope == DEFAULT_QUOTA_ENVELOPE
+
+    def test_from_dict_non_dict_tags_become_empty(self) -> None:
+        usage = TokenUsage.from_dict(
+            {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "model": "sonnet",
+                "cost_usd": 0.1,
+                "agent_id": "a",
+                "task_id": "t",
+                "cost_tags": "not-a-dict",
+            }
+        )
+        assert usage.cost_tags == {}
+
+
+# ---------------------------------------------------------------------------
+# cheaper_model_for + shareable_summary + buffer env + retry budget
+# ---------------------------------------------------------------------------
+
+
+class TestCheaperModelFor:
+    def test_no_cap_returns_none(self) -> None:
+        t = Tracker(run_id="r", budget_usd=0.0)
+        assert t.cheaper_model_for("opus") is None
+
+    def test_below_warn_threshold_returns_none(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0, warn_threshold=0.8)
+        t.record("a", "t", "opus", 0, 0, cost_usd=1.0)  # 10% spent
+        assert t.cheaper_model_for("opus") is None
+
+    def test_opus_reroutes_to_sonnet_when_warning(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0, warn_threshold=0.8)
+        t.record("a", "t", "opus", 0, 0, cost_usd=8.5)  # 85% spent
+        assert t.cheaper_model_for("opus") == "sonnet"
+
+    def test_sonnet_reroutes_to_haiku_when_warning(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0, warn_threshold=0.8)
+        t.record("a", "t", "sonnet", 0, 0, cost_usd=9.0)
+        assert t.cheaper_model_for("claude-sonnet-4") == "haiku"
+
+    def test_unknown_model_falls_back_to_default_cheap(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0, warn_threshold=0.8)
+        t.record("a", "t", "opus", 0, 0, cost_usd=9.0)
+        assert t.cheaper_model_for("some-random-model") == "haiku"
+
+    def test_already_cheapest_returns_none(self) -> None:
+        t = Tracker(run_id="r", budget_usd=10.0, warn_threshold=0.8)
+        t.record("a", "t", "opus", 0, 0, cost_usd=9.0)
+        # "haiku" is already the default cheap model -> nothing cheaper.
+        assert t.cheaper_model_for("haiku") is None
+
+
+class TestShareableSummary:
+    def test_summary_reports_tasks_and_cost(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 1000, 500, cost_usd=0.5)
+        out = t.shareable_summary(tasks_done=3, tasks_failed=1, total_duration_s=125.0)
+        assert "3 completed" in out
+        assert "1 failed" in out
+        assert "2m 5s" in out
+
+    def test_summary_includes_savings_when_cheaper_than_opus(self) -> None:
+        t = Tracker(run_id="r")
+        # haiku is far cheaper than opus -> baseline savings accrue.
+        t.record("a", "t", "haiku", 1_000_000, 1_000_000, cost_usd=6.0)
+        out = t.shareable_summary(tasks_done=1)
+        assert "Saved:" in out
+        assert "single agent" in out
+
+    def test_summary_no_savings_section_when_only_opus(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "opus", 1000, 1000, cost_usd=5.0)
+        out = t.shareable_summary(tasks_done=1)
+        # all-opus run accrues no "vs opus" savings.
+        assert "Saved:" not in out
+
+    def test_summary_seconds_only_when_under_a_minute(self) -> None:
+        t = Tracker(run_id="r")
+        t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        out = t.shareable_summary(tasks_done=1, total_duration_s=45.0)
+        assert "45s" in out
+        assert "m " not in out.split("Time:")[1].split("\n")[0]
+
+
+class TestUsageBufferEnv:
+    def test_env_override_buffer_size(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_COST_USAGE_BUFFER", "4")
+        t = Tracker(run_id="r")  # usage_buffer_size=None -> resolve from env
+        for _ in range(10):
+            t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        assert len(t.usages) == 4
+        assert t.total_usages_recorded == 10
+
+    def test_invalid_env_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_COST_USAGE_BUFFER", "not-an-int")
+        t = Tracker(run_id="r")
+        # Falls back to the large default; small records stay in memory.
+        for _ in range(3):
+            t.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        assert len(t.usages) == 3
+
+    def test_nonpositive_env_uses_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_COST_USAGE_BUFFER", "0")
+        t = Tracker(run_id="r")
+        assert t.usage_buffer_size == 10_000
+
+
+class TestRetryBudgetAttachment:
+    def test_attach_and_read_back(self) -> None:
+        t = Tracker(run_id="r")
+        sentinel = object()
+        assert t.retry_budget is None
+        t.attach_retry_budget(sentinel)
+        assert t.retry_budget is sentinel

--- a/tests/unit/protocols/mcp/__init__.py
+++ b/tests/unit/protocols/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP protocol-layer unit tests."""

--- a/tests/unit/protocols/mcp/test_config_validator.py
+++ b/tests/unit/protocols/mcp/test_config_validator.py
@@ -1,0 +1,154 @@
+"""Tests for MCP server config validation (startup checks).
+
+Covers ``mcp_config_validator`` without touching the network:
+
+* ``check_command_exists`` - stdio command present / absent / missing.
+* ``check_env_vars`` - ``${VAR}`` reference resolution against the env.
+* ``check_url_reachable`` - stdio skip, missing-url error, and the
+  URL-scheme rejection path (deterministic, no socket).
+* ``validate_mcp_configs`` aggregation across multiple configs.
+* ``McpConfigError.__str__`` formatting.
+
+``shutil.which`` and ``os.environ`` are stubbed so the command/env
+checks are deterministic; URL reachability is exercised only on paths
+that never open a socket.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.mcp.mcp_config_validator import (
+    McpConfigError,
+    check_command_exists,
+    check_env_vars,
+    check_url_reachable,
+    validate_mcp_configs,
+)
+from bernstein.core.protocols.mcp.mcp_manager import MCPServerConfig
+
+
+def _stdio(name: str = "srv", command: list[str] | None = None, env: dict[str, str] | None = None) -> MCPServerConfig:
+    return MCPServerConfig(name=name, command=command if command is not None else ["mytool"], env=env or {})
+
+
+def _remote(
+    name: str = "srv",
+    *,
+    transport: str = "streamable_http",
+    url: str = "",
+    env: dict[str, str] | None = None,
+) -> MCPServerConfig:
+    return MCPServerConfig(name=name, command=[], url=url, transport=transport, env=env or {})
+
+
+class TestCheckCommandExists:
+    def test_non_stdio_returns_none(self) -> None:
+        assert check_command_exists(_remote(transport="sse")) is None
+
+    def test_missing_command_flagged(self) -> None:
+        err = check_command_exists(_stdio(command=[]))
+        assert err is not None
+        assert err.check == "command_missing"
+
+    def test_command_not_in_path_flagged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "bernstein.core.protocols.mcp.mcp_config_validator.shutil.which",
+            lambda _exe: None,
+        )
+        err = check_command_exists(_stdio(command=["definitely-not-real-binary"]))
+        assert err is not None
+        assert err.check == "command_not_found"
+        assert "definitely-not-real-binary" in err.message
+
+    def test_command_present_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "bernstein.core.protocols.mcp.mcp_config_validator.shutil.which",
+            lambda _exe: "/usr/bin/mytool",
+        )
+        assert check_command_exists(_stdio(command=["mytool"])) is None
+
+
+class TestCheckEnvVars:
+    def test_set_reference_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TOKEN", "secret")
+        errs = check_env_vars(_stdio(env={"TOKEN": "${MY_TOKEN}"}))
+        assert errs == []
+
+    def test_missing_reference_flagged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        errs = check_env_vars(_stdio(env={"TOKEN": "${MISSING_VAR}"}))
+        assert len(errs) == 1
+        assert errs[0].check == "env_var_missing"
+        assert "MISSING_VAR" in errs[0].message
+
+    def test_literal_value_not_treated_as_reference(self) -> None:
+        # plain literals are never checked against the environment.
+        assert check_env_vars(_stdio(env={"MODE": "production"})) == []
+
+    def test_multiple_missing_refs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("A_VAR", raising=False)
+        monkeypatch.delenv("B_VAR", raising=False)
+        errs = check_env_vars(_stdio(env={"a": "${A_VAR}", "b": "${B_VAR}"}))
+        assert len(errs) == 2
+
+
+class TestCheckUrlReachable:
+    def test_stdio_transport_skipped(self) -> None:
+        assert check_url_reachable(_stdio()) is None
+
+    def test_missing_url_flagged(self) -> None:
+        err = check_url_reachable(_remote(url=""))
+        assert err is not None
+        assert err.check == "url_missing"
+
+    def test_disallowed_scheme_flagged(self) -> None:
+        # A non-http(s) scheme is rejected by the allowlist before any
+        # socket is opened, so this stays offline + deterministic.
+        err = check_url_reachable(_remote(url="ftp://example.com/feed"))
+        assert err is not None
+        assert err.check == "url_scheme"
+
+
+class TestValidateMcpConfigs:
+    def test_clean_stdio_config_no_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "bernstein.core.protocols.mcp.mcp_config_validator.shutil.which",
+            lambda _exe: "/usr/bin/mytool",
+        )
+        errors = validate_mcp_configs([_stdio(command=["mytool"])], check_urls=False)
+        assert errors == []
+
+    def test_aggregates_errors_across_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "bernstein.core.protocols.mcp.mcp_config_validator.shutil.which",
+            lambda _exe: None,
+        )
+        monkeypatch.delenv("ABSENT", raising=False)
+        configs = [
+            _stdio(name="a", command=["ghost-binary"]),
+            _stdio(name="b", command=["mytool"], env={"T": "${ABSENT}"}),
+        ]
+        errors = validate_mcp_configs(configs, check_urls=False)
+        names = {e.server_name for e in errors}
+        # a has a missing command; b has a missing env var.
+        assert "a" in names
+        assert "b" in names
+        assert len(errors) >= 2
+
+    def test_url_check_skipped_when_disabled(self) -> None:
+        # A remote config with a missing URL would normally error, but
+        # check_urls=False suppresses the URL check entirely.
+        errors = validate_mcp_configs([_remote(url="")], check_urls=False)
+        assert errors == []
+
+    def test_url_check_runs_when_enabled(self) -> None:
+        # Missing URL on a remote transport surfaces with check_urls=True.
+        errors = validate_mcp_configs([_remote(name="r", url="")], check_urls=True)
+        assert any(e.check == "url_missing" for e in errors)
+
+
+class TestMcpConfigError:
+    def test_str_format(self) -> None:
+        err = McpConfigError(server_name="gh", check="command_not_found", message="boom")
+        assert str(err) == "[gh] command_not_found: boom"

--- a/tests/unit/protocols/mcp/test_task_filter.py
+++ b/tests/unit/protocols/mcp/test_task_filter.py
@@ -1,0 +1,179 @@
+"""Tests for per-task MCP server filtering (MCP-010).
+
+Covers ``mcp_task_filter``:
+
+* ``RoleServerRule.matches_role`` (wildcard + exact) and
+  ``matches_scope`` (no-pattern allow, regex hit / miss).
+* ``TaskMCPFilter.filter_for_task`` decision tree: explicit
+  ``task.mcp_servers`` list, rule-derived allow set, scope gating, and
+  the ``default_allow_all`` vs deny-by-default fallbacks.
+* ``filter_names`` convenience + ``to_dict`` config serialisation +
+  ``FilterResult.to_dict``.
+
+Pure role/scope arithmetic - deterministic.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.models import Complexity, Scope, Task, TaskType
+
+from bernstein.core.protocols.mcp.mcp_task_filter import (
+    FilterResult,
+    RoleServerRule,
+    TaskMCPFilter,
+)
+
+
+def _task(
+    role: str = "backend",
+    *,
+    owned_files: list[str] | None = None,
+    mcp_servers: list[str] | None = None,
+) -> Task:
+    return Task(
+        id="t1",
+        title="Do something",
+        description="desc",
+        role=role,
+        complexity=Complexity.MEDIUM,
+        scope=Scope.MEDIUM,
+        priority=2,
+        owned_files=owned_files or [],
+        estimated_minutes=30,
+        task_type=TaskType.STANDARD,
+        metadata={},
+        mcp_servers=mcp_servers or [],
+    )
+
+
+class TestRoleServerRule:
+    def test_matches_exact_role(self) -> None:
+        rule = RoleServerRule(role="backend")
+        assert rule.matches_role("backend") is True
+        assert rule.matches_role("qa") is False
+
+    def test_wildcard_matches_any_role(self) -> None:
+        rule = RoleServerRule(role="*")
+        assert rule.matches_role("anything") is True
+
+    def test_no_scope_patterns_always_matches(self) -> None:
+        rule = RoleServerRule(role="backend")
+        assert rule.matches_scope([]) is True
+        assert rule.matches_scope(["whatever.py"]) is True
+
+    def test_scope_pattern_hit(self) -> None:
+        rule = RoleServerRule(role="backend", scope_patterns=(r"\.py$",))
+        assert rule.matches_scope(["src/api.py"]) is True
+
+    def test_scope_pattern_miss(self) -> None:
+        rule = RoleServerRule(role="backend", scope_patterns=(r"\.py$",))
+        assert rule.matches_scope(["README.md"]) is False
+
+    def test_scope_pattern_case_insensitive(self) -> None:
+        rule = RoleServerRule(role="backend", scope_patterns=(r"readme",))
+        assert rule.matches_scope(["README.MD"]) is True
+
+
+class TestFilterExplicit:
+    def test_explicit_mcp_servers_used(self) -> None:
+        f = TaskMCPFilter()
+        task = _task(mcp_servers=["gh", "fs"])
+        result = f.filter_for_task(task, ["gh", "fs", "slack"])
+        assert set(result.allowed) == {"gh", "fs"}
+        assert result.blocked == ["slack"]
+        assert "slack" in result.reasons
+
+    def test_explicit_overrides_rules(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("backend", ["everything"])
+        task = _task(role="backend", mcp_servers=["only-this"])
+        result = f.filter_for_task(task, ["only-this", "everything"])
+        # explicit list wins over the role rule.
+        assert result.allowed == ["only-this"]
+
+
+class TestFilterByRule:
+    def test_rule_allows_named_servers(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("backend", ["gh", "fs"])
+        result = f.filter_for_task(_task(role="backend"), ["gh", "fs", "slack"])
+        assert set(result.allowed) == {"gh", "fs"}
+        assert result.blocked == ["slack"]
+
+    def test_wildcard_rule_applies_to_all_roles(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("*", ["common"])
+        result = f.filter_for_task(_task(role="security"), ["common", "other"])
+        assert result.allowed == ["common"]
+
+    def test_scope_pattern_gates_rule(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("backend", ["db"], scope_patterns=[r"migrations/"])
+        # owns a migration file -> rule applies.
+        hit = f.filter_for_task(_task(role="backend", owned_files=["migrations/001.sql"]), ["db"])
+        assert hit.allowed == ["db"]
+        # owns no matching file -> rule does not apply -> deny-by-default.
+        miss = f.filter_for_task(_task(role="backend", owned_files=["src/api.py"]), ["db"])
+        assert miss.allowed == []
+        assert miss.blocked == ["db"]
+
+    def test_multiple_rules_union(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("backend", ["a"])
+        f.add_role_rule("*", ["b"])
+        result = f.filter_for_task(_task(role="backend"), ["a", "b", "c"])
+        assert set(result.allowed) == {"a", "b"}
+
+
+class TestDefaultPolicies:
+    def test_no_rules_allows_all(self) -> None:
+        # With no rules at all, every server passes through.
+        f = TaskMCPFilter()
+        result = f.filter_for_task(_task(role="backend"), ["a", "b"])
+        assert set(result.allowed) == {"a", "b"}
+
+    def test_default_allow_all_when_no_match(self) -> None:
+        f = TaskMCPFilter(default_allow_all=True)
+        f.add_role_rule("qa", ["x"])  # rule exists, but task role is backend
+        result = f.filter_for_task(_task(role="backend"), ["a", "b"])
+        assert set(result.allowed) == {"a", "b"}
+
+    def test_deny_by_default_when_no_match(self) -> None:
+        f = TaskMCPFilter(default_allow_all=False)
+        f.add_role_rule("qa", ["x"])  # no rule for backend
+        result = f.filter_for_task(_task(role="backend"), ["a", "b"])
+        assert result.allowed == []
+        assert set(result.blocked) == {"a", "b"}
+        assert all("no matching rule" in r for r in result.reasons.values())
+
+
+class TestConvenienceAndSerialisation:
+    def test_filter_names_returns_allowed_only(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("backend", ["gh"])
+        names = f.filter_names(_task(role="backend"), ["gh", "slack"])
+        assert names == ["gh"]
+
+    def test_rules_property_returns_copy(self) -> None:
+        f = TaskMCPFilter()
+        f.add_role_rule("backend", ["gh"])
+        rules = f.rules
+        rules.clear()
+        # mutating the returned list must not clear the internal rules.
+        assert len(f.rules) == 1
+
+    def test_to_dict_serialises_config(self) -> None:
+        f = TaskMCPFilter(default_allow_all=True)
+        f.add_role_rule("backend", ["gh"], scope_patterns=[r"\.py$"])
+        d = f.to_dict()
+        assert d["default_allow_all"] is True
+        assert d["rules"][0]["role"] == "backend"
+        assert d["rules"][0]["allowed_servers"] == ["gh"]
+        assert d["rules"][0]["scope_patterns"] == [r"\.py$"]
+
+    def test_filter_result_to_dict(self) -> None:
+        result = FilterResult(task_id="t1", role="backend", allowed=["a"], blocked=["b"], reasons={"b": "nope"})
+        d = result.to_dict()
+        assert d["task_id"] == "t1"
+        assert d["allowed"] == ["a"]
+        assert d["reasons"] == {"b": "nope"}

--- a/tests/unit/protocols/mcp/test_tool_normalization.py
+++ b/tests/unit/protocols/mcp/test_tool_normalization.py
@@ -1,0 +1,244 @@
+"""Tests for MCP tool name + schema normalization (MCP-003).
+
+Covers ``mcp_tool_normalization`` pure logic:
+
+* ``normalize_tool_name`` across camelCase, PascalCase, kebab, dotted,
+  acronym, and already-snake inputs (plus the empty short-circuit).
+* ``validate_tool_schema`` - type / properties / required / items checks.
+* ``validate_tool_params`` + ``_type_matches`` - presence + type gating,
+  including the bool-is-not-integer edge.
+* ``ToolNormalizer`` registry: register / lookup both directions /
+  ``normalize_call`` validation path / unregistered passthrough.
+* ``McpToolError.to_dict`` + ``McpToolException`` wrapping.
+* ``_decode_tool_result`` JSON-object decoding + error paths.
+
+All deterministic - no I/O.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.mcp.mcp_tool_normalization import (
+    McpToolError,
+    McpToolException,
+    ToolNormalizer,
+    _decode_tool_result,
+    _type_matches,
+    normalize_tool_name,
+    validate_tool_params,
+    validate_tool_schema,
+)
+
+
+class TestNormalizeToolName:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("searchIssues", "search_issues"),
+            ("SearchIssues", "search_issues"),
+            ("get-user-profile", "get_user_profile"),
+            ("myServer.SearchIssues", "my_server_search_issues"),
+            ("already_snake_case", "already_snake_case"),
+            ("HTTPSConnection", "https_connection"),
+            ("tool/with/slashes", "tool_with_slashes"),
+            ("Multiple___Underscores", "multiple_underscores"),
+        ],
+    )
+    def test_normalization(self, raw: str, expected: str) -> None:
+        assert normalize_tool_name(raw) == expected
+
+    def test_empty_returns_empty(self) -> None:
+        assert normalize_tool_name("") == ""
+
+    def test_leading_trailing_separators_stripped(self) -> None:
+        assert normalize_tool_name("__weird__name__") == "weird_name"
+
+
+class TestValidateToolSchema:
+    def test_valid_schema_no_errors(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        }
+        assert validate_tool_schema(schema) == []
+
+    def test_unknown_top_level_type(self) -> None:
+        errors = validate_tool_schema({"type": "frobnicate"})
+        assert any(e.path == "/type" for e in errors)
+
+    def test_properties_must_be_object(self) -> None:
+        errors = validate_tool_schema({"properties": ["not", "a", "dict"]})
+        assert any(e.path == "/properties" for e in errors)
+
+    def test_property_schema_must_be_object(self) -> None:
+        errors = validate_tool_schema({"properties": {"x": "not-a-dict"}})
+        assert any(e.path == "/properties/x" for e in errors)
+
+    def test_unknown_property_type(self) -> None:
+        errors = validate_tool_schema({"properties": {"x": {"type": "weird"}}})
+        assert any("Unknown type" in e.message for e in errors)
+
+    def test_required_must_be_array(self) -> None:
+        errors = validate_tool_schema({"required": "query"})
+        assert any(e.path == "/required" for e in errors)
+
+    def test_required_references_missing_property(self) -> None:
+        errors = validate_tool_schema({"properties": {"a": {"type": "string"}}, "required": ["b"]})
+        assert any("not found in properties" in e.message for e in errors)
+
+    def test_items_must_be_object(self) -> None:
+        errors = validate_tool_schema({"type": "array", "items": "string"})
+        assert any(e.path == "/items" for e in errors)
+
+    def test_items_unknown_type(self) -> None:
+        errors = validate_tool_schema({"type": "array", "items": {"type": "nope"}})
+        assert any(e.path == "/items/type" for e in errors)
+
+
+class TestTypeMatches:
+    def test_string(self) -> None:
+        assert _type_matches("x", "string") is True
+        assert _type_matches(5, "string") is False
+
+    def test_integer_rejects_bool(self) -> None:
+        # bool is an int subclass in Python but must not satisfy "integer".
+        assert _type_matches(5, "integer") is True
+        assert _type_matches(True, "integer") is False
+
+    def test_number_accepts_int_and_float(self) -> None:
+        assert _type_matches(5, "number") is True
+        assert _type_matches(5.0, "number") is True
+
+    def test_boolean(self) -> None:
+        assert _type_matches(True, "boolean") is True
+        assert _type_matches(1, "boolean") is False
+
+    def test_array_object_null(self) -> None:
+        assert _type_matches([], "array") is True
+        assert _type_matches({}, "object") is True
+        assert _type_matches(None, "null") is True
+
+    def test_unknown_type_passes(self) -> None:
+        assert _type_matches("anything", "made-up-type") is True
+
+
+class TestValidateToolParams:
+    def test_all_present_and_typed(self) -> None:
+        schema = {"properties": {"q": {"type": "string"}}, "required": ["q"]}
+        assert validate_tool_params({"q": "hello"}, schema) == []
+
+    def test_missing_required_param(self) -> None:
+        schema = {"properties": {"q": {"type": "string"}}, "required": ["q"]}
+        errors = validate_tool_params({}, schema)
+        assert len(errors) == 1
+        assert "Missing required parameter" in errors[0].message
+
+    def test_type_mismatch_flagged(self) -> None:
+        schema = {"properties": {"count": {"type": "integer"}}}
+        errors = validate_tool_params({"count": "five"}, schema)
+        assert len(errors) == 1
+        assert "Type mismatch" in errors[0].message
+
+    def test_extra_params_ignored(self) -> None:
+        schema = {"properties": {"q": {"type": "string"}}}
+        # 'extra' is not in properties -> not type-checked.
+        assert validate_tool_params({"q": "x", "extra": 123}, schema) == []
+
+    def test_non_list_required_ignored(self) -> None:
+        assert validate_tool_params({}, {"required": "q"}) == []
+
+
+class TestToolNormalizer:
+    def test_register_returns_normalized_name(self) -> None:
+        norm = ToolNormalizer()
+        assert norm.register_tool("searchIssues") == "search_issues"
+
+    def test_lookup_both_directions(self) -> None:
+        norm = ToolNormalizer()
+        norm.register_tool("searchIssues", server_name="gh")
+        assert norm.get_normalized_name("searchIssues") == "search_issues"
+        assert norm.get_original_name("search_issues") == "searchIssues"
+
+    def test_lookup_unknown_returns_none(self) -> None:
+        norm = ToolNormalizer()
+        assert norm.get_normalized_name("nope") is None
+        assert norm.get_original_name("nope") is None
+
+    def test_tool_count_and_list(self) -> None:
+        norm = ToolNormalizer()
+        norm.register_tool("a", server_name="s1")
+        norm.register_tool("bTool", server_name="s2")
+        assert norm.tool_count == 2
+        listed = norm.list_tools()
+        servers = {entry["server"] for entry in listed}
+        assert servers == {"s1", "s2"}
+
+    def test_normalize_call_validates_against_schema(self) -> None:
+        norm = ToolNormalizer()
+        norm.register_tool(
+            "searchIssues",
+            server_name="gh",
+            schema={"properties": {"q": {"type": "string"}}, "required": ["q"]},
+        )
+        # missing required 'q' -> one McpToolError.
+        name, params, errors = norm.normalize_call("searchIssues", {})
+        assert name == "search_issues"
+        # params are returned unchanged even when validation fails.
+        assert params == {}
+        assert len(errors) == 1
+        assert errors[0].code == "PARAM_VALIDATION_FAILED"
+        assert errors[0].original_name == "searchIssues"
+
+    def test_normalize_call_resolves_by_normalized_name(self) -> None:
+        norm = ToolNormalizer()
+        norm.register_tool("searchIssues")
+        # passing the normalized name still resolves the entry.
+        name, _params, errors = norm.normalize_call("search_issues", {})
+        assert name == "search_issues"
+        assert errors == []
+
+    def test_normalize_call_unregistered_passthrough(self) -> None:
+        norm = ToolNormalizer()
+        name, params, errors = norm.normalize_call("brandNewTool", {"x": 1})
+        assert name == "brand_new_tool"
+        assert params == {"x": 1}
+        assert errors == []
+
+    def test_normalize_call_success_no_errors(self) -> None:
+        norm = ToolNormalizer()
+        norm.register_tool("searchIssues", schema={"properties": {"q": {"type": "string"}}, "required": ["q"]})
+        _name, _params, errors = norm.normalize_call("searchIssues", {"q": "hello"})
+        assert errors == []
+
+
+class TestMcpToolError:
+    def test_to_dict_without_details(self) -> None:
+        err = McpToolError(tool_name="t", original_name="T", code="C", message="m")
+        d = err.to_dict()
+        assert d["tool_name"] == "t"
+        assert "details" not in d
+
+    def test_to_dict_with_details(self) -> None:
+        err = McpToolError(tool_name="t", original_name="T", code="C", message="m", details={"k": "v"})
+        assert err.to_dict()["details"] == {"k": "v"}
+
+    def test_exception_wraps_error(self) -> None:
+        err = McpToolError(tool_name="t", original_name="T", code="C", message="boom")
+        exc = McpToolException(err)
+        assert exc.error is err
+        assert str(exc) == "boom"
+
+
+class TestDecodeToolResult:
+    def test_valid_object(self) -> None:
+        assert _decode_tool_result('{"a": 1}') == {"a": 1}
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _decode_tool_result("{not json")
+
+    def test_non_object_raises(self) -> None:
+        with pytest.raises(ValueError, match="Expected a JSON object"):
+            _decode_tool_result("[1, 2, 3]")

--- a/tests/unit/protocols/mcp/test_version_compat.py
+++ b/tests/unit/protocols/mcp/test_version_compat.py
@@ -1,0 +1,169 @@
+"""Tests for MCP server protocol-version compatibility checking.
+
+Covers ``mcp_version_compat`` end to end:
+
+* ``ParsedVersion.parse`` across semver / date / prefixed / unparseable.
+* ``VersionChecker.check`` decision matrix: date >= / < / exact, semver
+  major mismatch, minor mismatch (strict vs lenient), patch-compatible,
+  and the unknown-version allow path.
+* ``check_many`` / ``get_incompatible`` / ``get_result`` / ``all_results``
+  result bookkeeping and ``to_dict`` serialisation.
+
+Pure version arithmetic - fully deterministic.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.protocols.mcp.mcp_version_compat import (
+    CompatLevel,
+    ParsedVersion,
+    VersionChecker,
+)
+
+
+class TestParsedVersion:
+    def test_parse_semver_three_parts(self) -> None:
+        pv = ParsedVersion.parse("1.2.3")
+        assert pv.parts == (1, 2, 3)
+        assert pv.is_date is False
+
+    def test_parse_date_version(self) -> None:
+        pv = ParsedVersion.parse("2025-11-05")
+        assert pv.parts == (2025, 11, 5)
+        assert pv.is_date is True
+
+    def test_parse_v_prefix_stripped(self) -> None:
+        pv = ParsedVersion.parse("v2.0")
+        assert pv.parts == (2, 0)
+
+    def test_parse_single_number(self) -> None:
+        assert ParsedVersion.parse("1").parts == (1,)
+
+    def test_parse_unparseable_empty_parts(self) -> None:
+        pv = ParsedVersion.parse("not-a-version")
+        assert pv.parts == ()
+        assert pv.raw == "not-a-version"
+
+    def test_parse_preserves_raw(self) -> None:
+        assert ParsedVersion.parse("  v1.2.3 ").raw == "  v1.2.3 "
+
+
+class TestDateVersionChecks:
+    def test_exact_date_match_compatible(self) -> None:
+        checker = VersionChecker(required_version="2025-11-05")
+        result = checker.check("gh", "2025-11-05")
+        assert result.compatible is True
+        assert result.level == CompatLevel.COMPATIBLE
+        assert result.message == "Exact version match"
+
+    def test_newer_date_compatible(self) -> None:
+        checker = VersionChecker(required_version="2025-11-05")
+        result = checker.check("gh", "2026-01-01")
+        assert result.compatible is True
+        assert result.level == CompatLevel.COMPATIBLE
+
+    def test_older_date_incompatible(self) -> None:
+        checker = VersionChecker(required_version="2025-11-05")
+        result = checker.check("gh", "2024-01-01")
+        assert result.compatible is False
+        assert result.level == CompatLevel.INCOMPATIBLE
+
+
+class TestSemverChecks:
+    def test_major_mismatch_incompatible(self) -> None:
+        checker = VersionChecker(required_version="2.0.0")
+        result = checker.check("srv", "1.5.0")
+        assert result.compatible is False
+        assert result.level == CompatLevel.INCOMPATIBLE
+        assert "Major version mismatch" in result.message
+
+    def test_minor_mismatch_lenient_compatible(self) -> None:
+        checker = VersionChecker(required_version="1.5.0", strict=False)
+        result = checker.check("srv", "1.2.0")
+        assert result.level == CompatLevel.MINOR_MISMATCH
+        assert result.compatible is True
+
+    def test_minor_mismatch_strict_incompatible(self) -> None:
+        checker = VersionChecker(required_version="1.5.0", strict=True)
+        result = checker.check("srv", "1.2.0")
+        assert result.level == CompatLevel.MINOR_MISMATCH
+        assert result.compatible is False
+
+    def test_higher_minor_is_compatible(self) -> None:
+        checker = VersionChecker(required_version="1.2.0")
+        result = checker.check("srv", "1.9.0")
+        assert result.compatible is True
+        assert result.level == CompatLevel.COMPATIBLE
+
+    def test_patch_difference_compatible(self) -> None:
+        checker = VersionChecker(required_version="1.2.3")
+        result = checker.check("srv", "1.2.99")
+        assert result.compatible is True
+        assert result.level == CompatLevel.COMPATIBLE
+
+    def test_exact_semver_compatible(self) -> None:
+        checker = VersionChecker(required_version="1.2.3")
+        assert checker.check("srv", "1.2.3").compatible is True
+
+
+class TestUnknownVersion:
+    def test_unparseable_server_version_allowed(self) -> None:
+        checker = VersionChecker(required_version="1.2.3")
+        result = checker.check("srv", "garbage")
+        assert result.level == CompatLevel.UNKNOWN
+        assert result.compatible is True
+
+    def test_unparseable_required_version_allows_all(self) -> None:
+        checker = VersionChecker(required_version="garbage")
+        result = checker.check("srv", "1.2.3")
+        assert result.level == CompatLevel.UNKNOWN
+        assert result.compatible is True
+
+
+class TestResultBookkeeping:
+    def test_check_many_returns_one_per_server(self) -> None:
+        checker = VersionChecker(required_version="1.2.0")
+        results = checker.check_many({"a": "1.3.0", "b": "2.0.0"})
+        assert len(results) == 2
+        by_name = {r.server_name: r for r in results}
+        assert by_name["a"].compatible is True
+        assert by_name["b"].compatible is False
+
+    def test_get_incompatible_filters(self) -> None:
+        checker = VersionChecker(required_version="2.0.0")
+        checker.check("good", "2.1.0")
+        checker.check("bad", "1.0.0")
+        incompatible = checker.get_incompatible()
+        assert [r.server_name for r in incompatible] == ["bad"]
+
+    def test_get_result_returns_last(self) -> None:
+        checker = VersionChecker(required_version="1.0.0")
+        checker.check("srv", "1.0.0")
+        assert checker.get_result("srv") is not None
+        assert checker.get_result("missing") is None
+
+    def test_all_results_accumulates(self) -> None:
+        checker = VersionChecker(required_version="1.0.0")
+        checker.check("a", "1.0.0")
+        checker.check("b", "1.0.0")
+        assert len(checker.all_results()) == 2
+
+    def test_required_version_property(self) -> None:
+        assert VersionChecker(required_version="2025-11-05").required_version == "2025-11-05"
+
+    def test_to_dict_serialisation(self) -> None:
+        checker = VersionChecker(required_version="1.2.0", strict=True)
+        checker.check("srv", "1.3.0")
+        d = checker.to_dict()
+        assert d["required_version"] == "1.2.0"
+        assert d["strict"] is True
+        assert "srv" in d["results"]
+        assert d["results"]["srv"]["compatible"] is True
+
+    def test_compat_result_to_dict(self) -> None:
+        checker = VersionChecker(required_version="1.0.0")
+        result = checker.check("srv", "1.0.0")
+        d = result.to_dict()
+        assert d["server_name"] == "srv"
+        assert d["server_version"] == "1.0.0"
+        assert d["level"] == "compatible"

--- a/tests/unit/protocols/test_a2a_handler.py
+++ b/tests/unit/protocols/test_a2a_handler.py
@@ -1,0 +1,313 @@
+"""Tests for the A2A protocol handler + value objects (``a2a/a2a.py``).
+
+The federation layer is covered by ``tests/unit/test_a2a_federation.py``;
+this module targets the handler and its value types:
+
+* ``A2ATaskStatus`` <-> Bernstein status round-trip mapping (both helpers
+  + the unknown-status fallbacks).
+* ``A2AMessage`` / ``A2AArtifact`` / ``A2ATask`` ``to_dict`` contracts.
+* ``AgentCard`` validate / from_dict / to_dict / json_schema, including
+  every malformed-input ``ValueError`` branch.
+* ``A2AHandler`` task lifecycle: create, link (+ reverse index), lookup
+  by A2A id and by Bernstein id, status sync, artifact attach, listing
+  with sender filter, message receive + list, and the ``KeyError``
+  paths for unknown task IDs.
+* ``send_message`` happy path + error propagation via an injected fake
+  async client (no real network).
+
+Deterministic; the one network method is exercised with a stub client.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bernstein.core.protocols.a2a.a2a import (
+    A2AArtifact,
+    A2AHandler,
+    A2AMessage,
+    A2ATask,
+    A2ATaskStatus,
+    AgentCard,
+)
+
+# ---------------------------------------------------------------------------
+# Status mapping
+# ---------------------------------------------------------------------------
+
+
+class TestStatusMapping:
+    @pytest.mark.parametrize(
+        ("bernstein", "expected"),
+        [
+            ("open", A2ATaskStatus.SUBMITTED),
+            ("claimed", A2ATaskStatus.WORKING),
+            ("in_progress", A2ATaskStatus.WORKING),
+            ("blocked", A2ATaskStatus.INPUT_REQUIRED),
+            ("done", A2ATaskStatus.COMPLETED),
+            ("failed", A2ATaskStatus.FAILED),
+            ("cancelled", A2ATaskStatus.CANCELED),
+        ],
+    )
+    def test_a2a_status_for(self, bernstein: str, expected: A2ATaskStatus) -> None:
+        assert A2AHandler.a2a_status_for(bernstein) == expected
+
+    def test_a2a_status_unknown_defaults_submitted(self) -> None:
+        assert A2AHandler.a2a_status_for("???") == A2ATaskStatus.SUBMITTED
+
+    @pytest.mark.parametrize(
+        ("a2a_status", "expected"),
+        [
+            (A2ATaskStatus.SUBMITTED, "open"),
+            (A2ATaskStatus.WORKING, "in_progress"),
+            (A2ATaskStatus.INPUT_REQUIRED, "blocked"),
+            (A2ATaskStatus.COMPLETED, "done"),
+            (A2ATaskStatus.FAILED, "failed"),
+            (A2ATaskStatus.CANCELED, "cancelled"),
+        ],
+    )
+    def test_bernstein_status_for(self, a2a_status: A2ATaskStatus, expected: str) -> None:
+        assert A2AHandler.bernstein_status_for(a2a_status) == expected
+
+
+# ---------------------------------------------------------------------------
+# Value object serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestValueObjects:
+    def test_message_to_dict(self) -> None:
+        msg = A2AMessage(id="m1", sender="a", recipient="b", content="hi", task_id="t1")
+        d = msg.to_dict()
+        assert d["id"] == "m1"
+        assert d["direction"] == "inbound"
+        assert d["delivered"] is False
+        assert d["external_endpoint"] is None
+
+    def test_artifact_to_dict(self) -> None:
+        art = A2AArtifact(name="out.txt", content_type="text/markdown", data="x")
+        d = art.to_dict()
+        assert d["name"] == "out.txt"
+        assert d["content_type"] == "text/markdown"
+        assert d["data"] == "x"
+
+    def test_task_to_dict_includes_artifacts(self) -> None:
+        task = A2ATask(id="t1", sender="agent", message="go")
+        task.artifacts.append(A2AArtifact(name="a"))
+        d = task.to_dict()
+        assert d["id"] == "t1"
+        assert d["status"] == "submitted"
+        assert len(d["artifacts"]) == 1
+        assert d["artifacts"][0]["name"] == "a"
+
+
+# ---------------------------------------------------------------------------
+# AgentCard
+# ---------------------------------------------------------------------------
+
+
+class TestAgentCard:
+    def test_to_dict_round_trip(self) -> None:
+        card = AgentCard(name="agent", description="does things", capabilities=["x", "y"])
+        rebuilt = AgentCard.from_dict(card.to_dict())
+        assert rebuilt == card
+
+    def test_from_dict_defaults(self) -> None:
+        card = AgentCard.from_dict({"name": "a", "description": "d"})
+        assert card.capabilities == []
+        assert card.protocol_version == "0.1"
+        assert card.provider == "bernstein"
+
+    def test_to_dict_copies_capabilities(self) -> None:
+        caps = ["x"]
+        card = AgentCard(name="a", description="d", capabilities=caps)
+        d = card.to_dict()
+        d["capabilities"].append("mutated")
+        # mutating the dict's list must not affect the frozen card.
+        assert card.capabilities == ["x"]
+
+    def test_validate_missing_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty 'name'"):
+            AgentCard.validate({"description": "d"})
+
+    def test_validate_empty_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty 'name'"):
+            AgentCard.validate({"name": "", "description": "d"})
+
+    def test_validate_missing_description_raises(self) -> None:
+        with pytest.raises(ValueError, match="'description' string"):
+            AgentCard.validate({"name": "a"})
+
+    def test_validate_capabilities_must_be_list(self) -> None:
+        with pytest.raises(ValueError, match="'capabilities' must be a list"):
+            AgentCard.validate({"name": "a", "description": "d", "capabilities": "nope"})
+
+    def test_validate_capability_items_must_be_strings(self) -> None:
+        with pytest.raises(ValueError, match="capability at index 1"):
+            AgentCard.validate({"name": "a", "description": "d", "capabilities": ["ok", 5]})
+
+    def test_validate_accepts_valid_card(self) -> None:
+        # no exception means valid.
+        AgentCard.validate({"name": "a", "description": "d", "capabilities": ["x"]})
+
+    def test_json_schema_shape(self) -> None:
+        schema = AgentCard.json_schema()
+        assert schema["required"] == ["name", "description"]
+        assert schema["properties"]["name"]["minLength"] == 1
+        assert schema["additionalProperties"] is False
+
+
+# ---------------------------------------------------------------------------
+# Handler lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerLifecycle:
+    def test_orchestrator_card(self) -> None:
+        handler = A2AHandler(server_url="http://host:1234")
+        card = handler.orchestrator_card()
+        assert card.name == "bernstein-orchestrator"
+        assert card.endpoint == "http://host:1234/a2a"
+        assert "a2a_message" in card.capabilities
+
+    def test_create_task_registers(self) -> None:
+        handler = A2AHandler()
+        task = handler.create_task(sender="peer", message="do x")
+        assert task.sender == "peer"
+        assert task.status == A2ATaskStatus.SUBMITTED
+        assert handler.get_task(task.id) is task
+
+    def test_task_ids_unique(self) -> None:
+        handler = A2AHandler()
+        ids = {handler.create_task("p", "g").id for _ in range(20)}
+        assert len(ids) == 20
+
+    def test_get_unknown_task_none(self) -> None:
+        assert A2AHandler().get_task("ghost") is None
+
+    def test_link_creates_reverse_index(self) -> None:
+        handler = A2AHandler()
+        task = handler.create_task("p", "g")
+        handler.link_bernstein_task(task.id, "bern-1")
+        assert handler.get_task(task.id).bernstein_task_id == "bern-1"
+        assert handler.get_by_bernstein_id("bern-1") is task
+
+    def test_get_by_unknown_bernstein_id_none(self) -> None:
+        assert A2AHandler().get_by_bernstein_id("nope") is None
+
+    def test_link_unknown_task_raises(self) -> None:
+        with pytest.raises(KeyError):
+            A2AHandler().link_bernstein_task("ghost", "bern-1")
+
+    def test_sync_status_maps(self) -> None:
+        handler = A2AHandler()
+        task = handler.create_task("p", "g")
+        new_status = handler.sync_status(task.id, "done")
+        assert new_status == A2ATaskStatus.COMPLETED
+        assert handler.get_task(task.id).status == A2ATaskStatus.COMPLETED
+
+    def test_sync_status_unknown_bernstein_status_defaults(self) -> None:
+        handler = A2AHandler()
+        task = handler.create_task("p", "g")
+        assert handler.sync_status(task.id, "weird-status") == A2ATaskStatus.SUBMITTED
+
+    def test_sync_unknown_task_raises(self) -> None:
+        with pytest.raises(KeyError):
+            A2AHandler().sync_status("ghost", "done")
+
+    def test_add_artifact(self) -> None:
+        handler = A2AHandler()
+        task = handler.create_task("p", "g")
+        art = handler.add_artifact(task.id, name="result.md", data="content")
+        assert art.name == "result.md"
+        assert handler.get_task(task.id).artifacts == [art]
+
+    def test_add_artifact_unknown_task_raises(self) -> None:
+        with pytest.raises(KeyError):
+            A2AHandler().add_artifact("ghost", name="x", data="y")
+
+    def test_list_tasks_all_and_by_sender(self) -> None:
+        handler = A2AHandler()
+        handler.create_task("alice", "g1")
+        handler.create_task("bob", "g2")
+        assert len(handler.list_tasks()) == 2
+        alice_tasks = handler.list_tasks(sender="alice")
+        assert len(alice_tasks) == 1
+        assert alice_tasks[0].sender == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Messages
+# ---------------------------------------------------------------------------
+
+
+class TestMessages:
+    def test_receive_message_records_inbound(self) -> None:
+        handler = A2AHandler()
+        msg = handler.receive_message(sender="ext", recipient="bernstein", content="hi", task_id="t1")
+        assert msg.direction == "inbound"
+        assert msg.delivered is True
+        assert handler.list_messages() == (msg,)
+
+    def test_list_messages_filtered_by_task(self) -> None:
+        handler = A2AHandler()
+        handler.receive_message(sender="a", recipient="b", content="1", task_id="t1")
+        handler.receive_message(sender="a", recipient="b", content="2", task_id="t2")
+        for_t1 = handler.list_messages(task_id="t1")
+        assert len(for_t1) == 1
+        assert for_t1[0].task_id == "t1"
+
+    @pytest.mark.asyncio
+    async def test_send_message_happy_path(self) -> None:
+        posted: dict[str, Any] = {}
+
+        class _FakeResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+        class _FakeClient:
+            async def post(self, url: str, *, json: dict[str, Any]) -> _FakeResponse:
+                posted["url"] = url
+                posted["json"] = json
+                return _FakeResponse()
+
+        handler = A2AHandler()
+        msg = await handler.send_message(
+            sender="bernstein",
+            recipient="peer",
+            content="hello",
+            task_id="t1",
+            external_endpoint="http://peer.example.com/",
+            client=_FakeClient(),  # type: ignore[arg-type]
+        )
+        assert msg.direction == "outbound"
+        assert msg.delivered is True
+        # trailing slash trimmed, /a2a/message appended.
+        assert posted["url"] == "http://peer.example.com/a2a/message"
+        assert posted["json"]["content"] == "hello"
+        assert handler.list_messages(task_id="t1") == (msg,)
+
+    @pytest.mark.asyncio
+    async def test_send_message_propagates_http_error(self) -> None:
+        class _BoomResponse:
+            def raise_for_status(self) -> None:
+                raise RuntimeError("502 Bad Gateway")
+
+        class _BoomClient:
+            async def post(self, url: str, *, json: dict[str, Any]) -> _BoomResponse:
+                return _BoomResponse()
+
+        handler = A2AHandler()
+        with pytest.raises(RuntimeError, match="502"):
+            await handler.send_message(
+                sender="a",
+                recipient="b",
+                content="c",
+                task_id="t1",
+                external_endpoint="http://peer/",
+                client=_BoomClient(),  # type: ignore[arg-type]
+            )
+        # a failed send must not record an outbound message.
+        assert handler.list_messages() == ()

--- a/tests/unit/protocols/test_acp_bridge.py
+++ b/tests/unit/protocols/test_acp_bridge.py
@@ -1,0 +1,158 @@
+"""Tests for the standalone ``protocols/acp`` BeeAI bridge.
+
+Covers the ACP run lifecycle and discovery surface:
+
+* ``ACPRunStatus.from_bernstein`` status mapping (every documented key
+  plus the unknown-status fallback).
+* ``ACPRun.to_dict`` serialisation contract.
+* ``ACPHandler`` discovery doc + agent metadata shape.
+* run creation, lookup, task linking, cancellation, status sync, and
+  listing - including the ``KeyError`` paths for unknown run IDs.
+
+The handler is in-memory and deterministic, so every assertion pins an
+observable fact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.acp import (
+    ACPHandler,
+    ACPRun,
+    ACPRunStatus,
+)
+
+
+class TestACPRunStatusMapping:
+    @pytest.mark.parametrize(
+        ("bernstein_status", "expected"),
+        [
+            ("open", ACPRunStatus.CREATED),
+            ("claimed", ACPRunStatus.RUNNING),
+            ("in_progress", ACPRunStatus.RUNNING),
+            ("blocked", ACPRunStatus.RUNNING),
+            ("done", ACPRunStatus.COMPLETED),
+            ("failed", ACPRunStatus.FAILED),
+            ("cancelled", ACPRunStatus.CANCELLED),
+        ],
+    )
+    def test_known_status_mapping(self, bernstein_status: str, expected: ACPRunStatus) -> None:
+        assert ACPRunStatus.from_bernstein(bernstein_status) == expected
+
+    def test_unknown_status_defaults_to_created(self) -> None:
+        assert ACPRunStatus.from_bernstein("totally-unknown") == ACPRunStatus.CREATED
+
+    def test_status_enum_values(self) -> None:
+        assert ACPRunStatus.RUNNING.value == "running"
+        assert ACPRunStatus.COMPLETED.value == "completed"
+
+
+class TestACPRunSerialisation:
+    def test_to_dict_contains_acp_fields(self) -> None:
+        run = ACPRun(id="abc123", input_text="build it", role="qa")
+        d = run.to_dict()
+        assert d["run_id"] == "abc123"
+        assert d["input"] == "build it"
+        assert d["role"] == "qa"
+        assert d["status"] == "created"
+        assert d["bernstein_task_id"] is None
+
+    def test_to_dict_reflects_linked_task(self) -> None:
+        run = ACPRun(id="abc123", bernstein_task_id="task-9")
+        assert run.to_dict()["bernstein_task_id"] == "task-9"
+
+    def test_default_role_is_backend(self) -> None:
+        assert ACPRun(id="x").role == "backend"
+
+
+class TestACPHandlerDiscovery:
+    def test_discovery_doc_protocol_and_version(self) -> None:
+        handler = ACPHandler(server_url="http://host:9999")
+        doc = handler.discovery_doc()
+        assert doc["protocol"] == "acp"
+        assert doc["version"] == "v0"
+        assert doc["agents"][0]["name"] == "bernstein"
+        assert doc["agents"][0]["endpoint"] == "http://host:9999/acp/v0"
+
+    def test_agent_metadata_capabilities(self) -> None:
+        handler = ACPHandler()
+        meta = handler.agent_metadata()
+        assert meta["name"] == "bernstein"
+        assert meta["protocol_version"] == "v0"
+        cap_names = {c["name"] for c in meta["capabilities"]}
+        assert {"orchestrate", "cost_governance", "verify", "multi_agent"} <= cap_names
+
+    def test_orchestrate_capability_requires_input(self) -> None:
+        handler = ACPHandler()
+        meta = handler.agent_metadata()
+        orchestrate = next(c for c in meta["capabilities"] if c["name"] == "orchestrate")
+        assert orchestrate["input_schema"]["required"] == ["input"]
+
+
+class TestACPHandlerLifecycle:
+    def test_create_run_registers_and_returns(self) -> None:
+        handler = ACPHandler()
+        run = handler.create_run("do work", role="security")
+        assert run.input_text == "do work"
+        assert run.role == "security"
+        assert run.status == ACPRunStatus.CREATED
+        # registered and retrievable.
+        assert handler.get_run(run.id) is run
+
+    def test_run_ids_are_unique(self) -> None:
+        handler = ACPHandler()
+        ids = {handler.create_run("g").id for _ in range(20)}
+        assert len(ids) == 20
+
+    def test_get_unknown_run_returns_none(self) -> None:
+        assert ACPHandler().get_run("ghost") is None
+
+    def test_link_bernstein_task(self) -> None:
+        handler = ACPHandler()
+        run = handler.create_run("g")
+        handler.link_bernstein_task(run.id, "task-42")
+        assert handler.get_run(run.id).bernstein_task_id == "task-42"
+
+    def test_link_unknown_run_raises(self) -> None:
+        handler = ACPHandler()
+        with pytest.raises(KeyError):
+            handler.link_bernstein_task("ghost", "task-42")
+
+    def test_cancel_run_sets_cancelled_status(self) -> None:
+        handler = ACPHandler()
+        run = handler.create_run("g")
+        prev_updated = run.updated_at
+        cancelled = handler.cancel_run(run.id)
+        assert cancelled.status == ACPRunStatus.CANCELLED
+        assert cancelled.updated_at >= prev_updated
+
+    def test_cancel_unknown_run_raises(self) -> None:
+        with pytest.raises(KeyError):
+            ACPHandler().cancel_run("ghost")
+
+    def test_sync_status_maps_bernstein_status(self) -> None:
+        handler = ACPHandler()
+        run = handler.create_run("g")
+        new_status = handler.sync_status(run.id, "done")
+        assert new_status == ACPRunStatus.COMPLETED
+        assert handler.get_run(run.id).status == ACPRunStatus.COMPLETED
+
+    def test_sync_status_running_states(self) -> None:
+        handler = ACPHandler()
+        run = handler.create_run("g")
+        assert handler.sync_status(run.id, "in_progress") == ACPRunStatus.RUNNING
+
+    def test_sync_unknown_run_raises(self) -> None:
+        with pytest.raises(KeyError):
+            ACPHandler().sync_status("ghost", "done")
+
+    def test_list_runs_returns_all(self) -> None:
+        handler = ACPHandler()
+        r1 = handler.create_run("a")
+        r2 = handler.create_run("b")
+        listed_ids = {r.id for r in handler.list_runs()}
+        assert listed_ids == {r1.id, r2.id}
+
+    def test_list_runs_empty_initially(self) -> None:
+        assert ACPHandler().list_runs() == []

--- a/tests/unit/routing/__init__.py
+++ b/tests/unit/routing/__init__.py
@@ -1,0 +1,1 @@
+"""Routing subsystem unit tests."""

--- a/tests/unit/routing/test_bandit_router_internals.py
+++ b/tests/unit/routing/test_bandit_router_internals.py
@@ -1,0 +1,425 @@
+"""Surgical tests for ``bandit_router`` internal math + loader dark paths.
+
+The public ``BanditRouter`` / ``BanditPolicy`` surface is exercised by
+``tests/unit/test_bandit_router.py``; this module targets the remaining
+uncovered helpers - pure linear-algebra primitives, JSON-load coercion,
+matrix validation, and the cold-start static selectors. All of these are
+RNG-free, so every assertion is deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import Complexity, Scope, Task, TaskType
+
+from bernstein.core.routing import bandit_router as br
+from bernstein.core.routing.bandit_router import (
+    FEATURE_DIM,
+    ArmScore,
+    BanditPolicy,
+    TaskContext,
+    _arm_score_payload,
+    _capability_floor,
+    _clamp_to_floor,
+    _coerce_int_mapping,
+    _dot,
+    _effort_for_task,
+    _identity,
+    _inv,
+    _is_high_stakes,
+    _is_matrix,
+    _is_vector,
+    _load_arm_matrices,
+    _load_arms,
+    _load_exploration_history,
+    _matmul_vec,
+    _sherman_morrison_update,
+    _static_select,
+    _validate_raw_matrices,
+    compute_reward,
+)
+
+
+def _task(
+    role: str = "backend",
+    complexity: Complexity = Complexity.MEDIUM,
+    scope: Scope = Scope.MEDIUM,
+    priority: int = 2,
+    *,
+    model: str | None = None,
+    effort: str | None = None,
+) -> Task:
+    return Task(
+        id="t1",
+        title="Do something",
+        description="desc",
+        role=role,
+        complexity=complexity,
+        scope=scope,
+        priority=priority,
+        model=model,
+        effort=effort,
+        owned_files=[],
+        estimated_minutes=30,
+        task_type=TaskType.STANDARD,
+        metadata={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Linear algebra primitives
+# ---------------------------------------------------------------------------
+
+
+class TestLinearAlgebra:
+    def test_identity_shape_and_diagonal(self) -> None:
+        m = _identity(3)
+        assert m == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+    def test_dot_product(self) -> None:
+        assert _dot([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]) == pytest.approx(32.0)
+
+    def test_matmul_vec(self) -> None:
+        mat = [[1.0, 0.0], [0.0, 2.0]]
+        assert _matmul_vec(mat, [3.0, 4.0]) == pytest.approx([3.0, 8.0])
+
+    def test_inv_of_diagonal(self) -> None:
+        inv = _inv([[2.0, 0.0], [0.0, 4.0]])
+        assert inv[0][0] == pytest.approx(0.5)
+        assert inv[1][1] == pytest.approx(0.25)
+
+    def test_inv_round_trip_identity(self) -> None:
+        mat = [[4.0, 7.0], [2.0, 6.0]]
+        inv = _inv(mat)
+        product = [[_dot(mat[i], [inv[0][j], inv[1][j]]) for j in range(2)] for i in range(2)]
+        assert product[0][0] == pytest.approx(1.0, abs=1e-9)
+        assert product[1][1] == pytest.approx(1.0, abs=1e-9)
+        assert product[0][1] == pytest.approx(0.0, abs=1e-9)
+
+    def test_inv_singular_returns_identity(self) -> None:
+        # A row of zeros makes the matrix singular -> fallback to identity.
+        singular = [[0.0, 0.0], [0.0, 0.0]]
+        assert _inv(singular) == _identity(2)
+
+    def test_sherman_morrison_matches_direct_inverse(self) -> None:
+        # (A + x x^T)^-1 via Sherman-Morrison should match a direct inverse.
+        a_inv = _identity(2)  # A = I
+        x = [1.0, 2.0]
+        sm = _sherman_morrison_update(a_inv, x)
+        # Direct: A + x x^T = [[2,2],[2,5]]; invert it.
+        direct = _inv([[2.0, 2.0], [2.0, 5.0]])
+        for i in range(2):
+            for j in range(2):
+                assert sm[i][j] == pytest.approx(direct[i][j], abs=1e-9)
+
+    def test_sherman_morrison_zero_vector_is_noop(self) -> None:
+        a_inv = _identity(3)
+        # x = 0 -> denom = 1, update leaves the inverse unchanged.
+        assert _sherman_morrison_update(a_inv, [0.0, 0.0, 0.0]) == a_inv
+
+
+# ---------------------------------------------------------------------------
+# JSON load coercion helpers
+# ---------------------------------------------------------------------------
+
+
+class TestLoadArms:
+    def test_valid_list_kept(self) -> None:
+        assert _load_arms(["haiku", "sonnet"], ["fallback"]) == ["haiku", "sonnet"]
+
+    def test_non_list_returns_fallback(self) -> None:
+        assert _load_arms("not-a-list", ["a", "b"]) == ["a", "b"]
+
+    def test_empty_after_filter_returns_fallback(self) -> None:
+        # non-string / empty items are dropped; empty result -> fallback.
+        assert _load_arms([1, "", None], ["x"]) == ["x"]
+
+    def test_fallback_is_copied(self) -> None:
+        fb = ["a"]
+        out = _load_arms("bad", fb)
+        out.append("b")
+        assert fb == ["a"]
+
+
+class TestVectorMatrixGuards:
+    def test_is_vector_correct_length(self) -> None:
+        assert _is_vector([0.0] * FEATURE_DIM, FEATURE_DIM) is True
+
+    def test_is_vector_wrong_length(self) -> None:
+        assert _is_vector([0.0, 1.0], FEATURE_DIM) is False
+
+    def test_is_vector_non_numeric(self) -> None:
+        bad = ["x"] * FEATURE_DIM
+        assert _is_vector(bad, FEATURE_DIM) is False
+
+    def test_is_vector_non_list(self) -> None:
+        assert _is_vector("nope", FEATURE_DIM) is False
+
+    def test_is_matrix_correct(self) -> None:
+        m = _identity(FEATURE_DIM)
+        assert _is_matrix(m, FEATURE_DIM) is True
+
+    def test_is_matrix_wrong_dim(self) -> None:
+        assert _is_matrix([[1.0, 0.0], [0.0, 1.0]], FEATURE_DIM) is False
+
+    def test_is_matrix_non_list(self) -> None:
+        assert _is_matrix(42, FEATURE_DIM) is False
+
+
+class TestCoerceIntMapping:
+    def test_coerces_floats_and_strings(self) -> None:
+        assert _coerce_int_mapping({"a": 1.9, "b": "3"}) == {"a": 1, "b": 3}
+
+    def test_non_dict_returns_empty(self) -> None:
+        assert _coerce_int_mapping("nope") == {}
+
+    def test_bool_values_skipped(self) -> None:
+        # bools are ints in Python but must not be counted.
+        assert _coerce_int_mapping({"flag": True, "n": 5}) == {"n": 5}
+
+
+class TestLoadExplorationHistory:
+    def test_initialises_arms_empty(self) -> None:
+        out = _load_exploration_history(None, ["haiku", "sonnet"])
+        assert out == {"haiku": [], "sonnet": []}
+
+    def test_loads_numeric_samples(self) -> None:
+        out = _load_exploration_history({"haiku": [0.1, 0.2]}, ["haiku"])
+        assert out["haiku"] == pytest.approx([0.1, 0.2])
+
+    def test_window_truncated_to_limit(self) -> None:
+        big = list(range(br._EXPLORATION_HISTORY_LIMIT + 50))
+        out = _load_exploration_history({"haiku": big}, ["haiku"])
+        # only the most recent _EXPLORATION_HISTORY_LIMIT samples kept.
+        assert len(out["haiku"]) == br._EXPLORATION_HISTORY_LIMIT
+        assert out["haiku"][-1] == pytest.approx(float(big[-1]))
+
+    def test_non_list_samples_skipped(self) -> None:
+        out = _load_exploration_history({"haiku": "garbage"}, ["haiku"])
+        assert out["haiku"] == []
+
+
+# ---------------------------------------------------------------------------
+# Matrix validation + load
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRawMatrices:
+    def test_missing_both_returns_none(self) -> None:
+        assert _validate_raw_matrices({}, Path("p")) is None
+
+    def test_invalid_inv_type_returns_none(self) -> None:
+        assert _validate_raw_matrices({"A_inv": "bad"}, Path("p")) is None
+
+    def test_invalid_legacy_matrix_type_returns_none(self) -> None:
+        assert _validate_raw_matrices({"A": "bad"}, Path("p")) is None
+
+    def test_invalid_vector_type_returns_none(self) -> None:
+        assert _validate_raw_matrices({"A_inv": {}, "b": "bad"}, Path("p")) is None
+
+    def test_valid_returns_three_dicts(self) -> None:
+        out = _validate_raw_matrices({"A_inv": {"haiku": []}, "b": {"haiku": []}}, Path("p"))
+        assert out is not None
+        raw_inv, raw_mat, raw_vec = out
+        assert "haiku" in raw_inv
+        assert raw_mat == {}
+        assert "haiku" in raw_vec
+
+
+class TestLoadArmMatrices:
+    def test_dimension_mismatch_returns_none(self) -> None:
+        raw = {"A_inv": {"haiku": [[1.0, 0.0]]}, "b": {"haiku": [0.0, 0.0]}}
+        assert _load_arm_matrices(raw, ["haiku"], Path("p")) is None
+
+    def test_valid_inv_loads_directly(self) -> None:
+        ident = _identity(FEATURE_DIM)
+        raw = {"A_inv": {"haiku": ident}, "b": {"haiku": [0.0] * FEATURE_DIM}}
+        out = _load_arm_matrices(raw, ["haiku"], Path("p"))
+        assert out is not None
+        loaded_inv, loaded_vec, legacy = out
+        assert legacy is False
+        assert loaded_inv["haiku"] == ident
+        assert loaded_vec["haiku"] == [0.0] * FEATURE_DIM
+
+    def test_legacy_matrix_sets_legacy_flag(self) -> None:
+        # Only legacy "A" present -> loader inverts and flags legacy.
+        ident = _identity(FEATURE_DIM)
+        raw = {"A": {"haiku": ident}, "b": {"haiku": [0.0] * FEATURE_DIM}}
+        out = _load_arm_matrices(raw, ["haiku"], Path("p"))
+        assert out is not None
+        _, _, legacy = out
+        assert legacy is True
+
+
+# ---------------------------------------------------------------------------
+# ArmScore payload
+# ---------------------------------------------------------------------------
+
+
+class TestArmScorePayload:
+    def test_none_returns_none(self) -> None:
+        assert _arm_score_payload(None) is None
+
+    def test_rounds_components(self) -> None:
+        payload = _arm_score_payload(ArmScore(arm="haiku", exploit=0.1234567, explore=0.7654321, total=0.8888888))
+        assert payload == {"exploit": 0.123457, "explore": 0.765432, "total": 0.888889}
+
+
+# ---------------------------------------------------------------------------
+# compute_reward (composite quality x cost)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReward:
+    def test_perfect_quality_no_budget_returns_quality(self) -> None:
+        assert compute_reward(1.0, cost_usd=100.0, budget_ceiling=0.0) == pytest.approx(1.0)
+
+    def test_negative_budget_skips_normalisation(self) -> None:
+        assert compute_reward(0.5, cost_usd=100.0, budget_ceiling=-1.0) == pytest.approx(0.5)
+
+    def test_half_cost_halves_reward(self) -> None:
+        # quality 1.0, cost = 50% of ceiling -> reward 0.5.
+        assert compute_reward(1.0, cost_usd=0.5, budget_ceiling=1.0) == pytest.approx(0.5)
+
+    def test_cost_over_ceiling_zero_reward(self) -> None:
+        assert compute_reward(1.0, cost_usd=5.0, budget_ceiling=1.0) == pytest.approx(0.0)
+
+    def test_quality_clamped_above_one(self) -> None:
+        assert compute_reward(2.0, cost_usd=0.0, budget_ceiling=1.0) == pytest.approx(1.0)
+
+    def test_quality_clamped_below_zero(self) -> None:
+        assert compute_reward(-1.0, cost_usd=0.0, budget_ceiling=1.0) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Static cold-start selectors
+# ---------------------------------------------------------------------------
+
+
+class TestStaticSelectors:
+    def test_high_stakes_starts_at_sonnet(self) -> None:
+        model, reason = _static_select(_task(role="security"))
+        assert model == "sonnet"
+        assert "high-stakes" in reason
+
+    def test_manager_override_when_valid_arm(self) -> None:
+        model, reason = _static_select(_task(role="backend", model="opus"))
+        assert model == "opus"
+        assert reason == "manager override"
+
+    def test_manager_override_invalid_arm_falls_to_haiku(self) -> None:
+        # a model not in _DEFAULT_ARMS is ignored -> default cheapest.
+        model, _ = _static_select(_task(role="backend", model="some-other-model"))
+        assert model == "haiku"
+
+    def test_default_cheapest_is_haiku(self) -> None:
+        model, reason = _static_select(_task(role="backend"))
+        assert model == "haiku"
+        assert "cheapest" in reason
+
+    def test_is_high_stakes_for_high_complexity(self) -> None:
+        assert _is_high_stakes(_task(complexity=Complexity.HIGH)) is True
+
+    def test_is_high_stakes_for_large_scope(self) -> None:
+        assert _is_high_stakes(_task(scope=Scope.LARGE)) is True
+
+    def test_is_high_stakes_priority_one(self) -> None:
+        assert _is_high_stakes(_task(priority=1)) is True
+
+    def test_not_high_stakes_for_plain_task(self) -> None:
+        assert _is_high_stakes(_task()) is False
+
+
+class TestEffortForTask:
+    def test_manager_effort_override_wins(self) -> None:
+        assert _effort_for_task("haiku", _task(effort="max")) == "max"
+
+    def test_opus_defaults_max(self) -> None:
+        assert _effort_for_task("opus", _task()) == "max"
+
+    def test_haiku_defaults_low(self) -> None:
+        assert _effort_for_task("haiku", _task()) == "low"
+
+    def test_other_models_default_high(self) -> None:
+        assert _effort_for_task("sonnet", _task()) == "high"
+
+
+class TestCapabilityFloorAndClamp:
+    def test_opus_floor_for_high_stakes_high_large(self) -> None:
+        floor = _capability_floor(_task(role="architect", complexity=Complexity.HIGH, scope=Scope.LARGE))
+        assert floor == "opus"
+
+    def test_sonnet_floor_for_high_stakes(self) -> None:
+        assert _capability_floor(_task(role="security")) == "sonnet"
+
+    def test_haiku_floor_for_plain(self) -> None:
+        assert _capability_floor(_task()) == "haiku"
+
+    def test_clamp_below_floor_raises(self) -> None:
+        model, clamped = _clamp_to_floor("haiku", "sonnet")
+        assert model == "sonnet"
+        assert clamped is True
+
+    def test_clamp_above_floor_passthrough(self) -> None:
+        model, clamped = _clamp_to_floor("opus", "sonnet")
+        assert model == "opus"
+        assert clamped is False
+
+    def test_clamp_unknown_arm_passthrough(self) -> None:
+        model, clamped = _clamp_to_floor("custom-model", "sonnet")
+        assert model == "custom-model"
+        assert clamped is False
+
+
+# ---------------------------------------------------------------------------
+# BanditPolicy seed_arm refusal + persistence edge
+# ---------------------------------------------------------------------------
+
+
+class TestSeedArmAndPersistence:
+    def test_seed_arm_creates_new_arm(self) -> None:
+        policy = BanditPolicy(arms=["haiku"])
+        policy.seed_arm("opus", mean_reward=0.9)
+        assert "opus" in policy.arms
+
+    def test_seed_arm_refuses_when_live_signal(self) -> None:
+        policy = BanditPolicy(arms=["haiku"])
+        ctx = TaskContext.from_task(_task())
+        policy.update("haiku", ctx, reward=1.0)
+        b_before = list(policy._b["haiku"])
+        policy.seed_arm("haiku", mean_reward=0.1)
+        # the live signal must not be overwritten by the prior.
+        assert policy._b["haiku"] == b_before
+
+    def test_seed_arm_shifts_bias_feature(self) -> None:
+        policy = BanditPolicy(arms=["haiku"])
+        policy.seed_arm("haiku", mean_reward=0.8, virtual_observations=5)
+        bias_idx = 5
+        # b[bias] = n * clamped = 5 * 0.8 = 4.0.
+        assert policy._b["haiku"][bias_idx] == pytest.approx(4.0)
+        # A_inv[bias,bias] = 1/(1+n) = 1/6.
+        assert policy._A_inv["haiku"][bias_idx][bias_idx] == pytest.approx(1.0 / 6.0)
+
+    def test_update_lazily_adds_unknown_arm(self) -> None:
+        policy = BanditPolicy(arms=["haiku"])
+        ctx = TaskContext.from_task(_task())
+        policy.update("brand-new-arm", ctx, reward=1.0)
+        assert "brand-new-arm" in policy.arms
+        assert policy.total_updates == 1
+
+    def test_load_non_dict_json_returns_fresh(self, tmp_path: Path) -> None:
+        path = tmp_path / "policy.json"
+        path.write_text(json.dumps([1, 2, 3]))
+        policy = BanditPolicy.load(path, arms=["haiku", "sonnet"])
+        # falls back to a fresh policy with the given arms.
+        assert policy.arms == ["haiku", "sonnet"]
+        assert policy.total_updates == 0
+
+    def test_load_corrupt_json_returns_fresh(self, tmp_path: Path) -> None:
+        path = tmp_path / "policy.json"
+        path.write_text("{ not json")
+        policy = BanditPolicy.load(path, arms=["haiku"])
+        assert policy.arms == ["haiku"]

--- a/tests/unit/routing/test_router_core.py
+++ b/tests/unit/routing/test_router_core.py
@@ -1,0 +1,857 @@
+"""Behavioural tests for ``router_core`` - tier-aware provider routing.
+
+Covers the dark paths of the deterministic routing engine:
+
+* Region normalisation + matching (prefix semantics).
+* Budget-aware opus downgrade predicate.
+* ``ProviderHealth`` EMA latency + success-rate + status transitions.
+* ``CostTracker`` per-request averages.
+* ``ProviderConfig`` free-tier exhaustion + reset + effective cost.
+* ``TierAwareRouter`` register / availability / quota / health / cost.
+* ``get_available_providers`` health + tier + policy filtering and the
+  weighted-score ordering.
+* ``select_provider_for_task`` dispatch chain: preferred tier ->
+  fallback tier -> last resort -> ``RouterError``, plus vision /
+  large-context capability gating and pinned-provider error paths.
+* ``record_outcome`` routing-weight bumps with clamping.
+* ``save_weights`` / ``load_weights`` round-trip.
+* ``validate_policy`` issue surfacing; ``get_provider_summary`` shape.
+* ``route_task`` deterministic model selection (manager override,
+  high-stakes, large scope, critical, heuristic) + batch flag +
+  budget-aware downgrade.
+
+Routing here is RNG-free (no bandit dir is passed), so every assertion
+is deterministic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import Complexity, ModelConfig, Scope, Task, TaskType
+
+from bernstein.core.routing.router_core import (
+    BUDGET_AWARE_OPUS_MARGIN,
+    DEFAULT_OPUS_TASK_COST_USD,
+    CostTracker,
+    ProviderConfig,
+    ProviderHealth,
+    ProviderHealthStatus,
+    RouterError,
+    RouterState,
+    Tier,
+    TierAwareRouter,
+    _check_opus_override,
+    _should_downgrade_from_opus,
+    clear_budget_context,
+    normalize_region,
+    region_matches,
+    route_task,
+    set_budget_context,
+)
+from bernstein.core.routing.router_policies import ModelPolicy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    role: str = "backend",
+    complexity: Complexity = Complexity.MEDIUM,
+    scope: Scope = Scope.MEDIUM,
+    priority: int = 2,
+    *,
+    title: str = "Do something",
+    description: str = "desc",
+    model: str | None = None,
+    effort: str | None = None,
+    batch_eligible: bool = False,
+) -> Task:
+    return Task(
+        id="t1",
+        title=title,
+        description=description,
+        role=role,
+        complexity=complexity,
+        scope=scope,
+        priority=priority,
+        model=model,
+        effort=effort,
+        owned_files=[],
+        estimated_minutes=30,
+        task_type=TaskType.STANDARD,
+        metadata={},
+        batch_eligible=batch_eligible,
+    )
+
+
+def _provider(
+    name: str,
+    *,
+    tier: Tier = Tier.STANDARD,
+    models: dict[str, ModelConfig] | None = None,
+    cost_per_1k: float = 0.01,
+    available: bool = True,
+    region: str = "global",
+    max_context: int = 200_000,
+    supports_vision: bool = False,
+) -> ProviderConfig:
+    return ProviderConfig(
+        name=name,
+        models=models or {"sonnet": ModelConfig(model="sonnet", effort="high")},
+        tier=tier,
+        cost_per_1k_tokens=cost_per_1k,
+        available=available,
+        region=region,
+        max_context_tokens=max_context,
+        supports_vision=supports_vision,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_budget_context() -> None:
+    # Module-level budget state leaks across tests; reset before each.
+    clear_budget_context()
+
+
+# ---------------------------------------------------------------------------
+# region helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRegionHelpers:
+    def test_normalize_lowercases_and_dashes(self) -> None:
+        assert normalize_region("US_East") == "us-east"
+
+    def test_normalize_none_and_empty(self) -> None:
+        assert normalize_region(None) == ""
+        assert normalize_region("  ") == ""
+
+    def test_no_required_region_matches_anything(self) -> None:
+        assert region_matches(None, "us-east") is True
+
+    def test_required_but_provider_unknown_fails(self) -> None:
+        assert region_matches("eu", None) is False
+
+    def test_exact_match(self) -> None:
+        assert region_matches("eu-west", "EU_West") is True
+
+    def test_prefix_match(self) -> None:
+        # provider "us-east-1" satisfies required "us".
+        assert region_matches("us", "us-east-1") is True
+
+    def test_prefix_must_be_dash_delimited(self) -> None:
+        # "useast" does not match required "us" (no dash boundary).
+        assert region_matches("us", "useast") is False
+
+
+# ---------------------------------------------------------------------------
+# budget-aware downgrade
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetDowngradePredicate:
+    def test_disabled_never_downgrades(self) -> None:
+        assert _should_downgrade_from_opus(0.0, enabled=False, estimated_opus_cost_usd=1.5) is False
+
+    def test_unknown_budget_never_downgrades(self) -> None:
+        assert _should_downgrade_from_opus(None, enabled=True, estimated_opus_cost_usd=1.5) is False
+
+    def test_infinite_budget_never_downgrades(self) -> None:
+        assert _should_downgrade_from_opus(float("inf"), enabled=True, estimated_opus_cost_usd=1.5) is False
+
+    def test_low_budget_downgrades(self) -> None:
+        # margin 2x * 1.5 = 3.0; remaining 2.0 < 3.0 -> downgrade.
+        assert _should_downgrade_from_opus(2.0, enabled=True, estimated_opus_cost_usd=1.5) is True
+
+    def test_high_budget_does_not_downgrade(self) -> None:
+        assert _should_downgrade_from_opus(10.0, enabled=True, estimated_opus_cost_usd=1.5) is False
+
+    def test_margin_constant_is_two(self) -> None:
+        assert BUDGET_AWARE_OPUS_MARGIN == 2.0
+        assert DEFAULT_OPUS_TASK_COST_USD == 1.5
+
+
+# ---------------------------------------------------------------------------
+# ProviderHealth state machine
+# ---------------------------------------------------------------------------
+
+
+class TestProviderHealth:
+    def test_consecutive_failures_degrade_then_unhealthy(self) -> None:
+        h = ProviderHealth()
+        h.update(success=False)
+        h.update(success=False)
+        assert h.status == ProviderHealthStatus.DEGRADED
+        for _ in range(3):
+            h.update(success=False)
+        assert h.status == ProviderHealthStatus.UNHEALTHY
+
+    def test_recovery_to_healthy_after_three_successes(self) -> None:
+        h = ProviderHealth()
+        for _ in range(5):
+            h.update(success=False)
+        assert h.status == ProviderHealthStatus.UNHEALTHY
+        for _ in range(3):
+            h.update(success=True)
+        assert h.status == ProviderHealthStatus.HEALTHY
+
+    def test_success_resets_failure_counter(self) -> None:
+        h = ProviderHealth()
+        h.update(success=False)
+        h.update(success=True)
+        assert h.consecutive_failures == 0
+        assert h.consecutive_successes == 1
+
+    def test_success_rate_recalculated(self) -> None:
+        h = ProviderHealth()
+        h.update(success=True)
+        # one success, zero failures -> 100%.
+        assert h.success_rate == pytest.approx(1.0)
+        assert h.error_rate == pytest.approx(0.0)
+
+    def test_latency_ema(self) -> None:
+        h = ProviderHealth()
+        h.update(success=True, latency_ms=100.0)
+        # first sample: alpha*100 + (1-alpha)*0 = 0.3*100 = 30.
+        assert h.avg_latency_ms == pytest.approx(30.0)
+        h.update(success=True, latency_ms=100.0)
+        # 0.3*100 + 0.7*30 = 51.
+        assert h.avg_latency_ms == pytest.approx(51.0)
+
+    def test_zero_latency_does_not_update_ema(self) -> None:
+        h = ProviderHealth()
+        h.update(success=True, latency_ms=50.0)
+        before = h.avg_latency_ms
+        h.update(success=True, latency_ms=0.0)
+        assert h.avg_latency_ms == pytest.approx(before)
+
+
+# ---------------------------------------------------------------------------
+# CostTracker (provider-level)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderCostTracker:
+    def test_record_accumulates(self) -> None:
+        c = CostTracker()
+        c.record_request(tokens=1000, cost_usd=0.5)
+        c.record_request(tokens=2000, cost_usd=1.0)
+        assert c.total_requests == 2
+        assert c.total_tokens == 3000
+        assert c.total_cost_usd == pytest.approx(1.5)
+
+    def test_avg_cost_per_request(self) -> None:
+        c = CostTracker()
+        c.record_request(tokens=1000, cost_usd=0.4)
+        c.record_request(tokens=1000, cost_usd=0.6)
+        assert c.avg_cost_per_request == pytest.approx(0.5)
+
+    def test_avg_cost_per_1k_tokens(self) -> None:
+        c = CostTracker()
+        c.record_request(tokens=2000, cost_usd=0.02)
+        # 0.02 / 2000 * 1000 = 0.01 per 1k.
+        assert c.avg_cost_per_1k_tokens == pytest.approx(0.01)
+
+
+# ---------------------------------------------------------------------------
+# ProviderConfig free tier
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConfigFreeTier:
+    def test_no_limit_never_exhausted(self) -> None:
+        p = _provider("p", tier=Tier.FREE)
+        assert p.is_free_tier_exhausted() is False
+
+    def test_exhausted_when_used_meets_limit(self) -> None:
+        p = _provider("p", tier=Tier.FREE)
+        p.free_tier_limit = 100
+        p.free_tier_used = 100
+        assert p.is_free_tier_exhausted() is True
+
+    def test_reset_clears_usage_after_reset_time(self) -> None:
+        import time
+
+        p = _provider("p", tier=Tier.FREE)
+        p.free_tier_limit = 10
+        p.free_tier_used = 10
+        p.free_tier_reset = time.time() - 1.0  # already passed
+        # reaching the check resets usage -> not exhausted.
+        assert p.is_free_tier_exhausted() is False
+        assert p.free_tier_used == 0
+
+    def test_effective_cost_zero_for_unexhausted_free(self) -> None:
+        p = _provider("p", tier=Tier.FREE, cost_per_1k=0.05)
+        assert p.get_effective_cost() == 0.0
+
+    def test_effective_cost_full_for_exhausted_free(self) -> None:
+        p = _provider("p", tier=Tier.FREE, cost_per_1k=0.05)
+        p.free_tier_limit = 1
+        p.free_tier_used = 1
+        assert p.get_effective_cost() == pytest.approx(0.05)
+
+    def test_effective_cost_standard_tier(self) -> None:
+        p = _provider("p", tier=Tier.STANDARD, cost_per_1k=0.02)
+        assert p.get_effective_cost() == pytest.approx(0.02)
+
+
+# ---------------------------------------------------------------------------
+# TierAwareRouter registration + mutators
+# ---------------------------------------------------------------------------
+
+
+class TestRouterRegistration:
+    def test_register_and_unregister(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p1"))
+        assert "p1" in r.state.providers
+        r.unregister_provider("p1")
+        assert "p1" not in r.state.providers
+
+    def test_unregister_missing_is_noop(self) -> None:
+        r = TierAwareRouter()
+        r.unregister_provider("ghost")  # must not raise
+
+    def test_update_availability(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p1"))
+        r.update_provider_availability("p1", False)
+        assert r.state.providers["p1"].available is False
+
+    def test_update_quota(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p1"))
+        r.update_provider_quota("p1", 42)
+        assert r.state.providers["p1"].quota_remaining == 42
+
+    def test_update_health_routes_to_provider(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p1"))
+        r.update_provider_health("p1", success=False, latency_ms=10.0)
+        assert r.state.providers["p1"].health.consecutive_failures == 1
+
+    def test_record_cost_routes_to_provider(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p1"))
+        r.record_provider_cost("p1", tokens=1000, cost_usd=0.5)
+        assert r.state.providers["p1"].cost_tracker.total_cost_usd == pytest.approx(0.5)
+
+    def test_get_max_context_tokens(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p1", max_context=128_000))
+        assert r.get_provider_max_context_tokens("p1") == 128_000
+        assert r.get_provider_max_context_tokens("missing") is None
+
+
+# ---------------------------------------------------------------------------
+# get_available_providers filtering + ordering
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableProviders:
+    def test_unavailable_excluded(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("up", available=True))
+        r.register_provider(_provider("down", available=False))
+        names = [p.name for p in r.get_available_providers()]
+        assert "up" in names
+        assert "down" not in names
+
+    def test_tier_filter(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("free", tier=Tier.FREE))
+        r.register_provider(_provider("std", tier=Tier.STANDARD))
+        names = [p.name for p in r.get_available_providers(tier=Tier.FREE)]
+        assert names == ["free"]
+
+    def test_unhealthy_excluded_when_require_healthy(self) -> None:
+        r = TierAwareRouter()
+        sick = _provider("sick")
+        for _ in range(5):
+            sick.health.update(success=False)
+        r.register_provider(sick)
+        r.register_provider(_provider("ok"))
+        names = [p.name for p in r.get_available_providers(require_healthy=True)]
+        assert "sick" not in names
+        assert "ok" in names
+
+    def test_unhealthy_included_when_not_require_healthy(self) -> None:
+        r = TierAwareRouter()
+        sick = _provider("sick")
+        for _ in range(5):
+            sick.health.update(success=False)
+        r.register_provider(sick)
+        names = [p.name for p in r.get_available_providers(require_healthy=False)]
+        assert "sick" in names
+
+    def test_policy_denied_provider_excluded(self) -> None:
+        state = RouterState(model_policy=ModelPolicy(denied_providers=["bad"]))
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("bad"))
+        r.register_provider(_provider("good"))
+        names = [p.name for p in r.get_available_providers()]
+        assert "bad" not in names
+        assert "good" in names
+
+    def test_free_tier_scores_higher_than_standard(self) -> None:
+        # With identical health, a free (cost 0) provider should sort
+        # ahead of a standard provider on score.
+        r = TierAwareRouter()
+        free = _provider("free", tier=Tier.FREE, cost_per_1k=0.0)
+        std = _provider("std", tier=Tier.STANDARD, cost_per_1k=0.05)
+        # warm both to HEALTHY with identical success history.
+        for p in (free, std):
+            for _ in range(3):
+                p.health.update(success=True)
+        r.register_provider(std)
+        r.register_provider(free)
+        ordered = [p.name for p in r.get_available_providers()]
+        assert ordered[0] == "free"
+
+
+# ---------------------------------------------------------------------------
+# select_provider_for_task dispatch + fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSelectProviderDispatch:
+    def test_preferred_tier_selected(self) -> None:
+        state = RouterState(preferred_tier=Tier.FREE)
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("free-p", tier=Tier.FREE))
+        decision = r.select_provider_for_task(_task(), base_config=ModelConfig(model="sonnet", effort="high"))
+        assert decision.provider == "free-p"
+        assert decision.reason == "preferred_tier"
+        assert decision.fallback is False
+
+    def test_fallback_to_standard_when_no_free(self) -> None:
+        state = RouterState(preferred_tier=Tier.FREE, fallback_enabled=True)
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("std-p", tier=Tier.STANDARD))
+        decision = r.select_provider_for_task(_task(), base_config=ModelConfig(model="sonnet", effort="high"))
+        assert decision.provider == "std-p"
+        assert decision.reason == "fallback"
+        assert decision.fallback is True
+
+    def test_last_resort_uses_degraded_provider(self) -> None:
+        state = RouterState(preferred_tier=Tier.FREE, fallback_enabled=True)
+        r = TierAwareRouter(state=state)
+        degraded = _provider("only", tier=Tier.STANDARD)
+        for _ in range(5):
+            degraded.health.update(success=False)  # UNHEALTHY
+        r.register_provider(degraded)
+        decision = r.select_provider_for_task(_task(), base_config=ModelConfig(model="sonnet", effort="high"))
+        assert decision.provider == "only"
+        assert decision.reason == "last_resort"
+        assert decision.fallback is True
+
+    def test_no_provider_raises_router_error(self) -> None:
+        r = TierAwareRouter()
+        with pytest.raises(RouterError, match="No available provider"):
+            r.select_provider_for_task(_task(), base_config=ModelConfig(model="sonnet", effort="high"))
+
+    def test_no_fallback_when_disabled_raises(self) -> None:
+        state = RouterState(preferred_tier=Tier.FREE, fallback_enabled=False)
+        r = TierAwareRouter(state=state)
+        # only a standard provider; fallback disabled -> last resort still
+        # tries any-available, which finds it.  Disable by making the model
+        # unsupported instead.
+        r.register_provider(
+            _provider("std", tier=Tier.STANDARD, models={"opus": ModelConfig(model="opus", effort="max")})
+        )
+        with pytest.raises(RouterError):
+            r.select_provider_for_task(_task(), base_config=ModelConfig(model="totally-unknown-model", effort="high"))
+
+    def test_vision_requirement_excludes_non_vision_provider(self) -> None:
+        state = RouterState(preferred_tier=Tier.STANDARD)
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("text-only", tier=Tier.STANDARD, supports_vision=False))
+        r.register_provider(_provider("visual", tier=Tier.STANDARD, supports_vision=True))
+        # title mentions a screenshot -> vision required.
+        task = _task(title="Analyze this screenshot")
+        decision = r.select_provider_for_task(task, base_config=ModelConfig(model="sonnet", effort="high"))
+        assert decision.provider == "visual"
+
+    def test_large_context_excludes_small_window_provider(self) -> None:
+        state = RouterState(preferred_tier=Tier.STANDARD)
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("small", tier=Tier.STANDARD, max_context=50_000))
+        r.register_provider(_provider("big", tier=Tier.STANDARD, max_context=200_000))
+        # LARGE scope -> requires >= 100k context.
+        task = _task(scope=Scope.LARGE)
+        decision = r.select_provider_for_task(task, base_config=ModelConfig(model="sonnet", effort="high"))
+        assert decision.provider == "big"
+
+
+class TestPreferredProviderPin:
+    def test_pinned_provider_selected(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("pinned", tier=Tier.STANDARD))
+        decision = r.select_provider_for_task(
+            _task(), base_config=ModelConfig(model="sonnet", effort="high"), preferred_provider="pinned"
+        )
+        assert decision.provider == "pinned"
+        assert decision.reason == "role_policy"
+
+    def test_pinned_unknown_provider_raises(self) -> None:
+        r = TierAwareRouter()
+        with pytest.raises(RouterError, match="not registered"):
+            r.select_provider_for_task(
+                _task(), base_config=ModelConfig(model="sonnet", effort="high"), preferred_provider="ghost"
+            )
+
+    def test_pinned_unavailable_provider_raises(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p", available=False))
+        with pytest.raises(RouterError, match="unavailable"):
+            r.select_provider_for_task(
+                _task(), base_config=ModelConfig(model="sonnet", effort="high"), preferred_provider="p"
+            )
+
+    def test_pinned_denied_by_policy_raises(self) -> None:
+        state = RouterState(model_policy=ModelPolicy(denied_providers=["p"]))
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("p"))
+        with pytest.raises(RouterError, match="denied by model_policy"):
+            r.select_provider_for_task(
+                _task(), base_config=ModelConfig(model="sonnet", effort="high"), preferred_provider="p"
+            )
+
+    def test_pinned_unsupported_model_raises(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p", models={"opus": ModelConfig(model="opus", effort="max")}))
+        with pytest.raises(RouterError, match="does not support model"):
+            r.select_provider_for_task(
+                _task(), base_config=ModelConfig(model="zzz-unknown", effort="high"), preferred_provider="p"
+            )
+
+
+# ---------------------------------------------------------------------------
+# record_outcome + weights persistence
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeAndWeights:
+    def test_success_increments_weight(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        r.record_outcome("p", success=True)
+        assert r.state.providers["p"].routing_weight == pytest.approx(1.1)
+
+    def test_failure_decrements_weight(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        r.record_outcome("p", success=False)
+        assert r.state.providers["p"].routing_weight == pytest.approx(0.8)
+
+    def test_weight_clamped_at_two(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        for _ in range(50):
+            r.record_outcome("p", success=True)
+        assert r.state.providers["p"].routing_weight == pytest.approx(2.0)
+
+    def test_weight_floored_at_point_one(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        for _ in range(50):
+            r.record_outcome("p", success=False)
+        assert r.state.providers["p"].routing_weight == pytest.approx(0.1)
+
+    def test_record_outcome_unknown_provider_noop(self) -> None:
+        r = TierAwareRouter()
+        r.record_outcome("ghost", success=True)  # must not raise
+
+    def test_save_and_load_weights_round_trip(self, tmp_path: Path) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        r.record_outcome("p", success=True)
+        r.record_outcome("p", success=True)
+        saved_weight = r.state.providers["p"].routing_weight
+        r.save_weights(tmp_path)
+
+        r2 = TierAwareRouter()
+        r2.register_provider(_provider("p"))
+        r2.load_weights(tmp_path)
+        assert r2.state.providers["p"].routing_weight == pytest.approx(saved_weight)
+
+    def test_load_weights_missing_file_noop(self, tmp_path: Path) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        r.load_weights(tmp_path)  # no weights.json -> no change, no raise
+        assert r.state.providers["p"].routing_weight == pytest.approx(1.0)
+
+    def test_load_weights_ignores_unregistered(self, tmp_path: Path) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p"))
+        r.record_outcome("p", success=True)
+        r.save_weights(tmp_path)
+        # new router without 'p' registered must not crash on load.
+        r2 = TierAwareRouter()
+        r2.load_weights(tmp_path)
+        assert "p" not in r2.state.providers
+
+
+# ---------------------------------------------------------------------------
+# validate_policy + summary
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAndSummary:
+    def test_denied_unregistered_provider_flagged(self) -> None:
+        state = RouterState(model_policy=ModelPolicy(denied_providers=["nope"]))
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("free", tier=Tier.FREE))
+        r.register_provider(_provider("std", tier=Tier.STANDARD))
+        r.register_provider(_provider("prem", tier=Tier.PREMIUM))
+        issues = r.validate_policy()
+        assert any("nope" in i and "not registered" in i for i in issues)
+
+    def test_missing_tier_coverage_flagged(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("only-standard", tier=Tier.STANDARD))
+        issues = r.validate_policy()
+        # FREE and PREMIUM have no providers.
+        assert any("free" in i for i in issues)
+        assert any("premium" in i for i in issues)
+
+    def test_get_provider_summary_shape(self) -> None:
+        r = TierAwareRouter()
+        r.register_provider(_provider("p", tier=Tier.FREE, region="eu-west"))
+        r.record_provider_cost("p", tokens=1000, cost_usd=0.5)
+        summary = r.get_provider_summary()
+        assert summary["p"]["tier"] == "free"
+        assert summary["p"]["total_cost_usd"] == pytest.approx(0.5)
+        assert summary["p"]["region"] == "eu-west"
+        assert summary["p"]["available"] is True
+
+
+# ---------------------------------------------------------------------------
+# route_task model selection
+# ---------------------------------------------------------------------------
+
+
+class TestRouteTaskSelection:
+    def test_manager_override_wins(self) -> None:
+        cfg = route_task(_task(model="haiku", effort="low"))
+        assert cfg.model == "haiku"
+        assert cfg.effort == "low"
+
+    def test_high_stakes_role_routes_opus(self) -> None:
+        cfg = route_task(_task(role="security"))
+        assert cfg.model == "opus"
+        assert cfg.effort == "max"
+
+    def test_architect_role_routes_opus(self) -> None:
+        assert route_task(_task(role="architect")).model == "opus"
+
+    def test_large_scope_routes_opus(self) -> None:
+        cfg = route_task(_task(scope=Scope.LARGE))
+        assert cfg.model == "opus"
+
+    def test_critical_priority_routes_opus(self) -> None:
+        cfg = route_task(_task(priority=1))
+        assert cfg.model == "opus"
+
+    def test_plain_medium_backend_routes_sonnet(self) -> None:
+        cfg = route_task(_task(role="backend", complexity=Complexity.MEDIUM, scope=Scope.MEDIUM, priority=2))
+        assert cfg.model == "sonnet"
+        assert cfg.effort == "high"
+
+    def test_high_complexity_heuristic_routes_sonnet(self) -> None:
+        cfg = route_task(_task(role="backend", complexity=Complexity.HIGH, scope=Scope.MEDIUM, priority=2))
+        assert cfg.model == "sonnet"
+
+    def test_batch_eligible_sets_is_batch(self) -> None:
+        cfg = route_task(_task(batch_eligible=True))
+        assert cfg.is_batch is True
+
+    def test_critical_batch_not_batched(self) -> None:
+        # priority=1 is never routed to batch even if eligible.
+        cfg = route_task(_task(priority=1, batch_eligible=True))
+        assert cfg.is_batch is False
+
+
+class TestRouteTaskBudgetAware:
+    def test_budget_downgrade_skips_opus_for_high_stakes(self) -> None:
+        # Low remaining budget -> high-stakes task lands on sonnet.
+        cfg = route_task(
+            _task(role="security"),
+            budget_remaining_usd=1.0,
+            budget_aware_routing_enabled=True,
+        )
+        assert cfg.model == "sonnet"
+
+    def test_ample_budget_keeps_opus(self) -> None:
+        cfg = route_task(
+            _task(role="security"),
+            budget_remaining_usd=100.0,
+            budget_aware_routing_enabled=True,
+        )
+        assert cfg.model == "opus"
+
+    def test_disabled_budget_routing_keeps_opus(self) -> None:
+        cfg = route_task(
+            _task(role="security"),
+            budget_remaining_usd=0.5,
+            budget_aware_routing_enabled=False,
+        )
+        assert cfg.model == "opus"
+
+    def test_module_context_drives_downgrade(self) -> None:
+        # When kwargs are omitted, set_budget_context state applies.
+        set_budget_context(1.0, enabled=True)
+        cfg = route_task(_task(role="manager"))
+        assert cfg.model == "sonnet"
+
+    def test_check_opus_override_returns_none_for_plain_task(self) -> None:
+        assert _check_opus_override(_task(role="backend", priority=2, scope=Scope.MEDIUM)) is None
+
+    def test_check_opus_override_reason_for_high_stakes(self) -> None:
+        reason = _check_opus_override(_task(role="security"))
+        assert reason is not None
+        assert "high-stakes" in reason
+
+
+# ---------------------------------------------------------------------------
+# batch routing + active-agent counts + default router
+# ---------------------------------------------------------------------------
+
+
+class TestRouterMisc:
+    def test_route_batch_returns_decision_per_task(self) -> None:
+        state = RouterState(preferred_tier=Tier.STANDARD)
+        r = TierAwareRouter(state=state)
+        r.register_provider(_provider("p", tier=Tier.STANDARD))
+        decisions = r.route_batch([_task(), _task(), _task()])
+        assert len(decisions) == 3
+        assert all(d.provider == "p" for d in decisions)
+
+    def test_update_active_agent_counts_copies(self) -> None:
+        r = TierAwareRouter()
+        counts = {"p": 3}
+        r.update_active_agent_counts(counts)
+        counts["p"] = 99  # mutate caller's dict
+        # router kept its own copy.
+        assert r.state.active_agent_counts["p"] == 3
+
+    def test_get_default_router_is_singleton(self) -> None:
+        from bernstein.core.routing.router_core import get_default_router
+
+        a = get_default_router()
+        b = get_default_router()
+        assert a is b
+        assert isinstance(a, TierAwareRouter)
+
+
+# ---------------------------------------------------------------------------
+# YAML provider + policy loading
+# ---------------------------------------------------------------------------
+
+
+class TestYamlLoading:
+    def test_load_providers_registers_entries(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_providers_from_yaml
+
+        yaml_text = """
+providers:
+  free-prov:
+    tier: free
+    cost_per_1k_tokens: 0.0
+    free_tier_limit: 1000
+    max_context_tokens: 128000
+    models:
+      sonnet:
+        model: sonnet
+        effort: high
+        aliases: [claude-sonnet]
+  paid-prov:
+    tier: standard
+    cost_per_1k_tokens: 0.02
+    supports_vision: true
+    region: eu-west
+"""
+        path = tmp_path / "providers.yaml"
+        path.write_text(yaml_text)
+        r = TierAwareRouter()
+        load_providers_from_yaml(path, r)
+        assert "free-prov" in r.state.providers
+        assert r.state.providers["free-prov"].tier == Tier.FREE
+        assert r.state.providers["free-prov"].free_tier_limit == 1000
+        assert r.state.providers["paid-prov"].supports_vision is True
+        assert r.state.providers["paid-prov"].region == "eu-west"
+
+    def test_load_providers_missing_key_noop(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_providers_from_yaml
+
+        path = tmp_path / "providers.yaml"
+        path.write_text("something_else: 1")
+        r = TierAwareRouter()
+        load_providers_from_yaml(path, r)
+        assert len(r.state.providers) == 0
+
+    def test_load_providers_malformed_entry_skipped(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_providers_from_yaml
+
+        # one good provider, one with an invalid tier (raises -> skipped).
+        yaml_text = """
+providers:
+  good:
+    tier: standard
+  broken:
+    tier: not-a-real-tier
+"""
+        path = tmp_path / "providers.yaml"
+        path.write_text(yaml_text)
+        r = TierAwareRouter()
+        load_providers_from_yaml(path, r)
+        assert "good" in r.state.providers
+        assert "broken" not in r.state.providers
+
+    def test_load_providers_bad_yaml_noop(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_providers_from_yaml
+
+        path = tmp_path / "providers.yaml"
+        path.write_text("::: not valid yaml :::\n  - [")
+        r = TierAwareRouter()
+        load_providers_from_yaml(path, r)  # must not raise
+        assert len(r.state.providers) == 0
+
+    def test_load_model_policy_applies(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_model_policy_from_yaml
+
+        yaml_text = """
+model_policy:
+  denied_providers: [evil-corp]
+  allowed_providers: [good-corp]
+"""
+        path = tmp_path / "policy.yaml"
+        path.write_text(yaml_text)
+        r = TierAwareRouter()
+        load_model_policy_from_yaml(path, r)
+        assert "evil-corp" in r.state.model_policy.denied_providers
+        assert r.state.model_policy.is_provider_allowed("evil-corp", "global") is False
+
+    def test_load_model_policy_bad_yaml_noop(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_model_policy_from_yaml
+
+        path = tmp_path / "policy.yaml"
+        path.write_text(":::not yaml")
+        r = TierAwareRouter()
+        before = r.state.model_policy
+        load_model_policy_from_yaml(path, r)
+        # policy unchanged on parse failure.
+        assert r.state.model_policy is before
+
+    def test_load_model_policy_non_dict_noop(self, tmp_path: Path) -> None:
+        from bernstein.core.routing.router_core import load_model_policy_from_yaml
+
+        path = tmp_path / "policy.yaml"
+        path.write_text("- just\n- a\n- list")
+        r = TierAwareRouter()
+        before = r.state.model_policy
+        load_model_policy_from_yaml(path, r)
+        assert r.state.model_policy is before


### PR DESCRIPTION
## Summary

Test-only PR. Adds **464 behavioural unit tests** across the protocols, routing, and cost subsystems, targeting the uncovered branches reported by `--cov-report=term-missing`. No source files changed.

## Coverage before / after (target modules)

| Module | Before | After |
|---|---|---|
| `cost/claude_cost_tracking.py` | 0% | 100% |
| `cost/cost_tracker.py` | 36% | 93% |
| `routing/router_core.py` | 36% | 85% |
| `routing/bandit_router.py` | 85% | 90% |
| `protocols/a2a/a2a.py` | 44% | 99% |
| `protocols/mcp/mcp_version_compat.py` | 0% | 100% |
| `protocols/mcp/mcp_config_validator.py` | 0% | 93% |
| `protocols/mcp/mcp_tool_normalization.py` | 0% | 96% |
| `protocols/mcp/mcp_task_filter.py` | 0% | 100% |
| `protocols/acp.py` (standalone BeeAI bridge) | untested | run-lifecycle covered |

## What is covered

**cost** (135 tests)
- `estimate_cost` exact per-1M pricing arithmetic + blended-rate fallback.
- `record` / `record_cumulative` delta-safe aggregation into `spent_by_model` / `spent_for_agent` / envelope rollups.
- Envelope hard caps (`EnvelopeBudgetError`), allowlist refusal, threshold hook firing exactly once.
- `status` soft thresholds + hard-cap kill switch + unlimited budget; `agent_summaries` / `model_breakdowns` ordering; `project`; `cache_savings_usd`; save/load round-trip; usage-buffer eviction + JSONL rotation.
- Session-output parser across stream-json / text-summary / structured-JSON shapes.

**routing** (155 tests)
- `router_core`: provider health state machine, scored `get_available_providers` filtering, `select_provider_for_task` dispatch -> fallback -> last-resort -> `RouterError`, pinned-provider error paths, `record_outcome` weight clamping, YAML provider + policy loading, `route_task` model selection + budget-aware downgrade.
- `bandit_router`: LinUCB math primitives (`_inv` singular fallback, Sherman-Morrison), JSON-load coercion + matrix validation, `compute_reward`, static cold-start selectors, `seed_arm` refusal-on-live-signal.

**protocols** (174 tests)
- `a2a` handler task lifecycle, `AgentCard` validate/from_dict/json_schema, async `send_message` happy + error paths via an injected fake client.
- standalone `acp` BeeAI bridge run lifecycle + status mapping.
- `mcp_version_compat`, `mcp_config_validator`, `mcp_tool_normalization`, `mcp_task_filter` pure-logic surfaces.

## Notes

- RNG-dependent routing is deterministic: LinUCB is closed-form and no bandit metrics dir is passed, so arm selection is reproducible.
- `mcp_config_validator` URL reachability lines and `a2a` owned-client `aclose` are deliberately not exercised (would require live sockets); all other branches are covered.
- No genuine bugs surfaced. One test assumption (`o3` blended fallback) was corrected to the actual detailed-pricing behaviour during authoring.

## Test plan

- [x] `uv run pytest tests/unit/protocols tests/unit/routing tests/unit/cost` (new files) green: 464 passed.
- [x] `uv run ruff check . --fix && uv run ruff format .` clean.
- [x] Rebased on latest `origin/main`; target source files unchanged by the rebase.