### PR TITLE
Fix lifecycle hookspec naming

### DIFF
--- a/src/bernstein/core/lifecycle/pluggy_bridge.py
+++ b/src/bernstein/core/lifecycle/pluggy_bridge.py
@@ -37,6 +37,14 @@ __all__ = [
 ]
 
 
+def _make_standard_hookspec(doc: str) -> Callable[[LifecycleContext], None]:
+    def hook(ctx: LifecycleContext) -> None:
+        del ctx
+
+    hook.__doc__ = doc
+    return hookspec(hook)
+
+
 class LifecycleHookSpec:
     """Pluggy hookspecs for the lifecycle events.
 
@@ -75,33 +83,21 @@ class LifecycleHookSpec:
     # pluggy dispatch (``getattr(pm.hook, event.value)``).
     # ------------------------------------------------------------------
 
-    @hookspec
-    def sessionStart(self, ctx: LifecycleContext) -> None:
-        """Fires when an agent session begins (cross-CLI event)."""
+    sessionStart = _make_standard_hookspec("Fires when an agent session begins (cross-CLI event).")
 
-    @hookspec
-    def userPromptSubmitted(self, ctx: LifecycleContext) -> None:
-        """Fires when a human submits a prompt to a session."""
+    userPromptSubmitted = _make_standard_hookspec("Fires when a human submits a prompt to a session.")
 
-    @hookspec
-    def preToolUse(self, ctx: LifecycleContext) -> None:
-        """Fires before a tool runs; ``deny`` blocks the tool call."""
+    preToolUse = _make_standard_hookspec("Fires before a tool runs; ``deny`` blocks the tool call.")
 
-    @hookspec
-    def postToolUse(self, ctx: LifecycleContext) -> None:
-        """Fires after a tool finishes, regardless of outcome."""
+    postToolUse = _make_standard_hookspec("Fires after a tool finishes, regardless of outcome.")
 
-    @hookspec
-    def errorOccurred(self, ctx: LifecycleContext) -> None:
-        """Fires whenever a structured error surfaces in a session."""
+    errorOccurred = _make_standard_hookspec("Fires whenever a structured error surfaces in a session.")
 
     @hookspec
     def idle(self, ctx: LifecycleContext) -> None:
         """Fires when a session has been idle longer than the threshold."""
 
-    @hookspec
-    def sessionEnd(self, ctx: LifecycleContext) -> None:
-        """Fires when an agent session terminates (any reason)."""
+    sessionEnd = _make_standard_hookspec("Fires when an agent session terminates (any reason).")
 
 
 def make_plugin_manager() -> pluggy.PluginManager:

--- a/tests/unit/test_lifecycle_pluggy_bridge.py
+++ b/tests/unit/test_lifecycle_pluggy_bridge.py
@@ -1,0 +1,32 @@
+"""Tests for lifecycle pluggy hook specifications."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from bernstein.core.lifecycle import pluggy_bridge
+from bernstein.core.lifecycle.hooks import LifecycleEvent
+from bernstein.core.lifecycle.pluggy_bridge import make_plugin_manager
+
+
+def test_standard_hookspecs_register_event_names_without_camelcase_defs() -> None:
+    """Cross-CLI hooks keep public event names without camelCase method definitions."""
+    source = Path(pluggy_bridge.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    hook_spec = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "LifecycleHookSpec")
+    method_names = {node.name for node in hook_spec.body if isinstance(node, ast.FunctionDef)}
+    standard_event_names = {
+        LifecycleEvent.SESSION_START.value,
+        LifecycleEvent.USER_PROMPT_SUBMITTED.value,
+        LifecycleEvent.PRE_TOOL_USE.value,
+        LifecycleEvent.POST_TOOL_USE.value,
+        LifecycleEvent.ERROR_OCCURRED.value,
+        LifecycleEvent.SESSION_END.value,
+    }
+
+    assert method_names.isdisjoint(standard_event_names)
+
+    pm = make_plugin_manager()
+    for event_name in standard_event_names:
+        assert hasattr(pm.hook, event_name)


### PR DESCRIPTION
Summary
- Replace camelCase lifecycle hookspec method definitions with generated hookspec callables registered under the same public event names.
- Add a regression test that checks pluggy still exposes the standard event hooks without camelCase method declarations.

Tests
- uv run pytest tests/unit/test_lifecycle_pluggy_bridge.py -q --tb=short
- uv run pytest tests/unit/test_lifecycle_pluggy_bridge.py tests/unit/test_standard_lifecycle_events.py tests/unit/test_lifecycle_hooks.py -q --tb=short
- uv run ruff check src/bernstein/core/lifecycle/pluggy_bridge.py tests/unit/test_lifecycle_pluggy_bridge.py
- uv run ruff format --check src/bernstein/core/lifecycle/pluggy_bridge.py tests/unit/test_lifecycle_pluggy_bridge.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785