### PR TITLE
Avoid direct policy replace return

### DIFF
--- a/src/bernstein/core/agents/harness_policy.py
+++ b/src/bernstein/core/agents/harness_policy.py
@@ -74,7 +74,8 @@ class HarnessPolicy:
         Raises:
             TypeError: If a non-existent flag name is supplied.
         """
-        return replace(self, **changes)
+        updated: HarnessPolicy = replace(self, **changes)
+        return updated
 
 
 #: Conservative all-off baseline - current Bernstein behaviour.

--- a/tests/unit/test_sonar_return_type_mismatches.py
+++ b/tests/unit/test_sonar_return_type_mismatches.py
@@ -35,6 +35,7 @@ def _direct_replace_returns(relative_path: str) -> list[str]:
 def test_s5886_cluster_avoids_direct_replace_returns() -> None:
     """Typed functions should not directly return dataclasses.replace calls."""
     paths = [
+        "src/bernstein/core/agents/harness_policy.py",
         "src/bernstein/core/orchestration/run_actor.py",
         "src/bernstein/core/orchestration/consensus_relay.py",
         "src/bernstein/core/cost/retry_budget.py",


### PR DESCRIPTION
## Summary
- avoid returning `dataclasses.replace` directly from `HarnessPolicy.with_overrides`
- extend the S5886 regression guard to cover the policy module

## Tests
- `uv run pytest tests/unit/test_sonar_return_type_mismatches.py -q --tb=short`
- `uv run pytest tests/unit/test_harness_policy.py -q --tb=short`
- `uv run ruff check src/bernstein/core/agents/harness_policy.py tests/unit/test_sonar_return_type_mismatches.py`
- `uv run ruff format --check src/bernstein/core/agents/harness_policy.py tests/unit/test_sonar_return_type_mismatches.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`