### PR TITLE
Document skill catalog default source

### DIFF
--- a/docs/operations/skills-catalog.md
+++ b/docs/operations/skills-catalog.md
@@ -25,6 +25,16 @@ All commands honour `--scope project` (writes into
 `<cwd>/.bernstein/skills/`) or `--scope user`
 (`~/.bernstein/skills/`). The default is `project`.
 
+## Catalog sources
+
+No catalog network request is made until a `bernstein skills catalog`
+command runs. The built-in primary source is
+`https://bernstein.run/skills-catalog.json`; on primary 5xx responses the
+fetcher tries the public mirror at
+`https://raw.githubusercontent.com/chernistry/bernstein-skills-catalog/main/skills-catalog.json`.
+Both URLs are validated as HTTPS before fetch, and fetched payloads must
+match the signed catalog schema before they are cached or used.
+
 ## Manifest schema
 
 A catalog entry is a strict JSON object. Unknown fields reject the

--- a/tests/unit/skills/test_catalog_docs.py
+++ b/tests/unit/skills/test_catalog_docs.py
@@ -1,0 +1,17 @@
+"""Documentation contracts for the signed skill catalog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.skills.catalog.fetcher import DEFAULT_SKILLS_CATALOG_URL, DEFAULT_SKILLS_MIRROR_URL
+
+
+def test_skills_catalog_docs_state_default_urls() -> None:
+    """The documented catalog posture must match the shipped defaults."""
+    docs = Path("docs/operations/skills-catalog.md").read_text(encoding="utf-8")
+    normalized_docs = " ".join(docs.split())
+
+    assert DEFAULT_SKILLS_CATALOG_URL in docs
+    assert DEFAULT_SKILLS_MIRROR_URL in docs
+    assert "No catalog network request is made until a `bernstein skills catalog` command runs." in normalized_docs


### PR DESCRIPTION
## Summary
- Document the built-in skill catalog primary URL and mirror.
- State that catalog network access starts only when a `bernstein skills catalog` command runs.
- Add a docs contract test tying the documented URLs to the shipped fetcher defaults.

## Validation
- `uv run pytest tests/unit/skills/test_catalog_docs.py -q`
- `uv run ruff check tests/unit/skills/test_catalog_docs.py`
- `uv run pyright tests/unit/skills/test_catalog_docs.py`
- `git diff --check`