### PR TITLE
style: resolve refurb FURB173 and FURB123 findings

### DIFF
--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -229,8 +229,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
             if isinstance(heartbeat_dir, str) and heartbeat_dir:
                 overrides["heartbeat_dir"] = heartbeat_dir
 
-        return {
-            **overrides,
+        return overrides | {
             "session_id": session_id,
             "prompt": prompt,
             "workdir": str(workdir),

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -3074,7 +3074,7 @@ class AgentSpawner:
         assert self._sandbox_backend is not None
         assert self._sandbox_manifest_factory is not None
         manifest = self._sandbox_manifest_factory()
-        sbx_session = asyncio.run(self._sandbox_backend.create(manifest, options=dict(self._sandbox_options)))
+        sbx_session = asyncio.run(self._sandbox_backend.create(manifest, options=self._sandbox_options.copy()))
         backend_name = getattr(sbx_session, "backend_name", "unknown")
         sandbox_session_created_total.labels(backend=backend_name).inc()
         logger.info(


### PR DESCRIPTION
Resolves the two open refurb code-scanning findings: dict union for the runner manifest merge (`openai_agents.py`) and `dict.copy()` for the per-spawn sandbox options snapshot (`spawner_core.py`). Behavior-preserving.

## Summary by Sourcery

Resolve static analysis refurb findings by modernizing dict handling in manifest construction and sandbox option snapshots.

Enhancements:
- Use dict union for building runner manifests.
- Use dict.copy() to snapshot sandbox options before sandbox session creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal implementation details for manifest building and sandbox session setup.
  * No user-facing behavior, settings, or outputs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->