### PR TITLE
Make PR review path parsing linear

### DIFF
--- a/src/bernstein/core/quality/pr_review_aggregator.py
+++ b/src/bernstein/core/quality/pr_review_aggregator.py
@@ -132,7 +132,7 @@ _STOPWORDS: frozenset[str] = frozenset(
 # whitespace / colon-space.  Tightened to reduce false positives on
 # arbitrary dotted names that happen to look like file paths.
 _FILE_LINE_RE = re.compile(
-    r"(?P<file>(?:[\w./\-]+/)?[\w\-]+\.[A-Za-z]{1,8})(?::(?P<line>\d+))?",
+    r"(?P<file>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_-]+\.[A-Za-z]{1,8})(?::(?P<line>\d+))?",
 )
 
 # Severity tag forms seen in the wild from cheap-tier reviewers:

--- a/src/bernstein/core/quality/pr_review_aggregator.py
+++ b/src/bernstein/core/quality/pr_review_aggregator.py
@@ -132,7 +132,9 @@ _STOPWORDS: frozenset[str] = frozenset(
 # whitespace / colon-space.  Tightened to reduce false positives on
 # arbitrary dotted names that happen to look like file paths.
 _FILE_LINE_RE = re.compile(
-    r"(?P<file>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_-]+\.[A-Za-z]{1,8})(?::(?P<line>\d+))?",
+    r"(?<![A-Za-z0-9_.:/-])"
+    r"(?P<file>(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_-]+\.[A-Za-z]{1,8})(?::(?P<line>\d+))?"
+    r"(?![A-Za-z0-9_.:/-])",
 )
 
 # Severity tag forms seen in the wild from cheap-tier reviewers:

--- a/tests/unit/quality/test_pr_review_aggregator.py
+++ b/tests/unit/quality/test_pr_review_aggregator.py
@@ -114,6 +114,16 @@ class TestParseFinding:
         assert f is not None
         assert f.confidence == 0.4
 
+    def test_does_not_extract_path_inside_larger_token(self) -> None:
+        f = parse_finding(
+            "prefixsrc/auth.py:42suffix should not be treated as a file citation",
+            source_role="r",
+            source_model="m",
+        )
+        assert f is not None
+        assert f.file == ""
+        assert f.line is None
+
     def test_slash_only_non_path_input_is_fast(self) -> None:
         text = "/" * 10_000 + " no path here"
 
@@ -123,6 +133,7 @@ class TestParseFinding:
 
         assert f is not None
         assert f.file == ""
+        assert f.line is None
         assert elapsed < 0.5
 
 

--- a/tests/unit/quality/test_pr_review_aggregator.py
+++ b/tests/unit/quality/test_pr_review_aggregator.py
@@ -9,6 +9,8 @@ Pure unit tests - no LLM, no subprocess calls.
 
 from __future__ import annotations
 
+import time
+
 from bernstein.core.quality.pr_review_aggregator import (
     DEFAULT_TOP_K,
     FindingCluster,
@@ -111,6 +113,17 @@ class TestParseFinding:
         )
         assert f is not None
         assert f.confidence == 0.4
+
+    def test_slash_only_non_path_input_is_fast(self) -> None:
+        text = "/" * 10_000 + " no path here"
+
+        started = time.perf_counter()
+        f = parse_finding(text, source_role="r", source_model="m")
+        elapsed = time.perf_counter() - started
+
+        assert f is not None
+        assert f.file == ""
+        assert elapsed < 0.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace loose PR-review file path matching with segment-based path matching.
- Add a slash-only non-path regression test for parser runtime.

## Validation
- `uv run pytest tests/unit/quality/test_pr_review_aggregator.py::TestParseFinding::test_slash_only_non_path_input_is_fast -q`
- `uv run pytest tests/unit/quality/test_pr_review_aggregator.py -q`
- `uv run ruff check src/bernstein/core/quality/pr_review_aggregator.py tests/unit/quality/test_pr_review_aggregator.py`
- `uv run ruff format --check src/bernstein/core/quality/pr_review_aggregator.py tests/unit/quality/test_pr_review_aggregator.py`
- `uv run pyright src/bernstein/core/quality/pr_review_aggregator.py`
- `uv run python scripts/run_tests.py --affected -x`

Refs #1785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of file references in reviewer comments to reduce false positives on dotted or embedded tokens.

* **Tests**
  * Added tests covering edge cases where file-like substrings appear inside larger tokens and for very long slash-only inputs.
  * Added a performance assertion ensuring parsing completes within 0.5 seconds for the edge-case input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->