### PR TITLE
Serialize claim ledger SQLite access

### DIFF
--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -52,12 +52,13 @@ import contextlib
 import hashlib
 import logging
 import sqlite3
+import threading
 import time
 import uuid
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Final, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
     from bernstein.core.lifecycle.hooks import HookRegistry
@@ -228,15 +229,16 @@ class PipelineConfig:
         stages_raw = raw.get("pipeline_stages", ())
         stages: list[PipelineStage] = []
         if isinstance(stages_raw, Iterable) and not isinstance(stages_raw, (str, bytes)):
-            for item in stages_raw:
+            for item in cast(Iterable[object], stages_raw):
                 if isinstance(item, Mapping):
-                    stages.append(PipelineStage.from_dict(item))
+                    stages.append(PipelineStage.from_dict(cast(Mapping[str, object], item)))
         ttl_raw = raw.get("claim_lock_ttl_seconds", DEFAULT_CLAIM_LOCK_TTL_SECONDS)
         ttl = int(ttl_raw) if isinstance(ttl_raw, (int, float)) else DEFAULT_CLAIM_LOCK_TTL_SECONDS
-        concurrency_raw = raw.get("concurrency", {}) or {}
         max_in_flight = DEFAULT_PER_ROLE_MAX_IN_FLIGHT
+        concurrency_raw = raw.get("concurrency")
         if isinstance(concurrency_raw, Mapping):
-            value = concurrency_raw.get("per_role_max_in_flight", DEFAULT_PER_ROLE_MAX_IN_FLIGHT)
+            concurrency = cast(Mapping[str, object], concurrency_raw)
+            value = concurrency.get("per_role_max_in_flight", DEFAULT_PER_ROLE_MAX_IN_FLIGHT)
             if isinstance(value, (int, float)):
                 max_in_flight = max(1, int(value))
         return cls(
@@ -549,6 +551,7 @@ class ClaimLedger:
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         self._conn: sqlite3.Connection | None = None
+        self._lock = threading.RLock()
 
     @property
     def db_path(self) -> Path:
@@ -556,30 +559,32 @@ class ClaimLedger:
         return self._db_path
 
     def _connect(self) -> sqlite3.Connection:
-        if self._conn is not None:
-            return self._conn
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(
-            str(self._db_path),
-            isolation_level=None,  # autocommit; we use explicit BEGIN IMMEDIATE
-            check_same_thread=False,
-        )
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA busy_timeout=5000")
-        conn.execute(self._SCHEMA)
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_claims_role ON claims(role)",
-        )
-        self._conn = conn
-        return conn
+        with self._lock:
+            if self._conn is not None:
+                return self._conn
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(
+                str(self._db_path),
+                isolation_level=None,  # autocommit; we use explicit BEGIN IMMEDIATE
+                check_same_thread=False,
+            )
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute(self._SCHEMA)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_claims_role ON claims(role)",
+            )
+            self._conn = conn
+            return conn
 
     def close(self) -> None:
         """Close the underlying SQLite connection (idempotent)."""
-        if self._conn is not None:
-            try:
-                self._conn.close()
-            finally:
-                self._conn = None
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                finally:
+                    self._conn = None
 
     # ------------------------------------------------------------------
     # Claim lifecycle
@@ -621,77 +626,79 @@ class ClaimLedger:
         """
         current = float(time.time() if now is None else now)
         expires_at = current + max(1, ttl_seconds)
-        conn = self._connect()
-        try:
-            conn.execute("BEGIN IMMEDIATE")
-            # Concurrency-ceiling check: count non-expired claims for the role.
-            row = conn.execute(
-                "SELECT COUNT(*) FROM claims WHERE role = ? AND lease_expires_at > ?",
-                (role, current),
-            ).fetchone()
-            in_flight = int(row[0]) if row else 0
-            # Drop expired rows so the next INSERT can succeed.
-            conn.execute(
-                "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND lease_expires_at <= ?",
-                (tracker, ticket_id, role, current),
-            )
-            existing = conn.execute(
-                "SELECT claimer_id, lease_expires_at FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
-                (tracker, ticket_id, role),
-            ).fetchone()
-            if existing is not None:
-                conn.execute("ROLLBACK")
-                return ClaimOutcome(
-                    granted=False,
-                    reason="held",
-                    claimer_id=str(existing[0]),
-                    lease_expires_at=float(existing[1]),
-                )
-            if per_role_max_in_flight >= 1 and in_flight >= per_role_max_in_flight:
-                conn.execute("ROLLBACK")
-                return ClaimOutcome(
-                    granted=False,
-                    reason="concurrency_ceiling",
-                    claimer_id="",
-                    lease_expires_at=0.0,
-                )
+        with self._lock:
+            conn = self._connect()
             try:
+                conn.execute("BEGIN IMMEDIATE")
+                # Concurrency-ceiling check: count non-expired claims for the role.
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM claims WHERE role = ? AND lease_expires_at > ?",
+                    (role, current),
+                ).fetchone()
+                in_flight = int(row[0]) if row else 0
+                # Drop expired rows so the next INSERT can succeed.
                 conn.execute(
-                    "INSERT OR FAIL INTO claims "
-                    "(tracker, ticket_id, role, claimer_id, lease_expires_at, stage_attempt, created_at) "
-                    "VALUES (?, ?, ?, ?, ?, 0, ?)",
-                    (tracker, ticket_id, role, claimer_id, expires_at, current),
+                    "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND lease_expires_at <= ?",
+                    (tracker, ticket_id, role, current),
                 )
-            except sqlite3.IntegrityError:
-                conn.execute("ROLLBACK")
-                row2 = conn.execute(
+                existing = conn.execute(
                     "SELECT claimer_id, lease_expires_at FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
                     (tracker, ticket_id, role),
                 ).fetchone()
-                if row2 is None:
+                if existing is not None:
+                    conn.execute("ROLLBACK")
                     return ClaimOutcome(
                         granted=False,
-                        reason="ledger_error",
+                        reason="held",
+                        claimer_id=str(existing[0]),
+                        lease_expires_at=float(existing[1]),
+                    )
+                if per_role_max_in_flight >= 1 and in_flight >= per_role_max_in_flight:
+                    conn.execute("ROLLBACK")
+                    return ClaimOutcome(
+                        granted=False,
+                        reason="concurrency_ceiling",
                         claimer_id="",
                         lease_expires_at=0.0,
                     )
+                try:
+                    conn.execute(
+                        "INSERT OR FAIL INTO claims "
+                        "(tracker, ticket_id, role, claimer_id, lease_expires_at, stage_attempt, created_at) "
+                        "VALUES (?, ?, ?, ?, ?, 0, ?)",
+                        (tracker, ticket_id, role, claimer_id, expires_at, current),
+                    )
+                except sqlite3.IntegrityError:
+                    conn.execute("ROLLBACK")
+                    row2 = conn.execute(
+                        "SELECT claimer_id, lease_expires_at FROM claims "
+                        "WHERE tracker = ? AND ticket_id = ? AND role = ?",
+                        (tracker, ticket_id, role),
+                    ).fetchone()
+                    if row2 is None:
+                        return ClaimOutcome(
+                            granted=False,
+                            reason="ledger_error",
+                            claimer_id="",
+                            lease_expires_at=0.0,
+                        )
+                    return ClaimOutcome(
+                        granted=False,
+                        reason="held",
+                        claimer_id=str(row2[0]),
+                        lease_expires_at=float(row2[1]),
+                    )
+                conn.execute("COMMIT")
+            except sqlite3.OperationalError:
+                log.exception("tracker_pipeline: ledger transaction failed")
+                with contextlib.suppress(sqlite3.Error):
+                    conn.execute("ROLLBACK")
                 return ClaimOutcome(
                     granted=False,
-                    reason="held",
-                    claimer_id=str(row2[0]),
-                    lease_expires_at=float(row2[1]),
+                    reason="ledger_error",
+                    claimer_id="",
+                    lease_expires_at=0.0,
                 )
-            conn.execute("COMMIT")
-        except sqlite3.OperationalError:
-            log.exception("tracker_pipeline: ledger transaction failed")
-            with contextlib.suppress(sqlite3.Error):
-                conn.execute("ROLLBACK")
-            return ClaimOutcome(
-                granted=False,
-                reason="ledger_error",
-                claimer_id="",
-                lease_expires_at=0.0,
-            )
         return ClaimOutcome(
             granted=True,
             reason="granted",
@@ -708,76 +715,81 @@ class ClaimLedger:
         callers can render a deterministic snapshot.
         """
         current = float(time.time() if now is None else now)
-        cursor = self._connect().execute(
-            "SELECT tracker, ticket_id, role, claimer_id, lease_expires_at, "
-            "stage_attempt FROM claims WHERE lease_expires_at > ? "
-            "ORDER BY tracker, role, ticket_id",
-            (current,),
-        )
-        rows: list[dict[str, Any]] = [
-            {
-                "tracker": tracker,
-                "ticket_id": ticket_id,
-                "role": role,
-                "claimer_id": claimer_id,
-                "stage_attempt": int(attempt),
-                "lease_seconds_remaining": float(expires) - current,
-            }
-            for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall()
-        ]
-        return rows
+        with self._lock:
+            cursor = self._connect().execute(
+                "SELECT tracker, ticket_id, role, claimer_id, lease_expires_at, "
+                "stage_attempt FROM claims WHERE lease_expires_at > ? "
+                "ORDER BY tracker, role, ticket_id",
+                (current,),
+            )
+            rows: list[dict[str, Any]] = [
+                {
+                    "tracker": tracker,
+                    "ticket_id": ticket_id,
+                    "role": role,
+                    "claimer_id": claimer_id,
+                    "stage_attempt": int(attempt),
+                    "lease_seconds_remaining": float(expires) - current,
+                }
+                for tracker, ticket_id, role, claimer_id, expires, attempt in cursor.fetchall()
+            ]
+            return rows
 
     def release(self, *, tracker: str, ticket_id: str, role: str, claimer_id: str) -> bool:
         """Drop the claim if ``claimer_id`` still owns it.
 
         Returns ``True`` when a row was removed.
         """
-        cursor = self._connect().execute(
-            "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
-            (tracker, ticket_id, role, claimer_id),
-        )
-        return bool(cursor.rowcount)
+        with self._lock:
+            cursor = self._connect().execute(
+                "DELETE FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
+                (tracker, ticket_id, role, claimer_id),
+            )
+            return bool(cursor.rowcount)
 
     def attempt_count(self, *, tracker: str, ticket_id: str, role: str) -> int:
         """Return ``stage_attempt`` for the live or last claim row, or ``0``."""
-        row = (
-            self._connect()
-            .execute(
-                "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
-                (tracker, ticket_id, role),
+        with self._lock:
+            row = (
+                self._connect()
+                .execute(
+                    "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ?",
+                    (tracker, ticket_id, role),
+                )
+                .fetchone()
             )
-            .fetchone()
-        )
-        if row is None:
-            return 0
-        return int(row[0])
+            if row is None:
+                return 0
+            return int(row[0])
 
     def bump_attempt(self, *, tracker: str, ticket_id: str, role: str, claimer_id: str) -> int:
         """Increment and return ``stage_attempt`` for the held claim.
 
         Returns ``-1`` when no live claim exists for ``claimer_id``.
         """
-        conn = self._connect()
-        conn.execute("BEGIN IMMEDIATE")
-        try:
-            row = conn.execute(
-                "SELECT stage_attempt FROM claims WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
-                (tracker, ticket_id, role, claimer_id),
-            ).fetchone()
-            if row is None:
+        with self._lock:
+            conn = self._connect()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = conn.execute(
+                    "SELECT stage_attempt FROM claims "
+                    "WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
+                    (tracker, ticket_id, role, claimer_id),
+                ).fetchone()
+                if row is None:
+                    conn.execute("ROLLBACK")
+                    return -1
+                attempt = int(row[0]) + 1
+                conn.execute(
+                    "UPDATE claims SET stage_attempt = ? "
+                    "WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
+                    (attempt, tracker, ticket_id, role, claimer_id),
+                )
+                conn.execute("COMMIT")
+            except sqlite3.Error:
                 conn.execute("ROLLBACK")
-                return -1
-            attempt = int(row[0]) + 1
-            conn.execute(
-                "UPDATE claims SET stage_attempt = ? "
-                "WHERE tracker = ? AND ticket_id = ? AND role = ? AND claimer_id = ?",
-                (attempt, tracker, ticket_id, role, claimer_id),
-            )
-            conn.execute("COMMIT")
-        except sqlite3.Error:
-            conn.execute("ROLLBACK")
-            raise
-        return attempt
+                raise
+            return attempt
 
 
 # ---------------------------------------------------------------------------
@@ -824,6 +836,7 @@ class PipelineDispatcher(Protocol):
         idempotency_key: str,
     ) -> DispatchOutcome:
         """Run ``role`` against ``ticket`` and return an outcome."""
+        ...
 
 
 # ---------------------------------------------------------------------------
@@ -855,6 +868,10 @@ class StageHandoff:
             "outcome": self.outcome,
             "idempotency_key": self.idempotency_key,
         }
+
+
+def _new_handoff_log() -> list[StageHandoff]:
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -906,7 +923,7 @@ class TrackerPipeline:
     dispatcher: PipelineDispatcher
     claimer_id: str = field(default_factory=lambda: f"worker-{uuid.uuid4().hex[:12]}")
     hook_registry: HookRegistry | None = None
-    handoffs: list[StageHandoff] = field(default_factory=list)
+    handoffs: list[StageHandoff] = field(default_factory=_new_handoff_log)
     """In-process log of handoffs emitted by the most recent ticks.
 
     Operators who do not wire a :class:`HookRegistry` can still inspect
@@ -1026,8 +1043,9 @@ class TrackerPipeline:
         # does not yet mandate one; we degrade to body-only matching
         # when the adapter does not provide it.
         haystacks: list[str] = [ticket.body or ""]
-        list_comments = getattr(adapter, "list_comments", None)
-        if callable(list_comments):
+        list_comments_raw = getattr(adapter, "list_comments", None)
+        if callable(list_comments_raw):
+            list_comments = cast(Callable[[str], Iterable[object]], list_comments_raw)
             try:
                 for comment in list_comments(ticket.id):
                     body = getattr(comment, "body", "")

--- a/src/bernstein/core/orchestration/tracker_pipeline.py
+++ b/src/bernstein/core/orchestration/tracker_pipeline.py
@@ -58,7 +58,7 @@ import uuid
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
     from bernstein.core.lifecycle.hooks import HookRegistry
@@ -530,9 +530,9 @@ class ClaimLedger:
     :meth:`try_claim` re-acquires it.
 
     The implementation pins ``check_same_thread=False`` and serialises
-    writes via a process-local lock; the underlying SQLite connection
-    is opened lazily so test code may instantiate many ledgers without
-    paying file-system cost up front.
+    writes via a per-database process-local lock; the underlying
+    SQLite connection is opened lazily so test code may instantiate
+    many ledgers without paying file-system cost up front.
     """
 
     _SCHEMA: Final[str] = """
@@ -547,16 +547,28 @@ class ClaimLedger:
             PRIMARY KEY (tracker, ticket_id, role)
         )
     """
+    _locks: ClassVar[dict[str, threading.RLock]] = {}
+    _locks_guard: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         self._conn: sqlite3.Connection | None = None
-        self._lock = threading.RLock()
+        self._lock = self._lock_for_path(db_path)
 
     @property
     def db_path(self) -> Path:
         """Filesystem path the ledger persists at."""
         return self._db_path
+
+    @classmethod
+    def _lock_for_path(cls, db_path: Path) -> threading.RLock:
+        key = str(db_path.expanduser().resolve(strict=False))
+        with cls._locks_guard:
+            lock = cls._locks.get(key)
+            if lock is None:
+                lock = threading.RLock()
+                cls._locks[key] = lock
+            return lock
 
     def _connect(self) -> sqlite3.Connection:
         with self._lock:

--- a/tests/unit/orchestration/test_tracker_pipeline.py
+++ b/tests/unit/orchestration/test_tracker_pipeline.py
@@ -443,6 +443,11 @@ class TestClaimLedger:
         assert len(losers) == 7
         assert all(r.reason == "held" for r in losers)
 
+    def test_same_database_ledgers_share_process_lock(self, tmp_path: Path) -> None:
+        ledger_a = ClaimLedger(tmp_path / "claims.db")
+        ledger_b = ClaimLedger(tmp_path / "nested" / ".." / "claims.db")
+        assert ledger_a._lock is ledger_b._lock
+
     def test_attempt_counter_starts_at_zero_then_bumps(self, tmp_path: Path) -> None:
         ledger = ClaimLedger(tmp_path / "claims.db")
         ledger.try_claim(


### PR DESCRIPTION
## Summary
- serialize ClaimLedger connection initialization and per-instance SQLite operations
- keep tracker-pipeline strict typing clean in the touched module

## Verification
- uv run pytest tests/unit/orchestration/test_tracker_pipeline.py -q --tb=short
- uv run python scripts/run_tests.py -k tracker_pipeline -x
- uv run ruff check src/bernstein/core/orchestration/tracker_pipeline.py tests/unit/orchestration/test_tracker_pipeline.py
- uv run ruff format --check src/bernstein/core/orchestration/tracker_pipeline.py tests/unit/orchestration/test_tracker_pipeline.py
- uv run pyright src/bernstein/core/orchestration/tracker_pipeline.py

Main CI evidence: run 26333872672 failed on ubuntu-latest / Python 3.12 shard 4 with sqlite3.OperationalError: database is locked during ClaimLedger._connect().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced thread-safety for ledger operations to reduce race conditions and improve reliability.
  * Refined pipeline configuration parsing to better respect concurrency settings and defaults.

* **Tests**
  * Added unit coverage validating ledger locking behavior across instances to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->