### PR TITLE
Add core redirect ledger

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -8,65 +8,66 @@ alwaysApply: false
 
 ### `src/bernstein/core/` - orchestration engine
 
-| File                    | Purpose |
-|-------------------------|---------|
-| `credential_scoping.py` | Agent credential scope minimization for least-privilege API keys |
-| `defaults.py`           | Centralized default values for the Bernstein orchestrator |
-| `streaming_merge.py`    | Streaming task results for long-running agents (incremental merge) |
-| `agents/`               | agents sub-package |
-| `approval/`             | Interactive tool-call approval (op-002) |
-| `autofix/`              | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
-| `autoheal/`             | Auto-heal v2 subpackage |
-| `chat/`                 | Chat-control bridges for driving Bernstein agents from messaging apps |
-| `communication/`        | communication sub-package |
-| `compliance/`           | Compliance subpackage |
-| `config/`               | Config: seed parsing, config management, settings, feature gates |
-| `cost/`                 | cost sub-package |
-| `daemon/`               | Daemon installation helpers for Bernstein |
-| `devops/`               | devops sub-package |
-| `distribution/`         | Distribution utilities - air-gap wheelhouse build, verify, signing |
-| `errors/`               | Structured first-run error categorization for Bernstein |
-| `fleet/`                | Fleet dashboard - supervise multiple Bernstein projects in one view |
-| `git/`                  | git sub-package |
-| `grpc_gen/`             | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
-| `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
-| `identity/`             | Install-rev identity module - passive, operator-decodable install fingerprint |
-| `integrations/`         | Integrations sub-package |
-| `interop/`              | Cross-organisation interoperability surfaces |
-| `knowledge/`            | knowledge sub-package |
-| `lifecycle/`            | Lifecycle-hooks subsystem |
-| `lineage/`              | Lineage v1 - Sigstore-style per-artefact transparency log |
-| `memory/`               | memory sub-package - persistent memory stores |
-| `notifications/`        | Outbound notification subsystem (release 1.9) |
-| `observability/`        | observability sub-package |
-| `orchestration/`        | orchestration sub-package |
-| `persistence/`          | persistence sub-package |
-| `planning/`             | planning sub-package |
-| `plugins_core/`         | plugins_core sub-package |
-| `preview/`              | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
-| `protocols/`            | protocols sub-package |
-| `quality/`              | quality sub-package |
-| `replay/`               | Deterministic replay package for Bernstein agent runs |
-| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
-| `review_responder/`     | PR review responder - react to inline review comments on Bernstein PRs |
-| `routes/`               | FastAPI router modules for the Bernstein task server |
-| `routing/`              | routing sub-package |
-| `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
-| `security/`             | security sub-package |
-| `server/`               | server sub-package - re-exports for backward compatibility |
-| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
-| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
-| `skills/`               | Progressive-disclosure skill packs (oai-004) |
-| `storage/`              | Pluggable artifact storage sinks (oai-003) |
-| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
-| `tasks/`                | tasks sub-package |
-| `telemetry/`            | Opt-in operator observability for Bernstein |
-| `tokens/`               | tokens sub-package |
-| `trackers/`             | Tracker adapter subsystem |
-| `trigger_sources/`      | Trigger source adapters - normalize raw events into TriggerEvent |
-| `tunnels/`              | Tunnel provider abstraction and registry |
-| `workflows/`            | Archon-inspired YAML workflow manifests |
-| `worktrees/`            | Worktree inventory and garbage-collection helpers |
+| File                        | Purpose |
+|-----------------------------|---------|
+| `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
+| `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `defaults.py`               | Centralized default values for the Bernstein orchestrator |
+| `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
+| `agents/`                   | agents sub-package |
+| `approval/`                 | Interactive tool-call approval (op-002) |
+| `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
+| `autoheal/`                 | Auto-heal v2 subpackage |
+| `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
+| `communication/`            | communication sub-package |
+| `compliance/`               | Compliance subpackage |
+| `config/`                   | Config: seed parsing, config management, settings, feature gates |
+| `cost/`                     | cost sub-package |
+| `daemon/`                   | Daemon installation helpers for Bernstein |
+| `devops/`                   | devops sub-package |
+| `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
+| `errors/`                   | Structured first-run error categorization for Bernstein |
+| `fleet/`                    | Fleet dashboard - supervise multiple Bernstein projects in one view |
+| `git/`                      | git sub-package |
+| `grpc_gen/`                 | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
+| `handoff/`                  | Session handoff between terminal and chat/dashboard surfaces (op-005) |
+| `identity/`                 | Install-rev identity module - passive, operator-decodable install fingerprint |
+| `integrations/`             | Integrations sub-package |
+| `interop/`                  | Cross-organisation interoperability surfaces |
+| `knowledge/`                | knowledge sub-package |
+| `lifecycle/`                | Lifecycle-hooks subsystem |
+| `lineage/`                  | Lineage v1 - Sigstore-style per-artefact transparency log |
+| `memory/`                   | memory sub-package - persistent memory stores |
+| `notifications/`            | Outbound notification subsystem (release 1.9) |
+| `observability/`            | observability sub-package |
+| `orchestration/`            | orchestration sub-package |
+| `persistence/`              | persistence sub-package |
+| `planning/`                 | planning sub-package |
+| `plugins_core/`             | plugins_core sub-package |
+| `preview/`                  | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
+| `protocols/`                | protocols sub-package |
+| `quality/`                  | quality sub-package |
+| `replay/`                   | Deterministic replay package for Bernstein agent runs |
+| `review/`                   | Per-adapter perspective assignment and chain coordination for reviews |
+| `review_responder/`         | PR review responder - react to inline review comments on Bernstein PRs |
+| `routes/`                   | FastAPI router modules for the Bernstein task server |
+| `routing/`                  | routing sub-package |
+| `sandbox/`                  | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
+| `security/`                 | security sub-package |
+| `server/`                   | server sub-package - re-exports for backward compatibility |
+| `sessions/`                 | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`                 | Digital-twin orchestration simulator (issue #1374) |
+| `skills/`                   | Progressive-disclosure skill packs (oai-004) |
+| `storage/`                  | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`                | Substrate: register Bernstein into host applications (MCP servers, etc.) |
+| `tasks/`                    | tasks sub-package |
+| `telemetry/`                | Opt-in operator observability for Bernstein |
+| `tokens/`                   | tokens sub-package |
+| `trackers/`                 | Tracker adapter subsystem |
+| `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
+| `tunnels/`                  | Tunnel provider abstraction and registry |
+| `workflows/`                | Archon-inspired YAML workflow manifests |
+| `worktrees/`                | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` - CLI agent adapters
 

--- a/.goosehints
+++ b/.goosehints
@@ -9,65 +9,66 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/core/` - orchestration engine
 
-| File                    | Purpose |
-|-------------------------|---------|
-| `credential_scoping.py` | Agent credential scope minimization for least-privilege API keys |
-| `defaults.py`           | Centralized default values for the Bernstein orchestrator |
-| `streaming_merge.py`    | Streaming task results for long-running agents (incremental merge) |
-| `agents/`               | agents sub-package |
-| `approval/`             | Interactive tool-call approval (op-002) |
-| `autofix/`              | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
-| `autoheal/`             | Auto-heal v2 subpackage |
-| `chat/`                 | Chat-control bridges for driving Bernstein agents from messaging apps |
-| `communication/`        | communication sub-package |
-| `compliance/`           | Compliance subpackage |
-| `config/`               | Config: seed parsing, config management, settings, feature gates |
-| `cost/`                 | cost sub-package |
-| `daemon/`               | Daemon installation helpers for Bernstein |
-| `devops/`               | devops sub-package |
-| `distribution/`         | Distribution utilities - air-gap wheelhouse build, verify, signing |
-| `errors/`               | Structured first-run error categorization for Bernstein |
-| `fleet/`                | Fleet dashboard - supervise multiple Bernstein projects in one view |
-| `git/`                  | git sub-package |
-| `grpc_gen/`             | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
-| `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
-| `identity/`             | Install-rev identity module - passive, operator-decodable install fingerprint |
-| `integrations/`         | Integrations sub-package |
-| `interop/`              | Cross-organisation interoperability surfaces |
-| `knowledge/`            | knowledge sub-package |
-| `lifecycle/`            | Lifecycle-hooks subsystem |
-| `lineage/`              | Lineage v1 - Sigstore-style per-artefact transparency log |
-| `memory/`               | memory sub-package - persistent memory stores |
-| `notifications/`        | Outbound notification subsystem (release 1.9) |
-| `observability/`        | observability sub-package |
-| `orchestration/`        | orchestration sub-package |
-| `persistence/`          | persistence sub-package |
-| `planning/`             | planning sub-package |
-| `plugins_core/`         | plugins_core sub-package |
-| `preview/`              | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
-| `protocols/`            | protocols sub-package |
-| `quality/`              | quality sub-package |
-| `replay/`               | Deterministic replay package for Bernstein agent runs |
-| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
-| `review_responder/`     | PR review responder - react to inline review comments on Bernstein PRs |
-| `routes/`               | FastAPI router modules for the Bernstein task server |
-| `routing/`              | routing sub-package |
-| `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
-| `security/`             | security sub-package |
-| `server/`               | server sub-package - re-exports for backward compatibility |
-| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
-| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
-| `skills/`               | Progressive-disclosure skill packs (oai-004) |
-| `storage/`              | Pluggable artifact storage sinks (oai-003) |
-| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
-| `tasks/`                | tasks sub-package |
-| `telemetry/`            | Opt-in operator observability for Bernstein |
-| `tokens/`               | tokens sub-package |
-| `trackers/`             | Tracker adapter subsystem |
-| `trigger_sources/`      | Trigger source adapters - normalize raw events into TriggerEvent |
-| `tunnels/`              | Tunnel provider abstraction and registry |
-| `workflows/`            | Archon-inspired YAML workflow manifests |
-| `worktrees/`            | Worktree inventory and garbage-collection helpers |
+| File                        | Purpose |
+|-----------------------------|---------|
+| `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
+| `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `defaults.py`               | Centralized default values for the Bernstein orchestrator |
+| `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
+| `agents/`                   | agents sub-package |
+| `approval/`                 | Interactive tool-call approval (op-002) |
+| `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
+| `autoheal/`                 | Auto-heal v2 subpackage |
+| `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
+| `communication/`            | communication sub-package |
+| `compliance/`               | Compliance subpackage |
+| `config/`                   | Config: seed parsing, config management, settings, feature gates |
+| `cost/`                     | cost sub-package |
+| `daemon/`                   | Daemon installation helpers for Bernstein |
+| `devops/`                   | devops sub-package |
+| `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
+| `errors/`                   | Structured first-run error categorization for Bernstein |
+| `fleet/`                    | Fleet dashboard - supervise multiple Bernstein projects in one view |
+| `git/`                      | git sub-package |
+| `grpc_gen/`                 | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
+| `handoff/`                  | Session handoff between terminal and chat/dashboard surfaces (op-005) |
+| `identity/`                 | Install-rev identity module - passive, operator-decodable install fingerprint |
+| `integrations/`             | Integrations sub-package |
+| `interop/`                  | Cross-organisation interoperability surfaces |
+| `knowledge/`                | knowledge sub-package |
+| `lifecycle/`                | Lifecycle-hooks subsystem |
+| `lineage/`                  | Lineage v1 - Sigstore-style per-artefact transparency log |
+| `memory/`                   | memory sub-package - persistent memory stores |
+| `notifications/`            | Outbound notification subsystem (release 1.9) |
+| `observability/`            | observability sub-package |
+| `orchestration/`            | orchestration sub-package |
+| `persistence/`              | persistence sub-package |
+| `planning/`                 | planning sub-package |
+| `plugins_core/`             | plugins_core sub-package |
+| `preview/`                  | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
+| `protocols/`                | protocols sub-package |
+| `quality/`                  | quality sub-package |
+| `replay/`                   | Deterministic replay package for Bernstein agent runs |
+| `review/`                   | Per-adapter perspective assignment and chain coordination for reviews |
+| `review_responder/`         | PR review responder - react to inline review comments on Bernstein PRs |
+| `routes/`                   | FastAPI router modules for the Bernstein task server |
+| `routing/`                  | routing sub-package |
+| `sandbox/`                  | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
+| `security/`                 | security sub-package |
+| `server/`                   | server sub-package - re-exports for backward compatibility |
+| `sessions/`                 | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`                 | Digital-twin orchestration simulator (issue #1374) |
+| `skills/`                   | Progressive-disclosure skill packs (oai-004) |
+| `storage/`                  | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`                | Substrate: register Bernstein into host applications (MCP servers, etc.) |
+| `tasks/`                    | tasks sub-package |
+| `telemetry/`                | Opt-in operator observability for Bernstein |
+| `tokens/`                   | tokens sub-package |
+| `trackers/`                 | Tracker adapter subsystem |
+| `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
+| `tunnels/`                  | Tunnel provider abstraction and registry |
+| `workflows/`                | Archon-inspired YAML workflow manifests |
+| `worktrees/`                | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` - CLI agent adapters
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,65 +9,66 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/core/` - orchestration engine
 
-| File                    | Purpose |
-|-------------------------|---------|
-| `credential_scoping.py` | Agent credential scope minimization for least-privilege API keys |
-| `defaults.py`           | Centralized default values for the Bernstein orchestrator |
-| `streaming_merge.py`    | Streaming task results for long-running agents (incremental merge) |
-| `agents/`               | agents sub-package |
-| `approval/`             | Interactive tool-call approval (op-002) |
-| `autofix/`              | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
-| `autoheal/`             | Auto-heal v2 subpackage |
-| `chat/`                 | Chat-control bridges for driving Bernstein agents from messaging apps |
-| `communication/`        | communication sub-package |
-| `compliance/`           | Compliance subpackage |
-| `config/`               | Config: seed parsing, config management, settings, feature gates |
-| `cost/`                 | cost sub-package |
-| `daemon/`               | Daemon installation helpers for Bernstein |
-| `devops/`               | devops sub-package |
-| `distribution/`         | Distribution utilities - air-gap wheelhouse build, verify, signing |
-| `errors/`               | Structured first-run error categorization for Bernstein |
-| `fleet/`                | Fleet dashboard - supervise multiple Bernstein projects in one view |
-| `git/`                  | git sub-package |
-| `grpc_gen/`             | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
-| `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
-| `identity/`             | Install-rev identity module - passive, operator-decodable install fingerprint |
-| `integrations/`         | Integrations sub-package |
-| `interop/`              | Cross-organisation interoperability surfaces |
-| `knowledge/`            | knowledge sub-package |
-| `lifecycle/`            | Lifecycle-hooks subsystem |
-| `lineage/`              | Lineage v1 - Sigstore-style per-artefact transparency log |
-| `memory/`               | memory sub-package - persistent memory stores |
-| `notifications/`        | Outbound notification subsystem (release 1.9) |
-| `observability/`        | observability sub-package |
-| `orchestration/`        | orchestration sub-package |
-| `persistence/`          | persistence sub-package |
-| `planning/`             | planning sub-package |
-| `plugins_core/`         | plugins_core sub-package |
-| `preview/`              | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
-| `protocols/`            | protocols sub-package |
-| `quality/`              | quality sub-package |
-| `replay/`               | Deterministic replay package for Bernstein agent runs |
-| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
-| `review_responder/`     | PR review responder - react to inline review comments on Bernstein PRs |
-| `routes/`               | FastAPI router modules for the Bernstein task server |
-| `routing/`              | routing sub-package |
-| `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
-| `security/`             | security sub-package |
-| `server/`               | server sub-package - re-exports for backward compatibility |
-| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
-| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
-| `skills/`               | Progressive-disclosure skill packs (oai-004) |
-| `storage/`              | Pluggable artifact storage sinks (oai-003) |
-| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
-| `tasks/`                | tasks sub-package |
-| `telemetry/`            | Opt-in operator observability for Bernstein |
-| `tokens/`               | tokens sub-package |
-| `trackers/`             | Tracker adapter subsystem |
-| `trigger_sources/`      | Trigger source adapters - normalize raw events into TriggerEvent |
-| `tunnels/`              | Tunnel provider abstraction and registry |
-| `workflows/`            | Archon-inspired YAML workflow manifests |
-| `worktrees/`            | Worktree inventory and garbage-collection helpers |
+| File                        | Purpose |
+|-----------------------------|---------|
+| `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
+| `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `defaults.py`               | Centralized default values for the Bernstein orchestrator |
+| `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
+| `agents/`                   | agents sub-package |
+| `approval/`                 | Interactive tool-call approval (op-002) |
+| `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
+| `autoheal/`                 | Auto-heal v2 subpackage |
+| `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
+| `communication/`            | communication sub-package |
+| `compliance/`               | Compliance subpackage |
+| `config/`                   | Config: seed parsing, config management, settings, feature gates |
+| `cost/`                     | cost sub-package |
+| `daemon/`                   | Daemon installation helpers for Bernstein |
+| `devops/`                   | devops sub-package |
+| `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
+| `errors/`                   | Structured first-run error categorization for Bernstein |
+| `fleet/`                    | Fleet dashboard - supervise multiple Bernstein projects in one view |
+| `git/`                      | git sub-package |
+| `grpc_gen/`                 | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
+| `handoff/`                  | Session handoff between terminal and chat/dashboard surfaces (op-005) |
+| `identity/`                 | Install-rev identity module - passive, operator-decodable install fingerprint |
+| `integrations/`             | Integrations sub-package |
+| `interop/`                  | Cross-organisation interoperability surfaces |
+| `knowledge/`                | knowledge sub-package |
+| `lifecycle/`                | Lifecycle-hooks subsystem |
+| `lineage/`                  | Lineage v1 - Sigstore-style per-artefact transparency log |
+| `memory/`                   | memory sub-package - persistent memory stores |
+| `notifications/`            | Outbound notification subsystem (release 1.9) |
+| `observability/`            | observability sub-package |
+| `orchestration/`            | orchestration sub-package |
+| `persistence/`              | persistence sub-package |
+| `planning/`                 | planning sub-package |
+| `plugins_core/`             | plugins_core sub-package |
+| `preview/`                  | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
+| `protocols/`                | protocols sub-package |
+| `quality/`                  | quality sub-package |
+| `replay/`                   | Deterministic replay package for Bernstein agent runs |
+| `review/`                   | Per-adapter perspective assignment and chain coordination for reviews |
+| `review_responder/`         | PR review responder - react to inline review comments on Bernstein PRs |
+| `routes/`                   | FastAPI router modules for the Bernstein task server |
+| `routing/`                  | routing sub-package |
+| `sandbox/`                  | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
+| `security/`                 | security sub-package |
+| `server/`                   | server sub-package - re-exports for backward compatibility |
+| `sessions/`                 | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`                 | Digital-twin orchestration simulator (issue #1374) |
+| `skills/`                   | Progressive-disclosure skill packs (oai-004) |
+| `storage/`                  | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`                | Substrate: register Bernstein into host applications (MCP servers, etc.) |
+| `tasks/`                    | tasks sub-package |
+| `telemetry/`                | Opt-in operator observability for Bernstein |
+| `tokens/`                   | tokens sub-package |
+| `trackers/`                 | Tracker adapter subsystem |
+| `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
+| `tunnels/`                  | Tunnel provider abstraction and registry |
+| `workflows/`                | Archon-inspired YAML workflow manifests |
+| `worktrees/`                | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` - CLI agent adapters
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,65 +9,66 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/core/` - orchestration engine
 
-| File                    | Purpose |
-|-------------------------|---------|
-| `credential_scoping.py` | Agent credential scope minimization for least-privilege API keys |
-| `defaults.py`           | Centralized default values for the Bernstein orchestrator |
-| `streaming_merge.py`    | Streaming task results for long-running agents (incremental merge) |
-| `agents/`               | agents sub-package |
-| `approval/`             | Interactive tool-call approval (op-002) |
-| `autofix/`              | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
-| `autoheal/`             | Auto-heal v2 subpackage |
-| `chat/`                 | Chat-control bridges for driving Bernstein agents from messaging apps |
-| `communication/`        | communication sub-package |
-| `compliance/`           | Compliance subpackage |
-| `config/`               | Config: seed parsing, config management, settings, feature gates |
-| `cost/`                 | cost sub-package |
-| `daemon/`               | Daemon installation helpers for Bernstein |
-| `devops/`               | devops sub-package |
-| `distribution/`         | Distribution utilities - air-gap wheelhouse build, verify, signing |
-| `errors/`               | Structured first-run error categorization for Bernstein |
-| `fleet/`                | Fleet dashboard - supervise multiple Bernstein projects in one view |
-| `git/`                  | git sub-package |
-| `grpc_gen/`             | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
-| `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
-| `identity/`             | Install-rev identity module - passive, operator-decodable install fingerprint |
-| `integrations/`         | Integrations sub-package |
-| `interop/`              | Cross-organisation interoperability surfaces |
-| `knowledge/`            | knowledge sub-package |
-| `lifecycle/`            | Lifecycle-hooks subsystem |
-| `lineage/`              | Lineage v1 - Sigstore-style per-artefact transparency log |
-| `memory/`               | memory sub-package - persistent memory stores |
-| `notifications/`        | Outbound notification subsystem (release 1.9) |
-| `observability/`        | observability sub-package |
-| `orchestration/`        | orchestration sub-package |
-| `persistence/`          | persistence sub-package |
-| `planning/`             | planning sub-package |
-| `plugins_core/`         | plugins_core sub-package |
-| `preview/`              | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
-| `protocols/`            | protocols sub-package |
-| `quality/`              | quality sub-package |
-| `replay/`               | Deterministic replay package for Bernstein agent runs |
-| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
-| `review_responder/`     | PR review responder - react to inline review comments on Bernstein PRs |
-| `routes/`               | FastAPI router modules for the Bernstein task server |
-| `routing/`              | routing sub-package |
-| `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
-| `security/`             | security sub-package |
-| `server/`               | server sub-package - re-exports for backward compatibility |
-| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
-| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
-| `skills/`               | Progressive-disclosure skill packs (oai-004) |
-| `storage/`              | Pluggable artifact storage sinks (oai-003) |
-| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
-| `tasks/`                | tasks sub-package |
-| `telemetry/`            | Opt-in operator observability for Bernstein |
-| `tokens/`               | tokens sub-package |
-| `trackers/`             | Tracker adapter subsystem |
-| `trigger_sources/`      | Trigger source adapters - normalize raw events into TriggerEvent |
-| `tunnels/`              | Tunnel provider abstraction and registry |
-| `workflows/`            | Archon-inspired YAML workflow manifests |
-| `worktrees/`            | Worktree inventory and garbage-collection helpers |
+| File                        | Purpose |
+|-----------------------------|---------|
+| `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
+| `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `defaults.py`               | Centralized default values for the Bernstein orchestrator |
+| `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
+| `agents/`                   | agents sub-package |
+| `approval/`                 | Interactive tool-call approval (op-002) |
+| `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
+| `autoheal/`                 | Auto-heal v2 subpackage |
+| `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
+| `communication/`            | communication sub-package |
+| `compliance/`               | Compliance subpackage |
+| `config/`                   | Config: seed parsing, config management, settings, feature gates |
+| `cost/`                     | cost sub-package |
+| `daemon/`                   | Daemon installation helpers for Bernstein |
+| `devops/`                   | devops sub-package |
+| `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
+| `errors/`                   | Structured first-run error categorization for Bernstein |
+| `fleet/`                    | Fleet dashboard - supervise multiple Bernstein projects in one view |
+| `git/`                      | git sub-package |
+| `grpc_gen/`                 | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
+| `handoff/`                  | Session handoff between terminal and chat/dashboard surfaces (op-005) |
+| `identity/`                 | Install-rev identity module - passive, operator-decodable install fingerprint |
+| `integrations/`             | Integrations sub-package |
+| `interop/`                  | Cross-organisation interoperability surfaces |
+| `knowledge/`                | knowledge sub-package |
+| `lifecycle/`                | Lifecycle-hooks subsystem |
+| `lineage/`                  | Lineage v1 - Sigstore-style per-artefact transparency log |
+| `memory/`                   | memory sub-package - persistent memory stores |
+| `notifications/`            | Outbound notification subsystem (release 1.9) |
+| `observability/`            | observability sub-package |
+| `orchestration/`            | orchestration sub-package |
+| `persistence/`              | persistence sub-package |
+| `planning/`                 | planning sub-package |
+| `plugins_core/`             | plugins_core sub-package |
+| `preview/`                  | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
+| `protocols/`                | protocols sub-package |
+| `quality/`                  | quality sub-package |
+| `replay/`                   | Deterministic replay package for Bernstein agent runs |
+| `review/`                   | Per-adapter perspective assignment and chain coordination for reviews |
+| `review_responder/`         | PR review responder - react to inline review comments on Bernstein PRs |
+| `routes/`                   | FastAPI router modules for the Bernstein task server |
+| `routing/`                  | routing sub-package |
+| `sandbox/`                  | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
+| `security/`                 | security sub-package |
+| `server/`                   | server sub-package - re-exports for backward compatibility |
+| `sessions/`                 | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`                 | Digital-twin orchestration simulator (issue #1374) |
+| `skills/`                   | Progressive-disclosure skill packs (oai-004) |
+| `storage/`                  | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`                | Substrate: register Bernstein into host applications (MCP servers, etc.) |
+| `tasks/`                    | tasks sub-package |
+| `telemetry/`                | Opt-in operator observability for Bernstein |
+| `tokens/`                   | tokens sub-package |
+| `trackers/`                 | Tracker adapter subsystem |
+| `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
+| `tunnels/`                  | Tunnel provider abstraction and registry |
+| `workflows/`                | Archon-inspired YAML workflow manifests |
+| `worktrees/`                | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` - CLI agent adapters
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -9,65 +9,66 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/core/` - orchestration engine
 
-| File                    | Purpose |
-|-------------------------|---------|
-| `credential_scoping.py` | Agent credential scope minimization for least-privilege API keys |
-| `defaults.py`           | Centralized default values for the Bernstein orchestrator |
-| `streaming_merge.py`    | Streaming task results for long-running agents (incremental merge) |
-| `agents/`               | agents sub-package |
-| `approval/`             | Interactive tool-call approval (op-002) |
-| `autofix/`              | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
-| `autoheal/`             | Auto-heal v2 subpackage |
-| `chat/`                 | Chat-control bridges for driving Bernstein agents from messaging apps |
-| `communication/`        | communication sub-package |
-| `compliance/`           | Compliance subpackage |
-| `config/`               | Config: seed parsing, config management, settings, feature gates |
-| `cost/`                 | cost sub-package |
-| `daemon/`               | Daemon installation helpers for Bernstein |
-| `devops/`               | devops sub-package |
-| `distribution/`         | Distribution utilities - air-gap wheelhouse build, verify, signing |
-| `errors/`               | Structured first-run error categorization for Bernstein |
-| `fleet/`                | Fleet dashboard - supervise multiple Bernstein projects in one view |
-| `git/`                  | git sub-package |
-| `grpc_gen/`             | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
-| `handoff/`              | Session handoff between terminal and chat/dashboard surfaces (op-005) |
-| `identity/`             | Install-rev identity module - passive, operator-decodable install fingerprint |
-| `integrations/`         | Integrations sub-package |
-| `interop/`              | Cross-organisation interoperability surfaces |
-| `knowledge/`            | knowledge sub-package |
-| `lifecycle/`            | Lifecycle-hooks subsystem |
-| `lineage/`              | Lineage v1 - Sigstore-style per-artefact transparency log |
-| `memory/`               | memory sub-package - persistent memory stores |
-| `notifications/`        | Outbound notification subsystem (release 1.9) |
-| `observability/`        | observability sub-package |
-| `orchestration/`        | orchestration sub-package |
-| `persistence/`          | persistence sub-package |
-| `planning/`             | planning sub-package |
-| `plugins_core/`         | plugins_core sub-package |
-| `preview/`              | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
-| `protocols/`            | protocols sub-package |
-| `quality/`              | quality sub-package |
-| `replay/`               | Deterministic replay package for Bernstein agent runs |
-| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
-| `review_responder/`     | PR review responder - react to inline review comments on Bernstein PRs |
-| `routes/`               | FastAPI router modules for the Bernstein task server |
-| `routing/`              | routing sub-package |
-| `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
-| `security/`             | security sub-package |
-| `server/`               | server sub-package - re-exports for backward compatibility |
-| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
-| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
-| `skills/`               | Progressive-disclosure skill packs (oai-004) |
-| `storage/`              | Pluggable artifact storage sinks (oai-003) |
-| `substrate/`            | Substrate: register Bernstein into host applications (MCP servers, etc.) |
-| `tasks/`                | tasks sub-package |
-| `telemetry/`            | Opt-in operator observability for Bernstein |
-| `tokens/`               | tokens sub-package |
-| `trackers/`             | Tracker adapter subsystem |
-| `trigger_sources/`      | Trigger source adapters - normalize raw events into TriggerEvent |
-| `tunnels/`              | Tunnel provider abstraction and registry |
-| `workflows/`            | Archon-inspired YAML workflow manifests |
-| `worktrees/`            | Worktree inventory and garbage-collection helpers |
+| File                        | Purpose |
+|-----------------------------|---------|
+| `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
+| `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `defaults.py`               | Centralized default values for the Bernstein orchestrator |
+| `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
+| `agents/`                   | agents sub-package |
+| `approval/`                 | Interactive tool-call approval (op-002) |
+| `autofix/`                  | Bernstein autofix daemon - auto-repair CI failures on Bernstein PRs |
+| `autoheal/`                 | Auto-heal v2 subpackage |
+| `chat/`                     | Chat-control bridges for driving Bernstein agents from messaging apps |
+| `communication/`            | communication sub-package |
+| `compliance/`               | Compliance subpackage |
+| `config/`                   | Config: seed parsing, config management, settings, feature gates |
+| `cost/`                     | cost sub-package |
+| `daemon/`                   | Daemon installation helpers for Bernstein |
+| `devops/`                   | devops sub-package |
+| `distribution/`             | Distribution utilities - air-gap wheelhouse build, verify, signing |
+| `errors/`                   | Structured first-run error categorization for Bernstein |
+| `fleet/`                    | Fleet dashboard - supervise multiple Bernstein projects in one view |
+| `git/`                      | git sub-package |
+| `grpc_gen/`                 | Generated gRPC stubs - run ``scripts/generate_proto.sh`` to populate |
+| `handoff/`                  | Session handoff between terminal and chat/dashboard surfaces (op-005) |
+| `identity/`                 | Install-rev identity module - passive, operator-decodable install fingerprint |
+| `integrations/`             | Integrations sub-package |
+| `interop/`                  | Cross-organisation interoperability surfaces |
+| `knowledge/`                | knowledge sub-package |
+| `lifecycle/`                | Lifecycle-hooks subsystem |
+| `lineage/`                  | Lineage v1 - Sigstore-style per-artefact transparency log |
+| `memory/`                   | memory sub-package - persistent memory stores |
+| `notifications/`            | Outbound notification subsystem (release 1.9) |
+| `observability/`            | observability sub-package |
+| `orchestration/`            | orchestration sub-package |
+| `persistence/`              | persistence sub-package |
+| `planning/`                 | planning sub-package |
+| `plugins_core/`             | plugins_core sub-package |
+| `preview/`                  | ``bernstein preview`` - sandboxed dev-server with public tunnel link |
+| `protocols/`                | protocols sub-package |
+| `quality/`                  | quality sub-package |
+| `replay/`                   | Deterministic replay package for Bernstein agent runs |
+| `review/`                   | Per-adapter perspective assignment and chain coordination for reviews |
+| `review_responder/`         | PR review responder - react to inline review comments on Bernstein PRs |
+| `routes/`                   | FastAPI router modules for the Bernstein task server |
+| `routing/`                  | routing sub-package |
+| `sandbox/`                  | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
+| `security/`                 | security sub-package |
+| `server/`                   | server sub-package - re-exports for backward compatibility |
+| `sessions/`                 | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`                 | Digital-twin orchestration simulator (issue #1374) |
+| `skills/`                   | Progressive-disclosure skill packs (oai-004) |
+| `storage/`                  | Pluggable artifact storage sinks (oai-003) |
+| `substrate/`                | Substrate: register Bernstein into host applications (MCP servers, etc.) |
+| `tasks/`                    | tasks sub-package |
+| `telemetry/`                | Opt-in operator observability for Bernstein |
+| `tokens/`                   | tokens sub-package |
+| `trackers/`                 | Tracker adapter subsystem |
+| `trigger_sources/`          | Trigger source adapters - normalize raw events into TriggerEvent |
+| `tunnels/`                  | Tunnel provider abstraction and registry |
+| `workflows/`                | Archon-inspired YAML workflow manifests |
+| `worktrees/`                | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` - CLI agent adapters
 

--- a/src/bernstein/core/compat_redirect_ledger.py
+++ b/src/bernstein/core/compat_redirect_ledger.py
@@ -1,0 +1,72 @@
+"""Compatibility ledger for legacy ``bernstein.core`` redirects."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class RedirectLedgerPolicy:
+    """Shared policy metadata for the core redirect map."""
+
+    owner: str
+    first_release: str
+    removal_policy: str
+
+
+@dataclass(frozen=True, slots=True)
+class RedirectLedgerEntry:
+    """One reviewed legacy import redirect."""
+
+    old_path: str
+    new_path: str
+    owner: str
+    first_release: str
+    removal_policy: str
+
+
+REDIRECT_LEDGER_POLICY: Final[RedirectLedgerPolicy] = RedirectLedgerPolicy(
+    owner="core-maintainers",
+    first_release="pre-1.0",
+    removal_policy=(
+        "Keep until a redirect-specific removal PR deletes the map entry and proves no live importers remain."
+    ),
+)
+
+REVIEWED_REDIRECT_MAP_DIGEST: Final[str] = "d35096b8ee9932b42510e4e704a60b276c9188855107c1e4d735f30ef9a13567"
+
+
+def redirect_map_digest(redirects: Mapping[str, str]) -> str:
+    """Return a stable SHA-256 digest for a redirect map."""
+    canonical = json.dumps(sorted(redirects.items()), separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_redirect_ledger(redirects: Mapping[str, str]) -> dict[str, RedirectLedgerEntry]:
+    """Build reviewed ledger entries for the current redirect map."""
+    return {
+        old: RedirectLedgerEntry(
+            old_path=f"bernstein.core.{old}",
+            new_path=new,
+            owner=REDIRECT_LEDGER_POLICY.owner,
+            first_release=REDIRECT_LEDGER_POLICY.first_release,
+            removal_policy=REDIRECT_LEDGER_POLICY.removal_policy,
+        )
+        for old, new in redirects.items()
+    }
+
+
+__all__ = [
+    "REDIRECT_LEDGER_POLICY",
+    "REVIEWED_REDIRECT_MAP_DIGEST",
+    "RedirectLedgerEntry",
+    "RedirectLedgerPolicy",
+    "build_redirect_ledger",
+    "redirect_map_digest",
+]

--- a/tests/unit/test_core_redirect_ledger.py
+++ b/tests/unit/test_core_redirect_ledger.py
@@ -1,0 +1,33 @@
+"""Tests for the core compatibility redirect ledger."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import bernstein.core as core_pkg
+from bernstein.core.compat_redirect_ledger import (
+    REDIRECT_LEDGER_POLICY,
+    REVIEWED_REDIRECT_MAP_DIGEST,
+    build_redirect_ledger,
+    redirect_map_digest,
+)
+
+REDIRECT_MAP = cast(dict[str, str], core_pkg.__dict__["_REDIRECT_MAP"])
+
+
+def test_redirect_map_matches_reviewed_ledger_digest() -> None:
+    """Adding or changing a redirect requires a policy ledger review."""
+    assert redirect_map_digest(REDIRECT_MAP) == REVIEWED_REDIRECT_MAP_DIGEST
+
+
+def test_redirect_ledger_covers_every_current_redirect() -> None:
+    """Every redirected legacy import path must have ledger metadata."""
+    ledger = build_redirect_ledger(REDIRECT_MAP)
+
+    assert set(ledger) == set(REDIRECT_MAP)
+    for old_path, entry in ledger.items():
+        assert entry.old_path == f"bernstein.core.{old_path}"
+        assert entry.new_path == REDIRECT_MAP[old_path]
+        assert entry.owner == REDIRECT_LEDGER_POLICY.owner
+        assert entry.first_release == REDIRECT_LEDGER_POLICY.first_release
+        assert entry.removal_policy == REDIRECT_LEDGER_POLICY.removal_policy


### PR DESCRIPTION
Refs #1827

Summary:
- Add a reviewed compatibility ledger helper for `bernstein.core` legacy redirects.
- Add a digest check so `_REDIRECT_MAP` changes require an explicit ledger-policy update.
- Add tests covering ledger coverage and redirect-map review state.

Verification:
- uv run pytest tests/unit/test_core_redirect_ledger.py tests/unit/test_orchestrator_lifecycle_deleted.py tests/unit/test_claude_md_shim_doc.py -q
- uv run ruff check src/bernstein/core/compat_redirect_ledger.py tests/unit/test_core_redirect_ledger.py
- uv run pyright src/bernstein/core/compat_redirect_ledger.py tests/unit/test_core_redirect_ledger.py
- git diff --check origin/main..HEAD