### PR TITLE
Report telemetry share endpoint presence

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -89,7 +89,10 @@ contents, args, prompts, paths, or resource names.
 ## Network behaviour
 
 - Endpoint: configurable via `BERNSTEIN_TELEMETRY_ENDPOINT`.  Default is
-  a Bernstein-owned receiver.
+  an illustrative placeholder host, not a real receiver.
+- Maintainer-share endpoint: configurable via
+  `BERNSTEIN_TELEMETRY_SHARE_ENDPOINT`.  No default is shipped, and
+  `bernstein telemetry status` prints only whether it is configured.
 - Single HTTP POST per event, 3-second timeout, no retries.
 - All errors are swallowed.  The command always completes normally
   whether or not the POST succeeded.
@@ -109,7 +112,7 @@ The first time `bernstein` runs, a one-time notice is printed to stderr:
 
 ```
 Bernstein collects no telemetry by default.
-Run `bernstein telemetry on` to opt in and share crash and error reports.
+Run `bernstein telemetry on` to opt in.
 This message will not appear again.
 ```
 

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -141,6 +141,9 @@ def telemetry_status(home: Path | None) -> None:
     share = resolve_share(home=home)
     install_id = read_install_id(home=home)
     dsn = os.environ.get(sidechannel.DSN_ENV) or "(unset)"
+    from bernstein.core.telemetry.share import resolve_share_endpoint
+
+    share_endpoint_configured = resolve_share_endpoint(dict(os.environ)) is not None
     lines: list[str] = [
         f"enabled: {str(state.enabled).lower()}",
         f"source: {state.source.value}",
@@ -151,6 +154,7 @@ def telemetry_status(home: Path | None) -> None:
         f"share_with_maintainer: {str(share.enabled).lower()}",
         f"share_source: {share.source.value} ({explain_share_source(share.source)})",
         f"share_config_file: {consent_file_path(home=home)}",
+        f"share_endpoint_configured: {str(share_endpoint_configured).lower()}",
         f"dsn: {dsn}",
     ]
     click.echo("\n".join(lines))

--- a/src/bernstein/core/telemetry/wire.py
+++ b/src/bernstein/core/telemetry/wire.py
@@ -42,7 +42,7 @@ _LOG = logging.getLogger(__name__)
 
 FIRST_RUN_NOTICE: Final[str] = (
     "Bernstein collects no telemetry by default.\n"
-    "Run `bernstein telemetry on` to opt in and help us prioritize.\n"
+    "Run `bernstein telemetry on` to opt in.\n"
     "This message will not appear again."
 )
 

--- a/tests/unit/telemetry/test_cli_command.py
+++ b/tests/unit/telemetry/test_cli_command.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -73,8 +74,25 @@ def test_status_snapshot_default(tmp_home: Path) -> None:
         "share_with_maintainer",
         "share_source",
         "share_config_file",
+        "share_endpoint_configured",
         "dsn",
     ]
+
+
+def test_status_reports_share_endpoint_presence_without_printing_url(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Status exposes maintainer-share endpoint presence without leaking its value."""
+    from bernstein.core.telemetry.share import SHARE_ENDPOINT_ENV
+
+    monkeypatch.setenv(SHARE_ENDPOINT_ENV, "https://maintainer.example.test/v1/events")
+
+    code, output = _invoke(["status", "--home", str(tmp_home)])
+
+    assert code == 0
+    assert "share_endpoint_configured: true" in output
+    assert "maintainer.example.test" not in output
 
 
 def test_status_overridden_by_env_off(
@@ -208,10 +226,18 @@ def test_probe_with_dsn_emits_synthetic_event(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv(sidechannel.DSN_ENV, "https://k@host/1")
 
     real_build = sidechannel.build_sidechannel
+    def build_with_transport(
+        *,
+        env: Mapping[str, str] | None = None,
+        transport: object | None = None,
+    ) -> sidechannel.SideChannelSink:
+        _ = transport
+        return real_build(env=env, transport=_Transport())
+
     monkeypatch.setattr(
         sidechannel,
         "build_sidechannel",
-        lambda **kw: real_build(transport=_Transport(), **kw),
+        build_with_transport,
     )
 
     code, output = _invoke(["probe", "--message", "hello probe"])

--- a/tests/unit/telemetry/test_cli_command.py
+++ b/tests/unit/telemetry/test_cli_command.py
@@ -226,6 +226,7 @@ def test_probe_with_dsn_emits_synthetic_event(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setenv(sidechannel.DSN_ENV, "https://k@host/1")
 
     real_build = sidechannel.build_sidechannel
+
     def build_with_transport(
         *,
         env: Mapping[str, str] | None = None,


### PR DESCRIPTION
Refs #1719

Summary:
- Add telemetry status output for whether the maintainer-share endpoint is configured.
- Keep the endpoint value out of CLI output.
- Correct telemetry docs so no maintainer endpoint default is implied.

Verification:
- uv run pytest tests/unit/telemetry/test_cli_command.py tests/unit/telemetry/test_first_run_notice.py tests/unit/telemetry/test_maintainer_share_sink.py tests/unit/telemetry/test_share_off_by_default.py -q
- uv run ruff check src/bernstein/cli/commands/telemetry_cmd.py src/bernstein/core/telemetry/wire.py tests/unit/telemetry/test_cli_command.py
- uv run pyright src/bernstein/cli/commands/telemetry_cmd.py src/bernstein/core/telemetry/wire.py tests/unit/telemetry/test_cli_command.py
- git diff --check origin/main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The telemetry status command now displays whether a maintainer-share endpoint is configured.

* **Documentation**
  * Updated telemetry documentation with clarified descriptions of endpoint configuration and behavior.
  * Refined the first-run telemetry opt-in notice text for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->