### PR TITLE
Fix observability docs CI trigger

### DIFF
--- a/.github/workflows/ci-gate-stub.yml
+++ b/.github/workflows/ci-gate-stub.yml
@@ -41,6 +41,7 @@ on:
       # Documentation & prose
       - "docs/**"
       - "!docs/operations/ci-topology.md"
+      - "!docs/observability/**"
       - "*.md"
       - "!README.md"
       - "LICENSE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       # Documentation & prose
       - "docs/**"
       - "!docs/operations/ci-topology.md"
+      - "!docs/observability/**"
       - "*.md"
       - "!README.md"
       - "LICENSE"
@@ -66,6 +67,7 @@ on:
       # Documentation & prose
       - "docs/**"
       - "!docs/operations/ci-topology.md"
+      - "!docs/observability/**"
       - "*.md"
       - "!README.md"
       - "LICENSE"

--- a/tests/unit/test_cross_platform_ci.py
+++ b/tests/unit/test_cross_platform_ci.py
@@ -85,7 +85,7 @@ def _ci_test_steps(data: dict[object, Any]) -> list[dict[str, Any]]:
 
 def _ci_trigger(data: dict[object, Any], event: str) -> dict[str, Any]:
     """Return the CI workflow trigger block for ``event``."""
-    on_section_raw = data["on"] if "on" in data else data.get(True, {})
+    on_section_raw = data.get(True, data.get("on", {}))
     on_section = cast("dict[str, Any]", on_section_raw if isinstance(on_section_raw, dict) else {})
     return cast("dict[str, Any]", on_section.get(event, {}))
 
@@ -122,14 +122,21 @@ class TestCIWorkflowExists:
         branches = cast("list[str]", push.get("branches", []))
         assert "main" in branches, "CI push trigger must include 'main' branch"
 
-    def test_observability_docs_prs_are_not_ci_ignored(self) -> None:
+    def test_observability_docs_prs_trigger_ci(self) -> None:
         data = _load_ci_workflow()
         for event in ("push", "pull_request"):
             trigger = _ci_trigger(data, event)
             paths_ignore = cast("list[str]", trigger.get("paths-ignore", []))
+            assert "docs/**" in paths_ignore, f"missing docs/** pattern in {event} paths-ignore: {paths_ignore}"
+            assert "!docs/observability/**" in paths_ignore, (
+                f"missing !docs/observability/** pattern in {event} paths-ignore: {paths_ignore}"
+            )
             docs_pattern = paths_ignore.index("docs/**")
-            assert "!docs/observability/**" in paths_ignore
-            assert paths_ignore.index("!docs/observability/**") > docs_pattern
+            observability_pattern = paths_ignore.index("!docs/observability/**")
+            assert observability_pattern > docs_pattern, (
+                f"!docs/observability/** must follow docs/** in {event} paths-ignore: "
+                f"docs_pattern={docs_pattern}, observability_pattern={observability_pattern}"
+            )
 
     def test_pull_request_test_job_fetches_base_ref_for_impacted_tests(self) -> None:
         data = _load_ci_workflow()

--- a/tests/unit/test_cross_platform_ci.py
+++ b/tests/unit/test_cross_platform_ci.py
@@ -83,6 +83,13 @@ def _ci_test_steps(data: dict[object, Any]) -> list[dict[str, Any]]:
     return typed_steps
 
 
+def _ci_trigger(data: dict[object, Any], event: str) -> dict[str, Any]:
+    """Return the CI workflow trigger block for ``event``."""
+    on_section_raw = data["on"] if "on" in data else data.get(True, {})
+    on_section = cast("dict[str, Any]", on_section_raw if isinstance(on_section_raw, dict) else {})
+    return cast("dict[str, Any]", on_section.get(event, {}))
+
+
 class TestCIWorkflowExists:
     """Validate the existing CI workflow file."""
 
@@ -111,12 +118,18 @@ class TestCIWorkflowExists:
 
     def test_ci_uses_main_branch(self) -> None:
         data = _load_ci_workflow()
-        # PyYAML parses bare `on:` as boolean True, so check both keys
-        on_section_raw = data["on"] if "on" in data else data.get(True, {})
-        on_section = cast("dict[str, Any]", on_section_raw if isinstance(on_section_raw, dict) else {})
-        push = cast("dict[str, Any]", on_section.get("push", {}))
+        push = _ci_trigger(data, "push")
         branches = cast("list[str]", push.get("branches", []))
         assert "main" in branches, "CI push trigger must include 'main' branch"
+
+    def test_observability_docs_prs_are_not_ci_ignored(self) -> None:
+        data = _load_ci_workflow()
+        for event in ("push", "pull_request"):
+            trigger = _ci_trigger(data, event)
+            paths_ignore = cast("list[str]", trigger.get("paths-ignore", []))
+            docs_pattern = paths_ignore.index("docs/**")
+            assert "!docs/observability/**" in paths_ignore
+            assert paths_ignore.index("!docs/observability/**") > docs_pattern
 
     def test_pull_request_test_job_fetches_base_ref_for_impacted_tests(self) -> None:
         data = _load_ci_workflow()


### PR DESCRIPTION
## Summary
- Allow docs/observability changes to enqueue CI on pull_request and push events.
- Add a regression test that keeps the ordered paths-ignore exception in place.

## Verification
- uv run pytest tests/unit/test_cross_platform_ci.py -q
- uv run ruff check tests/unit/test_cross_platform_ci.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated so changes under docs/observability/** do not trigger builds on push or pull requests, including the gate stub workflow.

* **Tests**
  * Added a unit test (and small helper) that verifies CI trigger path-ignore behavior and ordering to ensure observability documentation changes are ignored as intended.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->