### PR TITLE
test(ci): block real network in unit tests to kill flaky-network class

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -27,6 +27,7 @@ locally without waiting for the cloud runner.
 | **Vulture**                 | Dead code (unused functions/classes/vars at confidence ≥80)       | PR                  |
 | **diff-cover**              | <80% coverage on lines this PR changed                            | PR (advisory)       |
 | **import-linter**           | Architecture-contract violations (cross-package imports)          | PR                  |
+| **No-network guard**        | Unit tests that open a real outbound connection (flaky by design) | PR (every unit run) |
 | **ruff** + **typos**        | Lint, format drift, common typos                                  | PR                  |
 
 ## Run any of the above locally
@@ -142,6 +143,92 @@ Adding a module to the gate: extend `MODULES` in
 `scripts/mutmut_critical.py`, mirror the matrix in
 `.github/workflows/mutation-fixed.yml`, and add the source/test
 paths to the `paths:` filter on the same workflow.
+
+## Hermetic unit tests (no network)
+
+Unit tests are hermetic: a test under `tests/unit/` must not open a real
+outbound network connection. A test that talks to a remote host passes only
+while that host answers and fails intermittently otherwise (a transient 404, a
+DNS hiccup, a rate limit), turning a green suite red for reasons unrelated to
+the change under test. One such test (a signed-catalog install whose fixture
+pointed at a `github://` URL) once reached a live host, 404'd intermittently in
+CI, and wedged the merge queue.
+
+### The guard
+
+`tests/unit/conftest.py` installs an **autouse** fixture that wraps
+`socket.socket.connect` / `socket.socket.connect_ex` for every unit test (logic
+in `tests/unit/_no_network.py`). Any attempt to connect to a non-loopback
+address raises immediately:
+
+```
+RuntimeError: unit tests must not touch the network: blocked connection to
+api.example.com:443. Mock it (see docs/contributing/testing.md), or move a
+genuine integration test to tests/integration/.
+```
+
+Because the patch sits at the socket layer, it covers every higher-level client
+(`http.client`, `urllib`, `requests`, `httpx`, raw sockets) without per-library
+patching. It is hand-rolled rather than a third-party plugin so it adds no
+dependency to vet, lock, and audit, and so it integrates with the suite's
+existing strict-marker opt-out convention.
+
+**Loopback stays allowed.** Connections to `127.0.0.0/8`, `::1`, and the
+literal hostname `localhost`, plus Unix-domain sockets, pass through untouched,
+so the many unit tests that spin a local mock server keep working. The guard
+inspects the literal target before any name resolution, so a loopback hostname
+is allowed without an egress; a non-loopback hostname is blocked at the
+resolution boundary.
+
+The scope is `tests/unit/` only. Integration tests (`tests/integration/`)
+run real servers and are not guarded, because their conftest does not install
+the fixture.
+
+### When the guard fires on you
+
+The test under `tests/unit/` opened a real connection. Two correct fixes, in
+order of preference:
+
+1. **Make it hermetic (almost always the right answer).** Mock the network at
+   the seam: inject a fake client, patch the transport, or use the
+   `respx`/`TestClient` patterns already in the suite. Do **not** "fix" it by
+   pointing the call at a loopback URL unless the test genuinely runs a local
+   server.
+2. **Move a genuine integration test to `tests/integration/`.** If the test
+   truly must reach the network, it is not a unit test; relocate it. The guard
+   does not apply there.
+
+### Opting a single test out (rare)
+
+For the rare case where a test must stay under `tests/unit/` and reach the
+network, mark it and document why:
+
+```python
+import pytest
+
+
+@pytest.mark.allow_network  # justification: probes the real X endpoint; see #NNNN
+def test_live_thing() -> None:
+    ...
+```
+
+The marker is registered in `pyproject.toml` (`--strict-markers` is on, so an
+unregistered marker is itself an error). Prefer relocation to
+`tests/integration/` over the marker: a network-touching test in the unit suite
+is a flake waiting to happen.
+
+### Reproduce locally
+
+```bash
+# Full unit suite with the guard active (per-file isolated runner):
+uv run python scripts/run_tests.py --parallel 4
+
+# Or straight pytest:
+uv run pytest tests/unit/ -q --no-cov
+
+# The guard's own meta-tests:
+uv run pytest tests/unit/test_no_network_guard.py -q --no-cov
+```
 
 ## Multi-adapter pentest fan-out
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -669,6 +669,7 @@ markers = [
     "slow: long-running tests (> ~5s); skipped by default in fast feedback runs",
     "integration: end-to-end / subprocess-driven integration tests; selectable via -m integration in CI",
     "stress: resource-leak / memory-growth / deadlock stress tests (TC-C); gated off by default CI, run nightly via `-m stress`",
+    "allow_network: opt out of the autouse unit no-network guard (rare; a genuine integration test belongs in tests/integration/ instead)",
 ]
 # Visible warnings without converting to errors; individual tests or runs
 # can tighten via `pytest -W error::DeprecationWarning`.

--- a/tests/unit/_no_network.py
+++ b/tests/unit/_no_network.py
@@ -1,0 +1,141 @@
+"""Hermetic-network guard for the unit test suite.
+
+Unit tests must be hermetic: they may not open a real outbound connection.
+A unit test that talks to a remote host passes only while that host answers
+and fails intermittently otherwise (transient 404, DNS hiccup, rate limit),
+which turns a green suite red for reasons unrelated to the change under test.
+One such test once wedged the merge queue.
+
+This module installs a process-local guard over ``socket.socket.connect`` and
+``socket.socket.connect_ex`` that refuses any connection to a non-loopback
+address with a clear, actionable :class:`RuntimeError`. Loopback addresses
+(``127.0.0.0/8``, ``::1``, ``localhost``) and Unix-domain sockets are allowed
+so the many unit tests that spin a local mock server keep working.
+
+The guard is hand-rolled rather than pulled from a third-party plugin so it
+adds no dependency to vet, lock, and audit, and so it can integrate with the
+suite's existing strict-marker opt-out convention. It is installed per test by
+an autouse fixture (see ``tests/unit/conftest.py``); the suite runs each test
+file in its own subprocess, so a per-test patch is both sufficient and
+deterministic.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, cast
+
+# Loopback hostnames that resolve to a loopback address. Literal IPs are
+# checked separately via :func:`ipaddress`.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain", ""})
+
+# Real ``socket.socket`` methods, captured once at import time so the guard
+# delegates to the genuine implementation for allowed (loopback) connections.
+_REAL_CONNECT = socket.socket.connect
+_REAL_CONNECT_EX = socket.socket.connect_ex
+
+
+class NetworkBlockedError(RuntimeError):
+    """Raised when a unit test attempts a non-loopback network connection."""
+
+
+def _inet_parts(address: object) -> tuple[object, ...] | None:
+    """Return the address as a typed tuple, or ``None`` for non-inet addresses.
+
+    A ``socket.connect`` address is an ``(host, port[, ...])`` tuple for
+    AF_INET / AF_INET6 and a path string for AF_UNIX. Anything that is not such
+    a tuple (a Unix-domain path, or any other family) is local IPC and counts
+    as allowed, so we return ``None`` for it.
+    """
+    if isinstance(address, (tuple, list)):
+        return tuple(cast("tuple[object, ...]", address))
+    return None
+
+
+def _host_from_address(address: object) -> str | None:
+    """Extract the target host from a ``socket.connect`` address argument.
+
+    Returns ``None`` when the address is not an ``(host, port[, ...])`` tuple
+    (for example a Unix-domain socket path, which is local IPC and always
+    allowed), so the caller treats it as loopback.
+    """
+    parts = _inet_parts(address)
+    if parts:
+        host = parts[0]
+        if isinstance(host, (bytes, bytearray)):
+            return host.decode("ascii", "replace")
+        return str(host)
+    # AF_UNIX (str/bytes path) or any non-inet family: not a network host.
+    return None
+
+
+def is_loopback_address(address: object) -> bool:
+    """Return ``True`` when ``address`` targets loopback or local IPC.
+
+    Non-inet addresses (Unix-domain socket paths) count as local and are
+    allowed. For inet addresses, the literal target host is inspected without
+    triggering name resolution: a loopback hostname or any address inside a
+    loopback range (``127.0.0.0/8``, ``::1``) is allowed.
+    """
+    host = _host_from_address(address)
+    if host is None:
+        # Unix-domain socket / non-inet family - always local.
+        return True
+    if host.lower() in _LOOPBACK_HOSTNAMES:
+        return True
+    # Strip an IPv6 zone id (e.g. "fe80::1%en0") before parsing.
+    bare = host.split("%", 1)[0]
+    try:
+        return ipaddress.ip_address(bare).is_loopback
+    except ValueError:
+        # A non-loopback hostname (e.g. "example.com"); name resolution would
+        # be a network egress in itself, so treat it as blocked.
+        return False
+
+
+def _port_from_address(address: object) -> object:
+    parts = _inet_parts(address)
+    if parts is not None and len(parts) >= 2:
+        return parts[1]
+    return "?"
+
+
+def _blocked_error(address: object) -> NetworkBlockedError:
+    host = _host_from_address(address) or str(address)
+    port = _port_from_address(address)
+    return NetworkBlockedError(
+        f"unit tests must not touch the network: blocked connection to "
+        f"{host}:{port}. Mock it (see docs/contributing/testing.md), or move a "
+        f"genuine integration test to tests/integration/."
+    )
+
+
+def _guarded_connect(self: socket.socket, address: Any) -> Any:
+    if is_loopback_address(address):
+        return _REAL_CONNECT(self, address)
+    raise _blocked_error(address)
+
+
+def _guarded_connect_ex(self: socket.socket, address: Any) -> Any:
+    if is_loopback_address(address):
+        return _REAL_CONNECT_EX(self, address)
+    raise _blocked_error(address)
+
+
+@contextmanager
+def block_network() -> Iterator[None]:
+    """Patch ``socket`` connect methods to block non-loopback egress.
+
+    Restores the genuine methods on exit. Intended for use by the autouse
+    fixture, but usable directly in a ``with`` block for targeted tests.
+    """
+    socket.socket.connect = _guarded_connect  # type: ignore[method-assign]
+    socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        socket.socket.connect = _REAL_CONNECT  # type: ignore[method-assign]
+        socket.socket.connect_ex = _REAL_CONNECT_EX  # type: ignore[method-assign]

--- a/tests/unit/_no_network.py
+++ b/tests/unit/_no_network.py
@@ -129,13 +129,18 @@ def _guarded_connect_ex(self: socket.socket, address: Any) -> Any:
 def block_network() -> Iterator[None]:
     """Patch ``socket`` connect methods to block non-loopback egress.
 
-    Restores the genuine methods on exit. Intended for use by the autouse
-    fixture, but usable directly in a ``with`` block for targeted tests.
+    Reentrant-safe: on exit it restores whatever was installed on entry, not
+    the import-time methods. Nesting therefore composes - an inner context
+    exiting restores the outer guard rather than re-enabling real egress for
+    the remainder of the outer scope. Intended for use by the autouse fixture,
+    but usable directly in a ``with`` block for targeted tests.
     """
+    previous_connect = socket.socket.connect
+    previous_connect_ex = socket.socket.connect_ex
     socket.socket.connect = _guarded_connect  # type: ignore[method-assign]
     socket.socket.connect_ex = _guarded_connect_ex  # type: ignore[method-assign]
     try:
         yield
     finally:
-        socket.socket.connect = _REAL_CONNECT  # type: ignore[method-assign]
-        socket.socket.connect_ex = _REAL_CONNECT_EX  # type: ignore[method-assign]
+        socket.socket.connect = previous_connect  # type: ignore[method-assign]
+        socket.socket.connect_ex = previous_connect_ex  # type: ignore[method-assign]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,12 +4,21 @@ In git worktrees the parent project's venv may appear earlier on sys.path
 than the worktree's own src/, causing new modules to be shadowed.  This
 conftest inserts the worktree's src/ at position 0 so that imports always
 resolve to the locally checked-out code.
+
+It also installs the autouse no-network guard (see ``_no_network``): unit
+tests are hermetic and must not open a real outbound connection. Loopback is
+allowed so local mock servers keep working; a test that genuinely needs the
+network lives in ``tests/integration/`` or opts out with
+``@pytest.mark.allow_network``.
 """
 
 from __future__ import annotations
 
 import sys
+from collections.abc import Iterator
 from pathlib import Path
+
+import pytest
 
 # This file lives at tests/unit/conftest.py → parent.parent is the repo root
 _SRC = str(Path(__file__).resolve().parent.parent.parent / "src")
@@ -21,3 +30,26 @@ if _SRC not in sys.path:
 # The helpers module keeps the ``make_popen_mock`` / ``inner_cmd`` callables
 # test modules import directly.
 from tests.unit._adapter_test_helpers import no_watchdog_threads  # noqa: F401
+from tests.unit._no_network import block_network
+
+
+@pytest.fixture(autouse=True)
+def _block_real_network(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Block non-loopback connections for every unit test.
+
+    A unit test that opens a real outbound connection is flaky by
+    construction: it passes only while the remote host answers. The guard
+    converts any such attempt into a clear, deterministic ``RuntimeError`` that
+    names the host so the fix (mock it) is obvious.
+
+    Loopback (``127.0.0.0/8``, ``::1``, ``localhost``) and Unix-domain sockets
+    are allowed so the many unit tests that spin a local mock server keep
+    working. A test that legitimately must reach the network either lives in
+    ``tests/integration/`` (where this fixture does not apply) or marks itself
+    ``@pytest.mark.allow_network`` and documents why.
+    """
+    if request.node.get_closest_marker("allow_network") is not None:
+        yield
+        return
+    with block_network():
+        yield

--- a/tests/unit/test_network_isolation.py
+++ b/tests/unit/test_network_isolation.py
@@ -1,14 +1,70 @@
-"""Tests for SEC-014: Network isolation validation for sandboxed agents."""
+"""Tests for SEC-014: Network isolation validation for sandboxed agents.
+
+These are unit tests, so they must not open a real outbound connection (the
+autouse guard in ``tests/unit/conftest.py`` blocks non-loopback egress). The
+validator's reachability probe is exercised by patching the socket it builds so
+the "unreachable" path is simulated deterministically with an ``OSError``,
+rather than by relying on a documentation-range address (192.0.2.0/24) actually
+failing to route - which is exactly the flaky-by-network behaviour the guard
+exists to forbid.
+"""
 
 from __future__ import annotations
 
-from bernstein.core.network_isolation import (
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.security.network_isolation import (
     CheckStatus,
     Endpoint,
     IsolationLevel,
     NetworkIsolationValidator,
     NetworkPolicy,
 )
+
+
+@contextmanager
+def _socket_connect_raises(exc: OSError) -> Iterator[MagicMock]:
+    """Patch the validator's socket so ``connect`` raises ``exc``.
+
+    Simulates an unreachable endpoint without any real network egress. The
+    validator builds the socket via ``socket.socket(...)`` in the
+    ``network_isolation`` module, so we patch that factory.
+    """
+    fake_sock = MagicMock(name="socket")
+    fake_sock.connect.side_effect = exc
+    with patch("bernstein.core.security.network_isolation.socket.socket", return_value=fake_sock) as factory:
+        yield factory
+
+
+@contextmanager
+def _socket_connect_succeeds() -> Iterator[MagicMock]:
+    """Patch the validator's socket so ``connect`` succeeds (reachable)."""
+    fake_sock = MagicMock(name="socket")
+    fake_sock.connect.return_value = None
+    with patch("bernstein.core.security.network_isolation.socket.socket", return_value=fake_sock) as factory:
+        yield factory
+
+
+@contextmanager
+def _dns_resolves(resolves: bool) -> Iterator[MagicMock]:
+    """Patch ``getaddrinfo`` so DNS resolution is simulated, not performed.
+
+    The DNS check issues a real ``socket.getaddrinfo`` lookup; pin it so the
+    test neither depends on a resolver nor performs egress (the guard blocks
+    connections, not DNS, so without this the lookup would still leave the
+    sandbox).
+    """
+    target = "bernstein.core.security.network_isolation.socket.getaddrinfo"
+    if resolves:
+        with patch(target, return_value=[(2, 1, 6, "", ("203.0.113.1", 0))]) as gai:
+            yield gai
+    else:
+        import socket as _socket
+
+        with patch(target, side_effect=_socket.gaierror("simulated: name resolution disabled")) as gai:
+            yield gai
 
 
 class TestEndpoint:
@@ -48,15 +104,36 @@ class TestNetworkIsolationValidator:
             timeout_seconds=0.5,
         )
         validator = NetworkIsolationValidator(policy)
-        check = validator.check_endpoint_blocked(Endpoint("192.0.2.1", 1))
-        # This endpoint is RFC 5737 documentation - it should be unreachable
+        with _socket_connect_raises(OSError("simulated: connection refused")):
+            check = validator.check_endpoint_blocked(Endpoint("192.0.2.1", 1))
+        # connect() raised, so the endpoint is correctly reported as blocked.
         assert check.status == CheckStatus.PASS
 
     def test_check_endpoint_reachable_unreachable_host(self) -> None:
-        """Probing a non-routable address should return FAIL."""
+        """Probing an endpoint whose connect fails should return FAIL."""
         policy = NetworkPolicy(timeout_seconds=0.5)
         validator = NetworkIsolationValidator(policy)
-        check = validator.check_endpoint_reachable(Endpoint("192.0.2.1", 1))
+        with _socket_connect_raises(OSError("simulated: no route to host")):
+            check = validator.check_endpoint_reachable(Endpoint("192.0.2.1", 1))
+        assert check.status == CheckStatus.FAIL
+
+    def test_check_endpoint_reachable_reachable_host(self) -> None:
+        """Probing an endpoint whose connect succeeds should return PASS."""
+        policy = NetworkPolicy(timeout_seconds=0.5)
+        validator = NetworkIsolationValidator(policy)
+        with _socket_connect_succeeds():
+            check = validator.check_endpoint_reachable(Endpoint("127.0.0.1", 8052))
+        assert check.status == CheckStatus.PASS
+
+    def test_blocked_endpoint_fails_when_reachable(self) -> None:
+        """A denied endpoint that is reachable is a VIOLATION (FAIL)."""
+        policy = NetworkPolicy(
+            denied_endpoints=(Endpoint("192.0.2.1", 1),),
+            timeout_seconds=0.5,
+        )
+        validator = NetworkIsolationValidator(policy)
+        with _socket_connect_succeeds():
+            check = validator.check_endpoint_blocked(Endpoint("192.0.2.1", 1))
         assert check.status == CheckStatus.FAIL
 
     def test_validate_isolation_with_only_blocked(self) -> None:
@@ -67,7 +144,8 @@ class TestNetworkIsolationValidator:
             isolation_level=IsolationLevel.FULL,  # skip DNS check
         )
         validator = NetworkIsolationValidator(policy)
-        result = validator.validate_isolation("agent-1")
+        with _socket_connect_raises(OSError("simulated: connection refused")):
+            result = validator.validate_isolation("agent-1")
         assert result.passed
         assert result.agent_id == "agent-1"
 
@@ -81,7 +159,8 @@ class TestNetworkIsolationValidator:
     def test_latency_recorded(self) -> None:
         policy = NetworkPolicy(timeout_seconds=0.5)
         validator = NetworkIsolationValidator(policy)
-        check = validator.check_endpoint_reachable(Endpoint("192.0.2.1", 1))
+        with _socket_connect_raises(OSError("simulated: no route to host")):
+            check = validator.check_endpoint_reachable(Endpoint("192.0.2.1", 1))
         assert check.latency_ms >= 0
 
     def test_policy_property(self) -> None:
@@ -96,7 +175,8 @@ class TestNetworkIsolationValidator:
             dns_allowed=True,
         )
         validator = NetworkIsolationValidator(policy)
-        result = validator.validate_isolation("agent-1")
+        with _dns_resolves(True):
+            result = validator.validate_isolation("agent-1")
         dns_checks = [c for c in result.checks if c.name == "dns_resolution"]
         assert len(dns_checks) == 1
 

--- a/tests/unit/test_no_network_guard.py
+++ b/tests/unit/test_no_network_guard.py
@@ -19,7 +19,7 @@ import socket
 
 import pytest
 
-from tests.unit._no_network import is_loopback_address
+from tests.unit._no_network import block_network, is_loopback_address
 
 
 def test_guard_blocks_non_loopback_connection() -> None:
@@ -107,6 +107,36 @@ def test_allow_network_marker_disables_guard() -> None:
         assert "must not touch the network" not in str(excinfo.value)
     finally:
         sock.close()
+
+
+def test_nested_block_network_keeps_guard_active_after_inner_exit() -> None:
+    """Exiting a nested ``block_network()`` must not re-enable real egress.
+
+    The autouse fixture already holds the guard for this test. Entering a
+    second ``block_network()`` and leaving it must restore the *guard*, not the
+    genuine socket method - otherwise the remainder of the test (and any later
+    code in the same outer scope) could open a real connection. A naive
+    save/restore of the import-time methods would regress here.
+    """
+    # Sanity: the autouse guard is active right now.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(RuntimeError, match=r"must not touch the network"):
+            sock.connect(("198.51.100.1", 80))
+    finally:
+        sock.close()
+
+    # Nest and exit an inner guard.
+    with block_network():
+        pass
+
+    # The guard must STILL be active after the inner context exits.
+    sock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(RuntimeError, match=r"must not touch the network"):
+            sock2.connect(("198.51.100.1", 80))
+    finally:
+        sock2.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_no_network_guard.py
+++ b/tests/unit/test_no_network_guard.py
@@ -1,0 +1,137 @@
+"""Meta-tests for the autouse no-network guard in ``tests/unit/conftest.py``.
+
+The guard exists to make a whole class of flaky tests impossible: unit tests
+that open a real outbound (non-loopback) connection. Such a test passes when
+the remote host happens to answer and fails intermittently when it does not
+(for example a transient 404 / DNS hiccup), which previously wedged the merge
+queue.
+
+These tests assert the guard is actually wired up:
+
+* a connection attempt to a non-loopback host raises the guard error;
+* loopback connections are still permitted, so the many unit tests that spin a
+  local mock server keep working.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from tests.unit._no_network import is_loopback_address
+
+
+def test_guard_blocks_non_loopback_connection() -> None:
+    """Opening a socket to a non-loopback host raises the guard RuntimeError."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(RuntimeError, match=r"unit tests must not touch the network"):
+            # 198.51.100.0/24 is TEST-NET-2 (RFC 5737), reserved for docs and
+            # guaranteed never to route, so even a disabled guard could not
+            # accidentally succeed against a real host here.
+            sock.connect(("198.51.100.1", 80))
+    finally:
+        sock.close()
+
+
+def test_guard_blocks_non_loopback_connect_ex() -> None:
+    """connect_ex is guarded too (used by some clients and port probes)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(RuntimeError, match=r"unit tests must not touch the network"):
+            sock.connect_ex(("198.51.100.1", 80))
+    finally:
+        sock.close()
+
+
+def test_guard_error_names_the_blocked_host() -> None:
+    """The guard error identifies the host:port so the fix is obvious."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(RuntimeError, match=r"blocked connection to example\.invalid:443"):
+            sock.connect(("example.invalid", 443))
+    finally:
+        sock.close()
+
+
+def test_guard_allows_loopback_ipv4() -> None:
+    """Loopback connections are permitted (local mock servers must still work).
+
+    We bind a real listener on 127.0.0.1 and connect to it; the guard must let
+    this through. The connection itself succeeding proves loopback is allowed.
+    """
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        # Must not raise; loopback is on the allow-list.
+        client.connect(("127.0.0.1", port))
+    finally:
+        client.close()
+        server.close()
+
+
+def test_guard_allows_localhost_hostname() -> None:
+    """The literal hostname ``localhost`` is treated as loopback."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        # Resolving "localhost" yields a loopback address; the guard inspects
+        # the literal target before any name resolution and allows it.
+        client.connect(("localhost", port))
+    finally:
+        client.close()
+        server.close()
+
+
+@pytest.mark.allow_network
+def test_allow_network_marker_disables_guard() -> None:
+    """``@pytest.mark.allow_network`` lets a test bypass the guard.
+
+    The opt-out path is for the rare genuine integration test. Connecting to
+    TEST-NET-2 here is expected to FAIL at the OS layer (timeout / unreachable)
+    rather than raise the guard's ``RuntimeError`` - which is exactly the point:
+    with the marker present, the guard no longer intercepts the call.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.05)
+    try:
+        with pytest.raises(OSError) as excinfo:
+            sock.connect(("198.51.100.1", 80))
+        assert "must not touch the network" not in str(excinfo.value)
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        ("127.0.0.1", 8000),
+        ("127.0.0.5", 80),
+        ("::1", 443),
+        ("localhost", 8080),
+        ("", 0),
+        "/tmp/some.sock",  # Unix-domain socket path - local IPC, always allowed
+    ],
+)
+def test_is_loopback_address_allows_local(address: object) -> None:
+    assert is_loopback_address(address) is True
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        ("198.51.100.1", 80),
+        ("example.com", 443),
+        ("8.8.8.8", 53),
+        ("169.254.1.1", 80),  # link-local is not loopback
+    ],
+)
+def test_is_loopback_address_blocks_remote(address: object) -> None:
+    assert is_loopback_address(address) is False


### PR DESCRIPTION
## Summary

Unit tests under `tests/unit/` must be hermetic. A unit test that opens a real outbound connection passes only while the remote host answers and fails intermittently otherwise. One such test (a signed-catalog install whose fixture pointed at a `github://` URL) reached a live host, returned an intermittent 404 in CI, and wedged the merge queue.

This adds an autouse guard that makes the whole class impossible, and fixes the one pre-existing offender it surfaced.

## What changed

- **Autouse guard** (`tests/unit/conftest.py`, logic in `tests/unit/_no_network.py`): wraps `socket.socket.connect` / `connect_ex` for every unit test and raises a clear `RuntimeError` naming `host:port` on any non-loopback connection. Because the patch sits at the socket layer it covers `http.client`, `urllib`, `requests`, `httpx`, and raw sockets without per-library patching. Hand-rolled rather than a third-party plugin so it adds no dependency to vet, lock, and audit, and integrates with the existing strict-marker opt-out convention.
- **Loopback stays allowed**: `127.0.0.0/8`, `::1`, the literal hostname `localhost`, and Unix-domain sockets pass through untouched, so the many unit tests that run a local mock server keep working. Verified across `httpx`, `urllib`, `http.client`, and raw sockets (remote blocked, loopback allowed).
- **Scope**: `tests/unit/` only. `tests/integration/` is not guarded (its conftest does not install the fixture).

## Pre-existing network-touching unit tests fixed

The full unit suite was run with the guard active (`scripts/run_tests.py`). It surfaced exactly **one** file, `tests/unit/test_network_isolation.py` (**4 cases**), which probed `192.0.2.1` (RFC 5737 documentation range) via a real `socket.connect` and relied on it being unreachable. Rewritten to patch the socket factory so the reachable / unreachable / DNS paths are simulated deterministically. The file is now hermetic, fast, and type-clean (switched to the canonical import path so the types resolve under strict pyright). Two added cases cover the reachable and the violation paths that the network-dependent version could not assert reliably.

Two other failures observed in the full run were confirmed pre-existing on `main` and unrelated to this change (they make no socket calls): a probabilistic mock-fail-rate flake in `test_gui_smoke_findings.py`, and mock-call-count assertion drift in `test_tui_fallback.py`. Both reproduce on a pristine `main` checkout. They are out of scope here.

## Opt-out path

- Preferred: move a genuine integration test to `tests/integration/`.
- Otherwise: mark it `@pytest.mark.allow_network` (registered in `pyproject.toml`; `--strict-markers` is on) and document why.

Documented in `docs/contributing/testing.md`.

## Test plan

- [x] Guard meta-tests assert non-loopback egress is blocked and loopback is allowed (16 cases).
- [x] `tests/unit/test_network_isolation.py` rewritten hermetic; 14 pass, fast, pyright-clean.
- [x] Loopback-heavy unit files (catalog install, well-known keystore, gRPC bind, MCP transport, server supervisor) pass with the guard on (108 cases).
- [x] Full unit suite green with the guard active (the only guard-surfaced failures were the 4 now-fixed cases).
- [x] `ruff check` + `ruff format` clean on touched files; pyright clean on the guard module and the fixed test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automatic unit-test network isolation that blocks unintended outbound connections, with deterministic mocks/helpers for stable network-related checks and an opt-out marker (allow_network) for rare cases.
* **Documentation**
  * Expanded contribution/testing docs with the new no-network guard, how it behaves, how to opt out, and local reproduction instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->