### PR TITLE
Use direct pentest threshold comparison

### DIFF
--- a/src/bernstein/eval/pentest_runner.py
+++ b/src/bernstein/eval/pentest_runner.py
@@ -315,7 +315,7 @@ def _meets_thresholds(score: PentestScore, thresholds: dict[str, float]) -> bool
         return False
     if score.recall < thresholds.get("recall_min", 0.0) - 1e-9:
         return False
-    return not score.f1 < thresholds.get("f1_min", 0.0) - 1e-9
+    return score.f1 >= thresholds.get("f1_min", 0.0) - 1e-9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/eval/test_pentest_multi_adapter.py
+++ b/tests/unit/eval/test_pentest_multi_adapter.py
@@ -25,6 +25,7 @@ from bernstein.eval.pentest_scorer import Finding, PentestScorer
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SCENARIO_PATH = _REPO_ROOT / "eval" / "scenarios" / "security_pentest.yaml"
+_PENTEST_RUNNER_PATH = _REPO_ROOT / "src" / "bernstein" / "eval" / "pentest_runner.py"
 
 
 def _finding(vt: str, path: str) -> Finding:
@@ -41,6 +42,12 @@ def _make_adapter(findings: list[Finding], name: str | None = None):
     if name is not None:
         adapter.__name__ = name
     return adapter
+
+
+def test_threshold_check_uses_direct_f1_comparison() -> None:
+    """Threshold checks should not express ``>=`` as ``not <``."""
+    source = _PENTEST_RUNNER_PATH.read_text(encoding="utf-8")
+    assert "return not score.f1 <" not in source
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the inverted F1 threshold check with a direct `>=` comparison.
- Add a regression guard for the flagged expression form.

## Tests
- `uv run pytest tests/unit/eval/test_pentest_multi_adapter.py::test_threshold_check_uses_direct_f1_comparison -q --tb=short` (failed before fix)
- `uv run pytest tests/unit/eval/test_pentest_multi_adapter.py tests/integration/test_pentest_scenario_e2e.py -q --tb=short`
- `uv run ruff check src/bernstein/eval/pentest_runner.py tests/unit/eval/test_pentest_multi_adapter.py`
- `uv run ruff format --check src/bernstein/eval/pentest_runner.py tests/unit/eval/test_pentest_multi_adapter.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`