### PR TITLE
Expose Sonar hotspot rows in tracker

### DIFF
--- a/scripts/render_sonar_tracker.py
+++ b/scripts/render_sonar_tracker.py
@@ -130,6 +130,7 @@ _DETAILS_ITEM_CAP = 80
 # pathological project. When a list is truncated a ``*_keys_truncated`` count
 # is emitted alongside it so a consumer can tell the list is partial.
 _JSON_KEYS_CAP = 200
+_HOTSPOT_ITEM_CAP = 80
 
 _LIFECYCLE_NOTE = (
     "This thread is auto-rendered from Sonar on each scan. Resolve an item "
@@ -179,6 +180,31 @@ class QualityGateResult:
 
     status: str
     conditions: list[QualityGateCondition] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class SecurityHotspot:
+    """One SonarQube security hotspot row safe to render publicly."""
+
+    key: str
+    rule_key: str
+    component: str
+    line: int | None
+    status: str
+    security_category: str | None
+    vulnerability_probability: str | None
+
+    def as_json(self) -> dict[str, str | int | None]:
+        """Return a stable JSON shape for the tracker summary."""
+        return {
+            "component": self.component,
+            "key": self.key,
+            "line": self.line,
+            "rule_key": self.rule_key,
+            "security_category": self.security_category,
+            "status": self.status,
+            "vulnerability_probability": self.vulnerability_probability,
+        }
 
 
 def fetch_all_findings(
@@ -236,6 +262,58 @@ def fetch_all_findings(
         if owns_client:
             client.close()
     return findings
+
+
+def fetch_security_hotspots(
+    config: SonarConfig,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    client: httpx.Client | None = None,
+) -> list[SecurityHotspot]:
+    """Page through SonarQube security hotspots awaiting review."""
+    url = f"{config.host}/api/hotspots/search"
+    hotspots: list[SecurityHotspot] = []
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=_auth(config.token))
+    assert client is not None
+    try:
+        page = 1
+        while page <= MAX_PAGES:
+            params: dict[str, Any] = {
+                "projectKey": config.project_key,
+                "status": "TO_REVIEW",
+                "ps": str(page_size),
+                "p": str(page),
+            }
+            resp = _request_with_retries(client, url, params)
+            try:
+                payload = resp.json()
+            except ValueError as exc:
+                raise SonarAPIError("hotspot search returned invalid JSON") from exc
+            if not isinstance(payload, dict):
+                raise SonarAPIError("hotspot search returned a non-object payload")
+            raw_hotspots = payload.get("hotspots") or []
+            for raw in raw_hotspots:
+                if isinstance(raw, dict):
+                    hotspot = _normalise_hotspot(raw)
+                    if hotspot is not None:
+                        hotspots.append(hotspot)
+            paging = payload.get("paging") or {}
+            try:
+                total = int(paging.get("total", 0))
+                page_idx = int(paging.get("pageIndex", page))
+                size = int(paging.get("pageSize", page_size))
+            except (TypeError, ValueError) as exc:
+                raise SonarAPIError("hotspot search returned invalid paging metadata") from exc
+            if size <= 0 or page_idx * size >= total:
+                break
+            page += 1
+    finally:
+        if owns_client:
+            client.close()
+    hotspots.sort(key=lambda item: (_component_path(item.component), item.line or 0, item.key))
+    return hotspots
 
 
 def fetch_quality_gate(
@@ -308,6 +386,24 @@ def _parse_quality_gate_conditions(raw_conditions: Any) -> list[QualityGateCondi
     return conditions
 
 
+def _normalise_hotspot(raw: dict[str, Any]) -> SecurityHotspot | None:
+    key = _opt_str(raw.get("key"))
+    rule_key = _opt_str(raw.get("ruleKey") or raw.get("rule"))
+    component = _opt_str(raw.get("component"))
+    status = _opt_str(raw.get("status"))
+    if key is None or rule_key is None or component is None or status is None:
+        return None
+    return SecurityHotspot(
+        key=key,
+        rule_key=rule_key,
+        component=component,
+        line=_opt_int(raw.get("line")),
+        status=status,
+        security_category=_opt_str(raw.get("securityCategory")),
+        vulnerability_probability=_opt_str(raw.get("vulnerabilityProbability")),
+    )
+
+
 def fetch_coverage(
     config: SonarConfig,
     *,
@@ -356,6 +452,7 @@ class SonarSnapshot:
     host: str
     project_key: str
     quality_gate_conditions: list[QualityGateCondition] = dataclasses.field(default_factory=list)
+    security_hotspots: list[SecurityHotspot] = dataclasses.field(default_factory=list)
 
 
 def collect_snapshot(
@@ -372,6 +469,7 @@ def collect_snapshot(
         findings = fetch_all_findings(config, client=client)
         quality_gate = fetch_quality_gate_details(config, client=client)
         coverage = fetch_coverage(config, client=client)
+        security_hotspots = fetch_security_hotspots(config, client=client)
     finally:
         if owns_client:
             client.close()
@@ -382,6 +480,7 @@ def collect_snapshot(
         host=config.host,
         project_key=config.project_key,
         quality_gate_conditions=quality_gate.conditions,
+        security_hotspots=security_hotspots,
     )
 
 
@@ -453,6 +552,7 @@ def _tldr_table(
     *,
     quality_gate: str,
     coverage: float | None,
+    security_hotspot_count: int,
 ) -> list[str]:
     """Build the header summary table lines."""
     total = sum(len(v) for v in buckets.values())
@@ -466,6 +566,7 @@ def _tldr_table(
         f"- Quality gate: **{quality_gate}**",
         f"- Coverage: **{_coverage_text(coverage)}**",
         f"- Open findings: **{total}**",
+        f"- Security hotspots to review: **{security_hotspot_count}**",
         "",
         "| Severity | Open |",
         "| --- | ---: |",
@@ -552,6 +653,42 @@ def _quality_gate_conditions_section(conditions: Sequence[QualityGateCondition])
     return lines
 
 
+def _hotspot_permalink(host: str, project_key: str, hotspot_key: str) -> str:
+    """Build the deep link to a single security hotspot in the Sonar UI."""
+    return f"{host}/security_hotspots?id={project_key}&hotspots={hotspot_key}"
+
+
+def _security_hotspots_section(hotspots: Sequence[SecurityHotspot], host: str, project_key: str) -> list[str]:
+    """Render security hotspots that still need Sonar-side review."""
+    if not hotspots:
+        return []
+    shown = hotspots[:_HOTSPOT_ITEM_CAP]
+    remainder = len(hotspots) - len(shown)
+    lines = [
+        "## Security Hotspots To Review",
+        "",
+        "| Rule | Status | Category | Probability | Location |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for hotspot in shown:
+        location = _component_path(hotspot.component)
+        if hotspot.line is not None:
+            location = f"{location}:{hotspot.line}"
+        link = _hotspot_permalink(host, project_key, hotspot.key)
+        lines.append(
+            "| "
+            f"`{hotspot.rule_key}` | "
+            f"{hotspot.status} | "
+            f"{_condition_text(hotspot.security_category)} | "
+            f"{_condition_text(hotspot.vulnerability_probability)} | "
+            f"`{location}` ([view]({link})) |"
+        )
+    if remainder > 0:
+        lines.append(f"| n/a | n/a | n/a | n/a | {remainder} more, see Sonar |")
+    lines.append("")
+    return lines
+
+
 def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding]], generated_at: str) -> list[str]:
     """Build the trailing machine-readable JSON summary.
 
@@ -565,9 +702,13 @@ def _json_summary_block(snapshot: SonarSnapshot, buckets: dict[str, list[Finding
         "generated_at": generated_at,
         "quality_gate": snapshot.quality_gate,
         "quality_gate_conditions": [condition.as_json() for condition in snapshot.quality_gate_conditions],
+        "security_hotspots": [hotspot.as_json() for hotspot in snapshot.security_hotspots[:_JSON_KEYS_CAP]],
         "coverage": snapshot.coverage,
         "by_severity": by_severity,
     }
+    hotspot_truncated = len(snapshot.security_hotspots) - len(snapshot.security_hotspots[:_JSON_KEYS_CAP])
+    if hotspot_truncated > 0:
+        summary["security_hotspots_truncated"] = hotspot_truncated
     for name, severity in (("blocker", "BLOCKER"), ("critical", "CRITICAL")):
         all_keys = [f.key for f in buckets.get(severity, [])]
         summary[f"{name}_keys"] = all_keys[:_JSON_KEYS_CAP]
@@ -642,9 +783,11 @@ def render_body(snapshot: SonarSnapshot, *, generated_at: str | None = None) -> 
                 buckets,
                 quality_gate=snapshot.quality_gate,
                 coverage=snapshot.coverage,
+                security_hotspot_count=len(snapshot.security_hotspots),
             )
         )
         parts.extend(_quality_gate_conditions_section(snapshot.quality_gate_conditions))
+        parts.extend(_security_hotspots_section(snapshot.security_hotspots, host, project_key))
         for sev in SEVERITY_ORDER + tuple(extra_severities):
             items = buckets.get(sev, [])
             if not items:
@@ -893,6 +1036,7 @@ def _load_fixture(path: Path) -> SonarSnapshot:
         host=str(payload.get("host", "https://sonar.bernstein.run")),
         project_key=str(payload.get("project_key", "bernstein")),
         quality_gate_conditions=_parse_quality_gate_conditions(payload.get("quality_gate_conditions")),
+        security_hotspots=_parse_security_hotspots(payload.get("security_hotspots")),
     )
 
 
@@ -909,6 +1053,28 @@ def _opt_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _opt_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_security_hotspots(raw_hotspots: Any) -> list[SecurityHotspot]:
+    if not isinstance(raw_hotspots, list):
+        return []
+    hotspots: list[SecurityHotspot] = []
+    for raw in raw_hotspots:
+        if isinstance(raw, dict):
+            hotspot = _normalise_hotspot(raw)
+            if hotspot is not None:
+                hotspots.append(hotspot)
+    hotspots.sort(key=lambda item: (_component_path(item.component), item.line or 0, item.key))
+    return hotspots
 
 
 def run(args: argparse.Namespace) -> int:

--- a/tests/unit/scripts/test_render_sonar_tracker.py
+++ b/tests/unit/scripts/test_render_sonar_tracker.py
@@ -71,6 +71,28 @@ def _issue(
     }
 
 
+def _hotspot(
+    key: str,
+    *,
+    rule_key: str = "python:S5042",
+    component: str = "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+    line: int | None = 349,
+    status: str = "TO_REVIEW",
+    security_category: str = "command-injection",
+    vulnerability_probability: str = "HIGH",
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "ruleKey": rule_key,
+        "component": component,
+        "line": line,
+        "status": status,
+        "securityCategory": security_category,
+        "vulnerabilityProbability": vulnerability_probability,
+        "message": "vendor hotspot message that must never be rendered",
+    }
+
+
 def _snapshot(
     tracker: ModuleType,
     findings: list[dict[str, Any]],
@@ -78,6 +100,7 @@ def _snapshot(
     quality_gate: str = "ERROR",
     coverage: float | None = 19.3,
     quality_gate_conditions: list[Any] | None = None,
+    security_hotspots: list[Any] | None = None,
 ) -> Any:
     normalised = [tracker._normalise_issue(raw) for raw in findings]
     return tracker.SonarSnapshot(
@@ -87,6 +110,7 @@ def _snapshot(
         host=HOST,
         project_key=PROJECT,
         quality_gate_conditions=quality_gate_conditions or [],
+        security_hotspots=security_hotspots or [],
     )
 
 
@@ -185,6 +209,41 @@ def test_body_renders_quality_gate_conditions(tracker: ModuleType) -> None:
             "error_threshold": "80",
             "metric_key": "branch_coverage",
             "status": "ERROR",
+        }
+    ]
+
+
+def test_body_renders_security_hotspots_without_vendor_message(tracker: ModuleType) -> None:
+    hotspot = tracker.SecurityHotspot(
+        key="HS-1",
+        rule_key="python:S5042",
+        component="bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+        line=349,
+        status="TO_REVIEW",
+        security_category="command-injection",
+        vulnerability_probability="HIGH",
+    )
+    snapshot = _snapshot(tracker, [], security_hotspots=[hotspot])
+
+    body = tracker.render_body(snapshot, generated_at="2026-05-21T00:00:00+00:00")
+
+    assert "## Security Hotspots To Review" in body
+    assert "| `python:S5042` | TO_REVIEW | command-injection | HIGH |" in body
+    assert "`src/bernstein/core/persistence/disaster_recovery.py:349`" in body
+    assert f"{HOST}/security_hotspots?id={PROJECT}&hotspots=HS-1" in body
+    assert "vendor hotspot message" not in body
+    start = body.index("```json") + len("```json")
+    end = body.index("```", start)
+    parsed = json.loads(body[start:end])
+    assert parsed["security_hotspots"] == [
+        {
+            "component": "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+            "key": "HS-1",
+            "line": 349,
+            "rule_key": "python:S5042",
+            "security_category": "command-injection",
+            "status": "TO_REVIEW",
+            "vulnerability_probability": "HIGH",
         }
     ]
 
@@ -462,6 +521,15 @@ def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleTyp
                 json={"component": {"measures": [{"metric": "coverage", "value": "19.3"}]}},
             )
         )
+        mock.get(f"{HOST}/api/hotspots/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "hotspots": [_hotspot("HS-1")],
+                    "paging": {"pageIndex": 1, "pageSize": 500, "total": 1},
+                },
+            )
+        )
         snapshot = tracker.collect_snapshot(config)
 
     assert len(snapshot.findings) == 750
@@ -477,6 +545,17 @@ def test_collect_snapshot_paginates_and_fetches_gate_coverage(tracker: ModuleTyp
     ]
     assert snapshot.coverage is not None
     assert snapshot.coverage == pytest.approx(19.3, abs=0.001)  # pyright: ignore[reportUnknownMemberType]
+    assert snapshot.security_hotspots == [
+        tracker.SecurityHotspot(
+            key="HS-1",
+            rule_key="python:S5042",
+            component="bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+            line=349,
+            status="TO_REVIEW",
+            security_category="command-injection",
+            vulnerability_probability="HIGH",
+        )
+    ]
 
 
 def test_fetch_all_findings_raises_on_non_object_payload(tracker: ModuleType) -> None:


### PR DESCRIPTION
## Summary
- fetch Sonar security hotspots awaiting review in the tracker snapshot
- render hotspot rule, status, category, probability, and location without copying Sonar free-text messages
- include hotspot rows in the machine-readable tracker summary

## Tests
- uv run pytest tests/unit/scripts/test_render_sonar_tracker.py -q
- uv run ruff check scripts/render_sonar_tracker.py tests/unit/scripts/test_render_sonar_tracker.py
- uv run ruff format --check scripts/render_sonar_tracker.py tests/unit/scripts/test_render_sonar_tracker.py
- uv run pyright tests/unit/scripts/test_render_sonar_tracker.py
- uv run python scripts/run_tests.py --affected -x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SonarQube reports now display security hotspots awaiting review with rule, status, category, and vulnerability probability information.
  * New "Security Hotspots To Review" section added to reports for streamlined review.
  * Hotspot counts now included in report summaries and data exports.
  * Automatic pagination handles large hotspot lists efficiently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->