### PR TITLE
chore(release): 2.8.3

### DIFF
--- a/.github/workflows/review-bot-sweep.yml
+++ b/.github/workflows/review-bot-sweep.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Sweep merged PRs and collect missed findings
         id: collect
         env:
-          GH_TOKEN: ${{ secrets.LANDING_REPO_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           SINCE_DAYS: ${{ github.event.inputs.since_days || '30' }}
@@ -67,7 +67,7 @@ jobs:
         if: steps.collect.outputs.has_findings == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.LANDING_REPO_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "fix(review): apply deferred review-bot findings"
           title: "fix(review): apply deferred review-bot findings"
           body-path: review-sweep-manifest.md

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -226,7 +226,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/release-please.yml | workflow: {"contents": "read"}<br>release-please: {"contents": "write", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN, RELEASE_PLEASE_PAT |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
 | .github/workflows/review-bot-ack.yml | review-bot-ack: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
-| .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
+| .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/sbom-upload.yml | workflow: {"contents": "read"} | DT_API_KEY |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
 | .github/workflows/scorecard-90d-check.yml | workflow: {"contents": "read"}<br>age-check: {"contents": "read"}<br>scorecard-rerun: {"actions": "read", "contents": "read", "id-token": "write", "issues": "write", "security-events": "write"} | - |

--- a/docs/release-notes/v2.8.3.md
+++ b/docs/release-notes/v2.8.3.md
@@ -1,0 +1,16 @@
+# v2.8.3
+
+Released 2026-06-28.
+
+A maintenance release: a batch of dependency and CI-action updates, plus a fix for the scheduled review-bot sweep workflow that was failing daily.
+
+## Fixes
+
+- The scheduled review-bot sweep no longer fails when it has findings to file. It pushed its follow-up branch with a repository-scoped PAT that lacked write access to this repository; it now uses the job's own `GITHUB_TOKEN`, which already carries `contents: write` and `pull-requests: write`. This clears the recurring red run on `main`.
+
+## Dependencies
+
+- Web UI toolchain: react, @tanstack/react-query, recharts, vite, tailwindcss, radix-ui, autoprefixer, @types/node.
+- VS Code extension toolchain: @vscode/vsce, @types/vscode.
+- Python: reportlab 5, the `agents` dependency.
+- CI and infrastructure: actions/checkout v7, attest-build-provenance, trufflehog, zizmor, setup-uv, uv, grafana, the redis Helm chart, and the oss-fuzz base image.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.8.2"
+version = "2.8.3"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.8.2"
+version = "2.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },
@@ -4095,8 +4095,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Cuts the 2.8.3 patch release and fixes the red `main` status.

### Fixes
- **review-bot sweep** (the daily red run on main): it pushed its follow-up branch with `LANDING_REPO_PAT` (a repo-scoped PAT lacking write access here), failing every day. Now uses the job's own `GITHUB_TOKEN`, which already has `contents: write` + `pull-requests: write`. (Alternative would be rescoping that PAT, but GITHUB_TOKEN is the right token for this same-repo workflow.)

### Contents
- Bumps `pyproject.toml` + `uv.lock` 2.8.2 -> 2.8.3; notes at `docs/release-notes/v2.8.3.md`.
- The dependency / CI-action batch merged since 2.8.2 (react, react-query, recharts, vite, tailwind, radix, reportlab 5, checkout v7, attest, trufflehog, zizmor, setup-uv, uv, grafana, redis helm, oss-fuzz, @types/*).

On merge, a green main run triggers auto-release to tag `v2.8.3`; publish is completed via the `workflow_dispatch` path added in 2.8.2.

## Summary by Sourcery

Cut the 2.8.3 maintenance release, updating project metadata, dependencies, and release notes while fixing the review-bot sweep workflow so it runs cleanly on main.

Bug Fixes:
- Fix the scheduled review-bot sweep workflow by using the job-scoped GITHUB_TOKEN so its follow-up branch and PR creation succeed in this repository.

Enhancements:
- Bump the project version to 2.8.3 and update uv.lock with the latest dependency set.
- Refresh CI topology documentation to reflect the updated token usage for the review-bot sweep workflow.

Documentation:
- Add release notes for v2.8.3 describing the review-bot sweep fix and the batched dependency and CI-action updates.

Chores:
- Roll forward to the 2.8.3 maintenance release, incorporating the accumulated dependency and CI-action updates since 2.8.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the scheduled review-bot sweep could fail by using the correct built-in authentication token for the workflow.
* **Documentation**
  * Updated CI topology docs to reflect the current workflow permissions and secrets.
  * Added release notes for v2.8.3.
* **Chores**
  * Bumped the project version to 2.8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->