### PR TITLE
Make slash command matching linear

### DIFF
--- a/src/bernstein/github_app/slash_commands.py
+++ b/src/bernstein/github_app/slash_commands.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Matches /bernstein <action> [rest of line]
-_SLASH_RE = re.compile(r"^\s*/bernstein\s+(\w+)(?:\s+(.+))?$", re.MULTILINE | re.IGNORECASE)
+_SLASH_RE = re.compile(r"^[ \t]*/bernstein[ \t]+(\w+)(?:[ \t]+([^\r\n]*))?$", re.MULTILINE | re.IGNORECASE)
 
 # Supported actions and their task_type / role mappings
 _ACTION_MAP: dict[str, dict[str, str]] = {

--- a/src/bernstein/gitlab_app/slash_commands.py
+++ b/src/bernstein/gitlab_app/slash_commands.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # Matches /bernstein <action> [rest of line]
 _SLASH_RE = re.compile(
-    r"^\s*/bernstein\s+(\w+)(?:\s+(.+))?$",
+    r"^[ \t]*/bernstein[ \t]+(\w+)(?:[ \t]+([^\r\n]*))?$",
     re.MULTILINE | re.IGNORECASE,
 )
 

--- a/tests/unit/test_gitlab_slash_commands.py
+++ b/tests/unit/test_gitlab_slash_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from bernstein.gitlab_app.slash_commands import parse_slash_command, slash_command_to_task
@@ -59,6 +60,15 @@ class TestParseSlashCommand:
 
     def test_unicode_args(self) -> None:
         assert parse_slash_command("/bernstein fix добавить тест") == ("fix", "добавить тест")
+
+    def test_large_blank_note_without_command_is_fast(self) -> None:
+        text = "\n" * 50_000
+
+        started = time.perf_counter()
+        assert parse_slash_command(text) is None
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < 0.5
 
 
 class TestSlashCommandToTask:

--- a/tests/unit/test_slash_commands.py
+++ b/tests/unit/test_slash_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from bernstein.github_app.slash_commands import parse_slash_command, slash_command_to_task
@@ -78,6 +79,15 @@ class TestParseSlashCommand:
     def test_slash_bernstein_alone_returns_none(self) -> None:
         # No action word after /bernstein
         assert parse_slash_command("/bernstein") is None
+
+    def test_large_blank_comment_without_command_is_fast(self) -> None:
+        text = "\n" * 50_000
+
+        started = time.perf_counter()
+        assert parse_slash_command(text) is None
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < 0.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Make GitHub and GitLab `/bernstein` slash command matching use horizontal whitespace only.
- Keep optional argument matching line-local.
- Add large blank input regression tests for both parsers.

## Validation
- `uv run pytest tests/unit/test_slash_commands.py tests/unit/test_gitlab_slash_commands.py -q`
- `uv run ruff check src/bernstein/github_app/slash_commands.py src/bernstein/gitlab_app/slash_commands.py tests/unit/test_slash_commands.py tests/unit/test_gitlab_slash_commands.py`
- `uv run ruff format --check src/bernstein/github_app/slash_commands.py src/bernstein/gitlab_app/slash_commands.py tests/unit/test_slash_commands.py tests/unit/test_gitlab_slash_commands.py`
- `uv run pyright src/bernstein/github_app/slash_commands.py src/bernstein/gitlab_app/slash_commands.py`
- `uv run python scripts/run_tests.py --affected -x`

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced slash command parser to be more permissive with whitespace handling in both GitHub and GitLab integrations.

* **Tests**
  * Added performance tests ensuring slash command parsing completes efficiently even with large inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->