### PR TITLE
Fix publish workflow release guards

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,22 +34,25 @@ jobs:
         env:
           RELEASE_REF: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+
           # Install test dependencies
-          uv pip install mcp a2a || true
+          uv pip install mcp a2a
 
           # Run protocol tests
-          uv run pytest tests/protocol/ -v 2>&1 | tee test-output.log || true
+          set +e
+          uv run pytest tests/protocol/ -v 2>&1 | tee test-output.log
+          pytest_exit_code=${PIPESTATUS[0]}
+          set -e
 
           # Generate results
-          python << 'EOF'
+          PYTEST_EXIT_CODE="$pytest_exit_code" python << 'EOF'
           import json
           import os
 
           results = []
-          test_output = open('test-output.log').read()
-
-          # Simplified: mark as pass/fail based on pytest output
-          status = "pass" if "FAILED" not in test_output else "fail"
+          pytest_exit_code = int(os.environ["PYTEST_EXIT_CODE"])
+          status = "pass" if pytest_exit_code == 0 else "fail"
 
           result = {
             "python": "3.12",
@@ -68,6 +71,8 @@ jobs:
           with open('release-compat-results.json', 'w') as f:
               json.dump(compat_data, f, indent=2)
           EOF
+
+          exit "$pytest_exit_code"
 
       - name: Check against baseline
         run: |
@@ -113,6 +118,8 @@ jobs:
           enable-uv-cache: "false"
       - name: Quick lint check (full tests already passed in CI)
         run: uv run ruff check src/
+      - name: Release test guard
+        run: uv run python scripts/run_tests.py -k release -x
 
   version-check:
     name: Verify tag matches pyproject.toml
@@ -224,11 +231,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
           TAG="${GITHUB_REF#refs/tags/}"
-          gh release create "$TAG" dist/* \
-            --title "$TAG" \
-            --generate-notes \
-            || echo "Release already exists"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" dist/* \
+              --title "$TAG" \
+              --generate-notes
+          fi
+
+          asset_count=$(gh release view "$TAG" --json assets --jq '.assets | length')
+          if [ "$asset_count" -eq 0 ]; then
+            echo "::error::Release $TAG has no assets"
+            exit 1
+          fi
 
   publish-npm:
     name: Publish npm wrapper
@@ -275,4 +293,3 @@ jobs:
           if ! npm publish --access public; then
             echo "::warning::npm publish failed - continuing release. Likely cause: NPM_TOKEN needs to be re-issued with publish rights for bernstein-orchestrator."
           fi
-

--- a/tests/unit/test_release_attestation_workflow.py
+++ b/tests/unit/test_release_attestation_workflow.py
@@ -153,9 +153,7 @@ def test_protocol_gate_does_not_ignore_install_or_pytest_failures() -> None:
     data = _load_yaml(PUBLISH_WF)
     run = _step_run(data, "protocol-gate", "Run protocol compatibility check")
     unsafe_lines = [
-        line.strip()
-        for line in run.splitlines()
-        if line.strip().startswith(("uv pip install", "uv run pytest"))
+        line.strip() for line in run.splitlines() if line.strip().startswith(("uv pip install", "uv run pytest"))
     ]
     assert unsafe_lines
     assert all("|| true" not in line for line in unsafe_lines), unsafe_lines

--- a/tests/unit/test_release_attestation_workflow.py
+++ b/tests/unit/test_release_attestation_workflow.py
@@ -47,6 +47,23 @@ def _all_steps(jobs: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
     return out
 
 
+def _job(data: dict[str, Any], job_name: str) -> dict[str, Any]:
+    job = data["jobs"][job_name]
+    assert isinstance(job, dict)
+    return cast("dict[str, Any]", job)
+
+
+def _step_run(data: dict[str, Any], job_name: str, step_name: str) -> str:
+    job = _job(data, job_name)
+    steps = job.get("steps") or []
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            run = step.get("run")
+            assert isinstance(run, str)
+            return run
+    pytest.fail(f"{PUBLISH_WF.name}::{job_name} has no step named {step_name!r}")
+
+
 @pytest.mark.parametrize("workflow_path", [PUBLISH_WF])
 def test_workflow_yaml_parses(workflow_path: Path) -> None:
     """Workflow YAML is syntactically valid -- prevents typos breaking CI silently."""
@@ -129,3 +146,45 @@ def test_attest_action_pinned_to_commit_sha() -> None:
             )
             return
     pytest.fail("publish.yml has no attest-build-provenance step")
+
+
+def test_protocol_gate_does_not_ignore_install_or_pytest_failures() -> None:
+    """The protocol gate must fail when dependency install or pytest exits non-zero."""
+    data = _load_yaml(PUBLISH_WF)
+    run = _step_run(data, "protocol-gate", "Run protocol compatibility check")
+    unsafe_lines = [
+        line.strip()
+        for line in run.splitlines()
+        if line.strip().startswith(("uv pip install", "uv run pytest"))
+    ]
+    assert unsafe_lines
+    assert all("|| true" not in line for line in unsafe_lines), unsafe_lines
+
+
+def test_protocol_gate_status_uses_pytest_exit_code() -> None:
+    """The compat JSON status must use pytest's exit code rather than output substrings."""
+    data = _load_yaml(PUBLISH_WF)
+    run = _step_run(data, "protocol-gate", "Run protocol compatibility check")
+    assert '"FAILED" not in test_output' not in run
+    assert "pytest_exit_code" in run
+
+
+def test_publish_test_job_runs_release_tests() -> None:
+    """The release guard test job must run tests, not only lint."""
+    data = _load_yaml(PUBLISH_WF)
+    job = _job(data, "test")
+    assert job.get("name") == "Verify tests pass"
+
+    runs = [step["run"] for step in job.get("steps", []) if isinstance(step, dict) and isinstance(step.get("run"), str)]
+    assert "uv run python scripts/run_tests.py -k release -x" in "\n".join(runs)
+
+
+def test_github_release_uploads_and_asserts_dist_assets() -> None:
+    """Existing GitHub Releases must receive dist assets and fail if assets are absent."""
+    data = _load_yaml(PUBLISH_WF)
+    run = _step_run(data, "github-release", "Create release")
+    assert "|| echo" not in run
+    assert "gh release upload" in run
+    assert "--clobber" in run
+    assert "gh release view" in run
+    assert "asset_count" in run


### PR DESCRIPTION
## Summary
- Fail the protocol gate when dependency install or pytest exits non-zero.
- Write compatibility JSON status from the pytest exit code.
- Run the release-focused isolated test guard in the publish test job.
- Upload/clobber dist assets for existing GitHub Releases and assert assets are present.

## Root cause
- The protocol gate masked install and pytest failures with || true and inferred status from pytest text.
- The publish test job was named Verify tests pass but only ran ruff.
- Existing GitHub Release failures were swallowed without uploading or asserting assets.

## Tests
- uv run pytest tests/unit/test_release_attestation_workflow.py -q
- uv run ruff check tests/unit/test_release_attestation_workflow.py
- uv run python scripts/run_tests.py -k release -x

Fixes #1827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to validate release workflow procedures.

* **Chores**
  * Enhanced release process with stricter error handling and improved validation mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->