### PR TITLE
Scope adapter contract Sonar exclusion

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -115,7 +115,7 @@ sonar.cpd.exclusions=\
 # trip python:S125 "commented-out code" even though they are in-code
 # documentation. Suppress S125 on test files where those comments are
 # most common.
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e17,h1,h2,h3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e17,e18,h1,h2,h3
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S125
 sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*.py
 # Unused function parameters on Click CLI commands are the click pattern
@@ -165,6 +165,10 @@ sonar.issue.ignore.multicriteria.e15.resourceKey=src/bernstein/**/*.py
 # (S2486 empty catch, etc.) are NOT silenced — they get handled in code.
 sonar.issue.ignore.multicriteria.e17.ruleKey=css:S7924
 sonar.issue.ignore.multicriteria.e17.resourceKey=src/bernstein/dashboard/templates/**/*
+# S2638: adapter spawn overrides preserve CLIAdapter.spawn exactly at runtime;
+# the contract is checked in tests/unit/test_adapter_contract.py.
+sonar.issue.ignore.multicriteria.e18.ruleKey=python:S2638
+sonar.issue.ignore.multicriteria.e18.resourceKey=src/bernstein/adapters/**/*.py
 
 # -------------------------------------------------------------------------
 # Security-Hotspot scope (tests only)

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -23,6 +23,8 @@ from bernstein.adapters.base import CLIAdapter, SpawnResult
 from bernstein.adapters.generic import GenericAdapter
 from bernstein.adapters.registry import _ADAPTERS, get_adapter
 
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -39,6 +41,26 @@ def _popen_path(adapter: CLIAdapter) -> str:
     """Return the module path for patching subprocess.Popen for a given adapter."""
     mod = type(adapter).__module__
     return f"{mod}.subprocess.Popen"
+
+
+def _sonar_properties() -> dict[str, str]:
+    """Return logical key-value entries from sonar-project.properties."""
+    properties: dict[str, str] = {}
+    pending = ""
+    for raw_line in (PROJECT_ROOT / "sonar-project.properties").read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("\\"):
+            pending += line[:-1]
+            continue
+        line = f"{pending}{line}"
+        pending = ""
+        if "=" not in line:
+            continue
+        key, value = line.split("=", maxsplit=1)
+        properties[key.strip()] = value.strip()
+    return properties
 
 
 # ---------------------------------------------------------------------------
@@ -148,13 +170,7 @@ class TestAdapterContract:
 
     def test_spawn_signature_matches_base(self, name: str, factory: Any) -> None:
         adapter = factory()
-        sig = inspect.signature(adapter.spawn)
-        params = list(sig.parameters.keys())
-        assert "prompt" in params
-        assert "workdir" in params
-        assert "model_config" in params
-        assert "session_id" in params
-        assert "mcp_config" in params
+        assert inspect.signature(type(adapter).spawn) == inspect.signature(CLIAdapter.spawn)
 
     def test_spawn_returns_spawn_result(self, name: str, factory: Any, tmp_path: Path) -> None:
         adapter = factory()
@@ -199,6 +215,19 @@ class TestAdapterContract:
             from bernstein.core.models import ApiTierInfo
 
             assert isinstance(result, ApiTierInfo)
+
+
+def test_sonar_s2638_exclusion_is_scoped_to_adapter_spawn_contracts() -> None:
+    """Adapter overrides keep the base signature; the Sonar exclusion stays narrow."""
+    properties = _sonar_properties()
+    criteria = [item.strip() for item in properties["sonar.issue.ignore.multicriteria"].split(",")]
+    matching_resource_keys = [
+        properties[f"sonar.issue.ignore.multicriteria.{criterion}.resourceKey"]
+        for criterion in criteria
+        if properties.get(f"sonar.issue.ignore.multicriteria.{criterion}.ruleKey") == "python:S2638"
+    ]
+
+    assert matching_resource_keys == ["src/bernstein/adapters/**/*.py"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a scoped Sonar exclusion for python:S2638 on adapter implementations only
- strengthen adapter contract tests to require exact spawn signature parity
- cover the Sonar exclusion scope in tests

## Verification
- uv run pytest tests/unit/test_adapter_contract.py -q --tb=short
- uv run ruff check tests/unit/test_adapter_contract.py
- uv run ruff format --check tests/unit/test_adapter_contract.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785