### PR TITLE
fix(audit): chain-tail recovery uses byte-strict framing matching verify

### DIFF
--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -355,23 +355,53 @@ def _read_archived_segment(gz_path: Path, errors: list[str]) -> bytes | None:
         return None
 
 
-def _chain_tail_from_lines(lines: list[str]) -> str | None:
-    """Return the last ``hmac`` in ``lines`` (scanning in reverse), or None.
+def _chain_tail_from_bytes(raw_bytes: bytes) -> str | None:
+    """Return the last ``hmac`` in ``raw_bytes`` (scanning in reverse), or None.
 
     Shared by live-file and archived-segment chain recovery so both resolve
-    the tip with byte-identical line semantics.  A line that is blank or not
-    a JSON object carrying ``hmac`` is skipped, mirroring the tolerance the
-    recovery path needs for a freshly-rotated empty file or a crash mid-line.
+    the tip with the *same byte-strict framing the verifier uses*.  The bytes
+    are split on ``b"\\n"`` only (via :func:`_split_jsonl_bytes`), never with
+    ``str.splitlines()``; the latter treats ``\\v``, ``\\f``, ``\\r``, NEL,
+    and the unicode line/paragraph separators as record boundaries, so an
+    inter-line ``\\n`` -> ``\\v`` flip (the mutation pinned by
+    ``test_interline_newline_flip_is_detected``) would be split into two
+    clean records by recovery while the verifier glues them into one
+    malformed line and rejects the chain.  Recovery must agree with the
+    verifier on where records begin and end, otherwise a fresh ``AuditLog``
+    could resume from a tail ``verify()`` already considers tampered and keep
+    appending valid-HMAC events onto a broken chain (issue #1853).
+
+    A candidate record qualifies as the tip only if it parses cleanly *and*
+    its bytes equal the canonical re-serialisation
+    (``json.dumps(entry, sort_keys=True)``) - the identical check
+    :func:`_verify_log_bytes` applies - *and* it is a JSON object carrying an
+    ``hmac`` field.  Records that are blank, malformed, non-canonical, or not
+    an ``hmac``-bearing object are skipped, so recovery falls back to the last
+    byte-strict-valid record.  This tolerance keeps the genuine crash-recovery
+    case working: a truncated final line (writer crash mid-write, no trailing
+    ``\\n``) is skipped and recovery resumes from the last well-formed record,
+    exactly as the legitimate truncation path does today.
     """
-    for line in reversed(lines):
-        line = line.strip()
-        if not line:
+    for raw_line in reversed(_split_jsonl_bytes(raw_bytes)):
+        if raw_line == b"":
             continue
         try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
+            entry = json.loads(raw_line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            # ``json.loads`` on raw bytes raises ``UnicodeDecodeError`` (not
+            # ``JSONDecodeError``) when a flipped byte yields invalid UTF-8;
+            # both mean the record is unusable, so skip it and keep scanning
+            # rather than letting the decode error wedge ``AuditLog`` startup.
             continue
-        if isinstance(entry, dict) and "hmac" in entry:
+        if not isinstance(entry, dict):
+            continue
+        # Mirror the verifier's byte-for-byte canonical check so recovery and
+        # verification agree on record framing: a single-byte tamper that
+        # survives ``json.loads`` (e.g. injected whitespace) is non-canonical
+        # and is skipped rather than adopted as the tail.
+        if json.dumps(entry, sort_keys=True).encode() != raw_line:
+            continue
+        if "hmac" in entry:
             return str(entry["hmac"])
     return None
 
@@ -465,12 +495,16 @@ class AuditLog:
 
         Walks every live ``*.jsonl`` file from newest to oldest, then falls
         back to archived ``*.jsonl.gz`` segments (also newest-date first),
-        scanning each segment's lines in reverse, and returns the first line
-        that parses to a dict carrying an ``hmac`` field.  Earlier-only
-        inspection of the lex-last file would silently fork the chain when
-        that file is empty/truncated (e.g. a freshly-rotated day with no
-        events yet, or a writer crash mid-line) - see
-        test_truncated_last_file_does_not_fork_chain in
+        scanning each segment under the *same byte-strict ``b"\\n"`` framing
+        the verifier uses* (see :func:`_chain_tail_from_bytes`), and returns
+        the first record that parses to a canonical JSON object carrying an
+        ``hmac`` field.  Using the verifier's framing means recovery cannot
+        adopt a tail ``verify()`` would reject - e.g. an inter-line ``\\n``
+        flipped to ``\\v`` - and silently keep appending onto a broken chain
+        (issue #1853).  Earlier-only inspection of the lex-last file would
+        silently fork the chain when that file is empty/truncated (e.g. a
+        freshly-rotated day with no events yet, or a writer crash mid-line) -
+        see test_truncated_last_file_does_not_fork_chain in
         tests/property/test_audit_chain_bughunt.py.  Including archived
         segments means a writer reopening a log whose only events have aged
         into the archive resumes from the true tip instead of forking back
@@ -478,19 +512,19 @@ class AuditLog:
         """
         live_files = sorted(self._audit_dir.glob(_JSONL_GLOB))
         for log_path in reversed(live_files):
-            tip = _chain_tail_from_lines(log_path.read_text().splitlines())
+            tip = _chain_tail_from_bytes(log_path.read_bytes())
             if tip is not None:
                 return tip
 
         for gz_path in reversed(_archived_segment_paths(self._audit_dir)):
             try:
                 with gzip.open(gz_path, "rb") as fh:
-                    text = fh.read().decode()
+                    raw = fh.read()
             except (OSError, EOFError):
                 # A corrupt archived segment cannot yield a trustworthy tip;
                 # skip it and keep looking at older segments.
                 continue
-            tip = _chain_tail_from_lines(text.splitlines())
+            tip = _chain_tail_from_bytes(raw)
             if tip is not None:
                 return tip
         return _GENESIS_HMAC

--- a/tests/unit/test_audit_chain_byteflip_regression.py
+++ b/tests/unit/test_audit_chain_byteflip_regression.py
@@ -30,7 +30,10 @@ from pathlib import Path
 
 import pytest
 
-from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit import (
+    _GENESIS_HMAC,  # pyright: ignore[reportPrivateUsage]
+    AuditLog,
+)
 
 
 @pytest.fixture(name="audit_log")
@@ -147,3 +150,140 @@ def test_writer_uses_lf_only_terminator(audit_log: AuditLog) -> None:
     valid, errors = audit_log.verify()
     assert valid is True, f"freshly written log failed verify: {errors}"
     assert errors == [], f"unexpected errors on fresh log: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Recovery must agree with verify() on record framing.
+#
+# ``verify()`` splits strictly on ``b"\n"`` and rejects an inter-line
+# ``\n`` -> ``\v`` flip (the mutation pinned by
+# test_interline_newline_flip_is_detected). Chain-tail recovery
+# (``AuditLog.__init__`` -> ``_recover_chain_tail``) historically used
+# ``read_text().splitlines()``, which treats ``\v`` as a line separator.
+# Recovery therefore split the tampered file the way the writer's ``\n``
+# would have, recovered the last entry's ``hmac`` as if untouched, and a
+# fresh ``AuditLog`` would keep appending valid-HMAC events on top of a log
+# that ``verify()`` already considers broken - with no signal at recovery
+# time. These tests pin recovery to the same byte-strict framing.
+# ---------------------------------------------------------------------------
+
+
+def _make_audit_log() -> AuditLog:
+    """Return a fresh AuditLog over an isolated tempdir with a 0600 key."""
+    tmpdir = Path(tempfile.mkdtemp(prefix="bernstein-recover-"))
+    audit_dir = tmpdir / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    key_path = tmpdir / "audit.key"
+    key_path.write_bytes(b"regression-key-32-bytes-padding-pad")
+    key_path.chmod(0o600)
+    return AuditLog(audit_dir=audit_dir, key_path=key_path)
+
+
+def test_recovery_does_not_adopt_tail_that_verify_rejects(audit_log: AuditLog) -> None:
+    """An inter-line ``\\n`` -> ``\\v`` flip must not be silently absorbed by recovery.
+
+    Pre-fix path: ``splitlines()`` split the tampered file into two clean
+    records and recovery returned the last record's ``hmac`` - the exact
+    tail ``verify()`` rejects. Post-fix path: byte-strict ``b"\\n"`` framing
+    glues the two records into one malformed line, so recovery cannot adopt
+    the mis-framed tail and instead falls back (here, to genesis, since the
+    only file is the tampered one).
+    """
+    audit_log.log("evt1", "actor", "task", "rid", {"k": 1})
+    last_record_hmac = audit_log.log("evt2", "actor", "task", "rid", {"k": 2}).hmac
+
+    target = sorted(audit_log._audit_dir.glob("*.jsonl"))[0]  # pyright: ignore[reportPrivateUsage]
+    raw = target.read_bytes()
+    # The inter-line newline is the boundary that decides where the LAST
+    # record begins; flipping it is what desyncs recovery from the tail.
+    interline_offsets = [i for i, b in enumerate(raw[:-1]) if b == 0x0A]
+    assert interline_offsets, "test setup: no inter-line newline found"
+
+    mutated = bytearray(raw)
+    mutated[interline_offsets[-1]] ^= 0x01  # \n -> \v, between the two records
+    target.write_bytes(bytes(mutated))
+
+    # verify() still rejects the tampered file (sanity: the tamper is real).
+    valid, errors = audit_log.verify()
+    assert valid is False, "interline flip slipped past verify()"
+    assert errors
+
+    # A fresh AuditLog must NOT recover the tail verify() rejects.
+    reopened = AuditLog(audit_dir=audit_log._audit_dir, key=audit_log._key)  # pyright: ignore[reportPrivateUsage]
+    recovered = reopened._prev_hmac  # pyright: ignore[reportPrivateUsage]
+    assert recovered != last_record_hmac, (
+        "recovery adopted the last record's hmac from a file verify() rejects; "
+        "splitlines() over-split the tampered tail"
+    )
+
+    # A subsequent append must not chain onto the mis-framed record.
+    appended = reopened.log("evt-after", "actor", "task", "rid", {})
+    assert appended.prev_hmac != last_record_hmac, "append chained onto the mis-framed record's hmac"
+
+
+def test_clean_reopen_recovers_same_tail_hmac() -> None:
+    """A clean log recovers the same tail HMAC across a reopen (no regression).
+
+    Mirrors the contract behind test_append_after_reopen_continues_chain:
+    byte-strict recovery must not change the recovered tip for an untampered
+    log, and a subsequent append must chain onto the genuine last ``hmac``.
+    """
+    log = _make_audit_log()
+    log.log("evt1", "actor", "task", "rid", {"k": 1})
+    last = log.log("evt2", "actor", "task", "rid", {"k": 2})
+
+    reopened = AuditLog(audit_dir=log._audit_dir, key=log._key)  # pyright: ignore[reportPrivateUsage]
+    assert reopened._prev_hmac == last.hmac  # pyright: ignore[reportPrivateUsage]
+
+    appended = reopened.log("evt3", "actor", "task", "rid", {})
+    assert appended.prev_hmac == last.hmac
+    valid, errors = reopened.verify()
+    assert valid is True, f"reopened+appended chain failed verify: {errors}"
+
+
+def test_truncated_final_line_still_recovers_last_well_formed_record() -> None:
+    """A genuinely truncated final line (crash mid-write) still recovers.
+
+    A writer crash can leave a partial final record with no trailing ``\\n``.
+    Byte-strict recovery must skip that malformed tail and resume from the
+    last well-formed record, exactly as the legitimate truncation path does
+    today (test_truncated_last_file_does_not_fork_chain).
+    """
+    log = _make_audit_log()
+    last = log.log("evt1", "actor", "task", "rid", {"k": 1})
+
+    target = sorted(log._audit_dir.glob("*.jsonl"))[0]  # pyright: ignore[reportPrivateUsage]
+    # Append a truncated partial record (no trailing newline), as a crash
+    # mid-write would leave behind.
+    with target.open("ab") as fh:
+        fh.write(b'{"timestamp": "2099-01-01T00:00:00.0Z", "event_typ')
+
+    reopened = AuditLog(audit_dir=log._audit_dir, key=log._key)  # pyright: ignore[reportPrivateUsage]
+    assert reopened._prev_hmac == last.hmac, (  # pyright: ignore[reportPrivateUsage]
+        "recovery did not skip the truncated final line back to the last well-formed record"
+    )
+    # Genesis fallback is the wrong answer here - there IS a valid record.
+    assert reopened._prev_hmac != _GENESIS_HMAC  # pyright: ignore[reportPrivateUsage]
+
+
+def test_recovery_tolerates_invalid_utf8_in_tampered_tail() -> None:
+    """A non-UTF-8 byte in the tail must not crash ``AuditLog`` construction.
+
+    Byte-strict recovery decodes each record via ``json.loads`` on raw
+    bytes. A flipped byte can produce invalid UTF-8 (e.g. a lone ``0x80``),
+    which raises ``UnicodeDecodeError`` rather than ``json.JSONDecodeError``.
+    Recovery must treat such a record as corrupt - skip it and resume from
+    the last well-formed record - instead of letting the decode error
+    propagate out of the constructor and wedge startup.
+    """
+    log = _make_audit_log()
+    last = log.log("evt1", "actor", "task", "rid", {"k": 1})
+
+    target = sorted(log._audit_dir.glob("*.jsonl"))[0]  # pyright: ignore[reportPrivateUsage]
+    # Append a final record carrying a lone continuation byte (invalid UTF-8).
+    with target.open("ab") as fh:
+        fh.write(b'{"x": "\x80"}\n')
+
+    # Construction must not raise; recovery skips the undecodable tail.
+    reopened = AuditLog(audit_dir=log._audit_dir, key=log._key)  # pyright: ignore[reportPrivateUsage]
+    assert reopened._prev_hmac == last.hmac  # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/test_audit_chain_byteflip_regression.py
+++ b/tests/unit/test_audit_chain_byteflip_regression.py
@@ -36,16 +36,26 @@ from bernstein.core.security.audit import (
 )
 
 
-@pytest.fixture(name="audit_log")
-def _audit_log() -> AuditLog:
-    """Return a fresh AuditLog inside an isolated tempdir."""
-    tmpdir = Path(tempfile.mkdtemp(prefix="bernstein-byteflip-"))
+def _create_audit_log(prefix: str = "bernstein-byteflip-") -> AuditLog:
+    """Return a fresh AuditLog over an isolated tempdir with a 0600 key.
+
+    Shared by the ``audit_log`` fixture and the recovery tests that need a
+    fresh log outside fixture scope, so the tempdir/key-permission setup
+    lives in one place.
+    """
+    tmpdir = Path(tempfile.mkdtemp(prefix=prefix))
     audit_dir = tmpdir / "audit"
     audit_dir.mkdir(parents=True, exist_ok=True)
     key_path = tmpdir / "audit.key"
     key_path.write_bytes(b"regression-key-32-bytes-padding-pad")
     key_path.chmod(0o600)
     return AuditLog(audit_dir=audit_dir, key_path=key_path)
+
+
+@pytest.fixture(name="audit_log")
+def _audit_log() -> AuditLog:
+    """Return a fresh AuditLog inside an isolated tempdir."""
+    return _create_audit_log()
 
 
 def _flip_byte(path: Path, offset: int) -> None:
@@ -170,13 +180,7 @@ def test_writer_uses_lf_only_terminator(audit_log: AuditLog) -> None:
 
 def _make_audit_log() -> AuditLog:
     """Return a fresh AuditLog over an isolated tempdir with a 0600 key."""
-    tmpdir = Path(tempfile.mkdtemp(prefix="bernstein-recover-"))
-    audit_dir = tmpdir / "audit"
-    audit_dir.mkdir(parents=True, exist_ok=True)
-    key_path = tmpdir / "audit.key"
-    key_path.write_bytes(b"regression-key-32-bytes-padding-pad")
-    key_path.chmod(0o600)
-    return AuditLog(audit_dir=audit_dir, key_path=key_path)
+    return _create_audit_log(prefix="bernstein-recover-")
 
 
 def test_recovery_does_not_adopt_tail_that_verify_rejects(audit_log: AuditLog) -> None:


### PR DESCRIPTION
## Summary

`AuditLog._recover_chain_tail` read the newest log file with
`read_text().splitlines()`. `str.splitlines()` treats `\v`, `\f`, `\r`,
NEL, and the unicode line/paragraph separators as record boundaries; the
HMAC-chain verifier deliberately does not - it splits on `b"\n"` only and
requires each record to equal its canonical re-serialisation byte-for-byte.

Recovery and verification therefore disagreed on record framing. If an
inter-line `\n` in the newest file is flipped to `\v`:

- `verify()` glues the two affected records into one malformed line and
  reports the chain broken (correct, fail-closed).
- recovery treated `\v` as a separator, recovered the last record's `hmac`
  as if untouched, and a fresh `AuditLog` kept appending valid-HMAC events
  onto a log `verify()` already rejects - with no signal at recovery time.

This routes recovery through the existing `_split_jsonl_bytes` helper and
applies the verifier's canonical-bytes check to each candidate record, so
recovery and verification agree on where records begin and end.

- A blank, malformed, non-canonical, or undecodable record is skipped, so
  recovery falls back to the last byte-strict-valid record.
- A truncated final line (writer crash mid-write, no trailing `\n`) still
  recovers to the last well-formed record.
- An invalid-UTF-8 byte in a tampered tail is skipped instead of letting
  `UnicodeDecodeError` escape the `AuditLog` constructor.

The change is meaningful only because the chain's continuation point
depends on selecting the correct last `hmac` under tamper-evident framing;
without an HMAC chain and byte-canonical records there is no recovery-vs-
verify contract to keep consistent.

## Changes

- `src/bernstein/core/security/audit.py`: replace `_chain_tail_from_lines`
  (`splitlines()`-based) with `_chain_tail_from_bytes`, which splits on
  `b"\n"` only, applies the verifier's canonical check, and tolerates
  undecodable records. Both recovery call sites now pass raw bytes.

## Test plan

- [x] RED then GREEN: `test_recovery_does_not_adopt_tail_that_verify_rejects`
  fails on the prior `splitlines()` code and passes after the fix.
- [x] `test_clean_reopen_recovers_same_tail_hmac`: clean log recovers the
  same tail HMAC and a subsequent append continues the chain.
- [x] `test_truncated_final_line_still_recovers_last_well_formed_record`:
  truncated final line still recovers to the last well-formed record.
- [x] `test_recovery_tolerates_invalid_utf8_in_tampered_tail`: invalid-UTF-8
  tail does not wedge construction.
- [x] `pytest tests/unit/test_audit_chain_byteflip_regression.py tests/property/test_audit_chain_properties.py tests/property/test_audit_chain_bughunt.py tests/unit/test_audit_log_mutation_kill.py tests/unit/test_audit.py tests/unit/test_audit_adversarial.py tests/unit/test_journal_chain.py tests/stress/test_audit_throughput.py` -> 139 passed, 1 xfailed.
- [x] `ruff check` and `ruff format --check` clean on changed files.

Closes #1853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit log recovery mechanism to correctly handle byte-level corruption and truncated records.
  * Enhanced validation to ensure only properly formatted records are recovered during chain reconstruction.
  * Better resilience when handling invalid or corrupted data in audit logs.

* **Tests**
  * Added comprehensive test coverage for audit log recovery resilience across various corruption scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->