### PR TITLE
chore(release): 2.7.1

### DIFF
--- a/docs/release-notes/v2.7.1.md
+++ b/docs/release-notes/v2.7.1.md
@@ -1,0 +1,27 @@
+# v2.7.1
+
+Released 2026-06-25.
+
+A maintenance release. The headline is that the Codex adapter now works with a ChatGPT OAuth login instead of an API key, and the rest of the release cleans up the dependency and CI-workflow security surface.
+
+## Fixes
+
+- Codex with a ChatGPT subscription is usable again. Three things were in the way and all three are fixed:
+  - A run pinned to `--cli codex` no longer hands a Claude tier name to `codex exec -m` (Codex rejects `opus`/`sonnet`). For a non-Claude adapter the scheduler now substitutes that adapter's own default model when you have not pinned one, so the model recorded in the audit chain is the model that actually ran, not a name Codex would refuse.
+  - The adapter detects a Codex OAuth session in `~/.codex/auth.json` (written by `codex login`) and only warns about a missing `OPENAI_API_KEY` when there is neither an API key nor an OAuth session. No more false "spawn will fail" warning on every step.
+  - `bernstein demo --real` no longer crashes on its closing summary. It reads the task list from the real `/status` response shape instead of assuming a flat list. (#2086)
+
+## Security and dependencies
+
+- Closed out the open code-scanning and Dependabot findings. The test and macOS test jobs dropped stale `checks: write` and `pull-requests: write` grants that were left behind when their reporter actions were removed, so those jobs now run with `contents: read` only. The job-level writes that remain (release tagging, the auto-commit-back jobs, workflow-run cleanup) are the minimum each job needs and are documented as such. (#2087)
+- Bumped every dependency the scanners flagged to its fixed version: cryptography, starlette, aiohttp, pypdf, pydantic-settings, pyjwt, and python-multipart on the Python side, and js-yaml and `@babel/core` in the VS Code extension toolchain. (#2059, #2066, #2072, #2073, #2077, #2083, #2087)
+- Routine base-image and toolchain refreshes: the Python base image digest, the OpenTelemetry collector, Prometheus, PostgreSQL, ovsx, react-router, lucide, uv, and the codecov and setup-python actions.
+
+## Docs and community
+
+- The Web UI docs now include screenshots of all seven screens. (#2061)
+- Added the first community-submitted component benchmark, from an Intel i3 on Linux. (#2065)
+
+## Quality
+
+- Resolved the open refurb idiom findings across 15 modules. These are behavior-preserving cleanups (constructor copies to `.copy()`, chained comparisons, `operator.itemgetter`, a list comprehension, and a few fluent-interface chains) that keep the code-scanning surface clean.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.7.0"
+version = "2.7.1"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.7.0"
+version = "2.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Cuts the 2.7.1 maintenance and bugfix release.

- Bumps the version in `pyproject.toml` (and the `uv.lock` self-entry) from 2.7.0 to 2.7.1, which is what the auto-release gate keys on.
- Adds human release notes at `docs/release-notes/v2.7.1.md`.

### What is in 2.7.1
- **Fix**: Codex adapter usable with a ChatGPT OAuth login (model selection, OAuth detection, and the `demo --real` summary crash). (#2086)
- **Security**: cleared the open code-scanning and Dependabot findings, trimmed CI token permissions to least privilege, and bumped the flagged dependencies to their fixed versions. (#2087, #2083, and the security dependency PRs)
- **Docs**: Web UI screenshots (#2061) and the first community benchmark (#2065).

On merge, a green main run triggers auto-release to tag `v2.7.1` and hand off to publish.

## Summary by Sourcery

Prepare the 2.7.1 maintenance release with version bump, security hardening, dependency updates, and accompanying release notes.

New Features:
- Document the first community-submitted component benchmark and expand Web UI docs with full-screen screenshots.

Bug Fixes:
- Restore Codex adapter usability with ChatGPT OAuth logins, including correct model selection, OAuth-session detection, and preventing demo summary crashes.

Enhancements:
- Clean up code quality by resolving refurb idiom findings across multiple modules to keep static analysis surfaces clean.

Build:
- Refresh base images and toolchain components, including Python image, observability stack, database, package managers, and CI actions.

CI:
- Tighten CI job permissions to least privilege and document remaining write scopes while clearing code-scanning and Dependabot findings.

Documentation:
- Add detailed release notes for v2.7.1 describing fixes, security changes, and documentation updates.
- Update Web UI documentation with screenshots for all interface screens and include the first community benchmark entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored access for users with a ChatGPT subscription.
  * Fixed scheduler/model selection issues for incompatible model tier names.
  * Improved account session detection to avoid incorrect API key warnings.
  * Resolved a crash in the demo flow when loading live status data.

* **Security**
  * Tightened access permissions for certain background jobs.

* **Documentation**
  * Updated web UI docs with screenshots.
  * Added a new community benchmark example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->