### PR TITLE
Ignore missing sources in coverage XML export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1459,7 +1459,7 @@ jobs:
             exit 1
           fi
           uv run python -m coverage combine coverage-shards/.coverage.*
-          uv run python -m coverage xml -o coverage.xml
+          uv run python -m coverage xml --ignore-errors -o coverage.xml
           test -s coverage.xml
       - name: Upload coverage report artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tests/unit/test_ci_coverage_workflow_yaml.py
+++ b/tests/unit/test_ci_coverage_workflow_yaml.py
@@ -90,7 +90,7 @@ def test_coverage_report_job_merges_shard_data(ci_doc: dict[str, object]) -> Non
     merge = next(step for step in steps if step.get("name") == "Merge coverage shards")
     merge_run = str(merge.get("run", ""))
     assert "coverage combine" in merge_run
-    assert "coverage xml -o coverage.xml" in merge_run
+    assert "coverage xml --ignore-errors -o coverage.xml" in merge_run
 
     upload = next(step for step in steps if step.get("name") == "Upload coverage report artifact")
     assert "actions/upload-artifact" in str(upload.get("uses", ""))


### PR DESCRIPTION
## Summary
- keep combining all coverage shard data for the push-only coverage report
- export coverage.xml with missing-source errors ignored for deleted temp files
- update the workflow structure test for the XML export command

## Tests
- uv run pytest tests/unit/test_ci_coverage_workflow_yaml.py -q
- uv run pytest tests/unit/test_ci_coverage_workflow_yaml.py tests/unit/test_required_check_canary_workflow_yaml.py -q
- actionlint .github/workflows/ci.yml
- git diff --check
- synthetic missing-source coverage export with and without --ignore-errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of coverage report generation in CI pipeline to better handle edge cases during report processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->