### PR TITLE
chore(release): 2.8.4

### DIFF
--- a/.github/workflows/review-bot-sweep.yml
+++ b/.github/workflows/review-bot-sweep.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
       - name: Sweep merged PRs and collect missed findings
         id: collect
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.LANDING_REPO_PAT || secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           SINCE_DAYS: ${{ github.event.inputs.since_days || '30' }}
@@ -65,9 +65,13 @@ jobs:
 
       - name: Open consolidated follow-up PR
         if: steps.collect.outputs.has_findings == 'true'
+        # Best-effort: if the configured token cannot push the follow-up
+        # branch (e.g. LANDING_REPO_PAT lacks write access to this repo), log
+        # it but do not fail the scheduled sweep and red main.
+        continue-on-error: true
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LANDING_REPO_PAT || secrets.GITHUB_TOKEN }}
           commit-message: "fix(review): apply deferred review-bot findings"
           title: "fix(review): apply deferred review-bot findings"
           body-path: review-sweep-manifest.md

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -226,7 +226,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/release-please.yml | workflow: {"contents": "read"}<br>release-please: {"contents": "write", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN, RELEASE_PLEASE_PAT |
 | .github/workflows/required-check-canary.yml | verify: {"contents": "read"} | - |
 | .github/workflows/review-bot-ack.yml | review-bot-ack: {"contents": "read", "issues": "write", "pull-requests": "write"} | - |
-| .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN |
+| .github/workflows/review-bot-sweep.yml | sweep: {"contents": "write", "pull-requests": "write"} | GITHUB_TOKEN, LANDING_REPO_PAT |
 | .github/workflows/sbom-upload.yml | workflow: {"contents": "read"} | DT_API_KEY |
 | .github/workflows/sbom.yml | workflow: {"contents": "read"}<br>sbom: {"contents": "write"} | - |
 | .github/workflows/scorecard-90d-check.yml | workflow: {"contents": "read"}<br>age-check: {"contents": "read"}<br>scorecard-rerun: {"actions": "read", "contents": "read", "id-token": "write", "issues": "write", "security-events": "write"} | - |

--- a/docs/release-notes/v2.8.4.md
+++ b/docs/release-notes/v2.8.4.md
@@ -1,4 +1,4 @@
-# v2.8.3
+# v2.8.4
 
 Released 2026-06-28.
 
@@ -6,7 +6,7 @@ A maintenance release: a batch of dependency and CI-action updates, plus a fix f
 
 ## Fixes
 
-- The scheduled review-bot sweep no longer fails when it has findings to file. It pushed its follow-up branch with a repository-scoped PAT that lacked write access to this repository; it now uses the job's own `GITHUB_TOKEN`, which already carries `contents: write` and `pull-requests: write`. This clears the recurring red run on `main`.
+- The scheduled review-bot sweep no longer reds main when it cannot push its follow-up branch. The follow-up-PR step is now best-effort (continue-on-error), so a token without write access to this repository logs and skips instead of failing the whole scheduled job.
 
 ## Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.8.3"
+version = "2.8.4"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.8.3"
+version = "2.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Recovers from the failed 2.8.3 CI and re-cuts the patch.

### What happened
2.8.3 was bumped on main but its CI failed: an attempt to switch the review-bot sweep token to `GITHUB_TOKEN` broke `test_sweep_uses_landing_repo_pat_with_fallback`, which pins the intended `LANDING_REPO_PAT || GITHUB_TOKEN` auth (the PAT is deliberate so sweep follow-up PRs trigger CI). So 2.8.3 never tagged.

### Fix
- Restored the sweep workflow's `LANDING_REPO_PAT || GITHUB_TOKEN` auth (test green).
- Made the follow-up-PR step `continue-on-error`, so a token that cannot push (the daily failure: `LANDING_REPO_PAT` lacks write access to this repo) logs and skips instead of failing the scheduled job and reddening main.
- Bumps to 2.8.4 (2.8.3 was never released); notes at `docs/release-notes/v2.8.4.md`; carries the dependency batch.

**Note:** the real fix for the sweep actually creating follow-up PRs is to give `LANDING_REPO_PAT` write access to this repo (a repo-secret change). This PR just stops it from reddening main.

## Summary by Sourcery

Cut 2.8.4 as a maintenance release to restore the review-bot sweep token behavior and prevent recurring CI failures while updating metadata and docs accordingly.

Enhancements:
- Make the review-bot sweep follow-up pull request step best-effort so missing token write access no longer fails scheduled sweeps.

Build:
- Bump the project version from 2.8.3 to 2.8.4 and refresh the lockfile.

CI:
- Restore the review-bot sweep workflow to use LANDING_REPO_PAT with a GITHUB_TOKEN fallback and update its checkout action pin.
- Document the additional LANDING_REPO_PAT secret requirement in the CI topology.

Documentation:
- Add release notes for v2.8.4 describing the review-bot sweep behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the scheduled review sweep so it no longer fails the whole run when it can’t create a follow-up pull request.
  * Added a fallback token for workflow operations to make automated cleanup more reliable.
* **Documentation**
  * Updated operational docs to reflect the additional access needed by the scheduled sweep workflow.
  * Refreshed release notes for the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: 3487716805 reason=PAT scope is a repository-secret configuration not changed by this PR; this PR restores the existing intended LANDING_REPO_PAT auth and makes the follow-up push best-effort. Rescoping the secret is a repo-settings change tracked separately. -->