### PR TITLE
fix(compliance): bind auditor pack verify to on-disk log bytes (#1871)

### DIFF
--- a/docs/decisions/009-lineage-v1.md
+++ b/docs/decisions/009-lineage-v1.md
@@ -180,8 +180,11 @@ When `bernstein conduct` spawns an agent:
 ### 5.3 Verification
 
 External auditor (with `bernstein-verify`):
-1. Reads `log.jsonl`.
-2. For each entry: re-canonicalize, recompute `entry_hash`.
+1. Reads `log.jsonl` as bytes; splits strictly on `\n`.
+2. For each entry: require the on-disk line to equal `canonicalise(entry)`
+   byte-for-byte (reject non-canonical bytes), then recompute `entry_hash`
+   from the canonical bytes. (Compliance-pack logs follow the same rule for
+   format v2; see §8.4 for the v1 fallback.)
 3. Fetches Agent Card from `.sdd/agents/<agent-id>/card.json` or signed registry.
 4. Verifies JWS using card's public key.
 5. Walks `parent_hashes` chain back to genesis.
@@ -290,6 +293,36 @@ A compliance officer at a regulated company can:
 
 This is the **artifact** that closes a procurement loop. Without it, lineage is invisible to the buyer.
 
+### 8.4 Pack format versions and on-disk byte binding (#1871)
+
+`pack-manifest.json` records `pack_format_version`. The offline auditor
+(`bernstein-verify pack`) dispatches its log-parsing rule on it:
+
+| Version | `lineage-log.jsonl` on disk | Verification rule |
+|---|---|---|
+| **v2** (current) | Each entry written in its exact RFC 8785 canonical bytes, one per line, single trailing `\n`. | Bound to the on-disk bytes: split strictly on `\n`, every line must equal `canonicalise(entry)` byte-for-byte, a missing trailing newline is tamper-evidence. |
+| **v1** (pre-fix) / no manifest | Each entry written with `json.dumps(..., sort_keys=True)` default separators (spaced `", "` / `": "`), so the bytes are **not** canonical. | Original rule: re-canonicalise the parsed entry and verify the JWS against that re-derived form. |
+
+**Why the split exists.** v1 packs re-canonicalised the parsed entry before
+checking the signature, so any value-preserving byte rewrite - reordered JSON
+keys, inserted whitespace, a flipped or stripped line terminator - parsed to
+identical fields, re-canonicalised to identical bytes, and verified as
+authentic. v2 binds verification to the exact stored bytes (matching the
+in-tree lineage gate, §4 / #1848), so such a rewrite is rejected.
+
+**Legacy default.** An absent manifest or an absent/unparseable
+`pack_format_version` is treated as v1 (re-canonicalise rule), mirroring the
+Merkle seal's scheme dispatch (#1866) so pre-fix packs still verify. The
+version field rides inside the operator-signed manifest body, so a downgrade
+that rewrites it to escape the v2 rule invalidates `pack-manifest.json.sig` -
+the signature an operator checks on the with-key path.
+
+**Operator action (one-time re-pack).** Packs built before this change are
+v1 and verify under the weaker re-canonicalise rule. To get byte-level tamper
+protection for an existing window, re-run `bernstein compliance pack` for that
+`(since, until, org)` triple; the regenerated pack is v2. Existing archived v1
+packs remain verifiable - no forced break.
+
 ---
 
 ## 9. `bernstein-verify` - auditor CLI
@@ -310,8 +343,8 @@ bernstein-verify forks <path> [--lineage-dir DIR]     # report unresolved forks 
 
 ### 9.3 Output
 
-- Exit 0 = all signatures valid + chains complete + no unresolved forks.
-- Exit 1 = any failure; structured JSON to stderr, human summary to stdout.
+- Exit 0 = on-disk log bytes are canonical (format v2) + all signatures valid + chains complete + no unresolved forks.
+- Exit 1 = any failure; structured JSON to stderr, human summary to stdout. A non-canonical line in a v2 pack is reported as `non-canonical line bytes`; a stripped terminator as `missing trailing newline`.
 
 ---
 

--- a/src/bernstein/core/compliance/pack.py
+++ b/src/bernstein/core/compliance/pack.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import hashlib
 import json
 import zipfile
-from dataclasses import asdict
 from datetime import UTC, datetime
 from importlib import metadata
 from typing import TYPE_CHECKING, Any
@@ -28,17 +27,33 @@ from bernstein.core.compliance.article12 import (
     render_csv,
     render_pdf,
 )
-from bernstein.core.lineage.entry import LineageEntry, entry_hash
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
 from bernstein.core.lineage.identity import sign_detached
 
 if TYPE_CHECKING:
     from datetime import date
     from pathlib import Path
 
-__all__ = ["build_pack"]
+__all__ = ["PACK_FORMAT_VERSION", "build_pack"]
 
 
 _OPERATOR_KID = "operator-pack-signer"
+
+#: Compliance-pack format version recorded in ``pack-manifest.json``.
+#:
+#: v1 (pre-fix) wrote ``lineage-log.jsonl`` with ``json.dumps(..., sort_keys=
+#: True)`` default separators (spaced ``", "`` / ``": "``), so the on-disk
+#: bytes did not equal the JCS-canonical signed form. The offline auditor
+#: therefore re-canonicalised the parsed entry to verify, which accepted any
+#: value-preserving byte rewrite (issue #1871).
+#:
+#: v2 writes each entry as its exact JCS-canonical bytes (``canonicalise``)
+#: terminated by a single ``\n``, so the offline auditor binds verification to
+#: the on-disk bytes (``canonicalise(entry) == raw_line``) and rejects a
+#: value-preserving tamper. ``bernstein_verify.verify.verify_pack`` dispatches
+#: on this recorded version, so pre-fix v1 packs still verify under their
+#: original rule.
+PACK_FORMAT_VERSION = 2
 
 
 def _date_to_ns_inclusive(d: date, *, end_of_day: bool = False) -> int:
@@ -107,13 +122,24 @@ def _verify_instructions() -> str:
         "bernstein-verify pack ./acme-compliance-2026-q2.zip\n"
         "```\n\n"
         "Exit 0 + a one-line PASS summary indicates: every entry in\n"
-        "`lineage-log.jsonl` re-canonicalises to a hash whose detached JWS in\n"
-        "`signatures/` verifies under the Agent Card in `agent-cards/`, and\n"
-        "`pack-manifest.json.sig` verifies against the operator public key.\n\n"
+        "`lineage-log.jsonl` is stored in its exact RFC 8785 canonical bytes,\n"
+        "its detached JWS in `signatures/` verifies under the Agent Card in\n"
+        "`agent-cards/`, and `pack-manifest.json.sig` verifies against the\n"
+        "operator public key.\n\n"
+        "This pack is format v2 (`pack-manifest.json:pack_format_version`):\n"
+        "verification is bound to the on-disk log bytes. Each line must equal\n"
+        "its canonical form byte-for-byte (including a single trailing `\\n`),\n"
+        "so a value-preserving rewrite - reordered JSON keys, inserted\n"
+        "whitespace, a flipped or stripped line terminator - is rejected even\n"
+        "though it parses to the same field values.\n\n"
         "## Manual path (no Bernstein install)\n\n"
         "1. Unzip the bundle.\n"
-        "2. For every line in `lineage-log.jsonl`, RFC 8785 canonicalise the\n"
-        "   JSON, sha256 it -> `entry_hash`.\n"
+        "2. Read `lineage-log.jsonl` as bytes and split strictly on `\\n`\n"
+        "   (not `splitlines()` - that treats `\\r` and other characters as\n"
+        "   record boundaries). For every line, RFC 8785 canonicalise the\n"
+        "   parsed JSON and assert the result equals the original line bytes;\n"
+        "   reject the pack on any mismatch. Then sha256 the canonical bytes\n"
+        "   -> `entry_hash`.\n"
         "3. Open `signatures/<hex(entry_hash)>.jws`; verify the detached\n"
         "   Ed25519 JWS (RFC 7515 + RFC 7797 `b64=false`) against the public\n"
         "   key in the matching `agent-cards/<agent_id>.json`.\n"
@@ -178,8 +204,16 @@ def build_pack(
     filtered = _filter_entries(all_entries, since, until)
 
     # 1. lineage-log.jsonl (filtered)
-    log_lines = [json.dumps(asdict(e), sort_keys=True) for e in filtered]
-    log_bytes = ("\n".join(log_lines) + ("\n" if log_lines else "")).encode("utf-8")
+    #
+    # Emit each entry as its exact JCS-canonical bytes (the same form that was
+    # signed) terminated by a single ``\n``, so the offline auditor can bind
+    # verification to these on-disk bytes (``canonicalise(entry) == raw_line``)
+    # rather than re-canonicalising the parsed entry. Re-using ``canonicalise``
+    # keeps the writer and the signature over one byte-form; a value-preserving
+    # rewrite (reordered keys, spaced separators, a flipped or stripped
+    # terminator) then no longer matches and is rejected at verify time (#1871).
+    log_lines = [canonicalise(e) for e in filtered]
+    log_bytes = b"\n".join(log_lines) + (b"\n" if log_lines else b"")
 
     # 2. article12-evidence.csv
     csv_bytes = render_csv(filtered).encode("utf-8")
@@ -250,6 +284,7 @@ def build_pack(
 
     manifest: dict[str, Any] = {
         "schema": "https://bernstein.run/compliance/pack-manifest/v1",
+        "pack_format_version": PACK_FORMAT_VERSION,
         "builder": _builder_label(),
         "org": org,
         "period": {"since": since.isoformat(), "until": until.isoformat()},

--- a/tests/unit/compliance/test_pack.py
+++ b/tests/unit/compliance/test_pack.py
@@ -303,3 +303,56 @@ class TestBuildPack:
         with zipfile.ZipFile(out_path) as zf:
             log_lines = zf.read("lineage-log.jsonl").decode().splitlines()
         assert log_lines == []
+
+    def test_log_bytes_are_canonical(self, tmp_path: Path, lineage_layout: dict[str, Path]) -> None:
+        """Each lineage-log.jsonl line equals canonicalise(entry) byte-for-byte.
+
+        The offline auditor binds verification to these exact bytes (issue
+        #1871). A non-canonical write (default ``json.dumps`` spacing, key
+        order other than sorted, missing terminator) would mean the bytes on
+        disk no longer equal the canonical signed form, defeating byte-level
+        tamper detection.
+        """
+        key_path, _ = _operator_key(tmp_path)
+        out_path = tmp_path / "pack.zip"
+        build_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 5, 13),
+            org="Acme",
+            lineage_dir=lineage_layout["lineage_dir"],
+            agent_cards_dir=lineage_layout["agent_cards_dir"],
+            output_path=out_path,
+            operator_key_path=key_path,
+        )
+
+        with zipfile.ZipFile(out_path) as zf:
+            log_bytes = zf.read("lineage-log.jsonl")
+
+        # File must end with a single trailing newline.
+        assert log_bytes.endswith(b"\n")
+        # Strict split on b"\n"; each non-empty record must be canonical.
+        raw_lines = [ln for ln in log_bytes.split(b"\n") if ln]
+        assert raw_lines, "expected at least one entry in window"
+        for raw in raw_lines:
+            entry = LineageEntry(**json.loads(raw))
+            assert canonicalise(entry) == raw, (
+                f"log line is not byte-canonical: on-disk={raw!r} canonical={canonicalise(entry)!r}"
+            )
+
+    def test_manifest_records_pack_format_version(self, tmp_path: Path, lineage_layout: dict[str, Path]) -> None:
+        """The manifest records pack_format_version=2 so the offline verifier
+        can dispatch the byte-binding rule (issue #1871)."""
+        key_path, _ = _operator_key(tmp_path)
+        out_path = tmp_path / "pack.zip"
+        build_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 5, 13),
+            org="Acme",
+            lineage_dir=lineage_layout["lineage_dir"],
+            agent_cards_dir=lineage_layout["agent_cards_dir"],
+            output_path=out_path,
+            operator_key_path=key_path,
+        )
+        with zipfile.ZipFile(out_path) as zf:
+            manifest = json.loads(zf.read("pack-manifest.json"))
+        assert manifest["pack_format_version"] == 2

--- a/verify_cli/bernstein_verify/verify.py
+++ b/verify_cli/bernstein_verify/verify.py
@@ -35,6 +35,24 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 _LOG_NAME = "lineage-log.jsonl"
 _SIG_DIR = "signatures/"
 _CARD_DIR = "agent-cards/"
+_MANIFEST_NAME = "pack-manifest.json"
+
+#: Compliance-pack format version that binds verification to the on-disk log
+#: bytes. v1 (pre-fix) packs wrote ``lineage-log.jsonl`` non-canonically
+#: (``json.dumps(..., sort_keys=True)`` default separators), so this verifier
+#: had to re-canonicalise the parsed entry to check a signature - which
+#: accepted any value-preserving byte rewrite (reordered keys, spaced
+#: separators, a flipped or stripped line terminator) (issue #1871). v2 packs
+#: write each entry as its exact JCS-canonical bytes terminated by ``\n``, so a
+#: v2 pack is verified by requiring the on-disk line to equal
+#: ``jcs_canonicalise(entry)`` byte-for-byte.
+_PACK_FORMAT_BYTE_BINDING = 2
+
+#: Format assumed when ``pack-manifest.json`` predates the
+#: ``pack_format_version`` field (or is absent). Mirrors the Merkle seal's
+#: legacy-default scheme dispatch (issue #1866): an unmarked pack is pre-fix,
+#: so it is verified under the original re-canonicalise rule.
+_PACK_FORMAT_LEGACY = 1
 
 
 # ---------- RFC 8785 JCS ----------
@@ -198,6 +216,123 @@ def _read_text_member(zf: zipfile.ZipFile, name: str) -> str | None:
         return None
 
 
+def _read_bytes_member(zf: zipfile.ZipFile, name: str) -> bytes | None:
+    try:
+        with zf.open(name) as f:
+            return f.read()
+    except KeyError:
+        return None
+
+
+def _pack_format_version(zf: zipfile.ZipFile) -> int:
+    """Return the pack's ``pack_format_version``, defaulting to legacy.
+
+    The version lives in ``pack-manifest.json``. An absent manifest, an
+    absent/unparseable field, or a stray boolean maps to the legacy format
+    (re-canonicalise rule), mirroring the Merkle seal's ``_seal_scheme``
+    legacy-default (issue #1866). The version field rides inside the
+    operator-signed manifest body, so a tamperer who downgrades it to defeat
+    the v2 byte-binding rule invalidates ``pack-manifest.json.sig`` - the
+    signature an operator verifies on the with-key path.
+    """
+    raw = _read_text_member(zf, _MANIFEST_NAME)
+    if raw is None:
+        return _PACK_FORMAT_LEGACY
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError:
+        return _PACK_FORMAT_LEGACY
+    if not isinstance(manifest, dict):
+        return _PACK_FORMAT_LEGACY
+    value = manifest.get("pack_format_version", _PACK_FORMAT_LEGACY)
+    if isinstance(value, bool):
+        # ``bool`` is an ``int`` subclass; a stray boolean is not a version.
+        return _PACK_FORMAT_LEGACY
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return _PACK_FORMAT_LEGACY
+    return _PACK_FORMAT_LEGACY
+
+
+def _split_jsonl_bytes(raw_bytes: bytes) -> list[bytes]:
+    """Strictly split the log's raw bytes on ``b"\\n"`` only.
+
+    Text-mode iteration / ``str.splitlines()`` treats ``\\r``, ``\\r\\n`` and
+    every universal newline (and ``\\v``, ``\\f``, ``\\x1c``-``\\x1e``,
+    ``\\x85``, ``\\u2028``, ``\\u2029``) as a record boundary, so flipping a
+    terminator (``0x0A`` -> ``0x0D``) reframes the file without changing any
+    ``json.loads`` result for the survivors - a framing attack that hides or
+    merges records while every surviving signature still verifies. Splitting
+    on ``b"\\n"`` only keeps any other separator *inside* a record, where the
+    byte-canonical check surfaces it as a verification failure. This mirrors
+    ``bernstein.core.lineage.gate._split_jsonl_bytes`` so the offline auditor
+    offers the same tamper-evidence as the in-tree lineage gate (issue #1871).
+    """
+    parts = raw_bytes.split(b"\n")
+    # The v2 writer always ends the file with ``\n`` -> a trailing empty
+    # element which we drop. A genuinely missing terminator is reported
+    # separately by the caller before this is used.
+    if parts and parts[-1] == b"":
+        parts.pop()
+    return parts
+
+
+def _parse_log_v1(log_raw: str) -> tuple[list[dict[str, Any]], list[str]]:
+    """Legacy (v1) parse: text-mode ``splitlines`` + parse each line.
+
+    Verification re-canonicalises the parsed entry, so pre-fix packs (written
+    with non-canonical bytes) still verify under their original rule. Retained
+    only for backward compatibility (issue #1871).
+    """
+    entries: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for lineno, line in enumerate(log_raw.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{_LOG_NAME}:{lineno}: invalid JSON ({exc.msg})")
+    return entries, errors
+
+
+def _parse_log_v2(log_bytes: bytes) -> tuple[list[dict[str, Any]], list[str]]:
+    """Byte-binding (v2) parse: split on ``b"\\n"``, require canonical bytes.
+
+    Every record must equal its JCS-canonical form byte-for-byte
+    (``jcs_canonicalise(entry) == raw_line``). A value-preserving rewrite -
+    reordered keys, inserted whitespace, a flipped terminator - parses to
+    identical fields but differs on disk, so it is rejected here rather than
+    silently re-canonicalised and accepted. A missing trailing newline is
+    surfaced as tamper-evidence (a truncated or terminator-stripped final
+    record). Mirrors the in-tree lineage gate's ``_parse_log`` (issue #1848).
+    """
+    entries: list[dict[str, Any]] = []
+    errors: list[str] = []
+    if log_bytes and not log_bytes.endswith(b"\n"):
+        errors.append(f"{_LOG_NAME}: missing trailing newline")
+    for lineno, raw_line in enumerate(_split_jsonl_bytes(log_bytes), start=1):
+        if raw_line == b"":
+            continue
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"{_LOG_NAME}:{lineno}: invalid JSON ({exc.msg})")
+            continue
+        if not isinstance(obj, dict):
+            errors.append(f"{_LOG_NAME}:{lineno}: not a JSON object")
+            continue
+        if jcs_canonicalise(obj) != raw_line:
+            errors.append(f"{_LOG_NAME}:{lineno}: non-canonical line bytes")
+            continue
+        entries.append(obj)
+    return entries, errors
+
+
 def verify_pack(zip_path: Path | str) -> VerifyResult:
     """Verify a compliance-pack ZIP end-to-end.
 
@@ -209,7 +344,12 @@ def verify_pack(zip_path: Path | str) -> VerifyResult:
 
     Steps:
       1. Open the zip (defensive: never extractall - read members in memory).
-      2. Parse log.jsonl into a list of entries.
+      2. Read ``pack-manifest.json:pack_format_version`` and dispatch the log
+         parse: v2 binds verification to the exact on-disk bytes (split on
+         ``b"\\n"``, every record must equal its JCS-canonical form
+         byte-for-byte, a missing trailing newline is tamper-evidence); v1 (or
+         an unmarked legacy pack) keeps the original re-canonicalise rule so
+         pre-fix packs still verify (issues #1871, #1848, #1866).
       3. Walk the parent-hash chain (orphans, dupes).
       4. For every entry: compute entry_hash, find sidecar JWS, find Agent
          Card by agent_id, verify Ed25519 JWS using card's public key + kid.
@@ -228,19 +368,18 @@ def verify_pack(zip_path: Path | str) -> VerifyResult:
         return VerifyResult(ok=False, errors=[f"not a valid zip archive: {path}"])
 
     with zf:
-        log_raw = _read_text_member(zf, _LOG_NAME)
-        if log_raw is None:
-            return VerifyResult(ok=False, errors=[f"missing {_LOG_NAME} in pack"])
+        pack_format = _pack_format_version(zf)
 
-        entries: list[dict[str, Any]] = []
-        parse_errors: list[str] = []
-        for lineno, line in enumerate(log_raw.splitlines(), start=1):
-            if not line.strip():
-                continue
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError as exc:
-                parse_errors.append(f"{_LOG_NAME}:{lineno}: invalid JSON ({exc.msg})")
+        if pack_format >= _PACK_FORMAT_BYTE_BINDING:
+            log_bytes = _read_bytes_member(zf, _LOG_NAME)
+            if log_bytes is None:
+                return VerifyResult(ok=False, errors=[f"missing {_LOG_NAME} in pack"])
+            entries, parse_errors = _parse_log_v2(log_bytes)
+        else:
+            log_raw = _read_text_member(zf, _LOG_NAME)
+            if log_raw is None:
+                return VerifyResult(ok=False, errors=[f"missing {_LOG_NAME} in pack"])
+            entries, parse_errors = _parse_log_v1(log_raw)
 
         result_errors: list[str] = list(parse_errors)
 
@@ -306,6 +445,7 @@ def verify_pack(zip_path: Path | str) -> VerifyResult:
             "agents": len(cards),
             "chain_ok": chain_ok,
             "signature_failures": sig_failures,
+            "pack_format_version": pack_format,
         }
         ok = not parse_errors and chain_ok and sig_failures == 0
         return VerifyResult(ok=ok, errors=result_errors, stats=stats)

--- a/verify_cli/tests/test_verify.py
+++ b/verify_cli/tests/test_verify.py
@@ -339,6 +339,297 @@ def test_verify_pack_zip_slip_blocked(tmp_path):
     assert not sentinel.exists()
 
 
+# ---------- verify_pack: byte-binding for v2 packs (issue #1871) ----------
+
+
+def _build_pack_bytes(
+    tmp_path: Path,
+    *,
+    log_bytes: bytes,
+    pack_format_version: int | None = 2,
+    name: str = "bundle.zip",
+) -> Path:
+    """Build a compliance pack with caller-supplied raw log bytes.
+
+    The signature is computed over the *canonical* entry (what the real
+    writer signs); ``log_bytes`` is whatever the caller wants on disk, so a
+    test can write a value-preserving byte tamper (reordered keys, spaced
+    separators, flipped or missing terminator) and assert the verifier still
+    rejects it.
+
+    A ``pack-manifest.json`` is written carrying ``pack_format_version`` so
+    the verifier can dispatch its byte-binding rule. ``None`` omits the field
+    entirely (a genuine pre-fix / legacy pack shape).
+    """
+    priv, pub = bernstein_generate_keypair()
+    kid = "k1"
+    agent_id = "agent:t"
+
+    entry = LineageEntry(
+        v=1,
+        artefact_path="src/foo.py",
+        artefact_kind="file",
+        content_hash="sha256:" + "a" * 64,
+        parent_hashes=[],
+        agent_id=agent_id,
+        agent_card_kid=kid,
+        tool_call_id="tc-1",
+        span_id="00f067aa0ba902b7",
+        ts_ns=1_715_600_000_000_000_000,
+        operator_hmac="deadbeef" * 8,
+    )
+    payload = bernstein_canonicalise(entry)
+    jws = bernstein_sign_detached(payload, priv, kid=kid)
+    entry_hash = "sha256:" + hashlib.sha256(payload).hexdigest()
+    card = {
+        "agent_id": agent_id,
+        "kid": kid,
+        "public_key_pem": pub,
+        "protocol_version": "a2a/1.0",
+    }
+    manifest: dict = {"schema": "https://bernstein.run/compliance/pack-manifest/v1"}
+    if pack_format_version is not None:
+        manifest["pack_format_version"] = pack_format_version
+
+    bundle = tmp_path / name
+    with zipfile.ZipFile(bundle, "w") as z:
+        z.writestr("lineage-log.jsonl", log_bytes)
+        z.writestr(f"signatures/{entry_hash}.jws", jws)
+        z.writestr(f"agent-cards/{agent_id}.json", json.dumps(card))
+        z.writestr(
+            "pack-manifest.json", json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+        )
+    return bundle
+
+
+#: Field overrides matching the entry minted by ``_build_pack_bytes``.
+_V2_ENTRY_OVERRIDES = {
+    "artefact_path": "src/foo.py",
+    "agent_id": "agent:t",
+    "agent_card_kid": "k1",
+    "tool_call_id": "tc-1",
+}
+
+
+def _v2_entry() -> LineageEntry:
+    """The entry ``_build_pack_bytes`` signs (the canonical reference)."""
+    return LineageEntry(**_sample_entry_dict(**_V2_ENTRY_OVERRIDES))
+
+
+def _canonical_entry_line() -> bytes:
+    """The exact canonical bytes the real writer emits for the test entry."""
+    return bernstein_canonicalise(_v2_entry())
+
+
+def _legacy_entry_line() -> bytes:
+    """Pre-fix (non-canonical) bytes: ``json.dumps`` default spaced separators."""
+    return json.dumps(asdict(_v2_entry()), sort_keys=True).encode("utf-8")
+
+
+def test_verify_pack_v2_canonical_verifies(tmp_path):
+    """An untampered v2 pack (canonical bytes + trailing newline) verifies."""
+    bundle = _build_pack_bytes(tmp_path, log_bytes=_canonical_entry_line() + b"\n")
+    result = verify_pack(bundle)
+    assert result.ok is True, result.errors
+
+
+def test_verify_pack_v2_reordered_keys_rejected(tmp_path):
+    """Value-preserving tamper: reordered JSON keys must be rejected.
+
+    The fields are unchanged, so re-canonicalising the parsed entry would
+    still verify the JWS. Binding to the on-disk bytes is what catches it.
+    """
+    # Insertion-order dump (NOT sorted) + canonical separators: same values,
+    # different byte order from the canonical (sorted-key) form.
+    reordered = json.dumps(asdict(_v2_entry()), sort_keys=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    assert reordered != _canonical_entry_line()  # guard: genuinely different bytes
+    bundle = _build_pack_bytes(tmp_path, log_bytes=reordered + b"\n")
+    result = verify_pack(bundle)
+    assert result.ok is False
+    assert any("canonical" in e.lower() for e in result.errors), result.errors
+
+
+def test_verify_pack_v2_inserted_whitespace_rejected(tmp_path):
+    """Value-preserving tamper: spaced separators (', '/': ') must be rejected."""
+    spaced = _canonical_entry_line().replace(b'","', b'", "').replace(b'":', b'": ')
+    assert spaced != _canonical_entry_line()
+    bundle = _build_pack_bytes(tmp_path, log_bytes=spaced + b"\n")
+    result = verify_pack(bundle)
+    assert result.ok is False
+    assert any("canonical" in e.lower() for e in result.errors), result.errors
+
+
+def test_verify_pack_v2_missing_trailing_newline_rejected(tmp_path):
+    """Value-preserving tamper: stripped trailing newline must be rejected."""
+    bundle = _build_pack_bytes(tmp_path, log_bytes=_canonical_entry_line())  # no \n
+    result = verify_pack(bundle)
+    assert result.ok is False
+    assert any("newline" in e.lower() or "trailing" in e.lower() for e in result.errors), (
+        result.errors
+    )
+
+
+def test_verify_pack_v2_flipped_terminator_rejected(tmp_path):
+    """Value-preserving tamper: flipped \\n -> \\r terminator must be rejected.
+
+    `str.splitlines()` treats `\\r` as a record boundary; splitting strictly
+    on `b"\\n"` keeps the stray `\\r` inside the record where the canonical
+    check surfaces it.
+    """
+    bundle = _build_pack_bytes(tmp_path, log_bytes=_canonical_entry_line() + b"\r")
+    result = verify_pack(bundle)
+    assert result.ok is False
+
+
+def test_verify_pack_legacy_v1_verifies_under_original_rule(tmp_path):
+    """A genuine pre-fix v1 pack (non-canonical bytes, version 1 recorded)
+    still verifies under the original re-canonicalise rule.
+
+    Pre-fix packs were written with `json.dumps(..., sort_keys=True)` default
+    separators (spaced), so they are NOT canonical on disk. The v1 dispatch
+    path must re-canonicalise the parsed entry exactly as before.
+    """
+    legacy_line = _legacy_entry_line()
+    assert legacy_line != _canonical_entry_line()  # genuinely non-canonical
+    bundle = _build_pack_bytes(tmp_path, log_bytes=legacy_line + b"\n", pack_format_version=1)
+    result = verify_pack(bundle)
+    assert result.ok is True, result.errors
+
+
+def test_verify_pack_no_manifest_defaults_to_legacy_rule(tmp_path):
+    """A pack with no manifest (oldest packs) defaults to the v1 rule.
+
+    Mirrors the Merkle seal's legacy-default (#1866): an absent scheme means
+    pre-fix, so the original re-canonicalise rule applies and a genuinely
+    non-canonical pre-fix log still verifies.
+    """
+    bundle = _build_pack_bytes(
+        tmp_path, log_bytes=_legacy_entry_line() + b"\n", pack_format_version=None
+    )
+    result = verify_pack(bundle)
+    assert result.ok is True, result.errors
+
+
+def _build_real_pack(tmp_path: Path) -> tuple[Path, LineageEntry]:
+    """Build a pack via the real ``build_pack`` and return (zip_path, entry).
+
+    The on-disk source log is written deliberately non-canonically so the
+    test proves the writer normalises it to canonical bytes on the way out.
+    """
+    from datetime import UTC, date, datetime
+
+    from bernstein.core.compliance.pack import build_pack
+    from bernstein.core.lineage.identity import AgentCard
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    lineage_dir = tmp_path / "lineage"
+    signatures_dir = lineage_dir / "signatures"
+    agents_dir = tmp_path / "agents"
+    lineage_dir.mkdir()
+    signatures_dir.mkdir()
+    agents_dir.mkdir()
+
+    _priv_pem, pub_pem = bernstein_generate_keypair()
+    agent_id = "agent:worker-1"
+    kid = f"{agent_id}-kid"
+    card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=pub_pem)
+    (agents_dir / f"{agent_id.replace(':', '_')}.json").write_text(
+        json.dumps(asdict(card), sort_keys=True), encoding="utf-8"
+    )
+
+    ts_ns = int(datetime(2026, 3, 15, tzinfo=UTC).timestamp() * 1_000_000_000)
+    entry = LineageEntry(
+        v=1,
+        artefact_path="src/in_window.py",
+        artefact_kind="file",
+        content_hash="sha256:" + hashlib.sha256(b"hello").hexdigest(),
+        parent_hashes=[],
+        agent_id=agent_id,
+        agent_card_kid=kid,
+        tool_call_id="tc-1",
+        span_id="00f067aa0ba902b7",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef",
+    )
+    # Deliberately non-canonical input (default ``json.dumps`` spacing) so the
+    # writer must re-emit it canonically.
+    (lineage_dir / "log.jsonl").write_text(
+        json.dumps(asdict(entry), sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    op_priv = Ed25519PrivateKey.generate()
+    op_key_path = tmp_path / "operator.key"
+    op_key_path.write_bytes(
+        op_priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+
+    out_path = tmp_path / "pack.zip"
+    build_pack(
+        since=date(2026, 1, 1),
+        until=date(2026, 5, 13),
+        org="Acme",
+        lineage_dir=lineage_dir,
+        agent_cards_dir=agents_dir,
+        output_path=out_path,
+        operator_key_path=op_key_path,
+    )
+    return out_path, entry
+
+
+def test_real_build_pack_log_is_v2_byte_canonical(tmp_path):
+    """A pack from the real ``build_pack`` records v2 and its on-disk log
+    bytes pass the v2 byte-binding parse with zero errors.
+
+    This is the writer/verifier lockstep proof for #1871: the bytes the
+    production writer emits are exactly the canonical form the offline
+    auditor binds to. (The per-entry signature lookup is exercised by the
+    fabricated-pack tests above; this test isolates the byte-binding
+    contract, which is the subject of #1871.)
+    """
+    from bernstein.core.compliance.pack import PACK_FORMAT_VERSION
+
+    from bernstein_verify.verify import _pack_format_version, _parse_log_v2
+
+    out_path, _entry = _build_real_pack(tmp_path)
+
+    with zipfile.ZipFile(out_path) as zf:
+        assert _pack_format_version(zf) == PACK_FORMAT_VERSION
+        log_bytes = zf.read("lineage-log.jsonl")
+
+    entries, errors = _parse_log_v2(log_bytes)
+    assert errors == [], errors
+    assert len(entries) == 1
+    assert entries[0]["artefact_path"] == "src/in_window.py"
+
+
+def test_real_build_pack_log_byte_tamper_rejected(tmp_path):
+    """Value-preserving byte tamper of a real ``build_pack`` log is rejected
+    by the v2 byte-binding parse - the end-to-end #1871 guarantee."""
+    from bernstein_verify.verify import _parse_log_v2
+
+    out_path, entry = _build_real_pack(tmp_path)
+
+    with zipfile.ZipFile(out_path) as zf:
+        canonical_log = zf.read("lineage-log.jsonl")
+
+    # Reorder keys: identical field values, different on-disk bytes.
+    reordered = (
+        json.dumps(asdict(entry), sort_keys=False, separators=(",", ":")).encode("utf-8") + b"\n"
+    )
+    assert reordered != canonical_log  # genuinely different bytes
+
+    entries, errors = _parse_log_v2(reordered)
+    assert entries == []
+    assert any("non-canonical" in e.lower() for e in errors), errors
+
+
 # ---------- combined: bernstein -> bernstein-verify round-trip ----------
 
 


### PR DESCRIPTION
## Summary

Closes #1871. The standalone auditor wheel (`bernstein-verify pack`) verified
each compliance-pack entry against a re-canonicalised form of the parsed record
instead of the bytes stored in `lineage-log.jsonl`, so value-preserving
byte-level tampering of a pack passed offline verification. This is the
offline-verifier sibling of #1848 (fixed in the in-tree lineage gate).

Two coupled defects, fixed in lockstep:

- **Verifier re-canonicalised.** `verify_pack` read the log with
  `str.splitlines()`, parsed each line, and verified the detached JWS against
  `jcs_canonicalise(parsed_entry)` - a byte form re-derived from the field
  values. Reordered JSON keys, inserted whitespace, a different integer
  spelling, a flipped or stripped line terminator all parsed to identical
  fields and verified as authentic.
- **Writer emitted non-canonical bytes.** `build_pack` wrote the packed log
  with `json.dumps(asdict(e), sort_keys=True)` default separators (spaced
  `", "` / `": "`), so the on-disk bytes were never canonical and a byte
  comparison was impossible.

## What changed

- `build_pack` emits each entry as its exact RFC 8785 canonical bytes (re-using
  the existing `canonicalise` helper) terminated by a single `\n`, and records
  `pack_format_version` in `pack-manifest.json`.
- `verify_pack` reads `pack_format_version` and dispatches:
  - **v2**: read the log as bytes, split strictly on `b"\n"`, require every
    line to equal `jcs_canonicalise(entry)` byte-for-byte, treat a missing
    trailing newline as tamper-evidence.
  - **v1 / unmarked legacy**: keep the original re-canonicalise rule so pre-fix
    packs still verify. Legacy-default mirrors the Merkle seal scheme dispatch
    (#1866); the version field rides inside the operator-signed manifest body.
- Docs: ADR-009 (`docs/decisions/009-lineage-v1.md`) gains the format-version
  table and the one-time re-pack note; the in-pack `verify-instructions.md`
  text now describes the byte-binding rule.

## Backward compatibility

Existing v1 packs verify unchanged. To gain byte-level tamper protection for a
window, re-run `bernstein compliance pack` once for that `(since, until, org)`
triple - the regenerated pack is v2. No forced break for archived packs.

## Test plan

- [x] RED first: value-preserving byte tampers (reordered keys, inserted
      whitespace, flipped `\n`->`\r`, stripped trailing newline) of a v2 pack
      were accepted before the fix; the new tests fail on the old code.
- [x] v2: each of those tampers is now rejected with a `non-canonical line
      bytes` / `missing trailing newline` error.
- [x] v2: an untampered pack and a real `build_pack` output verify.
- [x] v1 explicit and no-manifest legacy packs still verify under the original
      rule.
- [x] Writer: `lineage-log.jsonl` lines equal `canonicalise(entry)`
      byte-for-byte; manifest records `pack_format_version=2`.
- [x] `verify_cli` suite (51 tests) green in a clean isolated venv with
      `bernstein` not importable (air-gap isolation preserved).
- [x] `tests/unit/compliance` + `tests/unit/lineage` (209 tests) green; ruff
      clean; `pack.py` mypy-clean.