### PR TITLE
Run zizmor offline in required workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -46,5 +46,6 @@ jobs:
           # Upload SARIF to Code Scanning even on findings; CI does not fail
           # the build on findings, GH Security tab is the source of truth.
           advanced-security: true
-        env:
-          GH_TOKEN: ${{ github.token }}
+          # The default repository token can be rejected by external action
+          # tag lookups. Keep this required workflow on offline audits.
+          online-audits: false

--- a/tests/unit/test_zizmor_workflow_yaml.py
+++ b/tests/unit/test_zizmor_workflow_yaml.py
@@ -1,0 +1,46 @@
+"""Structural assertions on ``.github/workflows/zizmor.yml``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "zizmor.yml"
+
+
+def _load_workflow() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _zizmor_step(workflow: dict[str, Any]) -> dict[str, Any]:
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("zizmor")
+    assert isinstance(job, dict)
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == "Run zizmor":
+            return step
+    pytest.fail("zizmor workflow must include a `Run zizmor` step")
+
+
+def test_zizmor_required_check_runs_offline_audits() -> None:
+    """The required workflow must not false-red on default-token online tag lookups."""
+    workflow = _load_workflow()
+    step = _zizmor_step(workflow)
+    with_block = step.get("with")
+
+    assert isinstance(with_block, dict)
+    assert with_block.get("advanced-security") is True
+    assert with_block.get("online-audits") is False
+    assert "GH_TOKEN" not in (step.get("env") or {})

--- a/tests/unit/test_zizmor_workflow_yaml.py
+++ b/tests/unit/test_zizmor_workflow_yaml.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, cast
+from typing import TypedDict, cast
 
 import pytest
 
@@ -17,20 +18,43 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "zizmor.yml"
 
 
-def _load_workflow() -> dict[str, Any]:
-    return cast("dict[str, Any]", yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")))
+StepSpec = TypedDict(
+    "StepSpec",
+    {"name": object, "uses": object, "with": object, "env": object},
+    total=False,
+)
 
 
-def _zizmor_step(workflow: dict[str, Any]) -> dict[str, Any]:
+class JobSpec(TypedDict, total=False):
+    """Subset of a GitHub Actions job used by these tests."""
+
+    steps: list[object]
+
+
+class WorkflowSpec(TypedDict, total=False):
+    """Subset of a GitHub Actions workflow used by these tests."""
+
+    jobs: Mapping[str, object]
+
+
+def _load_workflow() -> WorkflowSpec:
+    loaded: object = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"{WORKFLOW} must parse as a mapping, got {type(loaded).__name__}")
+    return cast("WorkflowSpec", loaded)
+
+
+def _zizmor_step(workflow: WorkflowSpec) -> StepSpec:
     jobs = workflow.get("jobs")
-    assert isinstance(jobs, dict)
+    assert isinstance(jobs, Mapping)
     job = jobs.get("zizmor")
     assert isinstance(job, dict)
-    steps = job.get("steps")
+    job_spec = cast("JobSpec", job)
+    steps = job_spec.get("steps")
     assert isinstance(steps, list)
     for step in steps:
         if isinstance(step, dict) and step.get("name") == "Run zizmor":
-            return step
+            return cast("StepSpec", step)
     pytest.fail("zizmor workflow must include a `Run zizmor` step")
 
 
@@ -43,4 +67,6 @@ def test_zizmor_required_check_runs_offline_audits() -> None:
     assert isinstance(with_block, dict)
     assert with_block.get("advanced-security") is True
     assert with_block.get("online-audits") is False
-    assert "GH_TOKEN" not in (step.get("env") or {})
+    env_block = step.get("env", {})
+    assert isinstance(env_block, Mapping)
+    assert "GH_TOKEN" not in env_block


### PR DESCRIPTION
## What
- Run the required zizmor workflow with offline audits.
- Remove the explicit `GH_TOKEN` export from the zizmor step.
- Add a structural workflow test for the offline-audit contract.
- Refine the test YAML parsing helper to validate mappings and use explicit typed shapes.

## Why
The default repository token can be rejected by external action tag lookups during online audits, which makes the workflow fail before SARIF is produced.

## How
- Set `online-audits: false` for the `zizmor-action` step.
- Keep SARIF upload enabled through `advanced-security: true`.
- Assert the workflow contract in `tests/unit/test_zizmor_workflow_yaml.py`.

## Validation
- `uv run pytest tests/unit/test_zizmor_workflow_yaml.py -q --tb=short`
- `GH_TOKEN=bad-token uvx zizmor --no-online-audits --format=sarif .`
- `uv run python scripts/run_tests.py -k zizmor -x`
- `uv run ruff check src/ tests/unit/test_zizmor_workflow_yaml.py`
- `uv run ruff format --check src/ tests/unit/test_zizmor_workflow_yaml.py`
- `uv run pyright --project pyrightconfig.strict.json`

<!-- bot-ack: 4524725621 reason=PR body updated to include What, Why, How, and Validation sections. -->
