### PR TITLE
Make npm wrapper publish advisory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -282,8 +282,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN is required for npm publish"
-            exit 1
+            echo "::warning::NPM_TOKEN is not configured; skipping npm wrapper publish"
+            exit 0
           fi
           cd packaging/npm
-          npm publish --access public
+          if ! npm publish --access public; then
+            echo "::warning::npm wrapper publish failed; continuing release"
+          fi

--- a/tests/unit/test_release_attestation_workflow.py
+++ b/tests/unit/test_release_attestation_workflow.py
@@ -235,16 +235,16 @@ def test_auto_release_does_not_create_github_releases() -> None:
     assert "gh release upload" not in text
 
 
-def test_npm_publish_failures_block_tag_publish() -> None:
-    """The tag publish workflow must not silently ignore npm publish failures."""
+def test_npm_publish_failures_do_not_block_python_release() -> None:
+    """The npm wrapper is advisory and must not block Python release publication."""
     data = _load_yaml(PUBLISH_WF)
     job = _job(data, "publish-npm")
     assert job.get("name") == "Publish npm wrapper"
 
     publish_step = _step(data, "publish-npm", "Publish to npm")
-    assert publish_step.get("continue-on-error") is not True
     run = publish_step.get("run")
     assert isinstance(run, str)
-    assert "NPM_TOKEN is required for npm publish" in run
+    assert "::error::" not in run
+    assert "::warning::NPM_TOKEN is not configured; skipping npm wrapper publish" in run
+    assert "::warning::npm wrapper publish failed; continuing release" in run
     assert "npm publish --access public" in run
-    assert "continuing release" not in run


### PR DESCRIPTION
## Summary
- keep PyPI and GitHub Release publication strict
- let the npm wrapper publish warn and continue when registry credentials cannot publish the package
- update the release workflow regression test for the advisory npm wrapper path

## Verification
- uv run pytest tests/unit/test_release_attestation_workflow.py -q
- uv run ruff check tests/unit/test_release_attestation_workflow.py
- git diff --check

## Context
The `v2.7.0` publish run completed PyPI and GitHub Release jobs, but `Publish npm wrapper` failed with npm 404 for `bernstein-orchestrator@2.7.0` despite `NPM_TOKEN` being present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow robustness: missing npm credentials now triggers a warning instead of blocking the release process.
  * npm publish failures no longer prevent Python package releases from completing successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/2042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->