### PR TITLE
Gate Sonar scans on successful CI

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,12 +1,12 @@
 name: SonarQube scan
 
-# Runs after main CI reaches a terminal state or on manual dispatch.
+# Runs after main CI succeeds or on manual dispatch.
 #
 # The workflow consumes the coverage-report artifact from the same CI run
 # that triggered it. It intentionally does not run directly on push:
 # push-time scans can start before CI uploads coverage.xml and then report
 # a partial fallback coverage number for main.
-on:
+on:  # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["CI"]
     branches: [main]
@@ -26,12 +26,13 @@ jobs:
     name: SonarQube scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Run after main CI completes or on manual dispatch.
+    # Run after main CI succeeds or on manual dispatch.
     # SONAR_HOST_URL must be configured as a repo variable.
     if: >-
       ${{ vars.SONAR_HOST_URL != '' &&
           (github.event_name == 'workflow_dispatch' ||
            (github.event_name == 'workflow_run' &&
+            github.event.workflow_run.conclusion == 'success' &&
             github.event.workflow_run.head_branch == 'main')) }}
     steps:
       - name: Harden runner

--- a/tests/unit/test_sonar_scan_workflow_yaml.py
+++ b/tests/unit/test_sonar_scan_workflow_yaml.py
@@ -1,13 +1,14 @@
 """Structural assertions on the SonarQube scan workflow.
 
 These tests pin the contract that the Sonar scan consumes the coverage
-artifact from the CI run for the same main commit. The scan must not
-start on the raw push event and fall back before the matching CI
-coverage artifact exists.
+artifact from a successful CI run for the same main commit. The scan
+must not start on the raw push event or on a cancelled CI run before the
+matching CI coverage artifact exists.
 
 The tests below assert the workflow has:
 
     * a ``workflow_run`` trigger for completed main CI runs,
+    * a job guard that accepts only successful main CI workflow runs,
     * no direct ``push`` trigger, because that races the CI artifact,
     * a workflow-run artifact download keyed to the triggering CI run,
     * a thin fallback limited to manual dispatch only.
@@ -65,8 +66,8 @@ def test_sonar_scan_keeps_workflow_dispatch(sonar_doc: dict[str, object]) -> Non
     assert "workflow_dispatch" in on_block, "Sonar scan must keep its manual dispatch trigger"
 
 
-def test_sonar_scan_job_if_accepts_workflow_run_and_dispatch(sonar_doc: dict[str, object]) -> None:
-    """The job-level `if` must accept completed CI runs and manual dispatch."""
+def test_sonar_scan_job_if_accepts_successful_workflow_run_and_dispatch(sonar_doc: dict[str, object]) -> None:
+    """The job-level `if` must accept successful CI runs and manual dispatch."""
     jobs = sonar_doc.get("jobs")
     assert isinstance(jobs, dict) and jobs, "Workflow must declare a `jobs:` block"
     scan_job = jobs.get("scan")
@@ -76,6 +77,9 @@ def test_sonar_scan_job_if_accepts_workflow_run_and_dispatch(sonar_doc: dict[str
     flat = " ".join(job_if.split())
     assert "workflow_dispatch" in flat, "Job `if` must accept workflow_dispatch events"
     assert "workflow_run" in flat, "Job `if` must accept workflow_run events from CI"
+    assert "github.event.workflow_run.conclusion == 'success'" in flat, (
+        "Workflow-run scans must ignore cancelled or failed CI runs that do not produce coverage artifacts"
+    )
     assert "head_branch" in flat and "main" in flat, "Workflow-run scans must stay pinned to main"
 
 


### PR DESCRIPTION
## What
- Require workflow-run Sonar scans to come from successful main CI runs.
- Keep manual Sonar dispatch available.
- Add a structural workflow test for the CI conclusion guard.

## Why
Cancelled CI runs do not produce the `coverage-report` artifact.
The previous guard let those runs start Sonar, skip the upload, and finish successfully, which could refresh the tracker from stale Sonar data.

## How
- Add `github.event.workflow_run.conclusion == 'success'` to the Sonar scan job guard.
- Keep the workflow-run trigger itself so successful CI completions still start scans.
- Add the existing zizmor suppression marker for the workflow-run trigger on this trusted internal workflow.

## Validation
- `uv run pytest tests/unit/test_sonar_scan_workflow_yaml.py -q --tb=short`
- `uv run python scripts/run_tests.py -k sonar_scan -x`
- `uv run ruff check src/ tests/unit/test_sonar_scan_workflow_yaml.py`
- `uv run ruff format --check src/ tests/unit/test_sonar_scan_workflow_yaml.py`
- `uv run pyright --project pyrightconfig.strict.json`
- `actionlint .github/workflows/sonar-scan.yml`
- `GH_TOKEN=bad-token uvx zizmor --no-online-audits --format=plain .github/workflows/sonar-scan.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarQube scan workflow configuration to enhance CI integration validation.

* **Tests**
  * Added test coverage for SonarQube workflow success condition validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->