### PR TITLE
Exercise lineage gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,10 +451,9 @@ jobs:
           # `fail_on_error` is deprecated; `fail_level: error` replaces it.
 
   lineage-gate:
-    # ADR-009 Lineage Gate - required check. Verifies the on-disk lineage
-    # log (.sdd/lineage/log.jsonl) is internally consistent: every entry
-    # signature verifies, no unresolved forks, parent_hashes resolve.
-    # No-op PASS when the log does not exist (pre-bootstrap state).
+    # ADR-009 Lineage Gate - required check. CI generates a minimal signed
+    # lineage fixture and verifies it so the job always exercises the gate
+    # logic even when runtime `.sdd/lineage/log.jsonl` is absent.
     name: Lineage Gate
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -471,11 +470,63 @@ jobs:
       - uses: ./.github/actions/bootstrap
       - name: Run lineage gate
         run: |
-          if [ -f .sdd/lineage/log.jsonl ]; then
-            uv run python scripts/check_lineage.py
-          else
-            echo "::notice::No .sdd/lineage/log.jsonl - lineage gate is a no-op PASS."
-          fi
+          set -euo pipefail
+          LINEAGE_FIXTURE="${RUNNER_TEMP}/lineage-fixture"
+          export LINEAGE_FIXTURE
+          uv run python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+          from bernstein.core.lineage.identity import generate_keypair, sign_detached
+
+          root = Path(os.environ["LINEAGE_FIXTURE"])
+          log = root / "lineage" / "log.jsonl"
+          cards = root / "agents" / "agent:ci"
+          log.parent.mkdir(parents=True, exist_ok=True)
+          cards.mkdir(parents=True, exist_ok=True)
+
+          private_key, public_key = generate_keypair()
+          (cards / "card.json").write_text(
+              json.dumps(
+                  {
+                      "protocolVersion": "a2a/1.0",
+                      "agent_id": "agent:ci",
+                      "kid": "ci-fixture",
+                      "public_key_pem": public_key,
+                  }
+              ),
+              encoding="utf-8",
+          )
+
+          entry = LineageEntry(
+              v=1,
+              artefact_path="ci/lineage-fixture.txt",
+              artefact_kind="file",
+              content_hash="sha256:" + ("1" * 64),
+              parent_hashes=[],
+              agent_id="agent:ci",
+              agent_card_kid="ci-fixture",
+              tool_call_id="ci-lineage-gate",
+              span_id="ci-lineage-gate",
+              ts_ns=1,
+              operator_hmac="0" * 64,
+          )
+          canonical = canonicalise(entry)
+          log.write_bytes(canonical + b"\n")
+
+          jws = sign_detached(canonical, private_key, kid="ci-fixture")
+          path_hash = hashlib.sha256(entry.artefact_path.encode()).hexdigest()
+          entry_digest = entry_hash(entry).replace("sha256:", "")
+          sig_dir = log.parent / "signatures" / path_hash[:2] / path_hash
+          sig_dir.mkdir(parents=True, exist_ok=True)
+          (sig_dir / f"{entry_digest}.jws").write_text(jws, encoding="utf-8")
+          PY
+          uv run python scripts/check_lineage.py \
+            --log "${LINEAGE_FIXTURE}/lineage/log.jsonl" \
+            --cards "${LINEAGE_FIXTURE}/agents"
 
   # ─── Medium checks (cancel old runs, 5-20 min) ────────────────────────
 

--- a/tests/unit/test_lineage_gate_workflow_yaml.py
+++ b/tests/unit/test_lineage_gate_workflow_yaml.py
@@ -1,0 +1,71 @@
+"""Structural assertions for the CI lineage gate workflow job."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+
+class WorkflowStep(TypedDict, total=False):
+    name: object
+    run: object
+
+
+class WorkflowJob(TypedDict, total=False):
+    name: object
+    steps: list[object]
+
+
+class WorkflowFile(TypedDict, total=False):
+    jobs: dict[str, WorkflowJob]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load() -> WorkflowFile:
+    return cast("WorkflowFile", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _job(name: str) -> WorkflowJob:
+    jobs = _load().get("jobs", {})
+    assert isinstance(jobs, dict)
+    job = jobs.get(name)
+    assert isinstance(job, dict), f"expected job {name!r}"
+    return job
+
+
+def _step(name: str) -> WorkflowStep:
+    steps = _job("lineage-gate").get("steps", [])
+    assert isinstance(steps, list)
+    for step_value in steps:
+        if not isinstance(step_value, dict):
+            continue
+        step = cast("WorkflowStep", step_value)
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"expected lineage-gate step {name!r}")
+
+
+def _run(name: str) -> str:
+    run = _step(name).get("run", "")
+    assert isinstance(run, str)
+    return run
+
+
+def test_lineage_gate_generates_checked_fixture_instead_of_skipping() -> None:
+    """CI should verify a concrete lineage fixture when runtime state is absent."""
+    run = _run("Run lineage gate")
+
+    assert "No .sdd/lineage/log.jsonl" not in run
+    assert "no-op PASS" not in run
+    assert "if [ -f .sdd/lineage/log.jsonl ]" not in run
+    assert "generate_keypair" in run
+    assert "sign_detached" in run
+    assert "scripts/check_lineage.py" in run
+    assert 'LINEAGE_FIXTURE="${RUNNER_TEMP}/lineage-fixture"' in run
+    assert '--log "${LINEAGE_FIXTURE}/lineage/log.jsonl"' in run
+    assert '--cards "${LINEAGE_FIXTURE}/agents"' in run


### PR DESCRIPTION
## What
- Replaces the missing-runtime-log no-op with a generated signed lineage fixture in the CI lineage job.
- Runs `scripts/check_lineage.py` against that fixture with explicit `--log` and `--cards` paths.
- Adds a structural test that prevents the lineage job from returning to a missing-log no-op.

## Why
- Addresses #1827 F-005 and F-055 by making the lineage job exercise concrete lineage verification in ordinary CI.

## Verification
- uv run pytest tests/unit/test_lineage_gate_workflow_yaml.py -q
- uv run ruff check tests/unit/test_lineage_gate_workflow_yaml.py
- uv run pyright tests/unit/test_lineage_gate_workflow_yaml.py
- actionlint .github/workflows/ci.yml
- extracted `Run lineage gate` shell block with RUNNER_TEMP set: Lineage gate: PASS
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI lineage verification process to automatically generate and validate fixtures.

* **Tests**
  * Added validation tests for CI workflow lineage verification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->