### PR TITLE
feat(worktrees): anchor GC reaps to the HMAC audit chain

### DIFF
--- a/docs/operations/worktrees.md
+++ b/docs/operations/worktrees.md
@@ -36,13 +36,13 @@ with a fresh trace stays `active` to avoid racing a restart.
 
 ```text
 bernstein worktrees list   [--workdir DIR] [--json]
-bernstein worktrees gc     [--workdir DIR] [--yes] [--dry-run]
+bernstein worktrees gc     [--workdir DIR] [--yes] [--dry]
 ```
 
 - `list` - tabular dump with path, task id, state, age, size, PID. Use
   `--json` for scripting.
 - `gc` - reap non-`active` worktrees. `--yes` skips the confirmation
-  prompt; `--dry-run` prints what would be reaped without touching
+  prompt; `--dry` prints what would be reaped without touching
   disk.
 
 ## GC lock
@@ -126,7 +126,7 @@ bernstein worktrees list
 Preview reap plan without touching disk:
 
 ```bash
-bernstein worktrees gc --dry-run
+bernstein worktrees gc --dry
 ```
 
 Reap non-interactively (CI / cron):

--- a/docs/operations/worktrees.md
+++ b/docs/operations/worktrees.md
@@ -10,9 +10,11 @@ crashes, or aborted experiments.
 left behind. The classifier in
 `src/bernstein/core/worktrees/classifier.py` is the single source of
 truth for state. The CLI module
-(`src/bernstein/cli/commands/worktrees_cmd.py`) only handles I/O:
-rendering the table, holding the GC lock, prompting the operator, and
-emitting the `worktree.gc` lifecycle event for plugins.
+(`src/bernstein/cli/commands/worktrees_cmd.py`) handles I/O:
+rendering the table, holding the GC lock, prompting the operator,
+appending a tamper-evident `worktree.reap` event to the HMAC audit
+chain (see [Audit trail](#audit-trail)), and emitting the `worktree.gc`
+lifecycle event for plugins.
 
 The tool honours both the spec layout (`.sdd/runtime/worktrees/`) and
 the legacy layout (`.sdd/worktrees/`) the `WorktreeManager` currently
@@ -53,9 +55,59 @@ the lock file is stale).
 
 ## Lifecycle event
 
-The CLI emits `worktree.gc` after each reap (or, with `--dry-run`,
+The CLI emits `worktree.gc` after each reap (or, with `--dry`,
 once per would-be reap). Plugins can hook this event; the env keys
-exposed to handlers are `BERNSTEIN_WORKTREE_GC_*`.
+exposed to handlers are `BERNSTEIN_WORKTREE_GC_*`. This notification is
+best-effort and ephemeral - it requires a plugin `HookRegistry` and
+leaves no durable record. For the durable, tamper-evident record see
+the audit trail below.
+
+## Audit trail
+
+Reaping a worktree is the orchestrator's only routine destructive
+action, so each reap is anchored to the HMAC-chained audit log under
+`.sdd/audit/` alongside the best-effort lifecycle event. The audit
+write does **not** depend on a plugin `HookRegistry`: it is written
+even when the CLI runs standalone.
+
+For every reaped worktree, `gc` appends one event:
+
+| Field | Value |
+|-------|-------|
+| `event_type` | `worktree.reap` |
+| `actor` | `worktrees-gc` |
+| `resource_type` | `worktree` |
+| `resource_id` | session id (worktree directory basename) |
+
+The `details` payload captures, before deletion: `state`, `task_id`,
+`path`, `size_bytes`, `age_seconds`, `last_trace_mtime`, the
+pre-deletion git `head_sha`, a `dirty` flag (uncommitted/unmerged
+changes present), and `dry_run`.
+
+**Pre-deletion fingerprint.** `head_sha` and `dirty` are read from the
+worktree *before* `rmtree`, so the entry proves exactly which commit
+and working-tree state were destroyed - enough to decide whether to
+restore from reflog after an accidental GC. A `corrupt` worktree may
+have no readable `.git`; its fingerprint degrades to `head_sha=null`
+and `dirty=null` rather than crashing GC or attributing the enclosing
+repository's HEAD.
+
+**Fail-closed contract.** The audit event is appended *before* the
+directory is removed. If the append fails (e.g. audit key permission
+error, full disk) the reap is aborted and the error propagates - a
+worktree is never destroyed without a record. Operators whose audit
+key is misconfigured will see `gc` fail rather than silently delete;
+fix the key (see `docs/security/audit-log.md`) and retry.
+
+**`--dry` mode** records the event flagged `dry_run=true` and performs
+no `rmtree`, so a dry run is itself auditable.
+
+Verify and inspect the reap events:
+
+```bash
+bernstein audit verify-hmac                       # exits non-zero on any tamper
+bernstein audit query --event-type worktree.reap  # list reap events
+```
 
 ## TUI integration
 

--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -28,17 +28,24 @@ from rich.table import Table
 from bernstein.core.worktrees.classifier import (
     GC_LOCK_RELPATH,
     WORKTREE_GC_LIFECYCLE_EVENT,
+    WORKTREE_REAP_EVENT,
     ClassifiedWorktree,
     WorktreeState,
     classify_worktrees,
     format_size,
     reap_worktree,
+    worktree_fingerprint,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
+    from bernstein.core.security.audit import AuditLog
+
 logger = logging.getLogger(__name__)
+
+#: Actor recorded on every ``worktree.reap`` audit event - the GC surface.
+_AUDIT_ACTOR = "worktrees-gc"
 
 __all__ = ["format_age", "lock_gc", "render_worktrees_table", "worktrees_group"]
 
@@ -314,19 +321,97 @@ def run_gc(
     *,
     dry_run: bool,
     on_progress: Callable[[ClassifiedWorktree, bool], None] | None = None,
+    audit_log: AuditLog | None = None,
 ) -> int:
-    """Reap ``rows`` under the GC lock and emit lifecycle events.
+    """Reap ``rows`` under the GC lock, anchoring each reap to the audit chain.
 
-    Returns the number of worktrees actually removed (always 0 in
-    ``--dry`` mode after the lock work completes).
+    For every row, in order, *inside the GC lock*:
+
+    1. Capture a pre-deletion fingerprint (git HEAD sha + dirty flag) while
+       the worktree still exists.
+    2. Append one ``worktree.reap`` event to the HMAC-chained audit log
+       (issue #1833). This is **fail-closed**: if the append raises (e.g.
+       audit key permission error, full disk) the exception propagates and
+       the worktree is *not* reaped - we never destroy a worktree we could
+       not record. The audit write does not depend on any plugin
+       ``HookRegistry``; the lifecycle notification below is separate and
+       best-effort.
+    3. Reap the directory (skipped in ``--dry`` mode).
+    4. Fire the best-effort lifecycle event for plugins.
+
+    Args:
+        repo_root: Absolute repository root.
+        rows: Reapable classifier rows to process.
+        dry_run: When ``True``, record the event flagged ``dry_run=true``
+            and perform no filesystem mutation.
+        on_progress: Optional per-row progress callback ``(row, removed)``.
+        audit_log: Optional pre-opened :class:`AuditLog` (used by tests to
+            inject a fixed key). When ``None`` a project log rooted at
+            ``<repo_root>/.sdd/audit`` is opened once for the whole sweep.
+
+    Returns:
+        The number of worktrees actually removed (always 0 in ``--dry``
+        mode after the lock work completes).
     """
     removed_count = 0
     with lock_gc(repo_root):
+        log = audit_log if audit_log is not None else _open_audit_log(repo_root)
         for row in rows:
+            # 1-2: fingerprint then record BEFORE any destruction. A raised
+            # exception here aborts the sweep with the worktree intact.
+            _append_reap_event(log, row, dry_run=dry_run)
+            # 3: only now is it safe to destroy.
             removed = reap_worktree(repo_root, row, dry_run=dry_run)
             if on_progress is not None:
                 on_progress(row, removed)
             if removed and not dry_run:
                 removed_count += 1
+            # 4: best-effort plugin notification (independent of the audit).
             _emit_worktree_gc(repo_root, row, dry_run)
     return removed_count
+
+
+def _open_audit_log(repo_root: Path) -> AuditLog:
+    """Open the project HMAC audit log rooted at ``<repo_root>/.sdd/audit``.
+
+    Imported lazily so ``bernstein worktrees --help`` never drags in the
+    security/audit module (and its key resolution) unnecessarily.
+    """
+    from bernstein.core.security.audit import AuditLog
+
+    return AuditLog(audit_dir=repo_root / ".sdd" / "audit")
+
+
+def _append_reap_event(
+    log: AuditLog,
+    row: ClassifiedWorktree,
+    *,
+    dry_run: bool,
+) -> None:
+    """Append one ``worktree.reap`` event capturing the pre-deletion state.
+
+    The fingerprint (git HEAD sha + dirty flag) is captured here, before
+    the caller reaps the directory. The ``details`` payload is restricted
+    to the fields the issue enumerates so the daily JSONL does not bloat.
+
+    Fail-closed: any exception raised by :meth:`AuditLog.log` propagates to
+    the caller, which then skips the reap.
+    """
+    fingerprint = worktree_fingerprint(row.path)
+    log.log(
+        event_type=WORKTREE_REAP_EVENT,
+        actor=_AUDIT_ACTOR,
+        resource_type="worktree",
+        resource_id=row.session_id,
+        details={
+            "state": row.state.value,
+            "task_id": row.task_id,
+            "path": str(row.path),
+            "size_bytes": row.size_bytes,
+            "age_seconds": int(row.age_seconds),
+            "last_trace_mtime": row.last_trace_mtime,
+            "head_sha": fingerprint.head_sha,
+            "dirty": fingerprint.dirty,
+            "dry_run": dry_run,
+        },
+    )

--- a/src/bernstein/core/worktrees/classifier.py
+++ b/src/bernstein/core/worktrees/classifier.py
@@ -37,12 +37,15 @@ __all__ = [
     "GC_LOCK_RELPATH",
     "STALE_TRACE_AGE_S",
     "WORKTREE_GC_LIFECYCLE_EVENT",
+    "WORKTREE_REAP_EVENT",
     "ClassifiedWorktree",
+    "WorktreeFingerprint",
     "WorktreeState",
     "classify_worktrees",
     "format_size",
     "iter_worktree_dirs",
     "reap_worktree",
+    "worktree_fingerprint",
     "worktrees_root",
 ]
 
@@ -62,6 +65,17 @@ STALE_TRACE_AGE_S: int = 24 * 60 * 60
 #: registry. Adding a brand-new enum entry would ripple through the
 #: notify bridge, so the classifier uses a free-form event id instead.
 WORKTREE_GC_LIFECYCLE_EVENT = "worktree.gc"
+
+#: Issue #1833 - audit event-type appended to the HMAC-chained audit log
+#: (``.sdd/audit/``) for every reaped worktree. Distinct from the
+#: best-effort lifecycle event above: the audit entry is tamper-evident,
+#: signed, and written even when no plugin ``HookRegistry`` is installed.
+WORKTREE_REAP_EVENT = "worktree.reap"
+
+#: Timeout (seconds) for the per-worktree ``git`` calls used to capture a
+#: pre-deletion fingerprint. Kept short so a slow/hung git on a corrupt
+#: worktree degrades to "unknown" quickly rather than stalling GC.
+_FINGERPRINT_GIT_TIMEOUT_S = 10
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +135,28 @@ class ClassifiedWorktree:
     def is_reapable(self) -> bool:
         """Return ``True`` when the worktree is safe to delete."""
         return self.state in (WorktreeState.ORPHAN, WorktreeState.STALE, WorktreeState.CORRUPT)
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeFingerprint:
+    """Pre-deletion content fingerprint of a worktree (issue #1833).
+
+    Captured *before* :func:`reap_worktree` destroys the directory so the
+    audit entry proves what state the worktree was in at deletion time. A
+    ``corrupt`` worktree may have no readable ``.git``; in that case both
+    fields degrade to ``None`` (rendered ``"unknown"``/``null`` in the
+    audit payload) rather than raising.
+
+    Attributes:
+        head_sha: Full git HEAD sha of the worktree, or ``None`` when git
+            could not resolve it (corrupt/unreadable ``.git``).
+        dirty: ``True`` if the worktree had uncommitted/unmerged changes,
+            ``False`` if clean, ``None`` when the working-tree state could
+            not be determined.
+    """
+
+    head_sha: str | None
+    dirty: bool | None
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +341,112 @@ def _classify_one(
 # ---------------------------------------------------------------------------
 # Reaper
 # ---------------------------------------------------------------------------
+
+
+def worktree_fingerprint(path: Path) -> WorktreeFingerprint:
+    """Capture a worktree's git HEAD sha + dirty flag before deletion.
+
+    Issue #1833: this is the load-bearing forensic capture - it MUST run
+    before :func:`reap_worktree` removes the directory, and it MUST never
+    crash. A ``corrupt`` worktree (no readable ``.git``) is exactly the
+    case most likely to matter, so any git failure degrades to
+    ``head_sha=None`` / ``dirty=None`` instead of raising.
+
+    Args:
+        path: Absolute path to the (still-present) worktree directory.
+
+    Returns:
+        A :class:`WorktreeFingerprint`; both fields are ``None`` when git
+        cannot read the worktree.
+    """
+    # A corrupt worktree (no readable ``.git``) must NOT inherit the parent
+    # orchestrator repo's HEAD: git discovery walks up the tree, so running
+    # ``git`` with ``cwd`` inside ``.sdd/runtime/worktrees/<sid>`` would
+    # otherwise resolve the enclosing repo. We only trust git output when
+    # the worktree directory is itself the git top-level - otherwise we
+    # degrade to "unknown", which is the correct forensic answer.
+    if not _is_own_worktree_root(path):
+        return WorktreeFingerprint(head_sha=None, dirty=None)
+    head_sha = _git_head_sha(path)
+    dirty = _git_is_dirty(path)
+    return WorktreeFingerprint(head_sha=head_sha, dirty=dirty)
+
+
+def _is_own_worktree_root(path: Path) -> bool:
+    """Return ``True`` when ``path`` is itself a git work-tree top level.
+
+    Guards against git's upward repo discovery attributing an enclosing
+    repository's HEAD to a corrupt worktree that merely lives inside it.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_FINGERPRINT_GIT_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("fingerprint: git show-toplevel failed for %s: %s", path, exc)
+        return False
+    if proc.returncode != 0:
+        return False
+    toplevel = proc.stdout.strip()
+    if not toplevel:
+        return False
+    try:
+        return Path(toplevel).resolve() == path.resolve()
+    except OSError:
+        return False
+
+
+def _git_head_sha(path: Path) -> str | None:
+    """Return the full HEAD sha of the worktree at ``path``, or ``None``.
+
+    Returns ``None`` on any failure (git missing, detached/unborn HEAD,
+    corrupt ``.git``, timeout) so the caller can degrade gracefully.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_FINGERPRINT_GIT_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("fingerprint: git rev-parse failed for %s: %s", path, exc)
+        return None
+    if proc.returncode != 0:
+        return None
+    sha = proc.stdout.strip()
+    return sha or None
+
+
+def _git_is_dirty(path: Path) -> bool | None:
+    """Return whether the worktree at ``path`` has uncommitted changes.
+
+    ``True`` when ``git status --porcelain`` reports any tracked or
+    untracked change, ``False`` when the tree is clean, and ``None`` when
+    the state cannot be determined (git failure on a corrupt worktree).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_FINGERPRINT_GIT_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("fingerprint: git status failed for %s: %s", path, exc)
+        return None
+    if proc.returncode != 0:
+        return None
+    return bool(proc.stdout.strip())
 
 
 def reap_worktree(

--- a/tests/unit/test_worktrees_cmd.py
+++ b/tests/unit/test_worktrees_cmd.py
@@ -24,17 +24,24 @@ from bernstein.cli.commands.worktrees_cmd import (
     run_gc,
     worktrees_group,
 )
+from bernstein.core.security.audit import AuditLog
 from bernstein.core.worktrees.classifier import (
     GC_LOCK_RELPATH,
     STALE_TRACE_AGE_S,
+    WORKTREE_REAP_EVENT,
     ClassifiedWorktree,
     WorktreeState,
     classify_worktrees,
     format_size,
     iter_worktree_dirs,
     reap_worktree,
+    worktree_fingerprint,
     worktrees_root,
 )
+
+#: 32-byte HMAC key injected into every test AuditLog so the suite never
+#: touches the operator's real signing key.
+_AUDIT_KEY = b"worktree-reap-test-key-32-bytes!"
 
 # ---------------------------------------------------------------------------
 # Fixture builders
@@ -430,3 +437,287 @@ def test_cli_gc_concurrent_lock_collision(repo_root: Path) -> None:
     result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--yes"])
     assert result.exit_code == 2
     assert "already running" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Audit anchoring (issue #1833) - reaps recorded in the HMAC chain
+# ---------------------------------------------------------------------------
+
+
+def _audit_log(repo_root: Path) -> AuditLog:
+    """Return an AuditLog rooted at the project's ``.sdd/audit`` dir.
+
+    Always injects a fixed test key so verification is deterministic and the
+    operator's real signing key is never read or created.
+    """
+    return AuditLog(audit_dir=repo_root / ".sdd" / "audit", key=_AUDIT_KEY)
+
+
+def _add_real_worktree(repo_root: Path, session_id: str, *, dirty: bool = False) -> Path:
+    """Create a genuine ``git worktree`` so HEAD/dirty capture has real data.
+
+    Unlike :func:`_make_worktree_dir`, this registers the directory with git
+    so ``worktree_fingerprint`` can read a real HEAD sha. The worktree is
+    placed under ``.sdd/runtime/worktrees`` exactly like a Bernstein agent
+    worktree so the classifier picks it up.
+    """
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    wt = base / session_id
+    subprocess.run(
+        ["git", "-C", str(repo_root), "worktree", "add", "-q", "--detach", str(wt)],
+        check=True,
+    )
+    if dirty:
+        (wt / "scratch.txt").write_text("uncommitted change")
+    return wt
+
+
+def test_worktree_fingerprint_reads_head_and_clean_flag(repo_root: Path) -> None:
+    """A real, clean worktree fingerprints to its HEAD sha + dirty=False."""
+    wt = _add_real_worktree(repo_root, "fp-clean")
+    expected = subprocess.run(
+        ["git", "-C", str(wt), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    fp = worktree_fingerprint(wt)
+    assert fp.head_sha == expected
+    assert fp.dirty is False
+
+
+def test_worktree_fingerprint_flags_dirty_tree(repo_root: Path) -> None:
+    """An uncommitted file makes the fingerprint report dirty=True."""
+    wt = _add_real_worktree(repo_root, "fp-dirty", dirty=True)
+    fp = worktree_fingerprint(wt)
+    assert fp.dirty is True
+    assert fp.head_sha is not None
+
+
+def test_worktree_fingerprint_corrupt_degrades_to_unknown(repo_root: Path) -> None:
+    """A directory with no readable ``.git`` degrades, never crashes."""
+    wt = _make_worktree_dir(repo_root, "fp-corrupt", with_git=False)
+    fp = worktree_fingerprint(wt)
+    assert fp.head_sha is None
+    assert fp.dirty is None
+
+
+def test_run_gc_writes_one_reap_event_with_expected_fields(repo_root: Path) -> None:
+    """A reap appends exactly one ``worktree.reap`` event with all fields.
+
+    The injected AuditLog must verify cleanly afterwards.
+    """
+    sid = "audited"
+    _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+    log = _audit_log(repo_root)
+
+    removed = run_gc(repo_root, [row], dry_run=False, audit_log=log)
+    assert removed == 1
+
+    events = log.query(event_type=WORKTREE_REAP_EVENT)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.resource_type == "worktree"
+    assert ev.resource_id == sid
+    d = ev.details
+    assert d["state"] == "orphan"
+    assert d["task_id"] is None
+    assert d["path"] == str(row.path)
+    assert d["size_bytes"] == row.size_bytes
+    assert d["dry_run"] is False
+    # Fingerprint + classifier metadata are present (corrupt-degrade allowed
+    # for head_sha, but the keys must exist for forensic reconstruction).
+    assert "head_sha" in d
+    assert "dirty" in d
+    assert "age_seconds" in d
+    assert "last_trace_mtime" in d
+
+    valid, errors = log.verify()
+    assert valid is True
+    assert errors == []
+
+
+def test_run_gc_records_pre_deletion_head_and_dirty(repo_root: Path) -> None:
+    """The reap event proves the pre-deletion git HEAD sha and dirty flag."""
+    sid = "fp-recorded"
+    wt = _add_real_worktree(repo_root, sid, dirty=True)
+    expected_head = subprocess.run(
+        ["git", "-C", str(wt), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    row = _orphan_row(repo_root, sid)
+    log = _audit_log(repo_root)
+
+    run_gc(repo_root, [row], dry_run=False, audit_log=log)
+
+    ev = log.query(event_type=WORKTREE_REAP_EVENT)[0]
+    assert ev.details["head_sha"] == expected_head
+    assert ev.details["dirty"] is True
+    assert not wt.exists()  # the worktree really was reaped
+
+
+def test_run_gc_dry_run_flags_event_and_keeps_disk(repo_root: Path) -> None:
+    """``--dry`` records the event flagged ``dry_run=true`` and deletes nothing."""
+    sid = "dry-audited"
+    wt = _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+    log = _audit_log(repo_root)
+
+    removed = run_gc(repo_root, [row], dry_run=True, audit_log=log)
+    assert removed == 0
+    assert wt.exists()  # nothing destroyed
+
+    events = log.query(event_type=WORKTREE_REAP_EVENT)
+    assert len(events) == 1
+    assert events[0].details["dry_run"] is True
+    valid, _ = log.verify()
+    assert valid is True
+
+
+def test_run_gc_fail_closed_when_audit_append_raises(repo_root: Path) -> None:
+    """If the audit append fails the worktree must NOT be reaped (fail-closed)."""
+    sid = "fail-closed"
+    wt = _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+
+    class _ExplodingLog:
+        def log(self, *args: object, **kwargs: object) -> None:
+            raise OSError("simulated full disk / key permission error")
+
+    with pytest.raises(OSError, match="simulated full disk"):
+        run_gc(repo_root, [row], dry_run=False, audit_log=_ExplodingLog())  # type: ignore[arg-type]
+
+    # Fail-closed contract: the directory survives because the reap was aborted.
+    assert wt.exists()
+
+
+def test_run_gc_writes_event_without_hook_registry(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The audit event is written even when no plugin HookRegistry exists.
+
+    We force the lifecycle bridge to be unavailable; the audit append must
+    still happen (the trail does not depend on the lifecycle hook).
+    """
+    sid = "no-registry"
+    _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+    log = _audit_log(repo_root)
+
+    import bernstein.cli.commands.worktrees_cmd as wt_cmd
+
+    monkeypatch.setattr(wt_cmd, "_shared_registry", lambda: None)
+
+    run_gc(repo_root, [row], dry_run=False, audit_log=log)
+    assert len(log.query(event_type=WORKTREE_REAP_EVENT)) == 1
+
+
+def test_run_gc_corrupt_worktree_records_unknown_head(repo_root: Path) -> None:
+    """A corrupt worktree (no .git) is reaped with head_sha=null, no crash."""
+    sid = "corrupt-audited"
+    wt = _make_worktree_dir(repo_root, sid, with_git=False)
+    row = _orphan_row(repo_root, sid)
+    assert row.state is WorktreeState.CORRUPT
+    log = _audit_log(repo_root)
+
+    run_gc(repo_root, [row], dry_run=False, audit_log=log)
+    assert not wt.exists()
+
+    ev = log.query(event_type=WORKTREE_REAP_EVENT)[0]
+    assert ev.details["state"] == "corrupt"
+    assert ev.details["head_sha"] is None
+    assert ev.details["dirty"] is None
+    valid, _ = log.verify()
+    assert valid is True
+
+
+def test_run_gc_default_audit_log_targets_sdd_audit(repo_root: Path) -> None:
+    """With no injected log, run_gc writes to ``<repo>/.sdd/audit`` itself.
+
+    Uses a per-test key path so the operator's real key is untouched.
+    """
+    sid = "default-log"
+    _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+
+    key_path = repo_root / "audit.key"
+    key_path.write_bytes(_AUDIT_KEY)
+    key_path.chmod(0o600)
+    os.environ["BERNSTEIN_AUDIT_KEY_PATH"] = str(key_path)
+    try:
+        run_gc(repo_root, [row], dry_run=False)
+    finally:
+        os.environ.pop("BERNSTEIN_AUDIT_KEY_PATH", None)
+
+    audit_dir = repo_root / ".sdd" / "audit"
+    assert audit_dir.is_dir()
+    log = AuditLog(audit_dir=audit_dir, key=_AUDIT_KEY)
+    assert len(log.query(event_type=WORKTREE_REAP_EVENT)) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI + negative integration (issue #1833 acceptance criteria)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_gc_yes_writes_reap_events_and_verifies(repo_root: Path) -> None:
+    """``gc --yes`` over two reapable worktrees writes 2 verifiable events.
+
+    Mirrors the issue integration AC: after the sweep the chain verifies and
+    contains exactly N ``worktree.reap`` rows. We pin the audit key via env so
+    the CLI's own AuditLog is reproducible.
+    """
+    _make_worktree_dir(repo_root, "sweep-a")
+    _make_worktree_dir(repo_root, "sweep-b")
+
+    key_path = repo_root / "audit.key"
+    key_path.write_bytes(_AUDIT_KEY)
+    key_path.chmod(0o600)
+    os.environ["BERNSTEIN_AUDIT_KEY_PATH"] = str(key_path)
+    try:
+        runner = CliRunner()
+        result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--yes"])
+        assert result.exit_code == 0, result.output
+    finally:
+        os.environ.pop("BERNSTEIN_AUDIT_KEY_PATH", None)
+
+    log = AuditLog(audit_dir=repo_root / ".sdd" / "audit", key=_AUDIT_KEY)
+    events = log.query(event_type=WORKTREE_REAP_EVENT)
+    assert len(events) == 2
+    valid, errors = log.verify()
+    assert valid is True, errors
+
+
+def test_tampering_with_recorded_head_breaks_verify(repo_root: Path) -> None:
+    """Editing a recorded HEAD sha in the JSONL trips an HMAC mismatch."""
+    sid = "tamper"
+    _add_real_worktree(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+    log = _audit_log(repo_root)
+    run_gc(repo_root, [row], dry_run=False, audit_log=log)
+
+    # Sanity: clean chain before tampering.
+    assert log.verify()[0] is True
+
+    audit_dir = repo_root / ".sdd" / "audit"
+    jsonl = sorted(audit_dir.glob("*.jsonl"))[0]
+    lines = jsonl.read_text().splitlines()
+    reap_idx = next(i for i, ln in enumerate(lines) if WORKTREE_REAP_EVENT in ln)
+    entry = json.loads(lines[reap_idx])
+    # Flip one hex char of the recorded HEAD sha (keep it valid JSON).
+    original = entry["details"]["head_sha"]
+    flipped = ("b" if original[0] != "b" else "a") + original[1:]
+    entry["details"]["head_sha"] = flipped
+    lines[reap_idx] = json.dumps(entry, sort_keys=True)
+    jsonl.write_text("\n".join(lines) + "\n")
+
+    fresh = AuditLog(audit_dir=audit_dir, key=_AUDIT_KEY)
+    valid, errors = fresh.verify()
+    assert valid is False
+    assert any("HMAC mismatch" in e or "non-canonical" in e for e in errors)


### PR DESCRIPTION
Closes #1833

## Summary

Worktree GC was the one routine destructive path with no entry in the tamper-evident HMAC audit chain. Previously a reap fired only a best-effort lifecycle hook (`_emit_worktree_gc`); with no plugin `HookRegistry` a deletion left nothing but a console line. Every other state-changing surface writes `.sdd/audit/` via `core/security/audit.py`. This closes the gap.

`run_gc` now opens the project `AuditLog` once inside the existing `.sdd/runtime/worktree-gc.lock` critical section and appends one `worktree.reap` event per reaped worktree, alongside (not replacing) the lifecycle notification. It reuses `core/security/audit.py` - no parallel chain.

## Fail-closed contract

The audit append happens **before** `rmtree`. If the append raises (audit key permission error, full disk) the reap is aborted and the error propagates - a worktree is **never destroyed without a record**. This is intentional and documented in `docs/operations/worktrees.md`; operators whose audit key is misconfigured will see `gc` fail rather than silently delete.

The audit write does **not** depend on the lifecycle bridge - it is written even when no plugin `HookRegistry` is installed.

## Pre-deletion fingerprint

A new `worktree_fingerprint()` captures the worktree's git HEAD sha + dirty/clean flag **before** deletion, so the entry proves exactly which commit and working-tree state were destroyed (enough to decide on a reflog restore). It is anchored to the worktree's own git top-level (`--show-toplevel`), so a `corrupt` worktree never inherits the enclosing orchestrator repo's HEAD, and degrades to `head_sha=null` / `dirty=null` instead of crashing GC.

The `details` payload is restricted to: `state`, `task_id`, `path`, `size_bytes`, `age_seconds`, `last_trace_mtime`, `head_sha`, `dirty`, `dry_run` (no bloat).

## Acceptance criteria

- [x] After `bernstein worktrees gc --yes` removes N worktrees, `bernstein audit verify` still passes and the chain contains exactly N new `worktree.reap` events with intact `prev_hmac` linkage.
- [x] Each `worktree.reap` event records the pre-deletion git HEAD sha and a dirty/clean flag.
- [x] `bernstein worktrees gc --dry` records the event flagged `dry_run=true` and performs no `rmtree`.
- [x] With no plugin `HookRegistry`, the audit event is still written.
- [x] Tampering with a recorded HEAD sha is caught by `bernstein audit verify` as an HMAC mismatch.
- [x] Corrupt-worktree HEAD capture degrades gracefully (records `null`, never crashes).

## Test plan

- [x] `uv run pytest tests/unit -k "worktree and (gc or reap)" -q --no-cov --timeout=120` -> 22 passed
- [x] Full `tests/unit/test_worktrees_cmd.py` -> 34 passed; TUI worktree-status regression -> 45 passed
- [x] Unit: injected `AuditLog` -> one `worktree.reap` event with expected fields + `verify() == (True, [])`
- [x] Fail-closed: a raising `AuditLog.log` aborts the reap and leaves the directory intact
- [x] Negative: hand-edit a recorded HEAD sha in the JSONL -> `verify()` fails with HMAC mismatch
- [x] Live CLI: `gc --yes` over two reapable worktrees -> `audit verify-hmac` exit 0, `audit query --event-type worktree.reap` 2 rows
- [x] `ruff check` / `ruff format` clean; no new mypy/pyright findings (the one pre-existing `_coerce_pid` finding is unchanged from `main`)

## Docs

`docs/operations/worktrees.md` gains an "Audit trail" section documenting the `worktree.reap` event, the fail-closed contract, the pre-deletion fingerprint, and the `--dry` behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree GC now appends tamper-evident reap audit events capturing pre-deletion git state (commit SHA and dirty status) and refuses deletion if audit append fails.
  * `gc --dry` supports auditable dry runs and generated events can be verified.

* **Bug Fixes**
  * Improved handling of corrupt/unreadable worktrees: fingerprints degrade to null instead of failing.

* **Documentation**
  * Expanded worktrees docs with lifecycle, audit semantics, env var guidance, examples and verification commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->