### PR TITLE
Simplify suggest-docs topic sorting

### DIFF
--- a/src/bernstein/cli/doctor/suggest_docs.py
+++ b/src/bernstein/cli/doctor/suggest_docs.py
@@ -134,8 +134,7 @@ def top_n_topics(
     """
     if n <= 0:
         return []
-    materialised = list(topics)
-    sorted_topics = sorted(materialised, key=lambda t: t.count, reverse=True)
+    sorted_topics = sorted(topics, key=lambda t: t.count, reverse=True)
     return sorted_topics[:n]
 
 

--- a/tests/unit/cli/test_doctor_suggest_docs.py
+++ b/tests/unit/cli/test_doctor_suggest_docs.py
@@ -8,6 +8,7 @@ crashes the diagnostic surface.
 
 from __future__ import annotations
 
+import ast
 import json
 from io import StringIO
 from pathlib import Path
@@ -194,6 +195,22 @@ def test_top_n_with_zero_returns_empty() -> None:
 def test_top_n_with_negative_n_returns_empty() -> None:
     """Defensive: negative limits must not Python-slice into a tail."""
     assert top_n_topics([_make_topic(1)], n=-3) == []
+
+
+def test_top_n_topics_sorts_iterable_without_intermediate_list_copy() -> None:
+    """The sorter can consume the iterable directly."""
+    module = ast.parse(Path("src/bernstein/cli/doctor/suggest_docs.py").read_text(encoding="utf-8"))
+    top_n = next(node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "top_n_topics")
+    list_copy_assignments = [
+        node
+        for node in ast.walk(top_n)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "list"
+    ]
+
+    assert list_copy_assignments == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the intermediate list copy from suggest-docs topic sorting
- add a regression test for the sorter implementation shape

## Validation
- uv run pytest tests/unit/cli/test_doctor_suggest_docs.py -q --tb=short
- uv run ruff check src/bernstein/cli/doctor/suggest_docs.py tests/unit/cli/test_doctor_suggest_docs.py
- uv run ruff format --check src/bernstein/cli/doctor/suggest_docs.py tests/unit/cli/test_doctor_suggest_docs.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check