### PR TITLE
docs: expand v2.6.0 release notes to the full delta

### DIFF
--- a/docs/release-notes/v2.6.0.md
+++ b/docs/release-notes/v2.6.0.md
@@ -1,40 +1,69 @@
 # v2.6.0
 
-Released 2026-05-21.
+Released 2026-05-22.
 
-## Features
+A large release. Highlights: bidirectional chat drivers with verifiable approvals, per-step replay with a hash-chained journal, operator-registered recurring goals, a signed supervisor surface, a skill catalog with signed manifests, image-attachment provenance, and a sharded CI test suite behind a native merge queue.
 
-- Multi-adapter pentest fan-out: `bernstein eval pentest --adapters a,b,c` now runs the same scenario across multiple adapters and aggregates consensus on the dedup key `(canonical_vuln_type, normalized_path)`. New `PentestScorer.score_multi` returns per-adapter and aggregate scores; single-adapter behaviour stays byte-identical. (#1754)
-- SOTA merge-gate stack: pre-merge autosync regenerates AGENTS.md mirrors + ruff format on PR branches; main-red-guard blocks PR merges while main CI is red; nightly drift sweep opens a PR if mirror or format drift accumulates overnight; CI workflow now also responds to `merge_group:` events so a native merge queue can run the existing suite against the combined branch. Operator runbook at `docs/operations/merge-gate.md`. (#1756)
-- Per-row source-adapter provenance for the memory subsystem: `SQLiteMemoryStore` now carries an optional `source_adapter` column, supports `add_many` plus `query(read_only_from_adapters=[...])`, and uses additive NULL-backfill migration so existing rows still surface from default reads. (#1759)
-- Static-analysis sweeper for Sonar findings: `bernstein doctor sonar-sweep --dry-run` walks `/api/issues/search` and emits backlog tickets to `.sdd/backlog/open/` keyed on the Sonar issue id. Phase-1 rollout config: BLOCKER severity only, cap 10 per day, GH-issue creation off until the operator graduates the workflow. (#1763)
-- PR text-hygiene gate scans PR title / body / branch / commit messages against the deny-list configured in `vars.PR_TEXT_HYGIENE_DENYLIST` repo variable; opt-in via the repo settings page. (#1765 / #1766)
+## Chat and operator surfaces
 
-## Fixes
+- Slack bidirectional driver: drive a session, approve or reject a tool call, and watch streamed output from Slack. Every approval is recorded as a signed entry in the audit chain (covering approver, message timestamp, decision, and tool-call hash), approval scope is pinned to the worker's git worktree, and outbound messages carry an Ed25519 signature so a recipient can verify the workspace identity. Optional `bernstein[slack]` extra. (#1794)
+- Discord bidirectional driver: the same attested-approval model as Slack, plus a per-channel scheduling fence so tasks emitted from one channel cannot land on workers bound to another. Optional `bernstein[discord]` extra. (#1795)
+- Image attachment passthrough: `bernstein run "<prompt>" --attach ./shot.png` carries an image to a vision-capable adapter (Claude, Gemini). The image's SHA-256 is recorded in the audit chain at decision time and anchored as a lineage parent of any artefact produced that turn; spawning with `--attach` on a non-multimodal adapter fails before any process launches. (#1797)
 
-- Post-CI dispatcher no longer crashes with `startup_failure`; per-job permissions are now declared explicitly on each reusable-workflow call. (#1746)
-- Gemini adapter golden replay test is environment-independent (`shutil.which` mock pins the resolver), so the recorded argv matches across hosts whether `gemini` or `antigravity` is installed. (#1748)
-- Discord and Slack stub bridges now raise `NotImplementedError` at handler-registration time instead of silently dropping the callback. (#1751)
-- `bernstein audit export --standard` only accepts `ai-act`; the `dora` and `finos-aigf` placeholders were removed until their clause mappings are reviewed. (#1752)
-- HSM lineage kind fails fast at config-load when no real `HSMKMSAdapter` subclass is on the classpath; opt-in to the stub via `BERNSTEIN_ALLOW_HSM_STUB=1` for smoke tests. (#1753)
-- Workflow loader rejects `interactive: true` nodes at config-load instead of crashing mid-run (closes #1110). (#1760)
-- GlitchTip-insights workflow guards against an empty `GLITCHTIP_BASE_URL` repo variable; observe-snapshot tolerates the `bernstein doctor observe` exit code on Sonar WARN. Top-level CLI exception barrier explicitly captures unhandled exceptions to the configured telemetry sink. Dead `workflow_run` trigger and dead SonarCloud project key dropped from the sonar-scan workflow. (#1762)
-- Ruff `extend-exclude` now skips `templates/**`, so cookiecutter Jinja sources no longer break the pre-merge autosync workflow. (#1758)
-- Pre-merge autosync sources its deny-list from `vars.PR_TEXT_HYGIENE_DENYLIST`; when the variable is unset the script logs a notice and exits 0. (#1766)
-- `pentest_runner.run_multi_adapter` uses `sorted_findings.copy()` instead of `list(sorted_findings)` (closes FURB123 alert #2443). (#1776)
-- Dependabot config: the github-actions ecosystem block dropped `semver-major-days` from `cooldown` (not a supported property for that ecosystem). Trufflehog gate now only fails on verified secrets; the unknown bucket was dominated by test-fixture connection strings. (#1776)
+## Orchestration
+
+- Per-step session replay: each agent step is recorded in a hash-chained journal where `step_hash = H(prev_hash, input_hash, model, prompt, tool_call, tool_result)`. `bernstein replay <agent-id>` walks the chain, `bernstein session fork <id> --from-step N` branches a sibling worktree from a chosen step, and replay divergence surfaces as a precise hash mismatch rather than a flaky result. Exported receipts verify offline against the install public key. (#1799)
+- Operator-registered recurring goals: `bernstein schedule add --cron "<expr>" --goal "<text>"` registers a recurring goal that fires inside a single installation, no host cron or external scheduler required. Each fire is a deterministic projection of `(schedule_id, fire_time, last_state)` onto a canonical task graph and is recorded in the audit chain, so `bernstein schedule audit` can prove a nightly sequence ran exactly as expected. (#1798)
+- Operator supervisor surface: `bernstein supervisor status` aggregates the existing stall, watchdog, and respawn-budget detectors into one view. A detected stall produces a signed escalation receipt (last audit entries, identity tokens, structured reason, and a deterministic recommended action) that any verifier can check offline. (#1800)
+- Worktree GC reaps are now anchored to the audit chain: each reap appends a `worktree.reap` event capturing the pre-deletion git HEAD and a clean/dirty flag, and the reap is fail-closed (a worktree is not deleted if the reap cannot be recorded). (#1833)
+- Deterministic replay is now hermetic: a cache miss in replay mode raises a typed error and aborts instead of silently calling the live model, the replay key folds in provider, temperature, and max-tokens, and a coverage line reports hits, misses, and strict violations. A non-strict fall-through stays available behind an explicit, logged opt-in. (#1832)
+
+## Skills
+
+- Skill catalog with signed manifest installs: `bernstein skills catalog browse|search|install|upgrade|info|status`. Each install appends a signed audit-chain entry referencing the manifest URL and content digest, refuses unverified manifests by default, keeps a lockfile that stays consistent across parallel worktrees, and a CI lineage gate rejects a lockfile referencing an unknown manifest digest. (#1796)
+- Skill lifecycle CLI foundation: install, sync, lock, lint, watch, and a local activation log with an env-var opt-out. (#1734)
+
+## Evaluation and observability
+
+- GlitchTip event ingester: a scraper turns open self-hosted error-tracker issues into one regression eval case each, deduped on the issue id, with administrative wiring-probe issues filtered out. The nightly real-run canary feeds this loop. (#1820)
+- CI-failure post-mortem ingestion: a scraper walks merged PRs that needed fix-up commits and synthesizes regression eval cases, so the eval suite tracks the failure modes that surface first in CI. (#1793)
+- Nightly real-run canary: a scheduled job runs real end-to-end flows (worker spawn, git worktree lifecycle, audit-chain append plus verify, signed lineage receipt) against a deterministic stub adapter, with no API key or network, and routes any failure to the telemetry sink. (#1822)
+- Multi-adapter pentest fan-out: `bernstein eval pentest --adapters a,b,c` runs one scenario across adapters and aggregates consensus on `(canonical_vuln_type, normalized_path)`. Single-adapter behaviour stays byte-identical. (#1754)
+- Consolidated SonarQube findings tracker auto-rendered from the live Sonar API. (#1781)
+- Terminal orchestration failures route to the configured error sink. (#1762)
+- Per-row source-adapter provenance for the memory subsystem: `SQLiteMemoryStore` carries an optional `source_adapter` column with `add_many` and `query(read_only_from_adapters=[...])`, via an additive NULL-backfill migration. (#1759)
+
+## CI and quality infrastructure
+
+- Merge-gate stack: pre-merge autosync regenerates mirror docs and formatting on PR branches, a main-red guard blocks merges while main is red, a nightly drift sweep opens a PR on accumulated drift, and the suite now responds to `merge_group:` so a native merge queue tests each PR against the combined branch. Operator runbook at `docs/operations/merge-queue.md`. (#1756)
+- The unit-test job is sharded across parallel runners (`scripts/run_tests.py --shard i/N`), so the per-file isolated suite scales as the test count grows. (#1845)
+- Coverage ratchet: a monotonic gate keeps total coverage from regressing and nudges the per-PR diff-coverage floor up over time. (#1829)
+- Static-analysis sweeper for Sonar findings, widened to MAJOR severity, turns open findings into backlog tickets keyed on the Sonar issue id. (#1763 / #1819)
+- Unit tests are now hermetic: an autouse guard blocks real outbound network connections in `tests/unit/` (loopback allowed), so a network-dependent unit test fails deterministically instead of flaking in CI. (#1856)
+- Opt-in telemetry foundation: consent CLI, a schema guard, and an off-by-default proof. (#1736)
+
+## Reliability and correctness fixes
+
+- Deterministic replay no longer calls the live model on a cache miss (see Orchestration above). (#1832)
+- HSM lineage kind fails fast at config-load when no real adapter is on the classpath; opt-in to the stub via `BERNSTEIN_ALLOW_HSM_STUB=1`. (#1753)
+- MCP OAuth discovery metadata corrected; the Tier-3 cordon now catches deletions and renames. (#1755)
+- Sensitive paths are no longer logged in clear text on the always-allow tamper path; the forensic record keeps the full value with pre-hashed digests. (#1814)
+- Resolved SonarQube findings: S8413 router double-mount, S125 commented-code, S3516 invariant-return, S5754 broad-except, plus a refurb sweep across the new subsystems. (#1786 / #1787 / #1788 / #1807 / #1813 / #1814 / #1815 / #1817 / #1818)
+- Post-CI dispatcher declares per-job permissions explicitly; its child-secret expectations were synced with the GlitchTip forward. (#1746 / #1801)
+- The tampered-signature catalog test corrupts the leading signature byte so verification fails deterministically (a trailing-byte flip could be a no-op and let the test reach the network). (#1843)
+- Workflow loader rejects `interactive: true` at config-load instead of crashing mid-run (closes #1110). (#1760)
+- Adapter dual-binary discovery handles the antigravity / gemini migration. (#1748 and follow-ups)
 
 ## Internals and docs hygiene
 
-- Dropped the unused `bernstein.benchmark.head_to_head` module and its test from the wheel. (#1767)
-- Reorganized the docs tree: internal working notes were consolidated under `docs/_internal/`. The two genuinely public pages (adapter-selection comparison, orchestration-approaches architecture note) moved into existing public nav sections. (#1768)
-- Front-page content, page metadata, and eleven stale README translations were dropped or refreshed. (#1769)
-- Repository-wide formatting pass across markdown, yaml, html, typescript, and python sources. AGENTS.md mirror set regenerated. (#1771 / #1776 / #1777)
-- Docs-drift playbook inventory matches the new on-disk layout. (#1770)
+- Dropped the unused `bernstein.benchmark.head_to_head` module from the wheel. (#1767)
+- Reorganized the docs tree; internal working notes consolidated under `docs/_internal/`. (#1768)
+- Front-page content, page metadata, and stale README translations refreshed. (#1769)
+- Repository-wide formatting pass; AGENTS.md mirror set regenerated. (#1771 / #1776 / #1777)
 
 ## Operator follow-ups
 
-- Set `vars.PR_TEXT_HYGIENE_DENYLIST` in repo settings to activate the PR text-hygiene gate (currently no-op when unset).
-- Set `BERNSTEIN_AUTOSYNC_TOKEN` repo secret to a fine-grained PAT or GitHub App token with `contents:write` so pre-merge autosync amends trigger downstream CI re-runs without manual empty commits.
-- Pin additional checks (`Repo hygiene`, `docs-drift / Run drift check`, `main-red-guard`, multi-OS Test matrix jobs) to the required-check list per `docs/operations/merge-gate.md`.
-- Schedule the Sonar sweeper graduation (BLOCKER -> CRITICAL -> all severities) per `docs/operations/sonar-sweeper.md`.
+- Set `BERNSTEIN_AUTOSYNC_TOKEN` (fine-grained PAT or GitHub App token with `contents:write`) so autosync amends trigger downstream CI without manual empty commits.
+- Set `vars.PR_TEXT_HYGIENE_DENYLIST` to activate the PR text-hygiene gate.
+- Configure the chat drivers (`BERNSTEIN_SLACK_TOKEN` / `BERNSTEIN_DISCORD_TOKEN`) and the telemetry DSN to enable the chat surfaces and the GlitchTip ingester loop.
+- Graduate the Sonar sweeper severity per `docs/operations/sonar-sweeper.md` and review the merge-queue runbook at `docs/operations/merge-queue.md`.


### PR DESCRIPTION
Expand docs/release-notes/v2.6.0.md to cover every feature + fix shipped in v2.6.0 (the release is already cut from the curated notes via --notes-file; this lands the same content on main for consistency). Cringe-free, ASCII-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and reorganized release notes with improved structure, including dedicated sections for chat and operator surfaces, orchestration, skills, evaluation and observability, CI and quality infrastructure, and reliability fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->