### PR TITLE
chore(release): 2.10.0

### DIFF
--- a/docs/release-notes/v2.10.0.md
+++ b/docs/release-notes/v2.10.0.md
@@ -1,0 +1,15 @@
+# v2.10.0
+
+Released 2026-07-02.
+
+## Features
+- `--sandbox docker` now provisions a real Docker sandbox for spawned agents end to end: the seed launcher wires `DockerSandboxBackend` into the spawner, the host repo is bind-mounted read-only and cloned into an isolated workspace, and a host-side heartbeat proxy keeps sandboxed agents visible to the stall watchdog. Falls back to the legacy path when Docker is unavailable. Known limits of this first cut (result sync-back, per-agent sessions) are tracked in #2162. Contributed by @shanemmattner. (#2156)
+- `bernstein run --worker <role>` spawns a single worker directly against the seed goal, bypassing manager decomposition; combining it with an inline goal or `--plan-file` is a usage error. (#2156)
+
+## Fixes
+- Role templates render again: the orchestrator passed the templates root where the spawner expects `templates/roles/`, so every role silently fell back to a generic prompt. The fallback now warns, and a regression test pins the call site. (#2155, #2156)
+- `--model` propagates to manager-created child tasks and the server launch path instead of a hardcoded default, so non-Claude CLIs run on the requested model end to end. A/B pinned models survive the server round trip. (#2156)
+- Container execution hardening: adapter commands are shell-quoted, only the resolved adapter's API keys are forwarded into a sandbox, the sandbox container uses host networking for task-server parity with the legacy path, and containers are cleaned up on provisioning failure and on orchestrator exit. (#2156)
+
+## Dependencies
+- Routine updates: vite 8.1.3, lucide-react 1.23.0, prom/prometheus v3.13.0, docker/build-push-action, docker/login-action, and oss-fuzz base-builder digest bumps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.9.0"
+version = "2.10.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
New minor release.

- **Features**: end-to-end Docker sandbox execution (`--sandbox docker`) and the `--worker <role>` single-agent path (#2156, on main).
- **Fixes**: role templates render again (#2155), `--model` propagation to child tasks, container execution hardening (on main).
- **Dependencies**: routine renovate batch (on main).

Bumps `pyproject.toml` + `uv.lock` 2.9.0 -> 2.10.0; notes at `docs/release-notes/v2.10.0.md`. Merge LAST so auto-release tags `v2.10.0`; publish via the workflow_dispatch path.

## Summary by Sourcery

Bump project version to 2.10.0 and add release-notes documentation for the 2.10.0 release, including its features, fixes, and dependency updates.

Build:
- Update project version metadata from 2.9.0 to 2.10.0 in pyproject configuration.

Documentation:
- Add release-notes page for version 2.10.0 describing new sandboxing and worker features, bug fixes, and dependency updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running commands in a real Docker-based sandbox with improved isolation and fallback behavior.
  * Added direct worker launching from a seed goal for supported workflows.

* **Bug Fixes**
  * Fixed role template rendering issues and added a warning for affected cases.
  * Improved model selection handling so configured models are preserved in more task and server flows.

* **Chores**
  * Updated the release version to 2.10.0 and refreshed dependency/version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->