### PR TITLE
Fix test runner timeout report

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 _TEST_REQUIRED_PREFIXES = (
     ".github/workflows/",
@@ -31,6 +32,8 @@ _TEST_REQUIRED_PREFIXES = (
     "src/",
     "tests/",
 )
+
+TEST_FILE_TIMEOUT_SECONDS = 300
 
 
 def _default_workers() -> int:
@@ -129,7 +132,7 @@ def run_file(path: Path, extra_args: list[str], coverage: bool = False) -> tuple
             *extra_args,
         ]
     start = time.monotonic()
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=TEST_FILE_TIMEOUT_SECONDS)
     duration = time.monotonic() - start
     output = result.stdout + result.stderr
     return path, result.returncode, duration, output
@@ -193,7 +196,7 @@ def run_sequential(files: list[Path], extra_args: list[str], fail_fast: bool, co
         try:
             _fpath, code, duration, output = run_file(path, extra_args, coverage=coverage)
         except subprocess.TimeoutExpired:
-            print(f"  TIMEOUT {label} (>120s)")
+            print(f"  TIMEOUT {label} (>{TEST_FILE_TIMEOUT_SECONDS}s)")
             failed += 1
             if fail_fast:
                 break
@@ -470,10 +473,16 @@ def _finalize_coverage() -> None:
         )
         if Path("coverage.json").exists():
             try:
-                data = json.loads(Path("coverage.json").read_text(encoding="utf-8"))
-                totals = data.get("totals", {}) if isinstance(data, dict) else {}
-                pct = totals.get("percent_covered") if isinstance(totals, dict) else None
-                if pct is not None:
+                data: object = json.loads(Path("coverage.json").read_text(encoding="utf-8"))
+                if not isinstance(data, dict):
+                    return
+                root = cast("dict[str, object]", data)
+                totals_raw = root.get("totals")
+                if not isinstance(totals_raw, dict):
+                    return
+                totals = cast("dict[str, object]", totals_raw)
+                pct = totals.get("percent_covered")
+                if isinstance(pct, int | float | str):
                     print(f"\nCoverage: {float(pct):.2f}%")
             except (json.JSONDecodeError, OSError, ValueError):
                 pass

--- a/tests/unit/scripts/test_run_tests_sharding.py
+++ b/tests/unit/scripts/test_run_tests_sharding.py
@@ -208,8 +208,14 @@ def test_empty_affected_selection_fails_for_source_changes(
     run_tests_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(run_tests_module, "discover_affected_files", lambda _base: [])
-    monkeypatch.setattr(run_tests_module, "discover_changed_files", lambda _base: ["src/bernstein/core/models.py"])
+    def no_affected_files(_base: str) -> list[Path]:
+        return []
+
+    def changed_source_files(_base: str) -> list[str]:
+        return ["src/bernstein/core/models.py"]
+
+    monkeypatch.setattr(run_tests_module, "discover_affected_files", no_affected_files)
+    monkeypatch.setattr(run_tests_module, "discover_changed_files", changed_source_files)
     monkeypatch.setattr(sys, "argv", ["run_tests.py", "--affected", "origin/main"])
 
     with pytest.raises(SystemExit) as exc_info:
@@ -222,13 +228,32 @@ def test_empty_affected_shard_remains_success_when_other_shards_have_tests(
     run_tests_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(run_tests_module, "discover_affected_files", lambda _base: [Path("tests/unit/test_models.py")])
+    def one_affected_file(_base: str) -> list[Path]:
+        return [Path("tests/unit/test_models.py")]
+
+    monkeypatch.setattr(run_tests_module, "discover_affected_files", one_affected_file)
     monkeypatch.setattr(sys, "argv", ["run_tests.py", "--affected", "origin/main", "--shard", "2/2"])
 
     with pytest.raises(SystemExit) as exc_info:
         run_tests_module.main()
 
     assert exc_info.value.code == 0
+
+
+def test_sequential_timeout_message_matches_subprocess_timeout(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_run_file(*_: object, **__: object) -> tuple[Path, int, float, str]:
+        raise subprocess.TimeoutExpired(cmd=["pytest"], timeout=300)
+
+    monkeypatch.setattr(run_tests_module, "run_file", fake_run_file)
+
+    result = run_tests_module.run_sequential([Path("tests/unit/test_slow.py")], [], fail_fast=True)
+
+    assert result == 1
+    assert "TIMEOUT [1/1] test_slow.py (>300s)" in capsys.readouterr().out
 
 
 def test_discover_changed_files_falls_back_to_two_dot_diff_without_merge_base(


### PR DESCRIPTION
## Summary
- Use one constant for the per-file test subprocess timeout.
- Report the same timeout threshold when sequential test execution times out.
- Add a regression test for the timeout message.

## Validation
- `uv run pytest tests/unit/scripts/test_run_tests_sharding.py -q`
- `uv run ruff check scripts/run_tests.py tests/unit/scripts/test_run_tests_sharding.py`
- `uv run pyright scripts/run_tests.py tests/unit/scripts/test_run_tests_sharding.py`
- `git diff --check HEAD~1 HEAD`