### PR TITLE
Harden plugin zip extraction

### DIFF
--- a/src/bernstein/core/plugins_core/plugin_installer.py
+++ b/src/bernstein/core/plugins_core/plugin_installer.py
@@ -230,14 +230,17 @@ def _extract_archive(archive_path: Path, dest: Path) -> None:
     name = archive_path.name
     if name.endswith(".zip"):
         with zipfile.ZipFile(archive_path) as zf:
-            # Validate member paths to prevent Zip Slip (path traversal via
-            # absolute paths or ".." components).
             resolved_dest = dest.resolve()
             for info in zf.infolist():
                 target = (resolved_dest / info.filename).resolve()
-                if not str(target).startswith(str(resolved_dest)):
+                if not target.is_relative_to(resolved_dest):
                     raise ValueError(f"Zip entry would escape target directory: {info.filename}")
-            zf.extractall(dest)
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, target.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
     elif name.endswith((".tar.gz", ".tgz")):
         with tarfile.open(archive_path, "r:gz") as tf:
             tf.extractall(dest, filter="data")  # type: ignore[call-arg]

--- a/src/bernstein/core/plugins_core/plugin_installer.py
+++ b/src/bernstein/core/plugins_core/plugin_installer.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 _GITHUB_API_RELEASE_URL = "https://api.github.com/repos/{repo}/releases/{tag}"
 _GITHUB_API_LATEST = "latest"
 _DEFAULT_ASSET_SUFFIXES = (".zip", ".tar.gz", ".tgz")
+_ZIP_UNIX_MODE_MASK = 0o777
 
 # ---------------------------------------------------------------------------
 # PluginSource union - 5 source variants
@@ -216,6 +217,19 @@ def _fetch_github_release_asset_url(repo: str, tag: str, asset: str | None) -> s
     )
 
 
+def _zip_unix_mode(info: zipfile.ZipInfo) -> int | None:
+    """Return Unix permission bits stored in a ZIP entry, when present."""
+    raw_mode = info.external_attr >> 16
+    mode = raw_mode & _ZIP_UNIX_MODE_MASK
+    return mode or None
+
+
+def _apply_zip_unix_mode(path: Path, info: zipfile.ZipInfo) -> None:
+    mode = _zip_unix_mode(info)
+    if mode is not None:
+        path.chmod(mode)
+
+
 def _extract_archive(archive_path: Path, dest: Path) -> None:
     """Extract a .zip or .tar.gz archive into *dest*.
 
@@ -237,10 +251,12 @@ def _extract_archive(archive_path: Path, dest: Path) -> None:
                     raise ValueError(f"Zip entry would escape target directory: {info.filename}")
                 if info.is_dir():
                     target.mkdir(parents=True, exist_ok=True)
+                    _apply_zip_unix_mode(target, info)
                     continue
                 target.parent.mkdir(parents=True, exist_ok=True)
                 with zf.open(info) as src, target.open("wb") as dst:
                     shutil.copyfileobj(src, dst)
+                _apply_zip_unix_mode(target, info)
     elif name.endswith((".tar.gz", ".tgz")):
         with tarfile.open(archive_path, "r:gz") as tf:
             tf.extractall(dest, filter="data")  # type: ignore[call-arg]

--- a/tests/unit/test_plugin_installer.py
+++ b/tests/unit/test_plugin_installer.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import stat
+import sys
 import tarfile
 import zipfile
 from pathlib import Path
@@ -30,6 +32,15 @@ def _make_zip(dest: Path, contents: dict[str, str]) -> Path:
     with zipfile.ZipFile(dest, "w") as zf:
         for name, data in contents.items():
             zf.writestr(name, data)
+    return dest
+
+
+def _make_zip_with_mode(dest: Path, name: str, data: str, mode: int) -> Path:
+    """Create a zip archive containing one entry with a Unix mode."""
+    info = zipfile.ZipInfo(filename=name)
+    info.external_attr = mode << 16
+    with zipfile.ZipFile(dest, "w") as zf:
+        zf.writestr(info, data)
     return dest
 
 
@@ -115,6 +126,15 @@ class TestExtractArchive:
             _extract_archive(archive, dest)
 
         assert not (tmp_path / "out_evil" / "pwned.txt").exists()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix mode bits are POSIX-only")
+    def test_extract_zip_preserves_unix_file_mode(self, tmp_path: Path) -> None:
+        archive = _make_zip_with_mode(tmp_path / "plugin.zip", "bin/plugin", "#!/bin/sh\n", 0o755)
+        dest = tmp_path / "out"
+
+        _extract_archive(archive, dest)
+
+        assert stat.S_IMODE((dest / "bin" / "plugin").stat().st_mode) == 0o755
 
     def test_extract_tar_gz(self, tmp_path: Path) -> None:
         archive = _make_tgz(tmp_path / "plugin.tar.gz", {"readme.md": "# Plugin"})

--- a/tests/unit/test_plugin_installer.py
+++ b/tests/unit/test_plugin_installer.py
@@ -107,6 +107,15 @@ class TestExtractArchive:
         _extract_archive(archive, dest)
         assert (dest / "hello.txt").read_text() == "world"
 
+    def test_extract_zip_rejects_sibling_prefix_escape(self, tmp_path: Path) -> None:
+        archive = _make_zip(tmp_path / "plugin.zip", {"../out_evil/pwned.txt": "owned"})
+        dest = tmp_path / "out"
+
+        with pytest.raises(ValueError, match="Zip entry would escape target directory"):
+            _extract_archive(archive, dest)
+
+        assert not (tmp_path / "out_evil" / "pwned.txt").exists()
+
     def test_extract_tar_gz(self, tmp_path: Path) -> None:
         archive = _make_tgz(tmp_path / "plugin.tar.gz", {"readme.md": "# Plugin"})
         dest = tmp_path / "out"


### PR DESCRIPTION
## Summary
- replace plugin ZIP bulk extraction with checked member streaming
- reject resolved ZIP members that escape the install directory
- add a sibling-prefix traversal regression test

## Tests
- uv run pytest tests/unit/test_plugin_installer.py::TestExtractArchive::test_extract_zip_rejects_sibling_prefix_escape -q
- uv run pytest tests/unit/test_plugin_installer.py::TestExtractArchive -q
- uv run pytest tests/unit/test_plugin_installer.py -q
- uv run ruff check src/ tests/unit/test_plugin_installer.py
- uv run ruff format --check src/bernstein/core/plugins_core/plugin_installer.py tests/unit/test_plugin_installer.py
- uv run pyright src/bernstein/core/plugins_core/plugin_installer.py
- uv run python scripts/run_tests.py --affected -x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin installation ZIP extraction to prevent path traversal and ensure extracted files remain inside the destination.
  * Preserve Unix file permission bits when installing plugins (where supported).

* **Tests**
  * Added unit tests verifying extraction safety and that permission bits are preserved (permission test skipped on Windows).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->