### PR TITLE
fix(replay): make deterministic replay hermetic, fail on cache miss

### DIFF
--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -1,0 +1,80 @@
+# Deterministic LLM replay (hermetic by default)
+
+Bernstein can record every LLM call of a run to
+`.sdd/runs/<run_id>/llm_calls.jsonl` and replay those responses on a later
+run, so a re-run produces an identical task decomposition without paying the
+model bill. This page covers the orchestrator-wired `DeterministicStore`
+path (selected with `BERNSTEIN_REPLAY_RUN_ID`).
+
+## TL;DR
+
+| Item | Behaviour |
+|---|---|
+| Replay default | Strict / hermetic. A cache miss aborts the run. |
+| On a miss (strict) | Raises `ReplayMissError`; the live model is never called. |
+| Escape hatch | `BERNSTEIN_REPLAY_ALLOW_LIVE_MISS=1` -> miss logs a WARNING and falls through to the live model. |
+| Replay key | `(model, prompt, provider, temperature, max_tokens)`. Any drift is a miss, not a hit. |
+| Coverage line | `hits` / `misses` / `strict_violations`; a fully covered replay reports `misses=0`. |
+
+## How to record and replay
+
+```bash
+# Record: run with a deterministic seed; LLM calls are saved to
+# .sdd/runs/<run_id>/llm_calls.jsonl
+BERNSTEIN_DETERMINISTIC_SEED=42 bernstein run plan.yaml
+
+# Replay: point at the recorded run. Replay is hermetic by default.
+BERNSTEIN_REPLAY_RUN_ID=<run_id> bernstein run plan.yaml
+```
+
+A replay that matches every recorded call completes with zero live provider
+calls and a coverage line whose `misses=0`.
+
+## Strict mode (the default)
+
+Replay is hermetic: if a prompt is not in the recording (a new prompt, a
+reordered tool result, a changed model id, or a drifted
+provider/temperature/max_tokens), `get_replay` raises `ReplayMissError`
+instead of silently calling the live model. The run aborts. This guarantees a
+run launched for replay is genuinely a replay - it cannot reach the network.
+
+`ReplayMissError` subclasses `RuntimeError` and carries the prompt `key` and
+`model`, and its message names exactly how to re-record.
+
+## The replay key folds in every response-determining input
+
+The lookup key is a SHA-256 over
+`model \x00 prompt \x00 provider \x00 repr(temperature) \x00 max_tokens`. A
+cache "hit" therefore cannot mask a parameter drift: the same `(model,
+prompt)` recorded at `temperature=0.7` is a **miss** when replayed at
+`temperature=0.0`.
+
+### Re-recording note (behaviour change)
+
+Folding provider/temperature/max_tokens into the key **invalidates
+`llm_calls.jsonl` files recorded before this change** - older recordings used
+a narrower `model \x00 prompt` key and now read as full misses under strict
+replay. To re-record, run the original workload again with
+`BERNSTEIN_DETERMINISTIC_SEED` set (and `BERNSTEIN_REPLAY_RUN_ID` unset). The
+`ReplayMissError` message states this inline so an operator who hits a stale
+recording knows the fix without leaving the log.
+
+## Escape hatch (opt-in, non-hermetic)
+
+For record-extend workflows you can keep the old fall-through behaviour:
+
+```bash
+BERNSTEIN_REPLAY_ALLOW_LIVE_MISS=1 BERNSTEIN_REPLAY_RUN_ID=<run_id> bernstein run plan.yaml
+```
+
+In this mode a miss emits a WARNING for each occurrence and then calls the
+live provider. It is opt-in precisely so the hermetic guarantee stays closed
+unless deliberately disabled; do not set it globally in CI or air-gapped
+contexts.
+
+## Related
+
+- Source: `src/bernstein/core/orchestration/deterministic.py`
+- Call site: `src/bernstein/core/routing/llm.py` (`call_llm`)
+- Sibling subsystem with the same miss contract:
+  `src/bernstein/core/replay/gateway.py` (`ReplayMissError`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -240,6 +240,7 @@ nav:
       - Incident-to-eval synthesis: eval/incident-synthesis.md
       - A/B runner primitive: eval/ab-runner.md
       - Verification tracking: operations/verification-tracking.md
+      - Deterministic replay: operations/deterministic-replay.md
       - Observability: operations/observability-overview.md
       - Side-channel telemetry: observability/side-channel.md
       - LLM watcher (opt-in): observability/llm-watcher.md

--- a/src/bernstein/core/orchestration/deterministic.py
+++ b/src/bernstein/core/orchestration/deterministic.py
@@ -17,6 +17,18 @@ Workflow::
 The deterministic seed is applied to Python's ``random`` module so that routing
 decisions using ``random.choice`` / ``random.random`` are identical across runs
 with the same seed value.
+
+**Hermetic replay (issue #1832).** Replay is strict by default: a cache miss
+raises :class:`ReplayMissError` and aborts the run rather than silently calling
+the live model. This mirrors the contract of
+:class:`bernstein.core.replay.gateway.ReplayMissError`. Operators who genuinely
+want record-extend-on-miss behaviour must opt in with the
+:data:`ALLOW_LIVE_MISS_ENV` environment flag, which downgrades misses to a
+logged warning + live fall-through. The replay key folds in every
+response-determining input (model, prompt, provider, temperature, max_tokens),
+so a parameter drift can never masquerade as a hit. Widening the key
+invalidates ``llm_calls.jsonl`` files recorded before #1832; re-record by
+running with ``BERNSTEIN_DETERMINISTIC_SEED`` set again.
 """
 
 from __future__ import annotations
@@ -24,6 +36,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import time
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
@@ -36,18 +49,93 @@ logger = logging.getLogger(__name__)
 # Module-level active store (one per orchestrator subprocess).
 _active_store: DeterministicStore | None = None
 
+#: Environment flag that opts replay out of strict mode. When set to a truthy
+#: value, a cache miss emits a WARNING and falls through to the live provider
+#: (the pre-#1832 record-extend behaviour) instead of raising. Strict mode is
+#: the default precisely so this hole stays closed unless deliberately opened.
+ALLOW_LIVE_MISS_ENV = "BERNSTEIN_REPLAY_ALLOW_LIVE_MISS"
 
-def _prompt_key(prompt: str, model: str) -> str:
-    """Compute a stable lookup key for a (prompt, model) pair.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+#: Default LLM parameters folded into the replay key. These mirror the
+#: defaults of :func:`bernstein.core.routing.llm.call_llm`, so a re-recorded
+#: run keys identically to a live run that takes the default path.
+_DEFAULT_PROVIDER = "openrouter_free"
+_DEFAULT_TEMPERATURE = 0.7
+_DEFAULT_MAX_TOKENS = 4000
+
+
+def allow_live_miss(env: dict[str, str] | None = None) -> bool:
+    """Return whether replay may fall through to a live call on a miss.
+
+    Args:
+        env: Optional env mapping (defaults to :data:`os.environ`).
+
+    Returns:
+        ``True`` only when :data:`ALLOW_LIVE_MISS_ENV` is set to a truthy
+        value. Replay is hermetic (strict) by default.
+    """
+    src = env if env is not None else os.environ
+    return src.get(ALLOW_LIVE_MISS_ENV, "").strip().lower() in _TRUTHY
+
+
+class ReplayMissError(RuntimeError):
+    """Raised in strict replay mode when no recorded response matches.
+
+    Mirrors :class:`bernstein.core.replay.gateway.ReplayMissError` so the two
+    replay subsystems share one miss contract. Subclasses :class:`RuntimeError`
+    so existing ``call_llm`` callers that catch ``RuntimeError`` propagate the
+    abort rather than swallowing a fake response.
+
+    Attributes:
+        key: The widened prompt key that was looked up (never ``None``).
+        model: The model identifier that was requested (never ``None``).
+    """
+
+    def __init__(self, key: str, model: str, *, run_dir: str | None = None) -> None:
+        self.key = key
+        self.model = model
+        location = f" in {run_dir}/llm_calls.jsonl" if run_dir else ""
+        super().__init__(
+            f"Deterministic replay miss: no recorded response for model={model!r} "
+            f"(key={key}){location}. Strict replay will not call the live model. "
+            "Either the run diverged from the recording, a response-determining "
+            "input (provider/temperature/max_tokens) drifted, or the recording "
+            "predates the #1832 key widening and must be re-recorded. To re-record, "
+            "re-run with BERNSTEIN_DETERMINISTIC_SEED set (and BERNSTEIN_REPLAY_RUN_ID "
+            "unset). To allow live fall-through on misses (non-hermetic), set "
+            f"{ALLOW_LIVE_MISS_ENV}=1.",
+        )
+
+
+def _prompt_key(
+    prompt: str,
+    model: str,
+    *,
+    provider: str = _DEFAULT_PROVIDER,
+    temperature: float = _DEFAULT_TEMPERATURE,
+    max_tokens: int = _DEFAULT_MAX_TOKENS,
+) -> str:
+    """Compute a stable lookup key for one LLM request.
+
+    The key folds in every input that changes the model's response so a
+    cache hit cannot mask a parameter drift (issue #1832). Widening the key
+    invalidates ``llm_calls.jsonl`` files recorded before this change.
 
     Args:
         prompt: Full prompt string.
         model: Model identifier.
+        provider: Provider name (e.g. ``"openrouter_free"``).
+        temperature: Sampling temperature.
+        max_tokens: Maximum response tokens.
 
     Returns:
-        Hex-encoded SHA-256 of ``model\\x00prompt``.
+        Hex-encoded SHA-256 over the NUL-separated request tuple.
     """
-    data = f"{model}\x00{prompt}".encode()
+    # NUL separators keep field boundaries unambiguous; ``temperature`` is
+    # formatted with ``repr`` so 0.7 and 0.70 hash identically while 0.7 and
+    # 0.0 stay distinct.
+    data = f"{model}\x00{prompt}\x00{provider}\x00{temperature!r}\x00{max_tokens}".encode()
     return hashlib.sha256(data).hexdigest()
 
 
@@ -61,17 +149,30 @@ class DeterministicStore:
     existing ``llm_calls.jsonl`` and :meth:`get_replay` returns stored
     responses without touching the file.
 
+    Replay is **strict by default** (issue #1832): a cache miss raises
+    :class:`ReplayMissError` instead of returning ``None``, so a run launched
+    for replay cannot silently call the live model. Pass ``strict=False`` (the
+    orchestrator does this when :func:`allow_live_miss` is set) to restore the
+    old return-``None``-on-miss escape hatch.
+
     Args:
         run_dir: Directory for this run (``{sdd_dir}/runs/{run_id}``).
         replay: If ``True``, load and replay recorded responses instead of
             writing new ones.
+        strict: When replaying, raise :class:`ReplayMissError` on a cache
+            miss. Defaults to ``True`` and is ignored outside replay mode.
     """
 
-    def __init__(self, run_dir: Path, *, replay: bool = False) -> None:
+    def __init__(self, run_dir: Path, *, replay: bool = False, strict: bool = True) -> None:
         self._run_dir = run_dir
         self._replay = replay
+        self._strict = strict
         self._calls_path = run_dir / "llm_calls.jsonl"
         self._cache: dict[str, str] = {}
+        # Replay-coverage counters backing :meth:`coverage_line`.
+        self._hits = 0
+        self._misses = 0
+        self._strict_violations = 0
         run_dir.mkdir(parents=True, exist_ok=True)
         if replay and self._calls_path.exists():
             self._load_cache()
@@ -101,23 +202,40 @@ class DeterministicStore:
     # Public API
     # ------------------------------------------------------------------
 
-    def record(self, prompt: str, model: str, response: str) -> None:
+    def record(
+        self,
+        prompt: str,
+        model: str,
+        response: str,
+        *,
+        provider: str = _DEFAULT_PROVIDER,
+        temperature: float = _DEFAULT_TEMPERATURE,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+    ) -> None:
         """Append an LLM call record to the JSONL store.
 
-        No-op when in replay mode.
+        No-op when in replay mode. The persisted key folds in
+        ``provider``/``temperature``/``max_tokens`` so a later strict replay
+        matches only when every response-determining input is identical.
 
         Args:
             prompt: Full prompt sent to the LLM.
             model: Model identifier (e.g. ``"claude-3-5-sonnet"``).
             response: Response returned by the LLM.
+            provider: Provider name used for the call.
+            temperature: Sampling temperature used for the call.
+            max_tokens: Max response tokens used for the call.
         """
         if self._replay:
             return
-        key = _prompt_key(prompt, model)
+        key = _prompt_key(prompt, model, provider=provider, temperature=temperature, max_tokens=max_tokens)
         entry: dict[str, Any] = {
             "ts": time.time(),
             "key": key,
             "model": model,
+            "provider": provider,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
             "prompt_len": len(prompt),
             "response": response,
         }
@@ -127,26 +245,75 @@ class DeterministicStore:
         except OSError as exc:
             logger.warning("DeterministicStore: failed to record LLM call: %s", exc)
 
-    def get_replay(self, prompt: str, model: str) -> str | None:
-        """Return a cached response if in replay mode and a match exists.
+    def get_replay(
+        self,
+        prompt: str,
+        model: str,
+        *,
+        provider: str = _DEFAULT_PROVIDER,
+        temperature: float = _DEFAULT_TEMPERATURE,
+        max_tokens: int = _DEFAULT_MAX_TOKENS,
+    ) -> str | None:
+        """Return a cached response, or signal a miss.
 
         Args:
             prompt: Full prompt string.
             model: Model identifier.
+            provider: Provider name (folded into the lookup key).
+            temperature: Sampling temperature (folded into the lookup key).
+            max_tokens: Max response tokens (folded into the lookup key).
 
         Returns:
-            Cached response string, or ``None`` if not in replay mode or
-            no matching record was found.
+            The cached response string on a hit. Returns ``None`` when the
+            store is not in replay mode, or on a miss in non-strict replay
+            mode.
+
+        Raises:
+            ReplayMissError: On a cache miss when the store is in strict
+                replay mode (the default). The error carries the prompt key
+                and model.
         """
         if not self._replay:
             return None
-        key = _prompt_key(prompt, model)
-        return self._cache.get(key)
+        key = _prompt_key(prompt, model, provider=provider, temperature=temperature, max_tokens=max_tokens)
+        cached = self._cache.get(key)
+        if cached is not None:
+            self._hits += 1
+            return cached
+        # Cache miss.
+        if self._strict:
+            self._strict_violations += 1
+            # Emit the coverage line at the failure point so the abort log
+            # carries a verifiable summary of what the replay consumed.
+            logger.error("DeterministicStore: strict replay miss; %s", self.coverage_line())
+            raise ReplayMissError(key, model, run_dir=str(self._run_dir))
+        self._misses += 1
+        return None
 
     @property
     def is_replay(self) -> bool:
         """Whether this store is in replay (read-only) mode."""
         return self._replay
+
+    @property
+    def is_strict(self) -> bool:
+        """Whether replay misses raise instead of falling through."""
+        return self._strict
+
+    @property
+    def hits(self) -> int:
+        """Count of replay lookups served from the recording."""
+        return self._hits
+
+    @property
+    def misses(self) -> int:
+        """Count of non-strict replay misses (live fall-through)."""
+        return self._misses
+
+    @property
+    def strict_violations(self) -> int:
+        """Count of strict replay misses (each aborts the run)."""
+        return self._strict_violations
 
     @property
     def cached_count(self) -> int:
@@ -157,6 +324,19 @@ class DeterministicStore:
     def calls_path(self) -> Path:
         """Path to the ``llm_calls.jsonl`` file."""
         return self._calls_path
+
+    def coverage_line(self) -> str:
+        """Return a one-line replay-coverage summary for operators.
+
+        A fully-covered hermetic replay reports ``misses=0`` and
+        ``strict_violations=0``, so an operator can confirm the run consumed
+        100% recorded responses.
+        """
+        return (
+            f"replay-coverage run_dir={self._run_dir} cached={len(self._cache)} "
+            f"hits={self._hits} misses={self._misses} "
+            f"strict_violations={self._strict_violations} strict={self._strict}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +366,9 @@ def set_active_store(store: DeterministicStore | None) -> None:
 def load_replay_store(run_id: str, sdd_dir: Path) -> DeterministicStore:
     """Create a DeterministicStore in replay mode for the given run.
 
+    Replay is hermetic (strict) unless :data:`ALLOW_LIVE_MISS_ENV` is set, in
+    which case misses fall through to the live provider with a warning.
+
     Args:
         run_id: Run ID whose ``llm_calls.jsonl`` should be replayed.
         sdd_dir: Path to the ``.sdd`` directory.
@@ -194,4 +377,4 @@ def load_replay_store(run_id: str, sdd_dir: Path) -> DeterministicStore:
         Store loaded with cached responses from the specified run.
     """
     run_dir = sdd_dir / "runs" / run_id
-    return DeterministicStore(run_dir, replay=True)
+    return DeterministicStore(run_dir, replay=True, strict=not allow_live_miss())

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4460,15 +4460,26 @@ if __name__ == "__main__":
     _replay_run_id = os.environ.get("BERNSTEIN_REPLAY_RUN_ID", "").strip()
     _sdd_dir = workdir / ".sdd"
     if _replay_run_id:
-        from bernstein.core.orchestration.deterministic import DeterministicStore, set_active_store
+        from bernstein.core.orchestration.deterministic import (
+            DeterministicStore,
+            allow_live_miss,
+            set_active_store,
+        )
 
+        # Hermetic by default (issue #1832): a cache miss aborts the run via
+        # ReplayMissError rather than silently calling the live model. The
+        # opt-in BERNSTEIN_REPLAY_ALLOW_LIVE_MISS flag restores live
+        # fall-through (logged per miss) for record-extend workflows.
+        _strict_replay = not allow_live_miss()
         _det_store = DeterministicStore(
             _sdd_dir / "runs" / _replay_run_id,
             replay=True,
+            strict=_strict_replay,
         )
         set_active_store(_det_store)
         logger.info(
-            "Deterministic replay mode: loaded %d cached LLM responses from run %s",
+            "Deterministic replay mode (%s): loaded %d cached LLM responses from run %s",
+            "strict/hermetic" if _strict_replay else "non-strict/live-miss-allowed",
             _det_store.cached_count,
             _replay_run_id,
         )

--- a/src/bernstein/core/routing/llm.py
+++ b/src/bernstein/core/routing/llm.py
@@ -238,14 +238,31 @@ async def call_llm(
     Raises:
         RuntimeError: If the API call fails.
     """
-    from bernstein.core.deterministic import get_active_store
+    from bernstein.core.orchestration.deterministic import get_active_store
 
     _store = get_active_store()
-    if _store is not None:
-        _replay = _store.get_replay(prompt, model)
+    if _store is not None and _store.is_replay:
+        # ``get_replay`` raises ReplayMissError on a miss in strict mode
+        # (the default), keeping replay hermetic - we never reach the live
+        # provider below. In the opt-in non-strict mode it returns ``None``
+        # and we log a warning before falling through to the live call.
+        _replay = _store.get_replay(
+            prompt,
+            model,
+            provider=provider,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
         if _replay is not None:
             logger.debug("DeterministicStore: replaying cached response for model=%s", model)
             return _replay
+        logger.warning(
+            "DeterministicStore: replay miss for model=%s provider=%s temperature=%s; "
+            "falling through to live provider (non-strict mode)",
+            model,
+            provider,
+            temperature,
+        )
 
     # API-based providers go through the OpenAI-compatible client.
     _API_PROVIDERS = {"openrouter", "openrouter_free", "oxen", "together", "g4f"}
@@ -256,7 +273,7 @@ async def call_llm(
         result = await _call_cli_provider(prompt, model, provider)
 
     if _store is not None:
-        _store.record(prompt, model, result)
+        _store.record(prompt, model, result, provider=provider, temperature=temperature, max_tokens=max_tokens)
     return result
 
 

--- a/tests/unit/test_deterministic_store.py
+++ b/tests/unit/test_deterministic_store.py
@@ -1,0 +1,409 @@
+"""Strict deterministic-replay contract for ``DeterministicStore`` (issue #1832).
+
+These tests pin the hermetic-replay behaviour:
+
+* a cache miss in strict replay mode raises a typed error carrying the
+  prompt key and model (never ``None``);
+* the replay key folds in provider, temperature, and max_tokens, so a
+  parameter drift is a miss, not a silent hit;
+* hit/miss/strict-violation counters back the operator coverage line.
+
+No network, no agents - pure store logic over a fixture JSONL file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.deterministic import (
+    DeterministicStore,
+    ReplayMissError,
+    _prompt_key,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_MODEL = "claude-3-5-sonnet"
+_PROMPT = "decompose this objective into tasks"
+_RESPONSE = "1. task one\n2. task two"
+
+
+def _write_recording(
+    run_dir: Path,
+    *,
+    prompt: str = _PROMPT,
+    model: str = _MODEL,
+    response: str = _RESPONSE,
+    provider: str = "openrouter_free",
+    temperature: float = 0.7,
+    max_tokens: int = 4000,
+) -> Path:
+    """Write a one-line ``llm_calls.jsonl`` recording and return its path.
+
+    The recording is produced via :func:`_prompt_key` so the on-disk key
+    matches whatever the production keying does, keeping the fixture
+    honest if the key recipe changes.
+    """
+    run_dir.mkdir(parents=True, exist_ok=True)
+    calls_path = run_dir / "llm_calls.jsonl"
+    key = _prompt_key(prompt, model, provider=provider, temperature=temperature, max_tokens=max_tokens)
+    entry = {
+        "ts": 1.0,
+        "key": key,
+        "model": model,
+        "provider": provider,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "prompt_len": len(prompt),
+        "response": response,
+    }
+    calls_path.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+    return calls_path
+
+
+# ---------------------------------------------------------------------------
+# Strict replay: known vs unknown key
+# ---------------------------------------------------------------------------
+
+
+class TestStrictReplayLookup:
+    def test_known_key_returns_recorded_response(self, tmp_path: Path) -> None:
+        """A prompt present in the recording replays its stored response."""
+        run_dir = tmp_path / "runs" / "rec-1"
+        _write_recording(run_dir)
+
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        result = store.get_replay(_PROMPT, _MODEL)
+        assert result == _RESPONSE
+
+    def test_unknown_key_raises_replay_miss_error(self, tmp_path: Path) -> None:
+        """A prompt absent from the recording raises a typed miss error."""
+        run_dir = tmp_path / "runs" / "rec-2"
+        _write_recording(run_dir)
+
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        with pytest.raises(ReplayMissError):
+            store.get_replay("a prompt that was never recorded", _MODEL)
+
+    def test_miss_error_carries_key_and_model_not_none(self, tmp_path: Path) -> None:
+        """The error exposes the prompt key and model (never ``None``)."""
+        run_dir = tmp_path / "runs" / "rec-3"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        with pytest.raises(ReplayMissError) as excinfo:
+            store.get_replay("unseen prompt", "some-other-model")
+
+        err = excinfo.value
+        assert err.model == "some-other-model"
+        assert err.key is not None
+        assert err.key == _prompt_key("unseen prompt", "some-other-model")
+
+    def test_miss_error_message_names_run_and_rerecord(self, tmp_path: Path) -> None:
+        """The miss message tells the operator how to re-record."""
+        run_dir = tmp_path / "runs" / "rec-help"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        with pytest.raises(ReplayMissError) as excinfo:
+            store.get_replay("unseen prompt", _MODEL)
+
+        msg = str(excinfo.value)
+        assert "re-record" in msg.lower()
+        assert "BERNSTEIN_REPLAY_RUN_ID" in msg
+
+
+# ---------------------------------------------------------------------------
+# Key widening: provider / temperature / max_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestKeyWidening:
+    def test_different_temperature_is_a_miss(self, tmp_path: Path) -> None:
+        """Same (model, prompt) but a different temperature is a miss."""
+        run_dir = tmp_path / "runs" / "temp-drift"
+        _write_recording(run_dir, temperature=0.7)
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        # Exact temperature hits.
+        assert store.get_replay(_PROMPT, _MODEL, temperature=0.7) == _RESPONSE
+
+        # Drifted temperature misses.
+        with pytest.raises(ReplayMissError):
+            store.get_replay(_PROMPT, _MODEL, temperature=0.0)
+
+    def test_different_provider_is_a_miss(self, tmp_path: Path) -> None:
+        """Same (model, prompt) but a different provider is a miss."""
+        run_dir = tmp_path / "runs" / "provider-drift"
+        _write_recording(run_dir, provider="openrouter_free")
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        assert store.get_replay(_PROMPT, _MODEL, provider="openrouter_free") == _RESPONSE
+
+        with pytest.raises(ReplayMissError):
+            store.get_replay(_PROMPT, _MODEL, provider="openrouter")
+
+    def test_different_max_tokens_is_a_miss(self, tmp_path: Path) -> None:
+        """Same (model, prompt) but a different max_tokens is a miss."""
+        run_dir = tmp_path / "runs" / "tokens-drift"
+        _write_recording(run_dir, max_tokens=4000)
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        assert store.get_replay(_PROMPT, _MODEL, max_tokens=4000) == _RESPONSE
+
+        with pytest.raises(ReplayMissError):
+            store.get_replay(_PROMPT, _MODEL, max_tokens=256)
+
+    def test_prompt_key_changes_with_each_response_determining_input(self) -> None:
+        """The key recipe is sensitive to every response-determining input."""
+        base = _prompt_key(_PROMPT, _MODEL, provider="openrouter_free", temperature=0.7, max_tokens=4000)
+        assert base != _prompt_key("other prompt", _MODEL, provider="openrouter_free", temperature=0.7, max_tokens=4000)
+        assert base != _prompt_key(_PROMPT, "other-model", provider="openrouter_free", temperature=0.7, max_tokens=4000)
+        assert base != _prompt_key(_PROMPT, _MODEL, provider="openrouter", temperature=0.7, max_tokens=4000)
+        assert base != _prompt_key(_PROMPT, _MODEL, provider="openrouter_free", temperature=0.0, max_tokens=4000)
+        assert base != _prompt_key(_PROMPT, _MODEL, provider="openrouter_free", temperature=0.7, max_tokens=256)
+
+
+# ---------------------------------------------------------------------------
+# Non-strict escape hatch
+# ---------------------------------------------------------------------------
+
+
+class TestNonStrictEscapeHatch:
+    def test_non_strict_miss_returns_none(self, tmp_path: Path) -> None:
+        """With strict=False a miss returns ``None`` (the old fall-through)."""
+        run_dir = tmp_path / "runs" / "lax"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=False)
+
+        assert store.get_replay("unseen prompt", _MODEL) is None
+
+    def test_non_strict_hit_still_returns_response(self, tmp_path: Path) -> None:
+        """Non-strict mode still serves recorded hits."""
+        run_dir = tmp_path / "runs" / "lax-hit"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=False)
+
+        assert store.get_replay(_PROMPT, _MODEL) == _RESPONSE
+
+    def test_replay_defaults_to_strict(self, tmp_path: Path) -> None:
+        """``replay=True`` defaults to strict mode."""
+        run_dir = tmp_path / "runs" / "default"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True)
+
+        assert store.is_strict is True
+        with pytest.raises(ReplayMissError):
+            store.get_replay("unseen prompt", _MODEL)
+
+    def test_recording_mode_never_raises(self, tmp_path: Path) -> None:
+        """A recording-mode store returns ``None`` and never raises on miss."""
+        run_dir = tmp_path / "runs" / "recording"
+        store = DeterministicStore(run_dir, replay=False)
+
+        assert store.get_replay("anything", _MODEL) is None
+
+
+# ---------------------------------------------------------------------------
+# Coverage counters / coverage line
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageCounters:
+    def test_hits_and_misses_counted(self, tmp_path: Path) -> None:
+        """Hits and strict violations are tallied for the coverage line."""
+        run_dir = tmp_path / "runs" / "cov"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        store.get_replay(_PROMPT, _MODEL)  # hit
+        store.get_replay(_PROMPT, _MODEL)  # hit
+        with pytest.raises(ReplayMissError):
+            store.get_replay("miss", _MODEL)  # strict violation
+
+        assert store.hits == 2
+        assert store.strict_violations == 1
+
+    def test_non_strict_miss_increments_miss_counter(self, tmp_path: Path) -> None:
+        """A non-strict miss bumps ``misses`` (not ``strict_violations``)."""
+        run_dir = tmp_path / "runs" / "cov-lax"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=False)
+
+        store.get_replay(_PROMPT, _MODEL)  # hit
+        store.get_replay("miss", _MODEL)  # non-strict miss
+
+        assert store.hits == 1
+        assert store.misses == 1
+        assert store.strict_violations == 0
+
+    def test_coverage_line_reports_zero_misses_on_full_replay(self, tmp_path: Path) -> None:
+        """A fully covered replay reports miss-count 0 in the coverage line."""
+        run_dir = tmp_path / "runs" / "cov-full"
+        _write_recording(run_dir)
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        store.get_replay(_PROMPT, _MODEL)
+
+        line = store.coverage_line()
+        assert "hits=1" in line
+        assert "misses=0" in line
+        assert "strict_violations=0" in line
+
+
+# ---------------------------------------------------------------------------
+# Stale recordings (key widening invalidates old llm_calls.jsonl)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleRecordings:
+    def test_legacy_narrow_key_recording_is_a_miss(self, tmp_path: Path) -> None:
+        """An old recording keyed on only ``model\\x00prompt`` is a miss now.
+
+        Pre-#1832 recordings hashed only ``model\\x00prompt``. Under the
+        widened key those rows no longer match, so strict replay treats
+        them as misses (the documented behaviour change).
+        """
+        import hashlib
+
+        run_dir = tmp_path / "runs" / "legacy"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        legacy_key = hashlib.sha256(f"{_MODEL}\x00{_PROMPT}".encode()).hexdigest()
+        entry = {"ts": 1.0, "key": legacy_key, "model": _MODEL, "prompt_len": len(_PROMPT), "response": _RESPONSE}
+        (run_dir / "llm_calls.jsonl").write_text(json.dumps(entry) + "\n", encoding="utf-8")
+
+        store = DeterministicStore(run_dir, replay=True, strict=True)
+
+        with pytest.raises(ReplayMissError):
+            store.get_replay(_PROMPT, _MODEL)
+
+
+# ---------------------------------------------------------------------------
+# Env-driven escape hatch (BERNSTEIN_REPLAY_ALLOW_LIVE_MISS)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowLiveMissEnv:
+    def test_load_replay_store_is_strict_by_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``load_replay_store`` builds a strict store unless opted out."""
+        from bernstein.core.orchestration.deterministic import ALLOW_LIVE_MISS_ENV, load_replay_store
+
+        monkeypatch.delenv(ALLOW_LIVE_MISS_ENV, raising=False)
+        _write_recording(tmp_path / "runs" / "run-x")
+
+        store = load_replay_store("run-x", tmp_path)
+        assert store.is_strict is True
+
+    def test_load_replay_store_honours_escape_hatch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The env flag downgrades the loaded store to non-strict."""
+        from bernstein.core.orchestration.deterministic import ALLOW_LIVE_MISS_ENV, load_replay_store
+
+        monkeypatch.setenv(ALLOW_LIVE_MISS_ENV, "1")
+        _write_recording(tmp_path / "runs" / "run-y")
+
+        store = load_replay_store("run-y", tmp_path)
+        assert store.is_strict is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: orchestrator-style replay wiring is hermetic end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestReplayWiringHermetic:
+    """Reproduce the orchestrator's BERNSTEIN_REPLAY_RUN_ID wiring and drive
+    ``call_llm`` through it with a provider double.
+
+    This is the integration guarantee from issue #1832: a fully-covered
+    replay makes zero live provider calls, and an unknown prompt raises and
+    aborts without ever touching a provider.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_active_store(self):
+        from bernstein.core.orchestration.deterministic import set_active_store
+
+        set_active_store(None)
+        yield
+        set_active_store(None)
+
+    def _wire_replay_store(self, sdd_dir: Path, run_id: str):
+        """Mimic orchestrator._run_orchestrator's replay wiring exactly."""
+        from bernstein.core.orchestration.deterministic import (
+            DeterministicStore,
+            allow_live_miss,
+            set_active_store,
+        )
+
+        store = DeterministicStore(
+            sdd_dir / "runs" / run_id,
+            replay=True,
+            strict=not allow_live_miss(),
+        )
+        set_active_store(store)
+        return store
+
+    @pytest.mark.asyncio
+    async def test_full_replay_makes_zero_live_calls(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A replay covering every prompt completes with 0 live calls, misses=0."""
+        from unittest.mock import patch
+
+        from bernstein.core.llm import call_llm
+
+        from bernstein.core.orchestration.deterministic import ALLOW_LIVE_MISS_ENV
+
+        monkeypatch.delenv(ALLOW_LIVE_MISS_ENV, raising=False)
+        sdd_dir = tmp_path / ".sdd"
+        _write_recording(sdd_dir / "runs" / "run-cov", prompt="p1", model="gpt-4", response="r1")
+
+        store = self._wire_replay_store(sdd_dir, "run-cov")
+
+        live_calls = {"n": 0}
+
+        async def _spy(*_a: object, **_k: object) -> str:
+            live_calls["n"] += 1
+            return "LIVE"
+
+        with patch("bernstein.core.llm._call_api_provider", new=_spy):
+            out = await call_llm("p1", "gpt-4", provider="openrouter_free")
+
+        assert out == "r1"
+        assert live_calls["n"] == 0
+        assert store.hits == 1
+        assert store.misses == 0
+        assert store.strict_violations == 0
+        assert "misses=0" in store.coverage_line()
+
+    @pytest.mark.asyncio
+    async def test_unknown_prompt_raises_and_aborts(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An injected unknown prompt raises ReplayMissError; no live call."""
+        from unittest.mock import patch
+
+        from bernstein.core.llm import call_llm
+
+        from bernstein.core.orchestration.deterministic import ALLOW_LIVE_MISS_ENV
+
+        monkeypatch.delenv(ALLOW_LIVE_MISS_ENV, raising=False)
+        sdd_dir = tmp_path / ".sdd"
+        _write_recording(sdd_dir / "runs" / "run-miss", prompt="p1", model="gpt-4", response="r1")
+
+        store = self._wire_replay_store(sdd_dir, "run-miss")
+
+        live_calls = {"n": 0}
+
+        async def _spy(*_a: object, **_k: object) -> str:
+            live_calls["n"] += 1
+            return "LIVE"
+
+        with patch("bernstein.core.llm._call_api_provider", new=_spy), pytest.raises(ReplayMissError):
+            await call_llm("a brand new prompt never recorded", "gpt-4", provider="openrouter_free")
+
+        assert live_calls["n"] == 0
+        assert store.strict_violations == 1

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -338,6 +338,124 @@ class TestCallLLM:
 
 
 # ---------------------------------------------------------------------------
+# call_llm - deterministic replay (issue #1832)
+# ---------------------------------------------------------------------------
+
+
+class _ProviderDouble:
+    """Records every live provider invocation so tests can assert zero."""
+
+    def __init__(self, response: str = "live response") -> None:
+        self.calls = 0
+        self._response = response
+
+    async def __call__(self, *_args: object, **_kwargs: object) -> str:
+        self.calls += 1
+        return self._response
+
+
+class TestCallLLMReplay:
+    """``call_llm`` must be hermetic under a strict replay store."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_active_store(self):
+        """Ensure no store leaks across tests."""
+        from bernstein.core.orchestration.deterministic import set_active_store
+
+        set_active_store(None)
+        yield
+        set_active_store(None)
+
+    def _replay_store(self, tmp_path, *, strict: bool, recorded: dict[str, str] | None = None):
+        """Build a replay-mode DeterministicStore over a written recording."""
+        import json
+
+        from bernstein.core.orchestration.deterministic import DeterministicStore, _prompt_key
+
+        run_dir = tmp_path / "runs" / "rep"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        lines: list[str] = []
+        for prompt, response in (recorded or {}).items():
+            key = _prompt_key(prompt, "gpt-4", provider="openrouter_free", temperature=0.7, max_tokens=4000)
+            lines.append(json.dumps({"key": key, "model": "gpt-4", "response": response}))
+        (run_dir / "llm_calls.jsonl").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+        return DeterministicStore(run_dir, replay=True, strict=strict)
+
+    @pytest.mark.asyncio
+    async def test_replay_hit_returns_recorded_without_calling_provider(self, tmp_path) -> None:
+        """A recorded prompt replays its response; no live provider call."""
+        from bernstein.core.orchestration.deterministic import set_active_store
+
+        store = self._replay_store(tmp_path, strict=True, recorded={"recorded prompt": "cached answer"})
+        set_active_store(store)
+        double = _ProviderDouble()
+
+        with patch("bernstein.core.llm._call_api_provider", new=double):
+            result = await call_llm("recorded prompt", "gpt-4", provider="openrouter_free")
+
+        assert result == "cached answer"
+        assert double.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_strict_replay_miss_raises_and_makes_no_live_call(self, tmp_path) -> None:
+        """An unknown prompt under strict replay raises and never calls live."""
+        from bernstein.core.orchestration.deterministic import ReplayMissError, set_active_store
+
+        store = self._replay_store(tmp_path, strict=True, recorded={"recorded prompt": "cached answer"})
+        set_active_store(store)
+        double = _ProviderDouble()
+        cli_double = _ProviderDouble()
+
+        with (
+            patch("bernstein.core.llm._call_api_provider", new=double),
+            patch("bernstein.core.llm._call_cli_provider", new=cli_double),
+            pytest.raises(ReplayMissError),
+        ):
+            await call_llm("an unseen prompt", "gpt-4", provider="openrouter_free")
+
+        assert double.calls == 0
+        assert cli_double.calls == 0
+        assert store.strict_violations == 1
+
+    @pytest.mark.asyncio
+    async def test_non_strict_miss_warns_and_falls_through(self, tmp_path, caplog) -> None:
+        """Non-strict replay logs a WARNING per miss and calls the provider."""
+        import logging
+
+        from bernstein.core.orchestration.deterministic import set_active_store
+
+        store = self._replay_store(tmp_path, strict=False, recorded={"recorded prompt": "cached answer"})
+        set_active_store(store)
+        double = _ProviderDouble(response="fresh live answer")
+
+        with patch("bernstein.core.llm._call_api_provider", new=double), caplog.at_level(logging.WARNING):
+            result = await call_llm("an unseen prompt", "gpt-4", provider="openrouter_free")
+
+        assert result == "fresh live answer"
+        assert double.calls == 1
+        assert store.misses == 1
+        assert any("miss" in rec.message.lower() for rec in caplog.records if rec.levelno >= logging.WARNING)
+
+    @pytest.mark.asyncio
+    async def test_replay_key_includes_temperature(self, tmp_path) -> None:
+        """A recording made at temp 0.7 misses when called at temp 0.0."""
+        from bernstein.core.orchestration.deterministic import ReplayMissError, set_active_store
+
+        store = self._replay_store(tmp_path, strict=True, recorded={"recorded prompt": "cached answer"})
+        set_active_store(store)
+        double = _ProviderDouble()
+
+        # temp 0.7 matches the recording.
+        with patch("bernstein.core.llm._call_api_provider", new=double):
+            assert await call_llm("recorded prompt", "gpt-4", temperature=0.7) == "cached answer"
+
+        # temp 0.0 is a different request -> strict miss, no live call.
+        with patch("bernstein.core.llm._call_api_provider", new=double), pytest.raises(ReplayMissError):
+            await call_llm("recorded prompt", "gpt-4", temperature=0.0)
+        assert double.calls == 0
+
+
+# ---------------------------------------------------------------------------
 # tavily_search - web search via Tavily API
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1832

## Problem

Deterministic replay silently called the live model on a cache miss. `core/routing/llm.py` consulted the active `DeterministicStore`; when `get_replay(prompt, model)` returned `None` it fell through to `_call_api_provider` / `_call_cli_provider`. A run launched with `BERNSTEIN_REPLAY_RUN_ID` was therefore not guaranteed hermetic: any unrecorded prompt quietly hit a live provider with no error, no counter, no signal.

## Change

- **Strict replay by default.** `DeterministicStore(replay=True)` defaults `strict=True`. A cache miss raises a typed `ReplayMissError` carrying the prompt `key` + `model` (never `None`), mirroring `core/replay/gateway.py:ReplayMissError`. `ReplayMissError` subclasses `RuntimeError` so existing `call_llm` callers propagate the abort.
- **Propagate the miss.** `call_llm` lets the strict miss propagate instead of calling a provider. The orchestrator wiring constructs the store with `strict=not allow_live_miss()`.
- **Escape hatch (opt-in).** `BERNSTEIN_REPLAY_ALLOW_LIVE_MISS=1` restores the old fall-through and emits a `WARNING` for each miss. Strict is the default precisely so the hole stays closed unless deliberately opened.
- **Key widening.** The replay key folds in `provider`, `temperature`, and `max_tokens` alongside `model` + `prompt`, so a cache "hit" cannot mask a parameter drift. **This invalidates `llm_calls.jsonl` files recorded before this change** (older narrow-key recordings read as full misses under strict mode). The `ReplayMissError` message names how to re-record: re-run with `BERNSTEIN_DETERMINISTIC_SEED` set and `BERNSTEIN_REPLAY_RUN_ID` unset.
- **Coverage line.** `hits` / `misses` / `strict_violations` counters + `coverage_line()`; a fully covered replay reports `misses=0`. The line is logged at the strict-violation (abort) point.
- Docs: new `docs/operations/deterministic-replay.md` (strict default, escape hatch, key widening, re-record note) + nav entry.

## Acceptance criteria

- [x] Unknown prompt under strict mode raises a typed replay-miss error and aborts; no live provider call (asserted via a provider double that counts invocations -> 0).
- [x] A fully covered replay completes with zero live provider calls and reports miss-count 0.
- [x] A recording made at a different temperature or provider for the same `(model, prompt)` is treated as a miss, not a hit.
- [x] Non-strict fall-through is gated behind an explicit env flag and emits a WARNING per miss.
- [x] Old narrow-key recordings (pre-change) read as misses under strict mode; the miss error names the re-record path.

## Test plan

- [x] `uv run pytest tests/unit/test_deterministic_run.py tests/unit/test_replay.py tests/unit/test_deterministic_store.py tests/unit/test_llm.py -q --no-cov --timeout=120` -> 80 passed.
- [x] New `tests/unit/test_deterministic_store.py` (20 tests): store-level strict/non-strict, key widening, counters, stale-recording miss, env escape hatch, orchestrator-style wiring driven through `call_llm` with a provider double (0 live calls on full replay; unknown prompt raises + aborts).
- [x] New `TestCallLLMReplay` in `tests/unit/test_llm.py` (5 tests): hit replays without a live call; strict miss raises + 0 live calls; non-strict miss warns + falls through; temperature folded into the key.
- [x] Regression-integrity: neutering the strict raise turns the three hermetic-guarantee tests red, confirming they catch the exact hole.
- [x] `ruff check` + `ruff format` clean on touched files; `pyright` clean on `deterministic.py` and `routing/llm.py`; no new pyright errors in the touched orchestrator region.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide for deterministic LLM replay behavior and configuration.

* **New Features**
  * Deterministic replay now enforces hermetic strict mode by default—replay cache misses abort without invoking live providers.
  * Added optional environment flag to allow live fallback when replay cache misses occur.
  * Expanded replay cache key to include provider, temperature, and max_tokens for finer-grained differentiation.
  * Added coverage tracking to monitor replay hits, misses, and strict violations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->