### PR TITLE
Close CI issues after aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1695,9 +1695,10 @@ jobs:
   close-ci-issues:
     name: Close resolved CI issues
     runs-on: ubuntu-latest
-    needs: [repo-hygiene, lint, typecheck, test, spelling, dead-code]
+    needs: [ci-gate]
     if: >
       success() &&
+      needs.ci-gate.result == 'success' &&
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push'
     timeout-minutes: 5
@@ -1716,9 +1717,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          GATE_RESULT="${{ needs.ci-gate.result }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           ISSUES=$(gh issue list --label ci-fix --state open --json number --jq '.[].number' 2>/dev/null || echo "")
           for NUM in $ISSUES; do
-            gh issue close "$NUM" --comment "CI is green again (commit \`${{ github.sha }}\`)." || true
+            gh issue close "$NUM" --comment "CI aggregate gate result: ${GATE_RESULT}. Run: ${RUN_URL}. Commit: \`${{ github.sha }}\`." || true
           done
 
   # Note: the previous `self-heal` issue-creating job was superseded by the
@@ -1836,6 +1839,7 @@ jobs:
   #
   # Excluded from `needs:`:
   #   * `autofix`        - runs only on push to main, mutates the tree
+  #   * `close-ci-issues` - post-gate issue update, must not gate merges
   #   * `pr-summary`     - cosmetic PR comment, must not gate merges
   #   * `typecheck`      - advisory report while repo-wide pyright is being typed
   #   * `mutmut-diff`    - advisory report until mutation score enforcement is enabled
@@ -1872,7 +1876,6 @@ jobs:
       - adapter-integration-macos
       - test
       - test-macos
-      - close-ci-issues
     timeout-minutes: 3
     permissions:
       contents: read
@@ -1916,16 +1919,6 @@ jobs:
               "install-smoke-pipx",
               "install-smoke-uv",
           }
-          # Jobs intentionally gated by `if:` on event / branch - `skipped`
-          # is the expected outcome under these conditions.
-          ALWAYS_SKIPPABLE = {
-              # Only on push to main.
-              "close-ci-issues",
-          }
-          # PR-only jobs: skipped on push events is intentional.
-          PR_ONLY = set()
-          # Push-to-main-only jobs: skipped on PRs is intentional.
-          PUSH_ONLY = {"close-ci-issues"}
           # macOS-gated jobs (see #1468): on PRs these are skipped unless
           # the diff is macos_sensitive or the PR carries the
           # `macos-needed` label. Always run on push events.
@@ -1965,12 +1958,6 @@ jobs:
               if r == "success":
                   continue
               if r == "skipped":
-                  if name in ALWAYS_SKIPPABLE:
-                      continue
-                  if event == "pull_request" and name in PUSH_ONLY:
-                      continue
-                  if event != "pull_request" and name in PR_ONLY:
-                      continue
                   if docs_only and name in DOCS_ONLY_SKIPPABLE:
                       continue
                   # macOS-gated jobs are allowed to skip on:

--- a/tests/unit/test_ci_close_issues_workflow_yaml.py
+++ b/tests/unit/test_ci_close_issues_workflow_yaml.py
@@ -1,0 +1,74 @@
+"""Structural assertions for CI issue closure ordering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+CI = Path(".github/workflows/ci.yml")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, object]:
+    parsed = cast("object", yaml.safe_load(CI.read_text(encoding="utf-8")))
+    assert isinstance(parsed, dict)
+    return {str(key): value for key, value in cast("dict[object, object]", parsed).items()}
+
+
+def _mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return {str(key): item for key, item in cast("dict[object, object]", value).items()}
+
+
+def _jobs(workflow: dict[str, object]) -> dict[str, object]:
+    jobs = workflow.get("jobs")
+    return _mapping(jobs)
+
+
+def _needs(job: dict[str, object]) -> list[str]:
+    needs = job.get("needs", [])
+    if isinstance(needs, str):
+        return [needs]
+    assert isinstance(needs, list)
+    return [need for need in cast("list[object]", needs) if isinstance(need, str)]
+
+
+def test_close_ci_issues_waits_for_ci_gate(workflow: dict[str, object]) -> None:
+    """CI-fix issues may close only after the aggregate required gate is green."""
+    jobs = _jobs(workflow)
+    ci_gate = _mapping(jobs.get("ci-gate"))
+    close_issues = _mapping(jobs.get("close-ci-issues"))
+
+    assert "close-ci-issues" not in _needs(ci_gate), "ci-gate must not depend on its post-gate issue closer"
+    assert _needs(close_issues) == ["ci-gate"], "close-ci-issues must wait for the aggregate CI gate"
+
+    condition = close_issues.get("if", "")
+    assert isinstance(condition, str)
+    assert "needs.ci-gate.result == 'success'" in " ".join(condition.split())
+
+
+def test_close_ci_issues_comment_reports_gate_and_run_url(workflow: dict[str, object]) -> None:
+    """Issue closure comments must point at the exact successful aggregate run."""
+    close_issues = _mapping(_jobs(workflow).get("close-ci-issues"))
+    steps = close_issues.get("steps", [])
+    assert isinstance(steps, list)
+    close_step: dict[str, object] | None = None
+    for step in cast("list[object]", steps):
+        step_map = _mapping(step)
+        if step_map.get("name") == "Close ci-fix issues":
+            close_step = step_map
+            break
+    assert close_step is not None
+    run = close_step.get("run", "")
+    assert isinstance(run, str)
+
+    assert "needs.ci-gate.result" in run
+    assert "github.run_id" in run

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -352,7 +352,7 @@ def _run_rollup(
 # A typical (non-macOS-sensitive) merge_group entry: every required job
 # succeeds except the ones whose `if:` excludes merge_group. Under
 # merge_group: macOS-gated jobs skip (if: only fires on push / sensitive /
-# label), PR-only jobs skip (if: pull_request), and the push-only job skips.
+# label), and PR-only jobs skip (if: pull_request).
 _MERGE_GROUP_NEEDS = {
     "determine-changes": {"result": "success"},
     "repo-hygiene": {"result": "success"},
@@ -377,7 +377,6 @@ _MERGE_GROUP_NEEDS = {
     "adapter-integration-macos": {"result": "skipped"},  # if: push/sensitive/label
     "test": {"result": "success"},
     "test-macos": {"result": "skipped"},  # if: push/sensitive/label
-    "close-ci-issues": {"result": "skipped"},  # if: push to main
 }
 
 


### PR DESCRIPTION
## Summary
- Move `close-ci-issues` behind the aggregate `ci-gate` job.
- Remove the issue closer from the CI gate roll-up inputs.
- Include the aggregate gate result and run URL in automatic closure comments.

## Validation
- `uv run pytest tests/unit/test_required_check_canary_workflow_yaml.py tests/unit/test_ci_close_issues_workflow_yaml.py -q`
- `uv run ruff check tests/unit/test_ci_close_issues_workflow_yaml.py tests/unit/test_required_check_canary_workflow_yaml.py`
- `uv run pyright tests/unit/test_ci_close_issues_workflow_yaml.py`
- `actionlint -shellcheck= .github/workflows/ci.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for CI workflow configuration to ensure reliability of automated issue-closing notifications.
  * Updated existing test fixtures to reflect recent CI pipeline refinements.

* **Chores**
  * Enhanced CI workflow to improve automated issue tracking and provide clearer status notifications in build reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->