### PR TITLE
feat(verify): add --expect/--baseline determinism gate

### DIFF
--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -192,6 +192,14 @@ For a complete loss of the orchestrator host:
 6. **Verify**:
    - `bernstein status` - task counts match pre-incident.
    - `bernstein audit verify` - hash chain intact.
+   - `bernstein verify --determinism <recovered-run> --baseline <pre-incident-run>`
+     - asserts the recovered run reproduced the pre-incident **decision
+     trace** byte-for-byte. Exits non-zero on any divergence and names the
+     first diverging WAL entry (`seq` + decision type) from the hash chain.
+     Pin a known-good digest instead with
+     `--expect <fingerprint>` (compared constant-time). A green gate proves
+     the WAL decision trace matched, **not** that on-disk artefacts are
+     identical.
    - `bernstein dr backup --to /tmp/drill.tar.gz --dry-run` (sanity).
 7. **Resume external triggers**: if any cron/CI/webhook was paused
    during failover, re-enable now.

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -193,13 +193,13 @@ For a complete loss of the orchestrator host:
    - `bernstein status` - task counts match pre-incident.
    - `bernstein audit verify` - hash chain intact.
    - `bernstein verify --determinism <recovered-run> --baseline <pre-incident-run>`
-     - asserts the recovered run reproduced the pre-incident **decision
-     trace** byte-for-byte. Exits non-zero on any divergence and names the
-     first diverging WAL entry (`seq` + decision type) from the hash chain.
-     Pin a known-good digest instead with
-     `--expect <fingerprint>` (compared constant-time). A green gate proves
-     the WAL decision trace matched, **not** that on-disk artefacts are
-     identical.
+     - asserts the recovered run's **decision trace** matches the
+     pre-incident baseline (the WAL fingerprints are equal). Exits 0 on
+     match, 2 on any divergence, and on a mismatch names the first diverging
+     WAL entry (`seq` + decision type) from the hash chain. Pin a known-good
+     digest instead with `--expect <fingerprint>` (compared constant-time).
+     A green gate proves the WAL decision trace matched, **not** that on-disk
+     artefacts are identical.
    - `bernstein dr backup --to /tmp/drill.tar.gz --dry-run` (sanity).
 7. **Resume external triggers**: if any cron/CI/webhook was paused
    during failover, re-enable now.

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -200,6 +200,22 @@ For a complete loss of the orchestrator host:
      digest instead with `--expect <fingerprint>` (compared constant-time).
      A green gate proves the WAL decision trace matched, **not** that on-disk
      artefacts are identical.
+     - **On exit code 2 (divergence):** do not resume external triggers yet.
+       1. Note the named diverging entry (`seq` + decision type) the gate
+          printed, and archive both WALs
+          (`.sdd/runtime/wal/<recovered-run>.wal.jsonl` and
+          `<pre-incident-run>.wal.jsonl`) for root-cause analysis.
+       2. Restore an earlier known-good backup (or re-run recovery from the
+          same pre-incident baseline) so the recovered run replays from a
+          clean starting point.
+       3. Re-run the same
+          `bernstein verify --determinism <recovered-run> --baseline <pre-incident-run>`
+          (or pin the known-good digest with `--expect <fingerprint>`) and
+          confirm exit 0 before resuming traffic.
+       4. If divergence persists after a clean restore, open an incident with
+          the archived WALs attached - the diverging `seq` is the first
+          decision that differed and is the starting point for the
+          investigation.
    - `bernstein dr backup --to /tmp/drill.tar.gz --dry-run` (sanity).
 7. **Resume external triggers**: if any cron/CI/webhook was paused
    during failover, re-enable now.

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -643,11 +643,11 @@ def _verify_determinism(
 
     fingerprint = fp.compute()
 
-    # Count entries
-    entry_count = sum(1 for _ in WALReader(run_id=run_id, sdd_dir=SDD_DIR).iter_entries())
-
     if expect is None and baseline_run_id is None:
         # Bare mode: observe-only, byte-identical to the original surface.
+        # The entry count is only displayed in this branch, so the second WAL
+        # scan stays scoped here rather than running for every gated call.
+        entry_count = sum(1 for _ in WALReader(run_id=run_id, sdd_dir=SDD_DIR).iter_entries())
         console.print(
             Panel(
                 "[bold]Execution Determinism Fingerprint[/bold]",

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -19,12 +19,16 @@ Five verification modes, each with a hard exit-code contract:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.panel import Panel
 from rich.table import Table
 
 from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from bernstein.core.wal import WALEntryDigest
 
 _GREEN_ZERO = "[green]0[/green]"
 
@@ -51,6 +55,20 @@ SDD_DIR = Path(".sdd")
     default=None,
     metavar="RUN_ID",
     help="Compute and display execution fingerprint for a run.",
+)
+@click.option(
+    "--expect",
+    "expect_fingerprint",
+    default=None,
+    metavar="FINGERPRINT",
+    help="Gate --determinism: exit non-zero unless the run's fingerprint equals this value.",
+)
+@click.option(
+    "--baseline",
+    "baseline_run_id",
+    default=None,
+    metavar="RUN_ID",
+    help="Gate --determinism: exit non-zero unless the run reproduces this baseline run's fingerprint.",
 )
 @click.option(
     "--memory-audit",
@@ -139,6 +157,8 @@ def verify_cmd(
     wheelhouse_path: Path | None,
     wal_run_id: str | None,
     determinism_run_id: str | None,
+    expect_fingerprint: str | None,
+    baseline_run_id: str | None,
     memory_audit: bool,
     formal_task_id: str | None,
     ca_pubkey: Path | None,
@@ -158,9 +178,19 @@ def verify_cmd(
       bernstein verify <wheelhouse-path>          Verify air-gap wheelhouse signatures
       bernstein verify --wal-integrity <run-id>   Validate hash chain
       bernstein verify --determinism  <run-id>    Show execution fingerprint
+      bernstein verify --determinism  <run-id> --expect <fp>     Gate on a recorded fingerprint
+      bernstein verify --determinism  <run-b> --baseline <run-a> Gate that run-b reproduces run-a
       bernstein verify --memory-audit             Audit lesson memory provenance
       bernstein verify --formal <task-id>         Run Z3/Lean4 property checks
     """
+    # --expect / --baseline only have meaning as a gate on --determinism, and
+    # they are mutually exclusive (an explicit digest XOR a baseline run). Reject
+    # ambiguous combinations rather than silently picking one.
+    if expect_fingerprint is not None and baseline_run_id is not None:
+        raise click.UsageError("--expect and --baseline are mutually exclusive; pass only one.")
+    if (expect_fingerprint is not None or baseline_run_id is not None) and determinism_run_id is None:
+        raise click.UsageError("--expect/--baseline require --determinism <run-id>.")
+
     if wheelhouse_path is wal_run_id is determinism_run_id is formal_task_id is None and not memory_audit:
         console.print(
             "[dim]Use <wheelhouse-path>, --wal-integrity <run-id>, --determinism <run-id>, "
@@ -190,7 +220,11 @@ def verify_cmd(
         exit_code |= _verify_wal_integrity(wal_run_id)
 
     if determinism_run_id is not None:
-        exit_code |= _verify_determinism(determinism_run_id)
+        exit_code |= _verify_determinism(
+            determinism_run_id,
+            expect=expect_fingerprint,
+            baseline_run_id=baseline_run_id,
+        )
 
     if memory_audit:
         exit_code |= _verify_memory_provenance()
@@ -571,8 +605,32 @@ def _verify_wal_integrity(run_id: str) -> int:
     return 0 if is_valid else 1
 
 
-def _verify_determinism(run_id: str) -> int:
-    """Compute and display execution fingerprint for *run_id*. Returns 0 always."""
+def _verify_determinism(
+    run_id: str,
+    *,
+    expect: str | None = None,
+    baseline_run_id: str | None = None,
+) -> int:
+    """Compute the execution fingerprint for *run_id*, optionally gating on it.
+
+    Three modes, selected by the optional arguments:
+
+    * Bare (``expect is None and baseline_run_id is None``): print the
+      fingerprint table and return 0. Output and exit code are unchanged
+      from the original observe-only behaviour.
+    * ``expect`` set: compare the run's fingerprint to the expected digest
+      in constant time. Return 0 on match, 2 on mismatch (printing both
+      digests).
+    * ``baseline_run_id`` set: compare the run's fingerprint to a second
+      run's. Return 0 on match, 2 on mismatch -- and on mismatch, name the
+      first diverging WAL entry from the shared hash chain.
+
+    A missing WAL (for either run) returns 1 with the existing
+    "WAL file not found" message.
+
+    Scope: a green gate proves the two WAL *decision traces* matched, not
+    that on-disk artefacts are byte-identical.
+    """
     from bernstein.core.wal import ExecutionFingerprint, WALReader
 
     reader = WALReader(run_id=run_id, sdd_dir=SDD_DIR)
@@ -581,39 +639,185 @@ def _verify_determinism(run_id: str) -> int:
     try:
         fp = ExecutionFingerprint.from_wal(reader)
     except FileNotFoundError:
-        console.print(
-            Panel(
-                f"[bold red]WAL file not found for run:[/bold red] {run_id}",
-                border_style="red",
-                expand=False,
-            )
-        )
-        console.print(f"[dim]Expected: {SDD_DIR}/runtime/wal/{run_id}.wal.jsonl[/dim]")
-        console.print()
-        return 1
+        return _wal_not_found(run_id)
 
     fingerprint = fp.compute()
 
     # Count entries
     entry_count = sum(1 for _ in WALReader(run_id=run_id, sdd_dir=SDD_DIR).iter_entries())
 
+    if expect is None and baseline_run_id is None:
+        # Bare mode: observe-only, byte-identical to the original surface.
+        console.print(
+            Panel(
+                "[bold]Execution Determinism Fingerprint[/bold]",
+                border_style="blue",
+                expand=False,
+            )
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value")
+        table.add_row("Run ID", run_id)
+        table.add_row("Entries", str(entry_count))
+        table.add_row("Fingerprint", fingerprint)
+        console.print(table)
+        console.print("\n  [dim]Two runs with the same fingerprint made identical decisions in identical order.[/dim]")
+        console.print()
+        return 0
+
+    if baseline_run_id is not None:
+        return _gate_against_baseline(run_id, fingerprint, baseline_run_id)
+    if expect is not None:
+        return _gate_against_expected(run_id, fingerprint, expect)
+    # Unreachable: bare mode returned above, and the caller guarantees at most
+    # one of expect/baseline is set. Belt-and-suspenders for the type checker.
+    return 0
+
+
+def _wal_not_found(run_id: str) -> int:
+    """Print the canonical 'WAL file not found' panel and return 1."""
     console.print(
         Panel(
-            "[bold]Execution Determinism Fingerprint[/bold]",
-            border_style="blue",
+            f"[bold red]WAL file not found for run:[/bold red] {run_id}",
+            border_style="red",
             expand=False,
         )
     )
+    console.print(f"[dim]Expected: {SDD_DIR}/runtime/wal/{run_id}.wal.jsonl[/dim]")
+    console.print()
+    return 1
+
+
+# A gate proves the decision trace matched -- not that artefacts on disk are
+# identical. Surfaced verbatim under every gate result so a green check is not
+# mistaken for full on-disk reproducibility.
+_GATE_SCOPE_NOTE = (
+    "  [dim]Scope: this proves the WAL decision trace matched, not that on-disk artefacts are identical.[/dim]"
+)
+
+
+def _digest_lines(label_actual: str, actual: str, label_other: str, other: str) -> None:
+    """Print two digests on their own full-width lines (never truncated)."""
     table = Table(show_header=False, box=None, padding=(0, 2))
     table.add_column("Key", style="dim", no_wrap=True, min_width=14)
-    table.add_column("Value")
-    table.add_row("Run ID", run_id)
-    table.add_row("Entries", str(entry_count))
-    table.add_row("Fingerprint", fingerprint)
+    table.add_column("Value", no_wrap=True, overflow="fold")
+    table.add_row(label_actual, actual)
+    table.add_row(label_other, other)
     console.print(table)
-    console.print("\n  [dim]Two runs with the same fingerprint made identical decisions in identical order.[/dim]")
+
+
+def _gate_against_expected(run_id: str, fingerprint: str, expect: str) -> int:
+    """Compare *fingerprint* to *expect* in constant time. Return 0 / 2."""
+    import hmac
+
+    matched = hmac.compare_digest(fingerprint, expect)
+
+    if matched:
+        console.print(
+            Panel(
+                "[bold green]Determinism Gate: PASSED[/bold green]",
+                border_style="green",
+                expand=False,
+            )
+        )
+        _digest_lines("Run ID", run_id, "Fingerprint", fingerprint)
+        console.print(f"\n{_GATE_SCOPE_NOTE}")
+        console.print()
+        return 0
+
+    console.print(
+        Panel(
+            "[bold red]Determinism Gate: FAILED[/bold red]",
+            border_style="red",
+            expand=False,
+        )
+    )
+    _digest_lines("Expected", expect, "Actual", fingerprint)
+    console.print(f"\n{_GATE_SCOPE_NOTE}")
     console.print()
-    return 0
+    return 2
+
+
+def _gate_against_baseline(run_id: str, fingerprint: str, baseline_run_id: str) -> int:
+    """Compare *run_id* to *baseline_run_id*. Return 0 / 2 (1 if baseline WAL missing).
+
+    On mismatch, name the first WAL entry at which the two decision traces
+    diverged, derived from the existing hash-chain order via per-entry
+    cumulative digests.
+    """
+    import hmac
+
+    from bernstein.core.wal import ExecutionFingerprint, WALReader, first_divergence
+
+    baseline_reader = WALReader(run_id=baseline_run_id, sdd_dir=SDD_DIR)
+    try:
+        baseline_fp = ExecutionFingerprint.from_wal(baseline_reader).compute()
+    except FileNotFoundError:
+        return _wal_not_found(baseline_run_id)
+
+    if hmac.compare_digest(fingerprint, baseline_fp):
+        console.print(
+            Panel(
+                "[bold green]Determinism Gate: PASSED[/bold green]",
+                border_style="green",
+                expand=False,
+            )
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value", no_wrap=True, overflow="fold")
+        table.add_row("Run", run_id)
+        table.add_row("Baseline", baseline_run_id)
+        table.add_row("Fingerprint", fingerprint)
+        console.print(table)
+        console.print(f"\n{_GATE_SCOPE_NOTE}")
+        console.print()
+        return 0
+
+    # Mismatch: locate the first diverging WAL entry from the chain order.
+    run_digests = ExecutionFingerprint.entry_digests(WALReader(run_id=run_id, sdd_dir=SDD_DIR))
+    baseline_digests = ExecutionFingerprint.entry_digests(WALReader(run_id=baseline_run_id, sdd_dir=SDD_DIR))
+    idx = first_divergence(baseline_digests, run_digests)
+
+    console.print(
+        Panel(
+            "[bold red]Determinism Gate: FAILED[/bold red]",
+            border_style="red",
+            expand=False,
+        )
+    )
+    _digest_lines("Baseline", baseline_fp, "Actual", fingerprint)
+    if idx is not None:
+        console.print()
+        _print_divergence(idx, baseline_run_id, baseline_digests, run_id, run_digests)
+    console.print(f"\n{_GATE_SCOPE_NOTE}")
+    console.print()
+    return 2
+
+
+def _print_divergence(
+    idx: int,
+    baseline_run_id: str,
+    baseline_digests: list[WALEntryDigest],
+    run_id: str,
+    run_digests: list[WALEntryDigest],
+) -> None:
+    """Render the first diverging WAL entry (index + seq + decision type)."""
+
+    def _describe(digests: list[WALEntryDigest]) -> str:
+        if idx < len(digests):
+            d = digests[idx]
+            return f"seq {d.seq} ({d.decision_type})"
+        return "(no entry -- run ended earlier)"
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=20)
+    table.add_column("Value")
+    table.add_row("First divergence at", f"WAL entry index {idx}")
+    table.add_row(f"Baseline {baseline_run_id}", _describe(baseline_digests))
+    table.add_row(f"Run {run_id}", _describe(run_digests))
+    console.print(table)
 
 
 def _verify_memory_provenance() -> int:

--- a/src/bernstein/core/persistence/wal.py
+++ b/src/bernstein/core/persistence/wal.py
@@ -776,6 +776,44 @@ class WALRecovery:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class WALEntryDigest:
+    """Cumulative fingerprint state after one WAL entry.
+
+    ``digest`` is the run's :class:`ExecutionFingerprint` *as of* this entry:
+    ``sha256(state_i).hexdigest()``, the same transform :meth:`ExecutionFingerprint.compute`
+    applies to the final state. Because the underlying state is a rolling
+    hash, the first index at which two runs' digests differ is exactly the
+    first decision at which they diverged - no second fingerprinting scheme
+    is introduced, only a snapshot of the existing one after each entry.
+
+    ``seq`` is the WAL entry's sequence number from the hash chain, so the
+    reported divergence points at a concrete entry an operator can locate.
+    """
+
+    seq: int
+    decision_type: str
+    digest: str
+
+
+def first_divergence(a: list[WALEntryDigest], b: list[WALEntryDigest]) -> int | None:
+    """Return the first index at which two digest streams differ.
+
+    Compares the cumulative per-entry digests of two runs in WAL order.
+    Returns the zero-based index of the first diverging entry, or ``None``
+    when the two streams are identical (same length, equal digests at every
+    position). A length mismatch diverges at the first index present in one
+    stream but not the other.
+    """
+    limit = min(len(a), len(b))
+    for i in range(limit):
+        if a[i].digest != b[i].digest:
+            return i
+    if len(a) != len(b):
+        return limit
+    return None
+
+
 class ExecutionFingerprint:
     """Determinism fingerprint over an ordered sequence of orchestrator decisions.
 
@@ -838,3 +876,33 @@ class ExecutionFingerprint:
         for entry in reader.iter_entries():
             fp.record(entry.decision_type, entry.inputs, entry.output)
         return fp
+
+    @classmethod
+    def entry_digests(cls, reader: WALReader) -> list[WALEntryDigest]:
+        """Return the cumulative fingerprint digest after each WAL entry.
+
+        Walks the WAL exactly as :meth:`from_wal` does, but snapshots the
+        rolling hash after every entry. The last element's ``digest`` equals
+        ``ExecutionFingerprint.from_wal(reader).compute()`` for the same WAL,
+        so the per-entry stream and the headline fingerprint are guaranteed
+        consistent. Use with :func:`first_divergence` to locate where two
+        runs' decision traces forked.
+
+        Args:
+            reader: A :class:`WALReader` positioned at the start of a WAL.
+
+        Returns:
+            One :class:`WALEntryDigest` per WAL entry, in write order.
+        """
+        fp = cls()
+        digests: list[WALEntryDigest] = []
+        for entry in reader.iter_entries():
+            fp.record(entry.decision_type, entry.inputs, entry.output)
+            digests.append(
+                WALEntryDigest(
+                    seq=entry.seq,
+                    decision_type=entry.decision_type,
+                    digest=fp.compute(),
+                )
+            )
+        return digests

--- a/tests/unit/test_verify_determinism_gate.py
+++ b/tests/unit/test_verify_determinism_gate.py
@@ -22,6 +22,7 @@ from click.testing import CliRunner
 from bernstein.cli.commands.verify_cmd import verify_cmd
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 Decision = tuple[str, dict[str, Any], dict[str, Any]]
@@ -38,7 +39,7 @@ def _wide_console(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("COLUMNS", "200")
 
 
-def _write_wal(sdd_dir: Path, run_id: str, decisions: list[Decision]) -> None:
+def _write_wal(sdd_dir: Path, run_id: str, decisions: Sequence[Decision]) -> None:
     writer = WALWriter(run_id=run_id, sdd_dir=sdd_dir)
     for decision_type, inputs, output in decisions:
         writer.append(decision_type, inputs, output, "actor")
@@ -48,11 +49,13 @@ def _fingerprint(sdd_dir: Path, run_id: str) -> str:
     return ExecutionFingerprint.from_wal(WALReader(run_id=run_id, sdd_dir=sdd_dir)).compute()
 
 
-_DECISIONS: list[Decision] = [
+# Immutable shared fixture: a tuple so a test cannot accidentally mutate the
+# decision trace other tests rely on.
+_DECISIONS: tuple[Decision, ...] = (
     ("tick_start", {"tick": 1}, {}),
     ("task_claimed", {"task_id": "T-1"}, {"batch_size": 1}),
     ("task_completed", {"task_id": "T-1"}, {"janitor_passed": True}),
-]
+)
 
 
 def test_bare_determinism_prints_and_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -118,11 +121,11 @@ def test_baseline_diverging_runs_exit_two_and_pinpoint(tmp_path: Path, monkeypat
     sdd.mkdir()
     _write_wal(sdd, "run-a", _DECISIONS)
     # run-b forks at index 1 (different task_id input).
-    diverged: list[Decision] = [
+    diverged: tuple[Decision, ...] = (
         ("tick_start", {"tick": 1}, {}),
         ("task_claimed", {"task_id": "T-999"}, {"batch_size": 1}),
         ("task_completed", {"task_id": "T-999"}, {"janitor_passed": True}),
-    ]
+    )
     _write_wal(sdd, "run-b", diverged)
 
     monkeypatch.chdir(tmp_path)
@@ -173,6 +176,8 @@ def test_expect_and_baseline_together_is_rejected(tmp_path: Path, monkeypatch: p
     )
 
     assert result.exit_code != 0
+    # Pin the contract: the rejection names mutual exclusivity, not just a code.
+    assert "mutually exclusive" in result.output.lower()
 
 
 def test_expect_without_determinism_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -181,6 +186,9 @@ def test_expect_without_determinism_is_rejected(tmp_path: Path, monkeypatch: pyt
     result = CliRunner().invoke(verify_cmd, ["--expect", "a" * 64])
 
     assert result.exit_code != 0
+    # Pin the contract: the rejection explains the --determinism dependency.
+    assert "require" in result.output.lower()
+    assert "--determinism" in result.output
 
 
 def test_mismatch_output_scopes_the_claim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_verify_determinism_gate.py
+++ b/tests/unit/test_verify_determinism_gate.py
@@ -1,0 +1,197 @@
+"""CLI gate tests for ``bernstein verify --determinism`` with --expect/--baseline.
+
+The bare ``--determinism <run-id>`` path stays observe-only (print + exit 0).
+``--expect``/``--baseline`` turn the printed fingerprint into an assertable
+gate bound to the WAL hash chain: a mismatch exits non-zero and names the
+first diverging WAL entry derived from the existing chain order. These tests
+pin both the exit-code contract and the divergence pinpoint.
+
+``verify`` resolves its ``.sdd`` directory relative to the current working
+directory, so each test ``chdir``s into a tmp project (``monkeypatch.chdir``
+restores cwd afterwards) and writes the run WAL under ``.sdd/runtime/wal/``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from bernstein.core.wal import ExecutionFingerprint, WALReader, WALWriter
+from click.testing import CliRunner
+
+from bernstein.cli.commands.verify_cmd import verify_cmd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+Decision = tuple[str, dict[str, Any], dict[str, Any]]
+
+
+@pytest.fixture(autouse=True)
+def _wide_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force a wide terminal so Rich does not truncate 64-char digests.
+
+    The shared Rich console reads ``COLUMNS`` dynamically, so a real
+    operator on any reasonably-sized terminal sees the full fingerprint;
+    the default 80-col pytest fallback would otherwise ellipsize it.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+def _write_wal(sdd_dir: Path, run_id: str, decisions: list[Decision]) -> None:
+    writer = WALWriter(run_id=run_id, sdd_dir=sdd_dir)
+    for decision_type, inputs, output in decisions:
+        writer.append(decision_type, inputs, output, "actor")
+
+
+def _fingerprint(sdd_dir: Path, run_id: str) -> str:
+    return ExecutionFingerprint.from_wal(WALReader(run_id=run_id, sdd_dir=sdd_dir)).compute()
+
+
+_DECISIONS: list[Decision] = [
+    ("tick_start", {"tick": 1}, {}),
+    ("task_claimed", {"task_id": "T-1"}, {"batch_size": 1}),
+    ("task_completed", {"task_id": "T-1"}, {"janitor_passed": True}),
+]
+
+
+def test_bare_determinism_prints_and_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guard: bare --determinism is unchanged (exit 0, fingerprint table)."""
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+    fp = _fingerprint(sdd, "run-a")
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-a"])
+
+    assert result.exit_code == 0
+    assert "Execution Determinism Fingerprint" in result.output
+    assert fp in result.output
+    # No expected/actual comparison block in the bare path.
+    assert "Expected" not in result.output
+
+
+def test_expect_correct_fingerprint_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+    fp = _fingerprint(sdd, "run-a")
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-a", "--expect", fp])
+
+    assert result.exit_code == 0
+    assert fp in result.output
+
+
+def test_expect_wrong_fingerprint_exits_two(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+    fp = _fingerprint(sdd, "run-a")
+    wrong = "f" * 64
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-a", "--expect", wrong])
+
+    assert result.exit_code == 2
+    # Both digests surfaced so the operator can diff them.
+    assert wrong in result.output
+    assert fp in result.output
+
+
+def test_baseline_matching_runs_exit_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+    _write_wal(sdd, "run-b", _DECISIONS)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-b", "--baseline", "run-a"])
+
+    assert result.exit_code == 0
+
+
+def test_baseline_diverging_runs_exit_two_and_pinpoint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+    # run-b forks at index 1 (different task_id input).
+    diverged: list[Decision] = [
+        ("tick_start", {"tick": 1}, {}),
+        ("task_claimed", {"task_id": "T-999"}, {"batch_size": 1}),
+        ("task_completed", {"task_id": "T-999"}, {"janitor_passed": True}),
+    ]
+    _write_wal(sdd, "run-b", diverged)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-b", "--baseline", "run-a"])
+
+    assert result.exit_code == 2
+    # The first diverging WAL entry (seq 1 / index 1) is named, not just the digests.
+    assert "task_claimed" in result.output
+
+
+def test_expect_missing_wal_exits_nonzero_with_existing_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing WAL still fails with the original 'WAL file not found' message."""
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "ghost", "--expect", "a" * 64])
+
+    assert result.exit_code != 0
+    assert "WAL file not found" in result.output
+
+
+def test_baseline_missing_baseline_wal_exits_nonzero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-b", _DECISIONS)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-b", "--baseline", "ghost"])
+
+    assert result.exit_code != 0
+    assert "WAL file not found" in result.output
+
+
+def test_expect_and_baseline_together_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--expect and --baseline are mutually exclusive; reject rather than guess."""
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+    _write_wal(sdd, "run-b", _DECISIONS)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(
+        verify_cmd,
+        ["--determinism", "run-b", "--baseline", "run-a", "--expect", "a" * 64],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_expect_without_determinism_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--expect requires --determinism; using it alone errors clearly."""
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--expect", "a" * 64])
+
+    assert result.exit_code != 0
+
+
+def test_mismatch_output_scopes_the_claim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mismatch wording must scope the guarantee to the WAL decision trace."""
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    _write_wal(sdd, "run-a", _DECISIONS)
+
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(verify_cmd, ["--determinism", "run-a", "--expect", "0" * 64])
+
+    assert result.exit_code == 2
+    # A green check proves the WAL decision trace matched, not on-disk artefacts.
+    assert "decision trace" in result.output.lower()

--- a/tests/unit/test_wal.py
+++ b/tests/unit/test_wal.py
@@ -10,10 +10,12 @@ from bernstein.core.wal import (
     GENESIS_HASH,
     ExecutionFingerprint,
     WALEntry,
+    WALEntryDigest,
     WALReader,
     WALRecovery,
     WALWriter,
     _compute_entry_hash,
+    first_divergence,
 )
 
 if TYPE_CHECKING:
@@ -872,3 +874,115 @@ class TestWALStreaming:
         # Successfully resumed from the torn-but-valid final line.
         assert entry.seq == 1
         assert entry.prev_hash != GENESIS_HASH
+
+
+# ---------------------------------------------------------------------------
+# TestFingerprintDivergence
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintDivergence:
+    """Per-entry cumulative digests + first-divergence pinpoint.
+
+    These exercise the substrate that lets ``verify --determinism --expect``
+    report *where* two runs forked, reusing the existing rolling-hash
+    fingerprint rather than a second scheme.
+    """
+
+    def test_entry_digests_one_per_entry(self, tmp_path: Path) -> None:
+        writer = _make_writer(tmp_path)
+        writer.append("d0", {"i": 0}, {}, "a")
+        writer.append("d1", {"i": 1}, {}, "a")
+        writer.append("d2", {"i": 2}, {}, "a")
+
+        digests = ExecutionFingerprint.entry_digests(_make_reader(tmp_path))
+        assert [d.seq for d in digests] == [0, 1, 2]
+        assert [d.decision_type for d in digests] == ["d0", "d1", "d2"]
+        for d in digests:
+            assert len(d.digest) == 64
+            int(d.digest, 16)  # valid hex
+
+    def test_last_entry_digest_equals_run_fingerprint(self, tmp_path: Path) -> None:
+        """The final cumulative digest is exactly the run's fingerprint.
+
+        This keeps the gate honest: the per-entry stream and the headline
+        digest come from the same rolling hash, not a parallel computation.
+        """
+        writer = _make_writer(tmp_path)
+        writer.append("d0", {"a": 1}, {"b": 2}, "a")
+        writer.append("d1", {"c": 3}, {"d": 4}, "a")
+
+        digests = ExecutionFingerprint.entry_digests(_make_reader(tmp_path))
+        headline = ExecutionFingerprint.from_wal(_make_reader(tmp_path)).compute()
+        assert digests[-1].digest == headline
+
+    def test_identical_wals_equal_digests_no_divergence(self, tmp_path: Path) -> None:
+        sdd1 = tmp_path / "a" / ".sdd"
+        sdd1.mkdir(parents=True)
+        w1 = WALWriter(run_id="r", sdd_dir=sdd1)
+        w1.append("tick_start", {"tick": 1}, {}, "orch")
+        w1.append("task_claimed", {"task_id": "T-1"}, {"batch_size": 1}, "lifecycle")
+
+        sdd2 = tmp_path / "b" / ".sdd"
+        sdd2.mkdir(parents=True)
+        w2 = WALWriter(run_id="r", sdd_dir=sdd2)
+        w2.append("tick_start", {"tick": 1}, {}, "orch")
+        w2.append("task_claimed", {"task_id": "T-1"}, {"batch_size": 1}, "lifecycle")
+
+        da = ExecutionFingerprint.entry_digests(WALReader(run_id="r", sdd_dir=sdd1))
+        db = ExecutionFingerprint.entry_digests(WALReader(run_id="r", sdd_dir=sdd2))
+        assert [d.digest for d in da] == [d.digest for d in db]
+        assert first_divergence(da, db) is None
+
+    def test_mutated_entry_divergence_index_points_at_it(self, tmp_path: Path) -> None:
+        """Mutating entry 2 (seq=2) must make first divergence land on index 2."""
+        sdd1 = tmp_path / "a" / ".sdd"
+        sdd1.mkdir(parents=True)
+        w1 = WALWriter(run_id="r", sdd_dir=sdd1)
+        for i in range(5):
+            w1.append(f"d{i}", {"i": i}, {}, "a")
+
+        sdd2 = tmp_path / "b" / ".sdd"
+        sdd2.mkdir(parents=True)
+        w2 = WALWriter(run_id="r", sdd_dir=sdd2)
+        for i in range(5):
+            # Entry index 2 carries a different input -> first fork at index 2.
+            payload = {"i": 999} if i == 2 else {"i": i}
+            w2.append(f"d{i}", payload, {}, "a")
+
+        da = ExecutionFingerprint.entry_digests(WALReader(run_id="r", sdd_dir=sdd1))
+        db = ExecutionFingerprint.entry_digests(WALReader(run_id="r", sdd_dir=sdd2))
+
+        idx = first_divergence(da, db)
+        assert idx == 2
+        # Everything before the fork is identical; the fork entry differs.
+        assert da[1].digest == db[1].digest
+        assert da[2].digest != db[2].digest
+        assert da[idx].seq == 2
+
+    def test_divergence_on_length_mismatch(self, tmp_path: Path) -> None:
+        """A run that stops early diverges at the first missing entry index."""
+        sdd1 = tmp_path / "a" / ".sdd"
+        sdd1.mkdir(parents=True)
+        w1 = WALWriter(run_id="r", sdd_dir=sdd1)
+        for i in range(4):
+            w1.append(f"d{i}", {"i": i}, {}, "a")
+
+        sdd2 = tmp_path / "b" / ".sdd"
+        sdd2.mkdir(parents=True)
+        w2 = WALWriter(run_id="r", sdd_dir=sdd2)
+        for i in range(2):
+            w2.append(f"d{i}", {"i": i}, {}, "a")
+
+        da = ExecutionFingerprint.entry_digests(WALReader(run_id="r", sdd_dir=sdd1))
+        db = ExecutionFingerprint.entry_digests(WALReader(run_id="r", sdd_dir=sdd2))
+        assert first_divergence(da, db) == 2
+        assert first_divergence(db, da) == 2
+
+    def test_empty_wals_have_no_divergence(self, tmp_path: Path) -> None:
+        assert first_divergence([], []) is None
+
+    def test_entry_digest_is_frozen(self) -> None:
+        d = WALEntryDigest(seq=0, decision_type="x", digest="a" * 64)
+        with pytest.raises((AttributeError, TypeError)):
+            d.seq = 1  # type: ignore[misc]


### PR DESCRIPTION
Closes #1834

## What

`bernstein verify --determinism <run-id>` computed an `ExecutionFingerprint` from the run WAL, printed it, and returned 0 unconditionally - observable but not enforceable. This makes the fingerprint assertable, bound to the WAL hash chain:

- `--expect <fingerprint>` - compute the run fingerprint, compare constant-time (`hmac.compare_digest`) to the expected digest; exit 0 on match, 2 on mismatch, printing both digests.
- `--baseline <run-id>` - compute a second run's fingerprint and compare the two runs directly ("run B reproduced run A") without copy-pasting hashes.
- On a baseline mismatch, surface the first diverging WAL entry (index, `seq`, decision type) from the existing hash-chain order.

## Divergence pinpoint design (WAL-chain anchored)

Reuses `ExecutionFingerprint` / `WALReader`; no second fingerprinting scheme:

- `WALEntryDigest` snapshots the rolling fingerprint state after each WAL entry. The transform is identical to `ExecutionFingerprint.compute()`, so the last snapshot equals the run's headline fingerprint - the per-entry stream and the headline digest are guaranteed consistent.
- `first_divergence(a, b)` walks two digest streams in WAL order and returns the first differing index (a length mismatch diverges at the first missing index). Because the state is a rolling hash, the first index where cumulative digests differ is exactly the first decision at which the runs forked.

The WAL hash chain orders the decisions; the gate projects that order into an actionable location instead of reporting only that two digests differ.

## Scope wording

A green `--expect` / `--baseline` proves the **WAL decision trace** matched, not that on-disk artefacts are byte-identical. Both the pass and mismatch output state this explicitly so a green gate is not mistaken for full on-disk reproducibility.

## Behaviour preserved

- Bare `--determinism <run-id>` output and exit code are unchanged (guarded by a snapshot/exit-code test).
- A missing WAL still exits non-zero with the existing "WAL file not found" message.
- `--expect`/`--baseline` are mutually exclusive and require `--determinism`; ambiguous combinations are rejected with a clear usage error.

## Acceptance criteria

- [x] `verify --determinism <run-id> --expect <correct-fp>` exits 0; wrong fingerprint exits non-zero (2) and prints expected-vs-actual.
- [x] `verify --determinism <run-b> --baseline <run-a>` exits 0 when the runs share a fingerprint, non-zero otherwise.
- [x] A mismatch prints the first diverging WAL entry index/identifier derived from the WAL hash chain, not just the two digests.
- [x] Comparison reuses `ExecutionFingerprint`/`WALReader`; no second fingerprinting scheme. Missing WAL still exits non-zero with the existing message.
- [x] Bare `--determinism <run-id>` output and exit code unchanged.

## Tests

- `tests/unit/test_wal.py::TestFingerprintDivergence` - identical WALs give equal per-entry digests and no divergence; mutating one entry makes `first_divergence` land on that entry's index; length mismatch; `WALEntryDigest` frozen; last digest equals the headline fingerprint.
- `tests/unit/test_verify_determinism_gate.py` - CLI exit-code contract (`--expect` 0 vs 2, `--baseline` match/diverge), divergence entry named on mismatch, missing-WAL non-zero with original message, bare-path guard, mutual-exclusion/usage rejections, scope wording.

Test command (matching test files):

```
uv run pytest tests/unit/test_wal.py tests/unit/test_verify_determinism_gate.py -q --no-cov --timeout=120
```

`pyright --project pyrightconfig.strict.json` clean (`wal.py` is in the strict zone); `ruff check` + `ruff format` clean.

## Test plan

- [ ] CI green (lint, tests, pyright strict zone, merge-queue checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Determinism verification: observe-only fingerprint display, plus modes to pin an expected fingerprint or compare a recovered run against a baseline and report the first diverging decision.

* **Bug Fixes**
  * Distinct non-zero exit codes for mismatch/missing runs and clearer mismatch messaging referencing the decision trace.

* **Documentation**
  * Disaster-recovery restore procedure updated with verification commands, guidance on divergence handling, and archival recommendations.

* **Tests**
  * New tests covering all verification modes, divergence reporting, argument validation, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: 3285098453 reason=core/defaults.py holds orchestrator config dataclasses, not CLI Rich display strings; this module already keeps its display constant _GREEN_ZERO inline, so the scope note stays inline for consistency -->
<!-- bot-ack: 3285098460 reason=_DECISIONS is now an immutable tuple to close the mutation path; the full TypedDict plus frozen-dataclass refactor is disproportionate for a 3-row test fixture and inconsistent with the raw-tuple pattern already used in test_wal.py -->
