### PR TITLE
Add deterministic skill authoring commands

### DIFF
--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -441,6 +441,103 @@ def skills_lint(names: tuple[str, ...], scope: str) -> None:
         console.print(f"\n[dim]{all_findings} finding(s) total (advisory only)[/dim]")
 
 
+@skills_group.command("test")
+@click.argument("suite", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--skills-root",
+    "skills_root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Skill root to test. Defaults to <cwd>/.bernstein/skills.",
+)
+def skills_test(suite: Path, skills_root: Path | None) -> None:
+    """Run a deterministic trigger-set suite without model calls."""
+    from bernstein.core.skills.authoring import SkillAuthoringError, run_trigger_suite
+
+    root = skills_root if skills_root is not None else Path.cwd() / ".bernstein" / "skills"
+    try:
+        result = run_trigger_suite(root.resolve(), suite.resolve())
+    except SkillAuthoringError as exc:
+        console.print(f"[red]test failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    for case_result in result.cases:
+        if case_result.passed:
+            console.print(f"[green]ok[/green] {case_result.case.name}")
+            continue
+        details: list[str] = []
+        if case_result.missing:
+            details.append("missing: " + ", ".join(case_result.missing))
+        if case_result.unexpected:
+            details.append("unexpected: " + ", ".join(case_result.unexpected))
+        console.print(f"[red]fail[/red] {case_result.case.name} ({'; '.join(details)})")
+
+    total = len(result.cases)
+    console.print(f"\n{result.passed_count} passed / {total} case(s)")
+    if not result.passed:
+        raise SystemExit(1)
+
+
+@skills_group.command("diff")
+@click.argument("left", type=click.Path(exists=True, path_type=Path))
+@click.argument("right", type=click.Path(exists=True, path_type=Path))
+def skills_diff(left: Path, right: Path) -> None:
+    """Compare two skill directories using canonical manifest/body digests."""
+    from bernstein.core.skills.authoring import diff_skill_dirs
+    from bernstein.core.skills.lifecycle import SkillLifecycleError
+
+    try:
+        result = diff_skill_dirs(left.resolve(), right.resolve())
+    except SkillLifecycleError as exc:
+        console.print(f"[red]diff failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if not result.changed:
+        console.print(f"[green]unchanged[/green] digest {result.left_digest.digest}")
+        return
+
+    console.print("[yellow]changed[/yellow] " + ", ".join(result.changed_sections))
+    console.print(f"left:  {result.left_digest.digest}")
+    console.print(f"right: {result.right_digest.digest}")
+    raise SystemExit(1)
+
+
+@skills_group.command("bench")
+@click.argument("suite", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--skills-root",
+    "skills_root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Skill root to bench. Defaults to <cwd>/.bernstein/skills.",
+)
+@click.option(
+    "--iterations",
+    "iterations",
+    type=click.IntRange(min=1),
+    default=10,
+    show_default=True,
+    help="Number of deterministic trigger-set iterations.",
+)
+def skills_bench(suite: Path, skills_root: Path | None, iterations: int) -> None:
+    """Benchmark a deterministic trigger-set suite without model calls."""
+    from bernstein.core.skills.authoring import SkillAuthoringError, bench_trigger_suite
+
+    root = skills_root if skills_root is not None else Path.cwd() / ".bernstein" / "skills"
+    try:
+        result = bench_trigger_suite(root.resolve(), suite.resolve(), iterations=iterations)
+    except SkillAuthoringError as exc:
+        console.print(f"[red]bench failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(
+        f"{result.iterations} iteration(s), {result.elapsed_seconds:.6f}s, "
+        f"{result.suite.passed_count}/{len(result.suite.cases)} case(s) passing"
+    )
+    if not result.suite.passed:
+        raise SystemExit(1)
+
+
 @skills_group.command("watch")
 @click.argument(
     "path",

--- a/src/bernstein/core/skills/authoring.py
+++ b/src/bernstein/core/skills/authoring.py
@@ -1,0 +1,321 @@
+"""Deterministic authoring helpers for local skill packs."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+from bernstein.core.skills.lifecycle import SkillDigest, SkillLifecycleError, compute_skill_digest
+from bernstein.core.skills.loader import SkillLoader
+from bernstein.core.skills.sources.local_dir import LocalDirSkillSource
+
+_TOKEN_RE: re.Pattern[str] = re.compile(r"[a-z0-9][a-z0-9-]*")
+_VALID_BUCKETS: tuple[str, ...] = ("references", "scripts", "assets")
+
+
+class SkillAuthoringError(ValueError):
+    """Raised when an authoring suite or skill directory is invalid."""
+
+
+@dataclass(frozen=True)
+class TriggerExpectation:
+    """Expected trigger-set membership for one suite case."""
+
+    include: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TriggerCase:
+    """One deterministic skill trigger-set case."""
+
+    name: str
+    query: str
+    expect: TriggerExpectation
+
+
+@dataclass(frozen=True)
+class TriggerCaseResult:
+    """Result for one trigger-set case."""
+
+    case: TriggerCase
+    matched: tuple[str, ...]
+    missing: tuple[str, ...]
+    unexpected: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return whether this case matched its include/exclude expectation."""
+        return not self.missing and not self.unexpected
+
+
+@dataclass(frozen=True)
+class TriggerSuiteResult:
+    """Result for a full trigger-set suite."""
+
+    cases: tuple[TriggerCaseResult, ...]
+
+    @property
+    def passed(self) -> bool:
+        """Return whether every suite case passed."""
+        return all(case.passed for case in self.cases)
+
+    @property
+    def passed_count(self) -> int:
+        """Return the number of passing cases."""
+        return sum(1 for case in self.cases if case.passed)
+
+
+@dataclass(frozen=True)
+class SkillDiffResult:
+    """Structural diff summary for two skill directories."""
+
+    left_digest: SkillDigest
+    right_digest: SkillDigest
+    changed_sections: tuple[str, ...]
+
+    @property
+    def changed(self) -> bool:
+        """Return whether the canonical skill digests differ."""
+        return self.left_digest.digest != self.right_digest.digest
+
+
+@dataclass(frozen=True)
+class SkillBenchResult:
+    """Timing result for repeated deterministic trigger-set runs."""
+
+    suite: TriggerSuiteResult
+    iterations: int
+    elapsed_seconds: float
+
+
+def load_trigger_suite(path: Path) -> tuple[TriggerCase, ...]:
+    """Load a deterministic trigger-set suite from YAML."""
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise SkillAuthoringError(f"{path}: failed to read trigger suite: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise SkillAuthoringError(f"{path}: suite must be a YAML mapping")
+    suite_data = cast("dict[str, object]", loaded)
+    raw_cases = suite_data.get("cases")
+    if not isinstance(raw_cases, list):
+        raise SkillAuthoringError(f"{path}: suite must contain a cases list")
+
+    cases: list[TriggerCase] = []
+    for index, raw_case in enumerate(cast("list[object]", raw_cases), start=1):
+        if not isinstance(raw_case, dict):
+            raise SkillAuthoringError(f"{path}: case #{index} must be a mapping")
+        case_data = cast("dict[str, object]", raw_case)
+        name = _required_str(case_data, "name", path=path, index=index)
+        query = _required_str(case_data, "query", path=path, index=index)
+        expect = _expectation(case_data.get("expect"), path=path, index=index)
+        cases.append(TriggerCase(name=name, query=query, expect=expect))
+    return tuple(cases)
+
+
+def run_trigger_suite(skills_root: Path, suite_path: Path) -> TriggerSuiteResult:
+    """Run a deterministic trigger-set suite against a local skills root."""
+    cases = load_trigger_suite(suite_path)
+    results: list[TriggerCaseResult] = []
+    for case in cases:
+        matched = match_skills(skills_root, case.query)
+        matched_set = set(matched)
+        missing = tuple(name for name in case.expect.include if name not in matched_set)
+        unexpected = tuple(name for name in case.expect.exclude if name in matched_set)
+        results.append(
+            TriggerCaseResult(
+                case=case,
+                matched=matched,
+                missing=missing,
+                unexpected=unexpected,
+            )
+        )
+    return TriggerSuiteResult(cases=tuple(results))
+
+
+def match_skills(skills_root: Path, query: str) -> tuple[str, ...]:
+    """Return skill names whose deterministic trigger hints match ``query``."""
+    loader = SkillLoader([LocalDirSkillSource(skills_root, source_name="local-authoring")])
+    query_tokens = frozenset(_TOKEN_RE.findall(query.casefold()))
+    query_text = " ".join(sorted(query_tokens))
+    matches: list[str] = []
+    for skill in loader.list_all():
+        needles = (skill.name, *skill.trigger_keywords)
+        if any(_needle_matches(needle, query_tokens=query_tokens, query_text=query_text) for needle in needles):
+            matches.append(skill.name)
+    return tuple(matches)
+
+
+def diff_skill_dirs(left: Path, right: Path) -> SkillDiffResult:
+    """Return a canonical structural diff summary for two skill directories."""
+    left_dir = _coerce_skill_dir(left)
+    right_dir = _coerce_skill_dir(right)
+    left_digest = compute_skill_digest(left_dir)
+    right_digest = compute_skill_digest(right_dir)
+    changed: list[str] = []
+
+    left_front, left_body = _read_skill_parts(left_dir)
+    right_front, right_body = _read_skill_parts(right_dir)
+    if _canonical_frontmatter(left_front) != _canonical_frontmatter(right_front):
+        changed.append("manifest")
+    if _normalise_body(left_body) != _normalise_body(right_body):
+        changed.append("body")
+    if _referenced_file_changes(left_dir, right_dir, left_front, right_front):
+        changed.append("files")
+
+    if left_digest.digest != right_digest.digest and not changed:
+        changed.append("digest")
+    return SkillDiffResult(left_digest=left_digest, right_digest=right_digest, changed_sections=tuple(changed))
+
+
+def bench_trigger_suite(skills_root: Path, suite_path: Path, *, iterations: int) -> SkillBenchResult:
+    """Run the deterministic trigger-set suite repeatedly and time it."""
+    if iterations < 1:
+        raise SkillAuthoringError("iterations must be at least 1")
+    start = time.perf_counter()
+    suite = TriggerSuiteResult(cases=())
+    for _ in range(iterations):
+        suite = run_trigger_suite(skills_root, suite_path)
+    return SkillBenchResult(
+        suite=suite,
+        iterations=iterations,
+        elapsed_seconds=time.perf_counter() - start,
+    )
+
+
+def _required_str(data: dict[str, object], key: str, *, path: Path, index: int) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SkillAuthoringError(f"{path}: case #{index} missing string {key!r}")
+    return value
+
+
+def _expectation(raw: object, *, path: Path, index: int) -> TriggerExpectation:
+    if raw is None:
+        return TriggerExpectation()
+    if not isinstance(raw, dict):
+        raise SkillAuthoringError(f"{path}: case #{index} expect must be a mapping")
+    data = cast("dict[str, object]", raw)
+    return TriggerExpectation(
+        include=_string_tuple(data.get("include"), path=path, index=index, key="include"),
+        exclude=_string_tuple(data.get("exclude"), path=path, index=index, key="exclude"),
+    )
+
+
+def _string_tuple(raw: object, *, path: Path, index: int, key: str) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise SkillAuthoringError(f"{path}: case #{index} expect.{key} must be a list")
+    values: list[str] = []
+    for item in cast("list[object]", raw):
+        if not isinstance(item, str) or not item:
+            raise SkillAuthoringError(f"{path}: case #{index} expect.{key} entries must be strings")
+        values.append(item)
+    return tuple(values)
+
+
+def _needle_matches(needle: str, *, query_tokens: frozenset[str], query_text: str) -> bool:
+    normalised = needle.casefold().strip()
+    if not normalised:
+        return False
+    if " " in normalised:
+        return normalised in query_text
+    return normalised in query_tokens
+
+
+def _coerce_skill_dir(path: Path) -> Path:
+    if path.is_dir():
+        return path
+    if path.name == "SKILL.md" and path.parent.is_dir():
+        return path.parent
+    raise SkillLifecycleError(f"{path}: expected a skill directory or SKILL.md")
+
+
+def _read_skill_parts(skill_dir: Path) -> tuple[str, str]:
+    skill_md = skill_dir / "SKILL.md"
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillLifecycleError(f"{skill_md}: cannot read SKILL.md: {exc}") from exc
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != "---":
+        return ("", text)
+    front: list[str] = []
+    for index in range(1, len(lines)):
+        if lines[index].rstrip() == "---":
+            return ("\n".join(front), "\n".join(lines[index + 1 :]).strip("\n"))
+        front.append(lines[index])
+    return ("", text)
+
+
+def _canonical_frontmatter(front_raw: str) -> bytes:
+    try:
+        loaded = yaml.safe_load(front_raw)
+    except yaml.YAMLError:
+        return front_raw.encode("utf-8")
+    if loaded is None:
+        loaded = {}
+    return yaml.safe_dump(
+        loaded,
+        sort_keys=True,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).encode("utf-8")
+
+
+def _normalise_body(body: str) -> bytes:
+    return body.replace("\r\n", "\n").encode("utf-8")
+
+
+def _referenced_file_changes(left: Path, right: Path, left_front: str, right_front: str) -> bool:
+    rels = _declared_files(left_front) | _declared_files(right_front)
+    for rel in sorted(rels):
+        left_file = left / rel
+        right_file = right / rel
+        if left_file.is_file() != right_file.is_file():
+            return True
+        if left_file.is_file() and left_file.read_bytes() != right_file.read_bytes():
+            return True
+    return False
+
+
+def _declared_files(front_raw: str) -> set[Path]:
+    try:
+        loaded = yaml.safe_load(front_raw)
+    except yaml.YAMLError:
+        return set()
+    if not isinstance(loaded, dict):
+        return set()
+    raw = cast("dict[str, Any]", loaded)
+    out: set[Path] = set()
+    for bucket in _VALID_BUCKETS:
+        values = raw.get(bucket, [])
+        if not isinstance(values, list):
+            continue
+        for value in cast("list[object]", values):
+            if isinstance(value, str) and value:
+                out.add(Path(bucket) / value)
+    return out
+
+
+__all__ = [
+    "SkillAuthoringError",
+    "SkillBenchResult",
+    "SkillDiffResult",
+    "TriggerCase",
+    "TriggerCaseResult",
+    "TriggerExpectation",
+    "TriggerSuiteResult",
+    "bench_trigger_suite",
+    "diff_skill_dirs",
+    "load_trigger_suite",
+    "match_skills",
+    "run_trigger_suite",
+]

--- a/tests/unit/skills/test_cli_authoring.py
+++ b/tests/unit/skills/test_cli_authoring.py
@@ -1,0 +1,159 @@
+"""CLI tests for deterministic skill authoring tools (#1720)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from bernstein.cli.commands.skills_cmd import skills_group
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    *,
+    keywords: tuple[str, ...],
+    body: str = "# Skill\n\nUse this skill for deterministic tests.\n",
+) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    frontmatter = yaml.safe_dump(
+        {
+            "manifest_schema": 1,
+            "name": name,
+            "description": f"Skill {name} used by deterministic authoring command tests.",
+            "trigger_keywords": list(keywords),
+            "references": [],
+            "scripts": [],
+            "assets": [],
+        },
+        sort_keys=False,
+    )
+    skill_dir.joinpath("SKILL.md").write_text(
+        "---\n" + frontmatter + "---\n" + body,
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_skills_test_runs_trigger_suite_without_llm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    skills_root = workdir / ".bernstein" / "skills"
+    workdir.mkdir()
+    _write_skill(skills_root, "pytest-helper", keywords=("pytest", "regression"))
+    _write_skill(skills_root, "docs-helper", keywords=("markdown", "docs"))
+    suite = workdir / "skill-triggers.yaml"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            cases:
+              - name: pytest task
+                query: Fix the pytest regression in the task router.
+                expect:
+                  include:
+                    - pytest-helper
+                  exclude:
+                    - docs-helper
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["test", str(suite)])
+
+    assert result.exit_code == 0
+    assert "1 passed" in result.output
+
+
+def test_skills_test_fails_when_expected_skill_is_not_matched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    skills_root = workdir / ".bernstein" / "skills"
+    workdir.mkdir()
+    _write_skill(skills_root, "pytest-helper", keywords=("pytest",))
+    suite = workdir / "skill-triggers.yaml"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            cases:
+              - name: docs task
+                query: Update the README.
+                expect:
+                  include:
+                    - pytest-helper
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["test", str(suite)])
+
+    assert result.exit_code == 1
+    assert "docs task" in result.output
+    assert "missing: pytest-helper" in result.output
+
+
+def test_skills_diff_reports_structural_changes(tmp_path: Path) -> None:
+    left_root = tmp_path / "left"
+    right_root = tmp_path / "right"
+    left = _write_skill(left_root, "pytest-helper", keywords=("pytest",))
+    right = _write_skill(
+        right_root,
+        "pytest-helper",
+        keywords=("pytest", "regression"),
+        body="# Skill\n\nUse this skill for regression tests.\n",
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["diff", str(left), str(right)])
+
+    assert result.exit_code == 1
+    assert "changed" in result.output
+    assert "manifest" in result.output
+    assert "body" in result.output
+
+
+def test_skills_bench_requires_explicit_suite_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    skills_root = workdir / ".bernstein" / "skills"
+    workdir.mkdir()
+    _write_skill(skills_root, "pytest-helper", keywords=("pytest",))
+    suite = workdir / "skill-triggers.yaml"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            cases:
+              - name: pytest task
+                query: Fix the pytest regression.
+                expect:
+                  include:
+                    - pytest-helper
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    missing_suite = runner.invoke(skills_group, ["bench"])
+    explicit_suite = runner.invoke(skills_group, ["bench", str(suite), "--iterations", "2"])
+
+    assert missing_suite.exit_code != 0
+    assert explicit_suite.exit_code == 0
+    assert "2 iteration(s)" in explicit_suite.output


### PR DESCRIPTION
## Summary
- Add deterministic skills test, diff, and bench commands for local skill packs.
- Add core authoring helpers for trigger-suite loading, canonical diff summaries, and repeated deterministic bench runs.
- Add CLI tests for pass/fail trigger suites, structural diffs, and the explicit bench suite requirement.

## Verification
- uv run pytest tests/unit/skills/test_cli_authoring.py tests/unit/skills/test_cli_init.py tests/unit/skills/test_cli_strict_lint.py tests/unit/skills/test_lifecycle_digest.py -q
- uv run ruff check src/bernstein/core/skills/authoring.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_cli_authoring.py
- uv run ruff format --check src/bernstein/core/skills/authoring.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_cli_authoring.py
- uv run pyright src/bernstein/core/skills/authoring.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_cli_authoring.py
