### PR TITLE
fix(audit): harden Merkle seal leaf and root against tamper and second-preimage

### DIFF
--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -210,6 +210,36 @@ result = verify_audit_integrity(Path(".sdd/audit"), count=10_000)
 print(result.valid, result.entries_checked, result.errors)
 ```
 
+### Merkle seal (second integrity layer)
+
+`bernstein audit seal` writes a Merkle root over the daily `*.jsonl`
+files into `.sdd/audit/merkle/seal-<ISO>.json`. it is a file-level
+integrity layer on top of the per-line HMAC chain: it detects a
+deleted, inserted, reordered, or content-tampered daily file.
+
+what the seal binds:
+
+- **leaf per file** - each file's leaf is the hash of its *whole*
+  canonical byte content, so flipping any byte of any line (not just
+  the last) changes the leaf and trips `TAMPERED` on verify.
+- **domain-separated tree** - leaves are hashed `H(0x00 || bytes)` and
+  internal nodes `H(0x01 || left || right)` (RFC-6962 style). a lone
+  node at an odd level is promoted unchanged rather than paired with
+  itself, so a leaf set with its last entry duplicated cannot collide
+  with the un-duplicated set.
+- **chain precheck** - `audit seal` verifies the HMAC chain before
+  writing the root. a broken chain raises and **no seal is written**,
+  so re-sealing can never launder a pre-existing tamper into a fresh
+  root. seal a known-broken chain on purpose only via the recovery
+  procedure below.
+
+scheme versioning: seals carry a `"scheme"` field. verification
+dispatches on it, so seals written before this hardening (`scheme` 1,
+or absent) still verify under their original rule. roots produced
+before and after the upgrade are **not comparable** - re-seal once
+after upgrading, and keep any pinned pre-upgrade root labelled as the
+old scheme. this is a scheme upgrade, not a tamper alert.
+
 ## Replaying a log
 
 the `query` verb walks all JSONL files under `.sdd/audit/` and
@@ -369,10 +399,12 @@ rare benign causes:
    webhook / splunk export was healthy, the SIEM has the original
    payload and you can identify exactly which fields were edited.
 4. seal the broken chain so the corruption is itself tamper-evident
-   forensically:
+   forensically. a plain `audit seal` refuses a broken chain (so
+   re-sealing can't hide a tamper) - pass `--allow-broken-chain` to
+   capture the corrupted state on purpose:
 
    ```bash
-   bernstein audit seal
+   bernstein audit seal --allow-broken-chain
    ```
 
 5. file an incident, preserve the snapshot, and start a fresh chain

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -105,9 +105,21 @@ def show_cmd(limit: int) -> None:
 
 @audit_group.command("seal")
 @click.option("--anchor-git", is_flag=True, default=False, help="Anchor root hash as a git tag.")
-def seal_cmd(anchor_git: bool) -> None:
-    """Compute a Merkle root across all audit log files and store the seal."""
-    from bernstein.core.merkle import anchor_to_git, compute_seal, save_seal
+@click.option(
+    "--allow-broken-chain",
+    is_flag=True,
+    default=False,
+    help="Seal even if the HMAC chain is broken (forensic capture of a corrupted log).",
+)
+def seal_cmd(anchor_git: bool, allow_broken_chain: bool) -> None:
+    """Compute a Merkle root across all audit log files and store the seal.
+
+    By default the HMAC chain is verified first and a broken chain aborts
+    the seal, so re-sealing cannot launder a pre-existing tamper into a
+    fresh root. Pass --allow-broken-chain to seal a known-corrupted log on
+    purpose (forensic evidence capture during the recovery procedure).
+    """
+    from bernstein.core.merkle import ChainBrokenError, anchor_to_git, compute_seal, save_seal
 
     if not AUDIT_DIR.is_dir():
         console.print(f"[red]Audit directory not found:[/red] {AUDIT_DIR}")
@@ -115,9 +127,16 @@ def seal_cmd(anchor_git: bool) -> None:
         raise SystemExit(1)
 
     try:
-        _tree, seal = compute_seal(AUDIT_DIR)
+        _tree, seal = compute_seal(AUDIT_DIR, verify_chain=not allow_broken_chain)
     except ValueError as exc:
         console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+    except ChainBrokenError as exc:
+        console.print(f"[red]Refusing to seal: the HMAC chain is broken.[/red]\n  {exc}")
+        console.print(
+            "[dim]Run 'bernstein audit verify --hmac-only' to locate the break. "
+            "To seal a known-corrupted log for forensics, re-run with --allow-broken-chain.[/dim]"
+        )
         raise SystemExit(1) from None
 
     seal_path = save_seal(seal, MERKLE_DIR)
@@ -138,8 +157,11 @@ def seal_cmd(anchor_git: bool) -> None:
     table.add_row("Root hash", str(seal["root_hash"]))
     table.add_row("Leaves", str(seal["leaf_count"]))
     table.add_row("Algorithm", str(seal["algorithm"]))
+    table.add_row("Scheme", str(seal.get("scheme", 1)))
     table.add_row("Sealed at", str(seal["sealed_at_iso"]))
     table.add_row("Seal file", str(seal_path))
+    if allow_broken_chain:
+        console.print("[yellow]Sealed WITHOUT chain verification (--allow-broken-chain).[/yellow]")
     console.print(table)
 
     if anchor_git:

--- a/src/bernstein/core/persistence/merkle.py
+++ b/src/bernstein/core/persistence/merkle.py
@@ -1,8 +1,20 @@
 """Merkle-tree integrity seal for audit log files.
 
 Builds a binary Merkle tree from daily HMAC-chained audit log files.
-Each file's final HMAC (or SHA-256 hash of the full file) becomes a leaf.
-The root hash proves no file was deleted, inserted, reordered, or tampered with.
+Each file's leaf binds the whole canonical file content, so a byte change
+in any line (not just the last) changes the leaf. The root hash proves no
+file was deleted, inserted, reordered, or tampered with.
+
+The tree is domain-separated RFC-6962 style: leaves are hashed with a
+``0x00`` tag and internal nodes with a ``0x01`` tag, so a leaf digest and
+an internal-node digest can never be confused (second-preimage hardening).
+A lone node at an odd level is promoted unchanged to the next level rather
+than self-paired, so ``[A, B, C]`` and ``[A, B, C, C]`` cannot collide.
+
+Scheme versioning: seals written by this module record ``"scheme"`` (see
+:data:`SEAL_SCHEME_VERSION`). Verification dispatches on the recorded
+scheme so pre-hardening (v1) seals still verify under their original
+last-line-hmac leaf rule; new seals verify under the v2 whole-file rule.
 
 Storage: ``.sdd/audit/merkle/seal-<ISO-timestamp>.json``
 """
@@ -18,6 +30,23 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+#: Seal schema version. v1 (pre-hardening) used the last JSONL line's stored
+#: ``hmac`` as the file leaf with no leaf/internal domain separation and
+#: self-paired odd nodes. v2 binds the whole canonical file content as a
+#: domain-separated leaf, domain-separates internal nodes, and promotes lone
+#: odd nodes unchanged. Verification dispatches on the recorded value so a
+#: v1 seal still verifies under the v1 rules.
+SEAL_SCHEME_VERSION = 2
+
+#: Default scheme assumed when a seal predates the ``scheme`` field.
+_LEGACY_SCHEME_VERSION = 1
+
+#: Domain-separation tags (RFC-6962 style). A leaf and an internal node can
+#: never produce the same digest because their inputs start with disjoint
+#: one-byte tags.
+_LEAF_TAG = b"\x00"
+_INTERNAL_TAG = b"\x01"
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -54,9 +83,33 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def _leaf_digest(data: bytes) -> str:
+    """Hash *data* as a Merkle leaf (``H(0x00 || data)``).
+
+    The ``0x00`` prefix domain-separates leaves from internal nodes so a
+    leaf digest can never be reinterpreted as an internal-node digest
+    (the general second-preimage attack on plain Merkle trees).
+    """
+    return hashlib.sha256(_LEAF_TAG + data).hexdigest()
+
+
 def _combine_hashes(left: str, right: str) -> str:
-    """Combine two child hashes into a parent hash (domain-separated)."""
+    """Combine two child hashes into a parent hash (v1 internal combine).
+
+    Retained for verifying pre-hardening (v1) seals only. v1 internal nodes
+    used ``H("merkle:{left}:{right}")`` with no leaf/internal separation.
+    """
     return _sha256(f"merkle:{left}:{right}".encode())
+
+
+def _combine_internal(left: str, right: str) -> str:
+    """Combine two child hashes into a parent (``H(0x01 || left || right)``).
+
+    The two child hashes are hex digests of equal, fixed width, so the
+    concatenation is unambiguous and the ``0x01`` tag keeps internal-node
+    digests disjoint from leaf digests.
+    """
+    return hashlib.sha256(_INTERNAL_TAG + left.encode() + right.encode()).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -64,17 +117,41 @@ def _combine_hashes(left: str, right: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def file_leaf_hash(path: Path) -> str:
+def file_leaf_hash(path: Path, *, scheme: int = SEAL_SCHEME_VERSION) -> str:
     """Compute the leaf hash for a single audit log file.
 
-    If the file contains HMAC-chained JSONL entries, the final entry's
-    ``hmac`` field is used directly.  Otherwise, the entire file is hashed.
+    Under the current scheme (v2) the leaf binds the *whole* canonical file
+    content as a domain-separated leaf digest, so a byte change in any line
+    - not only the last - changes the leaf. An empty or whitespace-only file
+    maps to a stable, reproducible leaf.
+
+    Under the legacy scheme (v1, ``scheme=1``) the historical rule is used:
+    the final JSONL entry's stored ``hmac`` is the leaf, or a plain
+    ``SHA-256`` of the file when the last line is not HMAC-chained JSONL.
+    This path exists only so pre-hardening seals continue to verify.
+
+    Args:
+        path: Audit log file to hash.
+        scheme: Seal scheme version governing leaf derivation.
+
+    Returns:
+        Hex-encoded leaf digest.
     """
     content = path.read_bytes()
+
+    if scheme <= _LEGACY_SCHEME_VERSION:
+        return _legacy_file_leaf_hash(content)
+
+    # v2: bind the whole file. Empty/whitespace files still get a stable
+    # leaf via the domain-separated digest of their exact bytes.
+    return _leaf_digest(content)
+
+
+def _legacy_file_leaf_hash(content: bytes) -> str:
+    """v1 leaf rule: last-line ``hmac`` or whole-file ``SHA-256``."""
     if not content.strip():
         return _sha256(b"empty")
 
-    # Try to extract the final HMAC from JSONL
     lines = content.rstrip().split(b"\n")
     last_line = lines[-1]
     with suppress(json.JSONDecodeError, KeyError, UnicodeDecodeError):
@@ -90,11 +167,33 @@ def file_leaf_hash(path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 
-def build_merkle_tree(leaf_hashes: list[tuple[str, str]]) -> MerkleTree:
+def build_merkle_tree(
+    leaf_hashes: list[tuple[str, str]],
+    *,
+    scheme: int = SEAL_SCHEME_VERSION,
+) -> MerkleTree:
     """Build a binary Merkle tree from ``(relative_path, hash)`` pairs.
 
-    Leaves must be in deterministic (sorted) order.  When the number of
-    leaves at a level is odd, the last node is duplicated.
+    Leaves must be in deterministic (sorted) order. The incoming ``hash``
+    values are already leaf digests (see :func:`file_leaf_hash`); this
+    function only combines them into internal nodes.
+
+    Under the current scheme (v2) a lone node at an odd level is *promoted
+    unchanged* to the next level instead of being paired with itself, so a
+    tree over ``[A, B, C]`` and a tree over ``[A, B, C, C]`` produce
+    different roots. Internal nodes are domain-separated from leaves with a
+    ``0x01`` tag (RFC-6962 style).
+
+    Under the legacy scheme (v1, ``scheme=1``) the historical construction
+    is used (self-pair the last odd node, ``H("merkle:{l}:{r}")`` internal
+    combine) so pre-hardening seals continue to verify.
+
+    Args:
+        leaf_hashes: ``(relative_path, leaf_digest)`` pairs in sorted order.
+        scheme: Seal scheme version governing tree construction.
+
+    Returns:
+        The constructed :class:`MerkleTree`.
     """
     if not leaf_hashes:
         empty = MerkleNode(hash=_sha256(b"empty-tree"))
@@ -102,14 +201,25 @@ def build_merkle_tree(leaf_hashes: list[tuple[str, str]]) -> MerkleTree:
 
     leaves = [MerkleNode(hash=h, leaf_path=p) for p, h in leaf_hashes]
     level: list[MerkleNode] = leaves.copy()
+    legacy = scheme <= _LEGACY_SCHEME_VERSION
 
     while len(level) > 1:
         next_level: list[MerkleNode] = []
         for i in range(0, len(level), 2):
             left = level[i]
-            right = level[i + 1] if i + 1 < len(level) else left
+            if i + 1 < len(level):
+                right = level[i + 1]
+            elif legacy:
+                # v1: self-pair the lone odd node (the weakness being fixed).
+                right = left
+            else:
+                # v2: promote the lone odd node unchanged - no self-pairing,
+                # so [A,B,C] and [A,B,C,C] cannot collide.
+                next_level.append(left)
+                continue
+            combine = _combine_hashes if legacy else _combine_internal
             parent = MerkleNode(
-                hash=_combine_hashes(left.hash, right.hash),
+                hash=combine(left.hash, right.hash),
                 left=left,
                 right=right,
             )
@@ -124,14 +234,56 @@ def build_merkle_tree(leaf_hashes: list[tuple[str, str]]) -> MerkleTree:
 # ---------------------------------------------------------------------------
 
 
-def compute_seal(audit_dir: Path) -> tuple[MerkleTree, dict[str, object]]:
+class ChainBrokenError(RuntimeError):
+    """Raised when the HMAC audit chain is broken at seal time.
+
+    Sealing over a broken chain would let the new (whole-file) leaf adopt
+    already-tampered content as if valid, masking the tamper behind a fresh
+    root. The seal therefore refuses to anchor a chain that does not verify.
+    """
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        head = "; ".join(errors[:3])
+        super().__init__(f"Audit HMAC chain is broken; refusing to seal: {head}")
+
+
+def compute_seal(
+    audit_dir: Path,
+    *,
+    verify_chain: bool = True,
+    key: bytes | None = None,
+    key_path: Path | None = None,
+) -> tuple[MerkleTree, dict[str, object]]:
     """Compute a Merkle seal across all ``*.jsonl`` files in *audit_dir*.
+
+    The leaf for each file binds the whole canonical file content under the
+    current scheme, so the seal is independent tamper coverage over the
+    entire file rather than a restatement of its last stored ``hmac``.
+
+    Before computing the seal the underlying HMAC chain is verified (unless
+    *verify_chain* is ``False``). A broken chain raises
+    :class:`ChainBrokenError` rather than sealing over tampered content -
+    re-sealing must never silently launder a pre-existing tamper into a new
+    root. The chain is verified with the same key the log was written with
+    (*key*/*key_path*, or the canonical resolver when both are omitted).
 
     Returns ``(tree, seal_dict)`` where *seal_dict* is JSON-serializable
     metadata ready to be written to disk.
 
-    Raises ``FileNotFoundError`` if the audit directory does not exist.
-    Raises ``ValueError`` if no log files are found.
+    Args:
+        audit_dir: Directory holding the daily ``*.jsonl`` log files.
+        verify_chain: When ``True`` (default) the HMAC chain is verified
+            before sealing.
+        key: Raw HMAC key used to verify the chain. Defaults to the
+            canonical resolver (the same default the writer uses).
+        key_path: Optional explicit key-file path for chain verification.
+
+    Raises:
+        FileNotFoundError: If the audit directory does not exist.
+        ValueError: If no log files are found.
+        ChainBrokenError: If *verify_chain* is set and the HMAC chain does
+            not verify.
     """
     if not audit_dir.is_dir():
         msg = f"Audit directory does not exist: {audit_dir}"
@@ -142,18 +294,40 @@ def compute_seal(audit_dir: Path) -> tuple[MerkleTree, dict[str, object]]:
         msg = f"No audit log files (*.jsonl) found in {audit_dir}"
         raise ValueError(msg)
 
+    if verify_chain:
+        chain_ok, chain_errors = _verify_hmac_chain(audit_dir, key=key, key_path=key_path)
+        if not chain_ok:
+            raise ChainBrokenError(chain_errors)
+
     leaf_hashes = [(f.name, file_leaf_hash(f)) for f in log_files]
     tree = build_merkle_tree(leaf_hashes)
 
     seal: dict[str, object] = {
         "root_hash": tree.root.hash,
         "algorithm": _HASH_ALGO,
+        "scheme": SEAL_SCHEME_VERSION,
         "leaf_count": tree.leaf_count,
         "leaves": [{"file": name, "hash": h} for name, h in leaf_hashes],
         "sealed_at": time.time(),
         "sealed_at_iso": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
     return tree, seal
+
+
+def _verify_hmac_chain(
+    audit_dir: Path,
+    *,
+    key: bytes | None = None,
+    key_path: Path | None = None,
+) -> tuple[bool, list[str]]:
+    """Verify the HMAC chain under *audit_dir*; return ``(ok, errors)``.
+
+    Imported lazily so the Merkle module stays importable without the full
+    audit subsystem (and to avoid a circular import at module load).
+    """
+    from bernstein.core.security.audit import AuditLog
+
+    return AuditLog(audit_dir, key=key, key_path=key_path).verify()
 
 
 def save_seal(seal: dict[str, object], merkle_dir: Path) -> Path:
@@ -227,23 +401,46 @@ def _check_inserted_files(current_files: list[Path], sealed_name_set: set[str]) 
     return [f"INSERTED: {f.name} (on disk, not in seal)" for f in current_files if f.name not in sealed_name_set]
 
 
-def _check_tampered_content(sealed_leaves: list[dict[str, str]], audit_dir: Path) -> list[str]:
-    """Return errors for files whose content hash doesn't match the seal."""
+def _check_tampered_content(sealed_leaves: list[dict[str, str]], audit_dir: Path, scheme: int) -> list[str]:
+    """Return errors for files whose leaf hash doesn't match the seal.
+
+    Leaf derivation is recomputed under *scheme* so a seal produced under
+    one scheme always verifies the same way (byte-identical leaf rule).
+    """
     errors: list[str] = []
     for leaf in sealed_leaves:
         fpath = audit_dir / leaf["file"]
         if fpath.exists():
-            current_hash = file_leaf_hash(fpath)
+            current_hash = file_leaf_hash(fpath, scheme=scheme)
             if current_hash != leaf["hash"]:
                 errors.append(f"TAMPERED: {leaf['file']} (hash mismatch)")
     return errors
 
 
+def _seal_scheme(seal: dict[str, object]) -> int:
+    """Return the seal's scheme version, defaulting to the legacy scheme."""
+    raw = seal.get("scheme", _LEGACY_SCHEME_VERSION)
+    if isinstance(raw, bool):
+        # ``bool`` is an ``int`` subclass; a stray boolean is not a scheme.
+        return _LEGACY_SCHEME_VERSION
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return int(raw)
+        except ValueError:
+            return _LEGACY_SCHEME_VERSION
+    return _LEGACY_SCHEME_VERSION
+
+
 def verify_merkle(audit_dir: Path, merkle_dir: Path) -> VerifyResult:
     """Verify the Merkle tree against current audit log files.
 
-    Detects: deleted files, inserted files, tampered content, reordered
-    files, and root-hash mismatches.
+    Detects: deleted files, inserted files, tampered content (any byte of
+    any line under the v2 scheme), reordered files, and root-hash
+    mismatches. Verification recomputes leaves and the tree under the
+    scheme recorded in the seal, so pre-hardening (v1) seals still verify
+    under their original rules.
     """
     result = VerifyResult(valid=False)
 
@@ -255,6 +452,7 @@ def verify_merkle(audit_dir: Path, merkle_dir: Path) -> VerifyResult:
     seal, seal_path = loaded
     result.seal_path = seal_path
     result.root_hash = str(seal.get("root_hash", ""))
+    scheme = _seal_scheme(seal)
 
     sealed_leaves: list[dict[str, str]] = seal.get("leaves", [])  # type: ignore[assignment]
     sealed_names = [leaf["file"] for leaf in sealed_leaves]
@@ -265,12 +463,12 @@ def verify_merkle(audit_dir: Path, merkle_dir: Path) -> VerifyResult:
 
     result.errors.extend(_check_deleted_files(sealed_names, current_name_set))
     result.errors.extend(_check_inserted_files(current_files, sealed_name_set))
-    result.errors.extend(_check_tampered_content(sealed_leaves, audit_dir))
+    result.errors.extend(_check_tampered_content(sealed_leaves, audit_dir, scheme))
 
     # Rebuild tree and verify root
     if not result.errors:
         leaf_hashes = [(leaf["file"], leaf["hash"]) for leaf in sealed_leaves]
-        tree = build_merkle_tree(leaf_hashes)
+        tree = build_merkle_tree(leaf_hashes, scheme=scheme)
         if tree.root.hash != seal.get("root_hash"):
             result.errors.append(f"ROOT MISMATCH: computed={tree.root.hash}, sealed={seal.get('root_hash')}")
 

--- a/src/bernstein/core/security/compliance_report.py
+++ b/src/bernstein/core/security/compliance_report.py
@@ -111,6 +111,29 @@ class EvidenceSummary:
 
 _MAX_SAMPLE_EVENTS = 5
 
+#: Compliance Merkle-root scheme version. v2 hardens the root against the
+#: textbook second-preimage / duplication weakness: leaves are
+#: domain-separated from internal nodes (RFC-6962 style) and a lone odd node
+#: is promoted unchanged instead of being self-paired. Recorded alongside the
+#: root by :func:`build_compliance_package` so an external verifier knows
+#: which rule the root was computed under.
+MERKLE_ROOT_SCHEME_VERSION = 2
+
+#: Domain-separation tags. Disjoint one-byte prefixes keep leaf and
+#: internal-node digests in non-overlapping domains.
+_LEAF_TAG = b"\x00"
+_INTERNAL_TAG = b"\x01"
+
+
+def _leaf_digest(data: bytes) -> str:
+    """Hash *data* as a Merkle leaf (``H(0x00 || data)``)."""
+    return hashlib.sha256(_LEAF_TAG + data).hexdigest()
+
+
+def _internal_digest(left: str, right: str) -> str:
+    """Combine two child hex digests into a parent (``H(0x01 || l || r)``)."""
+    return hashlib.sha256(_INTERNAL_TAG + left.encode() + right.encode()).hexdigest()
+
 
 @dataclass(frozen=True)
 class CompliancePackage:
@@ -123,6 +146,9 @@ class CompliancePackage:
         controls: Control mappings included in this package.
         evidence: Per-control evidence summaries.
         total_events: Total number of events in the input set.
+        merkle_scheme: Version of the Merkle-root construction the
+            ``merkle_root`` was computed under, so an external verifier can
+            recompute it under the correct (domain-separated) rule.
     """
 
     period: str
@@ -131,6 +157,7 @@ class CompliancePackage:
     controls: list[ControlMapping]
     evidence: list[EvidenceSummary]
     total_events: int
+    merkle_scheme: int = MERKLE_ROOT_SCHEME_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -139,14 +166,23 @@ class CompliancePackage:
 
 
 def compute_merkle_root(events: list[dict[str, Any]]) -> str:
-    """Compute a SHA-256 binary Merkle tree root over sorted event HMACs.
+    """Compute a domain-separated SHA-256 Merkle root over sorted event HMACs.
 
-    Each event dict is expected to carry an ``hmac`` key.  The HMACs are
+    Each event dict is expected to carry an ``hmac`` key. The HMACs are
     sorted lexicographically before tree construction so that the root is
     deterministic regardless of input order.
 
-    For zero events the root is the SHA-256 of the empty byte string.
-    For a single event the root is SHA-256 of its HMAC.
+    Hardening (scheme v2):
+
+    * Leaves are hashed as ``H(0x00 || hmac)`` and internal nodes as
+      ``H(0x01 || left || right)``, so an internal-node digest can never be
+      reinterpreted as a leaf (general Merkle second-preimage attack).
+    * A lone node at an odd level is promoted unchanged instead of being
+      paired with itself, so an event set with its last HMAC duplicated does
+      not collide with the un-duplicated set.
+
+    For zero events the root is the SHA-256 of the empty byte string. For a
+    single event the root is the leaf digest of its HMAC.
 
     Args:
         events: List of audit event dicts, each containing an ``hmac`` key.
@@ -158,17 +194,17 @@ def compute_merkle_root(events: list[dict[str, Any]]) -> str:
         return hashlib.sha256(b"").hexdigest()
 
     hmacs = sorted(str(e.get("hmac", "")) for e in events)
-    leaves: list[str] = [hashlib.sha256(h.encode()).hexdigest() for h in hmacs]
+    layer: list[str] = [_leaf_digest(h.encode()) for h in hmacs]
 
-    # Build binary Merkle tree bottom-up.
-    layer = leaves
+    # Build the binary Merkle tree bottom-up with domain-separated internal
+    # nodes and odd-node promotion (no self-pairing).
     while len(layer) > 1:
         next_layer: list[str] = []
         for i in range(0, len(layer), 2):
-            left = layer[i]
-            right = layer[i + 1] if i + 1 < len(layer) else left
-            combined = hashlib.sha256((left + right).encode()).hexdigest()
-            next_layer.append(combined)
+            if i + 1 < len(layer):
+                next_layer.append(_internal_digest(layer[i], layer[i + 1]))
+            else:
+                next_layer.append(layer[i])
         layer = next_layer
 
     return layer[0]

--- a/tests/property/test_merkle_seal_properties.py
+++ b/tests/property/test_merkle_seal_properties.py
@@ -180,7 +180,8 @@ def test_single_byte_flip_in_sealed_file_detected(
     if any(_last_line_is_hmac_json(payload) for _, payload in files):
         pytest.skip("file would short-circuit to embedded hmac field")
 
-    _, seal = compute_seal(audit)
+    # Synthetic content isolates the Merkle file-level layer.
+    _, seal = compute_seal(audit, verify_chain=False)
     merkle.mkdir(parents=True, exist_ok=True)
     (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
 
@@ -231,7 +232,8 @@ def test_file_deletion_detected(
     merkle = tmp / "merkle"
     _write_audit_files(audit, files)
 
-    _, seal = compute_seal(audit)
+    # Synthetic content isolates the Merkle file-level layer.
+    _, seal = compute_seal(audit, verify_chain=False)
     merkle.mkdir(parents=True, exist_ok=True)
     (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
 
@@ -274,7 +276,8 @@ def test_file_insertion_detected(
     merkle = tmp / "merkle"
     _write_audit_files(audit, files)
 
-    _, seal = compute_seal(audit)
+    # Synthetic content isolates the Merkle file-level layer.
+    _, seal = compute_seal(audit, verify_chain=False)
     merkle.mkdir(parents=True, exist_ok=True)
     (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
 
@@ -333,7 +336,8 @@ def test_duplicate_leaf_does_not_collapse_tree(leaves: list[str]) -> None:
 
 
 def _build_canonical_seal(audit: Path) -> dict[str, Any]:
-    _, seal = compute_seal(audit)
+    # Synthetic content isolates the Merkle file-level layer.
+    _, seal = compute_seal(audit, verify_chain=False)
     return seal
 
 

--- a/tests/unit/cli/test_audit_cmd_paths.py
+++ b/tests/unit/cli/test_audit_cmd_paths.py
@@ -236,6 +236,29 @@ def test_seal_then_verify_merkle_passes(isolated_audit: Path) -> None:
     assert "Merkle Verification Passed" in verify_result.output
 
 
+def test_seal_refuses_broken_chain(isolated_audit: Path) -> None:
+    """`audit seal` aborts on a broken HMAC chain so a tamper can't be sealed over."""
+    _seed_corrupt(isolated_audit / ".sdd" / "audit", "2026-05-14", count=2)
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["seal"])
+    assert result.exit_code == 1, result.output
+    assert "chain is broken" in result.output.lower()
+    # No seal must have been written.
+    merkle_dir = isolated_audit / ".sdd" / "audit" / "merkle"
+    assert not merkle_dir.exists() or not any(merkle_dir.glob("seal-*.json"))
+
+
+def test_seal_allow_broken_chain_overrides(isolated_audit: Path) -> None:
+    """--allow-broken-chain seals a known-corrupted log for forensic capture."""
+    _seed_corrupt(isolated_audit / ".sdd" / "audit", "2026-05-14", count=2)
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["seal", "--allow-broken-chain"])
+    assert result.exit_code == 0, result.output
+    assert "Root hash" in result.output
+    merkle_dir = isolated_audit / ".sdd" / "audit" / "merkle"
+    assert any(merkle_dir.glob("seal-*.json"))
+
+
 # ---------------------------------------------------------------------------
 # audit query
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_compliance_report.py
+++ b/tests/unit/test_compliance_report.py
@@ -85,8 +85,8 @@ class TestComputeMerkleRoot:
     def test_single_event(self) -> None:
         event = _make_event(hmac="deadbeef")
         root = compute_merkle_root([event])
-        leaf = hashlib.sha256(b"deadbeef").hexdigest()
-        # Single leaf: only one node in the tree, so root == leaf hash.
+        # v2: a single leaf is the domain-separated leaf digest H(0x00 || hmac).
+        leaf = hashlib.sha256(b"\x00deadbeef").hexdigest()
         assert root == leaf
 
     def test_two_events(self) -> None:
@@ -94,10 +94,11 @@ class TestComputeMerkleRoot:
         e2 = _make_event(hmac="bbb")
         root = compute_merkle_root([e1, e2])
 
-        # HMACs sorted: ["aaa", "bbb"]
-        leaf_a = hashlib.sha256(b"aaa").hexdigest()
-        leaf_b = hashlib.sha256(b"bbb").hexdigest()
-        expected = hashlib.sha256((leaf_a + leaf_b).encode()).hexdigest()
+        # HMACs sorted: ["aaa", "bbb"]. v2: leaves H(0x00 || hmac),
+        # internal node H(0x01 || left || right).
+        leaf_a = hashlib.sha256(b"\x00aaa").hexdigest()
+        leaf_b = hashlib.sha256(b"\x00bbb").hexdigest()
+        expected = hashlib.sha256(b"\x01" + (leaf_a + leaf_b).encode()).hexdigest()
         assert root == expected
 
     def test_three_events(self) -> None:
@@ -108,13 +109,12 @@ class TestComputeMerkleRoot:
         ]
         root = compute_merkle_root(events)
 
-        # Sorted HMACs: aaa, bbb, ccc
-        leaves = [hashlib.sha256(h.encode()).hexdigest() for h in ["aaa", "bbb", "ccc"]]
-        # Layer 1: combine(leaves[0], leaves[1]), combine(leaves[2], leaves[2])
-        n01 = hashlib.sha256((leaves[0] + leaves[1]).encode()).hexdigest()
-        n22 = hashlib.sha256((leaves[2] + leaves[2]).encode()).hexdigest()
-        # Root
-        expected = hashlib.sha256((n01 + n22).encode()).hexdigest()
+        # Sorted HMACs: aaa, bbb, ccc. v2: leaf digests, domain-separated
+        # internal nodes, and the lone "ccc" leaf promoted unchanged (no
+        # self-pairing) so [A,B,C] != [A,B,C,C].
+        leaves = [hashlib.sha256(b"\x00" + h.encode()).hexdigest() for h in ["aaa", "bbb", "ccc"]]
+        n01 = hashlib.sha256(b"\x01" + (leaves[0] + leaves[1]).encode()).hexdigest()
+        expected = hashlib.sha256(b"\x01" + (n01 + leaves[2]).encode()).hexdigest()
         assert root == expected
 
     def test_deterministic_regardless_of_order(self) -> None:

--- a/tests/unit/test_merkle.py
+++ b/tests/unit/test_merkle.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 import pytest
 from bernstein.core.merkle import (
     _combine_hashes,
+    _combine_internal,
+    _leaf_digest,
     _sha256,
     build_merkle_tree,
     compute_seal,
@@ -53,21 +55,38 @@ class TestFileLeafHash:
         h = file_leaf_hash(f)
         assert isinstance(h, str) and len(h) == 64  # SHA-256 hex
 
-    def test_hmac_chained_file_uses_final_hmac(self, tmp_path: Path) -> None:
+    def test_v2_leaf_binds_whole_file_not_last_hmac(self, tmp_path: Path) -> None:
+        """Under the v2 scheme the leaf binds the whole file, not the last hmac."""
         f = tmp_path / "log.jsonl"
         lines = [
             json.dumps({"event": "a", "hmac": "aaa111"}),
             json.dumps({"event": "b", "hmac": "bbb222"}),
             json.dumps({"event": "c", "hmac": "final_hmac_value"}),
         ]
+        content = ("\n".join(lines) + "\n").encode()
+        f.write_bytes(content)
+        # The leaf is the domain-separated digest of the whole file content -
+        # editing any non-final line changes it (the GH-1844 fix).
+        assert file_leaf_hash(f) == _leaf_digest(content)
+        assert file_leaf_hash(f) != "final_hmac_value"
+
+    def test_legacy_scheme_uses_final_hmac(self, tmp_path: Path) -> None:
+        """The v1 path is retained for verifying pre-hardening seals."""
+        f = tmp_path / "log.jsonl"
+        lines = [
+            json.dumps({"event": "a", "hmac": "aaa111"}),
+            json.dumps({"event": "c", "hmac": "final_hmac_value"}),
+        ]
         f.write_text("\n".join(lines) + "\n")
-        assert file_leaf_hash(f) == "final_hmac_value"
+        assert file_leaf_hash(f, scheme=1) == "final_hmac_value"
 
     def test_empty_file(self, tmp_path: Path) -> None:
         f = tmp_path / "empty.jsonl"
         f.write_text("")
-        h = file_leaf_hash(f)
-        assert h == _sha256(b"empty")
+        # v2: stable, reproducible leaf for empty content.
+        assert file_leaf_hash(f) == _leaf_digest(b"")
+        # v1 legacy path keeps its historical sentinel.
+        assert file_leaf_hash(f, scheme=1) == _sha256(b"empty")
 
     def test_non_json_file(self, tmp_path: Path) -> None:
         f = tmp_path / "raw.jsonl"
@@ -96,10 +115,11 @@ class TestBuildMerkleTree:
     def test_two_leaves(self) -> None:
         tree = build_merkle_tree([("a.jsonl", "aaa"), ("b.jsonl", "bbb")])
         assert tree.leaf_count == 2
-        expected = _combine_hashes("aaa", "bbb")
+        # v2: internal nodes are domain-separated (H(0x01 || l || r)).
+        expected = _combine_internal("aaa", "bbb")
         assert tree.root.hash == expected
 
-    def test_three_leaves_odd_padding(self) -> None:
+    def test_three_leaves_odd_promotion(self) -> None:
         tree = build_merkle_tree(
             [
                 ("a.jsonl", "aaa"),
@@ -108,10 +128,10 @@ class TestBuildMerkleTree:
             ]
         )
         assert tree.leaf_count == 3
-        # Level 1: combine(aaa, bbb), combine(ccc, ccc)  (odd -> duplicate last)
-        left = _combine_hashes("aaa", "bbb")
-        right = _combine_hashes("ccc", "ccc")
-        expected = _combine_hashes(left, right)
+        # v2: Level 1 promotes the lone "ccc" unchanged (no self-pairing),
+        # so the root differs from the [A,B,C,C] tree.
+        left = _combine_internal("aaa", "bbb")
+        expected = _combine_internal(left, "ccc")
         assert tree.root.hash == expected
 
     def test_four_leaves(self) -> None:
@@ -124,9 +144,9 @@ class TestBuildMerkleTree:
             ]
         )
         assert tree.leaf_count == 4
-        left = _combine_hashes("a1", "b2")
-        right = _combine_hashes("c3", "d4")
-        expected = _combine_hashes(left, right)
+        left = _combine_internal("a1", "b2")
+        right = _combine_internal("c3", "d4")
+        expected = _combine_internal(left, right)
         assert tree.root.hash == expected
 
     def test_deterministic(self) -> None:
@@ -159,10 +179,12 @@ class TestComputeSeal:
         (audit / "2026-03-28.jsonl").write_text('{"event":"a","hmac":"h1"}\n')
         (audit / "2026-03-29.jsonl").write_text('{"event":"b","hmac":"h2"}\n')
 
-        tree, seal = compute_seal(audit)
+        # Synthetic (non-chained) content isolates the Merkle layer.
+        tree, seal = compute_seal(audit, verify_chain=False)
         assert seal["root_hash"] == tree.root.hash
         assert seal["leaf_count"] == 2
         assert seal["algorithm"] == "sha256"
+        assert seal["scheme"] == 2
         assert len(seal["leaves"]) == 2  # type: ignore[arg-type]
         assert seal["sealed_at"] is not None
 
@@ -183,7 +205,7 @@ class TestComputeSeal:
         (audit / "z.jsonl").write_text('{"x":1}\n')
         (audit / "a.jsonl").write_text('{"x":2}\n')
 
-        _, seal = compute_seal(audit)
+        _, seal = compute_seal(audit, verify_chain=False)
         leaves = seal["leaves"]
         assert leaves[0]["file"] == "a.jsonl"  # type: ignore[index]
         assert leaves[1]["file"] == "z.jsonl"  # type: ignore[index]
@@ -230,7 +252,12 @@ class TestSealPersistence:
 
 
 def _setup_audit(tmp_path: Path) -> tuple[Path, Path]:
-    """Create an audit dir with two log files and compute a seal."""
+    """Create an audit dir with two log files and compute a seal.
+
+    Uses synthetic (non-chained) content to isolate the Merkle file-level
+    layer, so the chain precheck is disabled. Real-chain coverage lives in
+    tests/unit/test_merkle_second_preimage.py.
+    """
     audit = tmp_path / "audit"
     audit.mkdir()
     merkle = audit / "merkle"
@@ -238,7 +265,7 @@ def _setup_audit(tmp_path: Path) -> tuple[Path, Path]:
     (audit / "2026-03-28.jsonl").write_text('{"event":"a","hmac":"h1"}\n')
     (audit / "2026-03-29.jsonl").write_text('{"event":"b","hmac":"h2"}\n')
 
-    _, seal = compute_seal(audit)
+    _, seal = compute_seal(audit, verify_chain=False)
     save_seal(seal, merkle)
     return audit, merkle
 
@@ -293,8 +320,8 @@ class TestVerifyMerkle:
         result = verify_merkle(audit, merkle)
         assert not result.valid
 
-        # Reseal
-        _, new_seal = compute_seal(audit)
+        # Reseal (synthetic content -> skip the chain precheck)
+        _, new_seal = compute_seal(audit, verify_chain=False)
         save_seal(new_seal, merkle)
 
         # New seal should pass
@@ -314,7 +341,7 @@ class TestSingleFileSeal:
         merkle = audit / "merkle"
         (audit / "only.jsonl").write_text('{"event":"solo"}\n')
 
-        _, seal = compute_seal(audit)
+        _, seal = compute_seal(audit, verify_chain=False)
         save_seal(seal, merkle)
 
         result = verify_merkle(audit, merkle)

--- a/tests/unit/test_merkle_second_preimage.py
+++ b/tests/unit/test_merkle_second_preimage.py
@@ -1,0 +1,303 @@
+"""Security tests for Merkle second-preimage / tamper weaknesses.
+
+Covers two reported defects:
+
+* GH-1844 - the audit seal leaf must bind the *whole* file, not just the
+  last JSONL line's stored ``hmac``. A byte change in any non-final line
+  must surface as ``TAMPERED`` from :func:`verify_merkle`.
+
+* GH-1854 - both Merkle-root builders must be collision-resistant under
+  last-node duplication and must domain-separate leaf hashes from
+  internal-node hashes (RFC 6962 style: ``H(0x00 || leaf)`` for leaves,
+  ``H(0x01 || left || right)`` for internal nodes). Duplicating the final
+  leaf must not reproduce the un-duplicated root, and an internal-node
+  digest must not be reusable as a leaf to reproduce a different tree's
+  root.
+
+These properties are the verifiable core of the audit substrate, so the
+assertions prove the security guarantee empirically (tamper -> detected;
+distinct leaf sets -> distinct roots) rather than restating the docstring.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from typing import TYPE_CHECKING
+
+from bernstein.core.persistence.merkle import (
+    build_merkle_tree,
+    compute_seal,
+    save_seal,
+    verify_merkle,
+)
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.compliance_report import compute_merkle_root
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _event(hmac: str) -> dict[str, object]:
+    return {"event_type": "task.complete", "hmac": hmac}
+
+
+def _real_chained_log(audit_dir: Path, count: int) -> bytes:
+    """Write *count* genuinely HMAC-chained events under *audit_dir*.
+
+    Uses a real :class:`AuditLog` with an in-test key so the seal's chain
+    verification passes; this proves the Merkle leaf (not just the HMAC
+    chain) catches subsequent tampering. Returns the in-test key so the
+    caller can pass it to :func:`compute_seal`.
+    """
+    key = secrets.token_bytes(32)
+    log = AuditLog(audit_dir, key=key)
+    for i in range(count):
+        log.log(
+            event_type="task.complete",
+            actor="agent-1",
+            resource_type="task",
+            resource_id=f"t-{i}",
+            details={"i": i},
+        )
+    return key
+
+
+# ---------------------------------------------------------------------------
+# GH-1844: mid-file tamper must be detected by the Merkle seal
+# ---------------------------------------------------------------------------
+
+
+class TestMidFileTamperDetection:
+    def _seal_chained_file(self, tmp_path: Path) -> tuple[Path, Path, Path, list[bytes]]:
+        """Seal a real 3-event HMAC-chained log; return its file + lines."""
+        audit = tmp_path / "audit"
+        merkle = audit / "merkle"
+        key = _real_chained_log(audit, count=3)
+        # AuditLog names the file by today's UTC date; resolve it.
+        target = sorted(audit.glob("*.jsonl"))[0]
+        lines = target.read_bytes().rstrip(b"\n").split(b"\n")
+        assert len(lines) == 3, "fixture expected a single 3-line daily file"
+
+        _, seal = compute_seal(audit, key=key)
+        save_seal(seal, merkle)
+        # Sanity: the seal verifies clean before any tamper.
+        assert verify_merkle(audit, merkle).valid
+        return audit, merkle, target, lines
+
+    def test_non_final_line_byte_flip_detected(self, tmp_path: Path) -> None:
+        """Flipping a byte in a non-final line (last line intact) trips TAMPERED.
+
+        This is the exact case the old last-line-hmac leaf missed: the
+        final record is untouched, so a last-line-only leaf would still
+        match the seal.
+        """
+        audit, merkle, target, lines = self._seal_chained_file(tmp_path)
+        name = target.name
+
+        middle = bytearray(lines[1])
+        middle[5] ^= 0x01  # flip a byte well inside the middle record
+        lines[1] = bytes(middle)
+        target.write_bytes(b"\n".join(lines) + b"\n")
+
+        result = verify_merkle(audit, merkle)
+        assert not result.valid
+        assert any("TAMPERED" in e and name in e for e in result.errors)
+
+    def test_first_line_byte_flip_detected(self, tmp_path: Path) -> None:
+        """A single-byte flip in the first line must trip TAMPERED."""
+        audit, merkle, target, lines = self._seal_chained_file(tmp_path)
+        name = target.name
+
+        first = bytearray(lines[0])
+        first[5] ^= 0x01
+        lines[0] = bytes(first)
+        target.write_bytes(b"\n".join(lines) + b"\n")
+
+        result = verify_merkle(audit, merkle)
+        assert not result.valid
+        assert any("TAMPERED" in e and name in e for e in result.errors)
+
+    def test_final_line_tamper_still_detected(self, tmp_path: Path) -> None:
+        """The previously-covered last-line case must remain detected."""
+        audit, merkle, target, lines = self._seal_chained_file(tmp_path)
+        name = target.name
+
+        last = bytearray(lines[-1])
+        last[5] ^= 0x01
+        lines[-1] = bytes(last)
+        target.write_bytes(b"\n".join(lines) + b"\n")
+
+        result = verify_merkle(audit, merkle)
+        assert not result.valid
+        assert any("TAMPERED" in e and name in e for e in result.errors)
+
+    def test_clean_roundtrip_still_valid(self, tmp_path: Path) -> None:
+        """An untouched dir seals and verifies clean under the new scheme."""
+        audit, merkle, _target, _ = self._seal_chained_file(tmp_path)
+        result = verify_merkle(audit, merkle)
+        assert result.valid
+        assert result.errors == []
+
+    def test_empty_file_stable_and_verifies(self, tmp_path: Path) -> None:
+        """An empty/whitespace daily file gets a stable leaf and verifies clean."""
+        from bernstein.core.persistence.merkle import file_leaf_hash
+
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        merkle = audit / "merkle"
+        empty = audit / "2026-04-01.jsonl"
+        empty.write_text("   \n")
+
+        # A whitespace-only file maps to a stable, reproducible leaf.
+        assert file_leaf_hash(empty) == file_leaf_hash(empty)
+
+        # No HMAC-chained records present, so disable the chain precheck and
+        # exercise the Merkle leaf/verify path directly.
+        _, seal = compute_seal(audit, verify_chain=False)
+        save_seal(seal, merkle)
+
+        result = verify_merkle(audit, merkle)
+        assert result.valid, result.errors
+
+
+# ---------------------------------------------------------------------------
+# GH-1854: second-preimage / duplication weakness in build_merkle_tree
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMerkleTreeSecondPreimage:
+    def test_duplicated_last_leaf_differs(self) -> None:
+        """[A,B,C] and [A,B,C,C] must produce different roots."""
+        abc = build_merkle_tree([("a", "A"), ("b", "B"), ("c", "C")]).root.hash
+        abcc = build_merkle_tree(
+            [("a", "A"), ("b", "B"), ("c", "C"), ("d", "C")],
+        ).root.hash
+        assert abc != abcc
+
+    def test_determinism_preserved(self) -> None:
+        leaves = [("a", "x"), ("b", "y"), ("c", "z")]
+        assert build_merkle_tree(leaves).root.hash == build_merkle_tree(leaves).root.hash
+
+    def test_order_still_matters(self) -> None:
+        t1 = build_merkle_tree([("a", "x"), ("b", "y")]).root.hash
+        t2 = build_merkle_tree([("b", "y"), ("a", "x")]).root.hash
+        assert t1 != t2
+
+
+# ---------------------------------------------------------------------------
+# GH-1854: duplication + domain separation in compute_merkle_root
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMerkleRootSecondPreimage:
+    def test_duplicated_last_leaf_differs(self) -> None:
+        """[A,B,C] and [A,B,C,C] event sets must produce different roots."""
+        three = compute_merkle_root([_event("a"), _event("b"), _event("c")])
+        four = compute_merkle_root([_event("a"), _event("b"), _event("c"), _event("c")])
+        assert three != four
+
+    def test_internal_node_not_reusable_as_leaf(self) -> None:
+        """An internal-node digest must not reproduce a 2-leaf root.
+
+        Without leaf/internal domain separation, the root over hmacs
+        {a, b} equals ``H(H(a) || H(b))`` and an attacker can present a
+        single leaf whose hmac is that internal digest to forge a tree of
+        a different shape. Domain separation (0x00 vs 0x01) breaks this.
+        """
+        leaf_a = hashlib.sha256(b"a").hexdigest()
+        leaf_b = hashlib.sha256(b"b").hexdigest()
+        raw_internal = hashlib.sha256((leaf_a + leaf_b).encode()).hexdigest()
+
+        root_two = compute_merkle_root([_event("a"), _event("b")])
+        # The forged single leaf carrying the raw internal concat as its
+        # hmac must NOT reproduce the two-leaf root.
+        root_forged = compute_merkle_root([_event(raw_internal)])
+        assert root_two != raw_internal
+        assert root_two != root_forged
+
+    def test_determinism_regardless_of_order(self) -> None:
+        a = compute_merkle_root([_event("xxx"), _event("yyy")])
+        b = compute_merkle_root([_event("yyy"), _event("xxx")])
+        assert a == b
+
+    def test_empty_events_stable(self) -> None:
+        assert compute_merkle_root([]) == compute_merkle_root([])
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: pre-hardening (v1) seals still verify
+# ---------------------------------------------------------------------------
+
+
+class TestLegacySchemeVerification:
+    def test_v1_seal_verifies_under_v1_rules(self, tmp_path: Path) -> None:
+        """A seal recorded under scheme v1 verifies via the legacy leaf rule.
+
+        Operators with seals written before the hardening must still be able
+        to verify them; verification dispatches on the seal's recorded
+        scheme rather than always recomputing under v2.
+        """
+        from bernstein.core.persistence.merkle import (
+            _legacy_file_leaf_hash,
+            build_merkle_tree,
+            save_seal,
+        )
+
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        merkle = audit / "merkle"
+        f1 = audit / "2026-03-28.jsonl"
+        f2 = audit / "2026-03-29.jsonl"
+        f1.write_text(json.dumps({"event": "a", "hmac": "h1"}) + "\n")
+        f2.write_text(json.dumps({"event": "b", "hmac": "h2"}) + "\n")
+
+        # Hand-build a v1 seal exactly as the pre-fix code would have.
+        leaf_hashes = [
+            (f1.name, _legacy_file_leaf_hash(f1.read_bytes())),
+            (f2.name, _legacy_file_leaf_hash(f2.read_bytes())),
+        ]
+        tree = build_merkle_tree(leaf_hashes, scheme=1)
+        v1_seal: dict[str, object] = {
+            "root_hash": tree.root.hash,
+            "algorithm": "sha256",
+            "scheme": 1,
+            "leaf_count": tree.leaf_count,
+            "leaves": [{"file": n, "hash": h} for n, h in leaf_hashes],
+            "sealed_at": 1.0,
+            "sealed_at_iso": "2026-03-29T00:00:00Z",
+        }
+        save_seal(v1_seal, merkle)
+
+        # The v1 seal verifies clean under its own rules.
+        assert verify_merkle(audit, merkle).valid
+
+    def test_seal_without_scheme_field_treated_as_v1(self, tmp_path: Path) -> None:
+        """A seal predating the ``scheme`` field defaults to the v1 rule."""
+        from bernstein.core.persistence.merkle import (
+            _legacy_file_leaf_hash,
+            build_merkle_tree,
+            save_seal,
+        )
+
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        merkle = audit / "merkle"
+        f1 = audit / "2026-03-28.jsonl"
+        f1.write_text(json.dumps({"event": "a", "hmac": "h1"}) + "\n")
+
+        leaf_hashes = [(f1.name, _legacy_file_leaf_hash(f1.read_bytes()))]
+        tree = build_merkle_tree(leaf_hashes, scheme=1)
+        # No "scheme" key at all - the verifier must assume v1.
+        seal: dict[str, object] = {
+            "root_hash": tree.root.hash,
+            "algorithm": "sha256",
+            "leaf_count": tree.leaf_count,
+            "leaves": [{"file": n, "hash": h} for n, h in leaf_hashes],
+            "sealed_at": 1.0,
+            "sealed_at_iso": "2026-03-29T00:00:00Z",
+        }
+        save_seal(seal, merkle)
+
+        assert verify_merkle(audit, merkle).valid


### PR DESCRIPTION
## Summary

Closes #1844 and #1854 - two related weaknesses in the audit / compliance Merkle surfaces, both confirmed by reproducing tests before any fix was written.

**#1844 - seal leaf trusted the unverified last-line hmac.** `file_leaf_hash` returned the last JSONL line's stored `hmac` verbatim, without recomputing it or hashing the rest of the file. Editing any non-final line of a sealed file left the leaf unchanged, so `verify_merkle` returned `valid=True`. The seal added no tamper coverage beyond each file's final record.

**#1854 - duplication and node-confusion second-preimage.** Both builders (`persistence/merkle.py:build_merkle_tree` and `security/compliance_report.py:compute_merkle_root`) self-paired the last node on an odd level, so a tree over `[A,B,C]` and one over `[A,B,C,C]` produced an identical root. `compute_merkle_root` also concatenated child hashes with no leaf/internal domain separation, so an internal-node digest could be reused as a leaf to reproduce a different tree's root.

## Fix

- Leaf now binds the whole canonical file content as `H(0x00 || bytes)`; a byte change in any line changes the leaf. Empty/whitespace files map to a stable, reproducible leaf.
- Both builders domain-separate leaves (`H(0x00 || data)`) from internal nodes (`H(0x01 || left || right)`) RFC-6962 style, and promote a lone odd node unchanged instead of self-pairing.
- `compute_seal` verifies the HMAC chain (with the same key the log was written with) before writing the root and raises `ChainBrokenError` on a break, so re-sealing cannot launder a pre-existing tamper into a fresh root. `bernstein audit seal` aborts on a broken chain by default; `--allow-broken-chain` keeps the deliberate forensic-capture path.
- Seals record a `scheme` version; `verify_merkle` dispatches on it so pre-fix (v1) seals still verify under their original rule. Compliance packages record `merkle_scheme` alongside the root.

Leaf/root values change under the new scheme, so operators must re-seal once; pre-fix roots are incomparable to new ones (scheme upgrade, not a tamper alert). Documented in `docs/security/audit-log.md`.

## Test plan

- [x] Reproducing tests fail on the pre-fix code, pass after: mid-file and first-line byte flips trip `TAMPERED`; `[A,B,C]` != `[A,B,C,C]` for both builders; an internal-node digest does not reproduce a 2-leaf root.
- [x] Backward-compat: a hand-built v1 seal (and a seal with no `scheme` field) still verifies clean.
- [x] CLI: `audit seal` exits 1 on a broken chain and writes no seal; `--allow-broken-chain` seals it.
- [x] Regression: existing root-value assertions updated to the v2 scheme; clean seal/verify round-trips pass.
- [x] `tests/unit/test_merkle.py tests/unit/test_compliance_report.py tests/unit/test_merkle_second_preimage.py tests/property/test_merkle_seal_properties.py tests/unit/test_audit_mode.py tests/unit/cli/test_audit_cmd_paths.py` - 115 passed, 2 skipped.
- [x] `ruff check` + `ruff format --check` clean on changed files; import-linter contracts kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-broken-chain` flag to `audit seal` command for recovery scenarios when chain verification fails.

* **Documentation**
  * Enhanced audit log documentation detailing Merkle seal integrity verification and recovery procedures.

* **Security**
  * Improved Merkle seal integrity verification with versioned schemes and domain separation, maintaining backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->