### PR TITLE
Fix uv setup in workflow installers

### DIFF
--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -34,14 +34,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - name: Set up uv
+        uses: ./.github/actions/bootstrap
         with:
           python-version: '3.13'
 
       - name: Install bernstein
         run: |
-          pip install --quiet uv
           uv sync --group dev
 
       - name: Capture observe snapshot

--- a/.github/workflows/glitchtip-ingester.yml
+++ b/.github/workflows/glitchtip-ingester.yml
@@ -96,16 +96,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Python
+      - name: Set up uv
         if: steps.gate.outputs.skip != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        uses: ./.github/actions/bootstrap
         with:
           python-version: '3.13'
 
-      - name: Install uv and project deps
+      - name: Install project deps
         if: steps.gate.outputs.skip != 'true'
         run: |
-          pip install --quiet uv
           uv sync --group dev
 
       - name: Scrape GlitchTip events

--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -55,14 +55,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - name: Set up uv
+        uses: ./.github/actions/bootstrap
         with:
           python-version: '3.13'
 
-      - name: Install uv and project deps
+      - name: Install project deps
         run: |
-          pip install --quiet uv
           uv sync --group dev
 
       - name: Configure git identity for worktree flow

--- a/.github/workflows/pr-observability-summary.yml
+++ b/.github/workflows/pr-observability-summary.yml
@@ -39,14 +39,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - name: Set up uv
+        uses: ./.github/actions/bootstrap
         with:
           python-version: '3.13'
 
       - name: Install bernstein
         run: |
-          pip install --quiet uv
           uv sync --group dev
 
       - name: Run doctor observe (JSON)

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -154,6 +154,10 @@ jobs:
             echo "missing=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up uv for fallback
+        if: steps.coverage_check.outputs.missing == 'true'
+        uses: ./.github/actions/bootstrap
+
       # Thin coverage fallback: run a fast unit-test subset with coverage
       # so Sonar receives a non-zero coverage signal even when no upstream
       # artifact was usable. This is intentionally NOT the full suite
@@ -166,10 +170,6 @@ jobs:
         continue-on-error: true  # coverage is advisory; never block the scan
         run: |
           set +e
-          if ! command -v uv >/dev/null 2>&1; then
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-            export PATH="$HOME/.local/bin:$PATH"
-          fi
           uv sync --group dev --no-progress 2>&1 | tail -20 || true
           uv run --no-progress python -m coverage run -m pytest \
             tests/unit/observability \

--- a/.github/workflows/sweep-sonar-findings.yml
+++ b/.github/workflows/sweep-sonar-findings.yml
@@ -120,16 +120,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up Python
+      - name: Set up uv
         if: steps.gate.outputs.skip != 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        uses: ./.github/actions/bootstrap
         with:
           python-version: '3.13'
 
-      - name: Install uv and project deps
+      - name: Install project deps
         if: steps.gate.outputs.skip != 'true'
         run: |
-          pip install --quiet uv
           uv sync --group dev
 
       - name: Run sweeper

--- a/tests/unit/sweep/test_sweep_sonar_workflow_yaml.py
+++ b/tests/unit/sweep/test_sweep_sonar_workflow_yaml.py
@@ -52,12 +52,16 @@ def test_workflow_has_concurrency_group() -> None:
 
 def test_workflow_pins_action_shas() -> None:
     text = _WORKFLOW.read_text(encoding="utf-8")
-    # Every `uses:` line must use a 40-char SHA pin, never a floating tag.
+    # Every external `uses:` line must use a 40-char SHA pin, never a
+    # floating tag. Repo-local composite actions are versioned with this
+    # workflow and therefore do not have an `@<ref>` suffix.
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped.startswith("uses:"):
             continue
         ref = stripped.removeprefix("uses:").strip()
+        if ref.startswith("./"):
+            continue
         # actions/checkout@<sha> # vN.N.N -- split off the SHA.
         if "@" not in ref:
             raise AssertionError(f"uses line missing '@<sha>': {line!r}")

--- a/tests/unit/test_workflow_uv_installers_yaml.py
+++ b/tests/unit/test_workflow_uv_installers_yaml.py
@@ -1,0 +1,82 @@
+"""Structural checks for uv installer usage in selected workflows."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+OWNED_WORKFLOWS = (
+    "sonar-scan.yml",
+    "docs-observability-snapshot.yml",
+    "pr-observability-summary.yml",
+    "glitchtip-ingester.yml",
+    "nightly-canary.yml",
+    "sweep-sonar-findings.yml",
+)
+
+CURL_PIPE_SH_RE = re.compile(r"curl\b[^\n|]*\|\s*(?:ba)?sh\b")
+UNPINNED_PIP_UV_RE = re.compile(r"\bpip\s+install\b[^\n]*\buv\b")
+
+
+def _load_workflow(path: Path) -> dict[str, object]:
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{path} must parse as a YAML mapping"
+    return parsed
+
+
+def _iter_steps(value: object) -> list[dict[str, object]]:
+    steps: list[dict[str, object]] = []
+    if isinstance(value, dict):
+        if isinstance(value.get("steps"), list):
+            steps.extend(step for step in value["steps"] if isinstance(step, dict))
+        for child in value.values():
+            steps.extend(_iter_steps(child))
+    elif isinstance(value, list):
+        for child in value:
+            steps.extend(_iter_steps(child))
+    return steps
+
+
+@pytest.mark.parametrize("workflow_name", OWNED_WORKFLOWS)
+def test_owned_workflows_do_not_install_uv_with_curl_pipe_shell(workflow_name: str) -> None:
+    """Owned workflows must not pipe a live installer script into a shell."""
+    workflow = WORKFLOWS_DIR / workflow_name
+    text = workflow.read_text(encoding="utf-8")
+    assert not CURL_PIPE_SH_RE.search(text), f"{workflow_name} must not install uv with `curl ... | sh`"
+
+
+@pytest.mark.parametrize("workflow_name", OWNED_WORKFLOWS)
+def test_owned_workflows_do_not_install_uv_with_unpinned_pip(workflow_name: str) -> None:
+    """Owned workflows must not install uv from an unpinned pip requirement."""
+    workflow = WORKFLOWS_DIR / workflow_name
+    text = workflow.read_text(encoding="utf-8")
+    assert not UNPINNED_PIP_UV_RE.search(text), f"{workflow_name} must not install uv with unpinned pip"
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    (
+        "docs-observability-snapshot.yml",
+        "pr-observability-summary.yml",
+        "glitchtip-ingester.yml",
+        "nightly-canary.yml",
+        "sweep-sonar-findings.yml",
+    ),
+)
+def test_project_install_workflows_use_local_bootstrap_action(workflow_name: str) -> None:
+    """Project install workflows must use the repo bootstrap action for uv setup."""
+    workflow = WORKFLOWS_DIR / workflow_name
+    steps = _iter_steps(_load_workflow(workflow))
+    uses_values = [step.get("uses") for step in steps]
+    assert "./.github/actions/bootstrap" in uses_values


### PR DESCRIPTION
## Summary
- Replace the live uv shell installer in the Sonar fallback with the repo bootstrap action.
- Replace unpinned `pip install uv` in the owned workflows with the local bootstrap action.
- Add structural tests for owned workflow uv installer patterns.

## Root cause
The affected workflows installed uv through floating runtime installer paths instead of the pinned repo setup path.

## Tests
- `uv run pytest tests/unit/test_workflow_uv_installers_yaml.py -q`
- `uv run pytest tests/unit/test_workflow_uv_installers_yaml.py tests/unit/test_sonar_scan_workflow_yaml.py tests/unit/sweep/test_sweep_sonar_workflow_yaml.py -q`
- `uv run ruff check tests/unit/test_workflow_uv_installers_yaml.py tests/unit/sweep/test_sweep_sonar_workflow_yaml.py`
- `git diff --check`
- `actionlint .github/workflows/sonar-scan.yml .github/workflows/docs-observability-snapshot.yml .github/workflows/pr-observability-summary.yml .github/workflows/glitchtip-ingester.yml .github/workflows/nightly-canary.yml .github/workflows/sweep-sonar-findings.yml`