### PR TITLE
Expose Sonar gate conditions in tracker

### DIFF
--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -152,6 +152,35 @@ _TRACKER_FORBIDDEN: tuple[str, ...] = _SWEEPER_FORBIDDEN
 # ---------------------------------------------------------------------------
 
 
+@dataclasses.dataclass(frozen=True)
+class QualityGateCondition:
+    """One condition row from SonarQube's project quality-gate status."""
+
+    metric_key: str
+    status: str
+    comparator: str | None
+    error_threshold: str | None
+    actual_value: str | None
+
+    def as_json(self) -> dict[str, str | None]:
+        """Return a stable JSON shape for the tracker summary."""
+        return {
+            "actual_value": self.actual_value,
+            "comparator": self.comparator,
+            "error_threshold": self.error_threshold,
+            "metric_key": self.metric_key,
+            "status": self.status,
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class QualityGateResult:
+    """Quality-gate status plus its condition rows."""
+
+    status: str
+    conditions: list[QualityGateCondition] = dataclasses.field(default_factory=list)
+
+
 def fetch_all_findings(
     config: SonarConfig,
     *,
@@ -219,6 +248,15 @@ def fetch_quality_gate(
     Returns ``"UNKNOWN"`` when the server omits the field or the call
     fails; the tracker still renders with the issue counts.
     """
+    return fetch_quality_gate_details(config, client=client).status
+
+
+def fetch_quality_gate_details(
+    config: SonarConfig,
+    *,
+    client: httpx.Client | None = None,
+) -> QualityGateResult:
+    """Return the project quality-gate status and condition rows."""
     url = f"{config.host}/api/qualitygates/project_status"
     params = {"projectKey": config.project_key}
     owns_client = client is None
@@ -229,22 +267,45 @@ def fetch_quality_gate(
         try:
             resp = _request_with_retries(client, url, params)
         except SonarAPIError:
-            return "UNKNOWN"
+            return QualityGateResult("UNKNOWN")
         try:
             payload = resp.json()
         except ValueError:
-            return "UNKNOWN"
+            return QualityGateResult("UNKNOWN")
     finally:
         if owns_client:
             client.close()
     if not isinstance(payload, dict):
-        return "UNKNOWN"
+        return QualityGateResult("UNKNOWN")
     status = payload.get("projectStatus")
     if isinstance(status, dict):
         value = status.get("status")
         if isinstance(value, str) and value:
-            return value
-    return "UNKNOWN"
+            return QualityGateResult(value, _parse_quality_gate_conditions(status.get("conditions")))
+    return QualityGateResult("UNKNOWN")
+
+
+def _parse_quality_gate_conditions(raw_conditions: Any) -> list[QualityGateCondition]:
+    if not isinstance(raw_conditions, list):
+        return []
+    conditions: list[QualityGateCondition] = []
+    for raw in raw_conditions:
+        if not isinstance(raw, dict):
+            continue
+        metric_key = _opt_str(raw.get("metricKey"))
+        status = _opt_str(raw.get("status"))
+        if metric_key is None or status is None:
+            continue
+        conditions.append(
+            QualityGateCondition(
+                metric_key=metric_key,
+                status=status,
+                comparator=_opt_str(raw.get("comparator")),
+                error_threshold=_opt_str(raw.get("errorThreshold")),
+                actual_value=_opt_str(raw.get("actualValue")),
+            )
+        )
+    return conditions
 
 
 def fetch_coverage(
@@ -294,6 +355,7 @@ class SonarSnapshot:
     coverage: float | None
     host: str
     project_key: str
+    quality_gate_conditions: list[QualityGateCondition] = dataclasses.field(default_factory=list)
 
 
 def collect_snapshot(
@@ -308,17 +370,18 @@ def collect_snapshot(
     assert client is not None
     try:
         findings = fetch_all_findings(config, client=client)
-        quality_gate = fetch_quality_gate(config, client=client)
+        quality_gate = fetch_quality_gate_details(config, client=client)
         coverage = fetch_coverage(config, client=client)
     finally:
         if owns_client:
             client.close()
     return SonarSnapshot(
         findings=findings,
-        quality_gate=quality_gate,
+        quality_gate=quality_gate.status,
         coverage=coverage,
         host=config.host,
         project_key=config.project_key,
+        quality_gate_conditions=quality_gate.conditions,
     )
 
 
@@ -377,6 +440,12 @@ def _coverage_text(coverage: float | None) -> str:
     if coverage is None:
         return "n/a"
     return f"{coverage:.1f}%"
+
+
+def _condition_text(value: str | None) -> str:
+    if value is None or value == "":
+        return "n/a"
+    return value
 
 
 def _tldr_table(
@@ -460,6 +529,29 @@ def _counts_only_section(severity: str, items: list[Finding], host: str, project
     return [f"- **{severity}**: {len(items)} open ([view]({link}))", ""]
 
 
+def _quality_gate_conditions_section(conditions: Sequence[QualityGateCondition]) -> list[str]:
+    """Render Sonar quality-gate condition rows."""
+    if not conditions:
+        return []
+    lines = [
+        "## Quality Gate Conditions",
+        "",
+        "| Metric | Status | Actual | Comparator | Threshold |",
+        "| --- | --- | ---: | --- | ---: |",
+    ]
+    for condition in conditions:
+        lines.append(
+            "| "
+            f"`{condition.metric_key}` | "
+            f"{condition.status} | "
+            f"{_condition_text(condition.actual_value)} | "
+            f"{_condition_text(condition.comparator)} | "
+            f"{_condition_text(condition.error_threshold)} |"
+        )
+    lines.append("")
+    return lines
+
+
 def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding]], generated_at: str) -> list[str]:
     """Build the trailing machine-readable JSON summary.
 
@@ -472,6 +564,7 @@ def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding
     summary: dict[str, Any] = {
         "generated_at": generated_at,
         "quality_gate": snapshot.quality_gate,
+        "quality_gate_conditions": [condition.as_json() for condition in snapshot.quality_gate_conditions],
         "coverage": snapshot.coverage,
         "by_severity": by_severity,
     }
@@ -551,6 +644,7 @@ def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> 
                 coverage=snapshot.coverage,
             )
         )
+        parts.extend(_quality_gate_conditions_section(snapshot.quality_gate_conditions))
         for sev in SEVERITY_ORDER + tuple(extra_severities):
             items = buckets.get(sev, [])
             if not items:
@@ -798,7 +892,14 @@ def _load_fixture(path: Path) -> SonarSnapshot:
         coverage=_opt_float(payload.get("coverage")),
         host=str(payload.get("host", "https://sonar.bernstein.run")),
         project_key=str(payload.get("project_key", "bernstein")),
+        quality_gate_conditions=_parse_quality_gate_conditions(payload.get("quality_gate_conditions")),
     )
+
+
+def _opt_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
 
 
 def _opt_float(value: Any) -> float | None:

--- a/tests/unit/scripts/test_render_sonar_tracker.py
+++ b/tests/unit/scripts/test_render_sonar_tracker.py
@@ -476,7 +476,7 @@ def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleTyp
         )
     ]
     assert snapshot.coverage is not None
-    assert abs(snapshot.coverage - 19.3) < 0.001
+    assert snapshot.coverage == pytest.approx(19.3, abs=0.001)  # pyright: ignore[reportUnknownMemberType]
 
 
 def test_fetch_all_findings_raises_on_non_object_payload(tracker: ModuleType) -> None:

--- a/tests/unit/scripts/test_render_sonar_tracker.py
+++ b/tests/unit/scripts/test_render_sonar_tracker.py
@@ -77,6 +77,7 @@ def _snapshot(
     *,
     quality_gate: str = "ERROR",
     coverage: float | None = 19.3,
+    quality_gate_conditions: list[Any] | None = None,
 ) -> Any:
     normalised = [tracker._normalise_issue(raw) for raw in findings]
     return tracker.SonarSnapshot(
@@ -85,6 +86,7 @@ def _snapshot(
         coverage=coverage,
         host=HOST,
         project_key=PROJECT,
+        quality_gate_conditions=quality_gate_conditions or [],
     )
 
 
@@ -150,6 +152,41 @@ def test_json_summary_block_shape(tracker: ModuleType) -> None:
     assert parsed["by_severity"] == {"BLOCKER": 1, "CRITICAL": 2, "MAJOR": 1}
     assert parsed["blocker_keys"] == ["b1"]
     assert sorted(parsed["critical_keys"]) == ["c1", "c2"]
+
+
+def test_body_renders_quality_gate_conditions(tracker: ModuleType) -> None:
+    condition = tracker.QualityGateCondition(
+        metric_key="branch_coverage",
+        status="ERROR",
+        comparator="LT",
+        error_threshold="80",
+        actual_value="71.2",
+    )
+    snapshot = _snapshot(
+        tracker,
+        [],
+        quality_gate="ERROR",
+        coverage=80.1,
+        quality_gate_conditions=[condition],
+    )
+
+    body = tracker.render_body(snapshot, generated_at="2026-05-21T00:00:00+00:00")
+
+    assert "## Quality Gate Conditions" in body
+    assert "| Metric | Status | Actual | Comparator | Threshold |" in body
+    assert "| `branch_coverage` | ERROR | 71.2 | LT | 80 |" in body
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    assert parsed["quality_gate_conditions"] == [
+        {
+            "actual_value": "71.2",
+            "comparator": "LT",
+            "error_threshold": "80",
+            "metric_key": "branch_coverage",
+            "status": "ERROR",
+        }
+    ]
 
 
 def test_blocker_and_critical_rendered_as_checkboxes_with_permalink(tracker: ModuleType) -> None:
@@ -401,7 +438,23 @@ def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleTyp
     with respx.mock(assert_all_called=False) as mock:
         mock.get(f"{HOST}/api/issues/search").mock(side_effect=_issues_responder)
         mock.get(f"{HOST}/api/qualitygates/project_status").mock(
-            return_value=httpx.Response(200, json={"projectStatus": {"status": "ERROR"}})
+            return_value=httpx.Response(
+                200,
+                json={
+                    "projectStatus": {
+                        "status": "ERROR",
+                        "conditions": [
+                            {
+                                "metricKey": "branch_coverage",
+                                "status": "ERROR",
+                                "comparator": "LT",
+                                "errorThreshold": "80",
+                                "actualValue": "71.2",
+                            }
+                        ],
+                    }
+                },
+            )
         )
         mock.get(f"{HOST}/api/measures/component").mock(
             return_value=httpx.Response(
@@ -413,7 +466,17 @@ def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleTyp
 
     assert len(snapshot.findings) == 750
     assert snapshot.quality_gate == "ERROR"
-    assert snapshot.coverage == pytest.approx(19.3)
+    assert snapshot.quality_gate_conditions == [
+        tracker.QualityGateCondition(
+            metric_key="branch_coverage",
+            status="ERROR",
+            comparator="LT",
+            error_threshold="80",
+            actual_value="71.2",
+        )
+    ]
+    assert snapshot.coverage is not None
+    assert abs(snapshot.coverage - 19.3) < 0.001
 
 
 def test_fetch_all_findings_raises_on_non_object_payload(tracker: ModuleType) -> None:


### PR DESCRIPTION
## Summary
- Parse quality-gate condition rows from the SonarQube project-status response.
- Render condition rows in the tracker issue and include them in the machine-readable summary.

## Validation
- uv run pytest tests/unit/scripts/test_render_sonar_tracker.py -q
- uv run ruff check scripts/render_sonar_tracker.py tests/unit/scripts/test_render_sonar_tracker.py
- uv run ruff format --check scripts/render_sonar_tracker.py tests/unit/scripts/test_render_sonar_tracker.py
- uv run pyright tests/unit/scripts/test_render_sonar_tracker.py
- uv run python scripts/run_tests.py --affected -x
- uv run ruff check src/
- uv run ruff format --check src/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quality Gate Conditions tracking now captures individual SonarQube condition metrics (status, comparator, thresholds, and actual/unknown values) alongside overall quality gate status. Reports include a new "Quality Gate Conditions" table and the machine-readable summary now exposes these conditions.

* **Tests**
  * Added end-to-end tests for capturing and rendering quality gate conditions in both markdown and JSON outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->