### PR TITLE
Bump version to 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.6.1"
+version = "2.7.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -279,7 +279,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.6.1"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary
- Bump the package version from 2.6.1 to 2.7.0.
- Refresh the uv lockfile editable package entry.

## Verification
- uv lock --check
- uv run pytest tests/unit/test_auto_release_workflow_yaml.py tests/unit/test_reconcile_release_workflow_yaml.py tests/unit/test_release_attestation_workflow.py -q
- uv build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 2.7.0.
  * Metadata-only update with no functional or behavioral changes detected.
  * Low-risk release: intended for distribution/version tracking rather than feature or bug fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->