### PR TITLE
Document release workflow ownership

### DIFF
--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -1,0 +1,26 @@
+# Release Operations
+
+This page documents which GitHub Actions workflows own each release entrypoint.
+
+Update this table whenever a release workflow is added, renamed, or moved.
+
+## Release Workflow Ownership
+
+| Workflow | Name | Triggers | Owns | Handoff |
+|---|---|---|---|---|
+| `.github/workflows/post-ci-dispatcher.yml` | Post-CI dispatcher | `workflow_run` | Routes completed main-branch CI runs to release and recovery child workflows. | Calls `.github/workflows/auto-release.yml` when the upstream CI run targets `main`. |
+| `.github/workflows/auto-release.yml` | Auto-release | `workflow_call` | Decides whether a green main-branch CI run should create a release tag. | Pushes a `v*` tag; `.github/workflows/publish.yml` owns tag publish. |
+| `.github/workflows/publish.yml` | Publish | `push` | Builds release distributions, attests `dist/*`, publishes PyPI and npm packages, and creates or updates the GitHub Release for a `v*` tag. | GitHub Release publication triggers Docker, Homebrew, and release-scoped SBOM follow-up workflows. |
+| `.github/workflows/release-major-minor.yml` | Major/Minor Release | `workflow_dispatch` | Manually cuts major or minor releases after checking CI and applying the version bump. | Pushes the version commit and tag, then builds and publishes from the same run. |
+| `.github/workflows/release-please.yml` | Release Please | `workflow_dispatch` | Maintains release PRs and release metadata when an operator runs it manually. | Does not publish artifacts; publish still starts from a `v*` tag or a manual major/minor run. |
+| `.github/workflows/reconcile-release.yml` | Reconcile release drift | `schedule`, `workflow_dispatch` | Compares `pyproject.toml`, PyPI, and GitHub Release assets to detect missed publish work. | Opens or updates a `release-drift` issue when published state is inconsistent. |
+| `.github/workflows/publish-docker.yml` | Publish Docker Image | `release`, `workflow_dispatch` | Publishes the GHCR image and image provenance for a released tag. | Runs after a GitHub Release is published, or manually for a selected tag. |
+| `.github/workflows/publish-homebrew.yml` | Publish Homebrew Formula | `release`, `workflow_dispatch` | Updates the Homebrew tap formula for a released version. | Runs after a GitHub Release is published, or manually for a selected version. |
+| `.github/workflows/sbom-upload.yml` | SBOM upload | `push`, `release` | Generates and uploads the CycloneDX SBOM when the Dependency-Track endpoint is configured. | Runs on main updates and after a GitHub Release is published. |
+
+## Guardrails
+
+- `.github/workflows/auto-release.yml` only creates tags.
+- `.github/workflows/publish.yml` owns tag-triggered package and GitHub Release publication.
+- `.github/workflows/reconcile-release.yml` is the drift detector for missing PyPI versions or empty GitHub Release assets.
+- New release entrypoints must be added to the ownership table and covered by `tests/unit/test_release_entrypoint_docs.py`.

--- a/tests/unit/test_release_entrypoint_docs.py
+++ b/tests/unit/test_release_entrypoint_docs.py
@@ -1,0 +1,102 @@
+"""Release entrypoint documentation stays aligned with workflow files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_DOC = REPO_ROOT / "docs" / "operations" / "release.md"
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+type YamlMap = dict[object, object]
+
+RELEASE_ENTRYPOINTS: dict[str, tuple[str, ...]] = {
+    "post-ci-dispatcher.yml": ("workflow_run",),
+    "auto-release.yml": ("workflow_call",),
+    "publish.yml": ("push",),
+    "release-major-minor.yml": ("workflow_dispatch",),
+    "release-please.yml": ("workflow_dispatch",),
+    "reconcile-release.yml": ("schedule", "workflow_dispatch"),
+    "publish-docker.yml": ("release", "workflow_dispatch"),
+    "publish-homebrew.yml": ("release", "workflow_dispatch"),
+    "sbom-upload.yml": ("push", "release"),
+}
+
+
+@dataclass(frozen=True)
+class ReleaseDocRow:
+    """One row in the release workflow ownership table."""
+
+    workflow_path: str
+    workflow_name: str
+    triggers: str
+    owns: str
+    handoff: str
+
+
+def _load_yaml(path: Path) -> YamlMap:
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{path} must parse as a YAML mapping"
+    return cast("YamlMap", parsed)
+
+
+def _workflow_name(path: Path) -> str:
+    name = _load_yaml(path).get("name")
+    assert isinstance(name, str), f"{path} must declare a workflow name"
+    return name
+
+
+def _workflow_triggers(path: Path) -> set[str]:
+    data = _load_yaml(path)
+    on_block = data.get("on")
+    if on_block is None:
+        on_block = data.get(True)
+    assert isinstance(on_block, dict), f"{path} must declare mapping-style triggers"
+    trigger_map = cast("YamlMap", on_block)
+    return {str(trigger) for trigger in trigger_map}
+
+
+def _release_table_rows(text: str) -> dict[str, ReleaseDocRow]:
+    rows: dict[str, ReleaseDocRow] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) != 5 or not cells[0].startswith("`.github/workflows/"):
+            continue
+        workflow_path = cells[0].strip("`")
+        rows[workflow_path] = ReleaseDocRow(
+            workflow_path=workflow_path,
+            workflow_name=cells[1],
+            triggers=cells[2],
+            owns=cells[3],
+            handoff=cells[4],
+        )
+    return rows
+
+
+def test_release_entrypoint_doc_references_actual_workflows() -> None:
+    """The release operations doc must name the real workflow entrypoints."""
+    assert RELEASE_DOC.exists(), f"{RELEASE_DOC} must document release workflow ownership"
+    rows = _release_table_rows(RELEASE_DOC.read_text(encoding="utf-8"))
+
+    for workflow_file, expected_triggers in RELEASE_ENTRYPOINTS.items():
+        workflow_path = WORKFLOWS_DIR / workflow_file
+        documented_path = f".github/workflows/{workflow_file}"
+        assert workflow_path.exists(), f"{documented_path} no longer exists"
+        assert documented_path in rows, f"{documented_path} is missing from {RELEASE_DOC}"
+
+        row = rows[documented_path]
+        assert row.workflow_name == _workflow_name(workflow_path)
+        assert row.owns, f"{documented_path} must document ownership"
+        assert row.handoff, f"{documented_path} must document the handoff"
+
+        workflow_triggers = _workflow_triggers(workflow_path)
+        for trigger in expected_triggers:
+            assert trigger in workflow_triggers, f"{documented_path} no longer has trigger {trigger}"
+            assert trigger in row.triggers, f"{documented_path} doc row must list trigger {trigger}"


### PR DESCRIPTION
## Summary
- document the release workflow entrypoints, triggers, ownership, and handoffs
- add a structural test that keeps the release operations table aligned with workflow files

## Tests
- `uv run pytest tests/unit/test_release_entrypoint_docs.py -x -q`
- `uv run ruff check tests/unit/test_release_entrypoint_docs.py`
- `uv run pyright tests/unit/test_release_entrypoint_docs.py`
- `git diff --check HEAD~1 HEAD`

Refs #1827