### PR TITLE
ci(publish): allow re-running a release publish via workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,26 @@ on:
   push:
     tags:
       - "v*"
+  # Manual re-publish path: dispatch on the default branch with the tag to
+  # publish. Used when an auto-release tag push did not start this workflow
+  # (a tag pushed with GITHUB_TOKEN does not always trigger downstream runs).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v2.8.1)"
+        required: true
+        type: string
 
 # Permissions are declared per-job so that each job gets only what it
 # needs (Sonar S8264). The default permission for any job that does not
 # declare ``permissions:`` is an empty set.
 permissions: {}
+
+# Resolved release tag: the dispatch input when run manually, else the tag
+# that triggered the push. Drives the version checks, the GitHub Release
+# name, the npm version, and the ref every job checks out.
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   # Protocol compatibility gate - blocks release if breaking changes found
@@ -25,6 +40,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - uses: ./.github/actions/bootstrap
         with:
@@ -32,7 +48,7 @@ jobs:
 
       - name: Run protocol compatibility check
         env:
-          RELEASE_REF: ${{ github.ref_name }}
+          RELEASE_REF: ${{ env.RELEASE_TAG }}
         run: |
           set -euo pipefail
 
@@ -111,6 +127,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - uses: ./.github/actions/bootstrap
         with:
@@ -133,10 +150,11 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - name: Compare tag to pyproject.toml version
         run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
+          TAG="${RELEASE_TAG#v}"
           PKG=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           echo "Tag version:    $TAG"
           echo "Package version: $PKG"
@@ -159,6 +177,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - uses: ./.github/actions/bootstrap
         with:
@@ -221,6 +240,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -232,7 +252,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${RELEASE_TAG}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" dist/* --clobber
           else
@@ -261,6 +281,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
       # zizmor cache-poisoning: explicit no-cache on tag-triggered npm publish
       # so a transitive lockfile bump can't be cached and re-served.
@@ -270,7 +291,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Sync version from tag
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION="${RELEASE_TAG#v}"
           cd packaging/npm
           npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Publish to npm

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -58,7 +58,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/publish-docker.yml | Publish Docker Image | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-docker-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-extension.yml | Publish VS Code Extension | push, release | {"cancel-in-progress": "false", "group": "publish-extension-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-homebrew.yml | Publish Homebrew Formula | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-homebrew-${{ github.ref }}"} | 1 |
-| .github/workflows/publish.yml | Publish | push | - | 7 |
+| .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 7 |
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/release-please.yml | Release Please | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-please-${{ github.ref }}"} | 1 |


### PR DESCRIPTION
Makes the publish workflow re-runnable so a tagged release whose publish did not auto-start can be completed.

### Why
`auto-release` pushes the version tag with `GITHUB_TOKEN`. A tag pushed by `GITHUB_TOKEN` does not reliably start `publish.yml` (the v2.8.1 tag is currently tagged but unpublished for exactly this reason), and `publish.yml` had no manual trigger.

### What
- Adds a `workflow_dispatch` trigger with a `tag` input.
- Introduces a top-level `RELEASE_TAG` = `inputs.tag || github.ref_name`, correct for both a manual dispatch and a tag push.
- Every job now checks out `RELEASE_TAG` and derives the version, GitHub Release name, and npm version from it instead of `GITHUB_REF`. Tag-push behaviour is byte-identical (the input is empty, so it falls back to the pushed tag).

After merge: `gh workflow run publish.yml --ref main -f tag=v2.8.1` publishes v2.8.1 to PyPI, npm, and creates the GitHub Release; GHCR follows via publish-docker on release publish.

## Summary by Sourcery

Make the publish workflow manually re-runnable for an existing release tag while preserving existing tag-push behavior.

CI:
- Add a workflow_dispatch trigger with a required tag input to the publish workflow so releases can be manually (re)published by tag.
- Standardize release tag handling via a RELEASE_TAG environment variable used across jobs for checkout and version/tag derivation instead of relying on GITHUB_REF.

Documentation:
- Update CI topology documentation to reflect the new workflow_dispatch trigger on the publish workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual publish/re-publish option so releases can be triggered with a selected tag.
  * Release steps now consistently use the chosen tag for versioning, publishing, and release creation.

* **Documentation**
  * Updated the CI workflow topology docs to reflect the new manual trigger option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->