### PR TITLE
Run Sonar after CI coverage is ready

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,25 +1,16 @@
 name: SonarQube scan
 
-# Runs after a push to main or on manual dispatch.
+# Runs after main CI reaches a terminal state or on manual dispatch.
 #
-# Historically a third `workflow_run` arm chained off the main `CI`
-# workflow's `completed` event, but ci.yml's branch-scoped
-# `cancel-in-progress: true` (ci.yml lines 112-135) almost never lets a
-# main CI run reach a `success` conclusion under the normal rapid-merge
-# cadence: each new merge cancels the prior in-flight run, so the
-# job-level `if: workflow_run.conclusion == 'success'` short-circuited
-# to `skipped` on every recent run (0/19 successful in the last 50
-# observed). The `push: branches: [main]` trigger keeps the Sonar
-# surface fresh on its own; the `push` arm runs a thin fallback
-# coverage pass when there is no usable upstream coverage artifact.
+# The workflow consumes the coverage-report artifact from the same CI run
+# that triggered it. It intentionally does not run directly on push:
+# push-time scans can start before CI uploads coverage.xml and then report
+# a partial fallback coverage number for main.
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/pull_request_template.md'
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -35,12 +26,13 @@ jobs:
     name: SonarQube scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Run on direct push to main or manual dispatch.
+    # Run after main CI completes or on manual dispatch.
     # SONAR_HOST_URL must be configured as a repo variable.
     if: >-
       ${{ vars.SONAR_HOST_URL != '' &&
           (github.event_name == 'workflow_dispatch' ||
-           github.event_name == 'push') }}
+           (github.event_name == 'workflow_run' &&
+            github.event.workflow_run.head_branch == 'main')) }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
@@ -53,16 +45,11 @@ jobs:
         with:
           # Sonar needs full git history for accurate blame.
           fetch-depth: 0
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
 
-      # When triggered manually we have no upstream run-id, so resolve the
-      # most recent successful CI run on main and pull its coverage-report
-      # artifact. This lets an operator bootstrap or re-scan the project with
-      # full Python coverage even when the latest main CI runs were cancelled
-      # by ci.yml's cancel-in-progress concurrency (which is the normal state
-      # under a rapid merge cadence and is why workflow_run almost never sees
-      # a 'success' conclusion to fire on).
+      # Manual dispatch has no upstream run id, so resolve the most recent
+      # successful main CI run and pull its coverage-report artifact.
       - name: Resolve latest successful CI run (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
         id: ci_run
@@ -84,62 +71,22 @@ jobs:
             echo "::warning::No successful CI run found on main; scanning without coverage"
           fi
 
+      - name: Download coverage artifact (workflow_run)
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true  # cancelled CI runs may not have reached the upload step
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download coverage artifact (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch' && steps.ci_run.outputs.run_id != ''
-        continue-on-error: true  # coverage is advisory; never block the bootstrap scan
+        continue-on-error: true  # manual bootstrap may not have a usable artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: coverage-report
           run-id: ${{ steps.ci_run.outputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Direct push to main: try to pull the freshest coverage-report
-      # artifact from any recent CI run on main (succeeded or cancelled),
-      # so a partial coverage snapshot still feeds Sonar even when the
-      # upstream CI run never reached `success`. This is the dominant
-      # case under the rapid-merge cadence and is the root cause of the
-      # historical "Coverage 0.0" comment on the project.
-      - name: Resolve latest CI run with coverage (push)
-        if: github.event_name == 'push'
-        id: ci_run_push
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Search the last 20 main CI runs for one that uploaded the
-          # `coverage-report` artifact. Cancelled runs can still have
-          # uploaded the artifact if the coverage step ran before the
-          # cancellation, so we do not filter by status here.
-          for run_id in $(gh run list \
-              --repo "${{ github.repository }}" \
-              --workflow ci.yml \
-              --branch main \
-              --limit 20 \
-              --json databaseId \
-              --jq '.[].databaseId'); do
-            if gh run view "$run_id" \
-                --repo "${{ github.repository }}" \
-                --json jobs \
-                --jq '.jobs[].name' >/dev/null 2>&1; then
-              artifacts=$(gh api "repos/${{ github.repository }}/actions/runs/$run_id/artifacts" \
-                  --jq '.artifacts[].name' 2>/dev/null || true)
-              if printf '%s\n' "$artifacts" | grep -qx coverage-report; then
-                echo "Found coverage-report artifact in CI run: $run_id"
-                echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-                break
-              fi
-            fi
-          done
-          if [ -z "${run_id:-}" ] || ! grep -q '^run_id=' "$GITHUB_OUTPUT"; then
-            echo "::notice::No recent CI run with coverage-report artifact found; will run thin coverage fallback"
-          fi
-
-      - name: Download coverage artifact (push)
-        if: github.event_name == 'push' && steps.ci_run_push.outputs.run_id != ''
-        continue-on-error: true  # coverage is advisory; never block the scan
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-        with:
-          name: coverage-report
-          run-id: ${{ steps.ci_run_push.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify coverage.xml present
@@ -155,19 +102,16 @@ jobs:
           fi
 
       - name: Set up uv for fallback
-        if: steps.coverage_check.outputs.missing == 'true'
+        if: github.event_name == 'workflow_dispatch' && steps.coverage_check.outputs.missing == 'true'
         uses: ./.github/actions/bootstrap
 
-      # Thin coverage fallback: run a fast unit-test subset with coverage
-      # so Sonar receives a non-zero coverage signal even when no upstream
-      # artifact was usable. This is intentionally NOT the full suite
-      # (which is ~25 minutes sharded) - it runs the fastest unit modules
-      # with --no-cov-on-fail and a hard timeout so the Sonar workflow
-      # itself never becomes the slow CI path.
+      # Thin coverage fallback is manual-dispatch only. Automatic main
+      # scans without a CI coverage artifact skip the Sonar upload instead
+      # of sending a partial fallback coverage report.
       - name: Thin coverage fallback
-        if: steps.coverage_check.outputs.missing == 'true'
+        if: github.event_name == 'workflow_dispatch' && steps.coverage_check.outputs.missing == 'true'
         timeout-minutes: 10
-        continue-on-error: true  # coverage is advisory; never block the scan
+        continue-on-error: true  # manual bootstrap should not fail before the scan step
         run: |
           set +e
           uv sync --group dev --no-progress 2>&1 | tail -20 || true
@@ -181,10 +125,21 @@ jobs:
           if [ -f coverage.xml ] && [ -s coverage.xml ]; then
             echo "Thin coverage fallback produced coverage.xml ($(wc -c < coverage.xml) bytes)"
           else
-            echo "::warning::Thin coverage fallback did not produce coverage.xml; Sonar will scan without coverage"
+            echo "::warning::Thin coverage fallback did not produce coverage.xml; Sonar scan will be skipped"
+          fi
+
+      - name: Verify scan coverage input
+        id: scan_coverage
+        run: |
+          if [ -f coverage.xml ] && [ -s coverage.xml ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No usable coverage.xml available; skipping Sonar scan"
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: SonarQube scan
+        if: steps.scan_coverage.outputs.available == 'true'
         timeout-minutes: 10
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995  # v8.1.0
         env:

--- a/tests/unit/test_sonar_scan_workflow_yaml.py
+++ b/tests/unit/test_sonar_scan_workflow_yaml.py
@@ -1,21 +1,16 @@
 """Structural assertions on the SonarQube scan workflow.
 
-These tests pin the contract that the Sonar scan stays reachable on
-main without depending on a successful upstream CI conclusion. The
-root cause of the historical "all sonar-scan runs return skipped" was
-the job-level ``if: workflow_run.conclusion == 'success'`` combined
-with ``ci.yml``'s ``cancel-in-progress: true`` policy on main: a
-rapid merge cadence cancels almost every CI run before it finishes,
-so the success conclusion is never observed.
+These tests pin the contract that the Sonar scan consumes the coverage
+artifact from the CI run for the same main commit. The scan must not
+start on the raw push event and fall back before the matching CI
+coverage artifact exists.
 
 The tests below assert the workflow has:
 
-    * a direct ``push: branches: [main]`` trigger so the scan runs
-      independently of CI's conclusion,
-    * a fallback coverage step that activates when no upstream
-      ``coverage-report`` artifact is available,
-    * a job-level ``if`` that accepts ``push`` and ``workflow_dispatch``
-      events, not only the historical workflow_run success.
+    * a ``workflow_run`` trigger for completed main CI runs,
+    * no direct ``push`` trigger, because that races the CI artifact,
+    * a workflow-run artifact download keyed to the triggering CI run,
+    * a thin fallback limited to manual dispatch only.
 
 The tests are cheap; they parse YAML only and do not call the GitHub
 API.
@@ -47,21 +42,20 @@ def test_sonar_scan_workflow_file_exists() -> None:
     assert SONAR_WF.is_file(), f"Missing workflow: {SONAR_WF}"
 
 
-def test_sonar_scan_triggers_on_push_to_main(sonar_doc: dict[str, object]) -> None:
-    """Sonar scan must trigger directly on push to main.
+def test_sonar_scan_triggers_after_main_ci_completion(sonar_doc: dict[str, object]) -> None:
+    """Sonar scan must trigger after the main CI run reaches a terminal state.
 
-    Without this trigger the scan relied entirely on
-    ``workflow_run.conclusion == 'success'``, which under the normal
-    rapid-merge cadence almost never fires because ci.yml cancels
-    in-flight runs on each new push. The push trigger is the only
-    one that guarantees the scan reaches main on every merge.
+    This avoids the push-time race where Sonar starts before the
+    matching ``coverage-report`` artifact has been uploaded.
     """
     on_block = sonar_doc.get(True) or sonar_doc.get("on")
     assert isinstance(on_block, dict), f"Workflow `on:` block must be a mapping, got {type(on_block)!r}"
-    push_block = on_block.get("push")
-    assert isinstance(push_block, dict), "Sonar scan workflow must define a `push:` trigger"
-    branches = push_block.get("branches") or []
-    assert "main" in branches, "Sonar scan `push` trigger must include `main`"
+    workflow_run = on_block.get("workflow_run")
+    assert isinstance(workflow_run, dict), "Sonar scan workflow must define a `workflow_run:` trigger"
+    assert workflow_run.get("workflows") == ["CI"]
+    assert workflow_run.get("branches") == ["main"]
+    assert workflow_run.get("types") == ["completed"]
+    assert "push" not in on_block, "Sonar scan must not race CI coverage on raw push events"
 
 
 def test_sonar_scan_keeps_workflow_dispatch(sonar_doc: dict[str, object]) -> None:
@@ -71,13 +65,8 @@ def test_sonar_scan_keeps_workflow_dispatch(sonar_doc: dict[str, object]) -> Non
     assert "workflow_dispatch" in on_block, "Sonar scan must keep its manual dispatch trigger"
 
 
-def test_sonar_scan_job_if_accepts_push_and_dispatch(sonar_doc: dict[str, object]) -> None:
-    """The job-level `if` must accept `push` and `workflow_dispatch`.
-
-    Regression guard: an earlier version gated the job purely on
-    ``github.event.workflow_run.conclusion == 'success'``, which never
-    fires under the rapid-merge cancellation pattern.
-    """
+def test_sonar_scan_job_if_accepts_workflow_run_and_dispatch(sonar_doc: dict[str, object]) -> None:
+    """The job-level `if` must accept completed CI runs and manual dispatch."""
     jobs = sonar_doc.get("jobs")
     assert isinstance(jobs, dict) and jobs, "Workflow must declare a `jobs:` block"
     scan_job = jobs.get("scan")
@@ -86,18 +75,38 @@ def test_sonar_scan_job_if_accepts_push_and_dispatch(sonar_doc: dict[str, object
     assert isinstance(job_if, str)
     flat = " ".join(job_if.split())
     assert "workflow_dispatch" in flat, "Job `if` must accept workflow_dispatch events"
-    assert "'push'" in flat or '"push"' in flat or "push" in flat, (
-        "Job `if` must accept push events so a direct push to main is not gated by upstream CI conclusion"
-    )
+    assert "workflow_run" in flat, "Job `if` must accept workflow_run events from CI"
+    assert "head_branch" in flat and "main" in flat, "Workflow-run scans must stay pinned to main"
 
 
-def test_sonar_scan_has_coverage_fallback(sonar_doc: dict[str, object]) -> None:
-    """Workflow must have a thin coverage fallback for cancelled CI runs.
+def test_sonar_scan_downloads_workflow_run_coverage_artifact(sonar_doc: dict[str, object]) -> None:
+    """Workflow-run scans must download coverage from the triggering CI run."""
+    jobs = sonar_doc.get("jobs", {})
+    assert isinstance(jobs, dict)
+    scan = jobs.get("scan", {})
+    assert isinstance(scan, dict)
+    steps = scan.get("steps", [])
+    assert isinstance(steps, list) and steps, "scan job must declare steps"
 
-    When ci.yml cancels in-flight runs the ``coverage-report``
-    artifact may be missing or empty. The Sonar workflow must run a
-    thin coverage pass in that case so the project never sits at
-    Coverage=0 forever.
+    download_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("name") == "Download coverage artifact (workflow_run)"
+        and "actions/download-artifact" in str(step.get("uses", ""))
+    ]
+    assert len(download_steps) == 1
+    with_block = download_steps[0].get("with") or {}
+    assert isinstance(with_block, dict)
+    assert with_block.get("name") == "coverage-report"
+    assert with_block.get("run-id") == "${{ github.event.workflow_run.id }}"
+
+
+def test_sonar_scan_limits_thin_fallback_to_manual_dispatch(sonar_doc: dict[str, object]) -> None:
+    """Thin fallback must not replace missing main CI coverage.
+
+    A push or workflow-run scan without the matching CI artifact should
+    skip the scan instead of reporting a partial coverage number.
     """
     jobs = sonar_doc.get("jobs", {})
     assert isinstance(jobs, dict)
@@ -107,11 +116,21 @@ def test_sonar_scan_has_coverage_fallback(sonar_doc: dict[str, object]) -> None:
     assert isinstance(steps, list) and steps, "scan job must declare steps"
 
     step_names = [s.get("name", "") for s in steps if isinstance(s, dict)]
-    has_fallback = any("fallback" in name.lower() or "thin coverage" in name.lower() for name in step_names)
-    assert has_fallback, (
-        "Sonar scan must include a thin coverage fallback step so "
-        "Coverage stays > 0 even when the upstream CI artifact is missing. "
-        f"Found steps: {step_names!r}"
+    fallback_steps = [step for step in steps if isinstance(step, dict) and step.get("name") == "Thin coverage fallback"]
+    assert len(fallback_steps) == 1, f"Found steps: {step_names!r}"
+    fallback_if = str(fallback_steps[0].get("if", ""))
+    assert "github.event_name == 'workflow_dispatch'" in fallback_if
+    assert "workflow_run" not in fallback_if
+
+    sonar_steps = [
+        step
+        for step in steps
+        if isinstance(step, dict) and "SonarSource/sonarqube-scan-action" in str(step.get("uses", ""))
+    ]
+    assert len(sonar_steps) == 1
+    sonar_if = str(sonar_steps[0].get("if", ""))
+    assert "steps.scan_coverage.outputs.available == 'true'" in sonar_if, (
+        "Sonar scan must require a usable coverage.xml after artifact download or manual fallback"
     )
 
 


### PR DESCRIPTION
Summary:
- Run automatic Sonar scans from completed main CI workflow_run events instead of push events.
- Download coverage-report from the triggering CI run and skip automatic scans without coverage.xml.
- Keep thin coverage fallback for manual dispatch only.

Tests:
- uv run pytest tests/unit/test_sonar_scan_workflow_yaml.py tests/unit/test_cross_platform_ci.py tests/unit/test_main_sha_marker_workflow_yaml.py -q --tb=short
- uv run ruff check tests/unit/test_sonar_scan_workflow_yaml.py
- uv run ruff format --check tests/unit/test_sonar_scan_workflow_yaml.py
- actionlint .github/workflows/sonar-scan.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modified SonarQube scan workflow to trigger after CI completion on the main branch instead of direct pushes
  * Enhanced coverage artifact retrieval and added explicit validation to ensure coverage data is available before scanning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->