### PR TITLE
fix(persistence): verify content-address on CAS read (fail closed)

### DIFF
--- a/docs/architecture/cas-store.md
+++ b/docs/architecture/cas-store.md
@@ -29,9 +29,11 @@ new. Properties that follow:
 
 - **Automatic dedup.** Two agents emitting the same artifact share one
   blob.
-- **Tamper evidence.** A digest mismatch on read = corruption, full
-  stop. Pair with a Merkle tree to prove the whole store hasn't been
-  tampered with.
+- **Tamper evidence.** Every `get()` re-hashes the bytes it read and
+  compares them to the requested digest; a mismatch raises
+  `CASIntegrityError` (corruption, full stop) rather than handing back
+  the wrong bytes. Pair with a Merkle tree to prove the whole store
+  hasn't been tampered with.
 - **Cheap snapshots.** A "manifest" (list of digests) is a tiny pointer
   into the blob store; you can move snapshots around without copying
   blob content.
@@ -128,8 +130,13 @@ Public methods:
 
 - `put(content, content_type, metadata)` → digest. No-op if digest
   already exists (`_dedup_saves` counter increments).
-- `get(digest)` → bytes or `None`. Validates the digest format first to
-  prevent path traversal (`_validate_digest`).
+- `get(digest, *, verify=True)` → bytes or `None`. Validates the digest
+  format first to prevent path traversal (`_validate_digest`), then
+  re-hashes the stored bytes and raises `CASIntegrityError` if they do
+  not match the requested digest. A missing blob still returns `None`.
+  Pass `verify=False` only on hot paths that have already verified the
+  content upstream - the opt-out re-opens the integrity hole for that
+  call and must be used deliberately.
 - `has(digest)` → bool.
 - `delete(digest)` → bool. Removes blob + sidecar; cleans up empty
   shard directories.

--- a/docs/observability/trace-store.md
+++ b/docs/observability/trace-store.md
@@ -31,8 +31,12 @@ JSON) without paying for one.
 - `index.jsonl` carries the searchable metadata: `trace_id`, `task_id`,
   `sha256`, `byte_size`, `started_at`, `ended_at`, `model`, `cost_usd`,
   `codec`. The viewer reads this file; nothing else.
-- The sha256 is the source of truth. `bernstein trace verify <id>`
-  rereads the blob bytes and rehashes them.
+- The sha256 is the source of truth. `store.get()` rereads the blob,
+  decompresses it, rehashes, and raises `CASIntegrityError` if the bytes
+  no longer match the indexed digest - so the "index does not have to be
+  trusted" property holds on the hot read path, not only when an operator
+  runs `bernstein trace verify <id>` explicitly. The explicit verify
+  command remains for an on-demand check that returns a boolean.
 
 ## CLI
 
@@ -79,8 +83,9 @@ store = ContentAddressedTraceStore(Path(".sdd/traces"))
 # Store finalised trace bytes (idempotent).
 entry = store.put(trace_bytes, hints=TraceMetadataHints(task_id="T-12"))
 
-# Read back, verify, search.
-raw = store.get(entry.trace_id)
+# Read back (verifies the bytes against the indexed digest by default),
+# verify on demand, search.
+raw = store.get(entry.trace_id)  # raises CASIntegrityError on a mismatch
 assert store.verify(entry.trace_id)
 results = store.search(task_id="T-12", model="sonnet")
 

--- a/src/bernstein/core/observability/trace_store.py
+++ b/src/bernstein/core/observability/trace_store.py
@@ -49,6 +49,8 @@ import logging
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Final
 
+from bernstein.core.persistence.cas_store import CASIntegrityError
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
@@ -397,12 +399,36 @@ class ContentAddressedTraceStore:
 
     # -- Reads --------------------------------------------------------------
 
-    def get(self, trace_id: str) -> bytes | None:
+    def get(self, trace_id: str, *, verify: bool = True) -> bytes | None:
         """Return uncompressed trace bytes for ``trace_id``.
 
         ``trace_id`` can be either the logical trace identifier or the
         sha256 digest of the blob. Returns ``None`` if no matching entry
         exists in the index or the blob is missing on disk.
+
+        By default the decompressed bytes are re-hashed and checked against
+        the indexed ``sha256`` - the same property :meth:`verify` provides -
+        so the documented "index does not have to be trusted" guarantee
+        holds on the hot read path, not only when an operator calls
+        :meth:`verify` explicitly. On a mismatch a
+        :class:`~bernstein.core.persistence.cas_store.CASIntegrityError` is
+        raised rather than decompressed-but-wrong bytes being returned.
+
+        Args:
+            trace_id: Logical trace id or sha256 digest of the blob.
+            verify: When ``True`` (default), re-hash the decompressed bytes
+                and raise on a mismatch with the indexed digest. Set
+                ``False`` only for callers that have already verified the
+                content upstream; the opt-out re-opens the integrity hole
+                for that call.
+
+        Returns:
+            The uncompressed trace bytes, or ``None`` when the trace is
+            unknown or its blob is missing.
+
+        Raises:
+            CASIntegrityError: If *verify* is ``True`` and the decompressed
+                bytes do not hash to the indexed digest.
         """
         entry = self._lookup_entry(trace_id)
         if entry is None:
@@ -411,7 +437,17 @@ class ContentAddressedTraceStore:
         if path is None:
             return None
         codec = _codec_for_ext(path.suffix.lstrip("."))
-        return _decompress(path.read_bytes(), codec)
+        raw = _decompress(path.read_bytes(), codec)
+        if verify:
+            actual = hashlib.sha256(raw).hexdigest()
+            if actual != entry.sha256:
+                logger.error(
+                    "trace_store integrity check failed: indexed %s, on-disk bytes hash to %s",
+                    entry.sha256,
+                    actual,
+                )
+                raise CASIntegrityError(expected=entry.sha256, actual=actual)
+        return raw
 
     def index(self) -> list[TraceIndexEntry]:
         """Return all index entries, most recent ``started_at`` first."""

--- a/src/bernstein/core/persistence/cas_store.py
+++ b/src/bernstein/core/persistence/cas_store.py
@@ -35,6 +35,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class CASIntegrityError(Exception):
+    """Raised when stored bytes no longer hash to the requested digest.
+
+    The store's contract is content-addressing: the key is
+    ``sha256(content)``. When a verified read finds that the bytes on disk
+    hash to something other than the requested key, the blob has been
+    corrupted (bit rot, a torn write) or tampered with, and is no longer the
+    content the key promises. This is surfaced rather than masked as a cache
+    miss so the caller can treat it as corruption and re-fetch or re-derive.
+
+    Attributes:
+        expected: The digest the caller requested (the content-address key).
+        actual: The SHA-256 hex digest recomputed from the on-disk bytes.
+    """
+
+    def __init__(self, expected: str, actual: str) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"CAS integrity check failed for {expected}: on-disk bytes hash to {actual}",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
 
@@ -182,23 +210,47 @@ class CASStore:
         logger.debug("CAS stored %d bytes as %s", len(content), digest[:12])
         return digest
 
-    def get(self, digest: str) -> bytes | None:
+    def get(self, digest: str, *, verify: bool = True) -> bytes | None:
         """Retrieve stored content by *digest*, or ``None`` if absent.
+
+        By default the bytes read from disk are re-hashed and checked against
+        *digest*: a content-addressed store whose read path does not verify
+        the address is not content-addressed. On a mismatch a
+        :class:`CASIntegrityError` is raised rather than the corrupted bytes
+        being returned (and rather than masking the corruption as a cache
+        miss). A missing blob is still reported as ``None``.
 
         Args:
             digest: SHA-256 hex digest returned by :meth:`put`.
+            verify: When ``True`` (default), re-hash the stored bytes and
+                raise :class:`CASIntegrityError` if they do not match
+                *digest*. Set ``False`` only for hot paths that have already
+                verified the content upstream; the opt-out re-opens the
+                integrity hole for that call and must be used deliberately.
 
         Returns:
             The stored bytes, or ``None`` when the digest is unknown.
 
         Raises:
             ValueError: If *digest* is not a valid 64-char hex string.
+            CASIntegrityError: If *verify* is ``True`` and the stored bytes
+                do not hash to *digest*.
         """
         self._validate_digest(digest)
         blob = self._blob_path(digest)
         if not blob.exists():
             return None
-        return blob.read_bytes()
+        content = blob.read_bytes()
+        if verify:
+            actual = self._digest(content)
+            if actual != digest:
+                logger.error(
+                    "CAS integrity check failed: requested %s, on-disk bytes hash to %s",
+                    digest,
+                    actual,
+                )
+                raise CASIntegrityError(expected=digest, actual=actual)
+        return content
 
     def has(self, digest: str) -> bool:
         """Check whether *digest* exists in the store.

--- a/tests/property/test_cas_store_properties.py
+++ b/tests/property/test_cas_store_properties.py
@@ -26,6 +26,11 @@ hash collisions on benign inputs (correctness bug). Properties:
 * **Repeated puts dedup correctly** - the second put of an
   identical payload increments the dedup counter and does not touch
   the blob on disk.
+
+* **A single-byte mutation of any stored blob fails the verifying
+  read** - the read path re-hashes against the requested digest, so
+  tampering or bit rot surfaces as ``CASIntegrityError`` rather than
+  being served as authentic.
 """
 
 from __future__ import annotations
@@ -37,7 +42,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from bernstein.core.persistence.cas_store import CASStore
+from bernstein.core.persistence.cas_store import CASIntegrityError, CASStore
 
 _HEX_64 = re.compile(r"\A[0-9a-f]{64}\Z")
 
@@ -169,3 +174,35 @@ def test_get_returns_none_for_unknown_digest(tmp_path_factory: pytest.TempPathFa
     # Don't put - the digest is unknown to the store.
     assert store.get(digest) is None
     assert not store.has(digest)
+
+
+@given(
+    content=st.binary(min_size=1, max_size=512),
+    flip_index=st.integers(min_value=0),
+)
+def test_single_byte_mutation_fails_verifying_read(
+    tmp_path_factory: pytest.TempPathFactory,
+    content: bytes,
+    flip_index: int,
+) -> None:
+    """Mutating any single byte of a stored blob makes the verifying read fail.
+
+    This is the core content-addressing guarantee: the bytes ``get``
+    returns hash to the key requested. A flipped byte changes the
+    digest, so the verifying read must raise ``CASIntegrityError`` (and
+    name the requested key) rather than serving the tampered bytes.
+    """
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    digest = store.put(content)
+
+    blob = store.root / digest[:2] / digest
+    data = bytearray(blob.read_bytes())
+    pos = flip_index % len(data)
+    data[pos] ^= 0xFF
+    blob.write_bytes(bytes(data))
+
+    with pytest.raises(CASIntegrityError) as exc_info:
+        store.get(digest)
+    assert exc_info.value.expected == digest
+    # The opt-out still returns the (now corrupted) bytes verbatim.
+    assert store.get(digest, verify=False) == bytes(data)

--- a/tests/unit/observability/test_trace_store.py
+++ b/tests/unit/observability/test_trace_store.py
@@ -28,6 +28,7 @@ from bernstein.core.observability.trace_store import (
     TraceMetadataHints,
     build_viewer_app,
 )
+from bernstein.core.persistence.cas_store import CASIntegrityError
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -156,6 +157,58 @@ def test_verify_handles_missing_blob(tmp_path: Path) -> None:
     (tmp_path / "blobs" / entry.sha256[:2] / f"{entry.sha256}.jsonl.gz").unlink()
     assert store.verify("trace-001") is False
     assert store.get("trace-001") is None
+
+
+def test_get_raises_on_corrupted_blob(tmp_path: Path) -> None:
+    # The default read path must fail the same way verify() reports, rather
+    # than returning decompressed-but-wrong bytes.
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+
+    blob = tmp_path / "blobs" / entry.sha256[:2] / f"{entry.sha256}.jsonl.gz"
+    blob.write_bytes(gzip.compress(b"tampered"))
+
+    assert store.verify("trace-001") is False
+    with pytest.raises(CASIntegrityError) as exc_info:
+        store.get("trace-001")
+    # The error names the digest the bytes were supposed to match.
+    assert entry.sha256 in str(exc_info.value)
+    assert exc_info.value.expected == entry.sha256
+
+
+def test_get_corrupted_blob_resolves_by_sha256_too(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+
+    blob = tmp_path / "blobs" / entry.sha256[:2] / f"{entry.sha256}.jsonl.gz"
+    blob.write_bytes(gzip.compress(b"tampered"))
+
+    with pytest.raises(CASIntegrityError):
+        store.get(entry.sha256)
+
+
+def test_get_verify_off_returns_corrupted_bytes(tmp_path: Path) -> None:
+    # Explicit opt-out skips the rehash for callers that verified upstream.
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+
+    blob = tmp_path / "blobs" / entry.sha256[:2] / f"{entry.sha256}.jsonl.gz"
+    blob.write_bytes(gzip.compress(b"tampered"))
+
+    assert store.get("trace-001", verify=False) == b"tampered"
+
+
+def test_get_intact_blob_passes_verification(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    store.put(raw)
+
+    # Clean round-trip still returns the original bytes with verify on.
+    assert store.get("trace-001") == raw
+    assert store.get("trace-001", verify=True) == raw
 
 
 def test_reindex_rebuilds_index_from_blobs(tmp_path: Path) -> None:

--- a/tests/unit/test_cas_store.py
+++ b/tests/unit/test_cas_store.py
@@ -10,6 +10,7 @@ import pytest
 
 from bernstein.core.persistence.cas_store import (
     CASEntry,
+    CASIntegrityError,
     CASStats,
     CASStore,
     put_file,
@@ -103,6 +104,61 @@ class TestCASStorePutGet:
         data = b"x" * 1_000_000
         digest = cas.put(data)
         assert cas.get(digest) == data
+
+
+# ---------------------------------------------------------------------------
+# CASStore - read-path integrity verification
+# ---------------------------------------------------------------------------
+
+
+class TestCASStoreIntegrity:
+    def _corrupt_blob(self, cas: CASStore, digest: str) -> None:
+        """Flip one byte of the on-disk blob for *digest* in place."""
+        blob = cas.root / digest[:2] / digest
+        data = bytearray(blob.read_bytes())
+        data[0] ^= 0xFF
+        blob.write_bytes(bytes(data))
+
+    def test_get_raises_on_corrupted_blob(self, cas: CASStore) -> None:
+        digest = cas.put(b"authentic content")
+        self._corrupt_blob(cas, digest)
+        with pytest.raises(CASIntegrityError) as exc_info:
+            cas.get(digest)
+        # The error must name the requested key so a caller can act on it.
+        assert digest in str(exc_info.value)
+
+    def test_get_corruption_error_carries_expected_and_actual(self, cas: CASStore) -> None:
+        digest = cas.put(b"authentic content")
+        self._corrupt_blob(cas, digest)
+        corrupted = (cas.root / digest[:2] / digest).read_bytes()
+        actual = hashlib.sha256(corrupted).hexdigest()
+        with pytest.raises(CASIntegrityError) as exc_info:
+            cas.get(digest)
+        assert exc_info.value.expected == digest
+        assert exc_info.value.actual == actual
+
+    def test_get_does_not_mask_corruption_as_miss(self, cas: CASStore) -> None:
+        # A corrupted blob must surface as an integrity error, never as None
+        # (which would let tampering look like a cache miss).
+        digest = cas.put(b"authentic content")
+        self._corrupt_blob(cas, digest)
+        with pytest.raises(CASIntegrityError):
+            cas.get(digest)
+
+    def test_intact_round_trip_passes_verification(self, cas: CASStore) -> None:
+        digest = cas.put(b"authentic content")
+        assert cas.get(digest) == b"authentic content"
+
+    def test_verify_off_returns_corrupted_bytes(self, cas: CASStore) -> None:
+        # The opt-out is explicit and bypasses the rehash for callers that
+        # have already verified upstream or read enormous blobs in tight loops.
+        digest = cas.put(b"authentic content")
+        self._corrupt_blob(cas, digest)
+        corrupted = (cas.root / digest[:2] / digest).read_bytes()
+        assert cas.get(digest, verify=False) == corrupted
+
+    def test_missing_blob_still_returns_none_with_verify_on(self, cas: CASStore) -> None:
+        assert cas.get("0" * 64, verify=True) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Content-addressed reads returned blob bytes without confirming they still hash to the requested digest, so on-disk corruption or tampering was served silently. The store key is `sha256(content)` (enforced on write in `put`), but the read path only validated the shape of the key and returned the bytes verbatim.
- `CASStore.get` now re-hashes the stored bytes by default and raises a typed `CASIntegrityError` (carrying expected vs actual digest) on mismatch, instead of returning corrupted bytes or masking corruption as a cache miss. A missing blob still returns `None`. `verify=False` is an explicit, documented opt-out for hot paths that have verified upstream.
- `ContentAddressedTraceStore.get` re-hashes the decompressed bytes against the indexed `sha256` with the same default, reusing `CASIntegrityError`, so the documented "index does not have to be trusted" property holds on the read path and not only when an operator calls `verify()` explicitly. `put` is unchanged on both stores.

## Why

`CASStore` backs lineage/audit/replay anchors (e.g. the bytes a model saw at a decision, resolved in `multimodal_attestation`). A content-addressed store whose `get` does not verify the address is not content-addressed: the digest stops being proof-of-content exactly when an auditor or a replay pulls the bytes back. The trace store already shipped a `verify(trace_id)` rehash primitive but did not use it on the default read; this closes that asymmetry.

## Changes

- `src/bernstein/core/persistence/cas_store.py`: add `CASIntegrityError`; `get(digest, *, verify=True)` re-hashes and fails closed.
- `src/bernstein/core/observability/trace_store.py`: `get(trace_id, *, verify=True)` re-hashes the decompressed bytes against the indexed digest; reuses `CASIntegrityError`.
- Tests: unit corruption + intact round-trip + opt-out on both stores; a property test that mutating any single byte of any stored blob fails the verifying read.
- Docs: `docs/architecture/cas-store.md`, `docs/observability/trace-store.md`.

## Test plan

- [ ] `pytest tests/unit/test_cas_store.py tests/unit/observability/test_trace_store.py tests/property/test_cas_store_properties.py -q`
- [ ] `pytest tests/unit/test_multimodal_attestation.py tests/integration/test_run_attach.py -q` (no regression for the wired CAS consumer)
- [ ] `ruff check` + `ruff format --check` on the changed files
- [ ] Manual: `put` a blob, flip one on-disk byte, confirm `get(digest)` raises `CASIntegrityError` naming the key and `get(digest, verify=False)` returns the corrupted bytes

Closes #1849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content retrieval operations now support optional integrity verification with automatic re-validation of stored data (default enabled)
  * New exception type for integrity validation failures on digest mismatches

* **Documentation**
  * Updated documentation to clarify integrity checking mechanisms and verification behavior for both archive and trace storage

* **Tests**
  * Added comprehensive test coverage for integrity verification and corruption detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->