### PR TITLE
chore(release): 2.11.0

### DIFF
--- a/docs/release-notes/v2.11.0.md
+++ b/docs/release-notes/v2.11.0.md
@@ -1,0 +1,15 @@
+# v2.11.0
+
+Released 2026-07-02.
+
+## Features
+- The openai_agents runner accepts optional sampling and endpoint parameters: `temperature`, `top_p`, `top_k`, `base_url`, and `api_key_env` on the runner manifest, flowing into the SDK client and model settings. Absent fields keep the previous behavior byte-identical. When `base_url` is set the runner switches to the chat-completions API and excludes the custom client from tracing, so a third-party key is never sent to the default tracing endpoint. Every effective parameter is logged in the runner start event, so runs stay self-describing. Design validated in daily runs by @shanemmattner (#2159). (#2173)
+- `api_key_env` is fail-closed: it must name a known LLM provider key from the built-in allowlist; anything else requires the operator to allow it via `BERNSTEIN_ALLOWED_API_KEY_ENVS` on the host, which a repository cannot set. Requesting sampling parameters on an adapter without the new `SUPPORTS_SAMPLING_PARAMS` capability fails loudly instead of silently dropping them. (#2173)
+- SDK runners now write heartbeats, so they are visible to the stall watchdog between spawn and exit. (#2173)
+
+## Fixes
+- The Docker sandbox path from v2.10.0 is hardened: each spawned agent gets its own sandbox session (one exec timeout no longer tears down every agent's container), committed work is bundled out of the container and fetched into the host repo under `sandbox/<session_id>` refs, sandbox lifecycle events land in the HMAC-chained audit log with emissions serialized so concurrent lifecycles cannot fork the chain, and provisioning probes task-server reachability and warns on daemons without host networking. (#2162, #2172)
+- The `bernstein worker` loop can spawn agents again: it constructed the spawner with arguments that never existed and raised `TypeError` on the first claimed task. The server URL now also reaches spawned agents through the environment allowlist. (#2163, #2171)
+
+## Dependencies
+- Routine CI action digest updates (github/codeql-action, docker/setup-buildx-action).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.10.0"
+version = "2.11.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.10.0"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
New minor release.

- **Feature**: openai_agents runner sampling + endpoint params, fail-closed api_key_env allowlist, SUPPORTS_SAMPLING_PARAMS capability, runner heartbeat (#2173, on main).
- **Fixes**: hardened Docker sandbox session path (#2172), worker-loop spawn fix (#2171), both on main.
- **Dependencies**: CI action digest bumps (on main).

Bumps 2.10.0 -> 2.11.0; notes at docs/release-notes/v2.11.0.md. Merge LAST; auto-release tags on green CI.

## Summary by Sourcery

Release version 2.11.0 with new runner capabilities, sandbox hardening, and worker-loop fixes, documented in new release notes.

New Features:
- Add optional sampling and endpoint parameters to the openai_agents runner, including fail-closed api_key_env handling and SUPPORTS_SAMPLING_PARAMS capability.
- Add SDK runner heartbeats so long-running tasks are visible to the stall watchdog.

Bug Fixes:
- Harden Docker sandbox session handling and lifecycle logging to isolate agents and preserve the audit log chain.
- Fix the bernstein worker loop so it can spawn agents correctly and propagate the server URL via the environment allowlist.

Build:
- Bump project version from 2.10.0 to 2.11.0 and update dependency lockfile for the new release.

CI:
- Refresh CI GitHub Action digests for security and reproducibility.

Documentation:
- Add v2.11.0 release notes documenting new features, fixes, and dependency updates.