### PR TITLE
Add Sonar hotspot review workflow

### DIFF
--- a/.github/workflows/sonar-hotspot-review.yml
+++ b/.github/workflows/sonar-hotspot-review.yml
@@ -1,0 +1,67 @@
+name: SonarQube hotspot review
+
+# Applies explicit reviewed decisions for SonarQube security hotspots. The
+# manifest is committed for review; the workflow defaults to dry-run and only
+# mutates Sonar when manually dispatched with dry_run=false.
+
+on:
+  workflow_dispatch:
+    inputs:
+      manifest_path:
+        description: "Path to the hotspot review manifest JSON."
+        required: true
+        default: "docs/operations/sonar-hotspot-review-1785.json"
+      dry_run:
+        description: "Validate without changing Sonar hotspot status."
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonar-hotspot-review
+  cancel-in-progress: false
+
+jobs:
+  review:
+    name: Apply hotspot review manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ vars.SONAR_HOST_URL != '' }}
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+          disable-sudo: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Bootstrap (uv + python)
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: '3.13'
+
+      - name: Apply review manifest
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          MANIFEST_PATH: ${{ inputs.manifest_path }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SONAR_TOKEN}" ]; then
+            echo "::notice::SONAR_TOKEN is empty; skipping hotspot review (no-op on forks)."
+            exit 0
+          fi
+          args=(--manifest "${MANIFEST_PATH}")
+          if [ "${DRY_RUN}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          uv run python scripts/review_sonar_hotspots.py "${args[@]}"

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -70,6 +70,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/scorecard-90d-check.yml | Scorecard 90d MaintainedID re-check | schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-90d-check-${{ github.ref }}"} | 2 |
 | .github/workflows/scorecard.yml | OSSF Scorecard | branch_protection_rule, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "scorecard-${{ github.ref }}"} | 2 |
 | .github/workflows/soc2-evidence-nightly.yml | soc2-evidence-nightly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
+| .github/workflows/sonar-hotspot-review.yml | SonarQube hotspot review | workflow_dispatch | {"cancel-in-progress": "false", "group": "sonar-hotspot-review"} | 1 |
 | .github/workflows/sonar-pr-comment.yml | SonarQube PR insights comment | pull_request | {"cancel-in-progress": "true", "group": "sonar-pr-comment-${{ github.event.pull_request.number }}"} | 1 |
 | .github/workflows/sonar-scan.yml | SonarQube scan | workflow_dispatch, workflow_run | {"cancel-in-progress": "false", "group": "sonar-scan-${{ github.ref }}"} | 1 |
 | .github/workflows/sonar-tracker.yml | SonarQube findings tracker | schedule, workflow_dispatch, workflow_run | {"cancel-in-progress": "false", "group": "sonar-tracker"} | 1 |
@@ -150,6 +151,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/scorecard-90d-check.yml | age-check: 90-day age gate<br>scorecard-rerun: Scorecard rerun + report |
 | .github/workflows/scorecard.yml | analysis: Scorecard analysis<br>upload: Filter suppressions and upload to Code Scanning |
 | .github/workflows/soc2-evidence-nightly.yml | pack: generate evidence pack<br>preflight: preflight (gate) |
+| .github/workflows/sonar-hotspot-review.yml | review: Apply hotspot review manifest |
 | .github/workflows/sonar-pr-comment.yml | comment: Sonar smells delta comment |
 | .github/workflows/sonar-scan.yml | scan: SonarQube scan |
 | .github/workflows/sonar-tracker.yml | render: Render Sonar tracker issue |
@@ -230,6 +232,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/scorecard-90d-check.yml | workflow: {"contents": "read"}<br>age-check: {"contents": "read"}<br>scorecard-rerun: {"actions": "read", "contents": "read", "id-token": "write", "issues": "write", "security-events": "write"} | - |
 | .github/workflows/scorecard.yml | workflow: {"contents": "read"}<br>analysis: {"actions": "read", "contents": "read", "id-token": "write", "security-events": "write"}<br>upload: {"contents": "read", "security-events": "write"} | - |
 | .github/workflows/soc2-evidence-nightly.yml | workflow: {"contents": "read"} | SOC2_EVIDENCE_ENABLED |
+| .github/workflows/sonar-hotspot-review.yml | workflow: {"contents": "read"} | SONAR_TOKEN |
 | .github/workflows/sonar-pr-comment.yml | workflow: {"contents": "read", "issues": "write", "pull-requests": "write"} | SONAR_TOKEN |
 | .github/workflows/sonar-scan.yml | workflow: {"actions": "read", "contents": "read"} | GITHUB_TOKEN, SONAR_TOKEN |
 | .github/workflows/sonar-tracker.yml | workflow: {"contents": "read"}<br>render: {"contents": "read", "issues": "write"} | SONAR_TOKEN |

--- a/docs/operations/sonar-hotspot-review-1785.json
+++ b/docs/operations/sonar-hotspot-review-1785.json
@@ -1,0 +1,621 @@
+{
+  "project_key": "bernstein",
+  "decisions": [
+    {
+      "key": "5fb7e6bb-660e-4aa7-892d-7030880459a0",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/adapters/ci/github_actions.py",
+      "line": 99,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "7e58def2-df05-47eb-bd14-54724c3eeb20",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/adapters/ci/gitlab_ci.py",
+      "line": 23,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "e3ecdfa3-98e6-4469-ba9b-5c8cf4d410c3",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/benchmark/programbench.py",
+      "line": 649,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "38f33f92-4e51-45cf-a511-ee99535a19d9",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/benchmark/reproducible.py",
+      "line": 500,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "138dab59-5ca5-488e-a641-4682b5a325b7",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/benchmark/swe_bench.py",
+      "line": 446,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "4adc8d8c-ca28-43fe-8c12-0ef2b9e2a0ce",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/bridges/r2_sync.py",
+      "line": 534,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: endpoint is local, internal, or operator-configured infrastructure."
+    },
+    {
+      "key": "1c205dd5-9ec8-4f5b-b10f-6a1c6e3b2ca4",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/cli/api_warmup.py",
+      "line": 55,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: endpoint is local, internal, or operator-configured infrastructure."
+    },
+    {
+      "key": "e80c7135-a821-46fe-95ad-4f1ddcf92d76",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/autofix/daemon.py",
+      "line": 154,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "d52f9baf-f586-49c4-a61b-a7b0ae3acf01",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/autofix/daemon.py",
+      "line": 522,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "d67d60b5-6341-4dc5-a5fa-a1715c5eec73",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py",
+      "line": 59,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: schema namespace URI, not a network transport endpoint."
+    },
+    {
+      "key": "1ff5c1ee-648b-4263-ad4c-6b5cd2cadbc5",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/config/platform_compat.py",
+      "line": 243,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "758ef1d4-fe16-4a04-a8f1-2c6385ce46f7",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/config/platform_compat.py",
+      "line": 255,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "3d46e298-185a-47be-ae1b-12629d7c4ccc",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/config/platform_compat.py",
+      "line": 281,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "394672db-72ce-4a15-926e-0b74c9e562ea",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/config/platform_compat.py",
+      "line": 370,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "f7160aa3-dc8d-4969-aaa2-d423d3c6aa27",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/config/seed_config.py",
+      "line": 141,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: endpoint is local, internal, or operator-configured infrastructure."
+    },
+    {
+      "key": "d74649b7-f3e4-4edb-a689-803156746cbc",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/config/seed_config.py",
+      "line": 142,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: endpoint is local, internal, or operator-configured infrastructure."
+    },
+    {
+      "key": "1d689a81-95ad-4e6c-8b16-83f8fd7f87f0",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/fleet/prometheus_proxy.py",
+      "line": 31,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "8d6ea1e7-1ae8-48da-9476-8dd444f98407",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/observability/apm_integration.py",
+      "line": 282,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: Datadog Agent OTLP endpoint is operator-configured local infrastructure."
+    },
+    {
+      "key": "ab871f9f-c057-417e-b845-e26081fd2ccc",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/observability/apm_integration.py",
+      "line": 282,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: Datadog Agent OTLP endpoint is operator-configured local infrastructure."
+    },
+    {
+      "key": "eee684f7-b7e5-47a0-a621-0f18ed08d845",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/observability/ticket_bundle.py",
+      "line": 543,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "bc08b6b4-19b0-445b-b3b8-2dde29f42b69",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/observability/ticket_bundle.py",
+      "line": 610,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "a3a4cc73-b0ce-4189-863b-67f34d36566a",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/orchestration/operator.py",
+      "line": 37,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: Kubernetes service URL is in-cluster task-server transport."
+    },
+    {
+      "key": "772a74db-606b-4574-b542-bb09e4e5a930",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/orchestration/operator.py",
+      "line": 604,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: Kubernetes service URL is in-cluster task-server transport."
+    },
+    {
+      "key": "fc25f602-9c13-4cb9-b0a1-5c4063e03dd6",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/orchestration/orchestrator.py",
+      "line": 3815,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "8c8b4914-8b38-426d-b787-1d2e23f36b40",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/orchestration/orchestrator.py",
+      "line": 3817,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "cd6504c3-2613-41b9-bc6d-868e8f770801",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/orchestration/orchestrator.py",
+      "line": 3819,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "042bce34-1fb6-44af-84ff-6024205af341",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/orchestration/orchestrator_evolve.py",
+      "line": 376,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "1a73e073-fa1d-4ec8-bd71-fec9b875a3fb",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/orchestration/orchestrator_evolve.py",
+      "line": 379,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "7305df2b-b79d-4e15-a3d5-71e439c7d90d",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/orchestration/phase_gates.py",
+      "line": 265,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "2d864f91-eea1-48b5-9f01-5bce278a6f2e",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/orchestration/rolling_restart.py",
+      "line": 286,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "23748054-9390-483f-a6b7-66795e342b73",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/persistence/agent_checkpoint.py",
+      "line": 127,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "8e8b64e0-509d-40c3-afed-960b9e4875ad",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+      "line": 246,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "c45c025a-ff07-4fd3-9fd2-d2f77e74a1c5",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+      "line": 318,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "4c3139e0-f953-4cb7-a6d4-ab8f33753cb2",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+      "line": 328,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "8cdf934a-4806-4913-8523-6ae2409a3140",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+      "line": 346,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "bb58b95d-6ad7-4def-9205-4c31cf20f69f",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/disaster_recovery.py",
+      "line": 353,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "2ac0f15a-54e9-4389-bb99-51f8fe4fcc91",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/journal_export.py",
+      "line": 271,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "e98d601f-bf01-4ee0-a4c7-9c608b435768",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/journal_export.py",
+      "line": 403,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "2257c82d-c5e5-447c-84b0-873f3ac03938",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/journal_export.py",
+      "line": 468,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "3f8dd140-800d-470a-b18c-0200bb212791",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/persistence/journal_publish.py",
+      "line": 235,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive operation is constrained to controlled local paths or safe filters."
+    },
+    {
+      "key": "1cc1b2d4-efcf-49a9-acb1-62e36abab325",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/planning/spec_assertions.py",
+      "line": 68,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "9f3b5e6f-8411-4b43-a13d-3a04283bf919",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/preview/manager.py",
+      "line": 775,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "c72c35dd-76d2-4569-99c9-5c4b92524b40",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/preview/manager.py",
+      "line": 778,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "f535deb0-e7ac-4770-82a4-56a9ea42c075",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/quality/comment_quality.py",
+      "line": 58,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "878539fc-88ab-4de6-aae7-6bc0d8cb4776",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/quality/quality_gates.py",
+      "line": 558,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "a3abdfcb-84d3-450f-b11c-d332c90fa526",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/quality/quality_gates.py",
+      "line": 559,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "338e2f6c-3a25-4daa-963c-083437b5c673",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/sandbox/playwright_runner.py",
+      "line": 666,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: browser control endpoint is local sandbox infrastructure."
+    },
+    {
+      "key": "f6b9a13f-0e19-4780-80e9-d5302b2e86e4",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/security/approval.py",
+      "line": 447,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "633cce01-9aad-4e7e-b736-e7e2ad73a870",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/security/approval.py",
+      "line": 449,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "0b1fb527-862f-46ed-9072-f646110d1bcb",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/security/approval.py",
+      "line": 451,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "f9a3d525-46a0-4f16-9f19-afc017678385",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/core/security/auth.py",
+      "line": 790,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: endpoint is local, internal, or operator-configured infrastructure."
+    },
+    {
+      "key": "8c398d87-b825-4b81-a0ad-06e3bbae5e44",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/security/dlp_scanner_v2.py",
+      "line": 344,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "4319048a-67b9-445b-86b5-e7f2c27b98d4",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/security/promptware_detector.py",
+      "line": 198,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "bbc6dbda-199a-4356-a01a-f77b231f6562",
+      "rule_key": "python:S5443",
+      "component": "bernstein:src/bernstein/core/security/sandbox_escape_detector.py",
+      "line": 91,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: temporary path is a local sandbox artifact, not shared secret storage."
+    },
+    {
+      "key": "5ce4afff-7e69-4421-9270-db53b41e77d1",
+      "rule_key": "python:S5443",
+      "component": "bernstein:src/bernstein/core/security/sandbox_profiles.py",
+      "line": 182,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: temporary path is a local sandbox artifact, not shared secret storage."
+    },
+    {
+      "key": "b4675dec-522e-44bb-8070-f6aaca07728b",
+      "rule_key": "python:S5443",
+      "component": "bernstein:src/bernstein/core/security/sandbox_profiles.py",
+      "line": 195,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: temporary path is a local sandbox artifact, not shared secret storage."
+    },
+    {
+      "key": "c2df62a4-d217-45c5-8e65-73d0db68582f",
+      "rule_key": "python:S5443",
+      "component": "bernstein:src/bernstein/core/security/sandbox_profiles.py",
+      "line": 209,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: temporary path is a local sandbox artifact, not shared secret storage."
+    },
+    {
+      "key": "6fb2b68e-88d5-4041-9f2f-7cbd74633ef7",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/tasks/backlog_parser.py",
+      "line": 261,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "91b43e2a-0f27-48a6-97a6-375c073507dc",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/tasks/backlog_parser.py",
+      "line": 262,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "df1b388d-245f-4fd4-aa04-5419ad1e2b89",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/tasks/backlog_parser.py",
+      "line": 263,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "1bc55eb0-0bfd-4bc2-aa1a-b52ba7bb02fd",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/core/tokens/prompt_injection.py",
+      "line": 144,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "437b3da2-6091-4f30-a6e4-5dd9b9b69662",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/core/tokens/prompt_versioning.py",
+      "line": 419,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "dec34b63-6103-4e36-9161-5ce95d20f6c5",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/core/worktrees/classifier.py",
+      "line": 714,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "390a9f82-24d9-4daa-a73a-77178fa5f2de",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/eval/scenario_generator.py",
+      "line": 595,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "edbe79c3-e1cd-403a-ba76-06f814511f54",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/eval/scenario_generator.py",
+      "line": 754,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "634a7495-310b-4618-8404-ce804adf50d6",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/evolution/detector.py",
+      "line": 509,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "2bf06c9c-8f71-441f-ab92-d46ebb423611",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/evolution/sandbox.py",
+      "line": 344,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "521030ec-80d7-443f-9033-dd44446ec84d",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/evolution/sandbox.py",
+      "line": 345,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "16303ca3-17f2-45de-9f15-a4799143df95",
+      "rule_key": "python:S4828",
+      "component": "bernstein:src/bernstein/gui/cli.py",
+      "line": 153,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: local process lifecycle operation on Bernstein-owned process state."
+    },
+    {
+      "key": "22f6541f-d993-4de8-85f2-fd88118dc069",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/gui/cli.py",
+      "line": 246,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: default endpoint is loopback or local browser origin."
+    },
+    {
+      "key": "4fb2b6b1-318a-4492-947d-9a6410273881",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/gui/cli.py",
+      "line": 246,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: default endpoint is loopback or local browser origin."
+    },
+    {
+      "key": "e9d7e9b1-04f0-4d97-a200-5e49b58b5697",
+      "rule_key": "python:S5332",
+      "component": "bernstein:src/bernstein/mcp/remote_transport.py",
+      "line": 100,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: default endpoint is loopback or local browser origin."
+    },
+    {
+      "key": "0b2929b0-9fa8-409a-b043-0a0ab2a5da9c",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/plugins/security_review.py",
+      "line": 159,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "c00cc3b3-28f4-4de1-b93f-1411c29dfe50",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/plugins/security_review.py",
+      "line": 174,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "60a79725-3822-4e95-8393-dcd6b80659af",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/testing/patch_harness.py",
+      "line": 36,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "2f305191-23a9-40a8-95be-31b9f489fcbe",
+      "rule_key": "python:S2245",
+      "component": "bernstein:src/bernstein/tui/contextual_tips.py",
+      "line": 149,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: deterministic or non-cryptographic randomness; no secret generation."
+    },
+    {
+      "key": "b66e9c58-7156-4d70-a77c-158b00b418e3",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/tui/diff_folding.py",
+      "line": 60,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    }
+  ]
+}

--- a/scripts/review_sonar_hotspots.py
+++ b/scripts/review_sonar_hotspots.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Apply reviewed SonarQube security-hotspot decisions from a manifest.
+
+The manifest is intentionally explicit: every hotspot key must be listed with
+the reviewed resolution and a short comment. The script first fetches the
+current ``TO_REVIEW`` hotspot set and only mutates keys that are still present,
+so stale entries from a prior scan are skipped instead of failing the run.
+
+Env vars:
+  - ``SONAR_HOST_URL`` e.g. ``https://sonar.bernstein.run``
+  - ``SONAR_TOKEN`` user token with permission to review security hotspots
+  - ``SONAR_PROJECT_KEY`` optional, defaults to the manifest project key or
+    ``bernstein``
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import sys
+from pathlib import Path
+from typing import cast
+
+import httpx
+
+DEFAULT_PROJECT_KEY = "bernstein"
+DEFAULT_PAGE_SIZE = 500
+DEFAULT_TIMEOUT_SECONDS = 20.0
+MAX_PAGES = 40
+VALID_RESOLUTIONS = frozenset({"SAFE", "FIXED"})
+
+
+class ManifestError(ValueError):
+    """Raised when a hotspot review manifest is malformed."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ReviewConfig:
+    """SonarQube API connection settings."""
+
+    host: str
+    token: str
+    project_key: str = DEFAULT_PROJECT_KEY
+
+
+@dataclasses.dataclass(frozen=True)
+class HotspotDecision:
+    """One reviewed hotspot decision from the manifest."""
+
+    key: str
+    rule_key: str
+    component: str
+    line: int | None
+    resolution: str
+    comment: str
+
+
+@dataclasses.dataclass(frozen=True)
+class ReviewManifest:
+    """Validated hotspot review manifest."""
+
+    project_key: str
+    decisions: tuple[HotspotDecision, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class CurrentHotspot:
+    """One current SonarQube hotspot awaiting review."""
+
+    key: str
+    rule_key: str
+    component: str
+    line: int | None
+
+
+@dataclasses.dataclass(frozen=True)
+class ReviewResult:
+    """Summary of one review run."""
+
+    reviewed: int
+    skipped: int
+    failed: int
+    dry_run: bool
+
+
+def load_manifest(path: Path) -> ReviewManifest:
+    """Load and validate a hotspot review manifest."""
+    try:
+        loaded: object = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"invalid JSON manifest: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise ManifestError("manifest must be a JSON object")
+    raw = cast("dict[str, object]", loaded)
+    project_key = _required_str(raw, "project_key")
+    raw_decisions = raw.get("decisions")
+    if not isinstance(raw_decisions, list) or not raw_decisions:
+        raise ManifestError("manifest decisions must be a non-empty list")
+    raw_decision_list = cast("list[object]", raw_decisions)
+
+    seen: set[str] = set()
+    decisions: list[HotspotDecision] = []
+    for idx, raw_decision_obj in enumerate(raw_decision_list, start=1):
+        if not isinstance(raw_decision_obj, dict):
+            raise ManifestError(f"decision {idx} must be an object")
+        raw_decision = cast("dict[str, object]", raw_decision_obj)
+        decision = _parse_decision(raw_decision, idx)
+        if decision.key in seen:
+            raise ManifestError(f"duplicate hotspot key: {decision.key}")
+        seen.add(decision.key)
+        decisions.append(decision)
+    return ReviewManifest(project_key=project_key, decisions=tuple(decisions))
+
+
+def apply_decisions(
+    config: ReviewConfig,
+    manifest: ReviewManifest,
+    *,
+    dry_run: bool,
+    client: httpx.Client | None = None,
+) -> ReviewResult:
+    """Apply manifest decisions for hotspots that are still awaiting review."""
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS, auth=(config.token, ""))
+    assert client is not None
+    try:
+        current = _fetch_current_hotspots(config, client)
+        current_by_key = {hotspot.key: hotspot for hotspot in current}
+        reviewed = 0
+        skipped = 0
+        failed = 0
+        for decision in manifest.decisions:
+            hotspot = current_by_key.get(decision.key)
+            if hotspot is None:
+                skipped += 1
+                print(f"skip {decision.key}: not currently TO_REVIEW")
+                continue
+            if not _matches_manifest(decision, hotspot):
+                failed += 1
+                print(f"fail {decision.key}: current hotspot does not match manifest metadata", file=sys.stderr)
+                continue
+            if dry_run:
+                reviewed += 1
+                print(f"dry-run {decision.key}: would mark {decision.resolution}")
+                continue
+            _change_status(config, decision, client)
+            reviewed += 1
+            print(f"reviewed {decision.key}: marked {decision.resolution}")
+        return ReviewResult(reviewed=reviewed, skipped=skipped, failed=failed, dry_run=dry_run)
+    finally:
+        if owns_client:
+            client.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True, help="Path to a hotspot review manifest JSON file.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print planned changes without mutating Sonar.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        manifest = load_manifest(args.manifest)
+        config = _config_from_env(manifest)
+        result = apply_decisions(config, manifest, dry_run=bool(args.dry_run))
+    except (ManifestError, RuntimeError, httpx.HTTPError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "sonar-hotspot-review: "
+        f"reviewed={result.reviewed} skipped={result.skipped} failed={result.failed} dry_run={int(result.dry_run)}"
+    )
+    return 1 if result.failed else 0
+
+
+def _parse_decision(raw: dict[str, object], idx: int) -> HotspotDecision:
+    resolution = _required_str(raw, "resolution").upper()
+    if resolution not in VALID_RESOLUTIONS:
+        valid = ", ".join(sorted(VALID_RESOLUTIONS))
+        raise ManifestError(f"decision {idx} has invalid resolution {resolution!r}; expected one of: {valid}")
+    return HotspotDecision(
+        key=_required_str(raw, "key"),
+        rule_key=_required_str(raw, "rule_key"),
+        component=_required_str(raw, "component"),
+        line=_optional_int(raw, "line"),
+        resolution=resolution,
+        comment=_required_str(raw, "comment"),
+    )
+
+
+def _fetch_current_hotspots(config: ReviewConfig, client: httpx.Client) -> list[CurrentHotspot]:
+    url = f"{config.host}/api/hotspots/search"
+    hotspots: list[CurrentHotspot] = []
+    page = 1
+    while page <= MAX_PAGES:
+        response = client.get(
+            url,
+            params={
+                "projectKey": config.project_key,
+                "status": "TO_REVIEW",
+                "ps": str(DEFAULT_PAGE_SIZE),
+                "p": str(page),
+            },
+        )
+        response.raise_for_status()
+        payload_obj: object = response.json()
+        if not isinstance(payload_obj, dict):
+            raise RuntimeError("hotspot search returned a non-object payload")
+        payload = cast("dict[str, object]", payload_obj)
+        raw_hotspots = payload.get("hotspots")
+        if isinstance(raw_hotspots, list):
+            raw_hotspot_list = cast("list[object]", raw_hotspots)
+            for raw_hotspot_obj in raw_hotspot_list:
+                if not isinstance(raw_hotspot_obj, dict):
+                    continue
+                raw_hotspot = cast("dict[str, object]", raw_hotspot_obj)
+                hotspot = _normalise_current_hotspot(raw_hotspot)
+                if hotspot is not None:
+                    hotspots.append(hotspot)
+        paging_obj = payload.get("paging")
+        paging = cast("dict[str, object]", paging_obj) if isinstance(paging_obj, dict) else {}
+        try:
+            total = _coerce_required_int(paging.get("total", 0), "total")
+            page_idx = _coerce_required_int(paging.get("pageIndex", page), "pageIndex")
+            page_size = _coerce_required_int(paging.get("pageSize", DEFAULT_PAGE_SIZE), "pageSize")
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError("hotspot search returned invalid paging metadata") from exc
+        if page_size <= 0 or page_idx * page_size >= total:
+            break
+        page += 1
+    return hotspots
+
+
+def _change_status(config: ReviewConfig, decision: HotspotDecision, client: httpx.Client) -> None:
+    response = client.post(
+        f"{config.host}/api/hotspots/change_status",
+        data={
+            "hotspot": decision.key,
+            "status": "REVIEWED",
+            "resolution": decision.resolution,
+            "comment": decision.comment,
+        },
+    )
+    response.raise_for_status()
+
+
+def _normalise_current_hotspot(raw: dict[str, object]) -> CurrentHotspot | None:
+    key = _optional_str(raw.get("key"))
+    rule_key = _optional_str(raw.get("ruleKey") or raw.get("rule"))
+    component = _optional_str(raw.get("component"))
+    if key is None or rule_key is None or component is None:
+        return None
+    return CurrentHotspot(key=key, rule_key=rule_key, component=component, line=_coerce_optional_int(raw.get("line")))
+
+
+def _matches_manifest(decision: HotspotDecision, hotspot: CurrentHotspot) -> bool:
+    return (
+        decision.rule_key == hotspot.rule_key
+        and decision.component == hotspot.component
+        and decision.line == hotspot.line
+    )
+
+
+def _config_from_env(manifest: ReviewManifest) -> ReviewConfig:
+    host = os.environ.get("SONAR_HOST_URL", "").strip().rstrip("/")
+    token = os.environ.get("SONAR_TOKEN", "").strip()
+    project_key = os.environ.get("SONAR_PROJECT_KEY", "").strip() or manifest.project_key or DEFAULT_PROJECT_KEY
+    if not host:
+        raise RuntimeError("SONAR_HOST_URL must be set")
+    if not token:
+        raise RuntimeError("SONAR_TOKEN must be set")
+    return ReviewConfig(host=host, token=token, project_key=project_key)
+
+
+def _required_str(raw: dict[str, object], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ManifestError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(raw: dict[str, object], key: str) -> int | None:
+    return _coerce_optional_int(raw.get(key))
+
+
+def _coerce_optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    return _coerce_required_int(value, "line")
+
+
+def _coerce_required_int(value: object, field: str) -> int:
+    if isinstance(value, bool):
+        raise ManifestError(f"{field} must be an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise ManifestError(f"{field} must be an integer") from exc
+    raise ManifestError(f"{field} must be an integer")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_review_sonar_hotspots.py
+++ b/tests/unit/scripts/test_review_sonar_hotspots.py
@@ -1,0 +1,122 @@
+"""Unit tests for ``scripts/review_sonar_hotspots.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "review_sonar_hotspots.py"
+HOST = "https://sonar.test"
+PROJECT = "bernstein"
+
+
+@pytest.fixture
+def reviewer() -> ModuleType:
+    """Load scripts/review_sonar_hotspots.py as a module."""
+    spec = importlib.util.spec_from_file_location("review_sonar_hotspots_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manifest(*decisions: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "project_key": PROJECT,
+        "decisions": list(decisions),
+    }
+
+
+def _decision(
+    key: str,
+    *,
+    rule_key: str = "python:S5332",
+    component: str = "bernstein:src/bernstein/core/observability/apm_integration.py",
+    line: int = 282,
+    resolution: str = "SAFE",
+    comment: str = "Reviewed for #1785: local transport endpoint.",
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "rule_key": rule_key,
+        "component": component,
+        "line": line,
+        "resolution": resolution,
+        "comment": comment,
+    }
+
+
+def test_load_manifest_rejects_duplicate_hotspot_keys(tmp_path: Path, reviewer: ModuleType) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(_manifest(_decision("HS-1"), _decision("HS-1"))), encoding="utf-8")
+
+    with pytest.raises(reviewer.ManifestError, match="duplicate hotspot key"):
+        reviewer.load_manifest(manifest_path)
+
+
+@respx.mock
+def test_apply_decisions_posts_safe_review_for_current_hotspot(tmp_path: Path, reviewer: ModuleType) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(_manifest(_decision("HS-1"))), encoding="utf-8")
+    manifest = reviewer.load_manifest(manifest_path)
+    config = reviewer.ReviewConfig(host=HOST, token="token", project_key=PROJECT)
+    respx.get(f"{HOST}/api/hotspots/search").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "hotspots": [
+                    {
+                        "key": "HS-1",
+                        "ruleKey": "python:S5332",
+                        "component": "bernstein:src/bernstein/core/observability/apm_integration.py",
+                        "line": 282,
+                        "status": "TO_REVIEW",
+                    }
+                ],
+                "paging": {"pageIndex": 1, "pageSize": 500, "total": 1},
+            },
+        )
+    )
+    change = respx.post(f"{HOST}/api/hotspots/change_status").mock(return_value=httpx.Response(204))
+
+    result = reviewer.apply_decisions(config, manifest, dry_run=False)
+
+    assert result.reviewed == 1
+    assert result.skipped == 0
+    assert change.called
+    request = change.calls.last.request
+    body = dict(httpx.QueryParams(request.content.decode()))
+    assert body == {
+        "comment": "Reviewed for #1785: local transport endpoint.",
+        "hotspot": "HS-1",
+        "resolution": "SAFE",
+        "status": "REVIEWED",
+    }
+
+
+@respx.mock
+def test_apply_decisions_skips_hotspots_missing_from_current_review_set(tmp_path: Path, reviewer: ModuleType) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(_manifest(_decision("HS-1"))), encoding="utf-8")
+    manifest = reviewer.load_manifest(manifest_path)
+    config = reviewer.ReviewConfig(host=HOST, token="token", project_key=PROJECT)
+    respx.get(f"{HOST}/api/hotspots/search").mock(
+        return_value=httpx.Response(200, json={"hotspots": [], "paging": {"pageIndex": 1, "pageSize": 500, "total": 0}})
+    )
+    change = respx.post(f"{HOST}/api/hotspots/change_status").mock(return_value=httpx.Response(204))
+
+    result = reviewer.apply_decisions(config, manifest, dry_run=False)
+
+    assert result.reviewed == 0
+    assert result.skipped == 1
+    assert not change.called

--- a/tests/unit/test_workflow_uv_installers_yaml.py
+++ b/tests/unit/test_workflow_uv_installers_yaml.py
@@ -21,6 +21,7 @@ PINNED_UV_VERSION = "0.11.3"
 
 OWNED_WORKFLOWS = (
     "sonar-scan.yml",
+    "sonar-hotspot-review.yml",
     "docs-observability-snapshot.yml",
     "pr-observability-summary.yml",
     "glitchtip-ingester.yml",
@@ -75,6 +76,7 @@ def test_owned_workflows_do_not_install_uv_with_unpinned_pip(workflow_name: str)
     "workflow_name",
     (
         "sonar-scan.yml",
+        "sonar-hotspot-review.yml",
         "docs-observability-snapshot.yml",
         "pr-observability-summary.yml",
         "glitchtip-ingester.yml",


### PR DESCRIPTION
## Summary
- Add a manifest-driven helper for applying reviewed Sonar security hotspot decisions.
- Add a manual workflow that defaults to dry-run and uses the existing Sonar token only when dispatched.
- Add the reviewed #1785 hotspot manifest and refresh the workflow topology document.

## Validation
- `uv run pytest tests/unit/scripts/test_review_sonar_hotspots.py tests/unit/test_workflow_uv_installers_yaml.py tests/unit/test_workflow_topology_report.py -q`
- `uv run ruff check scripts/review_sonar_hotspots.py tests/unit/scripts/test_review_sonar_hotspots.py tests/unit/test_workflow_uv_installers_yaml.py`
- `uv run ruff format --check scripts/review_sonar_hotspots.py tests/unit/scripts/test_review_sonar_hotspots.py tests/unit/test_workflow_uv_installers_yaml.py`
- `uv run pyright scripts/review_sonar_hotspots.py`
- `uv run python scripts/gen_workflow_topology.py --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow for reviewing and marking SonarQube security hotspots as safe via manifest-based decisions.
  * Updated CI topology documentation to reflect new workflow.

* **Tests**
  * Added test coverage for the security hotspot review process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->