### PR TITLE
Fix Sonar tracker GitHub token

### DIFF
--- a/.github/workflows/review-bot-ack.yml
+++ b/.github/workflows/review-bot-ack.yml
@@ -41,6 +41,7 @@ jobs:
     if: github.event.pull_request != null
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Harden runner (audit mode)
@@ -59,7 +60,7 @@ jobs:
 
       - name: Run review-bot acknowledgement gate
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/sonar-pr-comment.yml
+++ b/.github/workflows/sonar-pr-comment.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -87,6 +88,7 @@ jobs:
           HOTSPOTS: ${{ steps.query.outputs.security_hotspots }}
           COVERAGE: ${{ steps.query.outputs.coverage }}
         with:
+          github-token: ${{ github.token }}
           script: |
             const marker = '<!-- sonar-pr-comment:smells -->';
             const prNumber = Number(process.env.PR_NUMBER);

--- a/.github/workflows/sonar-tracker.yml
+++ b/.github/workflows/sonar-tracker.yml
@@ -67,7 +67,7 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/sonar-tracker.yml
+++ b/.github/workflows/sonar-tracker.yml
@@ -68,6 +68,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/tests/unit/scripts/test_sonar_tracker_workflow.py
+++ b/tests/unit/scripts/test_sonar_tracker_workflow.py
@@ -17,15 +17,27 @@ class RenderSyncEnv(TypedDict):
     GITHUB_TOKEN: str
 
 
-class WorkflowStep(TypedDict, total=False):
-    """Subset of a GitHub Actions step used by this test."""
+GitHubScriptConfig = TypedDict(
+    "GitHubScriptConfig",
+    {"github-token": str, "script": str},
+    total=False,
+)
 
-    name: str
-    env: RenderSyncEnv
+WorkflowPermissions = TypedDict(
+    "WorkflowPermissions",
+    {"contents": str, "issues": str, "pull-requests": str},
+    total=False,
+)
+
+WorkflowStep = TypedDict(
+    "WorkflowStep",
+    {"name": str, "env": RenderSyncEnv, "uses": str, "with": GitHubScriptConfig},
+    total=False,
+)
 
 
-class RenderJob(TypedDict):
-    """Subset of the tracker render job used by this test."""
+class WorkflowJob(TypedDict):
+    """Subset of a workflow job used by these tests."""
 
     steps: list[WorkflowStep]
 
@@ -33,7 +45,8 @@ class RenderJob(TypedDict):
 class WorkflowJobs(TypedDict):
     """Workflow jobs needed by this test."""
 
-    render: RenderJob
+    render: WorkflowJob
+    comment: WorkflowJob
 
 
 def test_sonar_tracker_workflow_exports_gh_token_for_cli() -> None:
@@ -47,3 +60,16 @@ def test_sonar_tracker_workflow_exports_gh_token_for_cli() -> None:
 
     assert env["GH_TOKEN"] == "${{ github.token }}"
     assert env["GITHUB_TOKEN"] == "${{ github.token }}"
+
+
+def test_sonar_pr_comment_workflow_can_update_issue_comments() -> None:
+    """The Sonar PR comment workflow must grant issue-comment access."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "sonar-pr-comment.yml").read_text())
+    permissions = cast("WorkflowPermissions", workflow["permissions"])
+    jobs = cast("WorkflowJobs", workflow["jobs"])
+    comment_job = jobs["comment"]
+    script_step = next(step for step in comment_job["steps"] if step.get("name") == "Post or update sticky comment")
+    script_config = script_step["with"]
+
+    assert permissions["issues"] == "write"
+    assert script_config["github-token"] == "${{ github.token }}"

--- a/tests/unit/scripts/test_sonar_tracker_workflow.py
+++ b/tests/unit/scripts/test_sonar_tracker_workflow.py
@@ -1,0 +1,22 @@
+"""Tests for the Sonar tracker workflow wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def test_sonar_tracker_workflow_exports_gh_token_for_cli() -> None:
+    """The tracker workflow must authenticate GitHub CLI operations."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "sonar-tracker.yml").read_text())
+    jobs = cast("dict[str, Any]", workflow["jobs"])
+    render_job = cast("dict[str, Any]", jobs["render"])
+    steps = cast("list[dict[str, Any]]", render_job["steps"])
+    sync_step = next(step for step in steps if step.get("name") == "Render and sync tracker")
+    env = cast("dict[str, str]", sync_step["env"])
+
+    assert env["GH_TOKEN"] == "${{ github.token }}"

--- a/tests/unit/scripts/test_sonar_tracker_workflow.py
+++ b/tests/unit/scripts/test_sonar_tracker_workflow.py
@@ -3,20 +3,47 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
+from typing import TypedDict, cast
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 
+class RenderSyncEnv(TypedDict):
+    """Environment block used by the tracker sync step."""
+
+    GH_TOKEN: str
+    GITHUB_TOKEN: str
+
+
+class WorkflowStep(TypedDict, total=False):
+    """Subset of a GitHub Actions step used by this test."""
+
+    name: str
+    env: RenderSyncEnv
+
+
+class RenderJob(TypedDict):
+    """Subset of the tracker render job used by this test."""
+
+    steps: list[WorkflowStep]
+
+
+class WorkflowJobs(TypedDict):
+    """Workflow jobs needed by this test."""
+
+    render: RenderJob
+
+
 def test_sonar_tracker_workflow_exports_gh_token_for_cli() -> None:
     """The tracker workflow must authenticate GitHub CLI operations."""
     workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "sonar-tracker.yml").read_text())
-    jobs = cast("dict[str, Any]", workflow["jobs"])
-    render_job = cast("dict[str, Any]", jobs["render"])
-    steps = cast("list[dict[str, Any]]", render_job["steps"])
+    jobs = cast("WorkflowJobs", workflow["jobs"])
+    render_job = jobs["render"]
+    steps = render_job["steps"]
     sync_step = next(step for step in steps if step.get("name") == "Render and sync tracker")
-    env = cast("dict[str, str]", sync_step["env"])
+    env = sync_step["env"]
 
     assert env["GH_TOKEN"] == "${{ github.token }}"
+    assert env["GITHUB_TOKEN"] == "${{ github.token }}"

--- a/tests/unit/scripts/test_sonar_tracker_workflow.py
+++ b/tests/unit/scripts/test_sonar_tracker_workflow.py
@@ -10,8 +10,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 
-class RenderSyncEnv(TypedDict):
-    """Environment block used by the tracker sync step."""
+class WorkflowEnv(TypedDict, total=False):
+    """Environment block used by the workflow steps under test."""
 
     GH_TOKEN: str
     GITHUB_TOKEN: str
@@ -31,14 +31,15 @@ WorkflowPermissions = TypedDict(
 
 WorkflowStep = TypedDict(
     "WorkflowStep",
-    {"name": str, "env": RenderSyncEnv, "uses": str, "with": GitHubScriptConfig},
+    {"name": str, "env": WorkflowEnv, "uses": str, "with": GitHubScriptConfig},
     total=False,
 )
 
 
-class WorkflowJob(TypedDict):
+class WorkflowJob(TypedDict, total=False):
     """Subset of a workflow job used by these tests."""
 
+    permissions: WorkflowPermissions
     steps: list[WorkflowStep]
 
 
@@ -47,6 +48,12 @@ class WorkflowJobs(TypedDict):
 
     render: WorkflowJob
     comment: WorkflowJob
+
+
+ReviewBotAckJobs = TypedDict(
+    "ReviewBotAckJobs",
+    {"review-bot-ack": WorkflowJob},
+)
 
 
 def test_sonar_tracker_workflow_exports_gh_token_for_cli() -> None:
@@ -73,3 +80,16 @@ def test_sonar_pr_comment_workflow_can_update_issue_comments() -> None:
 
     assert permissions["issues"] == "write"
     assert script_config["github-token"] == "${{ github.token }}"
+
+
+def test_review_bot_ack_workflow_uses_job_scoped_token() -> None:
+    """The review-bot acknowledgement workflow must use the live job token."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "review-bot-ack.yml").read_text())
+    jobs = cast("ReviewBotAckJobs", workflow["jobs"])
+    ack_job = jobs["review-bot-ack"]
+    permissions = ack_job["permissions"]
+    gate_step = next(step for step in ack_job["steps"] if step.get("name") == "Run review-bot acknowledgement gate")
+    env = gate_step["env"]
+
+    assert permissions["issues"] == "write"
+    assert env["GH_TOKEN"] == "${{ github.token }}"


### PR DESCRIPTION
## Summary
- export GH_TOKEN for the Sonar tracker sync step
- add a regression test for the workflow token wiring

## Verification
- uv run pytest tests/unit/scripts/test_sonar_tracker_workflow.py -q --tb=short
- uv run python scripts/run_tests.py -k sonar_tracker_workflow -x
- uv run ruff check tests/unit/scripts/test_sonar_tracker_workflow.py
- uv run ruff format --check tests/unit/scripts/test_sonar_tracker_workflow.py
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to pass the workflow-provided token into relevant steps and to grant issue write permission so jobs can create/update PR comments.

* **Tests**
  * Added unit tests covering the updated workflows, asserting token exposure to steps and the ability to update issue/comments via workflow permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->