### PR TITLE
Audit release assets during reconciliation

### DIFF
--- a/.github/workflows/reconcile-release.yml
+++ b/.github/workflows/reconcile-release.yml
@@ -42,9 +42,10 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Compare versions
+      - name: Compare versions and release assets
         id: cmp
         env:
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           python3 - <<'PY' >> "${GITHUB_OUTPUT}"
@@ -82,6 +83,33 @@ jobs:
           pj_t = parse_version(pj_version)
           pypi_t = parse_version(pypi_version)
 
+          release_tag = f"v{pj_version}"
+          release_assets = subprocess.run(
+              [
+                  "gh",
+                  "release",
+                  "view",
+                  release_tag,
+                  "--repo",
+                  os.environ["REPO"],
+                  "--json",
+                  "assets",
+                  "--jq",
+                  ".assets | length",
+              ],
+              check=False,
+              capture_output=True,
+              text=True,
+          )
+          release_exists = release_assets.returncode == 0
+          asset_count = 0
+          if release_exists:
+              try:
+                  asset_count = int(release_assets.stdout.strip())
+              except ValueError:
+                  print(f"::error::could not parse GitHub Release asset count for {release_tag}")
+                  sys.exit(1)
+
           # Age of the pyproject.toml change (when did the version line last move?).
           # We use git blame on the version line; the diff threshold is >24h.
           blame = subprocess.run(
@@ -96,8 +124,15 @@ jobs:
           print(f"pj_version={pj_version}")
           print(f"pypi_version={pypi_version}")
           print(f"pj_age_hours={pj_age_hours}")
+          print(f"release_exists={'true' if release_exists else 'false'}")
+          print(f"asset_count={asset_count}")
 
-          drift = pj_t > pypi_t and pj_age_hours >= 24
+          version_drift = pj_t > pypi_t and pj_age_hours >= 24
+          missing_assets = release_exists and asset_count == 0
+          print(f"version_drift={'true' if version_drift else 'false'}")
+          print(f"missing_assets={'true' if missing_assets else 'false'}")
+
+          drift = version_drift or missing_assets
           print(f"drift={'true' if drift else 'false'}")
           PY
 
@@ -131,14 +166,23 @@ jobs:
           PJ: ${{ steps.cmp.outputs.pj_version }}
           PYPI: ${{ steps.cmp.outputs.pypi_version }}
           AGE: ${{ steps.cmp.outputs.pj_age_hours }}
+          RELEASE_EXISTS: ${{ steps.cmp.outputs.release_exists }}
+          ASSET_COUNT: ${{ steps.cmp.outputs.asset_count }}
+          MISSING_ASSETS: ${{ steps.cmp.outputs.missing_assets }}
           REPO: ${{ github.repository }}
         run: |
           TITLE="release drift: pyproject=\`${PJ}\` pypi=\`${PYPI}\`"
-          BODY=$(printf 'Detected by `.github/workflows/reconcile-release.yml`.\n\n- pyproject.toml on main: **%s**\n- latest on PyPI: **%s**\n- age of pyproject bump: %sh\n\nLikely cause: a CI run was cancelled/timed_out/action_required so `auto-release.yml` silently skipped the publish (see #1273).\n\nRun `gh workflow run reconcile-release.yml` after fixing to clear.\n' \
-            "${PJ}" "${PYPI}" "${AGE}")
+          if [ "${MISSING_ASSETS}" = "true" ]; then
+            CAUSE="GitHub Release missing dist assets."
+          else
+            CAUSE="Likely cause: a CI run was cancelled/timed_out/action_required so \`auto-release.yml\` silently skipped the publish (see #1273)."
+          fi
+          # shellcheck disable=SC2016
+          BODY=$(printf 'Detected by `.github/workflows/reconcile-release.yml`.\n\n- pyproject.toml on main: **%s**\n- latest on PyPI: **%s**\n- age of pyproject bump: %sh\n- GitHub Release exists: **%s**\n- GitHub Release asset count: **%s**\n\n%s\n\nRun `gh workflow run reconcile-release.yml` after fixing to clear.\n' \
+            "${PJ}" "${PYPI}" "${AGE}" "${RELEASE_EXISTS}" "${ASSET_COUNT}" "${CAUSE}")
 
           # Idempotency: search for an open issue whose title matches the
-          # exact pyproject↔pypi pair. Re-runs the same day just comment.
+          # exact pyproject/pypi pair. Re-runs the same day just comment.
           EXISTING=$(gh issue list --repo "${REPO}" --state open \
             --search "in:title release drift pyproject=${PJ} pypi=${PYPI}" \
             --json number,title \
@@ -193,5 +237,7 @@ jobs:
         env:
           PJ_VERSION: ${{ steps.cmp.outputs.pj_version }}
           PYPI_VERSION: ${{ steps.cmp.outputs.pypi_version }}
+          ASSET_COUNT: ${{ steps.cmp.outputs.asset_count }}
+          MISSING_ASSETS: ${{ steps.cmp.outputs.missing_assets }}
         run: |
-          echo "::notice::No release drift detected (pyproject=${PJ_VERSION}, pypi=${PYPI_VERSION})."
+          echo "::notice::No release drift detected (pyproject=${PJ_VERSION}, pypi=${PYPI_VERSION}, assets=${ASSET_COUNT}, missing_assets=${MISSING_ASSETS})."

--- a/tests/unit/test_reconcile_release_workflow_yaml.py
+++ b/tests/unit/test_reconcile_release_workflow_yaml.py
@@ -1,0 +1,103 @@
+"""Structural assertions for the release reconciliation workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+WorkflowStep = TypedDict(
+    "WorkflowStep",
+    {
+        "name": object,
+        "id": object,
+        "if": object,
+        "env": object,
+        "run": object,
+    },
+    total=False,
+)
+
+
+class WorkflowJob(TypedDict, total=False):
+    steps: list[object]
+    permissions: dict[str, object]
+
+
+class WorkflowFile(TypedDict, total=False):
+    jobs: dict[str, WorkflowJob]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "reconcile-release.yml"
+
+
+def _load() -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _steps() -> list[WorkflowStep]:
+    jobs = _load().get("jobs", {})
+    assert isinstance(jobs, dict)
+    job = jobs.get("reconcile")
+    assert isinstance(job, dict), "expected reconcile job"
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    return [cast("WorkflowStep", step) for step in steps if isinstance(step, dict)]
+
+
+def _step(name: str) -> WorkflowStep:
+    match = next((step for step in _steps() if step.get("name") == name), None)
+    assert match is not None, f"expected step {name!r}"
+    return match
+
+
+def _run(step: WorkflowStep) -> str:
+    run = step.get("run", "")
+    assert isinstance(run, str)
+    return run
+
+
+def test_compare_step_audits_github_release_assets() -> None:
+    """Release reconciliation must detect tag releases that exist without dist assets."""
+    run = _run(_step("Compare versions and release assets"))
+
+    assert '"gh",' in run
+    assert '"release",' in run
+    assert '"view",' in run
+    assert '"--json",' in run
+    assert '"assets",' in run
+    assert "asset_count" in run
+    assert "missing_assets = release_exists and asset_count == 0" in run
+    assert "missing_assets=" in run
+    assert "drift = version_drift or missing_assets" in run
+
+
+def test_drift_issue_includes_missing_asset_context() -> None:
+    """The tracking issue should open for missing assets and include asset evidence."""
+    step = _step("Open or update drift issue (idempotent)")
+    condition = step.get("if", "")
+    assert isinstance(condition, str)
+    assert "steps.cmp.outputs.drift == 'true'" in condition
+
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+    assert "MISSING_ASSETS" in env
+    assert "ASSET_COUNT" in env
+
+    run = _run(step)
+    assert "GitHub Release missing dist assets" in run
+    assert "GitHub Release asset count" in run
+
+
+def test_no_drift_notice_reports_asset_count() -> None:
+    """A clean reconciliation should make the checked asset count visible in logs."""
+    step = _step("No drift")
+    env = step.get("env", {})
+    assert isinstance(env, dict)
+    assert "ASSET_COUNT" in env
+    assert "MISSING_ASSETS" in env
+
+    run = _run(step)
+    assert "assets=${ASSET_COUNT}" in run


### PR DESCRIPTION
## What
- Makes reconcile-release check the GitHub Release asset count for the current pyproject version.
- Opens the existing release-drift path when a published release exists without dist assets.
- Adds structural tests for the asset audit outputs and issue context.

## Why
- Addresses #1827 F-035 by making release reconciliation check missing release assets, not only PyPI version drift.

## Verification
- uv run pytest tests/unit/test_reconcile_release_workflow_yaml.py -q
- uv run ruff check tests/unit/test_reconcile_release_workflow_yaml.py
- uv run pyright tests/unit/test_reconcile_release_workflow_yaml.py
- actionlint .github/workflows/reconcile-release.yml
- git diff --check