### PR TITLE
Fix PR review action checkout trust boundary

### DIFF
--- a/.github/workflows/bernstein-pr-review.yml
+++ b/.github/workflows/bernstein-pr-review.yml
@@ -54,11 +54,12 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          PR_DIFF_URL: ${{ github.event.pull_request.diff_url }}
         run: |
           curl --fail --location --silent --show-error --retry 3 \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github.v3.diff" \
-            "${{ github.event.pull_request.diff_url }}" \
+            "${PR_DIFF_URL}" \
             -o .bernstein-pr.diff
 
       - name: Review PR

--- a/.github/workflows/bernstein-pr-review.yml
+++ b/.github/workflows/bernstein-pr-review.yml
@@ -47,8 +47,19 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
+
+      - name: Fetch PR diff
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          curl --fail --location --silent --show-error --retry 3 \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github.v3.diff" \
+            "${{ github.event.pull_request.diff_url }}" \
+            -o .bernstein-pr.diff
 
       - name: Review PR
         if: steps.check.outputs.skip != 'true'
@@ -58,7 +69,8 @@ jobs:
           task: >
             Review pull request #${{ github.event.pull_request.number }}
             titled "${{ github.event.pull_request.title }}".
-            Check code quality, run the test suite, verify type correctness, and
+            Use .bernstein-pr.diff as the PR diff data. Check code quality,
+            run the test suite, verify type correctness, and
             identify any security or correctness issues. Summarise your findings
             and post them as a PR comment. Do not push any changes.
           budget: "3.00"

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -77,7 +77,11 @@ def test_pr_review_runs_local_action_from_base_checkout(review_steps: list[dict[
     run = fetch_diff.get("run", "")
     assert isinstance(run, str)
     assert ".bernstein-pr.diff" in run, "PR diff must be fetched as data for review context"
-    assert "github.event.pull_request.diff_url" in run
+    assert "github.event.pull_request.diff_url" not in run, "PR diff URL expression must not be expanded in shell"
+    assert "${PR_DIFF_URL}" in run
+    fetch_env = fetch_diff.get("env", {})
+    assert isinstance(fetch_env, dict)
+    assert fetch_env.get("PR_DIFF_URL") == "${{ github.event.pull_request.diff_url }}"
 
     assert review_step.get("uses") == "./"
     inputs = review_step.get("with", {})

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -3,16 +3,27 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypedDict, cast
 
 import pytest
-
-try:
-    import yaml
-except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
-    pytest.skip("pyyaml not installed", allow_module_level=True)
-
+import yaml
 
 WORKFLOW = Path(".github/workflows/bernstein-pr-review.yml")
+WorkflowStep = TypedDict(
+    "WorkflowStep",
+    {
+        "env": object,
+        "name": object,
+        "run": object,
+        "uses": object,
+        "with": object,
+    },
+    total=False,
+)
+
+
+class Workflow(TypedDict, total=False):
+    jobs: object
 
 
 @pytest.fixture(scope="module")
@@ -21,22 +32,24 @@ def workflow_text() -> str:
 
 
 @pytest.fixture(scope="module")
-def workflow(workflow_text: str) -> dict[str, object]:
-    return yaml.safe_load(workflow_text)
+def workflow(workflow_text: str) -> Workflow:
+    loaded = yaml.safe_load(workflow_text)
+    assert isinstance(loaded, dict)
+    return cast(Workflow, loaded)
 
 
 @pytest.fixture(scope="module")
-def review_steps(workflow: dict[str, object]) -> list[dict[str, object]]:
+def review_steps(workflow: Workflow) -> list[WorkflowStep]:
     jobs = workflow.get("jobs", {})
     assert isinstance(jobs, dict)
     review = jobs.get("review")
     assert isinstance(review, dict), "expected a 'review' job"
     steps = review.get("steps", [])
     assert isinstance(steps, list)
-    return [step for step in steps if isinstance(step, dict)]
+    return [cast(WorkflowStep, step) for step in steps if isinstance(step, dict)]
 
 
-def _step_named(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+def _step_named(steps: list[WorkflowStep], name: str) -> WorkflowStep:
     step = next((item for item in steps if item.get("name") == name), None)
     assert step is not None, f"missing workflow step: {name}"
     return step
@@ -46,7 +59,7 @@ def test_workflow_file_exists() -> None:
     assert WORKFLOW.exists(), "Bernstein PR review workflow must exist"
 
 
-def test_pr_review_runs_local_action_from_base_checkout(review_steps: list[dict[str, object]]) -> None:
+def test_pr_review_runs_local_action_from_base_checkout(review_steps: list[WorkflowStep]) -> None:
     """The local action must not execute PR head code while the API key is set."""
     review_step = _step_named(review_steps, "Review PR")
     review_index = review_steps.index(review_step)

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -85,4 +85,3 @@ def test_pr_review_runs_local_action_from_base_checkout(review_steps: list[dict[
     task = inputs.get("task", "")
     assert isinstance(task, str)
     assert ".bernstein-pr.diff" in task, "Review task must point the action at the fetched PR diff"
-

--- a/tests/unit/test_bernstein_pr_review_workflow_yaml.py
+++ b/tests/unit/test_bernstein_pr_review_workflow_yaml.py
@@ -1,0 +1,88 @@
+"""Structural assertions on ``.github/workflows/bernstein-pr-review.yml``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+WORKFLOW = Path(".github/workflows/bernstein-pr-review.yml")
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def workflow(workflow_text: str) -> dict[str, object]:
+    return yaml.safe_load(workflow_text)
+
+
+@pytest.fixture(scope="module")
+def review_steps(workflow: dict[str, object]) -> list[dict[str, object]]:
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+    review = jobs.get("review")
+    assert isinstance(review, dict), "expected a 'review' job"
+    steps = review.get("steps", [])
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step_named(steps: list[dict[str, object]], name: str) -> dict[str, object]:
+    step = next((item for item in steps if item.get("name") == name), None)
+    assert step is not None, f"missing workflow step: {name}"
+    return step
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW.exists(), "Bernstein PR review workflow must exist"
+
+
+def test_pr_review_runs_local_action_from_base_checkout(review_steps: list[dict[str, object]]) -> None:
+    """The local action must not execute PR head code while the API key is set."""
+    review_step = _step_named(review_steps, "Review PR")
+    review_index = review_steps.index(review_step)
+
+    checkout_steps = [
+        step
+        for step in review_steps[:review_index]
+        if isinstance(step.get("uses"), str) and str(step["uses"]).startswith("actions/checkout@")
+    ]
+    assert checkout_steps, "Review PR must be preceded by a checkout of trusted action code"
+    trusted_checkout = checkout_steps[-1]
+    checkout_with = trusted_checkout.get("with", {})
+    assert isinstance(checkout_with, dict)
+    assert checkout_with.get("ref") == "${{ github.event.pull_request.base.sha }}", (
+        "Review PR must run `uses: ./` from the base checkout, not from pull_request.head.sha"
+    )
+    assert checkout_with.get("persist-credentials") is False
+
+    for step in checkout_steps:
+        step_with = step.get("with", {})
+        assert isinstance(step_with, dict)
+        assert step_with.get("ref") != "${{ github.event.pull_request.head.sha }}", (
+            "PR head code must not be checked out before running the local action with ANTHROPIC_API_KEY"
+        )
+
+    fetch_diff = _step_named(review_steps, "Fetch PR diff")
+    assert review_steps.index(fetch_diff) < review_index
+    run = fetch_diff.get("run", "")
+    assert isinstance(run, str)
+    assert ".bernstein-pr.diff" in run, "PR diff must be fetched as data for review context"
+    assert "github.event.pull_request.diff_url" in run
+
+    assert review_step.get("uses") == "./"
+    inputs = review_step.get("with", {})
+    assert isinstance(inputs, dict)
+    task = inputs.get("task", "")
+    assert isinstance(task, str)
+    assert ".bernstein-pr.diff" in task, "Review task must point the action at the fetched PR diff"
+


### PR DESCRIPTION
## Summary
- Checkout pull_request.base.sha before running the local action.
- Fetch the PR diff into .bernstein-pr.diff as review data.
- Add a workflow structure test for the checkout and diff contract.

## Root cause
The workflow checked out pull_request.head.sha and then ran uses: ./ with ANTHROPIC_API_KEY in job env. Same-repo PR changes could replace the local action code.

## Validation
- uv run pytest tests/unit/test_bernstein_pr_review_workflow_yaml.py -q
- uv run ruff check tests/unit/test_bernstein_pr_review_workflow_yaml.py
- git diff --check
- pre-push hook: lint passed; import-linter passed; typecheck emitted an advisory Pyright version warning and continued

Addresses F-041 in #1827.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite to validate PR review workflow, checkout configuration, and diff file handling.

* **Chores**
  * Enhanced PR review workflow configuration for improved security and verification processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->