### PR TITLE
Remove redundant chat cancellation handlers

### DIFF
--- a/src/bernstein/core/chat/drivers/discord.py
+++ b/src/bernstein/core/chat/drivers/discord.py
@@ -711,12 +711,7 @@ class DiscordBridge(BridgeProtocol):
         key: str,
     ) -> None:
         """Sleep ``delay`` then flush the pending body for ``key``."""
-        try:
-            await asyncio.sleep(delay)
-        except asyncio.CancelledError:
-            # Propagate cancellation; swallowing it would desync the
-            # asyncio task tree (Sonar python:S7497, mirror Slack).
-            raise
+        await asyncio.sleep(delay)
         async with self._edit_lock:
             state = self._edit_state.get(key)
             if state is None or not state.pending_text:

--- a/src/bernstein/core/chat/drivers/slack.py
+++ b/src/bernstein/core/chat/drivers/slack.py
@@ -656,12 +656,7 @@ class SlackBridge(BridgeProtocol):
         key: str,
     ) -> None:
         """Sleep ``delay`` then flush the pending body for ``key``."""
-        try:
-            await asyncio.sleep(delay)
-        except asyncio.CancelledError:
-            # Propagate cancellation after releasing local state; swallowing
-            # CancelledError silently would desync the asyncio task tree.
-            raise
+        await asyncio.sleep(delay)
         async with self._edit_lock:
             state = self._edit_state.get(key)
             if state is None or not state.pending_text:

--- a/src/bernstein/core/chat/drivers/telegram.py
+++ b/src/bernstein/core/chat/drivers/telegram.py
@@ -270,13 +270,7 @@ class TelegramBridge(BridgeProtocol):
         key: str,
     ) -> None:
         """Sleep ``delay`` then flush the pending body for ``key``."""
-        try:
-            await asyncio.sleep(delay)
-        except asyncio.CancelledError:
-            # Propagate cancellation after releasing local state; swallowing
-            # CancelledError silently would desync the asyncio task tree
-            # (Sonar python:S7497).
-            raise
+        await asyncio.sleep(delay)
         async with self._edit_lock:
             state = self._edit_state.get(key)
             if state is None or not state.pending_text:

--- a/tests/unit/core/chat/test_driver_cancellation_handlers.py
+++ b/tests/unit/core/chat/test_driver_cancellation_handlers.py
@@ -1,0 +1,32 @@
+"""Regression tests for chat driver cancellation handlers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHAT_DRIVER_PATHS = (
+    Path("src/bernstein/core/chat/drivers/discord.py"),
+    Path("src/bernstein/core/chat/drivers/slack.py"),
+    Path("src/bernstein/core/chat/drivers/telegram.py"),
+)
+
+
+def test_chat_drivers_do_not_catch_cancelled_error_only_to_rethrow() -> None:
+    """CancelledError should propagate without a redundant handler."""
+    redundant_handlers: list[tuple[Path, int]] = []
+    for path in CHAT_DRIVER_PATHS:
+        tree = ast.parse((REPO_ROOT / path).read_text(encoding="utf-8"), filename=str(path))
+        for handler in ast.walk(tree):
+            if (
+                isinstance(handler, ast.ExceptHandler)
+                and isinstance(handler.type, ast.Attribute)
+                and handler.type.attr == "CancelledError"
+                and len(handler.body) == 1
+                and isinstance(handler.body[0], ast.Raise)
+                and handler.body[0].exc is None
+            ):
+                redundant_handlers.append((path, handler.lineno))
+
+    assert redundant_handlers == []


### PR DESCRIPTION
## Summary
- remove redundant CancelledError catch-and-rethrow blocks from chat edit throttles
- leave cancellation propagation to asyncio
- add a regression test for the redundant handler pattern in chat drivers

## Tests
- uv run pytest tests/unit/core/chat/test_driver_cancellation_handlers.py tests/unit/core/chat/test_discord_driver.py tests/unit/core/chat/test_slack_driver.py tests/unit/test_chat_drivers.py -q --tb=short
- uv run ruff check src/bernstein/core/chat/drivers/discord.py src/bernstein/core/chat/drivers/slack.py src/bernstein/core/chat/drivers/telegram.py tests/unit/core/chat/test_driver_cancellation_handlers.py
- uv run ruff format --check src/bernstein/core/chat/drivers/discord.py src/bernstein/core/chat/drivers/slack.py src/bernstein/core/chat/drivers/telegram.py tests/unit/core/chat/test_driver_cancellation_handlers.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined asynchronous error handling across chat drivers by removing redundant cancellation exception wrapper patterns for cleaner, more efficient error propagation.

* **Tests**
  * Added comprehensive test suite validating that task cancellation properly propagates without unnecessary intermediate exception handling in chat driver implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->