### PR TITLE
Use concise regex forms

### DIFF
--- a/src/bernstein/core/communication/direct.py
+++ b/src/bernstein/core/communication/direct.py
@@ -38,7 +38,7 @@ MessageId = str
 
 # ``@`` followed by a session-id-like token (alnum, ``-``, ``_``).
 # Anchored on an ASCII word boundary so emails (``user@host``) do not match.
-_MENTION_RE = re.compile(r"(?<!\w)@([A-Za-z0-9][\w-]*)", re.ASCII)
+_MENTION_RE = re.compile(r"(?<!\w)@([^\W_][\w-]*)", re.ASCII)
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/devops/trend_scan.py
+++ b/src/bernstein/core/devops/trend_scan.py
@@ -63,7 +63,7 @@ Tier = Literal[1, 2, 3]
 GapStatus = Literal["new", "duplicate", "recently-closed"]
 
 
-_WORD_RE = re.compile(r"[A-Za-z][\w+-]{1,}", re.ASCII)
+_WORD_RE = re.compile(r"[A-Za-z][\w+-]+", re.ASCII)
 
 
 def _tokens(text: str) -> list[str]:

--- a/src/bernstein/core/lifecycle/hook_filter.py
+++ b/src/bernstein/core/lifecycle/hook_filter.py
@@ -55,7 +55,7 @@ class HookFilterError(ValueError):
 _FILTER_RE = re.compile(
     r"""
     ^\s*
-    (?P<tool>[A-Za-z_]\w*)             # tool selector token
+    (?P<tool>[^\W\d]\w*)               # tool selector token
     (?:
         \(                              # opening paren
         (?P<arg>[^)]*)                  # argument glob (may be empty)

--- a/src/bernstein/core/persistence/action_cache.py
+++ b/src/bernstein/core/persistence/action_cache.py
@@ -56,11 +56,11 @@ _RECORD_VERSION: Final[int] = 1
 # if it looks remotely like a credential, redact.  Order matters: longer /
 # stricter patterns first.
 _REDACT_PATTERNS: Final[tuple[tuple[re.Pattern[str], str], ...]] = (
-    (re.compile(r"sk-[A-Za-z0-9_\-]{20,}"), "[REDACTED_OPENAI_KEY]"),
-    (re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"), "[REDACTED_ANTHROPIC_KEY]"),
-    (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "[REDACTED_GH_TOKEN]"),
+    (re.compile(r"sk-[\w-]{20,}", re.ASCII), "[REDACTED_OPENAI_KEY]"),
+    (re.compile(r"sk-ant-[\w-]{20,}", re.ASCII), "[REDACTED_ANTHROPIC_KEY]"),
+    (re.compile(r"ghp_[^\W_]{20,}", re.ASCII), "[REDACTED_GH_TOKEN]"),
     (re.compile(r"github_pat_\w{20,}", re.ASCII), "[REDACTED_GH_PAT]"),
-    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED_AWS_KEY]"),
+    (re.compile(r"AKIA[\dA-Z]{16}", re.ASCII), "[REDACTED_AWS_KEY]"),
     (re.compile(r"bearer\s+[\w.-]{16,}", re.IGNORECASE | re.ASCII), "Bearer [REDACTED]"),
     (
         re.compile(r"(?i)(authorization|x-api-key|api[_-]?key)\s*[:=]\s*[^\s,;]{8,}"),

--- a/src/bernstein/core/quality/pr_review_aggregator.py
+++ b/src/bernstein/core/quality/pr_review_aggregator.py
@@ -382,7 +382,7 @@ def parse_findings_from_agent(agent: AgentVerdict) -> list[PRFinding]:
 
 def _normalise_tokens(text: str) -> frozenset[str]:
     """Lowercase, drop stopwords, return a token set for Jaccard similarity."""
-    tokens = re.findall(r"[A-Za-z_]\w+", text.lower(), flags=re.ASCII)
+    tokens = re.findall(r"[^\W\d]\w+", text.lower(), flags=re.ASCII)
     return frozenset(t for t in tokens if t not in _STOPWORDS and len(t) >= 3)
 
 

--- a/src/bernstein/core/quality/review_consensus.py
+++ b/src/bernstein/core/quality/review_consensus.py
@@ -267,7 +267,7 @@ def bucket_for_score(score: float) -> ConsensusLevel:
 
 def _normalise_tokens(text: str) -> frozenset[str]:
     """Lowercase, drop stopwords / short tokens, return a set for Jaccard."""
-    tokens = re.findall(r"[A-Za-z_]\w+", text.lower(), flags=re.ASCII)
+    tokens = re.findall(r"[^\W\d]\w+", text.lower(), flags=re.ASCII)
     return frozenset(t for t in tokens if t not in _STOPWORDS and len(t) >= 3)
 
 

--- a/src/bernstein/core/tasks/backlog_parser.py
+++ b/src/bernstein/core/tasks/backlog_parser.py
@@ -259,8 +259,8 @@ _CHECKBOX_PREFIX = re.compile(r"^[-*]\s+\[[ xX]\]\s+")
 _MARKER_TOKEN = re.compile(r"^\[([^\[\]]+)\]\s*")
 # Inline dependency arrow: ``-> T002, T003`` at the end of a line.
 _DEPENDS_INLINE = re.compile(r"(?:->|→)\s*([\w,\s-]+?)\s*$", re.ASCII)
-_TASK_ID = re.compile(r"^T[0-9]+[\w-]*$", re.ASCII)
-_STORY_ID = re.compile(r"^US[0-9]+[\w-]*$", re.IGNORECASE | re.ASCII)
+_TASK_ID = re.compile(r"^T\d+[\w-]*$", re.ASCII)
+_STORY_ID = re.compile(r"^US\d+[\w-]*$", re.IGNORECASE | re.ASCII)
 
 
 def parse_task_line(line: str) -> ParsedTaskLine | None:

--- a/src/bernstein/eval/incident_synthesizer.py
+++ b/src/bernstein/eval/incident_synthesizer.py
@@ -844,7 +844,7 @@ def _safe_tag(value: str) -> str:
     Used so an exception class like ``ValueError`` becomes the tag
     ``valueerror`` without colons, dots, or other YAML-hostile bytes.
     """
-    out = re.sub(r"[^\w]+", "_", value.strip(), flags=re.ASCII).strip("_")
+    out = re.sub(r"\W+", "_", value.strip(), flags=re.ASCII).strip("_")
     return out.lower() or "unknown"
 
 
@@ -902,12 +902,12 @@ def _redact(text: str) -> str | None:
 # pii_output_gate.SECRET_RULES. Regex-only is sufficient because the
 # scanner is also regex-only - anything it flags one of these will mask.
 _SECRET_REDACTION_RES: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-    re.compile(r"\bghp_[A-Za-z0-9]{36,}\b"),
+    re.compile(r"\bAKIA[\dA-Z]{16}\b", re.ASCII),
+    re.compile(r"\bghp_[^\W_]{36,}\b", re.ASCII),
     re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
-    re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b"),
+    re.compile(r"\bsk_(?:live|test)_[^\W_]{16,}\b", re.ASCII),
     re.compile(r"\beyJ[A-Za-z0-9_=\-]+?\.[A-Za-z0-9._=\-]+?\.[A-Za-z0-9._\-+/=]+\b"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.DOTALL),
     re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),
     re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
     re.compile(r"\b(?:\+?\d{1,2}[ \-.])?\(?\d{3}\)?[ \-.]\d{3}[ \-.]\d{4}\b"),

--- a/tests/unit/test_sonar_regex_concision.py
+++ b/tests/unit/test_sonar_regex_concision.py
@@ -1,0 +1,84 @@
+"""Regression tests for tracked regex-concision findings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.communication.direct import _MENTION_RE
+from bernstein.core.devops.trend_scan import _tokens
+from bernstein.core.lifecycle.hook_filter import HookFilterError, parse_hook_filter
+from bernstein.core.persistence.action_cache import redact_secrets
+from bernstein.core.quality.pr_review_aggregator import _normalise_tokens as aggregate_tokens
+from bernstein.core.quality.review_consensus import _normalise_tokens as consensus_tokens
+from bernstein.core.tasks.backlog_parser import _STORY_ID, _TASK_ID
+from bernstein.eval.incident_synthesizer import _safe_tag
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACKED_FILES = (
+    Path("src/bernstein/core/communication/direct.py"),
+    Path("src/bernstein/core/devops/trend_scan.py"),
+    Path("src/bernstein/core/lifecycle/hook_filter.py"),
+    Path("src/bernstein/core/persistence/action_cache.py"),
+    Path("src/bernstein/core/quality/pr_review_aggregator.py"),
+    Path("src/bernstein/core/quality/review_consensus.py"),
+    Path("src/bernstein/core/tasks/backlog_parser.py"),
+    Path("src/bernstein/eval/incident_synthesizer.py"),
+)
+OLD_REGEX_FRAGMENTS = (
+    "[A-Za-z0-9]",
+    "[A-Za-z_]",
+    "[A-Za-z][\\w+-]{1,}",
+    "[A-Za-z0-9_\\-]",
+    "[A-Za-z0-9]{20,}",
+    "[0-9",
+    "{1,}",
+    "[^\\w]+",
+)
+
+
+def test_tracked_regexes_use_concise_forms() -> None:
+    findings: list[tuple[Path, str]] = []
+    for path in TRACKED_FILES:
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+        for fragment in OLD_REGEX_FRAGMENTS:
+            if fragment in text:
+                findings.append((path, fragment))
+
+    assert findings == []
+
+
+def test_regex_behavior_is_preserved_for_representative_inputs() -> None:
+    assert _MENTION_RE.findall("wake @abc-123 and user@example.com") == ["abc-123"]
+    assert _MENTION_RE.findall("skip @_hidden and @9agent") == ["9agent"]
+
+    assert _tokens("fix bug, x, ai, release+note alpha_1 123bad") == [
+        "fix",
+        "bug",
+        "ai",
+        "release+note",
+        "alpha_1",
+        "bad",
+    ]
+
+    assert parse_hook_filter("Bash(git *)") is not None
+    try:
+        parse_hook_filter("1Tool(name)")
+    except HookFilterError:
+        pass
+    else:  # pragma: no cover - assertion branch
+        raise AssertionError("digit-leading tool names must stay invalid")
+
+    redacted = redact_secrets("sk-" + "A" * 20 + " ghp_" + "C" * 20 + " AKIA" + "D" * 16)
+    assert "[REDACTED_OPENAI_KEY]" in redacted
+    assert "[REDACTED_GH_TOKEN]" in redacted
+    assert "[REDACTED_AWS_KEY]" in redacted
+
+    assert aggregate_tokens("A retry-safe review_1 123skip") == frozenset({"retry", "safe", "review_1", "skip"})
+    assert consensus_tokens("A retry-safe review_1 123skip") == frozenset({"retry", "safe", "review_1", "skip"})
+
+    assert _TASK_ID.match("T123-alpha") is not None
+    assert _TASK_ID.match("Tabc") is None
+    assert _STORY_ID.match("US123-alpha") is not None
+    assert _STORY_ID.match("USabc") is None
+
+    assert _safe_tag("ValueError: bad/path") == "valueerror_bad_path"


### PR DESCRIPTION
## Summary
- replace tracked verbose regex fragments with concise equivalent forms
- preserve ASCII matching where the old character classes were ASCII-only
- add regression coverage for the tracked regex fragments and representative behavior

## Tests
- uv run pytest tests/unit/test_sonar_regex_concision.py tests/unit/devops/test_trend_scan.py tests/unit/lifecycle/test_hook_filter.py tests/unit/test_direct_channels.py tests/unit/test_action_cache.py tests/unit/quality/test_pr_review_aggregator.py tests/unit/quality/test_review_consensus.py tests/unit/tasks/test_backlog_parser_dag.py tests/unit/test_backlog_parser.py tests/unit/test_incident_synthesizer.py tests/unit/eval/test_incident_synthesizer.py -q --tb=short
- uv run ruff check src/bernstein/core/communication/direct.py src/bernstein/core/devops/trend_scan.py src/bernstein/core/lifecycle/hook_filter.py src/bernstein/core/persistence/action_cache.py src/bernstein/core/quality/pr_review_aggregator.py src/bernstein/core/quality/review_consensus.py src/bernstein/core/tasks/backlog_parser.py src/bernstein/eval/incident_synthesizer.py tests/unit/test_sonar_regex_concision.py
- uv run ruff format --check src/bernstein/core/communication/direct.py src/bernstein/core/devops/trend_scan.py src/bernstein/core/lifecycle/hook_filter.py src/bernstein/core/persistence/action_cache.py src/bernstein/core/quality/pr_review_aggregator.py src/bernstein/core/quality/review_consensus.py src/bernstein/core/tasks/backlog_parser.py src/bernstein/eval/incident_synthesizer.py tests/unit/test_sonar_regex_concision.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Refs #1785