### PR TITLE
Fix Sonar empty tuple constructor findings

### DIFF
--- a/src/bernstein/core/orchestration/federation.py
+++ b/src/bernstein/core/orchestration/federation.py
@@ -86,6 +86,8 @@ log = logging.getLogger(__name__)
 type _StringTuple = tuple[str, ...]
 
 
+_EMPTY_STRING_TUPLE: Final[_StringTuple] = ()
+
 DEFAULT_AUDIT_RELPATH: Final[Path] = Path("lineage") / "cross-tracker-audit.jsonl"
 """Path under ``.sdd/`` where cross-tracker audit records land by default."""
 
@@ -446,13 +448,13 @@ class FederationConfig:
 
 def _to_string_tuple(value: object) -> _StringTuple:
     if value is None:
-        return tuple()
+        return _EMPTY_STRING_TUPLE
     if isinstance(value, str):
         return (value,)
     try:
         values = iter(cast("Iterable[object]", value))
     except TypeError:
-        return tuple()
+        return _EMPTY_STRING_TUPLE
     return tuple(item for item in values if isinstance(item, str))
 
 

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -47,7 +47,7 @@ import logging
 import os
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -65,6 +65,8 @@ _PERM_TASKS_WRITE = "tasks:write"
 _PERM_ADMIN_MANAGE = "admin:manage"
 
 type _ExpectedResourceConfig = str | Sequence[str] | None
+
+_EMPTY_EXPECTED_RESOURCES: Final[tuple[str, ...]] = ()
 
 logger = logging.getLogger(__name__)
 
@@ -198,11 +200,11 @@ def _normalise_expected_resource(raw: _ExpectedResourceConfig) -> tuple[str, ...
     claim by :func:`_resource_indicator_check`.
     """
     if raw is None:
-        return tuple()
+        return _EMPTY_EXPECTED_RESOURCES
     if isinstance(raw, str):
         text = raw.strip()
         if not text:
-            return tuple()
+            return _EMPTY_EXPECTED_RESOURCES
         if "," in text:
             return tuple(part.strip() for part in text.split(",") if part.strip())
         return (text,)

--- a/src/bernstein/core/security/permission_policy.py
+++ b/src/bernstein/core/security/permission_policy.py
@@ -39,7 +39,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from bernstein.core.security.policy_engine import (
     DecisionType,
@@ -67,6 +67,8 @@ BUILTIN_PROFILE_NAMES: tuple[str, ...] = (
     PROFILE_REVIEWER,
     PROFILE_CUSTOM,
 )
+
+_EMPTY_STRINGS: Final[tuple[str, ...]] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -204,12 +206,12 @@ def list_builtin_profiles() -> tuple[PermissionProfile, ...]:
 def _coerce_str_tuple(value: object) -> tuple[str, ...]:
     """Normalize a YAML/TOML list-of-strings into ``tuple[str, ...]``."""
     if value is None:
-        return tuple()
+        return _EMPTY_STRINGS
     if isinstance(value, (list, tuple)):
         return tuple(str(item) for item in cast("Sequence[object]", value) if item is not None)
     if isinstance(value, str):
         return (value,)
-    return tuple()
+    return _EMPTY_STRINGS
 
 
 def _merge_overrides(base: PermissionProfile, overrides: Mapping[str, Any]) -> PermissionProfile:

--- a/tests/unit/test_sonar_s8495_typing_annotations.py
+++ b/tests/unit/test_sonar_s8495_typing_annotations.py
@@ -99,6 +99,18 @@ def _direct_tuple_return_lengths(function: ast.FunctionDef) -> set[int]:
     return lengths
 
 
+def _empty_tuple_constructor_lines(function: ast.FunctionDef) -> list[int]:
+    lines: list[int] = []
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id == "tuple" and not node.args and not node.keywords:
+            lines.append(node.lineno)
+    return lines
+
+
 def test_scoped_s8495_functions_do_not_return_mixed_tuple_literal_lengths() -> None:
     """The scoped S8495 findings must avoid direct tuple literals with mixed lengths."""
     for path, function_path in TUPLE_RETURN_EXPECTATIONS:
@@ -106,3 +118,12 @@ def test_scoped_s8495_functions_do_not_return_mixed_tuple_literal_lengths() -> N
         function = _find_function(module, function_path)
 
         assert len(_direct_tuple_return_lengths(function)) <= 1
+
+
+def test_scoped_tuple_functions_do_not_call_empty_tuple_constructor() -> None:
+    """The scoped S7498 findings must avoid no-arg tuple constructors."""
+    for path, function_path in TUPLE_RETURN_EXPECTATIONS:
+        _source, module = _source_for(path)
+        function = _find_function(module, function_path)
+
+        assert _empty_tuple_constructor_lines(function) == []


### PR DESCRIPTION
## Summary
- replace empty tuple constructor returns with typed empty tuple constants in scoped helpers
- add a static regression test for no-arg tuple constructor calls in the Sonar tuple helper coverage

## Validation
- uv run pytest tests/unit/test_sonar_s8495_typing_annotations.py tests/unit/test_sonar_1785_runtime_typing.py tests/unit/test_auth_middleware_resource_indicator.py tests/unit/test_permission_policy.py tests/unit/orchestration/test_federation.py -q
- uv run ruff check src/ tests/unit/test_sonar_s8495_typing_annotations.py
- uv run ruff format --check src/bernstein/core/orchestration/federation.py src/bernstein/core/security/auth_middleware.py src/bernstein/core/security/permission_policy.py tests/unit/test_sonar_s8495_typing_annotations.py
- uv run pyright src/bernstein/core/orchestration/federation.py src/bernstein/core/security/auth_middleware.py src/bernstein/core/security/permission_policy.py
- uv run pyright --project pyrightconfig.strict.json
- uv run python scripts/run_tests.py --affected -x

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal resource allocation patterns for improved efficiency.

* **Tests**
  * Added regression tests to verify code quality standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->