### PR TITLE
Fix return type mismatch findings

### DIFF
--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -184,11 +184,13 @@ class Criterion:
         """
         if self.is_at_floor:
             raise CriterionExhaustedError(self)
-        return replace(self, level=self.level - 1)
+        updated: Criterion = replace(self, level=self.level - 1)
+        return updated
 
     def reset(self) -> Criterion:
         """Return a new criterion restored to ``max_level``."""
-        return replace(self, level=self.max_level)
+        updated: Criterion = replace(self, level=self.max_level)
+        return updated
 
 
 # ---------------------------------------------------------------------------
@@ -277,9 +279,9 @@ class RetryBudget:
     """
 
     retries: int
-    criterion_degradation: Sequence[Criterion] = field(default_factory=list)
+    criterion_degradation: Sequence[Criterion] = field(default_factory=list[Criterion])
     _attempts_used: int = field(default=0, init=False)
-    _criteria: dict[str, Criterion] = field(default_factory=dict, init=False)
+    _criteria: dict[str, Criterion] = field(default_factory=dict[str, Criterion], init=False)
 
     def __post_init__(self) -> None:
         if self.retries < 0:

--- a/src/bernstein/core/orchestration/consensus_relay.py
+++ b/src/bernstein/core/orchestration/consensus_relay.py
@@ -207,7 +207,7 @@ class RelayDocument:
     open_questions: tuple[str, ...]
     blockers: tuple[str, ...]
     next_action: str
-    calibration: Mapping[str, str] = field(default_factory=dict)
+    calibration: Mapping[str, str] = field(default_factory=dict[str, str])
     lineage_child: str | None = None
     acknowledged: bool = False
     operator_hmac: str = ""
@@ -302,7 +302,8 @@ class RelayDocument:
     # ------------------------------------------------------------------
     def acknowledge(self) -> RelayDocument:
         """Return a copy with ``acknowledged=True``."""
-        return replace(self, acknowledged=True)
+        updated: RelayDocument = replace(self, acknowledged=True)
+        return updated
 
     def with_next(self, next_action: str) -> RelayDocument:
         """Return a copy with a new ``next_action``.
@@ -310,7 +311,8 @@ class RelayDocument:
         The HMAC is cleared because the body changes; callers should
         re-sign before persisting.
         """
-        return replace(self, next_action=next_action, operator_hmac="")
+        updated: RelayDocument = replace(self, next_action=next_action, operator_hmac="")
+        return updated
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/run_actor.py
+++ b/src/bernstein/core/orchestration/run_actor.py
@@ -80,7 +80,7 @@ class Event:
         seq: Monotonic sequence number assigned by the actor. ``-1`` for
             unstamped events.
         source: Free-form caller tag for tracing (``"watchdog"``,
-            ``"worker"``, …).
+            ``"worker"``, ...).
     """
 
     kind: EventKind
@@ -157,6 +157,11 @@ def _merge_task(
     return new
 
 
+def _replace_state(state: RunState, **changes: Any) -> RunState:
+    updated: RunState = replace(state, **changes)
+    return updated
+
+
 def apply_event(state: RunState, event: Event) -> RunState:
     """Pure reducer mapping ``(state, event)`` to a new state.
 
@@ -190,18 +195,18 @@ def apply_event(state: RunState, event: Event) -> RunState:
     payload = event.payload
 
     if kind == "session_started":
-        return replace(state, status="running", last_seq=event.seq)
+        return _replace_state(state, status="running", last_seq=event.seq)
 
     if kind == "session_ended":
         end_status = payload.get("status", "done")
         if end_status not in {"done", "failed"}:
             end_status = "done"
-        return replace(state, status=end_status, last_seq=event.seq)
+        return _replace_state(state, status=end_status, last_seq=event.seq)
 
     if kind in {"task_started", "task_progress", "task_completed", "task_failed"}:
         task_id = str(payload.get("task_id", ""))
         if not task_id:
-            return replace(state, last_seq=event.seq)
+            return _replace_state(state, last_seq=event.seq)
         status_map = {
             "task_started": "running",
             "task_progress": "running",
@@ -212,7 +217,7 @@ def apply_event(state: RunState, event: Event) -> RunState:
         for k, v in payload.items():
             if k != "task_id":
                 patch[k] = v
-        return replace(
+        return _replace_state(
             state,
             tasks=_merge_task(state.tasks, task_id, patch),
             last_seq=event.seq,
@@ -221,7 +226,7 @@ def apply_event(state: RunState, event: Event) -> RunState:
     if kind in {"approval_requested", "approval_granted", "approval_denied"}:
         approval_id = str(payload.get("approval_id", ""))
         if not approval_id:
-            return replace(state, last_seq=event.seq)
+            return _replace_state(state, last_seq=event.seq)
         status_map_a: dict[str, Literal["pending", "granted", "denied"]] = {
             "approval_requested": "pending",
             "approval_granted": "granted",
@@ -229,15 +234,15 @@ def apply_event(state: RunState, event: Event) -> RunState:
         }
         new_approvals = dict(state.approvals)
         new_approvals[approval_id] = status_map_a[kind]
-        return replace(state, approvals=new_approvals, last_seq=event.seq)
+        return _replace_state(state, approvals=new_approvals, last_seq=event.seq)
 
     if kind == "watchdog_tick":
         # Pure liveness ping; only advances seq.
-        return replace(state, last_seq=event.seq)
+        return _replace_state(state, last_seq=event.seq)
 
     # Unknown kind: advance seq so we do not block the log, but do not mutate.
     logger.warning("apply_event: unknown event kind %r; advancing seq only", kind)
-    return replace(state, last_seq=event.seq)
+    return _replace_state(state, last_seq=event.seq)
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +485,7 @@ def fold(events: Iterable[Event], initial: RunState) -> RunState:
 
     Args:
         events: Stamped events in ascending sequence order.
-        initial: Starting state (typically ``RunState(session_id=…)``).
+        initial: Starting state (typically ``RunState(session_id=...)``).
 
     Returns:
         Final state after every event has been applied.

--- a/tests/integration/test_simulate_e2e.py
+++ b/tests/integration/test_simulate_e2e.py
@@ -103,12 +103,14 @@ def test_simulate_large_plan_critical_path_smaller_than_sum(tmp_path: Path) -> N
 # ---------------------------------------------------------------------------
 
 
-def test_cli_end_to_end_on_seed_plan(tmp_path: Path) -> None:
+def test_cli_end_to_end_on_seed_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     plans = _seed_plans()
     if not plans:
         pytest.skip("no seed plans found")
     plan = plans[0]
     out_path = tmp_path / "report.json"
+    # Keep repo-local .sdd calibration dirs from changing the CLI defaults under test.
+    monkeypatch.chdir(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         simulate_cmd,

--- a/tests/unit/test_sonar_return_type_mismatches.py
+++ b/tests/unit/test_sonar_return_type_mismatches.py
@@ -1,0 +1,41 @@
+"""Regression tests for Sonar python:S5886 return-type mismatch findings."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _direct_replace_returns(relative_path: str) -> list[str]:
+    tree = ast.parse((PROJECT_ROOT / relative_path).read_text(encoding="utf-8"))
+    findings: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Return):
+                continue
+            value = child.value
+            if not isinstance(value, ast.Call):
+                continue
+            func = value.func
+            if isinstance(func, ast.Name) and func.id == "replace":
+                findings.append(f"{relative_path}:{node.name}:{child.lineno}")
+
+    return findings
+
+
+def test_s5886_cluster_avoids_direct_replace_returns() -> None:
+    """Typed functions should not directly return dataclasses.replace calls."""
+    paths = [
+        "src/bernstein/core/orchestration/run_actor.py",
+        "src/bernstein/core/orchestration/consensus_relay.py",
+        "src/bernstein/core/cost/retry_budget.py",
+    ]
+
+    findings = [finding for path in paths for finding in _direct_replace_returns(path)]
+
+    assert findings == []

--- a/tests/unit/test_sonar_return_type_mismatches.py
+++ b/tests/unit/test_sonar_return_type_mismatches.py
@@ -22,7 +22,9 @@ def _direct_replace_returns(relative_path: str) -> list[str]:
             if not isinstance(value, ast.Call):
                 continue
             func = value.func
-            if isinstance(func, ast.Name) and func.id == "replace":
+            is_replace_name = isinstance(func, ast.Name) and func.id == "replace"
+            is_replace_attribute = isinstance(func, ast.Attribute) and func.attr == "replace"
+            if is_replace_name or is_replace_attribute:
                 findings.append(f"{relative_path}:{node.name}:{child.lineno}")
 
     return findings
@@ -39,3 +41,31 @@ def test_s5886_cluster_avoids_direct_replace_returns() -> None:
     findings = [finding for path in paths for finding in _direct_replace_returns(path)]
 
     assert findings == []
+
+
+def test_direct_replace_scanner_detects_attribute_calls(tmp_path: Path) -> None:
+    """The scanner should catch module-qualified replace calls too."""
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "\n".join(
+            [
+                "from __future__ import annotations",
+                "",
+                "import dataclasses",
+                "",
+                "def update(value: object) -> object:",
+                "    return dataclasses.replace(value)",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    global PROJECT_ROOT
+    previous_root = PROJECT_ROOT
+    try:
+        PROJECT_ROOT = tmp_path
+        findings = _direct_replace_returns("sample.py")
+    finally:
+        PROJECT_ROOT = previous_root
+
+    assert findings == ["sample.py:update:6"]

--- a/tests/unit/test_sonar_return_type_mismatches.py
+++ b/tests/unit/test_sonar_return_type_mismatches.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -43,7 +45,7 @@ def test_s5886_cluster_avoids_direct_replace_returns() -> None:
     assert findings == []
 
 
-def test_direct_replace_scanner_detects_attribute_calls(tmp_path: Path) -> None:
+def test_direct_replace_scanner_detects_attribute_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The scanner should catch module-qualified replace calls too."""
     sample = tmp_path / "sample.py"
     sample.write_text(
@@ -60,12 +62,7 @@ def test_direct_replace_scanner_detects_attribute_calls(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    global PROJECT_ROOT
-    previous_root = PROJECT_ROOT
-    try:
-        PROJECT_ROOT = tmp_path
-        findings = _direct_replace_returns("sample.py")
-    finally:
-        PROJECT_ROOT = previous_root
+    monkeypatch.setattr("tests.unit.test_sonar_return_type_mismatches.PROJECT_ROOT", tmp_path)
+    findings = _direct_replace_returns("sample.py")
 
     assert findings == ["sample.py:update:6"]


### PR DESCRIPTION
## Summary
- Avoid direct dataclasses.replace returns in the S5886 cluster.
- Add a focused regression test for the affected files.
- Keep typed default factories explicit in touched dataclasses.

## Validation
- uv run pytest tests/unit/test_sonar_return_type_mismatches.py tests/unit/run_actor/test_pure_apply.py tests/unit/run_actor/test_replay_after_gap.py tests/unit/test_retry_budget_criterion.py tests/unit/orchestration/test_consensus_relay.py -q
- uv run ruff check src/ tests/unit/test_sonar_return_type_mismatches.py
- uv run pyright src/bernstein/core/orchestration/run_actor.py src/bernstein/core/orchestration/consensus_relay.py src/bernstein/core/cost/retry_budget.py
- git diff --check HEAD~1..HEAD

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new code quality checks to detect and prevent type mismatch issues in return statements.

* **Chores**
  * Improved type safety through enhanced type annotations across core modules.
  * Updated test infrastructure for better consistency with working directory handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->