### PR TITLE
Map workflow changes to workflow tests

### DIFF
--- a/src/bernstein/core/quality/test_impact.py
+++ b/src/bernstein/core/quality/test_impact.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 _ANALYZER_CACHE_VERSION = "2"
 _COMPAT_CACHE_VERSION = "2"
+_WORKFLOW_PATH_PREFIX = ".github/workflows/"
 
 
 type _JsonObject = dict[str, object]
@@ -252,6 +253,16 @@ def _collect_changed_test_files(
     return affected
 
 
+def _has_workflow_change(changed_files: list[str]) -> bool:
+    """Return True when a changed path is a GitHub Actions workflow."""
+    return any(Path(path).as_posix().startswith(_WORKFLOW_PATH_PREFIX) for path in changed_files)
+
+
+def _workflow_test_files(test_files: list[str]) -> set[str]:
+    """Return tests that validate workflow YAML or workflow tooling."""
+    return {test_file for test_file in test_files if "workflow" in Path(test_file).name}
+
+
 def _collect_tests_for_modules(
     all_affected: set[str],
     module_to_tests: dict[str, set[str]],
@@ -292,6 +303,8 @@ def compat_get_affected_tests(
 
     all_affected = _expand_transitive_modules(changed_modules, source_imports)
     affected_tests = _collect_changed_test_files(changed_files, root, test_deps)
+    if _has_workflow_change(changed_files):
+        affected_tests.update(_workflow_test_files(list(test_deps)))
     affected_tests.update(_collect_tests_for_modules(all_affected, module_to_tests))
 
     return sorted(root / rel for rel in affected_tests)
@@ -449,6 +462,16 @@ class TestImpactAnalyzer:
 
         affected: set[str] = set()
         mappings: list[TestMapping] = []
+        workflow_tests = sorted(_workflow_test_files(all_tests)) if _has_workflow_change(normalized) else []
+        if workflow_tests:
+            affected.update(workflow_tests)
+            mappings.append(
+                TestMapping(
+                    source_file=_WORKFLOW_PATH_PREFIX.rstrip("/"),
+                    test_files=workflow_tests,
+                    reason="workflow",
+                )
+            )
         changed_sources = [
             path for path in normalized if path.endswith(".py") and (self._root / path).is_relative_to(self._src_root)
         ]

--- a/tests/unit/test_test_impact.py
+++ b/tests/unit/test_test_impact.py
@@ -411,6 +411,30 @@ class TestGetAffectedTests:
 
         assert affected == []
 
+    def test_workflow_change_selects_workflow_yaml_tests(self, tmp_path: Path) -> None:
+        import test_impact as ti  # type: ignore[import]
+
+        src = tmp_path / "src"
+        self._make_dep_map(tmp_path, src=src)
+        test_dir = tmp_path / "tests" / "unit"
+        (test_dir / "test_ci_workflow_yaml.py").write_text("def test_ci() -> None:\n    assert True\n")
+        (test_dir / "test_autoheal_workflow_yaml.py").write_text("def test_autoheal() -> None:\n    assert True\n")
+
+        orig_src, orig_root = ti.SRC_ROOT, ti.ROOT
+        ti.SRC_ROOT = src
+        ti.ROOT = tmp_path
+        try:
+            dep_map = build_dep_map(test_dirs=[test_dir])
+            affected = get_affected_tests([".github/workflows/ci.yml"], dep_map)
+        finally:
+            ti.SRC_ROOT = orig_src
+            ti.ROOT = orig_root
+
+        assert [path.relative_to(tmp_path).as_posix() for path in affected] == [
+            "tests/unit/test_autoheal_workflow_yaml.py",
+            "tests/unit/test_ci_workflow_yaml.py",
+        ]
+
     def test_conftest_change_runs_all(self, tmp_path: Path) -> None:
         import test_impact as ti  # type: ignore[import]
 

--- a/tests/unit/test_test_impact_core.py
+++ b/tests/unit/test_test_impact_core.py
@@ -101,6 +101,27 @@ def test_direct_test_file_change_is_always_selected(tmp_path: Path) -> None:
     assert analysis.affected_tests == ["tests/unit/test_core.py"]
 
 
+def test_workflow_change_selects_workflow_yaml_tests(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "demo" / "__init__.py", "")
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "name: CI\n")
+    _write(tmp_path / "tests" / "unit" / "test_ci_workflow_yaml.py", "def test_ci() -> None:\n    assert True\n")
+    _write(
+        tmp_path / "tests" / "unit" / "test_autoheal_workflow_yaml.py",
+        "def test_autoheal() -> None:\n    assert True\n",
+    )
+    _write(tmp_path / "tests" / "unit" / "test_models.py", "def test_model() -> None:\n    assert True\n")
+
+    analyzer = ImpactAnalyzer(tmp_path, test_dirs=[tmp_path / "tests" / "unit"])
+    analysis = analyzer.analyze([".github/workflows/ci.yml"])
+
+    assert analysis.fallback_used is False
+    assert analysis.coverage_pct == pytest.approx(100.0)
+    assert analysis.affected_tests == [
+        "tests/unit/test_autoheal_workflow_yaml.py",
+        "tests/unit/test_ci_workflow_yaml.py",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # get_dependent_source_files
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Map GitHub Actions workflow changes to the existing workflow test files in test-impact analysis.
- Keep the existing fail-closed behavior when no workflow tests are present.

## Tests
- uv run pytest tests/unit/test_test_impact_core.py::test_workflow_change_selects_workflow_yaml_tests tests/unit/test_test_impact.py::TestGetAffectedTests::test_workflow_change_selects_workflow_yaml_tests -q
- uv run pytest tests/unit/test_test_impact_core.py tests/unit/test_test_impact.py tests/unit/scripts/test_run_tests_sharding.py -q
- uv run ruff check src/bernstein/core/quality/test_impact.py tests/unit/test_test_impact_core.py tests/unit/test_test_impact.py
- uv run pyright src/bernstein/core/quality/test_impact.py
- uv run python scripts/test_impact.py --files .github/workflows/ci.yml --print-paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Actions workflow change detection to test impact analysis, automatically selecting only workflow-related tests when workflow files are modified.

* **Tests**
  * Added comprehensive unit tests verifying workflow change detection and correct test selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->