### PR TITLE
fix(tests): align stalled-manager tests with the 170s threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.10.0"
+version = "2.9.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/test_stalled_manager.py
+++ b/tests/unit/test_stalled_manager.py
@@ -92,7 +92,7 @@ def test_detect_returns_none_when_manager_under_threshold(tmp_path: Path) -> Non
 
 def test_detect_returns_none_when_child_tasks_exist(tmp_path: Path) -> None:
     now = 1_000.0
-    session = _manager_session(spawn_ts=now - 120.0)  # past threshold
+    session = _manager_session(spawn_ts=now - (STALL_THRESHOLD_S + 30.0))  # past threshold
     orch = _build_orch(tmp_path, session=session, extra_tasks=["task-2"])
     with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
         assert detect_stalled_manager(orch) is None
@@ -100,7 +100,7 @@ def test_detect_returns_none_when_child_tasks_exist(tmp_path: Path) -> None:
 
 def test_detect_fires_when_manager_alive_with_no_children(tmp_path: Path) -> None:
     now = 1_000.0
-    session = _manager_session(spawn_ts=now - 120.0)
+    session = _manager_session(spawn_ts=now - (STALL_THRESHOLD_S + 30.0))
     _write_hook_events(
         tmp_path,
         session.id,
@@ -116,7 +116,7 @@ def test_detect_fires_when_manager_alive_with_no_children(tmp_path: Path) -> Non
     assert diag is not None
     assert diag.session_id == session.id
     assert diag.manager_task_id == "manager-task-1"
-    assert diag.runtime_s == 120.0
+    assert diag.runtime_s == STALL_THRESHOLD_S + 30.0
     assert diag.hook_event_count == 3
     # Last 5 Bash commands - there are only 2 here.
     assert diag.last_bash_commands == [
@@ -151,7 +151,7 @@ def test_detect_ignores_non_manager_roles(tmp_path: Path) -> None:
 
 def test_handle_writes_failure_record_and_log_and_aborts(tmp_path: Path, capsys: Any) -> None:
     now = 1_000.0
-    session = _manager_session(spawn_ts=now - 120.0)
+    session = _manager_session(spawn_ts=now - (STALL_THRESHOLD_S + 30.0))
     _write_hook_events(
         tmp_path,
         session.id,

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.10.0"
+version = "2.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Main CI failed on the 2.10.0 release commit: three stalled-manager test fixtures used a 120s manager runtime, past the old 90s threshold but under the 170s threshold from #2156. Fixtures now derive from `STALL_THRESHOLD_S` (+30s) so future tuning cannot silently break them.

Also reverts the version bump to 2.9.0 so the re-bump PR that follows is the release-triggering commit (auto-release gate requires the version change in the triggering commit). Fixes the failure behind #2166.

## Summary by Sourcery

Align stalled-manager tests with the configurable stall threshold and revert the project version bump to make the subsequent re-bump the release-triggering commit.

Bug Fixes:
- Update stalled-manager test fixtures to compute manager runtime from the configured stall threshold plus a safety margin, preventing future threshold changes from silently breaking tests.
- Revert the project version from 2.10.0 to 2.9.0 so that the upcoming version re-bump can correctly trigger the automated release pipeline.

Tests:
- Adjust stalled-manager runtime assertions and fixtures to derive from STALL_THRESHOLD_S instead of hard-coded values, matching the new 170s threshold behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version metadata to `2.9.0`.
* **Tests**
  * Aligned stall-related unit test timing checks with the configured stall threshold for more reliable coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->