### PR TITLE
Fix Sonar tracker token guard

### DIFF
--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -50,6 +50,7 @@ import argparse
 import dataclasses
 import datetime as _dt
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -484,12 +485,21 @@ def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding
     return ["## Machine-readable summary", "", "```json", blob, "```", ""]
 
 
-def _assert_no_forbidden(body: str) -> None:
-    """Raise if the rendered body carries any disallowed substring."""
+def _contains_forbidden(body: str, forbidden: str) -> bool:
+    """Return true when ``forbidden`` appears as a standalone token or phrase."""
     lower = body.lower()
+    needle = forbidden.lower()
+    if not needle.isalnum():
+        return needle in lower
+    pattern = rf"(?<![A-Za-z0-9_]){re.escape(needle)}(?![A-Za-z0-9_])"
+    return re.search(pattern, lower) is not None
+
+
+def _assert_no_forbidden(body: str) -> None:
+    """Raise if the rendered body carries any disallowed token or phrase."""
     for forbidden in _TRACKER_FORBIDDEN:
-        if forbidden.lower() in lower:
-            raise AssertionError(f"rendered tracker body contains forbidden substring {forbidden!r}")
+        if _contains_forbidden(body, forbidden):
+            raise AssertionError(f"rendered tracker body contains forbidden token or phrase {forbidden!r}")
 
 
 def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> str:

--- a/tests/unit/scripts/test_render_sonar_tracker.py
+++ b/tests/unit/scripts/test_render_sonar_tracker.py
@@ -478,3 +478,14 @@ def test_cli_dry_run_with_fixture(tracker: ModuleType, tmp_path: Path) -> None:
     assert "open=b1" in text
     # Raw vendor message is never rendered.
     assert "vendor message" not in text
+
+
+def test_forbidden_guard_ignores_token_inside_identifier(tracker: ModuleType) -> None:
+    """Guard must not reject ordinary identifiers that contain a token."""
+    tracker._assert_no_forbidden("rule `python:S1172` in `src/bernstein/adapters/droid.py`")
+
+
+def test_forbidden_guard_blocks_standalone_token(tracker: ModuleType) -> None:
+    """Guard still blocks standalone disallowed terms."""
+    with pytest.raises(AssertionError, match="roi"):
+        tracker._assert_no_forbidden("remove ROI wording from the tracker")


### PR DESCRIPTION
Summary:
- Match public-text forbidden terms as standalone tokens or exact phrases.
- Keep exact matching for punctuation-bearing phrases and dash code points.
- Add regression coverage for identifiers that contain a forbidden token.

Tests:
- uv run pytest tests/unit/scripts/test_render_sonar_tracker.py -q --tb=short
- uv run ruff check scripts/render_sonar_tracker.py tests/unit/scripts/test_render_sonar_tracker.py
- uv run ruff format --check scripts/render_sonar_tracker.py tests/unit/scripts/test_render_sonar_tracker.py