### PR TITLE
Fix invalid type check escapes

### DIFF
--- a/src/bernstein/core/autofix/daemon.py
+++ b/src/bernstein/core/autofix/daemon.py
@@ -40,6 +40,8 @@ from bernstein.core.autofix.ladder import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from bernstein.core.autofix.config import AutofixConfig, RepoConfig
     from bernstein.core.autofix.dispatcher import Dispatcher
 
@@ -443,8 +445,8 @@ def start(
     failing_source: FailingPRSource,
     workdir: Path,
     extra_repo_filter: set[str] | None = None,
-    sleep_fn: object = time.sleep,
-    now_fn: object = time.time,
+    sleep_fn: Callable[[float], object] = time.sleep,
+    now_fn: Callable[[], float] = time.time,
     iterations: int | None = None,
 ) -> int:
     """Run the daemon's main loop in the *current* process.
@@ -492,12 +494,10 @@ def start(
             ticks += 1
             if iterations is not None and ticks >= iterations:
                 break
-            assert callable(sleep_fn)
             sleep_fn(config.poll_interval_seconds)
     finally:
         _clear_pid(workdir)
-    # Touch ``now_fn`` so type-checkers do not flag it as unused.
-    assert callable(now_fn)
+    _ = now_fn
     return ticks
 
 

--- a/src/bernstein/core/planning/routine_bridge.py
+++ b/src/bernstein/core/planning/routine_bridge.py
@@ -36,6 +36,7 @@ from bernstein.core.planning.scenario_library import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from bernstein.core.planning.scenario_library import ScenarioLibrary
@@ -443,7 +444,7 @@ class RoutineBridge:
 def spawn_scenario_tasks(
     payloads: list[ScenarioTaskPayload],
     *,
-    poster: object,
+    poster: Callable[[str, dict[str, Any]], object],
 ) -> list[str]:
     """POST each payload at the Bernstein task server.
 
@@ -463,7 +464,7 @@ def spawn_scenario_tasks(
     task_ids: list[str] = []
     for payload in payloads:
         try:
-            result = poster("/tasks", payload.as_server_payload())  # type: ignore[misc]
+            result = poster("/tasks", payload.as_server_payload())
         except Exception:
             logger.exception("Failed to POST scenario task %s", payload.title)
             continue

--- a/src/bernstein/core/security/rfc3161_verifier.py
+++ b/src/bernstein/core/security/rfc3161_verifier.py
@@ -46,7 +46,7 @@ import hashlib
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -68,6 +68,11 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+
+class _Asn1Node(Protocol):
+    def __getitem__(self, key: str) -> Any: ...
+
 
 #: Supported message-imprint hash OIDs → ``hashlib`` constructor name.
 _HASH_OID_TO_NAME: dict[str, str] = {
@@ -166,9 +171,9 @@ def load_trusted_tsa_certs(bundle_path: Path) -> list[x509.Certificate]:
 
 def _try_parse_response_or_token(
     token_bytes: bytes,
-    tsp_module: object,
-    cms_module: object,
-) -> object:
+    tsp_module: Any,
+    cms_module: Any,
+) -> _Asn1Node:
     """Parse *token_bytes* as either ``TimeStampResp`` or bare ``ContentInfo``.
 
     Returns the wrapping ``ContentInfo``. Raises :class:`ValueError` when:
@@ -180,12 +185,12 @@ def _try_parse_response_or_token(
     * Both shapes fail to parse.
     """
     try:
-        resp = tsp_module.TimeStampResp.load(token_bytes)  # type: ignore[attr-defined]
+        resp = tsp_module.TimeStampResp.load(token_bytes)
         status = resp["status"]["status"].native
     except (ValueError, KeyError, TypeError) as exc:
         # Not a TimeStampResp shape - fall through to ContentInfo.
         try:
-            return cms_module.ContentInfo.load(token_bytes)  # type: ignore[attr-defined]
+            return cms_module.ContentInfo.load(token_bytes)
         except (ValueError, KeyError, TypeError) as exc2:
             raise ValueError(
                 f"could not parse RFC 3161 token: {exc2} (and not a TimeStampResp: {exc})",
@@ -195,7 +200,7 @@ def _try_parse_response_or_token(
     return resp["time_stamp_token"]
 
 
-def _parse_token(token_bytes: bytes) -> tuple[object, object, list[x509.Certificate], object]:
+def _parse_token(token_bytes: bytes) -> tuple[_Asn1Node, _Asn1Node, list[x509.Certificate], _Asn1Node]:
     """Extract SignedData, TSTInfo, embedded certs, and the SignerInfo.
 
     Accepts either:
@@ -259,7 +264,7 @@ def _parse_token(token_bytes: bytes) -> tuple[object, object, list[x509.Certific
 
 
 def _signing_cert(
-    signer_info: object,
+    signer_info: _Asn1Node,
     embedded_certs: list[x509.Certificate],
 ) -> x509.Certificate:
     """Find the cert in ``embedded_certs`` that matches ``signer_info.sid``.
@@ -267,16 +272,16 @@ def _signing_cert(
     SignerInfo.sid is either ``IssuerAndSerialNumber`` or
     ``SubjectKeyIdentifier``; we handle both.
     """
-    sid = signer_info["sid"]  # type: ignore[index]
+    sid = signer_info["sid"]
     sid_kind = sid.name
     if sid_kind == "issuer_and_serial_number":
-        target_issuer_dn = sid.chosen["issuer"].chosen.dump()  # type: ignore[union-attr]
-        target_serial = int(sid.chosen["serial_number"].native)  # type: ignore[union-attr]
+        target_issuer_dn = sid.chosen["issuer"].chosen.dump()
+        target_serial = int(sid.chosen["serial_number"].native)
         for cert in embedded_certs:
             if cert.serial_number == target_serial and cert.issuer.public_bytes() == target_issuer_dn:
                 return cert
     elif sid_kind == "subject_key_identifier":
-        target_ski = bytes(sid.chosen.native)  # type: ignore[union-attr]
+        target_ski = bytes(sid.chosen.native)
         for cert in embedded_certs:
             try:
                 ski_ext = cert.extensions.get_extension_for_class(
@@ -298,7 +303,7 @@ def _signing_cert(
 
 
 def _verify_signed_attrs_signature(
-    signer_info: object,
+    signer_info: _Asn1Node,
     signing_cert: x509.Certificate,
     tst_info_bytes: bytes,
 ) -> None:
@@ -319,10 +324,10 @@ def _verify_signed_attrs_signature(
             mismatches.
         InvalidSignature: When the signature does not validate.
     """
-    digest_alg = signer_info["digest_algorithm"]["algorithm"].native  # type: ignore[index]
-    sig_alg = signer_info["signature_algorithm"]["algorithm"].native  # type: ignore[index]
-    sig_bytes = bytes(signer_info["signature"].native)  # type: ignore[index]
-    signed_attrs = signer_info["signed_attrs"]  # type: ignore[index]
+    digest_alg = signer_info["digest_algorithm"]["algorithm"].native
+    sig_alg = signer_info["signature_algorithm"]["algorithm"].native
+    sig_bytes = bytes(signer_info["signature"].native)
+    signed_attrs = signer_info["signed_attrs"]
 
     hash_obj = _hash_for_oid_or_name(digest_alg)
     if hash_obj is None:
@@ -477,7 +482,7 @@ def verify_rfc3161_token(
 
     # Step 4 (early) - message imprint. Fails fast before chain walk.
     try:
-        mi = tst_info["message_imprint"]  # type: ignore[index]
+        mi = tst_info["message_imprint"]
         hash_oid = mi["hash_algorithm"]["algorithm"].dotted
         embedded_hash = bytes(mi["hashed_message"].native)
         hash_alg_name = _HASH_OID_TO_NAME.get(hash_oid, hash_oid)
@@ -493,7 +498,7 @@ def verify_rfc3161_token(
         errors.append(f"messageImprint: {exc}")
 
     try:
-        gen_time = tst_info["gen_time"].native  # type: ignore[index]
+        gen_time = tst_info["gen_time"].native
     except (KeyError, AttributeError):
         errors.append("TSTInfo missing genTime")
 
@@ -504,7 +509,7 @@ def verify_rfc3161_token(
         eku_timestamping = _has_timestamping_eku(signing_cert)
     except ValueError as exc:
         errors.append(f"trust: {exc}")
-        signing_cert = None  # type: ignore[assignment]
+        signing_cert = None
 
     if signing_cert is not None:
         chain_time = verification_time or gen_time or datetime.now(tz=signing_cert.not_valid_after_utc.tzinfo)
@@ -524,7 +529,7 @@ def verify_rfc3161_token(
     if signing_cert is not None:
         try:
             tst_info_bytes = bytes(
-                signed_data["encap_content_info"]["content"].contents,  # type: ignore[index]
+                signed_data["encap_content_info"]["content"].contents,
             )
             _verify_signed_attrs_signature(signer_info, signing_cert, tst_info_bytes)
         except (InvalidSignature, ValueError) as exc:

--- a/src/bernstein/core/substrate/host_registry.py
+++ b/src/bernstein/core/substrate/host_registry.py
@@ -19,6 +19,10 @@ import sys
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 #: Key under ``mcpServers`` that Bernstein owns in any host config.
 SERVER_ID = "bernstein"
@@ -166,7 +170,7 @@ class HostSpec:
     config_format: ConfigFormat = ConfigFormat.JSON
     scope: str = "user"
     notes: str = ""
-    _path_resolver: object = field(default=None, repr=False, compare=False)
+    _path_resolver: Callable[[], Path] | None = field(default=None, repr=False, compare=False)
 
     @property
     def supported(self) -> bool:
@@ -181,7 +185,7 @@ class HostSpec:
         resolver = self._path_resolver
         if resolver is None:
             return None
-        return resolver()  # type: ignore[operator]
+        return resolver()
 
 
 def bernstein_server_entry() -> dict[str, object]:

--- a/src/bernstein/gui/cli.py
+++ b/src/bernstein/gui/cli.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 import click
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
     from bernstein.core.tunnels.protocol import TunnelHandle
     from bernstein.core.tunnels.registry import TunnelRegistry
 
@@ -105,7 +107,7 @@ def read_passphrase_file(path: Path) -> dict[str, str] | None:
     return result
 
 
-def _print_onboarding(url: str, passphrase: str, *, echo: object = None) -> str:
+def _print_onboarding(url: str, passphrase: str, *, echo: Callable[[str], object] | None = None) -> str:
     """Format the operator-facing onboarding block and return the rendered text.
 
     The QR is rendered alongside a short instruction block.  The function
@@ -127,7 +129,7 @@ def _print_onboarding(url: str, passphrase: str, *, echo: object = None) -> str:
         click.echo(out)
     else:
         # Test-injection seam: callers can pass a list-append or similar.
-        echo(out)  # type: ignore[operator]
+        echo(out)
     return out
 
 

--- a/tests/unit/test_sonar_invalid_type_checks.py
+++ b/tests/unit/test_sonar_invalid_type_checks.py
@@ -1,0 +1,41 @@
+"""Regression coverage for Sonar invalid runtime type-check findings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DISALLOWED_FRAGMENTS: dict[str, tuple[str, ...]] = {
+    "src/bernstein/core/autofix/daemon.py": (
+        "sleep_fn: object",
+        "now_fn: object",
+    ),
+    "src/bernstein/core/planning/routine_bridge.py": ("poster: object",),
+    "src/bernstein/core/security/rfc3161_verifier.py": (
+        "signer_info: object",
+        "tuple[object, object, list[x509.Certificate], object]",
+        "type: ignore[index]",
+    ),
+    "src/bernstein/core/substrate/host_registry.py": (
+        "_path_resolver: object",
+        "type: ignore[operator]",
+    ),
+    "src/bernstein/gui/cli.py": (
+        "echo: object",
+        "type: ignore[operator]",
+    ),
+}
+
+
+def test_sonar_invalid_type_check_patterns_do_not_regress() -> None:
+    """Call seams should use callable protocols instead of object escapes."""
+    failures: list[str] = []
+
+    for relative_path, fragments in DISALLOWED_FRAGMENTS.items():
+        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        for fragment in fragments:
+            if fragment in source:
+                failures.append(f"{relative_path}: {fragment}")
+
+    assert not failures


### PR DESCRIPTION
## Summary
- Type callable injection seams directly instead of routing through object plus runtime escapes.
- Add a small ASN.1 structural protocol for RFC 3161 token nodes.
- Add regression coverage for the Sonar invalid type-check patterns.

## Tests
- uv run pytest tests/unit/test_sonar_invalid_type_checks.py tests/unit/test_rfc3161_verifier.py tests/unit/test_routine_bridge.py tests/unit/substrate/test_host_registry.py tests/unit/test_gui_cli.py -q --tb=short
- uv run ruff format --check src/bernstein/core/autofix/daemon.py src/bernstein/core/planning/routine_bridge.py src/bernstein/core/security/rfc3161_verifier.py src/bernstein/core/substrate/host_registry.py src/bernstein/gui/cli.py tests/unit/test_sonar_invalid_type_checks.py
- uv run ruff check src/bernstein/core/autofix/daemon.py src/bernstein/core/planning/routine_bridge.py src/bernstein/core/security/rfc3161_verifier.py src/bernstein/core/substrate/host_registry.py src/bernstein/gui/cli.py tests/unit/test_sonar_invalid_type_checks.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785