### PR TITLE
Fix adapter multimodal spawn contract

### DIFF
--- a/src/bernstein/adapters/aichat.py
+++ b/src/bernstein/adapters/aichat.py
@@ -44,6 +44,7 @@ class AIChatAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch an AIChat session.
 
@@ -68,6 +69,7 @@ class AIChatAdapter(CLIAdapter):
             RuntimeError: If the ``aichat`` binary is missing from PATH
                 or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/aider.py
+++ b/src/bernstein/adapters/aider.py
@@ -50,7 +50,9 @@ class AiderAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/amp.py
+++ b/src/bernstein/adapters/amp.py
@@ -50,7 +50,9 @@ class AmpAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/auggie.py
+++ b/src/bernstein/adapters/auggie.py
@@ -37,6 +37,7 @@ class AuggieAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch an Auggie process with the given prompt.
 
@@ -60,6 +61,7 @@ class AuggieAdapter(CLIAdapter):
             RuntimeError: The ``auggie`` binary is missing from PATH or
                 cannot be executed due to permissions.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/autohand.py
+++ b/src/bernstein/adapters/autohand.py
@@ -34,6 +34,7 @@ class AutohandAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn an Autohand Code session.
 
@@ -55,6 +56,7 @@ class AutohandAdapter(CLIAdapter):
             RuntimeError: If the ``autohand`` binary cannot be found or
                 executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -467,6 +467,39 @@ class CLIAdapter(ABC):
         for host, port in self.external_endpoints:
             policy.check(host, port, source=f"adapter:{self.name()}")
 
+    def refuse_multimodal_if_needed(self, multimodal_context: Any | None) -> None:
+        """Reject attachments for adapters that do not support multimodal input.
+
+        Args:
+            multimodal_context: Optional multimodal context from the worker
+                launch path.
+
+        Raises:
+            CapabilityRefusal: When attachments are present and this adapter is
+                not registered as multimodal-capable.
+        """
+        if multimodal_context is None:
+            return
+
+        inputs = getattr(multimodal_context, "inputs", ()) or ()
+        attachments: list[str] = []
+        for input_item in inputs:
+            content_path = getattr(input_item, "content_path", None)
+            if content_path is not None:
+                attachments.append(str(content_path))
+                continue
+            description = getattr(input_item, "description", "") or "<inline attachment>"
+            attachments.append(str(description))
+        if not attachments:
+            return
+
+        from bernstein.core.agents.multimodal_attestation import refuse_when_incapable
+
+        refuse_when_incapable(
+            adapter_name=self._derive_session_namespace(),
+            attachments=tuple(attachments),
+        )
+
     def set_resource_limits(self, limits: ResourceLimits | None) -> None:
         """Configure OS-level resource limits applied to spawned child processes.
 

--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -106,6 +106,7 @@ class CachingAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn agent with caching: process prompt, check response cache, then delegate.
 
@@ -165,7 +166,7 @@ class CachingAdapter(CLIAdapter):
         )
         cached_entry, similarity = self._response_cache.lookup_entry(key)
 
-        if cached_entry and cached_entry.verified:
+        if multimodal_context is None and cached_entry and cached_entry.verified:
             logger.info(
                 "Response cache hit (similarity=%.3f) for session %s -- skipping spawn",
                 similarity,
@@ -193,6 +194,7 @@ class CachingAdapter(CLIAdapter):
             task_scope=task_scope,
             budget_multiplier=budget_multiplier,
             system_addendum=system_addendum,
+            multimodal_context=multimodal_context,
         )
 
     def name(self) -> str:

--- a/src/bernstein/adapters/charm.py
+++ b/src/bernstein/adapters/charm.py
@@ -34,6 +34,7 @@ class CharmAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn a Crush session.
 
@@ -55,6 +56,7 @@ class CharmAdapter(CLIAdapter):
             RuntimeError: If the ``crush`` binary cannot be found or
                 executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/cline.py
+++ b/src/bernstein/adapters/cline.py
@@ -36,6 +36,7 @@ class ClineAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn a Cline CLI session.
 
@@ -57,6 +58,7 @@ class ClineAdapter(CLIAdapter):
         Raises:
             RuntimeError: If ``cline`` is not installed or is not executable.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/clm.py
+++ b/src/bernstein/adapters/clm.py
@@ -379,7 +379,9 @@ class ClmAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/cloudflare_agents.py
+++ b/src/bernstein/adapters/cloudflare_agents.py
@@ -55,6 +55,7 @@ class CloudflareAgentsAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Cloudflare Agents worker via ``npx wrangler dev``.
 
@@ -76,6 +77,7 @@ class CloudflareAgentsAdapter(CLIAdapter):
             RuntimeError: If ``npx`` is not found or permission is denied.
             NetworkPolicyDenied: When the active --allow-network policy denies api.cloudflare.com.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/codebuff.py
+++ b/src/bernstein/adapters/codebuff.py
@@ -35,6 +35,7 @@ class CodebuffAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Codebuff session.
 
@@ -57,6 +58,7 @@ class CodebuffAdapter(CLIAdapter):
             RuntimeError: If the ``codebuff`` binary is missing or not
                 executable.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -46,7 +46,9 @@ class CodexAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/cody.py
+++ b/src/bernstein/adapters/cody.py
@@ -62,6 +62,7 @@ class CodyAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Cody agent process.
 
@@ -79,6 +80,7 @@ class CodyAdapter(CLIAdapter):
         Raises:
             RuntimeError: If ``cody`` is not found in PATH.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/composio.py
+++ b/src/bernstein/adapters/composio.py
@@ -44,6 +44,7 @@ class ComposioAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Composio Agent Orchestrator session.
 
@@ -68,6 +69,7 @@ class ComposioAdapter(CLIAdapter):
             RuntimeError: If the ``ao`` binary is missing from PATH or
                 cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -575,6 +575,8 @@ class {class_name}(CLIAdapter):
         mcp_config: dict[str, Any] | None = None,
         timeout_seconds: int = 1800,
         task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
         multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch {cli_name} with the given prompt.
@@ -586,6 +588,10 @@ class {class_name}(CLIAdapter):
             session_id: Unique session identifier.
             mcp_config: Optional MCP tool configuration.
             timeout_seconds: Maximum runtime before kill.
+            task_scope: Task scope for adapters that support budget caps.
+            budget_multiplier: Scope budget multiplier.
+            system_addendum: Extra system prompt text for adapters that support it.
+            multimodal_context: Optional multimodal attachments.
 
         Returns:
             SpawnResult with PID and log path.

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -575,6 +575,7 @@ class {class_name}(CLIAdapter):
         mcp_config: dict[str, Any] | None = None,
         timeout_seconds: int = 1800,
         task_scope: str = "medium",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch {cli_name} with the given prompt.
 
@@ -589,6 +590,7 @@ class {class_name}(CLIAdapter):
         Returns:
             SpawnResult with PID and log path.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / f"{adapter_id}-{{session_id}}.log"
         cmd = ["{cli_command}", "--prompt", prompt]
         proc = subprocess.Popen(

--- a/src/bernstein/adapters/continue_dev.py
+++ b/src/bernstein/adapters/continue_dev.py
@@ -51,6 +51,7 @@ class ContinueDevAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Continue.dev agent process.
 
@@ -70,6 +71,7 @@ class ContinueDevAdapter(CLIAdapter):
         Raises:
             RuntimeError: If the ``cn`` binary is not found in PATH.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/copilot.py
+++ b/src/bernstein/adapters/copilot.py
@@ -39,6 +39,7 @@ class CopilotAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a GitHub Copilot CLI session.
 
@@ -62,6 +63,7 @@ class CopilotAdapter(CLIAdapter):
             RuntimeError: If the ``copilot`` binary is missing from PATH
                 or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/cursor.py
+++ b/src/bernstein/adapters/cursor.py
@@ -76,7 +76,9 @@ class CursorAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/devin_terminal.py
+++ b/src/bernstein/adapters/devin_terminal.py
@@ -87,6 +87,7 @@ class DevinTerminalAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a one-shot Devin for Terminal session.
 
@@ -116,6 +117,7 @@ class DevinTerminalAdapter(CLIAdapter):
             RuntimeError: The ``devin`` binary is missing from PATH or
                 the OS denies execution.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/droid.py
+++ b/src/bernstein/adapters/droid.py
@@ -35,6 +35,7 @@ class DroidAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Droid CLI session.
 
@@ -57,6 +58,7 @@ class DroidAdapter(CLIAdapter):
             RuntimeError: If the Droid CLI is not installed or not
                 executable on the configured PATH.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/forge.py
+++ b/src/bernstein/adapters/forge.py
@@ -34,6 +34,7 @@ class ForgeAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Forge CLI process for the given prompt.
 
@@ -56,6 +57,7 @@ class ForgeAdapter(CLIAdapter):
             RuntimeError: The ``forge`` binary is missing from PATH or the
                 current user lacks permission to execute it.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/generic.py
+++ b/src/bernstein/adapters/generic.py
@@ -56,7 +56,9 @@ class GenericAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/goose.py
+++ b/src/bernstein/adapters/goose.py
@@ -63,6 +63,7 @@ class GooseAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Goose agent process.
 
@@ -80,6 +81,7 @@ class GooseAdapter(CLIAdapter):
         Raises:
             RuntimeError: If the Goose binary is not found.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/gptme.py
+++ b/src/bernstein/adapters/gptme.py
@@ -54,6 +54,7 @@ class GptmeAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a gptme CLI session.
 
@@ -76,6 +77,7 @@ class GptmeAdapter(CLIAdapter):
             RuntimeError: If the ``gptme`` binary is missing from PATH or
                 cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/hermes.py
+++ b/src/bernstein/adapters/hermes.py
@@ -34,6 +34,7 @@ class HermesAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn a Hermes Agent session.
 
@@ -55,6 +56,7 @@ class HermesAdapter(CLIAdapter):
             RuntimeError: If the ``hermes`` binary cannot be found or
                 executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/iac.py
+++ b/src/bernstein/adapters/iac.py
@@ -126,8 +126,10 @@ class IaCAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn an IaC plan-then-apply process."""
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         tool = self._resolve_tool()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"

--- a/src/bernstein/adapters/junie.py
+++ b/src/bernstein/adapters/junie.py
@@ -124,6 +124,7 @@ class JunieAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a one-shot Junie headless session.
 
@@ -155,6 +156,7 @@ class JunieAdapter(CLIAdapter):
             RuntimeError: The ``junie`` binary is missing from PATH or
                 the OS denies execution.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         provider = self._resolve_provider(model_config)
         # Bind external endpoints for the network policy check based on
         # the routed provider; class-level remains empty so this is the

--- a/src/bernstein/adapters/kilo.py
+++ b/src/bernstein/adapters/kilo.py
@@ -32,7 +32,9 @@ class KiloAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/kimi.py
+++ b/src/bernstein/adapters/kimi.py
@@ -36,6 +36,7 @@ class KimiAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Kimi CLI process with the given prompt.
 
@@ -59,6 +60,7 @@ class KimiAdapter(CLIAdapter):
             RuntimeError: The ``kimi`` binary is missing from PATH or
                 cannot be executed due to permissions.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/kiro.py
+++ b/src/bernstein/adapters/kiro.py
@@ -36,7 +36,9 @@ class KiroAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/letta_code.py
+++ b/src/bernstein/adapters/letta_code.py
@@ -50,6 +50,7 @@ class LettaCodeAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Letta Code CLI session.
 
@@ -74,6 +75,7 @@ class LettaCodeAdapter(CLIAdapter):
             RuntimeError: If the ``letta`` binary is missing from PATH
                 or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/manager.py
+++ b/src/bernstein/adapters/manager.py
@@ -29,7 +29,9 @@ class ManagerAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/mistral.py
+++ b/src/bernstein/adapters/mistral.py
@@ -34,6 +34,7 @@ class MistralAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn a Mistral Vibe session.
 
@@ -54,6 +55,7 @@ class MistralAdapter(CLIAdapter):
         Raises:
             RuntimeError: If the ``vibe`` binary cannot be found or executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/mock.py
+++ b/src/bernstein/adapters/mock.py
@@ -68,6 +68,7 @@ class MockAgentAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn a mock agent subprocess that applies demo changes.
 
@@ -82,6 +83,7 @@ class MockAgentAdapter(CLIAdapter):
             SpawnResult with mock process PID and log path.
         """
         # Create log file
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"agent-{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -195,7 +195,9 @@ class OllamaAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         from urllib.parse import urlparse
 
         from bernstein.core.security.network_policy import policy_from_env

--- a/src/bernstein/adapters/open_interpreter.py
+++ b/src/bernstein/adapters/open_interpreter.py
@@ -46,6 +46,7 @@ class OpenInterpreterAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch an Open Interpreter CLI session.
 
@@ -69,6 +70,7 @@ class OpenInterpreterAdapter(CLIAdapter):
             RuntimeError: If the ``interpreter`` binary is missing from
                 PATH or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -232,6 +232,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch the OpenAI Agents runner subprocess.
 
@@ -240,6 +241,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
         line to stdout; the spawner collects those events via the log
         file and Bernstein's existing log tail/hook machinery.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/opencode.py
+++ b/src/bernstein/adapters/opencode.py
@@ -37,7 +37,9 @@ class OpenCodeAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/openhands.py
+++ b/src/bernstein/adapters/openhands.py
@@ -41,6 +41,7 @@ class OpenHandsAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch an OpenHands CLI session in headless mode.
 
@@ -64,6 +65,7 @@ class OpenHandsAdapter(CLIAdapter):
             RuntimeError: If the ``openhands`` binary is missing from PATH
                 or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/pi.py
+++ b/src/bernstein/adapters/pi.py
@@ -36,6 +36,7 @@ class PiAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Pi coding-agent session.
 
@@ -58,6 +59,7 @@ class PiAdapter(CLIAdapter):
             RuntimeError: If the ``pi`` binary is missing or not
                 executable.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/plandex.py
+++ b/src/bernstein/adapters/plandex.py
@@ -58,6 +58,7 @@ class PlandexAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a Plandex CLI session.
 
@@ -83,6 +84,7 @@ class PlandexAdapter(CLIAdapter):
             RuntimeError: If the ``plandex`` binary is missing from PATH
                 or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/adapters/plugin_sdk.py
+++ b/src/bernstein/adapters/plugin_sdk.py
@@ -141,6 +141,7 @@ class PluginAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch an agent process with the given prompt."""
         ...

--- a/src/bernstein/adapters/q_dev.py
+++ b/src/bernstein/adapters/q_dev.py
@@ -111,6 +111,7 @@ class QDevAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a one-shot ``q chat`` session.
 
@@ -143,6 +144,7 @@ class QDevAdapter(CLIAdapter):
             RuntimeError: The ``q`` binary is missing from PATH or the OS
                 denies execution.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -110,7 +110,9 @@ class QwenAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
+        self.refuse_multimodal_if_needed(multimodal_context)
         self.enforce_network_policy()
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/bernstein/adapters/ralphex.py
+++ b/src/bernstein/adapters/ralphex.py
@@ -49,6 +49,7 @@ class RalphexAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Launch a ralphex session over a synthesized plan file.
 
@@ -75,6 +76,7 @@ class RalphexAdapter(CLIAdapter):
             RuntimeError: If the ``ralphex`` binary is missing from PATH
                 or cannot be executed.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         runtime_dir = workdir / ".sdd" / "runtime"
         runtime_dir.mkdir(parents=True, exist_ok=True)
         log_path = runtime_dir / f"{session_id}.log"

--- a/src/bernstein/adapters/rovo.py
+++ b/src/bernstein/adapters/rovo.py
@@ -37,6 +37,7 @@ class RovoAdapter(CLIAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         """Spawn a Rovo Dev CLI session.
 
@@ -58,6 +59,7 @@ class RovoAdapter(CLIAdapter):
         Raises:
             RuntimeError: If ``acli`` is not installed or is not executable.
         """
+        self.refuse_multimodal_if_needed(multimodal_context)
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/bernstein/core/agents/multimodal.py
+++ b/src/bernstein/core/agents/multimodal.py
@@ -219,6 +219,7 @@ def build_multimodal_context(files: list[str | Path]) -> MultiModalContext:
 
 _MULTIMODAL_ADAPTERS: frozenset[str] = frozenset(
     {
+        "antigravity",
         "claude",
         "gemini",
     }

--- a/tests/unit/test_adapter_conformance.py
+++ b/tests/unit/test_adapter_conformance.py
@@ -542,6 +542,13 @@ def test_scaffold_contains_spawn_method() -> None:
     assert "def spawn(" in code
 
 
+def test_scaffold_spawn_signature_matches_optional_base_kwargs() -> None:
+    code = generate_adapter_scaffold("MyAgent", "MyAgentAdapter", "myagent", "myagent")
+    assert "budget_multiplier: float = 1.0" in code
+    assert 'system_addendum: str = ""' in code
+    assert "multimodal_context: Any | None = None" in code
+
+
 def test_scaffold_is_valid_python_syntax() -> None:
     import ast
 

--- a/tests/unit/test_adapter_consistency.py
+++ b/tests/unit/test_adapter_consistency.py
@@ -99,6 +99,11 @@ class TestAdapterProtocolCompliance:
     def test_spawn_has_optional_multimodal_context(self, adapter_name: str, adapter: CLIAdapter) -> None:
         sig = inspect.signature(adapter.spawn)
         assert "multimodal_context" in sig.parameters, f"{adapter_name}.spawn() should accept multimodal_context"
+        multimodal_param = sig.parameters["multimodal_context"]
+        assert multimodal_param.default is None, f"{adapter_name}.spawn() multimodal_context should default to None"
+        assert multimodal_param.kind is inspect.Parameter.KEYWORD_ONLY, (
+            f"{adapter_name}.spawn() multimodal_context should be keyword-only"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -170,8 +175,8 @@ class TestAdapterSpawnResult:
 
 
 @pytest.mark.parametrize(
-    "adapter_name,adapter",
-    _TESTABLE_ADAPTERS,
+    "adapter_name",
+    [name for name, _adapter in _TESTABLE_ADAPTERS],
     ids=[t[0] for t in _TESTABLE_ADAPTERS],
 )
 class TestAdapterMultimodalRefusal:
@@ -180,12 +185,12 @@ class TestAdapterMultimodalRefusal:
     def test_non_multimodal_adapter_refuses_multimodal_context(
         self,
         adapter_name: str,
-        adapter: CLIAdapter,
         tmp_path: Path,
     ) -> None:
         if is_multimodal_capable(adapter_name):
             pytest.skip(f"{adapter_name} supports multimodal attachments")
 
+        adapter = _instantiate_adapter(adapter_name)
         attachment = tmp_path / "screenshot.png"
         attachment.write_bytes(b"fake image")
         context = MultiModalContext(

--- a/tests/unit/test_adapter_consistency.py
+++ b/tests/unit/test_adapter_consistency.py
@@ -24,6 +24,13 @@ from bernstein.core.models import ApiTierInfo, ModelConfig
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
 from bernstein.adapters.registry import _ADAPTERS, get_adapter
+from bernstein.core.agents.multimodal import (
+    ModalityType,
+    MultiModalContext,
+    MultiModalInput,
+    is_multimodal_capable,
+)
+from bernstein.core.agents.multimodal_attestation import CapabilityRefusal
 
 # ---------------------------------------------------------------------------
 # Adapter factories - enumerate every known adapter
@@ -88,6 +95,10 @@ class TestAdapterProtocolCompliance:
     def test_spawn_has_optional_timeout(self, adapter_name: str, adapter: CLIAdapter) -> None:
         sig = inspect.signature(adapter.spawn)
         assert "timeout_seconds" in sig.parameters, f"{adapter_name}.spawn() should accept timeout_seconds"
+
+    def test_spawn_has_optional_multimodal_context(self, adapter_name: str, adapter: CLIAdapter) -> None:
+        sig = inspect.signature(adapter.spawn)
+        assert "multimodal_context" in sig.parameters, f"{adapter_name}.spawn() should accept multimodal_context"
 
 
 # ---------------------------------------------------------------------------
@@ -156,6 +167,48 @@ class TestAdapterSpawnResult:
         assert isinstance(result.pid, int), f"{adapter_name}: pid must be int"
         assert result.pid > 0, f"{adapter_name}: pid must be positive, got {result.pid}"
         assert isinstance(result.log_path, Path), f"{adapter_name}: log_path must be a Path"
+
+
+@pytest.mark.parametrize(
+    "adapter_name,adapter",
+    _TESTABLE_ADAPTERS,
+    ids=[t[0] for t in _TESTABLE_ADAPTERS],
+)
+class TestAdapterMultimodalRefusal:
+    """Adapters that cannot consume attachments must refuse before spawning."""
+
+    def test_non_multimodal_adapter_refuses_multimodal_context(
+        self,
+        adapter_name: str,
+        adapter: CLIAdapter,
+        tmp_path: Path,
+    ) -> None:
+        if is_multimodal_capable(adapter_name):
+            pytest.skip(f"{adapter_name} supports multimodal attachments")
+
+        attachment = tmp_path / "screenshot.png"
+        attachment.write_bytes(b"fake image")
+        context = MultiModalContext(
+            inputs=(
+                MultiModalInput(
+                    modality=ModalityType.IMAGE,
+                    content_path=attachment,
+                    mime_type="image/png",
+                    description="screenshot",
+                ),
+            ),
+            primary_modality=ModalityType.IMAGE,
+        )
+
+        with pytest.raises(CapabilityRefusal):
+            adapter.spawn(
+                prompt="Test prompt",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="test-sess-001",
+                timeout_seconds=0,
+                multimodal_context=context,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_caching_adapter.py
+++ b/tests/unit/test_caching_adapter.py
@@ -13,6 +13,7 @@ from bernstein.core.semantic_cache import ResponseCacheManager
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
 from bernstein.adapters.caching_adapter import CachingAdapter
+from bernstein.core.agents.multimodal import ModalityType, MultiModalContext, MultiModalInput
 
 
 @pytest.fixture
@@ -80,6 +81,41 @@ def test_cache_hit_returns_pid_0_without_inner_call(adapter: CachingAdapter, moc
     # Inner spawn should NOT have been called (it was only called by Orchestrator usually,
     # but here we are testing the adapter's own bypass).
     assert mock_inner.spawn.call_count == 0
+
+
+def test_multimodal_context_delegates_even_on_cache_hit(adapter: CachingAdapter, mock_inner: MagicMock) -> None:
+    """Multimodal context is part of task input and must reach the inner adapter."""
+    prompt = "Inspect attached screenshot"
+    context = MultiModalContext(
+        inputs=(
+            MultiModalInput(
+                modality=ModalityType.IMAGE,
+                content_base64="ZmFrZQ==",
+                mime_type="image/png",
+                description="screenshot",
+            ),
+        ),
+        primary_modality=ModalityType.IMAGE,
+    )
+    cache = _response_cache(adapter)
+    cache.store(
+        cache.task_key("mock-adapter", prompt[:100], prompt),
+        "Cached text-only result",
+        verified=True,
+    )
+    cache.save()
+
+    res = adapter.spawn(
+        prompt=prompt,
+        workdir=Path("/tmp"),
+        model_config=_model_config("sonnet"),
+        session_id="session-2",
+        multimodal_context=context,
+    )
+
+    assert res.pid == 1234
+    assert mock_inner.spawn.call_count == 1
+    assert mock_inner.spawn.call_args.kwargs["multimodal_context"] is context
 
 
 def test_ttl_expiry_causes_re_delegation(tmp_path: Path, mock_inner: MagicMock) -> None:


### PR DESCRIPTION
## Summary
- Adds `multimodal_context` to concrete adapter `spawn()` overrides so they match the base adapter contract.
- Refuses multimodal attachments before process launch for adapters that do not support them.
- Forwards multimodal context through `CachingAdapter` and bypasses text-only response cache hits when attachments are present.

## Verification
- `uv run pytest tests/unit/test_adapter_consistency.py -q --tb=short`
- `uv run pytest tests/unit/test_caching_adapter.py -q --tb=short`
- `uv run ruff format --check src/bernstein/adapters src/bernstein/core/agents/multimodal.py tests/unit/test_adapter_consistency.py tests/unit/test_caching_adapter.py`
- `uv run ruff check src/bernstein/adapters src/bernstein/core/agents/multimodal.py tests/unit/test_adapter_consistency.py tests/unit/test_caching_adapter.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`

Refs #1785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multimodal input gating across adapters; non-multimodal adapters will refuse multimodal context.
  * Marked an adapter as multimodal-capable and updated capability detection.
  * Response-cache reuse now bypassed when multimodal context is provided; multimodal context is forwarded when delegating.

* **Tests**
  * Added tests verifying multimodal rejection for non-capable adapters and forwarding behavior.
  * Enhanced adapter conformance tests to require an optional multimodal parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->