### PR TITLE
fix(approval): wire smart auto-approve classifier into the live tool-call gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable project changes are tracked here (code + docs).
 
 - `bernstein audit export --standard` no longer accepts `dora` or `finos-aigf`; the click choice list is `ai-act` only. The previous control maps for those two standards contained only placeholder rows (`status: "todo"`, `selector: "TODO"`) and have been removed from `SUPPORTED_STANDARDS` until their clause mappings are reviewed by subject-matter experts. Operators who pass either value now receive a clean usage error rather than a TODO-only zip (#1316).
 
+### Fixed
+
+- The smart command/tool auto-approve classifier (`src/bernstein/core/security/auto_approve.py`) is now wired into the live tool-call approval path (`bernstein.core.approval.gate.await_tool_call`); previously it was unit-tested but never invoked at runtime, so its deny-list and evasion defenses gated nothing in a live run. Precedence is deny-wins and the posture is fail-closed: a deny-listed command (`rm -rf`, `git push --force`, `DROP TABLE`, `curl ... | bash`, control-plane/credential writes, and the rest of the list) is rejected by the production path regardless of interactive mode, and every decision the gate acts on is appended to the HMAC-chained audit log under `.sdd/audit/` as an `auto_approve_decision` event carrying the matched pattern - so an auditor can replay the chain and prove which calls were rejected or auto-approved and why. A safe verdict only short-circuits the operator queue when `approvals.smart_auto_approve: true` is set in `bernstein.yaml` (default `false`); an ambiguous verdict, or any classifier error, always falls through to human review and never auto-approves. `NotebookEdit` is removed from the classifier's safe-tools allow list so it falls through to ASK like `Edit`/`Write`, matching the edit-tool classification used elsewhere in the codebase (`observability/traces.py`). A regression test asserts the gate actually invokes the classifier, so the wiring cannot silently rot back into dead code (#1850).
+
 ## [2.5.0] - Interoperability surfaces, host portability, deterministic replay
 
 22 commits since v2.4.0. Full notes: [`docs/release-notes/v2.5.0.md`](docs/release-notes/v2.5.0.md).

--- a/docs/security/audit-log.md
+++ b/docs/security/audit-log.md
@@ -47,6 +47,45 @@ entry uses the last `hmac` from yesterday.
 
 source: `src/bernstein/core/security/audit.py`.
 
+### auto-approve decisions
+
+the tool-call approval gate runs a deterministic command/tool
+classifier (`src/bernstein/core/security/auto_approve.py`) before a tool
+call reaches the operator queue. each decision the gate acts on is
+recorded as an `auto_approve_decision` event so an auditor can prove,
+after the fact, which calls were rejected or auto-approved and which
+pattern drove the verdict:
+
+```json
+{
+  "event_type": "auto_approve_decision",
+  "actor": "backend",
+  "resource_type": "tool_call",
+  "resource_id": "Bash",
+  "details": {
+    "decision": "deny",
+    "tool": "Bash",
+    "reason": "Dangerous command detected: 'rm -rf /tmp/x'",
+    "matched_pattern": "\\brm\\s+-rf\\b",
+    "command": "rm -rf /tmp/x"
+  }
+}
+```
+
+precedence is deny-wins and the posture is fail-closed:
+
+- a deny-listed command (e.g. `rm -rf`, `git push --force`, `DROP
+  TABLE`, `curl ... | bash`) is rejected by the production path
+  regardless of interactive mode, and the rejection is written to the
+  chain with its matched pattern.
+- a safe command is only auto-approved when the operator opts in via
+  `approvals.smart_auto_approve: true` in `bernstein.yaml`. with the
+  default (`false`) a safe verdict still goes to the queue.
+- an ambiguous (`ask`) verdict, or any classifier error, never
+  auto-approves - it falls through to human review.
+
+source: `src/bernstein/core/approval/gate.py`.
+
 ## Key management
 
 the HMAC key is loaded from, in order:

--- a/src/bernstein/core/approval/gate.py
+++ b/src/bernstein/core/approval/gate.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -33,6 +33,13 @@ from bernstein.core.approval.queue import (
 from bernstein.core.security.always_allow import (
     AlwaysAllowEngine,
     load_always_allow_rules,
+)
+from bernstein.core.security.auto_approve import (
+    ApprovalResult as ClassifierResult,
+)
+from bernstein.core.security.auto_approve import (
+    Decision,
+    classify_tool_call,
 )
 from bernstein.core.security.guardrails import check_always_allow_tool
 from bernstein.core.security.permission_policy import (
@@ -57,10 +64,19 @@ class ApprovalConfig:
             configured.
         timeout_seconds: How long the gate blocks waiting for a
             decision. Defaults to ten minutes.
+        smart_auto_approve: When ``True`` a classifier APPROVE verdict
+            short-circuits the queue and auto-approves the call. The
+            default is ``False`` (fail-closed): a classifier APPROVE only
+            suppresses an interactive prompt when the operator has opted
+            in. The classifier deny-list and write-tool ASK rules apply
+            regardless of this flag - this flag only controls whether a
+            *safe* verdict skips human review, never whether a *risky*
+            one is blocked.
     """
 
     interactive: bool = False
     timeout_seconds: int = DEFAULT_TTL_SECONDS
+    smart_auto_approve: bool = False
 
 
 def load_approval_config(workdir: Path | None = None) -> ApprovalConfig:
@@ -80,12 +96,19 @@ def load_approval_config(workdir: Path | None = None) -> ApprovalConfig:
         return ApprovalConfig()
     if not isinstance(raw, dict):
         return ApprovalConfig()
-    section = raw.get("approvals") or {}
-    if not isinstance(section, dict):
+    raw_mapping = cast("dict[str, Any]", raw)
+    raw_section: object = raw_mapping.get("approvals")
+    if not isinstance(raw_section, dict):
         return ApprovalConfig()
+    section = cast("dict[str, Any]", raw_section)
     interactive = bool(section.get("interactive", False))
     timeout = int(section.get("timeout_seconds", DEFAULT_TTL_SECONDS))
-    return ApprovalConfig(interactive=interactive, timeout_seconds=max(1, timeout))
+    smart_auto_approve = bool(section.get("smart_auto_approve", False))
+    return ApprovalConfig(
+        interactive=interactive,
+        timeout_seconds=max(1, timeout),
+        smart_auto_approve=smart_auto_approve,
+    )
 
 
 def _always_allow_hit(
@@ -141,6 +164,135 @@ def _policy_reject(
     return None
 
 
+def _classify(tool_name: str, tool_args: dict[str, Any]) -> ClassifierResult:
+    """Run the smart auto-approve classifier, fail-closed on any error.
+
+    Any unexpected exception inside the classifier is mapped to an
+    :class:`Decision.ASK` result so an errored classifier can never
+    silently auto-approve a call. The deny-list and write-tool rules are
+    enforced by :func:`classify_tool_call`; this wrapper only guarantees
+    the gate degrades to "ask the human" rather than to "allow" when the
+    classifier itself misbehaves.
+    """
+    try:
+        return classify_tool_call(tool_name, tool_args)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Auto-approve classifier raised for tool %s: %s -- failing closed to ASK",
+            tool_name,
+            exc,
+        )
+        return ClassifierResult(Decision.ASK, f"classifier error: {exc}")
+
+
+def _record_classifier_decision(
+    *,
+    classification: ClassifierResult,
+    session_id: str,
+    agent_role: str,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    workdir: Path | None,
+) -> None:
+    """Append the classifier verdict to the HMAC-chained audit log.
+
+    Every APPROVE/DENY/ASK verdict that the gate acts on is recorded as a
+    signed, replayable ``auto_approve_decision`` event so an auditor can
+    prove, after the fact, exactly which calls were auto-approved or
+    rejected and which pattern drove the decision. Audit persistence is
+    best-effort: a write failure is logged but never blocks a deny (the
+    REJECT is returned to the caller regardless).
+    """
+    # Imported lazily so the approval gate does not pull in the audit
+    # subsystem (and its key material) unless a decision is actually
+    # being recorded.
+    from bernstein.core.security.audit import AuditLog
+
+    root = workdir if workdir is not None else Path.cwd()
+    cmd = str(tool_args.get("command") or tool_args.get("shell_cmd") or "")
+    details: dict[str, Any] = {
+        "decision": classification.decision.value,
+        "tool": tool_name,
+        "reason": classification.reason,
+        "matched_pattern": classification.matched_pattern,
+        "session_id": session_id,
+        "agent_role": agent_role,
+    }
+    if cmd:
+        details["command"] = cmd
+    try:
+        log = AuditLog(audit_dir=root / ".sdd" / "audit")
+        log.log(
+            event_type="auto_approve_decision",
+            actor=agent_role or "agent",
+            resource_type="tool_call",
+            resource_id=tool_name,
+            details=details,
+        )
+    except Exception as exc:  # pragma: no cover - filesystem/permission
+        logger.warning(
+            "Could not record auto-approve decision to audit log: %s",
+            exc,
+        )
+
+
+def _smart_classifier_decision(
+    *,
+    session_id: str,
+    agent_role: str,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    workdir: Path | None,
+    smart_auto_approve: bool,
+) -> ResolvedApproval | None:
+    """Apply the smart classifier ahead of the interactive queue.
+
+    Precedence is deny-wins:
+
+    * ``DENY``  -> reject immediately and record the verdict, regardless
+      of ``smart_auto_approve`` or interactive mode.
+    * ``APPROVE`` -> auto-approve (and record) only when the operator has
+      opted in via ``smart_auto_approve``; otherwise fall through so the
+      call is still surfaced for review.
+    * ``ASK`` / anything else -> return ``None`` so the existing approval
+      flow handles it. Uncertainty never auto-approves (fail-closed).
+    """
+    classification = _classify(tool_name, tool_args)
+
+    if classification.decision is Decision.DENY:
+        _record_classifier_decision(
+            classification=classification,
+            session_id=session_id,
+            agent_role=agent_role,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            workdir=workdir,
+        )
+        return ResolvedApproval(
+            approval_id=f"auto-approve-deny:{tool_name}",
+            decision=ApprovalDecision.REJECT,
+            reason=classification.reason,
+        )
+
+    if classification.decision is Decision.APPROVE and smart_auto_approve:
+        _record_classifier_decision(
+            classification=classification,
+            session_id=session_id,
+            agent_role=agent_role,
+            tool_name=tool_name,
+            tool_args=tool_args,
+            workdir=workdir,
+        )
+        return ResolvedApproval(
+            approval_id=f"auto-approve-allow:{tool_name}",
+            decision=ApprovalDecision.ALLOW,
+            reason=classification.reason,
+        )
+
+    # ASK, or APPROVE without opt-in: defer to the existing approval flow.
+    return None
+
+
 async def await_tool_call(
     *,
     session_id: str,
@@ -177,6 +329,23 @@ async def await_tool_call(
         return policy_decision
 
     cfg = config if config is not None else load_approval_config(workdir)
+
+    # Smart auto-approve classifier. The deny-list runs unconditionally
+    # (deny wins, even headless), so a deny-listed command is rejected and
+    # audited regardless of interactive mode or the opt-in flag. A safe
+    # (APPROVE) verdict only short-circuits the queue when the operator
+    # opted in; uncertainty (ASK) always falls through to human review.
+    classifier_decision = _smart_classifier_decision(
+        session_id=session_id,
+        agent_role=agent_role,
+        tool_name=tool_name,
+        tool_args=tool_args,
+        workdir=workdir,
+        smart_auto_approve=cfg.smart_auto_approve,
+    )
+    if classifier_decision is not None:
+        return classifier_decision
+
     if not cfg.interactive:
         return None
 

--- a/src/bernstein/core/security/auto_approve.py
+++ b/src/bernstein/core/security/auto_approve.py
@@ -517,6 +517,13 @@ _compiled_allow: list[re.Pattern[str]] = [re.compile(p) for p in _ALLOW_PATTERNS
 _compiled_deny: list[re.Pattern[str]] = [re.compile(p) for p in _DENY_PATTERNS]
 
 # Non-bash tool allow-list: tools that are always safe to approve.
+#
+# Only read-only / no-side-effect tools belong here.  Write-capable tools
+# (``Edit``, ``Write``, ``NotebookEdit``) are intentionally excluded so they
+# fall through to ASK - ``NotebookEdit`` rewrites ``.ipynb`` files (which may
+# embed shell-executing cells) and is classified as an edit tool elsewhere in
+# the codebase (``observability/traces.py`` ``_EDIT_TOOLS``), so auto-approving
+# it would contradict the write-tool policy below.
 _SAFE_TOOLS: Final[frozenset[str]] = frozenset(
     {
         "Read",
@@ -527,7 +534,6 @@ _SAFE_TOOLS: Final[frozenset[str]] = frozenset(
         "WebFetch",
         "WebSearch",
         "NotebookRead",
-        "NotebookEdit",
     }
 )
 

--- a/tests/unit/test_approval_gate_classifier_wiring.py
+++ b/tests/unit/test_approval_gate_classifier_wiring.py
@@ -1,0 +1,270 @@
+"""Wiring tests: the smart auto-approve classifier gates the live path.
+
+Issue #1850 - the ``auto_approve`` classifier was fully implemented and
+unit-tested but never invoked by any runtime code path, so its deny-list
+and evasion defenses gated nothing in a live run. These tests assert the
+classifier is now on the production approval path
+(``bernstein.core.approval.gate.await_tool_call``) end-to-end, never by
+calling ``classify_command`` directly, plus that:
+
+* a deny-listed command is rejected by the production path and the
+  rejection is written to the HMAC-chained audit log with the matched
+  pattern (and the chain still verifies);
+* the auto-approve posture is fail-closed: a safe command is NOT
+  auto-approved unless the operator opts in via config;
+* ``NotebookEdit`` is treated as a write tool (ASK), matching the
+  module's own policy and ``traces.py``'s ``_EDIT_TOOLS`` set;
+* removing the wiring fails CI (a spy asserts the classifier is called).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.core.approval.gate import (
+    ApprovalConfig,
+    await_tool_call,
+)
+from bernstein.core.approval.models import ApprovalDecision
+from bernstein.core.security.always_allow import AlwaysAllowEngine
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.auto_approve import Decision
+
+
+def _audit_dir(workdir: Path) -> Path:
+    return workdir / ".sdd" / "audit"
+
+
+# ---------------------------------------------------------------------------
+# Deny-listed command is rejected by the production path (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestDenyListedCommandRejectedEndToEnd:
+    def test_rm_rf_is_rejected_even_with_interactive_on(self, tmp_path: Path) -> None:
+        async def scenario() -> None:
+            result = await await_tool_call(
+                session_id="S",
+                agent_role="backend",
+                tool_name="Bash",
+                tool_args={"command": "rm -rf /tmp/x"},
+                workdir=tmp_path,
+                engine=AlwaysAllowEngine(rules=[]),
+                config=ApprovalConfig(interactive=True, timeout_seconds=1),
+            )
+            assert result is not None
+            assert result.decision is ApprovalDecision.REJECT
+
+        asyncio.run(scenario())
+
+    def test_rm_rf_is_rejected_even_when_interactive_off(self, tmp_path: Path) -> None:
+        # The deny check must apply regardless of interactive mode, so a
+        # fail-closed deny cannot be bypassed by disabling approvals.
+        async def scenario() -> None:
+            result = await await_tool_call(
+                session_id="S",
+                agent_role="backend",
+                tool_name="Bash",
+                tool_args={"command": "rm -rf /tmp/x"},
+                workdir=tmp_path,
+                engine=AlwaysAllowEngine(rules=[]),
+                config=ApprovalConfig(interactive=False, timeout_seconds=1),
+            )
+            assert result is not None
+            assert result.decision is ApprovalDecision.REJECT
+
+        asyncio.run(scenario())
+
+    def test_denied_command_is_written_to_audit_chain_and_verifies(self, tmp_path: Path) -> None:
+        async def scenario() -> None:
+            await await_tool_call(
+                session_id="S",
+                agent_role="backend",
+                tool_name="Bash",
+                tool_args={"command": "rm -rf /tmp/x"},
+                workdir=tmp_path,
+                engine=AlwaysAllowEngine(rules=[]),
+                config=ApprovalConfig(interactive=True, timeout_seconds=1),
+            )
+
+        asyncio.run(scenario())
+
+        log = AuditLog(audit_dir=_audit_dir(tmp_path))
+        valid, errors = log.verify()
+        assert valid, f"audit chain did not verify: {errors}"
+
+        events = list(log.query())
+        deny_events = [
+            e for e in events if e.event_type == "auto_approve_decision" and e.details.get("decision") == "deny"
+        ]
+        assert deny_events, f"no deny audit event recorded; events={[e.event_type for e in events]}"
+        evt = deny_events[0]
+        assert evt.details.get("tool") == "Bash"
+        # The matched deny pattern must be recorded so an auditor can prove why.
+        assert evt.details.get("matched_pattern")
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed posture for safe commands
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedAutoApprovePosture:
+    def test_safe_command_not_auto_approved_by_default(self, tmp_path: Path) -> None:
+        # Default posture: a classifier APPROVE does NOT silently auto-approve.
+        # With interactive on and the auto-approve flag off (default), a safe
+        # command still goes to the operator queue rather than short-circuiting.
+        from bernstein.core.approval.queue import ApprovalQueue
+
+        queue = ApprovalQueue(base_dir=tmp_path)
+
+        async def scenario() -> None:
+            gate_task = asyncio.create_task(
+                await_tool_call(
+                    session_id="S",
+                    agent_role="backend",
+                    tool_name="Bash",
+                    tool_args={"command": "ls -la"},
+                    workdir=tmp_path,
+                    queue=queue,
+                    engine=AlwaysAllowEngine(rules=[]),
+                    config=ApprovalConfig(interactive=True, timeout_seconds=2),
+                )
+            )
+            for _ in range(50):
+                pending = queue.list_pending()
+                if pending:
+                    queue.resolve(pending[0].id, ApprovalDecision.ALLOW)
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                gate_task.cancel()
+                pytest.fail("Safe command was auto-approved instead of queued (fail-open!)")
+            resolution = await gate_task
+            assert resolution is not None
+            assert resolution.decision is ApprovalDecision.ALLOW
+
+        asyncio.run(scenario())
+
+    def test_safe_command_auto_approved_when_operator_opts_in(self, tmp_path: Path) -> None:
+        # Opt-in posture: when smart_auto_approve is enabled, a classifier
+        # APPROVE short-circuits to ALLOW without queueing.
+        async def scenario() -> None:
+            result = await await_tool_call(
+                session_id="S",
+                agent_role="backend",
+                tool_name="Bash",
+                tool_args={"command": "ls -la"},
+                workdir=tmp_path,
+                engine=AlwaysAllowEngine(rules=[]),
+                config=ApprovalConfig(
+                    interactive=True,
+                    timeout_seconds=1,
+                    smart_auto_approve=True,
+                ),
+            )
+            assert result is not None
+            assert result.decision is ApprovalDecision.ALLOW
+
+        asyncio.run(scenario())
+
+    def test_ambiguous_command_falls_through_to_queue_even_when_opted_in(self, tmp_path: Path) -> None:
+        # An ASK classification must NOT auto-approve even with the flag on;
+        # it falls through to the interactive queue (fail-closed on uncertainty).
+        from bernstein.core.approval.queue import ApprovalQueue
+
+        queue = ApprovalQueue(base_dir=tmp_path)
+
+        async def scenario() -> None:
+            gate_task = asyncio.create_task(
+                await_tool_call(
+                    session_id="S",
+                    agent_role="backend",
+                    tool_name="Bash",
+                    tool_args={"command": "make build"},
+                    workdir=tmp_path,
+                    queue=queue,
+                    engine=AlwaysAllowEngine(rules=[]),
+                    config=ApprovalConfig(
+                        interactive=True,
+                        timeout_seconds=2,
+                        smart_auto_approve=True,
+                    ),
+                )
+            )
+            for _ in range(50):
+                pending = queue.list_pending()
+                if pending:
+                    queue.resolve(pending[0].id, ApprovalDecision.ALLOW)
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                gate_task.cancel()
+                pytest.fail("Ambiguous command was auto-approved (fail-open on uncertainty!)")
+            resolution = await gate_task
+            assert resolution is not None
+
+        asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# Wiring regression: the classifier must actually be called
+# ---------------------------------------------------------------------------
+
+
+class TestClassifierIsWired:
+    def test_await_tool_call_invokes_classifier(self, tmp_path: Path) -> None:
+        # Spy on the classifier as imported by the gate module. If the
+        # wiring is removed, this assertion fails and CI catches it.
+        from bernstein.core.security.auto_approve import ApprovalResult
+
+        sentinel = ApprovalResult(Decision.ASK, "spy")
+
+        async def scenario() -> None:
+            with patch(
+                "bernstein.core.approval.gate.classify_tool_call",
+                return_value=sentinel,
+            ) as spy:
+                await await_tool_call(
+                    session_id="S",
+                    agent_role="backend",
+                    tool_name="Bash",
+                    tool_args={"command": "ls"},
+                    workdir=tmp_path,
+                    engine=AlwaysAllowEngine(rules=[]),
+                    config=ApprovalConfig(interactive=False, timeout_seconds=1),
+                )
+                assert spy.called, "approval gate did not invoke the auto-approve classifier"
+
+        asyncio.run(scenario())
+
+    def test_classifier_error_is_fail_closed(self, tmp_path: Path) -> None:
+        # If the classifier raises, the gate must NOT auto-approve; it falls
+        # through to the existing approval flow (here: interactive off -> None,
+        # meaning "no auto-decision, defer to legacy ask-mode"), never ALLOW.
+        async def scenario() -> None:
+            with patch(
+                "bernstein.core.approval.gate.classify_tool_call",
+                side_effect=RuntimeError("boom"),
+            ):
+                result = await await_tool_call(
+                    session_id="S",
+                    agent_role="backend",
+                    tool_name="Bash",
+                    tool_args={"command": "ls"},
+                    workdir=tmp_path,
+                    engine=AlwaysAllowEngine(rules=[]),
+                    config=ApprovalConfig(
+                        interactive=False,
+                        timeout_seconds=1,
+                        smart_auto_approve=True,
+                    ),
+                )
+                # Fail-closed: an errored classifier never yields an ALLOW.
+                assert result is None or result.decision is not ApprovalDecision.ALLOW
+
+        asyncio.run(scenario())

--- a/tests/unit/test_approval_hook.py
+++ b/tests/unit/test_approval_hook.py
@@ -91,13 +91,17 @@ def test_gate_short_circuits_when_allow_list_matches(tmp_path: Path) -> None:
 def test_gate_pushes_when_allow_list_misses(tmp_path: Path) -> None:
     queue = ApprovalQueue(base_dir=tmp_path)
 
+    # Use a command that misses both the always-allow rules and the smart
+    # classifier's allow/deny lists, so it is genuinely ambiguous (ASK) and
+    # reaches the operator queue. A deny-listed command (e.g. ``rm -rf /``)
+    # is now rejected outright by the wired classifier and never queued.
     async def scenario() -> None:
         gate_task = asyncio.create_task(
             await_tool_call(
                 session_id="S-9",
                 agent_role="backend",
                 tool_name="shell",
-                tool_args={"command": "rm -rf /"},
+                tool_args={"command": "make build"},
                 workdir=tmp_path,
                 queue=queue,
                 engine=AlwaysAllowEngine(rules=[]),
@@ -125,13 +129,16 @@ def test_gate_pushes_when_allow_list_misses(tmp_path: Path) -> None:
 def test_gate_raises_timeout_when_unresolved(tmp_path: Path) -> None:
     queue = ApprovalQueue(base_dir=tmp_path)
 
+    # ``make build`` is ambiguous (not allow-listed, not deny-listed) so it
+    # queues and then times out. A deny-listed command would instead be
+    # rejected immediately by the wired classifier and never time out.
     async def scenario() -> None:
         with pytest.raises(ApprovalTimeoutError):
             await await_tool_call(
                 session_id="S",
                 agent_role="backend",
                 tool_name="shell",
-                tool_args={"command": "rm -rf /"},
+                tool_args={"command": "make build"},
                 workdir=tmp_path,
                 queue=queue,
                 engine=AlwaysAllowEngine(rules=[]),

--- a/tests/unit/test_auto_approve.py
+++ b/tests/unit/test_auto_approve.py
@@ -259,6 +259,13 @@ class TestClassifyToolCall:
         result = classify_tool_call("Write", {"file_path": "foo.py", "content": "..."})
         assert result.decision == Decision.ASK
 
+    def test_notebook_edit_asks(self) -> None:
+        # NotebookEdit is a write-capable tool (see traces.py _EDIT_TOOLS and
+        # this module's own fall-through policy), so it must ASK like
+        # Edit/Write rather than auto-approve (issue #1850).
+        result = classify_tool_call("NotebookEdit", {"notebook_path": "x.ipynb"})
+        assert result.decision == Decision.ASK
+
     def test_unknown_tool_asks(self) -> None:
         result = classify_tool_call("SomeFancyTool", {})
         assert result.decision == Decision.ASK


### PR DESCRIPTION
## Summary

Closes #1850.

The command/tool auto-approve classifier in `src/bernstein/core/security/auto_approve.py` was fully implemented and unit-tested but never invoked by any runtime code path. The only reference to the module anywhere in `src/` was the back-compat alias in `core/__init__.py`; the live tool-call approval gate (`bernstein.core.approval.gate.await_tool_call`) routed decisions through the per-tool permission policy only and never consulted the classifier. Its deny-list and evasion defenses therefore gated nothing in a live run.

This wires `classify_tool_call` into the production approval path with deny-wins precedence and a fail-closed posture, and records every decision to the HMAC-chained audit log so the outcome is replayable and auditable rather than an ephemeral branch.

- Deny-listed command (`rm -rf`, `git push --force`, `DROP TABLE`, `curl ... | bash`, control-plane / credential writes, and the rest of the list) is rejected by the production path regardless of interactive mode.
- Every decision the gate acts on is appended to `.sdd/audit/` as an `auto_approve_decision` event carrying the matched pattern; the chain still verifies, so an auditor can replay it and prove which calls were rejected or auto-approved and why.
- A safe verdict only short-circuits the operator queue when `approvals.smart_auto_approve: true` is set in `bernstein.yaml` (default `false`). An ambiguous verdict, or any classifier error, always falls through to human review and never auto-approves.
- `NotebookEdit` is removed from the classifier safe-tools allow list so it falls through to ASK like `Edit`/`Write`, matching the edit-tool set in `observability/traces.py`.
- A regression test asserts the gate actually invokes the classifier (via a spy), so the wiring cannot silently rot back into dead code.

### Operator-facing behaviour change

- Default posture is unchanged for safe and ambiguous calls (still queued / asked).
- New: a deny-listed command is now rejected outright by the gate instead of being queued for review. This is the intended fail-closed behaviour but is a behaviour change for any workflow that previously relied on no enforcement.
- New opt-in flag `approvals.smart_auto_approve` (default `false`) lets operators allow a safe classifier verdict to skip the interactive prompt.

## Test plan

- [x] `pytest tests/unit/test_auto_approve.py tests/unit/test_command_normalization.py tests/unit/test_approval_gates.py tests/unit/test_approval_hook.py tests/unit/test_approval_gate_classifier_wiring.py` (237 passed)
- [x] New `tests/unit/test_approval_gate_classifier_wiring.py`: deny-listed command rejected end-to-end via the production path (interactive on and off); decision written to the audit chain with the matched pattern and the chain verifies; safe command not auto-approved by default; safe command auto-approved only when opted in; ambiguous command and classifier errors never auto-approve; spy proves the gate invokes the classifier.
- [x] `classify_tool_call("NotebookEdit", ...)` returns ASK.
- [x] `ruff check`, `ruff format --check`, and `pyright` clean on changed source.

## Docs

- `docs/security/audit-log.md` documents the new `auto_approve_decision` event type, the deny-wins precedence, and the `approvals.smart_auto_approve` flag.
- `CHANGELOG.md` updated under Unreleased / Fixed.