### PR TITLE
Simplify MCP catalog install flow

### DIFF
--- a/src/bernstein/cli/commands/mcp_catalog_cmd.py
+++ b/src/bernstein/cli/commands/mcp_catalog_cmd.py
@@ -287,11 +287,12 @@ def install_cmd(entry_id: str, yes: bool, refresh: bool) -> None:
         if not outcome.confirmed:
             console.print("[yellow]Install aborted by user.[/yellow]")
             return
-    else:
-        console.print(
-            f"[green]Installed[/green] {outcome.installed.id} "
-            f"({outcome.installed.version_pin}) into {service.user_config_path}"
-        )
+        return
+
+    console.print(
+        f"[green]Installed[/green] {outcome.installed.id} "
+        f"({outcome.installed.version_pin}) into {service.user_config_path}"
+    )
 
 
 @catalog_group.command("list-installed")

--- a/tests/unit/test_mcp_catalog_cmd_sonar.py
+++ b/tests/unit/test_mcp_catalog_cmd_sonar.py
@@ -1,0 +1,24 @@
+"""Regression tests for MCP catalog command static-analysis findings."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+MODULE = Path("src/bernstein/cli/commands/mcp_catalog_cmd.py")
+
+
+def test_install_cmd_does_not_keep_redundant_else_after_abort_return() -> None:
+    """Install success rendering should not live behind a redundant else."""
+    tree = ast.parse(MODULE.read_text(encoding="utf-8"))
+    install_cmd = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "install_cmd"
+    )
+    installed_none_branches = [
+        node
+        for node in ast.walk(install_cmd)
+        if isinstance(node, ast.If) and ast.unparse(node.test) == "outcome.installed is None"
+    ]
+
+    assert len(installed_none_branches) == 1
+    assert installed_none_branches[0].orelse == []


### PR DESCRIPTION
## Summary
- remove the redundant else branch in MCP catalog install success rendering
- add an AST regression test for the install command control flow

## Validation
- uv run pytest tests/unit/test_mcp_catalog_cmd_sonar.py tests/unit/protocols/mcp_catalog/test_service.py tests/unit/protocols/mcp_catalog/test_sandbox_preview.py -q --tb=short
- uv run ruff check src/bernstein/cli/commands/mcp_catalog_cmd.py tests/unit/test_mcp_catalog_cmd_sonar.py
- uv run ruff format --check src/bernstein/cli/commands/mcp_catalog_cmd.py tests/unit/test_mcp_catalog_cmd_sonar.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control flow in the installation command to properly handle certain failure scenarios.

* **Tests**
  * Added regression test to verify correct behavior in installation command edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->