### PR TITLE
Remove redundant core exception handlers

### DIFF
--- a/src/bernstein/core/protocols/acp/transport.py
+++ b/src/bernstein/core/protocols/acp/transport.py
@@ -188,8 +188,6 @@ class StdioAcpTransport:
                 if exc.partial:
                     await self._handle_line(exc.partial)
                 return
-            except asyncio.CancelledError:  # pragma: no cover
-                raise
             if not line:
                 return
             await self._handle_line(line)

--- a/src/bernstein/core/security/lineage_kms.py
+++ b/src/bernstein/core/security/lineage_kms.py
@@ -233,10 +233,7 @@ class EnvBasedKMSAdapter:
         # Reuse the on-disk loader's parser so the error messages are
         # identical regardless of source -- one less surprise for the
         # operator who flips between file/env adapters.
-        try:
-            private_key = _load_ed25519_private(data, Path(f"<env:{env_var}>"))
-        except LineageSignerError:
-            raise
+        private_key = _load_ed25519_private(data, Path(f"<env:{env_var}>"))
         if scrub_env:
             # Best-effort scrub. We cannot guarantee no other thread/
             # process snapshotted ``os.environ`` between import and now,

--- a/tests/unit/test_sonar_redundant_handlers.py
+++ b/tests/unit/test_sonar_redundant_handlers.py
@@ -1,0 +1,37 @@
+"""Regression tests for redundant exception handlers tracked by Sonar."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGETS = (
+    Path("src/bernstein/core/protocols/acp/transport.py"),
+    Path("src/bernstein/core/security/lineage_kms.py"),
+)
+
+
+def _handler_name(handler: ast.ExceptHandler) -> str:
+    if isinstance(handler.type, ast.Name):
+        return handler.type.id
+    if isinstance(handler.type, ast.Attribute):
+        return handler.type.attr
+    return ""
+
+
+def test_target_files_do_not_catch_only_to_rethrow() -> None:
+    """Handlers should either add behavior or be omitted."""
+    redundant_handlers: list[tuple[Path, int, str]] = []
+    for path in TARGETS:
+        tree = ast.parse((REPO_ROOT / path).read_text(encoding="utf-8"), filename=str(path))
+        for handler in ast.walk(tree):
+            if (
+                isinstance(handler, ast.ExceptHandler)
+                and len(handler.body) == 1
+                and isinstance(handler.body[0], ast.Raise)
+                and handler.body[0].exc is None
+            ):
+                redundant_handlers.append((path, handler.lineno, _handler_name(handler)))
+
+    assert redundant_handlers == []


### PR DESCRIPTION
## Summary
- remove redundant catch-and-rethrow handlers from ACP transport and lineage KMS
- keep existing error propagation behavior unchanged
- add a scoped regression test for no-op exception handlers in those files

## Tests
- uv run pytest tests/unit/test_sonar_redundant_handlers.py tests/unit/protocols/acp/test_transport.py tests/unit/test_lineage_kms_adapters.py -q --tb=short
- uv run ruff check src/bernstein/core/protocols/acp/transport.py src/bernstein/core/security/lineage_kms.py tests/unit/test_sonar_redundant_handlers.py
- uv run ruff format --check src/bernstein/core/protocols/acp/transport.py src/bernstein/core/security/lineage_kms.py tests/unit/test_sonar_redundant_handlers.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785