### PR TITLE
fix(cli): construct AgentSpawner with its real contract in the worker loop

### DIFF
--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -127,6 +127,13 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         # bypasses verification - not a failure, but keeps behaviour
         # symmetric.
         "BERNSTEIN_AUTH_DISABLED",
+        # ``BERNSTEIN_SERVER_URL`` tells the agent's server-facing plumbing
+        # (CLI helpers, hook posts) where the central server lives.  Remote
+        # workers export it before spawning; without it in the allowlist
+        # the agent falls back to http://localhost:8052 and its progress
+        # reporting never reaches the central server.  It is a URL, not a
+        # credential, so passing it through is safe.
+        "BERNSTEIN_SERVER_URL",
     }
 )
 

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -246,7 +246,10 @@ class WorkerLoop:
                 workdir=self._workdir,
             )
             # Spawned agents reach the central server through the standard
-            # env vars (agent subprocesses inherit the worker environment).
+            # env vars. Adapters launch agents with an allowlist-filtered
+            # environment (build_filtered_env), so only allowlisted vars
+            # propagate; both vars below are in the base allowlist in
+            # adapters/env_isolation.py.
             os.environ["BERNSTEIN_SERVER_URL"] = self._server_url
             if self._auth_token:
                 os.environ["BERNSTEIN_AUTH_TOKEN"] = self._auth_token

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -226,6 +226,9 @@ class WorkerLoop:
 
     def _spawn_agent(self, task: dict) -> int | None:
         """Spawn a CLI agent process to work on a task. Returns PID or None."""
+        from bernstein import get_templates_dir
+        from bernstein.adapters.registry import get_adapter
+        from bernstein.core.models import Task
         from bernstein.core.spawner import AgentSpawner
 
         task_id = task.get("id", "unknown")
@@ -236,18 +239,18 @@ class WorkerLoop:
         logger.info("Spawning agent for task %s: %s", task_id, title[:60])
 
         try:
+            adapter = get_adapter(self._adapter_name)
             spawner = AgentSpawner(
-                adapter_name=self._adapter_name,
+                adapter=adapter,
+                templates_dir=get_templates_dir(self._workdir) / "roles",
                 workdir=self._workdir,
-                server_url=self._server_url,
-                auth_token=self._auth_token,
             )
-            session = spawner.spawn_for_task(
-                task_id=task_id,
-                title=title,
-                description=description,
-                role=role,
-            )
+            # Spawned agents reach the central server through the standard
+            # env vars (agent subprocesses inherit the worker environment).
+            os.environ["BERNSTEIN_SERVER_URL"] = self._server_url
+            if self._auth_token:
+                os.environ["BERNSTEIN_AUTH_TOKEN"] = self._auth_token
+            session = spawner.spawn_for_tasks([Task(id=task_id, title=title, description=description, role=role)])
             if session and session.pid:
                 return session.pid
         except Exception as exc:

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -71,6 +71,23 @@ class TestBuildFilteredEnv:
         assert result["BERNSTEIN_HOOK_SECRET"] == "shared-secret"
         assert result["BERNSTEIN_AUTH_DISABLED"] == "0"
 
+    def test_bernstein_server_url_passes_through(self) -> None:
+        """BERNSTEIN_SERVER_URL must reach the agent.
+
+        Remote workers export it before spawning so the agent's
+        server-facing plumbing targets the central server instead of
+        falling back to http://localhost:8052. It is a URL, not a
+        credential, so the allowlist passes it through.
+        """
+        env = {
+            "PATH": "/bin",
+            "HOME": "/home/u",
+            "BERNSTEIN_SERVER_URL": "http://central:8052",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", env):
+            result = build_filtered_env()
+        assert result["BERNSTEIN_SERVER_URL"] == "http://central:8052"
+
     def test_extra_keys_included(self) -> None:
         """API key names passed via extra_keys are included."""
         env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "sk-ant-abc", "UNRELATED_SECRET": "boom"}

--- a/tests/unit/test_worker_cmd_spawn.py
+++ b/tests/unit/test_worker_cmd_spawn.py
@@ -6,6 +6,7 @@ import os
 from typing import TYPE_CHECKING
 from unittest import mock
 
+import pytest
 from bernstein.core.models import AgentSession, Task
 
 from bernstein.cli.commands.worker_cmd import WorkerLoop
@@ -19,6 +20,26 @@ TASK_DICT = {
     "description": "Heartbeat loop drops the node after eviction.",
     "role": "backend",
 }
+
+_ENV_KEYS = ("BERNSTEIN_SERVER_URL", "BERNSTEIN_AUTH_TOKEN")
+
+
+@pytest.fixture(autouse=True)
+def _restore_server_env():
+    """Snapshot and restore the env vars _spawn_agent mutates.
+
+    _spawn_agent exports BERNSTEIN_SERVER_URL / BERNSTEIN_AUTH_TOKEN into
+    os.environ as a side effect. Without an explicit restore those values
+    leak into the rest of the pytest session and change the behaviour of
+    later tests that read them (e.g. auth middleware and CLI helpers).
+    """
+    saved = {key: os.environ.get(key) for key in _ENV_KEYS}
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 def _make_loop(tmp_path: Path) -> WorkerLoop:

--- a/tests/unit/test_worker_cmd_spawn.py
+++ b/tests/unit/test_worker_cmd_spawn.py
@@ -1,0 +1,111 @@
+"""Tests for WorkerLoop._spawn_agent in the worker CLI command."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest import mock
+
+from bernstein.core.models import AgentSession, Task
+
+from bernstein.cli.commands.worker_cmd import WorkerLoop
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TASK_DICT = {
+    "id": "task-42",
+    "title": "Fix the flaky heartbeat",
+    "description": "Heartbeat loop drops the node after eviction.",
+    "role": "backend",
+}
+
+
+def _make_loop(tmp_path: Path) -> WorkerLoop:
+    return WorkerLoop(
+        server_url="http://central:8052",
+        name="test-node",
+        auth_token="secret-token",
+        adapter="claude",
+        workdir=tmp_path,
+    )
+
+
+class TestSpawnAgent:
+    """Tests for WorkerLoop._spawn_agent."""
+
+    def test_spawn_returns_pid_and_uses_roles_templates_dir(self, tmp_path: Path, monkeypatch) -> None:
+        """_spawn_agent resolves the adapter, builds a Task, and returns the session PID."""
+        monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+        monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+        loop = _make_loop(tmp_path)
+        fake_adapter = mock.MagicMock(name="adapter")
+        session = AgentSession(id="backend-abc", role="backend", pid=4242)
+
+        with (
+            mock.patch("bernstein.adapters.registry.get_adapter", return_value=fake_adapter) as get_adapter,
+            mock.patch("bernstein.core.agents.spawner.AgentSpawner", autospec=True) as spawner_cls,
+        ):
+            spawner_cls.return_value.spawn_for_tasks.return_value = session
+            pid = loop._spawn_agent(TASK_DICT)
+
+        assert pid == 4242
+        get_adapter.assert_called_once_with("claude")
+        # AgentSpawner must be constructed with the real contract:
+        # an adapter instance and the templates/roles directory.
+        kwargs = spawner_cls.call_args.kwargs
+        assert kwargs["adapter"] is fake_adapter
+        assert kwargs["templates_dir"].name == "roles"
+        assert kwargs["workdir"] == tmp_path
+        # spawn_for_tasks receives a single Task built from the claimed dict.
+        (tasks,) = spawner_cls.return_value.spawn_for_tasks.call_args.args
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], Task)
+        assert tasks[0].id == "task-42"
+        assert tasks[0].role == "backend"
+
+    def test_spawn_exports_server_env_for_agents(self, tmp_path: Path, monkeypatch) -> None:
+        """Spawned agents inherit server URL and auth token via env vars."""
+        monkeypatch.delenv("BERNSTEIN_SERVER_URL", raising=False)
+        monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+        loop = _make_loop(tmp_path)
+        session = AgentSession(id="backend-abc", role="backend", pid=4242)
+
+        with (
+            mock.patch("bernstein.adapters.registry.get_adapter", return_value=mock.MagicMock()),
+            mock.patch("bernstein.core.agents.spawner.AgentSpawner", autospec=True) as spawner_cls,
+        ):
+            spawner_cls.return_value.spawn_for_tasks.return_value = session
+            loop._spawn_agent(TASK_DICT)
+
+        assert os.environ["BERNSTEIN_SERVER_URL"] == "http://central:8052"
+        assert os.environ["BERNSTEIN_AUTH_TOKEN"] == "secret-token"
+
+    def test_spawn_failure_returns_none_and_warns(self, tmp_path: Path, caplog) -> None:
+        """A spawn error is logged as a warning and returns None instead of raising."""
+        loop = _make_loop(tmp_path)
+
+        with (
+            mock.patch("bernstein.adapters.registry.get_adapter", return_value=mock.MagicMock()),
+            mock.patch("bernstein.core.agents.spawner.AgentSpawner", autospec=True) as spawner_cls,
+            caplog.at_level("WARNING", logger="bernstein.cli.commands.worker_cmd"),
+        ):
+            spawner_cls.return_value.spawn_for_tasks.side_effect = RuntimeError("boom")
+            pid = loop._spawn_agent(TASK_DICT)
+
+        assert pid is None
+        assert any("Failed to spawn agent for task task-42" in rec.getMessage() for rec in caplog.records)
+
+    def test_spawn_returns_none_when_session_has_no_pid(self, tmp_path: Path) -> None:
+        """A session without a PID yields None so the slot is not consumed."""
+        loop = _make_loop(tmp_path)
+        session = AgentSession(id="backend-abc", role="backend", pid=None)
+
+        with (
+            mock.patch("bernstein.adapters.registry.get_adapter", return_value=mock.MagicMock()),
+            mock.patch("bernstein.core.agents.spawner.AgentSpawner", autospec=True) as spawner_cls,
+        ):
+            spawner_cls.return_value.spawn_for_tasks.return_value = session
+            pid = loop._spawn_agent(TASK_DICT)
+
+        assert pid is None


### PR DESCRIPTION
Fixes #2163.

The worker loop's _spawn_agent constructed AgentSpawner with keyword arguments the class never accepted and called a method that does not exist, so the path raised TypeError as soon as a task was claimed. It now resolves the adapter instance from the configured name, passes the real contract (adapter, templates/roles dir, workdir), builds a Task, and calls spawn_for_tasks. BERNSTEIN_SERVER_URL joins the env allowlist so the server URL actually reaches spawned agents; the auth token was already allowlisted. New tests fail on the old code (TypeError) and pass on this.

## Summary by Sourcery

Fix the worker CLI agent-spawning path so remote workers can successfully launch agents connected to the central server.

Bug Fixes:
- Correct WorkerLoop._spawn_agent to construct AgentSpawner with the expected adapter instance, templates directory, and workdir, and to spawn using Task models instead of the previous broken call path.

Enhancements:
- Ensure spawned agents inherit the server URL and auth token via environment variables so they talk to the correct central server.
- Allow BERNSTEIN_SERVER_URL to pass through the adapter environment isolation allowlist so remote workers can configure agent connectivity.

Tests:
- Add unit tests for WorkerLoop._spawn_agent covering successful spawn, environment propagation, failure handling, and sessions without PIDs.
- Add an environment isolation test verifying that BERNSTEIN_SERVER_URL is preserved in filtered environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worker-launched agents now inherit the server URL so they can report progress correctly.
  * Improved agent startup handling to return a clean failure state when launch issues occur or no process ID is available.

* **Tests**
  * Added coverage for environment filtering and worker agent spawning behavior, including environment propagation and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->