### PR TITLE
chore(release): 2.9.0

### DIFF
--- a/docs/release-notes/v2.9.0.md
+++ b/docs/release-notes/v2.9.0.md
@@ -1,0 +1,12 @@
+# v2.9.0
+
+Released 2026-06-30.
+
+## Features
+- The GitHub Copilot CLI adapter now runs in non-interactive print mode (`copilot -p ... -s --allow-all-tools --no-ask-user`) so a scheduled run never blocks on a permission or clarifying prompt, and it maps Claude cascade tier names that reach the adapter to Copilot's `auto` router instead of passing a model id Copilot rejects. Includes adapter contract coverage and tests. (#2128)
+
+## Security
+- Bumped js-yaml in the VS Code extension lockfile to a patched release (3.15.0) to clear the merge-key quadratic-complexity DoS advisory.
+
+## Quality
+- Resolved the open refurb FURB173 finding in the worktrees unlock command (dict union operator). (#2140)

--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -2260,9 +2260,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@textlint/linter-formatter/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -6167,9 +6167,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7385,9 +7385,9 @@
       "license": "Python-2.0"
     },
     "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.8.5"
+version = "2.9.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.8.5"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
New minor release.

- **Feature**: Copilot CLI adapter non-interactive print mode + model-name mapping (#2128, already on main).
- **Security**: bumps js-yaml in `packages/vscode/package-lock.json` to 3.15.0, clearing Dependabot alert #74 (merge-key quadratic DoS, <3.15.0).
- **Quality**: refurb FURB173 fix (#2140, already on main).

Bumps `pyproject.toml` + `uv.lock` 2.8.5 -> 2.9.0; notes at `docs/release-notes/v2.9.0.md`. On merge, auto-release tags `v2.9.0`; publish via the workflow_dispatch path.

## Summary by Sourcery

Prepare the 2.9.0 release by updating version metadata, dependency locks, and adding release notes.

New Features:
- Document the GitHub Copilot CLI adapter non-interactive print mode and model-name mapping introduced in this release.

Enhancements:
- Update project and lockfile versions from 2.8.5 to 2.9.0 for the core package and tooling.

Documentation:
- Add v2.9.0 release notes covering new Copilot CLI behavior, security dependency bump, and refurb quality fix.

Chores:
- Refresh dependency locks for the VS Code extension, including a js-yaml bump to a patched release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for smoother scheduled run behavior and improved handling of certain router choices in AI-assisted workflows.
* **Bug Fixes**
  * Resolved a security issue in a bundled dependency.
  * Fixed a quality issue in the worktrees unlock command.
* **Chores**
  * Bumped the project version to **v2.9.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->