### PR TITLE
Fix Sonar regex findings

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -37,6 +37,9 @@ from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Any, Literal
 
+PY_IDENTIFIER_RE_FRAGMENT = r"[A-Z_][A-Z0-9_]*"
+"""Regex fragment for Python identifiers when compiled with ``re.IGNORECASE``."""
+
 
 @dataclass(frozen=True)
 class DashboardStaticAsset:

--- a/src/bernstein/core/planning/spec_assertions.py
+++ b/src/bernstein/core/planning/spec_assertions.py
@@ -65,7 +65,8 @@ AssertionKind = Literal["file_exists", "import_resolves", "test_passes", "regex_
 DEFAULT_PYTEST_OUTPUT = Path("tests/spec/test_plan_contract.py")
 
 _RE_EXISTS = re.compile(r"^\s*(?:file\s+)?exists\s+(?P<path>\S.+?)\s*$", re.IGNORECASE)
-_RE_IMPORT = re.compile(r"^\s*import\s+(?P<module>[A-Za-z_][\w.]*)\s*$", re.IGNORECASE)
+_PY_IDENTIFIER = r"[A-Z_][A-Z0-9_]*"
+_RE_IMPORT = re.compile(rf"^\s*import\s+(?P<module>{_PY_IDENTIFIER}(?:\.{_PY_IDENTIFIER})*)\s*$", re.IGNORECASE)
 _RE_CONTAINS = re.compile(
     r"^\s*contains\s+(?P<path>\S+?)\s+/(?P<pattern>.+)/\s*$",
     re.IGNORECASE,

--- a/src/bernstein/core/planning/spec_assertions.py
+++ b/src/bernstein/core/planning/spec_assertions.py
@@ -50,6 +50,7 @@ from itertools import starmap
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from bernstein.core.defaults import PY_IDENTIFIER_RE_FRAGMENT
 from bernstein.core.planning.feature_contract import (
     DEFAULT_CONTRACT_PATH,
     FeatureContract,
@@ -65,8 +66,10 @@ AssertionKind = Literal["file_exists", "import_resolves", "test_passes", "regex_
 DEFAULT_PYTEST_OUTPUT = Path("tests/spec/test_plan_contract.py")
 
 _RE_EXISTS = re.compile(r"^\s*(?:file\s+)?exists\s+(?P<path>\S.+?)\s*$", re.IGNORECASE)
-_PY_IDENTIFIER = r"[A-Z_][A-Z0-9_]*"
-_RE_IMPORT = re.compile(rf"^\s*import\s+(?P<module>{_PY_IDENTIFIER}(?:\.{_PY_IDENTIFIER})*)\s*$", re.IGNORECASE)
+_RE_IMPORT = re.compile(
+    rf"^\s*import\s+(?P<module>{PY_IDENTIFIER_RE_FRAGMENT}(?:\.{PY_IDENTIFIER_RE_FRAGMENT})*)\s*$",
+    re.IGNORECASE,
+)
 _RE_CONTAINS = re.compile(
     r"^\s*contains\s+(?P<path>\S+?)\s+/(?P<pattern>.+)/\s*$",
     re.IGNORECASE,

--- a/src/bernstein/core/quality/citation_verifier.py
+++ b/src/bernstein/core/quality/citation_verifier.py
@@ -50,7 +50,7 @@ _ARXIV_RE: Final[re.Pattern[str]] = re.compile(
     (
         \d{4}\.\d{4,5}(?:v\d+)?           # modern
         |
-        [a-z\-]+(?:\.[a-z]{2})?/\d{7}     # legacy
+        [a-z]+(?:-[a-z]+)*(?:\.[a-z]{2})?/\d{7}  # legacy
     )
     """,
 )

--- a/src/bernstein/core/security/promptware_detector.py
+++ b/src/bernstein/core/security/promptware_detector.py
@@ -174,7 +174,9 @@ _PATTERNS: Final[tuple[_Pattern, ...]] = (
     _Pattern(
         pattern_id="imperative.disregard_instructions",
         regex=re.compile(
-            r"(?i)\b(?:disregard|forget|override)\s+(?:your\s+|the\s+|all\s+)?(?:earlier\s+|prior\s+|previous\s+)?(?:instructions?|system\s+prompt|guardrails?)\b"
+            r"(?i)\b(?:disregard|forget|override)\s+"
+            r"(?:(?:your|the|all)\s+)?(?:(?:earlier|prior|previous)\s+)?"
+            r"(?:instructions?|system\s+prompt|guardrails?)\b"
         ),
         weight=0.90,
         reason="instruction to disregard guardrails",
@@ -199,7 +201,7 @@ _PATTERNS: Final[tuple[_Pattern, ...]] = (
     ),
     _Pattern(
         pattern_id="imperative.base64_payload",
-        regex=re.compile(r"(?i)base64\s+(?:-d|--decode|-D)"),
+        regex=re.compile(r"(?i)base64\s+(?:-[dD]|--decode)"),
         weight=0.65,
         reason="base64 decode payload",
     ),
@@ -227,7 +229,7 @@ _URL_RX: Final[re.Pattern[str]] = re.compile(r"https?://[^\s'\"<>)]+")
 
 # Shell-command-like tokens used for density features.
 _COMMAND_TOKEN_RX: Final[re.Pattern[str]] = re.compile(
-    r"(?i)(?:^|[\s`])(?:curl|wget|bash|sh|zsh|python3?|node|rm|mv|cp|chmod|chown|scp|rsync|nc|netcat|nmap|sudo|apt|brew|pip|npm)\b",
+    r"(?i)(?:^|\s|`)(?:curl|wget|bash|sh|zsh|python3?|node|rm|mv|cp|chmod|chown|scp|rsync|nc|netcat|nmap|sudo|apt|brew|pip|npm)\b",
 )
 
 

--- a/src/bernstein/core/tokens/compaction_pipeline.py
+++ b/src/bernstein/core/tokens/compaction_pipeline.py
@@ -117,7 +117,7 @@ def strip_media_blocks(text: str) -> str:
         Cleaned text with media blocks replaced by placeholders.
     """
     # Strip markdown images: ![alt](url_or_data)
-    cleaned = re.sub(r"!\[.*?\]\(data:.*?\)", "[image stripped]", text)
+    cleaned = re.sub(r"!\[[^\]\n]*\]\(data:[^\)\n]*\)", "[image stripped]", text)
     # Strip fenced code blocks with media data URIs
     cleaned = re.sub(
         r"```[a-zA-Z]*\ndata:[^\n]*\n```",

--- a/src/bernstein/core/tokens/context_fallback.py
+++ b/src/bernstein/core/tokens/context_fallback.py
@@ -64,8 +64,7 @@ _FENCED_CODE_RE = re.compile(
 
 #: Regex for traceback blocks (Python-style).
 _TRACEBACK_RE = re.compile(
-    r"(Traceback \(most recent call last\):.*?)(?=\n\n|\Z)",
-    re.DOTALL,
+    r"(Traceback \(most recent call last\):(?:\n(?!\n).*)*)(?=\n\n|\Z)",
 )
 
 

--- a/src/bernstein/eval/calibration.py
+++ b/src/bernstein/eval/calibration.py
@@ -62,7 +62,7 @@ _DEFAULT_BIN_COUNT: Final[int] = 10
 """Default number of reliability buckets - the standard 10-bin ECE config."""
 
 _DURATION_RE: Final[re.Pattern[str]] = re.compile(
-    r"^\s*(\d+)\s*(s|m|h|d|w)\s*$",
+    r"^\s*(\d+)\s*([smhdw])\s*$",
     re.IGNORECASE,
 )
 

--- a/src/bernstein/tui/log_viewer.py
+++ b/src/bernstein/tui/log_viewer.py
@@ -143,7 +143,7 @@ def apply_diff_folding(text: str, max_lines: int = _DIFF_FOLD_THRESHOLD) -> str:
 # Patterns that suggest a line is markdown-formatted.
 _MD_HEADING = re.compile(r"^#{1,6} ")
 _MD_BOLD = re.compile(r"\*\*[^*]+\*\*")
-_MD_ITALIC = re.compile(r"\*.+?\*")
+_MD_ITALIC = re.compile(r"\*[^*\n]+\*")
 _MD_LIST = re.compile(r"^(\s*[-*+]|\s*\d+\.) ")
 _MD_BLOCKQUOTE = re.compile(r"^> ")
 _MD_HR = re.compile(r"^(-{3,}|\*{3,}|_{3,})$")

--- a/tests/unit/test_sonar_regex_hygiene.py
+++ b/tests/unit/test_sonar_regex_hygiene.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class RegexFinding:
+    """Disallowed regex fragments for one source file."""
+
+    path: str
+    disallowed_fragments: tuple[str, ...]
 
 
 def _source(path: str) -> str:
@@ -13,34 +22,45 @@ def _source(path: str) -> str:
 
 def test_sonar_regex_findings_are_rewritten() -> None:
     """Guard the targeted regexes against the reported fragile shapes."""
-    findings = {
-        "src/bernstein/core/planning/spec_assertions.py": [
-            r"[A-Za-z",
-            r"(?P<module>[A-Za-z_][\w.]*)",
-        ],
-        "src/bernstein/core/quality/citation_verifier.py": [
-            r"[a-z\-]+(?:\.[a-z]{2})?/\d{7}",
-        ],
-        "src/bernstein/core/security/promptware_detector.py": [
-            r"(?:your\s+|the\s+|all\s+)?(?:earlier\s+|prior\s+|previous\s+)?",
-            r"(?:-d|--decode|-D)",
-            r"(?:^|[\s`])",
-        ],
-        "src/bernstein/core/tokens/context_fallback.py": [
-            r"(Traceback \(most recent call last\):.*?)(?=\n\n|\Z)",
-        ],
-        "src/bernstein/eval/calibration.py": [
-            r"(s|m|h|d|w)",
-        ],
-        "src/bernstein/core/tokens/compaction_pipeline.py": [
-            r"!\[.*?\]\(data:.*?\)",
-        ],
-        "src/bernstein/tui/log_viewer.py": [
-            r"\*.+?\*",
-        ],
-    }
+    findings = (
+        RegexFinding(
+            path="src/bernstein/core/planning/spec_assertions.py",
+            disallowed_fragments=(
+                r"[A-Za-z",
+                r"(?P<module>[A-Za-z_][\w.]*)",
+            ),
+        ),
+        RegexFinding(
+            path="src/bernstein/core/quality/citation_verifier.py",
+            disallowed_fragments=(r"[a-z\-]+(?:\.[a-z]{2})?/\d{7}",),
+        ),
+        RegexFinding(
+            path="src/bernstein/core/security/promptware_detector.py",
+            disallowed_fragments=(
+                r"(?:your\s+|the\s+|all\s+)?(?:earlier\s+|prior\s+|previous\s+)?",
+                r"(?:-d|--decode|-D)",
+                r"(?:^|[\s`])",
+            ),
+        ),
+        RegexFinding(
+            path="src/bernstein/core/tokens/context_fallback.py",
+            disallowed_fragments=(r"(Traceback \(most recent call last\):.*?)(?=\n\n|\Z)",),
+        ),
+        RegexFinding(
+            path="src/bernstein/eval/calibration.py",
+            disallowed_fragments=(r"(s|m|h|d|w)",),
+        ),
+        RegexFinding(
+            path="src/bernstein/core/tokens/compaction_pipeline.py",
+            disallowed_fragments=(r"!\[.*?\]\(data:.*?\)",),
+        ),
+        RegexFinding(
+            path="src/bernstein/tui/log_viewer.py",
+            disallowed_fragments=(r"\*.+?\*",),
+        ),
+    )
 
-    for path, disallowed_fragments in findings.items():
-        source = _source(path)
-        for fragment in disallowed_fragments:
-            assert fragment not in source, f"{path} still contains {fragment}"
+    for finding in findings:
+        source = _source(finding.path)
+        for fragment in finding.disallowed_fragments:
+            assert fragment not in source, f"{finding.path} still contains {fragment}"

--- a/tests/unit/test_sonar_regex_hygiene.py
+++ b/tests/unit/test_sonar_regex_hygiene.py
@@ -1,0 +1,46 @@
+"""Regression tests for Sonar-reported regex shapes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _source(path: str) -> str:
+    return (_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_sonar_regex_findings_are_rewritten() -> None:
+    """Guard the targeted regexes against the reported fragile shapes."""
+    findings = {
+        "src/bernstein/core/planning/spec_assertions.py": [
+            r"[A-Za-z",
+            r"(?P<module>[A-Za-z_][\w.]*)",
+        ],
+        "src/bernstein/core/quality/citation_verifier.py": [
+            r"[a-z\-]+(?:\.[a-z]{2})?/\d{7}",
+        ],
+        "src/bernstein/core/security/promptware_detector.py": [
+            r"(?:your\s+|the\s+|all\s+)?(?:earlier\s+|prior\s+|previous\s+)?",
+            r"(?:-d|--decode|-D)",
+            r"(?:^|[\s`])",
+        ],
+        "src/bernstein/core/tokens/context_fallback.py": [
+            r"(Traceback \(most recent call last\):.*?)(?=\n\n|\Z)",
+        ],
+        "src/bernstein/eval/calibration.py": [
+            r"(s|m|h|d|w)",
+        ],
+        "src/bernstein/core/tokens/compaction_pipeline.py": [
+            r"!\[.*?\]\(data:.*?\)",
+        ],
+        "src/bernstein/tui/log_viewer.py": [
+            r"\*.+?\*",
+        ],
+    }
+
+    for path, disallowed_fragments in findings.items():
+        source = _source(path)
+        for fragment in disallowed_fragments:
+            assert fragment not in source, f"{path} still contains {fragment}"


### PR DESCRIPTION
## Summary
- Rewrite the remaining regex patterns flagged by Sonar for duplicate classes and fragile matching.
- Add a regression guard for the targeted regex shapes.

## Verification
- uv run pytest tests/unit/test_sonar_regex_hygiene.py tests/unit/test_spec_assertions.py tests/unit/quality/test_citation_verifier.py tests/unit/security/test_promptware_detector.py tests/unit/test_context_fallback.py tests/unit/test_calibration.py tests/unit/test_compaction_pipeline.py tests/unit/test_log_viewer.py -x -q
- uv run ruff check src/bernstein/core/planning/spec_assertions.py src/bernstein/core/quality/citation_verifier.py src/bernstein/core/security/promptware_detector.py src/bernstein/core/tokens/compaction_pipeline.py src/bernstein/core/tokens/context_fallback.py src/bernstein/eval/calibration.py src/bernstein/tui/log_viewer.py tests/unit/test_sonar_regex_hygiene.py
- git diff --check

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test to guard against fragile regex patterns.

* **Refactor**
  * Tightened pattern matching across parsing, citation extraction, prompt-detection, traceback compaction, markdown rendering, media stripping, and duration parsing — improving accuracy and consistency for text processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->