### PR TITLE
fix(sandbox): result sync-back, per-agent sessions, audit events, reachability check

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -96,6 +96,7 @@ from bernstein.templates.renderer import TemplateError, render_role_prompt
 if TYPE_CHECKING:
     import subprocess
     import threading
+    from collections.abc import Callable
 
     from bernstein.adapters.base import CLIAdapter
     from bernstein.agents.catalog import CatalogAgent, CatalogRegistry
@@ -107,7 +108,8 @@ if TYPE_CHECKING:
     from bernstein.core.mcp_manager import MCPManager
     from bernstein.core.mcp_registry import MCPRegistry
     from bernstein.core.resource_limits import ResourceLimits
-    from bernstein.core.sandbox.backend import SandboxSession
+    from bernstein.core.sandbox.backend import SandboxBackend, SandboxSession
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
     from bernstein.core.workspace import Workspace
 
 # ---------------------------------------------------------------------------
@@ -870,6 +872,10 @@ class AgentSpawner:
         warm_pool: WarmPool | None = None,
         spawn_rate_limiter: SpawnRateLimiter | None = None,
         sandbox_session: SandboxSession | None = None,
+        sandbox_backend: SandboxBackend | None = None,
+        sandbox_manifest_factory: Callable[[], WorkspaceManifest] | None = None,
+        sandbox_options: dict[str, Any] | None = None,
+        sandbox_server_port: int | None = None,
         default_model: str | None = None,
     ) -> None:
         self._enable_caching = enable_caching
@@ -950,6 +956,25 @@ class AgentSpawner:
         self._sandbox_session: SandboxSession | None = sandbox_session
         if sandbox_session is not None:
             sandbox_session_created_total.labels(backend=getattr(sandbox_session, "backend_name", "unknown")).inc()
+        # Issue #2162: per-agent sandbox sessions. When a backend plus a
+        # manifest factory are attached (instead of a single pre-built
+        # session), _spawn_via_sandbox_session provisions ONE session per
+        # spawn and destroys it when the exec future resolves, so an exec
+        # timeout that kills a container only kills that agent and
+        # concurrent agents never share a single workspace clone. The
+        # sandbox_session parameter above keeps working unchanged for
+        # callers that pass a shared session (tests, back-compat).
+        self._sandbox_backend = sandbox_backend
+        self._sandbox_manifest_factory = sandbox_manifest_factory
+        self._sandbox_options: dict[str, Any] = dict(sandbox_options or {})
+        self._sandbox_server_port = sandbox_server_port
+        # session_id -> per-spawn SandboxSession owned (and destroyed)
+        # by this spawner.  Popped exactly once by _destroy_sandbox_session
+        # so the exec-done callback and kill() cannot double-destroy.
+        self._sandbox_owned_sessions: dict[str, SandboxSession] = {}
+        # One reachability probe per spawner instance is enough - the
+        # answer is a property of the Docker daemon, not of the session.
+        self._sandbox_reachability_checked = False
         # session_id -> SandboxExecHandle for agents whose exec went
         # through SandboxSession.exec.  Consulted by check_alive / kill
         # so the orchestrator's lifecycle paths keep working without a
@@ -1097,6 +1122,21 @@ class AgentSpawner:
         routes adapter exec through ``sandbox_session.exec``.
         """
         return self._sandbox_session
+
+    def _sandbox_session_routing_active(self) -> bool:
+        """Return True when spawns must route through a sandbox session.
+
+        Two wiring shapes activate the routing seam:
+
+        1. A shared non-worktree :class:`SandboxSession` attached at
+           construction (oai-002 phase 2 back-compat).
+        2. A :class:`SandboxBackend` plus manifest factory attached at
+           construction, which makes ``_spawn_via_sandbox_session``
+           provision one session per spawn (issue #2162).
+        """
+        if self._sandbox_session is not None:
+            return getattr(self._sandbox_session, "backend_name", "worktree") != "worktree"
+        return self._sandbox_backend is not None and self._sandbox_manifest_factory is not None
 
     def cleanup_worktree(self, session_id: str) -> None:
         """Remove the worktree and branch for a dead agent session."""
@@ -2221,13 +2261,13 @@ class AgentSpawner:
                                 mcp_config=effective_mcp,
                             )
                             result = SpawnResult(pid=fake_pid, log_path=actual_log_path)
-                        elif (
-                            self._sandbox_session is not None
-                            and getattr(self._sandbox_session, "backend_name", "worktree") != "worktree"
-                        ):
-                            # oai-002 phase 2: route exec through the
-                            # attached SandboxSession (Docker, E2B,
-                            # Modal, plugin).  The local-worktree
+                        elif self._sandbox_session_routing_active():
+                            # oai-002 phase 2: route exec through a
+                            # SandboxSession (Docker, E2B, Modal,
+                            # plugin) - either the shared session
+                            # attached at construction or a per-spawn
+                            # session provisioned from the attached
+                            # backend (issue #2162).  The local-worktree
                             # backend is intentionally excluded so the
                             # existing direct-subprocess path keeps
                             # worker-wrapper / PID semantics intact.
@@ -2773,14 +2813,18 @@ class AgentSpawner:
         session: AgentSession,
         adapter: CLIAdapter,
     ) -> SpawnResult:
-        """Route adapter exec through the attached :class:`SandboxSession`.
+        """Route adapter exec through a :class:`SandboxSession`.
 
         Phase 2 of ``oai-002``. When the spawner has been wired with a
         non-worktree :class:`SandboxBackend` (Docker, E2B, Modal,
         custom plugin), the adapter command is run via
         :meth:`SandboxSession.exec` and the prompt is injected via
         :meth:`SandboxSession.write` instead of mutating the host
-        worktree directly. The local-worktree backend is intentionally
+        worktree directly. Issue #2162: when a backend plus manifest
+        factory are attached (production wiring), a dedicated session
+        is provisioned for this spawn and destroyed when the exec
+        future resolves; a shared session attached at construction is
+        used as-is for back-compat. The local-worktree backend is intentionally
         excluded: keeping it on the legacy direct-subprocess path
         preserves the worker-wrapper, process-group, and timeout-watchdog
         bookkeeping that production tooling depends on, and matches the
@@ -2804,8 +2848,34 @@ class AgentSpawner:
             the :class:`SandboxExecHandle` stored in
             ``_sandbox_exec_handles``.
         """
-        assert self._sandbox_session is not None
-        sbx_session = self._sandbox_session
+        sbx_session: SandboxSession
+        owned = False
+        if self._sandbox_session is not None:
+            # Back-compat: a single shared session attached at
+            # construction. Its lifecycle belongs to whoever built it.
+            sbx_session = self._sandbox_session
+        else:
+            # Issue #2162: one session per spawn. Provisioning failure
+            # falls back to the direct adapter spawn, mirroring the
+            # ContainerError fallback in _spawn_in_sandbox.
+            try:
+                sbx_session = self._provision_sandbox_session(session_id)
+            except Exception as exc:
+                logger.warning(
+                    "Sandbox session provisioning failed for %s, falling back to direct spawn: %s",
+                    session_id,
+                    exc,
+                )
+                session.isolation = IsolationMode.WORKTREE.value if self._use_worktrees else IsolationMode.NONE.value
+                return adapter.spawn(
+                    prompt=prompt,
+                    workdir=spawn_cwd,
+                    model_config=model_config,
+                    session_id=session_id,
+                    mcp_config=mcp_config,
+                )
+            owned = True
+            self._sandbox_owned_sessions[session_id] = sbx_session
 
         log_dir = spawn_cwd / ".sdd" / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -2851,6 +2921,23 @@ class AgentSpawner:
             _env_keys.extend(["OPENAI_API_KEY", "OPENAI_BASE_URL"])
         sandbox_env = {k: v for k in _env_keys if (v := _os.environ.get(k)) is not None}
 
+        # 2c) Audit the exec submission (issue #2162). The argv embeds
+        #     prompt paths and model names, so only its hash is chained.
+        import hashlib as _hashlib
+
+        from bernstein.core.security.audit import SANDBOX_EXEC_START
+
+        self._emit_sandbox_audit(
+            SANDBOX_EXEC_START,
+            resource_id=sbx_session.session_id,
+            details={
+                "session_id": sbx_session.session_id,
+                "adapter": adapter.name(),
+                "cmd_hash": _hashlib.sha256(" ".join(cmd).encode("utf-8")).hexdigest(),
+                "agent_session_id": session_id,
+            },
+        )
+
         # 3) Submit the exec on a dedicated thread; the future drives
         #    liveness checks via SandboxSession-aware paths.
         handle = submit_session_exec(
@@ -2864,9 +2951,10 @@ class AgentSpawner:
         self._sandbox_exec_handles[session_id] = handle
 
         # When the future resolves we increment the per-exit-code
-        # counter so operators can see how often agents inside a given
-        # backend exit cleanly.
-        def _record_exit(_h: SandboxExecHandle = handle) -> None:
+        # counter, chain the exec_end audit event, sync committed work
+        # back to the host, and (for per-spawn sessions) destroy the
+        # session so no container outlives its agent (issue #2162).
+        def _record_exit(_h: SandboxExecHandle = handle, _owned: bool = owned) -> None:
             try:
                 if _h.future.cancelled():
                     code = "cancelled"
@@ -2877,12 +2965,247 @@ class AgentSpawner:
             except Exception:  # pragma: no cover - defensive
                 code = "error"
             sandbox_exec_count_total.labels(backend=_h.backend_name, exit_code=code).inc()
+            from bernstein.core.security.audit import SANDBOX_EXEC_END
+
+            self._emit_sandbox_audit(
+                SANDBOX_EXEC_END,
+                resource_id=sbx_session.session_id,
+                details={
+                    "session_id": sbx_session.session_id,
+                    "exit_code": code,
+                    "agent_session_id": session_id,
+                },
+            )
+            # Retrieve committed work from the sandbox-local clone
+            # before the session goes away. Skipped for cancelled or
+            # crashed execs where the container state is undefined.
+            if code not in ("cancelled", "error"):
+                self._sync_back_sandbox_work(sbx_session, session_id)
+            if _owned:
+                self._destroy_sandbox_session(session_id)
 
         handle.future.add_done_callback(lambda _f: _record_exit())
 
         session.isolation = IsolationMode.CONTAINER.value
         session.runtime_backend = handle.backend_name
         return SpawnResult(pid=0, log_path=log_path)
+
+    def _provision_sandbox_session(self, session_id: str) -> SandboxSession:
+        """Provision a dedicated sandbox session for one spawn (issue #2162).
+
+        One session per agent means one container per agent: an exec
+        timeout that kills a container only kills that agent, and
+        concurrent agents no longer share a single workspace clone.
+
+        Args:
+            session_id: Agent session identifier, recorded in the audit
+                event for correlation. The backend allocates its own
+                sandbox session id.
+
+        Returns:
+            The freshly created :class:`SandboxSession`.
+
+        Raises:
+            Exception: Whatever the backend raised; the caller falls
+                back to a direct adapter spawn.
+        """
+        assert self._sandbox_backend is not None
+        assert self._sandbox_manifest_factory is not None
+        manifest = self._sandbox_manifest_factory()
+        sbx_session = asyncio.run(self._sandbox_backend.create(manifest, options=dict(self._sandbox_options)))
+        backend_name = getattr(sbx_session, "backend_name", "unknown")
+        sandbox_session_created_total.labels(backend=backend_name).inc()
+        logger.info(
+            "Provisioned sandbox session %s for agent %s (backend=%s)",
+            sbx_session.session_id,
+            session_id,
+            backend_name,
+        )
+        from bernstein.core.security.audit import SANDBOX_SESSION_CREATE
+
+        self._emit_sandbox_audit(
+            SANDBOX_SESSION_CREATE,
+            resource_id=sbx_session.session_id,
+            details={
+                "session_id": sbx_session.session_id,
+                "image": self._sandbox_options.get("image"),
+                "backend": backend_name,
+                "agent_session_id": session_id,
+            },
+        )
+        self._check_task_server_reachability(sbx_session)
+        return sbx_session
+
+    def _destroy_sandbox_session(self, session_id: str) -> None:
+        """Destroy the per-spawn sandbox session owned by *session_id*.
+
+        Idempotent and race-safe: the owned-session map is popped
+        first, so a :meth:`kill` racing the exec-done callback destroys
+        the session exactly once. Failures log a warning, never raise.
+
+        Args:
+            session_id: Agent session whose sandbox session should go.
+        """
+        sbx_session = self._sandbox_owned_sessions.pop(session_id, None)
+        if sbx_session is None:
+            return
+        try:
+            if self._sandbox_backend is not None:
+                asyncio.run(self._sandbox_backend.destroy(sbx_session))
+            else:  # pragma: no cover - owned sessions always have a backend
+                asyncio.run(sbx_session.shutdown())
+        except Exception as exc:
+            logger.warning(
+                "Failed to destroy sandbox session %s for agent %s: %s",
+                sbx_session.session_id,
+                session_id,
+                exc,
+            )
+            return
+        logger.info("Destroyed sandbox session %s for agent %s", sbx_session.session_id, session_id)
+        from bernstein.core.security.audit import SANDBOX_SESSION_DESTROY
+
+        self._emit_sandbox_audit(
+            SANDBOX_SESSION_DESTROY,
+            resource_id=sbx_session.session_id,
+            details={"session_id": sbx_session.session_id, "agent_session_id": session_id},
+        )
+
+    def _sync_back_sandbox_work(self, sbx_session: SandboxSession, session_id: str) -> None:
+        """Best-effort sync of sandbox-local commits back to the host.
+
+        Agent commits land in the sandbox's own clone (e.g.
+        ``/workspace`` inside a Docker container) and would vanish with
+        the session. Bundle every ref inside the sandbox, copy the
+        bundle to ``.sdd/runtime/sandbox/<session_id>.bundle`` on the
+        host, then fetch it into ``refs/remotes/sandbox/<session_id>/*``
+        so the work stays inspectable after the run (issue #2162).
+
+        Failures log a warning and never crash the run.
+
+        Args:
+            sbx_session: The session holding the agent's clone.
+            session_id: Agent session identifier; used as the bundle
+                basename and the remote-ref namespace.
+        """
+        import subprocess as _subprocess
+
+        bundle_in_sandbox = f"/tmp/{session_id}.bundle"
+        try:
+            bundle_result = asyncio.run(
+                sbx_session.exec(["git", "bundle", "create", bundle_in_sandbox, "--all"], timeout=120)
+            )
+            if bundle_result.exit_code != 0:
+                logger.warning(
+                    "Sandbox sync-back for %s: git bundle create failed (exit %d): %s",
+                    session_id,
+                    bundle_result.exit_code,
+                    bundle_result.stderr[:500].decode("utf-8", errors="replace"),
+                )
+                return
+            bundle_bytes = asyncio.run(sbx_session.read(bundle_in_sandbox))
+            bundle_dir = self._workdir / ".sdd" / "runtime" / "sandbox"
+            bundle_dir.mkdir(parents=True, exist_ok=True)
+            bundle_path = bundle_dir / f"{session_id}.bundle"
+            bundle_path.write_bytes(bundle_bytes)
+
+            refspec = f"refs/heads/*:refs/remotes/sandbox/{session_id}/*"
+            fetch = _subprocess.run(
+                ["git", "fetch", str(bundle_path), refspec],
+                cwd=self._workdir,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+            if fetch.returncode != 0:
+                logger.warning(
+                    "Sandbox sync-back for %s: git fetch from bundle failed: %s",
+                    session_id,
+                    fetch.stderr.strip()[:500],
+                )
+                return
+            refs_result = _subprocess.run(
+                ["git", "for-each-ref", "--format=%(refname)", f"refs/remotes/sandbox/{session_id}/"],
+                cwd=self._workdir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            fetched_refs = [line for line in refs_result.stdout.splitlines() if line]
+            logger.info(
+                "Synced sandbox work for %s: bundle at %s, fetched refs: %s",
+                session_id,
+                bundle_path,
+                ", ".join(fetched_refs) or "(none)",
+            )
+        except Exception as exc:
+            logger.warning("Sandbox sync-back for %s failed: %s", session_id, exc)
+
+    def _check_task_server_reachability(self, sbx_session: SandboxSession) -> None:
+        """Warn once when the sandbox cannot reach the host task server.
+
+        Some Docker Desktop configurations do not support host
+        networking, so agents inside the container cannot POST to the
+        task server on 127.0.0.1. This probe surfaces the condition as
+        an explicit warning instead of a silent run stall; the run
+        proceeds and relies on the legacy path behavior (issue #2162).
+        Never fails the run.
+
+        Args:
+            sbx_session: A freshly provisioned session to probe from.
+        """
+        port = self._sandbox_server_port
+        if port is None or self._sandbox_reachability_checked:
+            return
+        self._sandbox_reachability_checked = True
+        probe = f'import socket; socket.create_connection(("127.0.0.1", {int(port)}), timeout=3).close()'
+        try:
+            result = asyncio.run(sbx_session.exec(["python3", "-c", probe], timeout=15))
+        except Exception as exc:
+            logger.warning(
+                "Could not probe task server reachability from sandbox session %s: %s",
+                sbx_session.session_id,
+                exc,
+            )
+            return
+        if result.exit_code != 0:
+            logger.warning(
+                "Sandbox session %s cannot reach the task server on 127.0.0.1:%d; "
+                "agents inside containers on this Docker daemon will not reach the "
+                "task server (some Docker Desktop configurations do not support "
+                "host networking). The run will rely on the legacy path behavior.",
+                sbx_session.session_id,
+                port,
+            )
+
+    def _emit_sandbox_audit(self, event_type: str, *, resource_id: str, details: dict[str, Any]) -> None:
+        """Append a sandbox lifecycle event to the HMAC-chained audit log.
+
+        Best-effort by design (issue #2162): audit failures (key
+        permission, disk full) are logged at warning level and never
+        block the spawn or teardown paths that emit them.
+
+        Args:
+            event_type: One of the ``sandbox.*`` event-type constants
+                from :mod:`bernstein.core.security.audit`.
+            resource_id: Audit resource identifier (sandbox session id).
+            details: Structured event payload.
+        """
+        try:
+            from bernstein.core.security.audit import AuditLog
+
+            audit = AuditLog(audit_dir=self._workdir / ".sdd" / "audit")
+            audit.log(
+                event_type=event_type,
+                actor="spawner",
+                resource_type="sandbox_session",
+                resource_id=resource_id,
+                details=details,
+            )
+        except Exception as exc:  # audit must never block execution
+            logger.warning("Could not emit %s audit event for %s: %s", event_type, resource_id, exc)
 
     def _adapter_cmd_for_container(
         self,
@@ -3101,6 +3424,10 @@ class AgentSpawner:
         if sbx_handle is not None:
             cancel_session_exec(sbx_handle)
             self._sandbox_exec_handles.pop(session.id, None)
+            # Issue #2162: per-spawn sessions are destroyed on kill so a
+            # cancelled agent never leaves its container behind. No-op
+            # when the exec-done callback already destroyed it.
+            self._destroy_sandbox_session(session.id)
             self._transition_to_dead(
                 session,
                 "kill requested",

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import json
 import logging
 import shutil
+import threading
 import time
 import uuid
 from contextlib import suppress
@@ -95,7 +96,6 @@ from bernstein.templates.renderer import TemplateError, render_role_prompt
 
 if TYPE_CHECKING:
     import subprocess
-    import threading
     from collections.abc import Callable
 
     from bernstein.adapters.base import CLIAdapter
@@ -117,6 +117,18 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 _FILE_CACHE: dict[str, tuple[float, str]] = {}
 _DIR_CACHE: dict[str, tuple[float, list[str]]] = {}
+
+# Serializes every sandbox lifecycle audit append across threads.
+#
+# AuditLog has no internal locking: each instance recovers the chain tail
+# from disk in __init__ and appends with that prev_hmac. Sandbox events are
+# emitted concurrently - session_create/exec_start on the spawn thread,
+# exec_end/session_destroy on per-agent exec-done callback threads - so
+# unserialized appends let two writers recover the same tail and write
+# sibling records, forking the HMAC chain and breaking verify() for the
+# whole daily log. Module-level (not per-spawner) so multiple spawner
+# instances in one process share the same critical section.
+_SANDBOX_AUDIT_LOCK = threading.Lock()
 
 
 def _read_cached(path: Path) -> str:
@@ -3187,6 +3199,12 @@ class AgentSpawner:
         permission, disk full) are logged at warning level and never
         block the spawn or teardown paths that emit them.
 
+        All emissions are serialized through ``_SANDBOX_AUDIT_LOCK``:
+        exec_end/session_destroy fire from exec-done callback threads
+        while the spawn thread emits session_create/exec_start for other
+        agents, and AuditLog's tail-recover-then-append sequence is not
+        concurrency-safe (overlapping writers fork the HMAC chain).
+
         Args:
             event_type: One of the ``sandbox.*`` event-type constants
                 from :mod:`bernstein.core.security.audit`.
@@ -3196,14 +3214,15 @@ class AgentSpawner:
         try:
             from bernstein.core.security.audit import AuditLog
 
-            audit = AuditLog(audit_dir=self._workdir / ".sdd" / "audit")
-            audit.log(
-                event_type=event_type,
-                actor="spawner",
-                resource_type="sandbox_session",
-                resource_id=resource_id,
-                details=details,
-            )
+            with _SANDBOX_AUDIT_LOCK:
+                audit = AuditLog(audit_dir=self._workdir / ".sdd" / "audit")
+                audit.log(
+                    event_type=event_type,
+                    actor="spawner",
+                    resource_type="sandbox_session",
+                    resource_id=resource_id,
+                    details=details,
+                )
         except Exception as exc:  # audit must never block execution
             logger.warning("Could not emit %s audit event for %s: %s", event_type, resource_id, exc)
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4705,17 +4705,17 @@ if __name__ == "__main__":
             ensure_agent_image(_container_iso.runtime, _container_iso.image)
 
         # ``--sandbox docker`` (BERNSTEIN_SANDBOX_RUNTIME=docker) previously
-        # only built the ``sandbox_config`` dataclass above, which routes
-        # spawns through the legacy ``ContainerManager`` bind-mount path
-        # (``AgentSpawner._spawn_in_sandbox``). Provision an actual
-        # DockerSandboxBackend SandboxSession here and attach it to the
-        # spawner so runs prefer the newer, fully-isolated
-        # ``_spawn_via_sandbox_session`` path (oai-002b). Fully
+        # provisioned one run-level SandboxSession shared by every agent,
+        # so a single exec timeout killed the container for all of them
+        # and concurrent agents shared one /workspace clone. Attach the
+        # DockerSandboxBackend plus a manifest factory instead: the
+        # spawner provisions ONE session per spawn and destroys it when
+        # the exec future resolves (issue #2162). Fully
         # backward-compatible: without ``--sandbox docker`` this block
-        # never runs, and any provisioning failure falls back to the
-        # existing legacy container path unchanged.
-        docker_sandbox_session = None
+        # never runs, and any wiring failure falls back to the existing
+        # legacy container path unchanged.
         _docker_sandbox_backend = None
+        _docker_manifest_factory = None
         if _sandbox_runtime == "docker":
             try:
                 import subprocess as _subprocess
@@ -4736,42 +4736,47 @@ if __name__ == "__main__":
                 )
                 _current_branch = _branch_result.stdout.strip() or "HEAD"
 
-                _docker_manifest = WorkspaceManifest(
-                    root="/workspace",
-                    repo=GitRepoEntry(src_path=str(workdir), branch=_current_branch),
-                )
+                def _make_docker_manifest(
+                    _src: str = str(workdir), _branch: str = _current_branch
+                ) -> WorkspaceManifest:
+                    return WorkspaceManifest(
+                        root="/workspace",
+                        repo=GitRepoEntry(src_path=_src, branch=_branch),
+                    )
+
                 _docker_backend = DockerSandboxBackend()
-                docker_sandbox_session = _asyncio.run(
-                    _docker_backend.create(_docker_manifest, options={"image": _container_image}),
-                )
+                # Fail fast at wiring time so a dead daemon still falls
+                # back to legacy isolation instead of failing per spawn.
+                _docker_backend.ensure_available()
                 _docker_sandbox_backend = _docker_backend
+                _docker_manifest_factory = _make_docker_manifest
                 logger.info(
-                    "Docker sandbox session %s provisioned for this run (branch=%s)",
-                    docker_sandbox_session.session_id,
+                    "Docker sandbox backend attached; one session per agent spawn (branch=%s)",
                     _current_branch,
                 )
             except DockerUnavailableError as exc:
                 logger.warning("Docker sandbox unavailable (%s); falling back to legacy container isolation", exc)
             except Exception as exc:
                 logger.warning(
-                    "Failed to provision Docker sandbox session, falling back to legacy container isolation: %s",
+                    "Failed to attach Docker sandbox backend, falling back to legacy container isolation: %s",
                     exc,
                 )
 
         def _teardown_docker_sandbox() -> None:
-            """Destroy the run-level Docker sandbox session, if any.
+            """Destroy any Docker sandbox sessions the backend still tracks.
 
-            Without this every ``--sandbox docker`` run leaves a
-            ``sleep infinity`` container behind after the orchestrator
-            exits.
+            Per-agent sessions are normally destroyed when their exec
+            future resolves; this backend-level sweep catches anything
+            left behind so no ``sleep infinity`` container outlives the
+            orchestrator.
             """
-            if docker_sandbox_session is None or _docker_sandbox_backend is None:
+            if _docker_sandbox_backend is None:
                 return
             try:
-                _asyncio.run(_docker_sandbox_backend.destroy(docker_sandbox_session))
-                logger.info("Docker sandbox session %s destroyed", docker_sandbox_session.session_id)
+                _asyncio.run(_docker_sandbox_backend.destroy_all())
+                logger.info("Docker sandbox backend cleanup complete")
             except Exception:
-                logger.warning("Failed to destroy Docker sandbox session", exc_info=True)
+                logger.warning("Failed to clean up Docker sandbox sessions", exc_info=True)
 
         runtime_bridge = None
         openclaw_cfg = seed.bridges.openclaw if seed is not None and seed.bridges is not None else None
@@ -4839,7 +4844,10 @@ if __name__ == "__main__":
             runtime_bridge=runtime_bridge,
             resource_limits=agent_rlimits,
             warm_pool=warm_pool,
-            sandbox_session=docker_sandbox_session,
+            sandbox_backend=_docker_sandbox_backend,
+            sandbox_manifest_factory=_docker_manifest_factory,
+            sandbox_options={"image": _container_image} if _docker_sandbox_backend is not None else None,
+            sandbox_server_port=args.port,
             default_model=run_model,
         )
         run_config_budget_usd: float | None = None

--- a/src/bernstein/core/sandbox/backends/docker.py
+++ b/src/bernstein/core/sandbox/backends/docker.py
@@ -368,6 +368,23 @@ class DockerSandboxBackend:
                 raise DockerUnavailableError(f"Could not connect to Docker daemon: {exc}") from exc
         return self._client
 
+    def ensure_available(self) -> None:
+        """Verify the SDK imports and the daemon answers a ping.
+
+        Lets callers that provision sessions lazily (one session per
+        agent spawn) fail fast at wiring time instead of at the first
+        spawn, preserving the fall-back-to-legacy-isolation behaviour.
+
+        Raises:
+            DockerUnavailableError: The SDK is missing or the daemon
+                did not respond.
+        """
+        client = self._get_client()
+        try:
+            client.ping()
+        except Exception as exc:
+            raise DockerUnavailableError(f"Docker daemon did not respond to ping: {exc}") from exc
+
     @staticmethod
     def _allocate_session_id(hint: str | None = None) -> str:
         if hint:
@@ -502,6 +519,22 @@ class DockerSandboxBackend:
     async def destroy(self, session: SandboxSession) -> None:
         await session.shutdown()
         self._sessions.pop(session.session_id, None)
+
+    async def destroy_all(self) -> None:
+        """Destroy every session this backend still tracks.
+
+        Run-teardown safety net for per-agent sessions: any session
+        whose exec-done destroy hook never fired (orchestrator crash,
+        SIGKILL'd worker thread) is stopped and removed here so no
+        ``sleep infinity`` container outlives the run. Failures are
+        logged and never raised - teardown must not mask the run's
+        own exit path.
+        """
+        for session in list(self._sessions.values()):
+            try:
+                await self.destroy(session)
+            except Exception:
+                logger.warning("Failed to destroy sandbox session %s during cleanup", session.session_id, exc_info=True)
 
 
 __all__ = [

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -189,7 +189,14 @@ def load_or_create_audit_key(key_path: Path | None = None) -> bytes:
 
     key = secrets.token_hex(32).encode()
     # Create with restrictive mode from the start - never widen then narrow.
-    fd = os.open(str(resolved), os.O_WRONLY | os.O_CREAT | os.O_EXCL, _REQUIRED_KEY_MODE)
+    try:
+        fd = os.open(str(resolved), os.O_WRONLY | os.O_CREAT | os.O_EXCL, _REQUIRED_KEY_MODE)
+    except FileExistsError:
+        # Another thread/process won the first-boot race between the
+        # exists() check above and this O_EXCL create. Their key is as
+        # good as ours; adopt it instead of failing the caller.
+        _enforce_key_permissions(resolved)
+        return resolved.read_bytes().strip()
     try:
         os.write(fd, key)
     finally:

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -84,6 +84,23 @@ REPLAY_EXPORT = "replay.export"
 #: privacy transform.
 REPLAY_PUBLISH = "replay.publish"
 
+#: Issue #2162 - emitted when a per-agent sandbox session is provisioned.
+#: Details carry the sandbox session id, image, and backend name.
+SANDBOX_SESSION_CREATE = "sandbox.session_create"
+
+#: Issue #2162 - emitted when an adapter command is submitted to a sandbox
+#: session. Details carry the sandbox session id, adapter name, and a
+#: SHA-256 hash of the command (the raw argv embeds prompt paths and model
+#: names; the hash keeps the chain verifiable without recording them).
+SANDBOX_EXEC_START = "sandbox.exec_start"
+
+#: Issue #2162 - emitted when a sandbox exec future resolves. Details carry
+#: the sandbox session id and the exit code (or ``cancelled``/``error``).
+SANDBOX_EXEC_END = "sandbox.exec_end"
+
+#: Issue #2162 - emitted when a per-agent sandbox session is destroyed.
+SANDBOX_SESSION_DESTROY = "sandbox.session_destroy"
+
 
 class AuditKeyPermissionError(RuntimeError):
     """Raised when the audit key file has permissions looser than 0600."""

--- a/tests/unit/sandbox/test_docker_backend_unit.py
+++ b/tests/unit/sandbox/test_docker_backend_unit.py
@@ -1,0 +1,63 @@
+"""Unit tests for DockerSandboxBackend helpers with a mocked docker client.
+
+Live-daemon coverage lives in ``tests/integration/sandbox/``; these tests
+exercise the daemon-availability probe and the run-teardown session sweep
+(issue #2162) without requiring Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from bernstein.core.sandbox import WorkspaceManifest
+from bernstein.core.sandbox.backends.docker import DockerSandboxBackend, DockerUnavailableError
+
+
+def _make_client() -> MagicMock:
+    """Build a docker client mock whose containers run and exec cleanly."""
+    client = MagicMock()
+    container = MagicMock()
+    exec_result = MagicMock()
+    exec_result.exit_code = 0
+    exec_result.output = b""
+    container.exec_run.return_value = exec_result
+    client.containers.run.return_value = container
+    return client
+
+
+def test_ensure_available_pings_the_daemon() -> None:
+    """A responsive daemon passes the availability probe."""
+    client = _make_client()
+    backend = DockerSandboxBackend(client=client)
+    backend.ensure_available()
+    client.ping.assert_called_once()
+
+
+def test_ensure_available_raises_when_ping_fails() -> None:
+    """An unreachable daemon surfaces as DockerUnavailableError."""
+    client = _make_client()
+    client.ping.side_effect = RuntimeError("daemon down")
+    backend = DockerSandboxBackend(client=client)
+    with pytest.raises(DockerUnavailableError):
+        backend.ensure_available()
+
+
+def test_destroy_all_removes_every_tracked_session() -> None:
+    """destroy_all sweeps sessions left behind at run teardown."""
+    client = _make_client()
+    backend = DockerSandboxBackend(client=client)
+    manifest = WorkspaceManifest(root="/workspace")
+
+    asyncio.run(backend.create(manifest))
+    asyncio.run(backend.create(manifest))
+    assert len(backend._sessions) == 2  # pyright: ignore[reportPrivateUsage]
+
+    asyncio.run(backend.destroy_all())
+
+    assert backend._sessions == {}  # pyright: ignore[reportPrivateUsage]
+    container = client.containers.run.return_value
+    assert container.stop.call_count == 2
+    assert container.remove.call_count == 2

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -22,6 +23,7 @@ from bernstein.core.spawner import AgentSpawner
 from bernstein.adapters.base import CLIAdapter, SpawnResult
 from bernstein.core.sandbox import WorkspaceManifest
 from bernstein.core.sandbox.backend import ExecResult, SandboxSession
+from bernstein.core.security.audit import AuditLog
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -429,6 +431,49 @@ def test_audit_events_appended_for_session_lifecycle(tmp_path: Path, monkeypatch
         "sandbox.session_destroy",
     ):
         assert expected in types, f"missing audit event {expected} in {types}"
+
+    valid, errors = AuditLog(audit_dir=audit_dir).verify()
+    assert valid, f"audit chain not verifiable: {errors}"
+
+
+def test_concurrent_lifecycles_keep_audit_chain_verifiable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent emissions from spawn + exec-done threads never fork the HMAC chain.
+
+    Overlapping spawns emit session_create/exec_start from the spawning
+    threads while exec_end/session_destroy fire from per-agent exec-done
+    callback threads. Unserialized appends would recover the same chain
+    tail twice and write sibling records, so verify() - not mere event
+    presence - is the assertion that matters here.
+    """
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    backend = _FakeBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    session_ids = [f"S-CC-{i}" for i in range(4)]
+    spawn_threads = [threading.Thread(target=_spawn_one, args=(spawner, adapter, sid)) for sid in session_ids]
+    for thread in spawn_threads:
+        thread.start()
+    for thread in spawn_threads:
+        thread.join(timeout=10.0)
+
+    for sid in session_ids:
+        spawner._sandbox_exec_handles[sid].future.result(timeout=5.0)  # pyright: ignore[reportPrivateUsage]
+
+    audit_dir = tmp_path / ".sdd" / "audit"
+
+    def _destroy_events() -> int:
+        count = 0
+        for jsonl in audit_dir.glob("*.jsonl"):
+            for line in jsonl.read_text(encoding="utf-8").splitlines():
+                if json.loads(line)["event_type"] == "sandbox.session_destroy":
+                    count += 1
+        return count
+
+    _wait_until(lambda: _destroy_events() >= len(session_ids))
+
+    valid, errors = AuditLog(audit_dir=audit_dir).verify()
+    assert valid, f"audit chain forked under concurrent emission: {errors}"
+    assert errors == []
 
 
 class _GitBundleSession(_FakeSession):

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -1,8 +1,17 @@
-"""Unit tests for AgentSpawner sandbox-session routing (oai-002 phase 2)."""
+"""Unit tests for AgentSpawner sandbox-session routing (oai-002 phase 2).
+
+Issue #2162 extends the seam with per-spawn sessions (backend + manifest
+factory wiring), result sync-back, audit events, and the task-server
+reachability probe; those paths are covered here with mocked sessions.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
+import subprocess
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -11,10 +20,13 @@ from bernstein.core.models import AgentSession, ModelConfig
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.sandbox import WorkspaceManifest
 from bernstein.core.sandbox.backend import ExecResult, SandboxSession
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
+
+    import pytest
 
 
 class _FakeAdapter(CLIAdapter):
@@ -200,3 +212,293 @@ def test_sandbox_session_check_alive_and_kill(tmp_path: Path) -> None:
     spawner._kill_local(agent_session)  # pyright: ignore[reportPrivateUsage]
     assert "S-9" not in spawner._sandbox_exec_handles  # pyright: ignore[reportPrivateUsage]
     assert agent_session.status == "dead"
+
+
+# ---------------------------------------------------------------------------
+# Issue #2162: per-spawn sessions, sync-back, audit events, reachability
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackend:
+    """In-memory SandboxBackend that mints one :class:`_FakeSession` per create."""
+
+    name = "docker"
+    capabilities: frozenset[object] = frozenset()
+
+    def __init__(self, root: Path, *, block_exec: bool = False, exec_exit_code: int = 0) -> None:
+        self._root = root
+        self._block_exec = block_exec
+        self._exec_exit_code = exec_exit_code
+        self.created: list[_FakeSession] = []
+        self.destroyed: list[str] = []
+
+    async def create(self, manifest: object, options: dict[str, object] | None = None) -> _FakeSession:
+        del manifest, options
+        session_obj = _FakeSession(backend_name="docker", root=self._root)
+        session_obj.session_id = f"sbx-{len(self.created)}"
+        session_obj.exit_code = self._exec_exit_code
+        if self._block_exec:
+            session_obj._exec_blocker = asyncio.Event()  # pyright: ignore[reportPrivateUsage]
+        self.created.append(session_obj)
+        return session_obj
+
+    async def resume(self, snapshot_id: str) -> _FakeSession:
+        raise NotImplementedError
+
+    async def destroy(self, session: SandboxSession) -> None:
+        self.destroyed.append(session.session_id)
+        await session.shutdown()
+
+
+def _build_spawner_with_backend(
+    tmp_path: Path,
+    *,
+    backend: _FakeBackend,
+    server_port: int | None = None,
+) -> tuple[AgentSpawner, _FakeAdapter]:
+    adapter = _FakeAdapter("claude")
+    with patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=False,
+            sandbox_backend=backend,  # pyright: ignore[reportArgumentType]
+            sandbox_manifest_factory=lambda: WorkspaceManifest(root=str(tmp_path)),
+            sandbox_options={"image": "img:test"},
+            sandbox_server_port=server_port,
+        )
+    return spawner, adapter
+
+
+def _wait_until(predicate: Callable[[], object], timeout: float = 5.0) -> None:
+    """Poll *predicate* until truthy; exec-done callbacks run off-thread."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    raise AssertionError("condition not met within timeout")
+
+
+def _spawn_one(spawner: AgentSpawner, adapter: _FakeAdapter, session_id: str) -> AgentSession:
+    agent_session = AgentSession(id=session_id, role="backend")
+    spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id=session_id,
+        prompt="do the thing",
+        spawn_cwd=spawner._workdir,  # pyright: ignore[reportPrivateUsage]
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=adapter,
+    )
+    return agent_session
+
+
+def test_backend_wiring_activates_session_routing(tmp_path: Path) -> None:
+    """Backend + manifest factory activates the routing gate without a session."""
+    backend = _FakeBackend(tmp_path)
+    spawner, _ = _build_spawner_with_backend(tmp_path, backend=backend)
+    assert spawner.sandbox_session is None
+    assert spawner._sandbox_session_routing_active() is True  # pyright: ignore[reportPrivateUsage]
+
+
+def test_per_spawn_session_provisioned_and_destroyed(tmp_path: Path) -> None:
+    """Each spawn gets its own session; it is destroyed when the future resolves."""
+    backend = _FakeBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    agent_session = _spawn_one(spawner, adapter, "S-20")
+    handle = spawner._sandbox_exec_handles["S-20"]  # pyright: ignore[reportPrivateUsage]
+    handle.future.result(timeout=5.0)
+
+    _wait_until(lambda: backend.destroyed)
+    assert len(backend.created) == 1
+    assert backend.destroyed == [backend.created[0].session_id]
+    assert "S-20" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
+    assert agent_session.runtime_backend == "docker"
+
+
+def test_per_spawn_sessions_are_distinct_across_spawns(tmp_path: Path) -> None:
+    """Two spawns never share a session (one container per agent)."""
+    backend = _FakeBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    _spawn_one(spawner, adapter, "S-21")
+    _spawn_one(spawner, adapter, "S-22")
+    for session_id in ("S-21", "S-22"):
+        spawner._sandbox_exec_handles[session_id].future.result(timeout=5.0)  # pyright: ignore[reportPrivateUsage]
+
+    _wait_until(lambda: len(backend.destroyed) == 2)
+    assert len(backend.created) == 2
+    assert backend.created[0].session_id != backend.created[1].session_id
+
+
+def test_kill_destroys_per_spawn_session(tmp_path: Path) -> None:
+    """kill() cancels the exec and tears down the agent's own session."""
+    backend = _FakeBackend(tmp_path, block_exec=True)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    agent_session = _spawn_one(spawner, adapter, "S-23")
+    assert spawner._check_alive_sandbox_session(agent_session) is True  # pyright: ignore[reportPrivateUsage]
+
+    spawner._kill_local(agent_session)  # pyright: ignore[reportPrivateUsage]
+    _wait_until(lambda: backend.destroyed)
+    assert "S-23" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
+    assert agent_session.status == "dead"
+
+
+def test_sync_back_invoked_on_completion(tmp_path: Path) -> None:
+    """The exec-done callback bundles the sandbox clone (best effort)."""
+    backend = _FakeBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    _spawn_one(spawner, adapter, "S-24")
+    spawner._sandbox_exec_handles["S-24"].future.result(timeout=5.0)  # pyright: ignore[reportPrivateUsage]
+
+    session_obj = backend.created[0]
+    _wait_until(lambda: any(call[:3] == ["git", "bundle", "create"] for call in session_obj.exec_calls))
+    bundle_calls = [call for call in session_obj.exec_calls if call[:3] == ["git", "bundle", "create"]]
+    assert bundle_calls[0][3] == "/tmp/S-24.bundle"
+
+
+def test_provisioning_failure_falls_back_to_direct_spawn(tmp_path: Path) -> None:
+    """A backend that cannot create sessions falls back to adapter.spawn."""
+
+    class _BrokenBackend(_FakeBackend):
+        async def create(self, manifest: object, options: dict[str, object] | None = None) -> _FakeSession:
+            raise RuntimeError("daemon went away")
+
+    backend = _BrokenBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    agent_session = AgentSession(id="S-25", role="backend")
+    result = spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-25",
+        prompt="fallback",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=adapter,
+    )
+    assert result.pid == 99
+    assert adapter.spawn_calls == [("fallback", tmp_path)]
+    assert "S-25" not in spawner._sandbox_owned_sessions  # pyright: ignore[reportPrivateUsage]
+
+
+def test_reachability_probe_warns_when_unreachable(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A failed in-container TCP probe logs a warning and never fails the spawn."""
+    backend = _FakeBackend(tmp_path, exec_exit_code=1)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend, server_port=8052)
+
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.agents.spawner_core"):
+        _spawn_one(spawner, adapter, "S-26")
+        spawner._sandbox_exec_handles["S-26"].future.result(timeout=5.0)  # pyright: ignore[reportPrivateUsage]
+
+    assert any("cannot reach the task server" in record.getMessage() for record in caplog.records)
+    # The probe itself was routed through the session.
+    probe_calls = [call for call in backend.created[0].exec_calls if call[0] == "python3"]
+    assert probe_calls and "socket.create_connection" in probe_calls[0][2]
+
+
+def test_audit_events_appended_for_session_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lifecycle events land in the HMAC-chained audit log."""
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+    backend = _FakeBackend(tmp_path)
+    spawner, adapter = _build_spawner_with_backend(tmp_path, backend=backend)
+
+    _spawn_one(spawner, adapter, "S-27")
+    spawner._sandbox_exec_handles["S-27"].future.result(timeout=5.0)  # pyright: ignore[reportPrivateUsage]
+
+    audit_dir = tmp_path / ".sdd" / "audit"
+
+    def _event_types() -> list[str]:
+        events: list[str] = []
+        for jsonl in audit_dir.glob("*.jsonl"):
+            for line in jsonl.read_text(encoding="utf-8").splitlines():
+                events.append(json.loads(line)["event_type"])
+        return events
+
+    _wait_until(lambda: "sandbox.session_destroy" in _event_types())
+    types = _event_types()
+    for expected in (
+        "sandbox.session_create",
+        "sandbox.exec_start",
+        "sandbox.exec_end",
+        "sandbox.session_destroy",
+    ):
+        assert expected in types, f"missing audit event {expected} in {types}"
+
+
+class _GitBundleSession(_FakeSession):
+    """Fake session whose exec runs real git against a local clone.
+
+    The sandbox-absolute ``/tmp/<sid>.bundle`` path is redirected into a
+    per-test directory so the sync-back flow never touches the real /tmp.
+    """
+
+    def __init__(self, *, clone_root: Path, bundle_dir: Path) -> None:
+        super().__init__(backend_name="docker", root=clone_root)
+        self._clone_root = clone_root
+        self._bundle_dir = bundle_dir
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        del cwd, env, timeout, stdin
+        argv = [str(self._bundle_dir / Path(arg).name) if arg.startswith("/tmp/") else arg for arg in cmd]
+        proc = subprocess.run(argv, cwd=self._clone_root, capture_output=True, check=False)
+        return ExecResult(exit_code=proc.returncode, stdout=proc.stdout, stderr=proc.stderr, duration_seconds=0.0)
+
+    async def read(self, path: str) -> bytes:
+        return (self._bundle_dir / Path(path).name).read_bytes()
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@example.com", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_sync_back_fetches_bundle_refs_into_host_repo(tmp_path: Path) -> None:
+    """Committed sandbox work becomes refs/remotes/sandbox/<sid>/* on the host."""
+    host = tmp_path / "host"
+    host.mkdir()
+    _git(["init", "-q", "-b", "main"], host)
+    (host / "a.txt").write_text("one")
+    _git(["add", "."], host)
+    _git(["commit", "-q", "-m", "init"], host)
+
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", str(host), str(clone)], check=True, capture_output=True)
+    _git(["checkout", "-q", "-b", "agent-work"], clone)
+    (clone / "b.txt").write_text("two")
+    _git(["add", "."], clone)
+    _git(["commit", "-q", "-m", "agent commit"], clone)
+
+    bundle_dir = tmp_path / "bundles"
+    bundle_dir.mkdir()
+    session_obj = _GitBundleSession(clone_root=clone, bundle_dir=bundle_dir)
+    spawner, _ = _build_spawner(host, session=None)
+
+    spawner._sync_back_sandbox_work(session_obj, "S-42")  # pyright: ignore[reportPrivateUsage]
+
+    assert (host / ".sdd" / "runtime" / "sandbox" / "S-42.bundle").exists()
+    refs = subprocess.run(
+        ["git", "for-each-ref", "--format=%(refname)", "refs/remotes/sandbox/S-42/"],
+        cwd=host,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "refs/remotes/sandbox/S-42/agent-work" in refs


### PR DESCRIPTION
Fixes #2162. All four follow-ups from the v1 sandbox merge:

- **Result sync-back**: when a sandbox exec resolves, the container clone's commits are bundled and fetched into the host repo under sandbox/<session_id> refs (best-effort, logged).
- **Per-agent sessions**: the orchestrator now hands the spawner a backend plus manifest factory; each spawn provisions its own session, destroyed when its exec future resolves or the agent is killed. A single passed session keeps the old behavior for tests.
- **Audit events**: sandbox.session_create / exec_start / exec_end / session_destroy are appended to the HMAC-chained audit log; emissions are serialized so concurrent lifecycle events cannot fork the chain, and a test asserts the chain verifies after 4 overlapping lifecycles.
- **Reachability check**: after provisioning, a short in-container TCP probe against the task server logs a warning on daemons where host networking is unavailable.

## Summary by Sourcery

Introduce per-agent sandbox sessions with audit logging, result sync-back, and Docker backend wiring improvements for sandboxed agent execution.

New Features:
- Provision one sandbox session per agent spawn using a configured sandbox backend and manifest factory, while retaining support for a shared pre-built session.
- Sync committed work from sandbox-local git clones back into the host repository under sandbox-scoped remote refs after sandbox exec completion.
- Emit sandbox lifecycle audit events for session creation, exec start, exec end, and session destruction into the HMAC-chained audit log.
- Probe task-server reachability from inside newly provisioned sandbox sessions to surface host networking issues as warnings.

Enhancements:
- Add orchestration wiring to attach a DockerSandboxBackend plus manifest factory to the AgentSpawner instead of a single shared session, and clean up any lingering Docker sessions at run teardown.
- Extend DockerSandboxBackend with a daemon availability probe and a helper to destroy all tracked sessions, improving failure handling and cleanup behavior.
- Serialize sandbox audit log writes across threads to keep the HMAC chain verifiable under concurrent lifecycle events.
- Make audit key creation resilient to concurrent first-boot races by adopting an already-created key when the key file appears between existence check and creation.

Tests:
- Expand sandbox session routing tests to cover per-spawn sessions, sync-back behavior, audit event emission, reachability probing, and concurrent lifecycle scenarios.
- Add unit tests for DockerSandboxBackend daemon availability checks and destroy-all cleanup with a mocked Docker client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-spawn sandbox sessions when running agent spawns in a sandboxed environment.
  * Improved sandbox lifecycle handling, including startup, cleanup, and host sync-back behavior.

* **Bug Fixes**
  * Made sandbox teardown more reliable when spawns are canceled or killed.
  * Added a warning when the sandbox cannot reach the host task server.
  * Improved audit key creation to avoid startup races.

* **Tests**
  * Expanded coverage for sandbox session routing, cleanup, fallback behavior, audit logging, and concurrent spawn handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->