### PR TITLE
chore(release): bump version to 2.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.6.0"
+version = "2.6.1"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -279,7 +279,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.6.0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Bumps `pyproject.toml` 2.6.0 -> 2.6.1.

Releases the fixes merged to main since v2.6.0 (20 commits): lineage, CAS read verification, Merkle seal hardening, WAL, deterministic replay ordering, audit chain, worktree reaping safety, schedule projection, and approval-gate wiring.

On merge, `auto-release.yml` detects the untagged version, pushes tag `v2.6.1`, then `publish.yml` (PyPI / npm / GitHub Release) and `publish-docker.yml` (GHCR) ship the artefacts.

Single-line change. `__version__` is derived dynamically from package metadata; the npm version is synced from the tag at publish time, so no other version files need touching.