### PR TITLE
Use finite checks in cost preflight

### DIFF
--- a/src/bernstein/core/cost/preflight.py
+++ b/src/bernstein/core/cost/preflight.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import statistics
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
@@ -105,11 +106,7 @@ def _sanitize(value: float) -> float:
         amount = value
     except (TypeError, ValueError):
         return 0.0
-    if amount != amount:  # NaN
-        return 0.0
-    if amount < 0.0:
-        return 0.0
-    if amount in (float("inf"), float("-inf")):
+    if not math.isfinite(amount) or amount < 0.0:
         return 0.0
     return round(amount, 2)
 
@@ -191,9 +188,7 @@ def load_history(
             cost = float(cost_raw)  # type: ignore[arg-type]
         except (TypeError, ValueError):
             continue
-        if cost != cost or cost < 0.0:  # NaN or negative
-            continue
-        if cost == float("inf"):
+        if not math.isfinite(cost) or cost < 0.0:
             continue
         matched.append(cost)
 

--- a/tests/unit/test_cost_preflight_v2.py
+++ b/tests/unit/test_cost_preflight_v2.py
@@ -84,7 +84,7 @@ def test_load_history_accepts_cli_and_model_aliases(metrics_dir: Path) -> None:
 
 
 def test_load_history_skips_invalid_records(metrics_dir: Path) -> None:
-    """Corrupt lines, negative/NaN/non-numeric costs must be silently skipped."""
+    """Corrupt lines and non-finite costs must be silently skipped."""
     history = metrics_dir / "cost.jsonl"
     history.write_text(
         "\n".join(
@@ -92,6 +92,7 @@ def test_load_history_skips_invalid_records(metrics_dir: Path) -> None:
                 "not-json",
                 json.dumps({"role": "backend", "adapter": "claude", "cost_usd": -1.0}),
                 json.dumps({"role": "backend", "adapter": "claude", "cost_usd": "NaN"}),
+                json.dumps({"role": "backend", "adapter": "claude", "cost_usd": "Infinity"}),
                 json.dumps({"role": "backend", "adapter": "claude", "cost_usd": "oops"}),
                 json.dumps({"role": "backend", "adapter": "claude", "cost_usd": 1.5}),
                 "",
@@ -104,6 +105,13 @@ def test_load_history_skips_invalid_records(metrics_dir: Path) -> None:
 
     samples = load_history(history, role="backend", adapter="claude")
     assert samples == [1.5]
+
+
+def test_cost_preflight_uses_explicit_finite_checks() -> None:
+    """Avoid self-comparison NaN checks flagged by static analysis."""
+    source = Path("src/bernstein/core/cost/preflight.py").read_text(encoding="utf-8")
+    assert "amount != amount" not in source
+    assert "cost != cost" not in source
 
 
 def test_load_history_keeps_only_last_n(metrics_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- Replace NaN self-comparisons with explicit finite checks in cost preflight.
- Extend preflight tests to cover non-finite history entries and the static-analysis regression pattern.

## Tests
- uv run pytest tests/unit/test_cost_preflight_v2.py -q --tb=short
- uv run ruff format --check src/bernstein/core/cost/preflight.py tests/unit/test_cost_preflight_v2.py
- uv run ruff check src/bernstein/core/cost/preflight.py tests/unit/test_cost_preflight_v2.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cost data validation to properly detect and handle non-finite values
  * Invalid cost records are now skipped during processing
  * Non-finite cost values are clamped to zero

* **Tests**
  * Expanded test coverage for cost validation edge cases
  * Added validation enforcement for explicit finite-value checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->