### PR TITLE
Fix task_type validation for task creation

### DIFF
--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -75,12 +75,14 @@ def _ensure_task_enum(value: str, field_name: str) -> str:
     """
     from bernstein.core.tasks.models import Complexity, Scope, TaskType
 
-    enum_classes = {
-        "complexity": Complexity,
-        "scope": Scope,
-        "task_type": TaskType,
-    }
-    enum_cls = enum_classes[field_name]
+    if field_name == "complexity":
+        enum_cls = Complexity
+    elif field_name == "scope":
+        enum_cls = Scope
+    elif field_name == "task_type":
+        enum_cls = TaskType
+    else:
+        raise ValueError(f"unsupported enum field: {field_name}")
     try:
         enum_cls(value)
     except ValueError:

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -10,8 +10,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
-from bernstein.core.bulletin import MessageType  # noqa: TC001 - Pydantic needs at runtime
-from bernstein.core.task_store import ProgressEntry  # noqa: TC001 - Pydantic needs at runtime
+from bernstein.core.communication.bulletin import MessageType  # noqa: TC001 - Pydantic needs at runtime
+from bernstein.core.tasks.task_store import ProgressEntry
 
 # ---------------------------------------------------------------------------
 # Pydantic request / response schemas
@@ -65,17 +65,22 @@ def _enforce_dict_size(value: dict[str, Any] | None, *, field_name: str) -> dict
 
 
 def _ensure_task_enum(value: str, field_name: str) -> str:
-    """Reject scope/complexity values outside their Task enum at the API boundary.
+    """Reject task enum values outside their valid set at the API boundary.
 
     These fields stay typed as ``str`` for backward compatibility, so without
     this check an out-of-range value (e.g. ``""``) passes pydantic and then
-    raises ``ValueError`` deep in the task store when ``Scope(value)`` /
-    ``Complexity(value)`` is constructed, surfacing as an unhandled 500.
+    raises ``ValueError`` deep in the task store when the corresponding enum is
+    constructed, surfacing as an unhandled 500.
     Raising here turns that into a 422.
     """
-    from bernstein.core.tasks.models import Complexity, Scope
+    from bernstein.core.tasks.models import Complexity, Scope, TaskType
 
-    enum_cls = Scope if field_name == "scope" else Complexity
+    enum_classes = {
+        "complexity": Complexity,
+        "scope": Scope,
+        "task_type": TaskType,
+    }
+    enum_cls = enum_classes[field_name]
     try:
         enum_cls(value)
     except ValueError:
@@ -111,7 +116,10 @@ class TaskCreate(BaseModel):
     effort: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)  # "max", "high", "medium", "low"
     cli: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)  # adapter override: "claude", "opencode", …
     batch_eligible: bool = False  # Non-urgent: eligible for provider batch APIs at ~50% cost
-    completion_signals: list[CompletionSignalSchema] = Field(default_factory=list, max_length=_MAX_LIST_LEN)
+    completion_signals: list[CompletionSignalSchema] = Field(
+        default_factory=lambda: list[CompletionSignalSchema](),
+        max_length=_MAX_LIST_LEN,
+    )
     slack_context: dict[str, Any] | None = None  # Slack slash command metadata
     metadata: dict[str, Any] = Field(default_factory=dict)  # Trigger-source metadata (e.g. issue_number)
     deadline: float | None = None  # Epoch timestamp when task must be complete
@@ -126,9 +134,9 @@ class TaskCreate(BaseModel):
     max_output_tokens: int | None = None  # Per-task output-token cap (escalated on retry)
     meta_messages: list[str] | None = Field(default=None, max_length=_MAX_LIST_LEN)
 
-    @field_validator("scope", "complexity")
+    @field_validator("scope", "complexity", "task_type")
     @classmethod
-    def _validate_scope_complexity(cls, value: str, info: ValidationInfo) -> str:
+    def _validate_task_enums(cls, value: str, info: ValidationInfo) -> str:
         return _ensure_task_enum(value, info.field_name or "")
 
     # cap serialized size of dict-of-any fields to block deeply-nested
@@ -214,7 +222,7 @@ class TaskResponse(BaseModel):
     created_at: float
     claimed_at: float | None = None
     deadline: float | None = None
-    progress_log: list[ProgressEntry] = Field(default_factory=list)
+    progress_log: list[ProgressEntry] = Field(default_factory=lambda: list[ProgressEntry]())
     version: int = 1
     parent_session_id: str | None = None  # Coordinator session that owns this task
     # Retry bookkeeping: typed fields are the single source of truth.

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -402,6 +402,22 @@ def test_post_tasks_empty_complexity_returns_422_not_500(_app_with_auth_disabled
     assert asyncio.run(_run()) == 422
 
 
+def test_post_tasks_empty_task_type_returns_422_not_500(_app_with_auth_disabled) -> None:
+    """POST /tasks with task_type="" must 422, never 500 (regression)."""
+    transport = ASGITransport(app=_app_with_auth_disabled)
+    import asyncio
+
+    async def _run() -> int:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/tasks",
+                json={"title": "x", "description": "x", "task_type": ""},
+            )
+            return resp.status_code
+
+    assert asyncio.run(_run()) == 422
+
+
 def test_post_tasks_batch_invalid_scope_returns_422_not_500(_app_with_auth_disabled) -> None:
     """POST /tasks/batch with an invalid scope must 422, never 500 (regression)."""
     transport = ASGITransport(app=_app_with_auth_disabled)

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -12,7 +12,7 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
 from fastapi import FastAPI
@@ -26,6 +26,25 @@ from bernstein.core.server.server_app import (
     create_app,
 )
 from bernstein.core.server.server_models import TaskCreate
+
+
+class TaskPostPayload(TypedDict, total=False):
+    title: str
+    description: str
+    role: str
+    complexity: str
+    task_type: str
+
+
+class TaskBatchItemPayload(TypedDict, total=False):
+    title: str
+    description: str
+    scope: str
+
+
+class TaskBatchPayload(TypedDict):
+    tasks: list[TaskBatchItemPayload]
+
 
 # ---------------------------------------------------------------------------
 # TaskCreate pydantic caps
@@ -333,9 +352,14 @@ def test_post_tasks_200kb_description_returns_422(_app_with_auth_disabled) -> No
 
     async def _run() -> int:
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            payload: TaskPostPayload = {
+                "title": "big",
+                "description": "z" * 200_000,
+                "role": "backend",
+            }
             resp = await client.post(
                 "/tasks",
-                json={"title": "big", "description": "z" * 200_000, "role": "backend"},
+                json=payload,
             )
             return resp.status_code
 
@@ -371,9 +395,14 @@ def test_post_tasks_small_payload_still_works(_app_with_auth_disabled) -> None:
 
     async def _run() -> tuple[int, dict[str, Any]]:
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            payload: TaskPostPayload = {
+                "title": "ok",
+                "description": "normal task",
+                "role": "backend",
+            }
             resp = await client.post(
                 "/tasks",
-                json={"title": "ok", "description": "normal task", "role": "backend"},
+                json=payload,
             )
             return resp.status_code, resp.json()
 
@@ -393,9 +422,14 @@ def test_post_tasks_empty_complexity_returns_422_not_500(_app_with_auth_disabled
 
     async def _run() -> int:
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            payload: TaskPostPayload = {
+                "title": "x",
+                "description": "x",
+                "complexity": "",
+            }
             resp = await client.post(
                 "/tasks",
-                json={"title": "x", "description": "x", "complexity": ""},
+                json=payload,
             )
             return resp.status_code
 
@@ -409,9 +443,14 @@ def test_post_tasks_empty_task_type_returns_422_not_500(_app_with_auth_disabled)
 
     async def _run() -> int:
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            payload: TaskPostPayload = {
+                "title": "x",
+                "description": "x",
+                "task_type": "",
+            }
             resp = await client.post(
                 "/tasks",
-                json={"title": "x", "description": "x", "task_type": ""},
+                json=payload,
             )
             return resp.status_code
 
@@ -425,9 +464,12 @@ def test_post_tasks_batch_invalid_scope_returns_422_not_500(_app_with_auth_disab
 
     async def _run() -> int:
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            payload: TaskBatchPayload = {
+                "tasks": [{"title": "x", "description": "x", "scope": "nope"}],
+            }
             resp = await client.post(
                 "/tasks/batch",
-                json={"tasks": [{"title": "x", "description": "x", "scope": "nope"}]},
+                json=payload,
             )
             return resp.status_code
 


### PR DESCRIPTION
## Summary
- Reject invalid task_type values at the Pydantic request boundary.
- Keep invalid task creation requests as 422 responses instead of task-store ValueError 500s.
- Add regression coverage for empty task_type on POST /tasks.

## Validation
- uv run pytest tests/unit/test_task_create_bounds.py -q
- SCHEMATHESIS_PROFILE=smoke uv run pytest tests/contract/test_task_server_schemathesis.py -q
- uv run ruff check src/bernstein/core/server/server_models.py tests/unit/test_task_create_bounds.py
- uv run pyright src/bernstein/core/server/server_models.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API now properly validates the task type field and returns the correct error status code for invalid submissions instead of server errors, improving error handling clarity.

* **Tests**
  * Added validation regression test to ensure proper error handling for invalid task type values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->