### PR TITLE
Gate sandboxed skill installs

### DIFF
--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -298,7 +298,14 @@ def skills_init(name: str, scope: str, description: str | None) -> None:
     default=False,
     help="Fail install when skill lint reports ERROR findings.",
 )
-def skills_install(source: Path, scope: str, override_name: str | None, strict: bool) -> None:
+@click.option(
+    "--accept-risk",
+    "accept_risk",
+    is_flag=True,
+    default=False,
+    help="Allow installs that require explicit risk acceptance.",
+)
+def skills_install(source: Path, scope: str, override_name: str | None, strict: bool, accept_risk: bool) -> None:
     """Install a skill from a local path.
 
     \b
@@ -313,6 +320,7 @@ def skills_install(source: Path, scope: str, override_name: str | None, strict: 
             workdir=Path.cwd(),
             override_name=override_name,
             strict_lint=strict,
+            accept_risk=accept_risk,
         )
     except SkillLifecycleError as exc:
         console.print(f"[red]install failed:[/red] {exc}")
@@ -364,7 +372,14 @@ def skills_remove(name: str, scope: str) -> None:
     default=False,
     help="Fail sync when skill lint reports ERROR findings.",
 )
-def skills_sync(manifest: Path | None, scope: str, strict: bool) -> None:
+@click.option(
+    "--accept-risk",
+    "accept_risk",
+    is_flag=True,
+    default=False,
+    help="Allow installs that require explicit risk acceptance.",
+)
+def skills_sync(manifest: Path | None, scope: str, strict: bool, accept_risk: bool) -> None:
     """Install every skill declared in ``bernstein-skills.toml``.
 
     Re-runs are idempotent: skills whose digest already matches are
@@ -379,6 +394,7 @@ def skills_sync(manifest: Path | None, scope: str, strict: bool) -> None:
             scope=install_scope,
             workdir=Path.cwd(),
             strict_lint=strict,
+            accept_risk=accept_risk,
         )
     except (SkillsTomlError, SkillLifecycleError) as exc:
         console.print(f"[red]sync failed:[/red] {exc}")

--- a/src/bernstein/core/skills/lifecycle.py
+++ b/src/bernstein/core/skills/lifecycle.py
@@ -30,9 +30,9 @@ Out of scope for this module (deferred to follow-up tracks):
 
 - Source types beyond ``local`` (Git, OCI, index).
 - Signature verification and trust roots.
-- Source-content scans beyond the invisible Unicode install gate. Strict lint
-  can block ERROR findings; the default path remains advisory for backwards
-  compatibility.
+- Source-content scans beyond the invisible Unicode install gate and the
+  reserved sandbox-profile gate. Strict lint can block ERROR findings; the
+  default path remains advisory for backwards compatibility.
 """
 
 from __future__ import annotations
@@ -563,6 +563,30 @@ def _raise_for_invisible_unicode(
         )
 
 
+def _raise_for_unsupported_sandbox_profile(
+    skill_dir: Path,
+    *,
+    skill_name: str,
+    accept_risk: bool,
+) -> None:
+    """Raise when a skill asks for sandbox injection that is not available."""
+    if accept_risk:
+        return
+    skill_md = skill_dir / "SKILL.md"
+    try:
+        content = skill_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SkillLifecycleError(f"{skill_name}: cannot read SKILL.md for sandbox profile gate: {exc}") from exc
+
+    front_raw, _body = _split_skill_md(content)
+    frontmatter = _frontmatter_dict(front_raw)
+    if frontmatter.get("sandbox_profile") is None:
+        return
+    raise SkillLifecycleError(
+        f"{skill_name}: sandbox_profile requires sandbox injector support; refusing install unless accept_risk=True",
+    )
+
+
 def install_local(
     source: Path,
     *,
@@ -572,6 +596,7 @@ def install_local(
     override_name: str | None = None,
     strict_lint: bool = False,
     allow_invisible_unicode: bool = False,
+    accept_risk: bool = False,
 ) -> InstallResult:
     """Install a skill from a local path into the chosen scope.
 
@@ -593,6 +618,8 @@ def install_local(
             WARNING findings remain advisory.
         allow_invisible_unicode: When ``True``, bypass the install-time
             invisible Unicode refusal for controlled reproduction.
+        accept_risk: When ``True``, bypass explicit-risk install refusals
+            such as reserved ``sandbox_profile`` injection metadata.
 
     Returns:
         :class:`InstallResult` with the target directory and digest.
@@ -635,7 +662,12 @@ def install_local(
         _raise_for_invisible_unicode(
             staging_dir,
             skill_name=name,
-            allow_invisible_unicode=allow_invisible_unicode,
+            allow_invisible_unicode=allow_invisible_unicode or accept_risk,
+        )
+        _raise_for_unsupported_sandbox_profile(
+            staging_dir,
+            skill_name=name,
+            accept_risk=accept_risk,
         )
         digest = compute_skill_digest(staging_dir)
         if strict_lint:
@@ -807,6 +839,7 @@ def sync_skills(
     home: Path | None = None,
     strict_lint: bool = False,
     allow_invisible_unicode: bool = False,
+    accept_risk: bool = False,
 ) -> list[SyncOutcome]:
     """Reconcile ``bernstein-skills.toml`` with the chosen scope.
 
@@ -824,6 +857,8 @@ def sync_skills(
             unchanged installs. WARNING findings remain advisory.
         allow_invisible_unicode: When ``True``, bypass the install-time
             invisible Unicode refusal for controlled reproduction.
+        accept_risk: When ``True``, bypass explicit-risk install refusals
+            such as reserved ``sandbox_profile`` injection metadata.
 
     Returns:
         One :class:`SyncOutcome` per skill, in declaration order.
@@ -885,7 +920,12 @@ def sync_skills(
             _raise_for_invisible_unicode(
                 existing_install,
                 skill_name=entry.name,
-                allow_invisible_unicode=allow_invisible_unicode,
+                allow_invisible_unicode=allow_invisible_unicode or accept_risk,
+            )
+            _raise_for_unsupported_sandbox_profile(
+                existing_install,
+                skill_name=entry.name,
+                accept_risk=accept_risk,
             )
             if strict_lint:
                 _raise_for_strict_lint_errors(existing_install, skill_name=entry.name)
@@ -915,6 +955,7 @@ def sync_skills(
             override_name=entry.name,
             strict_lint=strict_lint,
             allow_invisible_unicode=allow_invisible_unicode,
+            accept_risk=accept_risk,
         )
         action = "updated" if entry.name in previous_lock else "installed"
         outcomes.append(

--- a/src/bernstein/core/skills/manifest.py
+++ b/src/bernstein/core/skills/manifest.py
@@ -13,6 +13,7 @@ Schema (all fields strict-validated by Pydantic):
 - ``references``  - list of files under ``<skill>/references/``
 - ``scripts``     - list of files under ``<skill>/scripts/``
 - ``assets``      - list of files under ``<skill>/assets/``
+- ``sandbox_profile`` - optional sandbox profile label, reserved for injector support
 - ``version``     - semver-ish; defaults to ``1.0.0``
 - ``author``      - optional free-form attribution
 
@@ -81,6 +82,12 @@ class SkillManifest(BaseModel):
     references: list[str] = Field(default_factory=list[str])
     scripts: list[str] = Field(default_factory=list[str])
     assets: list[str] = Field(default_factory=list[str])
+    sandbox_profile: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z][a-z0-9-]*$",
+    )
     version: str = "1.0.0"
     author: str | None = None
 

--- a/tests/unit/skills/test_cli_strict_lint.py
+++ b/tests/unit/skills/test_cli_strict_lint.py
@@ -31,6 +31,26 @@ def _write_broken_skill(path: Path) -> None:
     )
 
 
+def _write_sandbox_profile_skill(path: Path) -> None:
+    """Write a skill that asks for sandbox injection support."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: sandboxed
+            description: Valid skill declaring a sandbox profile for future injector support.
+            sandbox_profile: read-only
+            ---
+
+            # Sandboxed skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_skills_install_strict_blocks_error_findings_but_default_installs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -51,6 +71,27 @@ def test_skills_install_strict_blocks_error_findings_but_default_installs(
     strict_result = runner.invoke(skills_group, ["install", str(source), "--strict"])
     assert strict_result.exit_code == 1
     assert not installed.exists()
+
+
+def test_skills_install_accept_risk_allows_sandbox_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "sources" / "sandboxed.md"
+    _write_sandbox_profile_skill(source)
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    default_result = runner.invoke(skills_group, ["install", str(source)])
+    installed = workdir / ".bernstein" / "skills" / "sandboxed"
+    assert default_result.exit_code == 1
+    assert not installed.exists()
+
+    accepted_result = runner.invoke(skills_group, ["install", str(source), "--accept-risk"])
+    assert accepted_result.exit_code == 0
+    assert installed.is_dir()
 
 
 def test_skills_sync_strict_blocks_error_findings_but_default_syncs(
@@ -78,3 +119,28 @@ def test_skills_sync_strict_blocks_error_findings_but_default_syncs(
     strict_result = runner.invoke(skills_group, ["sync", "--strict"])
     assert strict_result.exit_code == 1
     assert not installed.exists()
+
+
+def test_skills_sync_accept_risk_allows_sandbox_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = workdir / "sources" / "sandboxed.md"
+    _write_sandbox_profile_skill(source)
+    (workdir / SKILLS_TOML_FILENAME).write_text(
+        '[[skills]]\nname = "sandboxed"\nsource = "local"\npath = "./sources/sandboxed.md"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    default_result = runner.invoke(skills_group, ["sync"])
+    installed = workdir / ".bernstein" / "skills" / "sandboxed"
+    assert default_result.exit_code == 1
+    assert not installed.exists()
+
+    accepted_result = runner.invoke(skills_group, ["sync", "--accept-risk"])
+    assert accepted_result.exit_code == 0
+    assert installed.is_dir()

--- a/tests/unit/skills/test_lifecycle_install.py
+++ b/tests/unit/skills/test_lifecycle_install.py
@@ -370,6 +370,35 @@ def test_install_local_accepts_invisible_unicode_when_explicitly_allowed(tmp_pat
     assert "\U000e0048" in (result.install_dir / "SKILL.md").read_text(encoding="utf-8")
 
 
+def test_install_local_rejects_sandbox_profile_without_accept_risk(tmp_path: Path) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    source = tmp_path / "sandboxed-skill.md"
+    source.write_text(
+        textwrap.dedent(
+            """
+            ---
+            name: sandboxed-skill
+            description: Valid skill declaring a sandbox profile for future injector support.
+            sandbox_profile: read-only
+            ---
+
+            # Sandboxed skill
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    install_dir = scope_root(InstallScope.PROJECT, workdir=workdir) / "sandboxed-skill"
+    with pytest.raises(SkillLifecycleError, match="sandbox_profile"):
+        install_local(source, scope=InstallScope.PROJECT, workdir=workdir)
+    assert not install_dir.exists()
+
+    result = install_local(source, scope=InstallScope.PROJECT, workdir=workdir, accept_risk=True)
+    assert result.install_dir.is_dir()
+
+
 def test_install_overwrites_previous(
     tmp_path: Path,
     single_file_skill: Path,

--- a/tests/unit/skills/test_manifest.py
+++ b/tests/unit/skills/test_manifest.py
@@ -72,6 +72,24 @@ def test_parse_skill_md_accepts_optional_fields(tmp_path: Path) -> None:
     assert manifest.author == "Team QA"
 
 
+def test_parse_skill_md_accepts_sandbox_profile(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        name: sandboxed
+        description: Skill declaring a sandbox profile for future injector support.
+        sandbox_profile: read-only
+        ---
+        body
+        """,
+    )
+
+    manifest, _ = parse_skill_md(skill_md)
+
+    assert manifest.sandbox_profile == "read-only"
+
+
 def test_parse_skill_md_accepts_future_manifest_schema_additive_fields(tmp_path: Path) -> None:
     skill_md = _write(
         tmp_path / "SKILL.md",


### PR DESCRIPTION
Summary:
- Add optional `sandbox_profile` metadata to the skill manifest schema.
- Refuse installs and syncs that declare sandbox injection metadata unless `--accept-risk` is passed.
- Keep invisible Unicode refusal on the same explicit risk path for CLI installs.

Tests:
- uv run pytest tests/unit/skills/test_manifest.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_lifecycle_sync.py tests/unit/skills/test_cli_strict_lint.py -q --tb=short
- uv run ruff check src/bernstein/core/skills/manifest.py src/bernstein/core/skills/lifecycle.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_manifest.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_cli_strict_lint.py
- uv run ruff format --check src/bernstein/core/skills/manifest.py src/bernstein/core/skills/lifecycle.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_manifest.py tests/unit/skills/test_lifecycle_install.py tests/unit/skills/test_cli_strict_lint.py
- uv run pyright --project pyrightconfig.strict.json