### PR TITLE
Align Sonar scan scope with project config

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -148,15 +148,11 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
         with:
           # `sonar.projectKey` and `sonar.projectName` come from
-          # `sonar-project.properties`. The overrides below cover values
-          # the workflow needs to differ from the file (e.g. broader
-          # python.version matrix, top-level `src/` for full-tree scans,
-          # workflow-run SHA pinning).
+          # `sonar-project.properties`. Keep source, test, exclusion,
+          # and coverage-exclusion scope in that file so local and CI
+          # scans use the same analysis boundary.
           args: >
             -Dsonar.python.version=3.12,3.13
-            -Dsonar.sources=src
-            -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=coverage.xml
-            -Dsonar.exclusions=src/bernstein/_default_templates/**,src/bernstein/grpc_gen/**
             -Dsonar.scm.revision=${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
             -Dsonar.ws.timeout=600

--- a/tests/unit/test_operator_surface_imports.py
+++ b/tests/unit/test_operator_surface_imports.py
@@ -1,0 +1,35 @@
+"""Smoke import tests for operator-facing modules."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from collections.abc import Iterator
+
+_IMPORT_ROOTS = (
+    "bernstein.cli.commands",
+    "bernstein.cli.display",
+    "bernstein.tui",
+    "bernstein.evolution",
+    "bernstein.core.sandbox",
+    "bernstein.core.storage.sinks",
+)
+
+
+def _iter_modules(root_name: str) -> Iterator[str]:
+    root = importlib.import_module(root_name)
+    yield root_name
+
+    paths = getattr(root, "__path__", None)
+    if paths is None:
+        return
+
+    for info in pkgutil.walk_packages(paths, f"{root_name}."):
+        yield info.name
+
+
+def test_operator_surface_modules_import_cleanly() -> None:
+    """CLI, TUI, evolution, and optional backend modules must import cleanly."""
+    for root_name in _IMPORT_ROOTS:
+        for module_name in _iter_modules(root_name):
+            importlib.import_module(module_name)

--- a/tests/unit/test_sonar_scan_workflow_yaml.py
+++ b/tests/unit/test_sonar_scan_workflow_yaml.py
@@ -154,6 +154,24 @@ def test_sonar_scan_references_coverage_xml_in_args(sonar_doc: dict[str, object]
     )
 
 
+def test_sonar_scan_scope_comes_from_project_properties(sonar_doc: dict[str, object]) -> None:
+    """The workflow must not clobber the canonical Sonar scope config."""
+    jobs = sonar_doc.get("jobs", {})
+    scan = jobs.get("scan", {})
+    steps = scan.get("steps", [])
+    sonar_step = next(
+        (s for s in steps if isinstance(s, dict) and "SonarSource/sonarqube-scan-action" in (s.get("uses") or "")),
+        None,
+    )
+    assert sonar_step is not None, "Workflow must invoke SonarSource/sonarqube-scan-action"
+    args = (sonar_step.get("with") or {}).get("args", "")
+
+    assert "sonar.sources=" not in args
+    assert "sonar.tests=" not in args
+    assert "sonar.exclusions=" not in args
+    assert "sonar.coverage.exclusions=" not in args
+
+
 def test_sonar_scan_revision_matches_workflow_run_head_sha(sonar_doc: dict[str, object]) -> None:
     """Workflow-run scans must report the same commit that was checked out."""
     jobs = sonar_doc.get("jobs", {})


### PR DESCRIPTION
## Summary
- Stop overriding Sonar source, test, and exclusion scope in the scan workflow.
- Keep scope in sonar-project.properties so CI and local scans use the same analysis boundary.
- Add an import smoke test for CLI, TUI, evolution, sandbox, and storage modules.

## Tests
- uv run pytest tests/unit/test_sonar_scan_workflow_yaml.py tests/unit/test_operator_surface_imports.py -q
- uv run ruff check tests/unit/test_sonar_scan_workflow_yaml.py tests/unit/test_operator_surface_imports.py
- uv run ruff format --check tests/unit/test_sonar_scan_workflow_yaml.py tests/unit/test_operator_surface_imports.py
- uv run pyright tests/unit/test_operator_surface_imports.py
- uv run python scripts/run_tests.py --affected -x

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive smoke test validating all operator-facing component imports work correctly
  * Added validation test for SonarQube scan workflow configuration

* **Chores**
  * Simplified SonarQube scan workflow by removing redundant property overrides and centralizing configuration through project properties file

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->