### PR TITLE
feat(openai_agents): sampling params, per-role endpoints, runner heartbeat

### DIFF
--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -144,3 +144,30 @@ The matrix is the source of truth; this table is regenerated from
 `strategy_conformance_table()`. Out of scope for this contract: runtime
 capability discovery, and removing every adapter-specific conditional (some
 output-formatting quirks remain as overrides).
+
+## Sampling and endpoint parameters
+
+Adapters that can honour per-spawn sampling and endpoint overrides declare
+`AdapterCapability.SUPPORTS_SAMPLING_PARAMS` in their `plugin_info()`
+capabilities. The overrides travel in the per-spawn `mcp_config` and, for
+`openai_agents`, land in the runner manifest as optional fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `temperature` | float | Sampling temperature. Absent = provider default. |
+| `top_p` | float | Nucleus sampling. Absent = provider default. |
+| `top_k` | int | Top-k sampling, forwarded for OpenAI-compatible endpoints that accept it. Absent = provider default. |
+| `base_url` | str | OpenAI-compatible endpoint URL. Absent = default endpoint. |
+| `api_key_env` | str | NAME of the environment variable holding the API key for `base_url`. Never a literal key. |
+
+All fields are optional; a manifest without them behaves exactly as before.
+If `api_key_env` names a variable that is not set, the runner fails at
+startup with an error naming the variable (exit code 2). The runner logs
+every effective value in its `start` event; only the env var name is ever
+logged, never the key itself.
+
+The spawn path enforces the capability: requesting any of these keys for an
+adapter that does not declare `SUPPORTS_SAMPLING_PARAMS` raises
+`SamplingParamsRefusal` instead of silently dropping the parameters. See
+`ensure_sampling_params_supported` in
+[`src/bernstein/adapters/plugin_sdk.py`](../../src/bernstein/adapters/plugin_sdk.py).

--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -166,13 +166,18 @@ API (third-party OpenAI-compatible endpoints do not serve `/responses`) and
 excludes the custom client from tracing so the endpoint's key is never sent
 to api.openai.com.
 
-`api_key_env` must match `^[A-Z][A-Z0-9_]*$` AND end with `_API_KEY`,
-`_KEY`, or `_TOKEN`. Any other name is rejected at startup with a
-`config_invalid` error (exit code 2), the same failure path as a name whose
-variable is not set. This keeps the override from being used to read
-unrelated host environment variables. The runner logs every effective value
-in its `start` event; only the env var name is ever logged, never the key
-itself.
+`api_key_env` must match `^[A-Z][A-Z0-9_]*$` AND be a known LLM provider
+key (`OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `DEEPSEEK_API_KEY`, and the
+rest of the built-in allowlist in `openai_agents_runner.py`). Any other
+name - including credential-shaped names of unrelated secrets such as
+`GITHUB_TOKEN` - is rejected at startup with a `config_invalid` error
+(exit code 2), the same failure path as a name whose variable is not set.
+To use a provider key outside the built-in set, the operator sets
+`BERNSTEIN_ALLOWED_API_KEY_ENVS` (comma-separated names) on the host; a
+repo-carried config cannot set host environment variables, so the
+override cannot be forged by the repo. The runner logs every effective
+value in its `start` event; only the env var name is ever logged, never
+the key itself.
 
 The spawn path enforces the capability: requesting any of these keys for an
 adapter that does not declare `SUPPORTS_SAMPLING_PARAMS` raises

--- a/docs/adapters/capability_contract.md
+++ b/docs/adapters/capability_contract.md
@@ -161,10 +161,18 @@ capabilities. The overrides travel in the per-spawn `mcp_config` and, for
 | `api_key_env` | str | NAME of the environment variable holding the API key for `base_url`. Never a literal key. |
 
 All fields are optional; a manifest without them behaves exactly as before.
-If `api_key_env` names a variable that is not set, the runner fails at
-startup with an error naming the variable (exit code 2). The runner logs
-every effective value in its `start` event; only the env var name is ever
-logged, never the key itself.
+When `base_url` is set, the runner switches the SDK to the chat-completions
+API (third-party OpenAI-compatible endpoints do not serve `/responses`) and
+excludes the custom client from tracing so the endpoint's key is never sent
+to api.openai.com.
+
+`api_key_env` must match `^[A-Z][A-Z0-9_]*$` AND end with `_API_KEY`,
+`_KEY`, or `_TOKEN`. Any other name is rejected at startup with a
+`config_invalid` error (exit code 2), the same failure path as a name whose
+variable is not set. This keeps the override from being used to read
+unrelated host environment variables. The runner logs every effective value
+in its `start` event; only the env var name is ever logged, never the key
+itself.
 
 The spawn path enforces the capability: requesting any of these keys for an
 adapter that does not declare `SUPPORTS_SAMPLING_PARAMS` raises

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.openai_agents_runner import validate_api_key_env_name
 from bernstein.adapters.plugin_sdk import (
     AdapterCapability,
     AdapterPluginInfo,
@@ -94,6 +95,13 @@ class OpenAIAgentsAdapter(PluginAdapter):
     # The SDK forwards 429s from api.openai.com with the standard
     # ``rate_limit_exceeded`` / ``insufficient_quota`` error codes.
     rate_limit_provider = "openai"
+
+    # The runner writes its own heartbeat files, but it runs inside a
+    # per-session worktree and cannot derive the orchestrator project
+    # root on its own.  This flag tells the spawner to inject a
+    # ``heartbeat_dir`` key (the orchestrator-root heartbeat directory
+    # the HeartbeatMonitor polls) into the per-spawn ``mcp_config``.
+    consumes_heartbeat_dir = True
 
     def plugin_info(self) -> AdapterPluginInfo:
         """Return metadata for the ``bernstein agents`` listing."""
@@ -173,9 +181,10 @@ class OpenAIAgentsAdapter(PluginAdapter):
             workdir: Worktree root for sandbox constraint.
             model_config: Model/effort selection.
             session_id: Bernstein session ID for log correlation.
-            mcp_config: Optional MCP servers, sandbox provider choice, and
+            mcp_config: Optional MCP servers, sandbox provider choice,
                 sampling/endpoint overrides (``temperature``, ``top_p``,
-                ``top_k``, ``base_url``, ``api_key_env``).
+                ``top_k``, ``base_url``, ``api_key_env``), and the
+                spawner-injected ``heartbeat_dir``.
             timeout_seconds: Hard timeout forwarded to the runner.
             task_scope: "small" | "medium" | "large".
             budget_multiplier: Retry multiplier applied to the scope budget.
@@ -187,7 +196,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
         sandbox_provider = _DEFAULT_SANDBOX_PROVIDER
         tools: list[dict[str, Any]] = []
         mcp_servers: dict[str, Any] = {}
-        sampling: dict[str, Any] = {}
+        overrides: dict[str, Any] = {}
         if mcp_config:
             provider = mcp_config.get("sandbox_provider")
             if isinstance(provider, str) and provider:
@@ -204,17 +213,24 @@ class OpenAIAgentsAdapter(PluginAdapter):
             for float_key in ("temperature", "top_p"):
                 float_value = mcp_config.get(float_key)
                 if isinstance(float_value, (int, float)) and not isinstance(float_value, bool):
-                    sampling[float_key] = float(float_value)
+                    overrides[float_key] = float(float_value)
             top_k = mcp_config.get("top_k")
             if isinstance(top_k, int) and not isinstance(top_k, bool):
-                sampling["top_k"] = top_k
+                overrides["top_k"] = top_k
             for str_key in ("base_url", "api_key_env"):
                 str_value = mcp_config.get(str_key)
                 if isinstance(str_value, str) and str_value:
-                    sampling[str_key] = str_value
+                    overrides[str_key] = str_value
+            # Heartbeat delivery target injected by the spawner: the
+            # orchestrator-root directory the HeartbeatMonitor polls.
+            # ``workdir`` is a per-session worktree under default
+            # isolation, so the runner cannot derive this path itself.
+            heartbeat_dir = mcp_config.get("heartbeat_dir")
+            if isinstance(heartbeat_dir, str) and heartbeat_dir:
+                overrides["heartbeat_dir"] = heartbeat_dir
 
         return {
-            **sampling,
+            **overrides,
             "session_id": session_id,
             "prompt": prompt,
             "workdir": str(workdir),
@@ -279,8 +295,13 @@ class OpenAIAgentsAdapter(PluginAdapter):
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
         # ``api_key_env`` overrides which env var holds the key; only its
-        # NAME is ever recorded, never the value.
-        api_key_env = str(manifest.get("api_key_env") or "OPENAI_API_KEY")
+        # NAME is ever recorded, never the value.  The name is validated
+        # BEFORE it widens the filtered environment below so a repo-carried
+        # config cannot forward arbitrary host variables to the runner.
+        api_key_env_override = manifest.get("api_key_env")
+        if api_key_env_override is not None:
+            validate_api_key_env_name(str(api_key_env_override))
+        api_key_env = str(api_key_env_override or "OPENAI_API_KEY")
         if not os.environ.get(api_key_env):
             logger.warning(
                 "OpenAIAgentsAdapter: %s is not set - spawn will fail",

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -110,6 +110,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
                 AdapterCapability.MULTI_MODEL,
                 AdapterCapability.RATE_LIMIT_DETECTION,
                 AdapterCapability.STRUCTURED_OUTPUT,
+                AdapterCapability.SUPPORTS_SAMPLING_PARAMS,
             ),
         )
 
@@ -172,7 +173,9 @@ class OpenAIAgentsAdapter(PluginAdapter):
             workdir: Worktree root for sandbox constraint.
             model_config: Model/effort selection.
             session_id: Bernstein session ID for log correlation.
-            mcp_config: Optional MCP servers and sandbox provider choice.
+            mcp_config: Optional MCP servers, sandbox provider choice, and
+                sampling/endpoint overrides (``temperature``, ``top_p``,
+                ``top_k``, ``base_url``, ``api_key_env``).
             timeout_seconds: Hard timeout forwarded to the runner.
             task_scope: "small" | "medium" | "large".
             budget_multiplier: Retry multiplier applied to the scope budget.
@@ -184,6 +187,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
         sandbox_provider = _DEFAULT_SANDBOX_PROVIDER
         tools: list[dict[str, Any]] = []
         mcp_servers: dict[str, Any] = {}
+        sampling: dict[str, Any] = {}
         if mcp_config:
             provider = mcp_config.get("sandbox_provider")
             if isinstance(provider, str) and provider:
@@ -194,8 +198,23 @@ class OpenAIAgentsAdapter(PluginAdapter):
             raw_servers: object = mcp_config.get("mcpServers")
             if isinstance(raw_servers, dict):
                 mcp_servers = cast("dict[str, Any]", raw_servers)
+            # Optional sampling/endpoint overrides.  Absent keys are not
+            # serialized so the runner's defaults (None) apply and the
+            # manifest stays byte-identical to pre-override builds.
+            for float_key in ("temperature", "top_p"):
+                float_value = mcp_config.get(float_key)
+                if isinstance(float_value, (int, float)) and not isinstance(float_value, bool):
+                    sampling[float_key] = float(float_value)
+            top_k = mcp_config.get("top_k")
+            if isinstance(top_k, int) and not isinstance(top_k, bool):
+                sampling["top_k"] = top_k
+            for str_key in ("base_url", "api_key_env"):
+                str_value = mcp_config.get(str_key)
+                if isinstance(str_value, str) and str_value:
+                    sampling[str_key] = str_value
 
         return {
+            **sampling,
             "session_id": session_id,
             "prompt": prompt,
             "workdir": str(workdir),
@@ -259,9 +278,13 @@ class OpenAIAgentsAdapter(PluginAdapter):
         )
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
-        if not os.environ.get("OPENAI_API_KEY"):
+        # ``api_key_env`` overrides which env var holds the key; only its
+        # NAME is ever recorded, never the value.
+        api_key_env = str(manifest.get("api_key_env") or "OPENAI_API_KEY")
+        if not os.environ.get(api_key_env):
             logger.warning(
-                "OpenAIAgentsAdapter: OPENAI_API_KEY is not set - spawn will fail",
+                "OpenAIAgentsAdapter: %s is not set - spawn will fail",
+                api_key_env,
             )
 
         cmd = [*self._runner_command(), "--manifest", str(manifest_path)]
@@ -278,7 +301,12 @@ class OpenAIAgentsAdapter(PluginAdapter):
             model=str(getattr(model_config, "model", "")),
         )
 
-        env = build_filtered_env(list(_OPENAI_CREDENTIAL_KEYS))
+        env_keys = list(_OPENAI_CREDENTIAL_KEYS)
+        if api_key_env not in env_keys:
+            # Pass the override key through the filtered env so the runner
+            # can resolve it by name.
+            env_keys.append(api_key_env)
+        env = build_filtered_env(env_keys)
         preexec_fn = self._get_preexec_fn()
         with log_path.open("w") as log_file:
             try:

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -20,7 +20,9 @@ events strictly - they are persisted to the session log and exposed via
 the existing log tail + hooks plumbing - but the schema below is what
 tests and downstream cost-tracking code rely on::
 
-    {"type": "start", "session_id": "...", "model": "gpt-5-mini"}
+    {"type": "start", "session_id": "...", "model": "gpt-5-mini",
+     "temperature": null, "top_p": null, "top_k": null,
+     "base_url": null, "api_key_env": null}
     {"type": "tool_call", "name": "file_read", "args": {...}}
     {"type": "tool_result", "name": "file_read", "output": "..."}
     {"type": "progress", "message": "..."}
@@ -32,7 +34,8 @@ Exit codes
 ----------
 
 * ``0`` - completion event emitted successfully
-* ``2`` - manifest missing or malformed
+* ``2`` - manifest missing or malformed, or ``api_key_env`` names an
+  environment variable that is not set
 * ``3`` - optional ``openai-agents`` SDK not installed
 * ``4`` - provider rate-limit detected (maps to Bernstein's back-off)
 * ``1`` - any other runtime error
@@ -41,10 +44,14 @@ Exit codes
 from __future__ import annotations
 
 import argparse
+import contextlib
 import dataclasses
 import json
 import logging
+import os
 import sys
+import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -89,6 +96,21 @@ class RunnerManifest:
             the SDK so the Agent can call into them *without* letting the
             SDK spawn its own server processes (avoids duplicate
             connections and double cost accounting).
+        temperature: Optional sampling temperature forwarded to the SDK's
+            ``ModelSettings``.  ``None`` keeps the provider default.
+        top_p: Optional nucleus-sampling value forwarded to
+            ``ModelSettings``.  ``None`` keeps the provider default.
+        top_k: Optional top-k sampling value forwarded to ``ModelSettings``
+            via ``extra_args`` (the OpenAI API itself has no ``top_k``, but
+            OpenAI-compatible endpoints selected via ``base_url`` do).
+            ``None`` keeps the provider default.
+        base_url: Optional OpenAI-compatible endpoint URL.  When set the
+            runner constructs its own ``AsyncOpenAI`` client instead of the
+            SDK default.  ``None`` keeps today's single-endpoint behavior.
+        api_key_env: Optional NAME of the environment variable holding the
+            API key for ``base_url``.  Never a literal key.  When set but
+            the variable is missing the runner fails at startup with
+            :data:`EXIT_MANIFEST_ERROR`.
     """
 
     session_id: str
@@ -104,6 +126,11 @@ class RunnerManifest:
     sandbox_provider: str = "unix_local"
     tools: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     mcp_servers: dict[str, Any] = field(default_factory=dict[str, Any])
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    base_url: str | None = None
+    api_key_env: str | None = None
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> RunnerManifest:
@@ -224,6 +251,110 @@ def _build_run_config(manifest: RunnerManifest) -> dict[str, Any]:
     }
 
 
+def _build_model_settings_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
+    """Translate optional sampling params into ``ModelSettings`` kwargs.
+
+    Only fields present in the manifest are emitted so an all-``None``
+    manifest yields an empty dict and the runner skips ``ModelSettings``
+    entirely (exactly today's behavior).  ``top_k`` is not a first-class
+    ``ModelSettings`` field in the SDK, so it travels via ``extra_args``
+    for OpenAI-compatible endpoints that accept it.
+
+    Returns:
+        Kwargs for ``agents.ModelSettings``, possibly empty.
+    """
+    kwargs: dict[str, Any] = {}
+    if manifest.temperature is not None:
+        kwargs["temperature"] = manifest.temperature
+    if manifest.top_p is not None:
+        kwargs["top_p"] = manifest.top_p
+    if manifest.top_k is not None:
+        kwargs["extra_args"] = {"top_k": manifest.top_k}
+    return kwargs
+
+
+def _resolve_client_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
+    """Build ``AsyncOpenAI(...)`` kwargs for the optional endpoint override.
+
+    Returns an empty dict when neither ``base_url`` nor ``api_key_env`` is
+    set, in which case the runner leaves the SDK's default client alone.
+    The key is resolved from the environment by NAME - the manifest never
+    carries a literal secret.
+
+    Raises:
+        RuntimeError: ``api_key_env`` is set but the named environment
+            variable is missing or empty.
+    """
+    kwargs: dict[str, Any] = {}
+    if manifest.base_url:
+        kwargs["base_url"] = manifest.base_url
+    if manifest.api_key_env:
+        api_key = os.environ.get(manifest.api_key_env)
+        if not api_key:
+            msg = (
+                f"manifest api_key_env names environment variable "
+                f"{manifest.api_key_env!r} but it is not set. Export "
+                f"{manifest.api_key_env} before spawning the openai_agents "
+                f"runner."
+            )
+            raise RuntimeError(msg)
+        kwargs["api_key"] = api_key
+    return kwargs
+
+
+def _start_heartbeat(
+    session_id: str,
+    workdir: Path,
+    interval_s: float = 15.0,
+) -> threading.Event:
+    """Write heartbeat files while the runner process is alive.
+
+    Mirrors the payload schema of ``_start_heartbeat_proxy`` in
+    :mod:`bernstein.core.agents.spawner_sandbox_session` so the
+    orchestrator's ``HeartbeatMonitor`` treats runner sessions exactly
+    like sandbox sessions.
+
+    Args:
+        session_id: Runner session identifier (heartbeat file basename).
+        workdir: Working directory (project root) where
+            ``.sdd/runtime/heartbeats/`` lives.
+        interval_s: Seconds between heartbeat writes (default 15).
+
+    Returns:
+        A :class:`threading.Event` the caller sets to stop the writer.
+    """
+    stop_event = threading.Event()
+    heartbeat_dir = workdir / ".sdd" / "runtime" / "heartbeats"
+
+    def _heartbeat_loop() -> None:
+        with contextlib.suppress(OSError):  # best effort
+            heartbeat_dir.mkdir(parents=True, exist_ok=True)
+        heartbeat_file = heartbeat_dir / f"{session_id}.json"
+        while not stop_event.is_set():
+            payload = json.dumps(
+                {
+                    "timestamp": int(time.time()),
+                    "phase": "implementing",
+                    "progress_pct": 0,
+                    "current_file": "",
+                    "message": "openai-agents runner working",
+                    "status": "working",
+                    "files_changed": 0,
+                }
+            )
+            with contextlib.suppress(OSError):  # best effort
+                heartbeat_file.write_text(payload, encoding="utf-8")
+            stop_event.wait(interval_s)
+
+    thread = threading.Thread(
+        target=_heartbeat_loop,
+        name=f"heartbeat-runner-{session_id}",
+        daemon=True,
+    )
+    thread.start()
+    return stop_event
+
+
 def run(manifest: RunnerManifest) -> int:
     """Execute the SDK session described by ``manifest``.
 
@@ -236,15 +367,54 @@ def run(manifest: RunnerManifest) -> int:
     Returns:
         Process exit code.  See module docstring for the contract.
     """
+    # Every effective sampling/endpoint param is logged here.  The key
+    # itself is never logged - only the NAME of the env var that holds it.
     emit_event(
         {
             "type": "start",
             "session_id": manifest.session_id,
             "model": manifest.model,
             "sandbox_provider": manifest.sandbox_provider,
+            "temperature": manifest.temperature,
+            "top_p": manifest.top_p,
+            "top_k": manifest.top_k,
+            "base_url": manifest.base_url,
+            "api_key_env": manifest.api_key_env,
         },
     )
 
+    # Resolve the endpoint override before any SDK work so a missing key
+    # env var fails loudly at startup instead of mid-session.
+    try:
+        client_kwargs = _resolve_client_kwargs(manifest)
+    except RuntimeError as exc:
+        emit_event(
+            {
+                "type": "error",
+                "kind": "config_invalid",
+                "message": str(exc),
+            },
+        )
+        return EXIT_MANIFEST_ERROR
+
+    heartbeat_stop = _start_heartbeat(manifest.session_id, Path(manifest.workdir))
+    try:
+        return _run_session(manifest, client_kwargs)
+    finally:
+        heartbeat_stop.set()
+
+
+def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int:
+    """Run the SDK session after startup validation has passed.
+
+    Args:
+        manifest: Parsed manifest describing the run.
+        client_kwargs: Non-empty when the manifest overrides the endpoint
+            or API key; forwarded to ``AsyncOpenAI``.
+
+    Returns:
+        Process exit code.  See module docstring for the contract.
+    """
     try:
         # Lazy import so the module itself stays importable without
         # the optional ``openai-agents`` package.  Tests stub this by
@@ -277,8 +447,30 @@ def run(manifest: RunnerManifest) -> int:
         )
         return EXIT_GENERIC
 
+    if client_kwargs:
+        # The manifest overrides the endpoint and/or API key.  Hand the SDK
+        # a dedicated client instead of letting it read the ambient
+        # OPENAI_* environment.
+        try:
+            from openai import AsyncOpenAI  # type: ignore[import-not-found]
+
+            sdk.set_default_openai_client(AsyncOpenAI(**client_kwargs))
+        except Exception as exc:
+            emit_event(
+                {
+                    "type": "error",
+                    "kind": "runtime",
+                    "message": f"failed to configure OpenAI client: {type(exc).__name__}: {exc}",
+                },
+            )
+            return EXIT_GENERIC
+
     try:
-        agent: Any = agent_cls(**_build_agent_kwargs(manifest))
+        agent_kwargs = _build_agent_kwargs(manifest)
+        settings_kwargs = _build_model_settings_kwargs(manifest)
+        if settings_kwargs:
+            agent_kwargs["model_settings"] = sdk.ModelSettings(**settings_kwargs)
+        agent: Any = agent_cls(**agent_kwargs)
         run_config = _build_run_config(manifest)
         # ``Runner.run_sync`` is the SDK's synchronous API - we avoid
         # ``asyncio.run`` here so the runner stays compatible with

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -49,6 +49,7 @@ import dataclasses
 import json
 import logging
 import os
+import re
 import sys
 import threading
 import time
@@ -68,6 +69,39 @@ EXIT_GENERIC: int = 1
 EXIT_MANIFEST_ERROR: int = 2
 EXIT_SDK_MISSING: int = 3
 EXIT_RATE_LIMIT: int = 4
+
+# ``api_key_env`` must look like a credential variable name.  The name both
+# widens the filtered environment handed to this subprocess and selects the
+# secret sent as the bearer key to ``base_url``, so an unconstrained value
+# would let a repo-carried config forward arbitrary host variables to an
+# arbitrary endpoint.  Keep in sync with the constraint documented in
+# ``docs/adapters/capability_contract.md``.
+_API_KEY_ENV_RE: re.Pattern[str] = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_API_KEY_ENV_SUFFIXES: tuple[str, ...] = ("_API_KEY", "_KEY", "_TOKEN")
+
+
+def validate_api_key_env_name(name: str) -> None:
+    """Reject ``api_key_env`` values that are not credential-shaped names.
+
+    Accepted names match ``^[A-Z][A-Z0-9_]*$`` AND end with ``_API_KEY``,
+    ``_KEY``, or ``_TOKEN``.  Everything else (``PATH``, ``HOME``,
+    lowercase names, names with other suffixes) is rejected so the
+    override cannot be used to read unrelated host environment variables.
+
+    Args:
+        name: Candidate environment variable name from the manifest.
+
+    Raises:
+        RuntimeError: The name does not satisfy the constraint above.
+    """
+    if _API_KEY_ENV_RE.match(name) and name.endswith(_API_KEY_ENV_SUFFIXES):
+        return
+    msg = (
+        f"api_key_env {name!r} is not an accepted credential variable "
+        f"name: it must match ^[A-Z][A-Z0-9_]*$ and end with _API_KEY, "
+        f"_KEY, or _TOKEN."
+    )
+    raise RuntimeError(msg)
 
 
 @dataclass(frozen=True)
@@ -106,11 +140,23 @@ class RunnerManifest:
             ``None`` keeps the provider default.
         base_url: Optional OpenAI-compatible endpoint URL.  When set the
             runner constructs its own ``AsyncOpenAI`` client instead of the
-            SDK default.  ``None`` keeps today's single-endpoint behavior.
+            SDK default, switches the SDK to the chat-completions API
+            (third-party endpoints do not serve ``/responses``), and
+            excludes the client from tracing so the endpoint's key is
+            never sent to api.openai.com.  ``None`` keeps today's
+            single-endpoint behavior.
         api_key_env: Optional NAME of the environment variable holding the
-            API key for ``base_url``.  Never a literal key.  When set but
-            the variable is missing the runner fails at startup with
-            :data:`EXIT_MANIFEST_ERROR`.
+            API key for ``base_url``.  Never a literal key.  Must satisfy
+            :func:`validate_api_key_env_name`.  When set but the variable
+            is missing (or the name is rejected) the runner fails at
+            startup with :data:`EXIT_MANIFEST_ERROR`.
+        heartbeat_dir: Optional absolute path of the heartbeat directory
+            the orchestrator's ``HeartbeatMonitor`` watches (the project
+            root's ``.sdd/runtime/heartbeats``).  Set by the spawner
+            because ``workdir`` is a per-session worktree under default
+            isolation - a worktree-relative heartbeat would never be
+            observed.  When absent the runner falls back to
+            ``<workdir>/.sdd/runtime/heartbeats``.
     """
 
     session_id: str
@@ -131,6 +177,7 @@ class RunnerManifest:
     top_k: int | None = None
     base_url: str | None = None
     api_key_env: str | None = None
+    heartbeat_dir: str | None = None
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> RunnerManifest:
@@ -282,13 +329,15 @@ def _resolve_client_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
     carries a literal secret.
 
     Raises:
-        RuntimeError: ``api_key_env`` is set but the named environment
+        RuntimeError: ``api_key_env`` is set but the name fails
+            :func:`validate_api_key_env_name`, or the named environment
             variable is missing or empty.
     """
     kwargs: dict[str, Any] = {}
     if manifest.base_url:
         kwargs["base_url"] = manifest.base_url
     if manifest.api_key_env:
+        validate_api_key_env_name(manifest.api_key_env)
         api_key = os.environ.get(manifest.api_key_env)
         if not api_key:
             msg = (
@@ -302,9 +351,21 @@ def _resolve_client_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
     return kwargs
 
 
+def _resolve_heartbeat_dir(manifest: RunnerManifest) -> Path:
+    """Return the directory heartbeat files must be written to.
+
+    Prefers ``manifest.heartbeat_dir`` (the orchestrator-root directory
+    the ``HeartbeatMonitor`` polls, injected by the spawner) and falls
+    back to a workdir-relative path for standalone runner invocations.
+    """
+    if manifest.heartbeat_dir:
+        return Path(manifest.heartbeat_dir)
+    return Path(manifest.workdir) / ".sdd" / "runtime" / "heartbeats"
+
+
 def _start_heartbeat(
     session_id: str,
-    workdir: Path,
+    heartbeat_dir: Path,
     interval_s: float = 15.0,
 ) -> threading.Event:
     """Write heartbeat files while the runner process is alive.
@@ -316,15 +377,16 @@ def _start_heartbeat(
 
     Args:
         session_id: Runner session identifier (heartbeat file basename).
-        workdir: Working directory (project root) where
-            ``.sdd/runtime/heartbeats/`` lives.
+        heartbeat_dir: Directory the heartbeat file is written to.  Must
+            be the same ``.sdd/runtime/heartbeats`` directory the
+            orchestrator's ``HeartbeatMonitor`` reads - see
+            :func:`_resolve_heartbeat_dir`.
         interval_s: Seconds between heartbeat writes (default 15).
 
     Returns:
         A :class:`threading.Event` the caller sets to stop the writer.
     """
     stop_event = threading.Event()
-    heartbeat_dir = workdir / ".sdd" / "runtime" / "heartbeats"
 
     def _heartbeat_loop() -> None:
         with contextlib.suppress(OSError):  # best effort
@@ -397,7 +459,7 @@ def run(manifest: RunnerManifest) -> int:
         )
         return EXIT_MANIFEST_ERROR
 
-    heartbeat_stop = _start_heartbeat(manifest.session_id, Path(manifest.workdir))
+    heartbeat_stop = _start_heartbeat(manifest.session_id, _resolve_heartbeat_dir(manifest))
     try:
         return _run_session(manifest, client_kwargs)
     finally:
@@ -454,7 +516,18 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
         try:
             from openai import AsyncOpenAI  # type: ignore[import-not-found]
 
-            sdk.set_default_openai_client(AsyncOpenAI(**client_kwargs))
+            client = AsyncOpenAI(**client_kwargs)
+            if manifest.base_url:
+                # Third-party OpenAI-compatible endpoints (the reason
+                # ``base_url`` exists) serve the chat-completions API,
+                # not ``/responses``, so switch the SDK's default API.
+                # ``use_for_tracing=False`` keeps the SDK's tracing
+                # exporter from uploading traces to api.openai.com
+                # authenticated with the third-party key.
+                sdk.set_default_openai_client(client, use_for_tracing=False)
+                sdk.set_default_openai_api("chat_completions")
+            else:
+                sdk.set_default_openai_client(client)
         except Exception as exc:
             emit_event(
                 {

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -70,23 +70,64 @@ EXIT_MANIFEST_ERROR: int = 2
 EXIT_SDK_MISSING: int = 3
 EXIT_RATE_LIMIT: int = 4
 
-# ``api_key_env`` must look like a credential variable name.  The name both
+# ``api_key_env`` must name a known LLM-provider credential.  The name both
 # widens the filtered environment handed to this subprocess and selects the
 # secret sent as the bearer key to ``base_url``, so an unconstrained value
-# would let a repo-carried config forward arbitrary host variables to an
-# arbitrary endpoint.  Keep in sync with the constraint documented in
-# ``docs/adapters/capability_contract.md``.
+# would let a repo-carried config forward arbitrary host secrets
+# (``GITHUB_TOKEN``, ``AWS_SESSION_TOKEN``, ...) to an arbitrary endpoint.
+# Fail-closed: names outside the built-in provider set are rejected unless
+# the OPERATOR allows them via ``BERNSTEIN_ALLOWED_API_KEY_ENVS`` on the
+# host (a repo-carried config cannot set host environment variables, so the
+# override cannot be forged by the repo).  Keep in sync with the constraint
+# documented in ``docs/adapters/capability_contract.md``.
 _API_KEY_ENV_RE: re.Pattern[str] = re.compile(r"^[A-Z][A-Z0-9_]*$")
-_API_KEY_ENV_SUFFIXES: tuple[str, ...] = ("_API_KEY", "_KEY", "_TOKEN")
+_API_KEY_ENV_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "TOGETHER_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "FIREWORKS_API_KEY",
+        "XAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "CEREBRAS_API_KEY",
+        "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY",
+        "NVIDIA_API_KEY",
+        "PERPLEXITY_API_KEY",
+        "HF_TOKEN",
+        "LLM_API_KEY",
+    }
+)
+_ALLOWED_API_KEY_ENVS_VAR = "BERNSTEIN_ALLOWED_API_KEY_ENVS"
+
+
+def _operator_allowed_api_key_envs() -> frozenset[str]:
+    """Extra credential names the operator allowed on this host.
+
+    Read from the comma-separated ``BERNSTEIN_ALLOWED_API_KEY_ENVS``
+    host environment variable. Names are stripped; empty entries are
+    ignored.
+    """
+    raw = os.environ.get(_ALLOWED_API_KEY_ENVS_VAR, "")
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
 
 
 def validate_api_key_env_name(name: str) -> None:
-    """Reject ``api_key_env`` values that are not credential-shaped names.
+    """Reject ``api_key_env`` values outside the credential allowlist.
 
-    Accepted names match ``^[A-Z][A-Z0-9_]*$`` AND end with ``_API_KEY``,
-    ``_KEY``, or ``_TOKEN``.  Everything else (``PATH``, ``HOME``,
-    lowercase names, names with other suffixes) is rejected so the
-    override cannot be used to read unrelated host environment variables.
+    Accepted names match ``^[A-Z][A-Z0-9_]*$`` AND are either in the
+    built-in LLM-provider allowlist or explicitly allowed by the
+    operator via ``BERNSTEIN_ALLOWED_API_KEY_ENVS`` (comma-separated,
+    host-set). Everything else - including credential-shaped names of
+    unrelated secrets such as ``GITHUB_TOKEN`` - is rejected so a
+    repo-carried config cannot forward arbitrary host secrets to an
+    arbitrary ``base_url``.
 
     Args:
         name: Candidate environment variable name from the manifest.
@@ -94,12 +135,13 @@ def validate_api_key_env_name(name: str) -> None:
     Raises:
         RuntimeError: The name does not satisfy the constraint above.
     """
-    if _API_KEY_ENV_RE.match(name) and name.endswith(_API_KEY_ENV_SUFFIXES):
+    if _API_KEY_ENV_RE.match(name) and (name in _API_KEY_ENV_ALLOWLIST or name in _operator_allowed_api_key_envs()):
         return
     msg = (
-        f"api_key_env {name!r} is not an accepted credential variable "
-        f"name: it must match ^[A-Z][A-Z0-9_]*$ and end with _API_KEY, "
-        f"_KEY, or _TOKEN."
+        f"api_key_env {name!r} is not an allowed credential variable name: "
+        f"it must match ^[A-Z][A-Z0-9_]*$ and be a known LLM provider key, "
+        f"or be explicitly allowed by the operator via "
+        f"{_ALLOWED_API_KEY_ENVS_VAR} (comma-separated env var names)."
     )
     raise RuntimeError(msg)
 

--- a/src/bernstein/adapters/plugin_sdk.py
+++ b/src/bernstein/adapters/plugin_sdk.py
@@ -57,6 +57,75 @@ class AdapterCapability(Enum):
     RATE_LIMIT_DETECTION = "rate_limit_detection"
     STRUCTURED_OUTPUT = "structured_output"
     BATCH_MODE = "batch_mode"
+    SUPPORTS_SAMPLING_PARAMS = "supports_sampling_params"
+
+
+# Per-spawn keys in ``mcp_config`` that request sampling or endpoint
+# overrides.  An adapter must declare
+# :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS` before any of these
+# are honoured - see :func:`ensure_sampling_params_supported`.
+SAMPLING_PARAM_KEYS: tuple[str, ...] = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "base_url",
+    "api_key_env",
+)
+
+
+class SamplingParamsRefusal(RuntimeError):
+    """Raised when sampling params are requested for an incapable adapter.
+
+    Attributes:
+        adapter_name: The adapter that was asked.
+        requested_keys: The sampling/endpoint keys present in the request.
+    """
+
+    def __init__(self, adapter_name: str, requested_keys: tuple[str, ...]) -> None:
+        self.adapter_name = adapter_name
+        self.requested_keys = requested_keys
+        super().__init__(
+            f"Adapter {adapter_name!r} does not declare the "
+            f"{AdapterCapability.SUPPORTS_SAMPLING_PARAMS.value!r} capability "
+            f"but sampling/endpoint parameters were requested: "
+            f"{', '.join(requested_keys)}. Refusing to spawn instead of "
+            f"silently dropping them."
+        )
+
+
+def ensure_sampling_params_supported(
+    adapter: CLIAdapter,
+    mcp_config: dict[str, Any] | None,
+) -> None:
+    """Refuse sampling/endpoint overrides for adapters that cannot honour them.
+
+    Silently dropping a requested ``temperature`` or ``base_url`` would run
+    the task with parameters the operator did not ask for, so the spawn path
+    calls this gate before dispatching to the adapter.
+
+    Args:
+        adapter: The adapter selected for the spawn attempt.
+        mcp_config: Per-spawn configuration that may carry keys from
+            :data:`SAMPLING_PARAM_KEYS`.
+
+    Raises:
+        SamplingParamsRefusal: When any sampling/endpoint key is present and
+            the adapter does not declare
+            :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS`.
+    """
+    if not mcp_config:
+        return
+    requested = tuple(k for k in SAMPLING_PARAM_KEYS if mcp_config.get(k) is not None)
+    if not requested:
+        return
+    if isinstance(adapter, PluginAdapter):
+        try:
+            capabilities = adapter.plugin_info().capabilities
+        except Exception:  # pragma: no cover - defensive against bad plugins
+            capabilities = ()
+        if AdapterCapability.SUPPORTS_SAMPLING_PARAMS in capabilities:
+            return
+    raise SamplingParamsRefusal(adapter.name(), requested)
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.adapters.base import RateLimitError, SpawnError, SpawnResult
+from bernstein.adapters.plugin_sdk import ensure_sampling_params_supported
 from bernstein.adapters.registry import get_adapter
 from bernstein.adapters.skills_injector import inject_skills
 from bernstein.agents.registry import AgentRegistry, get_registry
@@ -2205,6 +2206,14 @@ class AgentSpawner:
                     except Exception as exc:
                         attempt_errors.append(f"{adapter_name}: {exc}")
                         break
+
+                    # Fail loudly when sampling/endpoint overrides are
+                    # requested for an adapter that does not declare the
+                    # SUPPORTS_SAMPLING_PARAMS capability.  Silently
+                    # dropping them would run the task with parameters the
+                    # operator did not ask for, so this raises instead of
+                    # falling through to provider failover.
+                    ensure_sampling_params_supported(target_adapter, effective_mcp)
 
                     try:
                         # Apply OS-level resource limits to non-sandboxed spawns.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -14,7 +14,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.adapters.base import RateLimitError, SpawnError, SpawnResult
-from bernstein.adapters.plugin_sdk import ensure_sampling_params_supported
+from bernstein.adapters.plugin_sdk import (
+    SAMPLING_PARAM_KEYS,
+    SamplingParamsRefusal,
+    ensure_sampling_params_supported,
+)
 from bernstein.adapters.registry import get_adapter
 from bernstein.adapters.skills_injector import inject_skills
 from bernstein.agents.registry import AgentRegistry, get_registry
@@ -1556,6 +1560,29 @@ class AgentSpawner:
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             return pool.submit(asyncio.run, awaitable).result()
 
+    def _mcp_config_for_adapter(
+        self,
+        adapter: CLIAdapter,
+        mcp_config: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Attach adapter-specific extras to the per-spawn MCP config.
+
+        Adapters that opt in via a truthy ``consumes_heartbeat_dir``
+        attribute (currently ``openai_agents``) receive the orchestrator
+        root's heartbeat directory as a ``heartbeat_dir`` key.  Their
+        runner processes write heartbeats themselves, but they execute
+        inside a per-session worktree and cannot derive the project root
+        the ``HeartbeatMonitor`` polls - without this injection the
+        heartbeat would land in the worktree and never be observed.
+
+        Adapters without the attribute get ``mcp_config`` back unchanged
+        so their MCP config files stay byte-identical.
+        """
+        if not getattr(adapter, "consumes_heartbeat_dir", False):
+            return mcp_config
+        heartbeat_dir = str(self._workdir / ".sdd" / "runtime" / "heartbeats")
+        return {**(mcp_config or {}), "heartbeat_dir": heartbeat_dir}
+
     def _spawn_via_runtime_bridge(
         self,
         *,
@@ -2138,6 +2165,16 @@ class AgentSpawner:
 
         remote_spawned = False
         if self._runtime_bridge is not None:
+            # Same capability gate as the local adapter loop below: the
+            # bridge spawn request has no way to carry sampling/endpoint
+            # overrides, so requesting them alongside a configured bridge
+            # must fail loudly instead of running the task remotely with
+            # provider defaults.
+            _bridge_sampling_keys = tuple(
+                key for key in SAMPLING_PARAM_KEYS if effective_mcp is not None and effective_mcp.get(key) is not None
+            )
+            if _bridge_sampling_keys:
+                raise SamplingParamsRefusal(self._runtime_bridge.name(), _bridge_sampling_keys)
             try:
                 remote_spawned = self._spawn_via_runtime_bridge(
                     session=session,
@@ -2215,6 +2252,10 @@ class AgentSpawner:
                     # falling through to provider failover.
                     ensure_sampling_params_supported(target_adapter, effective_mcp)
 
+                    # Per-attempt config so a failover to a different
+                    # adapter never inherits another adapter's extras.
+                    attempt_mcp = self._mcp_config_for_adapter(target_adapter, effective_mcp)
+
                     try:
                         # Apply OS-level resource limits to non-sandboxed spawns.
                         target_adapter.set_resource_limits(self._resource_limits)
@@ -2227,7 +2268,7 @@ class AgentSpawner:
                                 workdir=spawn_cwd,
                                 model_config=model_config,
                                 session_id=session_id,
-                                mcp_config=effective_mcp,
+                                mcp_config=attempt_mcp,
                             )
                             result = SpawnResult(pid=fake_pid, log_path=actual_log_path)
                         elif (
@@ -2245,7 +2286,7 @@ class AgentSpawner:
                                 prompt=prompt,
                                 spawn_cwd=spawn_cwd,
                                 model_config=model_config,
-                                mcp_config=effective_mcp,
+                                mcp_config=attempt_mcp,
                                 session=session,
                                 adapter=target_adapter,
                             )
@@ -2255,7 +2296,7 @@ class AgentSpawner:
                                 prompt=prompt,
                                 spawn_cwd=spawn_cwd,
                                 model_config=model_config,
-                                mcp_config=effective_mcp,
+                                mcp_config=attempt_mcp,
                                 session=session,
                                 adapter=target_adapter,
                                 task_scope=max_scope,
@@ -2266,7 +2307,7 @@ class AgentSpawner:
                                 prompt=prompt,
                                 spawn_cwd=spawn_cwd,
                                 model_config=model_config,
-                                mcp_config=effective_mcp,
+                                mcp_config=attempt_mcp,
                                 session=session,
                                 adapter=target_adapter,
                                 task_scope=max_scope,
@@ -2282,7 +2323,7 @@ class AgentSpawner:
                                 workdir=spawn_cwd,
                                 model_config=model_config,
                                 session_id=session_id,
-                                mcp_config=effective_mcp,
+                                mcp_config=attempt_mcp,
                                 task_scope=max_scope,
                                 budget_multiplier=_budget_mult,
                                 system_addendum="",

--- a/src/bernstein/core/protocols/mcp/mcp_manager.py
+++ b/src/bernstein/core/protocols/mcp/mcp_manager.py
@@ -604,10 +604,13 @@ class MCPManager:
         if task_config is None:
             return base_config
 
-        # Merge: task config wins on conflicts (task explicitly requested those)
+        # Merge: task config wins on conflicts (task explicitly requested
+        # those).  Non-mcpServers keys from base_config (per-spawn sampling
+        # and endpoint overrides such as temperature/base_url) must survive
+        # the merge so the adapter capability gate can see them.
         merged_servers = dict(base_config.get("mcpServers", {}))
         merged_servers.update(task_config.get("mcpServers", {}))
-        return {"mcpServers": merged_servers}
+        return {**base_config, "mcpServers": merged_servers}
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/protocols/mcp/mcp_registry.py
+++ b/src/bernstein/core/protocols/mcp/mcp_registry.py
@@ -395,7 +395,10 @@ class MCPRegistry:
         if auto_config is None:
             return base_config
 
-        # Both exist - merge auto into base (base takes precedence)
+        # Both exist - merge auto into base (base takes precedence).
+        # Non-mcpServers keys from base_config (per-spawn sampling and
+        # endpoint overrides such as temperature/base_url) must survive
+        # the merge so the adapter capability gate can see them.
         merged_servers = dict(auto_config.get("mcpServers", {}))
         merged_servers.update(base_config.get("mcpServers", {}))
-        return {"mcpServers": merged_servers}
+        return {**base_config, "mcpServers": merged_servers}

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,21 +28,19 @@ from bernstein.adapters.openai_agents_runner import (
     _build_run_config,
     _is_rate_limit,
     _resolve_client_kwargs,
+    _resolve_heartbeat_dir,
     _start_heartbeat,
     emit_event,
     load_manifest,
     main,
     run,
+    validate_api_key_env_name,
 )
 from bernstein.adapters.plugin_sdk import (
     AdapterCapability,
     ensure_sampling_params_supported,
 )
 from bernstein.adapters.registry import get_adapter
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -278,6 +276,107 @@ class TestSpawnCommand:
         )
         for key in ("temperature", "top_p", "top_k", "base_url", "api_key_env"):
             assert key not in manifest
+
+    def test_manifest_carries_spawner_injected_heartbeat_dir(self, tmp_path: Path) -> None:
+        """The spawner-injected heartbeat_dir must reach the runner manifest.
+
+        Under default worktree isolation the spawn workdir is NOT the
+        orchestrator root, so the manifest must carry the orchestrator-root
+        heartbeat directory the HeartbeatMonitor polls.
+        """
+        orchestrator_root = tmp_path / "project"
+        worktree = orchestrator_root / ".sdd" / "worktrees" / "oai-hb1"
+        worktree.mkdir(parents=True)
+        heartbeat_dir = str(orchestrator_root / ".sdd" / "runtime" / "heartbeats")
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1009)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=worktree,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-hb1",
+                mcp_config={"heartbeat_dir": heartbeat_dir},
+            )
+        manifest = json.loads(
+            (worktree / ".sdd" / "runtime" / "oai-hb1.manifest.json").read_text(),
+        )
+        assert manifest["heartbeat_dir"] == heartbeat_dir
+        assert manifest["workdir"] == str(worktree)
+
+    def test_sampling_overrides_survive_real_mcp_merge_into_manifest(self, tmp_path: Path) -> None:
+        """End-to-end: sampling keys survive the MCPManager merge to the manifest.
+
+        Mirrors the spawner flow where the operator-provided MCP config is
+        rebuilt by ``MCPManager.build_mcp_config_for_task`` before it
+        reaches the adapter. The merged config must still deliver the
+        sampling/endpoint overrides into the runner manifest.
+        """
+        from bernstein.core.mcp_manager import MCPManager, MCPServerConfig
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 100
+        mock_proc.poll.return_value = None
+        with patch(
+            "bernstein.core.protocols.mcp_manager.subprocess.Popen",
+            return_value=mock_proc,
+        ):
+            mgr = MCPManager([MCPServerConfig(name="github", command=["npx"])])
+            mgr.start_all()
+            base = {
+                "mcpServers": {"tavily": {"command": "npx", "args": ["tavily"]}},
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_k": 40,
+                "base_url": "http://localhost:8000/v1",
+                "api_key_env": "MY_PROXY_KEY",
+            }
+            merged = mgr.build_mcp_config_for_task(
+                task_mcp_servers=["github"],
+                base_config=base,
+            )
+
+        assert merged is not None
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1010)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-merge1",
+                mcp_config=merged,
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-merge1.manifest.json").read_text(),
+        )
+        assert manifest["temperature"] == pytest.approx(0.2)
+        assert manifest["top_p"] == pytest.approx(0.9)
+        assert manifest["top_k"] == 40
+        assert manifest["base_url"] == "http://localhost:8000/v1"
+        assert manifest["api_key_env"] == "MY_PROXY_KEY"
+        assert set(manifest["mcp_servers"]) == {"tavily", "github"}
+
+    def test_spawn_rejects_non_credential_api_key_env(self, tmp_path: Path) -> None:
+        adapter = OpenAIAgentsAdapter()
+        with (
+            patch("bernstein.adapters.openai_agents.subprocess.Popen") as popen,
+            pytest.raises(RuntimeError, match="PATH"),
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-bad-env",
+                mcp_config={"api_key_env": "PATH"},
+            )
+        popen.assert_not_called()
 
     def test_log_path_uses_session_id(self, tmp_path: Path) -> None:
         adapter = OpenAIAgentsAdapter()
@@ -751,6 +850,53 @@ class TestRunnerHelpers:
         ):
             _resolve_client_kwargs(manifest)
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "MY_PROXY_KEY",
+            "HF_TOKEN",
+            "DEEPSEEK_API_KEY",
+            "A_KEY",
+        ],
+    )
+    def test_validate_api_key_env_name_accepts_credential_names(self, name: str) -> None:
+        validate_api_key_env_name(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "PATH",
+            "HOME",
+            "LD_PRELOAD",
+            "my_proxy_key",
+            "OPENAI-API-KEY",
+            "1KEY_TOKEN",
+            "_API_KEY",
+            "SSH_AUTH_SOCK",
+            "KEY",
+            "TOKEN",
+        ],
+    )
+    def test_validate_api_key_env_name_rejects_non_credential_names(self, name: str) -> None:
+        with pytest.raises(RuntimeError, match="api_key_env"):
+            validate_api_key_env_name(name)
+
+    def test_resolve_client_kwargs_rejects_non_credential_name(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+            api_key_env="PATH",
+        )
+        with (
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            pytest.raises(RuntimeError, match="PATH"),
+        ):
+            _resolve_client_kwargs(manifest)
+
     def test_is_rate_limit_detects_429_message(self) -> None:
         assert _is_rate_limit(RuntimeError("429 Too Many Requests")) is True
 
@@ -1001,7 +1147,38 @@ class TestRunnerRun:
             base_url="http://localhost:8000/v1",
             api_key="sk-proxy",
         )
+        # With a custom endpoint the client must be excluded from tracing
+        # (never send the third-party key to api.openai.com) and the SDK
+        # must use the chat-completions API (third-party endpoints do not
+        # serve /responses).
+        fake_sdk.set_default_openai_client.assert_called_once_with(
+            client_sentinel,
+            use_for_tracing=False,
+        )
+        fake_sdk.set_default_openai_api.assert_called_once_with("chat_completions")
+
+    def test_run_keeps_default_api_and_tracing_without_base_url(self) -> None:
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            api_key_env="MY_PROXY_KEY",
+        )
+        client_sentinel = object()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        fake_openai = MagicMock(AsyncOpenAI=MagicMock(return_value=client_sentinel))
+        with (
+            patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
+            patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True),
+        ):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        # No base_url: default Responses API and default tracing stay intact.
         fake_sdk.set_default_openai_client.assert_called_once_with(client_sentinel)
+        fake_sdk.set_default_openai_api.assert_not_called()
 
     def test_run_leaves_default_client_alone_without_overrides(self) -> None:
         fake_runner = MagicMock()
@@ -1029,6 +1206,28 @@ class TestRunnerRun:
         error = next(e for e in events if e["type"] == "error")
         assert error["kind"] == "config_invalid"
         assert "MISSING_PROXY_KEY" in error["message"]
+
+    def test_run_fails_loudly_for_non_credential_api_key_env(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            base_url="http://localhost:8000/v1",
+            api_key_env="LD_PRELOAD",
+        )
+        with patch.dict("os.environ", {"LD_PRELOAD": "libx.so"}, clear=True):
+            rc = run(manifest)
+        assert rc == EXIT_MANIFEST_ERROR
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        error = next(e for e in events if e["type"] == "error")
+        assert error["kind"] == "config_invalid"
+        assert "LD_PRELOAD" in error["message"]
+        # The rejected variable's value is never echoed.
+        assert "libx.so" not in json.dumps(events)
 
     def test_run_starts_and_stops_heartbeat(self) -> None:
         stop_event = threading.Event()
@@ -1069,8 +1268,9 @@ class TestRunnerRun:
 
 class TestRunnerHeartbeat:
     def test_heartbeat_writes_proxy_shaped_payload(self, tmp_path: Path) -> None:
-        stop_event = _start_heartbeat("hb-sess", tmp_path, interval_s=0.05)
-        hb_file = tmp_path / ".sdd" / "runtime" / "heartbeats" / "hb-sess.json"
+        hb_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        stop_event = _start_heartbeat("hb-sess", hb_dir, interval_s=0.05)
+        hb_file = hb_dir / "hb-sess.json"
         try:
             deadline = time.monotonic() + 5.0
             while not hb_file.exists() and time.monotonic() < deadline:
@@ -1094,8 +1294,9 @@ class TestRunnerHeartbeat:
         assert isinstance(payload["timestamp"], int)
 
     def test_heartbeat_stops_after_event_set(self, tmp_path: Path) -> None:
-        stop_event = _start_heartbeat("hb-stop", tmp_path, interval_s=0.05)
-        hb_file = tmp_path / ".sdd" / "runtime" / "heartbeats" / "hb-stop.json"
+        hb_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        stop_event = _start_heartbeat("hb-stop", hb_dir, interval_s=0.05)
+        hb_file = hb_dir / "hb-stop.json"
         deadline = time.monotonic() + 5.0
         while not hb_file.exists() and time.monotonic() < deadline:
             time.sleep(0.01)
@@ -1104,6 +1305,55 @@ class TestRunnerHeartbeat:
         hb_file.unlink()
         time.sleep(0.15)
         assert not hb_file.exists()
+
+    def test_resolve_heartbeat_dir_prefers_manifest_field(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/project/.sdd/worktrees/s",
+            model="gpt-5",
+            heartbeat_dir="/project/.sdd/runtime/heartbeats",
+        )
+        assert _resolve_heartbeat_dir(manifest) == Path("/project/.sdd/runtime/heartbeats")
+
+    def test_resolve_heartbeat_dir_falls_back_to_workdir(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+        )
+        assert _resolve_heartbeat_dir(manifest) == Path("/workspace/.sdd/runtime/heartbeats")
+
+    def test_run_writes_heartbeat_where_monitor_reads(self, tmp_path: Path) -> None:
+        """Worktree isolation: heartbeats must land at the orchestrator root.
+
+        spawn_cwd is a per-session worktree, so the manifest carries the
+        orchestrator-root heartbeat directory. The file the runner writes
+        must be exactly the path the HeartbeatMonitor polls:
+        ``<orchestrator_workdir>/.sdd/runtime/heartbeats/<session_id>.json``.
+        """
+        orchestrator_root = tmp_path / "project"
+        worktree = orchestrator_root / ".sdd" / "worktrees" / "hb-mon"
+        worktree.mkdir(parents=True)
+        manifest = RunnerManifest(
+            session_id="hb-mon",
+            prompt="hello",
+            workdir=str(worktree),
+            model="gpt-5-mini",
+            heartbeat_dir=str(orchestrator_root / ".sdd" / "runtime" / "heartbeats"),
+        )
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with patch.object(runner_module, "_start_heartbeat") as start_hb:
+            start_hb.return_value = threading.Event()
+            with patch.dict(sys.modules, {"agents": fake_sdk}):
+                rc = run(manifest)
+        assert rc == EXIT_OK
+        # Same expression as HeartbeatMonitor: workdir / ".sdd" / "runtime" / "heartbeats"
+        monitor_dir = orchestrator_root / ".sdd" / "runtime" / "heartbeats"
+        start_hb.assert_called_once_with("hb-mon", monitor_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -246,7 +246,7 @@ class TestSpawnCommand:
                     "top_p": 0.9,
                     "top_k": 40,
                     "base_url": "http://localhost:8000/v1",
-                    "api_key_env": "MY_PROXY_KEY",
+                    "api_key_env": "OPENROUTER_API_KEY",
                 },
             )
         manifest = json.loads(
@@ -256,7 +256,7 @@ class TestSpawnCommand:
         assert manifest["top_p"] == pytest.approx(0.9)
         assert manifest["top_k"] == 40
         assert manifest["base_url"] == "http://localhost:8000/v1"
-        assert manifest["api_key_env"] == "MY_PROXY_KEY"
+        assert manifest["api_key_env"] == "OPENROUTER_API_KEY"
 
     def test_manifest_omits_absent_sampling_fields(self, tmp_path: Path) -> None:
         adapter = OpenAIAgentsAdapter()
@@ -332,7 +332,7 @@ class TestSpawnCommand:
                 "top_p": 0.9,
                 "top_k": 40,
                 "base_url": "http://localhost:8000/v1",
-                "api_key_env": "MY_PROXY_KEY",
+                "api_key_env": "OPENROUTER_API_KEY",
             }
             merged = mgr.build_mcp_config_for_task(
                 task_mcp_servers=["github"],
@@ -360,7 +360,7 @@ class TestSpawnCommand:
         assert manifest["top_p"] == pytest.approx(0.9)
         assert manifest["top_k"] == 40
         assert manifest["base_url"] == "http://localhost:8000/v1"
-        assert manifest["api_key_env"] == "MY_PROXY_KEY"
+        assert manifest["api_key_env"] == "OPENROUTER_API_KEY"
         assert set(manifest["mcp_servers"]) == {"tavily", "github"}
 
     def test_spawn_rejects_non_credential_api_key_env(self, tmp_path: Path) -> None:
@@ -486,7 +486,7 @@ class TestSpawnEnvIsolation:
             ) as popen,
             patch.dict(
                 "os.environ",
-                {"MY_PROXY_KEY": "sk-proxy", "PATH": "/usr/bin"},
+                {"OPENROUTER_API_KEY": "sk-proxy", "PATH": "/usr/bin"},
                 clear=True,
             ),
         ):
@@ -495,10 +495,10 @@ class TestSpawnEnvIsolation:
                 workdir=tmp_path,
                 model_config=ModelConfig(model="gpt-5-mini", effort="high"),
                 session_id="oai-env3",
-                mcp_config={"api_key_env": "MY_PROXY_KEY"},
+                mcp_config={"api_key_env": "OPENROUTER_API_KEY"},
             )
         env = popen.call_args.kwargs.get("env", {})
-        assert env["MY_PROXY_KEY"] == "sk-proxy"
+        assert env["OPENROUTER_API_KEY"] == "sk-proxy"
 
 
 # ---------------------------------------------------------------------------
@@ -729,14 +729,14 @@ class TestRunnerManifest:
                 "top_p": 0.9,
                 "top_k": 40,
                 "base_url": "http://localhost:8000/v1",
-                "api_key_env": "MY_PROXY_KEY",
+                "api_key_env": "OPENROUTER_API_KEY",
             },
         )
         assert manifest.temperature == pytest.approx(0.2)
         assert manifest.top_p == pytest.approx(0.9)
         assert manifest.top_k == 40
         assert manifest.base_url == "http://localhost:8000/v1"
-        assert manifest.api_key_env == "MY_PROXY_KEY"
+        assert manifest.api_key_env == "OPENROUTER_API_KEY"
 
 
 # ---------------------------------------------------------------------------
@@ -830,9 +830,9 @@ class TestRunnerHelpers:
             workdir="/workspace",
             model="gpt-5",
             base_url="http://localhost:8000/v1",
-            api_key_env="MY_PROXY_KEY",
+            api_key_env="OPENROUTER_API_KEY",
         )
-        with patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True):
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-proxy"}, clear=True):
             kwargs = _resolve_client_kwargs(manifest)
         assert kwargs == {"base_url": "http://localhost:8000/v1", "api_key": "sk-proxy"}
 
@@ -842,11 +842,11 @@ class TestRunnerHelpers:
             prompt="p",
             workdir="/workspace",
             model="gpt-5",
-            api_key_env="MISSING_PROXY_KEY",
+            api_key_env="OPENROUTER_API_KEY",
         )
         with (
             patch.dict("os.environ", {}, clear=True),
-            pytest.raises(RuntimeError, match="MISSING_PROXY_KEY"),
+            pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"),
         ):
             _resolve_client_kwargs(manifest)
 
@@ -855,14 +855,19 @@ class TestRunnerHelpers:
         [
             "OPENAI_API_KEY",
             "OPENROUTER_API_KEY",
-            "MY_PROXY_KEY",
             "HF_TOKEN",
             "DEEPSEEK_API_KEY",
-            "A_KEY",
+            "MISTRAL_API_KEY",
         ],
     )
-    def test_validate_api_key_env_name_accepts_credential_names(self, name: str) -> None:
+    def test_validate_api_key_env_name_accepts_allowlisted_names(self, name: str) -> None:
         validate_api_key_env_name(name)
+
+    def test_validate_api_key_env_name_accepts_operator_allowed_name(self) -> None:
+        """Names outside the built-in set pass only with the host override."""
+        with patch.dict("os.environ", {"BERNSTEIN_ALLOWED_API_KEY_ENVS": "MY_PROXY_KEY, OTHER_KEY"}):
+            validate_api_key_env_name("MY_PROXY_KEY")
+            validate_api_key_env_name("OTHER_KEY")
 
     @pytest.mark.parametrize(
         "name",
@@ -877,6 +882,10 @@ class TestRunnerHelpers:
             "SSH_AUTH_SOCK",
             "KEY",
             "TOKEN",
+            "GITHUB_TOKEN",
+            "AWS_SESSION_TOKEN",
+            "STRIPE_SECRET_KEY",
+            "MY_PROXY_KEY",
         ],
     )
     def test_validate_api_key_env_name_rejects_non_credential_names(self, name: str) -> None:
@@ -1048,7 +1057,7 @@ class TestRunnerRun:
             top_p=0.9,
             top_k=40,
             base_url="http://localhost:8000/v1",
-            api_key_env="MY_PROXY_KEY",
+            api_key_env="OPENROUTER_API_KEY",
         )
         fake_runner = MagicMock()
         fake_runner.run_sync.return_value = _FakeResult(summary="ok")
@@ -1056,7 +1065,7 @@ class TestRunnerRun:
         fake_openai = MagicMock()
         with (
             patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
-            patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True),
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-proxy"}, clear=True),
         ):
             rc = run(manifest)
         assert rc == EXIT_OK
@@ -1067,7 +1076,7 @@ class TestRunnerRun:
         assert start["top_k"] == 40
         assert start["base_url"] == "http://localhost:8000/v1"
         # Only the env var NAME is logged - never the key value.
-        assert start["api_key_env"] == "MY_PROXY_KEY"
+        assert start["api_key_env"] == "OPENROUTER_API_KEY"
         assert "sk-proxy" not in json.dumps(events)
 
     def test_run_start_event_defaults_are_null(
@@ -1130,7 +1139,7 @@ class TestRunnerRun:
             workdir="/workspace",
             model="gpt-5-mini",
             base_url="http://localhost:8000/v1",
-            api_key_env="MY_PROXY_KEY",
+            api_key_env="OPENROUTER_API_KEY",
         )
         client_sentinel = object()
         fake_runner = MagicMock()
@@ -1139,7 +1148,7 @@ class TestRunnerRun:
         fake_openai = MagicMock(AsyncOpenAI=MagicMock(return_value=client_sentinel))
         with (
             patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
-            patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True),
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-proxy"}, clear=True),
         ):
             rc = run(manifest)
         assert rc == EXIT_OK
@@ -1163,7 +1172,7 @@ class TestRunnerRun:
             prompt="hello",
             workdir="/workspace",
             model="gpt-5-mini",
-            api_key_env="MY_PROXY_KEY",
+            api_key_env="OPENROUTER_API_KEY",
         )
         client_sentinel = object()
         fake_runner = MagicMock()
@@ -1172,7 +1181,7 @@ class TestRunnerRun:
         fake_openai = MagicMock(AsyncOpenAI=MagicMock(return_value=client_sentinel))
         with (
             patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
-            patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True),
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-proxy"}, clear=True),
         ):
             rc = run(manifest)
         assert rc == EXIT_OK

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import threading
+import time
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +14,7 @@ import pytest
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
 from bernstein.adapters import openai_agents as adapter_module
+from bernstein.adapters import openai_agents_runner as runner_module
 from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
 from bernstein.adapters.openai_agents_runner import (
     EXIT_GENERIC,
@@ -21,14 +24,20 @@ from bernstein.adapters.openai_agents_runner import (
     EXIT_SDK_MISSING,
     RunnerManifest,
     _build_agent_kwargs,
+    _build_model_settings_kwargs,
     _build_run_config,
     _is_rate_limit,
+    _resolve_client_kwargs,
+    _start_heartbeat,
     emit_event,
     load_manifest,
     main,
     run,
 )
-from bernstein.adapters.plugin_sdk import AdapterCapability
+from bernstein.adapters.plugin_sdk import (
+    AdapterCapability,
+    ensure_sampling_params_supported,
+)
 from bernstein.adapters.registry import get_adapter
 
 if TYPE_CHECKING:
@@ -75,6 +84,13 @@ class TestPluginInfo:
         assert AdapterCapability.MULTI_MODEL in info.capabilities
         assert AdapterCapability.RATE_LIMIT_DETECTION in info.capabilities
         assert AdapterCapability.STRUCTURED_OUTPUT in info.capabilities
+        assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS in info.capabilities
+
+    def test_sampling_gate_passes_for_openai_agents(self) -> None:
+        ensure_sampling_params_supported(
+            OpenAIAgentsAdapter(),
+            {"temperature": 0.5, "base_url": "http://localhost:8000/v1"},
+        )
 
     def test_display_name(self) -> None:
         assert OpenAIAgentsAdapter().name() == "OpenAI Agents SDK"
@@ -215,6 +231,54 @@ class TestSpawnCommand:
         assert manifest["sandbox_provider"] == "e2b"
         assert manifest["tools"] == [{"name": "file_read"}]
 
+    def test_manifest_includes_sampling_overrides(self, tmp_path: Path) -> None:
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1007)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-s6",
+                mcp_config={
+                    "temperature": 0.2,
+                    "top_p": 0.9,
+                    "top_k": 40,
+                    "base_url": "http://localhost:8000/v1",
+                    "api_key_env": "MY_PROXY_KEY",
+                },
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-s6.manifest.json").read_text(),
+        )
+        assert manifest["temperature"] == pytest.approx(0.2)
+        assert manifest["top_p"] == pytest.approx(0.9)
+        assert manifest["top_k"] == 40
+        assert manifest["base_url"] == "http://localhost:8000/v1"
+        assert manifest["api_key_env"] == "MY_PROXY_KEY"
+
+    def test_manifest_omits_absent_sampling_fields(self, tmp_path: Path) -> None:
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1008)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-s7",
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-s7.manifest.json").read_text(),
+        )
+        for key in ("temperature", "top_p", "top_k", "base_url", "api_key_env"):
+            assert key not in manifest
+
     def test_log_path_uses_session_id(self, tmp_path: Path) -> None:
         adapter = OpenAIAgentsAdapter()
         proc_mock = _make_popen_mock(pid=1005)
@@ -312,6 +376,30 @@ class TestSpawnEnvIsolation:
         env = popen.call_args.kwargs.get("env", {})
         assert "ANTHROPIC_API_KEY" not in env
         assert "DATABASE_URL" not in env
+
+    def test_env_passes_api_key_env_override_through(self, tmp_path: Path) -> None:
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=2003)
+        with (
+            patch(
+                "bernstein.adapters.openai_agents.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {"MY_PROXY_KEY": "sk-proxy", "PATH": "/usr/bin"},
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5-mini", effort="high"),
+                session_id="oai-env3",
+                mcp_config={"api_key_env": "MY_PROXY_KEY"},
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert env["MY_PROXY_KEY"] == "sk-proxy"
 
 
 # ---------------------------------------------------------------------------
@@ -516,6 +604,41 @@ class TestRunnerManifest:
         with pytest.raises(TypeError):
             load_manifest(path)
 
+    def test_sampling_fields_default_to_none(self) -> None:
+        manifest = RunnerManifest.from_dict(
+            {
+                "session_id": "s1",
+                "prompt": "hi",
+                "workdir": "/workspace",
+                "model": "gpt-5-mini",
+            },
+        )
+        assert manifest.temperature is None
+        assert manifest.top_p is None
+        assert manifest.top_k is None
+        assert manifest.base_url is None
+        assert manifest.api_key_env is None
+
+    def test_from_dict_parses_sampling_fields(self) -> None:
+        manifest = RunnerManifest.from_dict(
+            {
+                "session_id": "s1",
+                "prompt": "hi",
+                "workdir": "/workspace",
+                "model": "gpt-5-mini",
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_k": 40,
+                "base_url": "http://localhost:8000/v1",
+                "api_key_env": "MY_PROXY_KEY",
+            },
+        )
+        assert manifest.temperature == pytest.approx(0.2)
+        assert manifest.top_p == pytest.approx(0.9)
+        assert manifest.top_k == 40
+        assert manifest.base_url == "http://localhost:8000/v1"
+        assert manifest.api_key_env == "MY_PROXY_KEY"
+
 
 # ---------------------------------------------------------------------------
 # Runner helpers
@@ -565,6 +688,68 @@ class TestRunnerHelpers:
         # Defensive copy - mutating the output must not mutate manifest state.
         cfg["mcp_servers"]["other"] = {"command": "x"}
         assert "other" not in manifest.mcp_servers
+
+    def test_build_model_settings_kwargs_empty_when_absent(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+        )
+        assert _build_model_settings_kwargs(manifest) == {}
+
+    def test_build_model_settings_kwargs_maps_params(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+            temperature=0.2,
+            top_p=0.9,
+            top_k=40,
+        )
+        kwargs = _build_model_settings_kwargs(manifest)
+        assert kwargs["temperature"] == pytest.approx(0.2)
+        assert kwargs["top_p"] == pytest.approx(0.9)
+        # top_k travels via extra_args - the OpenAI API has no first-class
+        # top_k field but OpenAI-compatible endpoints accept it.
+        assert kwargs["extra_args"] == {"top_k": 40}
+
+    def test_resolve_client_kwargs_empty_by_default(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+        )
+        assert _resolve_client_kwargs(manifest) == {}
+
+    def test_resolve_client_kwargs_reads_key_from_env(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+            base_url="http://localhost:8000/v1",
+            api_key_env="MY_PROXY_KEY",
+        )
+        with patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True):
+            kwargs = _resolve_client_kwargs(manifest)
+        assert kwargs == {"base_url": "http://localhost:8000/v1", "api_key": "sk-proxy"}
+
+    def test_resolve_client_kwargs_raises_when_env_var_missing(self) -> None:
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/workspace",
+            model="gpt-5",
+            api_key_env="MISSING_PROXY_KEY",
+        )
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(RuntimeError, match="MISSING_PROXY_KEY"),
+        ):
+            _resolve_client_kwargs(manifest)
 
     def test_is_rate_limit_detects_429_message(self) -> None:
         assert _is_rate_limit(RuntimeError("429 Too Many Requests")) is True
@@ -703,6 +888,222 @@ class TestRunnerRun:
         assert rc == EXIT_GENERIC
         events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
         assert any(e["type"] == "error" and e["kind"] == "runtime" for e in events)
+
+    def test_run_start_event_logs_sampling_and_endpoint_params(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            temperature=0.2,
+            top_p=0.9,
+            top_k=40,
+            base_url="http://localhost:8000/v1",
+            api_key_env="MY_PROXY_KEY",
+        )
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        fake_openai = MagicMock()
+        with (
+            patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
+            patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True),
+        ):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        start = next(e for e in events if e["type"] == "start")
+        assert start["temperature"] == pytest.approx(0.2)
+        assert start["top_p"] == pytest.approx(0.9)
+        assert start["top_k"] == 40
+        assert start["base_url"] == "http://localhost:8000/v1"
+        # Only the env var NAME is logged - never the key value.
+        assert start["api_key_env"] == "MY_PROXY_KEY"
+        assert "sk-proxy" not in json.dumps(events)
+
+    def test_run_start_event_defaults_are_null(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            run(self._manifest())
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        start = next(e for e in events if e["type"] == "start")
+        for key in ("temperature", "top_p", "top_k", "base_url", "api_key_env"):
+            assert start[key] is None
+
+    def test_run_wires_model_settings_into_agent(self) -> None:
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            temperature=0.3,
+            top_p=0.8,
+            top_k=20,
+        )
+        settings_sentinel = object()
+        fake_agent_cls = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(
+            Agent=fake_agent_cls,
+            Runner=fake_runner,
+            ModelSettings=MagicMock(return_value=settings_sentinel),
+        )
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        fake_sdk.ModelSettings.assert_called_once_with(
+            temperature=0.3,
+            top_p=0.8,
+            extra_args={"top_k": 20},
+        )
+        assert fake_agent_cls.call_args.kwargs["model_settings"] is settings_sentinel
+
+    def test_run_skips_model_settings_when_no_params(self) -> None:
+        fake_agent_cls = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=fake_agent_cls, Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            run(self._manifest())
+        fake_sdk.ModelSettings.assert_not_called()
+        assert "model_settings" not in fake_agent_cls.call_args.kwargs
+
+    def test_run_constructs_client_from_manifest(self) -> None:
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            base_url="http://localhost:8000/v1",
+            api_key_env="MY_PROXY_KEY",
+        )
+        client_sentinel = object()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        fake_openai = MagicMock(AsyncOpenAI=MagicMock(return_value=client_sentinel))
+        with (
+            patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
+            patch.dict("os.environ", {"MY_PROXY_KEY": "sk-proxy"}, clear=True),
+        ):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        fake_openai.AsyncOpenAI.assert_called_once_with(
+            base_url="http://localhost:8000/v1",
+            api_key="sk-proxy",
+        )
+        fake_sdk.set_default_openai_client.assert_called_once_with(client_sentinel)
+
+    def test_run_leaves_default_client_alone_without_overrides(self) -> None:
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            run(self._manifest())
+        fake_sdk.set_default_openai_client.assert_not_called()
+
+    def test_run_fails_loudly_when_api_key_env_var_missing(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            api_key_env="MISSING_PROXY_KEY",
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            rc = run(manifest)
+        assert rc == EXIT_MANIFEST_ERROR
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        error = next(e for e in events if e["type"] == "error")
+        assert error["kind"] == "config_invalid"
+        assert "MISSING_PROXY_KEY" in error["message"]
+
+    def test_run_starts_and_stops_heartbeat(self) -> None:
+        stop_event = threading.Event()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with (
+            patch.object(
+                runner_module,
+                "_start_heartbeat",
+                return_value=stop_event,
+            ) as start_hb,
+            patch.dict(sys.modules, {"agents": fake_sdk}),
+        ):
+            run(self._manifest())
+        start_hb.assert_called_once()
+        assert stop_event.is_set()
+
+    def test_run_stops_heartbeat_on_sdk_missing(self) -> None:
+        stop_event = threading.Event()
+        with (
+            patch.object(
+                runner_module,
+                "_start_heartbeat",
+                return_value=stop_event,
+            ),
+            patch.dict(sys.modules, {"agents": None}),
+        ):
+            rc = run(self._manifest())
+        assert rc == EXIT_SDK_MISSING
+        assert stop_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Runner heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerHeartbeat:
+    def test_heartbeat_writes_proxy_shaped_payload(self, tmp_path: Path) -> None:
+        stop_event = _start_heartbeat("hb-sess", tmp_path, interval_s=0.05)
+        hb_file = tmp_path / ".sdd" / "runtime" / "heartbeats" / "hb-sess.json"
+        try:
+            deadline = time.monotonic() + 5.0
+            while not hb_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+        finally:
+            stop_event.set()
+        assert hb_file.exists()
+        payload = json.loads(hb_file.read_text(encoding="utf-8"))
+        # Schema mirrors _start_heartbeat_proxy in spawner_sandbox_session.
+        assert set(payload) == {
+            "timestamp",
+            "phase",
+            "progress_pct",
+            "current_file",
+            "message",
+            "status",
+            "files_changed",
+        }
+        assert payload["status"] == "working"
+        assert payload["phase"] == "implementing"
+        assert isinstance(payload["timestamp"], int)
+
+    def test_heartbeat_stops_after_event_set(self, tmp_path: Path) -> None:
+        stop_event = _start_heartbeat("hb-stop", tmp_path, interval_s=0.05)
+        hb_file = tmp_path / ".sdd" / "runtime" / "heartbeats" / "hb-stop.json"
+        deadline = time.monotonic() + 5.0
+        while not hb_file.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        stop_event.set()
+        time.sleep(0.15)
+        hb_file.unlink()
+        time.sleep(0.15)
+        assert not hb_file.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_plugin_sdk.py
+++ b/tests/unit/test_adapter_plugin_sdk.py
@@ -13,6 +13,8 @@ from bernstein.adapters.plugin_sdk import (
     AdapterPluginInfo,
     PluginAdapter,
     PluginRegistry,
+    SamplingParamsRefusal,
+    ensure_sampling_params_supported,
     validate_plugin,
 )
 
@@ -149,6 +151,7 @@ class TestAdapterCapability:
             "RATE_LIMIT_DETECTION",
             "STRUCTURED_OUTPUT",
             "BATCH_MODE",
+            "SUPPORTS_SAMPLING_PARAMS",
         }
         assert set(AdapterCapability.__members__.keys()) == expected
 
@@ -163,6 +166,7 @@ class TestAdapterCapability:
         assert AdapterCapability.RATE_LIMIT_DETECTION.value == "rate_limit_detection"
         assert AdapterCapability.STRUCTURED_OUTPUT.value == "structured_output"
         assert AdapterCapability.BATCH_MODE.value == "batch_mode"
+        assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS.value == "supports_sampling_params"
 
 
 # ---------------------------------------------------------------------------
@@ -383,3 +387,51 @@ class TestPluginRegistry:
 
         assert count == 1
         assert registry.get("prebuilt") is instance
+
+
+# ---------------------------------------------------------------------------
+# Sampling params capability gate
+# ---------------------------------------------------------------------------
+
+
+class _SamplingStubAdapter(_StubPluginAdapter):
+    """Stub adapter that declares SUPPORTS_SAMPLING_PARAMS."""
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        return AdapterPluginInfo(
+            name="sampling-stub",
+            version="1.0.0",
+            capabilities=(AdapterCapability.SUPPORTS_SAMPLING_PARAMS,),
+        )
+
+
+class TestEnsureSamplingParamsSupported:
+    """Tests for the spawn-time sampling/endpoint capability gate."""
+
+    def test_none_config_passes(self) -> None:
+        ensure_sampling_params_supported(_StubPluginAdapter(), None)
+
+    def test_config_without_sampling_keys_passes(self) -> None:
+        ensure_sampling_params_supported(
+            _StubPluginAdapter(),
+            {"sandbox_provider": "e2b", "tools": []},
+        )
+
+    def test_raises_for_non_supporting_adapter(self) -> None:
+        with pytest.raises(SamplingParamsRefusal, match="temperature"):
+            ensure_sampling_params_supported(_StubPluginAdapter(), {"temperature": 0.2})
+
+    def test_error_names_adapter_and_keys(self) -> None:
+        with pytest.raises(SamplingParamsRefusal) as excinfo:
+            ensure_sampling_params_supported(
+                _StubPluginAdapter(),
+                {"top_k": 40, "base_url": "http://localhost:8000/v1"},
+            )
+        assert excinfo.value.adapter_name == "stub"
+        assert excinfo.value.requested_keys == ("top_k", "base_url")
+
+    def test_passes_for_supporting_adapter(self) -> None:
+        ensure_sampling_params_supported(
+            _SamplingStubAdapter(),
+            {"temperature": 0.2, "top_p": 0.9, "api_key_env": "MY_PROXY_KEY"},
+        )

--- a/tests/unit/test_mcp_manager.py
+++ b/tests/unit/test_mcp_manager.py
@@ -524,6 +524,44 @@ class TestBuildMCPConfigForTask:
         # Task config should win
         assert result["mcpServers"]["github"]["command"] == "custom-github"
 
+    @patch("bernstein.core.protocols.mcp_manager.subprocess.Popen")
+    def test_merge_preserves_sampling_overrides_from_base(self, mock_popen: MagicMock) -> None:
+        """Top-level sampling/endpoint keys must survive the merge.
+
+        The spawn path transports per-spawn sampling and endpoint
+        overrides as top-level keys of the base MCP config; dropping
+        them here would bypass the adapter capability gate silently.
+        """
+        mock_proc = MagicMock()
+        mock_proc.pid = 100
+        mock_proc.poll.return_value = None
+        mock_popen.return_value = mock_proc
+
+        cfg = MCPServerConfig(name="github", command=["npx"])
+        mgr = MCPManager([cfg])
+        mgr.start_all()
+
+        base = {
+            "mcpServers": {"tavily": {"command": "npx", "args": ["tavily"]}},
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "top_k": 40,
+            "base_url": "http://localhost:8000/v1",
+            "api_key_env": "MY_PROXY_KEY",
+        }
+        result = mgr.build_mcp_config_for_task(
+            task_mcp_servers=["github"],
+            base_config=base,
+        )
+        assert result is not None
+        assert "tavily" in result["mcpServers"]
+        assert "github" in result["mcpServers"]
+        assert result["temperature"] == 0.2
+        assert result["top_p"] == 0.9
+        assert result["top_k"] == 40
+        assert result["base_url"] == "http://localhost:8000/v1"
+        assert result["api_key_env"] == "MY_PROXY_KEY"
+
 
 # ---------------------------------------------------------------------------
 # Env merging

--- a/tests/unit/test_mcp_registry.py
+++ b/tests/unit/test_mcp_registry.py
@@ -394,6 +394,37 @@ class TestMCPRegistryResolveForTasks:
         # Base config should win
         assert result["mcpServers"]["tavily"]["command"] == "custom"
 
+    def test_merge_preserves_sampling_overrides_from_base(self, make_task) -> None:
+        """Top-level sampling/endpoint keys must survive the merge.
+
+        The spawn path transports per-spawn sampling and endpoint
+        overrides as top-level keys of the base MCP config; dropping
+        them here would bypass the adapter capability gate silently.
+        """
+        registry = _make_registry(
+            [
+                {"name": "tavily", "package": "pkg", "keywords": ["web search"], "env_required": []},
+            ]
+        )
+        base_config: dict[str, Any] = {
+            "mcpServers": {"existing": {"command": "npx", "args": ["-y", "existing-pkg"]}},
+            "temperature": 0.2,
+            "top_k": 40,
+            "base_url": "http://localhost:8000/v1",
+            "api_key_env": "MY_PROXY_KEY",
+        }
+        task = make_task(description="Use web search to find docs")
+
+        result = registry.resolve_for_tasks([task], base_config=base_config)
+
+        assert result is not None
+        assert "existing" in result["mcpServers"]
+        assert "tavily" in result["mcpServers"]
+        assert result["temperature"] == 0.2
+        assert result["top_k"] == 40
+        assert result["base_url"] == "http://localhost:8000/v1"
+        assert result["api_key_env"] == "MY_PROXY_KEY"
+
     def test_no_servers_returns_base(self, make_task) -> None:
         registry = _make_registry(
             [

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -38,7 +38,12 @@ from bernstein.core.spawner import (
 )
 from bernstein.core.worktree import WorktreeError
 
-from bernstein.adapters.base import SpawnError
+from bernstein.adapters.base import SpawnError, SpawnResult
+from bernstein.adapters.plugin_sdk import (
+    AdapterCapability,
+    AdapterPluginInfo,
+    PluginAdapter,
+)
 
 # --- spawn_for_tasks ---
 
@@ -1390,3 +1395,106 @@ class TestOrchestratorSpawnerCallSite:
             "(templates root breaks every role template lookup; see #2155)"
         )
         assert "templates_dir=get_templates_dir(workdir),\n            adapter" not in source
+
+
+# --- Sampling/endpoint overrides and heartbeat delivery through spawn ---
+
+
+class _SamplingCapableAdapter(PluginAdapter):
+    """Concrete plugin adapter that records the mcp_config it received.
+
+    Declares ``SUPPORTS_SAMPLING_PARAMS`` (so the capability gate passes)
+    and opts into spawner-injected heartbeat delivery via
+    ``consumes_heartbeat_dir`` - the same shape as the openai_agents
+    adapter, without spawning a real subprocess.
+    """
+
+    consumes_heartbeat_dir = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_mcp_config: dict[str, Any] | None = None
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        return AdapterPluginInfo(
+            name="sampling-capable",
+            version="1.0.0",
+            capabilities=(AdapterCapability.SUPPORTS_SAMPLING_PARAMS,),
+        )
+
+    def health_check(self) -> bool:
+        return True
+
+    def supported_models(self) -> list[str]:
+        return []
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: object,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        self.seen_mcp_config = mcp_config
+        return SpawnResult(pid=4242, log_path=workdir / "stub.log")
+
+    def name(self) -> str:
+        return "sampling-capable"
+
+
+class TestSamplingParamsSpawnPath:
+    """Sampling keys and heartbeat_dir must reach the adapter intact."""
+
+    def test_sampling_params_reach_capable_adapter(self, tmp_path: Path, make_task) -> None:
+        adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            mcp_config={"temperature": 0.2, "top_k": 40, "api_key_env": "MY_PROXY_KEY"},
+        )
+
+        spawner.spawn_for_tasks([make_task()])
+
+        assert adapter.seen_mcp_config is not None
+        assert adapter.seen_mcp_config["temperature"] == 0.2
+        assert adapter.seen_mcp_config["top_k"] == 40
+        assert adapter.seen_mcp_config["api_key_env"] == "MY_PROXY_KEY"
+
+    def test_heartbeat_dir_injected_at_orchestrator_root(self, tmp_path: Path, make_task) -> None:
+        """The injected heartbeat_dir must equal the HeartbeatMonitor path.
+
+        The monitor polls ``<orchestrator_workdir>/.sdd/runtime/heartbeats``;
+        the runner writes wherever the spawner points it. Both sides must
+        agree even when the spawn cwd is a per-session worktree.
+        """
+        adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        spawner.spawn_for_tasks([make_task()])
+
+        assert adapter.seen_mcp_config is not None
+        assert adapter.seen_mcp_config["heartbeat_dir"] == str(tmp_path / ".sdd" / "runtime" / "heartbeats")
+
+    def test_heartbeat_dir_not_injected_for_regular_adapter(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        adapter = mock_adapter_factory(pid=99)
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        spawner.spawn_for_tasks([make_task()])
+
+        assert adapter.spawn.call_args.kwargs["mcp_config"] is None

--- a/tests/unit/test_spawner_openclaw_bridge.py
+++ b/tests/unit/test_spawner_openclaw_bridge.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock
 
+import pytest
 from bernstein.core.models import AgentSession
 from bernstein.core.spawner import AgentSpawner
 
+from bernstein.adapters.plugin_sdk import SamplingParamsRefusal
 from bernstein.bridges.base import AgentState, AgentStatus, BridgeConfig, BridgeError, RuntimeBridge, SpawnRequest
 
 if TYPE_CHECKING:
@@ -181,3 +183,34 @@ def test_reap_completed_agent_syncs_remote_logs(
     spawner.reap_completed_agent(session, skip_merge=True)
 
     assert bridge.log_calls == [session.id]
+
+
+def test_bridge_refuses_sampling_params(
+    tmp_path: Path,
+    make_task: Callable[..., Task],
+    mock_adapter_factory: Callable[..., CLIAdapter],
+) -> None:
+    """Sampling/endpoint overrides must not be silently dropped by the bridge.
+
+    The bridge spawn request has no way to carry them, so a configured
+    bridge plus requested overrides raises the same refusal the local
+    adapter capability gate uses - never a remote run with defaults.
+    """
+    adapter = cast("MagicMock", mock_adapter_factory(pid=42))
+    bridge = _FakeBridge()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(
+        adapter,
+        templates_dir,
+        tmp_path,
+        use_worktrees=False,
+        runtime_bridge=bridge,
+        mcp_config={"temperature": 0.2, "base_url": "http://localhost:8000/v1"},
+    )
+
+    with pytest.raises(SamplingParamsRefusal, match="temperature"):
+        spawner.spawn_for_tasks([make_task()])
+
+    assert bridge.spawn_calls == []
+    adapter.spawn.assert_not_called()


### PR DESCRIPTION
Implements the runner-wiring part of #2159 (design and daily-run validation by @shanemmattner, thank you).

- RunnerManifest gains optional temperature, top_p, top_k, base_url, api_key_env; absent fields keep today's behavior byte-identical.
- base_url + the key resolved from the named env var flow into the SDK client; when base_url is set the runner switches to the chat-completions API and excludes the custom client from tracing so third-party keys never reach the default tracing endpoint.
- api_key_env is fail-closed: it must name a known LLM provider key from the built-in allowlist, or be explicitly allowed by the operator via BERNSTEIN_ALLOWED_API_KEY_ENVS (host-set, not repo-carried). Missing env var fails at startup naming the variable; only the name is ever logged.
- Every effective param lands in the runner start event, so runs stay self-describing.
- AdapterCapability.SUPPORTS_SAMPLING_PARAMS: requesting params on an adapter without the capability raises instead of silently dropping (both spawn paths).
- Runner-side heartbeat thread writes the same payload the host-side proxy uses, into the heartbeat dir the monitor actually reads.
- Docs: manifest fields + constraints in capability_contract.md.

PR B from the RFC (role_model_policy / ModeProfile config surface) stays open for the follow-up discussed on the issue.

## Summary by Sourcery

Add configurable sampling and endpoint parameters and secure API key handling for openai_agents, enforce a capability gate for sampling overrides across adapters and bridges, and wire runner heartbeats into the orchestrator’s monitoring path.

New Features:
- Allow per-role sampling and endpoint overrides (temperature, top_p, top_k, base_url, api_key_env) to be passed via MCP config into the openai_agents runner manifest and SDK.
- Introduce an adapter capability (SUPPORTS_SAMPLING_PARAMS) and gating logic so only capable adapters can receive sampling and endpoint parameters.
- Add runner-side heartbeat emission that writes monitor-compatible heartbeat files to the orchestrator’s heartbeat directory.

Enhancements:
- Implement secure api_key_env validation and resolution, including an operator-controlled allowlist, and ensure secrets never appear in logs or tracing.
- Extend the openai_agents runner to construct custom AsyncOpenAI clients from manifest settings, switch to chat-completions for custom base_url endpoints, and log all effective sampling/endpoint parameters in start events.
- Ensure per-spawn sampling and endpoint overrides survive MCP config merges and are propagated through the spawner and runtime bridge without being silently dropped.
- Inject heartbeat_dir into MCP config for adapters that opt in, so runner heartbeats are written where the HeartbeatMonitor reads them, even with per-session worktrees.

Documentation:
- Document the sampling and endpoint parameter contract, including SUPPORTS_SAMPLING_PARAMS, api_key_env constraints, and runner behavior, in capability_contract.md.

Tests:
- Add comprehensive tests for sampling and endpoint overrides, api_key_env validation, MCP config merging, spawner behavior, runtime bridge refusals, and runner heartbeat emission and shutdown.
- Extend openai_agents adapter and runner tests to cover new manifest fields, client construction, ModelSettings wiring, error handling, and heartbeat directory resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing sampling and endpoint override settings through compatible adapters and runners.
  * Added heartbeat directory handling for supported adapters.
  * Added validation for configurable API key environment names.

* **Bug Fixes**
  * Preserved top-level configuration fields when merging task-specific MCP settings.
  * Refused unsupported sampling overrides instead of silently dropping them in certain spawn paths.

* **Documentation**
  * Expanded adapter capability docs with sampling, endpoint, validation, and logging behavior details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->