### PR TITLE
fix(worktrees): refuse to reap worktrees holding unsaved work

### DIFF
--- a/docs/operations/worktrees.md
+++ b/docs/operations/worktrees.md
@@ -32,18 +32,52 @@ produces.
 Priority on conflicts: `corrupt > orphan > stale > active`. A dead PID
 with a fresh trace stays `active` to avoid racing a restart.
 
+## Unsaved-work safety
+
+Reaching a terminal state (`orphan`/`stale`/`corrupt`) is necessary but
+not sufficient for a reap. Before a worktree is considered reapable the
+classifier probes its git state *inside the worktree itself*:
+
+- `git status --porcelain` - any uncommitted change (tracked or
+  untracked) marks the worktree as holding unsaved work.
+- `git merge-base --is-ancestor HEAD <integration-branch>` (default
+  `main`, with an upstream-ahead fallback) - if the worktree branch has
+  commits that are not reachable from the integration branch they are
+  unmerged work that a reap would destroy.
+
+A worktree that holds unsaved work is **not reapable** and `gc` skips it
+with an operator-visible message naming the directory. This matches the
+invariant the rest of the codebase already enforces (the `maintenance`
+command preserves unmerged branches by default). A missing PID record -
+the trigger for `orphan` - is exactly the crash-recovery case where
+committed-but-unmerged work is most likely stranded, so "no PID record"
+is never treated as "safe to delete".
+
+A `corrupt` worktree has no readable `.git` and cannot be probed: it is
+reapable only when its directory is empty of files, otherwise it is
+preserved for manual handling. Any git probe that cannot decide
+(timeout, missing ref) errs toward preserving the worktree - the guard
+only ever blocks deletion, it never deletes more.
+
 ## CLI
 
 ```text
 bernstein worktrees list   [--workdir DIR] [--json]
-bernstein worktrees gc     [--workdir DIR] [--yes] [--dry]
+bernstein worktrees gc     [--workdir DIR] [--yes] [--dry] [--force-unsaved]
 ```
 
 - `list` - tabular dump with path, task id, state, age, size, PID. Use
-  `--json` for scripting.
-- `gc` - reap non-`active` worktrees. `--yes` skips the confirmation
-  prompt; `--dry` prints what would be reaped without touching
-  disk.
+  `--json` for scripting. The JSON `reapable` field already reflects the
+  unsaved-work veto.
+- `gc` - reap non-`active` worktrees that carry no unsaved work. `--yes`
+  skips the confirmation prompt; `--dry` prints what would be reaped
+  without touching disk.
+- `--force-unsaved` - also reap worktrees that hold unsaved work
+  (uncommitted changes or unmerged commits). **Dangerous:** this
+  destroys the only copy of that work. It requires a second explicit
+  confirmation (unless `--yes` is also passed) and mirrors the
+  `maintenance` command's `--force`. The reap is recorded with
+  `forced=true` in the audit trail.
 
 ## GC lock
 
@@ -56,11 +90,14 @@ the lock file is stale).
 ## Lifecycle event
 
 The CLI emits `worktree.gc` after each reap (or, with `--dry`,
-once per would-be reap). Plugins can hook this event; the env keys
-exposed to handlers are `BERNSTEIN_WORKTREE_GC_*`. This notification is
-best-effort and ephemeral - it requires a plugin `HookRegistry` and
-leaves no durable record. For the durable, tamper-evident record see
-the audit trail below.
+once per would-be reap), and once per worktree preserved for safety.
+Plugins can hook this event; the env keys exposed to handlers are
+`BERNSTEIN_WORKTREE_GC_*`, including `BERNSTEIN_WORKTREE_GC_REAPED`
+(`0` for a safety-skip, `1` for a reap) and
+`BERNSTEIN_WORKTREE_GC_UNSAVED` (`1` when the worktree held unsaved
+work). This notification is best-effort and ephemeral - it requires a
+plugin `HookRegistry` and leaves no durable record. For the durable,
+tamper-evident record see the audit trail below.
 
 ## Audit trail
 
@@ -70,7 +107,8 @@ action, so each reap is anchored to the HMAC-chained audit log under
 write does **not** depend on a plugin `HookRegistry`: it is written
 even when the CLI runs standalone.
 
-For every reaped worktree, `gc` appends one event:
+For every reaped worktree - and for every worktree *skipped* for safety -
+`gc` appends one event:
 
 | Field | Value |
 |-------|-------|
@@ -82,7 +120,16 @@ For every reaped worktree, `gc` appends one event:
 The `details` payload captures, before deletion: `state`, `task_id`,
 `path`, `size_bytes`, `age_seconds`, `last_trace_mtime`, the
 pre-deletion git `head_sha`, a `dirty` flag (uncommitted/unmerged
-changes present), and `dry_run`.
+changes present), `has_unsaved_work` (the classifier's reap veto),
+`reaped` (`false` for a safety-skip, `true` for an actual deletion),
+`forced` (`true` when `--force-unsaved` overrode the veto), and
+`dry_run`.
+
+**Safety-skips are recorded, not silent.** When `gc` preserves a
+worktree because it holds unsaved work, it still appends a
+`worktree.reap` event flagged `reaped=false` with the unsaved-work
+reason, so the decision to preserve is anchored in the same
+tamper-evident chain as a real reap.
 
 **Pre-deletion fingerprint.** `head_sha` and `dirty` are read from the
 worktree *before* `rmtree`, so the entry proves exactly which commit
@@ -153,6 +200,16 @@ process) or the last trace is fresh enough that the classifier holds
 `active`. Wait 24h for the rule to flip to `stale`, or remove the
 `pids/<sid>.json` file by hand.
 
-**`corrupt` rows after a bad merge.** Reap them. The classifier marks
-any worktree without a `.git` anchor as corrupt regardless of task
-record, and `gc` removes the directory tree.
+**`corrupt` rows after a bad merge.** The classifier marks any worktree
+without a `.git` anchor as corrupt regardless of task record. An empty
+corrupt directory is reaped automatically. A corrupt directory that
+still holds files cannot be probed for unsaved work, so `gc` preserves
+it and reports it; inspect the contents, salvage anything you need, then
+delete the directory by hand (or rerun `gc --force-unsaved`).
+
+**`gc` skipped a worktree with unsaved work.** This is the safety guard:
+the worktree has uncommitted changes or commits not merged into the
+integration branch. Open the directory and commit/push or salvage the
+work. Once it is clean and merged, `gc` reaps it normally. To delete it
+regardless - destroying the unsaved work - rerun with `--force-unsaved`
+(an extra confirmation is required).

--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -164,11 +164,15 @@ def lock_gc(repo_root: Path):  # type: ignore[no-untyped-def]
 # ---------------------------------------------------------------------------
 
 
-def _emit_worktree_gc(repo_root: Path, row: ClassifiedWorktree, dry_run: bool) -> None:
-    """Notify plugins that ``row`` was reaped.
+def _emit_worktree_gc(repo_root: Path, row: ClassifiedWorktree, dry_run: bool, *, reaped: bool = True) -> None:
+    """Notify plugins that ``row`` was reaped (or preserved for safety).
 
     We import lazily so importing this CLI module never drags in pluggy
     when the operator only ran ``--help``.
+
+    Args:
+        reaped: ``True`` for an actual reap, ``False`` for a safety-skip so
+            subscribers can distinguish a deletion from a preserved worktree.
     """
     try:
         from bernstein.core.lifecycle.hooks import HookRegistry, LifecycleContext, LifecycleEvent
@@ -193,6 +197,8 @@ def _emit_worktree_gc(repo_root: Path, row: ClassifiedWorktree, dry_run: bool) -
             "BERNSTEIN_WORKTREE_GC_STATE": row.state.value,
             "BERNSTEIN_WORKTREE_GC_PATH": str(row.path),
             "BERNSTEIN_WORKTREE_GC_DRY_RUN": "1" if dry_run else "0",
+            "BERNSTEIN_WORKTREE_GC_REAPED": "1" if reaped else "0",
+            "BERNSTEIN_WORKTREE_GC_UNSAVED": "1" if row.has_unsaved_work else "0",
         },
     )
     try:
@@ -276,32 +282,95 @@ def list_cmd(workdir: Path, as_json: bool) -> None:
     default=False,
     help="Print what would be deleted without touching disk.",
 )
-def gc_cmd(workdir: Path, yes: bool, dry_run: bool) -> None:
-    """Delete orphan, stale, and corrupt worktrees."""
+@click.option(
+    "--force-unsaved",
+    is_flag=True,
+    default=False,
+    help=(
+        "Also reap worktrees that hold UNSAVED work (a dirty working tree or "
+        "commits not merged into the integration branch). Dangerous: this "
+        "destroys the only copy of that work. Requires an extra confirmation."
+    ),
+)
+def gc_cmd(workdir: Path, yes: bool, dry_run: bool, force_unsaved: bool) -> None:
+    """Delete orphan, stale, and corrupt worktrees.
+
+    Worktrees that still hold unsaved work (uncommitted changes or unmerged
+    commits) are preserved and reported as safety-skips unless
+    ``--force-unsaved`` is passed. The safety decision - reap or skip - is
+    recorded in the HMAC-chained audit log either way, so a skip is never
+    silent.
+    """
     repo_root = workdir.resolve()
     rows = classify_worktrees(repo_root)
     reapable = [r for r in rows if r.is_reapable]
+    # Terminal-state worktrees the classifier vetoed because they hold
+    # unsaved work. These never enter ``reapable`` (``is_reapable`` is False).
+    unsaved = [r for r in rows if r.has_unsaved_work and r.state is not WorktreeState.ACTIVE]
 
     console = Console()
-    if not reapable:
+    if not reapable and not unsaved:
         console.print("[green]No reapable worktrees - nothing to do.[/green]")
         return
 
-    console.print(render_worktrees_table(reapable))
-    if not yes and not dry_run and not click.confirm(f"Reap {len(reapable)} worktree(s)?", default=False):
-        click.echo("Aborted.")
-        raise SystemExit(1)
+    targets = list(reapable)
+    if force_unsaved:
+        targets.extend(unsaved)
+
+    if reapable:
+        console.print(render_worktrees_table(reapable))
+    if unsaved and not force_unsaved:
+        _report_safety_skips(console, unsaved)
+    if unsaved and force_unsaved:
+        console.print(render_worktrees_table(unsaved))
+
+    if not targets:
+        # Everything reapable was actually an unsaved worktree we are
+        # preserving; record the skips for audit and stop.
+        try:
+            run_gc(repo_root, [], dry_run=dry_run, skipped=unsaved)
+        except GcLockError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise SystemExit(2) from exc
+        return
+
+    if not yes and not dry_run:
+        if not click.confirm(f"Reap {len(targets)} worktree(s)?", default=False):
+            click.echo("Aborted.")
+            raise SystemExit(1)
+        if (
+            force_unsaved
+            and unsaved
+            and not click.confirm(
+                f"--force-unsaved will DESTROY unsaved work in {len(unsaved)} worktree(s). Continue?",
+                default=False,
+            )
+        ):
+            click.echo("Aborted.")
+            raise SystemExit(1)
 
     try:
         run_gc(
             repo_root,
-            reapable,
+            targets,
             dry_run=dry_run,
+            force_unsaved=force_unsaved,
+            skipped=[] if force_unsaved else unsaved,
             on_progress=lambda row, removed: _print_reap_progress(console, row, removed, dry_run=dry_run),
         )
     except GcLockError as exc:
         console.print(f"[red]{exc}[/red]")
         raise SystemExit(2) from exc
+
+
+def _report_safety_skips(console: Console, skipped: list[ClassifiedWorktree]) -> None:
+    """Print an operator-visible line per worktree preserved for safety."""
+    console.print(
+        f"[yellow]Preserving {len(skipped)} worktree(s) with unsaved work "
+        f"(pass [bold]--force-unsaved[/bold] to override):[/yellow]"
+    )
+    for row in skipped:
+        console.print(f"[yellow]  skipped[/yellow] {row.path} ({row.state.value}) - holds unsaved work")
 
 
 def _print_reap_progress(
@@ -320,6 +389,8 @@ def run_gc(
     rows: list[ClassifiedWorktree],
     *,
     dry_run: bool,
+    force_unsaved: bool = False,
+    skipped: list[ClassifiedWorktree] | None = None,
     on_progress: Callable[[ClassifiedWorktree, bool], None] | None = None,
     audit_log: AuditLog | None = None,
 ) -> int:
@@ -339,11 +410,22 @@ def run_gc(
     3. Reap the directory (skipped in ``--dry`` mode).
     4. Fire the best-effort lifecycle event for plugins.
 
+    Worktrees in ``skipped`` are NOT deleted; instead each gets one
+    ``worktree.reap`` event flagged ``reaped=false`` with the unsaved-work
+    reason, so a safety-skip is recorded in the same forensic chain as a
+    real reap rather than being silent (issue #1847).
+
     Args:
         repo_root: Absolute repository root.
-        rows: Reapable classifier rows to process.
+        rows: Reapable classifier rows to process. When ``force_unsaved`` is
+            set this may include rows whose ``has_unsaved_work`` is ``True``.
         dry_run: When ``True``, record the event flagged ``dry_run=true``
             and perform no filesystem mutation.
+        force_unsaved: When ``True``, the operator explicitly opted in to
+            destroying unsaved work; recorded as ``forced=true`` on any
+            reaped row that held unsaved work.
+        skipped: Worktrees preserved for safety (unsaved work, no force).
+            Recorded as ``reaped=false`` and never deleted.
         on_progress: Optional per-row progress callback ``(row, removed)``.
         audit_log: Optional pre-opened :class:`AuditLog` (used by tests to
             inject a fixed key). When ``None`` a project log rooted at
@@ -356,10 +438,15 @@ def run_gc(
     removed_count = 0
     with lock_gc(repo_root):
         log = audit_log if audit_log is not None else _open_audit_log(repo_root)
+        # Record safety-skips first so the audit chain shows what was
+        # deliberately preserved before any destruction in this sweep.
+        for row in skipped or []:
+            _append_reap_event(log, row, dry_run=dry_run, reaped=False, forced=False)
+            _emit_worktree_gc(repo_root, row, dry_run, reaped=False)
         for row in rows:
             # 1-2: fingerprint then record BEFORE any destruction. A raised
             # exception here aborts the sweep with the worktree intact.
-            _append_reap_event(log, row, dry_run=dry_run)
+            _append_reap_event(log, row, dry_run=dry_run, reaped=True, forced=force_unsaved)
             # 3: only now is it safe to destroy.
             removed = reap_worktree(repo_root, row, dry_run=dry_run)
             if on_progress is not None:
@@ -367,7 +454,7 @@ def run_gc(
             if removed and not dry_run:
                 removed_count += 1
             # 4: best-effort plugin notification (independent of the audit).
-            _emit_worktree_gc(repo_root, row, dry_run)
+            _emit_worktree_gc(repo_root, row, dry_run, reaped=True)
     return removed_count
 
 
@@ -387,12 +474,23 @@ def _append_reap_event(
     row: ClassifiedWorktree,
     *,
     dry_run: bool,
+    reaped: bool,
+    forced: bool,
 ) -> None:
     """Append one ``worktree.reap`` event capturing the pre-deletion state.
 
     The fingerprint (git HEAD sha + dirty flag) is captured here, before
     the caller reaps the directory. The ``details`` payload is restricted
     to the fields the issue enumerates so the daily JSONL does not bloat.
+
+    Args:
+        log: Open HMAC-chained audit log.
+        row: Classifier row being reaped or preserved.
+        dry_run: Whether this is a ``--dry`` sweep (no filesystem mutation).
+        reaped: ``True`` when the directory is being deleted; ``False`` for
+            a safety-skip (unsaved work preserved without ``--force-unsaved``).
+        forced: ``True`` when ``--force-unsaved`` overrode the unsaved-work
+            veto for this reap.
 
     Fail-closed: any exception raised by :meth:`AuditLog.log` propagates to
     the caller, which then skips the reap.
@@ -412,6 +510,9 @@ def _append_reap_event(
             "last_trace_mtime": row.last_trace_mtime,
             "head_sha": fingerprint.head_sha,
             "dirty": fingerprint.dirty,
+            "has_unsaved_work": row.has_unsaved_work,
+            "reaped": reaped,
+            "forced": forced,
             "dry_run": dry_run,
         },
     )

--- a/src/bernstein/core/worktrees/classifier.py
+++ b/src/bernstein/core/worktrees/classifier.py
@@ -66,6 +66,12 @@ STALE_TRACE_AGE_S: int = 24 * 60 * 60
 #: notify bridge, so the classifier uses a free-form event id instead.
 WORKTREE_GC_LIFECYCLE_EVENT = "worktree.gc"
 
+#: Branch a worktree's commits are checked against before the worktree is
+#: considered free of unmerged work. When every commit on the worktree's
+#: HEAD is reachable from this branch the work is already integrated and the
+#: worktree is safe to reap. Mirrors ``git_hygiene.DEFAULT_TARGET_BRANCH``.
+DEFAULT_INTEGRATION_BRANCH = "main"
+
 #: Issue #1833 - audit event-type appended to the HMAC-chained audit log
 #: (``.sdd/audit/``) for every reaped worktree. Distinct from the
 #: best-effort lifecycle event above: the audit entry is tamper-evident,
@@ -119,6 +125,14 @@ class ClassifiedWorktree:
             ``pid`` is ``None``.
         last_trace_mtime: Unix timestamp of the most recent trace
             event, or ``None`` if no trace file exists.
+        has_unsaved_work: ``True`` when the worktree still holds work that
+            a reap would destroy - a dirty working tree
+            (``git status --porcelain`` non-empty), commits on the
+            worktree branch that are not reachable from the integration
+            branch, or - for a ``CORRUPT`` directory git cannot probe -
+            tracked-looking content on disk. The probe runs *inside* each
+            candidate worktree, so the guarantee holds independently per
+            per-task git worktree.
     """
 
     path: Path
@@ -130,10 +144,22 @@ class ClassifiedWorktree:
     pid: int | None
     pid_alive: bool
     last_trace_mtime: float | None
+    has_unsaved_work: bool = False
 
     @property
     def is_reapable(self) -> bool:
-        """Return ``True`` when the worktree is safe to delete."""
+        """Return ``True`` when the worktree is safe to delete.
+
+        A worktree is reapable only when it is in a terminal state
+        (``ORPHAN``/``STALE``/``CORRUPT``) *and* the classifier proved it
+        carries no unsaved work. ``has_unsaved_work`` vetoes the reap
+        regardless of state, so a directory holding the only copy of
+        unmerged commits or uncommitted edits is never silently deleted.
+        The ``bernstein worktrees gc --force-unsaved`` path overrides this
+        veto explicitly; the classifier itself never does.
+        """
+        if self.has_unsaved_work:
+            return False
         return self.state in (WorktreeState.ORPHAN, WorktreeState.STALE, WorktreeState.CORRUPT)
 
 
@@ -258,6 +284,10 @@ def _classify_one(
     age_seconds = _dir_age(path, now=now)
 
     # 1. Corrupt - directory exists but git can't see a .git anchor.
+    # Without a ``.git`` anchor we cannot run any git probe, so we fall back
+    # to a filesystem check: an empty directory is safe to reap, while one
+    # holding files may carry the only copy of an agent's output and is
+    # surfaced for manual handling instead of being deleted blindly.
     git_anchor = path / ".git"
     if not git_anchor.exists():
         return ClassifiedWorktree(
@@ -270,6 +300,7 @@ def _classify_one(
             pid=None,
             pid_alive=False,
             last_trace_mtime=None,
+            has_unsaved_work=_corrupt_dir_has_content(path),
         )
 
     # Load the task record, if any.
@@ -279,7 +310,9 @@ def _classify_one(
     alive = pid is not None and _process_alive(pid)
     last_trace_mtime = _last_trace_mtime(repo_root, session_id)
 
-    # 2. Orphan - directory has no task record at all.
+    # 2. Orphan - directory has no task record at all. A missing PID record
+    # is exactly the crash-recovery case where committed-but-unmerged work
+    # is most likely stranded, so probe the worktree before allowing a reap.
     if pid_record is None:
         return ClassifiedWorktree(
             path=path,
@@ -291,6 +324,7 @@ def _classify_one(
             pid=pid,
             pid_alive=alive,
             last_trace_mtime=last_trace_mtime,
+            has_unsaved_work=_probe_unsaved_work(path, repo_root),
         )
 
     # 3. Active - task record exists and PID is alive.
@@ -323,6 +357,7 @@ def _classify_one(
             pid=pid,
             pid_alive=False,
             last_trace_mtime=last_trace_mtime,
+            has_unsaved_work=_probe_unsaved_work(path, repo_root),
         )
 
     return ClassifiedWorktree(
@@ -447,6 +482,141 @@ def _git_is_dirty(path: Path) -> bool | None:
     if proc.returncode != 0:
         return None
     return bool(proc.stdout.strip())
+
+
+def _git_has_unmerged_commits(path: Path, integration_branch: str) -> bool | None:
+    """Return whether the worktree branch carries commits not yet integrated.
+
+    A worktree HEAD is "merged" when every one of its commits is reachable
+    from ``integration_branch`` - i.e. ``git merge-base --is-ancestor HEAD
+    <integration_branch>`` succeeds. That mirrors
+    :func:`git_hygiene._is_branch_merged` and never reports false "ahead"
+    commits for a branch that was merged but not fast-forwarded locally.
+
+    When the integration branch is missing (a throw-away clone, a repo that
+    renamed ``main``) the ancestor check cannot decide, so we fall back to
+    "is HEAD ahead of its configured upstream" via
+    ``git rev-list --count @{upstream}..HEAD``. If neither ref resolves we
+    return ``None`` (undecided) and the caller preserves the worktree.
+
+    Returns:
+        ``True`` when the branch has unmerged/unpushed commits, ``False``
+        when it is fully integrated, ``None`` when git could not decide.
+    """
+    head = _git_head_sha(path)
+    if head is None:
+        # No resolvable HEAD (unborn branch, detached empty tree). There is
+        # no commit that a reap would strand, so report "merged".
+        return False
+
+    ancestor = _run_probe_git(path, ["merge-base", "--is-ancestor", "HEAD", integration_branch])
+    if ancestor is not None and ancestor.returncode == 0:
+        # Every HEAD commit is reachable from the integration branch.
+        return False
+    if ancestor is not None and ancestor.returncode == 1 and not ancestor.stderr.strip():
+        # Definitive "not an ancestor" (exit 1, no error text) - unmerged.
+        return True
+
+    # The integration branch is unknown or git errored. Fall back to the
+    # upstream-ahead heuristic so a missing ``main`` does not defeat the GC.
+    ahead = _run_probe_git(path, ["rev-list", "--count", "@{upstream}..HEAD"])
+    if ahead is not None and ahead.returncode == 0:
+        count = ahead.stdout.strip()
+        return count.isdigit() and int(count) > 0
+
+    # Could not decide either way - preserve the worktree on uncertainty.
+    return None
+
+
+def _run_probe_git(path: Path, args: list[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run a read-only git probe inside ``path`` with the fingerprint timeout.
+
+    Returns ``None`` (rather than raising) on any spawn/timeout failure so a
+    hung or corrupt worktree degrades to "undecided" instead of stalling
+    ``gc``.
+    """
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_FINGERPRINT_GIT_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("probe: git %s failed for %s: %s", " ".join(args), path, exc)
+        return None
+
+
+def _corrupt_dir_has_content(path: Path) -> bool:
+    """Return ``True`` when a ``.git``-less directory still holds any file.
+
+    A ``CORRUPT`` worktree cannot be probed with git, so we cannot prove it
+    is empty of unmerged work. We treat a directory that contains any file
+    (recursively, at any depth) as carrying possible unsaved work and leave
+    it for manual handling; a genuinely empty directory is safe to reap.
+    Errors walking the tree degrade to ``True`` (preserve) - never ``False``.
+    """
+    try:
+        for _root, _dirs, files in os.walk(path, onerror=_raise_walk_error):
+            if files:
+                return True
+    except OSError as exc:
+        logger.debug("corrupt-probe: walk failed for %s: %s", path, exc)
+        return True
+    return False
+
+
+def _raise_walk_error(exc: OSError) -> None:
+    """``os.walk`` error callback that re-raises so the caller can preserve."""
+    raise exc
+
+
+def _probe_unsaved_work(path: Path, repo_root: Path, *, integration_branch: str = DEFAULT_INTEGRATION_BRANCH) -> bool:
+    """Return ``True`` when reaping ``path`` would destroy unsaved work.
+
+    The probe runs git *inside the worktree itself* so the guarantee is
+    evaluated per-task git worktree, independently of every other worktree.
+    Two cheap, local, read-only git calls are made:
+
+    1. ``git status --porcelain`` - any tracked or untracked change.
+    2. ``git merge-base --is-ancestor HEAD <integration_branch>`` (with an
+       upstream-ahead fallback) - commits that exist only on this branch.
+
+    A worktree whose directory is not its own git top level (git's upward
+    discovery would otherwise resolve the enclosing orchestrator repo) is
+    conservatively treated as carrying unsaved work, because we cannot probe
+    it safely. Any git failure on a probe degrades to "preserve" - the GC
+    only ever blocks deletion on uncertainty, it never deletes more.
+
+    Args:
+        path: Absolute path to the candidate worktree directory.
+        repo_root: Repository root (unused by the probe today; kept so the
+            signature can grow a per-repo integration-branch lookup without
+            churning every call site).
+        integration_branch: Branch HEAD must be contained in to count as
+            merged. Defaults to :data:`DEFAULT_INTEGRATION_BRANCH`.
+
+    Returns:
+        ``True`` when the worktree holds uncommitted changes or unmerged
+        commits (or could not be probed safely); ``False`` only when both
+        probes proved the worktree clean and fully integrated.
+    """
+    del repo_root  # reserved for a future per-repo integration-branch lookup
+    if not _is_own_worktree_root(path):
+        # Cannot trust git output here without leaking the enclosing repo's
+        # state; preserve rather than risk a wrong reap.
+        return True
+
+    dirty = _git_is_dirty(path)
+    if dirty is None or dirty:
+        # ``None`` (undecidable) is treated as dirty: preserve on doubt.
+        return True
+
+    unmerged = _git_has_unmerged_commits(path, integration_branch)
+    # ``None`` (undecidable) is treated as unmerged: preserve on doubt.
+    return unmerged is None or unmerged
 
 
 def reap_worktree(

--- a/tests/unit/test_tui_worktree_status.py
+++ b/tests/unit/test_tui_worktree_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 
 from bernstein.core.worktrees.classifier import ClassifiedWorktree, WorktreeState
@@ -105,11 +106,38 @@ def test_worktree_list_panel_set_rows() -> None:
 
 
 def test_worktree_list_panel_refresh_from_repo(tmp_path: Path) -> None:
-    """``refresh_from_repo`` loads classifier output for the configured root."""
+    """``refresh_from_repo`` loads classifier output for the configured root.
+
+    The orphan must be a *real* clean git worktree: the classifier probes
+    git state to refuse reaping unsaved work, so an unprobeable fake ``.git``
+    stub would be preserved (count 0) rather than counted as reapable.
+    """
+    git_id = ["-c", "user.email=test@bernstein", "-c", "user.name=test", "-c", "commit.gpgsign=false"]
+    subprocess.run(["git", "init", "-q", "-b", "main", str(tmp_path)], check=True)
+    (tmp_path / "seed.txt").write_text("seed")
+    subprocess.run(["git", "-C", str(tmp_path), *git_id, "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), *git_id, "commit", "-q", "-m", "seed"], check=True, capture_output=True)
+
     base = tmp_path / ".sdd" / "runtime" / "worktrees"
     base.mkdir(parents=True)
-    (base / "stranded").mkdir()
-    (base / "stranded" / ".git").write_text("gitdir: /fake")
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(tmp_path),
+            *git_id,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "agent/stranded",
+            str(base / "stranded"),
+            "main",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
     panel = WorktreeListPanel(repo_root=tmp_path)
     panel.refresh_from_repo()

--- a/tests/unit/test_worktree_classifier.py
+++ b/tests/unit/test_worktree_classifier.py
@@ -1,0 +1,231 @@
+"""Data-loss guards for the worktree garbage collector.
+
+These tests build *real* git worktrees under a throw-away repo's
+``.sdd/runtime/worktrees/`` directory (not the fake ``.git`` stubs used by
+:mod:`tests.unit.test_worktrees_cmd`) so the classifier can probe genuine
+git state - uncommitted changes and unmerged commits.
+
+Invariant under test: ``bernstein worktrees gc`` must never ``rmtree`` a
+worktree that still holds the only copy of unsaved work. A worktree drops
+to ``ORPHAN`` precisely when its PID record is missing - exactly the
+crash-recovery situation where unmerged commits are most likely stranded -
+so "no PID record" must not be treated as "safe to delete".
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.worktrees_cmd import run_gc, worktrees_group
+from bernstein.core.worktrees.classifier import (
+    WorktreeState,
+    classify_worktrees,
+)
+
+# ---------------------------------------------------------------------------
+# Real-git fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command in *repo_root* with a deterministic identity."""
+    return subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "-c",
+            "user.email=test@bernstein",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(repo_root: Path) -> None:
+    """Initialise a git repo with one commit on ``main`` at *repo_root*."""
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo_root)], check=True)
+    (repo_root / "seed.txt").write_text("seed")
+    _git(repo_root, "add", ".")
+    _git(repo_root, "commit", "-q", "-m", "seed")
+
+
+def _add_worktree(repo_root: Path, session_id: str) -> Path:
+    """Create a real git worktree on a fresh ``agent/<session>`` branch.
+
+    The worktree lives under ``.sdd/runtime/worktrees/<session>`` so the
+    classifier discovers it. With no PID record it classifies as ORPHAN.
+    """
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    wt = base / session_id
+    _git(repo_root, "worktree", "add", "-q", "-b", f"agent/{session_id}", str(wt), "main")
+    return wt
+
+
+def _commit_in_worktree(wt: Path, filename: str, content: str) -> None:
+    """Create and commit a file inside the worktree (an unmerged commit)."""
+    (wt / filename).write_text(content)
+    _git(wt, "add", ".")
+    _git(wt, "commit", "-q", "-m", f"work on {filename}")
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Initialised throw-away repo root with real git."""
+    _init_repo(tmp_path)
+    return tmp_path
+
+
+def _row(repo_root: Path, session_id: str):  # type: ignore[no-untyped-def]
+    rows = classify_worktrees(repo_root)
+    matching = [r for r in rows if r.session_id == session_id]
+    assert matching, f"no classifier row for {session_id}"
+    return matching[0]
+
+
+# ---------------------------------------------------------------------------
+# Classifier safety: dirty / unmerged worktrees are not reapable
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_with_untracked_file_is_not_reapable(repo_root: Path) -> None:
+    """A dirty working tree (untracked file) blocks reaping.
+
+    Acceptance: ``git status --porcelain`` is non-empty -> not reapable.
+    """
+    wt = _add_worktree(repo_root, "dirty-untracked")
+    (wt / "scratch.txt").write_text("uncommitted agent work")
+
+    row = _row(repo_root, "dirty-untracked")
+    assert row.state is WorktreeState.ORPHAN
+    assert row.has_unsaved_work is True
+    assert row.is_reapable is False
+
+
+def test_orphan_with_staged_change_is_not_reapable(repo_root: Path) -> None:
+    """A staged-but-uncommitted change blocks reaping."""
+    wt = _add_worktree(repo_root, "dirty-staged")
+    (wt / "seed.txt").write_text("modified and staged")
+    _git(wt, "add", "seed.txt")
+
+    row = _row(repo_root, "dirty-staged")
+    assert row.has_unsaved_work is True
+    assert row.is_reapable is False
+
+
+def test_orphan_with_unmerged_commit_is_not_reapable(repo_root: Path) -> None:
+    """A branch with commits absent from main blocks reaping.
+
+    Acceptance: commit on the worktree branch, run classify -> not reapable.
+    """
+    wt = _add_worktree(repo_root, "unmerged")
+    _commit_in_worktree(wt, "feature.py", "print('new')\n")
+
+    row = _row(repo_root, "unmerged")
+    assert row.state is WorktreeState.ORPHAN
+    assert row.has_unsaved_work is True
+    assert row.is_reapable is False
+
+
+def test_clean_orphan_still_reapable(repo_root: Path) -> None:
+    """A clean worktree whose branch is merged into main still reaps.
+
+    Regression guard: the common case the GC was built for is unaffected.
+    """
+    _add_worktree(repo_root, "clean")
+    # agent/clean was branched from main and has no extra commits, so it is
+    # an ancestor of main (fully merged) and the tree is clean.
+
+    row = _row(repo_root, "clean")
+    assert row.state is WorktreeState.ORPHAN
+    assert row.has_unsaved_work is False
+    assert row.is_reapable is True
+
+
+def test_corrupt_empty_dir_is_reapable(repo_root: Path) -> None:
+    """A CORRUPT worktree with no tracked content reaps (cannot be probed)."""
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    empty = base / "corrupt-empty"
+    empty.mkdir()
+
+    row = _row(repo_root, "corrupt-empty")
+    assert row.state is WorktreeState.CORRUPT
+    assert row.has_unsaved_work is False
+    assert row.is_reapable is True
+
+
+def test_corrupt_dir_with_content_is_not_reapable(repo_root: Path) -> None:
+    """A CORRUPT worktree (no .git) holding files is surfaced, not reaped."""
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    corrupt = base / "corrupt-content"
+    corrupt.mkdir()
+    (corrupt / "rescue-me.txt").write_text("the only copy")
+
+    row = _row(repo_root, "corrupt-content")
+    assert row.state is WorktreeState.CORRUPT
+    assert row.has_unsaved_work is True
+    assert row.is_reapable is False
+
+
+# ---------------------------------------------------------------------------
+# run_gc end-to-end: dirty/unmerged survive, clean is removed
+# ---------------------------------------------------------------------------
+
+
+def test_run_gc_preserves_unsaved_and_reaps_clean(repo_root: Path) -> None:
+    """A batch ``gc`` over mixed worktrees keeps unsaved work, reaps clean."""
+    clean = _add_worktree(repo_root, "gc-clean")
+    dirty = _add_worktree(repo_root, "gc-dirty")
+    (dirty / "scratch.txt").write_text("unsaved")
+    unmerged = _add_worktree(repo_root, "gc-unmerged")
+    _commit_in_worktree(unmerged, "x.py", "x=1\n")
+
+    rows = classify_worktrees(repo_root)
+    reapable = [r for r in rows if r.is_reapable]
+    run_gc(repo_root, reapable, dry_run=False)
+
+    assert not clean.exists(), "clean worktree should have been reaped"
+    assert dirty.exists(), "dirty worktree must survive gc"
+    assert unmerged.exists(), "unmerged worktree must survive gc"
+
+
+def test_force_unsaved_reaps_dirty_worktree(repo_root: Path) -> None:
+    """``--force-unsaved`` deletes a dirty worktree after confirmation."""
+    dirty = _add_worktree(repo_root, "force-dirty")
+    (dirty / "scratch.txt").write_text("unsaved")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        worktrees_group,
+        ["gc", "--workdir", str(repo_root), "--yes", "--force-unsaved"],
+    )
+    assert result.exit_code == 0, result.output
+    assert not dirty.exists(), "--force-unsaved should reap the dirty worktree"
+
+
+def test_gc_without_force_reports_safety_skip(repo_root: Path) -> None:
+    """Plain ``gc`` reports the unsaved-work skip and leaves the dir."""
+    dirty = _add_worktree(repo_root, "skip-dirty")
+    (dirty / "scratch.txt").write_text("unsaved")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        worktrees_group,
+        ["gc", "--workdir", str(repo_root), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert dirty.exists(), "dirty worktree must survive a plain gc"
+    assert "unsaved" in result.output.lower() or "skip" in result.output.lower()

--- a/tests/unit/test_worktrees_cmd.py
+++ b/tests/unit/test_worktrees_cmd.py
@@ -72,18 +72,50 @@ def _init_repo(repo_root: Path) -> None:
 
 
 def _make_worktree_dir(repo_root: Path, session_id: str, *, with_git: bool = True) -> Path:
-    """Create a fake worktree directory under ``.sdd/runtime/worktrees``.
+    """Create a worktree directory under ``.sdd/runtime/worktrees``.
 
-    We do not actually call ``git worktree add`` - the classifier only
-    needs the directory layout (`.git` anchor + size on disk).
+    With ``with_git=True`` (the default) this creates a *real* git worktree
+    via ``git worktree add`` on a fresh ``agent/<session>`` branch off
+    ``main``. A real worktree is required because the classifier now probes
+    git state (``git status --porcelain`` and merge-ancestry) to refuse
+    reaping worktrees that hold unsaved work; a fake ``.git`` stub cannot be
+    probed and is conservatively preserved. The fresh worktree is clean and
+    fully merged, so it classifies as reapable - matching the common case
+    the GC was built for.
+
+    With ``with_git=False`` it creates a plain directory (no ``.git``
+    anchor) holding one file, which the classifier marks ``CORRUPT``.
     """
     base = repo_root / ".sdd" / "runtime" / "worktrees"
     base.mkdir(parents=True, exist_ok=True)
     wt = base / session_id
+    if with_git:
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "-c",
+                "user.email=test@bernstein",
+                "-c",
+                "user.name=test",
+                "-c",
+                "commit.gpgsign=false",
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                f"agent/{session_id}",
+                str(wt),
+                "main",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return wt
     wt.mkdir()
     (wt / "file.txt").write_text("hello")
-    if with_git:
-        (wt / ".git").write_text("gitdir: /fake")
     return wt
 
 
@@ -158,12 +190,30 @@ def test_classifier_stale(repo_root: Path) -> None:
 
 
 def test_classifier_corrupt(repo_root: Path) -> None:
-    """Directory has no .git anchor => corrupt."""
+    """Directory has no .git anchor => corrupt.
+
+    A corrupt directory cannot be probed with git. When it still holds
+    files (the helper writes ``file.txt``) we cannot prove it is free of
+    unsaved work, so it is preserved for manual handling rather than reaped.
+    """
     sid = "corrupt"
     _make_worktree_dir(repo_root, sid, with_git=False)
 
     rows = classify_worktrees(repo_root)
     assert rows[0].state is WorktreeState.CORRUPT
+    assert rows[0].has_unsaved_work is True
+    assert rows[0].is_reapable is False
+
+
+def test_classifier_corrupt_empty_is_reapable(repo_root: Path) -> None:
+    """An empty corrupt directory (no tracked content) still reaps."""
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "corrupt-empty").mkdir()
+
+    rows = classify_worktrees(repo_root)
+    assert rows[0].state is WorktreeState.CORRUPT
+    assert rows[0].has_unsaved_work is False
     assert rows[0].is_reapable is True
 
 
@@ -269,7 +319,8 @@ def test_reap_worktree_dry_run_does_not_touch_disk(repo_root: Path) -> None:
 
     assert reap_worktree(repo_root, row, dry_run=True) is True
     assert wt.exists()
-    assert (wt / "file.txt").read_text() == "hello"
+    # The real worktree checks out main's seed file; dry-run leaves it intact.
+    assert (wt / "seed.txt").read_text() == "seed"
 
 
 def test_reap_worktree_real_removes_directory(repo_root: Path) -> None:


### PR DESCRIPTION
## Summary

`bernstein worktrees gc` could delete a per-task git worktree that still held the only copy of uncommitted changes or unmerged commits. The classifier marked any directory with no PID record as `orphan` and `is_reapable` returned `True` for `orphan`/`stale`/`corrupt`, so the reaper ran `shutil.rmtree` unconditionally - with no inspection of the worktree's working tree or branch. A worktree drops to `orphan` precisely when its PID record is missing (cleaned up after a crash, written under an older layout, or never created), which is exactly the case where committed-but-unmerged work is most likely stranded. This contradicted the invariant the `maintenance` command already enforces (unmerged branches preserved by default behind `--force`).

Fixes #1847.

## What changed

- Probe each candidate worktree's git state before allowing a reap, inside the worktree itself so the check is evaluated per worktree:
  - `git status --porcelain` for uncommitted changes.
  - `git merge-base --is-ancestor HEAD <integration-branch>` (default `main`, with an `@{upstream}..HEAD` ahead fallback) for commits not yet integrated. This mirrors the existing `git_hygiene` merge-ancestry check, so a branch that was merged but not fast-forwarded locally is not wrongly preserved.
- Add `has_unsaved_work` to `ClassifiedWorktree`. `is_reapable` returns `False` when it is set, regardless of state. A `corrupt` worktree (no `.git` to probe) is reapable only when its directory is empty of files; otherwise it is surfaced for manual handling.
- Add a `--force-unsaved` escape hatch on `bernstein worktrees gc`, defaulting off and requiring a second explicit confirmation, mirroring `maintenance --force`.
- Record the reap-or-skip decision in the HMAC-chained audit trail (`has_unsaved_work`, `reaped`, `forced`) and in the `worktree.gc` lifecycle event, so a worktree preserved for safety is recorded rather than silent.
- All git probes use a timeout and degrade to "preserve" on any uncertainty (timeout, missing ref, unprobeable directory) - the guard only ever blocks deletion, never deletes more.
- Update `docs/operations/worktrees.md`.

## Test plan

- [x] New `tests/unit/test_worktree_classifier.py` builds real git worktrees (clean / dirty-working-tree / unmerged-commit / corrupt) under a throw-away repo and asserts: dirty and unmerged worktrees are not reapable and survive `gc`; a clean `orphan` still reaps; an empty `corrupt` dir reaps; a `corrupt` dir with content is preserved; `--force-unsaved` deletes a dirty worktree after confirmation; a plain `gc` reports the safety-skip.
- [x] Existing worktree fixtures updated to use real git worktrees so the probe is exercised; `tests/unit/test_worktrees_cmd.py` and `tests/unit/test_tui_worktree_status.py` updated for the new safe behavior.
- [x] `tests/unit/` worktree/gc/hygiene/salvage/graveyard suites: 86 passed.
- [x] `ruff check` and `ruff format --check` clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--force-unsaved` CLI option to override safety checks when deleting worktrees with unsaved work
  * Enhanced worktree cleanup to automatically detect and preserve worktrees containing uncommitted changes or unmerged commits
  * Added new environment variables for plugin lifecycle event notifications

* **Documentation**
  * Updated worktree operations guide with safety check details, new options, and troubleshooting guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->