### PR TITLE
Fix affected-test selector fail-closed paths

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -25,6 +25,13 @@ import sys
 import time
 from pathlib import Path
 
+_TEST_REQUIRED_PREFIXES = (
+    ".github/workflows/",
+    "scripts/",
+    "src/",
+    "tests/",
+)
+
 
 def _default_workers() -> int:
     """Pick a sensible default worker count: min(cpu_count, 8), at least 1."""
@@ -284,8 +291,48 @@ def discover_affected_files(base: str) -> list[Path]:
         capture_output=True,
         text=True,
     )
+    if result.returncode != 0:
+        print(result.stderr.strip() or result.stdout.strip() or "test_impact.py failed")
+        sys.exit(result.returncode)
     paths = [Path(p.strip()) for p in result.stdout.splitlines() if p.strip()]
     return sorted(paths)
+
+
+def discover_changed_files(base: str) -> list[str]:
+    """Return repo-relative changed paths for empty affected-set decisions."""
+    root = Path(__file__).parent.parent
+    try:
+        if base == "HEAD":
+            unstaged = subprocess.run(
+                ["git", "diff", "--name-only", "HEAD"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
+            staged = subprocess.run(
+                ["git", "diff", "--name-only", "--cached"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
+            return sorted({path for path in [*unstaged, *staged] if path})
+        return subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.splitlines()
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr.strip() or f"Unable to inspect changed files against {base}")
+        sys.exit(exc.returncode)
+
+
+def changed_files_require_tests(changed_files: list[str]) -> bool:
+    """Return True when an empty affected set must fail closed."""
+    return any(Path(path).as_posix().startswith(_TEST_REQUIRED_PREFIXES) for path in changed_files)
 
 
 def main() -> None:
@@ -335,12 +382,20 @@ def main() -> None:
             sys.exit(2)
 
     if args.affected is not None:
-        files = discover_affected_files(args.affected)
+        affected_files = discover_affected_files(args.affected)
+        files = affected_files
         if args.keyword:
             files = [f for f in files if args.keyword in f.stem]
         if shard is not None:
             files = shard_files(files, *shard)
         if not files:
+            if not affected_files:
+                changed_files = discover_changed_files(args.affected)
+                if changed_files_require_tests(changed_files):
+                    print("No affected tests found for code or workflow changes; failing closed.")
+                    for changed_file in changed_files:
+                        print(f"  {changed_file}")
+                    sys.exit(1)
             _report_empty_selection(shard, context="affected ")
             sys.exit(0)
         shard_label = f" [shard {shard[0]}/{shard[1]}]" if shard else ""

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -318,13 +318,24 @@ def discover_changed_files(base: str) -> list[str]:
                 check=True,
             ).stdout.splitlines()
             return sorted({path for path in [*unstaged, *staged] if path})
-        return subprocess.run(
-            ["git", "diff", "--name-only", f"{base}...HEAD"],
-            cwd=root,
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.splitlines()
+        try:
+            return subprocess.run(
+                ["git", "diff", "--name-only", f"{base}...HEAD"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
+        except subprocess.CalledProcessError as exc:
+            if exc.returncode != 128:
+                raise
+            return subprocess.run(
+                ["git", "diff", "--name-only", f"{base}..HEAD"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
     except subprocess.CalledProcessError as exc:
         print(exc.stderr.strip() or f"Unable to inspect changed files against {base}")
         sys.exit(exc.returncode)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -317,7 +317,14 @@ def discover_changed_files(base: str) -> list[str]:
                 text=True,
                 check=True,
             ).stdout.splitlines()
-            return sorted({path for path in [*unstaged, *staged] if path})
+            untracked = subprocess.run(
+                ["git", "ls-files", "--others", "--exclude-standard"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
+            return sorted({path for path in [*unstaged, *staged, *untracked] if path})
         try:
             return subprocess.run(
                 ["git", "diff", "--name-only", f"{base}...HEAD"],

--- a/scripts/test_impact.py
+++ b/scripts/test_impact.py
@@ -13,7 +13,7 @@ ROOT = Path(__file__).parent.parent
 CACHE_PATH = ROOT / ".sdd" / "test_deps.json"
 SRC_ROOT = ROOT / "src"
 TEST_DIRS = [ROOT / "tests" / "unit", ROOT / "tests" / "integration"]
-CACHE_VERSION = "1"
+CACHE_VERSION = "2"
 
 if str(ROOT / "src") not in sys.path:
     sys.path.insert(0, str(ROOT / "src"))

--- a/scripts/test_impact.py
+++ b/scripts/test_impact.py
@@ -83,13 +83,24 @@ def get_changed_files(base: str = "HEAD") -> list[str]:
             ).stdout.splitlines()
             files = list(set(unstaged) | set(staged))
         else:
-            files = subprocess.run(
-                ["git", "diff", "--name-only", f"{base}...HEAD"],
-                cwd=ROOT,
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout.splitlines()
+            try:
+                files = subprocess.run(
+                    ["git", "diff", "--name-only", f"{base}...HEAD"],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.splitlines()
+            except subprocess.CalledProcessError as exc:
+                if exc.returncode != 128:
+                    raise
+                files = subprocess.run(
+                    ["git", "diff", "--name-only", f"{base}..HEAD"],
+                    cwd=ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.splitlines()
         return [f for f in files if f]
     except subprocess.CalledProcessError:
         return []

--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -20,11 +20,10 @@ from typing_extensions import TypedDict
 logger = logging.getLogger(__name__)
 
 _ANALYZER_CACHE_VERSION = "2"
-_COMPAT_CACHE_VERSION = "1"
+_COMPAT_CACHE_VERSION = "2"
 
 
-# Shared cast-type constants to avoid string duplication (Sonar S1192).
-_CAST_DICT_STR_OBJ = "dict[str, object]"
+type _JsonObject = dict[str, object]
 
 
 class AnalyzerCacheData(TypedDict):
@@ -135,7 +134,7 @@ def build_compat_dep_map(
     for test_dir in test_dirs:
         if not test_dir.exists():
             continue
-        for test_file in sorted(test_dir.glob("test_*.py")):
+        for test_file in sorted(test_dir.rglob("test_*.py")):
             rel = test_file.relative_to(root).as_posix()
             test_deps[rel] = {
                 "hash": _file_hash(test_file),
@@ -169,7 +168,7 @@ def _check_hashes_fresh(
         entry = dep_map.get(key)
         if not isinstance(entry, dict):
             return False
-        entry_dict = cast(_CAST_DICT_STR_OBJ, entry)
+        entry_dict = cast("_JsonObject", entry)
         if entry_dict.get("hash") != _file_hash(file_path):
             return False
     return True
@@ -187,13 +186,13 @@ def compat_cache_is_fresh(
         return False
     test_deps_raw = cached.get("test_deps")
     source_imports_raw = cached.get("source_imports")
-    test_deps = cast(_CAST_DICT_STR_OBJ, test_deps_raw) if isinstance(test_deps_raw, dict) else {}
-    source_imports = cast(_CAST_DICT_STR_OBJ, source_imports_raw) if isinstance(source_imports_raw, dict) else {}
+    test_deps = cast("_JsonObject", test_deps_raw) if isinstance(test_deps_raw, dict) else {}
+    source_imports = cast("_JsonObject", source_imports_raw) if isinstance(source_imports_raw, dict) else {}
 
     test_files: list[tuple[str, Path]] = []
     for test_dir in test_dirs:
         if test_dir.exists():
-            test_files.extend((tf.relative_to(root).as_posix(), tf) for tf in test_dir.glob("test_*.py"))
+            test_files.extend((tf.relative_to(root).as_posix(), tf) for tf in test_dir.rglob("test_*.py"))
     if not _check_hashes_fresh(test_files, test_deps):
         return False
 
@@ -211,7 +210,7 @@ def _build_module_to_tests_map(test_deps: dict[str, object]) -> dict[str, set[st
     for test_rel, entry in test_deps.items():
         if not isinstance(entry, dict):
             continue
-        entry_dict = cast(_CAST_DICT_STR_OBJ, entry)
+        entry_dict = cast("_JsonObject", entry)
         for module in _normalize_string_list(entry_dict.get("imports", [])):
             module_to_tests.setdefault(module, set()).add(test_rel)
     return module_to_tests
@@ -229,7 +228,7 @@ def _expand_transitive_modules(
         for module, info in source_imports.items():
             if not isinstance(info, dict):
                 continue
-            info_dict = cast(_CAST_DICT_STR_OBJ, info)
+            info_dict = cast("_JsonObject", info)
             imports = _normalize_string_list(info_dict.get("imports", []))
             if current in imports and module not in all_affected:
                 all_affected.add(module)
@@ -277,8 +276,8 @@ def compat_get_affected_tests(
     """Return affected test file paths for the legacy script contract."""
     test_deps_raw = dep_map.get("test_deps")
     source_imports_raw = dep_map.get("source_imports")
-    test_deps = cast(_CAST_DICT_STR_OBJ, test_deps_raw) if isinstance(test_deps_raw, dict) else {}
-    source_imports = cast(_CAST_DICT_STR_OBJ, source_imports_raw) if isinstance(source_imports_raw, dict) else {}
+    test_deps = cast("_JsonObject", test_deps_raw) if isinstance(test_deps_raw, dict) else {}
+    source_imports = cast("_JsonObject", source_imports_raw) if isinstance(source_imports_raw, dict) else {}
 
     if any("conftest.py" in changed for changed in changed_files):
         return sorted(root / rel for rel in test_deps)
@@ -340,7 +339,7 @@ class TestImpactAnalyzer:
         self._all_tests: set[str] = set()
         self._built = False
 
-    def _restore_from_cache(self, cached: dict[str, Any]) -> None:
+    def _restore_from_cache(self, cached: AnalyzerCacheData) -> None:
         """Restore index state from a cached dict."""
         self._graph = {key: set(value) for key, value in cached["graph"].items()}
         self._reverse = {key: set(value) for key, value in cached["reverse"].items()}
@@ -543,7 +542,7 @@ class TestImpactAnalyzer:
             return None
         if not isinstance(raw, dict):
             return None
-        data = cast(_CAST_DICT_STR_OBJ, raw)
+        data = cast("_JsonObject", raw)
         if data.get("version") != _ANALYZER_CACHE_VERSION:
             return None
         snapshot = data.get("snapshot")

--- a/tests/unit/scripts/test_run_tests_sharding.py
+++ b/tests/unit/scripts/test_run_tests_sharding.py
@@ -250,3 +250,32 @@ def test_discover_changed_files_falls_back_to_two_dot_diff_without_merge_base(
 
     assert run_tests_module.discover_changed_files("origin/main") == ["src/bernstein/core/models.py"]
     assert calls[-1][-1] == "origin/main..HEAD"
+
+
+def test_discover_changed_files_includes_untracked_files_for_head(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str],
+        **_: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd == ["git", "diff", "--name-only", "HEAD"]:
+            return subprocess.CompletedProcess(cmd, 0, "src/bernstein/core/models.py\n", "")
+        if cmd == ["git", "diff", "--name-only", "--cached"]:
+            return subprocess.CompletedProcess(cmd, 0, "tests/unit/test_models.py\n", "")
+        if cmd == ["git", "ls-files", "--others", "--exclude-standard"]:
+            return subprocess.CompletedProcess(cmd, 0, "src/bernstein/core/new_module.py\n", "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(run_tests_module.subprocess, "run", fake_run)
+
+    assert run_tests_module.discover_changed_files("HEAD") == [
+        "src/bernstein/core/models.py",
+        "src/bernstein/core/new_module.py",
+        "tests/unit/test_models.py",
+    ]
+    assert ["git", "ls-files", "--others", "--exclude-standard"] in calls

--- a/tests/unit/scripts/test_run_tests_sharding.py
+++ b/tests/unit/scripts/test_run_tests_sharding.py
@@ -166,3 +166,65 @@ def test_shard_files_rejects_out_of_range_index(run_tests_module: ModuleType) ->
         run_tests_module.shard_files(files, 0, 4)
     with pytest.raises(ValueError):
         run_tests_module.shard_files(files, 5, 4)
+
+
+# --- affected empty-selection fail-closed behavior -------------------------
+
+
+@pytest.mark.parametrize(
+    "changed_file",
+    [
+        "src/bernstein/core/models.py",
+        "tests/unit/test_models.py",
+        ".github/workflows/ci.yml",
+        "scripts/run_tests.py",
+        "scripts/test_impact.py",
+    ],
+)
+def test_changed_files_require_tests_for_code_and_workflow_paths(
+    run_tests_module: ModuleType,
+    changed_file: str,
+) -> None:
+    assert run_tests_module.changed_files_require_tests([changed_file])
+
+
+@pytest.mark.parametrize(
+    "changed_file",
+    [
+        "README.md",
+        "docs/operations/release.md",
+        "CHANGELOG.md",
+    ],
+)
+def test_changed_files_do_not_require_tests_for_docs_paths(
+    run_tests_module: ModuleType,
+    changed_file: str,
+) -> None:
+    assert not run_tests_module.changed_files_require_tests([changed_file])
+
+
+def test_empty_affected_selection_fails_for_source_changes(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_tests_module, "discover_affected_files", lambda _base: [])
+    monkeypatch.setattr(run_tests_module, "discover_changed_files", lambda _base: ["src/bernstein/core/models.py"])
+    monkeypatch.setattr(sys, "argv", ["run_tests.py", "--affected", "origin/main"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_tests_module.main()
+
+    assert exc_info.value.code == 1
+
+
+def test_empty_affected_shard_remains_success_when_other_shards_have_tests(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_tests_module, "discover_affected_files", lambda _base: [Path("tests/unit/test_models.py")])
+    monkeypatch.setattr(sys, "argv", ["run_tests.py", "--affected", "origin/main", "--shard", "2/2"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_tests_module.main()
+
+    assert exc_info.value.code == 0

--- a/tests/unit/scripts/test_run_tests_sharding.py
+++ b/tests/unit/scripts/test_run_tests_sharding.py
@@ -20,6 +20,7 @@ These tests pin those four properties plus the ``i/N`` spec parser.
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -228,3 +229,24 @@ def test_empty_affected_shard_remains_success_when_other_shards_have_tests(
         run_tests_module.main()
 
     assert exc_info.value.code == 0
+
+
+def test_discover_changed_files_falls_back_to_two_dot_diff_without_merge_base(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str],
+        **_: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[-1] == "origin/main...HEAD":
+            raise subprocess.CalledProcessError(128, cmd, stderr="no merge base")
+        return subprocess.CompletedProcess(cmd, 0, "src/bernstein/core/models.py\n", "")
+
+    monkeypatch.setattr(run_tests_module.subprocess, "run", fake_run)
+
+    assert run_tests_module.discover_changed_files("origin/main") == ["src/bernstein/core/models.py"]
+    assert calls[-1][-1] == "origin/main..HEAD"

--- a/tests/unit/test_test_impact.py
+++ b/tests/unit/test_test_impact.py
@@ -141,8 +141,27 @@ class TestBuildDepMap:
             ti.SRC_ROOT = orig_src
             ti.ROOT = orig_root
 
-        assert dep_map["version"] == "1"
+        assert dep_map["version"] == "2"
         assert any("test_models.py" in k for k in dep_map["test_deps"])
+
+    def test_nested_tests_are_discovered(self, tmp_path: Path) -> None:
+        import test_impact as ti  # type: ignore[import]
+
+        src, test_dir, _ = self._make_layout(tmp_path)
+        nested = test_dir / "core" / "test_nested_models.py"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("from bernstein.core.models import Task\n")
+
+        orig_src, orig_root = ti.SRC_ROOT, ti.ROOT
+        ti.SRC_ROOT = src
+        ti.ROOT = tmp_path
+        try:
+            dep_map = build_dep_map(test_dirs=[test_dir])
+        finally:
+            ti.SRC_ROOT = orig_src
+            ti.ROOT = orig_root
+
+        assert "tests/unit/core/test_nested_models.py" in dep_map["test_deps"]
 
     def test_imports_captured(self, tmp_path: Path) -> None:
         import test_impact as ti  # type: ignore[import]
@@ -255,6 +274,32 @@ class TestCacheIsFresh:
 
     def test_wrong_version_is_stale(self) -> None:
         assert not _cache_is_fresh({"version": "0", "test_deps": {}, "source_imports": {}})
+
+    def test_nested_test_hash_changes_make_cache_stale(self, tmp_path: Path) -> None:
+        import test_impact as ti  # type: ignore[import]
+
+        src = tmp_path / "src"
+        (src / "bernstein").mkdir(parents=True)
+        (src / "bernstein" / "__init__.py").touch()
+
+        test_dir = tmp_path / "tests" / "unit"
+        nested_dir = test_dir / "core"
+        nested_dir.mkdir(parents=True)
+        nested_test = nested_dir / "test_foo.py"
+        nested_test.write_text("import bernstein\n")
+
+        orig_src, orig_root, orig_dirs = ti.SRC_ROOT, ti.ROOT, ti.TEST_DIRS
+        ti.SRC_ROOT = src
+        ti.ROOT = tmp_path
+        ti.TEST_DIRS = [test_dir]
+        try:
+            dep_map = build_dep_map(test_dirs=[test_dir])
+            nested_test.write_text("import bernstein\nimport os\n")
+            assert not _cache_is_fresh(dep_map)
+        finally:
+            ti.SRC_ROOT = orig_src
+            ti.ROOT = orig_root
+            ti.TEST_DIRS = orig_dirs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_test_impact.py
+++ b/tests/unit/test_test_impact.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
+
+import pytest
 
 # Make scripts/ importable
 _SCRIPTS = Path(__file__).parent.parent.parent / "scripts"
@@ -16,6 +19,7 @@ from test_impact import (
     _extract_bernstein_imports,
     build_dep_map,
     get_affected_tests,
+    get_changed_files,
 )
 
 # ---------------------------------------------------------------------------
@@ -300,6 +304,35 @@ class TestCacheIsFresh:
             ti.SRC_ROOT = orig_src
             ti.ROOT = orig_root
             ti.TEST_DIRS = orig_dirs
+
+
+# ---------------------------------------------------------------------------
+# get_changed_files
+# ---------------------------------------------------------------------------
+
+
+class TestGetChangedFiles:
+    def test_falls_back_to_two_dot_diff_when_merge_base_is_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import test_impact as ti  # type: ignore[import]
+
+        calls: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str],
+            **_: object,
+        ) -> subprocess.CompletedProcess[str]:
+            calls.append(cmd)
+            if cmd[-1] == "origin/main...HEAD":
+                raise subprocess.CalledProcessError(128, cmd, stderr="no merge base")
+            return subprocess.CompletedProcess(cmd, 0, "src/bernstein/core/models.py\n", "")
+
+        monkeypatch.setattr(ti.subprocess, "run", fake_run)
+
+        assert get_changed_files("origin/main") == ["src/bernstein/core/models.py"]
+        assert calls[-1][-1] == "origin/main..HEAD"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- discover nested unit and integration tests in the legacy affected-test map
- bump the affected-test cache version after recursive discovery changes
- fail closed when `--affected` returns no tests for code, test, script, or workflow changes

## Validation

- `uv run pytest tests/unit/test_test_impact.py -q`
- `uv run pytest tests/unit/scripts/test_run_tests_sharding.py -q`
- `uv run ruff check src/bernstein/core/quality/test_impact.py scripts/test_impact.py scripts/run_tests.py tests/unit/test_test_impact.py tests/unit/scripts/test_run_tests_sharding.py`
- `uv run pyright src/bernstein/core/quality/test_impact.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Test discovery now recursively finds test files in nested directories for better coverage detection.
  * Added fail-closed validation to prevent missed test runs when source code changes are detected without corresponding test changes.

* **Chores**
  * Updated test impact cache schema version for improved performance.

* **Tests**
  * Added comprehensive test coverage for affected test selection and fail-closed validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->