### PR TITLE
chore(release): 2.8.0

### DIFF
--- a/docs/release-notes/v2.8.0.md
+++ b/docs/release-notes/v2.8.0.md
@@ -1,0 +1,33 @@
+# v2.8.0
+
+Released 2026-06-25.
+
+A reliability and maintenance release. The Codex adapter works with a ChatGPT OAuth login again, the worktree garbage collector no longer loses unmerged work or wedges itself after a crash, and the open code-scanning and Dependabot security surface is cleared.
+
+## Features
+
+- `bernstein worktrees unlock` inspects and recovers a stuck GC lock. `worktrees gc` holds an exclusive lock for the duration of a sweep; a crashed or killed run could leave it behind. The new command reports who holds the lock (pid, liveness, age), clears it when the owner process is gone, and refuses a lock held by a live, recent process unless `--force` is passed. The unlock is recorded as a tamper-evident `worktree.gc_unlock` event in the HMAC-chained audit log, so an operator recovery is reconstructable rather than a silent file deletion. (#2094)
+
+## Fixes
+
+- Codex with a ChatGPT subscription is usable again. Three things were in the way and all three are fixed:
+  - A run pinned to `--cli codex` no longer hands a Claude tier name to `codex exec -m` (Codex rejects `opus`/`sonnet`). For a non-Claude adapter the scheduler now substitutes that adapter's own default model when none is pinned, so the model recorded in the audit chain is the model that actually ran.
+  - The adapter detects a Codex OAuth session in `~/.codex/auth.json` (written by `codex login`) and only warns about a missing `OPENAI_API_KEY` when there is neither an API key nor an OAuth session.
+  - `bernstein demo --real` no longer crashes on its closing summary; it reads the task list from the real `/status` response shape. (#2086)
+- Worktree GC no longer loses unmerged agent work on a repository whose default branch is not `main`. The graveyard pre-check compared against a hardcoded `main`, so when `main` did not exist the check failed and was read as "nothing to preserve", letting a stale worktree be deleted with its unmerged commits. The base branch is now resolved from the repo default, and an inconclusive check preserves the branch to the graveyard instead of dropping it. (#2093)
+- A worktree GC lock left behind by a crashed or killed run no longer wedges every later `bernstein worktrees gc`. The lock records its owner pid and start time, and a run reclaims a lock once when the owner is gone (or the lock is older than a generous bound), while still refusing a lock held by a live, recent process. (#2093)
+
+## Security and dependencies
+
+- Cleared the open code-scanning and Dependabot findings. The test jobs dropped stale `checks: write` and `pull-requests: write` grants left behind when their reporter actions were removed, so those jobs now run with `contents: read` only; the job-level writes that remain are the minimum each job needs. (#2087)
+- Bumped every dependency the scanners flagged to its fixed version: cryptography, starlette, aiohttp, pypdf, pydantic-settings, pyjwt, and python-multipart on the Python side, and js-yaml and `@babel/core` in the VS Code extension toolchain. (#2059, #2066, #2072, #2073, #2077, #2083, #2087)
+- Routine base-image and toolchain refreshes: the Python base image digest, the OpenTelemetry collector, Prometheus, PostgreSQL, ovsx, react-router, lucide, uv, and the codecov and setup-python actions.
+
+## Docs and community
+
+- The Web UI docs now include screenshots of all seven screens. (#2061)
+- Added the first community-submitted component benchmark, from an Intel i3 on Linux. (#2065)
+
+## Quality
+
+- Resolved the open refurb idiom findings across 15 modules. These are behavior-preserving cleanups that keep the code-scanning surface clean. (#2087)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.7.0"
+version = "2.8.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.7.0"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Cuts the 2.8.0 release.

- Bumps `pyproject.toml` (and the `uv.lock` self-entry) from 2.7.0 to 2.8.0, which the auto-release gate keys on.
- Adds human release notes at `docs/release-notes/v2.8.0.md`.

### Highlights
- **Feature**: `bernstein worktrees unlock` to inspect and recover a stuck GC lock, recorded as a tamper-evident audit event. (#2094)
- **Fixes**: Codex usable with a ChatGPT OAuth login (#2086); worktree GC no longer loses unmerged work on non-`main` repos or wedges after a crash (#2093).
- **Security**: cleared the open code-scanning and Dependabot findings and bumped the flagged dependencies (#2087, #2083).

Minor bump because of the new feature. On merge, a green main run triggers auto-release to tag `v2.8.0` and hand off to publish (PyPI, GHCR, GitHub Release).

## Summary by Sourcery

Cut the 2.8.0 release by bumping the package version and adding release notes for the new features, fixes, and security updates.

New Features:
- Document the new `bernstein worktrees unlock` command for inspecting and recovering stuck GC locks with audit logging.

Bug Fixes:
- Document fixes for Codex usage with ChatGPT OAuth login, worktree GC losing unmerged work on non-`main` default branches, and GC lock wedging after crashes.

Enhancements:
- Summarize maintenance improvements including cleared code-scanning findings, dependency upgrades, documentation additions, and quality cleanups in the 2.8.0 release notes.

Documentation:
- Add human-readable release notes for v2.8.0 covering features, fixes, security updates, documentation changes, and quality work.

Tests:
- Note CI permission tightening and dependency updates that help keep the test and scanning surface clean as part of the 2.8.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to inspect and recover stuck worktree lock situations, with audit logging.

* **Bug Fixes**
  * Improved reliability around ChatGPT sign-in/session handling and fixed a demo crash regression.
  * Reduced issues caused by stale worktree locks, including better handling for repositories whose default branch is not `main`.

* **Security**
  * Cleared several outstanding security findings and removed outdated permission grants.
  * Updated bundled dependencies and tooling.

* **Documentation**
  * Added release notes updates, UI screenshots, and a community benchmark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->