### PR TITLE
Fix autosync drift failure gates

### DIFF
--- a/.github/workflows/nightly-drift-sweep.yml
+++ b/.github/workflows/nightly-drift-sweep.yml
@@ -49,14 +49,14 @@ jobs:
 
       - name: Install project (for the bernstein CLI)
         run: uv sync --no-dev --frozen
-        continue-on-error: true
 
       - name: Regenerate AGENTS.md mirrors
         run: uv run bernstein agents-md sync --workdir .
 
       - name: Run ruff fix and format
         run: |
-          uv run ruff check . --fix --unsafe-fixes || true
+          set -euo pipefail
+          uv run ruff check . --fix --unsafe-fixes
           uv run ruff format .
 
       - name: Detect drift

--- a/.github/workflows/pre-merge-autosync.yml
+++ b/.github/workflows/pre-merge-autosync.yml
@@ -24,12 +24,10 @@ name: Pre-merge autosync
 #   * A `skip-autosync` PR label disables this workflow per-PR for operator
 #     escape-hatches (e.g. tracking-only WIP PRs that intentionally keep stale
 #     mirrors).
-#   * Push prefers BERNSTEIN_AUTOSYNC_TOKEN (fine-grained PAT or GitHub App
-#     token with contents:write on this repo). Falls back to GITHUB_TOKEN
-#     when the named secret is not configured; in that case GitHub mutes
-#     downstream workflow_run / pull_request triggers so the source PR's CI
-#     does not automatically re-run on the amend. The operator runbook in
-#     docs/operations/merge-gate.md documents the token setup.
+#   * Push requires BERNSTEIN_AUTOSYNC_TOKEN (fine-grained PAT or GitHub App
+#     token with contents:write on this repo). The workflow refuses to push
+#     with GITHUB_TOKEN because those commits do not retrigger the source PR's
+#     downstream checks.
 
 on:
   pull_request:
@@ -67,35 +65,40 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Require named autosync token
+        env:
+          BERNSTEIN_AUTOSYNC_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BERNSTEIN_AUTOSYNC_TOKEN}" ]; then
+            echo "::error::BERNSTEIN_AUTOSYNC_TOKEN is required for autosync pushes; refusing to push with GITHUB_TOKEN."
+            exit 1
+          fi
+
       # Persist credentials so the post-step push lands on the PR head ref.
-      # Use the named PAT/App token when present so the amend commit triggers
-      # downstream workflows on the PR (GITHUB_TOKEN-authored commits are
-      # muted by GitHub's recursion protection).
+      # Use the named PAT/App token so the amend commit triggers downstream
+      # workflows on the PR.
       - name: Checkout PR head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6  # zizmor: ignore[artipacked]
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN }}
 
       - uses: ./.github/actions/bootstrap
 
       - name: Install project (for the bernstein CLI)
         run: uv sync --no-dev --frozen
-        continue-on-error: true
 
       - name: Regenerate AGENTS.md mirrors
         run: uv run bernstein agents-md sync --workdir .
 
       - name: Run ruff fix and format
         run: |
-          # Tolerate non-zero from both steps so unrelated lint failures
-          # (e.g. cookiecutter Jinja sources in templates/, intentionally
-          # vulnerable security-pentest fixtures) never abort the inline
-          # auto-amend. The reformatted files still land in the next step.
-          uv run ruff check . --fix --unsafe-fixes || true
-          uv run ruff format . || true
+          set -euo pipefail
+          uv run ruff check . --fix --unsafe-fixes
+          uv run ruff format .
 
       - name: Detect drift
         id: drift
@@ -112,7 +115,6 @@ jobs:
         if: steps.drift.outputs.changed == 'true'
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          USING_NAMED_TOKEN: ${{ secrets.BERNSTEIN_AUTOSYNC_TOKEN != '' }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -125,6 +127,3 @@ jobs:
           # let the push fail and the next pull_request.synchronize event
           # will re-run the job.
           git push origin "HEAD:${PR_HEAD_REF}"
-          if [ "${USING_NAMED_TOKEN}" != "true" ]; then
-            echo "::notice::BERNSTEIN_AUTOSYNC_TOKEN not configured. The amend commit was authored by GITHUB_TOKEN and will NOT trigger downstream workflows on the source PR. See docs/operations/merge-gate.md for the named-secret setup."
-          fi

--- a/tests/unit/test_autosync_drift_workflows_yaml.py
+++ b/tests/unit/test_autosync_drift_workflows_yaml.py
@@ -1,0 +1,91 @@
+"""Structural assertions for autosync drift workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_MERGE = REPO_ROOT / ".github" / "workflows" / "pre-merge-autosync.yml"
+NIGHTLY = REPO_ROOT / ".github" / "workflows" / "nightly-drift-sweep.yml"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
+def _steps(path: Path, job_name: str) -> list[dict[str, Any]]:
+    workflow = _load(path)
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+    job = jobs.get(job_name)
+    assert isinstance(job, dict), f"expected job {job_name!r}"
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _step(steps: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    match = next((step for step in steps if step.get("name") == name), None)
+    assert match is not None, f"expected step {name!r}"
+    return match
+
+
+def _run(step: dict[str, Any]) -> str:
+    run = step.get("run", "")
+    assert isinstance(run, str)
+    return run
+
+
+def test_pre_merge_setup_and_format_fail_before_commit() -> None:
+    steps = _steps(PRE_MERGE, "autosync")
+    install = _step(steps, "Install project (for the bernstein CLI)")
+    formatter = _step(steps, "Run ruff fix and format")
+
+    assert install.get("continue-on-error") is not True
+    run = _run(formatter)
+    assert "|| true" not in run
+    assert "uv run ruff check . --fix --unsafe-fixes" in run
+    assert "uv run ruff format ." in run
+
+
+def test_pre_merge_push_requires_named_autosync_token() -> None:
+    steps = _steps(PRE_MERGE, "autosync")
+    checkout = _step(steps, "Checkout PR head")
+    require_token = _step(steps, "Require named autosync token")
+    push = _step(steps, "Commit and push regen to PR head ref")
+
+    with_block = checkout.get("with", {})
+    assert isinstance(with_block, dict)
+    token = with_block.get("token", "")
+    assert isinstance(token, str)
+    assert "BERNSTEIN_AUTOSYNC_TOKEN" in token
+    assert "GITHUB_TOKEN" not in token
+
+    require_run = _run(require_token)
+    assert "BERNSTEIN_AUTOSYNC_TOKEN is required" in require_run
+    assert "exit 1" in require_run
+
+    push_run = _run(push)
+    assert "USING_NAMED_TOKEN" not in push_run
+    assert "GITHUB_TOKEN" not in push_run
+
+
+def test_nightly_setup_and_format_fail_before_opening_pr() -> None:
+    steps = _steps(NIGHTLY, "sweep")
+    install = _step(steps, "Install project (for the bernstein CLI)")
+    formatter = _step(steps, "Run ruff fix and format")
+
+    assert install.get("continue-on-error") is not True
+    run = _run(formatter)
+    assert "|| true" not in run
+    assert "uv run ruff check . --fix --unsafe-fixes" in run
+    assert "uv run ruff format ." in run

--- a/tests/unit/test_autosync_drift_workflows_yaml.py
+++ b/tests/unit/test_autosync_drift_workflows_yaml.py
@@ -3,14 +3,28 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
+from typing import TypedDict, cast
 
-import pytest
+import yaml
 
-try:
-    import yaml
-except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
-    pytest.skip("pyyaml not installed", allow_module_level=True)
+WorkflowStep = TypedDict(
+    "WorkflowStep",
+    {
+        "name": object,
+        "run": object,
+        "continue-on-error": object,
+        "with": object,
+    },
+    total=False,
+)
+
+
+class WorkflowJob(TypedDict, total=False):
+    steps: list[object]
+
+
+class WorkflowFile(TypedDict, total=False):
+    jobs: dict[str, WorkflowJob]
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -18,11 +32,11 @@ PRE_MERGE = REPO_ROOT / ".github" / "workflows" / "pre-merge-autosync.yml"
 NIGHTLY = REPO_ROOT / ".github" / "workflows" / "nightly-drift-sweep.yml"
 
 
-def _load(path: Path) -> dict[str, Any]:
-    return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
+def _load(path: Path) -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(path.read_text(encoding="utf-8")))
 
 
-def _steps(path: Path, job_name: str) -> list[dict[str, Any]]:
+def _steps(path: Path, job_name: str) -> list[WorkflowStep]:
     workflow = _load(path)
     jobs = workflow.get("jobs", {})
     assert isinstance(jobs, dict)
@@ -30,16 +44,16 @@ def _steps(path: Path, job_name: str) -> list[dict[str, Any]]:
     assert isinstance(job, dict), f"expected job {job_name!r}"
     steps = job.get("steps", [])
     assert isinstance(steps, list)
-    return [step for step in steps if isinstance(step, dict)]
+    return [cast("WorkflowStep", step) for step in steps if isinstance(step, dict)]
 
 
-def _step(steps: list[dict[str, Any]], name: str) -> dict[str, Any]:
+def _step(steps: list[WorkflowStep], name: str) -> WorkflowStep:
     match = next((step for step in steps if step.get("name") == name), None)
     assert match is not None, f"expected step {name!r}"
     return match
 
 
-def _run(step: dict[str, Any]) -> str:
+def _run(step: WorkflowStep) -> str:
     run = step.get("run", "")
     assert isinstance(run, str)
     return run
@@ -65,7 +79,8 @@ def test_pre_merge_push_requires_named_autosync_token() -> None:
 
     with_block = checkout.get("with", {})
     assert isinstance(with_block, dict)
-    token = with_block.get("token", "")
+    with_values = cast("dict[str, object]", with_block)
+    token = with_values.get("token", "")
     assert isinstance(token, str)
     assert "BERNSTEIN_AUTOSYNC_TOKEN" in token
     assert "GITHUB_TOKEN" not in token


### PR DESCRIPTION
## Summary
- Fail pre-merge autosync before committing when install or formatter commands fail.
- Require BERNSTEIN_AUTOSYNC_TOKEN for pre-merge autosync pushes instead of falling back to GITHUB_TOKEN.
- Fail nightly drift sweep before opening a PR when install or formatter commands fail.
- Add structural regression tests for these workflow shapes.

## Root cause
The workflows masked setup or formatter failures with continue-on-error and shell fallbacks, and pre-merge autosync allowed a GITHUB_TOKEN push path that does not retrigger downstream PR checks.

## Validation
- uv run pytest tests/unit/test_autosync_drift_workflows_yaml.py -q
- uv run ruff check tests/unit/test_autosync_drift_workflows_yaml.py
- git diff --check
- actionlint .github/workflows/pre-merge-autosync.yml .github/workflows/nightly-drift-sweep.yml
- zizmor --format plain .github/workflows/pre-merge-autosync.yml .github/workflows/nightly-drift-sweep.yml

Fixes #1827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **CI/CD Improvements**
  * Workflows now fail fast on errors instead of continuing, enabling earlier error detection in the CI/CD pipeline.
  * Code formatting and style check failures now block commits.

* **Authentication**
  * Push operations now require a dedicated authentication token.

* **Tests**
  * Added workflow configuration validation tests to ensure CI/CD pipeline integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->