### PR TITLE
Harden issue decomposition trust boundary

### DIFF
--- a/.github/workflows/bernstein-issues-decompose.yml
+++ b/.github/workflows/bernstein-issues-decompose.yml
@@ -1,7 +1,9 @@
 name: "Bernstein Issue Decompose"
 
-# Trigger: when an issue is labeled with "bernstein", decompose it into
-# agent tasks and open a pull request with the implementation.
+# Trigger: when a trusted-author issue is labeled with "bernstein",
+# decompose it into agent tasks and open a pull request with the
+# implementation. Issues from external authors are acknowledged by a
+# deterministic job and are not passed to the write-scoped agent job.
 on:
   issues:
     types: [labeled]
@@ -20,7 +22,9 @@ jobs:
     name: Decompose issue with Bernstein
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: github.event.label.name == 'bernstein'
+    if: >-
+      github.event.label.name == 'bernstein' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
     permissions:
       contents: write
       issues: write
@@ -65,3 +69,22 @@ jobs:
           gh issue edit ${{ github.event.issue.number }} \
             --remove-label "bernstein" \
             --add-label "bernstein:in-progress" 2>/dev/null || true
+
+  reject-untrusted-issue:
+    name: Reject untrusted issue decomposition
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event.label.name == 'bernstein' &&
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+    permissions:
+      issues: write
+    steps:
+      - name: Remove automation label and explain skip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --remove-label "bernstein" 2>/dev/null || true
+          gh issue comment "$ISSUE_NUMBER" \
+            --body "Bernstein issue decomposition was not started because the issue author is not a repository collaborator. A maintainer can run it from a trusted issue after review."

--- a/tests/unit/test_issue_decompose_workflow_yaml.py
+++ b/tests/unit/test_issue_decompose_workflow_yaml.py
@@ -1,0 +1,84 @@
+"""Structural assertions for the issue decomposition workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+WorkflowStep = TypedDict(
+    "WorkflowStep",
+    {
+        "name": object,
+        "uses": object,
+        "run": object,
+        "env": object,
+        "with": object,
+    },
+    total=False,
+)
+
+WorkflowJob = TypedDict(
+    "WorkflowJob",
+    {
+        "if": object,
+        "permissions": object,
+        "steps": list[object],
+    },
+    total=False,
+)
+
+
+class WorkflowFile(TypedDict, total=False):
+    jobs: dict[str, WorkflowJob]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "bernstein-issues-decompose.yml"
+
+
+def _load() -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _job(name: str) -> WorkflowJob:
+    jobs = _load().get("jobs", {})
+    assert isinstance(jobs, dict)
+    job = jobs.get(name)
+    assert isinstance(job, dict), f"expected job {name!r}"
+    return job
+
+
+def _steps(job: WorkflowJob) -> list[WorkflowStep]:
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    return [cast("WorkflowStep", step) for step in steps if isinstance(step, dict)]
+
+
+def test_decompose_job_requires_trusted_issue_author() -> None:
+    job = _job("decompose")
+    condition = job.get("if", "")
+
+    assert isinstance(condition, str)
+    assert "github.event.label.name == 'bernstein'" in condition
+    assert "github.event.issue.author_association" in condition
+    assert "OWNER" in condition
+    assert "MEMBER" in condition
+    assert "COLLABORATOR" in condition
+
+
+def test_untrusted_issue_path_does_not_run_agent_or_receive_llm_secret() -> None:
+    job = _job("reject-untrusted-issue")
+    condition = job.get("if", "")
+    permissions = job.get("permissions", {})
+
+    assert isinstance(condition, str)
+    assert "github.event.issue.author_association" in condition
+    assert isinstance(permissions, dict)
+    assert permissions == {"issues": "write"}
+
+    for step in _steps(job):
+        assert step.get("uses") != "./"
+        env = step.get("env", {})
+        assert not isinstance(env, dict) or "ANTHROPIC_API_KEY" not in env


### PR DESCRIPTION
## Summary
- Restrict the issue decomposition agent job to trusted issue authors.
- Add a deterministic untrusted-author path that removes the automation label and comments without invoking the local action.
- Add workflow-shape tests for the trusted and untrusted paths.

## Validation
- uv run pytest tests/unit/test_issue_decompose_workflow_yaml.py -q
- uv run ruff check tests/unit/test_issue_decompose_workflow_yaml.py
- uv run pyright tests/unit/test_issue_decompose_workflow_yaml.py
- actionlint .github/workflows/bernstein-issues-decompose.yml
- git diff --check