### PR TITLE
Fix float sentinel comparisons

### DIFF
--- a/src/bernstein/core/autofix/review_router.py
+++ b/src/bernstein/core/autofix/review_router.py
@@ -629,7 +629,7 @@ class WorktreeRegistry:
         if not record.worktree_path:
             raise ValueError("WorktreeRecord.worktree_path must be non-empty")
         stamped = record
-        if record.created_at == 0.0:
+        if record.created_at <= 0.0:
             stamped = WorktreeRecord(
                 pr_number=record.pr_number,
                 worktree_path=record.worktree_path,

--- a/src/bernstein/core/cost/cost_rollup_by_envelope.py
+++ b/src/bernstein/core/cost/cost_rollup_by_envelope.py
@@ -165,7 +165,7 @@ def rollup(
             bucket.models.add(rec.model)
         ts = rec.timestamp
         if ts > 0:
-            if bucket.first_ts == 0.0 or ts < bucket.first_ts:
+            if bucket.first_ts <= 0.0 or ts < bucket.first_ts:
                 bucket.first_ts = ts
             if ts > bucket.last_ts:
                 bucket.last_ts = ts

--- a/tests/unit/test_sonar_float_comparisons.py
+++ b/tests/unit/test_sonar_float_comparisons.py
@@ -1,0 +1,25 @@
+"""Regression coverage for Sonar float-comparison findings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sonar_float_sentinel_comparisons_use_ordered_checks() -> None:
+    """Avoid exact equality checks against float sentinel values."""
+    files = (
+        REPO_ROOT / "src/bernstein/core/autofix/review_router.py",
+        REPO_ROOT / "src/bernstein/core/cost/cost_rollup_by_envelope.py",
+    )
+    disallowed = ("== 0.0", "!= 0.0")
+
+    offenders: list[str] = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        offenders.extend(
+            f"{path.relative_to(REPO_ROOT)} contains {fragment}" for fragment in disallowed if fragment in text
+        )
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
- Replace exact float sentinel equality checks with ordered non-positive checks.
- Add regression coverage for the reported Sonar float-comparison patterns.

## Tests
- uv run pytest tests/unit/test_sonar_float_comparisons.py tests/unit/autofix/test_review_router.py tests/unit/test_cost_envelope.py -q --tb=short
- uv run ruff format --check src/bernstein/core/autofix/review_router.py src/bernstein/core/cost/cost_rollup_by_envelope.py tests/unit/test_sonar_float_comparisons.py
- uv run ruff check src/bernstein/core/autofix/review_router.py src/bernstein/core/cost/cost_rollup_by_envelope.py tests/unit/test_sonar_float_comparisons.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785