### PR TITLE
Remove redundant catalog install handler

### DIFF
--- a/src/bernstein/core/skills/catalog/installer.py
+++ b/src/bernstein/core/skills/catalog/installer.py
@@ -149,10 +149,7 @@ def install_catalog_entry(
                 f"plugin installer failed for {entry.id!r}: {install_result.error or 'unknown error'}",
             )
 
-        try:
-            skill_root = _locate_skill_root(install_result.install_path)
-        except CatalogInstallError:
-            raise
+        skill_root = _locate_skill_root(install_result.install_path)
 
         try:
             promote_result: InstallResult = install_local(

--- a/tests/unit/core/skills/test_catalog.py
+++ b/tests/unit/core/skills/test_catalog.py
@@ -12,6 +12,7 @@ Covers the acceptance criteria:
 
 from __future__ import annotations
 
+import ast
 import textwrap
 from collections.abc import Callable
 from dataclasses import replace
@@ -51,6 +52,9 @@ from bernstein.core.skills.catalog import (
     worktree_id_for,
 )
 from bernstein.core.skills.catalog.signature import attach_signature
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CATALOG_INSTALLER_PATH = Path("src/bernstein/core/skills/catalog/installer.py")
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -823,3 +827,22 @@ def test_canonical_payload_excludes_signature_and_verified() -> None:
         )
     )
     assert bytes_a == bytes_b
+
+
+def test_catalog_installer_has_no_redundant_catch_and_rethrow() -> None:
+    """The catalog installer should let CatalogInstallError propagate directly."""
+    source = (REPO_ROOT / CATALOG_INSTALLER_PATH).read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(CATALOG_INSTALLER_PATH))
+
+    redundant_handlers = [
+        handler
+        for handler in ast.walk(tree)
+        if isinstance(handler, ast.ExceptHandler)
+        and isinstance(handler.type, ast.Name)
+        and handler.type.id == "CatalogInstallError"
+        and len(handler.body) == 1
+        and isinstance(handler.body[0], ast.Raise)
+        and handler.body[0].exc is None
+    ]
+
+    assert not redundant_handlers


### PR DESCRIPTION
## Summary
- remove a redundant CatalogInstallError catch-and-rethrow in the catalog installer
- add a regression test that rejects the no-op handler pattern

## Tests
- uv run pytest tests/unit/core/skills/test_catalog.py -q --tb=short
- uv run ruff check src/bernstein/core/skills/catalog/installer.py tests/unit/core/skills/test_catalog.py
- uv run ruff format --check src/bernstein/core/skills/catalog/installer.py tests/unit/core/skills/test_catalog.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785