### PR TITLE
Add branch protection audit

### DIFF
--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -1,0 +1,152 @@
+name: Branch protection audit
+
+# Read live branch protection for `main` and compare its required status
+# checks with the in-tree required-check canary expectation. This catches
+# repository-setting drift that workflow-file tests cannot see.
+
+on:
+  schedule:
+    - cron: "37 8 * * 2"  # Weekly, Tuesday 08:37 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: branch-protection-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  audit:
+    name: Branch protection audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Read live branch protection
+        run: |
+          set -euo pipefail
+
+          set +e
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${GITHUB_REPOSITORY}/branches/main/protection" \
+            > branch-protection.json \
+            2> branch-protection.err
+          gh_status=$?
+          set -e
+
+          if [ "${gh_status}" -ne 0 ]; then
+            echo "::error::Unable to read live branch protection for main with GITHUB_TOKEN."
+            echo "::error::GitHub API exit code: ${gh_status}"
+            if [ -s branch-protection.err ]; then
+              while IFS= read -r line; do
+                echo "::error::${line}"
+              done < branch-protection.err
+            fi
+            exit 1
+          fi
+
+      - name: Compare live required contexts with canary
+        run: |
+          python3 - <<'PY'
+          """Compare live required status checks with canary expectations."""
+          from __future__ import annotations
+
+          import json
+          import sys
+          from pathlib import Path
+
+          CANARY = Path(".github/workflows/required-check-canary.yml")
+          PROTECTION = Path("branch-protection.json")
+
+          def fail(message: str) -> None:
+              print(f"::error::{message}")
+              sys.exit(1)
+
+          def read_expected_contexts(path: Path) -> set[str]:
+              if not path.exists():
+                  fail(f"{path} not found")
+
+              for line in path.read_text(encoding="utf-8").splitlines():
+                  stripped = line.strip()
+                  if not stripped.startswith("BRANCH_PROTECTION_CONTEXTS_JSON:"):
+                      continue
+
+                  raw = stripped.split(":", 1)[1].strip()
+                  if raw.startswith(('"', "'")) and raw.endswith(raw[0]):
+                      raw = raw[1:-1]
+                  try:
+                      parsed = json.loads(raw)
+                  except json.JSONDecodeError as exc:
+                      fail(f"{path} has invalid BRANCH_PROTECTION_CONTEXTS_JSON: {exc}")
+                  if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+                      fail(f"{path} BRANCH_PROTECTION_CONTEXTS_JSON must be a JSON string list")
+                  contexts = {item for item in parsed if item}
+                  if contexts:
+                      return contexts
+
+              fail(f"{path} does not define BRANCH_PROTECTION_CONTEXTS_JSON")
+              raise AssertionError("unreachable")
+
+          expected = read_expected_contexts(CANARY)
+
+          try:
+              protection = json.loads(PROTECTION.read_text(encoding="utf-8"))
+          except json.JSONDecodeError as exc:
+              fail(f"Live branch protection response is not valid JSON: {exc}")
+
+          if not isinstance(protection, dict):
+              fail("Live branch protection response is not a JSON object")
+
+          required_status_checks = protection.get("required_status_checks")
+          if not isinstance(required_status_checks, dict):
+              fail("Live branch protection for main has no required_status_checks object")
+
+          live: set[str] = set()
+
+          contexts = required_status_checks.get("contexts", [])
+          if isinstance(contexts, list):
+              live.update(context for context in contexts if isinstance(context, str))
+
+          checks = required_status_checks.get("checks", [])
+          if isinstance(checks, list):
+              for check in checks:
+                  if not isinstance(check, dict):
+                      continue
+                  context = check.get("context", check.get("name"))
+                  if isinstance(context, str):
+                      live.add(context)
+
+          if not live:
+              fail("Live branch protection for main has zero required status check contexts")
+
+          missing = sorted(expected - live)
+          extra = sorted(live - expected)
+
+          print("Branch protection audit")
+          print(f"  expected contexts: {sorted(expected)}")
+          print(f"  live contexts    : {sorted(live)}")
+
+          if missing or extra:
+              print("::error::Live branch protection required contexts differ from required-check canary")
+              if missing:
+                  print(f"::error::missing from live protection: {missing}")
+              if extra:
+                  print(f"::error::extra in live protection: {extra}")
+              sys.exit(1)
+
+          print("Live branch protection required contexts match required-check canary.")
+          PY

--- a/.github/workflows/required-check-canary.yml
+++ b/.github/workflows/required-check-canary.yml
@@ -1,11 +1,9 @@
 name: Required-check name canary
 
-# Branch protection on `main` requires a single context named `CI gate`,
-# emitted by the `ci-gate` job in `.github/workflows/ci.yml`. If a future
-# refactor renames the job key, edits its `name:`, or adds a second job
-# that also produces a `CI gate` check, the required-context rule
-# silently weakens -- GitHub treats an unknown required-context name as
-# pass-through, so PRs would merge without the rolled-up gate signal.
+# Branch protection on `main` requires `CI gate` and `review-bot-ack`.
+# This workflow verifies the in-tree `CI gate` emitters. The scheduled
+# branch-protection audit reads `BRANCH_PROTECTION_CONTEXTS_JSON` below
+# and compares it with live repository settings.
 #
 # This canary fails the PR (and the weekly scheduled run) if any of the
 # locked invariants drifts. It is intentionally narrow: it does not try
@@ -63,6 +61,7 @@ jobs:
       - name: Verify required-check invariants
         env:
           REQUIRED_CONTEXT: "CI gate"
+          BRANCH_PROTECTION_CONTEXTS_JSON: '["CI gate","review-bot-ack"]'
           REQUIRED_JOB_KEY: "ci-gate"
           MACOS_JOB_KEY: "test-macos"
           MACOS_JOB_NAME: "Test (macos-latest, Python 3.13)"

--- a/tests/unit/test_branch_protection_audit_workflow_yaml.py
+++ b/tests/unit/test_branch_protection_audit_workflow_yaml.py
@@ -1,0 +1,134 @@
+"""Structural assertions for the branch protection audit workflow."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+
+class WorkflowJob(TypedDict, total=False):
+    name: object
+    permissions: dict[str, object]
+    env: dict[str, object]
+    steps: list[object]
+
+
+class WorkflowFile(TypedDict, total=False):
+    on: object
+    permissions: object
+    jobs: dict[str, WorkflowJob]
+
+
+WORKFLOW = Path(".github/workflows/branch-protection-audit.yml")
+CANARY = Path(".github/workflows/required-check-canary.yml")
+REQUIRED_CONTEXTS = {"CI gate", "review-bot-ack"}
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _workflow() -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(_workflow_text()))
+
+
+def _on(workflow: WorkflowFile) -> dict[str, object]:
+    # PyYAML 1.1 parses bare ``on:`` as boolean True; tolerate both.
+    raw_workflow = cast("dict[object, object]", workflow)
+    value = raw_workflow.get(True, workflow.get("on"))
+    assert isinstance(value, dict), "workflow must define triggers"
+    return cast("dict[str, object]", value)
+
+
+def _audit_job(workflow: WorkflowFile) -> WorkflowJob:
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict), "workflow must define jobs"
+    job = jobs.get("audit")
+    assert isinstance(job, dict), "workflow must define an audit job"
+    return job
+
+
+def _canary_expected_contexts() -> set[str]:
+    canary = cast("dict[str, object]", yaml.safe_load(CANARY.read_text(encoding="utf-8")))
+    jobs = canary.get("jobs")
+    assert isinstance(jobs, dict)
+    job_map = cast("dict[str, object]", jobs)
+    verify = job_map.get("verify")
+    assert isinstance(verify, dict)
+    verify_map = cast("dict[str, object]", verify)
+    steps = verify_map.get("steps")
+    assert isinstance(steps, list)
+    for step_value in cast("list[object]", steps):
+        if not isinstance(step_value, dict):
+            continue
+        step = cast("dict[str, object]", step_value)
+        if step.get("name") != "Verify required-check invariants":
+            continue
+        env = step.get("env")
+        assert isinstance(env, dict)
+        env_map = cast("dict[str, object]", env)
+        raw = env_map.get("BRANCH_PROTECTION_CONTEXTS_JSON")
+        assert isinstance(raw, str)
+        parsed = json.loads(raw)
+        assert isinstance(parsed, list)
+        parsed_items = cast("list[object]", parsed)
+        assert all(isinstance(item, str) for item in parsed_items)
+        return {cast("str", item) for item in parsed_items}
+    raise AssertionError("canary must define BRANCH_PROTECTION_CONTEXTS_JSON")
+
+
+def test_branch_protection_audit_workflow_exists() -> None:
+    assert WORKFLOW.exists(), "branch-protection-audit.yml is missing"
+
+
+def test_branch_protection_audit_is_scheduled_and_manual_only() -> None:
+    triggers = _on(_workflow())
+    assert "schedule" in triggers, "audit must run on a schedule"
+    assert "workflow_dispatch" in triggers, "audit must be manually runnable"
+    assert "pull_request" not in triggers, "live branch protection audit must not run on untrusted PR events"
+    assert "push" not in triggers, "live branch protection audit must not run on every push"
+
+    schedule = triggers["schedule"]
+    assert isinstance(schedule, list)
+    assert schedule, "scheduled audit must include at least one cron entry"
+
+
+def test_branch_protection_audit_permissions_are_read_only() -> None:
+    workflow = _workflow()
+    assert workflow.get("permissions") in ({}, "{}"), "workflow-level permissions must be default-deny"
+    assert _audit_job(workflow).get("permissions") == {"contents": "read"}
+
+
+def test_branch_protection_audit_reads_main_protection_without_mutating() -> None:
+    workflow_text = _workflow_text()
+    assert "gh api" in workflow_text, "audit must read live branch protection through the GitHub API"
+    assert "repos/${GITHUB_REPOSITORY}/branches/main/protection" in workflow_text
+    assert not re.search(r"\b(?:POST|PUT|PATCH|DELETE)\b", workflow_text), "audit workflow must not mutate settings"
+    assert "--method" not in workflow_text
+    assert " -X " not in workflow_text
+
+
+def test_branch_protection_audit_compares_live_contexts_with_canary_expectations() -> None:
+    workflow_text = _workflow_text()
+    canary_text = CANARY.read_text(encoding="utf-8")
+
+    assert _canary_expected_contexts() == REQUIRED_CONTEXTS
+    assert "BRANCH_PROTECTION_CONTEXTS_JSON" in canary_text
+    assert "required-check-canary.yml" in workflow_text
+    assert "BRANCH_PROTECTION_CONTEXTS_JSON" in workflow_text
+    assert "required_status_checks" in workflow_text
+    assert "contexts" in workflow_text
+    assert "checks" in workflow_text
+    assert "missing" in workflow_text
+    assert "extra" in workflow_text
+
+
+def test_branch_protection_audit_fails_when_live_protection_is_unreadable() -> None:
+    workflow_text = _workflow_text()
+    assert "::error::Unable to read live branch protection for main" in workflow_text
+    assert "exit 1" in workflow_text
+    assert "continue-on-error: true" not in workflow_text


### PR DESCRIPTION
## What
- Adds a scheduled and manual read-only audit for live main branch protection required contexts.
- Records the expected required-context set in the existing required-check canary.
- Adds structural tests for triggers, permissions, API read behavior, context comparison, and fail-closed handling.

## Why
- Addresses #1827 F-020 by checking live branch protection settings, not only workflow file names.

## Verification
- Live branch protection read: CI gate, review-bot-ack
- uv run pytest tests/unit/test_branch_protection_audit_workflow_yaml.py tests/unit/test_required_check_canary_workflow_yaml.py -q
- uv run ruff check tests/unit/test_branch_protection_audit_workflow_yaml.py tests/unit/test_required_check_canary_workflow_yaml.py
- uv run pyright tests/unit/test_branch_protection_audit_workflow_yaml.py
- actionlint .github/workflows/branch-protection-audit.yml .github/workflows/required-check-canary.yml
- git diff --check