### PR TITLE
Fix evolution feedback loop test scheduling

### DIFF
--- a/tests/integration/test_evolution_feedback_loop.py
+++ b/tests/integration/test_evolution_feedback_loop.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -35,6 +36,8 @@ from bernstein.evolution.types import UpgradeProposal as EvolutionUpgradeProposa
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pytest import MonkeyPatch
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -122,6 +125,17 @@ def _make_orchestrator(
         workdir=tmp_path,
         client=client,
         evolution=coordinator,
+    )
+
+
+def _force_slow_phase_every_tick(monkeypatch: MonkeyPatch) -> None:
+    """Make slow-phase work run on every tick for these focused integration tests."""
+    from bernstein.core.orchestration import orchestrator as orchestrator_module
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "ORCHESTRATOR",
+        replace(orchestrator_module.ORCHESTRATOR, slow_tick_phase=1),
     )
 
 
@@ -269,8 +283,13 @@ class TestEvolutionFeedbackLoop:
         for pid in routed_ids:
             assert pid in logged, f"No decision logged for proposal {pid}"
 
-    def test_orchestrator_tick_triggers_evolution_and_writes_pending_json(self, tmp_path: Path) -> None:
+    def test_orchestrator_tick_triggers_evolution_and_writes_pending_json(
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
         """Tick with evolution_tick_interval=1 fires the cycle and writes pending.json."""
+        _force_slow_phase_every_tick(monkeypatch)
         state_dir = tmp_path / ".sdd"
         state_dir.mkdir()
 
@@ -315,8 +334,13 @@ class TestEvolutionFeedbackLoop:
             assert "title" in entry
             assert "status" in entry
 
-    def test_orchestrator_tick_interval_controls_when_cycle_fires(self, tmp_path: Path) -> None:
+    def test_orchestrator_tick_interval_controls_when_cycle_fires(
+        self,
+        tmp_path: Path,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
         """Evolution cycle fires only when tick_count % interval == 0."""
+        _force_slow_phase_every_tick(monkeypatch)
         state_dir = tmp_path / ".sdd"
         state_dir.mkdir()
 
@@ -360,8 +384,9 @@ class TestEvolutionFeedbackLoop:
         data = json.loads(pending_path.read_text())
         assert len(data) > 0, "Cycle on tick 3 must produce proposals"
 
-    def test_full_feedback_loop(self, tmp_path: Path) -> None:
+    def test_full_feedback_loop(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         """Complete integration: task completions → metrics → evolution → proposals → pending."""
+        _force_slow_phase_every_tick(monkeypatch)
         state_dir = tmp_path / ".sdd"
         state_dir.mkdir()
 


### PR DESCRIPTION
Summary:
- Make evolution feedback loop tests explicitly run slow-phase work when asserting short evolution intervals.
- Keep production tick scheduling unchanged.

Verification:
- uv run pytest tests/integration/test_evolution_feedback_loop.py::TestEvolutionFeedbackLoop::test_orchestrator_tick_triggers_evolution_and_writes_pending_json tests/integration/test_evolution_feedback_loop.py::TestEvolutionFeedbackLoop::test_orchestrator_tick_interval_controls_when_cycle_fires tests/integration/test_evolution_feedback_loop.py::TestEvolutionFeedbackLoop::test_full_feedback_loop -q --tb=short
- uv run pytest tests/integration/test_evolution_feedback_loop.py -q --tb=short
- uv run ruff check tests/integration/test_evolution_feedback_loop.py
- uv run ruff format --check tests/integration/test_evolution_feedback_loop.py
- uv run pyright --project pyrightconfig.strict.json

Notes:
- Repo-wide pyright remains advisory in CI; strict-zone pyright is the blocking check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration tests to run with improved consistency and deterministic behavior verification for orchestrator cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->