### PR TITLE
fix(persistence): revalidate journal hash chain on recovery (fail closed)

### DIFF
--- a/docs/operations/replay.md
+++ b/docs/operations/replay.md
@@ -61,6 +61,39 @@ to the tail. Errors surface as:
 Each error carries the offending line number so an operator can grep
 the file.
 
+## Recovery on open (fail-closed)
+
+`Journal.open` recovers the chain head before any new step is appended
+(after a crash, a restart, or when seeding a fork). Recovery **revalidates
+the hash chain** rather than trusting the last on-disk row: it walks the
+bucket from genesis, recomputes every `step_hash` with the same
+`compute_step_hash` primitive `verify` uses, checks `prev_hash` linkage and
+`seq` continuity, and takes the tip from the last *recomputed* hash.
+
+Recovery fails closed. If a parseable row does not verify - a recomputed
+`step_hash` that differs from the stored value, a `prev_hash` that does not
+chain onto the previous row, or a `seq` gap - `Journal.open` raises
+`JournalError` naming the offending line, instead of adopting the row and
+letting subsequent appends grow valid-looking children on a poisoned anchor.
+This closes the gap where a tampered or truncated-then-edited journal could
+be silently extended after a restart or a `session fork --from-step`.
+
+Distinct from tampering: a **torn or unparseable trailing line** (a writer
+killed mid-write) still degrades gracefully. Recovery stops at the last
+validated row and a subsequent append chains onto it, preserving the
+legitimate crash-recovery path. A malformed line that is *followed* by a
+well-formed row is treated as interior corruption and raises.
+
+Operator remedy when recovery refuses to open: the error names the bucket
+file and the offending line. Move the corrupt journal aside (for example,
+rename `000000.jsonl` to `000000.jsonl.corrupt`) so the agent can start a
+fresh chain, and keep the quarantined file for forensic inspection with
+`JournalReader.verify`.
+
+Cost note: recovery now recomputes every step hash on open (O(steps)) rather
+than reading the tail (O(1)). For very long single-agent runs this is a
+measurable - but bounded - startup cost, paid once per open.
+
 ## Fork-from-step
 
 `bernstein session fork <session_id> --from-step <n>` materialises a

--- a/src/bernstein/core/persistence/journal.py
+++ b/src/bernstein/core/persistence/journal.py
@@ -41,7 +41,13 @@ Storage layout
 ``<journal_root>/<bucket>.jsonl`` where ``<journal_root>`` is typically
 ``.sdd/runtime/journal/<agent_id>/``. One JSON object per line, one line
 per step, append-only. The chain head hash is recovered on open by
-walking the last bucket file from tail to head.
+walking the bucket file from genesis and **revalidating every step hash**
+(reusing ``compute_step_hash``); the tip is taken from the last recomputed
+hash, never read verbatim from the tail. Recovery fails closed: a parseable
+row whose chain does not verify raises :class:`JournalError` so a tampered
+or truncated-then-edited journal cannot be silently extended from a
+poisoned anchor (#1836). A torn/unparseable trailing line (crash mid-write)
+still degrades gracefully to the last validated row.
 
 Atomicity
 ---------
@@ -250,6 +256,131 @@ class VerificationResult:
 
 
 # ---------------------------------------------------------------------------
+# Recovery-time chain validation (#1836)
+# ---------------------------------------------------------------------------
+
+
+def _parse_journal_row(stripped: str) -> dict[str, Any] | None:
+    """Parse one stripped line into a journal row, or ``None`` if malformed.
+
+    A line is malformed (``None``) when it is not valid JSON, is not a JSON
+    object, or lacks the ``step_hash`` field - i.e. it cannot be a chain row.
+    Returning a concrete ``dict[str, Any]`` lets callers read fields without
+    re-narrowing on every access.
+    """
+    try:
+        row: Any = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(row, dict) or "step_hash" not in row:
+        return None
+    return row
+
+
+def _validate_chain_for_recovery(bucket_path: Path) -> tuple[str, int]:
+    """Walk *bucket_path* and revalidate the hash chain for tip recovery.
+
+    Returns ``(tip_hash, validated_count)`` where ``tip_hash`` is the last
+    *recomputed* ``step_hash`` (or :data:`GENESIS_HASH` for an empty file)
+    and ``validated_count`` is the number of rows that verified.
+
+    Fail-closed contract (the lever the replay/fork surface rests on):
+
+    * A parseable JSON object that is a journal row (has ``step_hash``) whose
+      recomputed ``step_hash`` does not match the stored value, whose
+      ``prev_hash`` does not chain onto the previous row, or whose ``seq``
+      skips a slot raises :class:`JournalError` naming the offending line.
+      This is interior/tail tampering and must not be silently adopted.
+    * A torn/unparseable trailing line (crash mid-write) is tolerated only
+      when it is the final non-empty line: recovery stops at the last
+      validated row. If a malformed line is *followed* by a well-formed row,
+      the malformed line is interior corruption and raises.
+
+    Reuses :func:`compute_step_hash` - the single chain primitive - so there
+    is no second hashing scheme to drift against :meth:`JournalReader.verify`.
+    """
+    prev_hash = GENESIS_HASH
+    expected_seq = 0
+    validated = 0
+    # A malformed line is only a legitimate torn tail if nothing well-formed
+    # follows it. Remember the first malformed line number and raise lazily if
+    # a later row proves it was an interior break.
+    pending_torn_line: int | None = None
+
+    with bucket_path.open(encoding="utf-8") as fh:
+        for line_no, raw in enumerate(fh, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+
+            row = _parse_journal_row(stripped)
+            if row is None:
+                # Defer: could be a torn final line (ok) or an interior break.
+                if pending_torn_line is None:
+                    pending_torn_line = line_no
+                continue
+
+            if pending_torn_line is not None:
+                # A well-formed row appeared after a malformed line: the
+                # earlier line was interior corruption, not a torn tail.
+                msg = (
+                    f"journal {bucket_path}: line {pending_torn_line} is corrupt but "
+                    f"line {line_no} continues the chain; refusing to recover across a "
+                    f"broken interior row. Move the journal aside to recover."
+                )
+                raise JournalError(msg)
+
+            seq = int(row.get("seq", -1))
+            if seq != expected_seq:
+                msg = (
+                    f"journal {bucket_path}: line {line_no} seq mismatch "
+                    f"(expected {expected_seq}, got {seq}); chain is broken. "
+                    f"Move the journal aside to recover."
+                )
+                raise JournalError(msg)
+
+            stored_prev = str(row.get("prev_hash", ""))
+            if stored_prev != prev_hash:
+                msg = (
+                    f"journal {bucket_path}: line {line_no} prev_hash mismatch "
+                    f"(expected {prev_hash[:16]}..., got {stored_prev[:16]}...); "
+                    f"chain is broken. Move the journal aside to recover."
+                )
+                raise JournalError(msg)
+
+            recomputed = compute_step_hash(
+                prev_hash=stored_prev,
+                input_hash=str(row.get("input_hash", "")),
+                model=row.get("model"),
+                prompt=row.get("prompt"),
+                tool_call=row.get("tool_call"),
+                tool_result=row.get("tool_result"),
+            )
+            stored_hash = str(row.get("step_hash", ""))
+            if recomputed != stored_hash:
+                msg = (
+                    f"journal {bucket_path}: line {line_no} step_hash mismatch "
+                    f"(recomputed {recomputed[:16]}..., stored {stored_hash[:16]}...); "
+                    f"the row is tampered or inconsistent. Move the journal aside to recover."
+                )
+                raise JournalError(msg)
+
+            prev_hash = stored_hash
+            expected_seq += 1
+            validated += 1
+
+    if pending_torn_line is not None:
+        logger.warning(
+            "journal %s: torn trailing line %d ignored; recovered %d validated step(s)",
+            bucket_path,
+            pending_torn_line,
+            validated,
+        )
+
+    return prev_hash, validated
+
+
+# ---------------------------------------------------------------------------
 # Journal (writer)
 # ---------------------------------------------------------------------------
 
@@ -395,36 +526,28 @@ class Journal:
     # -- internal -----------------------------------------------------------
 
     def _recover_tail(self) -> None:
-        """Walk the bucket file from tail to head to recover ``tip_hash`` + ``seq``."""
+        """Recover ``tip_hash`` + ``seq`` by revalidating the chain on open.
+
+        The tip is recovered from the last *recomputed* ``step_hash`` and
+        ``seq`` is set to the count of validated rows - never read verbatim
+        from the tail. Recovery fails closed (#1836): a parseable row whose
+        chain does not verify (recomputed ``step_hash`` mismatch, ``prev_hash``
+        break, or ``seq`` gap) raises :class:`JournalError` naming the
+        offending line, so a tampered or truncated-then-edited journal cannot
+        be silently extended from a poisoned anchor. A torn/unparseable
+        trailing line (crash mid-write) still degrades gracefully to the last
+        validated row, preserving legitimate crash recovery.
+        """
         if not self._bucket_path.exists():
             return
-        # We scan the whole file because the chain may have been touched by
-        # a previous, crashed process. Re-validating on open is cheap relative
-        # to the rest of the agent lifecycle.
-        last_seq = -1
-        last_hash = GENESIS_HASH
         try:
-            with self._bucket_path.open(encoding="utf-8") as fh:
-                for raw in fh:
-                    stripped = raw.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        row = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        # Truncated / torn tail: stop and trust the prior good entry.
-                        logger.warning("journal %s: skipping unparseable tail line", self._bucket_path)
-                        continue
-                    if not isinstance(row, dict):
-                        continue
-                    last_seq = int(row.get("seq", last_seq + 1))
-                    last_hash = str(row.get("step_hash", last_hash))
+            tip_hash, validated = _validate_chain_for_recovery(self._bucket_path)
         except OSError as exc:
             msg = f"journal recovery failed: {exc}"
             raise JournalError(msg) from exc
 
-        self._tip_hash = last_hash
-        self._seq = last_seq + 1
+        self._tip_hash = tip_hash
+        self._seq = validated
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/persistence/journal.py
+++ b/src/bernstein/core/persistence/journal.py
@@ -330,7 +330,16 @@ def _validate_chain_for_recovery(bucket_path: Path) -> tuple[str, int]:
                 )
                 raise JournalError(msg)
 
-            seq = int(row.get("seq", -1))
+            raw_seq = row.get("seq", -1)
+            try:
+                seq = int(raw_seq)
+            except (TypeError, ValueError) as exc:
+                msg = (
+                    f"journal {bucket_path}: line {line_no} has a non-integer seq "
+                    f"(got {raw_seq!r}); the row is tampered or inconsistent. "
+                    f"Move the journal aside to recover."
+                )
+                raise JournalError(msg) from exc
             if seq != expected_seq:
                 msg = (
                     f"journal {bucket_path}: line {line_no} seq mismatch "

--- a/tests/unit/test_journal_chain.py
+++ b/tests/unit/test_journal_chain.py
@@ -26,6 +26,7 @@ import json
 import os
 import threading
 from pathlib import Path
+from typing import Any, TypedDict
 
 import pytest
 
@@ -37,6 +38,26 @@ from bernstein.core.persistence.journal import (
     canonical_step_payload,
     compute_step_hash,
 )
+
+
+class JournalRow(TypedDict, total=False):
+    """On-disk shape of one journal row, mirroring :class:`JournalEntry`.
+
+    ``total=False`` because recovery tests deliberately omit or mangle fields
+    to exercise the fail-closed paths.
+    """
+
+    seq: int
+    prev_hash: str
+    input_hash: str
+    model: str | None
+    prompt: str | None
+    tool_call: Any
+    tool_result: Any
+    step_hash: str
+    ts: float
+    blob_refs: list[str]
+
 
 # ---------------------------------------------------------------------------
 # Step-hash determinism + canonical encoding contract
@@ -261,12 +282,13 @@ class TestRecoveryRevalidation:
     recovery)."""
 
     @staticmethod
-    def _rows(agent_dir: Path) -> list[dict]:
+    def _rows(agent_dir: Path) -> list[JournalRow]:
         log_file = next(agent_dir.glob("*.jsonl"))
-        return [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+        rows: list[JournalRow] = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+        return rows
 
     @staticmethod
-    def _write_rows(agent_dir: Path, rows: list[dict]) -> None:
+    def _write_rows(agent_dir: Path, rows: list[JournalRow]) -> None:
         log_file = next(agent_dir.glob("*.jsonl"))
         lines = [json.dumps(r, sort_keys=True, separators=(",", ":")) for r in rows]
         log_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -284,6 +306,7 @@ class TestRecoveryRevalidation:
         reopened = Journal.open(agent_dir)
         assert reopened.head_hash == head == entries[-1].step_hash
         assert reopened.next_seq == next_seq == 4
+        reopened.close()
 
     def test_reopen_rejects_tampered_final_step_hash(self, tmp_path: Path) -> None:
         """A final row whose stored ``step_hash`` does not match its recomputed
@@ -362,6 +385,25 @@ class TestRecoveryRevalidation:
         with pytest.raises(JournalError):
             Journal.open(agent_dir)
 
+    def test_reopen_non_integer_seq_raises_journal_error(self, tmp_path: Path) -> None:
+        """A tampered non-integer ``seq`` must surface as the operator-actionable
+        :class:`JournalError` (with line + remedy), never a raw ``ValueError``
+        that escapes the fail-closed contract."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        journal.append(input_hash="aa", model="m1", prompt="p1")
+        journal.close()
+
+        rows = self._rows(agent_dir)
+        # Deliberately violate the JournalRow contract: a non-integer seq is
+        # exactly the tampered shape recovery must reject.
+        rows[0]["seq"] = "abc"  # type: ignore[typeddict-item]
+        self._write_rows(agent_dir, rows)
+
+        with pytest.raises(JournalError) as exc_info:
+            Journal.open(agent_dir)
+        assert "line 1" in str(exc_info.value)
+
     def test_reopen_torn_final_line_recovers_last_good_entry(self, tmp_path: Path) -> None:
         """Existing crash-recovery behaviour preserved: a torn/unparseable
         trailing line degrades gracefully to the last validated row, and a
@@ -382,6 +424,7 @@ class TestRecoveryRevalidation:
         e1 = reopened.append(input_hash="bb", model="m1", prompt="p2")
         assert e1.prev_hash == e0.step_hash
         assert e1.seq == 1
+        reopened.close()
 
     def test_reopen_empty_journal_recovers_genesis(self, tmp_path: Path) -> None:
         """An empty bucket file (header-less, zero entries) recovers to
@@ -394,6 +437,7 @@ class TestRecoveryRevalidation:
 
         assert reopened.head_hash == GENESIS_HASH
         assert reopened.next_seq == 0
+        reopened.close()
 
     def test_fork_seed_rejects_corrupt_parent_journal(self, tmp_path: Path) -> None:
         """``session fork --from-step`` seeds parent entries into a fork bucket
@@ -402,7 +446,9 @@ class TestRecoveryRevalidation:
         not silently produce a fork whose first step chains onto an
         unvalidated hash (#1836 AC4)."""
         from bernstein.core.persistence.journal import agent_journal_dir
-        from bernstein.core.sessions.fork import _seed_fork_journal
+        from bernstein.core.sessions.fork import (
+            _seed_fork_journal,  # pyright: ignore[reportPrivateUsage]
+        )
 
         # Build a genuine parent chain, then poison the last entry's stored
         # step_hash so the seeded fork chain does not verify.
@@ -443,7 +489,9 @@ class TestRecoveryRevalidation:
         """The intact-parent path still works: seeding a valid chain recovers
         the parent's head so the fork's first append chains onto it."""
         from bernstein.core.persistence.journal import agent_journal_dir
-        from bernstein.core.sessions.fork import _seed_fork_journal
+        from bernstein.core.sessions.fork import (
+            _seed_fork_journal,  # pyright: ignore[reportPrivateUsage]
+        )
 
         parent_dir = tmp_path / "parent" / ".sdd"
         parent_journal_dir = agent_journal_dir(parent_dir, "parent-agent")
@@ -464,6 +512,7 @@ class TestRecoveryRevalidation:
         reopened = Journal.open(fork_journal_dir)
         assert reopened.head_hash == e1.step_hash
         assert reopened.next_seq == 2
+        reopened.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_journal_chain.py
+++ b/tests/unit/test_journal_chain.py
@@ -244,6 +244,229 @@ class TestJournalAppend:
 
 
 # ---------------------------------------------------------------------------
+# Recovery revalidates the hash chain on open (#1836)
+# ---------------------------------------------------------------------------
+
+
+class TestRecoveryRevalidation:
+    """``Journal.open`` must revalidate the hash chain when recovering the
+    tip, rather than trusting the last on-disk ``step_hash``/``seq`` verbatim.
+
+    Recovery fails closed: a parseable-but-inconsistent row (recomputed
+    ``step_hash`` mismatch, ``prev_hash`` break, or ``seq`` gap) raises
+    :class:`JournalError` at open time and names the offending line, so a
+    tampered or truncated-then-edited journal cannot grow valid-looking
+    children on a poisoned anchor. A torn/unparseable trailing line still
+    degrades gracefully to the last validated row (legitimate crash
+    recovery)."""
+
+    @staticmethod
+    def _rows(agent_dir: Path) -> list[dict]:
+        log_file = next(agent_dir.glob("*.jsonl"))
+        return [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+
+    @staticmethod
+    def _write_rows(agent_dir: Path, rows: list[dict]) -> None:
+        log_file = next(agent_dir.glob("*.jsonl"))
+        lines = [json.dumps(r, sort_keys=True, separators=(",", ":")) for r in rows]
+        log_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def test_reopen_intact_chain_recovers_same_head_and_seq(self, tmp_path: Path) -> None:
+        """No regression: an intact multi-entry chain recovers the identical
+        ``head_hash`` and ``next_seq`` it had before close."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        entries = [journal.append(input_hash=f"a{i}", model="m1", prompt=f"p{i}") for i in range(4)]
+        head = journal.head_hash
+        next_seq = journal.next_seq
+        journal.close()
+
+        reopened = Journal.open(agent_dir)
+        assert reopened.head_hash == head == entries[-1].step_hash
+        assert reopened.next_seq == next_seq == 4
+
+    def test_reopen_rejects_tampered_final_step_hash(self, tmp_path: Path) -> None:
+        """A final row whose stored ``step_hash`` does not match its recomputed
+        value must not be adopted as the tip. ``Journal.open`` fails closed."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        journal.append(input_hash="aa", model="m1", prompt="p1")
+        journal.append(input_hash="bb", model="m1", prompt="p2")
+        journal.close()
+
+        # Replace the last row's step_hash with a wrong-but-well-formed value.
+        rows = self._rows(agent_dir)
+        rows[-1]["step_hash"] = "1" * 64
+        self._write_rows(agent_dir, rows)
+
+        with pytest.raises(JournalError) as exc_info:
+            Journal.open(agent_dir)
+        # The error names the offending line so an operator can grep the file.
+        assert "line 2" in str(exc_info.value)
+
+    def test_reopen_then_append_then_verify_is_clean(self, tmp_path: Path) -> None:
+        """After recovery rejects a tampered tip, restoring the genuine row
+        lets a reopen + append + verify run fully clean - proving recovery did
+        not leave a poisoned anchor behind."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        journal.append(input_hash="aa", model="m1", prompt="p1")
+        e1 = journal.append(input_hash="bb", model="m1", prompt="p2")
+        journal.close()
+
+        reopened = Journal.open(agent_dir)
+        e2 = reopened.append(input_hash="cc", model="m1", prompt="p3")
+        reopened.close()
+        assert e2.prev_hash == e1.step_hash
+        assert e2.seq == 2
+
+        reader = JournalReader(agent_dir)
+        result = reader.verify(expected_head=e2.step_hash)
+        assert result.ok, result.errors
+
+    def test_reopen_surfaces_interior_break_not_deferred(self, tmp_path: Path) -> None:
+        """A tampered *interior* row must surface at open time. The old
+        behaviour adopted the tail verbatim and let a later ``verify`` report
+        a chain that was "valid above a broken row"; recovery must catch the
+        break itself rather than defer it."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        for i in range(4):
+            journal.append(input_hash=f"a{i}", model="m1", prompt=f"p{i}")
+        journal.close()
+
+        # Tamper an interior row (index 1) in the same canonical form so only
+        # the chain check - not a byte check - can catch it.
+        rows = self._rows(agent_dir)
+        rows[1]["model"] = "evil"
+        self._write_rows(agent_dir, rows)
+
+        # Recovery must refuse to silently append onto the chain.
+        with pytest.raises(JournalError) as exc_info:
+            Journal.open(agent_dir)
+        assert "line 2" in str(exc_info.value)
+
+    def test_reopen_rejects_seq_gap(self, tmp_path: Path) -> None:
+        """A ``seq`` discontinuity is a chain break; recovery must not paper
+        over it by trusting the stored ``seq`` of the tail."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        journal.append(input_hash="aa", model="m1", prompt="p1")
+        journal.append(input_hash="bb", model="m1", prompt="p2")
+        journal.close()
+
+        rows = self._rows(agent_dir)
+        rows[1]["seq"] = 5  # gap: 0 then 5
+        self._write_rows(agent_dir, rows)
+
+        with pytest.raises(JournalError):
+            Journal.open(agent_dir)
+
+    def test_reopen_torn_final_line_recovers_last_good_entry(self, tmp_path: Path) -> None:
+        """Existing crash-recovery behaviour preserved: a torn/unparseable
+        trailing line degrades gracefully to the last validated row, and a
+        subsequent append chains onto it."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        e0 = journal.append(input_hash="aa", model="m1", prompt="p1")
+        journal.close()
+
+        # Simulate a crash mid-write: a torn (unparseable) trailing line.
+        log_file = next(agent_dir.glob("*.jsonl"))
+        with log_file.open("a", encoding="utf-8") as fh:
+            fh.write('{"seq":1,"prev_hash":"' + e0.step_hash + '","truncated":')
+
+        reopened = Journal.open(agent_dir)
+        assert reopened.head_hash == e0.step_hash
+        assert reopened.next_seq == 1
+        e1 = reopened.append(input_hash="bb", model="m1", prompt="p2")
+        assert e1.prev_hash == e0.step_hash
+        assert e1.seq == 1
+
+    def test_reopen_empty_journal_recovers_genesis(self, tmp_path: Path) -> None:
+        """An empty bucket file (header-less, zero entries) recovers to
+        genesis without raising."""
+        agent_dir = tmp_path / "agent-1"
+        journal = Journal.open(agent_dir)
+        journal.close()  # never appended; bucket may not even exist
+        reopened = Journal.open(agent_dir)
+        from bernstein.core.persistence.journal import GENESIS_HASH
+
+        assert reopened.head_hash == GENESIS_HASH
+        assert reopened.next_seq == 0
+
+    def test_fork_seed_rejects_corrupt_parent_journal(self, tmp_path: Path) -> None:
+        """``session fork --from-step`` seeds parent entries into a fork bucket
+        and round-trips through ``Journal.open`` to recover the head. A fork
+        seeded from a corrupt parent journal must be rejected at seed time,
+        not silently produce a fork whose first step chains onto an
+        unvalidated hash (#1836 AC4)."""
+        from bernstein.core.persistence.journal import agent_journal_dir
+        from bernstein.core.sessions.fork import _seed_fork_journal
+
+        # Build a genuine parent chain, then poison the last entry's stored
+        # step_hash so the seeded fork chain does not verify.
+        parent_dir = tmp_path / "parent" / ".sdd"
+        parent_journal_dir = agent_journal_dir(parent_dir, "parent-agent")
+        journal = Journal.open(parent_journal_dir)
+        journal.append(input_hash="aa", model="m1", prompt="p1")
+        journal.append(input_hash="bb", model="m1", prompt="p2")
+        journal.close()
+
+        entries = list(JournalReader(parent_journal_dir).entries())
+        # Tamper the tail entry the fork would inherit as its anchor.
+        tail = entries[-1]
+        poisoned = [
+            *entries[:-1],
+            JournalEntry(
+                seq=tail.seq,
+                prev_hash=tail.prev_hash,
+                input_hash=tail.input_hash,
+                model=tail.model,
+                prompt=tail.prompt,
+                tool_call=tail.tool_call,
+                tool_result=tail.tool_result,
+                step_hash="1" * 64,  # wrong-but-well-formed
+                ts=tail.ts,
+            ),
+        ]
+
+        fork_worktree = tmp_path / "fork-worktree"
+        with pytest.raises(JournalError):
+            _seed_fork_journal(
+                fork_worktree=fork_worktree,
+                fork_session_id="fork-agent",
+                entries=poisoned,
+            )
+
+    def test_fork_seed_accepts_intact_parent_journal(self, tmp_path: Path) -> None:
+        """The intact-parent path still works: seeding a valid chain recovers
+        the parent's head so the fork's first append chains onto it."""
+        from bernstein.core.persistence.journal import agent_journal_dir
+        from bernstein.core.sessions.fork import _seed_fork_journal
+
+        parent_dir = tmp_path / "parent" / ".sdd"
+        parent_journal_dir = agent_journal_dir(parent_dir, "parent-agent")
+        journal = Journal.open(parent_journal_dir)
+        journal.append(input_hash="aa", model="m1", prompt="p1")
+        e1 = journal.append(input_hash="bb", model="m1", prompt="p2")
+        journal.close()
+
+        entries = list(JournalReader(parent_journal_dir).entries())
+        fork_worktree = tmp_path / "fork-worktree"
+        _seed_fork_journal(
+            fork_worktree=fork_worktree,
+            fork_session_id="fork-agent",
+            entries=entries,
+        )
+
+        fork_journal_dir = agent_journal_dir(fork_worktree / ".sdd", "fork-agent")
+        reopened = Journal.open(fork_journal_dir)
+        assert reopened.head_hash == e1.step_hash
+        assert reopened.next_seq == 2
+
+
+# ---------------------------------------------------------------------------
 # Chain verification + tamper detection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`Journal.open` recovered the chain tip by reading the last on-disk row's
`step_hash`/`seq` verbatim, never recomputing the chain. A tampered,
truncated-then-edited, or internally inconsistent tail therefore became the
new anchor, and freshly-appended steps chained cleanly onto it. The module
docstring claimed recovery re-validated, but no validation happened.
`JournalReader.verify` would later flag the bad row, but by then the chain
had grown valid-looking children on a broken parent.

This change makes recovery revalidate the hash chain and fail closed:

- `Journal.open` walks the bucket from genesis, recomputes every `step_hash`
  (reusing `compute_step_hash`, the single chain primitive), and checks
  `prev_hash` linkage and `seq` continuity, exactly as `verify` does.
- The tip is taken from the last *recomputed* hash; `seq` is the count of
  validated rows, never the stored `seq` of the tail.
- A parseable row whose chain does not verify (recomputed `step_hash`
  mismatch, `prev_hash` break, or `seq` gap) raises `JournalError` naming the
  offending line and the remedy, so the chain cannot be silently extended
  from a poisoned anchor after a restart or a `session fork --from-step`.
- A torn/unparseable trailing line (crash mid-write) still degrades
  gracefully to the last validated row; a malformed line *followed* by a
  well-formed row is treated as interior corruption and raises.
- `docs/operations/replay.md` documents the fail-closed recovery behaviour,
  the operator remedy, and the O(steps) startup cost.

Closes #1836

## Test plan

- [x] `pytest tests/unit/test_journal_chain.py -q` (28 passed; 9 new in `TestRecoveryRevalidation`)
- [x] Reopening an intact chain recovers the same `head_hash`/`next_seq` (no regression for `test_append_after_reopen_continues_chain`)
- [x] Tampered final `step_hash`, tampered interior row, and `seq` gap each raise `JournalError` at open time (not deferred to a later `verify`)
- [x] Torn/truncated final line still recovers to the last good entry
- [x] `_seed_fork_journal` rejects a fork seeded from a corrupt parent journal and accepts an intact one
- [x] RED-GREEN verified: the four tamper tests fail against the old recovery and pass with the fix
- [x] `ruff check` + `ruff format --check` clean; pyright adds no new errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Journal recovery now validates the entire hash chain from inception to detect and prevent corruption (fail-closed semantics), with clear error reporting identifying problematic entries.
  * Graceful handling of incomplete final lines while maintaining strict validation of complete records.

* **Documentation**
  * Added journal recovery behavior guide including operator remediation steps for corrupt journal files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->