### PR TITLE
Gate auto-release tags on version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,7 +1,8 @@
 name: Auto-release
 
 # Triggers after CI passes on main - pushes an operator-approved version tag
-# Only releases when meaningful source/test/template files changed.
+# Only releases when an explicit version bump and meaningful source/test/template
+# changes are present.
 #
 # This workflow is invoked by `post-ci-dispatcher.yml` via workflow_call.
 # The dispatcher pays the workflow_run cold start once and routes here
@@ -294,6 +295,19 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "No previous release - proceeding"
+            exit 0
+          fi
+
+          # The latest version must be introduced by the triggering commit.
+          # Otherwise an intentionally absent tag can be recreated by an
+          # unrelated green main run that merely compares differently from
+          # the previous release tag.
+          VERSION_FILE_CHANGED=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \
+            --jq '[.files[]? | select(.filename == "pyproject.toml" and ((.patch // "") | test("(?m)^[+-]version = "))) ] | length')
+          echo "Triggering commit pyproject.toml version changes: ${VERSION_FILE_CHANGED:-0}"
+          if [ "${VERSION_FILE_CHANGED:-0}" = "0" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: triggering commit did not change pyproject.toml version"
             exit 0
           fi
 

--- a/tests/unit/test_auto_release_workflow_yaml.py
+++ b/tests/unit/test_auto_release_workflow_yaml.py
@@ -1,0 +1,54 @@
+"""Structural assertions on ``.github/workflows/auto-release.yml``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-release.yml"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
+def _step_run(workflow: dict[str, Any], job_name: str, step_name: str) -> str:
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs[job_name]
+    assert isinstance(job, dict)
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    for step_value in steps:
+        if not isinstance(step_value, dict):
+            continue
+        if step_value.get("name") != step_name:
+            continue
+        run = step_value.get("run")
+        assert isinstance(run, str)
+        return run
+    pytest.fail(f"{WORKFLOW.name}::{job_name} has no step named {step_name!r}")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return _load(WORKFLOW)
+
+
+def test_release_gate_requires_triggering_commit_version_change(workflow: dict[str, Any]) -> None:
+    """A non-version source change must not recreate a missing release tag."""
+    run = _step_run(workflow, "gate", "Check for meaningful changes")
+    assert "repos/${REPO}/commits/${HEAD_SHA}" in run
+    assert ".files[]?" in run
+    assert 'select(.filename == "pyproject.toml"' in run
+    assert 'test("(?m)^[+-]version = ")' in run
+    assert "triggering commit did not change pyproject.toml version" in run


### PR DESCRIPTION
## Summary
- Require the triggering commit to change the pyproject.toml version line before auto-release can push a tag.
- Keep the existing meaningful-change check for source, tests, templates, scripts, and packaging paths.
- Add a workflow-structure regression test for the version gate.

## Tests
- uv run pytest tests/unit/test_auto_release_workflow_yaml.py -q --tb=short
- uv run pytest tests/unit/test_auto_release_workflow_yaml.py tests/unit/test_post_ci_dispatcher_yaml.py tests/unit/test_release_attestation_workflow.py -q --tb=short
- uv run ruff check src/
- uv run ruff check tests/unit/test_auto_release_workflow_yaml.py
- uv run ruff format --check tests/unit/test_auto_release_workflow_yaml.py
- uv run pyright --project pyrightconfig.strict.json
- uv run python scripts/run_tests.py -k auto_release -x
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to require explicit version updates before triggering a release.

* **Tests**
  * Added tests to validate release automation workflow behavior and enforcement of version change requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->