### PR TITLE
Use explicit float zero checks

### DIFF
--- a/src/bernstein/core/autofix/review_router.py
+++ b/src/bernstein/core/autofix/review_router.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import subprocess
 import time
@@ -629,7 +630,7 @@ class WorktreeRegistry:
         if not record.worktree_path:
             raise ValueError("WorktreeRecord.worktree_path must be non-empty")
         stamped = record
-        if record.created_at <= 0.0:
+        if record.created_at < 0.0 or math.isclose(record.created_at, 0.0, abs_tol=1e-12):
             stamped = WorktreeRecord(
                 pr_number=record.pr_number,
                 worktree_path=record.worktree_path,

--- a/src/bernstein/core/cost/cost_rollup_by_envelope.py
+++ b/src/bernstein/core/cost/cost_rollup_by_envelope.py
@@ -18,6 +18,7 @@ zero we return ``None`` for the forecast so dashboards can render
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -165,7 +166,7 @@ def rollup(
             bucket.models.add(rec.model)
         ts = rec.timestamp
         if ts > 0:
-            if bucket.first_ts <= 0.0 or ts < bucket.first_ts:
+            if bucket.first_ts < 0.0 or math.isclose(bucket.first_ts, 0.0, abs_tol=1e-12) or ts < bucket.first_ts:
                 bucket.first_ts = ts
             if ts > bucket.last_ts:
                 bucket.last_ts = ts

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -304,7 +305,7 @@ class ScheduleSupervisor:
                 upcoming = self.next_fire_for(schedule, anchor_epoch=int(now))
             except Exception:  # pragma: no cover - defensive
                 continue
-            if next_fire == 0.0 or upcoming < next_fire:
+            if math.isclose(next_fire, 0.0, abs_tol=1e-12) or upcoming < next_fire:
                 next_fire = float(upcoming)
                 next_id = schedule.id
         return SupervisorStatus(

--- a/src/bernstein/core/quality/review_pipeline/verdict.py
+++ b/src/bernstein/core/quality/review_pipeline/verdict.py
@@ -11,6 +11,7 @@ reproduces today's single-pass cross-model verifier behaviour.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -212,7 +213,7 @@ def _weighted(
         total_weight += weight
         if v.verdict == "approve":
             approve_weight += weight
-    if total_weight == 0.0:
+    if math.isclose(total_weight, 0.0, abs_tol=1e-12):
         # No weights match → fall back to fraction of approvals.
         approves = sum(1 for v in verdicts if v.verdict == "approve")
         score = approves / len(verdicts)

--- a/tests/unit/test_sonar_float_zero_comparisons.py
+++ b/tests/unit/test_sonar_float_zero_comparisons.py
@@ -1,0 +1,42 @@
+"""Regression tests for Sonar python:S1244 float-zero comparisons."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+_TRACKED_PATHS = [
+    "src/bernstein/core/autofix/review_router.py",
+    "src/bernstein/core/cost/cost_rollup_by_envelope.py",
+    "src/bernstein/core/orchestration/schedule_supervisor.py",
+    "src/bernstein/core/quality/review_pipeline/verdict.py",
+]
+
+
+def _is_zero_float(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and isinstance(node.value, float) and node.value == 0.0
+
+
+def _direct_zero_float_comparisons(relative_path: str) -> list[str]:
+    tree = ast.parse((PROJECT_ROOT / relative_path).read_text(encoding="utf-8"))
+    findings: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not any(isinstance(operator, ast.Eq | ast.NotEq | ast.LtE | ast.GtE) for operator in node.ops):
+            continue
+        compared = [node.left, *node.comparators]
+        if any(_is_zero_float(value) for value in compared):
+            findings.append(f"{relative_path}:{node.lineno}:{ast.unparse(node)}")
+
+    return findings
+
+
+def test_s1244_cluster_avoids_direct_zero_float_comparisons() -> None:
+    """Use explicit closeness checks when zero is part of a float comparison."""
+    findings = [finding for path in _TRACKED_PATHS for finding in _direct_zero_float_comparisons(path)]
+
+    assert findings == []


### PR DESCRIPTION
## Summary
- replace direct float-zero comparisons with explicit closeness checks
- add a structural S1244 regression guard for the tracked files

## Tests
- `uv run pytest tests/unit/test_sonar_float_zero_comparisons.py tests/unit/autofix/test_review_router.py tests/unit/test_schedule_supervisor.py tests/unit/quality/review_pipeline/test_verdict.py -q --tb=short`
- `uv run pytest tests/unit/test_sonar_float_zero_comparisons.py -q --tb=short`
- `uv run ruff check src/bernstein/core/autofix/review_router.py src/bernstein/core/cost/cost_rollup_by_envelope.py src/bernstein/core/orchestration/schedule_supervisor.py src/bernstein/core/quality/review_pipeline/verdict.py tests/unit/test_sonar_float_zero_comparisons.py`
- `uv run ruff format --check src/bernstein/core/autofix/review_router.py src/bernstein/core/cost/cost_rollup_by_envelope.py src/bernstein/core/orchestration/schedule_supervisor.py src/bernstein/core/quality/review_pipeline/verdict.py tests/unit/test_sonar_float_zero_comparisons.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`