### PR TITLE
Add deterministic skill routing tools

### DIFF
--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 import yaml
 
@@ -30,12 +30,18 @@ from bernstein.core.skills.activation_log import (
     ActivationRecord,
     log_activation,
 )
+from bernstein.core.skills.routing import auto_route_enabled, select_auto_route_templates
 from bernstein.core.skills.sanitizer import sanitize_skill_body
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from bernstein.core.models import Task
+    from bernstein.core.skills.routing import RoutableTask
+
+    class Task(RoutableTask, Protocol):
+        """Task fields used by the skill injector."""
+
+        id: str
 
 
 class _FrontmatterSchema(TypedDict, total=False):
@@ -162,7 +168,16 @@ def inject_skills(
     skills_dest_dir = workdir / ".claude" / "skills"
     skills_dest_dir.mkdir(parents=True, exist_ok=True)
 
-    templates_to_inject = _ALWAYS_INJECT + ROLE_SKILL_MAP.get(role, [])
+    templates_to_inject = list(dict.fromkeys(_ALWAYS_INJECT + ROLE_SKILL_MAP.get(role, [])))
+    trigger_by_template = {template_name: "role-binding" for template_name in templates_to_inject}
+    if auto_route_enabled():
+        for candidate in select_auto_route_templates(
+            skills_source_dir,
+            tasks,
+            excluded_templates=templates_to_inject,
+        ):
+            templates_to_inject.append(candidate.template_name)
+            trigger_by_template[candidate.template_name] = "auto-route"
 
     for template_name in templates_to_inject:
         source_path = skills_source_dir / template_name
@@ -213,7 +228,7 @@ def inject_skills(
                         skill=skill_name,
                         role=role,
                         task_id=task.id,
-                        trigger_source="role-binding",
+                        trigger_source=trigger_by_template[template_name],
                         version=version,
                         digest=digest,
                     ),
@@ -225,7 +240,7 @@ def inject_skills(
                         skill=skill_name,
                         role=role,
                         task_id="",
-                        trigger_source="role-binding",
+                        trigger_source=trigger_by_template[template_name],
                         version=version,
                         digest=digest,
                     ),

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -575,6 +575,40 @@ def skills_helpfulness() -> None:
         console.print(f"[dim]{report.unmatched_activations} activation(s) had no task outcome yet[/dim]")
 
 
+@skills_group.command("bisect")
+@click.argument("task_id")
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Print the bisect plan as JSON.",
+)
+def skills_bisect(task_id: str, json_output: bool) -> None:
+    """Build a local skill-activation bisect plan for a task."""
+    from bernstein.core.skills.bisect import SkillBisectError, build_skill_bisect_plan
+
+    try:
+        plan = build_skill_bisect_plan(Path.cwd(), task_id)
+    except SkillBisectError as exc:
+        console.print(f"[red]bisect failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    payload = plan.as_payload()
+    if json_output:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    console.print(f"[bold]task[/bold] {plan.task_id}: {plan.outcome}; {plan.candidate_count} candidate skill(s)")
+    console.print("[bold]next probe[/bold]")
+    console.print("disable: " + (", ".join(plan.next_probe.disable) or "(none)"))
+    console.print("keep: " + (", ".join(plan.next_probe.keep) or "(none)"))
+    for candidate in plan.candidates:
+        console.print(
+            f"- {candidate.skill} ({candidate.trigger_source or 'unknown'}, role={candidate.role or 'unknown'})"
+        )
+
+
 @skills_group.command("watch")
 @click.argument(
     "path",

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -35,10 +35,16 @@ import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from types import MappingProxyType
-from typing import Any, Literal
+from typing import Any, Final, Literal
 
 PY_IDENTIFIER_RE_FRAGMENT = r"[A-Z_][A-Z0-9_]*"
 """Regex fragment for Python identifiers when compiled with ``re.IGNORECASE``."""
+
+SKILLS_AUTO_ROUTE_ENV: Final[str] = "BERNSTEIN_SKILLS_AUTO_ROUTE"
+"""Environment variable enabling deterministic skill auto-routing."""
+
+SKILLS_AUTO_ROUTE_DEFAULT_LIMIT: Final[int] = 2
+"""Default number of auto-routed skill templates to inject."""
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/skills/bisect.py
+++ b/src/bernstein/core/skills/bisect.py
@@ -122,16 +122,24 @@ def _load_task_candidates(workdir: Path, task_id: str) -> tuple[SkillBisectCandi
 
 
 def _task_outcome(workdir: Path, task_id: str) -> str:
+    latest_key: tuple[float, int] | None = None
+    latest_success: bool | None = None
+    sequence = 0
     for path in iter_metric_files(workdir / ".sdd" / "metrics", _METRIC_TYPE):
         for row in _iter_jsonl_objects(path):
             labels = _mapping_field(row, "labels")
             if labels is None or _string_field(labels, "task_id") != task_id:
                 continue
-            success = _success_value(labels.get("success"))
-            if success is True:
-                return "passed"
-            if success is False:
-                return "failed"
+            sequence += 1
+            timestamp = _numeric_field(row, "timestamp")
+            candidate_key = (timestamp if timestamp is not None else float("-inf"), sequence)
+            if latest_key is None or candidate_key > latest_key:
+                latest_key = candidate_key
+                latest_success = _success_value(labels.get("success"))
+    if latest_success is True:
+        return "passed"
+    if latest_success is False:
+        return "failed"
     return "unknown"
 
 
@@ -172,6 +180,15 @@ def _mapping_field(row: dict[str, object], key: str) -> dict[str, object] | None
 def _string_field(row: dict[str, object], key: str) -> str:
     value = row.get(key)
     return value if isinstance(value, str) else ""
+
+
+def _numeric_field(row: dict[str, object], key: str) -> float | None:
+    value = row.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
 
 
 def _success_value(value: object) -> bool | None:

--- a/src/bernstein/core/skills/bisect.py
+++ b/src/bernstein/core/skills/bisect.py
@@ -1,0 +1,195 @@
+"""Local skill activation bisect planning."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, cast
+
+from bernstein.core.observability.metric_collector import iter_metric_files
+from bernstein.core.skills.activation_log import activation_log_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_METRIC_TYPE: Final[str] = "task_completion_time"
+
+
+class SkillBisectError(ValueError):
+    """Raised when a bisect plan cannot be built from local files."""
+
+
+@dataclass(frozen=True)
+class SkillBisectCandidate:
+    """One skill activated for a task."""
+
+    skill: str
+    role: str
+    trigger_source: str
+    version: str
+    digest: str
+    timestamp: str
+
+    def as_payload(self) -> dict[str, str]:
+        """Render this candidate as stable JSON."""
+        return {
+            "skill": self.skill,
+            "role": self.role,
+            "trigger_source": self.trigger_source,
+            "version": self.version,
+            "digest": self.digest,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass(frozen=True)
+class SkillBisectProbe:
+    """Next deterministic probe for a skill bisect."""
+
+    disable: tuple[str, ...]
+    keep: tuple[str, ...]
+
+    def as_payload(self) -> dict[str, list[str]]:
+        """Render this probe as stable JSON."""
+        return {
+            "disable": list(self.disable),
+            "keep": list(self.keep),
+        }
+
+
+@dataclass(frozen=True)
+class SkillBisectPlan:
+    """A deterministic local bisect plan for one task."""
+
+    task_id: str
+    outcome: str
+    candidates: tuple[SkillBisectCandidate, ...]
+    next_probe: SkillBisectProbe
+
+    @property
+    def candidate_count(self) -> int:
+        """Return the number of candidate skills in the plan."""
+        return len(self.candidates)
+
+    def as_payload(self) -> dict[str, object]:
+        """Render this plan as stable JSON."""
+        return {
+            "task_id": self.task_id,
+            "outcome": self.outcome,
+            "candidate_count": self.candidate_count,
+            "next_probe": self.next_probe.as_payload(),
+            "candidates": [candidate.as_payload() for candidate in self.candidates],
+        }
+
+
+def build_skill_bisect_plan(workdir: Path, task_id: str) -> SkillBisectPlan:
+    """Build a deterministic bisect plan from activation and metrics files."""
+    candidates = _load_task_candidates(workdir, task_id)
+    if not candidates:
+        raise SkillBisectError(f"{task_id}: no activations found")
+    midpoint = max(1, len(candidates) // 2)
+    disabled = tuple(candidate.skill for candidate in candidates[:midpoint])
+    kept = tuple(candidate.skill for candidate in candidates[midpoint:])
+    return SkillBisectPlan(
+        task_id=task_id,
+        outcome=_task_outcome(workdir, task_id),
+        candidates=candidates,
+        next_probe=SkillBisectProbe(disable=disabled, keep=kept),
+    )
+
+
+def _load_task_candidates(workdir: Path, task_id: str) -> tuple[SkillBisectCandidate, ...]:
+    seen: set[str] = set()
+    candidates: list[SkillBisectCandidate] = []
+    for row in _iter_jsonl_objects(activation_log_path(workdir)):
+        if _string_field(row, "task_id") != task_id:
+            continue
+        skill = _string_field(row, "skill")
+        if not skill or skill in seen:
+            continue
+        seen.add(skill)
+        candidates.append(
+            SkillBisectCandidate(
+                skill=skill,
+                role=_string_field(row, "role"),
+                trigger_source=_string_field(row, "trigger_source"),
+                version=_string_field(row, "version"),
+                digest=_string_field(row, "digest"),
+                timestamp=_string_field(row, "timestamp"),
+            )
+        )
+    return tuple(candidates)
+
+
+def _task_outcome(workdir: Path, task_id: str) -> str:
+    for path in iter_metric_files(workdir / ".sdd" / "metrics", _METRIC_TYPE):
+        for row in _iter_jsonl_objects(path):
+            labels = _mapping_field(row, "labels")
+            if labels is None or _string_field(labels, "task_id") != task_id:
+                continue
+            success = _success_value(labels.get("success"))
+            if success is True:
+                return "passed"
+            if success is False:
+                return "failed"
+    return "unknown"
+
+
+def _iter_jsonl_objects(path: Path) -> tuple[dict[str, object], ...]:
+    if not path.is_file():
+        return ()
+    rows: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            parsed: object = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        row: dict[str, object] = {}
+        parsed_dict = cast("dict[object, object]", parsed)
+        for key, value in parsed_dict.items():
+            if isinstance(key, str):
+                row[key] = value
+        rows.append(row)
+    return tuple(rows)
+
+
+def _mapping_field(row: dict[str, object], key: str) -> dict[str, object] | None:
+    value = row.get(key)
+    if not isinstance(value, dict):
+        return None
+    out: dict[str, object] = {}
+    value_dict = cast("dict[object, object]", value)
+    for nested_key, nested_value in value_dict.items():
+        if isinstance(nested_key, str):
+            out[nested_key] = nested_value
+    return out
+
+
+def _string_field(row: dict[str, object], key: str) -> str:
+    value = row.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _success_value(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalised = value.strip().lower()
+        if normalised in {"true", "1", "yes"}:
+            return True
+        if normalised in {"false", "0", "no"}:
+            return False
+    return None
+
+
+__all__ = [
+    "SkillBisectCandidate",
+    "SkillBisectError",
+    "SkillBisectPlan",
+    "SkillBisectProbe",
+    "build_skill_bisect_plan",
+]

--- a/src/bernstein/core/skills/routing.py
+++ b/src/bernstein/core/skills/routing.py
@@ -1,0 +1,205 @@
+"""Deterministic opt-in skill auto-routing."""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping, Sequence
+    from pathlib import Path
+
+ENV_AUTO_ROUTE = "BERNSTEIN_SKILLS_AUTO_ROUTE"
+DEFAULT_ROUTE_LIMIT = 2
+
+_ENABLE_TOKENS = frozenset({"1", "true", "yes", "on"})
+_TOKEN_RE: re.Pattern[str] = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+
+class RoutableTask(Protocol):
+    """Task fields used by deterministic skill auto-routing."""
+
+    title: str
+    description: str
+    owned_files: list[str]
+    requires: list[str]
+
+
+@dataclass(frozen=True)
+class SkillRouteCandidate:
+    """One deterministic skill routing candidate."""
+
+    template_name: str
+    skill_name: str
+    score: float
+
+
+def auto_route_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether opt-in auto-routing is enabled."""
+    values = env if env is not None else os.environ
+    return values.get(ENV_AUTO_ROUTE, "").strip().lower() in _ENABLE_TOKENS
+
+
+def select_auto_route_templates(
+    skills_source_dir: Path,
+    tasks: Sequence[RoutableTask],
+    *,
+    excluded_templates: Collection[str],
+    limit: int = DEFAULT_ROUTE_LIMIT,
+) -> tuple[SkillRouteCandidate, ...]:
+    """Select extra skill templates using deterministic TF-IDF scoring."""
+    if limit < 1 or not tasks or not skills_source_dir.is_dir():
+        return ()
+    query = _task_query(tasks)
+    query_counts = _token_counts(query)
+    if not query_counts:
+        return ()
+
+    documents = _load_skill_documents(skills_source_dir, excluded_templates=excluded_templates)
+    if not documents:
+        return ()
+
+    doc_freq: Counter[str] = Counter()
+    for document in documents:
+        doc_freq.update(document.tokens.keys())
+
+    query_weight = _tfidf_vector(query_counts, doc_freq=doc_freq, corpus_size=len(documents))
+    scored: list[SkillRouteCandidate] = []
+    for document in documents:
+        doc_weight = _tfidf_vector(document.tokens, doc_freq=doc_freq, corpus_size=len(documents))
+        score = _cosine(query_weight, doc_weight)
+        if score > 0:
+            scored.append(
+                SkillRouteCandidate(
+                    template_name=document.template_name,
+                    skill_name=document.skill_name,
+                    score=score,
+                )
+            )
+
+    scored.sort(key=lambda item: (-item.score, item.template_name))
+    return tuple(scored[:limit])
+
+
+@dataclass(frozen=True)
+class _SkillDocument:
+    template_name: str
+    skill_name: str
+    tokens: Counter[str]
+
+
+def _load_skill_documents(
+    skills_source_dir: Path,
+    *,
+    excluded_templates: Collection[str],
+) -> tuple[_SkillDocument, ...]:
+    documents: list[_SkillDocument] = []
+    for path in sorted(skills_source_dir.glob("*.md")):
+        if path.name in excluded_templates:
+            continue
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        frontmatter, body = _split_frontmatter(raw)
+        skill_name = _frontmatter_name(frontmatter) or path.stem
+        parts = [
+            path.stem.replace("-", " "),
+            skill_name.replace("-", " "),
+            _frontmatter_text(frontmatter),
+            body,
+        ]
+        tokens = _token_counts("\n".join(parts))
+        if tokens:
+            documents.append(_SkillDocument(template_name=path.name, skill_name=skill_name, tokens=tokens))
+    return tuple(documents)
+
+
+def _task_query(tasks: Sequence[RoutableTask]) -> str:
+    parts: list[str] = []
+    for task in tasks:
+        parts.extend([task.title, task.description])
+        parts.extend(task.owned_files)
+        parts.extend(task.requires)
+    return "\n".join(part for part in parts if part)
+
+
+def _token_counts(text: str) -> Counter[str]:
+    return Counter(_TOKEN_RE.findall(text.casefold()))
+
+
+def _tfidf_vector(counts: Counter[str], *, doc_freq: Counter[str], corpus_size: int) -> dict[str, float]:
+    total = sum(counts.values())
+    if total <= 0:
+        return {}
+    vector: dict[str, float] = {}
+    for token, count in counts.items():
+        df = doc_freq.get(token, 0)
+        idf = math.log((1 + corpus_size) / (1 + df)) + 1.0
+        vector[token] = (count / total) * idf
+    return vector
+
+
+def _cosine(left: dict[str, float], right: dict[str, float]) -> float:
+    if not left or not right:
+        return 0.0
+    numerator = sum(weight * right.get(token, 0.0) for token, weight in left.items())
+    if numerator <= 0:
+        return 0.0
+    left_norm = math.sqrt(sum(weight * weight for weight in left.values()))
+    right_norm = math.sqrt(sum(weight * weight for weight in right.values()))
+    if left_norm == 0 or right_norm == 0:
+        return 0.0
+    return numerator / (left_norm * right_norm)
+
+
+def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
+    lines = raw.splitlines()
+    if not lines or lines[0].rstrip() != "---":
+        return ({}, raw)
+    front: list[str] = []
+    for idx in range(1, len(lines)):
+        if lines[idx].rstrip() == "---":
+            loaded_obj: object = yaml.safe_load("\n".join(front)) if front else {}
+            if not isinstance(loaded_obj, dict):
+                return ({}, "\n".join(lines[idx + 1 :]))
+            typed: dict[str, object] = {}
+            for key, value in cast("dict[object, object]", loaded_obj).items():
+                if isinstance(key, str):
+                    typed[key] = value
+            return (typed, "\n".join(lines[idx + 1 :]))
+        front.append(lines[idx])
+    return ({}, raw)
+
+
+def _frontmatter_name(frontmatter: dict[str, object]) -> str | None:
+    value = frontmatter.get("name")
+    return value if isinstance(value, str) and value else None
+
+
+def _frontmatter_text(frontmatter: dict[str, object]) -> str:
+    parts: list[str] = []
+    for key in ("name", "description"):
+        value = frontmatter.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    keywords = frontmatter.get("trigger_keywords")
+    if isinstance(keywords, list):
+        keyword_items = cast("list[object]", keywords)
+        parts.extend(item for item in keyword_items if isinstance(item, str))
+    return "\n".join(parts)
+
+
+__all__ = [
+    "DEFAULT_ROUTE_LIMIT",
+    "ENV_AUTO_ROUTE",
+    "SkillRouteCandidate",
+    "auto_route_enabled",
+    "select_auto_route_templates",
+]

--- a/src/bernstein/core/skills/routing.py
+++ b/src/bernstein/core/skills/routing.py
@@ -11,12 +11,16 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 import yaml
 
+from bernstein.core.defaults import (
+    SKILLS_AUTO_ROUTE_DEFAULT_LIMIT as DEFAULT_ROUTE_LIMIT,
+)
+from bernstein.core.defaults import (
+    SKILLS_AUTO_ROUTE_ENV as ENV_AUTO_ROUTE,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping, Sequence
     from pathlib import Path
-
-ENV_AUTO_ROUTE = "BERNSTEIN_SKILLS_AUTO_ROUTE"
-DEFAULT_ROUTE_LIMIT = 2
 
 _ENABLE_TOKENS = frozenset({"1", "true", "yes", "on"})
 _TOKEN_RE: re.Pattern[str] = re.compile(r"[a-z0-9][a-z0-9-]*")
@@ -166,7 +170,10 @@ def _split_frontmatter(raw: str) -> tuple[dict[str, object], str]:
     front: list[str] = []
     for idx in range(1, len(lines)):
         if lines[idx].rstrip() == "---":
-            loaded_obj: object = yaml.safe_load("\n".join(front)) if front else {}
+            try:
+                loaded_obj: object = yaml.safe_load("\n".join(front)) if front else {}
+            except yaml.YAMLError:
+                return ({}, "\n".join(lines[idx + 1 :]))
             if not isinstance(loaded_obj, dict):
                 return ({}, "\n".join(lines[idx + 1 :]))
             typed: dict[str, object] = {}

--- a/tests/unit/skills/test_cli_authoring.py
+++ b/tests/unit/skills/test_cli_authoring.py
@@ -208,3 +208,82 @@ def test_skills_helpfulness_writes_local_report(
     assert "wrote" in result.output
     assert "pytest-helper" in result.output
     assert (workdir / ".sdd" / "skills" / "helpfulness.json").is_file()
+
+
+def test_skills_bisect_outputs_local_replay_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    activations_dir = workdir / ".sdd" / "skills"
+    activations_dir.mkdir(parents=True)
+    activations_dir.joinpath("activations.jsonl").write_text(
+        "\n".join(
+            json.dumps(row, sort_keys=True)
+            for row in (
+                {
+                    "skill": "pytest-helper",
+                    "version": "1.0.0",
+                    "digest": "aaa",
+                    "role": "backend",
+                    "task_id": "task-1",
+                    "trigger_source": "role-binding",
+                    "timestamp": "2026-05-22T12:00:00.000Z",
+                },
+                {
+                    "skill": "docs-helper",
+                    "version": "1.0.0",
+                    "digest": "bbb",
+                    "role": "docs",
+                    "task_id": "task-1",
+                    "trigger_source": "auto-route",
+                    "timestamp": "2026-05-22T12:01:00.000Z",
+                },
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    metrics_dir = workdir / ".sdd" / "metrics"
+    metrics_dir.mkdir(parents=True)
+    metrics_dir.joinpath("task_completion_time_2026-05-22.jsonl").write_text(
+        json.dumps(
+            {
+                "metric_type": "task_completion_time",
+                "timestamp": 1.0,
+                "value": 3.0,
+                "labels": {"task_id": "task-1", "role": "backend", "model": "sonnet", "success": "False"},
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["bisect", "task-1", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["task_id"] == "task-1"
+    assert payload["outcome"] == "failed"
+    assert payload["candidate_count"] == 2
+    assert payload["next_probe"]["disable"] == ["pytest-helper"]
+    assert [candidate["skill"] for candidate in payload["candidates"]] == ["pytest-helper", "docs-helper"]
+
+
+def test_skills_bisect_fails_for_task_without_activations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["bisect", "missing-task"])
+
+    assert result.exit_code == 1
+    assert "no activations found" in result.output

--- a/tests/unit/skills/test_cli_authoring.py
+++ b/tests/unit/skills/test_cli_authoring.py
@@ -274,6 +274,62 @@ def test_skills_bisect_outputs_local_replay_plan(
     assert [candidate["skill"] for candidate in payload["candidates"]] == ["pytest-helper", "docs-helper"]
 
 
+def test_skills_bisect_uses_latest_task_metric(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    activations_dir = workdir / ".sdd" / "skills"
+    activations_dir.mkdir(parents=True)
+    activations_dir.joinpath("activations.jsonl").write_text(
+        json.dumps(
+            {
+                "skill": "pytest-helper",
+                "version": "1.0.0",
+                "digest": "aaa",
+                "role": "backend",
+                "task_id": "task-2",
+                "trigger_source": "role-binding",
+                "timestamp": "2026-05-22T12:00:00.000Z",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    metrics_dir = workdir / ".sdd" / "metrics"
+    metrics_dir.mkdir(parents=True)
+    metrics_dir.joinpath("task_completion_time_2026-05-22.jsonl").write_text(
+        "\n".join(
+            json.dumps(row, sort_keys=True)
+            for row in (
+                {
+                    "metric_type": "task_completion_time",
+                    "timestamp": 1.0,
+                    "value": 3.0,
+                    "labels": {"task_id": "task-2", "role": "backend", "model": "sonnet", "success": "False"},
+                },
+                {
+                    "metric_type": "task_completion_time",
+                    "timestamp": 2.0,
+                    "value": 4.0,
+                    "labels": {"task_id": "task-2", "role": "backend", "model": "sonnet", "success": "True"},
+                },
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workdir)
+    runner = CliRunner()
+
+    result = runner.invoke(skills_group, ["bisect", "task-2", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["outcome"] == "passed"
+
+
 def test_skills_bisect_fails_for_task_without_activations(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/skills/test_injector_activation_log.py
+++ b/tests/unit/skills/test_injector_activation_log.py
@@ -151,3 +151,31 @@ def test_inject_skills_auto_route_adds_matching_skill_when_enabled(
     auto_rows = [row for row in rows if row["skill"] == "pytest-helper"]
     assert len(auto_rows) == 1
     assert auto_rows[0]["trigger_source"] == "auto-route"
+
+
+def test_inject_skills_auto_route_ignores_malformed_frontmatter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed skill template does not abort deterministic routing."""
+    monkeypatch.setenv("BERNSTEIN_SKILLS_AUTO_ROUTE", "1")
+    templates_dir = _make_skill_templates(tmp_path)
+    skills_dir = templates_dir.parent / "skills"
+    (skills_dir / "bad-frontmatter.md").write_text(
+        "---\nname: [unterminated\n---\n\n# Bad frontmatter\npytest routing should continue.\n",
+        encoding="utf-8",
+    )
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[
+            Task(id="T-005", title="Fix pytest regression", description="The pytest suite is failing.", role="security")
+        ],
+        session_id="sec-mno",
+        templates_dir=templates_dir,
+    )
+
+    assert (workdir / ".claude" / "skills" / "pytest-helper.md").is_file()

--- a/tests/unit/skills/test_injector_activation_log.py
+++ b/tests/unit/skills/test_injector_activation_log.py
@@ -28,6 +28,15 @@ def _make_skill_templates(root: Path) -> Path:
         "version: 2.0.0\n---\n\n# Signal\nSignals at {{SESSION_ID}}\n",
         encoding="utf-8",
     )
+    (skills_dir / "pytest-helper.md").write_text(
+        "---\nname: pytest-helper\n"
+        "description: Use for pytest regressions, failing unit tests, and test isolation work.\n"
+        "trigger_keywords:\n"
+        "  - pytest\n"
+        "  - regression\n"
+        "version: 1.0.0\n---\n\n# Pytest helper\nUse this for pytest regression fixes.\n",
+        encoding="utf-8",
+    )
     return root / "templates" / "roles"
 
 
@@ -92,3 +101,53 @@ def test_inject_skills_respects_activation_log_env_opt_out(
     assert (workdir / ".claude" / "skills" / "bernstein-completion-protocol.md").is_file()
     # But the activation log is not created.
     assert not activation_log_path(workdir).exists()
+
+
+def test_inject_skills_auto_route_is_off_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TF-IDF auto-routing is opt-in; role binding remains the default."""
+    monkeypatch.delenv("BERNSTEIN_SKILLS_AUTO_ROUTE", raising=False)
+    templates_dir = _make_skill_templates(tmp_path)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[
+            Task(id="T-003", title="Fix pytest regression", description="The pytest suite is failing.", role="security")
+        ],
+        session_id="sec-ghi",
+        templates_dir=templates_dir,
+    )
+
+    assert not (workdir / ".claude" / "skills" / "pytest-helper.md").exists()
+
+
+def test_inject_skills_auto_route_adds_matching_skill_when_enabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in TF-IDF routing injects deterministic task-matched skills."""
+    monkeypatch.setenv("BERNSTEIN_SKILLS_AUTO_ROUTE", "1")
+    templates_dir = _make_skill_templates(tmp_path)
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="security",
+        tasks=[
+            Task(id="T-004", title="Fix pytest regression", description="The pytest suite is failing.", role="security")
+        ],
+        session_id="sec-jkl",
+        templates_dir=templates_dir,
+    )
+
+    assert (workdir / ".claude" / "skills" / "pytest-helper.md").is_file()
+    rows = [json.loads(line) for line in activation_log_path(workdir).read_text(encoding="utf-8").splitlines()]
+    auto_rows = [row for row in rows if row["skill"] == "pytest-helper"]
+    assert len(auto_rows) == 1
+    assert auto_rows[0]["trigger_source"] == "auto-route"


### PR DESCRIPTION
## Summary
- Add opt-in deterministic TF-IDF skill auto-routing behind BERNSTEIN_SKILLS_AUTO_ROUTE.
- Add a local `bernstein skills bisect <task-id>` plan generated from activation and task metric files.
- Preserve role-bound skill injection as the default path.

## Verification
- uv run pytest tests/unit/skills/test_injector_activation_log.py tests/unit/skills/test_cli_authoring.py -q
- uv run pytest tests/unit/skills -q
- uv run ruff check src/bernstein/core/skills/routing.py src/bernstein/core/skills/bisect.py src/bernstein/adapters/skills_injector.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_injector_activation_log.py tests/unit/skills/test_cli_authoring.py
- uv run ruff format --check src/bernstein/core/skills/routing.py src/bernstein/core/skills/bisect.py src/bernstein/adapters/skills_injector.py src/bernstein/cli/commands/skills_cmd.py tests/unit/skills/test_injector_activation_log.py tests/unit/skills/test_cli_authoring.py
- uv run pyright src/bernstein/core/skills/routing.py src/bernstein/core/skills/bisect.py src/bernstein/adapters/skills_injector.py src/bernstein/cli/commands/skills_cmd.py

Closes #1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI "skills bisect" command to produce local skill-activation bisect plans (JSON or human-readable)
  * Added opt-in deterministic skill auto-routing that selects templates based on task content

* **Refactor**
  * Enhanced activation records to store per-template trigger source (e.g., role-binding vs auto-route)
  * Improved skill injection to deduplicate and order injected skills, incorporating auto-route candidates when enabled

* **Tests**
  * Added tests covering bisect CLI and auto-routing behavior (including opt-in gating and malformed-template resilience)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->