### PR TITLE
Add main SHA marker workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,20 +110,18 @@ on:
       - "scripts/gen_roadmap_*.py"
       - "scripts/generate_benchmark_docs.py"
 
-# Concurrency policy (split PR vs main pushes - see #1273):
+# Concurrency policy for heavy CI (see #1273):
 #
 #   - Pull requests: per-PR group (keyed off pull_request.number, stable
 #     across pushes to the same PR), cancel-in-progress=true. New commits
 #     on the same PR cancel older CI runs so reviewers only ever wait on
 #     the latest push and we don't burn minutes on stale SHAs.
 #
-#   - Pushes to main (incl. squash-merges from auto/bump-* PRs): per-SHA
-#     group, cancel-in-progress=false. Each merged commit gets its own
-#     un-cancellable CI run so the `workflow_run` listener in
-#     auto-release.yml always observes a real success/failure conclusion
-#     for that SHA - never `cancelled`-by-newer-push. This is the v2-merge
-#     unblocker: a tag/publish race that previously dropped the release
-#     when two merges landed in quick succession.
+#   - Pushes to main: branch-scoped group, cancel-in-progress=true.
+#     A rapid wave of merges can cancel older heavy CI runs on main so
+#     the latest push supersedes stale ones. Per-SHA main observability is
+#     provided separately by main-sha-marker.yml, which is keyed by
+#     github.sha and is not cancellable by newer main pushes.
 #
 # The conditional in `group:` selects the right key per event type, and
 # `cancel-in-progress` fires for both pull_request and push: a rapid

--- a/.github/workflows/main-sha-marker.yml
+++ b/.github/workflows/main-sha-marker.yml
@@ -1,0 +1,38 @@
+name: Main SHA marker
+
+# Cheap exact-SHA marker for every push to main.
+#
+# Heavy CI stays branch-cancellable in ci.yml. This workflow is intentionally
+# small and keyed by github.sha so newer main pushes do not cancel the marker
+# for an earlier landed commit.
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: main-sha-marker-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  marker:
+    name: Main SHA marker
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Record exact SHA marker
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "sha=${HEAD_SHA}"
+          {
+            echo "## Main SHA marker"
+            echo ""
+            echo "- event: ${EVENT_NAME}"
+            echo "- ref: ${REF_NAME}"
+            echo "- sha: \`${HEAD_SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/tests/unit/test_main_sha_marker_workflow_yaml.py
+++ b/tests/unit/test_main_sha_marker_workflow_yaml.py
@@ -1,0 +1,91 @@
+"""Structural assertions for main push exact-SHA marking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+
+class WorkflowJob(TypedDict, total=False):
+    name: object
+
+
+class WorkflowFile(TypedDict, total=False):
+    name: object
+    on: object
+    concurrency: object
+    jobs: dict[str, WorkflowJob]
+
+
+CI = Path(".github/workflows/ci.yml")
+MARKER = Path(".github/workflows/main-sha-marker.yml")
+MARKER_WORKFLOW_NAME = "Main SHA marker"
+CI_GATE_CHECK_NAME = "CI gate"
+
+
+def _load(path: Path) -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
+def _on(workflow: WorkflowFile) -> dict[str, object]:
+    raw_workflow = cast("dict[object, object]", workflow)
+    on = raw_workflow.get(True, workflow.get("on"))
+    assert isinstance(on, dict), "workflow must have an `on:` mapping"
+    return cast("dict[str, object]", on)
+
+
+def _mapping(value: object, message: str) -> dict[str, object]:
+    assert isinstance(value, dict), message
+    return cast("dict[str, object]", value)
+
+
+def test_ci_concurrency_comment_matches_branch_cancellation() -> None:
+    """The heavy CI comment must not promise per-SHA main push completion."""
+    ci_doc = _load(CI)
+    concurrency = _mapping(ci_doc.get("concurrency"), "CI workflow must define concurrency")
+    assert concurrency.get("cancel-in-progress") is True
+    group = concurrency.get("group")
+    assert isinstance(group, str)
+    assert "branch-" in group
+
+    text = CI.read_text(encoding="utf-8")
+    assert "Pushes to main (incl. squash-merges from auto/bump-* PRs): per-SHA" not in text
+    assert "cancel-in-progress=false" not in text
+    assert "main-sha-marker.yml" in text
+
+
+def test_main_sha_marker_workflow_is_exact_sha_and_non_cancellable() -> None:
+    """Main pushes need a cheap exact-SHA marker independent of heavy CI cancellation."""
+    assert MARKER.exists(), "main-sha-marker.yml must exist"
+    marker = _load(MARKER)
+
+    assert marker.get("name") == MARKER_WORKFLOW_NAME
+    assert marker.get("name") != "CI"
+
+    on = _on(marker)
+    push = _mapping(on.get("push"), "marker workflow must define push trigger")
+    assert push.get("branches") == ["main"]
+    assert "paths-ignore" not in push
+
+    concurrency = _mapping(marker.get("concurrency"), "marker workflow must define concurrency")
+    group = concurrency.get("group")
+    assert isinstance(group, str)
+    assert "github.sha" in group
+    assert "github.ref" not in group
+    assert concurrency.get("cancel-in-progress") is False
+
+
+def test_main_sha_marker_check_name_is_distinct_from_ci_gate() -> None:
+    """The marker must not satisfy or collide with the required CI gate context."""
+    marker = _load(MARKER)
+    jobs = marker.get("jobs", {})
+    assert isinstance(jobs, dict)
+    assert jobs
+
+    for key, job in jobs.items():
+        assert isinstance(job, dict), f"job `{key}` must be a mapping"
+        assert job.get("name") != CI_GATE_CHECK_NAME
+
+    assert any(job.get("name") == MARKER_WORKFLOW_NAME for job in jobs.values() if isinstance(job, dict))


### PR DESCRIPTION
## Summary
- Add a lightweight `Main SHA marker` workflow for every push to `main`.
- Key marker concurrency on `github.sha` with `cancel-in-progress: false`.
- Correct the heavy CI concurrency comment to match branch-scoped cancellation.
- Add structural tests for the marker and `CI gate` name separation.

## Root cause
`ci.yml` uses branch-scoped push concurrency with `cancel-in-progress: true`, but its comment still described per-SHA uncancellable main runs. Downstream workflows can therefore see cancelled heavy CI runs for intermediate main SHAs during rapid merge waves.

## Validation
- `uv run pytest tests/unit/test_main_sha_marker_workflow_yaml.py -q`
- `uv run ruff check tests/unit/test_main_sha_marker_workflow_yaml.py`
- `uv run pytest tests/unit/test_required_check_canary_workflow_yaml.py -q`
- `uv run pytest tests/unit/test_post_ci_dispatcher_yaml.py -q`
- `uv run pytest tests/unit/test_cross_platform_ci.py -q`

Refs #1827 (F-017).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow that records each main-branch push’s exact commit and appends a "Main SHA marker" summary.

* **Documentation**
  * Clarified CI concurrency docs to reflect branch-scoped grouping with newer runs canceling in-progress branch jobs.

* **Tests**
  * Added unit tests to verify the workflows’ triggers, concurrency semantics, and distinct marker behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->