### PR TITLE
Refuse skills with invisible Unicode

### DIFF
--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -30,8 +30,9 @@ Out of scope for this module (deferred to follow-up tracks):
 
 - Source types beyond ``local`` (Git, OCI, index).
 - Signature verification and trust roots.
-- Sensitive-pattern-scan-on-install. Strict lint can block ERROR findings;
-  the default path remains advisory for backwards compatibility.
+- Source-content scans beyond the invisible Unicode install gate. Strict lint
+  can block ERROR findings; the default path remains advisory for backwards
+  compatibility.
 """
 
 from __future__ import annotations
@@ -49,6 +50,7 @@ from pydantic import ValidationError
 
 from bernstein.core.skills.lint import LintSeverity, lint_skill
 from bernstein.core.skills.manifest import SkillManifest
+from bernstein.core.skills.sanitizer import strip_invisible_tags
 
 # ---------------------------------------------------------------------------
 # Public constants
@@ -538,6 +540,29 @@ def _raise_for_strict_lint_errors(skill_dir: Path, *, skill_name: str) -> None:
     raise SkillLifecycleError(f"{skill_name}: strict lint failed: {details}")
 
 
+def _raise_for_invisible_unicode(
+    skill_dir: Path,
+    *,
+    skill_name: str,
+    allow_invisible_unicode: bool,
+) -> None:
+    """Raise when ``SKILL.md`` contains invisible Unicode codepoints."""
+    if allow_invisible_unicode:
+        return
+    skill_md = skill_dir / "SKILL.md"
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillLifecycleError(f"{skill_name}: cannot read SKILL.md for sanitizer gate: {exc}") from exc
+
+    _cleaned, count = strip_invisible_tags(content)
+    if count > 0:
+        raise SkillLifecycleError(
+            f"{skill_name}: SKILL.md contains {count} invisible Unicode codepoint(s); "
+            "refusing install unless allow_invisible_unicode=True",
+        )
+
+
 def install_local(
     source: Path,
     *,
@@ -546,6 +571,7 @@ def install_local(
     home: Path | None = None,
     override_name: str | None = None,
     strict_lint: bool = False,
+    allow_invisible_unicode: bool = False,
 ) -> InstallResult:
     """Install a skill from a local path into the chosen scope.
 
@@ -565,6 +591,8 @@ def install_local(
             ``name`` field wins over filesystem layout when supplied.
         strict_lint: When ``True``, ERROR lint findings abort the install.
             WARNING findings remain advisory.
+        allow_invisible_unicode: When ``True``, bypass the install-time
+            invisible Unicode refusal for controlled reproduction.
 
     Returns:
         :class:`InstallResult` with the target directory and digest.
@@ -604,6 +632,11 @@ def install_local(
                 raise SkillLifecycleError(f"{source}: cannot read source: {exc}") from exc
             (staging_dir / "SKILL.md").write_text(content, encoding="utf-8")
 
+        _raise_for_invisible_unicode(
+            staging_dir,
+            skill_name=name,
+            allow_invisible_unicode=allow_invisible_unicode,
+        )
         digest = compute_skill_digest(staging_dir)
         if strict_lint:
             _raise_for_strict_lint_errors(staging_dir, skill_name=name)
@@ -773,6 +806,7 @@ def sync_skills(
     workdir: Path | None = None,
     home: Path | None = None,
     strict_lint: bool = False,
+    allow_invisible_unicode: bool = False,
 ) -> list[SyncOutcome]:
     """Reconcile ``bernstein-skills.toml`` with the chosen scope.
 
@@ -788,6 +822,8 @@ def sync_skills(
         home: Override for the user's home (tests).
         strict_lint: When ``True``, ERROR lint findings abort changed and
             unchanged installs. WARNING findings remain advisory.
+        allow_invisible_unicode: When ``True``, bypass the install-time
+            invisible Unicode refusal for controlled reproduction.
 
     Returns:
         One :class:`SyncOutcome` per skill, in declaration order.
@@ -846,6 +882,11 @@ def sync_skills(
             source_digest = hasher.hexdigest()
 
         if prior_digest == source_digest and existing_install.is_dir():
+            _raise_for_invisible_unicode(
+                existing_install,
+                skill_name=entry.name,
+                allow_invisible_unicode=allow_invisible_unicode,
+            )
             if strict_lint:
                 _raise_for_strict_lint_errors(existing_install, skill_name=entry.name)
             outcomes.append(
@@ -873,6 +914,7 @@ def sync_skills(
             home=home,
             override_name=entry.name,
             strict_lint=strict_lint,
+            allow_invisible_unicode=allow_invisible_unicode,
         )
         action = "updated" if entry.name in previous_lock else "installed"
         outcomes.append(

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -552,7 +552,7 @@ def _raise_for_invisible_unicode(
     skill_md = skill_dir / "SKILL.md"
     try:
         content = skill_md.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         raise SkillLifecycleError(f"{skill_name}: cannot read SKILL.md for sanitizer gate: {exc}") from exc
 
     _cleaned, count = strip_invisible_tags(content)

--- a/tests/unit/core/skills/test_catalog.py
+++ b/tests/unit/core/skills/test_catalog.py
@@ -413,6 +413,39 @@ def test_install_refuses_content_digest_mismatch(
         service.install("code-review")
 
 
+def test_catalog_install_refuses_invisible_unicode_skill(tmp_path: Path) -> None:
+    """Catalog installs inherit the local install-time Unicode gate."""
+
+    def poisoned_installer(source, install_dir):  # type: ignore[no-untyped-def]
+        _write_skill_dir(
+            install_dir,
+            name="code-review",
+            description=FIXTURE_DESCRIPTION,
+            body="# Code review\n\U000e0048\n",
+        )
+        return PluginInstallResult(
+            success=True,
+            install_path=install_dir / "code-review",
+            source_kind=source.kind,
+        )
+
+    priv, pub = generate_signer_keypair()
+    entry = _make_entry(content_digest="a" * 64)
+    signed = attach_signature(entry, sign_entry(entry, priv))
+    catalog = _make_catalog((signed,), signer_pubkey=pub)
+
+    config = SkillCatalogServiceConfig(workdir=tmp_path)
+    service = SkillCatalogService(
+        config=config,
+        preloaded_catalog=catalog,
+        auditor=SkillCatalogAuditor(audit_dir=_audit_dir(tmp_path)),
+        plugin_installer=poisoned_installer,
+    )
+
+    with pytest.raises(SkillCatalogError, match="invisible Unicode"):
+        service.install("code-review")
+
+
 # ---------------------------------------------------------------------------
 # Drift
 # ---------------------------------------------------------------------------

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -299,6 +299,62 @@ def test_install_local_strict_lint_allows_warning_findings(tmp_path: Path) -> No
     assert result.install_dir.is_dir()
 
 
+def test_install_local_rejects_invisible_unicode_by_default(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "poisoned-skill.md"
+    source.write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: poisoned-skill
+            description: Valid skill containing an invisible instruction marker.
+            ---
+
+            # Poisoned skill
+
+            Body before tag marker.
+            """
+        ).strip()
+        + "\U000e0048\n",
+        encoding="utf-8",
+    )
+
+    install_dir = scope_root(InstallScope.PROJECT, workdir=workdir) / "poisoned-skill"
+    with pytest.raises(SkillLifecycleError, match="invisible Unicode"):
+        install_local(source, scope=InstallScope.PROJECT, workdir=workdir)
+    assert not install_dir.exists()
+
+
+def test_install_local_accepts_invisible_unicode_when_explicitly_allowed(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "poisoned-skill.md"
+    source.write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: poisoned-skill
+            description: Valid skill containing an invisible instruction marker.
+            ---
+
+            # Poisoned skill
+            """
+        ).strip()
+        + "\n\U000e0048\n",
+        encoding="utf-8",
+    )
+
+    result = install_local(
+        source,
+        scope=InstallScope.PROJECT,
+        workdir=workdir,
+        allow_invisible_unicode=True,
+    )
+
+    assert "\U000e0048" in (result.install_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
 def test_install_overwrites_previous(
     tmp_path: Path,
     single_file_skill: Path,

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -326,6 +326,21 @@ def test_install_local_rejects_invisible_unicode_by_default(tmp_path: Path) -> N
     assert not install_dir.exists()
 
 
+def test_install_local_wraps_invalid_utf8_for_sanitizer_gate(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "bad-skill"
+    source.mkdir()
+    (source / "SKILL.md").write_bytes(
+        b"---\nname: bad-skill\ndescription: Invalid bytes.\n---\n\n# Bad skill\n\xff\n",
+    )
+
+    install_dir = scope_root(InstallScope.PROJECT, workdir=workdir) / "bad-skill"
+    with pytest.raises(SkillLifecycleError, match="cannot read SKILL.md for sanitizer gate"):
+        install_local(source, scope=InstallScope.PROJECT, workdir=workdir)
+    assert not install_dir.exists()
+
+
 def test_install_local_accepts_invisible_unicode_when_explicitly_allowed(tmp_path: Path) -> None:
     workdir = tmp_path / "project"
     workdir.mkdir()

--- a/tests/unit/skills/test_lifecycle_sync.py
+++ b/tests/unit/skills/test_lifecycle_sync.py
@@ -205,3 +205,15 @@ def test_sync_strict_lint_blocks_error_findings_but_default_syncs(tmp_path: Path
     with pytest.raises(SkillLifecycleError, match="strict lint failed.*invalid-manifest"):
         sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir, strict_lint=True)
     assert not installed.exists()
+
+
+def test_sync_rejects_invisible_unicode_skill(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    poisoned = workdir / "sources" / "poisoned.md"
+    _write_source_md(poisoned, name="poisoned", body="Body with tag marker \U000e0048.")
+    toml_path = _write_manifest(workdir, [("poisoned", "./sources/poisoned.md")])
+
+    with pytest.raises(SkillLifecycleError, match="invisible Unicode"):
+        sync_skills(toml_path, scope=InstallScope.PROJECT, workdir=workdir)
+    assert not (scope_root(InstallScope.PROJECT, workdir=workdir) / "poisoned").exists()


### PR DESCRIPTION
Summary:
- Add an install-time gate that refuses SKILL.md files containing invisible Unicode codepoints by default.
- Keep a core-only allow_invisible_unicode flag for controlled reproduction.
- Cover direct install, sync, and catalog install paths.

Verification:
- uv run pytest tests/unit/skills/test_lifecycle_install.py::test_install_local_rejects_invisible_unicode_by_default tests/unit/skills/test_lifecycle_install.py::test_install_local_accepts_invisible_unicode_when_explicitly_allowed tests/unit/skills/test_lifecycle_sync.py::test_sync_rejects_invisible_unicode_skill tests/unit/core/skills/test_catalog.py::test_catalog_install_refuses_invisible_unicode_skill -q --tb=short
- uv run pytest tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py tests/unit/core/skills/test_catalog.py tests/unit/skills/test_unicode_sanitizer.py -q --tb=short
- uv run ruff check src/bernstein/core/skills/lifecycle.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py tests/unit/core/skills/test_catalog.py
- uv run ruff format --check src/bernstein/core/skills/lifecycle.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py tests/unit/core/skills/test_catalog.py
- uv run pyright src/bernstein/core/skills/lifecycle.py
- uv run pyright --project pyrightconfig.strict.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to detect and reject skills containing invisible Unicode characters during installation and sync operations by default.
  * New `allow_invisible_unicode` parameter available to permit skills with invisible Unicode when explicitly enabled.

* **Tests**
  * Added comprehensive unit tests validating invisible Unicode detection and handling across skill installation and sync workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->