### PR TITLE
fix(tests): record two responses for the two-hit replay coverage case

### DIFF
--- a/tests/unit/test_deterministic_store.py
+++ b/tests/unit/test_deterministic_store.py
@@ -42,12 +42,17 @@ def _write_recording(
     provider: str = "openrouter_free",
     temperature: float = 0.7,
     max_tokens: int = 4000,
+    count: int = 1,
 ) -> Path:
-    """Write a one-line ``llm_calls.jsonl`` recording and return its path.
+    """Write a ``count``-line ``llm_calls.jsonl`` recording and return its path.
 
     The recording is produced via :func:`_prompt_key` so the on-disk key
     matches whatever the production keying does, keeping the fixture
     honest if the key recipe changes.
+
+    ``count`` repeats the same entry that many times. Because ``get_replay``
+    consumes one recorded response per hit (per-key FIFO, issue #1846), a key
+    that must serve N hits needs N recorded lines.
     """
     run_dir.mkdir(parents=True, exist_ok=True)
     calls_path = run_dir / "llm_calls.jsonl"
@@ -62,7 +67,7 @@ def _write_recording(
         "prompt_len": len(prompt),
         "response": response,
     }
-    calls_path.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+    calls_path.write_text((json.dumps(entry) + "\n") * count, encoding="utf-8")
     return calls_path
 
 
@@ -220,11 +225,13 @@ class TestCoverageCounters:
     def test_hits_and_misses_counted(self, tmp_path: Path) -> None:
         """Hits and strict violations are tallied for the coverage line."""
         run_dir = tmp_path / "runs" / "cov"
-        _write_recording(run_dir)
+        # Two recorded lines for the key: get_replay consumes one per hit
+        # (per-key FIFO, issue #1846), so two hits need two recordings.
+        _write_recording(run_dir, count=2)
         store = DeterministicStore(run_dir, replay=True, strict=True)
 
-        store.get_replay(_PROMPT, _MODEL)  # hit
-        store.get_replay(_PROMPT, _MODEL)  # hit
+        store.get_replay(_PROMPT, _MODEL)  # hit (consumes recording 1)
+        store.get_replay(_PROMPT, _MODEL)  # hit (consumes recording 2)
         with pytest.raises(ReplayMissError):
             store.get_replay("miss", _MODEL)  # strict violation
 

--- a/tests/unit/test_deterministic_store.py
+++ b/tests/unit/test_deterministic_store.py
@@ -54,6 +54,8 @@ def _write_recording(
     consumes one recorded response per hit (per-key FIFO, issue #1846), a key
     that must serve N hits needs N recorded lines.
     """
+    if count < 1:
+        raise ValueError(f"count must be >= 1 to record at least one call, got {count}")
     run_dir.mkdir(parents=True, exist_ok=True)
     calls_path = run_dir / "llm_calls.jsonl"
     key = _prompt_key(prompt, model, provider=provider, temperature=temperature, max_tokens=max_tokens)


### PR DESCRIPTION
## Summary

`tests/unit/test_deterministic_store.py::TestCoverageCounters::test_hits_and_misses_counted` fails on `main` (ubuntu Python 3.13 shard 4) with `ReplayMissError`.

Root cause: the per-key FIFO replay cache (issue #1846) consumes one recorded response per `get_replay` hit. The test wrote a single-line recording but called `get_replay` twice for the same key, so the second call over-consumed the queue and raised `ReplayMissError` under strict replay.

Fix: add a `count` parameter to the `_write_recording` test helper (default `1`, so every other case is byte-identical) and record the key twice in this test, so two hits are legitimately available and the third call is the intended strict-violation miss.

Store behaviour is unchanged - only the fixture is corrected to match the consume-on-hit contract.

## Test plan

- [x] `uv run pytest tests/unit/test_deterministic_store.py -q --no-cov` -> 20 passed
- [x] previously failing case `TestCoverageCounters::test_hits_and_misses_counted` now passes
- [x] replay-adjacent suites green: `test_deterministic_store_replay.py`, `test_replay_gateway_fifo_order.py`, `test_replay_gateway.py`, `test_deterministic_run.py` -> 55 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and test logic to better validate hit/miss counting in the deterministic store's replay functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->