### PR TITLE
chore(release): 2.8.5

### DIFF
--- a/docs/release-notes/v2.8.5.md
+++ b/docs/release-notes/v2.8.5.md
@@ -1,6 +1,6 @@
-# v2.8.4
+# v2.8.5
 
-Released 2026-06-28.
+Released 2026-06-29.
 
 A maintenance release: a batch of dependency and CI-action updates, plus a fix for the scheduled review-bot sweep workflow that was failing daily.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.8.4"
+version = "2.8.5"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.8.4"
+version = "2.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Final patch release after the 2.8.3/2.8.4 attempts failed mid-release (CI/infra issues, never published).

- Bumps `pyproject.toml` + `uv.lock` to 2.8.5; notes at `docs/release-notes/v2.8.5.md`.
- Carries: the review-bot sweep fix (follow-up-PR push is now best-effort, so a write-denied `LANDING_REPO_PAT` no longer reds main), and the full dependency / CI-action batch merged since 2.8.2.

On merge, a green main run triggers auto-release to tag `v2.8.5`; publish is completed via the workflow_dispatch path.

PyPI lineage: 2.7.0 -> 2.8.2 -> 2.8.5 (2.8.0/2.8.1/2.8.3/2.8.4 were intermediate tags only).

## Summary by Sourcery

Prepare the 2.8.5 patch release with updated metadata and release notes.

Build:
- Bump the project version metadata to 2.8.5 in pyproject and lockfile.

Documentation:
- Add release notes for version 2.8.5, reflecting the latest maintenance changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **2.8.5**.
* **Documentation**
  * Refreshed the release notes header and release date for **v2.8.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->