### PR TITLE
Fix publish protocol gate dependency install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,12 +36,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Install test dependencies
-          uv pip install mcp a2a
-
-          # Run protocol tests
+          # Run protocol tests with protocol packages injected by uv.
+          # Bare uv package installation fails on tag runners before
+          # the first `uv run` creates the project environment.
           set +e
-          uv run pytest tests/protocol/ -v 2>&1 | tee test-output.log
+          uv run --with mcp --with a2a pytest tests/protocol/ -v 2>&1 | tee test-output.log
           pytest_exit_code=${PIPESTATUS[0]}
           set -e
 

--- a/tests/unit/test_release_attestation_workflow.py
+++ b/tests/unit/test_release_attestation_workflow.py
@@ -178,9 +178,7 @@ def test_protocol_gate_does_not_ignore_install_or_pytest_failures() -> None:
     """The protocol gate must fail when dependency install or pytest exits non-zero."""
     data = _load_yaml(PUBLISH_WF)
     run = _step_run(data, "protocol-gate", "Run protocol compatibility check")
-    unsafe_lines = [
-        line.strip() for line in run.splitlines() if line.strip().startswith(("uv pip install", "uv run "))
-    ]
+    unsafe_lines = [line.strip() for line in run.splitlines() if line.strip().startswith(("uv pip install", "uv run "))]
     assert unsafe_lines
     assert all("|| true" not in line for line in unsafe_lines), unsafe_lines
 

--- a/tests/unit/test_release_attestation_workflow.py
+++ b/tests/unit/test_release_attestation_workflow.py
@@ -179,10 +179,18 @@ def test_protocol_gate_does_not_ignore_install_or_pytest_failures() -> None:
     data = _load_yaml(PUBLISH_WF)
     run = _step_run(data, "protocol-gate", "Run protocol compatibility check")
     unsafe_lines = [
-        line.strip() for line in run.splitlines() if line.strip().startswith(("uv pip install", "uv run pytest"))
+        line.strip() for line in run.splitlines() if line.strip().startswith(("uv pip install", "uv run "))
     ]
     assert unsafe_lines
     assert all("|| true" not in line for line in unsafe_lines), unsafe_lines
+
+
+def test_protocol_gate_installs_extra_dependencies_without_bare_uv_pip() -> None:
+    """The protocol gate must not call ``uv pip install`` without creating a venv first."""
+    data = _load_yaml(PUBLISH_WF)
+    run = _step_run(data, "protocol-gate", "Run protocol compatibility check")
+    assert "uv pip install" not in run
+    assert "uv run --with mcp --with a2a pytest tests/protocol/ -v" in run
 
 
 def test_protocol_gate_status_uses_pytest_exit_code() -> None:


### PR DESCRIPTION
## Summary
- run publish protocol tests with uv-managed extra dependencies
- add a regression test for the tag publish protocol gate

## Verification
- uv run pytest tests/unit/test_release_attestation_workflow.py -q
- uv run ruff check tests/unit/test_release_attestation_workflow.py
- git diff --check

## Context
The v2.7.0 tag publish run failed in `Protocol Compatibility Gate` because `uv pip install mcp a2a` ran before a virtual environment existed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow for protocol compatibility checks.
  * Enhanced test coverage for release automation process.

*Note: These are internal infrastructure changes with no end-user impact.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->