### PR TITLE
Add strict skill lint gates

### DIFF
--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -259,7 +259,14 @@ def _parse_scope(scope_str: str) -> InstallScope:
     default=None,
     help="Override the auto-detected skill name (uses source filename otherwise).",
 )
-def skills_install(source: Path, scope: str, override_name: str | None) -> None:
+@click.option(
+    "--strict",
+    "strict",
+    is_flag=True,
+    default=False,
+    help="Fail install when skill lint reports ERROR findings.",
+)
+def skills_install(source: Path, scope: str, override_name: str | None, strict: bool) -> None:
     """Install a skill from a local path.
 
     \b
@@ -273,6 +280,7 @@ def skills_install(source: Path, scope: str, override_name: str | None) -> None:
             scope=install_scope,
             workdir=Path.cwd(),
             override_name=override_name,
+            strict_lint=strict,
         )
     except SkillLifecycleError as exc:
         console.print(f"[red]install failed:[/red] {exc}")
@@ -317,7 +325,14 @@ def skills_remove(name: str, scope: str) -> None:
     default="project",
     help="Where to install declared skills.",
 )
-def skills_sync(manifest: Path | None, scope: str) -> None:
+@click.option(
+    "--strict",
+    "strict",
+    is_flag=True,
+    default=False,
+    help="Fail sync when skill lint reports ERROR findings.",
+)
+def skills_sync(manifest: Path | None, scope: str, strict: bool) -> None:
     """Install every skill declared in ``bernstein-skills.toml``.
 
     Re-runs are idempotent: skills whose digest already matches are
@@ -331,6 +346,7 @@ def skills_sync(manifest: Path | None, scope: str) -> None:
             toml_path.resolve(),
             scope=install_scope,
             workdir=Path.cwd(),
+            strict_lint=strict,
         )
     except (SkillsTomlError, SkillLifecycleError) as exc:
         console.print(f"[red]sync failed:[/red] {exc}")
@@ -413,8 +429,9 @@ def skills_watch(path: Path | None) -> None:
 
     reload_count = 0
 
-    def on_reload(_loader: SkillLoader) -> None:
+    def on_reload(loader: SkillLoader) -> None:
         nonlocal reload_count
+        del loader
         reload_count += 1
         console.print(f"[green]reloaded[/green] index (event #{reload_count})")
 

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -412,9 +412,7 @@ def _detect_skill_name(source: Path) -> str:
 def _raise_for_strict_lint_errors(skill_dir: Path, *, skill_name: str) -> None:
     """Raise when strict lint finds blocking errors for an installed skill."""
     errors = [
-        finding
-        for finding in lint_skill(skill_dir, skill_name=skill_name)
-        if finding.severity is LintSeverity.ERROR
+        finding for finding in lint_skill(skill_dir, skill_name=skill_name) if finding.severity is LintSeverity.ERROR
     ]
     if not errors:
         return

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -30,9 +30,8 @@ Out of scope for this module (deferred to follow-up tracks):
 
 - Source types beyond ``local`` (Git, OCI, index).
 - Signature verification and trust roots.
-- Sensitive-pattern-scan-on-install (the existing sanitiser already
-  scrubs invisible Unicode codepoints at load time; refusing installs on
-  sensitive patterns is track 4).
+- Sensitive-pattern-scan-on-install. Strict lint can block ERROR findings;
+  the default path remains advisory for backwards compatibility.
 """
 
 from __future__ import annotations
@@ -46,6 +45,8 @@ from pathlib import Path
 from typing import Any, cast
 
 import yaml
+
+from bernstein.core.skills.lint import LintSeverity, lint_skill
 
 # ---------------------------------------------------------------------------
 # Public constants
@@ -408,6 +409,19 @@ def _detect_skill_name(source: Path) -> str:
     return source.stem
 
 
+def _raise_for_strict_lint_errors(skill_dir: Path, *, skill_name: str) -> None:
+    """Raise when strict lint finds blocking errors for an installed skill."""
+    errors = [
+        finding
+        for finding in lint_skill(skill_dir, skill_name=skill_name)
+        if finding.severity is LintSeverity.ERROR
+    ]
+    if not errors:
+        return
+    details = "; ".join(f"{finding.code}: {finding.message}" for finding in errors)
+    raise SkillLifecycleError(f"{skill_name}: strict lint failed: {details}")
+
+
 def install_local(
     source: Path,
     *,
@@ -415,6 +429,7 @@ def install_local(
     workdir: Path,
     home: Path | None = None,
     override_name: str | None = None,
+    strict_lint: bool = False,
 ) -> InstallResult:
     """Install a skill from a local path into the chosen scope.
 
@@ -432,6 +447,8 @@ def install_local(
         home: Override for the user's home (tests).
         override_name: Override the auto-detected skill name. The TOML
             ``name`` field wins over filesystem layout when supplied.
+        strict_lint: When ``True``, ERROR lint findings abort the install.
+            WARNING findings remain advisory.
 
     Returns:
         :class:`InstallResult` with the target directory and digest.
@@ -472,6 +489,8 @@ def install_local(
             (staging_dir / "SKILL.md").write_text(content, encoding="utf-8")
 
         digest = compute_skill_digest(staging_dir)
+        if strict_lint:
+            _raise_for_strict_lint_errors(staging_dir, skill_name=name)
     except Exception:
         shutil.rmtree(staging_dir, ignore_errors=True)
         raise
@@ -637,6 +656,7 @@ def sync_skills(
     scope: InstallScope = InstallScope.PROJECT,
     workdir: Path | None = None,
     home: Path | None = None,
+    strict_lint: bool = False,
 ) -> list[SyncOutcome]:
     """Reconcile ``bernstein-skills.toml`` with the chosen scope.
 
@@ -650,6 +670,8 @@ def sync_skills(
         scope: Where to install. Defaults to PROJECT.
         workdir: Project root. Defaults to ``toml_path.parent``.
         home: Override for the user's home (tests).
+        strict_lint: When ``True``, ERROR lint findings abort changed and
+            unchanged installs. WARNING findings remain advisory.
 
     Returns:
         One :class:`SyncOutcome` per skill, in declaration order.
@@ -708,6 +730,8 @@ def sync_skills(
             source_digest = hasher.hexdigest()
 
         if prior_digest == source_digest and existing_install.is_dir():
+            if strict_lint:
+                _raise_for_strict_lint_errors(existing_install, skill_name=entry.name)
             outcomes.append(
                 SyncOutcome(
                     name=entry.name,
@@ -732,6 +756,7 @@ def sync_skills(
             workdir=workdir,
             home=home,
             override_name=entry.name,
+            strict_lint=strict_lint,
         )
         action = "updated" if entry.name in previous_lock else "installed"
         outcomes.append(

--- a/src/bernstein/core/skills/lint.py
+++ b/src/bernstein/core/skills/lint.py
@@ -1,12 +1,12 @@
-"""Advisory lint for installed skill directories (issue #1720, track 1 minimum).
+"""Lint for installed skill directories (issue #1720, track 1 minimum).
 
-The lint is intentionally non-blocking in this PR: ``bernstein skills install``
-and ``bernstein skills sync`` do not consult it. Operators run lint by hand
-or via CI to surface frontmatter typos, missing referenced files, sensitive
-patterns the sanitiser flags, and body conventions (heading order, max
-length).
+The default install and sync paths stay advisory for backward compatibility.
+When their strict mode is enabled, ERROR findings block the operation while
+WARNING findings remain advisory. Operators can also run lint by hand or via
+CI to surface frontmatter typos, missing referenced files, sensitive patterns
+the sanitiser flags, and body conventions (heading order, max length).
 
-Checks performed (all advisory):
+Checks performed:
 
 - Frontmatter parses as YAML and matches :class:`SkillManifest` after a
   loose pre-filter (extra Claude-style keys like ``whenToUse`` are
@@ -44,9 +44,8 @@ _VALID_BUCKETS: tuple[str, ...] = ("references", "scripts", "assets")
 class LintSeverity(StrEnum):
     """Severity of a lint finding.
 
-    ``WARNING`` is the default. ``ERROR`` does NOT block install in this
-    PR, but tests assert that real schema breakage is reported as ERROR
-    so a follow-up can flip the gate without a behaviour rewrite.
+    ``WARNING`` is the default. ``ERROR`` blocks install and sync only when
+    the caller opts in to strict mode.
     """
 
     ERROR = "error"

--- a/tests/unit/skills/test_cli_strict_lint.py
+++ b/tests/unit/skills/test_cli_strict_lint.py
@@ -1,0 +1,80 @@
+"""CLI tests for strict skill lint gates (#1720)."""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.skills_cmd import skills_group
+from bernstein.core.skills.lifecycle import SKILLS_LOCK_FILENAME, SKILLS_TOML_FILENAME
+
+
+def _write_broken_skill(path: Path) -> None:
+    """Write a skill that installs by default but emits an ERROR lint finding."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        textwrap.dedent(
+            """
+            ---
+            description: Missing the required skill name so lint reports an error.
+            ---
+
+            # Broken skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_skills_install_strict_blocks_error_findings_but_default_installs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "sources" / "broken.md"
+    _write_broken_skill(source)
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    default_result = runner.invoke(skills_group, ["install", str(source)])
+    installed = workdir / ".bernstein" / "skills" / "broken"
+    assert default_result.exit_code == 0
+    assert installed.is_dir()
+    shutil.rmtree(installed)
+
+    strict_result = runner.invoke(skills_group, ["install", str(source), "--strict"])
+    assert strict_result.exit_code == 1
+    assert not installed.exists()
+
+
+def test_skills_sync_strict_blocks_error_findings_but_default_syncs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = workdir / "sources" / "broken.md"
+    _write_broken_skill(source)
+    (workdir / SKILLS_TOML_FILENAME).write_text(
+        '[[skills]]\nname = "broken"\nsource = "local"\npath = "./sources/broken.md"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    default_result = runner.invoke(skills_group, ["sync"])
+    installed = workdir / ".bernstein" / "skills" / "broken"
+    assert default_result.exit_code == 0
+    assert installed.is_dir()
+    shutil.rmtree(installed)
+    (workdir / SKILLS_LOCK_FILENAME).unlink()
+
+    strict_result = runner.invoke(skills_group, ["sync", "--strict"])
+    assert strict_result.exit_code == 1
+    assert not installed.exists()

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -151,6 +151,59 @@ def test_install_local_directory_without_skill_md(tmp_path: Path) -> None:
         install_local(src, scope=InstallScope.PROJECT, workdir=workdir)
 
 
+def test_install_local_strict_lint_blocks_error_findings_but_default_installs(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "broken-skill.md"
+    source.write_text(
+        textwrap.dedent(
+            """
+            ---
+            description: Missing the required skill name so lint reports an error.
+            ---
+
+            # Broken skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    install_local(source, scope=InstallScope.PROJECT, workdir=workdir)
+    installed = scope_root(InstallScope.PROJECT, workdir=workdir) / "broken-skill"
+    assert installed.is_dir()
+    remove_skill("broken-skill", scope=InstallScope.PROJECT, workdir=workdir)
+
+    with pytest.raises(SkillLifecycleError, match="strict lint failed.*invalid-manifest"):
+        install_local(source, scope=InstallScope.PROJECT, workdir=workdir, strict_lint=True)
+    assert not installed.exists()
+
+
+def test_install_local_strict_lint_allows_warning_findings(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "warning-skill.md"
+    source.write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: warning-skill
+            description: Valid skill with an extra frontmatter key that lint reports as a warning.
+            whenToUse: When the agent needs this skill.
+            ---
+
+            # Warning skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = install_local(source, scope=InstallScope.PROJECT, workdir=workdir, strict_lint=True)
+
+    assert result.install_dir.is_dir()
+
+
 def test_install_overwrites_previous(
     tmp_path: Path,
     single_file_skill: Path,

--- a/tests/unit/skills/test_lifecycle_sync.py
+++ b/tests/unit/skills/test_lifecycle_sync.py
@@ -11,6 +11,7 @@ from bernstein.core.skills.lifecycle import (
     SKILLS_LOCK_FILENAME,
     SKILLS_TOML_FILENAME,
     InstallScope,
+    SkillLifecycleError,
     SkillsTomlError,
     read_lock_entries,
     scope_root,
@@ -169,3 +170,38 @@ def test_sync_directory_source_round_trips_referenced_files(tmp_path: Path) -> N
 
     installed_ref = scope_root(InstallScope.PROJECT, workdir=workdir) / "gamma" / "references" / "notes.md"
     assert installed_ref.is_file()
+
+
+def test_sync_strict_lint_blocks_error_findings_but_default_syncs(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    broken = workdir / "sources" / "broken.md"
+    broken.parent.mkdir(parents=True)
+    broken.write_text(
+        textwrap.dedent(
+            """
+            ---
+            description: Missing the required skill name so lint reports an error.
+            ---
+
+            # Broken skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    toml_path = _write_manifest(workdir, [("broken", "./sources/broken.md")])
+
+    outcomes = sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    installed = scope_root(InstallScope.PROJECT, workdir=workdir) / "broken"
+    assert outcomes[0].action == "installed"
+    assert installed.is_dir()
+    remove = installed
+    for child in remove.iterdir():
+        child.unlink()
+    remove.rmdir()
+    (workdir / SKILLS_LOCK_FILENAME).unlink()
+
+    with pytest.raises(SkillLifecycleError, match="strict lint failed.*invalid-manifest"):
+        sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir, strict_lint=True)
+    assert not installed.exists()


### PR DESCRIPTION
## Summary
- Add `--strict` to `bernstein skills install` and `bernstein skills sync`.
- Keep default install and sync behavior advisory for backward compatibility.
- Fail strict operations on ERROR lint findings while allowing WARNING findings.

## Validation
- `uv run pytest tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py tests/unit/skills/test_cli_strict_lint.py tests/unit/skills/test_lint.py -q`
- `uv run ruff check src/bernstein/cli/commands/skills_cmd.py src/bernstein/core/skills/lifecycle.py src/bernstein/core/skills/lint.py tests/unit/skills/test_cli_strict_lint.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py`
- `uv run pyright src/bernstein/cli/commands/skills_cmd.py src/bernstein/core/skills/lifecycle.py src/bernstein/core/skills/lint.py tests/unit/skills/test_cli_strict_lint.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py`
- `git diff --check`