### PR TITLE
Align Sonar scan revision with CI head

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -157,5 +157,5 @@ jobs:
             -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.exclusions=src/bernstein/_default_templates/**,src/bernstein/grpc_gen/**
-            -Dsonar.scm.revision=${{ github.sha }}
+            -Dsonar.scm.revision=${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
             -Dsonar.ws.timeout=600

--- a/tests/unit/test_sonar_scan_workflow_yaml.py
+++ b/tests/unit/test_sonar_scan_workflow_yaml.py
@@ -148,3 +148,18 @@ def test_sonar_scan_references_coverage_xml_in_args(sonar_doc: dict[str, object]
     assert "sonar.python.coverage.reportPaths=coverage.xml" in args, (
         "Sonar scan args must point at coverage.xml so Python coverage is ingested"
     )
+
+
+def test_sonar_scan_revision_matches_workflow_run_head_sha(sonar_doc: dict[str, object]) -> None:
+    """Workflow-run scans must report the same commit that was checked out."""
+    jobs = sonar_doc.get("jobs", {})
+    scan = jobs.get("scan", {})
+    steps = scan.get("steps", [])
+    sonar_step = next(
+        (s for s in steps if isinstance(s, dict) and "SonarSource/sonarqube-scan-action" in (s.get("uses") or "")),
+        None,
+    )
+    assert sonar_step is not None, "Workflow must invoke SonarSource/sonarqube-scan-action"
+    args = (sonar_step.get("with") or {}).get("args", "")
+
+    assert "github.event.workflow_run.head_sha" in args


### PR DESCRIPTION
## Summary
- set `sonar.scm.revision` to the triggering CI head SHA for workflow-run scans
- keep manual dispatch scans on `github.sha`
- add a workflow regression test for revision alignment

Fixes part of #1785.

## Tests
- `uv run pytest tests/unit/test_sonar_scan_workflow_yaml.py::test_sonar_scan_revision_matches_workflow_run_head_sha -q --tb=short` (red before the workflow change)
- `uv run pytest tests/unit/test_sonar_scan_workflow_yaml.py -q --tb=short`
- `uv run ruff check tests/unit/test_sonar_scan_workflow_yaml.py`
- `uv run ruff format --check tests/unit/test_sonar_scan_workflow_yaml.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced SonarQube code quality scan accuracy by fixing revision reporting to correctly match the analyzed code, ensuring consistency across different workflow trigger types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->