### PR TITLE
Use finite check in simulate predictor

### DIFF
--- a/src/bernstein/core/simulate/predictor.py
+++ b/src/bernstein/core/simulate/predictor.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -141,7 +142,7 @@ def _coerce_float(raw: object) -> float | None:
         value = float(raw)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return None
-    if value != value or value < 0.0 or value == float("inf"):
+    if not math.isfinite(value) or value < 0.0:
         return None
     return value
 

--- a/tests/unit/test_simulate_predictor.py
+++ b/tests/unit/test_simulate_predictor.py
@@ -176,6 +176,12 @@ def test_load_traces_skips_nan_latency(tmp_path: Path) -> None:
     assert samples == (7.0,)
 
 
+def test_load_traces_uses_explicit_finite_latency_check() -> None:
+    source = Path("src/bernstein/core/simulate/predictor.py").read_text(encoding="utf-8")
+
+    assert "value != value" not in source
+
+
 def test_load_traces_trims_to_limit(tmp_path: Path) -> None:
     lines = [
         '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": ' + str(float(i)) + "}\n"


### PR DESCRIPTION
## Summary
- Replace a NaN self-comparison in simulate trace latency parsing with an explicit finite check.
- Add a regression test for the static-analysis pattern.

## Tests
- uv run pytest tests/unit/test_simulate_predictor.py::test_load_traces_uses_explicit_finite_latency_check -q --tb=short
- uv run pytest tests/unit/test_simulate_predictor.py -q --tb=short
- uv run ruff format --check src/bernstein/core/simulate/predictor.py tests/unit/test_simulate_predictor.py
- uv run ruff check src/bernstein/core/simulate/predictor.py tests/unit/test_simulate_predictor.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785