### PR TITLE
fix(schedule): drift-proof last_state digest and verifying schedule audit (#1852, #1838)

### DIFF
--- a/docs/operations/schedule.md
+++ b/docs/operations/schedule.md
@@ -20,7 +20,13 @@ Key properties:
 - **Deterministic projection.** A fire is a pure function of
   `(schedule_id, fire_time, last_state)`; two operators with the same
   inputs land on the byte-identical task graph and the same
-  `projection_hash`.
+  `projection_hash`. `fire_time` is pinned to an integer epoch (a float
+  is rejected because sub-second drift forks two hosts), and `last_state`
+  is canonicalised before hashing: dict key order, set/frozenset member
+  order, and nested-container order do not perturb the digest, and a
+  non-portable scalar (`float`/`NaN`/`Infinity`) in the state mapping is
+  rejected with a `TypeError` rather than producing a host-dependent
+  hash. The genesis sentinel (`last_state=None`) is unchanged.
 - **Audit-chain integration.** Each fire appends a `schedule.fire` entry
   to the existing HMAC-chained audit log carrying
   `(schedule_id, fire_time, projection_hash, prev_chain_digest)`. No
@@ -93,27 +99,51 @@ Every fire appends a chain entry to `.sdd/audit/<date>.jsonl` with:
 - `resource_type = "schedule"`,
 - `resource_id = <schedule_id>`,
 - `details = {schedule_id, fire_time, projection_hash, rev,
-  misfire_policy, prev_chain_digest}`.
+  misfire_policy, prev_chain_digest, goal, scenario_id}`.
+
+`goal` and `scenario_id` are recorded in both the chain entry and the
+per-fire receipt so the audit verb can re-derive the projection from the
+recorded inputs alone, without depending on the live schedule store
+(which may have been edited or removed since the fire).
 
 The chain is the production HMAC chain
 (`bernstein.core.security.audit.AuditLog`). We do not introduce a
 parallel chain.
 
-Walk the chain:
+Verify the recorded fires:
 
 ```bash
-bernstein schedule audit          # human table
-bernstein schedule audit --json   # JSON, for diff-comparing two hosts
+bernstein schedule audit          # human table with per-fire status
+bernstein schedule audit --json   # JSON, for diff-comparing two hosts / CI gates
 ```
 
-`schedule audit` walks the persisted per-fire receipts under
-`.sdd/runtime/schedule_receipts/` and reports the projection hash + the
-chain digest for each fire. Two operators comparing the same nightly
-window diff this output to confirm byte-identical execution; the
-deterministic surface they care about is the
-`(schedule_id, fire_time, projection_hash, rev)` tuple. The per-host
-HMAC differs because it includes the wall-clock timestamp baked into
-the audit entry, which is intentional for tamper-evidence.
+`schedule audit` is a verification verb, not a printout. For every
+non-counterfactual receipt under `.sdd/runtime/schedule_receipts/` it:
+
+1. **Re-derives** the projection by re-running `project_schedule_fire`
+   from the receipt's persisted inputs
+   (`schedule_id, fire_time, goal, scenario_id`, `last_state=None`) under
+   the receipt's recorded `rev`, and confirms the recomputed
+   `projection_hash` equals the stored one. A receipt whose
+   `projection_hash` was edited to a self-consistent but wrong value is
+   caught here.
+2. **Cross-checks** the receipt against the matching `schedule.fire`
+   audit-chain entry: the entry's `projection_hash`, `prev_chain_digest`,
+   and HMAC must agree with the receipt. A receipt edited independently
+   of the chain (or vice versa) is reported as a mismatch.
+3. **Checks linkage**: the receipt-to-receipt
+   `prev_chain_digest -> chain_digest` sequence must be unbroken.
+
+The command exits non-zero and names the offending receipt on any
+mismatch, so it is safe to run as a CI gate. Counterfactual receipts
+carry empty hashes by design and are skipped. A receipt recorded under a
+different projection rev than the current in-tree algorithm cannot be
+re-derived locally and is reported as `rev-skip` rather than a false
+mismatch; the verifier honours `receipt.rev` rather than the current
+rev. Two operators comparing the same nightly window still diff the
+`(schedule_id, fire_time, projection_hash, rev)` tuple; the per-host
+HMAC differs because it includes the wall-clock timestamp baked into the
+audit entry, which is intentional for tamper-evidence.
 
 ## Lifecycle
 

--- a/src/bernstein/cli/commands/schedule_cmd.py
+++ b/src/bernstein/cli/commands/schedule_cmd.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json as _json
 import time
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +28,7 @@ import click
 from bernstein.core.orchestration.schedule_supervisor import (
     DEFAULT_TICK_INTERVAL_S,
     ScheduleSupervisor,
-    load_receipts,
+    verify_receipts,
 )
 from bernstein.core.planning.schedule_store import (
     CronParseError,
@@ -212,37 +211,55 @@ def schedule_remove(schedule_id: str) -> None:
 @schedule_group.command("audit")
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON output.")
 def schedule_audit(as_json: bool) -> None:
-    """Walk persisted fire receipts and prove the sequence is reproducible.
+    """Re-derive and chain-check persisted fire receipts (verification).
 
-    The verb iterates ``runtime/schedule_receipts/*.json`` in chronological
-    order and reports the projection_hash + chain digest for each fire.
-    Two operators comparing the same nightly window can diff this output
-    to confirm byte-identical execution.
+    For every non-counterfactual receipt the verb re-runs the
+    deterministic projection from the receipt's persisted inputs and
+    confirms the recomputed ``projection_hash`` equals the recorded one,
+    then cross-checks the receipt against the matching ``schedule.fire``
+    audit-chain entry and verifies the receipt-to-receipt chain linkage.
+    A tampered or chain-inconsistent receipt makes the command exit
+    non-zero and names the offending receipt, so the verb is safe to run
+    as a CI gate rather than only a human-readable table.
     """
     sdd = _sdd_dir()
-    receipts = load_receipts(sdd)
+    report = verify_receipts(sdd)
 
     if as_json:
         click.echo(
             _json.dumps(
-                {"receipts": [asdict(r) for r in receipts]},
+                {"receipts": report.to_json(), "ok": report.ok, "failures": list(report.failures)},
                 sort_keys=True,
                 indent=2,
             ),
         )
-        return
+        raise SystemExit(0 if report.ok else 1)
 
-    if not receipts:
+    if not report.results:
         click.echo("(no schedule fires recorded)")
         return
 
-    click.echo(f"{'FIRE_TIME':<20} {'SCHEDULE':<24} {'PROJECTION':<18} CHAIN")
-    for r in receipts:
-        kind = "skip" if r.counterfactual else "fire"
+    click.echo(f"{'FIRE_TIME':<20} {'SCHEDULE':<24} {'PROJECTION':<18} {'STATUS':<10} CHAIN")
+    for r in report.results:
         ts = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(r.fire_time))
-        chain_short = (r.chain_digest or "-")[:16]
-        proj_short = (r.projection_hash or "-")[:16]
-        click.echo(f"{ts:<20} {r.schedule_id:<24} {proj_short:<18} {chain_short}  [{kind}]")
+        proj_short = (r.recorded_projection_hash or "-")[:16]
+        chain_short = ("ok" if r.chain_match else "MISMATCH") if not r.counterfactual else "-"
+        if r.counterfactual:
+            status = "skip"
+        elif r.rev_skipped:
+            status = "rev-skip"
+        elif r.verified:
+            status = "verified"
+        else:
+            status = "MISMATCH"
+        click.echo(f"{ts:<20} {r.schedule_id:<24} {proj_short:<18} {status:<10} {chain_short}")
+
+    if not report.ok:
+        click.echo("", err=True)
+        click.echo("audit FAILED - the following receipts did not verify:", err=True)
+        for failure in report.failures:
+            click.echo(f"  - {failure}", err=True)
+        raise SystemExit(1)
 
 
 @schedule_group.command("run")

--- a/src/bernstein/core/orchestration/schedule_projection.py
+++ b/src/bernstein/core/orchestration/schedule_projection.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -81,16 +81,76 @@ class ProjectionResult:
         return json.loads(self.canonical_bytes.decode())
 
 
+def _canonicalize_last_state(value: Any) -> Any:
+    """Recursively normalise *value* into an order-stable, drift-proof form.
+
+    The deterministic contract requires that two operators with logically
+    equal ``last_state`` mappings land on byte-identical bytes. Plain
+    ``json.dumps(..., sort_keys=True)`` does NOT achieve this for the
+    full ``Any`` value space:
+
+    - ``set`` / ``frozenset`` members are not JSON-serialisable at all
+      (``json.dumps`` raises), and even when pre-converted their member
+      order is hash-randomised per ``PYTHONHASHSEED``.
+    - ``float`` members serialise with a platform/version-dependent
+      repr, and ``NaN``/``Infinity`` round-trip through a non-portable
+      ``json`` extension token rather than valid JSON.
+
+    Sets/frozensets are folded into a sorted ``["__set__", [...]]``
+    sentinel (the same canonical shape as
+    :func:`bernstein.core.persistence.fingerprint._canonicalize`, so the
+    two subsystems cannot diverge); dicts and sequences recurse so nested
+    sets are also normalised.
+
+    ``float`` is rejected with a ``TypeError`` mirroring the ``fire_time``
+    float guard rather than silently producing a host-dependent digest.
+    A caller that genuinely needs a real-valued component must quantise
+    or stringify it deterministically before folding it into the state.
+    """
+    if isinstance(value, bool):
+        # ``bool`` is an ``int`` subclass but JSON-stable; keep it as-is
+        # (and intercept before the float/int paths so it is not coerced).
+        return value
+    if isinstance(value, float):
+        raise TypeError(
+            "last_state must not contain a float; floats serialise with a "
+            "host-dependent repr and permit cross-host drift (mirrors the "
+            "fire_time float guard). Quantise or stringify deterministically."
+        )
+    if isinstance(value, dict):
+        mapping = cast("dict[Any, Any]", value)
+        items: list[tuple[Any, Any]] = sorted(mapping.items(), key=lambda kv: repr(kv[0]))
+        return {str(k): _canonicalize_last_state(v) for k, v in items}
+    if isinstance(value, (set, frozenset)):
+        container = cast("set[Any] | frozenset[Any]", value)
+        members: list[Any] = sorted((_canonicalize_last_state(v) for v in container), key=repr)
+        return ["__set__", members]
+    if isinstance(value, (list, tuple)):
+        sequence = cast("list[Any] | tuple[Any, ...]", value)
+        return [_canonicalize_last_state(v) for v in sequence]
+    return value
+
+
 def _digest_last_state(last_state: Mapping[str, Any] | None) -> str:
     """Hash the ``last_state`` mapping into a stable digest.
 
     A None / empty mapping hashes to a fixed sentinel so the very first
     fire of a fresh schedule produces a deterministic projection without
     requiring the caller to invent a synthetic state.
+
+    Non-empty mappings are canonicalised by :func:`_canonicalize_last_state`
+    before hashing so set member order, nested-container order, and dict
+    key order do not perturb the digest, and so non-portable scalar types
+    (``float``/``NaN``/``Infinity``) are rejected rather than silently
+    forking two operators' projections.
     """
     if not last_state:
         return "genesis"
-    canonical = json.dumps(last_state, sort_keys=True, separators=(",", ":")).encode()
+    canonical = json.dumps(
+        _canonicalize_last_state(dict(last_state)),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
     return hashlib.sha256(canonical).hexdigest()[:16]
 
 

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -32,7 +32,7 @@ import logging
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -142,6 +142,14 @@ class FireReceipt:
     Receipts give the operator a replayable record of every fire and
     every skipped window (when ``misfire_policy == skip``). The
     ``schedule audit`` verb walks these alongside the HMAC chain.
+
+    ``goal`` and ``scenario_id`` are persisted alongside the hash so the
+    audit verb can re-derive the projection from the receipt alone
+    (#1838) without depending on the live ScheduleStore, which may have
+    been edited or removed since the fire. They default to empty for
+    backward-compatibility with receipts written before this field
+    existed; such legacy receipts re-derive against an empty goal and are
+    reported as not-self-contained rather than silently mis-verified.
     """
 
     schedule_id: str
@@ -154,6 +162,8 @@ class FireReceipt:
     dispatched: bool
     skipped_windows: tuple[int, ...] = field(default_factory=tuple)
     counterfactual: bool = False
+    goal: str = ""
+    scenario_id: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -424,6 +434,8 @@ class ScheduleSupervisor:
             dispatched=not counterfactual,
             skipped_windows=(),
             counterfactual=counterfactual,
+            goal=schedule.goal,
+            scenario_id=schedule.scenario_id,
         )
         self._persist_receipt(receipt)
         return receipt
@@ -478,7 +490,10 @@ class ScheduleSupervisor:
         """Append a ``schedule.fire`` entry to the audit chain.
 
         The payload carries ``(schedule_id, fire_time, projection_hash,
-        prev_chain_digest)`` as called out in the AC. Counterfactual
+        prev_chain_digest)`` as called out in the AC, plus the projection
+        inputs ``goal`` and ``scenario_id`` so the audit verb can
+        re-derive the projection from the chain entry alone and prove the
+        recorded hash is the genuine projection (#1838). Counterfactual
         receipts skip the chain because they represent fires that did
         NOT happen; mixing them into the chain would defeat the
         byte-identical sequence guarantee.
@@ -492,6 +507,8 @@ class ScheduleSupervisor:
             "rev": projection.rev,
             "misfire_policy": schedule.misfire_policy,
             "prev_chain_digest": prev_chain,
+            "goal": schedule.goal,
+            "scenario_id": schedule.scenario_id,
         }
         return self._chain.append(
             event_type=AUDIT_EVENT_TYPE,
@@ -551,9 +568,311 @@ def load_receipts(sdd_dir: Path) -> list[FireReceipt]:
                     dispatched=bool(data.get("dispatched", False)),
                     skipped_windows=tuple(int(x) for x in data.get("skipped_windows", [])),
                     counterfactual=bool(data.get("counterfactual", False)),
+                    goal=str(data.get("goal", "")),
+                    scenario_id=str(data.get("scenario_id", "")),
                 ),
             )
         except (KeyError, TypeError, ValueError) as exc:
             logger.warning("Malformed receipt %s: %s", path, exc)
     out.sort(key=lambda r: (r.fire_time, r.schedule_id))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Audit verification for ``schedule audit`` (#1838)
+# ---------------------------------------------------------------------------
+
+
+def _read_schedule_fire_entries(sdd_dir: Path) -> dict[tuple[str, int], dict[str, Any]]:
+    """Read recorded ``schedule.fire`` chain entries keyed by (id, fire_time).
+
+    Returns a mapping from ``(schedule_id, fire_time)`` to the recorded
+    chain payload, enriched with the entry's own ``hmac`` under the
+    ``__hmac__`` key so the caller can cross-check the receipt's
+    ``chain_digest`` against the entry's HMAC.
+
+    This reads the on-disk JSONL payload only; HMAC-chain tamper-evidence
+    is the job of :meth:`AuditLog.verify`. The cross-check here proves a
+    receipt agrees with the chain it claims to be anchored in - a receipt
+    edited independently of the chain (or a chain entry edited
+    independently of the receipt) is caught even when each file is
+    internally well-formed.
+    """
+    audit_dir = sdd_dir / "audit"
+    if not audit_dir.exists():
+        return {}
+    entries: dict[tuple[str, int], dict[str, Any]] = {}
+    for path in sorted(audit_dir.glob("*.jsonl")):
+        try:
+            lines = path.read_text().splitlines()
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.warning("Could not read audit log %s: %s", path, exc)
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                parsed: Any = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            entry = cast("dict[str, Any]", parsed)
+            if entry.get("event_type") != AUDIT_EVENT_TYPE:
+                continue
+            details_raw = entry.get("details")
+            if not isinstance(details_raw, dict):
+                continue
+            details = cast("dict[str, Any]", details_raw)
+            try:
+                key = (str(details["schedule_id"]), int(details["fire_time"]))
+            except (KeyError, TypeError, ValueError):
+                continue
+            enriched: dict[str, Any] = dict(details)
+            enriched["__hmac__"] = str(entry.get("hmac", ""))
+            # Last writer wins: later daily segments override earlier ones
+            # for the same (id, fire_time), which cannot legitimately
+            # collide within one chain anyway.
+            entries[key] = enriched
+    return entries
+
+
+@dataclass(frozen=True)
+class ReceiptVerification:
+    """Per-receipt outcome of the ``schedule audit`` verification walk.
+
+    Attributes:
+        schedule_id: Schedule the receipt belongs to.
+        fire_time: Fire instant the receipt records.
+        counterfactual: True for skip/catch-up summary receipts that carry
+            empty hashes by design; these are skipped, never flagged.
+        rev: Projection rev recorded on the receipt.
+        recorded_projection_hash: The hash stored on the receipt.
+        recomputed_projection_hash: The hash re-derived from the receipt's
+            persisted inputs under its recorded rev (empty when skipped).
+        projection_match: recomputed == recorded (only meaningful when the
+            rev could be re-derived).
+        chain_match: The receipt agrees with the matching chain entry's
+            ``projection_hash``, ``prev_chain_digest`` and HMAC.
+        rev_skipped: The receipt's rev differs from the current projection
+            rev, so it cannot be re-derived with the in-tree algorithm.
+        reasons: Human-readable reasons the receipt failed (empty on pass).
+    """
+
+    schedule_id: str
+    fire_time: int
+    counterfactual: bool
+    rev: str
+    recorded_projection_hash: str
+    recomputed_projection_hash: str
+    projection_match: bool
+    chain_match: bool
+    rev_skipped: bool
+    reasons: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def skipped(self) -> bool:
+        """True when this receipt was intentionally not verified."""
+        return self.counterfactual or self.rev_skipped
+
+    @property
+    def verified(self) -> bool:
+        """True when the receipt passed every applicable check."""
+        if self.counterfactual:
+            return True
+        if self.rev_skipped:
+            # Honest stance: a foreign-rev receipt is neither verified nor
+            # a mismatch; it is simply not re-derivable here.
+            return False
+        return self.projection_match and self.chain_match and not self.reasons
+
+    @property
+    def mismatch(self) -> bool:
+        """True when the receipt failed a check it was eligible for."""
+        if self.skipped:
+            return False
+        return not self.verified
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    """Aggregate result of verifying every persisted fire receipt."""
+
+    results: tuple[ReceiptVerification, ...]
+    failures: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        """True when no receipt reported a mismatch or linkage break."""
+        return not self.failures
+
+    def to_json(self) -> list[dict[str, Any]]:
+        """Return a JSON-safe per-receipt view for ``--json`` output."""
+        out: list[dict[str, Any]] = []
+        for r in self.results:
+            out.append(
+                {
+                    "schedule_id": r.schedule_id,
+                    "fire_time": r.fire_time,
+                    "counterfactual": r.counterfactual,
+                    "rev": r.rev,
+                    "recorded_projection_hash": r.recorded_projection_hash,
+                    "recomputed_projection_hash": r.recomputed_projection_hash,
+                    "projection_match": r.projection_match,
+                    "chain_match": r.chain_match,
+                    "rev_skipped": r.rev_skipped,
+                    "skipped": r.skipped,
+                    "verified": r.verified,
+                    "mismatch": r.mismatch,
+                    "reasons": list(r.reasons),
+                },
+            )
+        return out
+
+
+def verify_receipts(sdd_dir: Path) -> AuditReport:
+    """Re-derive and cross-check every persisted fire receipt (#1838).
+
+    For each non-counterfactual receipt this:
+
+    1. Re-runs ``project_schedule_fire`` from the receipt's persisted
+       inputs (``schedule_id``, ``fire_time``, ``goal``, ``scenario_id``,
+       ``last_state=None``) under the receipt's recorded ``rev`` and
+       confirms the recomputed ``projection_hash`` equals the recorded
+       one. A mismatch names the receipt.
+    2. Cross-checks the receipt against the matching ``schedule.fire``
+       audit-chain entry: the entry's ``projection_hash`` must equal the
+       receipt's, the entry's ``prev_chain_digest`` must equal the
+       receipt's, and the entry's HMAC must equal the receipt's
+       ``chain_digest``. A receipt edited independently of the chain (or
+       vice versa) is caught.
+    3. Verifies the receipt-to-receipt ``prev_chain_digest -> chain_digest``
+       linkage forms an unbroken sequence across consecutive dispatched
+       receipts.
+
+    Counterfactual receipts carry empty hashes by design and are skipped.
+    Receipts recorded under a different projection rev than the current
+    in-tree algorithm cannot be re-derived here and are reported as
+    rev-skipped rather than false-flagged - the verifier honours
+    ``receipt.rev`` rather than the current rev (per the AC).
+
+    ``last_state`` is assumed ``None`` because the only supervisor caller
+    fires with ``last_state=None``; the receipt does not (yet) persist a
+    folded state. When/if a future rev folds load-bearing state into the
+    projection, the receipt must persist enough to reproduce it and this
+    function must read it back.
+
+    Returns an :class:`AuditReport`; ``report.ok`` is True only when every
+    eligible receipt verified and the chain linkage is unbroken.
+    """
+    from bernstein.core.orchestration.schedule_projection import (
+        SCHEDULE_PROJECTION_REV,
+        project_schedule_fire,
+    )
+
+    receipts = load_receipts(sdd_dir)
+    chain_entries = _read_schedule_fire_entries(sdd_dir)
+
+    results: list[ReceiptVerification] = []
+    failures: list[str] = []
+
+    for receipt in receipts:
+        name = f"{receipt.schedule_id}@{receipt.fire_time}"
+        reasons: list[str] = []
+
+        if receipt.counterfactual:
+            results.append(
+                ReceiptVerification(
+                    schedule_id=receipt.schedule_id,
+                    fire_time=receipt.fire_time,
+                    counterfactual=True,
+                    rev=receipt.rev,
+                    recorded_projection_hash=receipt.projection_hash,
+                    recomputed_projection_hash="",
+                    projection_match=True,
+                    chain_match=True,
+                    rev_skipped=False,
+                ),
+            )
+            continue
+
+        rev_skipped = receipt.rev != SCHEDULE_PROJECTION_REV
+        recomputed = ""
+        projection_match = False
+        if rev_skipped:
+            reasons.append(
+                f"receipt rev {receipt.rev!r} != current rev {SCHEDULE_PROJECTION_REV!r}; "
+                "cannot re-derive with the in-tree projection algorithm"
+            )
+        else:
+            rebuilt = project_schedule_fire(
+                schedule_id=receipt.schedule_id,
+                fire_time=receipt.fire_time,
+                last_state=None,
+                goal=receipt.goal,
+                scenario_id=receipt.scenario_id,
+            )
+            recomputed = rebuilt.projection_hash
+            projection_match = recomputed == receipt.projection_hash
+            if not projection_match:
+                reasons.append(
+                    f"projection hash mismatch: recorded {receipt.projection_hash[:16]}… "
+                    f"!= recomputed {recomputed[:16]}…"
+                )
+
+        # Chain cross-check.
+        chain_match = True
+        entry = chain_entries.get((receipt.schedule_id, receipt.fire_time))
+        if entry is None:
+            # A dispatched fire MUST have a chain entry. Its absence is a
+            # mismatch unless the chain was never wired (no audit dir).
+            if chain_entries or (sdd_dir / "audit").exists():
+                chain_match = False
+                reasons.append("no matching schedule.fire entry in the audit chain")
+        else:
+            if entry.get("projection_hash") != receipt.projection_hash:
+                chain_match = False
+                reasons.append(
+                    "chain projection_hash disagrees with receipt: "
+                    f"chain {str(entry.get('projection_hash'))[:16]}… "
+                    f"!= receipt {receipt.projection_hash[:16]}…"
+                )
+            if str(entry.get("prev_chain_digest", "")) != receipt.prev_chain_digest:
+                chain_match = False
+                reasons.append("chain prev_chain_digest disagrees with receipt")
+            if str(entry.get("__hmac__", "")) != receipt.chain_digest:
+                chain_match = False
+                reasons.append("chain entry HMAC disagrees with receipt chain_digest")
+
+        result = ReceiptVerification(
+            schedule_id=receipt.schedule_id,
+            fire_time=receipt.fire_time,
+            counterfactual=False,
+            rev=receipt.rev,
+            recorded_projection_hash=receipt.projection_hash,
+            recomputed_projection_hash=recomputed,
+            projection_match=projection_match,
+            chain_match=chain_match,
+            rev_skipped=rev_skipped,
+            reasons=tuple(reasons),
+        )
+        results.append(result)
+        if result.mismatch:
+            failures.append(f"{name}: " + "; ".join(reasons))
+
+    # Receipt-to-receipt chain linkage: each dispatched receipt's
+    # prev_chain_digest must equal the previous dispatched receipt's
+    # chain_digest, forming an unbroken sequence (mirrors the audit
+    # chain's prev_hmac linkage).
+    dispatched = [r for r in receipts if r.dispatched and not r.counterfactual]
+    prev_digest: str | None = None
+    for receipt in dispatched:
+        if prev_digest is not None and receipt.prev_chain_digest != prev_digest:
+            failures.append(
+                f"{receipt.schedule_id}@{receipt.fire_time}: chain linkage break - "
+                f"prev_chain_digest {receipt.prev_chain_digest[:16]}… "
+                f"!= previous chain_digest {prev_digest[:16]}…"
+            )
+        prev_digest = receipt.chain_digest
+
+    return AuditReport(results=tuple(results), failures=tuple(failures))

--- a/tests/unit/test_schedule_audit_verify.py
+++ b/tests/unit/test_schedule_audit_verify.py
@@ -1,0 +1,250 @@
+"""Unit tests for ``schedule audit`` projection + chain verification (#1838).
+
+``bernstein schedule audit`` must *re-derive* each fire's projection from
+its persisted inputs and compare the recomputed ``projection_hash`` to the
+recorded one, and cross-check the receipt against the matching
+``schedule.fire`` entry in the HMAC audit chain. A receipt whose
+``projection_hash`` was edited to a self-consistent but wrong value, or
+that disagrees with the chain, must be reported as a hard failure - not
+printed as if intact.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.orchestration.schedule_supervisor import (
+    AUDIT_EVENT_TYPE,
+    ScheduleSupervisor,
+    load_receipts,
+    verify_receipts,
+)
+from bernstein.core.planning.schedule_store import ScheduleStore
+from bernstein.core.security.audit import AuditLog
+
+
+def _audit_log_with_shared_key(sdd_dir: Path) -> AuditLog:
+    """Return an AuditLog rooted at ``<sdd>/audit`` (matches production).
+
+    ``bernstein schedule run`` wires the supervisor's audit log at
+    ``.sdd/audit`` and ``verify_receipts`` reads from the same path, so
+    the test must place the chain there for the chain cross-check to run.
+    """
+    audit_dir = sdd_dir / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    key_path = sdd_dir / "audit.key"
+    key_path.write_bytes(b"deterministic-schedule-key-32-bytes")
+    key_path.chmod(0o600)
+    return AuditLog(audit_dir=audit_dir, key_path=key_path)
+
+
+def _seed_and_run(sdd_dir: Path) -> str:
+    """Seed a schedule, run a deterministic burst, return the schedule id."""
+    store = ScheduleStore(sdd_dir)
+    schedule = store.add(cron="* * * * *", goal="Send nightly digest", misfire_policy="catch_up")
+    last_fire = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+    store.update_last_fire(schedule.id, float(last_fire))
+    audit = _audit_log_with_shared_key(sdd_dir)
+    dispatched: list[Any] = []
+    sup = ScheduleSupervisor(store, dispatched.append, audit, catch_up_limit=10)
+    now = int(datetime(2030, 1, 1, 12, 5, 30, tzinfo=UTC).timestamp())
+    sup.tick(now=now)
+    return schedule.id
+
+
+def _receipt_files(sdd_dir: Path) -> list[Path]:
+    return sorted((sdd_dir / "runtime" / "schedule_receipts").glob("*.json"))
+
+
+def _audit_files(sdd_dir: Path) -> list[Path]:
+    return sorted((sdd_dir / "audit").glob("*.jsonl"))
+
+
+class TestVerifyHonestReceipts:
+    def test_all_dispatched_receipts_verified(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / "sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+
+        report = verify_receipts(sdd_dir)
+        assert report.ok, report.failures
+        dispatched = [r for r in report.results if not r.counterfactual]
+        assert dispatched, "expected at least one dispatched fire"
+        for r in dispatched:
+            assert r.verified
+            assert r.projection_match
+            assert r.chain_match
+            # The recomputed hash must equal the recorded one byte-for-byte.
+            assert r.recomputed_projection_hash == r.recorded_projection_hash
+
+    def test_counterfactual_receipts_skipped_not_flagged(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / "sdd"
+        sdd_dir.mkdir(parents=True)
+        # A skip-policy schedule with many missed windows emits a
+        # counterfactual receipt carrying empty hashes by design.
+        store = ScheduleStore(sdd_dir)
+        schedule = store.add(cron="* * * * *", goal="Skip probe", misfire_policy="skip")
+        last_fire = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+        store.update_last_fire(schedule.id, float(last_fire))
+        audit = _audit_log_with_shared_key(sdd_dir)
+        sup = ScheduleSupervisor(store, lambda _e: None, audit, catch_up_limit=10)
+        now = int(datetime(2030, 1, 1, 12, 10, 30, tzinfo=UTC).timestamp())
+        sup.tick(now=now)
+
+        report = verify_receipts(sdd_dir)
+        counterfactuals = [r for r in report.results if r.counterfactual]
+        assert counterfactuals, "expected a counterfactual receipt"
+        for r in counterfactuals:
+            assert r.skipped
+            assert not r.mismatch
+        # Counterfactuals must not make the overall audit fail.
+        assert report.ok, report.failures
+
+
+class TestVerifyDetectsProjectionTamper:
+    def test_edited_receipt_projection_hash_fails(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / "sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+
+        # Pick a dispatched receipt and edit its projection_hash to a
+        # plausible-but-wrong value, leaving the file well-formed.
+        target = None
+        for path in _receipt_files(sdd_dir):
+            data = json.loads(path.read_text())
+            if data.get("dispatched") and data.get("projection_hash"):
+                target = path
+                break
+        assert target is not None
+        data = json.loads(target.read_text())
+        data["projection_hash"] = "0" * 64
+        target.write_text(json.dumps(data, sort_keys=True, indent=2))
+
+        report = verify_receipts(sdd_dir)
+        assert not report.ok
+        # The offending receipt must be named in the failures.
+        assert any(target.stem.rsplit("-", 1)[0] in f or "0000000000000000" in f for f in report.failures)
+        bad = [r for r in report.results if r.recorded_projection_hash == "0" * 64]
+        assert bad and bad[0].mismatch and not bad[0].projection_match
+
+
+class TestVerifyDetectsChainMismatch:
+    def test_chain_entry_projection_hash_disagrees_with_receipt(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / "sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+
+        # Mutate the schedule.fire chain entry's projection_hash, leaving
+        # the receipt intact. The receipt still self-verifies against the
+        # projection, but it now disagrees with the chain.
+        audit_file = _audit_files(sdd_dir)[0]
+        lines = audit_file.read_text().splitlines()
+        new_lines = []
+        mutated = False
+        for line in lines:
+            if not line.strip():
+                continue
+            entry = json.loads(line)
+            if not mutated and entry.get("event_type") == AUDIT_EVENT_TYPE:
+                entry["details"]["projection_hash"] = "f" * 64
+                mutated = True
+            new_lines.append(json.dumps(entry, sort_keys=True))
+        assert mutated
+        audit_file.write_text("\n".join(new_lines) + "\n")
+
+        report = verify_receipts(sdd_dir)
+        assert not report.ok
+        assert any(r.mismatch and not r.chain_match for r in report.results)
+
+
+class TestVerifyDetectsLinkageBreak:
+    def test_broken_prev_to_chain_linkage_reported(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / "sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+
+        # Break the receipt-to-receipt linkage: rewrite the second
+        # dispatched receipt's prev_chain_digest so it no longer points at
+        # the first receipt's chain_digest.
+        dispatched = [p for p in _receipt_files(sdd_dir) if json.loads(p.read_text()).get("dispatched")]
+        assert len(dispatched) >= 2
+        second = dispatched[1]
+        data = json.loads(second.read_text())
+        data["prev_chain_digest"] = "deadbeef" * 8
+        second.write_text(json.dumps(data, sort_keys=True, indent=2))
+
+        report = verify_receipts(sdd_dir)
+        assert not report.ok
+        assert any("linkage" in f.lower() for f in report.failures)
+
+
+class TestReDerivationIsByteIdentical:
+    def test_recomputed_matches_recorded_for_every_honest_fire(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / "sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+
+        receipts = [r for r in load_receipts(sdd_dir) if r.dispatched]
+        report = verify_receipts(sdd_dir)
+        by_key = {(r.schedule_id, r.fire_time): r for r in report.results}
+        for rec in receipts:
+            res = by_key[(rec.schedule_id, rec.fire_time)]
+            assert res.recomputed_projection_hash == rec.projection_hash
+
+
+class TestScheduleAuditCommand:
+    """The CLI verb must exit non-zero on tamper, 0 on honest records."""
+
+    def _invoke(self, sdd_dir: Path, as_json: bool = False) -> Any:
+        from click.testing import CliRunner
+
+        from bernstein.cli.commands.schedule_cmd import schedule_audit
+
+        runner = CliRunner()
+        # The command resolves .sdd relative to cwd.
+        import os
+
+        cwd = os.getcwd()
+        try:
+            os.chdir(sdd_dir.parent)
+            args = ["--json"] if as_json else []
+            return runner.invoke(schedule_audit, args)
+        finally:
+            os.chdir(cwd)
+
+    def test_exit_zero_when_intact(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+        result = self._invoke(sdd_dir)
+        assert result.exit_code == 0, result.output
+
+    def test_exit_nonzero_when_projection_tampered(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+        # Tamper a dispatched receipt.
+        for path in _receipt_files(sdd_dir):
+            data = json.loads(path.read_text())
+            if data.get("dispatched") and data.get("projection_hash"):
+                data["projection_hash"] = "0" * 64
+                path.write_text(json.dumps(data, sort_keys=True, indent=2))
+                break
+        result = self._invoke(sdd_dir)
+        assert result.exit_code != 0, result.output
+
+    def test_json_marks_each_receipt_verified(self, tmp_path: Path) -> None:
+        sdd_dir = tmp_path / ".sdd"
+        sdd_dir.mkdir(parents=True)
+        _seed_and_run(sdd_dir)
+        result = self._invoke(sdd_dir, as_json=True)
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["receipts"]
+        dispatched = [r for r in payload["receipts"] if not r.get("counterfactual")]
+        assert dispatched
+        for r in dispatched:
+            assert r["verified"] is True

--- a/tests/unit/test_schedule_projection.py
+++ b/tests/unit/test_schedule_projection.py
@@ -9,6 +9,8 @@ task graph and the byte-identical projection_hash.
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 
 import pytest
 
@@ -170,6 +172,198 @@ class TestProjectionInputContract:
         # the encoder sorts metadata tuples → list-of-lists; ensure it's sorted.
         sorted_meta = sorted(meta)
         assert meta == sorted_meta
+
+
+class TestLastStateCanonicalisation:
+    """``last_state`` must be as drift-proof as ``fire_time`` (#1852).
+
+    ``fire_time`` is pinned to ``int`` and floats are rejected because
+    they permit cross-host drift. ``last_state`` feeds the same
+    byte-identical-projection contract but is digested with a plain
+    ``json.dumps(..., sort_keys=True)`` over arbitrary ``Any``, which is
+    not canonical for sets (hash-randomised member order, or a hard
+    ``TypeError``), floats (platform-dependent repr), or non-finite
+    floats (``NaN``/``Infinity`` round-trip non-portably). These tests
+    pin the canonical contract so the latent hazard cannot land once a
+    caller folds real state into the projection.
+    """
+
+    def test_set_member_order_does_not_perturb_hash(self) -> None:
+        """A set member must not fork the projection on iteration order."""
+        a = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={"a": 1, "b": {2, 1}},
+            goal="g",
+        )
+        b = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={"b": {1, 2}, "a": 1},
+            goal="g",
+        )
+        assert a.projection_hash == b.projection_hash
+        assert a.canonical_bytes == b.canonical_bytes
+
+    def test_nested_container_order_does_not_perturb_hash(self) -> None:
+        """Nested sets inside lists/dicts must also canonicalise."""
+        a = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={"outer": [{"tags": {"x", "y"}}, 1]},
+            goal="g",
+        )
+        b = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={"outer": [{"tags": {"y", "x"}}, 1]},
+            goal="g",
+        )
+        assert a.projection_hash == b.projection_hash
+
+    def test_frozenset_member_canonicalised(self) -> None:
+        a = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={"f": frozenset({3, 1, 2})},
+            goal="g",
+        )
+        b = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={"f": frozenset({2, 3, 1})},
+            goal="g",
+        )
+        assert a.projection_hash == b.projection_hash
+
+    def test_float_member_rejected(self) -> None:
+        """A float in ``last_state`` mirrors the ``fire_time`` float guard.
+
+        Floats serialise with a platform/version-dependent repr, so two
+        operators can disagree on the digest for inputs that compare
+        equal in Python. We reject rather than silently fork.
+        """
+        with pytest.raises(TypeError):
+            project_schedule_fire(
+                schedule_id="sched_alpha",
+                fire_time=1_700_000_000,
+                last_state={"x": 0.1 + 0.2},
+                goal="g",
+            )
+
+    def test_nested_float_member_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            project_schedule_fire(
+                schedule_id="sched_alpha",
+                fire_time=1_700_000_000,
+                last_state={"outer": {"inner": [1, 2.5]}},
+                goal="g",
+            )
+
+    def test_nan_member_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            project_schedule_fire(
+                schedule_id="sched_alpha",
+                fire_time=1_700_000_000,
+                last_state={"x": float("nan")},
+                goal="g",
+            )
+
+    def test_infinity_member_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            project_schedule_fire(
+                schedule_id="sched_alpha",
+                fire_time=1_700_000_000,
+                last_state={"x": float("inf")},
+                goal="g",
+            )
+
+    def test_genesis_path_unchanged(self) -> None:
+        """The ``last_state=None`` sentinel path must not regress."""
+        result = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state=None,
+            goal="g",
+        )
+        assert result.last_state_digest == "genesis"
+
+    def test_none_state_projection_hash_is_stable_across_rev(self) -> None:
+        """The canonicalisation change must not move any recorded hash.
+
+        Every projection_hash recorded today was produced with
+        ``last_state=None`` (the supervisor's only caller). Pinning the
+        exact hash proves the #1852 canonicalisation is a no-op for the
+        ``None`` path, which is why ``SCHEDULE_PROJECTION_REV`` does NOT
+        need to be bumped: no historical receipt's hash changes.
+        """
+        result = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state=None,
+            goal="Send daily digest",
+        )
+        assert result.projection_hash == "b0323f98fd799b2d84441887e8885b2de73df61429d1cded3f245c3153e0ee11"
+
+    def test_canonical_form_matches_fingerprint_helper(self) -> None:
+        """The canonical set/dict shape must equal ``fingerprint._canonicalize``.
+
+        The ticket calls out divergence between two canonicalisers as a
+        bad outcome: if the schedule projection and the persistence
+        fingerprint canonicalise the same value differently, two
+        subsystems reintroduce drift. This pins byte equivalence for the
+        overlapping (non-float) value space.
+        """
+        from bernstein.core.orchestration.schedule_projection import _canonicalize_last_state
+        from bernstein.core.persistence.fingerprint import _canonicalize
+
+        value = {"a": 1, "b": {2, 1}, "nested": [{"tags": {"x", "y"}}], "fz": frozenset({3, 1})}
+        assert json.dumps(_canonicalize_last_state(value), sort_keys=True) == json.dumps(
+            _canonicalize(value), sort_keys=True
+        )
+
+    def test_empty_mapping_is_genesis(self) -> None:
+        result = project_schedule_fire(
+            schedule_id="sched_alpha",
+            fire_time=1_700_000_000,
+            last_state={},
+            goal="g",
+        )
+        assert result.last_state_digest == "genesis"
+
+    def test_hash_seed_independent_for_set_state(self) -> None:
+        """Two processes with different PYTHONHASHSEED agree on the hash.
+
+        Set member order is hash-randomised per process; without
+        canonicalisation the digest forks between operators. We force two
+        distinct seeds in subprocesses and assert identical hashes.
+        """
+        snippet = (
+            "from bernstein.core.orchestration.schedule_projection import project_schedule_fire;"
+            "r = project_schedule_fire(schedule_id='s', fire_time=1700000000,"
+            " last_state={'tags': {'alpha', 'beta', 'gamma', 'delta'}}, goal='g');"
+            "print(r.projection_hash)"
+        )
+
+        def _run(seed: str) -> str:
+            proc = subprocess.run(
+                [sys.executable, "-c", snippet],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={"PYTHONHASHSEED": seed, "PYTHONPATH": _src_path()},
+            )
+            return proc.stdout.strip()
+
+        assert _run("0") == _run("12345")
+
+
+def _src_path() -> str:
+    """Return the bernstein src dir for subprocess PYTHONPATH propagation."""
+    import bernstein
+
+    # bernstein/__init__.py -> bernstein/ -> src/
+    return str(__import__("pathlib").Path(bernstein.__file__).resolve().parents[1])
 
 
 class TestProjectionPurity:


### PR DESCRIPTION
## Summary

Two related fixes in the deterministic schedule subsystem, batched because they touch the same files.

### #1852 - last_state digest was not drift-proof
`project_schedule_fire` pinned `fire_time` to an integer and rejected floats (sub-second drift forks two hosts), but digested `last_state` with a plain `json.dumps(..., sort_keys=True)` over arbitrary values. That is not canonical:
- `set`/`frozenset` members are not JSON-serialisable (raise) and carry hash-randomised order;
- `float` members serialise with a host-dependent repr;
- `NaN`/`Infinity` round-trip through a non-portable json token.

Fix: canonicalise `last_state` with the same recursive set/dict normalisation as `persistence.fingerprint._canonicalize` (sorted `["__set__", [...]]` sentinel, recursive containers), and reject non-portable floats with a `TypeError` mirroring the `fire_time` guard. The `last_state=None` genesis path is unchanged and its `projection_hash` is pinned in a test, so no recorded hash moves and `SCHEDULE_PROJECTION_REV` does not need a bump.

### #1838 - schedule audit printed hashes without proving them
`bernstein schedule audit` displayed the recorded `projection_hash`/chain digest but never re-derived or chain-checked them, so a receipt with a self-consistent but wrong hash passed silently. The verb now:
1. **Re-derives** each fire's projection from the receipt's persisted inputs under the receipt's recorded `rev` and compares to the stored hash;
2. **Cross-checks** the receipt against the matching `schedule.fire` audit-chain entry (`projection_hash`, `prev_chain_digest`, HMAC);
3. **Checks** the receipt-to-receipt `prev_chain_digest -> chain_digest` linkage is unbroken.

Any mismatch exits non-zero and names the offending receipt, so the verb is safe as a CI gate. Receipts (and the chain entry) now persist `goal`/`scenario_id` so re-derivation is self-contained without the live store. Counterfactual receipts are skipped; foreign-rev receipts are reported as `rev-skip` rather than false-flagged (the verifier honours `receipt.rev`).

Closes #1852
Closes #1838

## Test plan

- [x] `pytest tests/unit/test_schedule_projection.py` - 24 pass (8 new for set/float/NaN/Infinity/hash-seed canonicalisation, plus pinned none-hash and fingerprint-equivalence)
- [x] `pytest tests/unit/test_schedule_audit_verify.py` - 9 pass (re-derivation, projection tamper, chain mismatch, linkage break, counterfactual skip, CLI exit codes)
- [x] `pytest tests/unit -k "schedule"` - 184 pass, 0 fail
- [x] `pytest tests/integration/test_schedule_audit_chain.py` - existing chain tests still green with the added `goal`/`scenario_id` payload fields
- [x] Red-green: confirmed the projection tamper test fails when re-derivation is neutered, and the new `last_state` tests fail against the pre-fix digest
- [x] `ruff check` + `ruff format --check` clean; `pyright` 0 errors on changed source
- [x] Subprocess test: two `PYTHONHASHSEED` values produce identical `projection_hash` for a set-containing `last_state`
- [x] Docs: `docs/operations/schedule.md` updated (audit is now verification; payload includes goal/scenario_id; last_state canonicalisation noted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `schedule audit` command now verifies receipt integrity with detailed per-receipt status reporting (verified, mismatched, or skipped).
  * Exit codes reflect verification success/failure for CI integration.

* **Documentation**
  * Updated operations guide with stricter schedule projection determinism requirements and comprehensive audit verification procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->