### PR TITLE
Parse retry budget specs linearly

### DIFF
--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -42,7 +42,6 @@ This file is pyright-strict and ruff clean.  Mutating state lives in
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, Final
@@ -515,22 +514,50 @@ class RetryBudget:
 # must be the first token (integer).  The degradation list is optional
 # and defaults to empty.
 
-_SPEC_RE: Final = re.compile(
-    r"""
-    ^\s*
-    (?P<retries>\d+)
-    \s*
-    (?:retr(?:y|ies)|attempts?)?
-    \s*
-    (?:
-        [,;]\s*
-        (?:degrade\s*:)?\s*
-        (?P<policy>[^,;]+(?:>[^,;]+)*)
-    )?
-    \s*$
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
+_RETRY_KEYWORDS: Final = ("retries", "retry", "attempts", "attempt")
+
+
+def _is_criterion_name(name: str) -> bool:
+    """Return True when *name* matches ``[A-Za-z_][A-Za-z0-9_-]*``."""
+    if not name:
+        return False
+    first = name[0]
+    if not (first == "_" or "A" <= first <= "Z" or "a" <= first <= "z"):
+        return False
+    return all(ch == "_" or ch == "-" or "0" <= ch <= "9" or "A" <= ch <= "Z" or "a" <= ch <= "z" for ch in name[1:])
+
+
+def _split_retry_budget_spec(spec: str) -> tuple[int, str | None]:
+    """Split a retry-budget CLI spec into retry count and optional policy."""
+    digit_end = 0
+    while digit_end < len(spec) and spec[digit_end].isdigit():
+        digit_end += 1
+    if digit_end == 0:
+        raise ValueError(f"could not parse retry budget spec: {spec!r}")
+
+    retries = int(spec[:digit_end])
+    remainder = spec[digit_end:].lstrip()
+    lowered = remainder.lower()
+    for keyword in _RETRY_KEYWORDS:
+        if lowered.startswith(keyword):
+            remainder = remainder[len(keyword) :].lstrip()
+            break
+
+    if not remainder:
+        return retries, None
+    if remainder[0] not in {",", ";"}:
+        raise ValueError(f"could not parse retry budget spec: {spec!r}")
+
+    policy = remainder[1:].lstrip()
+    if policy.lower().startswith("degrade"):
+        after_keyword = policy[len("degrade") :].lstrip()
+        if after_keyword.startswith(":"):
+            policy = after_keyword[1:].lstrip()
+
+    policy = policy.strip()
+    if not policy or "," in policy or ";" in policy:
+        raise ValueError(f"could not parse retry budget spec: {spec!r}")
+    return retries, policy
 
 
 def parse_retry_budget_spec(
@@ -569,11 +596,7 @@ def parse_retry_budget_spec(
     stripped = spec.strip()
     if not stripped:
         raise ValueError("retry budget spec is empty")
-    match = _SPEC_RE.match(stripped)
-    if match is None:
-        raise ValueError(f"could not parse retry budget spec: {spec!r}")
-    retries = int(match.group("retries"))
-    raw_policy = match.group("policy")
+    retries, raw_policy = _split_retry_budget_spec(stripped)
     criteria: list[Criterion] = []
     if raw_policy is not None:
         seen: set[str] = set()
@@ -581,7 +604,7 @@ def parse_retry_budget_spec(
             name = raw_name.strip()
             if not name:
                 raise ValueError(f"empty criterion name in retry budget spec: {spec!r}")
-            if not re.match(r"^[A-Za-z_][A-Za-z0-9_-]*$", name):
+            if not _is_criterion_name(name):
                 raise ValueError(f"invalid criterion name {name!r} in retry budget spec")
             if name in seen:
                 raise DuplicateCriterionError(name)

--- a/tests/unit/test_retry_budget_criterion.py
+++ b/tests/unit/test_retry_budget_criterion.py
@@ -10,6 +10,9 @@ this file is the criterion-aware (issue #1352) suite.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import pytest
 
 from bernstein.core.cost.retry_budget import (
@@ -418,6 +421,20 @@ class TestParseSpec:
         b = parse_retry_budget_spec("2; coverage>tests")
         assert b.retries == 2
         assert len(b.criterion_degradation) == 2
+
+    def test_rejects_adversarial_policy_without_regex_backtracking(self) -> None:
+        code = """
+from bernstein.core.cost.retry_budget import parse_retry_budget_spec
+try:
+    parse_retry_budget_spec("1, " + ("a>" * 50) + ",")
+except ValueError:
+    pass
+"""
+        subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            timeout=5,
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces the full retry-budget spec regex with a linear parser.
- Keeps the existing retry count, optional keyword, separator, and policy parsing behavior.
- Replaces criterion-name regex validation with explicit ASCII character checks.
- Adds a regression test for a malformed policy that previously triggered regex backtracking.

## Verification

- Red before fix: `uv run pytest tests/unit/test_retry_budget_criterion.py::TestParseSpec::test_rejects_adversarial_policy_without_regex_backtracking -q --tb=short`
- `uv run pytest tests/unit/test_retry_budget_criterion.py -q --tb=short`
- `uv run ruff check src/`
- `uv run ruff format --check src/`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`

Addresses part of #1785.
