### PR TITLE
Simplify autoheal cordon glob translation

### DIFF
--- a/src/bernstein/core/autoheal/cordon.py
+++ b/src/bernstein/core/autoheal/cordon.py
@@ -110,19 +110,10 @@ def _glob_to_regex(pattern: str) -> re.Pattern[str]:
             # zero-or-more components: a sequence of "<comp>/" any
             # number of times.
             out.append("(?:[^/]+/)*")
-            # If the next token exists, the literal slash that joins
-            # us to it is already consumed by the (?:[^/]+/)*; do not
-            # emit another one.
             continue
         out.append(tok)
         if i != len(tokens) - 1:
-            # Append a slash unless the next token is **, which already
-            # carries its own consume-the-slash semantics.
-            if tokens[i + 1] == "**":
-                # consume slash now since ** prefix is "(?:[^/]+/)*"
-                out.append("/")
-            else:
-                out.append("/")
+            out.append("/")
     body = "".join(out)
     return re.compile(r"\A" + body + r"\Z")
 

--- a/tests/unit/autoheal/test_cordon.py
+++ b/tests/unit/autoheal/test_cordon.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from bernstein.core.autoheal.cordon import (
@@ -71,6 +73,12 @@ def test_globs_are_stable() -> None:
     # Sanity: the configured globs cover the expected categories.
     assert any("cursor" in g for g in CORDON_GLOBS)
     assert any("src/bernstein" in g for g in WHITESPACE_OK_GLOBS)
+
+
+def test_glob_translation_uses_single_separator_path() -> None:
+    source = Path("src/bernstein/core/autoheal/cordon.py").read_text(encoding="utf-8")
+
+    assert 'if tokens[i + 1] == "**"' not in source
 
 
 def test_path_normalization_via_purelib() -> None:


### PR DESCRIPTION
## Summary
- Remove a redundant branch in autoheal cordon glob translation.
- Add a regression test for the static-analysis pattern.

## Tests
- uv run pytest tests/unit/autoheal/test_cordon.py::test_glob_translation_uses_single_separator_path -q --tb=short
- uv run pytest tests/unit/autoheal/test_cordon.py -q --tb=short
- uv run ruff format --check src/bernstein/core/autoheal/cordon.py tests/unit/autoheal/test_cordon.py
- uv run ruff check src/bernstein/core/autoheal/cordon.py tests/unit/autoheal/test_cordon.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785