### PR TITLE
Expand nested ternary coverage to schedule audit

### DIFF
--- a/src/bernstein/cli/commands/schedule_cmd.py
+++ b/src/bernstein/cli/commands/schedule_cmd.py
@@ -243,15 +243,17 @@ def schedule_audit(as_json: bool) -> None:
     for r in report.results:
         ts = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(r.fire_time))
         proj_short = (r.recorded_projection_hash or "-")[:16]
-        chain_short = ("ok" if r.chain_match else "MISMATCH") if not r.counterfactual else "-"
         if r.counterfactual:
+            chain_short = "-"
             status = "skip"
-        elif r.rev_skipped:
-            status = "rev-skip"
-        elif r.verified:
-            status = "verified"
         else:
-            status = "MISMATCH"
+            chain_short = "ok" if r.chain_match else "MISMATCH"
+            if r.rev_skipped:
+                status = "rev-skip"
+            elif r.verified:
+                status = "verified"
+            else:
+                status = "MISMATCH"
         click.echo(f"{ts:<20} {r.schedule_id:<24} {proj_short:<18} {status:<10} {chain_short}")
 
     if not report.ok:

--- a/tests/unit/test_sonar_s3358_nested_ternary.py
+++ b/tests/unit/test_sonar_s3358_nested_ternary.py
@@ -9,6 +9,7 @@ S3358_TARGETS: tuple[Path, ...] = (
     Path("src/bernstein/cli/commands/analyze_cmd.py"),
     Path("src/bernstein/cli/commands/doctor/backends.py"),
     Path("src/bernstein/cli/commands/recipes_cmd.py"),
+    Path("src/bernstein/cli/commands/schedule_cmd.py"),
     Path("src/bernstein/cli/commands/workflow_cmd.py"),
     Path("src/bernstein/cli/commands/worktrees_cmd.py"),
     Path("src/bernstein/core/security/network_policy.py"),


### PR DESCRIPTION
## Summary
- Replace the schedule audit nested ternary with explicit status and chain branches.
- Add schedule audit to the existing S3358 regression target list.

## Tests
- uv run pytest tests/unit/test_sonar_s3358_nested_ternary.py::test_sonar_s3358_targets_do_not_use_nested_ternaries -q --tb=short
- uv run pytest tests/unit/test_schedule_audit_verify.py -q --tb=short
- uv run pytest tests/unit/test_sonar_s3358_nested_ternary.py tests/unit/test_schedule_audit_verify.py -q --tb=short
- uv run ruff format --check src/bernstein/cli/commands/schedule_cmd.py tests/unit/test_sonar_s3358_nested_ternary.py
- uv run ruff check src/bernstein/cli/commands/schedule_cmd.py tests/unit/test_sonar_s3358_nested_ternary.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785