### PR TITLE
Fix Sonar replace return typing

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -12,6 +12,7 @@ alwaysApply: false
 |-----------------------------|---------|
 | `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
 | `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `agents/`                   | agents sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -13,6 +13,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |-----------------------------|---------|
 | `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
 | `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `agents/`                   | agents sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |-----------------------------|---------|
 | `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
 | `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `agents/`                   | agents sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |-----------------------------|---------|
 | `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
 | `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `agents/`                   | agents sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -13,6 +13,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |-----------------------------|---------|
 | `compat_redirect_ledger.py` | Compatibility ledger for legacy ``bernstein.core`` redirects |
 | `credential_scoping.py`     | Agent credential scope minimization for least-privilege API keys |
+| `dataclass_helpers.py`      | Helpers for preserving dataclass instance types through updates |
 | `defaults.py`               | Centralized default values for the Bernstein orchestrator |
 | `streaming_merge.py`        | Streaming task results for long-running agents (incremental merge) |
 | `agents/`                   | agents sub-package |

--- a/src/bernstein/core/dataclass_helpers.py
+++ b/src/bernstein/core/dataclass_helpers.py
@@ -1,0 +1,18 @@
+"""Helpers for preserving dataclass instance types through updates."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, ClassVar, Protocol, cast
+
+__all__ = ["typed_replace"]
+
+
+class _DataclassInstance(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+
+def typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
+    """Return ``instance`` with ``changes`` while preserving the concrete type."""
+    updated: object = replace(instance, **changes)
+    return cast(DataclassT, updated)  # pyright: ignore[reportUnnecessaryCast]

--- a/src/bernstein/core/orchestration/consensus_relay.py
+++ b/src/bernstein/core/orchestration/consensus_relay.py
@@ -65,7 +65,7 @@ import time
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Any, ClassVar, Final, Protocol, cast
 
 from bernstein.core.persistence.atomic_write import write_atomic_json
 
@@ -89,6 +89,14 @@ __all__ = [
 
 
 log = logging.getLogger(__name__)
+
+
+class _DataclassInstance(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+
+def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
+    return cast(DataclassT, replace(instance, **changes))
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +310,7 @@ class RelayDocument:
     # ------------------------------------------------------------------
     def acknowledge(self) -> RelayDocument:
         """Return a copy with ``acknowledged=True``."""
-        updated: RelayDocument = replace(self, acknowledged=True)
+        updated = _typed_replace(self, acknowledged=True)
         return updated
 
     def with_next(self, next_action: str) -> RelayDocument:
@@ -311,7 +319,7 @@ class RelayDocument:
         The HMAC is cleared because the body changes; callers should
         re-sign before persisting.
         """
-        updated: RelayDocument = replace(self, next_action=next_action, operator_hmac="")
+        updated = _typed_replace(self, next_action=next_action, operator_hmac="")
         return updated
 
 
@@ -639,7 +647,7 @@ class RelayStore:
             acknowledged=False,
             operator_hmac="",
         )
-        signed = replace(unsigned, operator_hmac=compute_relay_hmac(unsigned, self._key))
+        signed = _typed_replace(unsigned, operator_hmac=compute_relay_hmac(unsigned, self._key))
         write_atomic_json(self._entry_path(cycle_id), signed.to_dict())
         new_index = [*existing, cycle_id]
         self._write_index(new_index)
@@ -660,8 +668,8 @@ class RelayStore:
         doc = self.read(cycle_id)
         if doc.acknowledged:
             return doc
-        updated = replace(doc, acknowledged=True, operator_hmac="")
-        signed = replace(updated, operator_hmac=compute_relay_hmac(updated, self._key))
+        updated = _typed_replace(doc, acknowledged=True, operator_hmac="")
+        signed = _typed_replace(updated, operator_hmac=compute_relay_hmac(updated, self._key))
         write_atomic_json(self._entry_path(cycle_id), signed.to_dict())
         return signed
 

--- a/src/bernstein/core/orchestration/consensus_relay.py
+++ b/src/bernstein/core/orchestration/consensus_relay.py
@@ -63,10 +63,11 @@ import os
 import re
 import time
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar, Final, Protocol, cast
+from typing import Any, Final, cast
 
+from bernstein.core.dataclass_helpers import typed_replace as _typed_replace
 from bernstein.core.persistence.atomic_write import write_atomic_json
 
 __all__ = [
@@ -89,14 +90,6 @@ __all__ = [
 
 
 log = logging.getLogger(__name__)
-
-
-class _DataclassInstance(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Any]]
-
-
-def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
-    return cast(DataclassT, replace(instance, **changes))
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/run_actor.py
+++ b/src/bernstein/core/orchestration/run_actor.py
@@ -41,9 +41,17 @@ from collections import deque
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from itertools import count
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal, Protocol, cast
 
 logger = logging.getLogger(__name__)
+
+
+class _DataclassInstance(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+
+def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
+    return cast(DataclassT, replace(instance, **changes))
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +166,7 @@ def _merge_task(
 
 
 def _replace_state(state: RunState, **changes: Any) -> RunState:
-    updated: RunState = replace(state, **changes)
+    updated = _typed_replace(state, **changes)
     return updated
 
 

--- a/src/bernstein/core/orchestration/run_actor.py
+++ b/src/bernstein/core/orchestration/run_actor.py
@@ -39,19 +39,13 @@ import asyncio
 import logging
 from collections import deque
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from itertools import count
-from typing import Any, ClassVar, Literal, Protocol, cast
+from typing import Any, Literal
+
+from bernstein.core.dataclass_helpers import typed_replace as _typed_replace
 
 logger = logging.getLogger(__name__)
-
-
-class _DataclassInstance(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Any]]
-
-
-def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
-    return cast(DataclassT, replace(instance, **changes))
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/routing/criterion_profile.py
+++ b/src/bernstein/core/routing/criterion_profile.py
@@ -49,21 +49,15 @@ import logging
 import math
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+from bernstein.core.dataclass_helpers import typed_replace as _typed_replace
+
 logger = logging.getLogger(__name__)
-
-
-class _DataclassInstance(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Any]]
-
-
-def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
-    return cast(DataclassT, replace(instance, **changes))
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/routing/criterion_profile.py
+++ b/src/bernstein/core/routing/criterion_profile.py
@@ -50,12 +50,20 @@ import math
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Protocol, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class _DataclassInstance(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+
+def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
+    return cast(DataclassT, replace(instance, **changes))
 
 
 # ---------------------------------------------------------------------------
@@ -659,7 +667,7 @@ def replace_in_registry(name: str, **changes: Any) -> CriterionProfile:
     if name not in CRITERION_PROFILE_REGISTRY:
         raise KeyError(name)
     current = CRITERION_PROFILE_REGISTRY[name]
-    updated = replace(current, **changes)
+    updated = _typed_replace(current, **changes)
     updated.validate()
     CRITERION_PROFILE_REGISTRY[name] = updated
     return updated

--- a/src/bernstein/core/routing/mode_profile.py
+++ b/src/bernstein/core/routing/mode_profile.py
@@ -16,21 +16,16 @@ are honoured via ``Task.metadata['mode']`` (e.g. ``mode=fast``).
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+from bernstein.core.dataclass_helpers import typed_replace as _typed_replace
+
 logger = logging.getLogger(__name__)
-
-
-class _DataclassInstance(Protocol):
-    __dataclass_fields__: ClassVar[dict[str, Any]]
-
-
-def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
-    return cast(DataclassT, replace(instance, **changes))
 
 
 @dataclass(frozen=True)
@@ -181,8 +176,9 @@ def select_mode(
 
     if task is not None:
         metadata = getattr(task, "metadata", None)
-        if isinstance(metadata, dict):
-            override = metadata.get("mode")
+        if isinstance(metadata, Mapping):
+            metadata_map = cast(Mapping[str, object], metadata)
+            override = metadata_map.get("mode")
             if isinstance(override, str) and override in table:
                 return table[override]
 
@@ -194,9 +190,13 @@ def select_mode(
 def _coerce_profile(name: str, raw: dict[str, Any]) -> ModeProfile | None:
     """Build a :class:`ModeProfile` from a YAML-decoded dict; return ``None`` on bad input."""
     try:
-        tool_subset_raw = raw.get("tool_subset", []) or []
-        if not isinstance(tool_subset_raw, list):
-            raise TypeError(f"tool_subset must be a list, got {type(tool_subset_raw).__name__}")
+        tool_subset_value = raw.get("tool_subset", [])
+        if tool_subset_value is None:
+            tool_subset_raw: list[object] = []
+        elif isinstance(tool_subset_value, list):
+            tool_subset_raw = cast(list[object], tool_subset_value)
+        else:
+            raise TypeError(f"tool_subset must be a list, got {type(tool_subset_value).__name__}")
         return ModeProfile(
             name=str(raw.get("name", name)),
             system_prompt_preamble=str(raw.get("system_prompt_preamble", "")),
@@ -235,7 +235,7 @@ def load_profiles_from_dir(path: Path) -> dict[str, ModeProfile]:
         if not isinstance(raw, dict):
             logger.warning("Mode profile %s does not contain a mapping; skipped", yaml_file)
             continue
-        profile = _coerce_profile(yaml_file.stem, raw)
+        profile = _coerce_profile(yaml_file.stem, cast(dict[str, Any], raw))
         if profile is not None:
             loaded[profile.name] = profile
     return loaded

--- a/src/bernstein/core/routing/mode_profile.py
+++ b/src/bernstein/core/routing/mode_profile.py
@@ -17,12 +17,20 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, cast
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class _DataclassInstance(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, Any]]
+
+
+def _typed_replace[DataclassT: _DataclassInstance](instance: DataclassT, **changes: Any) -> DataclassT:
+    return cast(DataclassT, replace(instance, **changes))
 
 
 @dataclass(frozen=True)
@@ -276,7 +284,7 @@ def apply_mode(
 def replace_profile(name: str, **changes: Any) -> ModeProfile:
     """Replace fields on the registry entry *name* and return the new instance."""
     current = MODE_REGISTRY[name]
-    updated = replace(current, **changes)
+    updated = _typed_replace(current, **changes)
     MODE_REGISTRY[name] = updated
     return updated
 

--- a/tests/unit/test_sonar_return_type_mismatches.py
+++ b/tests/unit/test_sonar_return_type_mismatches.py
@@ -32,14 +32,18 @@ def _uncast_replace_values(relative_path: str) -> list[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
+        if node.name == "_typed_replace":
+            continue
         for child in ast.walk(node):
-            if isinstance(child, ast.Return) and _is_replace_call(child.value):
+            if isinstance(child, ast.Return) and _is_replace_call(child.value) and not _is_casted_replace(child.value):
                 findings.append(f"{relative_path}:{node.name}:{child.lineno}")
             if (
                 isinstance(child, ast.AnnAssign)
                 and _is_replace_call(child.value)
                 and not _is_casted_replace(child.value)
             ):
+                findings.append(f"{relative_path}:{node.name}:{child.lineno}")
+            if isinstance(child, ast.Assign) and _is_replace_call(child.value) and not _is_casted_replace(child.value):
                 findings.append(f"{relative_path}:{node.name}:{child.lineno}")
 
     return findings
@@ -49,7 +53,11 @@ def test_s5886_cluster_avoids_uncast_replace_values() -> None:
     """Typed functions should not expose raw dataclasses.replace values."""
     paths = [
         "src/bernstein/core/agents/harness_policy.py",
+        "src/bernstein/core/orchestration/consensus_relay.py",
+        "src/bernstein/core/orchestration/run_actor.py",
         "src/bernstein/core/cost/retry_budget.py",
+        "src/bernstein/core/routing/criterion_profile.py",
+        "src/bernstein/core/routing/mode_profile.py",
     ]
 
     findings = [finding for path in paths for finding in _uncast_replace_values(path)]

--- a/tests/unit/test_sonar_return_type_mismatches.py
+++ b/tests/unit/test_sonar_return_type_mismatches.py
@@ -32,6 +32,7 @@ def _uncast_replace_values(relative_path: str) -> list[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
+        # The typed wrapper is the one allowed bare dataclasses.replace call.
         if node.name == "_typed_replace":
             continue
         for child in ast.walk(node):


### PR DESCRIPTION
## Summary
- Wrap dataclass replacement helpers with explicit typed casts.
- Extend the Sonar return-type regression guard to the remaining replace-return files.

## Verification
- uv run pytest tests/unit/test_sonar_return_type_mismatches.py -q
- uv run ruff check src/bernstein/core/orchestration/consensus_relay.py src/bernstein/core/orchestration/run_actor.py src/bernstein/core/routing/criterion_profile.py src/bernstein/core/routing/mode_profile.py tests/unit/test_sonar_return_type_mismatches.py
- git diff --check

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal type safety across core orchestration and routing modules to improve code reliability.

* **Tests**
  * Updated regression test scanner to better handle type-checked code patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->