### PR TITLE
Review remaining Sonar hotspots

### DIFF
--- a/docs/operations/sonar-hotspot-review-1785.json
+++ b/docs/operations/sonar-hotspot-review-1785.json
@@ -616,6 +616,30 @@
       "line": 60,
       "resolution": "SAFE",
       "comment": "Reviewed for #1785: bounded parser or trusted local input; no adversarial regex surface."
+    },
+    {
+      "key": "7e33243a-1db9-4c83-bfee-8b551e5141bb",
+      "rule_key": "python:S5042",
+      "component": "bernstein:src/bernstein/core/plugins_core/plugin_installer.py",
+      "line": 261,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: archive extraction is constrained by zip path checks and tar data filters."
+    },
+    {
+      "key": "51c01a0a-da03-4029-afcf-c1beecb3e41b",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/github_app/slash_commands.py",
+      "line": 25,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: anchored line parser with bounded whitespace and argument classes."
+    },
+    {
+      "key": "04cb9f75-abdf-4fd0-8ba7-3452a771031a",
+      "rule_key": "python:S5852",
+      "component": "bernstein:src/bernstein/gitlab_app/slash_commands.py",
+      "line": 19,
+      "resolution": "SAFE",
+      "comment": "Reviewed for #1785: anchored line parser with bounded whitespace and argument classes."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add the three remaining Sonar hotspot review decisions for #1785.
- Keep the decisions in the existing explicit review manifest used by the hotspot review workflow.

## Verification
- uv run python -c 'from pathlib import Path; import importlib.util, sys; p=Path("scripts/review_sonar_hotspots.py"); spec=importlib.util.spec_from_file_location("review", p); assert spec and spec.loader; m=importlib.util.module_from_spec(spec); sys.modules[spec.name]=m; spec.loader.exec_module(m); manifest=m.load_manifest(Path("docs/operations/sonar-hotspot-review-1785.json")); print(len(manifest.decisions))'
- uv run pytest tests/unit/scripts/test_review_sonar_hotspots.py -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal security review documentation.

---

**Note:** This release contains only internal operational updates with no user-facing changes or new features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->