### PR TITLE
fix(ci): shard the Test job to scale the per-file suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1206,13 +1206,24 @@ jobs:
         run: uv run pytest tests/integration/test_adapter_e2e.py -x -q --timeout=60
 
   test:
-    name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    # Sharded across 4 parallel runners per (os, python) cell. The unit
+    # suite runs each of ~1.4k test files in its own subprocess (the
+    # OOM-avoidance model documented in the coverage step below); per-file
+    # Python startup + full-package import is a fixed ~2.7s/file, so at
+    # 1.4k files / 4 local workers a single runner spent 25+ min purely on
+    # startup churn (the file count crossed a threshold when discovery
+    # widened to rglob). Fanning the file list out over TEST_SHARD_COUNT
+    # runners (each runs `run_tests.py --shard i/N`, a deterministic
+    # disjoint slice) cuts each runner to ~1/4 of the files. The matrix
+    # `.result` ci-gate reads is `failure` if ANY shard cell fails, so all
+    # shards are still required - no shard can silently skip.
+    name: Test (${{ matrix.os }}, Python ${{ matrix.python-version }}, shard ${{ matrix.shard }})
     needs: [lint]  # fast-fail: don't waste 45min if lint fails
     runs-on: ${{ matrix.os }}
-    # 35 min for the unit suite + 25 min for the coverage re-run on
-    # ubuntu/3.13 = exactly 60 min, which kept clipping the job ceiling
-    # under coverage-step retries; 90 leaves enough headroom for slow
-    # runners without inviting hangs.
+    # Per-shard the unit suite is ~1/4 of the old wall time. The coverage
+    # re-run (ubuntu/3.13/push only) runs on shard 1 alone and still
+    # iterates every file (~25 min) since it has its own file loop; 90
+    # leaves headroom for that cell without inviting hangs on slow runners.
     timeout-minutes: 90
     permissions:
       contents: read
@@ -1224,6 +1235,11 @@ jobs:
       # ops gracefully on push events; the workflow-level Step Summary
       # is always populated.
       pull-requests: write
+    env:
+      # Single source of truth for the shard count. The `--shard i/N`
+      # denominator below and the per-shard slice both key off this; bump
+      # it (and the `shard:` list) together to rescale the fan-out.
+      TEST_SHARD_COUNT: "4"
     strategy:
       fail-fast: false
       matrix:
@@ -1235,6 +1251,9 @@ jobs:
         # safety-net run of the full macOS matrix.
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.12", "3.13"]
+        # Fan the per-file suite out across 4 deterministic shards per
+        # cell. Keep this list in sync with TEST_SHARD_COUNT above.
+        shard: [1, 2, 3, 4]
         exclude:
           # Coverage/JUnit upload only on ubuntu; skip duplicate slow jobs on Windows for 3.12
           - os: windows-latest
@@ -1262,40 +1281,61 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ env.TEST_SHARD_COUNT }}
         run: |
+          # `--shard i/N` runs a deterministic disjoint slice of the
+          # discovered (and, on PRs, affected) file list. On PRs the
+          # affected set is sharded too, so each runner runs ~1/N of the
+          # impacted files.
           if [ "${EVENT_NAME}" = "pull_request" ] && \
              git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
-            uv run python scripts/run_tests.py --parallel 4 --affected "refs/remotes/origin/${BASE_REF}"
+            uv run python scripts/run_tests.py --parallel 4 \
+              --shard "${SHARD}/${SHARD_COUNT}" \
+              --affected "refs/remotes/origin/${BASE_REF}"
           else
-            uv run python scripts/run_tests.py --parallel 4
+            uv run python scripts/run_tests.py --parallel 4 \
+              --shard "${SHARD}/${SHARD_COUNT}"
           fi
       - name: Run isolated test suite (Windows)
         if: runner.os == 'Windows'
         continue-on-error: true  # Windows has Unix-only tests (chmod, SIGKILL) that are skipped but some may remain
         shell: pwsh
-        run: uv run python scripts/run_tests.py -x --parallel 4
+        env:
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ env.TEST_SHARD_COUNT }}
+        run: uv run python scripts/run_tests.py -x --parallel 4 --shard "${env:SHARD}/${env:SHARD_COUNT}"
       - name: Run capability-matrix spawn-refusal integration tests (Linux/macOS)
-        if: runner.os != 'Windows'
-        # Lethal-trifecta integration coverage: every supported OS/Python
-        # cell exercises the AgentSpawner spawn-refusal path so we catch
-        # regressions in the structural rule before they ship.  See
+        # Pinned to shard 1 so this runs exactly once per (os, python) cell
+        # rather than once per shard - the unit suite is sharded, this
+        # integration probe is not. Lethal-trifecta integration coverage:
+        # every supported OS/Python cell exercises the AgentSpawner
+        # spawn-refusal path so we catch regressions in the structural rule
+        # before they ship.  See
         # tests/integration/test_capability_matrix_spawn_refusal.py.
+        if: runner.os != 'Windows' && matrix.shard == 1
         run: |
           uv run pytest tests/integration/test_capability_matrix_spawn_refusal.py \
             -x -q --tb=short --timeout=120
       - name: Run capability-matrix spawn-refusal integration tests (Windows)
-        if: runner.os == 'Windows'
+        # Pinned to shard 1 (see Linux/macOS counterpart): one run per cell.
+        if: runner.os == 'Windows' && matrix.shard == 1
         shell: pwsh
         run: |
           uv run pytest tests/integration/test_capability_matrix_spawn_refusal.py `
             -x -q --tb=short --timeout=120
-      - name: Generate coverage and JUnit reports (ubuntu, 3.13 only)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
+      - name: Generate coverage and JUnit reports (ubuntu, 3.13, shard 1 only)
+        # Pinned to shard 1 so coverage is generated exactly once even
+        # though ubuntu/3.13 now fans out across 4 shards. This step has
+        # its OWN file loop (rglob over all of tests/unit below), so it
+        # still covers every file regardless of which shard runs it - the
+        # shard pin only deduplicates, it does not narrow coverage.
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push'
         continue-on-error: true
         timeout-minutes: 25
         run: |
           # Run each test file in its own process with coverage to avoid OOM.
-          # pytest --cov on 562 files in one process exceeds 7GB runner RAM.
+          # pytest --cov on ~1.4k files in one process exceeds 7GB runner RAM.
           # JUnit XML is accumulated across all runs via --junitxml append logic.
           uv run python -c "
           import subprocess, sys, os
@@ -1354,9 +1394,9 @@ jobs:
         # `fail_on_failure: false` so we don't double-fail; the test job
         # already reports its own non-zero exit.
         #
-        # Gated to ubuntu/3.13 on push because that is the only matrix cell
-        # currently emitting junit.xml (see the coverage step above).
-        if: always() && !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
+        # Gated to ubuntu/3.13 shard 1 on push because that is the only
+        # matrix cell emitting junit.xml (see the coverage step above).
+        if: always() && !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push'
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         with:
           report_paths: '**/junit.xml'
@@ -1374,7 +1414,7 @@ jobs:
         #
         # Gated to the same matrix cell as the JUnit producer step so we
         # only invoke the reporter when junit.xml actually exists.
-        if: always() && !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
+        if: always() && !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push'
         uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1.0.28
         with:
           report-path: junit.xml
@@ -1390,7 +1430,7 @@ jobs:
         # Persist the CTRF JSON the reporter emits so the nightly flake-
         # quarantine job has a 7-day window of historical reports to
         # mine. retention-days lines up with the xflaky look-back window.
-        if: always() && !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
+        if: always() && !cancelled() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ctrf-report
@@ -1400,7 +1440,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
       - name: Upload coverage artifact
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
@@ -1410,14 +1450,14 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: coverage.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push' && !cancelled()
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && matrix.shard == 1 && github.event_name == 'push' && !cancelled()
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           files: junit.xml
@@ -1441,6 +1481,24 @@ jobs:
     #
     # Coverage / JUnit / Codecov uploads are NOT mirrored here; they
     # remain ubuntu-only (matches the previous matrix gating).
+    #
+    # macOS sharding decision (this PR): the ubuntu `test` job fans out
+    # across a `shard` matrix dimension, but macOS CANNOT - this job's
+    # `name:` MUST stay the literal string below (branch-protection
+    # required-context + required-check-canary.yml both pin it; a matrix
+    # `shard` dimension would template the name and break the lock). So
+    # instead of sharding macOS, we shrink its per-push workload to a
+    # single deterministic quarter of the file list (`--shard 1/MACOS
+    # _PUSH_SHARD_COUNT`). This fits the time budget without the 90-min
+    # wall the full macOS suite hit, keeps a real (deterministic, ~1/4)
+    # macOS signal on every commit that lands on main, and leaves
+    # ci-macos-nightly.yml to run the FULL macOS matrix as the safety
+    # net. On PRs the job already runs `--affected` (impacted slice), so
+    # macos_sensitive PRs still exercise exactly the touched code on macOS.
+    # The merge queue (merge_group) skips this job entirely (see the
+    # ci-gate MACOS_SKIP_EVENTS handling) - the post-merge push is what
+    # carries the macOS signal.
+    #
     # Literal job name -- NOT templated. The branch-protection required
     # context for macOS test runs depends on this exact string; when the
     # job is skipped via the `if:` gate, GitHub posts the templated form
@@ -1458,6 +1516,11 @@ jobs:
     permissions:
       contents: read
       checks: write
+    env:
+      # Per-push macOS runs only shard 1 of this many - a deterministic
+      # ~1/4 subset of the file list. ci-macos-nightly.yml runs the full
+      # matrix daily as the safety net.
+      MACOS_PUSH_SHARD_COUNT: "4"
     strategy:
       fail-fast: false
       matrix:
@@ -1484,12 +1547,18 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_NAME: ${{ github.event_name }}
+          MACOS_PUSH_SHARD_COUNT: ${{ env.MACOS_PUSH_SHARD_COUNT }}
         run: |
+          # On PRs: run only the affected slice (impacted by the diff).
+          # On push to main: run a single deterministic quarter of the
+          # file list (`--shard 1/N`) so the macOS cell fits its time
+          # budget; ci-macos-nightly.yml runs the full matrix daily.
           if [ "${EVENT_NAME}" = "pull_request" ] && \
              git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
             uv run python scripts/run_tests.py --parallel 4 --affected "refs/remotes/origin/${BASE_REF}"
           else
-            uv run python scripts/run_tests.py --parallel 4
+            uv run python scripts/run_tests.py --parallel 4 \
+              --shard "1/${MACOS_PUSH_SHARD_COUNT}"
           fi
       - name: Run capability-matrix spawn-refusal integration tests
         run: |

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -194,3 +194,43 @@ block tomorrow's PRs.
 The added PR-time jobs target ≤8 min wall-clock each and run in
 parallel after the lint job clears (so a typo PR fails fast in <2
 min without burning compute on the heavy stack).
+
+## Sharded unit suite
+
+`scripts/run_tests.py` runs each `tests/unit/test_*.py` file in its own
+subprocess (the OOM-avoidance model: a single `pytest --cov` over all
+files in one process exceeds the 7 GB runner ceiling). Each subprocess
+pays a fixed ~2.7 s of Python startup + full-package import regardless
+of how many tests the file holds, so at ~1.4k files a single runner
+spent most of its wall time on startup churn rather than test
+execution.
+
+The `Test` job therefore fans the file list out across parallel
+runners with `--shard i/N`:
+
+```
+# Run only shard 1 of 4 (a deterministic, disjoint quarter of the files):
+uv run python scripts/run_tests.py --shard 1/4
+
+# Compose with the affected-only selection used on PRs:
+uv run python scripts/run_tests.py --shard 1/4 --affected origin/main
+```
+
+The partition is **position-modulo over the sorted file list**: shard
+`i` owns every file whose index `j` satisfies `j % N == i - 1`. That
+makes it deterministic and stable (a failing shard reruns the identical
+slice), complete and disjoint (the union of all `N` shards is exactly
+the full list, no file runs twice), and balanced (shard sizes differ by
+at most one). An empty shard (when `N` exceeds the file count) is a
+legitimate no-op that exits 0.
+
+In CI the `ubuntu`/`windows` `Test` cells fan out across a `shard`
+matrix dimension; the rolled-up `needs.test.result` the `CI gate`
+aggregator reads is `failure` if *any* shard cell fails, so every shard
+is still required. Coverage / JUnit / Codecov upload runs on shard 1
+only (its own file loop still covers every file, so the pin
+deduplicates without narrowing coverage). The `macos` cell keeps a
+single literal job name (branch-protection required-context); it runs a
+deterministic `--shard 1/4` subset on push and the affected slice on
+PRs, with `ci-macos-nightly.yml` running the full macOS matrix daily as
+the safety net.

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -12,6 +12,7 @@ Usage:
     python scripts/run_tests.py --parallel 4 # run 4 files at once
     python scripts/run_tests.py --parallel 1 # force sequential execution
     python scripts/run_tests.py --coverage   # collect coverage and emit coverage.json
+    python scripts/run_tests.py --shard 1/4  # run only shard 1 of 4 (CI fan-out)
 """
 
 from __future__ import annotations
@@ -37,6 +38,49 @@ def discover_test_files(test_dir: Path, keyword: str | None = None) -> list[Path
     if keyword:
         files = [f for f in files if keyword in f.stem]
     return files
+
+
+def parse_shard_spec(spec: str) -> tuple[int, int]:
+    """Parse a ``i/N`` shard spec into ``(shard_index, shard_count)``.
+
+    ``shard_index`` is 1-based and must satisfy ``1 <= i <= N``; ``N`` must be
+    a positive integer. Raises ``ValueError`` on any malformed or out-of-range
+    input so the CLI fails loudly rather than silently running the wrong slice.
+    """
+    parts = spec.split("/")
+    if len(parts) != 2:
+        raise ValueError(f"shard spec must be 'i/N' (got {spec!r})")
+    try:
+        shard_index = int(parts[0])
+        shard_count = int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"shard spec parts must be integers (got {spec!r})") from exc
+    if shard_count < 1:
+        raise ValueError(f"shard count must be >= 1 (got {shard_count})")
+    if not 1 <= shard_index <= shard_count:
+        raise ValueError(f"shard index {shard_index} out of range 1..{shard_count}")
+    return shard_index, shard_count
+
+
+def shard_files(files: list[Path], shard_index: int, shard_count: int) -> list[Path]:
+    """Return the deterministic 1-based ``shard_index`` of ``shard_count`` shards.
+
+    Partition by position modulo ``shard_count`` over the (already sorted)
+    ``files`` list: shard ``i`` owns every file whose index ``j`` satisfies
+    ``j % shard_count == i - 1``. This is:
+
+    - **deterministic + stable** - no hashing, no salt; the same inputs always
+      yield the same slice across runs and machines (the repo's determinism
+      contract);
+    - **complete + disjoint** - every file lands in exactly one shard;
+    - **balanced** - shard sizes differ by at most one;
+    - **order-preserving** - each shard is a subsequence of ``files``.
+    """
+    if shard_count < 1:
+        raise ValueError(f"shard count must be >= 1 (got {shard_count})")
+    if not 1 <= shard_index <= shard_count:
+        raise ValueError(f"shard index {shard_index} out of range 1..{shard_count}")
+    return [f for j, f in enumerate(files) if j % shard_count == shard_index - 1]
 
 
 def run_file(path: Path, extra_args: list[str], coverage: bool = False) -> tuple[Path, int, float, str]:
@@ -214,6 +258,20 @@ def run_parallel(
     return 1 if failed else 0
 
 
+def _report_empty_selection(shard: tuple[int, int] | None, context: str) -> None:
+    """Print a clear message when the selected file set is empty.
+
+    An empty shard (N greater than the file count, or a small affected set
+    split across many shards) is a legitimate no-op that must exit 0 - not a
+    discovery failure. The message disambiguates the two for CI log readers.
+    """
+    if shard is not None:
+        print(f"No {context}test files in shard {shard[0]}/{shard[1]} - nothing to run (empty shard)")
+    else:
+        suffix = "affected tests found" if context else "test files found"
+        print(f"No {suffix} - nothing to run")
+
+
 def discover_affected_files(base: str) -> list[Path]:
     """Use test_impact.py to find test files affected by changed sources."""
     impact_script = Path(__file__).parent / "test_impact.py"
@@ -254,19 +312,39 @@ def main() -> None:
         action="store_true",
         help="Collect coverage per subprocess and emit coverage.json at the repo root",
     )
+    parser.add_argument(
+        "--shard",
+        metavar="i/N",
+        help=(
+            "Run only shard i of N (1-based, e.g. '1/4'). The discovered file "
+            "list is partitioned deterministically so reruns are reproducible "
+            "and the union of all N shards covers every file exactly once."
+        ),
+    )
     parser.add_argument("extra", nargs="*", help="Extra args passed to pytest")
     args = parser.parse_args()
 
     workers: int = max(1, args.parallel)
 
+    shard: tuple[int, int] | None = None
+    if args.shard is not None:
+        try:
+            shard = parse_shard_spec(args.shard)
+        except ValueError as exc:
+            print(f"Invalid --shard {args.shard!r}: {exc}")
+            sys.exit(2)
+
     if args.affected is not None:
         files = discover_affected_files(args.affected)
         if args.keyword:
             files = [f for f in files if args.keyword in f.stem]
+        if shard is not None:
+            files = shard_files(files, *shard)
         if not files:
-            print("No affected tests found - nothing to run")
+            _report_empty_selection(shard, context="affected ")
             sys.exit(0)
-        print(f"Running {len(files)} affected test files (each in its own process)")
+        shard_label = f" [shard {shard[0]}/{shard[1]}]" if shard else ""
+        print(f"Running {len(files)} affected test files{shard_label} (each in its own process)")
         print(f"{'=' * 60}")
         if workers > 1:
             code = run_parallel(files, args.extra, workers, args.fail_fast, args.coverage)
@@ -282,12 +360,15 @@ def main() -> None:
         sys.exit(1)
 
     files = discover_test_files(test_dir, args.keyword)
+    if shard is not None:
+        files = shard_files(files, *shard)
     if not files:
-        print("No test files found")
+        _report_empty_selection(shard, context="")
         sys.exit(0)
 
     mode = f"parallel ({workers} workers)" if workers > 1 else "sequential"
-    print(f"Running {len(files)} test files {mode} (each in its own process)")
+    shard_label = f" [shard {shard[0]}/{shard[1]}]" if shard else ""
+    print(f"Running {len(files)} test files{shard_label} {mode} (each in its own process)")
     print(f"{'=' * 60}")
 
     if workers > 1:

--- a/tests/unit/scripts/test_run_tests_sharding.py
+++ b/tests/unit/scripts/test_run_tests_sharding.py
@@ -1,0 +1,168 @@
+"""Unit tests for the deterministic sharding partition in ``scripts/run_tests.py``.
+
+The CI Test job fans a single ~1.4k-file unit suite out across N parallel
+runners. Each runner invokes ``run_tests.py --shard i/N`` and must execute a
+disjoint slice of the discovered file list. The partition has to be:
+
+- **Complete**: the union of all shards equals the full file list (no file is
+  silently dropped, which would mask a regression).
+- **Disjoint**: no file runs on two shards (wasted runner minutes + double
+  reporting).
+- **Deterministic + stable**: the same ``(files, i, N)`` always yields the same
+  slice across runs and across machines, so a failing shard reruns identically.
+  The repo's whole identity is determinism, so this is load-bearing.
+- **Balanced**: shard sizes differ by at most one, so no single runner becomes
+  the long pole.
+
+These tests pin those four properties plus the ``i/N`` spec parser.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_tests.py"
+
+
+@pytest.fixture
+def run_tests_module() -> Generator[ModuleType, None, None]:
+    """Load scripts/run_tests.py as an importable module."""
+    spec = importlib.util.spec_from_file_location(
+        "run_tests_under_test",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _fixed_files(count: int) -> list[Path]:
+    """A deterministic, sorted file list standing in for discovered tests."""
+    return sorted(Path(f"tests/unit/test_file_{i:04d}.py") for i in range(count))
+
+
+# --- parse_shard_spec ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("1/4", (1, 4)),
+        ("4/4", (4, 4)),
+        ("2/10", (2, 10)),
+        ("1/1", (1, 1)),
+    ],
+)
+def test_parse_shard_spec_valid(run_tests_module: ModuleType, spec: str, expected: tuple[int, int]) -> None:
+    assert run_tests_module.parse_shard_spec(spec) == expected
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "0/4",  # index below 1
+        "5/4",  # index above count
+        "1/0",  # zero count
+        "-1/4",  # negative index
+        "abc",  # not a fraction
+        "1",  # missing count
+        "1/4/2",  # too many parts
+        "1.5/4",  # non-integer
+        "",  # empty
+    ],
+)
+def test_parse_shard_spec_invalid_raises(run_tests_module: ModuleType, spec: str) -> None:
+    with pytest.raises(ValueError):
+        run_tests_module.parse_shard_spec(spec)
+
+
+# --- shard_files partition properties --------------------------------------
+
+
+def test_shard_files_covers_every_file_exactly_once(run_tests_module: ModuleType) -> None:
+    """Union of all 4 shards == full list; intersection of any pair is empty."""
+    files = _fixed_files(1428)
+    shard_count = 4
+
+    shards = [run_tests_module.shard_files(files, i, shard_count) for i in range(1, shard_count + 1)]
+
+    union: list[Path] = []
+    for shard in shards:
+        union.extend(shard)
+
+    # Complete: every file appears.
+    assert sorted(union) == sorted(files)
+    # Disjoint: no duplicates across shards.
+    assert len(union) == len(files)
+    assert len(set(union)) == len(files)
+
+
+def test_shard_files_partitions_are_disjoint_pairwise(run_tests_module: ModuleType) -> None:
+    files = _fixed_files(100)
+    shard_count = 4
+    shards = [set(run_tests_module.shard_files(files, i, shard_count)) for i in range(1, shard_count + 1)]
+    for a in range(len(shards)):
+        for b in range(a + 1, len(shards)):
+            assert shards[a].isdisjoint(shards[b]), f"shards {a + 1} and {b + 1} overlap"
+
+
+def test_shard_files_is_deterministic_across_runs(run_tests_module: ModuleType) -> None:
+    """Same inputs -> identical slice, every time (no hashing salt drift)."""
+    files = _fixed_files(257)
+    first = run_tests_module.shard_files(files, 2, 4)
+    second = run_tests_module.shard_files(files, 2, 4)
+    third = run_tests_module.shard_files(list(files), 2, 4)
+    assert first == second == third
+
+
+def test_shard_files_is_balanced(run_tests_module: ModuleType) -> None:
+    """Shard sizes differ by at most one (no long-pole runner)."""
+    files = _fixed_files(1428)
+    sizes = [len(run_tests_module.shard_files(files, i, 4)) for i in range(1, 5)]
+    assert max(sizes) - min(sizes) <= 1
+    assert sum(sizes) == 1428
+
+
+def test_shard_files_single_shard_returns_all(run_tests_module: ModuleType) -> None:
+    """N=1 is a no-op partition: shard 1/1 == the full list, order preserved."""
+    files = _fixed_files(37)
+    assert run_tests_module.shard_files(files, 1, 1) == files
+
+
+def test_shard_files_preserves_relative_order(run_tests_module: ModuleType) -> None:
+    """Within a shard, files keep their original discovery order."""
+    files = _fixed_files(50)
+    shard = run_tests_module.shard_files(files, 1, 4)
+    # The shard is a subsequence of the original list.
+    indices = [files.index(f) for f in shard]
+    assert indices == sorted(indices)
+
+
+def test_shard_files_more_shards_than_files(run_tests_module: ModuleType) -> None:
+    """When N > len(files), trailing shards are empty but coverage holds."""
+    files = _fixed_files(3)
+    shards = [run_tests_module.shard_files(files, i, 5) for i in range(1, 6)]
+    union: list[Path] = []
+    for shard in shards:
+        union.extend(shard)
+    assert sorted(union) == sorted(files)
+    # Exactly three shards are non-empty.
+    assert sum(1 for s in shards if s) == 3
+
+
+def test_shard_files_rejects_out_of_range_index(run_tests_module: ModuleType) -> None:
+    files = _fixed_files(10)
+    with pytest.raises(ValueError):
+        run_tests_module.shard_files(files, 0, 4)
+    with pytest.raises(ValueError):
+        run_tests_module.shard_files(files, 5, 4)


### PR DESCRIPTION
## Root cause

`scripts/run_tests.py` runs each of the ~1.4k `tests/unit/test_*.py` files in
its own subprocess. This is deliberate: a single `pytest --cov` over all files
in one process exceeds the 7 GB runner RAM ceiling (documented in the coverage
step). The trade-off is that **every subprocess pays a fixed ~2.7 s of Python
startup + full-package import regardless of how many tests the file holds.**

Measured locally (wall time vs pytest's own reported test time):

| File | pytest time | wall | fixed overhead |
|------|------------|------|----------------|
| `test_base_lineage_hook.py` | 1.53 s | 8.23 s | ~6.7 s |
| `test_capability_enums.py` | 6.55 s | 9.16 s | ~2.6 s |
| `test_registry.py` | 1.00 s | 4.01 s | ~3.0 s |

At ~1.4k files / 4 local workers that fixed overhead alone is ~16 min of pure
startup churn before any test runs. The file count crossed a threshold when
unit-test discovery widened to `rglob` (#1792, ~1160 -> ~1428 files), pushing
the ubuntu `Test` cell to 25+ min and the slower macOS `Test` cell past its
90-min budget (main showed red on the macOS cell). This is general per-file
overhead at scale, **not** a single hanging test (97% CPU across all workers =
churning through imports, not blocked on one test).

## The fix: shard on top of the per-file model

Add a deterministic `--shard i/N` flag to `scripts/run_tests.py`. The per-file
subprocess model is untouched; sharding sits on top of it.

**Partition scheme:** position-modulo over the already-sorted file list. Shard
`i` owns every file whose index `j` satisfies `j % N == i - 1`. Properties
(all pinned by `tests/unit/scripts/test_run_tests_sharding.py`):

- **Deterministic + stable** - no hashing, no salt; the same `(files, i, N)`
  always yields the same slice across runs and machines, so a failing shard
  reruns the identical slice.
- **Complete + disjoint** - the union of all `N` shards is exactly the full
  list; no file is dropped (which would mask a regression) and none runs twice.
- **Balanced** - shard sizes differ by at most one.
- An empty shard (when `N` exceeds the file count) is a legitimate no-op that
  exits 0; a shard whose slice contains a failure exits non-zero.
- **Back-compat:** without `--shard` the runner is byte-for-byte unchanged, so
  the release (`release-major-minor.yml`) and full-suite nightly
  (`ci-macos-nightly.yml`) callers keep running everything.

## CI matrix

The ubuntu/windows `Test` cells fan out across a `shard: [1, 2, 3, 4]` matrix
dimension; each runner handles ~1/4 of the files (~357 of 1428).

**The CI gate still requires every shard.** `ci-gate` reads
`needs.test.result`, which GitHub rolls up to `failure` if *any* shard cell
fails. No job keys changed (`test`, `test-macos`, `ci-gate` are intact), so the
existing skip-tolerance logic, the `MACOS_SKIP_EVENTS` handling, and the
`DOCS_ONLY_SKIPPABLE` set all keep working unchanged. A skipped/failed shard
fails the gate - it cannot be masked.

## Coverage is preserved

The coverage / JUnit / Codecov steps are pinned to `matrix.shard == 1`. That
step has **its own file loop** (`rglob` over all of `tests/unit`), so it still
covers every file - the shard pin only deduplicates it to one cell, it does not
narrow coverage. `coverage.xml` generation is byte-identical (verified: the
diff touches only the `if:` gate and a comment, never the loop or the
`coverage xml -o coverage.xml` producer). The coverage-ratchet work that
depends on `coverage.xml` is unaffected.

## macOS decision

macOS **cannot** take a shard matrix dimension: the `test-macos` job's `name:`
must stay the literal `Test (macos-latest, Python 3.13)` (branch-protection
required-context + `required-check-canary.yml` both pin it; a matrix dimension
would template the name and silently weaken the required check). So instead of
sharding macOS, its **per-push** workload shrinks to a deterministic
`--shard 1/4` subset - a fast, reproducible quarter of the files that fits the
time budget without the 90-min wall. On PRs it still runs the affected slice
(`--affected`), so macos-sensitive PRs exercise exactly the touched code.
`ci-macos-nightly.yml` runs the **full** macOS matrix daily as the safety net,
and the merge queue skips macOS entirely (the post-merge push carries the
signal). This keeps a real macOS signal on every commit that lands on main.

## Expected wall-time

- ubuntu `Test`: ~25+ min -> ~6-8 min per shard (4 shards in parallel). Shard 1
  on ubuntu/3.13/push additionally runs the ~25-min coverage loop, well within
  the 90-min ceiling.
- macOS `Test` on push: full suite (90-min budget overflow) -> ~1/4 subset,
  comfortably inside budget.
- Net effect on the merge queue: the per-merge `Test` drain drops from 25+ min
  to single-digit minutes, so the queue stops backing up.

## Test plan

- [x] `uv run python -m pytest tests/unit/scripts/test_run_tests_sharding.py` - 21 pass (partition completeness, disjointness, determinism across runs, balance, order-preservation, `i/N` parser)
- [x] `uv run python scripts/run_tests.py --shard 1/4` runs only its slice and exits 0
- [x] A shard whose slice contains a failing file exits non-zero; a shard of only passing files exits 0
- [x] Union of shards 1..4 covers every discovered file exactly once (verified on the real 1429-file list: 4 balanced shards of 357-358)
- [x] Back-compat: no `--shard` runs the full suite unchanged
- [x] `actionlint` clean on `ci.yml`
- [x] `required-check-canary.yml` invariants hold (literal macOS name, `CI gate` name, two emitters, `ci-gate.needs` includes `test` + `test-macos`)
- [x] `ruff check` + `ruff format` clean
- [ ] CI green across all shard cells in the merge queue