### PR TITLE
Separate advisory reports from CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,7 +480,7 @@ jobs:
   # ─── Medium checks (cancel old runs, 5-20 min) ────────────────────────
 
   typecheck:
-    name: Type check
+    name: Type check report
     needs: [lint]  # only run if lint passes (fast-fail)
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -998,10 +998,10 @@ jobs:
             -k 'lineage_signer or lineage_record or lineage_export'
 
   mutmut-diff:
-    # Mutation testing on PR-changed files only. Computes a mutation
-    # score over the lines actually touched in this PR. Fails when
-    # the score on changed lines is below 70%.
-    name: Mutation (diff-only)
+    # Mutation testing report on PR-changed files only. Computes a
+    # mutation score over the lines actually touched in this PR.
+    # Advisory until the command is allowed to fail this job.
+    name: Mutation report (diff-only)
     needs: [lint]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1057,20 +1057,18 @@ jobs:
           uv run mutmut results || true
 
   diff-coverage:
-    # LEVEL 1 of the coverage ratchet - diff-cover gate: lines touched in
-    # this PR must hit the committed diff-coverage floor. The floor lives
+    # LEVEL 1 of the coverage ratchet - diff-cover report: lines touched in
+    # this PR are compared with the committed diff-coverage floor. The floor lives
     # in .coverage-baseline.json (key: diff_coverage_floor_percent) so it
     # is a single source of truth that the weekly bump workflow nudges up
     # over time (see docs/operations/coverage-ratchet.md). Reuses the
     # coverage.xml uploaded by the main test job.
     #
-    # ADVISORY: the diff-cover step is continue-on-error, so this job's
+    # ADVISORY: the diff-cover step is continue-on-error, so this report's
     # result stays `success` even when diff coverage is below the floor.
-    # That keeps it safe to leave in the CI-gate `needs` set without
-    # wedging the merge queue. Promote it to blocking by removing the
-    # continue-on-error once coverage is healthy (documented in the ops
-    # runbook).
-    name: Diff coverage gate
+    # The report is outside the CI-gate `needs` set until PR coverage
+    # artifacts are reliable enough for a blocking threshold.
+    name: Diff coverage report
     needs: [test]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1714,7 +1712,7 @@ jobs:
             const jobs = [
               { name: 'Repo hygiene', result: '${{ needs.repo-hygiene.result }}' },
               { name: 'Lint', result: '${{ needs.lint.result }}' },
-              { name: 'Type check', result: '${{ needs.typecheck.result }}' },
+              { name: 'Type check report', result: '${{ needs.typecheck.result }}' },
               { name: 'Tests', result: '${{ needs.test.result }}' },
               { name: 'Tests (macOS)', result: '${{ needs.test-macos.result }}' },
               { name: 'Spelling', result: '${{ needs.spelling.result }}' },
@@ -1788,6 +1786,9 @@ jobs:
   # Excluded from `needs:`:
   #   * `autofix`        - runs only on push to main, mutates the tree
   #   * `pr-summary`     - cosmetic PR comment, must not gate merges
+  #   * `typecheck`      - advisory report while repo-wide pyright is being typed
+  #   * `mutmut-diff`    - advisory report until mutation score enforcement is enabled
+  #   * `diff-coverage`  - advisory report until PR coverage artifacts are reliable
   #   * `ci-gate` itself - would deadlock the dependency graph
   ci-gate:
     name: CI gate
@@ -1804,7 +1805,6 @@ jobs:
       - spelling
       - actionlint
       - lineage-gate
-      - typecheck
       - dead-code
       - dist-size
       - install-smoke-pipx
@@ -1816,8 +1816,6 @@ jobs:
       - bandit
       - pip-audit
       - beartype
-      - mutmut-diff
-      - diff-coverage
       - pyright-strict-zone
       - adapter-integration
       - adapter-integration-macos
@@ -1858,13 +1856,10 @@ jobs:
               "property-tests",
               "beartype",
               "adapter-integration",
-              "diff-coverage",
-              "mutmut-diff",
               "pyright-strict-zone",
               "semgrep",
               "bandit",
               "pip-audit",
-              "typecheck",
               "dead-code",
               "dist-size",
               "install-smoke-pipx",
@@ -1877,7 +1872,7 @@ jobs:
               "close-ci-issues",
           }
           # PR-only jobs: skipped on push events is intentional.
-          PR_ONLY = {"mutmut-diff", "diff-coverage"}
+          PR_ONLY = set()
           # Push-to-main-only jobs: skipped on PRs is intentional.
           PUSH_ONLY = {"close-ci-issues"}
           # macOS-gated jobs (see #1468): on PRs these are skipped unless

--- a/tests/unit/test_ci_advisory_reports_workflow_yaml.py
+++ b/tests/unit/test_ci_advisory_reports_workflow_yaml.py
@@ -1,0 +1,120 @@
+"""Structural assertions for advisory CI reports."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+
+class WorkflowJob(TypedDict, total=False):
+    name: object
+    needs: object
+    steps: list[object]
+
+
+class WorkflowFile(TypedDict, total=False):
+    jobs: dict[str, WorkflowJob]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+ADVISORY_JOBS = {
+    "typecheck": "Type check report",
+    "mutmut-diff": "Mutation report (diff-only)",
+    "diff-coverage": "Diff coverage report",
+}
+
+
+def _load() -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _jobs() -> dict[str, WorkflowJob]:
+    jobs = _load().get("jobs", {})
+    assert isinstance(jobs, dict)
+    return jobs
+
+
+def _job(name: str) -> WorkflowJob:
+    job = _jobs().get(name)
+    assert isinstance(job, dict), f"expected job {name!r}"
+    return job
+
+
+def _needs(job_name: str) -> list[str]:
+    needs = _job(job_name).get("needs", [])
+    assert isinstance(needs, list), f"{job_name}.needs must be a list"
+    return [need for need in cast("list[object]", needs) if isinstance(need, str)]
+
+
+def _run_blocks(job_name: str) -> list[str]:
+    steps = _job(job_name).get("steps", [])
+    assert isinstance(steps, list)
+    runs: list[str] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        step_map = cast("dict[str, object]", step)
+        run = step_map.get("run")
+        if isinstance(run, str):
+            runs.append(run)
+    return runs
+
+
+def _ci_gate_rollup_script() -> str:
+    run = next((body for body in _run_blocks("ci-gate") if "results.json" in body and "plan.json" in body), "")
+    assert run, "ci-gate roll-up step is missing"
+    match = re.search(r"<<'PY'\n(.*?)\n\s*PY\b", run, re.DOTALL)
+    assert match is not None, "ci-gate roll-up must keep its Python heredoc"
+    return match.group(1)
+
+
+def test_advisory_jobs_are_reports_not_gates() -> None:
+    """Jobs that mask tool failures must be labelled as reports."""
+    jobs = _jobs()
+    for job_name, expected_name in ADVISORY_JOBS.items():
+        assert jobs[job_name].get("name") == expected_name
+
+
+def test_advisory_jobs_are_not_ci_gate_inputs() -> None:
+    """The aggregate required gate must only depend on enforced jobs."""
+    gate_needs = set(_needs("ci-gate"))
+
+    assert gate_needs.isdisjoint(ADVISORY_JOBS)
+
+
+def test_ci_gate_rollup_does_not_treat_advisory_reports_as_required() -> None:
+    """The roll-up allow-lists should not mention jobs outside ci-gate needs."""
+    rollup = _ci_gate_rollup_script()
+
+    assert '"typecheck"' not in rollup
+    assert '"mutmut-diff"' not in rollup
+    assert '"diff-coverage"' not in rollup
+
+
+def test_mutation_report_comment_matches_advisory_behavior() -> None:
+    """Mutation testing is advisory until its command is allowed to fail the job."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    mutation_block = text.split("  mutmut-diff:", 1)[1].split("  diff-coverage:", 1)[0]
+
+    assert "Mutation testing report" in mutation_block
+    assert "Fails when" not in mutation_block
+    assert "continue-on-error: true" in mutation_block
+    assert "|| true" in mutation_block
+
+
+def test_diff_coverage_report_comment_matches_advisory_behavior() -> None:
+    """Diff coverage should be called a report while artifact download can fail open."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    diff_block = text.split("  diff-coverage:", 1)[1].split("  pyright-strict-zone:", 1)[0]
+
+    assert "Diff coverage report" in diff_block
+    assert "diff-cover report" in diff_block
+    job_name = _job("diff-coverage").get("name", "")
+    assert isinstance(job_name, str)
+    assert "gate" not in job_name.lower()
+    assert "continue-on-error: true" in diff_block

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -372,8 +372,6 @@ _MERGE_GROUP_NEEDS = {
     "bandit": {"result": "success"},
     "pip-audit": {"result": "success"},
     "beartype": {"result": "success"},
-    "mutmut-diff": {"result": "skipped"},  # if: pull_request
-    "diff-coverage": {"result": "skipped"},  # if: pull_request
     "pyright-strict-zone": {"result": "success"},
     "adapter-integration": {"result": "success"},
     "adapter-integration-macos": {"result": "skipped"},  # if: push/sensitive/label


### PR DESCRIPTION
## What
- Renames advisory typecheck, mutation, and diff coverage jobs as reports.
- Removes those advisory jobs from the aggregate CI gate inputs.
- Adds structural tests that keep advisory reports out of required-gate semantics.

## Why
- Addresses #1827 F-021, F-022, F-023, and F-059 by keeping the required aggregate gate limited to enforced checks.

## Verification
- uv run pytest tests/unit/test_ci_advisory_reports_workflow_yaml.py tests/unit/test_required_check_canary_workflow_yaml.py -q
- uv run ruff check tests/unit/test_ci_advisory_reports_workflow_yaml.py tests/unit/test_required_check_canary_workflow_yaml.py
- uv run pyright tests/unit/test_ci_advisory_reports_workflow_yaml.py
- actionlint .github/workflows/ci.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reconfigured CI pipeline to make type checking, mutation testing, and diff coverage advisory rather than merge-blocking, allowing pull requests to proceed while still providing feedback.
  * Added test validations to ensure advisory checks are properly configured and excluded from merge requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->