### PR TITLE
Fix adapter Sonar S2638 scope

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -168,7 +168,7 @@ sonar.issue.ignore.multicriteria.e17.resourceKey=src/bernstein/dashboard/templat
 # S2638: adapter spawn overrides preserve CLIAdapter.spawn exactly at runtime;
 # the contract is checked in tests/unit/test_adapter_contract.py.
 sonar.issue.ignore.multicriteria.e18.ruleKey=python:S2638
-sonar.issue.ignore.multicriteria.e18.resourceKey=src/bernstein/adapters/**/*.py
+sonar.issue.ignore.multicriteria.e18.resourceKey=src/bernstein/adapters/*.py
 
 # -------------------------------------------------------------------------
 # Security-Hotspot scope (tests only)

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import inspect
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -227,7 +227,15 @@ def test_sonar_s2638_exclusion_is_scoped_to_adapter_spawn_contracts() -> None:
         if properties.get(f"sonar.issue.ignore.multicriteria.{criterion}.ruleKey") == "python:S2638"
     ]
 
-    assert matching_resource_keys == ["src/bernstein/adapters/**/*.py"]
+    assert matching_resource_keys == ["src/bernstein/adapters/*.py"]
+
+
+def test_sonar_s2638_exclusion_matches_top_level_adapters() -> None:
+    """The scoped S2638 exclusion must match Sonar's top-level adapter paths."""
+    properties = _sonar_properties()
+    resource_key = properties["sonar.issue.ignore.multicriteria.e18.resourceKey"]
+
+    assert PurePosixPath("src/bernstein/adapters/aichat.py").match(resource_key)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- narrow the adapter S2638 Sonar ignore pattern to top-level adapter modules
- add a regression test proving the configured resource key matches a reported adapter path
- keep the existing adapter signature contract test in place

Fixes part of #1785.

## Tests
- `uv run pytest tests/unit/test_adapter_contract.py::test_sonar_s2638_exclusion_matches_top_level_adapters -q --tb=short` (red before the config change)
- `uv run pytest tests/unit/test_adapter_contract.py -q --tb=short`
- `uv run ruff check src/ tests/unit/test_adapter_contract.py`
- `uv run ruff format --check tests/unit/test_adapter_contract.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined code quality analysis scope by narrowing SonarQube issue-ignore configuration to apply only to top-level adapter files, improving precision of quality checks for nested components.
  * Added validation test to ensure adapter path pattern matching works as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->