### PR TITLE
chore(worktrees): resolve FURB173 in unlock command

### DIFF
--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -696,7 +696,7 @@ def unlock_cmd(workdir: Path, force: bool, as_json: bool) -> None:
     liveness = {True: "alive", False: "not running", None: "liveness unknown"}[alive]
 
     if as_json:
-        click.echo(json.dumps({**status, "removed": removed}, default=str))
+        click.echo(json.dumps(status | {"removed": removed}, default=str))
         if not removable:
             raise SystemExit(1)
         return


### PR DESCRIPTION
Resolves the open refurb FURB173 code-scanning alert (#2585): replaces `{**status, ...}` with the dict union operator `status | {...}` in the `worktrees unlock` JSON output. Behavior-identical; tests pass.

## Summary by Sourcery

Enhancements:
- Replace dict unpacking with the dict union operator in the worktrees unlock command JSON output for clearer and more modern dictionary merging semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling for `worktrees unlock` JSON output with no change to the returned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->