### PR TITLE
Add telemetry maintainer-share sink

### DIFF
--- a/docs/observability/side-channel.md
+++ b/docs/observability/side-channel.md
@@ -169,5 +169,5 @@ and review every agent's activity in a single stream.
 The side channel above is operator-controlled. A separate, additive consent
 flag (`share_with_maintainer`) is documented in
 [telemetry-share.md](./telemetry-share.md). That flag gates an opt-in path
-to a community-shared maintainer endpoint and is off by default. The two
-surfaces are independent.
+to a maintainer endpoint supplied via `BERNSTEIN_TELEMETRY_SHARE_ENDPOINT`
+and is off by default. The two surfaces are independent.

--- a/docs/observability/telemetry-share.md
+++ b/docs/observability/telemetry-share.md
@@ -6,9 +6,8 @@ the operator picks the backend, points the DSN at it, and reviews the stream.
 
 This page documents a separate, additive consent surface: the
 `share_with_maintainer` flag introduced by the RFC #1719 foundation. The flag
-gates an opt-in path that may, after the RFC settles, ship aggregate
-reliability signal to a community-shared maintainer endpoint. No endpoint is
-defined in this PR, and no default URL is baked into the package.
+gates an opt-in path to a maintainer-operated endpoint. No endpoint URL is
+baked into the package.
 
 ## TL;DR
 
@@ -21,6 +20,7 @@ defined in this PR, and no default URL is baked into the package.
   - `bernstein telemetry disable` to revert.
   - `bernstein telemetry tail [-n N]` to audit the stream offline.
 - One env var beats the file: `BERNSTEIN_TELEMETRY_SHARE=0` always disables.
+- The share sink also requires `BERNSTEIN_TELEMETRY_SHARE_ENDPOINT`.
 - `DO_NOT_TRACK=1` always wins, regardless of the file or any env var.
 
 ## How consent flows
@@ -51,6 +51,19 @@ The flag is resolved from the highest available signal:
 `bernstein telemetry status` prints the resolved value and the layer that
 won, so operators can diagnose surprising state in one command.
 
+## Endpoint configuration
+
+The maintainer-share sink is inert unless both values are present:
+
+| Setting | Required value |
+|---|---|
+| `share_with_maintainer` | `true` from the TOML file or `BERNSTEIN_TELEMETRY_SHARE=1` |
+| `BERNSTEIN_TELEMETRY_SHARE_ENDPOINT` | An HTTPS receiver URL supplied by the runtime environment |
+
+`BERNSTEIN_TELEMETRY_SHARE_ENDPOINT` has no default. Setting the endpoint
+without consent sends nothing. Setting consent without the endpoint sends
+nothing.
+
 ## What gets sent
 
 The event schema is the closed taxonomy already defined in
@@ -67,6 +80,22 @@ The event schema is the closed taxonomy already defined in
 Every event is wrapped in an envelope that adds `schema_version`,
 `install_id`, and `timestamp`. The install id is the opaque per-install
 fingerprint documented in `core/telemetry/install_id.py`.
+
+The maintainer-share request body is exactly the same serialized event JSON
+line written to the local audit queue. The detached Ed25519 receipt is carried
+in HTTP headers:
+
+| Header | Value |
+|---|---|
+| `x-bernstein-telemetry-agent-id` | `install:<install_id>` |
+| `x-bernstein-telemetry-kid` | Receipt key id |
+| `x-bernstein-telemetry-jws` | Detached JWS over the request body |
+| `x-bernstein-telemetry-public-key-pem-b64` | Base64url public key PEM |
+| `x-bernstein-telemetry-receipt-version` | Receipt format version |
+
+The receipt key is generated only after both consent and endpoint gates are
+enabled. The private key is stored locally at
+`~/.bernstein/telemetry-share-key.pem`.
 
 ## Redaction list
 
@@ -115,12 +144,8 @@ The operator-controlled side channel (`BERNSTEIN_TELEMETRY_DSN`) is
 unaffected by any of the above. Operators who run their own backend never
 need to touch the share flag.
 
-## What this PR does not do
+## What is not included
 
 - It does not define a maintainer endpoint URL.
-- It does not change the existing telemetry pipeline.
 - It does not flip the flag for any operator. The default stays off.
-
-The foundation lands so the consent surface is reviewable. The
-consent-posture decision (Option A opt-in vs B opt-out vs C nudged opt-in)
-stays in the RFC discussion at issue #1719.
+- It does not send fields outside the closed telemetry schema.

--- a/src/bernstein/core/telemetry/__init__.py
+++ b/src/bernstein/core/telemetry/__init__.py
@@ -82,12 +82,22 @@ from bernstein.core.telemetry.events import (
 from bernstein.core.telemetry.install_id import ensure as ensure_install_id
 from bernstein.core.telemetry.install_id import read as read_install_id
 from bernstein.core.telemetry.install_id import reset as reset_install_id
+from bernstein.core.telemetry.share import (
+    SHARE_ENDPOINT_ENV,
+    resolve_share_endpoint,
+    share_private_key_path,
+    share_public_key_path,
+)
+from bernstein.core.telemetry.share import (
+    emit_if_enabled as emit_share_if_enabled,
+)
 
 __all__ = [
     "BUILTIN_PRESETS",
     "DEFAULT_ENDPOINT",
     "ENDPOINT_ENV",
     "SCHEMA_VERSION",
+    "SHARE_ENDPOINT_ENV",
     "Client",
     "CommandInvokedPayload",
     "DailyActivePayload",
@@ -103,6 +113,7 @@ __all__ = [
     "TelemetryEvent",
     "build_envelope",
     "config_file_path",
+    "emit_share_if_enabled",
     "ensure_install_id",
     "first_run_marker_path",
     "get_client",
@@ -122,7 +133,10 @@ __all__ = [
     "reset_default_client",
     "reset_install_id",
     "resolve",
+    "resolve_share_endpoint",
     "serialize_event",
+    "share_private_key_path",
+    "share_public_key_path",
     "start_span",
     "write_enabled",
 ]

--- a/src/bernstein/core/telemetry/client.py
+++ b/src/bernstein/core/telemetry/client.py
@@ -39,6 +39,7 @@ from bernstein.core.telemetry.events import (
     build_envelope,
     serialize_event,
 )
+from bernstein.core.telemetry.share import emit_if_enabled as emit_share_if_enabled
 
 _LOG = logging.getLogger(__name__)
 
@@ -191,11 +192,21 @@ class Client:
                 return False
             envelope = build_envelope(name, install_id, payload)
             line = serialize_event(envelope)
+            local_appended = False
             try:
                 _append_local(line, self._home)
+                local_appended = True
             except OSError as exc:
                 _LOG.debug("telemetry: local queue append failed: %s", exc)
             self._post(line)
+            if local_appended:
+                emit_share_if_enabled(
+                    serialized_event=line,
+                    install_id=install_id,
+                    env=self._env,
+                    home=self._home,
+                    http_client=self._get_http(),
+                )
             return True
         except Exception as exc:
             _LOG.debug("telemetry: emit failed (suppressed): %s", exc)

--- a/src/bernstein/core/telemetry/share.py
+++ b/src/bernstein/core/telemetry/share.py
@@ -1,0 +1,177 @@
+"""Maintainer-share telemetry sink.
+
+This module implements the additive RFC #1719 path. It is inert unless both
+gates are true:
+
+* ``share_with_maintainer`` resolves to true via the consent resolver.
+* ``BERNSTEIN_TELEMETRY_SHARE_ENDPOINT`` is set by the runtime environment.
+
+The request body is the same closed telemetry event JSON that the local queue
+stores. Receipt data travels in HTTP headers so the maintainer-share path cannot
+grow a richer event schema than the operator-audited local record.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+import httpx
+
+from bernstein.core.lineage.identity import generate_keypair, sign_detached
+from bernstein.core.telemetry import consent
+
+_LOG = logging.getLogger(__name__)
+
+SHARE_ENDPOINT_ENV: Final[str] = "BERNSTEIN_TELEMETRY_SHARE_ENDPOINT"
+TIMEOUT_SECONDS: Final[float] = 3.0
+
+_PRIVATE_KEY_NAME: Final[str] = "telemetry-share-key.pem"
+_PUBLIC_KEY_NAME: Final[str] = "telemetry-share-public.pem"
+
+_HEADER_AGENT_ID: Final[str] = "x-bernstein-telemetry-agent-id"
+_HEADER_JWS: Final[str] = "x-bernstein-telemetry-jws"
+_HEADER_KID: Final[str] = "x-bernstein-telemetry-kid"
+_HEADER_PUBLIC_KEY: Final[str] = "x-bernstein-telemetry-public-key-pem-b64"
+_HEADER_RECEIPT_VERSION: Final[str] = "x-bernstein-telemetry-receipt-version"
+
+
+@dataclass(frozen=True, slots=True)
+class ShareIdentity:
+    """Per-install signing identity for maintainer-share receipts."""
+
+    agent_id: str
+    kid: str
+    private_key_pem: str
+    public_key_pem: str
+
+
+def _state_dir(home: Path | None = None) -> Path:
+    """Return the operator-local telemetry state directory."""
+    base = home if home is not None else Path.home()
+    return base / ".bernstein"
+
+
+def share_private_key_path(home: Path | None = None) -> Path:
+    """Return the private key path for maintainer-share receipts."""
+    return _state_dir(home) / _PRIVATE_KEY_NAME
+
+
+def share_public_key_path(home: Path | None = None) -> Path:
+    """Return the public key path for maintainer-share receipts."""
+    return _state_dir(home) / _PUBLIC_KEY_NAME
+
+
+def resolve_share_endpoint(env: dict[str, str] | None = None) -> str | None:
+    """Return the configured HTTPS maintainer-share endpoint, if one is set."""
+    real_env = env if env is not None else os.environ
+    endpoint = real_env.get(SHARE_ENDPOINT_ENV)
+    if endpoint is None:
+        return None
+    stripped = endpoint.strip()
+    if not stripped.startswith("https://"):
+        return None
+    return stripped
+
+
+def ensure_share_identity(
+    *,
+    install_id: str,
+    home: Path | None = None,
+) -> ShareIdentity:
+    """Return the local signing identity, generating it if needed.
+
+    The private key is created only after the caller has already verified
+    explicit share consent and endpoint configuration.
+    """
+    private_path = share_private_key_path(home)
+    public_path = share_public_key_path(home)
+    private_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        private_key_pem = private_path.read_text(encoding="ascii")
+        public_key_pem = public_path.read_text(encoding="ascii")
+    except OSError:
+        private_key_pem, public_key_pem = generate_keypair()
+        tmp_private = private_path.with_suffix(".tmp")
+        tmp_public = public_path.with_suffix(".tmp")
+        tmp_private.write_text(private_key_pem, encoding="ascii")
+        tmp_public.write_text(public_key_pem, encoding="ascii")
+        with contextlib.suppress(OSError):
+            os.chmod(tmp_private, 0o600)
+        os.replace(tmp_private, private_path)
+        os.replace(tmp_public, public_path)
+        with contextlib.suppress(OSError):
+            os.chmod(private_path, 0o600)
+
+    return ShareIdentity(
+        agent_id=f"install:{install_id}",
+        kid=f"telemetry-share:{install_id}",
+        private_key_pem=private_key_pem,
+        public_key_pem=public_key_pem,
+    )
+
+
+def emit_if_enabled(
+    *,
+    serialized_event: str,
+    install_id: str,
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+    http_client: httpx.Client | None = None,
+) -> bool:
+    """POST a signed maintainer-share event when both gates are enabled.
+
+    Returns ``True`` only when a send was attempted. Any error is suppressed so
+    telemetry cannot break the caller.
+    """
+    try:
+        endpoint = resolve_share_endpoint(env)
+        if endpoint is None:
+            return False
+        if not consent.is_sharing_with_maintainer(env=env, home=home):
+            return False
+
+        identity = ensure_share_identity(install_id=install_id, home=home)
+        body = serialized_event.encode("utf-8")
+        jws = sign_detached(body, identity.private_key_pem, kid=identity.kid)
+        public_key_b64 = base64.urlsafe_b64encode(identity.public_key_pem.encode("ascii")).rstrip(b"=").decode("ascii")
+        client = http_client if http_client is not None else httpx.Client(timeout=TIMEOUT_SECONDS)
+        owns_client = http_client is None
+        try:
+            client.post(
+                endpoint,
+                content=body,
+                headers={
+                    "content-type": "application/json",
+                    _HEADER_AGENT_ID: identity.agent_id,
+                    _HEADER_JWS: jws,
+                    _HEADER_KID: identity.kid,
+                    _HEADER_PUBLIC_KEY: public_key_b64,
+                    _HEADER_RECEIPT_VERSION: "1",
+                },
+                timeout=TIMEOUT_SECONDS,
+            )
+        finally:
+            if owns_client:
+                client.close()
+        return True
+    except Exception as exc:
+        _LOG.debug("telemetry share: emit failed (suppressed): %s", exc)
+        return False
+
+
+__all__ = [
+    "SHARE_ENDPOINT_ENV",
+    "ShareIdentity",
+    "emit_if_enabled",
+    "ensure_share_identity",
+    "resolve_share_endpoint",
+    "share_private_key_path",
+    "share_public_key_path",
+]

--- a/tests/unit/telemetry/test_maintainer_share_sink.py
+++ b/tests/unit/telemetry/test_maintainer_share_sink.py
@@ -1,0 +1,156 @@
+"""Maintainer-share telemetry sink tests."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from bernstein.core.lineage.identity import AgentCard, verify_detached
+from bernstein.core.telemetry import consent, write_enabled
+from bernstein.core.telemetry.client import Client
+from bernstein.core.telemetry.events import DailyActivePayload, TelemetryEvent
+from bernstein.core.telemetry.share import (
+    SHARE_ENDPOINT_ENV,
+    share_private_key_path,
+)
+
+
+class _RecordingTransport(httpx.MockTransport):
+    """HTTP transport that records every request body and header set."""
+
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+        super().__init__(self._handle)
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(204, content=b"")
+
+
+def _payload() -> DailyActivePayload:
+    return DailyActivePayload(day_iso="2026-05-22")
+
+
+def _emit_with(
+    tmp_home: Path,
+    transport: _RecordingTransport,
+    *,
+    env: dict[str, str],
+) -> bool:
+    write_enabled(True, home=tmp_home)
+    http = httpx.Client(transport=transport)
+    client = Client(
+        env=env,
+        home=tmp_home,
+        endpoint="https://operator.example.test/v1/events",
+        http_client=http,
+    )
+    try:
+        return client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    finally:
+        client.close()
+
+
+def test_share_flag_and_endpoint_send_same_event_with_detached_receipt(tmp_home: Path) -> None:
+    """Explicit share consent plus endpoint emits a signed copy of the event."""
+    consent.write_share_flag(True, home=tmp_home)
+    transport = _RecordingTransport()
+
+    assert _emit_with(
+        tmp_home,
+        transport,
+        env={SHARE_ENDPOINT_ENV: "https://maintainer.example.test/v1/events"},
+    )
+
+    assert [request.url.host for request in transport.requests] == [
+        "operator.example.test",
+        "maintainer.example.test",
+    ]
+    operator_request, share_request = transport.requests
+    assert share_request.content == operator_request.content
+
+    body = json.loads(share_request.content)
+    assert set(body) == {"install_id", "name", "payload", "schema_version", "timestamp"}
+    assert body["name"] == TelemetryEvent.DAILY_ACTIVE.value
+
+    jws = share_request.headers["x-bernstein-telemetry-jws"]
+    kid = share_request.headers["x-bernstein-telemetry-kid"]
+    public_key_pem = base64.urlsafe_b64decode(
+        share_request.headers["x-bernstein-telemetry-public-key-pem-b64"] + "=="
+    ).decode("ascii")
+    card = AgentCard(
+        agent_id=share_request.headers["x-bernstein-telemetry-agent-id"],
+        kid=kid,
+        public_key_pem=public_key_pem,
+    )
+    assert verify_detached(share_request.content, jws, card)
+
+
+def test_share_endpoint_without_share_consent_does_not_send_or_create_key(tmp_home: Path) -> None:
+    """Endpoint configuration alone is not consent."""
+    transport = _RecordingTransport()
+
+    assert _emit_with(
+        tmp_home,
+        transport,
+        env={SHARE_ENDPOINT_ENV: "https://maintainer.example.test/v1/events"},
+    )
+
+    assert [request.url.host for request in transport.requests] == ["operator.example.test"]
+    assert not share_private_key_path(tmp_home).exists()
+
+
+def test_share_consent_without_endpoint_does_not_send_or_create_key(tmp_home: Path) -> None:
+    """Consent alone is inert until the endpoint is configured out of package."""
+    consent.write_share_flag(True, home=tmp_home)
+    transport = _RecordingTransport()
+
+    assert _emit_with(tmp_home, transport, env={})
+
+    assert [request.url.host for request in transport.requests] == ["operator.example.test"]
+    assert not share_private_key_path(tmp_home).exists()
+
+
+def test_share_consent_with_non_https_endpoint_does_not_send_or_create_key(tmp_home: Path) -> None:
+    """The maintainer-share endpoint must be supplied as HTTPS."""
+    consent.write_share_flag(True, home=tmp_home)
+    transport = _RecordingTransport()
+
+    assert _emit_with(
+        tmp_home,
+        transport,
+        env={SHARE_ENDPOINT_ENV: "http://maintainer.example.test/v1/events"},
+    )
+
+    assert [request.url.host for request in transport.requests] == ["operator.example.test"]
+    assert not share_private_key_path(tmp_home).exists()
+
+
+def test_share_consent_does_not_send_when_local_audit_append_fails(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The share sink requires the local audit queue copy to exist first."""
+    consent.write_share_flag(True, home=tmp_home)
+    transport = _RecordingTransport()
+
+    from bernstein.core.telemetry import client as client_mod
+
+    def _raise(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(client_mod, "_append_local", _raise)
+
+    assert _emit_with(
+        tmp_home,
+        transport,
+        env={SHARE_ENDPOINT_ENV: "https://maintainer.example.test/v1/events"},
+    )
+
+    assert [request.url.host for request in transport.requests] == ["operator.example.test"]
+    assert not share_private_key_path(tmp_home).exists()


### PR DESCRIPTION
## Summary
- add an opt-in maintainer-share telemetry sink gated by `share_with_maintainer` and `BERNSTEIN_TELEMETRY_SHARE_ENDPOINT`
- send the same closed telemetry event body as the local audit queue, with a detached Ed25519 receipt in headers
- document the endpoint, consent, and receipt behavior

## Tests
- `uv run pytest tests/unit/telemetry/ -q`
- `uv run ruff check src/bernstein/core/telemetry/share.py src/bernstein/core/telemetry/client.py src/bernstein/core/telemetry/__init__.py tests/unit/telemetry/test_maintainer_share_sink.py`
- `uv run pyright src/bernstein/core/telemetry/share.py src/bernstein/core/telemetry/client.py src/bernstein/core/telemetry/__init__.py tests/unit/telemetry/test_maintainer_share_sink.py`
- `git diff --check`

Refs #1719