### PR TITLE
Raise Starlette dependency floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ classifiers = [
 ]
 dependencies = [
     "fastapi>=0.115",
+    # Direct floor for the Starlette ASGI layer so the resolved lockfile stays
+    # above PYSEC-2026-161 even when pulled through FastAPI or MCP.
+    "starlette>=1.0.1",
     "uvicorn>=0.30",
     "httpx>=0.27",
     "cryptography>=45.0.7",

--- a/uv.lock
+++ b/uv.lock
@@ -308,6 +308,7 @@ dependencies = [
     { name = "rich" },
     { name = "setproctitle" },
     { name = "signxml" },
+    { name = "starlette" },
     { name = "terminaltexteffects" },
     { name = "textual" },
     { name = "uvicorn" },
@@ -502,6 +503,7 @@ requires-dist = [
     { name = "signxml", specifier = ">=4.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27" },
     { name = "sse-starlette", marker = "extra == 'gui'", specifier = ">=2.1.0" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.6" },
     { name = "terminaltexteffects", specifier = ">=0.11" },
     { name = "textual", specifier = ">=1.0" },
@@ -4240,15 +4242,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
- Add a direct Starlette floor at 1.0.1.
- Refresh uv.lock so pip-audit no longer reports PYSEC-2026-161.

Verification:
- uv run pip-audit -r /tmp/bernstein-req-prod-starlette.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
- uv lock --check
- uv run pytest tests/unit/test_server.py tests/unit/routes/test_rate_limit_429_headers.py -q
- git diff --check origin/main..HEAD