### PR TITLE
fix(audit): verify HMAC chain across the retention archive boundary

### DIFF
--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -239,15 +239,24 @@ over the previous event's HMAC and the current event's payload, forming a
 hash chain that breaks if any record is rewritten or deleted.
 
 **Storage.** One JSONL file per UTC day in `.sdd/audit/YYYY-MM-DD.jsonl`.
-Default retention: 90 days (`audit.py:40`). Files older than the retention
-window are gzip-compressed into `.sdd/audit/archive/YYYY-MM-DD.jsonl.gz` by
+Default retention: 90 days (`DEFAULT_RETENTION_DAYS`, `audit.py:40`). Retention
+is configured programmatically by passing `RetentionPolicy(retention_days=N,
+archive_subdir="archive")` to `AuditLog.archive(...)`; there is no environment
+variable or config-file key for it. Files older than the retention window are
+gzip-compressed into `.sdd/audit/archive/YYYY-MM-DD.jsonl.gz` by
 `AuditLog.archive`. Archived segments remain first-class chain links:
 `AuditLog.verify` (and `bernstein audit verify` / `verify-hmac`) replay the
 archived `.gz` segments in date order before the live files, so the chain
-verifies end to end across the archive boundary. Do **not** hand-prune or
-rename files under `archive/`: removing a segment breaks the chain linkage
-and a deleted or byte-edited segment is reported as a verification failure
-naming that segment.
+verifies end to end across the archive boundary:
+
+```shell
+# Verify the full HMAC chain, including archived segments.
+bernstein audit verify-hmac
+```
+
+Do **not** hand-prune or rename files under `archive/`: removing a segment
+breaks the chain linkage, and a deleted or byte-edited segment is reported as
+a verification failure naming that segment.
 
 **Key handling.** The HMAC key lives **outside** the audit directory so an
 attacker with write access to the JSONL files cannot also read or rotate

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -239,7 +239,15 @@ over the previous event's HMAC and the current event's payload, forming a
 hash chain that breaks if any record is rewritten or deleted.
 
 **Storage.** One JSONL file per UTC day in `.sdd/audit/YYYY-MM-DD.jsonl`.
-Default retention: 90 days (`audit.py:40`).
+Default retention: 90 days (`audit.py:40`). Files older than the retention
+window are gzip-compressed into `.sdd/audit/archive/YYYY-MM-DD.jsonl.gz` by
+`AuditLog.archive`. Archived segments remain first-class chain links:
+`AuditLog.verify` (and `bernstein audit verify` / `verify-hmac`) replay the
+archived `.gz` segments in date order before the live files, so the chain
+verifies end to end across the archive boundary. Do **not** hand-prune or
+rename files under `archive/`: removing a segment breaks the chain linkage
+and a deleted or byte-edited segment is reported as a verification failure
+naming that segment.
 
 **Key handling.** The HMAC key lives **outside** the audit directory so an
 attacker with write access to the JSONL files cannot also read or rotate

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -34,6 +34,12 @@ from typing import Any
 
 _JSONL_GLOB = "*.jsonl"
 
+#: Glob for archived (gzip-compressed) daily segments under the archive
+#: subdirectory.  ``archive`` writes ``<YYYY-MM-DD>.jsonl.gz``; the verifier
+#: and chain-recovery paths treat these as first-class chain links rather
+#: than out-of-band cold storage (issue #1835).
+_ARCHIVED_GLOB = "*.jsonl.gz"
+
 logger = logging.getLogger(__name__)
 
 _GENESIS_HMAC = "0" * 64
@@ -256,16 +262,29 @@ def _split_jsonl_bytes(raw_bytes: bytes) -> list[bytes]:
     return parts
 
 
-def _verify_log_file(log_path: Path, prev_hmac: str, key: bytes, errors: list[str]) -> str:
-    """Verify all entries in a single JSONL log file, appending errors."""
-    raw_bytes = log_path.read_bytes()
+def _verify_log_bytes(
+    raw_bytes: bytes,
+    display_name: str,
+    prev_hmac: str,
+    key: bytes,
+    errors: list[str],
+) -> str:
+    """Verify the JSONL entries in ``raw_bytes``, appending errors.
+
+    ``display_name`` is the name used in every error message so callers can
+    point at either a live ``*.jsonl`` file or an archived ``*.jsonl.gz``
+    segment.  Verification is byte-for-byte identical for both: an archived
+    segment is decompressed to its original bytes and run through the same
+    canonicalisation, ``prev_hmac`` linkage, and HMAC checks, so archived
+    history stays exactly as tamper-evident as live history (issue #1835).
+    """
     if raw_bytes and not raw_bytes.endswith(b"\n"):
         # The writer always terminates with ``\n``; absence is itself
         # tamper-evidence (e.g. ``\n`` flipped to ``\v`` at EOF). Continue
         # into the per-line loop so a truncated last record is still
         # surfaced as ``invalid JSON`` for callers that key on that
         # message (test_partial_last_line_flagged_as_invalid_json).
-        errors.append(f"{log_path.name}: missing trailing newline")
+        errors.append(f"{display_name}: missing trailing newline")
 
     for line_no, raw_line in enumerate(_split_jsonl_bytes(raw_bytes), start=1):
         if raw_line == b"":
@@ -273,10 +292,10 @@ def _verify_log_file(log_path: Path, prev_hmac: str, key: bytes, errors: list[st
         try:
             entry = json.loads(raw_line)
         except json.JSONDecodeError as exc:
-            errors.append(f"{log_path.name}:{line_no}: invalid JSON - {exc}")
+            errors.append(f"{display_name}:{line_no}: invalid JSON - {exc}")
             continue
         if not isinstance(entry, dict):
-            errors.append(f"{log_path.name}:{line_no}: entry is not a JSON object")
+            errors.append(f"{display_name}:{line_no}: entry is not a JSON object")
             continue
 
         # Tamper-evidence beyond JSON: ``json.loads`` accepts incidental
@@ -287,7 +306,7 @@ def _verify_log_file(log_path: Path, prev_hmac: str, key: bytes, errors: list[st
         # surfaced as a verification failure.
         canonical = json.dumps(entry, sort_keys=True).encode()
         if canonical != raw_line:
-            errors.append(f"{log_path.name}:{line_no}: non-canonical line bytes")
+            errors.append(f"{display_name}:{line_no}: non-canonical line bytes")
             continue
 
         stored_hmac = entry.pop("hmac", "")
@@ -298,17 +317,94 @@ def _verify_log_file(log_path: Path, prev_hmac: str, key: bytes, errors: list[st
         # network surface.
         if not _hmac.compare_digest(entry_prev, prev_hmac):
             errors.append(
-                f"{log_path.name}:{line_no}: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {entry_prev[:16]}…)"
+                f"{display_name}:{line_no}: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {entry_prev[:16]}…)"
             )
 
         expected_hmac = _compute_hmac(key, prev_hmac, entry)
         if not _hmac.compare_digest(stored_hmac, expected_hmac):
             errors.append(
-                f"{log_path.name}:{line_no}: HMAC mismatch (expected {expected_hmac[:16]}…, got {stored_hmac[:16]}…)"
+                f"{display_name}:{line_no}: HMAC mismatch (expected {expected_hmac[:16]}…, got {stored_hmac[:16]}…)"
             )
 
         prev_hmac = stored_hmac
     return prev_hmac
+
+
+def _verify_log_file(log_path: Path, prev_hmac: str, key: bytes, errors: list[str]) -> str:
+    """Verify all entries in a single live JSONL log file, appending errors."""
+    return _verify_log_bytes(log_path.read_bytes(), log_path.name, prev_hmac, key, errors)
+
+
+def _read_archived_segment(gz_path: Path, errors: list[str]) -> bytes | None:
+    """Decompress an archived ``*.jsonl.gz`` segment to its original bytes.
+
+    A truncated or corrupt archive (e.g. a crash mid-``archive``) degrades to
+    a clear, named error rather than an uncaught ``gzip``/``OSError``
+    traceback, keeping ``verify`` a total function over a possibly-damaged
+    archive directory.
+
+    Returns:
+        The decompressed bytes, or ``None`` if the segment is unreadable
+        (in which case an error has been appended to ``errors``).
+    """
+    try:
+        with gzip.open(gz_path, "rb") as fh:
+            return fh.read()
+    except (OSError, EOFError) as exc:
+        errors.append(f"{gz_path.name}: unreadable archived segment - {exc}")
+        return None
+
+
+def _chain_tail_from_lines(lines: list[str]) -> str | None:
+    """Return the last ``hmac`` in ``lines`` (scanning in reverse), or None.
+
+    Shared by live-file and archived-segment chain recovery so both resolve
+    the tip with byte-identical line semantics.  A line that is blank or not
+    a JSON object carrying ``hmac`` is skipped, mirroring the tolerance the
+    recovery path needs for a freshly-rotated empty file or a crash mid-line.
+    """
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict) and "hmac" in entry:
+            return str(entry["hmac"])
+    return None
+
+
+def _archived_segment_paths(audit_dir: Path, policy: RetentionPolicy | None = None) -> list[Path]:
+    """Return archived ``*.jsonl.gz`` segments ordered by their embedded date.
+
+    Ordering is load-bearing: the verifier must replay archived segments in
+    chronological order *before* the live ``*.jsonl`` files so ``prev_hmac``
+    linkage is continuous from genesis to tail.  The sort key is the
+    ``YYYY-MM-DD`` date parsed from the filename (``<date>.jsonl.gz``); the
+    full name is the tie-breaker so two segments that somehow share a date
+    still order deterministically.  Files whose name does not start with a
+    parseable date sort last (by name) so a hand-renamed archive cannot
+    silently jump ahead of dated segments and forge a false ordering.
+    """
+    policy = policy or RetentionPolicy()
+    archive_dir = audit_dir / policy.archive_subdir
+    if not archive_dir.is_dir():
+        return []
+
+    def _date_key(path: Path) -> tuple[int, str, str]:
+        # ``<date>.jsonl.gz`` -> stem ``<date>.jsonl`` -> ``Path.stem`` again
+        # is brittle, so derive the date token from the leading filename part.
+        date_token = path.name.split(".", 1)[0]
+        try:
+            datetime.strptime(date_token, "%Y-%m-%d")
+        except ValueError:
+            # Undated/renamed segments sort after all dated ones.
+            return (1, "", path.name)
+        return (0, date_token, path.name)
+
+    return sorted(archive_dir.glob(_ARCHIVED_GLOB), key=_date_key)
 
 
 def _matches_query_filters(
@@ -367,26 +463,36 @@ class AuditLog:
     def _recover_chain_tail(self) -> str:
         """Walk existing logs in reverse to find the last valid HMAC.
 
-        Walks every ``*.jsonl`` file from newest to oldest, scanning each
-        file's lines in reverse, and returns the first line that parses
-        to a dict carrying an ``hmac`` field.  Earlier-only inspection of
-        the lex-last file would silently fork the chain when that file is
-        empty/truncated (e.g. a freshly-rotated day with no events yet,
-        or a writer crash mid-line) - see test_truncated_last_file_does_
-        not_fork_chain in tests/property/test_audit_chain_bughunt.py.
+        Walks every live ``*.jsonl`` file from newest to oldest, then falls
+        back to archived ``*.jsonl.gz`` segments (also newest-date first),
+        scanning each segment's lines in reverse, and returns the first line
+        that parses to a dict carrying an ``hmac`` field.  Earlier-only
+        inspection of the lex-last file would silently fork the chain when
+        that file is empty/truncated (e.g. a freshly-rotated day with no
+        events yet, or a writer crash mid-line) - see
+        test_truncated_last_file_does_not_fork_chain in
+        tests/property/test_audit_chain_bughunt.py.  Including archived
+        segments means a writer reopening a log whose only events have aged
+        into the archive resumes from the true tip instead of forking back
+        to genesis (issue #1835).
         """
-        log_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
-        for log_path in reversed(log_files):
-            for line in reversed(log_path.read_text().splitlines()):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(entry, dict) and "hmac" in entry:
-                    return str(entry["hmac"])
+        live_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
+        for log_path in reversed(live_files):
+            tip = _chain_tail_from_lines(log_path.read_text().splitlines())
+            if tip is not None:
+                return tip
+
+        for gz_path in reversed(_archived_segment_paths(self._audit_dir)):
+            try:
+                with gzip.open(gz_path, "rb") as fh:
+                    text = fh.read().decode()
+            except (OSError, EOFError):
+                # A corrupt archived segment cannot yield a trustworthy tip;
+                # skip it and keep looking at older segments.
+                continue
+            tip = _chain_tail_from_lines(text.splitlines())
+            if tip is not None:
+                return tip
         return _GENESIS_HMAC
 
     # -- write --------------------------------------------------------------
@@ -453,19 +559,35 @@ class AuditLog:
     # -- verify -------------------------------------------------------------
 
     def verify(self) -> tuple[bool, list[str]]:
-        """Walk all JSONL files and verify the HMAC chain.
+        """Walk archived then live JSONL segments and verify the HMAC chain.
+
+        Archived ``*.jsonl.gz`` segments are replayed first, in chronological
+        (filename-date) order, then the live ``*.jsonl`` files, so the
+        ``prev_hmac`` linkage is continuous from genesis to tail across the
+        retention/archive boundary (issue #1835).  A flipped byte inside a
+        ``.gz`` segment, or a deleted segment, surfaces as an HMAC/linkage
+        error naming the segment rather than passing silently.
 
         Returns:
             ``(valid, errors)`` where *valid* is True when the entire chain
             is intact and *errors* lists any violations found.
         """
         errors: list[str] = []
-        log_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
-        if not log_files:
+        archived = _archived_segment_paths(self._audit_dir)
+        live_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
+        if not archived and not live_files:
             return True, []
 
         prev_hmac = _GENESIS_HMAC
-        for log_path in log_files:
+        for gz_path in archived:
+            raw = _read_archived_segment(gz_path, errors)
+            if raw is None:
+                # Cannot establish linkage past an unreadable segment; the
+                # error is already recorded, so stop rather than mis-seed the
+                # live files from a wrong (genesis) prev_hmac.
+                return False, errors
+            prev_hmac = _verify_log_bytes(raw, gz_path.name, prev_hmac, self._key, errors)
+        for log_path in live_files:
             prev_hmac = _verify_log_file(log_path, prev_hmac, self._key, errors)
 
         return len(errors) == 0, errors
@@ -512,12 +634,18 @@ class AuditLog:
                 skipped.append(log_path.name)
                 continue
 
-            with log_path.open("rb") as f_in, gzip.open(gz_path, "wb") as f_out:
+            # Crash-safe compress: write to a sibling temp file and atomically
+            # rename into place, so a crash mid-archive never leaves a partial
+            # ``.gz`` that the verifier would later read (the original
+            # ``.jsonl`` is only unlinked once the full ``.gz`` is on disk).
+            tmp_path = gz_path.with_name(f"{gz_path.name}.tmp")
+            with log_path.open("rb") as f_in, gzip.open(tmp_path, "wb") as f_out:
                 shutil.copyfileobj(f_in, f_out)
+            tmp_path.replace(gz_path)
 
             log_path.unlink()
             archived.append(log_path.name)
-            logger.info("Archived audit log %s → %s", log_path.name, gz_path.name)
+            logger.info("Archived audit log %s -> %s", log_path.name, gz_path.name)
 
         return ArchiveResult(
             archived=archived,

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -243,6 +243,18 @@ def test_retention_policy_defaults() -> None:
 # -- archive-boundary chain verification (issue #1835) -----------------
 
 
+def _single_live_log(audit_dir: Path) -> Path:
+    """Return the sole live ``*.jsonl`` file in ``audit_dir``.
+
+    The chain-builder helpers append all events in one shot, so exactly one
+    daily file exists; resolving it (instead of recomputing today's date)
+    keeps date derivation immune to a UTC midnight roll-over mid-helper.
+    """
+    live = sorted(audit_dir.glob("*.jsonl"))
+    assert len(live) == 1, f"expected exactly one live log, found {[p.name for p in live]}"
+    return live[0]
+
+
 def _build_two_day_chain(audit_dir: Path, key: bytes = b"test-key") -> tuple[str, str]:
     """Build a genuine HMAC chain split across two dated JSONL files.
 
@@ -262,12 +274,16 @@ def _build_two_day_chain(audit_dir: Path, key: bytes = b"test-key") -> tuple[str
     log.log("e2", "a2", "r2", "i2")
     log.log("e3", "a3", "r3", "i3")
 
-    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
-    today_path = audit_dir / f"{today}.jsonl"
+    # Anchor every derived date on the file ``log`` actually wrote rather than
+    # a fresh ``datetime.now`` call: a UTC midnight roll-over between the log
+    # calls and date derivation would otherwise drift the filenames and flake
+    # the test. There is exactly one live file at this point.
+    today_path = _single_live_log(audit_dir)
+    today_date = datetime.strptime(today_path.stem, "%Y-%m-%d").replace(tzinfo=UTC)
     lines = today_path.read_text().splitlines()
     assert len(lines) == 3
 
-    yesterday = (datetime.now(tz=UTC) - timedelta(days=1)).strftime("%Y-%m-%d")
+    yesterday = (today_date - timedelta(days=1)).strftime("%Y-%m-%d")
     old_path = audit_dir / f"{yesterday}.jsonl"
     # First two events live in the older (archivable) file; the third
     # event - whose prev_hmac links back into the older file - stays live.
@@ -293,13 +309,15 @@ def _build_three_day_chain(audit_dir: Path, key: bytes = b"test-key") -> tuple[s
     for i in range(1, 6):
         log.log(f"e{i}", f"a{i}", f"r{i}", f"i{i}")
 
-    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
-    today_path = audit_dir / f"{today}.jsonl"
+    # Anchor on the file ``log`` wrote (see ``_build_two_day_chain``) so a
+    # midnight roll-over cannot drift the derived dates.
+    today_path = _single_live_log(audit_dir)
+    today_date = datetime.strptime(today_path.stem, "%Y-%m-%d").replace(tzinfo=UTC)
     lines = today_path.read_text().splitlines()
     assert len(lines) == 5
 
-    day1 = (datetime.now(tz=UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
-    day2 = (datetime.now(tz=UTC) - timedelta(days=1)).strftime("%Y-%m-%d")
+    day1 = (today_date - timedelta(days=2)).strftime("%Y-%m-%d")
+    day2 = (today_date - timedelta(days=1)).strftime("%Y-%m-%d")
     day1_path = audit_dir / f"{day1}.jsonl"
     day2_path = audit_dir / f"{day2}.jsonl"
     day1_path.write_text("\n".join(lines[:2]) + "\n")

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -238,3 +238,177 @@ def test_retention_policy_defaults() -> None:
     p = RetentionPolicy()
     assert p.retention_days == 90
     assert p.archive_subdir == "archive"
+
+
+# -- archive-boundary chain verification (issue #1835) -----------------
+
+
+def _build_two_day_chain(audit_dir: Path, key: bytes = b"test-key") -> tuple[str, str]:
+    """Build a genuine HMAC chain split across two dated JSONL files.
+
+    Events are produced via the real :meth:`AuditLog.log` API so the chain
+    is byte-identical to production output, then the first events are moved
+    into a file dated one day in the past while the remainder stay in
+    today's file. The result is a single continuous chain whose link
+    crosses the ``<yesterday> -> <today>`` file boundary, which is exactly
+    the boundary :meth:`AuditLog.archive` later compresses.
+
+    Returns:
+        ``(old_name, today_name)`` - the two dated filenames written.
+    """
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=key)
+    log.log("e1", "a1", "r1", "i1")
+    log.log("e2", "a2", "r2", "i2")
+    log.log("e3", "a3", "r3", "i3")
+
+    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    today_path = audit_dir / f"{today}.jsonl"
+    lines = today_path.read_text().splitlines()
+    assert len(lines) == 3
+
+    yesterday = (datetime.now(tz=UTC) - timedelta(days=1)).strftime("%Y-%m-%d")
+    old_path = audit_dir / f"{yesterday}.jsonl"
+    # First two events live in the older (archivable) file; the third
+    # event - whose prev_hmac links back into the older file - stays live.
+    old_path.write_text("\n".join(lines[:2]) + "\n")
+    today_path.write_text(lines[2] + "\n")
+    return old_path.name, today_path.name
+
+
+def _build_three_day_chain(audit_dir: Path, key: bytes = b"test-key") -> tuple[str, str, str]:
+    """Build a genuine HMAC chain split across three dated JSONL files.
+
+    Like :func:`_build_two_day_chain` but produces two archivable older days
+    plus today, so a test can archive *both* older days and then damage one
+    archived segment while a *later* archived segment still exists - the
+    linkage break is then only observable by a verifier that actually reads
+    archived segments in order (issue #1835).
+
+    Returns:
+        ``(day1_name, day2_name, today_name)`` oldest-first.
+    """
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=key)
+    for i in range(1, 6):
+        log.log(f"e{i}", f"a{i}", f"r{i}", f"i{i}")
+
+    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    today_path = audit_dir / f"{today}.jsonl"
+    lines = today_path.read_text().splitlines()
+    assert len(lines) == 5
+
+    day1 = (datetime.now(tz=UTC) - timedelta(days=2)).strftime("%Y-%m-%d")
+    day2 = (datetime.now(tz=UTC) - timedelta(days=1)).strftime("%Y-%m-%d")
+    day1_path = audit_dir / f"{day1}.jsonl"
+    day2_path = audit_dir / f"{day2}.jsonl"
+    day1_path.write_text("\n".join(lines[:2]) + "\n")
+    day2_path.write_text("\n".join(lines[2:4]) + "\n")
+    today_path.write_text(lines[4] + "\n")
+    return day1_path.name, day2_path.name, today_path.name
+
+
+def test_verify_passes_across_archive_boundary(tmp_path: Path) -> None:
+    """An intact chain still verifies after the older day is archived.
+
+    Reproduces issue #1835: ``archive`` gzips and unlinks the older
+    ``.jsonl`` while ``verify`` only globs live ``*.jsonl`` and re-seeds from
+    genesis, so the first surviving entry's ``prev_hmac`` (which points into
+    the archived file) wrongly reports a mismatch.
+    """
+    audit_dir = tmp_path / "audit"
+    old_name, _today = _build_two_day_chain(audit_dir)
+
+    # Sanity: the un-archived split chain is valid end to end.
+    pre_valid, pre_errors = AuditLog(audit_dir, key=b"test-key").verify()
+    assert pre_valid is True, pre_errors
+
+    result = AuditLog(audit_dir, key=b"test-key").archive(RetentionPolicy(retention_days=0))
+    assert old_name in result.archived
+    assert not (audit_dir / old_name).exists()
+    assert (audit_dir / "archive" / f"{old_name}.gz").exists()
+
+    # The reopened log must verify across the archive boundary.
+    valid, errors = AuditLog(audit_dir, key=b"test-key").verify()
+    assert valid is True, errors
+    assert errors == []
+
+
+def test_verify_detects_tamper_inside_archived_segment(tmp_path: Path) -> None:
+    """Flipping a byte inside an archived .gz surfaces as an HMAC error."""
+    audit_dir = tmp_path / "audit"
+    old_name, _today = _build_two_day_chain(audit_dir)
+    AuditLog(audit_dir, key=b"test-key").archive(RetentionPolicy(retention_days=0))
+
+    gz_path = audit_dir / "archive" / f"{old_name}.gz"
+    payload = gzip.decompress(gz_path.read_bytes()).decode()
+    tampered = payload.replace('"a1"', '"tampered"')
+    assert tampered != payload
+    gz_path.write_bytes(gzip.compress(tampered.encode()))
+
+    valid, errors = AuditLog(audit_dir, key=b"test-key").verify()
+    assert valid is False
+    assert any("HMAC mismatch" in err for err in errors)
+    # The error must name the offending archived segment, not a live file.
+    assert any(gz_path.name in err for err in errors)
+
+
+def test_verify_detects_deleted_archived_segment(tmp_path: Path) -> None:
+    """Deleting an interior archived .gz surfaces as a linkage break.
+
+    Two older days are archived; the *earlier* archived segment is then
+    removed (as an operator pruning ``archive/`` to save space would).  The
+    surviving later archived segment's ``prev_hmac`` points into the deleted
+    one, so the chain must report a linkage break naming that segment - a
+    break only a verifier that reads archived segments can detect.
+    """
+    audit_dir = tmp_path / "audit"
+    day1_name, day2_name, _today = _build_three_day_chain(audit_dir)
+    result = AuditLog(audit_dir, key=b"test-key").archive(RetentionPolicy(retention_days=0))
+    assert day1_name in result.archived
+    assert day2_name in result.archived
+
+    (audit_dir / "archive" / f"{day1_name}.gz").unlink()
+    surviving = f"{day2_name}.gz"
+
+    valid, errors = AuditLog(audit_dir, key=b"test-key").verify()
+    assert valid is False
+    assert any("prev_hmac mismatch" in err for err in errors)
+    # The break must be attributed to the now-orphaned surviving segment.
+    assert any(surviving in err and "prev_hmac mismatch" in err for err in errors)
+
+
+def test_verify_no_archive_unchanged(tmp_path: Path) -> None:
+    """A chain with zero archived segments verifies exactly as before."""
+    audit_dir = tmp_path / "audit"
+    log = AuditLog(audit_dir, key=b"test-key")
+    log.log("e1", "a1", "r1", "i1")
+    log.log("e2", "a2", "r2", "i2")
+
+    valid, errors = AuditLog(audit_dir, key=b"test-key").verify()
+    assert valid is True
+    assert errors == []
+
+
+def test_recover_chain_tail_stable_across_archive(tmp_path: Path) -> None:
+    """The recovered tip is identical whether or not old days are archived.
+
+    Guards the writer path: a process reopening an archived log must resume
+    from the true chain tip so a freshly appended event does not fork the
+    chain back to genesis.
+    """
+    audit_dir = tmp_path / "audit"
+    _build_two_day_chain(audit_dir)
+
+    tip_before = AuditLog(audit_dir, key=b"test-key")._prev_hmac  # pyright: ignore[reportPrivateUsage]
+
+    AuditLog(audit_dir, key=b"test-key").archive(RetentionPolicy(retention_days=0))
+
+    tip_after = AuditLog(audit_dir, key=b"test-key")._prev_hmac  # pyright: ignore[reportPrivateUsage]
+    assert tip_after == tip_before
+
+    # Appending after reopening an archived log keeps the chain intact.
+    reopened = AuditLog(audit_dir, key=b"test-key")
+    reopened.log("e4", "a4", "r4", "i4")
+    valid, errors = AuditLog(audit_dir, key=b"test-key").verify()
+    assert valid is True, errors


### PR DESCRIPTION
## Summary

- `AuditLog.archive` gzip-compresses daily logs older than the retention window into `archive/<date>.jsonl.gz` and unlinks the original, but `verify` and `_recover_chain_tail` only globbed the live `*.jsonl` files. After a single archive pass the first surviving entry's `prev_hmac` points at an archived (now invisible) event while `verify` re-seeds from genesis, so an intact chain reports a `prev_hmac mismatch` once it ages past the retention window.
- `verify` and `_recover_chain_tail` now walk archived `.gz` segments in chronological (filename-date) order before the live files, decompressing each and running the byte-identical verification used for live files. Archived segments are first-class chain links: a flipped byte or a deleted segment surfaces as an HMAC/linkage error naming the segment instead of passing silently.
- `archive` now compresses via a temp file plus atomic rename, so a crash mid-archive cannot leave a partial `.gz` that the verifier would later read; an unreadable archived segment degrades to a clear named error rather than a traceback.

## Behaviour change

Operators who externally prune or rename files under `.sdd/audit/archive/` will now see a verification failure (correct: the chain linkage is genuinely broken). Documented in `docs/operations/security-and-identity.md`.

## Test plan

- [x] `pytest tests/unit/test_audit.py -k "archive or verify"` (issue command) passes.
- [x] New regression tests: append events, `archive(RetentionPolicy(retention_days=0))`, then `verify()` returns `(True, [])` across the boundary; each new test verified red without the fix and green with it (red-green cycle).
- [x] Tamper inside an archived `.gz` reports an HMAC mismatch naming that segment; deleting an interior archived segment reports a `prev_hmac` linkage break (not a pass).
- [x] A chain with zero archived segments verifies identically (no regression for the common case).
- [x] `_recover_chain_tail` recovers the same tip whether or not older segments are archived, so a writer reopening an archived log does not fork the chain.
- [x] Full audit-chain test surface (unit, property bughunt, byteflip/mutation-kill, CLI) passes: 112 passed, 1 skipped, 1 xfailed.
- [x] `ruff check` + `ruff format --check` clean; pyright introduces zero new errors vs baseline.

Closes #1835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded audit-log retention/archival docs: archived gzip segments, verification behavior, and a warning not to manually edit or rename archived files.

* **Improvements**
  * Verification now treats archived segments as first-class and replays them in chronological order before live files to maintain chain continuity.
  * Chain recovery handles archived segments to avoid forking.
  * Archive compression is now crash-safe with atomic replacement.

* **Tests**
  * Added tests for archive-boundary verification, tamper detection, deletion handling, and recovery stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->