### PR TITLE
Version skill manifest schema

### DIFF
--- a/src/bernstein/core/skills/manifest.py
+++ b/src/bernstein/core/skills/manifest.py
@@ -6,6 +6,7 @@ the agent can load on demand.
 
 Schema (all fields strict-validated by Pydantic):
 
+- ``manifest_schema`` - integer manifest schema version; defaults to ``1``
 - ``name``        - lowercase slug ``[a-z][a-z0-9-]*``
 - ``description`` - 20-500 chars, shown in the index
 - ``trigger_keywords`` - optional keyword hints
@@ -44,6 +45,10 @@ _FENCE_LINE_RE: re.Pattern[str] = re.compile(r"^---[ \t]*$")
 # stay unbounded.
 _MAX_FRONTMATTER_BYTES = 16 * 1024
 
+# Parser schema understood by this client. Newer schemas are accepted when
+# their currently-known fields validate; additive unknown fields are ignored.
+_SUPPORTED_MANIFEST_SCHEMA = 1
+
 
 class SkillManifestError(ValueError):
     """Raised when a ``SKILL.md`` file is missing, malformed, or invalid.
@@ -61,13 +66,15 @@ class SkillManifestError(ValueError):
 class SkillManifest(BaseModel):
     """Strict-validated ``SKILL.md`` frontmatter.
 
-    Attributes mirror the OpenAI Agents SDK v2 Skills spec. Unknown keys are
-    rejected so typos (``keywords`` vs ``trigger_keywords``) do not silently
-    drop metadata.
+    Unknown keys are rejected for schema ``1`` so typos
+    (``keywords`` vs ``trigger_keywords``) do not silently drop metadata.
+    For newer schema values, additive unknown keys are ignored so older
+    clients can still index the fields they understand.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
+    manifest_schema: int = Field(default=1, ge=1)
     name: str = Field(min_length=1, max_length=64)
     description: str = Field(min_length=20, max_length=500)
     trigger_keywords: list[str] = Field(default_factory=list[str])
@@ -151,12 +158,23 @@ def parse_skill_md(path: Path) -> tuple[SkillManifest, str]:
             raise SkillManifestError(path, str(exc)) from exc
 
     try:
-        manifest = SkillManifest.model_validate(cleaned)
+        manifest = SkillManifest.model_validate(_validation_input_for_schema(cleaned))
     except ValidationError as exc:
         # Pydantic's default message is fine but we prefix it with the path.
         raise SkillManifestError(path, f"invalid manifest: {exc.errors()}") from exc
 
     return manifest, body
+
+
+_KNOWN_MANIFEST_FIELDS: frozenset[str] = frozenset(SkillManifest.model_fields)
+
+
+def _validation_input_for_schema(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the manifest fields this parser should validate."""
+    schema_value = data.get("manifest_schema", _SUPPORTED_MANIFEST_SCHEMA)
+    if type(schema_value) is int and schema_value > _SUPPORTED_MANIFEST_SCHEMA:
+        return {key: value for key, value in data.items() if key in _KNOWN_MANIFEST_FIELDS}
+    return data
 
 
 def _split_frontmatter(raw: str) -> tuple[str, str]:

--- a/tests/unit/skills/test_manifest.py
+++ b/tests/unit/skills/test_manifest.py
@@ -35,6 +35,7 @@ def test_parse_skill_md_round_trips_minimal_manifest(tmp_path: Path) -> None:
 
     manifest, body = parse_skill_md(skill_md)
 
+    assert manifest.manifest_schema == 1
     assert manifest.name == "backend"
     assert manifest.description.startswith("Backend skill")
     assert manifest.references == []
@@ -69,6 +70,28 @@ def test_parse_skill_md_accepts_optional_fields(tmp_path: Path) -> None:
     assert manifest.scripts == ["run.sh"]
     assert manifest.version == "2.1.0"
     assert manifest.author == "Team QA"
+
+
+def test_parse_skill_md_accepts_future_manifest_schema_additive_fields(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        manifest_schema: 2
+        name: future
+        description: Future schema skill with additive metadata older clients can ignore.
+        activation:
+          model: optional future field
+        ---
+        body
+        """,
+    )
+
+    manifest, body = parse_skill_md(skill_md)
+
+    assert manifest.manifest_schema == 2
+    assert manifest.name == "future"
+    assert body == "body"
 
 
 def test_parse_skill_md_rejects_missing_frontmatter(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `manifest_schema` to skill frontmatter with a default of `1`
- accept additive unknown fields for future manifest schema versions while keeping schema `1` strict
- add parser tests for the default and future-schema behavior

## Tests
- `uv run pytest tests/unit/skills/test_manifest.py tests/unit/skills/test_lint.py -q`
- `uv run ruff check src/bernstein/core/skills/manifest.py tests/unit/skills/test_manifest.py`
- `uv run pyright src/bernstein/core/skills/manifest.py tests/unit/skills/test_manifest.py`
- `git diff --check HEAD~1 HEAD`

Refs #1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced manifest schema versioning support, enabling manifest files to declare their format version and allowing the system to gracefully handle and process newer manifest formats as they evolve.

* **Tests**
  * Added test coverage for manifest schema versioning, including validation of future schema versions and verification of optional field parsing in newer manifest formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->