### PR TITLE
fix(lineage): bind the entry's signed kid to the verifying card

### DIFF
--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -154,8 +154,32 @@ make -C examples/lineage demo-eu-mfg
 |---|---|---|
 | `bernstein-verify pack` exits 1 with "fork detected" | Two agents wrote the same artefact in parallel without a Steward merge. | Run `bernstein lineage merge <path>` to record a merge entry; re-pack. |
 | `verify` exits 1 with "invalid signature" | The log was edited after the fact, or the Agent Card was swapped. | Treat as a security incident; do not ship the pack. |
+| `verify` exits 1 with "kid binding cannot be established" | No Agent Card on disk matches the `(agent_id, agent_card_kid)` the entry signed - typically a card for the entry's key id is missing after a rotation. | Restore the card for that key id under the per-kid layout (see [Key rotation](#key-rotation)); re-verify. |
+| `verify` exits 1 with "kid binding mismatch" | An entry's signed body names one key id while its JWS header names another - a key-substitution attempt. | Treat as a security incident; do not ship the pack. |
 | `verify` exits 1 with "HMAC mismatch" | Operator HMAC key rotated mid-window. | Re-pack with the correct key context; consult ADR-009 §6. |
 | Genesis entry shows up with `parent_hashes: []` | First-time write of a file that existed before lineage was enabled. | Expected - see ADR-009 §11 on bootstrap. |
+
+## Key rotation
+
+Each lineage entry signs the key id (`agent_card_kid`) it was produced under, and the gate verifies the signature against the Agent Card for that exact `(agent_id, kid)` pair - not against whatever card currently sits at the agent id. This keeps historical entries verifiable after an agent rotates its key.
+
+The gate reads two on-disk Agent Card layouts:
+
+| Layout | Path | Use |
+|---|---|---|
+| Single-card | `<cards-dir>/<agent-id>/card.json` | One key per agent (default). |
+| Per-kid | `<cards-dir>/<agent-id>/<kid>/card.json` | Multiple historical keys for one agent, one card per key id. |
+
+To rotate a key without invalidating prior entries, keep the old card and add the new one under the per-kid layout:
+
+```
+.sdd/agents/
+  agent:claude-worker-3/
+    k-2025-01/card.json   # old key - retained so old entries still verify
+    k-2025-06/card.json   # new key - signs entries from the rotation onward
+```
+
+Entries signed under `k-2025-01` continue to verify against the retained card; new entries under `k-2025-06` verify against the new one. Removing a card for a key id that historical entries still reference makes those entries fail the gate with a kid-binding error.
 
 ## See also
 

--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -26,6 +26,7 @@ from bernstein.core.lineage.gate import check as gate_check
 from bernstein.core.lineage.identity import (
     AgentCard,
     generate_keypair,
+    jws_header_kid,
     sign_detached,
     verify_detached,
 )
@@ -91,6 +92,7 @@ __all__ = [
     "gate_check",
     "generate_keypair",
     "is_v2_enabled",
+    "jws_header_kid",
     "resolve_policy",
     "sign_detached",
     "verify_detached",

--- a/src/bernstein/core/lineage/gate.py
+++ b/src/bernstein/core/lineage/gate.py
@@ -40,7 +40,7 @@ class GateResult:
     failures: list[str] = field(default_factory=list)
 
 
-def _load_cards(cards_dir: Path) -> dict[tuple[str, str], AgentCard]:
+def _load_cards(cards_dir: Path) -> tuple[dict[tuple[str, str], AgentCard], list[str]]:
     """Load all Agent Cards, keyed by ``(agent_id, kid)``.
 
     Two on-disk layouts are accepted so the gate stays verifiable across a key
@@ -53,13 +53,24 @@ def _load_cards(cards_dir: Path) -> dict[tuple[str, str], AgentCard]:
 
     The card's own ``agent_id`` and ``kid`` body fields are authoritative for
     the map key (not the directory names), so a misfiled card cannot
-    masquerade under a different identity. When both layouts carry a card for
-    the same ``(agent_id, kid)``, the last one read wins; they are expected to
-    be byte-identical for a given key.
+    masquerade under a different identity.
+
+    When two distinct card payloads map to the same ``(agent_id, kid)`` the
+    loader does *not* pick a winner: "last one read wins" would make the
+    verification outcome depend on filesystem read order, which a kid-binding
+    security gate must never do (issue #1837). The conflicting key is reported
+    as an explicit failure naming the ``agent_id``/``kid``. Byte-identical
+    duplicates - the normal case when the legacy and per-kid layouts carry the
+    same key - are accepted without error.
+
+    Returns:
+        ``(cards, failures)`` where ``cards`` maps ``(agent_id, kid)`` to the
+        loaded :class:`AgentCard` and ``failures`` lists any conflict messages.
     """
     out: dict[tuple[str, str], AgentCard] = {}
+    failures: list[str] = []
     if not cards_dir.exists():
-        return out
+        return out, failures
     # Legacy ``<agent-id>/card.json`` then per-kid ``<agent-id>/<kid>/card.json``.
     for card_file in (*cards_dir.glob("*/card.json"), *cards_dir.glob("*/*/card.json")):
         try:
@@ -71,13 +82,24 @@ def _load_cards(cards_dir: Path) -> dict[tuple[str, str], AgentCard]:
         pub = data.get("public_key_pem")
         if not (isinstance(agent_id, str) and isinstance(kid, str) and isinstance(pub, str)):
             continue
-        out[agent_id, kid] = AgentCard(
+        card = AgentCard(
             agent_id=agent_id,
             kid=kid,
             public_key_pem=pub,
             protocol_version=data.get("protocolVersion", "a2a/1.0"),
         )
-    return out
+        key = (agent_id, kid)
+        prev = out.get(key)
+        if prev is not None and prev != card:
+            # Two on-disk cards claim the same identity with different key
+            # material or protocol version. Refuse to choose; surface it.
+            failures.append(
+                f"conflicting agent cards for (agent_id={agent_id!r}, kid={kid!r}): "
+                "two on-disk cards map to the same identity with different contents"
+            )
+            continue
+        out[key] = card
+    return out, failures
 
 
 def _shard_path(artefact_path: str) -> tuple[str, str]:
@@ -144,7 +166,8 @@ def check(
     if not entries:
         return GateResult(ok=not failures, failures=failures)
 
-    cards = _load_cards(agent_cards_dir)
+    cards, card_failures = _load_cards(agent_cards_dir)
+    failures.extend(card_failures)
     log_dir = log_path.parent
 
     # Per-entry signature + HMAC + card lookups.

--- a/src/bernstein/core/lineage/gate.py
+++ b/src/bernstein/core/lineage/gate.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
-from bernstein.core.lineage.identity import AgentCard, verify_detached
+from bernstein.core.lineage.identity import AgentCard, jws_header_kid, verify_detached
 from bernstein.core.lineage.tips import compute_tips, detect_forks
 
 if TYPE_CHECKING:
@@ -40,12 +40,28 @@ class GateResult:
     failures: list[str] = field(default_factory=list)
 
 
-def _load_cards(cards_dir: Path) -> dict[str, AgentCard]:
-    """Load all Agent Cards under cards_dir/<agent-id>/card.json."""
-    out: dict[str, AgentCard] = {}
+def _load_cards(cards_dir: Path) -> dict[tuple[str, str], AgentCard]:
+    """Load all Agent Cards, keyed by ``(agent_id, kid)``.
+
+    Two on-disk layouts are accepted so the gate stays verifiable across a key
+    rotation (issue #1837):
+
+      * Legacy single-card: ``<agent-id>/card.json`` - one key per agent, the
+        layout production writes today.
+      * Per-kid: ``<agent-id>/<kid>/card.json`` - lets an agent keep multiple
+        historical keys side by side after rotating its ``kid``.
+
+    The card's own ``agent_id`` and ``kid`` body fields are authoritative for
+    the map key (not the directory names), so a misfiled card cannot
+    masquerade under a different identity. When both layouts carry a card for
+    the same ``(agent_id, kid)``, the last one read wins; they are expected to
+    be byte-identical for a given key.
+    """
+    out: dict[tuple[str, str], AgentCard] = {}
     if not cards_dir.exists():
         return out
-    for card_file in cards_dir.glob("*/card.json"):
+    # Legacy ``<agent-id>/card.json`` then per-kid ``<agent-id>/<kid>/card.json``.
+    for card_file in (*cards_dir.glob("*/card.json"), *cards_dir.glob("*/*/card.json")):
         try:
             data = json.loads(card_file.read_text())
         except (OSError, json.JSONDecodeError):
@@ -55,7 +71,7 @@ def _load_cards(cards_dir: Path) -> dict[str, AgentCard]:
         pub = data.get("public_key_pem")
         if not (isinstance(agent_id, str) and isinstance(kid, str) and isinstance(pub, str)):
             continue
-        out[agent_id] = AgentCard(
+        out[agent_id, kid] = AgentCard(
             agent_id=agent_id,
             kid=kid,
             public_key_pem=pub,
@@ -136,9 +152,19 @@ def check(
     for entry in entries:
         eh = entry_hash(entry)
         known_hashes.add(eh)
-        card = cards.get(entry.agent_id)
+        # Bind verification to the kid the entry *signed*: resolve the card by
+        # the ``(agent_id, agent_card_kid)`` pair, not by ``agent_id`` alone.
+        # Selecting the card by agent_id only let a kid-substitution slip
+        # through and broke every historical entry on key rotation - see
+        # issue #1837. A missing card for that exact kid is a kid-binding
+        # failure, distinct from a generic bad signature.
+        card = cards.get((entry.agent_id, entry.agent_card_kid))
         if card is None:
-            failures.append(f"{entry.artefact_path}: unknown agent card for {entry.agent_id!r} (entry {eh})")
+            failures.append(
+                f"{entry.artefact_path}: no agent card for "
+                f"(agent_id={entry.agent_id!r}, kid={entry.agent_card_kid!r}) - "
+                f"kid binding cannot be established (entry {eh})"
+            )
             continue
         # Signature
         sig_path = _signature_path(log_dir, entry, eh)
@@ -149,6 +175,17 @@ def check(
                 jws = sig_path.read_text().strip()
             except OSError as exc:
                 failures.append(f"{entry.artefact_path}: cannot read signature {sig_path}: {exc}")
+                continue
+            # The JWS header kid must match the kid the entry committed to in
+            # its signed body. A divergence means the signature was made under
+            # a different key id than the entry claims; reject it as a
+            # kid-binding failure even if it would verify against some card.
+            header_kid = jws_header_kid(jws)
+            if header_kid != entry.agent_card_kid:
+                failures.append(
+                    f"{entry.artefact_path}: kid binding mismatch on entry {eh} - "
+                    f"signed body kid {entry.agent_card_kid!r} != JWS header kid {header_kid!r}"
+                )
                 continue
             canonical = canonicalise(entry)
             if not verify_detached(canonical, jws, card):

--- a/src/bernstein/core/lineage/identity.py
+++ b/src/bernstein/core/lineage/identity.py
@@ -81,6 +81,29 @@ def sign_detached(payload: bytes, private_key_pem: str, *, kid: str) -> str:
     return protected + ".." + _b64url(sig)
 
 
+def jws_header_kid(jws: str) -> str | None:
+    """Return the ``kid`` from a detached JWS protected header.
+
+    Returns ``None`` when the JWS is malformed or the header has no string
+    ``kid``. The gate uses this to bind the *signed-body* ``agent_card_kid``
+    to the JWS the entry actually carries (issue #1837); a divergence between
+    the two is a verification failure, not merely a wrong key. Never raises on
+    bad input.
+    """
+    try:
+        protected_b64, empty, sig_b64 = jws.split(".", maxsplit=2)
+    except ValueError:
+        return None
+    if empty != "" or "." in sig_b64:
+        return None
+    try:
+        header = json.loads(_b64url_decode(protected_b64))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    kid = header.get("kid")
+    return kid if isinstance(kid, str) else None
+
+
 def verify_detached(payload: bytes, jws: str, card: AgentCard) -> bool:
     """Verify a detached Ed25519 JWS against the Agent Card's public key.
 

--- a/src/bernstein/core/lineage/identity.py
+++ b/src/bernstein/core/lineage/identity.py
@@ -14,6 +14,7 @@ option (RFC 7797). Algorithm is EdDSA per RFC 8037.
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 from dataclasses import dataclass
 
@@ -98,7 +99,12 @@ def jws_header_kid(jws: str) -> str | None:
         return None
     try:
         header = json.loads(_b64url_decode(protected_b64))
-    except (ValueError, json.JSONDecodeError):
+    except (ValueError, json.JSONDecodeError, binascii.Error, TypeError):
+        # ``binascii.Error`` is a ``ValueError`` subclass on CPython, so the
+        # bare ``ValueError`` above already catches malformed base64url; it is
+        # named explicitly to keep the "Never raises" contract robust if that
+        # hierarchy ever changes. ``TypeError`` guards a non-``str`` header
+        # segment reaching the decoder.
         return None
     kid = header.get("kid")
     return kid if isinstance(kid, str) else None
@@ -121,7 +127,7 @@ def verify_detached(payload: bytes, jws: str, card: AgentCard) -> bool:
         return False  # 4+ segments
     try:
         header = json.loads(_b64url_decode(protected_b64))
-    except (ValueError, json.JSONDecodeError):
+    except (ValueError, json.JSONDecodeError, binascii.Error, TypeError):
         return False
     if header.get("alg") != "EdDSA":
         return False
@@ -136,7 +142,7 @@ def verify_detached(payload: bytes, jws: str, card: AgentCard) -> bool:
     signing_input = protected_b64.encode("ascii") + b"." + payload
     try:
         sig_bytes = _b64url_decode(sig_b64)
-    except (ValueError, base64.binascii.Error):
+    except (ValueError, binascii.Error):
         return False
     try:
         pub.verify(sig_bytes, signing_input)

--- a/tests/unit/lineage/test_gate.py
+++ b/tests/unit/lineage/test_gate.py
@@ -6,12 +6,33 @@ import hashlib
 import json
 from dataclasses import asdict
 from pathlib import Path
+from typing import TypedDict
 
 from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
 from bernstein.core.lineage.gate import GateResult, check
 from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
 
 # ── Test fixtures and helpers ───────────────────────────────────────────────
+
+
+class _AgentCardPayload(TypedDict):
+    """On-disk ``card.json`` shape. Typed so the payload is explicit under
+    strict type-checking instead of an untyped inline dict."""
+
+    protocolVersion: str
+    agent_id: str
+    kid: str
+    public_key_pem: str
+
+
+def _card_payload(agent_id: str, kid: str, public_key_pem: str) -> _AgentCardPayload:
+    """Build a typed ``card.json`` payload for the given identity."""
+    return {
+        "protocolVersion": "a2a/1.0",
+        "agent_id": agent_id,
+        "kid": kid,
+        "public_key_pem": public_key_pem,
+    }
 
 
 class _TestAgent:
@@ -67,16 +88,8 @@ def _h(seed: str) -> str:
 def _write_card(cards_dir: Path, agent: _TestAgent) -> None:
     d = cards_dir / agent.agent_id
     d.mkdir(parents=True, exist_ok=True)
-    (d / "card.json").write_text(
-        json.dumps(
-            {
-                "protocolVersion": "a2a/1.0",
-                "agent_id": agent.agent_id,
-                "kid": agent.kid,
-                "public_key_pem": agent.pub,
-            }
-        )
-    )
+    payload = _card_payload(agent.agent_id, agent.kid, agent.pub)
+    (d / "card.json").write_text(json.dumps(payload))
 
 
 def _shard(s: str) -> str:
@@ -578,16 +591,8 @@ def _write_card_for_kid(cards_dir: Path, agent: _TestAgent) -> None:
     """
     d = cards_dir / agent.agent_id / agent.kid
     d.mkdir(parents=True, exist_ok=True)
-    (d / "card.json").write_text(
-        json.dumps(
-            {
-                "protocolVersion": "a2a/1.0",
-                "agent_id": agent.agent_id,
-                "kid": agent.kid,
-                "public_key_pem": agent.pub,
-            }
-        )
-    )
+    payload = _card_payload(agent.agent_id, agent.kid, agent.pub)
+    (d / "card.json").write_text(json.dumps(payload))
 
 
 def _sign_entry_into(log_path: Path, entry: LineageEntry, *, priv_pem: str, header_kid: str) -> None:
@@ -694,3 +699,311 @@ def test_gate_legacy_single_card_layout_still_passes(tmp_path: Path) -> None:
     _write_log_and_sigs(log, [(g, None), (c1, None)], {a.agent_id: a})
     result = check(log_path=log, agent_cards_dir=cards)
     assert result.ok is True, result.failures
+
+
+# ── Card-conflict detection (issue #1837, read-order independence) ──────────
+#
+# "Last one read wins" makes the verification outcome depend on filesystem
+# read order when two distinct cards claim the same ``(agent_id, kid)``. For a
+# kid-binding security gate that is a tamper/config-conflict hole, so the
+# loader must fail explicitly. Byte-identical duplicates (the legacy + per-kid
+# layouts carrying the same key) stay fine.
+
+
+def _write_raw_card(cards_dir: Path, agent_id: str, kid: str, *, pub: str, sub: str = "") -> None:
+    """Write a ``card.json`` with explicit field values under
+    ``<agent-id>[/sub]/card.json`` (``sub`` selects the per-kid layout)."""
+    d = cards_dir / agent_id
+    if sub:
+        d = d / sub
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(json.dumps(_card_payload(agent_id, kid, pub)))
+
+
+def test_gate_fails_on_conflicting_cards_for_same_agent_id_kid(tmp_path: Path) -> None:
+    """Two cards that claim the same ``(agent_id, kid)`` with *different* public
+    keys must produce an explicit conflict failure that names the agent_id and
+    kid - never a silent read-order-dependent winner."""
+    a1 = _TestAgent("agent:a", "k1")
+    a2 = _TestAgent("agent:a", "k1")  # same identity, different generated key
+    assert a1.pub != a2.pub
+    cards = tmp_path / "agents"
+    # Legacy layout carries a1's key; per-kid layout carries a2's key. Same
+    # (agent_id, kid), divergent public_key_pem -> conflict.
+    _write_raw_card(cards, "agent:a", "k1", pub=a1.pub)
+    _write_raw_card(cards, "agent:a", "k1", pub=a2.pub, sub="k1")
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a1, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, g, priv_pem=a1.priv, header_kid=a1.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    conflict = [f for f in result.failures if "conflicting agent cards" in f]
+    assert conflict, result.failures
+    # The message must name the exact identity in conflict.
+    assert "agent:a" in conflict[0] and "k1" in conflict[0], conflict[0]
+
+
+def test_gate_accepts_byte_identical_duplicate_cards(tmp_path: Path) -> None:
+    """The legacy ``<agent-id>/card.json`` and the per-kid
+    ``<agent-id>/<kid>/card.json`` carrying the *same* key for the same
+    ``(agent_id, kid)`` must NOT be flagged as a conflict - identical
+    duplicates are the normal cross-layout case."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)  # legacy
+    _write_card_for_kid(cards, a)  # per-kid, identical key material
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, g, priv_pem=a.priv, header_kid=a.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True, result.failures
+    assert not any("conflicting" in f for f in result.failures), result.failures
+
+
+def test_load_cards_skips_card_with_non_string_public_key(tmp_path: Path) -> None:
+    """``_load_cards`` must require *all* of agent_id/kid/public_key_pem to be
+    strings (the ``and`` chain). A card with a non-string ``public_key_pem``
+    but valid id/kid must be skipped, leaving the map empty - this kills the
+    ``and -> or`` mutation, which would otherwise admit the malformed card."""
+    from bernstein.core.lineage.gate import _load_cards
+
+    cards = tmp_path / "agents"
+    d = cards / "agent:a"
+    d.mkdir(parents=True, exist_ok=True)
+    # agent_id and kid are valid strings; only public_key_pem is wrong type.
+    (d / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": "agent:a",
+                "kid": "k1",
+                "public_key_pem": 1234,  # non-string -> whole card must be skipped
+            }
+        )
+    )
+    loaded, failures = _load_cards(cards)
+    assert loaded == {}, loaded
+    assert failures == []
+
+
+def test_gate_reports_kid_binding_cannot_be_established_message(tmp_path: Path) -> None:
+    """When no card exists for the entry's exact ``(agent_id, kid)`` the failure
+    text must state the binding *cannot* be established - kills the mutation
+    that strips ``not`` from ``cannot`` in that message."""
+    a_k1 = _TestAgent("agent:a", "k1")
+    a_k2 = _TestAgent("agent:a", "k2")
+    cards = tmp_path / "agents"
+    _write_card_for_kid(cards, a_k2)  # only k2 on disk; entry signed under k1
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a_k1, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, g, priv_pem=a_k1.priv, header_kid=a_k1.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("kid binding cannot be established" in f for f in result.failures), result.failures
+
+
+def test_gate_header_vs_body_kid_message_states_inequality(tmp_path: Path) -> None:
+    """The header/body kid-divergence message must spell out the inequality
+    (``!=``) between the signed-body kid and the JWS-header kid - kills the
+    ``!= -> ==`` mutation in that f-string."""
+    a_old = _TestAgent("agent:a", "k-old")
+    a_new = _TestAgent("agent:a", "k-new")
+    cards = tmp_path / "agents"
+    _write_card_for_kid(cards, a_old)
+    _write_card_for_kid(cards, a_new)
+    log = tmp_path / "lineage" / "log.jsonl"
+    entry = _entry_for(a_old, "src/x.py", _h("1"), [], ts_ns=1)
+    # Body names k-old; sign with k-new header kid so header != body.
+    _sign_entry_into(log, entry, priv_pem=a_new.priv, header_kid=a_new.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    mismatch = [f for f in result.failures if "kid binding mismatch" in f]
+    assert mismatch, result.failures
+    assert "!=" in mismatch[0], mismatch[0]
+    assert "k-old" in mismatch[0] and "k-new" in mismatch[0], mismatch[0]
+
+
+def test_gate_reports_unreadable_signature_sidecar(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """When the signature sidecar exists but cannot be read, the gate must
+    surface a 'cannot read signature' failure and keep going - kills the
+    mutation stripping ``not`` from ``cannot`` in that branch."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "src/x.py", _h("1"), [], ts_ns=1)
+    _write_log_and_sigs(log, [(g, None)], {a.agent_id: a})
+
+    real_read_text = Path.read_text
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> str:
+        if self.suffix == ".jws":
+            raise OSError("simulated unreadable signature")
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("cannot read signature" in f for f in result.failures), result.failures
+
+
+def test_gate_non_steward_merge_message_says_not_in_allowlist(tmp_path: Path) -> None:
+    """A merge entry written by a non-allow-listed agent must fail with a
+    message that includes 'not in allowlist' - kills the mutation that strips
+    ``not`` from that message."""
+    worker = _TestAgent("agent:worker", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, worker)
+    log = tmp_path / "lineage" / "log.jsonl"
+    p1 = _entry_for(worker, "x.py", _h("1"), [], ts_ns=1)
+    p2 = _entry_for(worker, "x.py", _h("2"), [], ts_ns=2)
+    merge = _entry_for(worker, "x.py", _h("3"), [entry_hash(p1), entry_hash(p2)], ts_ns=3)
+    _write_log_and_sigs(log, [(p1, None), (p2, None), (merge, None)], {worker.agent_id: worker})
+    result = check(
+        log_path=log,
+        agent_cards_dir=cards,
+        steward_allowlist=frozenset({"agent:steward"}),
+    )
+    assert result.ok is False
+    non_steward = [f for f in result.failures if "non-steward" in f]
+    assert non_steward, result.failures
+    assert "not in allowlist" in non_steward[0], non_steward[0]
+
+
+def test_gate_two_open_tips_exact_boundary(tmp_path: Path) -> None:
+    """Exactly two unresolved open tips on one artefact must fail (the guard is
+    ``> 1``). The reported count must equal 2 - this pins the threshold at 1
+    (killing the ``1 -> 2`` mutation, where two tips would no longer trip it)
+    and the count operand (killing ``len( -> 0 * len(``)."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(a, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    _write_log_and_sigs(log, [(g, None), (f1, None), (f2, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    tip_msgs = [f for f in result.failures if "unresolved open tips" in f]
+    assert tip_msgs, result.failures
+    assert "2 unresolved open tips" in tip_msgs[0], tip_msgs[0]
+
+
+def test_gate_unrelated_merge_does_not_resolve_a_different_fork(tmp_path: Path) -> None:
+    """Fork resolution requires an entry whose parent_hashes cover ALL of the
+    fork's children (``len(parents) >= 2 AND children.issubset(parents)``).
+
+    A *different* artefact's legitimate two-parent merge - which satisfies the
+    ``>= 2`` half but whose parents do NOT cover the unresolved fork's children
+    - must NOT clear that fork. This kills the ``and -> or`` mutation: under
+    ``or`` the unrelated merge's parent count alone would wrongly mark the open
+    fork resolved, flipping the gate to pass.
+    """
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    # Artefact A: an UNRESOLVED fork (g_a forks into c1_a and c2_a, never merged).
+    g_a = _entry_for(a, "a.py", _h("1"), [], ts_ns=1)
+    c1_a = _entry_for(a, "a.py", _h("2"), [entry_hash(g_a)], ts_ns=2)
+    c2_a = _entry_for(a, "a.py", _h("3"), [entry_hash(g_a)], ts_ns=3)
+    # Artefact B: a RESOLVED fork - g_b forks, then m_b merges both children.
+    # m_b has two parents (satisfies the >= 2 half) but they are {c1_b, c2_b},
+    # which do not cover artefact A's children {c1_a, c2_a}.
+    g_b = _entry_for(a, "b.py", _h("4"), [], ts_ns=4)
+    c1_b = _entry_for(a, "b.py", _h("5"), [entry_hash(g_b)], ts_ns=5)
+    c2_b = _entry_for(a, "b.py", _h("6"), [entry_hash(g_b)], ts_ns=6)
+    m_b = _entry_for(a, "b.py", _h("7"), [entry_hash(c1_b), entry_hash(c2_b)], ts_ns=7)
+    _write_log_and_sigs(
+        log,
+        [
+            (g_a, None),
+            (c1_a, None),
+            (c2_a, None),
+            (g_b, None),
+            (c1_b, None),
+            (c2_b, None),
+            (m_b, None),
+        ],
+        {a.agent_id: a},
+    )
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    fork_msgs = [f for f in result.failures if "unresolved fork" in f]
+    # Exactly artefact A's fork is unresolved; B's was correctly merged.
+    assert fork_msgs, result.failures
+    assert all("a.py" in f for f in fork_msgs), fork_msgs
+    assert not any("b.py" in f for f in fork_msgs), fork_msgs
+
+
+# ── Skill-lockfile admission check (issue #1796) ────────────────────────────
+#
+# ``check_skill_lockfile`` lives beside ``check`` in gate.py but its existing
+# coverage is under tests/unit/core/skills/. The per-module mutation gate runs
+# only tests/unit/lineage/ against gate.py, so these lineage-local tests pin
+# the lockfile branch logic for that gate too (kills the survivors at the
+# is_file / pass-result / membership / final-ok lines).
+
+
+def _write_catalog_lockfile(path: Path, *, manifest_sha256: str, entry_id: str = "code-review") -> None:
+    """Write a minimal single-row ``[[catalog]]`` lockfile (plain TOML) so the
+    lineage test stays free of the catalog package's writer."""
+    path.write_text(
+        "\n".join(
+            (
+                "[[catalog]]",
+                f'id = "{entry_id}"',
+                f'name = "{entry_id}"',
+                'version = "1.0.0"',
+                'manifest_url = "github://acme/code-review@v1"',
+                f'manifest_sha256 = "{manifest_sha256}"',
+                f'content_digest = "{"2" * 64}"',
+                'install_id = "install-1"',
+                f'chain_head = "{"3" * 64}"',
+                'installed_at = "2026-05-21T00:00:00Z"',
+                "",
+            )
+        )
+    )
+
+
+def test_check_skill_lockfile_passes_when_missing() -> None:
+    """A missing lockfile is a no-op pass (``ok=True``, empty failures). Kills
+    the ``is_file`` ``not`` strip, the ``True -> False`` flip, and the
+    ``[] -> [None]`` mutation on the missing-file return."""
+    from bernstein.core.lineage.gate import check_skill_lockfile
+
+    result = check_skill_lockfile(Path("/no/such/skills.lock"), frozenset())
+    assert result.ok is True
+    assert result.failures == []
+
+
+def test_check_skill_lockfile_accepts_anchored_row(tmp_path: Path) -> None:
+    """A row whose ``manifest_sha256`` is in the known-good set passes with no
+    failures. Together with the rejection test this pins ``ok = not failures``
+    (both the empty and non-empty branches)."""
+    from bernstein.core.lineage.gate import check_skill_lockfile
+
+    sha = "deadbeef" + "0" * 56
+    lockfile = tmp_path / "skills.lock"
+    _write_catalog_lockfile(lockfile, manifest_sha256=sha)
+    result = check_skill_lockfile(lockfile, frozenset({sha}))
+    assert result.ok is True, result.failures
+    assert result.failures == []
+
+
+def test_check_skill_lockfile_rejects_unanchored_row(tmp_path: Path) -> None:
+    """A row whose ``manifest_sha256`` is NOT in the known-good set must fail.
+    Kills the membership ``not`` strip (``not in`` -> ``in``), the final
+    ``ok = not failures`` mutation, and the 'is not present' message strip."""
+    from bernstein.core.lineage.gate import check_skill_lockfile
+
+    rogue = "rogue" + "0" * 59
+    lockfile = tmp_path / "skills.lock"
+    _write_catalog_lockfile(lockfile, manifest_sha256=rogue)
+    # known-good set holds a *different* sha, so the row is un-anchored.
+    result = check_skill_lockfile(lockfile, frozenset({"feed" + "0" * 60}))
+    assert result.ok is False
+    assert any("code-review" in f for f in result.failures), result.failures
+    assert any("is not present" in f for f in result.failures), result.failures

--- a/tests/unit/lineage/test_gate.py
+++ b/tests/unit/lineage/test_gate.py
@@ -559,3 +559,138 @@ def test_detect_forks_requires_at_least_two_children(tmp_path: Path) -> None:
     g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
     only_child = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
     assert detect_forks([g, only_child]) == []
+
+
+# ── Kid binding (issue #1837) ───────────────────────────────────────────────
+#
+# The gate must bind the entry's *signed* ``agent_card_kid`` to the card
+# actually used to verify it. Selecting the card by ``agent_id`` alone (a) lets
+# a kid-substitution slip through and (b) breaks every historical entry the
+# moment an agent rotates its key. These tests pin the binding.
+
+
+def _write_card_for_kid(cards_dir: Path, agent: _TestAgent) -> None:
+    """Write a card under the per-kid layout ``<agent-id>/<kid>/card.json``.
+
+    This is the layout that disambiguates multiple historical keys for one
+    agent (post key-rotation). The legacy ``<agent-id>/card.json`` layout is
+    written by :func:`_write_card`.
+    """
+    d = cards_dir / agent.agent_id / agent.kid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": agent.agent_id,
+                "kid": agent.kid,
+                "public_key_pem": agent.pub,
+            }
+        )
+    )
+
+
+def _sign_entry_into(log_path: Path, entry: LineageEntry, *, priv_pem: str, header_kid: str) -> None:
+    """Append ``entry`` to the log and write a detached JWS signed with an
+    explicit ``priv_pem`` and JWS-header ``kid`` (which may deliberately
+    diverge from the entry's signed ``agent_card_kid``)."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    sig_root = log_path.parent / "signatures"
+    sig_root.mkdir(exist_ok=True)
+    with log_path.open("a") as f:
+        f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    canonical = canonicalise(entry)
+    jws = sign_detached(canonical, priv_pem, kid=header_kid)
+    eh = entry_hash(entry)
+    path_hash = hashlib.sha256(entry.artefact_path.encode()).hexdigest()
+    dest_dir = sig_root / path_hash[:2] / path_hash
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+
+
+def test_gate_passes_with_single_per_kid_card(tmp_path: Path) -> None:
+    """An entry signed under kid ``k1`` verifies against a per-kid card for
+    ``k1``. This is the rotation-aware happy path for the new layout."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card_for_kid(cards, a)  # <agent-id>/k1/card.json
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, g, priv_pem=a.priv, header_kid=a.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True, result.failures
+
+
+def test_gate_fails_when_card_kid_does_not_match_entry_kid(tmp_path: Path) -> None:
+    """An entry signed under ``k1`` must FAIL with a clear kid-binding error
+    when the only card present for that agent is under a *different* kid
+    (``k2``) - even though the card directory has *a* card for the agent.
+
+    This is the substitution gap: previously the gate verified against
+    whatever single card sat at ``agent_id`` and ignored ``agent_card_kid``.
+    """
+    a_k1 = _TestAgent("agent:a", "k1")
+    a_k2 = _TestAgent("agent:a", "k2")  # same agent_id, different kid + key
+    cards = tmp_path / "agents"
+    # Only the k2 card is on disk; the entry is signed under k1.
+    _write_card_for_kid(cards, a_k2)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a_k1, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, g, priv_pem=a_k1.priv, header_kid=a_k1.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    # Must be a precise kid-binding failure, NOT a generic signature error.
+    assert any("kid" in f.lower() and "k1" in f for f in result.failures), result.failures
+
+
+def test_gate_passes_for_both_kids_after_rotation(tmp_path: Path) -> None:
+    """After an agent rotates its key (old + new card both present, one per
+    kid), historical entries under the old kid and new entries under the new
+    kid must BOTH pass ``check``."""
+    a_old = _TestAgent("agent:a", "k-old")
+    a_new = _TestAgent("agent:a", "k-new")
+    cards = tmp_path / "agents"
+    _write_card_for_kid(cards, a_old)
+    _write_card_for_kid(cards, a_new)
+    log = tmp_path / "lineage" / "log.jsonl"
+    old_entry = _entry_for(a_old, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, old_entry, priv_pem=a_old.priv, header_kid=a_old.kid)
+    new_entry = _entry_for(a_new, "src/x.py", _h("2"), [entry_hash(old_entry)], ts_ns=2)
+    _sign_entry_into(log, new_entry, priv_pem=a_new.priv, header_kid=a_new.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True, result.failures
+
+
+def test_gate_fails_when_header_kid_diverges_from_body_kid(tmp_path: Path) -> None:
+    """An entry whose signed body names ``agent_card_kid = "k-old"`` but whose
+    JWS header carries ``kid = "k-new"`` must FAIL with a kid-binding error,
+    even when a valid card for ``k-new`` exists and the signature would verify
+    against it."""
+    a_old = _TestAgent("agent:a", "k-old")
+    a_new = _TestAgent("agent:a", "k-new")
+    cards = tmp_path / "agents"
+    # Both cards present so neither side is "missing"; the divergence itself
+    # is the failure.
+    _write_card_for_kid(cards, a_old)
+    _write_card_for_kid(cards, a_new)
+    log = tmp_path / "lineage" / "log.jsonl"
+    # Body says k-old; sign with k-new's key AND k-new header kid.
+    entry = _entry_for(a_old, "src/x.py", _h("1"), [], ts_ns=1)
+    _sign_entry_into(log, entry, priv_pem=a_new.priv, header_kid=a_new.kid)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("kid" in f.lower() for f in result.failures), result.failures
+
+
+def test_gate_legacy_single_card_layout_still_passes(tmp_path: Path) -> None:
+    """No-rotation regression: a single legacy ``<agent-id>/card.json`` (the
+    layout production writes today) must still verify exactly as before."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)  # legacy <agent-id>/card.json
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "src/x.py", _h("1"), [], ts_ns=1)
+    c1 = _entry_for(a, "src/x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    _write_log_and_sigs(log, [(g, None), (c1, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True, result.failures

--- a/tests/unit/lineage/test_identity.py
+++ b/tests/unit/lineage/test_identity.py
@@ -7,6 +7,7 @@ import pytest
 from bernstein.core.lineage.identity import (
     AgentCard,
     generate_keypair,
+    jws_header_kid,
     sign_detached,
     verify_detached,
 )
@@ -113,3 +114,56 @@ def test_sign_with_non_ed25519_key_raises(tmp_path):
     ).decode("ascii")
     with pytest.raises(TypeError, match="Ed25519"):
         sign_detached(b"x", rsa_pem, kid="k1")
+
+
+# ── jws_header_kid: "Never raises on bad input" contract ────────────────────
+
+
+def test_jws_header_kid_returns_signed_kid():
+    priv, _pub = generate_keypair()
+    jws = sign_detached(b"payload", priv, kid="k-7")
+    assert jws_header_kid(jws) == "k-7"
+
+
+def test_jws_header_kid_none_on_wrong_segment_count():
+    # Too few segments and 4+ segments both yield None, never an exception.
+    assert jws_header_kid("only-one-segment") is None
+    assert jws_header_kid("a.b.c.d") is None
+
+
+def test_jws_header_kid_none_on_non_empty_payload_segment():
+    # The middle (payload) segment must be empty in detached form.
+    priv, _pub = generate_keypair()
+    protected = sign_detached(b"x", priv, kid="k1").split(".", 1)[0]
+    assert jws_header_kid(f"{protected}.notempty.AAAA") is None
+
+
+def test_jws_header_kid_never_raises_on_malformed_base64():
+    """``_b64url_decode`` calls ``base64.urlsafe_b64decode``, which raises
+    ``binascii.Error`` on malformed base64url. ``binascii.Error`` is a
+    ``ValueError`` subclass, so the contract holds, but this pins the "Never
+    raises on bad input" guarantee against a hierarchy change or a regression
+    that narrows the except clause."""
+    # '@' / '!' are outside the base64url alphabet -> decode error inside the
+    # protected-header parse. The function must swallow it and return None.
+    assert jws_header_kid("@@@bad-base64@@@..AAAA") is None
+    assert jws_header_kid("!!!..AAAA") is None
+
+
+def test_jws_header_kid_none_when_header_not_json():
+    import base64
+
+    seg = base64.urlsafe_b64encode(b"this is not json{").rstrip(b"=").decode("ascii")
+    assert jws_header_kid(f"{seg}..AAAA") is None
+
+
+def test_jws_header_kid_none_when_kid_not_a_string():
+    import base64
+    import json
+
+    header = (
+        base64.urlsafe_b64encode(json.dumps({"alg": "EdDSA", "kid": 12345}).encode("utf-8"))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert jws_header_kid(f"{header}..AAAA") is None


### PR DESCRIPTION
## Summary

- The lineage gate selected the verifying Agent Card by `agent_id` alone and never bound the `agent_card_kid` each entry committed to in its signed body. This let a kid-substitution be validated against whatever card sat at that `agent_id`, and made a key rotation silently invalidate every historical entry signed under the old kid.
- Bind verification to the signed kid: the card store is now keyed by `(agent_id, kid)` and resolves the card by the entry's `agent_card_kid`, failing with a clear kid-binding error when no card matches that exact kid for the agent.
- A divergence between the entry's signed-body kid and its JWS header kid is rejected as a kid-binding mismatch (new `jws_header_kid` helper reusing the existing detached-JWS parsing). Single-card, no-rotation logs verify exactly as before.

## What changed

- `gate.py`: `_load_cards` keys by `(agent_id, kid)` and reads both the legacy `<agent-id>/card.json` layout and a per-kid `<agent-id>/<kid>/card.json` layout (so an agent can retain multiple historical keys). `check` resolves the card by `(agent_id, agent_card_kid)` and adds the header/body kid binding check.
- `gate.py`: `_load_cards` now refuses to silently pick a winner when two distinct card payloads map to the same `(agent_id, kid)`. The previous "last one read wins" made the verification outcome depend on filesystem read order, which a kid-binding gate must not do; conflicting keys are returned as explicit failures naming the `agent_id` and `kid`. Byte-identical duplicates across the two layouts stay accepted without error.
- `identity.py`: adds `jws_header_kid(jws)` to extract the protected-header kid without raising on bad input, and names `binascii.Error` / `TypeError` explicitly in the protected-header decode `except` clauses of `jws_header_kid` and `verify_detached`. `binascii.Error` is a `ValueError` subclass on CPython, so the bare `ValueError` already caught malformed base64url; naming it keeps the documented "never raises" contract robust against a hierarchy change. `binascii` is now imported directly instead of through `base64.binascii`.
- `docs/lineage.md`: documents the per-kid card layout and the key-rotation workflow, plus two new failure-mode rows.

## Test plan

- [x] `pytest tests/unit/lineage/ -q` -> 168 passed (full lineage suite).
- [x] `pytest tests/unit -k "lineage and (gate or verify or kid or identity)" -q` -> 132 passed.
- [x] Adversarial + property lineage suites green: `tests/security/test_lineage_adversarial.py` and `tests/property/test_lineage_*` -> 93 passed, 4 xfailed.
- [x] Regression tests added and verified red-before / green-after:
  - entry signed under `k1` with only a `k2` card present fails with a kid-binding error (not a generic signature error)
  - both `k1` and `k2` cards present: entries under each kid both pass (post-rotation history stays verifiable)
  - signed-body kid vs JWS-header kid divergence fails the gate even when a card for the header kid exists
  - two conflicting cards for the same `(agent_id, kid)` produce an explicit conflict failure; byte-identical duplicates do not
  - `jws_header_kid` returns `None` (never raises) on malformed base64url, non-JSON headers, wrong segment counts, and non-string kids
  - legacy single-card layout still passes unchanged
- [x] `lineage_gate` mutation kill rate raised from 62.2% to 93.8% via `scripts/mutmut_critical.py --only lineage_gate` (>= 75% threshold; the 3 remaining survivors are a docstring string-literal, an equivalent mutant on the fork-resolution count, and the always-present-module `ImportError` branch).
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [x] `pyright` introduces no new errors (the pre-existing `binascii` / `failures` notes are present on `main` for the same unmodified lines).

Closes #1837

<!-- bot-ack: 3285349278 reason=fixed in fixup commit: _load_cards now fails explicitly on conflicting (agent_id, kid) cards instead of last-one-read-wins -->
<!-- bot-ack: 3285349281 reason=hardened: binascii.Error and TypeError named explicitly in the decode except clauses; binascii.Error is already a ValueError subclass so the contract held, regression test added -->
<!-- bot-ack: 3285349287 reason=applied: card payloads use a typed _AgentCardPayload TypedDict via a shared builder instead of an inline raw dict -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-key agent card layout support so historical entries remain verifiable after key rotation.
  * Tightened signature checks to detect and reject key-substitution or header/body key mismatches.

* **Documentation**
  * Expanded failure-mode guidance with two new kid-binding error cases.
  * Added a "Key rotation" section with on-disk layout and key-retention guidance.

* **Tests**
  * Added extensive unit tests covering kid-binding, rotation scenarios, conflicts, and malformed inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
