### PR TITLE
Remove unused Sonar locals

### DIFF
--- a/src/bernstein/core/knowledge/rag.py
+++ b/src/bernstein/core/knowledge/rag.py
@@ -176,11 +176,10 @@ _memoized_chunker: Any = None
 def _chunk_for_memo(*, chunk_sha: str, rel_path: str, source: str, is_python: bool) -> list[dict[str, object]]:
     """Memoization shim around the AST/line chunker.
 
-    Fingerprint key = (chunk_sha, rel_path, embedder_id="bm25_v1",
-    this-function-body-hash).  A change to the chunker invalidates the
-    cached chunks, so a bug fix in chunk shaping correctly re-derives.
+    Fingerprint key = (chunk_sha, rel_path, this-function-body-hash).
+    A change to the chunker invalidates the cached chunks, so a bug fix
+    in chunk shaping correctly re-derives.
     """
-    embedder_id = "bm25_v1"  # noqa: F841 -- folded into the fingerprint via locals
     if is_python:
         return _extract_python_chunks(source, rel_path)
     return _line_chunks(source, rel_path)

--- a/src/bernstein/core/knowledge/repo_analyzer.py
+++ b/src/bernstein/core/knowledge/repo_analyzer.py
@@ -108,6 +108,26 @@ class LanguageBreakdown:
     pct: float  # of total source files in the repo
 
 
+def _language_breakdowns() -> list[LanguageBreakdown]:
+    """Return a typed empty language-breakdown list."""
+    return []
+
+
+def _paths() -> list[Path]:
+    """Return a typed empty path list."""
+    return []
+
+
+def _file_line_pairs() -> list[tuple[Path, int]]:
+    """Return a typed empty file-line list."""
+    return []
+
+
+def _strings() -> list[str]:
+    """Return a typed empty string list."""
+    return []
+
+
 @dataclass
 class RepoAnalysis:
     """Result of analyzing a repo for orchestration readiness."""
@@ -119,7 +139,7 @@ class RepoAnalysis:
     largest_file_lines: int = 0
     largest_file_path: Path | None = None
 
-    languages: list[LanguageBreakdown] = field(default_factory=list)
+    languages: list[LanguageBreakdown] = field(default_factory=_language_breakdowns)
 
     test_files: int = 0
     source_files_without_tests_estimate: int = 0  # source files that have no matching test
@@ -128,13 +148,13 @@ class RepoAnalysis:
     has_ci: bool = False
     ci_kind: str = ""  # "github", "gitlab", "jenkins", or ""
 
-    modules_without_tests: list[Path] = field(default_factory=list)
-    files_over_300_lines: list[tuple[Path, int]] = field(default_factory=list)
+    modules_without_tests: list[Path] = field(default_factory=_paths)
+    files_over_300_lines: list[tuple[Path, int]] = field(default_factory=_file_line_pairs)
     python_files_without_type_hints: int = 0  # files where no `: ` annotation found
 
     readiness_score: float = 0.0  # 0-10 scale
-    strengths: list[str] = field(default_factory=list)
-    opportunities: list[str] = field(default_factory=list)
+    strengths: list[str] = field(default_factory=_strings)
+    opportunities: list[str] = field(default_factory=_strings)
     recommended_first_run: str = ""
 
 
@@ -157,15 +177,12 @@ def analyze_repo(root: Path) -> RepoAnalysis:
     analysis = RepoAnalysis(root=root)
 
     files_by_language: dict[str, int] = {}
-    other_files = 0
-
     # Single-pass walk.
     for path in _walk_files(root):
         analysis.total_files += 1
         ext = path.suffix.lower()
         lang = _LANGUAGE_BY_EXT.get(ext)
         if lang is None:
-            other_files += 1
             continue
 
         analysis.total_source_files += 1
@@ -381,7 +398,8 @@ def _compute_score_and_narrative(a: RepoAnalysis) -> None:
         a.readiness_score = round((c_tests + c_mod + c_ci + c_typed) / 4, 1)
 
     # Narrative.
-    strengths, opps = [], []
+    strengths: list[str] = []
+    opps: list[str] = []
 
     if c_tests >= 6:
         strengths.append("Good test coverage - agents can verify their work")

--- a/tests/unit/test_sonar_unused_locals.py
+++ b/tests/unit/test_sonar_unused_locals.py
@@ -1,0 +1,34 @@
+"""Regression tests for tracked Sonar unused-local findings."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _assigned_names(path: str) -> set[str]:
+    tree = ast.parse((ROOT / path).read_text(encoding="utf-8"), filename=path)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        match node:
+            case ast.Assign(targets=targets):
+                for target in targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+            case ast.AnnAssign(target=ast.Name(id=name)):
+                names.add(name)
+            case _:
+                pass
+    return names
+
+
+def test_rag_chunker_does_not_keep_dead_embedder_local() -> None:
+    """The RAG chunker no longer carries a dead local only for cache salting."""
+    assert "embedder_id" not in _assigned_names("src/bernstein/core/knowledge/rag.py")
+
+
+def test_repo_analyzer_does_not_count_unused_other_files() -> None:
+    """The repo analyzer should not maintain an unused non-source counter."""
+    assert "other_files" not in _assigned_names("src/bernstein/core/knowledge/repo_analyzer.py")


### PR DESCRIPTION
Summary:
- Remove two unused locals from the RAG chunker and repo analyzer.
- Add an AST regression test for the tracked unused-local Sonar findings.
- Tighten repo analyzer dataclass defaults so touched-file pyright stays clean.

Tests:
- uv run pytest tests/unit/test_sonar_unused_locals.py tests/unit/test_repo_analyzer.py tests/unit/test_rag.py -q --tb=short
- uv run ruff check src/bernstein/core/knowledge/rag.py src/bernstein/core/knowledge/repo_analyzer.py tests/unit/test_sonar_unused_locals.py
- uv run ruff format --check src/bernstein/core/knowledge/rag.py src/bernstein/core/knowledge/repo_analyzer.py tests/unit/test_sonar_unused_locals.py
- uv run pyright src/bernstein/core/knowledge/rag.py src/bernstein/core/knowledge/repo_analyzer.py tests/unit/test_sonar_unused_locals.py

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal caching fingerprint precision for chunk operations
  * Enhanced repository analysis handling of unrecognized file types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->