### PR TITLE
Stabilize atomic write concurrency test

### DIFF
--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -19,6 +19,7 @@ import json
 import os
 import threading
 from pathlib import Path
+from typing import NotRequired, TypedDict
 from unittest.mock import patch
 
 import pytest
@@ -31,6 +32,11 @@ from bernstein.core.persistence.atomic_write import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ATOMIC_WRITE_PATH = Path("src/bernstein/core/persistence/atomic_write.py")
+
+
+class VersionPayload(TypedDict):
+    v: int
+    pad: NotRequired[str]
 
 
 def test_atomic_write_bytes_creates_file(tmp_path: Path) -> None:
@@ -170,8 +176,8 @@ def test_atomic_write_tmp_path_unique_per_call(tmp_path: Path) -> None:
 def test_atomic_write_keeps_old_content_visible_until_replace(tmp_path: Path) -> None:
     """Readers must keep seeing the old complete file until ``os.replace`` runs."""
     target = tmp_path / "state.json"
-    old_payload = {"v": 0}
-    new_payload = {"v": 1, "pad": "x" * 4096}
+    old_payload: VersionPayload = {"v": 0}
+    new_payload: VersionPayload = {"v": 1, "pad": "x" * 4096}
     write_atomic_json(target, old_payload)
 
     real_replace = os.replace
@@ -194,13 +200,13 @@ def test_atomic_write_keeps_old_content_visible_until_replace(tmp_path: Path) ->
     with patch("bernstein.core.persistence.atomic_write.os.replace", side_effect=gated_replace):
         w = threading.Thread(target=writer)
         w.start()
-
-        assert replace_entered.wait(timeout=5), "writer did not reach os.replace"
-        for _ in range(100):
-            assert json.loads(target.read_text(encoding="utf-8")) == old_payload
-
-        allow_replace.set()
-        w.join(timeout=5)
+        try:
+            assert replace_entered.wait(timeout=5), "writer did not reach os.replace"
+            for _ in range(100):
+                assert json.loads(target.read_text(encoding="utf-8")) == old_payload
+        finally:
+            allow_replace.set()
+            w.join(timeout=5)
 
     assert not w.is_alive()
     assert writer_errors == []
@@ -228,7 +234,8 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
         i = 1
         while not stop.is_set():
             try:
-                write_atomic_json(target, {"v": i, "pad": "x" * 4096})
+                payload: VersionPayload = {"v": i, "pad": "x" * 4096}
+                write_atomic_json(target, payload)
             except OSError as exc:  # pragma: no cover - should not happen
                 with lock:
                     errors.append(f"write failed: {exc}")
@@ -260,14 +267,14 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
     for r in readers:
         r.start()
     w.start()
-
-    assert writer_started.wait(timeout=5), "writer did not complete any atomic writes"
-    threading.Event().wait(0.5)
-    stop.set()
-
-    w.join(timeout=5)
-    for r in readers:
-        r.join(timeout=5)
+    try:
+        assert writer_started.wait(timeout=5), "writer did not complete any atomic writes"
+        threading.Event().wait(0.5)
+    finally:
+        stop.set()
+        w.join(timeout=5)
+        for r in readers:
+            r.join(timeout=5)
 
     assert not w.is_alive()
     assert all(not r.is_alive() for r in readers)

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -227,6 +227,7 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
     observed_versions: set[int] = set()
     lock = threading.Lock()
     writer_started = threading.Event()
+    reader_observed_post_initial = threading.Event()
     latest_written = 0
 
     def writer() -> None:
@@ -261,6 +262,8 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
             if isinstance(v, int):
                 with lock:
                     observed_versions.add(v)
+                if v > 0:
+                    reader_observed_post_initial.set()
 
     w = threading.Thread(target=writer)
     readers = [threading.Thread(target=reader) for _ in range(4)]
@@ -269,7 +272,8 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
     w.start()
     try:
         assert writer_started.wait(timeout=5), "writer did not complete any atomic writes"
-        threading.Event().wait(0.5)
+        assert reader_observed_post_initial.wait(timeout=5), "readers did not observe any post-initial version"
+        threading.Event().wait(0.1)
     finally:
         stop.set()
         w.join(timeout=5)

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -167,6 +167,46 @@ def test_atomic_write_tmp_path_unique_per_call(tmp_path: Path) -> None:
     assert len(unique) >= 2
 
 
+def test_atomic_write_keeps_old_content_visible_until_replace(tmp_path: Path) -> None:
+    """Readers must keep seeing the old complete file until ``os.replace`` runs."""
+    target = tmp_path / "state.json"
+    old_payload = {"v": 0}
+    new_payload = {"v": 1, "pad": "x" * 4096}
+    write_atomic_json(target, old_payload)
+
+    real_replace = os.replace
+    replace_entered = threading.Event()
+    allow_replace = threading.Event()
+    writer_errors: list[BaseException] = []
+
+    def gated_replace(src: str, dst: str) -> None:
+        replace_entered.set()
+        if not allow_replace.wait(timeout=5):
+            raise AssertionError("timed out waiting to release os.replace")
+        real_replace(src, dst)
+
+    def writer() -> None:
+        try:
+            write_atomic_json(target, new_payload)
+        except BaseException as exc:  # pragma: no cover - surfaced after join
+            writer_errors.append(exc)
+
+    with patch("bernstein.core.persistence.atomic_write.os.replace", side_effect=gated_replace):
+        w = threading.Thread(target=writer)
+        w.start()
+
+        assert replace_entered.wait(timeout=5), "writer did not reach os.replace"
+        for _ in range(100):
+            assert json.loads(target.read_text(encoding="utf-8")) == old_payload
+
+        allow_replace.set()
+        w.join(timeout=5)
+
+    assert not w.is_alive()
+    assert writer_errors == []
+    assert json.loads(target.read_text(encoding="utf-8")) == new_payload
+
+
 def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Path) -> None:
     """Readers running while another thread repeatedly overwrites the target
     must always see a fully-parseable JSON document - never a partial/torn
@@ -179,15 +219,23 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
     stop = threading.Event()
     errors: list[str] = []
     observed_versions: set[int] = set()
+    lock = threading.Lock()
+    writer_started = threading.Event()
+    latest_written = 0
 
     def writer() -> None:
+        nonlocal latest_written
         i = 1
         while not stop.is_set():
             try:
                 write_atomic_json(target, {"v": i, "pad": "x" * 4096})
             except OSError as exc:  # pragma: no cover - should not happen
-                errors.append(f"write failed: {exc}")
+                with lock:
+                    errors.append(f"write failed: {exc}")
                 return
+            with lock:
+                latest_written = i
+            writer_started.set()
             i += 1
 
     def reader() -> None:
@@ -199,19 +247,21 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
             try:
                 data = json.loads(raw)
             except json.JSONDecodeError as exc:
-                errors.append(f"torn read: {exc!r} on {raw[:80]!r}")
+                with lock:
+                    errors.append(f"torn read: {exc!r} on {raw[:80]!r}")
                 return
             v = data.get("v")
             if isinstance(v, int):
-                observed_versions.add(v)
+                with lock:
+                    observed_versions.add(v)
 
     w = threading.Thread(target=writer)
     readers = [threading.Thread(target=reader) for _ in range(4)]
-    w.start()
     for r in readers:
         r.start()
+    w.start()
 
-    # Let them race for a short while.
+    assert writer_started.wait(timeout=5), "writer did not complete any atomic writes"
     threading.Event().wait(0.5)
     stop.set()
 
@@ -219,10 +269,13 @@ def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Pa
     for r in readers:
         r.join(timeout=5)
 
-    assert errors == [], f"concurrent access produced torn reads: {errors}"
-    # We should have observed many distinct versions - proves the reader/writer
-    # actually interleaved.
-    assert len(observed_versions) >= 5
+    assert not w.is_alive()
+    assert all(not r.is_alive() for r in readers)
+    with lock:
+        assert latest_written >= 1
+        assert observed_versions
+        assert all(0 <= version <= latest_written for version in observed_versions)
+        assert errors == [], f"concurrent access produced torn reads: {errors}"
 
 
 def test_persistence_write_session_json_atomic(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:
- Add a deterministic replace-boundary test for atomic write visibility.
- Keep the concurrent reader/writer stress test focused on parseable reads instead of scheduler-dependent version counts.

Checks:
- uv run --python 3.13 pytest tests/unit/test_atomic_write.py -q --tb=short
- uv run python scripts/run_tests.py -k atomic_write -x
- uv run ruff check src/ tests/ scripts/ --quiet
- uv run lint-imports
- uv run pyright --project pyrightconfig.strict.json
- git diff --check

Note:
- Repo-wide pyright remains advisory and currently reports baseline issues outside this test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test ensuring readers see the prior fully-written JSON until an atomic replace completes.
  * Refactored concurrent write/read tests to coordinate threads and reliably track latest written versions.
  * Improved error reporting for partial/torn reads by recording decode failures with content snippets.
  * Strengthened end-of-test assertions for thread termination, observed version bounds, and absence of decode errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->