### PR TITLE
Allow CI test file timeout override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1316,6 +1316,9 @@ jobs:
       # denominator below and the per-shard slice both key off this; bump
       # it (and the `shard:` list) together to rescale the fan-out.
       TEST_SHARD_COUNT: "4"
+      # Main push coverage runs are slower than local file runs; keep the
+      # per-file guard, but allow heavy adapter contract files to finish.
+      BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS: "600"
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -33,7 +33,22 @@ _TEST_REQUIRED_PREFIXES = (
     "tests/",
 )
 
-TEST_FILE_TIMEOUT_SECONDS = 300
+DEFAULT_TEST_FILE_TIMEOUT_SECONDS = 300
+TEST_FILE_TIMEOUT_ENV = "BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS"
+
+
+def test_file_timeout_seconds() -> int:
+    """Return the per-file subprocess timeout in seconds."""
+    raw = os.environ.get(TEST_FILE_TIMEOUT_ENV)
+    if raw is None or raw == "":
+        return DEFAULT_TEST_FILE_TIMEOUT_SECONDS
+    try:
+        timeout = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{TEST_FILE_TIMEOUT_ENV} must be an integer number of seconds") from exc
+    if timeout < 1:
+        raise ValueError(f"{TEST_FILE_TIMEOUT_ENV} must be at least 1 second")
+    return timeout
 
 
 def _default_workers() -> int:
@@ -132,7 +147,7 @@ def run_file(path: Path, extra_args: list[str], coverage: bool = False) -> tuple
             *extra_args,
         ]
     start = time.monotonic()
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=TEST_FILE_TIMEOUT_SECONDS)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=test_file_timeout_seconds())
     duration = time.monotonic() - start
     output = result.stdout + result.stderr
     return path, result.returncode, duration, output
@@ -195,8 +210,8 @@ def run_sequential(files: list[Path], extra_args: list[str], fail_fast: bool, co
         label = f"[{i}/{len(files)}] {path.name}"
         try:
             _fpath, code, duration, output = run_file(path, extra_args, coverage=coverage)
-        except subprocess.TimeoutExpired:
-            print(f"  TIMEOUT {label} (>{TEST_FILE_TIMEOUT_SECONDS}s)")
+        except subprocess.TimeoutExpired as exc:
+            print(f"  TIMEOUT {label} (>{exc.timeout:g}s)")
             failed += 1
             if fail_fast:
                 break

--- a/tests/unit/scripts/test_run_tests_sharding.py
+++ b/tests/unit/scripts/test_run_tests_sharding.py
@@ -256,6 +256,31 @@ def test_sequential_timeout_message_matches_subprocess_timeout(
     assert "TIMEOUT [1/1] test_slow.py (>300s)" in capsys.readouterr().out
 
 
+def test_run_file_uses_timeout_env_override(
+    run_tests_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timeouts: list[int] = []
+
+    def fake_run(
+        cmd: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, int)
+        timeouts.append(timeout)
+        return subprocess.CompletedProcess(cmd, 0, "ok\n", "")
+
+    monkeypatch.setenv("BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS", "600")
+    monkeypatch.setattr(run_tests_module.subprocess, "run", fake_run)
+
+    _path, code, _duration, output = run_tests_module.run_file(Path("tests/unit/test_slow.py"), [])
+
+    assert code == 0
+    assert output == "ok\n"
+    assert timeouts == [600]
+
+
 def test_discover_changed_files_falls_back_to_two_dot_diff_without_merge_base(
     run_tests_module: ModuleType,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- add a validated per-file timeout override for scripts/run_tests.py
- set the CI test job timeout override to 600 seconds for heavy coverage-backed files
- cover the override in the runner unit tests

## Testing
- uv run pytest tests/unit/scripts/test_run_tests_sharding.py -q
- uv run pytest tests/unit/test_cross_platform_ci.py tests/unit/test_ci_coverage_workflow_yaml.py -q
- uv run ruff check scripts/run_tests.py tests/unit/scripts/test_run_tests_sharding.py
- uv run ruff format --check scripts/run_tests.py tests/unit/scripts/test_run_tests_sharding.py
- uv run pyright scripts/run_tests.py tests/unit/scripts/test_run_tests_sharding.py
- BERNSTEIN_TEST_FILE_TIMEOUT_SECONDS=600 uv run python scripts/run_tests.py -k adapter_consistency --coverage --parallel 1
- actionlint .github/workflows/ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a unit test to verify that per-file test execution respects a timeout configured via environment variables.
  * Confirms the timeout value is correctly propagated to the underlying process runner and that results are returned as expected.
  * Improves confidence in timeout handling, reducing the risk of stalled test runs and enhancing reliability of the test execution workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->