### PR TITLE
Remove redundant tracker transition handlers

### DIFF
--- a/src/bernstein/core/trackers/builtin/github_projects_adapter.py
+++ b/src/bernstein/core/trackers/builtin/github_projects_adapter.py
@@ -466,10 +466,7 @@ class GitHubProjectsV2Adapter(AbstractTrackerAdapter):
             "optionId": option_id,
             "clientMutationId": idempotency_key,
         }
-        try:
-            self._graphql(_MUTATION_UPDATE_STATUS, variables, etag=etag)
-        except OptimisticConcurrencyError:
-            raise
+        self._graphql(_MUTATION_UPDATE_STATUS, variables, etag=etag)
         return TransitionResult(
             ticket_id=ticket_id,
             new_status=status_id,

--- a/src/bernstein/core/trackers/builtin/jira_cloud_adapter.py
+++ b/src/bernstein/core/trackers/builtin/jira_cloud_adapter.py
@@ -328,16 +328,13 @@ class JiraCloudTracker(AbstractTrackerAdapter):
         does not natively honour an idempotency key on this endpoint.
         """
         mapped = self._config.status_map.get(status_id, status_id)
-        try:
-            self._request(
-                "POST",
-                f"/rest/api/3/issue/{ticket_id}/transitions",
-                json={"transition": {"id": mapped}},
-                etag=etag,
-                idempotency_key=idempotency_key,
-            )
-        except OptimisticConcurrencyError:
-            raise
+        self._request(
+            "POST",
+            f"/rest/api/3/issue/{ticket_id}/transitions",
+            json={"transition": {"id": mapped}},
+            etag=etag,
+            idempotency_key=idempotency_key,
+        )
         return TransitionResult(
             ticket_id=ticket_id,
             new_status=status_id,

--- a/src/bernstein/core/trackers/linear.py
+++ b/src/bernstein/core/trackers/linear.py
@@ -380,10 +380,7 @@ class LinearTracker(AbstractTrackerAdapter):
         schema = self._ensure_schema()
         state_id = self._resolve_state_id(schema, status_id)
         variables = {"issueId": ticket_id, "stateId": state_id}
-        try:
-            data = self._graphql(_MUTATION_UPDATE_STATE, variables, etag=etag)
-        except OptimisticConcurrencyError:
-            raise
+        data = self._graphql(_MUTATION_UPDATE_STATE, variables, etag=etag)
         block = (data.get("data") or {}).get("issueUpdate") or {}
         if not block.get("success"):
             msg = f"Linear issueUpdate did not succeed: {block!r}"

--- a/tests/unit/trackers/test_redundant_transition_handlers.py
+++ b/tests/unit/trackers/test_redundant_transition_handlers.py
@@ -1,0 +1,32 @@
+"""Regression tests for tracker transition exception handlers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRACKER_FILES = (
+    Path("src/bernstein/core/trackers/builtin/github_projects_adapter.py"),
+    Path("src/bernstein/core/trackers/builtin/jira_cloud_adapter.py"),
+    Path("src/bernstein/core/trackers/linear.py"),
+)
+
+
+def test_tracker_transition_methods_do_not_catch_only_to_rethrow() -> None:
+    """Optimistic concurrency errors should propagate without a redundant handler."""
+    redundant_handlers: list[tuple[Path, int]] = []
+    for path in TRACKER_FILES:
+        tree = ast.parse((REPO_ROOT / path).read_text(encoding="utf-8"), filename=str(path))
+        for handler in ast.walk(tree):
+            if (
+                isinstance(handler, ast.ExceptHandler)
+                and isinstance(handler.type, ast.Name)
+                and handler.type.id == "OptimisticConcurrencyError"
+                and len(handler.body) == 1
+                and isinstance(handler.body[0], ast.Raise)
+                and handler.body[0].exc is None
+            ):
+                redundant_handlers.append((path, handler.lineno))
+
+    assert redundant_handlers == []


### PR DESCRIPTION
## Summary
- remove redundant catch-and-rethrow transition handlers from tracker adapters
- keep optimistic concurrency propagation unchanged
- add a scoped regression test for no-op transition handlers

## Tests
- uv run pytest tests/unit/trackers/test_redundant_transition_handlers.py tests/unit/trackers/test_github_projects_adapter.py tests/unit/trackers/test_jira_cloud_adapter.py tests/unit/core/trackers/test_linear.py -q --tb=short
- uv run ruff check src/bernstein/core/trackers/builtin/github_projects_adapter.py src/bernstein/core/trackers/builtin/jira_cloud_adapter.py src/bernstein/core/trackers/linear.py tests/unit/trackers/test_redundant_transition_handlers.py
- uv run ruff format --check src/bernstein/core/trackers/builtin/github_projects_adapter.py src/bernstein/core/trackers/builtin/jira_cloud_adapter.py src/bernstein/core/trackers/linear.py tests/unit/trackers/test_redundant_transition_handlers.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785