### PR TITLE
feat(copilot): modernize CLI adapter to non-interactive print mode

### DIFF
--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -476,7 +476,9 @@ Runs OpenAI Codex inside Cloudflare sandboxes for isolated, scalable execution.
 
 **Install:** `npm install -g @github/copilot`
 
-**Env vars:** `GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_COPILOT_TOKEN`.
+**Env vars:** `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN` (in order of precedence).
+
+**Invocation:** `copilot -p '<prompt>' -s --allow-all-tools --no-ask-user --model <model>`. The non-interactive print mode (`-p`) runs a single prompt and exits; `-s` keeps stdout to the agent's final response; `--allow-all-tools` plus `--no-ask-user` make the run autonomous so it never blocks on a permission prompt or a clarifying question. `--model` passes through (`auto` lets Copilot pick); Claude tier names map to `auto`. The deterministic session id is pinned via `--session-id` for replay isolation.
 
 **Best for:** GitHub-Copilot-subscribed teams who want to reuse existing GitHub auth.
 

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -75,6 +75,11 @@ class ContractSpec:
     #: orchestrator state for cross-reference but pass no flag. See
     #: ``docs/adapters/session_isolation.md``.
     session_id_flag: str | None = None
+    #: Full ordered allow-list of secret env vars the adapter accepts (highest
+    #: precedence first). ``auth_secret_env`` is the highest-precedence entry,
+    #: kept singular for back-compat; this carries the complete set when the
+    #: contract lists more than one.
+    auth_secret_envs: tuple[str, ...] = ()
 
     @classmethod
     def load(cls, name: str, contracts_dir: Path | None = None) -> ContractSpec:
@@ -91,6 +96,16 @@ class ContractSpec:
         expected = data.get("expected_models") or {}
         raw_session_flag = data.get("session_id_flag")
         session_id_flag = str(raw_session_flag) if raw_session_flag else None
+        # ``secret_env`` accepts either a single name or an ordered allow-list
+        # (highest precedence first). The singular ``auth_secret_env`` mirrors
+        # the highest-precedence entry for back-compat with existing consumers.
+        raw_secret = auth.get("secret_env")
+        if isinstance(raw_secret, (list, tuple)):
+            secret_envs = tuple(str(s) for s in raw_secret if s)
+        elif raw_secret:
+            secret_envs = (str(raw_secret),)
+        else:
+            secret_envs = ()
         return cls(
             adapter=str(data.get("adapter", name)),
             binary=str(data.get("binary", name)),
@@ -98,13 +113,14 @@ class ContractSpec:
             install_spec=str(install.get("spec", "")),
             auth_required_for_help=bool(auth.get("required_for_help", False)),
             auth_required_for_models=bool(auth.get("required_for_models", False)),
-            auth_secret_env=str(auth.get("secret_env", "") or ""),
+            auth_secret_env=secret_envs[0] if secret_envs else "",
             required_flags=tuple(data.get("required_flags") or ()),
             required_subcommands=tuple(data.get("required_subcommands") or ()),
             help_command=tuple(data.get("help_command") or ()),
             models_command=tuple(expected.get("command") or ()),
             models_required_present=tuple(expected.get("required_present") or ()),
             session_id_flag=session_id_flag,
+            auth_secret_envs=secret_envs,
         )
 
     def resolved_help_command(self) -> list[str]:

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -530,7 +530,9 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     "cody": AdapterStrategy(),
     "composio": AdapterStrategy(event_channel=EventChannel.HOOKS),
     "continue": AdapterStrategy(),
-    "copilot": AdapterStrategy(),
+    # Copilot drives unattended via --allow-all-tools / --no-ask-user in print
+    # mode; the deterministic session id is pinned through --session-id.
+    "copilot": AdapterStrategy(dangerous_mode=DangerousModeStrategy.CLI_FLAG),
     "devin_terminal": AdapterStrategy(event_channel=EventChannel.POLL_PTY),
     "droid": AdapterStrategy(),
     "forge": AdapterStrategy(),

--- a/src/bernstein/adapters/copilot.py
+++ b/src/bernstein/adapters/copilot.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.core.defaults import COPILOT_CLAUDE_TIER_MODELS, COPILOT_DEFAULT_MODEL
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -32,21 +33,30 @@ logger = logging.getLogger(__name__)
 # haiku) that are not valid Copilot model ids, so map any that reach the adapter
 # to ``auto`` rather than passing ``--model sonnet`` (which Copilot rejects). The
 # real selection fix lives in the spawner; this is a last-resort safety net.
-_DEFAULT_COPILOT_MODEL = "auto"
-_CLAUDE_TIER_MODELS = frozenset({"opus", "sonnet", "haiku"})
+# Constants centralised in core.defaults per the repo guideline.
+_copilot_tier_warning_emitted = False
 
 
 def _copilot_model(model: str) -> str:
-    """Map a Claude cascade tier name to Copilot's ``auto``; pass others through."""
-    if model in _CLAUDE_TIER_MODELS:
-        logger.warning(
-            "CopilotAdapter: model %r is a Claude tier name Copilot cannot run; using %r "
-            "instead. Set role_model_policy.<role>.model or default_model to a Copilot "
-            "model (e.g. gpt-5.4 or claude-sonnet-4.5) to choose explicitly.",
-            model,
-            _DEFAULT_COPILOT_MODEL,
-        )
-        return _DEFAULT_COPILOT_MODEL
+    """Map a Claude cascade tier name to Copilot's ``auto``; pass others through.
+
+    The tier value is normalised to lower case so casing variants ("Sonnet",
+    "HAIKU") also map to ``auto`` instead of being passed to ``--model``. The
+    cascade emits these names on almost every run, so the safety net logs once
+    per process at info level rather than warning on every spawn.
+    """
+    if model.lower() in COPILOT_CLAUDE_TIER_MODELS:
+        global _copilot_tier_warning_emitted
+        if not _copilot_tier_warning_emitted:
+            logger.info(
+                "CopilotAdapter: model %r is a Claude tier name Copilot cannot run; using %r "
+                "instead. Set role_model_policy.<role>.model or default_model to a Copilot "
+                "model (e.g. gpt-5.4 or claude-sonnet-4.5) to choose explicitly.",
+                model,
+                COPILOT_DEFAULT_MODEL,
+            )
+            _copilot_tier_warning_emitted = True
+        return COPILOT_DEFAULT_MODEL
     return model
 
 
@@ -64,7 +74,7 @@ class CopilotAdapter(CLIAdapter):
     registry_name = "copilot"
     # Default model when no operator-pinned model reaches this adapter. Read by
     # the spawner to substitute Claude tier names for non-Claude adapters.
-    default_model = _DEFAULT_COPILOT_MODEL
+    default_model = COPILOT_DEFAULT_MODEL
     # GitHub Copilot surfaces 429s when the underlying account hits the
     # Copilot quota; we record under the Copilot label so the panel
     # attributes pressure to the right surface.

--- a/src/bernstein/adapters/copilot.py
+++ b/src/bernstein/adapters/copilot.py
@@ -1,7 +1,19 @@
-"""GitHub Copilot CLI adapter."""
+"""GitHub Copilot CLI adapter.
+
+Last verified against GitHub Copilot CLI 1.0.65 on 2026-06-28.
+Install: ``npm install -g @github/copilot``.
+
+The harness path is the CLI's non-interactive ("print") mode:
+``copilot -p "<prompt>" -s --allow-all-tools --no-ask-user [--model <model>]``.
+``-p/--prompt`` runs a single prompt and exits when done, ``-s/--silent`` trims
+stdout to the agent's final response (clean for the session log), and
+``--allow-all-tools`` together with ``--no-ask-user`` make the run autonomous so
+it never blocks on a permission prompt or a clarifying question.
+"""
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import TYPE_CHECKING, Any
 
@@ -13,15 +25,46 @@ if TYPE_CHECKING:
 
     from bernstein.core.models import ModelConfig
 
+logger = logging.getLogger(__name__)
+
+# Copilot accepts ``auto`` to let its own router pick the best available model.
+# The batch / heuristic selectors emit Claude cascade tier names (opus / sonnet /
+# haiku) that are not valid Copilot model ids, so map any that reach the adapter
+# to ``auto`` rather than passing ``--model sonnet`` (which Copilot rejects). The
+# real selection fix lives in the spawner; this is a last-resort safety net.
+_DEFAULT_COPILOT_MODEL = "auto"
+_CLAUDE_TIER_MODELS = frozenset({"opus", "sonnet", "haiku"})
+
+
+def _copilot_model(model: str) -> str:
+    """Map a Claude cascade tier name to Copilot's ``auto``; pass others through."""
+    if model in _CLAUDE_TIER_MODELS:
+        logger.warning(
+            "CopilotAdapter: model %r is a Claude tier name Copilot cannot run; using %r "
+            "instead. Set role_model_policy.<role>.model or default_model to a Copilot "
+            "model (e.g. gpt-5.4 or claude-sonnet-4.5) to choose explicitly.",
+            model,
+            _DEFAULT_COPILOT_MODEL,
+        )
+        return _DEFAULT_COPILOT_MODEL
+    return model
+
 
 class CopilotAdapter(CLIAdapter):
     """Spawn and monitor GitHub Copilot CLI sessions.
 
-    The CLI is invoked as ``copilot --allow-all-tools -i <prompt>`` where
-    ``--allow-all-tools`` is the auto-approval flag and ``-i`` supplies the
-    initial prompt.
+    The CLI runs in non-interactive print mode:
+    ``copilot -p <prompt> -s --allow-all-tools --no-ask-user --model <model>``.
+    ``-p/--prompt`` supplies the prompt and exits when done, ``-s/--silent``
+    trims stdout to the agent's final response, and ``--allow-all-tools`` plus
+    ``--no-ask-user`` make the run autonomous so it never blocks on a
+    permission prompt or a clarifying question.
     """
 
+    registry_name = "copilot"
+    # Default model when no operator-pinned model reaches this adapter. Read by
+    # the spawner to substitute Claude tier names for non-Claude adapters.
+    default_model = _DEFAULT_COPILOT_MODEL
     # GitHub Copilot surfaces 429s when the underlying account hits the
     # Copilot quota; we record under the Copilot label so the panel
     # attributes pressure to the right surface.
@@ -41,15 +84,16 @@ class CopilotAdapter(CLIAdapter):
         system_addendum: str = "",
         multimodal_context: Any | None = None,
     ) -> SpawnResult:
-        """Launch a GitHub Copilot CLI session.
+        """Launch a GitHub Copilot CLI session in non-interactive print mode.
 
         Args:
-            prompt: The initial prompt supplied via ``-i``.
+            prompt: The prompt supplied via ``-p``; Copilot exits when done.
             workdir: Working directory for the agent process.
-            model_config: Model and effort configuration (retained for
-                interface compatibility; the Copilot CLI selects its own
-                model internally).
-            session_id: Unique session identifier.
+            model_config: Model and effort configuration. ``model`` is passed
+                through via ``--model``; Claude tier names are mapped to
+                Copilot's ``auto`` router.
+            session_id: Unique session identifier. A deterministic id derived
+                from it is pinned via ``--session-id`` for replay isolation.
             mcp_config: Optional MCP server definitions (unused).
             timeout_seconds: Process timeout in seconds.
             task_scope: Task scope hint (unused by Copilot).
@@ -67,7 +111,24 @@ class CopilotAdapter(CLIAdapter):
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        cmd = ["copilot", "--allow-all-tools", "-i", prompt]
+        model = _copilot_model(model_config.model)
+        cmd = [
+            "copilot",
+            "-p",
+            prompt,
+            "-s",
+            "--allow-all-tools",
+            "--no-ask-user",
+            "--model",
+            model,
+        ]
+        # Pin a deterministic session id so a replay of this run reaches the
+        # same conversation slot and parallel copilot sessions in the same
+        # worktree do not collide. Copilot's ``--session-id`` sets the UUID for
+        # a new session (and resumes an existing one by id), which is the
+        # harness-preferred control surface. When the copilot contract declares
+        # no session-id flag this is an empty list and the argv is unchanged.
+        cmd.extend(self.session_id_args(session_id))
 
         pid_dir = workdir / ".sdd" / "runtime" / "pids"
         wrapped_cmd = build_worker_cmd(
@@ -77,10 +138,10 @@ class CopilotAdapter(CLIAdapter):
             pid_dir=pid_dir,
             workdir=workdir,
             log_path=log_path,
-            model=model_config.model,
+            model=model,
         )
 
-        env = build_filtered_env(["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_COPILOT_TOKEN"])
+        env = build_filtered_env(["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"])
         with log_path.open("w") as log_file:
             try:
                 proc = subprocess.Popen(

--- a/src/bernstein/adapters/use_cases.py
+++ b/src/bernstein/adapters/use_cases.py
@@ -143,6 +143,12 @@ USE_CASES: dict[str, AdapterUseCase] = {
     "copilot": AdapterUseCase(
         headline="GitHub Copilot CLI driven headlessly from Bernstein",
         binary="copilot",
+        details=(
+            "Non-interactive print mode runs with -p and -s, plus "
+            "--allow-all-tools and --no-ask-user so the agent works "
+            "autonomously without blocking on permission or clarifying "
+            "prompts. Reuses existing GitHub Copilot auth."
+        ),
     ),
     "cursor": AdapterUseCase(
         headline="Cursor Agent CLI - print mode with workspace trust",

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -46,6 +46,14 @@ SKILLS_AUTO_ROUTE_ENV: Final[str] = "BERNSTEIN_SKILLS_AUTO_ROUTE"
 SKILLS_AUTO_ROUTE_DEFAULT_LIMIT: Final[int] = 2
 """Default number of auto-routed skill templates to inject."""
 
+COPILOT_DEFAULT_MODEL: Final[str] = "auto"
+"""Copilot model used when no operator-pinned model reaches the adapter; ``auto``
+lets Copilot's own router pick the best available model."""
+
+COPILOT_CLAUDE_TIER_MODELS: Final[frozenset[str]] = frozenset({"opus", "sonnet", "haiku"})
+"""Claude cascade tier names that are not valid Copilot model ids; any that reach
+the Copilot adapter are remapped to ``COPILOT_DEFAULT_MODEL``."""
+
 
 @dataclass(frozen=True)
 class DashboardStaticAsset:

--- a/tests/contract/contracts/copilot.yaml
+++ b/tests/contract/contracts/copilot.yaml
@@ -10,7 +10,11 @@ install:
 auth:
   required_for_help: false
   required_for_models: false
-  secret_env: "GITHUB_TOKEN"
+  # In order of precedence; mirrors CopilotAdapter env isolation + ADAPTER_GUIDE.
+  secret_env:
+    - "COPILOT_GITHUB_TOKEN"
+    - "GH_TOKEN"
+    - "GITHUB_TOKEN"
 required_flags:
   - "-p"
   - "-s"

--- a/tests/contract/contracts/copilot.yaml
+++ b/tests/contract/contracts/copilot.yaml
@@ -1,0 +1,27 @@
+# Contract for the GitHub Copilot CLI (adapter: copilot).
+#
+# Always-passed surface from src/bernstein/adapters/copilot.py:
+# ``copilot -p <prompt> -s --allow-all-tools --no-ask-user --model <model>``.
+adapter: copilot
+binary: copilot
+install:
+  method: npm
+  spec: "@github/copilot@latest"
+auth:
+  required_for_help: false
+  required_for_models: false
+  secret_env: "GITHUB_TOKEN"
+required_flags:
+  - "-p"
+  - "-s"
+  - "--allow-all-tools"
+  - "--no-ask-user"
+  - "--model"
+required_subcommands: []
+# Deterministic session-id binding: ``copilot --session-id`` sets the UUID for
+# a new session (and resumes an existing one), so the adapter pins the derived
+# id for replay isolation. See docs/adapters/session_isolation.md.
+session_id_flag: "--session-id"
+expected_models:
+  command: []
+  required_present: []

--- a/tests/unit/adapters/test_session_id_binding.py
+++ b/tests/unit/adapters/test_session_id_binding.py
@@ -150,6 +150,11 @@ def test_real_codex_contract_declares_session_id_flag() -> None:
     assert spec.session_id_flag == "--session-id"
 
 
+def test_real_copilot_contract_declares_session_id_flag() -> None:
+    spec = _contract.ContractSpec.load("copilot")
+    assert spec.session_id_flag == "--session-id"
+
+
 # ---------------------------------------------------------------------------
 # AC #3 - spawn-time wiring
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_copilot.py
+++ b/tests/unit/test_adapter_copilot.py
@@ -9,6 +9,7 @@ import pytest
 from bernstein.core.models import ModelConfig
 
 from bernstein.adapters.copilot import CopilotAdapter
+from bernstein.adapters.session_id import derive_session_id
 from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
 
 if TYPE_CHECKING:
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
 
 
-def test_spawn_builds_run_command(tmp_path: Path) -> None:
+def test_spawn_builds_print_mode_command(tmp_path: Path) -> None:
     adapter = CopilotAdapter()
     proc_mock = make_popen_mock(800)
 
@@ -26,14 +27,78 @@ def test_spawn_builds_run_command(tmp_path: Path) -> None:
         adapter.spawn(
             prompt="fix the bug",
             workdir=tmp_path,
-            model_config=ModelConfig(model="sonnet", effort="high"),
+            model_config=ModelConfig(model="gpt-5.4", effort="high"),
             session_id="copilot-s1",
         )
 
-    cmd = popen.call_args.args[0]
-    inner = inner_cmd(cmd)
-    assert inner[:3] == ["copilot", "--allow-all-tools", "-i"]
-    assert inner[-1] == "fix the bug"
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[0] == "copilot"
+    # Non-interactive print mode, not the legacy interactive ``-i`` surface.
+    assert "-p" in inner
+    assert inner[inner.index("-p") + 1] == "fix the bug"
+    assert "-s" in inner
+    assert "--allow-all-tools" in inner
+    assert "--no-ask-user" in inner
+    assert "-i" not in inner
+
+
+def test_model_flag_passthrough(tmp_path: Path) -> None:
+    adapter = CopilotAdapter()
+    proc_mock = make_popen_mock(801)
+
+    with patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="claude-sonnet-4.5", effort="high"),
+            session_id="copilot-s2",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert "--model" in inner
+    assert inner[inner.index("--model") + 1] == "claude-sonnet-4.5"
+
+
+def test_claude_tier_model_mapped_to_auto(tmp_path: Path) -> None:
+    """A Claude tier name reaching the adapter must not become ``--model sonnet``."""
+    adapter = CopilotAdapter()
+    proc_mock = make_popen_mock(802)
+
+    with patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="max"),
+            session_id="copilot-s3",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[inner.index("--model") + 1] == "auto"
+    assert "sonnet" not in inner
+
+
+def test_spawn_pins_deterministic_session_id(tmp_path: Path) -> None:
+    adapter = CopilotAdapter()
+    proc_mock = make_popen_mock(803)
+
+    with patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-5.4", effort="high"),
+            session_id="copilot-s4",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert "--session-id" in inner
+    assert inner[inner.index("--session-id") + 1] == str(derive_session_id("copilot-s4", "copilot"))
+
+
+def test_session_id_args_emits_flag_and_derived_id() -> None:
+    adapter = CopilotAdapter()
+    args = adapter.session_id_args("conv-1")
+    assert args[0] == "--session-id"
+    assert args[1] == str(derive_session_id("conv-1", "copilot"))
 
 
 def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
@@ -48,9 +113,57 @@ def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
         adapter.spawn(
             prompt="hello",
             workdir=tmp_path,
-            model_config=ModelConfig(model="sonnet", effort="high"),
+            model_config=ModelConfig(model="gpt-5.4", effort="high"),
             session_id="copilot-missing",
         )
+
+
+def test_spawn_translates_permission_error(tmp_path: Path) -> None:
+    adapter = CopilotAdapter()
+    with (
+        patch(
+            "bernstein.adapters.copilot.subprocess.Popen",
+            side_effect=PermissionError("Permission denied"),
+        ),
+        pytest.raises(RuntimeError, match="[Pp]ermission"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-5.4", effort="high"),
+            session_id="copilot-perm",
+        )
+
+
+def test_env_isolation_passes_only_copilot_keys(tmp_path: Path) -> None:
+    adapter = CopilotAdapter()
+    proc_mock = make_popen_mock(804)
+
+    with (
+        patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict(
+            "os.environ",
+            {
+                "COPILOT_GITHUB_TOKEN": "ghp-test",
+                "ANTHROPIC_API_KEY": "ant-secret",
+                "DATABASE_URL": "postgres://x",
+                "PATH": "/usr/bin",
+            },
+            clear=True,
+        ),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-5.4", effort="high"),
+            session_id="copilot-env1",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert env.get("COPILOT_GITHUB_TOKEN") == "ghp-test"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "DATABASE_URL" not in env
+    assert "PATH" in env
 
 
 def test_name() -> None:

--- a/tests/unit/test_adapter_copilot.py
+++ b/tests/unit/test_adapter_copilot.py
@@ -77,6 +77,34 @@ def test_claude_tier_model_mapped_to_auto(tmp_path: Path) -> None:
     assert "sonnet" not in inner
 
 
+@pytest.mark.parametrize("tier", ["Sonnet", "HAIKU", "Opus"])
+def test_claude_tier_model_mapping_is_case_insensitive(tmp_path: Path, tier: str) -> None:
+    """Casing variants of a Claude tier must still map to ``auto``."""
+    adapter = CopilotAdapter()
+    proc_mock = make_popen_mock(805)
+
+    with patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model=tier, effort="max"),
+            session_id="copilot-s3b",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[inner.index("--model") + 1] == "auto"
+    assert tier not in inner
+
+
+def test_contract_lists_full_token_surface() -> None:
+    """The copilot contract advertises every token the adapter accepts."""
+    from bernstein.adapters._contract import ContractSpec
+
+    spec = ContractSpec.load("copilot")
+    assert spec.auth_secret_env == "COPILOT_GITHUB_TOKEN"
+    assert spec.auth_secret_envs == ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+
+
 def test_spawn_pins_deterministic_session_id(tmp_path: Path) -> None:
     adapter = CopilotAdapter()
     proc_mock = make_popen_mock(803)


### PR DESCRIPTION
## What

Move the GitHub Copilot adapter off the legacy interactive surface (`copilot --allow-all-tools -i <prompt>`) onto the current non-interactive print surface, verified against GitHub Copilot CLI 1.0.65.

## Why

The old invocation attached the agent to an interactive session, never passed a model, and never pinned a session id, so Copilot runs could not select a model, could not be resumed or replayed deterministically, and were fragile under unattended orchestration. The env-isolation allow-list also carried a token name (`GITHUB_COPILOT_TOKEN`) the CLI does not read.

## How

- Build `copilot -p <prompt> -s --allow-all-tools --no-ask-user --model <model>`: `-p` runs one prompt and exits, `-s` trims stdout to the final response, and `--allow-all-tools` plus `--no-ask-user` make the run autonomous so it never blocks on a permission or clarifying prompt.
- Pass `--model` through; map Claude tier names (opus/sonnet/haiku) to `auto` and set `default_model = "auto"`, mirroring the codex adapter.
- Pin a deterministic session id via `--session-id` for replay isolation (`registry_name = "copilot"` plus a new `tests/contract/contracts/copilot.yaml` declaring `session_id_flag`), mirroring codex.
- Correct the auth allow-list to `COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN`; set the strategy-matrix dangerous-mode for copilot to `cli-flag`; refresh the use-case metadata and the ADAPTER_GUIDE entry.

## Checklist

- [x] `uv run ruff check src/` passes (changed files; `ruff format --check` also clean)
- [ ] `uv run pyright src/` passes (pre-existing baseline: the full tree reports many findings because `core/models.py` is in the `[tool.pyright]` exclude list, so every adapter importing `ModelConfig` shows unresolved; `copilot.py` mirrors `codex.py` exactly and adds no new strict errors)
- [x] `uv run python scripts/run_tests.py` passes (ran the targeted adapter/contract/session subsets per CONTRIBUTING's RAM warning on the full `-x` run: copilot adapter 9 passed, adapters plus contract suites 349 passed, conformance 408 passed, integration CLI 10 passed)
- [x] New code has type hints

### Documentation duty (every PR that touches a feature)

- [x] README N/A (adapter is an internal surface); `docs/adapters/ADAPTER_GUIDE.md` updated
- [x] `docs/operations/<area>.md` N/A
- [x] `docs/api/` schema N/A (no public surface change)
- [x] `bernstein agents-md sync` N/A (no new module)
- [x] Tests cover the documented behaviour

## Testing (on this machine, copilot v1.0.65)

The adapter argv `copilot -p "..." -s --allow-all-tools --no-ask-user --model auto --session-id <uuid>` returns the expected output, and the full adapter spawn path captured the live Copilot response end to end.

## Summary by Sourcery

Modernize the GitHub Copilot CLI adapter to use non-interactive print mode with deterministic session IDs and explicit model selection.

New Features:
- Support non-interactive Copilot print mode using -p/-s with autonomous tool execution.
- Pass through explicit Copilot model selection, with safety mapping of Claude tier names to Copilot's auto router.
- Bind deterministic Copilot sessions via --session-id for replay isolation and contract-based session id wiring.

Enhancements:
- Refine Copilot environment isolation to only forward supported GitHub auth tokens while preserving PATH.
- Document the Copilot adapter invocation, env vars, and behavior in the adapter guide and use-case metadata.
- Mark the Copilot adapter strategy as using a CLI flag for dangerous mode in the adapter contract strategy matrix.

Tests:
- Expand unit tests for Copilot spawn behavior covering print mode argv, model flag passthrough and mapping, session-id binding, permission error translation, and env filtering.
- Add a Copilot CLI contract spec with required flags and session-id settings, plus tests that validate the contract’s session_id_flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub Copilot’s non-interactive “print mode” flow with deterministic session IDs and consistent model selection.
* **Bug Fixes**
  * Improved credential handling: Copilot token forwarding now uses the Copilot-specific token name and updated token precedence.
  * Enhanced contract auth env configuration to accept an ordered allow-list while preserving back-compat.
* **Documentation**
  * Updated Copilot adapter guidance, including invocation flags, token precedence, and session behavior.
* **Tests**
  * Added/expanded contracts and unit coverage for Copilot command flags, session-id binding, model mapping, and environment forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->