### PR TITLE
Remove unused worktree classifier path scan

### DIFF
--- a/src/bernstein/core/worktrees/classifier.py
+++ b/src/bernstein/core/worktrees/classifier.py
@@ -257,12 +257,10 @@ def classify_worktrees(
         One :class:`ClassifiedWorktree` per directory, sorted by name.
     """
     clock = time.time() if now is None else now
-    git_paths = _git_worktree_paths(repo_root)
     rows: list[ClassifiedWorktree] = [
         _classify_one(
             path,
             repo_root=repo_root,
-            git_paths=git_paths,
             now=clock,
             stale_trace_age_s=stale_trace_age_s,
         )
@@ -275,7 +273,6 @@ def _classify_one(
     path: Path,
     *,
     repo_root: Path,
-    git_paths: frozenset[str],
     now: float,
     stale_trace_age_s: int,
 ) -> ClassifiedWorktree:
@@ -677,29 +674,6 @@ def reap_worktree(
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
-
-
-def _git_worktree_paths(repo_root: Path) -> frozenset[str]:
-    """Return absolute paths git considers active worktrees."""
-    try:
-        proc = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=15,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
-        logger.debug("git worktree list failed: %s", exc)
-        return frozenset()
-    if proc.returncode != 0:
-        return frozenset()
-    paths: set[str] = set()
-    for line in proc.stdout.splitlines():
-        if line.startswith("worktree "):
-            paths.add(line[len("worktree ") :].strip())
-    return frozenset(paths)
 
 
 def _read_pid_record(repo_root: Path, session_id: str) -> dict[str, object] | None:

--- a/tests/unit/test_worktree_classifier.py
+++ b/tests/unit/test_worktree_classifier.py
@@ -21,6 +21,7 @@ import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.worktrees_cmd import run_gc, worktrees_group
+from bernstein.core.worktrees import classifier
 from bernstein.core.worktrees.classifier import (
     WorktreeState,
     classify_worktrees,
@@ -163,6 +164,26 @@ def test_corrupt_empty_dir_is_reapable(repo_root: Path) -> None:
     row = _row(repo_root, "corrupt-empty")
     assert row.state is WorktreeState.CORRUPT
     assert row.has_unsaved_work is False
+    assert row.is_reapable is True
+
+
+def test_corrupt_empty_dir_does_not_need_git_worktree_paths(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt directory is classified from local filesystem state only."""
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    empty = base / "corrupt-empty"
+    empty.mkdir()
+
+    def fail_subprocess_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("git should not be queried for corrupt directory classification")
+
+    monkeypatch.setattr(classifier.subprocess, "run", fail_subprocess_run)
+
+    row = _row(repo_root, "corrupt-empty")
+    assert row.state is WorktreeState.CORRUPT
     assert row.is_reapable is True
 
 

--- a/tests/unit/test_worktree_classifier.py
+++ b/tests/unit/test_worktree_classifier.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
 from bernstein.cli.commands.worktrees_cmd import run_gc, worktrees_group
-from bernstein.core.worktrees import classifier
 from bernstein.core.worktrees.classifier import (
     WorktreeState,
     classify_worktrees,
@@ -167,22 +167,18 @@ def test_corrupt_empty_dir_is_reapable(repo_root: Path) -> None:
     assert row.is_reapable is True
 
 
-def test_corrupt_empty_dir_does_not_need_git_worktree_paths(
-    repo_root: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_corrupt_empty_dir_does_not_need_git_worktree_paths(repo_root: Path) -> None:
     """A corrupt directory is classified from local filesystem state only."""
     base = repo_root / ".sdd" / "runtime" / "worktrees"
     base.mkdir(parents=True, exist_ok=True)
     empty = base / "corrupt-empty"
     empty.mkdir()
 
-    def fail_subprocess_run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("git should not be queried for corrupt directory classification")
-
-    monkeypatch.setattr(classifier.subprocess, "run", fail_subprocess_run)
-
-    row = _row(repo_root, "corrupt-empty")
+    with patch(
+        "bernstein.core.worktrees.classifier.subprocess.run",
+        side_effect=AssertionError("git should not be queried for corrupt directory classification"),
+    ):
+        row = _row(repo_root, "corrupt-empty")
     assert row.state is WorktreeState.CORRUPT
     assert row.is_reapable is True
 


### PR DESCRIPTION
## Summary
- remove the unused git worktree path collection from the classifier
- keep corrupt-directory classification based on local filesystem state
- add a regression test that fails if corrupt-directory classification queries git

## Validation
- uv run pytest tests/unit/test_worktree_classifier.py tests/unit/test_worktrees_cmd.py -q --tb=short
- uv run ruff check src/bernstein/core/worktrees/classifier.py tests/unit/test_worktree_classifier.py
- uv run ruff format --check src/bernstein/core/worktrees/classifier.py tests/unit/test_worktree_classifier.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Stability**
  * Optimized worktree classification by streamlining internal dependency checks.
  * Enhanced detection and handling of corrupted or incomplete worktrees.
  * Added regression testing to ensure consistent behavior in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->