### PR TITLE
Fix nightly deep test failures

### DIFF
--- a/.github/workflows/nightly-deep-tests.yml
+++ b/.github/workflows/nightly-deep-tests.yml
@@ -167,8 +167,14 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/bootstrap
-      - name: Run pip-audit including dev deps
-        run: uv run pip-audit --strict
+      - name: Export production requirements (no project, hashed)
+        run: uv export --no-dev --no-emit-project --format requirements-txt -o /tmp/req-prod.txt
+      - name: Export dev requirements (no project, hashed)
+        run: uv export --no-emit-project --format requirements-txt -o /tmp/req-dev.txt
+      - name: Production deps (strict)
+        run: uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
+      - name: Dev deps (strict)
+        run: uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
 
   stress-leak-suite:
     # TC-C: resource-leak + memory-growth + lock-contention probes.

--- a/.github/workflows/nightly-deep-tests.yml
+++ b/.github/workflows/nightly-deep-tests.yml
@@ -172,8 +172,21 @@ jobs:
       - name: Export dev requirements (no project, hashed)
         run: uv export --no-emit-project --format requirements-txt -o /tmp/req-dev.txt
       - name: Production deps (strict)
+        # `--no-deps` is safe: the exported file is fully pinned and the
+        # transitive closure is resolved by `uv.lock`. `--disable-pip`
+        # avoids spinning up a sub-venv just to run `pip install`.
+        #
+        # `--ignore-vuln PYSEC-2025-183` (CVE-2025-45768): disputed advisory
+        # against pyjwt that affects all released versions (introduced at 0,
+        # no fix version published) and is pulled in transitively via `mcp`.
+        # The maintainer disputes it because the key length is chosen by the
+        # calling application, not the library. There is nothing to upgrade
+        # to, so it is ignored with the rationale recorded here.
         run: uv run pip-audit -r /tmp/req-prod.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
       - name: Dev deps (strict)
+        # Keep the dev-dependency audit on the same exported lockfile input as
+        # production so the local editable project package is not treated as a
+        # PyPI dependency.
         run: uv run pip-audit -r /tmp/req-dev.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
 
   stress-leak-suite:

--- a/src/bernstein/core/knowledge/diary.py
+++ b/src/bernstein/core/knowledge/diary.py
@@ -298,8 +298,10 @@ def _safe_filename(task_id: str) -> str:
     cannot escape the diary directory via path traversal.
     """
     cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", task_id.strip())
-    if not cleaned or cleaned in {".", ".."}:
+    if not cleaned:
         raise DiaryError(f"invalid task_id for filename: {task_id!r}")
+    if cleaned in {".", ".."}:
+        cleaned = cleaned.replace(".", "_")
     return f"{cleaned}.json"
 
 

--- a/tests/property/test_diary_properties.py
+++ b/tests/property/test_diary_properties.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 import hypothesis.strategies as st
 import pytest
@@ -133,6 +134,12 @@ def test_write_diary_does_not_escape_tree(
     sdd_dir = tmp_path_factory.mktemp("sdd")
     path = write_diary_from_transcript(task_id, transcript, sdd_dir)
     assert sdd_dir in path.parents
+
+
+def test_write_diary_sanitizes_dot_task_id(tmp_path: Path) -> None:
+    path = write_diary_from_transcript(".", "worked\n", tmp_path)
+    assert tmp_path in path.parents
+    assert path.name == "_.json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/property/test_diary_properties.py
+++ b/tests/property/test_diary_properties.py
@@ -141,6 +141,10 @@ def test_write_diary_sanitizes_dot_task_id(tmp_path: Path) -> None:
     assert tmp_path in path.parents
     assert path.name == "_.json"
 
+    parent_path = write_diary_from_transcript("..", "worked\n", tmp_path)
+    assert tmp_path in parent_path.parents
+    assert parent_path.name == "__.json"
+
 
 # ---------------------------------------------------------------------------
 # Jaccard + clustering


### PR DESCRIPTION
## Summary
- Sanitize dot-only diary task ids to a safe filename instead of raising.
- Add a deterministic regression for the deep Hypothesis counterexample.
- Audit exported dependency requirements in nightly pip-audit so the local project package is not audited as a PyPI dependency.

## Tests
- HYPOTHESIS_PROFILE=deep uv run pytest tests/property/test_diary_properties.py -q --no-cov
- uv export --no-dev --no-emit-project --format requirements-txt -o /tmp/bernstein-req-prod.txt
- uv export --no-emit-project --format requirements-txt -o /tmp/bernstein-req-dev.txt
- uv run pip-audit -r /tmp/bernstein-req-prod.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
- uv run pip-audit -r /tmp/bernstein-req-dev.txt --strict --disable-pip --no-deps --ignore-vuln PYSEC-2025-183
- uv run ruff check src/ tests/property/test_diary_properties.py
- uv run pyright src/bernstein/core/knowledge/diary.py tests/property/test_diary_properties.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diary file generation now sanitizes task IDs containing dots by replacing them with underscores instead of rejecting them, improving handling of edge-case identifiers.
* **Tests**
  * Added a unit test to verify dot-containing task IDs are correctly sanitized when writing diary files.
* **Chores**
  * CI vulnerability scans updated to run separate production and dev audits and to ignore a specific advisory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->