### PR TITLE
docs(replay): attribute the replay.jsonl fingerprint to its real surfaces

### DIFF
--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -91,26 +91,31 @@ live provider. It is opt-in precisely so the hermetic guarantee stays closed
 unless deliberately disabled; do not set it globally in CI or air-gapped
 contexts.
 
-## Execution fingerprint (determinism proof across runs)
+## Replay-log fingerprint (determinism proof across runs)
 
-`bernstein verify --determinism <run-id>` reports an execution fingerprint
-over the run's `replay.jsonl` event stream. The fingerprint hashes a canonical
-projection of each event - `event` plus the decision-relevant payload, with
-keys sorted and fixed separators - and **excludes the wall-clock envelope**
-(`ts` and `elapsed_s`). Those timing fields stay in `replay.jsonl` for the
-operator timeline; they are skipped only in the fingerprint computation.
+The orchestrator stamps a `replay.jsonl` execution fingerprint into the run
+metadata, and `bernstein replay <run-id>` prints it in its header. The
+fingerprint hashes a canonical projection of each event - `event` plus the
+decision-relevant payload, with keys sorted and fixed separators - and
+**excludes the wall-clock envelope** (`ts` and `elapsed_s`). Those timing
+fields stay in `replay.jsonl` for the operator timeline; they are skipped only
+in the fingerprint computation.
 
 Because the timing envelope is excluded, two byte-identical executions produce
 the **same** fingerprint even though their timestamps differ, so the value is a
 genuine cross-run identity: a recording and a faithful replay match, and any
 divergence in the decision stream (a different decision output, a reordered
-event, a changed event type) changes the fingerprint. Paired with the
-`verify --determinism --baseline` gate, this lets a replay report PASS for an
-identical re-execution and FAIL for a perturbed one.
+event, a changed event type) changes the fingerprint.
 
 Behaviour change: fingerprints computed before this change hashed the whole
 file (timestamps included), so old recorded fingerprint values are not
-comparable to new ones. Re-baseline once after upgrading.
+comparable to new ones.
+
+> Note: `bernstein verify --determinism` uses a separate fingerprint over the
+> WAL decision stream (`ExecutionFingerprint` in
+> `src/bernstein/core/persistence/wal.py`), which already excludes the WAL
+> entry timestamp. This section covers the `replay.jsonl` fingerprint, the one
+> surfaced in run metadata and the `bernstein replay` header.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Follow-up to #1865. The deterministic-replay page described the `replay.jsonl`
execution fingerprint as being reported by `bernstein verify --determinism`.
That command computes a separate fingerprint over the WAL decision stream
(`ExecutionFingerprint` in `wal.py`), which already excludes the WAL entry
timestamp. The `replay.jsonl` fingerprint fixed in #1865 is the one stamped
into run metadata and printed in the `bernstein replay` header.

This corrects the attribution and adds a short note disambiguating the two
fingerprints so an operator does not expect one surface to reflect the other.

Docs-only; no code change.

## Test plan

- [x] Docs-only edit; no tests affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated replay-log fingerprint documentation to clarify how determinism fingerprints are generated and reported.
  * Clarified that fingerprints are now printed via the replay command instead of the verify command.
  * Removed outdated baseline gate instructions and added clarification on cross-run fingerprint comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->