### PR TITLE
Fix uv bootstrap pin test invariant

### DIFF
--- a/tests/unit/test_workflow_uv_installers_yaml.py
+++ b/tests/unit/test_workflow_uv_installers_yaml.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 BOOTSTRAP_ACTION = REPO_ROOT / ".github" / "actions" / "bootstrap" / "action.yml"
-PINNED_UV_VERSION = "0.11.3"
+PINNED_UV_VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
 
 OWNED_WORKFLOWS = (
     "sonar-scan.yml",
@@ -107,4 +107,10 @@ def test_local_bootstrap_action_pins_setup_uv_version() -> None:
         with_block = step.get("with")
         assert isinstance(with_block, dict)
         with_values = cast(dict[str, object], with_block)
-        assert with_values.get("version") == PINNED_UV_VERSION
+        uv_version = with_values.get("version")
+        assert isinstance(uv_version, str)
+        assert PINNED_UV_VERSION_RE.fullmatch(uv_version), f"uv must use an explicit semver pin: {uv_version}"
+        assert uv_version != "latest"
+
+    pinned_versions = {cast(str, cast(dict[str, object], step["with"])["version"]) for step in setup_uv_steps}
+    assert len(pinned_versions) == 1, "bootstrap setup-uv steps must install the same uv version"


### PR DESCRIPTION
## Summary
- Check that the bootstrap uv version is an explicit semver pin.
- Keep the structural test independent from routine uv patch bumps.

## Verification
- uv run pytest tests/unit/test_workflow_uv_installers_yaml.py -q
- uv run ruff check tests/unit/test_workflow_uv_installers_yaml.py
- uv run pyright tests/unit/test_workflow_uv_installers_yaml.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated UV version validation in bootstrap workflow tests to enforce semantic versioning requirements and ensure consistency across setup steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->