### PR TITLE
Add skills init scaffold

### DIFF
--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -29,6 +29,7 @@ from bernstein.core.skills.lifecycle import (
     InstallScope,
     SkillLifecycleError,
     SkillsTomlError,
+    init_skill,
     install_local,
     remove_skill,
     sync_skills,
@@ -242,6 +243,37 @@ def _parse_scope(scope_str: str) -> InstallScope:
         return InstallScope(scope_str)
     except ValueError as exc:
         raise click.BadParameter(f"unknown scope {scope_str!r}; expected project or user") from exc
+
+
+@skills_group.command("init")
+@click.argument("name")
+@click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["project", "user"]),
+    default="project",
+    help="Scaffold under the project or user skill directory.",
+)
+@click.option(
+    "--description",
+    "description",
+    default=None,
+    help="Description to write into SKILL.md.",
+)
+def skills_init(name: str, scope: str, description: str | None) -> None:
+    """Create a deterministic local skill scaffold."""
+    install_scope = _parse_scope(scope)
+    try:
+        result = init_skill(
+            name,
+            scope=install_scope,
+            workdir=Path.cwd(),
+            description=description,
+        )
+    except SkillLifecycleError as exc:
+        console.print(f"[red]init failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+    console.print(f"[green]initialized[/green] {result.name} -> {result.install_dir}")
 
 
 @skills_group.command("install")

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -42,7 +42,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
 import yaml
 from pydantic import ValidationError
@@ -408,6 +408,18 @@ class InitSkillResult:
     install_dir: Path
 
 
+class _ScaffoldManifestData(TypedDict):
+    """Validated frontmatter fields for a deterministic skill scaffold."""
+
+    manifest_schema: int
+    name: str
+    description: str
+    trigger_keywords: list[str]
+    references: list[str]
+    scripts: list[str]
+    assets: list[str]
+
+
 def _detect_skill_name(source: Path) -> str:
     """Derive the canonical name for a local source.
 
@@ -424,7 +436,7 @@ def _skill_title(name: str) -> str:
     return name.replace("-", " ").capitalize()
 
 
-def _scaffold_manifest_data(name: str, description: str) -> dict[str, object]:
+def _scaffold_manifest_data(name: str, description: str) -> _ScaffoldManifestData:
     """Return validated starter frontmatter for a scaffolded skill."""
     return {
         "manifest_schema": 1,
@@ -484,7 +496,9 @@ def init_skill(
     except ValueError as exc:
         raise SkillLifecycleError(str(exc)) from exc
 
-    skill_description = description or f"Skill {name} scaffolded for deterministic authoring."
+    skill_description = (
+        description if description is not None else f"Skill {name} scaffolded for deterministic authoring."
+    )
     try:
         SkillManifest.model_validate(_scaffold_manifest_data(name, skill_description))
     except ValidationError as exc:
@@ -495,20 +509,20 @@ def init_skill(
     if install_dir.exists():
         raise SkillLifecycleError(f"{name}: skill already exists at {install_dir}")
 
-    dest_root.mkdir(parents=True, exist_ok=True)
     staging_dir = dest_root / f".{name}.init-tmp"
-    if staging_dir.exists():
-        shutil.rmtree(staging_dir)
-    staging_dir.mkdir(parents=True)
 
     try:
+        dest_root.mkdir(parents=True, exist_ok=True)
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+        staging_dir.mkdir(parents=True)
         (staging_dir / "SKILL.md").write_text(_scaffold_skill_md(name, skill_description), encoding="utf-8")
         for bucket in ("references", "scripts", "assets"):
             (staging_dir / bucket).mkdir()
         staging_dir.replace(install_dir)
-    except Exception:
+    except OSError as exc:
         shutil.rmtree(staging_dir, ignore_errors=True)
-        raise
+        raise SkillLifecycleError(f"{name}: failed to initialize scaffold: {exc}") from exc
 
     return InitSkillResult(name=name, install_dir=install_dir)
 

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -45,8 +45,10 @@ from pathlib import Path
 from typing import Any, cast
 
 import yaml
+from pydantic import ValidationError
 
 from bernstein.core.skills.lint import LintSeverity, lint_skill
+from bernstein.core.skills.manifest import SkillManifest
 
 # ---------------------------------------------------------------------------
 # Public constants
@@ -398,6 +400,14 @@ class InstallResult:
     changed: bool
 
 
+@dataclass(frozen=True)
+class InitSkillResult:
+    """Outcome of scaffolding a new local skill."""
+
+    name: str
+    install_dir: Path
+
+
 def _detect_skill_name(source: Path) -> str:
     """Derive the canonical name for a local source.
 
@@ -407,6 +417,100 @@ def _detect_skill_name(source: Path) -> str:
     if source.is_dir():
         return source.name
     return source.stem
+
+
+def _skill_title(name: str) -> str:
+    """Return a deterministic human-readable heading for a skill slug."""
+    return name.replace("-", " ").capitalize()
+
+
+def _scaffold_manifest_data(name: str, description: str) -> dict[str, object]:
+    """Return validated starter frontmatter for a scaffolded skill."""
+    return {
+        "manifest_schema": 1,
+        "name": name,
+        "description": description,
+        "trigger_keywords": [],
+        "references": [],
+        "scripts": [],
+        "assets": [],
+    }
+
+
+def _scaffold_skill_md(name: str, description: str) -> str:
+    """Render the deterministic starter ``SKILL.md`` body."""
+    frontmatter = yaml.safe_dump(
+        _scaffold_manifest_data(name, description),
+        sort_keys=False,
+        allow_unicode=False,
+    )
+    return (
+        "---\n"
+        f"{frontmatter}"
+        "---\n"
+        "\n"
+        f"# {_skill_title(name)}\n"
+        "\n"
+        "Describe when to use this skill and the exact workflow it should follow.\n"
+    )
+
+
+def init_skill(
+    name: str,
+    *,
+    scope: InstallScope,
+    workdir: Path,
+    home: Path | None = None,
+    description: str | None = None,
+) -> InitSkillResult:
+    """Create a deterministic local skill scaffold in the selected scope.
+
+    Args:
+        name: Lowercase skill slug.
+        scope: Project or user scope.
+        workdir: Current project root.
+        home: Override for the user's home (tests).
+        description: Optional description for the scaffold. Defaults to a
+            deterministic valid description derived from ``name``.
+
+    Returns:
+        :class:`InitSkillResult` with the target directory.
+
+    Raises:
+        SkillLifecycleError: When the name is invalid or the target exists.
+    """
+    try:
+        SkillManifest.validate_name(name)
+    except ValueError as exc:
+        raise SkillLifecycleError(str(exc)) from exc
+
+    skill_description = description or f"Skill {name} scaffolded for deterministic authoring."
+    try:
+        SkillManifest.model_validate(_scaffold_manifest_data(name, skill_description))
+    except ValidationError as exc:
+        raise SkillLifecycleError(f"{name}: invalid scaffold manifest: {exc.errors()}") from exc
+
+    dest_root = scope_root(scope, workdir=workdir, home=home)
+    install_dir = dest_root / name
+    if install_dir.exists():
+        raise SkillLifecycleError(f"{name}: skill already exists at {install_dir}")
+
+    dest_root.mkdir(parents=True, exist_ok=True)
+    staging_dir = dest_root / f".{name}.init-tmp"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True)
+
+    try:
+        (staging_dir / "SKILL.md").write_text(_scaffold_skill_md(name, skill_description), encoding="utf-8")
+        for bucket in ("references", "scripts", "assets"):
+            (staging_dir / bucket).mkdir()
+        staging_dir.replace(install_dir)
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
+    return InitSkillResult(name=name, install_dir=install_dir)
 
 
 def _raise_for_strict_lint_errors(skill_dir: Path, *, skill_name: str) -> None:
@@ -787,6 +891,7 @@ def read_lock_entries(toml_dir: Path) -> list[LockEntry]:
 __all__ = [
     "SKILLS_LOCK_FILENAME",
     "SKILLS_TOML_FILENAME",
+    "InitSkillResult",
     "InstallResult",
     "InstallScope",
     "LockEntry",
@@ -797,6 +902,7 @@ __all__ = [
     "SkillsTomlError",
     "SyncOutcome",
     "compute_skill_digest",
+    "init_skill",
     "install_local",
     "load_skills_toml",
     "read_lock_entries",

--- a/tests/unit/skills/test_cli_init.py
+++ b/tests/unit/skills/test_cli_init.py
@@ -1,0 +1,45 @@
+"""CLI tests for deterministic skill scaffolding (#1720)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.skills_cmd import skills_group
+
+
+def test_skills_init_creates_project_scaffold(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["init", "sample-skill"])
+
+    assert result.exit_code == 0
+    assert "initialized sample-skill" in result.output
+    assert (workdir / ".bernstein" / "skills" / "sample-skill" / "SKILL.md").is_file()
+    assert (workdir / ".bernstein" / "skills" / "sample-skill" / "references").is_dir()
+    assert (workdir / ".bernstein" / "skills" / "sample-skill" / "scripts").is_dir()
+    assert (workdir / ".bernstein" / "skills" / "sample-skill" / "assets").is_dir()
+
+
+def test_skills_init_surfaces_invalid_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["init", "Bad Name"])
+
+    assert result.exit_code == 1
+    assert "init failed" in result.output
+    assert not (workdir / ".bernstein" / "skills" / "Bad Name").exists()

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -10,10 +10,12 @@ import pytest
 from bernstein.core.skills.lifecycle import (
     InstallScope,
     SkillLifecycleError,
+    init_skill,
     install_local,
     remove_skill,
     scope_root,
 )
+from bernstein.core.skills.manifest import parse_skill_md
 
 
 @pytest.fixture
@@ -149,6 +151,72 @@ def test_install_local_directory_without_skill_md(tmp_path: Path) -> None:
     src.mkdir()
     with pytest.raises(SkillLifecycleError, match="does not contain SKILL.md"):
         install_local(src, scope=InstallScope.PROJECT, workdir=workdir)
+
+
+def test_init_skill_creates_deterministic_project_scaffold(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+
+    result = init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir)
+
+    install_dir = scope_root(InstallScope.PROJECT, workdir=workdir) / "sample-skill"
+    assert result.install_dir == install_dir
+    assert (install_dir / "references").is_dir()
+    assert (install_dir / "scripts").is_dir()
+    assert (install_dir / "assets").is_dir()
+    assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == textwrap.dedent(
+        """\
+        ---
+        manifest_schema: 1
+        name: sample-skill
+        description: Skill sample-skill scaffolded for deterministic authoring.
+        trigger_keywords: []
+        references: []
+        scripts: []
+        assets: []
+        ---
+
+        # Sample skill
+
+        Describe when to use this skill and the exact workflow it should follow.
+        """
+    )
+
+
+def test_init_skill_rejects_invalid_name(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+
+    with pytest.raises(SkillLifecycleError, match="must match regex"):
+        init_skill("Bad Name", scope=InstallScope.PROJECT, workdir=workdir)
+
+
+def test_init_skill_rejects_invalid_description(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+
+    with pytest.raises(SkillLifecycleError, match="invalid scaffold manifest"):
+        init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir, description="short")
+
+
+def test_init_skill_quotes_yaml_sensitive_description(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    description = "Use when: local deterministic authoring is needed."
+
+    result = init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir, description=description)
+
+    manifest, _body = parse_skill_md(result.install_dir / "SKILL.md")
+    assert manifest.description == description
+
+
+def test_init_skill_does_not_overwrite_existing_skill(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir)
+
+    with pytest.raises(SkillLifecycleError, match="already exists"):
+        init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir)
 
 
 def test_install_local_strict_lint_blocks_error_findings_but_default_installs(tmp_path: Path) -> None:

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -199,6 +199,33 @@ def test_init_skill_rejects_invalid_description(tmp_path: Path) -> None:
         init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir, description="short")
 
 
+def test_init_skill_rejects_empty_description(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+
+    with pytest.raises(SkillLifecycleError, match="invalid scaffold manifest"):
+        init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir, description="")
+
+
+def test_init_skill_wraps_scaffold_write_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+
+    def fail_write_text(
+        self: Path,
+        data: str,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> int:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "write_text", fail_write_text)
+
+    with pytest.raises(SkillLifecycleError, match="failed to initialize scaffold"):
+        init_skill("sample-skill", scope=InstallScope.PROJECT, workdir=workdir)
+
+
 def test_init_skill_quotes_yaml_sensitive_description(tmp_path: Path) -> None:
     workdir = tmp_path / "project"
     workdir.mkdir()


### PR DESCRIPTION
## Summary
- Add `bernstein skills init` for deterministic local skill scaffolds.
- Create `SKILL.md`, `references/`, `scripts/`, and `assets/` under the selected scope.
- Validate scaffold metadata and refuse existing targets.

## Validation
- `uv run ruff check src/bernstein/cli/commands/skills_cmd.py src/bernstein/core/skills/lifecycle.py tests/unit/skills/test_cli_init.py tests/unit/skills/test_lifecycle_install.py`
- `uv run pytest tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_cli_init.py tests/unit/skills/test_cli_strict_lint.py -q`
- `uv run pyright src/bernstein/cli/commands/skills_cmd.py src/bernstein/core/skills/lifecycle.py tests/unit/skills/test_cli_init.py tests/unit/skills/test_lifecycle_install.py`
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `bernstein skills init` to create new skills with name, scope (project or user), and optional description; scaffolds directories and default SKILL.md.
  * Validates names and descriptions and reports clear success or failure messages.

* **Tests**
  * Added unit tests covering the CLI init command and lifecycle scaffold behavior, including success and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->