### PR TITLE
Stabilize mock idle fail-rate parsing

### DIFF
--- a/src/bernstein/adapters/mock.py
+++ b/src/bernstein/adapters/mock.py
@@ -317,15 +317,16 @@ def _idle_mode(log_path: Path) -> None:
             write_log(log_path, f"idle: WARN bad {key}={raw!r}; using default {default}")
             return default
 
-    def _float_env(key: str, default: float) -> float:
+    def _float_env(key: str, default: float, *, invalid_default: float | None = None) -> float:
         raw = os.environ.get(key, "").strip()
         if not raw:
             return default
         try:
             return float(raw)
         except ValueError:
-            write_log(log_path, f"idle: WARN bad {key}={raw!r}; using default {default}")
-            return default
+            fallback = default if invalid_default is None else invalid_default
+            write_log(log_path, f"idle: WARN bad {key}={raw!r}; using default {fallback}")
+            return fallback
 
     lo = _int_env("BERNSTEIN_MOCK_IDLE_MIN_S", 15)
     hi = _int_env("BERNSTEIN_MOCK_IDLE_MAX_S", 120)
@@ -334,7 +335,7 @@ def _idle_mode(log_path: Path) -> None:
     hi = max(0, hi)
     if hi < lo:
         lo, hi = hi, lo
-    fail_rate = _float_env("BERNSTEIN_MOCK_FAIL_RATE", 0.05)
+    fail_rate = _float_env("BERNSTEIN_MOCK_FAIL_RATE", 0.05, invalid_default=0.0)
     will_fail = random.random() < fail_rate
     sleep_s = random.randint(lo, hi) if hi > 0 else 0
 


### PR DESCRIPTION
## Summary
- Keep the missing mock idle fail-rate default at 0.05.
- Use 0.0 only when `BERNSTEIN_MOCK_FAIL_RATE` is malformed.
- Remove the random non-zero exit path from the malformed-env validation case.

## Tests
- `uv run pytest tests/unit/test_gui_smoke_findings.py -q --tb=short`
- Repeated the failing test 80 times with `uv run python`
- `uv run ruff check src/bernstein/adapters/mock.py tests/unit/test_gui_smoke_findings.py`
- `uv run ruff format --check src/bernstein/adapters/mock.py tests/unit/test_gui_smoke_findings.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of invalid configuration values in the mock agent. Malformed failure rate settings now gracefully default to zero with appropriate warning logs, ensuring more predictable behavior when configuration is incorrect.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->