### PR TITLE
Remove redundant context dependency continue

### DIFF
--- a/src/bernstein/core/tokens/context_compression.py
+++ b/src/bernstein/core/tokens/context_compression.py
@@ -176,7 +176,6 @@ class DependencyGraph:
             if candidate.is_file():
                 with suppress(ValueError):
                     file_deps.append(candidate.relative_to(self.workdir).as_posix())
-                    continue
 
         return file_deps
 

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import ast
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 # --- Fixtures ---
 
@@ -119,6 +117,22 @@ class TestDependencyGraph:
         models_path = "src/myapp/models.py"
         dependents = graph.dependents_of(models_path)
         assert len(dependents) >= 1
+
+    def test_src_subdirectory_resolution_has_no_redundant_terminal_continue(self) -> None:
+        module = ast.parse(Path("src/bernstein/core/tokens/context_compression.py").read_text(encoding="utf-8"))
+        dependency_graph = next(
+            node for node in module.body if isinstance(node, ast.ClassDef) and node.name == "DependencyGraph"
+        )
+        resolve_method = next(
+            node
+            for node in dependency_graph.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_resolve_module_paths"
+        )
+        modules_loop = next(node for node in ast.walk(resolve_method) if isinstance(node, ast.For))
+        src_pattern_branch = modules_loop.body[-1]
+
+        assert isinstance(src_pattern_branch, ast.If)
+        assert not any(isinstance(node, ast.Continue) for node in ast.walk(src_pattern_branch))
 
 
 # --- TestBM25Ranker ---

--- a/tests/unit/test_context_compression.py
+++ b/tests/unit/test_context_compression.py
@@ -119,7 +119,9 @@ class TestDependencyGraph:
         assert len(dependents) >= 1
 
     def test_src_subdirectory_resolution_has_no_redundant_terminal_continue(self) -> None:
-        module = ast.parse(Path("src/bernstein/core/tokens/context_compression.py").read_text(encoding="utf-8"))
+        repo_root = Path(__file__).resolve().parents[2]
+        source_path = repo_root / "src" / "bernstein" / "core" / "tokens" / "context_compression.py"
+        module = ast.parse(source_path.read_text(encoding="utf-8"))
         dependency_graph = next(
             node for node in module.body if isinstance(node, ast.ClassDef) and node.name == "DependencyGraph"
         )


### PR DESCRIPTION
## Summary
- remove a redundant terminal continue from context dependency resolution
- add a regression test for the source-resolution branch shape

## Validation
- uv run pytest tests/unit/test_context_compression.py tests/unit/test_context_budget_enforcement.py -q --tb=short
- uv run ruff check src/bernstein/core/tokens/context_compression.py tests/unit/test_context_compression.py
- uv run ruff format --check src/bernstein/core/tokens/context_compression.py tests/unit/test_context_compression.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal module resolution control flow to streamline dependency processing.

* **Tests**
  * Added unit tests that increase coverage for dependency resolution logic and ensure the updated control flow behaves as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->