### PR TITLE
Expand import smoke coverage surface

### DIFF
--- a/tests/unit/test_operator_surface_imports.py
+++ b/tests/unit/test_operator_surface_imports.py
@@ -11,8 +11,39 @@ _IMPORT_ROOTS = (
     "bernstein.cli.display",
     "bernstein.tui",
     "bernstein.evolution",
+    "bernstein.core.autofix",
+    "bernstein.core.config",
+    "bernstein.core.fleet",
+    "bernstein.core.git",
+    "bernstein.core.knowledge",
+    "bernstein.core.observability",
+    "bernstein.core.orchestration",
+    "bernstein.core.protocols",
+    "bernstein.core.quality",
+    "bernstein.core.routes",
     "bernstein.core.sandbox",
+    "bernstein.core.security",
     "bernstein.core.storage.sinks",
+    "bernstein.core.tasks",
+)
+
+_IMPORT_MODULES = (
+    "bernstein.cli.advanced_cmd",
+    "bernstein.cli.dashboard_actions",
+    "bernstein.cli.dashboard_app",
+    "bernstein.cli.dashboard_header",
+    "bernstein.cli.dashboard_polling",
+    "bernstein.cli.live",
+    "bernstein.cli.main",
+    "bernstein.cli.run_confirm",
+    "bernstein.cli.status",
+    "bernstein.cli.status_cmd",
+    "bernstein.cli.task_cmd",
+    "bernstein.cli.ui",
+    "bernstein.cli.workspace_cmd",
+    "bernstein.core.persistence.store_factory",
+    "bernstein.core.persistence.store_postgres",
+    "bernstein.eval.vcr_fixture",
 )
 
 
@@ -29,7 +60,12 @@ def _iter_modules(root_name: str) -> Iterator[str]:
 
 
 def test_operator_surface_modules_import_cleanly() -> None:
-    """CLI, TUI, evolution, and optional backend modules must import cleanly."""
+    """Operator-facing and runtime modules must import cleanly."""
+    imported = set[str]()
     for root_name in _IMPORT_ROOTS:
         for module_name in _iter_modules(root_name):
+            imported.add(module_name)
+            importlib.import_module(module_name)
+    for module_name in _IMPORT_MODULES:
+        if module_name not in imported:
             importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- Expand the import smoke test to cover additional runtime packages.
- Include import-safe CLI support and persistence modules that are part of the local runtime surface.

## Tests
- uv run pytest tests/unit/test_operator_surface_imports.py -q
- uv run ruff check tests/unit/test_operator_surface_imports.py
- uv run ruff format --check tests/unit/test_operator_surface_imports.py
- uv run pyright tests/unit/test_operator_surface_imports.py
- uv run python scripts/run_tests.py --affected -x

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the operator-surface import smoke test to include additional core packages and modules.
  * Refactored test discovery mechanism to dynamically identify and validate all importable modules, ensuring comprehensive coverage of operator-facing and runtime modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->