### PR TITLE
fix(replay): preserve call order and exclude wall-clock from determinism proof

### DIFF
--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -14,6 +14,8 @@ path (selected with `BERNSTEIN_REPLAY_RUN_ID`).
 | On a miss (strict) | Raises `ReplayMissError`; the live model is never called. |
 | Escape hatch | `BERNSTEIN_REPLAY_ALLOW_LIVE_MISS=1` -> miss logs a WARNING and falls through to the live model. |
 | Replay key | `(model, prompt, provider, temperature, max_tokens)`. Any drift is a miss, not a hit. |
+| Repeated calls | A key called N times records N responses and replays them **in recorded order**; the Nth call returns the Nth response. |
+| Over-consumption | Requesting a key more times than recorded is a miss (strict: raises; non-strict: returns `None`). |
 | Coverage line | `hits` / `misses` / `strict_violations`; a fully covered replay reports `misses=0`. |
 
 ## How to record and replay
@@ -59,6 +61,23 @@ replay. To re-record, run the original workload again with
 `ReplayMissError` message states this inline so an operator who hits a stale
 recording knows the fix without leaving the log.
 
+## Repeated prompts replay in recorded order
+
+`llm_calls.jsonl` is append-only: each LLM call writes one line, in call
+order. When the same `(model, prompt, provider, temperature, max_tokens)` key
+is called more than once in a run - a retried decomposition, a re-asked
+routing question, an agent that re-issues the same probe - the recording holds
+one response per call. Replay keeps a per-key FIFO and consumes the next
+recorded response on each `get_replay`, so the first call replays the first
+recorded response, the second call the second, and so on. A run that records
+responses `A` then `B` for one key replays `A` then `B`, not `B` twice.
+
+Requesting a key more times than it was recorded is a replay-fidelity failure
+(the replay diverged from the recording). In strict mode it raises
+`ReplayMissError`; in the non-hermetic escape hatch it returns `None` and falls
+through. This makes a divergent replay fail loudly instead of silently
+re-serving a stale response.
+
 ## Escape hatch (opt-in, non-hermetic)
 
 For record-extend workflows you can keep the old fall-through behaviour:
@@ -72,9 +91,34 @@ live provider. It is opt-in precisely so the hermetic guarantee stays closed
 unless deliberately disabled; do not set it globally in CI or air-gapped
 contexts.
 
+## Execution fingerprint (determinism proof across runs)
+
+`bernstein verify --determinism <run-id>` reports an execution fingerprint
+over the run's `replay.jsonl` event stream. The fingerprint hashes a canonical
+projection of each event - `event` plus the decision-relevant payload, with
+keys sorted and fixed separators - and **excludes the wall-clock envelope**
+(`ts` and `elapsed_s`). Those timing fields stay in `replay.jsonl` for the
+operator timeline; they are skipped only in the fingerprint computation.
+
+Because the timing envelope is excluded, two byte-identical executions produce
+the **same** fingerprint even though their timestamps differ, so the value is a
+genuine cross-run identity: a recording and a faithful replay match, and any
+divergence in the decision stream (a different decision output, a reordered
+event, a changed event type) changes the fingerprint. Paired with the
+`verify --determinism --baseline` gate, this lets a replay report PASS for an
+identical re-execution and FAIL for a perturbed one.
+
+Behaviour change: fingerprints computed before this change hashed the whole
+file (timestamps included), so old recorded fingerprint values are not
+comparable to new ones. Re-baseline once after upgrading.
+
 ## Related
 
 - Source: `src/bernstein/core/orchestration/deterministic.py`
 - Call site: `src/bernstein/core/routing/llm.py` (`call_llm`)
+- Execution fingerprint: `src/bernstein/core/persistence/recorder.py`
+  (`RunRecorder.fingerprint`, `compute_replay_fingerprint`)
 - Sibling subsystem with the same miss contract:
-  `src/bernstein/core/replay/gateway.py` (`ReplayMissError`)
+  `src/bernstein/core/replay/gateway.py` (`ReplayMissError`); its replay
+  fixtures consume in recorded `seq` order, so duplicate response values cannot
+  desync the by-kind FIFO fallback.

--- a/src/bernstein/core/orchestration/deterministic.py
+++ b/src/bernstein/core/orchestration/deterministic.py
@@ -38,6 +38,7 @@ import json
 import logging
 import os
 import time
+from collections import deque
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
@@ -149,11 +150,21 @@ class DeterministicStore:
     existing ``llm_calls.jsonl`` and :meth:`get_replay` returns stored
     responses without touching the file.
 
-    Replay is **strict by default** (issue #1832): a cache miss raises
+    Replay preserves call **order and multiplicity** (issue #1846): the
+    recording is append-only, so a ``(prompt, model, ...)`` key called N times
+    records N responses in order. The cache keeps a per-key FIFO and
+    :meth:`get_replay` consumes the next recorded response for a key, so the
+    Nth call replays the Nth recorded response. Requesting a key more times
+    than it was recorded is a replay-fidelity failure (the run diverged from
+    the recording), handled by the strict/non-strict policy below.
+
+    Replay is **strict by default** (issue #1832): a cache miss - including
+    over-consuming a key past its recorded count - raises
     :class:`ReplayMissError` instead of returning ``None``, so a run launched
-    for replay cannot silently call the live model. Pass ``strict=False`` (the
-    orchestrator does this when :func:`allow_live_miss` is set) to restore the
-    old return-``None``-on-miss escape hatch.
+    for replay cannot silently call the live model or replay a stale response.
+    Pass ``strict=False`` (the orchestrator does this when
+    :func:`allow_live_miss` is set) to restore the old return-``None``-on-miss
+    escape hatch.
 
     Args:
         run_dir: Directory for this run (``{sdd_dir}/runs/{run_id}``).
@@ -168,7 +179,14 @@ class DeterministicStore:
         self._replay = replay
         self._strict = strict
         self._calls_path = run_dir / "llm_calls.jsonl"
-        self._cache: dict[str, str] = {}
+        # Per-key FIFO of recorded responses, in recorded order. A repeated
+        # ``(prompt, model, ...)`` key keeps every recorded response so replay
+        # reconstructs the exact recorded sequence instead of last-write-wins
+        # (issue #1846). ``get_replay`` consumes from the left.
+        self._cache: dict[str, deque[str]] = {}
+        # Total recorded responses retained across all keys; backs
+        # :attr:`cached_count` so it still reflects the journal size.
+        self._cached_total = 0
         # Replay-coverage counters backing :meth:`coverage_line`.
         self._hits = 0
         self._misses = 0
@@ -182,7 +200,11 @@ class DeterministicStore:
     # ------------------------------------------------------------------
 
     def _load_cache(self) -> None:
-        """Load all recorded responses into memory for fast replay."""
+        """Load recorded responses into per-key FIFO queues for replay.
+
+        Appends each recorded response to its key's queue in file order, so a
+        key recorded N times replays its N responses in sequence (#1846).
+        """
         try:
             with self._calls_path.open(encoding="utf-8") as f:
                 for line in f:
@@ -194,7 +216,8 @@ class DeterministicStore:
                         key = entry.get("key", "")
                         response = entry.get("response", "")
                         if key and response:
-                            self._cache[key] = response
+                            self._cache.setdefault(key, deque()).append(response)
+                            self._cached_total += 1
         except OSError as exc:
             logger.warning("DeterministicStore: failed to load cache: %s", exc)
 
@@ -264,9 +287,11 @@ class DeterministicStore:
             max_tokens: Max response tokens (folded into the lookup key).
 
         Returns:
-            The cached response string on a hit. Returns ``None`` when the
-            store is not in replay mode, or on a miss in non-strict replay
-            mode.
+            The next recorded response for the key on a hit (consuming it in
+            recorded order). Returns ``None`` when the store is not in replay
+            mode, or on a miss in non-strict replay mode. A miss includes both
+            an unknown key and over-consuming a known key past its recorded
+            count.
 
         Raises:
             ReplayMissError: On a cache miss when the store is in strict
@@ -276,11 +301,12 @@ class DeterministicStore:
         if not self._replay:
             return None
         key = _prompt_key(prompt, model, provider=provider, temperature=temperature, max_tokens=max_tokens)
-        cached = self._cache.get(key)
-        if cached is not None:
+        queue = self._cache.get(key)
+        if queue:
             self._hits += 1
-            return cached
-        # Cache miss.
+            return queue.popleft()
+        # Cache miss: unknown key, or a known key consumed past its recorded
+        # count (the run requested it more times than it was recorded).
         if self._strict:
             self._strict_violations += 1
             # Emit the coverage line at the failure point so the abort log
@@ -317,8 +343,12 @@ class DeterministicStore:
 
     @property
     def cached_count(self) -> int:
-        """Number of cached responses available for replay."""
-        return len(self._cache)
+        """Total recorded responses loaded for replay (across all keys).
+
+        Counts every recorded response, including repeats of the same key, so
+        it reflects the journal size rather than the number of distinct keys.
+        """
+        return self._cached_total
 
     @property
     def calls_path(self) -> Path:
@@ -333,7 +363,7 @@ class DeterministicStore:
         100% recorded responses.
         """
         return (
-            f"replay-coverage run_dir={self._run_dir} cached={len(self._cache)} "
+            f"replay-coverage run_dir={self._run_dir} cached={self._cached_total} "
             f"hits={self._hits} misses={self._misses} "
             f"strict_violations={self._strict_violations} strict={self._strict}"
         )

--- a/src/bernstein/core/persistence/recorder.py
+++ b/src/bernstein/core/persistence/recorder.py
@@ -26,9 +26,62 @@ from bernstein.core.defaults import JANITOR
 from bernstein.core.persistence.runtime_state import rotate_log_file
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+#: Event fields that vary across runs even when the execution is identical.
+#: They stay in ``replay.jsonl`` (operators want the timeline) but are excluded
+#: from the determinism fingerprint, which must be byte-stable across runs.
+#: Keep this set limited to provably non-deterministic envelope fields:
+#: over-excluding a real decision field would let two genuinely different runs
+#: collide on the same fingerprint (issue #1851).
+_NON_DETERMINISTIC_FIELDS = frozenset({"ts", "elapsed_s"})
+
+
+def _canonical_event_bytes(event: dict[str, Any]) -> bytes:
+    """Return canonical bytes for one event, excluding the timing envelope.
+
+    The wall-clock fields in :data:`_NON_DETERMINISTIC_FIELDS` are dropped and
+    the remaining keys are JSON-encoded with sorted keys and fixed separators,
+    so two recordings of the same decision stream hash identically regardless
+    of timing or incidental key order. Mirrors the canonical-bytes discipline
+    used by the audit log and lineage entries.
+
+    Args:
+        event: One decoded ``replay.jsonl`` row.
+
+    Returns:
+        UTF-8 canonical JSON bytes of the deterministic projection.
+    """
+    projected = {k: v for k, v in event.items() if k not in _NON_DETERMINISTIC_FIELDS}
+    return json.dumps(projected, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+
+def _fingerprint_lines(lines: Iterable[str]) -> str:
+    """Hash the deterministic projection of each non-blank JSONL line.
+
+    Lines that fail to parse as JSON are skipped (mirroring
+    :func:`load_replay_events`) so a partial trailing write cannot wedge the
+    fingerprint. The hash covers ``event`` plus the decision-relevant payload
+    and excludes the wall-clock envelope (issue #1851).
+    """
+    sha = hashlib.sha256()
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            # Defensive: a bare scalar/array line is not a recordable event.
+            continue
+        sha.update(_canonical_event_bytes(event))
+        sha.update(b"\n")
+    return sha.hexdigest()
 
 
 class RunRecorder:
@@ -82,22 +135,25 @@ class RunRecorder:
             logger.warning("RunRecorder: failed to write event %r: %s", event, exc)
 
     def fingerprint(self) -> str:
-        """Compute SHA-256 fingerprint of the entire replay log.
+        """Compute the deterministic execution fingerprint of the replay log.
+
+        Hashes a canonical projection of each event that keeps ``event`` and
+        the decision-relevant payload but excludes the wall-clock envelope
+        (``ts`` / ``elapsed_s``), so two byte-identical executions hash equal
+        regardless of timing (issue #1851). The on-disk log is unchanged; only
+        the fingerprint computation skips the timing fields.
 
         Returns:
             Hex-encoded SHA-256 hash, or empty string if the file doesn't exist.
         """
         if not self._path.exists():
             return ""
-        sha = hashlib.sha256()
         try:
-            with self._path.open("rb") as f:
-                for chunk in iter(lambda: f.read(8192), b""):
-                    sha.update(chunk)
+            with self._path.open(encoding="utf-8") as f:
+                return _fingerprint_lines(f)
         except OSError as exc:
             logger.warning("RunRecorder: failed to read replay log for fingerprint: %s", exc)
             return ""
-        return sha.hexdigest()
 
     def event_count(self) -> int:
         """Return the number of events recorded so far."""
@@ -135,7 +191,13 @@ def load_replay_events(replay_path: Path) -> list[dict[str, Any]]:
 
 
 def compute_replay_fingerprint(replay_path: Path) -> str:
-    """Compute SHA-256 fingerprint of a replay log file.
+    """Compute the deterministic execution fingerprint of a replay log file.
+
+    Hashes the same canonical, timing-excluded projection as
+    :meth:`RunRecorder.fingerprint`, so a recording and a faithful replay -
+    which differ only in their ``ts`` / ``elapsed_s`` envelope - share one
+    fingerprint, while any divergence in the decision stream changes it
+    (issue #1851).
 
     Args:
         replay_path: Path to the ``replay.jsonl`` file.
@@ -145,8 +207,9 @@ def compute_replay_fingerprint(replay_path: Path) -> str:
     """
     if not replay_path.exists():
         return ""
-    sha = hashlib.sha256()
-    with replay_path.open("rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            sha.update(chunk)
-    return sha.hexdigest()
+    try:
+        with replay_path.open(encoding="utf-8") as f:
+            return _fingerprint_lines(f)
+    except OSError as exc:
+        logger.warning("compute_replay_fingerprint: failed to read %s: %s", replay_path, exc)
+        return ""

--- a/src/bernstein/core/replay/gateway.py
+++ b/src/bernstein/core/replay/gateway.py
@@ -28,8 +28,9 @@ import logging
 import os
 import threading
 import time
+from collections import deque
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -91,6 +92,21 @@ class _Event:
     seq: int
 
 
+@dataclass
+class _Fixture:
+    """A recorded response plus its consumption state during replay.
+
+    Holds the recorded ``response`` and a ``consumed`` flag. The fixture lives
+    in exactly one per-kind ordered list (recorded order); the by-key index
+    references it by position, so a by-key consume and a by-kind consume mark
+    the same object - the two views can never disagree on which recorded slot
+    was served (#1855).
+    """
+
+    response: Any
+    consumed: bool = field(default=False)
+
+
 class ReplayGateway:
     """Thin wrapper around LLM + tool dispatch with record/replay support.
 
@@ -136,9 +152,15 @@ class ReplayGateway:
             mode = GatewayMode.RECORD if record or is_recording_enabled() else GatewayMode.OFF
         self._mode = mode
 
-        # Replay-mode fixture state.
-        self._fixtures_by_key: dict[tuple[str, str], list[Any]] = {}
-        self._fixtures_by_kind: dict[str, list[Any]] = {}
+        # Replay-mode fixture state. A single ordered list per kind is the
+        # source of truth (recorded order); the by-key index points into it by
+        # position, so consuming a fixture by key and by kind can never desync
+        # even when distinct keys recorded identical response values (#1855).
+        self._ordered_by_kind: dict[str, list[_Fixture]] = {}
+        self._positions_by_key: dict[tuple[str, str], deque[int]] = {}
+        # Per-kind cursor: index of the first not-yet-consumed fixture, so the
+        # by-kind FIFO fallback is amortised O(1) instead of rescanning.
+        self._kind_cursor: dict[str, int] = {}
 
         if self._mode is GatewayMode.RECORD:
             # Only create the directory when we'll actually write something.
@@ -257,7 +279,16 @@ class ReplayGateway:
     # ------------------------------------------------------------------
 
     def _load_fixtures(self) -> None:
-        """Load fixtures from ``events.jsonl`` into in-memory queues."""
+        """Load fixtures from ``events.jsonl`` into ordered per-kind lists.
+
+        Events are ordered by their recorded ``seq`` so the by-kind FIFO
+        fallback replays in recorded order regardless of duplicate response
+        values. Rows missing ``seq`` (legacy logs predating the per-event
+        sequence) fall back to file order, which is the implicit recorded
+        order. The by-key index records each fixture's *position* in its
+        kind's ordered list, so a by-key consume marks the exact recorded
+        slot rather than the first slot with a matching value (#1855).
+        """
         if not self._path.exists():
             raise ReplayMissError(
                 f"No events log at {self._path}; nothing to replay. "
@@ -265,8 +296,9 @@ class ReplayGateway:
             )
         # encoding="utf-8" mirrors the record path; relying on the platform
         # default broke replay on Windows runners where cp1252 was active.
+        rows: list[tuple[int, int, str, str, Any]] = []
         with self._path.open(encoding="utf-8") as f:
-            for raw in f:
+            for file_pos, raw in enumerate(f):
                 row_str = raw.strip()
                 if not row_str:
                     continue
@@ -278,32 +310,74 @@ class ReplayGateway:
                 kind = str(row.get("kind", ""))
                 key = str(row.get("key", ""))
                 response = row.get("response")
-                self._fixtures_by_key.setdefault((kind, key), []).append(response)
-                self._fixtures_by_kind.setdefault(kind, []).append(response)
+                # ``seq`` is the recorded order; legacy logs without it use file
+                # order. ``file_pos`` is the stable tiebreak so two rows sharing
+                # a seq (or both missing it) keep their on-disk order.
+                seq_raw = row.get("seq")
+                seq = int(seq_raw) if isinstance(seq_raw, int) else file_pos
+                rows.append((seq, file_pos, kind, key, response))
+
+        # Sort by (seq, file_pos) so the per-kind lists are in recorded order
+        # even if the log was written or stitched out of strict line order.
+        rows.sort(key=lambda r: (r[0], r[1]))
+        for _seq, _pos, kind, key, response in rows:
+            ordered = self._ordered_by_kind.setdefault(kind, [])
+            fixture = _Fixture(response=response)
+            position = len(ordered)
+            ordered.append(fixture)
+            self._positions_by_key.setdefault((kind, key), deque()).append(position)
+
+    def _next_unconsumed_index(self, kind: str, ordered: list[_Fixture]) -> int | None:
+        """Return the index of the lowest unconsumed fixture for ``kind``.
+
+        Advances and caches a per-kind cursor past already-consumed fixtures
+        so repeated by-kind fallbacks stay amortised O(1). Returns ``None``
+        when every fixture for the kind has been consumed.
+        """
+        cursor = self._kind_cursor.get(kind, 0)
+        while cursor < len(ordered) and ordered[cursor].consumed:
+            cursor += 1
+        self._kind_cursor[kind] = cursor
+        return cursor if cursor < len(ordered) else None
 
     def _replay_lookup(self, *, kind: str, key: str) -> Any:
-        """Pop the next fixture for ``(kind, key)`` (or FIFO by ``kind``).
+        """Consume the next fixture for ``(kind, key)`` (or FIFO by ``kind``).
 
-        Holds ``self._lock`` for the entire pop so concurrent dispatches
-        cannot drain the same bucket twice or skip rows that another
-        thread has already popped under the by-kind fallback.
+        On a by-key hit, consume the lowest unconsumed recorded position for
+        that exact ``(kind, key)``. On a miss, fall back to the lowest
+        unconsumed position for the kind (recorded-order FIFO). Both paths
+        mark the same per-kind ordered list, so duplicate response values can
+        never desync the two views (#1855).
+
+        Holds ``self._lock`` for the entire consume so concurrent dispatches
+        cannot drain the same fixture twice or skip rows another thread has
+        already consumed under the by-kind fallback.
         """
         with self._lock:
-            bucket = self._fixtures_by_key.get((kind, key))
-            if bucket:
-                response = bucket.pop(0)
-                # Also remove the matching entry from the by-kind queue
-                # (FIFO match - first identical response).
-                kind_bucket = self._fixtures_by_kind.get(kind, [])
-                for i, item in enumerate(kind_bucket):
-                    if item == response:
-                        kind_bucket.pop(i)
-                        break
-                return response
+            ordered = self._ordered_by_kind.get(kind)
+            if ordered is None:
+                raise ReplayMissError(
+                    f"No fixture for kind={kind!r} key={key!r} in {self._path}. "
+                    "Either the run diverged or recording was incomplete.",
+                )
 
-            kind_bucket = self._fixtures_by_kind.get(kind)
-            if kind_bucket:
-                return kind_bucket.pop(0)
+            positions = self._positions_by_key.get((kind, key))
+            # Skip positions already consumed via the by-kind fallback so a
+            # by-key hit never returns a slot that was served as FIFO filler.
+            while positions:
+                idx = positions[0]
+                if ordered[idx].consumed:
+                    positions.popleft()
+                    continue
+                positions.popleft()
+                ordered[idx].consumed = True
+                return ordered[idx].response
+
+            # By-kind FIFO fallback: lowest unconsumed recorded position.
+            fallback_idx = self._next_unconsumed_index(kind, ordered)
+            if fallback_idx is not None:
+                ordered[fallback_idx].consumed = True
+                return ordered[fallback_idx].response
 
         raise ReplayMissError(
             f"No fixture for kind={kind!r} key={key!r} in {self._path}. "

--- a/tests/unit/test_deterministic_store_replay.py
+++ b/tests/unit/test_deterministic_store_replay.py
@@ -1,0 +1,204 @@
+"""Replay-fidelity tests for :class:`DeterministicStore` (issue #1846).
+
+A recorded run appends one ``llm_calls.jsonl`` line per LLM call, in call
+order. Replay must return the recorded responses for a repeated
+``(prompt, model, ...)`` key *in that same order*, not collapse them to a
+single last-write-wins value. These tests pin the per-key sequence contract
+and the over-consumption guard.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.deterministic import (
+    DeterministicStore,
+    ReplayMissError,
+    _prompt_key,
+)
+from bernstein.core.persistence.recorder import RunRecorder
+
+
+def _write_calls(path: Path, rows: list[dict[str, object]]) -> None:
+    """Write ``rows`` as ``llm_calls.jsonl`` lines under ``path``'s run dir."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _record_run(run_dir: Path, calls: list[tuple[str, str, str]]) -> DeterministicStore:
+    """Record ``(prompt, model, response)`` calls and return the store."""
+    store = DeterministicStore(run_dir, replay=False)
+    for prompt, model, response in calls:
+        store.record(prompt, model, response)
+    return store
+
+
+def test_repeated_key_replays_in_recorded_order(tmp_path: Path) -> None:
+    """Two identical (prompt, model) calls replay as A then B, not B then B.
+
+    This is the core of issue #1846: a flat ``dict[key -> response]`` keeps
+    only the last recording, so the first call wrongly replays the second
+    response.
+    """
+    run_dir = tmp_path / "runs" / "rep-1"
+    _record_run(
+        run_dir,
+        [
+            ("same-prompt", "sonnet", "A"),
+            ("same-prompt", "sonnet", "B"),
+        ],
+    )
+
+    replay = DeterministicStore(run_dir, replay=True)
+    first = replay.get_replay("same-prompt", "sonnet")
+    second = replay.get_replay("same-prompt", "sonnet")
+
+    assert first == "A", "first replay must return the first recorded response"
+    assert second == "B", "second replay must return the second recorded response"
+
+
+def test_over_consumption_raises_replay_miss(tmp_path: Path) -> None:
+    """Requesting a key more times than recorded raises ReplayMissError.
+
+    Recording K responses for a key and replaying K+1 times is a
+    replay-fidelity failure: the run diverged from the recording. Strict
+    replay must surface it rather than silently re-returning a stale value.
+    """
+    run_dir = tmp_path / "runs" / "rep-2"
+    _record_run(
+        run_dir,
+        [
+            ("p", "sonnet", "A"),
+            ("p", "sonnet", "B"),
+        ],
+    )
+
+    replay = DeterministicStore(run_dir, replay=True)
+    assert replay.get_replay("p", "sonnet") == "A"
+    assert replay.get_replay("p", "sonnet") == "B"
+    with pytest.raises(ReplayMissError):
+        replay.get_replay("p", "sonnet")
+
+
+def test_single_occurrence_keys_unchanged(tmp_path: Path) -> None:
+    """Common case: distinct keys each replay their single recorded response."""
+    run_dir = tmp_path / "runs" / "rep-3"
+    _record_run(
+        run_dir,
+        [
+            ("prompt-a", "sonnet", "RA"),
+            ("prompt-b", "opus", "RB"),
+        ],
+    )
+
+    replay = DeterministicStore(run_dir, replay=True)
+    assert replay.get_replay("prompt-a", "sonnet") == "RA"
+    assert replay.get_replay("prompt-b", "opus") == "RB"
+
+
+def test_interleaved_distinct_keys_each_keep_their_sequence(tmp_path: Path) -> None:
+    """Per-key cursors are independent: interleaving keys does not cross streams."""
+    run_dir = tmp_path / "runs" / "rep-4"
+    _record_run(
+        run_dir,
+        [
+            ("p1", "sonnet", "1A"),
+            ("p2", "sonnet", "2A"),
+            ("p1", "sonnet", "1B"),
+            ("p2", "sonnet", "2B"),
+        ],
+    )
+
+    replay = DeterministicStore(run_dir, replay=True)
+    # Consume p1 fully, then p2 fully - each must follow its own order.
+    assert replay.get_replay("p1", "sonnet") == "1A"
+    assert replay.get_replay("p1", "sonnet") == "1B"
+    assert replay.get_replay("p2", "sonnet") == "2A"
+    assert replay.get_replay("p2", "sonnet") == "2B"
+
+
+def test_non_strict_over_consumption_returns_none(tmp_path: Path) -> None:
+    """Non-strict replay returns None on over-consumption instead of raising."""
+    run_dir = tmp_path / "runs" / "rep-5"
+    _record_run(run_dir, [("p", "sonnet", "A")])
+
+    replay = DeterministicStore(run_dir, replay=True, strict=False)
+    assert replay.get_replay("p", "sonnet") == "A"
+    assert replay.get_replay("p", "sonnet") is None
+
+
+def _replay_into_replay_log(run_dir: Path, replay_log: Path, n_calls: int) -> str:
+    """Drive a replay that folds each consumed response into ``replay.jsonl``.
+
+    Models the real coupling: an agent's decision (recorded as a replay event)
+    is a function of the LLM response it consumed. Returns the deterministic
+    fingerprint of the resulting decision stream.
+    """
+    store = DeterministicStore(run_dir, replay=True)
+    rec = RunRecorder(run_id=replay_log.parent.name, sdd_dir=replay_log.parent.parent.parent)
+    for i in range(n_calls):
+        response = store.get_replay("loop-prompt", "sonnet")
+        # The decision the agent records depends on the consumed response.
+        rec.record("agent_decision", step=i, decision=response)
+    return rec.fingerprint()
+
+
+def test_faithful_replay_and_swapped_replay_differ_in_fingerprint(tmp_path: Path) -> None:
+    """Tie the per-key sequence to the determinism fingerprint (issue #1846).
+
+    A faithful replay of the recording reproduces the decision stream, so its
+    fingerprint matches a second faithful replay. Swapping two same-key
+    responses in the fixture perturbs the consumed sequence and therefore the
+    fingerprint - proving the fix couples per-key order to the determinism
+    proof rather than masking the divergence.
+    """
+    sdd = tmp_path / ".sdd"
+    run_dir = sdd / "runs" / "fp-rec"
+    _record_run(
+        run_dir,
+        [
+            ("loop-prompt", "sonnet", "A"),
+            ("loop-prompt", "sonnet", "B"),
+        ],
+    )
+
+    # Two faithful replays of the same recording -> identical fingerprint.
+    fp_1 = _replay_into_replay_log(run_dir, sdd / "runs" / "faithful-1" / "replay.jsonl", 2)
+    fp_2 = _replay_into_replay_log(run_dir, sdd / "runs" / "faithful-2" / "replay.jsonl", 2)
+    assert fp_1 == fp_2
+    assert fp_1 != ""
+
+    # Swap the two same-key responses in the fixture (B then A) and replay.
+    swapped_dir = sdd / "runs" / "fp-swapped"
+    _record_run(
+        swapped_dir,
+        [
+            ("loop-prompt", "sonnet", "B"),
+            ("loop-prompt", "sonnet", "A"),
+        ],
+    )
+    fp_swapped = _replay_into_replay_log(swapped_dir, sdd / "runs" / "swapped-replay" / "replay.jsonl", 2)
+    assert fp_swapped != fp_1, "swapping the same-key response order must change the fingerprint"
+
+
+def test_recorded_lines_preserve_call_order_on_disk(tmp_path: Path) -> None:
+    """The journal itself stays append-only and order-preserving (sanity)."""
+    run_dir = tmp_path / "runs" / "rep-6"
+    store = _record_run(
+        run_dir,
+        [
+            ("p", "sonnet", "first"),
+            ("p", "sonnet", "second"),
+        ],
+    )
+    lines = store.calls_path.read_text(encoding="utf-8").splitlines()
+    responses = [json.loads(line)["response"] for line in lines]
+    assert responses == ["first", "second"]
+    # Both lines share the same key (repeated prompt+model).
+    keys = {json.loads(line)["key"] for line in lines}
+    assert keys == {_prompt_key("p", "sonnet")}

--- a/tests/unit/test_recorder_fingerprint_determinism.py
+++ b/tests/unit/test_recorder_fingerprint_determinism.py
@@ -1,0 +1,125 @@
+"""Determinism tests for the replay execution fingerprint (issue #1851).
+
+The fingerprint is advertised as a cross-run identity ("determinism proof
+across runs"). For that to hold it must hash only the deterministic decision
+stream, not the wall-clock envelope (``ts`` / ``elapsed_s``) that advances
+every run. These tests pin: identical decision streams hash equal even when
+timing differs, and real divergence still changes the hash.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.persistence.recorder import (
+    RunRecorder,
+    compute_replay_fingerprint,
+)
+
+
+def _write_replay(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_fingerprint_ignores_wall_clock_fields(tmp_path: Path) -> None:
+    """Two logs identical except for ts/elapsed_s hash to the same value.
+
+    This is the heart of issue #1851: a perfectly deterministic re-execution
+    only differs in its timing envelope, so the fingerprint must match.
+    """
+    a = tmp_path / "a" / "replay.jsonl"
+    b = tmp_path / "b" / "replay.jsonl"
+    _write_replay(
+        a,
+        [
+            {"ts": 100.0, "elapsed_s": 0.0, "event": "task_claimed", "task_id": "T-1"},
+            {"ts": 100.5, "elapsed_s": 0.5, "event": "task_completed", "task_id": "T-1"},
+        ],
+    )
+    _write_replay(
+        b,
+        [
+            {"ts": 999.0, "elapsed_s": 0.0, "event": "task_claimed", "task_id": "T-1"},
+            {"ts": 1003.25, "elapsed_s": 4.25, "event": "task_completed", "task_id": "T-1"},
+        ],
+    )
+
+    assert compute_replay_fingerprint(a) == compute_replay_fingerprint(b)
+
+
+def test_fingerprint_changes_on_decision_divergence(tmp_path: Path) -> None:
+    """A different decision payload changes the fingerprint."""
+    a = tmp_path / "a" / "replay.jsonl"
+    b = tmp_path / "b" / "replay.jsonl"
+    _write_replay(
+        a,
+        [{"ts": 1.0, "elapsed_s": 0.0, "event": "task_completed", "task_id": "T-1", "result": "ok"}],
+    )
+    _write_replay(
+        b,
+        [{"ts": 1.0, "elapsed_s": 0.0, "event": "task_completed", "task_id": "T-1", "result": "FAIL"}],
+    )
+
+    assert compute_replay_fingerprint(a) != compute_replay_fingerprint(b)
+
+
+def test_fingerprint_changes_on_event_reorder(tmp_path: Path) -> None:
+    """Reordering events changes the fingerprint (order is a decision)."""
+    a = tmp_path / "a" / "replay.jsonl"
+    b = tmp_path / "b" / "replay.jsonl"
+    rows = [
+        {"ts": 1.0, "elapsed_s": 0.0, "event": "task_claimed", "task_id": "T-1"},
+        {"ts": 2.0, "elapsed_s": 1.0, "event": "task_claimed", "task_id": "T-2"},
+    ]
+    _write_replay(a, rows)
+    _write_replay(b, list(reversed(rows)))
+
+    assert compute_replay_fingerprint(a) != compute_replay_fingerprint(b)
+
+
+def test_fingerprint_changes_on_event_type_change(tmp_path: Path) -> None:
+    """A changed ``event`` type changes the fingerprint."""
+    a = tmp_path / "a" / "replay.jsonl"
+    b = tmp_path / "b" / "replay.jsonl"
+    _write_replay(a, [{"ts": 1.0, "elapsed_s": 0.0, "event": "task_claimed", "task_id": "T-1"}])
+    _write_replay(b, [{"ts": 1.0, "elapsed_s": 0.0, "event": "task_aborted", "task_id": "T-1"}])
+
+    assert compute_replay_fingerprint(a) != compute_replay_fingerprint(b)
+
+
+def test_fingerprint_insensitive_to_key_order(tmp_path: Path) -> None:
+    """Canonicalisation makes incidental key order irrelevant."""
+    a = tmp_path / "a" / "replay.jsonl"
+    b = tmp_path / "b" / "replay.jsonl"
+    _write_replay(a, [{"event": "task_completed", "task_id": "T-1", "result": "ok", "ts": 1.0}])
+    _write_replay(b, [{"result": "ok", "ts": 1.0, "task_id": "T-1", "event": "task_completed"}])
+
+    assert compute_replay_fingerprint(a) == compute_replay_fingerprint(b)
+
+
+def test_recorder_instance_fingerprint_matches_module_function(tmp_path: Path) -> None:
+    """RunRecorder.fingerprint and compute_replay_fingerprint agree."""
+    rec = RunRecorder(run_id="run-x", sdd_dir=tmp_path)
+    rec.record("task_claimed", task_id="T-1")
+    rec.record("task_completed", task_id="T-1")
+
+    assert rec.fingerprint() == compute_replay_fingerprint(rec.path)
+
+
+def test_recorder_two_runs_same_decisions_same_fingerprint(tmp_path: Path) -> None:
+    """End-to-end: two RunRecorder runs with identical decisions but real
+    wall-clock differences produce the same fingerprint."""
+    rec_a = RunRecorder(run_id="run-a", sdd_dir=tmp_path)
+    rec_a.record("task_claimed", task_id="T-1", agent_id="backend")
+    rec_a.record("task_completed", task_id="T-1", files=["src/a.py"])
+
+    rec_b = RunRecorder(run_id="run-b", sdd_dir=tmp_path)
+    rec_b.record("task_claimed", task_id="T-1", agent_id="backend")
+    rec_b.record("task_completed", task_id="T-1", files=["src/a.py"])
+
+    assert rec_a.fingerprint() == rec_b.fingerprint()
+    assert rec_a.fingerprint() != ""

--- a/tests/unit/test_replay_gateway_fifo_order.py
+++ b/tests/unit/test_replay_gateway_fifo_order.py
@@ -1,0 +1,178 @@
+"""FIFO-ordering tests for the replay gateway (issue #1855).
+
+When two distinct keys recorded the same response value, the by-kind FIFO
+fallback must still pop responses in recorded order. The old by-value removal
+on a by-key hit deleted the wrong by-kind slot, silently desyncing the two
+structures. These tests pin the recorded-order contract under duplicate
+response values and mixed by-key / by-kind lookups.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.replay import (
+    EVENTS_FILENAME,
+    GatewayMode,
+    ReplayGateway,
+    ReplayMissError,
+)
+
+
+def _write_events(run_dir: Path, rows: list[dict[str, object]]) -> None:
+    """Write recorded ``events.jsonl`` rows for a run directory."""
+    path = run_dir / EVENTS_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _explode() -> object:
+    raise AssertionError("replay must not call invoke()")
+
+
+def test_bykey_hit_does_not_corrupt_bykind_fifo_with_dup_values(tmp_path: Path) -> None:
+    """The worked example from issue #1855.
+
+    Record kind=tool: A->R, B->R, C->S. A by-key hit on (tool, B) must not
+    remove A's slot from the by-kind FIFO. A later by-kind fallback must then
+    still see R (A's recorded slot) then S (C's), in recorded order.
+    """
+    run_dir = tmp_path / "runs" / "dup-1"
+    _write_events(
+        run_dir,
+        [
+            {"seq": 1, "kind": "tool", "key": "A", "response": "R"},
+            {"seq": 2, "kind": "tool", "key": "B", "response": "R"},
+            {"seq": 3, "kind": "tool", "key": "C", "response": "S"},
+        ],
+    )
+
+    gw = ReplayGateway("dup-1", tmp_path, mode=GatewayMode.REPLAY)
+
+    # By-key hit on B consumes B's recorded slot (seq 2).
+    assert gw.dispatch(kind="tool", key="B", invoke=_explode) == "R"
+    # Two by-kind fallbacks must return the remaining recorded slots in
+    # seq order: A's R (seq 1), then C's S (seq 3).
+    assert gw.dispatch(kind="tool", key="miss-1", invoke=_explode) == "R"
+    assert gw.dispatch(kind="tool", key="miss-2", invoke=_explode) == "S"
+
+
+def test_bykey_hit_steals_wrong_bykind_slot_corrupts_fallback(tmp_path: Path) -> None:
+    """Minimal corruption case: by-value removal serves a consumed slot.
+
+    Record kind=tool: A->R (s1), B->S (s2), C->R (s3); by-kind FIFO is
+    [R, S, R]. A by-key hit on C (recorded value R at seq 3) must consume
+    *C's* slot. With value-equality removal it instead deletes the first R
+    (A's seq-1 slot), so the by-kind queue becomes [S, R] = B's S and C's
+    *already-consumed* R. Two by-kind fallbacks then return S then R, but
+    the only unconsumed recorded slots are A (R) and B (S): the correct
+    fallback order is R then S. The second R is a phantom replay of C, which
+    was already served - a silent wrong-response substitution.
+    """
+    run_dir = tmp_path / "runs" / "dup-corrupt"
+    _write_events(
+        run_dir,
+        [
+            {"seq": 1, "kind": "tool", "key": "A", "response": "R"},
+            {"seq": 2, "kind": "tool", "key": "B", "response": "S"},
+            {"seq": 3, "kind": "tool", "key": "C", "response": "R"},
+        ],
+    )
+
+    gw = ReplayGateway("dup-corrupt", tmp_path, mode=GatewayMode.REPLAY)
+    # Consume C by key (its recorded response is R at seq 3).
+    assert gw.dispatch(kind="tool", key="C", invoke=_explode) == "R"
+    # Remaining unconsumed slots are A (R, seq 1) and B (S, seq 2). A by-kind
+    # fallback must return them in recorded seq order: R then S.
+    assert gw.dispatch(kind="tool", key="miss-1", invoke=_explode) == "R"
+    assert gw.dispatch(kind="tool", key="miss-2", invoke=_explode) == "S"
+
+
+def test_pure_bykey_replay_with_repeated_values_in_order(tmp_path: Path) -> None:
+    """Every call matches its recorded key; duplicate values stay in order."""
+    run_dir = tmp_path / "runs" / "dup-2"
+    _write_events(
+        run_dir,
+        [
+            {"seq": 1, "kind": "llm", "key": "k1", "response": "same"},
+            {"seq": 2, "kind": "llm", "key": "k2", "response": "same"},
+            {"seq": 3, "kind": "llm", "key": "k1", "response": "diff"},
+        ],
+    )
+
+    gw = ReplayGateway("dup-2", tmp_path, mode=GatewayMode.REPLAY)
+    # k1 recorded "same" (seq 1) then "diff" (seq 3); k2 recorded "same".
+    assert gw.dispatch(kind="llm", key="k1", invoke=_explode) == "same"
+    assert gw.dispatch(kind="llm", key="k2", invoke=_explode) == "same"
+    assert gw.dispatch(kind="llm", key="k1", invoke=_explode) == "diff"
+
+
+def test_bykind_fallback_strict_seq_order_with_dups(tmp_path: Path) -> None:
+    """A pure by-kind fallback returns responses in recorded seq order."""
+    run_dir = tmp_path / "runs" / "dup-3"
+    _write_events(
+        run_dir,
+        [
+            {"seq": 1, "kind": "tool", "key": "a", "response": {"ok": True}},
+            {"seq": 2, "kind": "tool", "key": "b", "response": {"ok": True}},
+            {"seq": 3, "kind": "tool", "key": "c", "response": {"ok": False}},
+        ],
+    )
+
+    gw = ReplayGateway("dup-3", tmp_path, mode=GatewayMode.REPLAY)
+    # All keys miss -> FIFO by seq: ok, ok, not-ok.
+    out = [gw.dispatch(kind="tool", key=f"x{i}", invoke=_explode) for i in range(3)]
+    assert out == [{"ok": True}, {"ok": True}, {"ok": False}]
+
+
+def test_mixed_interleave_returns_recorded_position(tmp_path: Path) -> None:
+    """Mixing by-key hits and by-kind fallbacks never substitutes a wrong
+    recorded response, even with all-identical values."""
+    run_dir = tmp_path / "runs" / "dup-4"
+    _write_events(
+        run_dir,
+        [
+            {"seq": 1, "kind": "tool", "key": "A", "response": "R"},
+            {"seq": 2, "kind": "tool", "key": "B", "response": "R"},
+            {"seq": 3, "kind": "tool", "key": "C", "response": "R"},
+            {"seq": 4, "kind": "tool", "key": "D", "response": "R"},
+        ],
+    )
+
+    gw = ReplayGateway("dup-4", tmp_path, mode=GatewayMode.REPLAY)
+    # by-key C (seq 3), then by-kind (seq 1 = A), by-key A would now miss but
+    # we instead consume by-kind twice more (seq 2, seq 4). All return "R" and
+    # crucially the bucket never under/over-drains.
+    assert gw.dispatch(kind="tool", key="C", invoke=_explode) == "R"
+    assert gw.dispatch(kind="tool", key="zzz", invoke=_explode) == "R"
+    assert gw.dispatch(kind="tool", key="A", invoke=_explode) == "R"
+    assert gw.dispatch(kind="tool", key="yyy", invoke=_explode) == "R"
+    # Exactly four fixtures recorded; the fifth consumption must miss.
+    with pytest.raises(ReplayMissError):
+        gw.dispatch(kind="tool", key="extra", invoke=_explode)
+
+
+def test_replay_is_byte_identical_across_two_runs_with_dups(tmp_path: Path) -> None:
+    """Replaying a duplicate-value recording twice yields identical output."""
+    run_dir = tmp_path / "runs" / "dup-5"
+    rows = [
+        {"seq": 1, "kind": "tool", "key": "A", "response": "R"},
+        {"seq": 2, "kind": "tool", "key": "B", "response": "R"},
+        {"seq": 3, "kind": "tool", "key": "C", "response": "S"},
+    ]
+    _write_events(run_dir, rows)
+
+    def _drain() -> list[object]:
+        gw = ReplayGateway("dup-5", tmp_path, mode=GatewayMode.REPLAY)
+        return [
+            gw.dispatch(kind="tool", key="B", invoke=_explode),
+            gw.dispatch(kind="tool", key="miss-1", invoke=_explode),
+            gw.dispatch(kind="tool", key="miss-2", invoke=_explode),
+        ]
+
+    assert _drain() == _drain()


### PR DESCRIPTION
## Summary

Three related replay-determinism defects let a "successful" replay execute a
different sequence than its recording without flagging the drift. They all live
in the replay recorder/gateway and are fixed together.

- **#1846** `DeterministicStore` collapsed repeated `(prompt, model, ...)` calls
  to last-write-wins. The replay cache was a flat `dict[key -> response]`, so a
  key recorded N times kept only the last response and replayed it for every
  call. Now a per-key FIFO loaded in recorded order; `get_replay` consumes the
  next recorded response (Nth call -> Nth recording). Over-consuming a key past
  its recorded count is a miss (strict raises `ReplayMissError`, non-strict
  returns `None`).
- **#1851** The execution fingerprint hashed the wall-clock envelope. Every
  `replay.jsonl` event carries `ts`/`elapsed_s`, and the fingerprint hashed the
  whole file, so two byte-identical runs never matched. The fingerprint now
  hashes a canonical projection of each event (sorted keys, fixed separators)
  that excludes `ts`/`elapsed_s`. Identical decision streams hash equal; a
  changed decision output, a reordered event, or a changed event type still
  changes the hash. The timing fields stay in `replay.jsonl` for the operator
  timeline.
- **#1855** `ReplayGateway` desynced its by-kind FIFO by removing the first
  by-kind entry equal to the response *value*. Two distinct keys recording the
  same value deleted the wrong slot, so a later by-kind fallback served an
  out-of-order or already-consumed response and never raised. Fixtures now load
  into one ordered list per kind (sorted by recorded `seq`, file-order fallback
  for legacy logs) plus a by-key index of positions; a by-key consume marks the
  exact recorded slot and the fallback pops the lowest unconsumed `seq`.

Each fix verifies only on bernstein's recorded substrate (append-only
`llm_calls.jsonl`, per-event `seq` in `events.jsonl`, the timing-excluded
fingerprint over `replay.jsonl`): without the recorded per-call/per-event order
the faithful sequence cannot be reconstructed.

## Test plan

- [x] `test_deterministic_store_replay.py` - repeated key replays A then B;
      over-consumption raises (strict) / returns None (non-strict); interleaved
      keys keep independent cursors; a faithful replay and a swapped-sequence
      replay produce different fingerprints.
- [x] `test_recorder_fingerprint_determinism.py` - two logs differing only in
      `ts`/`elapsed_s` hash equal; decision/reorder/event-type divergence changes
      the hash; key order is irrelevant.
- [x] `test_replay_gateway_fifo_order.py` - the duplicate-value corruption case
      now returns recorded order; mixed by-key/by-kind lookups never substitute a
      wrong recorded slot; replay is identical across two runs.
- [x] Affected superset green: `pytest tests/unit/test_recorder.py
      test_recorder_fingerprint_determinism.py test_deterministic_store_replay.py
      test_deterministic_run.py test_replay_gateway.py
      test_replay_gateway_fifo_order.py test_replay.py test_replay_cmd.py
      test_replay_filter_cmd.py test_replay_journal_cli.py test_wal_replay.py
      test_wal.py test_verify_determinism_gate.py test_fingerprint_determinism.py`
      -> 202 passed.
- [x] `ruff check` + `ruff format` clean on changed files; `mypy` clean on the
      three changed source modules.

Closes #1846
Closes #1851
Closes #1855

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed deterministic replay to maintain FIFO order for repeated identical prompts; responses are now replayed in recorded sequence instead of being overwritten
  * Fixed fingerprint computation to exclude wall-clock timing fields for consistent and reproducible execution verification

* **New Features**
  * Added strict replay miss detection that raises errors when requesting more occurrences of a key than were recorded
  * Added non-strict mode option to return `None` on replay misses instead of failing

* **Tests**
  * Added comprehensive test coverage for replay fidelity and fingerprint determinism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->