### PR TITLE
chore(release): 2.10.0 (take 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.9.0"
+version = "2.10.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Re-lands the 2.10.0 bump on top of #2167 (the stalled-manager test fix that failed the first release commit's CI). Notes already on main. Merge LAST; auto-release tags v2.10.0 on green CI.

## Summary by Sourcery

Build:
- Update package metadata in pyproject.toml to reflect version 2.10.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **2.10.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->