### PR TITLE
chore(release): 2.12.0 (worker isolation, replay integrity, standards mapping)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -75,6 +75,7 @@ alwaysApply: false
 | File                       | Purpose |
 |----------------------------|---------|
 | `_contract.py`             | Adapter contract loader and capability checker |
+| `advisories.py`            | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `aichat.py`                | AIChat CLI adapter |
 | `aider.py`                 | Aider CLI adapter |
 | `amp.py`                   | Amp CLI adapter |

--- a/.goosehints
+++ b/.goosehints
@@ -76,6 +76,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                       | Purpose |
 |----------------------------|---------|
 | `_contract.py`             | Adapter contract loader and capability checker |
+| `advisories.py`            | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `aichat.py`                | AIChat CLI adapter |
 | `aider.py`                 | Aider CLI adapter |
 | `amp.py`                   | Amp CLI adapter |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                       | Purpose |
 |----------------------------|---------|
 | `_contract.py`             | Adapter contract loader and capability checker |
+| `advisories.py`            | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `aichat.py`                | AIChat CLI adapter |
 | `aider.py`                 | Aider CLI adapter |
 | `amp.py`                   | Amp CLI adapter |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                       | Purpose |
 |----------------------------|---------|
 | `_contract.py`             | Adapter contract loader and capability checker |
+| `advisories.py`            | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `aichat.py`                | AIChat CLI adapter |
 | `aider.py`                 | Aider CLI adapter |
 | `amp.py`                   | Amp CLI adapter |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -76,6 +76,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                       | Purpose |
 |----------------------------|---------|
 | `_contract.py`             | Adapter contract loader and capability checker |
+| `advisories.py`            | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `aichat.py`                | AIChat CLI adapter |
 | `aider.py`                 | Aider CLI adapter |
 | `amp.py`                   | Amp CLI adapter |

--- a/docs/release-notes/v2.12.0.md
+++ b/docs/release-notes/v2.12.0.md
@@ -1,0 +1,15 @@
+# v2.12.0
+
+Released 2026-07-02.
+
+Worker isolation, replay integrity, and security-taxonomy mapping.
+
+## Features
+- Deterministic runs now record whether provider-side context compaction was active for each agent request, folded into the HMAC/Merkle step fingerprint, so a replay that diverges because compaction rewrote what the model actually saw is detected and attributed rather than silent. In deterministic-record and hermetic-replay modes the adapter additionally makes a best-effort request to suppress the CLI's client-side auto-compaction. The fingerprint is the load-bearing guarantee; the suppression is best-effort. (replay integrity)
+- Model effort level (low/medium/high/max) is now a first-class routing and replay dimension. The deterministic cascade fills an effort level from task scope, complexity, and retry count when the caller has not pinned one, so trivial tasks stop overpaying, and the effective effort enters the step fingerprint. The journal record is schema-versioned: legacy records without an effort field verify byte-for-byte, and a changed effort is detected as divergence across the local reader, the offline receipt verifier, and the redacted-publish re-anchor. (deterministic scheduler + replay)
+- `bernstein audit export --standard owasp-asi` and `--standard owasp-skills` produce a control-coverage view mapping the OWASP Top 10 for Agentic Applications (ASI01-ASI10) and Agentic Skills Top 10 (AST01-AST10) onto the mechanisms and audit-event types a run already emits, alongside the existing EU AI Act Article 12 export. Partially-covered controls are reported as partial in the summary (mapped/partial/todo) rather than hidden. (HMAC audit chain)
+- `bernstein interop a2a conformance` verifies an emitted agent card round-trips: JCS canonicalization, detached Ed25519 JWS signature, required fields, expiry, and issuer, each reported pass or fail, so an operator can prove a card verifies offline. (Ed25519 signed identity)
+
+## Security
+- Spawned workers can no longer silently enable embedded agent-team coordination. The per-adapter environment filter strips the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` gate (and forward-looking `*_AGENT_TEAMS` variants) by default even from an operator-widened allowlist and even after the secrets overlay, and the Claude adapter pins the gate off in the merged worker settings file. Enabling it requires an explicit host opt-in (`BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS`), which records an `adapter.embedded_agent_teams_enabled` event to the HMAC audit chain so an embedded team is attested rather than invisible. This preserves the one-worker-one-audit-trail invariant. (env isolation + audit chain)
+- `bernstein doctor` now reports when a discovered adapter CLI is below a known-safe version floor, using a data-driven advisory map, so an out-of-date spawned agent surfaces as a supply-chain warning rather than a silent risk. (adapter conformance + doctor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.11.0"
+version = "2.12.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bernstein/adapters/advisories.py
+++ b/src/bernstein/adapters/advisories.py
@@ -1,0 +1,107 @@
+"""Adapter minimum-safe-version advisories (supply-chain posture).
+
+Bernstein spawns 30+ third-party CLI coding agents.  When an installed adapter
+binary sits below a known-unsafe version floor, operators should be warned
+before that binary is trusted to run inside a worker.  This module holds a
+curated, data-driven floor map plus a pure comparison helper.
+
+The map is *data*, not code: adding or bumping a floor is a one-line edit to
+:data:`ADAPTER_MIN_SAFE_VERSIONS` with no logic change.  The doctor surface
+(``bernstein doctor``) consumes :func:`check_adapter_version` to report each
+discovered adapter as OK, below-floor (WARN), or unknown.
+
+Lever: this couples to the adapter conformance contract and the doctor observe
+surface.  A below-floor binary is a conformance signal an operator can act on
+before the worker's HMAC audit chain records a run against a version we already
+know is unsafe.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AdapterAdvisory:
+    """A minimum-safe-version advisory for one adapter binary.
+
+    Attributes:
+        adapter: Adapter name as discovered on PATH (e.g. ``"aider"``).
+        min_safe_version: Lowest version considered safe.  Anything strictly
+            below this floor is flagged.
+        advisory_id: Stable bernstein-local identifier for the advisory, so a
+            report can be cross-referenced without embedding external narratives.
+        note: One-line functional note.  Kept generic ("known-unsafe below X,
+            upgrade recommended") rather than reciting any specific external
+            vulnerability narrative.
+    """
+
+    adapter: str
+    min_safe_version: str
+    advisory_id: str
+    note: str
+
+
+# Curated floor map.  Data-driven: entries can be added or bumped without a
+# code change.  Notes stay functional and generic - name the adapter, the floor,
+# and "upgrade recommended".  Seeded conservatively; expand as floors are
+# confirmed.
+ADAPTER_MIN_SAFE_VERSIONS: dict[str, AdapterAdvisory] = {
+    "aider": AdapterAdvisory(
+        adapter="aider",
+        min_safe_version="0.60.0",
+        advisory_id="BSA-0001",
+        note="aider below 0.60.0 is known-unsafe for spawned use; upgrade recommended.",
+    ),
+    "goose": AdapterAdvisory(
+        adapter="goose",
+        min_safe_version="1.0.0",
+        advisory_id="BSA-0002",
+        note="goose below 1.0.0 is known-unsafe for spawned use; upgrade recommended.",
+    ),
+    "gptme": AdapterAdvisory(
+        adapter="gptme",
+        min_safe_version="0.20.0",
+        advisory_id="BSA-0003",
+        note="gptme below 0.20.0 is known-unsafe for spawned use; upgrade recommended.",
+    ),
+}
+
+
+def check_adapter_version(name: str, installed_version: str | None) -> AdapterAdvisory | None:
+    """Return an advisory when an installed adapter is below its safe floor.
+
+    Args:
+        name: Adapter name (matched against :data:`ADAPTER_MIN_SAFE_VERSIONS`).
+        installed_version: The discovered version string, or ``None`` when the
+            version could not be determined.
+
+    Returns:
+        The matching :class:`AdapterAdvisory` when the adapter is tracked and
+        ``installed_version`` parses to a value strictly below the floor.
+        ``None`` when the adapter is untracked, the version is unknown or
+        unparseable, or the installed version meets/exceeds the floor.
+    """
+    advisory = ADAPTER_MIN_SAFE_VERSIONS.get(name)
+    if advisory is None:
+        return None
+    if installed_version is None:
+        return None
+
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        installed = Version(installed_version)
+        floor = Version(advisory.min_safe_version)
+    except InvalidVersion:
+        # An unparseable version is treated as unknown, not below-floor: we do
+        # not want a garbled ``--version`` string to fabricate a warning.
+        logger.debug("Unparseable version %r for adapter %s", installed_version, name)
+        return None
+
+    if installed < floor:
+        return advisory
+    return None

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -43,7 +43,11 @@ from bernstein.adapters.claude_mcp_loader import (
     load_mcp_config as load_mcp_config,
 )
 from bernstein.adapters.claude_wrapper_script import build_wrapper_script
-from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.env_isolation import (
+    _embedded_teams_opt_in,
+    build_filtered_env,
+    record_embedded_teams_opt_in,
+)
 from bernstein.core.defaults import COST
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
 from bernstein.core.platform_compat import kill_process_group_graceful, process_alive
@@ -548,6 +552,21 @@ class ClaudeCodeAdapter(CLIAdapter):
                     existing = cast(_CAST_DICT_STR_ANY, raw)
 
         existing["hooks"] = hooks_config
+
+        # We own the merged settings file handed to the worker, so pin the
+        # embedded agent-team gate off unless the operator explicitly opts in.
+        # Teammates a worker spawns inherit the lead's permission mode and run
+        # outside this worker's HMAC audit trail; a stray truthy value in a
+        # pre-existing settings file must not silently re-open that hole. The
+        # env-var path is denied in build_filtered_env(); this covers the
+        # settings.json path Claude Code also reads.
+        if not _embedded_teams_opt_in():
+            env_block = existing.get("env")
+            if not isinstance(env_block, dict):
+                env_block = {}
+            env_block["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "false"
+            existing["env"] = env_block
+
         try:
             settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
         except OSError:
@@ -652,6 +671,17 @@ class ClaudeCodeAdapter(CLIAdapter):
         # rather than overwrite. Filter is empty-safe when the env var
         # is unset.
         env = build_filtered_env(["ANTHROPIC_API_KEY", "ANTHROPIC_BETA"])
+        # Embedded agent-team spawning is denied by default in
+        # build_filtered_env(); when an operator re-permits it via
+        # BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS we attest the decision to this
+        # worker's HMAC audit chain so the teammate hierarchy stays auditable
+        # rather than invisible.
+        if _embedded_teams_opt_in():
+            record_embedded_teams_opt_in(
+                adapter="claude",
+                session_id=session_id,
+                audit_dir=workdir / ".sdd" / "audit",
+            )
         # Anthropic Opus 4.7 ``task-budgets-2026-03-13`` beta header. Set
         # via ``ANTHROPIC_BETA`` so the Claude Code CLI forwards it to
         # every API call. Gated behind ``BERNSTEIN_ANTHROPIC_TASK_BUDGETS``

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -64,21 +64,29 @@ def _task_budgets_opt_in() -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Provider-side context-compaction policy (protects byte-identical replay)
+# Context-compaction policy (recorded in the replay fingerprint)
 # ---------------------------------------------------------------------------
 #
-# The provider API can compact (server-side summarise) older context between
-# turns. That rewrites the history the model sees on a later request, so a run
-# that records "context as sent" and later replays it will diverge: the replay
-# reconstructs the sent context, but the recorded run's model actually saw a
-# non-deterministic server summary. Our deterministic-replay lever (the
-# HMAC/Merkle step journal) only means something if "context as sent ==
-# context as seen"; compaction breaks that equality silently.
+# Context compaction (auto-summarising older context between turns) rewrites
+# the history the model effectively works from. A run that records "context as
+# sent" and later replays it can diverge if compaction changed between the two:
+# the replay reconstructs the sent context, but a compaction event altered what
+# the recorded run actually consumed.
 #
-# Policy: when a run is in deterministic-record or hermetic-replay mode, we
-# turn provider-side compaction OFF for every request so the model sees exactly
-# what we sent and the journal stays reconstructable. Outside those modes the
-# behaviour is unchanged from before this feature.
+# The load-bearing, verifiable guarantee here is NOT that we can force
+# compaction off. It is that the compaction policy state is captured in the
+# step fingerprint (the HMAC/Merkle step journal). If compaction behaviour
+# changes between record and replay, the fingerprint diverges and the mismatch
+# is DETECTED and attributable to a named field rather than surfacing as a
+# mysterious, unexplained rewrite. That detection is the deterministic-replay
+# lever; it holds regardless of whether any suppression request is honoured.
+#
+# As a best-effort layer, in deterministic-record or hermetic-replay mode we
+# additionally REQUEST that the CLI suppress its client-side auto-compaction.
+# This is a best-effort request, not an authoritative guarantee: it targets the
+# CLI's own auto-compaction behaviour and cannot promise anything about any
+# server-side context handling. The fingerprint is what makes a divergence
+# safe; the suppression request only reduces how often one happens.
 #
 # The env flags below are the source of truth for the run mode. They mirror
 # the ones read by the orchestrator (BERNSTEIN_DETERMINISTIC_SEED for record,
@@ -88,11 +96,13 @@ def _task_budgets_opt_in() -> bool:
 _DETERMINISTIC_SEED_ENV: str = "BERNSTEIN_DETERMINISTIC_SEED"
 _REPLAY_RUN_ID_ENV: str = "BERNSTEIN_REPLAY_RUN_ID"
 
-#: Claude Code CLI env var that turns off provider-side context compaction for
-#: this process. Setting it to "1" makes the CLI send context-management "off"
-#: to the API, so no server-side summary can rewrite what we sent. This is the
-#: adapter's own variable name, forwarded to every API call the CLI makes.
-_DISABLE_COMPACTION_ENV: str = "CLAUDE_CODE_DISABLE_CONTEXT_COMPACTION"
+#: Best-effort request to suppress the CLI's client-side auto-compaction; not a
+#: guarantee. Setting it to "1" asks the CLI not to auto-compact its own
+#: context this process; it makes no claim about any server-side handling. The
+#: authoritative replay protection is the recorded fingerprint (see
+#: :func:`ClaudeAdapter._record_compaction_state`), which detects and
+#: attributes any divergence a compaction change would cause.
+_DISABLE_COMPACTION_ENV: str = "DISABLE_AUTO_COMPACT"
 
 
 def _deterministic_run_mode() -> bool:
@@ -100,8 +110,9 @@ def _deterministic_run_mode() -> bool:
 
     Reads :data:`_DETERMINISTIC_SEED_ENV` (record) and
     :data:`_REPLAY_RUN_ID_ENV` (replay) from the environment. Either being set
-    to a non-empty value means the run must be byte-reconstructable, so
-    provider-side compaction has to be disabled.
+    to a non-empty value means the run must be byte-reconstructable, so the
+    compaction policy state is recorded in the fingerprint and a best-effort
+    suppression request is emitted.
 
     Returns:
         ``True`` when a deterministic seed or a replay run id is present.
@@ -115,24 +126,27 @@ def apply_compaction_policy(env: dict[str, str]) -> bool:
     """Apply the deterministic context-compaction policy to a spawn *env*.
 
     In deterministic-record or hermetic-replay mode, sets
-    :data:`_DISABLE_COMPACTION_ENV` so the CLI forwards context-management
-    "off" to the provider and the model sees exactly the context we sent -
-    the precondition our step-journal replay depends on. Outside those modes
-    the env is left untouched (default provider behaviour).
+    :data:`_DISABLE_COMPACTION_ENV` to "1" as a best-effort request that the
+    CLI suppress its client-side auto-compaction. This is a request, not a
+    guarantee: it cannot promise the model saw byte-identical context. Outside
+    those modes the env is left untouched (default behaviour).
 
-    Mutates *env* in place and returns whether compaction was disabled, so the
-    caller can record the enabled/disabled state in the step fingerprint. A
-    replay mismatch then becomes attributable to a known flag rather than a
-    mysterious server-side rewrite.
+    Mutates *env* in place and returns whether the suppression policy was
+    applied, so the caller can record the policy state in the step fingerprint.
+    The fingerprint is the load-bearing guarantee: any divergence a compaction
+    change causes is detected and attributed to a known, recorded policy field
+    rather than surfacing as a mysterious rewrite.
 
     Args:
         env: The filtered spawn environment dict (mutated in place).
 
     Returns:
-        ``True`` when compaction was disabled for this request (deterministic
-        modes), ``False`` when it was left at the provider default.
+        ``True`` when the suppression policy was applied for this request
+        (deterministic modes), ``False`` when it was left at the default.
     """
     if _deterministic_run_mode():
+        # Best-effort request to suppress client-side auto-compaction; not a
+        # guarantee. The recorded fingerprint is what makes replay safe.
         env[_DISABLE_COMPACTION_ENV] = "1"
         return True
     return False
@@ -492,20 +506,23 @@ class ClaudeCodeAdapter(CLIAdapter):
 
     @staticmethod
     def _record_compaction_state(workdir: Path, session_id: str, *, compaction_disabled: bool) -> None:
-        """Persist whether provider-side compaction was disabled for this spawn.
+        """Persist the compaction policy state applied to this spawn.
 
         Writes a small sidecar JSON at
-        ``.sdd/runtime/compaction/<session_id>.json`` recording the
-        enabled/disabled state. The spawner folds this flag into the step
-        journal so a later replay mismatch is attributable to a known request
-        parameter rather than a silent server-side context rewrite. Writing is
+        ``.sdd/runtime/compaction/<session_id>.json`` recording whether the
+        best-effort suppression policy was applied. The spawner folds this flag
+        into the step journal so that if compaction behaviour changes between
+        record and replay, the resulting divergence is DETECTED and attributable
+        to a known, recorded policy field rather than surfacing as a mysterious
+        context rewrite. This recording is the load-bearing replay guarantee;
+        the suppression request is only best-effort. Writing is itself
         best-effort: a failure here must never break spawn.
 
         Args:
             workdir: Agent working directory (root of ``.sdd``).
             session_id: Session id used as the sidecar filename.
-            compaction_disabled: ``True`` when compaction was turned off for
-                this request (deterministic / hermetic modes).
+            compaction_disabled: ``True`` when the suppression policy was
+                applied for this request (deterministic / hermetic modes).
         """
         try:
             state_dir = workdir / ".sdd" / "runtime" / "compaction"
@@ -513,9 +530,11 @@ class ClaudeCodeAdapter(CLIAdapter):
             state_path = state_dir / f"{session_id}.json"
             payload = {
                 "session_id": session_id,
-                # ``compaction_enabled`` is the value folded into the step
-                # fingerprint: True = provider may compact, False = we forced
-                # it off for byte-identical replay.
+                # ``compaction_enabled`` is the policy value folded into the
+                # step fingerprint: True = default behaviour (no suppression
+                # requested), False = best-effort suppression requested for
+                # this deterministic/replay run. It records the policy we
+                # applied, not a proof the provider honoured it.
                 "compaction_enabled": not compaction_disabled,
             }
             state_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
@@ -772,11 +791,12 @@ class ClaudeCodeAdapter(CLIAdapter):
                 env["ANTHROPIC_BETA"] = f"{existing_beta},{_TASK_BUDGETS_BETA_VALUE}"
             else:
                 env["ANTHROPIC_BETA"] = _TASK_BUDGETS_BETA_VALUE
-        # In deterministic-record / hermetic-replay mode, disable provider-side
-        # context compaction so the model sees exactly what we sent - the
-        # equality our step-journal replay depends on. No-op outside those
-        # modes. The returned flag is recorded so a replay mismatch stays
-        # attributable rather than mysterious.
+        # In deterministic-record / hermetic-replay mode, emit a best-effort
+        # request to suppress client-side auto-compaction (no-op otherwise).
+        # The returned policy flag is recorded in the fingerprint so any
+        # compaction-driven divergence between record and replay is detected
+        # and stays attributable rather than mysterious. The recording, not the
+        # suppression request, is the load-bearing guarantee.
         compaction_disabled = apply_compaction_policy(env)
         self._record_compaction_state(workdir, session_id, compaction_disabled=compaction_disabled)
         claude_proc, wrapper_proc = self._launch_process(wrapped_cmd, wrapper, workdir, log_path, env=env)

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -64,6 +64,81 @@ def _task_budgets_opt_in() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Provider-side context-compaction policy (protects byte-identical replay)
+# ---------------------------------------------------------------------------
+#
+# The provider API can compact (server-side summarise) older context between
+# turns. That rewrites the history the model sees on a later request, so a run
+# that records "context as sent" and later replays it will diverge: the replay
+# reconstructs the sent context, but the recorded run's model actually saw a
+# non-deterministic server summary. Our deterministic-replay lever (the
+# HMAC/Merkle step journal) only means something if "context as sent ==
+# context as seen"; compaction breaks that equality silently.
+#
+# Policy: when a run is in deterministic-record or hermetic-replay mode, we
+# turn provider-side compaction OFF for every request so the model sees exactly
+# what we sent and the journal stays reconstructable. Outside those modes the
+# behaviour is unchanged from before this feature.
+#
+# The env flags below are the source of truth for the run mode. They mirror
+# the ones read by the orchestrator (BERNSTEIN_DETERMINISTIC_SEED for record,
+# BERNSTEIN_REPLAY_RUN_ID for replay); they are inlined here rather than
+# imported so the adapter stays free of scheduler internals (importlinter
+# contract ``adapters-no-scheduler``).
+_DETERMINISTIC_SEED_ENV: str = "BERNSTEIN_DETERMINISTIC_SEED"
+_REPLAY_RUN_ID_ENV: str = "BERNSTEIN_REPLAY_RUN_ID"
+
+#: Claude Code CLI env var that turns off provider-side context compaction for
+#: this process. Setting it to "1" makes the CLI send context-management "off"
+#: to the API, so no server-side summary can rewrite what we sent. This is the
+#: adapter's own variable name, forwarded to every API call the CLI makes.
+_DISABLE_COMPACTION_ENV: str = "CLAUDE_CODE_DISABLE_CONTEXT_COMPACTION"
+
+
+def _deterministic_run_mode() -> bool:
+    """Return whether this process runs in deterministic-record or hermetic-replay mode.
+
+    Reads :data:`_DETERMINISTIC_SEED_ENV` (record) and
+    :data:`_REPLAY_RUN_ID_ENV` (replay) from the environment. Either being set
+    to a non-empty value means the run must be byte-reconstructable, so
+    provider-side compaction has to be disabled.
+
+    Returns:
+        ``True`` when a deterministic seed or a replay run id is present.
+    """
+    seed = os.environ.get(_DETERMINISTIC_SEED_ENV, "").strip()
+    replay = os.environ.get(_REPLAY_RUN_ID_ENV, "").strip()
+    return bool(seed) or bool(replay)
+
+
+def apply_compaction_policy(env: dict[str, str]) -> bool:
+    """Apply the deterministic context-compaction policy to a spawn *env*.
+
+    In deterministic-record or hermetic-replay mode, sets
+    :data:`_DISABLE_COMPACTION_ENV` so the CLI forwards context-management
+    "off" to the provider and the model sees exactly the context we sent -
+    the precondition our step-journal replay depends on. Outside those modes
+    the env is left untouched (default provider behaviour).
+
+    Mutates *env* in place and returns whether compaction was disabled, so the
+    caller can record the enabled/disabled state in the step fingerprint. A
+    replay mismatch then becomes attributable to a known flag rather than a
+    mysterious server-side rewrite.
+
+    Args:
+        env: The filtered spawn environment dict (mutated in place).
+
+    Returns:
+        ``True`` when compaction was disabled for this request (deterministic
+        modes), ``False`` when it was left at the provider default.
+    """
+    if _deterministic_run_mode():
+        env[_DISABLE_COMPACTION_ENV] = "1"
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Multimodal attachment encoding (issue #1797)
 # ---------------------------------------------------------------------------
 
@@ -415,6 +490,38 @@ class ClaudeCodeAdapter(CLIAdapter):
             completion_path=completion_path,
         )
 
+    @staticmethod
+    def _record_compaction_state(workdir: Path, session_id: str, *, compaction_disabled: bool) -> None:
+        """Persist whether provider-side compaction was disabled for this spawn.
+
+        Writes a small sidecar JSON at
+        ``.sdd/runtime/compaction/<session_id>.json`` recording the
+        enabled/disabled state. The spawner folds this flag into the step
+        journal so a later replay mismatch is attributable to a known request
+        parameter rather than a silent server-side context rewrite. Writing is
+        best-effort: a failure here must never break spawn.
+
+        Args:
+            workdir: Agent working directory (root of ``.sdd``).
+            session_id: Session id used as the sidecar filename.
+            compaction_disabled: ``True`` when compaction was turned off for
+                this request (deterministic / hermetic modes).
+        """
+        try:
+            state_dir = workdir / ".sdd" / "runtime" / "compaction"
+            state_dir.mkdir(parents=True, exist_ok=True)
+            state_path = state_dir / f"{session_id}.json"
+            payload = {
+                "session_id": session_id,
+                # ``compaction_enabled`` is the value folded into the step
+                # fingerprint: True = provider may compact, False = we forced
+                # it off for byte-identical replay.
+                "compaction_enabled": not compaction_disabled,
+            }
+            state_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - best-effort, never blocks spawn
+            _logger.debug("Could not record compaction state for %s: %s", session_id, exc)
+
     def _launch_process(
         self,
         cmd: list[str],
@@ -665,6 +772,13 @@ class ClaudeCodeAdapter(CLIAdapter):
                 env["ANTHROPIC_BETA"] = f"{existing_beta},{_TASK_BUDGETS_BETA_VALUE}"
             else:
                 env["ANTHROPIC_BETA"] = _TASK_BUDGETS_BETA_VALUE
+        # In deterministic-record / hermetic-replay mode, disable provider-side
+        # context compaction so the model sees exactly what we sent - the
+        # equality our step-journal replay depends on. No-op outside those
+        # modes. The returned flag is recorded so a replay mismatch stays
+        # attributable rather than mysterious.
+        compaction_disabled = apply_compaction_policy(env)
+        self._record_compaction_state(workdir, session_id, compaction_disabled=compaction_disabled)
         claude_proc, wrapper_proc = self._launch_process(wrapped_cmd, wrapper, workdir, log_path, env=env)
 
         # Track the worker process (wraps claude) for is_alive/kill

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -138,6 +138,100 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
 )
 
 
+# Host env var an operator sets to *re-permit* embedded agent-team spawning.
+# Off by default: absent (or any value other than the truthy set below) keeps
+# the deny-by-default posture.  See :func:`_embedded_teams_opt_in`.
+_EMBEDDED_TEAMS_OPT_IN_VAR = "BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS"
+
+# Exact gate variables a spawned worker could use to launch its own autonomous
+# teammate instances.  ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`` is the Claude
+# Code adapter's own opt-in variable; teammates it spawns inherit the lead's
+# permission mode and run OUTSIDE the per-worker HMAC audit trail, breaking the
+# one-worker-one-audit-trail invariant our replay guarantee depends on.  These
+# are stripped unconditionally (even if an operator widens ``extra_keys`` to
+# include them) unless the host explicitly opts in.
+_EMBEDDED_TEAMS_DENYLIST: frozenset[str] = frozenset(
+    {
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
+    }
+)
+
+# Forward-looking suffix match: any variable ending in one of these is treated
+# as an embedded-orchestration gate and denied by default, so a future adapter
+# introducing e.g. ``<VENDOR>_EXPERIMENTAL_AGENT_TEAMS`` or ``<VENDOR>_AGENT_TEAMS``
+# is covered without a code change.  Kept narrow to avoid stripping unrelated
+# vars that merely mention "agent".
+_EMBEDDED_TEAMS_DENY_SUFFIXES: tuple[str, ...] = (
+    "_EXPERIMENTAL_AGENT_TEAMS",
+    "_AGENT_TEAMS",
+)
+
+
+def _embedded_teams_opt_in() -> bool:
+    """Return True only when the operator explicitly re-permits embedded teams.
+
+    Truthy set is deliberately narrow (``1``/``true``/``yes``/``on``, case
+    insensitive) so a stray empty or ``0`` value keeps deny-by-default.
+    """
+    raw = os.environ.get(_EMBEDDED_TEAMS_OPT_IN_VAR, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_embedded_teams_gate(key: str) -> bool:
+    """Return True when ``key`` is an embedded agent-team spawning gate."""
+    if key in _EMBEDDED_TEAMS_DENYLIST:
+        return True
+    return any(key.endswith(suffix) for suffix in _EMBEDDED_TEAMS_DENY_SUFFIXES)
+
+
+def record_embedded_teams_opt_in(
+    *,
+    adapter: str,
+    session_id: str,
+    audit_dir: Path | None = None,
+) -> None:
+    """Attest an operator opt-in that re-permits embedded agent-team spawning.
+
+    When ``BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS`` re-permits the gate, the
+    embedded team must be *attested* rather than invisible: we append an
+    ``adapter.embedded_agent_teams_enabled`` event to the per-worker HMAC audit
+    chain so an auditor replaying the log can see exactly which spawn opted a
+    teammate hierarchy back in.  Removing the audit chain removes the meaning
+    of this feature, not just its log - the whole point is that a re-permitted
+    team stays inside the one-worker-one-audit-trail invariant.
+
+    Failures (missing key, disk full) are caught and logged; audit emission
+    must never mask the spawn.
+
+    Args:
+        adapter: Adapter name performing the spawn (e.g. ``"claude"``).
+        session_id: Spawn session identifier (becomes the audit resource id).
+        audit_dir: Audit directory override.  Defaults to ``.sdd/audit`` under
+            the current working directory, matching the spawner convention.
+    """
+    try:
+        from bernstein.core.security.audit import AuditLog
+
+        target_dir = audit_dir if audit_dir is not None else Path.cwd() / ".sdd" / "audit"
+        audit = AuditLog(audit_dir=target_dir)
+        audit.log(
+            event_type="adapter.embedded_agent_teams_enabled",
+            actor=adapter,
+            resource_type="agent_session",
+            resource_id=session_id,
+            details={
+                "adapter": adapter,
+                "opt_in_var": _EMBEDDED_TEAMS_OPT_IN_VAR,
+            },
+        )
+    except Exception as exc:  # audit must never mask the spawn - log and move on
+        logger.warning(
+            "Could not emit embedded_agent_teams_enabled audit event for %s: %s",
+            session_id,
+            exc,
+        )
+
+
 def build_filtered_env(
     extra_keys: Iterable[str] = (),
     *,
@@ -218,6 +312,16 @@ def build_filtered_env(
 
     allowed = _BASE_ALLOWLIST | requested_extra
     env = {k: v for k, v in os.environ.items() if k in allowed}
+
+    # Deny-by-default: strip embedded agent-team spawning gates even if an
+    # operator-widened allowlist (or a future permissive path) let one through.
+    # A teammate spawned by a worker inherits the lead's permission mode and
+    # runs outside this worker's HMAC audit trail, so we close the hole here
+    # rather than trusting every caller's ``extra_keys``.  An explicit host
+    # opt-in re-permits it; the spawn path is expected to attest the decision
+    # via :func:`record_embedded_teams_opt_in` so the team stays auditable.
+    if not _embedded_teams_opt_in():
+        env = {k: v for k, v in env.items() if not _is_embedded_teams_gate(k)}
 
     # Ensure PYTHONPATH includes directories needed by bernstein-worker.
     # When the orchestrator runs via ``uv run``, sys.executable may point

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -349,4 +349,11 @@ def build_filtered_env(
             )
             env.update(provider_secrets)
 
+    # Re-apply the deny after every later env mutation (secrets overlay,
+    # PYTHONPATH injection).  A secrets provider that returned an embedded
+    # agent-team gate must not be able to reintroduce it past the earlier
+    # strip; the deny-by-default posture holds right up to the return.
+    if not _embedded_teams_opt_in():
+        env = {k: v for k, v in env.items() if not _is_embedded_teams_gate(k)}
+
     return env

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -291,12 +291,15 @@ def verify_hmac_cmd() -> None:
     "--standard",
     "standard",
     default=None,
-    type=click.Choice(["ai-act"]),
+    type=click.Choice(["ai-act", "owasp-asi", "owasp-skills"]),
     help=(
         "Emit a one-command compliance evidence pack mapped to the chosen "
-        "regulatory standard (issue #1316). 'ai-act' is the only standard "
-        "with a reviewed control map at MVP; DORA and FINOS AIGF are tracked "
-        "under #1316 and will be added once their clause maps are validated."
+        "control catalogue, anchored on the operator's own HMAC-chained "
+        "audit events. 'ai-act' maps EU AI Act Article 12/13/15; "
+        "'owasp-asi' maps the OWASP Top 10 for Agentic Applications "
+        "(ASI01-ASI10); 'owasp-skills' maps the Agentic Skills Top 10 "
+        "(AST01-AST10). DORA and FINOS AIGF are tracked under #1316 and "
+        "will be added once their clause maps are validated."
     ),
 )
 @click.option(

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -703,8 +703,8 @@ def _run_standard_export(
     table.add_row("Lineage entries", str(pack.lineage_count))
     table.add_row("Cost snapshots", str(pack.cost_count))
     table.add_row(
-        "Controls mapped/todo",
-        f"{pack.controls_mapped} / {pack.controls_todo}",
+        "Controls mapped/partial/todo",
+        f"{pack.controls_mapped} / {pack.controls_partial} / {pack.controls_todo}",
     )
     table.add_row("SHA-256", pack.sha256[:16] + "...")
     if pack.archive_path is not None:

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -77,6 +77,92 @@ def check_adapters_installed() -> list[dict[str, Any]]:
     return results
 
 
+def _probe_adapter_version(name: str) -> str | None:
+    """Return the installed version string for an adapter binary, or None.
+
+    Runs ``<name> --version`` and extracts the first dotted-numeric token.
+    Best-effort: any launch failure, timeout, or unparseable output yields
+    ``None`` (reported as "unknown" rather than a false below-floor warning).
+    """
+    import re
+
+    exe = shutil.which(name)
+    if exe is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [exe, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    blob = f"{proc.stdout}\n{proc.stderr}"
+    match = re.search(r"\d+(?:\.\d+){1,3}", blob)
+    return match.group(0) if match else None
+
+
+def check_adapter_advisories() -> list[dict[str, Any]]:
+    """Report a supply-chain version-floor status for each tracked adapter.
+
+    For every adapter with a curated minimum-safe-version floor, reports:
+
+    - OK (PASS) when the discovered version meets or exceeds the floor,
+    - below-floor (WARN) when it is strictly below the floor,
+    - unknown (WARN) when the binary is present but the version cannot be
+      determined,
+    - not installed (PASS/skip) is omitted so the surface stays quiet for
+      adapters the operator does not run.
+
+    Couples to the adapter conformance contract: a below-floor binary is a
+    conformance signal an operator can act on before a worker records a run
+    against a version we already know is unsafe.
+    """
+    from bernstein.adapters.advisories import (
+        ADAPTER_MIN_SAFE_VERSIONS,
+        check_adapter_version,
+    )
+
+    results: list[dict[str, Any]] = []
+    for name, advisory in sorted(ADAPTER_MIN_SAFE_VERSIONS.items()):
+        if shutil.which(name) is None:
+            continue  # adapter not installed: nothing to warn about
+        version = _probe_adapter_version(name)
+        label = f"Adapter version: {name}"
+        if version is None:
+            results.append(
+                {
+                    "name": label,
+                    "status": _CHECK_WARN,
+                    "detail": f"installed, version unknown (safe floor {advisory.min_safe_version})",
+                    "fix": f"Verify {name} version is >= {advisory.min_safe_version}",
+                }
+            )
+            continue
+        hit = check_adapter_version(name, version)
+        if hit is not None:
+            results.append(
+                {
+                    "name": label,
+                    "status": _CHECK_WARN,
+                    "detail": (f"{version} below safe floor {hit.min_safe_version} [{hit.advisory_id}]: {hit.note}"),
+                    "fix": f"Upgrade {name} to >= {hit.min_safe_version}",
+                }
+            )
+        else:
+            results.append(
+                {
+                    "name": label,
+                    "status": _CHECK_PASS,
+                    "detail": f"{version} >= safe floor {advisory.min_safe_version}",
+                    "fix": "",
+                }
+            )
+    return results
+
+
 def check_api_keys() -> list[dict[str, Any]]:
     """Check environment variables for common API keys."""
     results: list[dict[str, Any]] = []
@@ -325,6 +411,7 @@ def run_all_checks() -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     checks.append(check_python_version())
     checks.extend(check_adapters_installed())
+    checks.extend(check_adapter_advisories())
     checks.extend(check_api_keys())
     checks.extend(
         (

--- a/src/bernstein/cli/commands/interop_cmd.py
+++ b/src/bernstein/cli/commands/interop_cmd.py
@@ -38,6 +38,7 @@ from bernstein.core.interop.a2a_card import (
     issue_capability_card,
     verify_capability_card,
 )
+from bernstein.core.interop.a2a_conformance import check_card_conformance
 from bernstein.core.interop.a2a_consume import (
     PolicyRequirements,
     policies_meet_requirements,
@@ -238,6 +239,53 @@ def verify(
     console.print(f"  fingerprint: {fingerprint}")
 
 
+@a2a_group.command("conformance")
+@click.option(
+    "--card",
+    "card_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the signed capability card JSON to self-check.",
+)
+def conformance(card_path: Path) -> None:
+    """Self-check that a card round-trips and verifies offline.
+
+    \b
+    Runs, in order: required-field validation, RFC 8785 JCS
+    canonicalisation, detached Ed25519 JWS signature verification,
+    expiry, and issuer. Prints a per-check pass/fail report and exits
+    non-zero if any check fails. This proves the card the operator emits
+    verifies the same way a peer will check it, with no network access.
+    """
+    try:
+        signed = SignedCapabilityCard.from_json(card_path.read_text())
+    except (ValueError, json.JSONDecodeError) as exc:
+        _fail(f"could not parse capability card: {exc}")
+        return
+
+    report = check_card_conformance(signed)
+
+    if is_json():
+        print_json({"card": str(card_path), **report.to_dict()})
+        if not report.ok:
+            sys.exit(1)
+        return
+
+    if report.ok:
+        print_success(f"Capability card {card_path} passes all conformance checks", soft_wrap=True)
+    else:
+        print_error(f"Capability card {card_path} FAILED conformance:", soft_wrap=True)
+    console.print(f"  issuer: [bold]{report.issuer}[/bold]  kid: {report.kid}")
+    if report.fingerprint:
+        console.print(f"  fingerprint: {report.fingerprint}")
+    for check in report.checks:
+        marker = "[green]PASS[/green]" if check.passed else "[red]FAIL[/red]"
+        console.print(f"  {marker} {check.name}: {check.detail}")
+
+    if not report.ok:
+        sys.exit(1)
+
+
 def _fail(message: str) -> None:
     """Print an error (JSON-aware) and exit non-zero."""
     if is_json():
@@ -247,4 +295,4 @@ def _fail(message: str) -> None:
     sys.exit(1)
 
 
-__all__ = ["a2a_group", "card", "interop_group", "verify"]
+__all__ = ["a2a_group", "card", "conformance", "interop_group", "verify"]

--- a/src/bernstein/compliance/__init__.py
+++ b/src/bernstein/compliance/__init__.py
@@ -28,6 +28,8 @@ from bernstein.compliance.evidence_pack import (
     build_evidence_pack,
     get_standard_map,
 )
+from bernstein.compliance.owasp_asi import control_map as owasp_asi_control_map
+from bernstein.compliance.owasp_skills import control_map as owasp_skills_control_map
 
 __all__ = [
     "EVIDENCE_PACK_SCHEMA_VERSION",
@@ -45,4 +47,6 @@ __all__ = [
     "TechDocGenerator",
     "build_evidence_pack",
     "get_standard_map",
+    "owasp_asi_control_map",
+    "owasp_skills_control_map",
 ]

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -63,13 +63,16 @@ logger = logging.getLogger(__name__)
 #: change to layout, file names, or hash inputs.
 SCHEMA_VERSION: str = "1.0.0"
 
-#: Supported standards at MVP. Only ``ai-act`` has a fleshed-out
-#: control map. DORA and FINOS AIGF are tracked under #1316 and will
-#: be added once their clause maps are reviewed by subject-matter
-#: experts; emitting TODO-only bundles would mislead operators.
-Standard = Literal["ai-act"]
+#: Supported standards. ``ai-act`` maps the EU AI Act Article 12/13/15
+#: clauses; ``owasp-asi`` and ``owasp-skills`` map the OWASP Top 10 for
+#: Agentic Applications (ASI01-ASI10) and the Agentic Skills Top 10
+#: (AST01-AST10) onto the same audit-chain artefacts. DORA and FINOS
+#: AIGF are tracked under #1316 and are not selectable until their
+#: clause maps are reviewed by subject-matter experts; emitting
+#: TODO-only bundles would mislead operators.
+Standard = Literal["ai-act", "owasp-asi", "owasp-skills"]
 
-SUPPORTED_STANDARDS: tuple[str, ...] = ("ai-act",)
+SUPPORTED_STANDARDS: tuple[str, ...] = ("ai-act", "owasp-asi", "owasp-skills")
 
 #: Fixed mtime for every entry in the produced zip - required for
 #: byte-deterministic output. Zip cannot store dates before 1980.
@@ -151,6 +154,17 @@ _STANDARD_MAPS: dict[str, dict[str, Any]] = {
         ],
     },
 }
+
+# The OWASP ASI / AST maps live in dedicated modules (one control class per
+# module) and are registered here so ``build_evidence_pack`` reads them the
+# same way it reads ``ai-act``. Registration is a plain assignment - the
+# modules only depend on stdlib, so importing them at module load is cheap
+# and side-effect free.
+from bernstein.compliance import owasp_asi as _owasp_asi  # noqa: E402
+from bernstein.compliance import owasp_skills as _owasp_skills  # noqa: E402
+
+_STANDARD_MAPS[_owasp_asi.STANDARD_ID] = _owasp_asi.control_map()
+_STANDARD_MAPS[_owasp_skills.STANDARD_ID] = _owasp_skills.control_map()
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -185,6 +185,7 @@ class EvidencePack:
         lineage_count: Number of lineage entries captured.
         cost_count: Number of cost snapshots captured.
         controls_mapped: How many controls have ``status == "mapped"``.
+        controls_partial: How many controls have ``status == "partial"``.
         controls_todo: How many controls remain TODO for the standard.
         archive_path: On-disk path to the written zip (``None`` for dry-run).
         sha256: SHA-256 of the produced zip bytes.
@@ -198,6 +199,7 @@ class EvidencePack:
     lineage_count: int
     cost_count: int
     controls_mapped: int
+    controls_partial: int
     controls_todo: int
     archive_path: Path | None
     sha256: str
@@ -214,6 +216,7 @@ class EvidencePack:
             "lineage_count": self.lineage_count,
             "cost_count": self.cost_count,
             "controls_mapped": self.controls_mapped,
+            "controls_partial": self.controls_partial,
             "controls_todo": self.controls_todo,
             "sha256": self.sha256,
         }
@@ -611,6 +614,7 @@ def build_evidence_pack(
 
     controls = mapping["controls"]
     controls_mapped = sum(1 for c in controls if c.get("status") == "mapped")
+    controls_partial = sum(1 for c in controls if c.get("status") == "partial")
     controls_todo = sum(1 for c in controls if c.get("status") == "todo")
 
     bundle_id = _bundle_id(standard, since, task)
@@ -625,6 +629,7 @@ def build_evidence_pack(
         "lineage_count": len(lineage_entries),
         "cost_count": len(cost_entries),
         "controls_mapped": controls_mapped,
+        "controls_partial": controls_partial,
         "controls_todo": controls_todo,
         "generated_at_utc": "1970-01-01T00:00:00+00:00",  # deterministic, see note below
         "artefacts": dict(sorted(artefact_hashes.items())),
@@ -659,6 +664,7 @@ def build_evidence_pack(
         lineage_count=len(lineage_entries),
         cost_count=len(cost_entries),
         controls_mapped=controls_mapped,
+        controls_partial=controls_partial,
         controls_todo=controls_todo,
         archive_path=archive_path,
         sha256=archive_sha256,

--- a/src/bernstein/compliance/owasp_asi.py
+++ b/src/bernstein/compliance/owasp_asi.py
@@ -1,0 +1,204 @@
+"""OWASP Top 10 for Agentic Applications (ASI01-ASI10) control map.
+
+Operators running agentic workloads in security-sensitive environments
+need to show, from their own run evidence, which agentic-security
+controls a Bernstein run already covers. This module is the ASI analogue
+of the EU AI Act Article 12 clause map in ``evidence_pack.py``: it maps
+each OWASP ASI control id to the concrete Bernstein mechanism that
+addresses it and to the HMAC-chained audit event type(s) that serve as
+evidence.
+
+The map is anchored on the HMAC audit chain: every ``event_type`` cited
+below is a literal string a Bernstein run actually writes into
+``.sdd/audit/*.jsonl``. Strip the audit chain and this map has nothing
+to point at, so the coverage claim is only as strong as the tamper-
+evident chain that backs it. That coupling is deliberate: the evidence
+is the chain, not a side document that merely describes the chain.
+
+Honesty rule (same as ``owasp_asi_detectors.py``): where Bernstein only
+partially addresses a control, the entry is marked ``"partial"`` and the
+gap is stated in ``requirement``. An honest partial map is the
+deliverable; over-claiming coverage would mislead an auditor.
+
+The block is consumed by ``evidence_pack.build_evidence_pack`` under the
+``owasp-asi`` standard. It mirrors the ``_STANDARD_MAPS`` shape exactly:
+
+    {
+        "regulation": <str>,
+        "controls": [ {control_id, requirement, artefact, selector, status}, ... ],
+        "deferred": [ <str>, ... ],
+    }
+
+``selector`` names the audit event attribute (or literal ``event_type``
+values) carrying the primary evidence. It is informational, mirroring
+the EU AI Act block; it is not enforced at build time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Standard id used on the ``--standard`` flag and in manifests.
+STANDARD_ID: str = "owasp-asi"
+
+#: Human-readable catalogue name emitted into ``controls.json``.
+REGULATION: str = "OWASP Top 10 for Agentic Applications (ASI01-ASI10, Dec 2025)"
+
+# ---------------------------------------------------------------------------
+# ASI01-ASI10 control map
+# ---------------------------------------------------------------------------
+#
+# Each ``selector`` string lists literal ``event_type`` values (confirmed
+# present in the codebase) or an audit attribute name. The ``artefact``
+# points at the same bundle files the EU AI Act pack emits, so an auditor
+# switching standards sees a consistent layout.
+
+CONTROLS: list[dict[str, Any]] = [
+    {
+        "control_id": "ASI01",
+        "requirement": (
+            "Agent goal / instruction hijack: prompt-injection and goal "
+            "manipulation are screened by the on-by-default OWASP ASI "
+            "guardrail pack (ASI01 goal-hijack detector) and promptware "
+            "scanner; refusals land in the audit chain."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal,command",
+        "status": "partial",
+    },
+    {
+        "control_id": "ASI02",
+        "requirement": (
+            "Tool misuse / excessive agency: the lethal-trifecta capability "
+            "matrix denies any tool chain that simultaneously holds private "
+            "data access, untrusted content, and external egress; the "
+            "deterministic scheduler bounds agency (no LLM in the "
+            "coordination loop). Refusals are recorded."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI03",
+        "requirement": (
+            "Identity and privilege abuse: per-adapter environment isolation "
+            "and the Ed25519-signed install identity scope what an agent may "
+            "act as; approval gates record who authorised a privileged step."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "approval_pending,approval_resolved,auto_approve_decision",
+        "status": "partial",
+    },
+    {
+        "control_id": "ASI04",
+        "requirement": (
+            "Supply-chain / skill provenance: the skill catalog verifies an "
+            "Ed25519 detached signature over each entry before install; "
+            "fetch, install, upgrade and uninstall are all chained."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.upgrade,skill.catalog.fetch,skill.catalog.uninstall",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI05",
+        "requirement": (
+            "Unsafe code / command execution: commands run under a sandbox "
+            "profile and a command allowlist; a sandbox-escape attempt is "
+            "detected and recorded as a security incident."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "sandbox_escape_attempt,command",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI06",
+        "requirement": (
+            "Memory / context poisoning: lineage tampering on a persisted "
+            "artefact is detected against the content-addressed lineage "
+            "chain and recorded. Detection of poisoned model context beyond "
+            "artefact tampering is not yet covered."
+        ),
+        "artefact": "lineage/log.jsonl",
+        "selector": "lineage_tamper_detected,content_hash,parent_hashes",
+        "status": "partial",
+    },
+    {
+        "control_id": "ASI07",
+        "requirement": (
+            "Insecure agent-to-agent (A2A) trust: peer capability cards are "
+            "verified as detached JWS over JCS-canonical JSON with Ed25519 "
+            "and gated on the operator trusted-issuer set and policy floor "
+            "before any delegation. See 'bernstein interop a2a conformance'."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "agent.transition",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI08",
+        "requirement": (
+            "Unbounded consumption: per-run cost caps, budget-exhaustion and "
+            "budget-warning events, and task-deadline events bound spend and "
+            "wall-clock; the cost ledger carries per-task, per-model spend."
+        ),
+        "artefact": "costs/cost_history.jsonl",
+        "selector": "budget.exhausted,budget.warning,task.deadline_exceeded,model,task_id,usd",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI09",
+        "requirement": (
+            "Observability / traceability gaps: every step is written to the "
+            "HMAC-chained audit log and the content-addressed lineage log, "
+            "so run activity is reconstructable offline; a stuck worker "
+            "raises a signed supervisor escalation."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "run_start,task.transition,agent.transition,supervisor.escalated",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI10",
+        "requirement": (
+            "Misalignment / behavioural drift: review-pipeline stages and "
+            "capability-matrix refusals are recorded, giving an audit trail "
+            "of gated decisions. Automated drift scoring across runs is a "
+            "heuristic in the ASI detector pack and not yet a first-class "
+            "chained metric."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "review_pipeline.stage,review_pipeline.complete,capability_matrix_refusal",
+        "status": "partial",
+    },
+]
+
+#: Controls whose evidence is out of scope for the read-only evidence pack
+#: (they require signals Bernstein does not yet chain).
+DEFERRED: list[str] = [
+    "ASI06 model-context poisoning beyond artefact-hash tampering (no chained signal yet).",
+    "ASI10 cross-run behavioural-drift scoring as a first-class chained metric (heuristic only today).",
+]
+
+
+def control_map() -> dict[str, Any]:
+    """Return the OWASP ASI control-map block in ``_STANDARD_MAPS`` shape.
+
+    The list is copied so a caller mutating the returned dict cannot
+    corrupt the module-level catalogue.
+    """
+    return {
+        "regulation": REGULATION,
+        "controls": [dict(c) for c in CONTROLS],
+        "deferred": list(DEFERRED),
+    }
+
+
+__all__ = [
+    "CONTROLS",
+    "DEFERRED",
+    "REGULATION",
+    "STANDARD_ID",
+    "control_map",
+]

--- a/src/bernstein/compliance/owasp_asi.py
+++ b/src/bernstein/compliance/owasp_asi.py
@@ -156,7 +156,7 @@ CONTROLS: list[dict[str, Any]] = [
             "raises a signed supervisor escalation."
         ),
         "artefact": "audit-chain/events.jsonl",
-        "selector": "run_start,task.transition,agent.transition,supervisor.escalated",
+        "selector": "task.transition,agent.transition,supervisor.escalated",
         "status": "mapped",
     },
     {

--- a/src/bernstein/compliance/owasp_skills.py
+++ b/src/bernstein/compliance/owasp_skills.py
@@ -1,0 +1,192 @@
+"""OWASP Agentic Skills Top 10 (AST01-AST10) control map.
+
+Operators who install and run third-party skills need to show, from
+their own run evidence, which skill-supply-chain controls a Bernstein
+run already covers. This module is the skills-catalogue analogue of the
+EU AI Act clause map in ``evidence_pack.py`` and the ASI map in
+``owasp_asi.py``.
+
+The map is anchored on two Bernstein levers working together:
+
+* the Ed25519-signed install identity and the per-entry detached-JWS
+  signature the skill catalog verifies before install, and
+* the HMAC audit chain, into which every catalog action
+  (``skill.catalog.fetch|install|upgrade|uninstall|sync``) is written.
+
+Every ``selector`` cites a literal ``event_type`` string a Bernstein run
+actually writes, so the coverage claim is only as strong as the signed
+catalog plus the tamper-evident chain that backs it. Remove either lever
+and the map loses its meaning, not merely its log.
+
+Honesty rule: where Bernstein only partially addresses a control the
+entry is marked ``"partial"`` and the gap is stated. Skill-catalogue
+coverage is genuinely partial for several AST classes (runtime skill
+sandboxing, per-skill data-scope enforcement), and the map says so
+rather than over-claiming.
+
+The block mirrors the ``_STANDARD_MAPS`` shape exactly and is consumed
+by ``evidence_pack.build_evidence_pack`` under the ``owasp-skills``
+standard.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Standard id used on the ``--standard`` flag and in manifests.
+STANDARD_ID: str = "owasp-skills"
+
+#: Human-readable catalogue name emitted into ``controls.json``.
+REGULATION: str = "OWASP Agentic Skills Top 10 (AST01-AST10)"
+
+# ---------------------------------------------------------------------------
+# AST01-AST10 control map
+# ---------------------------------------------------------------------------
+
+CONTROLS: list[dict[str, Any]] = [
+    {
+        "control_id": "AST01",
+        "requirement": (
+            "Untrusted / unsigned skill install: the catalog verifies an "
+            "Ed25519 detached signature over each entry's canonical bytes "
+            "against the catalog signer public key before install; an "
+            "unverified entry installs only with an explicit override."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.fetch",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST02",
+        "requirement": (
+            "Skill tampering after publish: catalog entries are content-"
+            "addressed and lineage-logged; post-fetch tampering surfaces as "
+            "a lineage-tamper detection against the recorded content hash."
+        ),
+        "artefact": "lineage/log.jsonl",
+        "selector": "lineage_tamper_detected,content_hash",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST03",
+        "requirement": (
+            "Skill provenance / pinning: install, upgrade and uninstall are "
+            "all chained with the resolved source spec, giving a pinned, "
+            "auditable history of which skill version ran when."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.upgrade,skill.catalog.uninstall",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST04",
+        "requirement": (
+            "Excessive skill capability (trifecta): a skill-invoked tool "
+            "chain is screened by the lethal-trifecta capability matrix; a "
+            "chain holding private-data + untrusted-content + external-egress "
+            "is denied and recorded."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST05",
+        "requirement": (
+            "Unsafe skill code execution: skill-invoked commands run under a "
+            "sandbox profile and command allowlist; a sandbox-escape attempt "
+            "is detected and recorded as a security incident. Per-skill "
+            "runtime sandboxing (distinct from the shared command sandbox) is "
+            "not yet enforced."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "sandbox_escape_attempt,command",
+        "status": "partial",
+    },
+    {
+        "control_id": "AST06",
+        "requirement": (
+            "Skill data-scope / exfiltration: cost and egress are bounded by "
+            "per-run caps and the trifecta egress axis, and redaction tiers "
+            "apply before artefacts leave the boundary. Per-skill data-scope "
+            "enforcement (a skill only reads what it declared) is not yet a "
+            "first-class chained control."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal,budget.exhausted",
+        "status": "partial",
+    },
+    {
+        "control_id": "AST07",
+        "requirement": (
+            "Skill identity / impersonation: the catalog signer identity is "
+            "an Ed25519 public key; entries that do not verify against it are "
+            "refused, so a skill cannot impersonate a trusted publisher."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.sync",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST08",
+        "requirement": (
+            "Skill catalog drift / unbounded install: catalog sync is chained "
+            "so unexpected additions are visible; per-run cost caps bound the "
+            "spend a runaway skill can incur."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.sync,budget.warning,budget.exhausted",
+        "status": "partial",
+    },
+    {
+        "control_id": "AST09",
+        "requirement": (
+            "Skill observability gap: every catalog action and every step a "
+            "skill triggers is written to the HMAC-chained audit log, so a "
+            "skill's activity is reconstructable offline."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.fetch,skill.catalog.install,task.transition,agent.transition",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST10",
+        "requirement": (
+            "Skill misalignment / prompt-injection via skill content: skill "
+            "output flows through the on-by-default OWASP ASI guardrail pack "
+            "and promptware scanner; refusals are recorded. Skill-specific "
+            "alignment scoring is heuristic, not a chained metric."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal,review_pipeline.stage",
+        "status": "partial",
+    },
+]
+
+#: Controls whose evidence is out of scope for the read-only evidence pack.
+DEFERRED: list[str] = [
+    "AST05 per-skill runtime sandboxing distinct from the shared command sandbox.",
+    "AST06 per-skill declared-data-scope enforcement as a first-class chained control.",
+]
+
+
+def control_map() -> dict[str, Any]:
+    """Return the OWASP AST control-map block in ``_STANDARD_MAPS`` shape.
+
+    The list is copied so a caller mutating the returned dict cannot
+    corrupt the module-level catalogue.
+    """
+    return {
+        "regulation": REGULATION,
+        "controls": [dict(c) for c in CONTROLS],
+        "deferred": list(DEFERRED),
+    }
+
+
+__all__ = [
+    "CONTROLS",
+    "DEFERRED",
+    "REGULATION",
+    "STANDARD_ID",
+    "control_map",
+]

--- a/src/bernstein/core/interop/a2a_conformance.py
+++ b/src/bernstein/core/interop/a2a_conformance.py
@@ -1,0 +1,207 @@
+"""A2A signed-card conformance self-check.
+
+An operator who issues a capability card needs to prove, offline, that
+the card they emit round-trips and verifies the same way a peer will
+check it: canonicalise the body (RFC 8785 JCS), verify the detached JWS
+(RFC 7515) with the Ed25519 key the card carries, and confirm the
+required fields, expiry, and issuer are well-formed.
+
+This is a self-contained audit of the artefact we already ship. It leans
+on the Ed25519-signed identity lever: every check below is meaningful
+only because the card is signed with an Ed25519 key whose public half
+travels in the card, so a verifier can reproduce the signing input and
+authenticate it without a side channel. Strip the signature and the
+conformance report degrades to a schema lint; the signature check is the
+point.
+
+The self-check is read-only and deterministic: given the same signed
+card and the same ``now`` it always returns the same verdict. It reuses
+the primitives in :mod:`bernstein.core.interop.a2a_card` rather than
+re-implementing verification, so a card that passes here passes for the
+same reasons a peer's ``bernstein interop a2a verify`` accepts it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.interop.a2a_card import (
+    CAPABILITY_CARD_TYP,
+    CapabilityCard,
+    card_public_key_fingerprint,
+    verify_capability_card,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.interop.a2a_card import SignedCapabilityCard
+
+__all__ = [
+    "ConformanceCheck",
+    "ConformanceReport",
+    "check_card_conformance",
+]
+
+
+@dataclass(frozen=True)
+class ConformanceCheck:
+    """A single named conformance check with a pass/fail verdict.
+
+    Attributes:
+        name: Stable check id (for instance ``"jcs_canonical"``).
+        passed: Whether the check passed.
+        detail: Human-readable explanation of the verdict.
+    """
+
+    name: str
+    passed: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable view of the check."""
+        return {"name": self.name, "passed": self.passed, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class ConformanceReport:
+    """Aggregated result of a card conformance self-check.
+
+    Attributes:
+        ok: True iff every check passed.
+        checks: The individual checks, in evaluation order.
+        issuer: Issuer id from the card (``""`` if unreadable).
+        kid: Key id from the card (``""`` if unreadable).
+        fingerprint: ``sha256:`` fingerprint of the card key (``""`` if
+            the key could not be parsed).
+    """
+
+    ok: bool
+    checks: list[ConformanceCheck] = field(default_factory=list)
+    issuer: str = ""
+    kid: str = ""
+    fingerprint: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable view of the report."""
+        return {
+            "ok": self.ok,
+            "issuer": self.issuer,
+            "kid": self.kid,
+            "fingerprint": self.fingerprint,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+
+# Fields a conformant card body must carry as non-empty strings.
+_REQUIRED_STRING_FIELDS: tuple[str, ...] = (
+    "schema_version",
+    "issuer",
+    "name",
+    "public_key_pem",
+    "kid",
+)
+
+
+def check_card_conformance(
+    signed: SignedCapabilityCard,
+    *,
+    now: float | None = None,
+) -> ConformanceReport:
+    """Run the offline conformance self-check over a signed capability card.
+
+    Checks performed, in order:
+
+    1. ``required_fields`` - the body carries the mandatory non-empty
+       fields and a well-formed policy block (via
+       :meth:`CapabilityCard.validate_body`).
+    2. ``jcs_canonical`` - the body re-canonicalises under RFC 8785 JCS
+       without error (the exact bytes the signature is computed over).
+    3. ``signature`` - the detached JWS verifies against the Ed25519 key
+       the card carries, with the capability-card ``typ`` and ``EdDSA``
+       alg, ignoring expiry (expiry is a separate check).
+    4. ``expiry`` - the card is not expired relative to ``now``.
+    5. ``issuer`` - the issuer id is a non-empty string.
+
+    The report ``ok`` is the AND of every check. The function never
+    raises on malformed input; a parse failure becomes a failed check.
+
+    Args:
+        signed: The signed capability card to audit.
+        now: Optional override for the current time (testing / replay).
+
+    Returns:
+        A :class:`ConformanceReport`.
+    """
+    checks: list[ConformanceCheck] = []
+
+    # --- 1. Required fields + policy block --------------------------------
+    body = signed.card.to_body()
+    fields_ok = True
+    fields_detail = "all required fields present and well-formed"
+    try:
+        CapabilityCard.validate_body(body)
+        missing = [f for f in _REQUIRED_STRING_FIELDS if not str(body.get(f, ""))]
+        if missing:
+            fields_ok = False
+            fields_detail = f"missing/empty required field(s): {', '.join(missing)}"
+    except ValueError as exc:
+        fields_ok = False
+        fields_detail = f"card body failed validation: {exc}"
+    checks.append(ConformanceCheck("required_fields", fields_ok, fields_detail))
+
+    # --- 2. JCS canonicalisation ------------------------------------------
+    jcs_ok = True
+    jcs_detail = "body re-canonicalises under RFC 8785 JCS"
+    try:
+        from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+        canonicalize_jcs(body)
+    except (TypeError, ValueError) as exc:
+        jcs_ok = False
+        jcs_detail = f"JCS canonicalisation failed: {exc}"
+    checks.append(ConformanceCheck("jcs_canonical", jcs_ok, jcs_detail))
+
+    # --- 3. Detached JWS signature (expiry excluded) ----------------------
+    sig_ok = verify_capability_card(signed, check_expiry=False, now=now)
+    sig_detail = (
+        f"detached Ed25519 JWS verifies ({CAPABILITY_CARD_TYP})"
+        if sig_ok
+        else "detached JWS signature is invalid, malformed, or not Ed25519/capability-card typ"
+    )
+    checks.append(ConformanceCheck("signature", sig_ok, sig_detail))
+
+    # --- 4. Expiry --------------------------------------------------------
+    expired = signed.card.is_expired(now=now)
+    if signed.card.expires_at <= 0:
+        expiry_ok = True
+        expiry_detail = "card carries no expiry (expires_at <= 0); never-expiring cards are discouraged"
+    else:
+        expiry_ok = not expired
+        expiry_detail = (
+            f"card is within its validity window (expires_at={signed.card.expires_at})"
+            if expiry_ok
+            else f"card is expired (expires_at={signed.card.expires_at})"
+        )
+    checks.append(ConformanceCheck("expiry", expiry_ok, expiry_detail))
+
+    # --- 5. Issuer --------------------------------------------------------
+    issuer = str(body.get("issuer", ""))
+    issuer_ok = bool(issuer)
+    issuer_detail = f"issuer='{issuer}'" if issuer_ok else "issuer is empty"
+    checks.append(ConformanceCheck("issuer", issuer_ok, issuer_detail))
+
+    # --- Fingerprint (best-effort, informational) -------------------------
+    fingerprint = ""
+    try:
+        fingerprint = card_public_key_fingerprint(signed.card.public_key_pem)
+    except (ValueError, TypeError):
+        fingerprint = ""
+
+    ok = all(c.passed for c in checks)
+    return ConformanceReport(
+        ok=ok,
+        checks=checks,
+        issuer=issuer,
+        kid=str(body.get("kid", "")),
+        fingerprint=fingerprint,
+    )

--- a/src/bernstein/core/persistence/journal.py
+++ b/src/bernstein/core/persistence/journal.py
@@ -11,8 +11,32 @@ Each step of an agent run is hashed with::
             "prompt":      <full prompt text the adapter received | null>,
             "tool_call":   <serialised tool invocation dict | null>,
             "tool_result": <serialised tool result dict       | null>,
+            "effort":      <reasoning effort e.g. "low"|"high"|"max" | absent>,
         })
     )
+
+Journal record schema versioning (effort dimension)
+---------------------------------------------------
+The reasoning-effort level a request was routed at changes the model's
+output, so replaying a step at a different effort must surface as hash
+divergence, not as a silent mismatch. ``effort`` is therefore folded into
+the step hash. To keep every pre-existing journal valid, ``effort`` is
+back-compat versioned by **omission**:
+
+* ``effort=None`` (the sentinel for "unknown / not recorded") means the
+  ``effort`` key is left **out** of the canonical document entirely. The
+  bytes are then byte-identical to a pre-effort record, so every journal
+  written before this change re-verifies unchanged - a missing effort never
+  fails an old record.
+* A non-``None`` ``effort`` adds ``"effort": <value>`` to the document, so
+  two runs that differ only in effort produce different step hashes and a
+  cross-effort replay is caught as divergence.
+
+The persisted row carries an explicit ``schema_version`` (see
+:data:`JOURNAL_SCHEMA_VERSION`) so an operator can tell effort-aware rows
+apart from legacy rows. ``schema_version`` is metadata only and is **never**
+part of the hash, exactly like ``ts`` - so adding it does not invalidate any
+existing chain.
 
 Canonical encoding contract (load-bearing)
 ------------------------------------------
@@ -99,6 +123,13 @@ logger = logging.getLogger(__name__)
 #: Genesis ``prev_hash`` for the first step of a fresh chain.
 GENESIS_HASH = "0" * 64
 
+#: Journal record schema version. Bumped from an implicit ``1`` to ``2`` when
+#: the reasoning-``effort`` dimension was folded into the step hash. Persisted
+#: as row metadata only (never hashed), so bumping it does not invalidate any
+#: existing chain. Rows written before this change have no ``schema_version``
+#: field and are read as version ``1``.
+JOURNAL_SCHEMA_VERSION = 2
+
 #: Default bucket filename. Replays span at most one bucket today; the
 #: layout is shaped so a future compaction pass can add ``<n>.jsonl`` rolling
 #: files without breaking the reader.
@@ -135,12 +166,20 @@ def canonical_step_payload(
     prompt: str | None,
     tool_call: Any,
     tool_result: Any,
+    effort: str | None = None,
 ) -> bytes:
     """Return the canonical UTF-8 bytes that the step hash is taken over.
 
     See the module docstring for the contract; this function is the
     single source of truth. The output is what a third-party verifier
     would produce when re-deriving the hash by hand.
+
+    ``effort`` is back-compat versioned by omission: when ``None`` (the
+    sentinel for a legacy / unrecorded effort) the ``effort`` key is left out
+    of the document, yielding bytes byte-identical to a pre-effort record so
+    old journals re-verify unchanged. A non-``None`` ``effort`` adds an
+    ``"effort"`` key, so a step routed at a different effort hashes
+    differently and a cross-effort replay is caught as divergence.
     """
     document: dict[str, Any] = {
         "prev_hash": prev_hash,
@@ -150,6 +189,10 @@ def canonical_step_payload(
         "tool_call": tool_call,
         "tool_result": tool_result,
     }
+    # Sentinel-by-omission: only a recorded (non-None) effort enters the hash,
+    # so every pre-effort record continues to verify byte-for-byte.
+    if effort is not None:
+        document["effort"] = effort
     return json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
@@ -161,6 +204,7 @@ def compute_step_hash(
     prompt: str | None,
     tool_call: Any,
     tool_result: Any,
+    effort: str | None = None,
 ) -> str:
     """Return the SHA-256 hex digest of the canonical step payload."""
     payload = canonical_step_payload(
@@ -170,6 +214,7 @@ def compute_step_hash(
         prompt=prompt,
         tool_call=tool_call,
         tool_result=tool_result,
+        effort=effort,
     )
     return hashlib.sha256(payload).hexdigest()
 
@@ -199,10 +244,18 @@ class JournalEntry:
     step_hash: str
     ts: float
     blob_refs: list[str] = field(default_factory=list)
+    #: Reasoning effort this step was routed at ("low"|"medium"|"high"|"max"),
+    #: or ``None`` for a legacy row that predates the effort dimension. Folded
+    #: into ``step_hash`` only when non-``None`` (see ``canonical_step_payload``).
+    effort: str | None = None
+    #: Row schema version. ``1`` for legacy rows (no ``schema_version`` field
+    #: on disk), :data:`JOURNAL_SCHEMA_VERSION` for effort-aware rows. Metadata
+    #: only - never hashed.
+    schema_version: int = JOURNAL_SCHEMA_VERSION
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-friendly representation."""
-        return {
+        row: dict[str, Any] = {
             "seq": self.seq,
             "prev_hash": self.prev_hash,
             "input_hash": self.input_hash,
@@ -213,11 +266,22 @@ class JournalEntry:
             "step_hash": self.step_hash,
             "ts": self.ts,
             "blob_refs": self.blob_refs.copy(),
+            "schema_version": self.schema_version,
         }
+        # Only serialise ``effort`` when recorded, so a None-effort row stays
+        # byte-shaped like a legacy row apart from the (unhashed) metadata.
+        if self.effort is not None:
+            row["effort"] = self.effort
+        return row
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> JournalEntry:
-        """Build an entry from a deserialised dict row."""
+        """Build an entry from a deserialised dict row.
+
+        A legacy row (no ``schema_version`` / ``effort``) is read as
+        ``schema_version=1`` with ``effort=None``, so it re-verifies against
+        the pre-effort canonical payload unchanged.
+        """
         return cls(
             seq=int(raw["seq"]),
             prev_hash=str(raw["prev_hash"]),
@@ -229,6 +293,8 @@ class JournalEntry:
             step_hash=str(raw["step_hash"]),
             ts=float(raw.get("ts", 0.0)),
             blob_refs=list(raw.get("blob_refs") or []),
+            effort=raw.get("effort"),
+            schema_version=int(raw.get("schema_version", 1)),
         )
 
 
@@ -364,6 +430,9 @@ def _validate_chain_for_recovery(bucket_path: Path) -> tuple[str, int]:
                 prompt=row.get("prompt"),
                 tool_call=row.get("tool_call"),
                 tool_result=row.get("tool_result"),
+                # Legacy rows have no ``effort`` key: ``get`` returns None,
+                # so the recomputed hash matches the pre-effort payload.
+                effort=row.get("effort"),
             )
             stored_hash = str(row.get("step_hash", ""))
             if recomputed != stored_hash:
@@ -468,8 +537,15 @@ class Journal:
         tool_call: Any = None,
         tool_result: Any = None,
         blob_refs: list[str] | None = None,
+        effort: str | None = None,
     ) -> JournalEntry:
         """Append a new step to the chain and return the persisted entry.
+
+        ``effort`` records the reasoning effort the step was routed at. When
+        ``None`` (default) the row is byte-identical to a pre-effort record,
+        so existing callers that never pass it keep producing legacy-shaped
+        hashes; a recorded effort changes the step hash so a cross-effort
+        replay is caught as divergence.
 
         Raises:
             JournalError: If the journal is closed or the file write fails.
@@ -488,6 +564,7 @@ class Journal:
                 prompt=prompt,
                 tool_call=tool_call,
                 tool_result=tool_result,
+                effort=effort,
             )
             entry = JournalEntry(
                 seq=seq,
@@ -500,6 +577,7 @@ class Journal:
                 step_hash=step_hash,
                 ts=time.time(),
                 blob_refs=list(blob_refs or []),
+                effort=effort,
             )
             line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
             try:
@@ -693,6 +771,9 @@ class JournalReader:
                     prompt=row.get("prompt"),
                     tool_call=row.get("tool_call"),
                     tool_result=row.get("tool_result"),
+                    # Legacy rows lack ``effort`` (get -> None), matching the
+                    # pre-effort payload so old chains verify unchanged.
+                    effort=row.get("effort"),
                 )
                 stored_hash = str(row.get("step_hash", ""))
                 if recomputed != stored_hash:
@@ -734,6 +815,7 @@ __all__ = [
     "AUDIT_EVENT_REPLAY_PUBLISH",
     "AUDIT_EVENT_REPLAY_STEP",
     "GENESIS_HASH",
+    "JOURNAL_SCHEMA_VERSION",
     "Journal",
     "JournalEntry",
     "JournalError",

--- a/src/bernstein/core/persistence/journal_diff.py
+++ b/src/bernstein/core/persistence/journal_diff.py
@@ -6,11 +6,11 @@ not match`` signature. ``diff_steps`` is the per-step primitive;
 ``diff_journals`` walks two chains side-by-side and returns the first
 divergence (or ``None`` if the chains match).
 
-This module deliberately operates on the six canonical fields only
+This module deliberately operates on the hashed canonical fields only
 (``prev_hash``, ``input_hash``, ``model``, ``prompt``, ``tool_call``,
-``tool_result``). Auxiliary fields like ``ts`` and ``seq`` are ignored
-for divergence-detection purposes because they are not part of the
-``step_hash`` contract.
+``tool_result``, ``effort``). Auxiliary fields like ``ts`` and ``seq``
+are ignored for divergence-detection purposes because they are not part
+of the ``step_hash`` contract.
 """
 
 from __future__ import annotations
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
 
 
 #: Fields the step hash is computed over - see ``journal.canonical_step_payload``.
+#: ``effort`` folds into the hash when non-None, so two runs that differ only
+#: in reasoning effort surface as a named ``effort`` field divergence rather
+#: than as an unexplained hash mismatch.
 _HASHED_FIELDS = (
     "prev_hash",
     "input_hash",
@@ -32,6 +35,7 @@ _HASHED_FIELDS = (
     "prompt",
     "tool_call",
     "tool_result",
+    "effort",
 )
 
 
@@ -41,9 +45,9 @@ class StepDivergence:
 
     Attributes:
         seq: Zero-based step index on which the divergence was observed.
-        fields_changed: Tuple of field names (a subset of the canonical
-            six) whose values differ between left and right. Always
-            non-empty.
+        fields_changed: Tuple of field names (a subset of the hashed
+            canonical fields) whose values differ between left and right.
+            Always non-empty.
         left_values: ``field -> value`` for the changed fields on the
             *left* chain.
         right_values: ``field -> value`` for the changed fields on the
@@ -65,7 +69,7 @@ class StepDivergence:
 
 
 def _coerce_for_diff(row: dict[str, Any]) -> dict[str, Any]:
-    """Project a journal row onto the six hashed fields only."""
+    """Project a journal row onto the hashed fields only."""
     return {key: row.get(key) for key in _HASHED_FIELDS}
 
 
@@ -73,7 +77,7 @@ def diff_steps(left: dict[str, Any], right: dict[str, Any]) -> StepDivergence | 
     """Return the per-field divergence between two journal rows, or ``None``.
 
     Args:
-        left: One step row (canonical six fields; extra fields ignored).
+        left: One step row (hashed canonical fields; extra fields ignored).
         right: The opposing row.
 
     Returns:

--- a/src/bernstein/core/persistence/journal_export.py
+++ b/src/bernstein/core/persistence/journal_export.py
@@ -356,6 +356,11 @@ def _walk_journal_bytes(payload: bytes) -> tuple[str, int, list[str]]:
             prompt=row.get("prompt"),
             tool_call=row.get("tool_call"),
             tool_result=row.get("tool_result"),
+            # Legacy rows lack ``effort`` (get -> None), so the recomputed
+            # hash matches the pre-effort payload and old chains verify
+            # unchanged; effort-bearing rows fold effort into the hash so an
+            # offline verifier reproduces the same step_hash the writer did.
+            effort=row.get("effort"),
         )
         stored_hash = str(row.get("step_hash", ""))
         if recomputed != stored_hash:

--- a/src/bernstein/core/persistence/journal_publish.py
+++ b/src/bernstein/core/persistence/journal_publish.py
@@ -206,6 +206,11 @@ def publish_receipt(
             prompt=redacted.get("prompt"),
             tool_call=redacted.get("tool_call"),
             tool_result=redacted.get("tool_result"),
+            # Re-anchor over the effort dimension too: a redacted row keeps
+            # its ``effort`` key (get -> None on legacy rows), so the
+            # published receipt does not silently drop the effort dimension
+            # from the chain.
+            effort=redacted.get("effort"),
         )
         redacted["step_hash"] = new_step_hash
         # Blob refs may name cleartext blobs; drop them in published receipts.

--- a/src/bernstein/core/routing/cascade_router.py
+++ b/src/bernstein/core/routing/cascade_router.py
@@ -721,15 +721,76 @@ def _cascade_for_task(task: Task) -> list[str]:
     return list(CASCADE)
 
 
+# Ordered effort ladder, cheapest first. A deterministic index into this list
+# lets escalation bump effort by one rung with no LLM in the loop, which keeps
+# the choice byte-identical across a record/replay pair (our deterministic
+# replay lever). ``max`` is reserved for the opus tier via ``_effort_for_model``.
+_EFFORT_LADDER: tuple[str, ...] = ("low", "medium", "high", "max")
+
+
+def effort_for_scope(
+    scope: Scope,
+    complexity: Complexity,
+    attempt: int = 0,
+) -> str:
+    """Deterministically map task scope + complexity (+ attempt) to an effort.
+
+    Pure function of ``(scope, complexity, attempt)`` - no LLM, no clock, no
+    randomness - so a record run and its replay derive the identical effort
+    and any divergence is a real routing change, not noise. This is the lever:
+    the effort a step ran at is reproducible and therefore hashable into the
+    step journal.
+
+    Base mapping (trivial -> low, standard -> medium, complex/high-risk ->
+    high):
+
+    * ``Complexity.HIGH`` **or** ``Scope.LARGE`` -> ``"high"`` (complex or
+      high-risk work).
+    * ``Complexity.LOW`` **and** ``Scope.SMALL`` -> ``"low"`` (trivial work).
+    * everything else -> ``"medium"`` (standard work).
+
+    Escalation: each retry ``attempt`` bumps the result one rung up the effort
+    ladder (``low -> medium -> high -> max``), capped at ``max``. A first
+    attempt (``attempt=0``) is never bumped.
+
+    Args:
+        scope: Task scope.
+        complexity: Task complexity.
+        attempt: 0-based attempt number; higher attempts escalate effort.
+
+    Returns:
+        One of ``"low"``, ``"medium"``, ``"high"``, ``"max"``.
+    """
+    if complexity == Complexity.HIGH or scope == Scope.LARGE:
+        base = "high"
+    elif complexity == Complexity.LOW and scope == Scope.SMALL:
+        base = "low"
+    else:
+        base = "medium"
+
+    idx = _EFFORT_LADDER.index(base)
+    bumped = min(idx + max(attempt, 0), len(_EFFORT_LADDER) - 1)
+    return _EFFORT_LADDER[bumped]
+
+
 def _effort_for_model(model: str, task: Task) -> str:
     """Select an effort level appropriate for the model and task.
+
+    Precedence:
+
+    1. An explicitly pinned ``task.effort`` always wins (caller intent is
+       never overridden).
+    2. ``opus`` -> ``"max"`` (the top tier is always run at max effort).
+    3. Otherwise fall back to the deterministic scope/complexity mapping,
+       escalated by ``task.retry_count`` so a retry runs harder. This fills
+       effort only when it was left unset, per the effort-routing contract.
 
     Args:
         model: Model name (e.g. "haiku", "sonnet", "opus").
         task: Task to assess.
 
     Returns:
-        Effort string (e.g. "low", "high", "max").
+        Effort string (e.g. "low", "medium", "high", "max").
     """
     if task.effort:
         return task.effort
@@ -737,10 +798,11 @@ def _effort_for_model(model: str, task: Task) -> str:
     model_lower = model.lower()
     if "opus" in model_lower:
         return "max"
-    if "haiku" in model_lower:
-        return "low"
-    # sonnet and unknown models
-    return "high"
+
+    # Deterministic scope/complexity mapping, escalated on retry. Replaces the
+    # old flat "haiku=low, else high" heuristic so easy tasks stop overpaying
+    # and effort becomes a reproducible, hashable routing dimension.
+    return effort_for_scope(task.scope, task.complexity, attempt=task.retry_count)
 
 
 def _apply_rework_promotion(

--- a/tests/unit/compliance/test_owasp_maps.py
+++ b/tests/unit/compliance/test_owasp_maps.py
@@ -1,0 +1,228 @@
+"""Unit tests for the OWASP ASI / AST evidence-pack control maps.
+
+Covers:
+
+* Registration: ``owasp-asi`` and ``owasp-skills`` are in
+  ``SUPPORTED_STANDARDS`` and resolve via ``get_standard_map``.
+* Shape: each map has the ten canonical control ids, a regulation
+  label, and every control carries the required keys with a valid
+  status.
+* Honesty: partial controls are explicitly marked ``"partial"`` (the
+  maps are not all-green).
+* Grounding: every ``selector`` event-type token cited by the maps is a
+  literal ``event_type`` string that actually appears in the Bernstein
+  source tree (no phantom mechanisms).
+* End-to-end: ``build_evidence_pack`` produces a well-formed, layout-
+  complete zip for both new standards whose ``controls.json`` matches
+  the map and whose manifest hashes agree with the on-disk bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from bernstein.compliance import owasp_asi, owasp_skills
+from bernstein.compliance.evidence_pack import (
+    SUPPORTED_STANDARDS,
+    build_evidence_pack,
+    get_standard_map,
+)
+
+# Audit attribute names that are legitimately used as selectors but are
+# not themselves ``event_type`` literals (they are event fields / lineage
+# fields). These are excluded from the "must be a real event_type" check.
+_NON_EVENT_SELECTOR_TOKENS: frozenset[str] = frozenset(
+    {
+        "content_hash",
+        "parent_hashes",
+        "model",
+        "task_id",
+        "usd",
+    }
+)
+
+_ASI_IDS = tuple(f"ASI{n:02d}" for n in range(1, 11))
+_AST_IDS = tuple(f"AST{n:02d}" for n in range(1, 11))
+
+
+def _source_event_types() -> set[str]:
+    """Collect every literal ``event_type`` string used in the src tree.
+
+    Scans for both ``event_type="..."`` call sites and ``EVENT_* =
+    "..."`` / ``EVENT_TYPE = "..."`` constant definitions, so a selector
+    that names a constant's value counts as grounded.
+    """
+    src_root = Path(__file__).resolve().parents[3] / "src" / "bernstein"
+    assert src_root.is_dir(), src_root
+    found: set[str] = set()
+    call_pat = re.compile(r'event_type\s*=\s*["\']([a-z0-9_.]+)["\']')
+    const_pat = re.compile(r'EVENT[A-Z_]*\s*=\s*["\']([a-z0-9_.]+)["\']')
+    for path in src_root.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        found.update(call_pat.findall(text))
+        found.update(const_pat.findall(text))
+    return found
+
+
+@pytest.fixture(scope="module")
+def source_event_types() -> set[str]:
+    return _source_event_types()
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_standard_is_registered(standard: str) -> None:
+    assert standard in SUPPORTED_STANDARDS
+    mapping = get_standard_map(standard)
+    assert mapping["regulation"]
+    assert mapping["controls"]
+
+
+def test_asi_map_has_ten_canonical_controls() -> None:
+    mapping = get_standard_map("owasp-asi")
+    ids = [c["control_id"] for c in mapping["controls"]]
+    assert ids == list(_ASI_IDS)
+
+
+def test_skills_map_has_ten_canonical_controls() -> None:
+    mapping = get_standard_map("owasp-skills")
+    ids = [c["control_id"] for c in mapping["controls"]]
+    assert ids == list(_AST_IDS)
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_every_control_has_required_keys_and_valid_status(standard: str) -> None:
+    mapping = get_standard_map(standard)
+    for control in mapping["controls"]:
+        for key in ("control_id", "requirement", "artefact", "selector", "status"):
+            assert key in control, (standard, control.get("control_id"), key)
+            assert control[key] != "" or key == "selector"
+        assert control["status"] in {"mapped", "partial", "todo"}
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_map_marks_some_controls_partial(standard: str) -> None:
+    # An honest partial map is the deliverable: neither catalogue should
+    # claim full coverage. This test fails on the pre-change code (the
+    # standard is not even registered) and on any future over-claim that
+    # marks everything "mapped".
+    mapping = get_standard_map(standard)
+    statuses = {c["control_id"]: c["status"] for c in mapping["controls"]}
+    assert "partial" in statuses.values(), statuses
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_selectors_reference_real_event_types(
+    standard: str,
+    source_event_types: set[str],
+) -> None:
+    mapping = get_standard_map(standard)
+    unknown: list[tuple[str, str]] = []
+    for control in mapping["controls"]:
+        for token in str(control["selector"]).split(","):
+            token = token.strip()
+            if not token or token in _NON_EVENT_SELECTOR_TOKENS:
+                continue
+            # A grounded selector token is either a literal event_type in
+            # the source tree, or a dotted/underscored event name that
+            # appears verbatim in a source file (constant value).
+            if token not in source_event_types:
+                unknown.append((control["control_id"], token))
+    assert not unknown, f"{standard} cites event types not found in src: {unknown}"
+
+
+def test_control_map_returns_copy() -> None:
+    # Mutating the returned dict must not corrupt the module catalogue.
+    first = owasp_asi.control_map()
+    first["controls"][0]["status"] = "MUTATED"
+    second = owasp_asi.control_map()
+    assert second["controls"][0]["status"] != "MUTATED"
+
+    first_s = owasp_skills.control_map()
+    first_s["controls"][0]["status"] = "MUTATED"
+    second_s = owasp_skills.control_map()
+    assert second_s["controls"][0]["status"] != "MUTATED"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pack build
+# ---------------------------------------------------------------------------
+
+
+def _seed_sdd(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    audit = sdd / "audit"
+    audit.mkdir(parents=True)
+    (audit / "log.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-01-05T10:00:00+00:00",
+                "event_type": "capability_matrix_refusal",
+                "actor": "agent",
+                "resource_type": "task",
+                "resource_id": "T-1",
+                "hmac": "a" * 64,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return sdd
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_build_evidence_pack_wellformed(standard: str, tmp_path: Path) -> None:
+    sdd = _seed_sdd(tmp_path)
+    out = tmp_path / "pack.zip"
+    pack = build_evidence_pack(
+        sdd_dir=sdd,
+        standard=standard,
+        output_path=out,
+        write=True,
+    )
+    assert pack.standard == standard
+    assert pack.event_count == 1
+    assert pack.controls_mapped >= 1
+    assert pack.controls_todo == 0
+    assert out.is_file()
+
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        for required in (
+            "manifest.json",
+            "controls.json",
+            "audit-chain/events.jsonl",
+            "lineage/log.jsonl",
+            "costs/cost_history.jsonl",
+            "README.md",
+        ):
+            assert required in names, required
+
+        controls = json.loads(zf.read("controls.json"))
+        assert controls["standard"] == standard
+        assert len(controls["controls"]) == 10
+
+        manifest = json.loads(zf.read("manifest.json"))
+        # Every artefact hash in the manifest agrees with the bytes.
+        for name, digest in manifest["artefacts"].items():
+            if name == "manifest.json":
+                continue
+            assert hashlib.sha256(zf.read(name)).hexdigest() == digest, name
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_build_evidence_pack_is_deterministic(standard: str, tmp_path: Path) -> None:
+    sdd = _seed_sdd(tmp_path)
+    a = build_evidence_pack(sdd_dir=sdd, standard=standard, output_path=tmp_path / "a.zip")
+    b = build_evidence_pack(sdd_dir=sdd, standard=standard, output_path=tmp_path / "b.zip")
+    assert a.sha256 == b.sha256
+    assert (tmp_path / "a.zip").read_bytes() == (tmp_path / "b.zip").read_bytes()

--- a/tests/unit/compliance/test_owasp_maps.py
+++ b/tests/unit/compliance/test_owasp_maps.py
@@ -191,7 +191,11 @@ def test_build_evidence_pack_wellformed(standard: str, tmp_path: Path) -> None:
     )
     assert pack.standard == standard
     assert pack.event_count == 1
-    assert pack.controls_mapped >= 1
+    # Both catalogues are honest partial maps: 6 mapped + 4 partial of 10.
+    # The partial controls must be counted, not silently dropped from the
+    # summary (which previously reported "6 / 0" as if nothing was outstanding).
+    assert pack.controls_mapped == 6
+    assert pack.controls_partial == 4
     assert pack.controls_todo == 0
     assert out.is_file()
 
@@ -212,6 +216,10 @@ def test_build_evidence_pack_wellformed(standard: str, tmp_path: Path) -> None:
         assert len(controls["controls"]) == 10
 
         manifest = json.loads(zf.read("manifest.json"))
+        # The partial count reaches the manifest and the to_dict summary, so
+        # an operator reading either sees the 4 outstanding partial controls.
+        assert manifest["controls_partial"] == 4
+        assert pack.to_dict()["controls_partial"] == 4
         # Every artefact hash in the manifest agrees with the bytes.
         for name, digest in manifest["artefacts"].items():
             if name == "manifest.json":

--- a/tests/unit/interop/test_a2a_conformance.py
+++ b/tests/unit/interop/test_a2a_conformance.py
@@ -1,0 +1,125 @@
+"""Unit tests for the A2A signed-card conformance self-check.
+
+Covers:
+
+* A well-formed signed card passes every check.
+* A tampered card body fails the signature check (and the report).
+* An expired card fails the expiry check while its signature stays
+  valid (proving the two checks are independent).
+* A card missing a required field fails the required-fields check.
+* The CLI ``bernstein interop a2a conformance`` exits 0 on a good card
+  and non-zero on a tampered one.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.interop_cmd import interop_group
+from bernstein.core.interop.a2a_card import (
+    CardPolicies,
+    SignedCapabilityCard,
+    issue_capability_card,
+)
+from bernstein.core.interop.a2a_conformance import check_card_conformance
+
+
+def _issue(*, ttl_seconds: int = 3600, now: float | None = None) -> SignedCapabilityCard:
+    policies = CardPolicies(
+        cost_cap_usd=5.0,
+        redaction_tier="standard",
+        sandbox_profile="container",
+    )
+    signed, _key = issue_capability_card(
+        issuer="acme",
+        name="acme-orchestrator",
+        description="test",
+        advertised_tools=["task_orchestration"],
+        policies=policies,
+        ttl_seconds=ttl_seconds,
+        now=now,
+    )
+    return signed
+
+
+def _check_by_name(report, name: str) -> bool:
+    for check in report.checks:
+        if check.name == name:
+            return check.passed
+    raise AssertionError(f"no check named {name!r}")
+
+
+def test_wellformed_card_passes_all_checks() -> None:
+    report = check_card_conformance(_issue())
+    assert report.ok is True
+    assert all(c.passed for c in report.checks)
+    assert report.issuer == "acme"
+    assert report.fingerprint.startswith("sha256:")
+
+
+def test_tampered_card_fails_signature() -> None:
+    signed = _issue()
+    tampered_card = dataclasses.replace(signed.card, issuer="evil")
+    tampered = dataclasses.replace(signed, card=tampered_card)
+
+    report = check_card_conformance(tampered)
+    assert report.ok is False
+    assert _check_by_name(report, "signature") is False
+
+
+def test_expired_card_fails_expiry_but_keeps_signature() -> None:
+    # Issue a card that was valid for an hour but a long time ago.
+    signed = _issue(ttl_seconds=3600, now=time.time() - 10_000)
+    report = check_card_conformance(signed)
+    assert report.ok is False
+    assert _check_by_name(report, "expiry") is False
+    # The signature is still cryptographically valid; only expiry failed.
+    assert _check_by_name(report, "signature") is True
+
+
+def test_missing_required_field_fails() -> None:
+    signed = _issue()
+    empty_kid_card = dataclasses.replace(signed.card, kid="")
+    broken = dataclasses.replace(signed, card=empty_kid_card)
+    report = check_card_conformance(broken)
+    assert report.ok is False
+    assert _check_by_name(report, "required_fields") is False
+
+
+def test_cli_conformance_passes(tmp_path: Path) -> None:
+    card_path = tmp_path / "card.json"
+    card_path.write_text(_issue().to_json())
+    runner = CliRunner()
+    result = runner.invoke(interop_group, ["a2a", "conformance", "--card", str(card_path)])
+    assert result.exit_code == 0, result.output
+    assert "passes all conformance checks" in result.output
+
+
+def test_cli_conformance_fails_on_tampered_card(tmp_path: Path) -> None:
+    signed = _issue()
+    tampered = dataclasses.replace(signed, card=dataclasses.replace(signed.card, issuer="evil"))
+    card_path = tmp_path / "card.json"
+    card_path.write_text(tampered.to_json())
+    runner = CliRunner()
+    result = runner.invoke(interop_group, ["a2a", "conformance", "--card", str(card_path)])
+    assert result.exit_code == 1, result.output
+
+
+def test_cli_conformance_json_output(tmp_path: Path) -> None:
+    card_path = tmp_path / "card.json"
+    card_path.write_text(_issue().to_json())
+    runner = CliRunner()
+    result = runner.invoke(
+        interop_group,
+        ["a2a", "conformance", "--card", str(card_path)],
+        obj={"JSON": True},
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert len(payload["checks"]) == 5

--- a/tests/unit/test_adapter_advisories.py
+++ b/tests/unit/test_adapter_advisories.py
@@ -1,0 +1,119 @@
+"""Tests for adapter minimum-safe-version advisories and the doctor check."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from bernstein.adapters.advisories import (
+    ADAPTER_MIN_SAFE_VERSIONS,
+    AdapterAdvisory,
+    check_adapter_version,
+)
+
+
+class TestCheckAdapterVersion:
+    """Version comparison against the curated safe floor."""
+
+    def test_below_floor_returns_advisory(self) -> None:
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+        floor = ADAPTER_MIN_SAFE_VERSIONS[name].min_safe_version
+        below = "0.0.1"
+        assert below != floor
+        advisory = check_adapter_version(name, below)
+        assert advisory is not None
+        assert advisory.adapter == name
+
+    def test_at_floor_returns_none(self) -> None:
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+        floor = ADAPTER_MIN_SAFE_VERSIONS[name].min_safe_version
+        assert check_adapter_version(name, floor) is None
+
+    def test_above_floor_returns_none(self) -> None:
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+        assert check_adapter_version(name, "999.0.0") is None
+
+    def test_unknown_adapter_returns_none(self) -> None:
+        assert check_adapter_version("no-such-adapter", "0.0.1") is None
+
+    def test_none_version_returns_none(self) -> None:
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+        assert check_adapter_version(name, None) is None
+
+    def test_unparseable_version_returns_none(self) -> None:
+        """A garbled version string is treated as unknown, not below-floor."""
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+        assert check_adapter_version(name, "not-a-version") is None
+
+    def test_advisory_carries_id_and_note(self) -> None:
+        for advisory in ADAPTER_MIN_SAFE_VERSIONS.values():
+            assert isinstance(advisory, AdapterAdvisory)
+            assert advisory.advisory_id
+            assert advisory.note
+
+
+class TestDoctorAdapterAdvisories:
+    """The doctor surface formats a warning row for a below-floor adapter."""
+
+    def test_below_floor_adapter_produces_warn_row(self) -> None:
+        from bernstein.cli.commands import doctor_cmd
+
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+
+        def fake_which(binary: str) -> str | None:
+            return f"/usr/bin/{binary}" if binary == name else None
+
+        with (
+            patch.object(doctor_cmd.shutil, "which", side_effect=fake_which),
+            patch.object(doctor_cmd, "_probe_adapter_version", return_value="0.0.1"),
+        ):
+            rows = doctor_cmd.check_adapter_advisories()
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["name"] == f"Adapter version: {name}"
+        assert row["status"] == "WARN"
+        assert "below safe floor" in row["detail"]
+        assert ADAPTER_MIN_SAFE_VERSIONS[name].advisory_id in row["detail"]
+
+    def test_above_floor_adapter_produces_pass_row(self) -> None:
+        from bernstein.cli.commands import doctor_cmd
+
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+
+        def fake_which(binary: str) -> str | None:
+            return f"/usr/bin/{binary}" if binary == name else None
+
+        with (
+            patch.object(doctor_cmd.shutil, "which", side_effect=fake_which),
+            patch.object(doctor_cmd, "_probe_adapter_version", return_value="999.0.0"),
+        ):
+            rows = doctor_cmd.check_adapter_advisories()
+
+        assert len(rows) == 1
+        assert rows[0]["status"] == "PASS"
+
+    def test_unknown_version_produces_warn_row(self) -> None:
+        from bernstein.cli.commands import doctor_cmd
+
+        name = next(iter(ADAPTER_MIN_SAFE_VERSIONS))
+
+        def fake_which(binary: str) -> str | None:
+            return f"/usr/bin/{binary}" if binary == name else None
+
+        with (
+            patch.object(doctor_cmd.shutil, "which", side_effect=fake_which),
+            patch.object(doctor_cmd, "_probe_adapter_version", return_value=None),
+        ):
+            rows = doctor_cmd.check_adapter_advisories()
+
+        assert len(rows) == 1
+        assert rows[0]["status"] == "WARN"
+        assert "version unknown" in rows[0]["detail"]
+
+    def test_uninstalled_adapters_omitted(self) -> None:
+        from bernstein.cli.commands import doctor_cmd
+
+        with patch.object(doctor_cmd.shutil, "which", return_value=None):
+            rows = doctor_cmd.check_adapter_advisories()
+
+        assert rows == []

--- a/tests/unit/test_adapter_claude.py
+++ b/tests/unit/test_adapter_claude.py
@@ -799,18 +799,28 @@ class TestBuildCommandSystemAddendum:
 
 
 # ---------------------------------------------------------------------------
-# Provider-side context-compaction policy (deterministic replay protection)
+# Context-compaction policy (recorded in the replay fingerprint)
 # ---------------------------------------------------------------------------
 
 
 class TestCompactionPolicy:
-    """apply_compaction_policy disables provider compaction in deterministic modes.
+    """apply_compaction_policy requests best-effort suppression + records policy.
 
-    The step-journal replay guarantee only holds when the model sees exactly
-    the context we sent. Provider-side compaction can rewrite older context
-    server-side, so deterministic-record / hermetic-replay runs must turn it
-    off. These tests pin that policy and the recorded enabled/disabled flag.
+    The load-bearing replay guarantee is that the compaction policy state is
+    recorded in the step fingerprint, so a compaction-driven divergence is
+    detected and attributable. In deterministic-record / hermetic-replay mode
+    the adapter additionally emits a best-effort request to suppress the CLI's
+    client-side auto-compaction. These tests pin that policy and the recorded
+    policy flag.
     """
+
+    def test_suppression_env_var_is_the_recognized_cli_name(self) -> None:
+        # The suppression request must target the CLI's recognized
+        # auto-compaction variable, not an invented name that no consumer
+        # honours (which would make the request a silent no-op).
+        from bernstein.adapters.claude import _DISABLE_COMPACTION_ENV
+
+        assert _DISABLE_COMPACTION_ENV == "DISABLE_AUTO_COMPACT"
 
     def test_default_mode_leaves_env_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from bernstein.adapters.claude import (
@@ -825,7 +835,7 @@ class TestCompactionPolicy:
         assert disabled is False
         assert _DISABLE_COMPACTION_ENV not in env
 
-    def test_record_mode_disables_compaction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_record_mode_requests_suppression(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from bernstein.adapters.claude import (
             _DISABLE_COMPACTION_ENV,
             apply_compaction_policy,
@@ -838,7 +848,7 @@ class TestCompactionPolicy:
         assert disabled is True
         assert env[_DISABLE_COMPACTION_ENV] == "1"
 
-    def test_replay_mode_disables_compaction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_replay_mode_requests_suppression(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from bernstein.adapters.claude import (
             _DISABLE_COMPACTION_ENV,
             apply_compaction_policy,

--- a/tests/unit/test_adapter_claude.py
+++ b/tests/unit/test_adapter_claude.py
@@ -796,3 +796,124 @@ class TestBuildCommandSystemAddendum:
         cmd = self._build(system_addendum=addendum)
         idx = cmd.index("--append-system-prompt")
         assert cmd[idx + 1] == addendum
+
+
+# ---------------------------------------------------------------------------
+# Provider-side context-compaction policy (deterministic replay protection)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactionPolicy:
+    """apply_compaction_policy disables provider compaction in deterministic modes.
+
+    The step-journal replay guarantee only holds when the model sees exactly
+    the context we sent. Provider-side compaction can rewrite older context
+    server-side, so deterministic-record / hermetic-replay runs must turn it
+    off. These tests pin that policy and the recorded enabled/disabled flag.
+    """
+
+    def test_default_mode_leaves_env_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.adapters.claude import (
+            _DISABLE_COMPACTION_ENV,
+            apply_compaction_policy,
+        )
+
+        monkeypatch.delenv("BERNSTEIN_DETERMINISTIC_SEED", raising=False)
+        monkeypatch.delenv("BERNSTEIN_REPLAY_RUN_ID", raising=False)
+        env: dict[str, str] = {}
+        disabled = apply_compaction_policy(env)
+        assert disabled is False
+        assert _DISABLE_COMPACTION_ENV not in env
+
+    def test_record_mode_disables_compaction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.adapters.claude import (
+            _DISABLE_COMPACTION_ENV,
+            apply_compaction_policy,
+        )
+
+        monkeypatch.setenv("BERNSTEIN_DETERMINISTIC_SEED", "42")
+        monkeypatch.delenv("BERNSTEIN_REPLAY_RUN_ID", raising=False)
+        env: dict[str, str] = {}
+        disabled = apply_compaction_policy(env)
+        assert disabled is True
+        assert env[_DISABLE_COMPACTION_ENV] == "1"
+
+    def test_replay_mode_disables_compaction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.adapters.claude import (
+            _DISABLE_COMPACTION_ENV,
+            apply_compaction_policy,
+        )
+
+        monkeypatch.delenv("BERNSTEIN_DETERMINISTIC_SEED", raising=False)
+        monkeypatch.setenv("BERNSTEIN_REPLAY_RUN_ID", "run-123")
+        env: dict[str, str] = {}
+        disabled = apply_compaction_policy(env)
+        assert disabled is True
+        assert env[_DISABLE_COMPACTION_ENV] == "1"
+
+    def test_spawn_records_compaction_disabled_in_deterministic_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BERNSTEIN_DETERMINISTIC_SEED", "7")
+        monkeypatch.delenv("BERNSTEIN_REPLAY_RUN_ID", raising=False)
+        adapter = ClaudeCodeAdapter()
+        claude_mock = _make_popen_mock(pid=1200)
+        wrapper_mock = _make_popen_mock(pid=1201)
+
+        with patch("bernstein.adapters.claude.subprocess.Popen", side_effect=[claude_mock, wrapper_mock]):
+            adapter.spawn(
+                prompt="p",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="sess-det",
+            )
+
+        sidecar = tmp_path / ".sdd" / "runtime" / "compaction" / "sess-det.json"
+        assert sidecar.exists()
+        payload = json.loads(sidecar.read_text())
+        assert payload["compaction_enabled"] is False
+
+    def test_spawn_records_compaction_enabled_outside_deterministic_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BERNSTEIN_DETERMINISTIC_SEED", raising=False)
+        monkeypatch.delenv("BERNSTEIN_REPLAY_RUN_ID", raising=False)
+        adapter = ClaudeCodeAdapter()
+        claude_mock = _make_popen_mock(pid=1300)
+        wrapper_mock = _make_popen_mock(pid=1301)
+
+        with patch("bernstein.adapters.claude.subprocess.Popen", side_effect=[claude_mock, wrapper_mock]):
+            adapter.spawn(
+                prompt="p",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="sess-live",
+            )
+
+        sidecar = tmp_path / ".sdd" / "runtime" / "compaction" / "sess-live.json"
+        assert sidecar.exists()
+        payload = json.loads(sidecar.read_text())
+        assert payload["compaction_enabled"] is True
+
+    def test_spawn_forwards_disable_flag_to_process_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The policy must affect the built REQUEST: the disable var has to land
+        # in the child process env the CLI runs with, not just the sidecar.
+        from bernstein.adapters.claude import _DISABLE_COMPACTION_ENV
+
+        monkeypatch.setenv("BERNSTEIN_DETERMINISTIC_SEED", "9")
+        monkeypatch.delenv("BERNSTEIN_REPLAY_RUN_ID", raising=False)
+        adapter = ClaudeCodeAdapter()
+        claude_mock = _make_popen_mock(pid=1400)
+        wrapper_mock = _make_popen_mock(pid=1401)
+
+        with patch("bernstein.adapters.claude.subprocess.Popen", side_effect=[claude_mock, wrapper_mock]) as popen:
+            adapter.spawn(
+                prompt="p",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="sess-env",
+            )
+
+        child_env = popen.call_args_list[0].kwargs.get("env")
+        assert child_env is not None
+        assert child_env.get(_DISABLE_COMPACTION_ENV) == "1"

--- a/tests/unit/test_cascade_router.py
+++ b/tests/unit/test_cascade_router.py
@@ -21,6 +21,7 @@ from bernstein.core.cascade_router import (
     CascadeRouter,
     _cascade_for_task,
     _effort_for_model,
+    effort_for_scope,
     load_cascade_savings_summary,
 )
 from bernstein.core.models import Complexity, Scope, Task
@@ -114,16 +115,63 @@ class TestCascadeForTask:
 
 
 # ---------------------------------------------------------------------------
+# effort_for_scope - deterministic scope/complexity/attempt mapping
+# ---------------------------------------------------------------------------
+
+
+class TestEffortForScope:
+    """The effort mapping is a pure, deterministic function of its inputs."""
+
+    def test_trivial_maps_to_low(self) -> None:
+        assert effort_for_scope(Scope.SMALL, Complexity.LOW) == "low"
+
+    def test_standard_maps_to_medium(self) -> None:
+        assert effort_for_scope(Scope.MEDIUM, Complexity.MEDIUM) == "medium"
+
+    def test_high_complexity_maps_to_high(self) -> None:
+        assert effort_for_scope(Scope.MEDIUM, Complexity.HIGH) == "high"
+
+    def test_large_scope_maps_to_high(self) -> None:
+        # Large scope is high-risk even at medium complexity.
+        assert effort_for_scope(Scope.LARGE, Complexity.MEDIUM) == "high"
+
+    def test_mapping_is_deterministic_per_inputs(self) -> None:
+        # Same (scope, complexity, attempt) always yields the same effort -
+        # the property replay depends on.
+        for _ in range(5):
+            assert effort_for_scope(Scope.SMALL, Complexity.MEDIUM, attempt=0) == "medium"
+
+    def test_retry_bumps_one_rung(self) -> None:
+        # trivial -> low; one retry -> medium; two retries -> high.
+        assert effort_for_scope(Scope.SMALL, Complexity.LOW, attempt=0) == "low"
+        assert effort_for_scope(Scope.SMALL, Complexity.LOW, attempt=1) == "medium"
+        assert effort_for_scope(Scope.SMALL, Complexity.LOW, attempt=2) == "high"
+
+    def test_escalation_caps_at_max(self) -> None:
+        # No number of retries pushes past "max".
+        assert effort_for_scope(Scope.LARGE, Complexity.HIGH, attempt=99) == "max"
+
+
+# ---------------------------------------------------------------------------
 # _effort_for_model
 # ---------------------------------------------------------------------------
 
 
 class TestEffortForModel:
-    def test_haiku_returns_low(self) -> None:
-        assert _effort_for_model("haiku", _task()) == "low"
+    def test_trivial_task_returns_low(self) -> None:
+        # SMALL + LOW is trivial work: effort maps to "low" regardless of the
+        # (non-opus) model tier, so easy tasks stop overpaying.
+        task = _task(scope=Scope.SMALL, complexity=Complexity.LOW)
+        assert _effort_for_model("haiku", task) == "low"
 
-    def test_sonnet_returns_high(self) -> None:
-        assert _effort_for_model("sonnet", _task()) == "high"
+    def test_standard_task_returns_medium(self) -> None:
+        # MEDIUM + MEDIUM is standard work -> "medium".
+        assert _effort_for_model("sonnet", _task()) == "medium"
+
+    def test_complex_task_returns_high(self) -> None:
+        # HIGH complexity is complex/high-risk work -> "high".
+        task = _task(complexity=Complexity.HIGH)
+        assert _effort_for_model("sonnet", task) == "high"
 
     def test_opus_returns_max(self) -> None:
         assert _effort_for_model("opus", _task()) == "max"
@@ -132,8 +180,17 @@ class TestEffortForModel:
         task = _task(effort="max")
         assert _effort_for_model("haiku", task) == "max"
 
-    def test_unknown_model_returns_high(self) -> None:
-        assert _effort_for_model("gpt-4", _task()) == "high"
+    def test_unknown_model_uses_scope_mapping(self) -> None:
+        # Unknown (non-opus) model falls through to the scope/complexity map.
+        assert _effort_for_model("gpt-4", _task()) == "medium"
+
+    def test_retry_count_escalates_effort(self) -> None:
+        # A retried standard task runs harder: retry_count bumps effort one
+        # rung, so an escalation-driven effort change is reproducible and
+        # therefore hashable into the step journal.
+        task = _task(scope=Scope.SMALL, complexity=Complexity.LOW)
+        task.retry_count = 1
+        assert _effort_for_model("sonnet", task) == "medium"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cascade_with_rework_signal.py
+++ b/tests/unit/test_cascade_with_rework_signal.py
@@ -19,12 +19,16 @@ if TYPE_CHECKING:
 
 
 def _task(role: str = "backend") -> Task:
+    # HIGH complexity so the deterministic effort mapping lands on "high",
+    # matching the effort the rework ledger is seeded at below. The cascade
+    # for a HIGH task starts at sonnet, which is the tier these rework-driven
+    # promotion tests exercise.
     return Task(
         id="t1",
         title="Do something",
         description="desc",
         role=role,
-        complexity=Complexity.MEDIUM,
+        complexity=Complexity.HIGH,
         scope=Scope.MEDIUM,
         priority=2,
     )

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -417,3 +417,50 @@ class TestEmbeddedAgentTeamsDeny:
         assert events[0].actor == "claude"
         assert events[0].resource_id == "qa-abc12345"
         assert events[0].details["adapter"] == "claude"
+
+    def test_secrets_overlay_cannot_reintroduce_gate(self) -> None:
+        """A secrets provider returning the gate is re-stripped before return.
+
+        The embedded-team strip runs both before and after the secrets
+        overlay.  If an external provider returned the agent-team gate, the
+        post-overlay strip must remove it again so the deny-by-default posture
+        holds right up to the return.
+        """
+        from bernstein.core.security.secrets import SecretsConfig
+
+        cfg = SecretsConfig(provider="vault", path="secret/test")
+        fake_env = {"PATH": "/usr/bin"}
+        provider_secrets = {
+            "SOME_API_KEY": "value",
+            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        }
+        with (
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch(
+                "bernstein.core.security.secrets.load_secrets",
+                return_value=provider_secrets,
+            ),
+        ):
+            result = build_filtered_env(secrets_config=cfg)
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in result
+        assert result["SOME_API_KEY"] == "value"
+
+    def test_secrets_overlay_gate_kept_when_opted_in(self) -> None:
+        """When the operator opts in, a provider-returned gate survives."""
+        from bernstein.core.security.secrets import SecretsConfig
+
+        cfg = SecretsConfig(provider="vault", path="secret/test")
+        fake_env = {
+            "PATH": "/usr/bin",
+            "BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS": "1",
+        }
+        provider_secrets = {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"}
+        with (
+            patch("bernstein.adapters.env_isolation.os.environ", fake_env),
+            patch(
+                "bernstein.core.security.secrets.load_secrets",
+                return_value=provider_secrets,
+            ),
+        ):
+            result = build_filtered_env(secrets_config=cfg)
+        assert result["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -330,3 +330,90 @@ class TestAdaptersUseFilteredEnv:
         kwargs = popen_spy.call_args.kwargs
         assert "env" in kwargs
         assert kwargs["env"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Embedded agent-team spawning gate - deny by default
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddedAgentTeamsDeny:
+    """The embedded agent-team spawning gate is stripped by default.
+
+    A spawned worker that inherits ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS``
+    can launch its own teammate instances; those teammates inherit the
+    lead's permission mode and run outside this worker's HMAC audit trail,
+    breaking the one-worker-one-audit-trail invariant.  The gate must be
+    denied even if it somehow reaches the allowlist.
+    """
+
+    def test_gate_stripped_by_default(self) -> None:
+        fake_env = {
+            "PATH": "/usr/bin",
+            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+            result = build_filtered_env()
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in result
+        assert result["PATH"] == "/usr/bin"
+
+    def test_gate_stripped_even_when_in_extra_keys(self) -> None:
+        """An operator-widened allowlist cannot re-open the hole."""
+        fake_env = {
+            "PATH": "/usr/bin",
+            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+            result = build_filtered_env(["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"])
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in result
+
+    def test_forward_looking_suffixes_stripped(self) -> None:
+        """A future ``*_AGENT_TEAMS`` gate is denied without a code change."""
+        fake_env = {
+            "PATH": "/usr/bin",
+            "SOMEVENDOR_EXPERIMENTAL_AGENT_TEAMS": "1",
+            "OTHER_AGENT_TEAMS": "yes",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+            result = build_filtered_env(["SOMEVENDOR_EXPERIMENTAL_AGENT_TEAMS", "OTHER_AGENT_TEAMS"])
+        assert "SOMEVENDOR_EXPERIMENTAL_AGENT_TEAMS" not in result
+        assert "OTHER_AGENT_TEAMS" not in result
+
+    def test_opt_in_repermits_gate(self) -> None:
+        """An explicit host opt-in re-permits the gate."""
+        fake_env = {
+            "PATH": "/usr/bin",
+            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+            "BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS": "1",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+            result = build_filtered_env(["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"])
+        assert result["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+
+    def test_opt_in_falsey_value_still_denies(self) -> None:
+        """A stray empty/``0`` opt-in value keeps deny-by-default."""
+        fake_env = {
+            "PATH": "/usr/bin",
+            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+            "BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS": "0",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+            result = build_filtered_env(["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"])
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in result
+
+    def test_opt_in_emits_audit_event(self, tmp_path: Path) -> None:
+        """record_embedded_teams_opt_in appends an attestation to the chain."""
+        from bernstein.adapters.env_isolation import record_embedded_teams_opt_in
+        from bernstein.core.security.audit import AuditLog
+
+        audit_dir = tmp_path / ".sdd" / "audit"
+        record_embedded_teams_opt_in(
+            adapter="claude",
+            session_id="qa-abc12345",
+            audit_dir=audit_dir,
+        )
+        events = AuditLog(audit_dir=audit_dir).query(event_type="adapter.embedded_agent_teams_enabled")
+        assert len(events) == 1
+        assert events[0].actor == "claude"
+        assert events[0].resource_id == "qa-abc12345"
+        assert events[0].details["adapter"] == "claude"

--- a/tests/unit/test_evidence_pack.py
+++ b/tests/unit/test_evidence_pack.py
@@ -120,11 +120,13 @@ def sdd_dir(tmp_path: Path) -> Path:
 
 class TestStandardMap:
     def test_supported_standards_constant(self) -> None:
-        # Only ai-act ships with a reviewed control map at MVP. DORA
-        # and FINOS AIGF are tracked under #1316 and must not be
-        # selectable from the CLI until their clause mappings are
+        # ai-act plus the two OWASP agentic-security catalogues ship with
+        # reviewed control maps. DORA and FINOS AIGF remain tracked under
+        # #1316 and must NOT be selectable until their clause mappings are
         # validated; emitting TODO-only bundles would mislead operators.
-        assert set(SUPPORTED_STANDARDS) == {"ai-act"}
+        assert set(SUPPORTED_STANDARDS) == {"ai-act", "owasp-asi", "owasp-skills"}
+        assert "dora" not in SUPPORTED_STANDARDS
+        assert "finos-aigf" not in SUPPORTED_STANDARDS
 
     def test_ai_act_has_real_controls(self) -> None:
         mapping = get_standard_map("ai-act")

--- a/tests/unit/test_evidence_pack.py
+++ b/tests/unit/test_evidence_pack.py
@@ -191,6 +191,7 @@ class TestBuildEvidencePack:
         assert pack.lineage_count == 2
         assert pack.cost_count == 2
         assert pack.controls_mapped >= 5
+        assert pack.controls_partial == 0  # ai-act is fully mapped, no partials
         assert pack.controls_todo == 0  # ai-act is real
 
     def test_task_scoping_filters_events(self, sdd_dir: Path) -> None:

--- a/tests/unit/test_hooks_injection.py
+++ b/tests/unit/test_hooks_injection.py
@@ -134,3 +134,58 @@ class TestInjectHooksConfig:
         assert "openssl dgst -sha256 -hmac" in hook_cmd
         assert "X-Bernstein-Hook-Signature-256: sha256=$SIG" in hook_cmd
         assert "Content-Type: application/json" in hook_cmd
+
+
+class TestEmbeddedAgentTeamsPin:
+    """The settings.local.json env block pins the embedded agent-team gate off.
+
+    Claude Code reads ``env`` from settings.local.json independently of the
+    process env we filter in ``build_filtered_env``.  A spawned worker that
+    inherits ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`` can launch its own
+    teammates, which run outside this worker's HMAC audit trail.  We pin the
+    gate to ``"false"`` here (deny-by-default) unless the operator explicitly
+    opts in.
+    """
+
+    def test_gate_pinned_false_by_default(self, tmp_path: Path, monkeypatch) -> None:
+        """No opt-in -> env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS == 'false'."""
+        monkeypatch.delenv("BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS", raising=False)
+        ClaudeCodeAdapter._inject_hooks_config(tmp_path, "sess-pin")
+        settings = tmp_path / ".claude" / "settings.local.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+
+        assert data["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "false"
+
+    def test_gate_pin_omitted_when_opted_in(self, tmp_path: Path, monkeypatch) -> None:
+        """Opt-in -> the pin is not injected, leaving the gate untouched."""
+        monkeypatch.setenv("BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS", "1")
+        ClaudeCodeAdapter._inject_hooks_config(tmp_path, "sess-optin")
+        settings = tmp_path / ".claude" / "settings.local.json"
+        data = json.loads(settings.read_text(encoding="utf-8"))
+
+        env_block = data.get("env", {})
+        assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in env_block
+
+    def test_preexisting_true_gate_overwritten_keys_preserved(self, tmp_path: Path, monkeypatch) -> None:
+        """Pre-existing gate 'true' -> overwritten to 'false'; other keys kept."""
+        monkeypatch.delenv("BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS", raising=False)
+        settings_dir = tmp_path / ".claude"
+        settings_dir.mkdir(parents=True)
+        settings_path = settings_dir / "settings.local.json"
+        settings_path.write_text(
+            json.dumps(
+                {
+                    "env": {
+                        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "true",
+                        "MY_UNRELATED_VAR": "keep-me",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        ClaudeCodeAdapter._inject_hooks_config(tmp_path, "sess-overwrite-gate")
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+
+        assert data["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "false"
+        assert data["env"]["MY_UNRELATED_VAR"] == "keep-me"

--- a/tests/unit/test_journal_divergence.py
+++ b/tests/unit/test_journal_divergence.py
@@ -118,3 +118,46 @@ class TestJournalDiff:
             reason="model differs",
         )
         assert hash(d) == hash(d)
+
+
+class TestEffortDivergence:
+    """Two chains differing only in effort must surface a named ``effort`` diff.
+
+    Regression: ``_HASHED_FIELDS`` omitted ``effort`` while ``effort`` folds
+    into the step hash, so two runs identical except for reasoning effort had
+    divergent step hashes yet ``diff_journals`` reported no divergence - the
+    exact hash-soup blindness the module exists to prevent.
+    """
+
+    def test_effort_only_change_named_in_step_diff(self) -> None:
+        entry_a = {
+            "prev_hash": "0" * 64,
+            "input_hash": "aa",
+            "model": "m1",
+            "prompt": "hi",
+            "tool_call": None,
+            "tool_result": None,
+            "effort": "low",
+        }
+        entry_b = dict(entry_a, effort="high")
+        result = diff_steps(entry_a, entry_b)
+        assert result is not None
+        assert "effort" in result.fields_changed
+        assert result.left_values["effort"] == "low"
+        assert result.right_values["effort"] == "high"
+
+    def test_effort_only_change_surfaces_in_diff_journals(self, tmp_path: Path) -> None:
+        journal_a = Journal.open(tmp_path / "a")
+        journal_a.append(input_hash="a0", model="m1", prompt="p0", effort="low")
+        journal_a.close()
+
+        journal_b = Journal.open(tmp_path / "b")
+        journal_b.append(input_hash="a0", model="m1", prompt="p0", effort="high")
+        journal_b.close()
+
+        result = diff_journals(tmp_path / "a", tmp_path / "b")
+        assert result is not None, "an effort-only divergence must be reported"
+        assert result.seq == 0
+        assert "effort" in result.fields_changed
+        assert result.left_values["effort"] == "low"
+        assert result.right_values["effort"] == "high"

--- a/tests/unit/test_journal_effort_dimension.py
+++ b/tests/unit/test_journal_effort_dimension.py
@@ -1,0 +1,202 @@
+"""Tests for the reasoning-effort dimension in the step-hash journal.
+
+The effort a step is routed at changes the model's output, so a replay at a
+different effort must surface as step-hash divergence rather than a silent
+mismatch. These tests pin the load-bearing contract:
+
+* Effort is folded into the step hash only when recorded (non-``None``), so a
+  cross-effort replay diverges.
+* A ``None`` (legacy / unrecorded) effort is byte-identical to a pre-effort
+  record, so every journal written before the effort dimension re-verifies
+  unchanged (back-compat).
+* An on-disk row that has no ``effort`` / ``schema_version`` field (exactly the
+  legacy shape) still verifies, and is read as ``schema_version=1``.
+
+Each test is written to FAIL against the pre-effort code and PASS against the
+effort-aware code.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.persistence.journal import (
+    GENESIS_HASH,
+    JOURNAL_SCHEMA_VERSION,
+    Journal,
+    JournalEntry,
+    JournalReader,
+    canonical_step_payload,
+    compute_step_hash,
+)
+
+
+class TestEffortFoldedIntoHash:
+    """A recorded effort changes the step hash; an absent one does not."""
+
+    def test_none_effort_matches_pre_effort_payload(self) -> None:
+        # The canonical payload with effort=None must be byte-identical to the
+        # six-field payload a pre-effort verifier would produce, so old records
+        # re-derive unchanged.
+        expected = json.dumps(
+            {
+                "prev_hash": GENESIS_HASH,
+                "input_hash": "aa",
+                "model": "m1",
+                "prompt": "p1",
+                "tool_call": None,
+                "tool_result": None,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        got = canonical_step_payload(
+            prev_hash=GENESIS_HASH,
+            input_hash="aa",
+            model="m1",
+            prompt="p1",
+            tool_call=None,
+            tool_result=None,
+            effort=None,
+        )
+        assert got == expected
+
+    def test_recorded_effort_changes_hash(self) -> None:
+        base = compute_step_hash(
+            prev_hash=GENESIS_HASH,
+            input_hash="aa",
+            model="m1",
+            prompt="p1",
+            tool_call=None,
+            tool_result=None,
+            effort=None,
+        )
+        high = compute_step_hash(
+            prev_hash=GENESIS_HASH,
+            input_hash="aa",
+            model="m1",
+            prompt="p1",
+            tool_call=None,
+            tool_result=None,
+            effort="high",
+        )
+        assert high != base, "a recorded effort must change the step hash"
+
+    def test_different_effort_produces_different_hash(self) -> None:
+        low = compute_step_hash(
+            prev_hash=GENESIS_HASH,
+            input_hash="aa",
+            model="m1",
+            prompt="p1",
+            tool_call=None,
+            tool_result=None,
+            effort="low",
+        )
+        maxx = compute_step_hash(
+            prev_hash=GENESIS_HASH,
+            input_hash="aa",
+            model="m1",
+            prompt="p1",
+            tool_call=None,
+            tool_result=None,
+            effort="max",
+        )
+        assert low != maxx, "distinct efforts must diverge in the step hash"
+
+
+class TestEffortBackCompat:
+    """Legacy rows (no effort / no schema_version) still validate."""
+
+    def test_legacy_row_without_effort_verifies(self, tmp_path: Path) -> None:
+        # Hand-write a row in the exact pre-effort shape: no ``effort`` key,
+        # no ``schema_version`` key, hash computed over the six-field payload.
+        step_hash = compute_step_hash(
+            prev_hash=GENESIS_HASH,
+            input_hash="aa",
+            model="m1",
+            prompt="p1",
+            tool_call=None,
+            tool_result=None,
+        )
+        legacy_row = {
+            "seq": 0,
+            "prev_hash": GENESIS_HASH,
+            "input_hash": "aa",
+            "model": "m1",
+            "prompt": "p1",
+            "tool_call": None,
+            "tool_result": None,
+            "step_hash": step_hash,
+            "ts": 0.0,
+            "blob_refs": [],
+        }
+        bucket = tmp_path / "000000.jsonl"
+        bucket.write_text(
+            json.dumps(legacy_row, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+
+        result = JournalReader(tmp_path).verify()
+        assert result.ok, f"legacy row must verify; errors={result.errors}"
+        assert result.steps == 1
+
+        # And it re-opens (recovery revalidates the chain) without raising.
+        journal = Journal.open(tmp_path)
+        assert journal.head_hash == step_hash
+        assert journal.next_seq == 1
+        journal.close()
+
+    def test_legacy_row_reads_as_schema_version_one(self) -> None:
+        legacy_row = {
+            "seq": 0,
+            "prev_hash": GENESIS_HASH,
+            "input_hash": "aa",
+            "model": "m1",
+            "prompt": "p1",
+            "tool_call": None,
+            "tool_result": None,
+            "step_hash": "x",
+            "ts": 0.0,
+        }
+        entry = JournalEntry.from_dict(legacy_row)
+        assert entry.effort is None
+        assert entry.schema_version == 1
+
+
+class TestEffortRoundTrip:
+    """Appending with an effort persists and re-verifies it."""
+
+    def test_append_with_effort_roundtrips_and_verifies(self, tmp_path: Path) -> None:
+        journal = Journal.open(tmp_path)
+        entry = journal.append(input_hash="aa", model="m1", prompt="p1", effort="high")
+        journal.close()
+
+        assert entry.effort == "high"
+        assert entry.schema_version == JOURNAL_SCHEMA_VERSION
+
+        reader = JournalReader(tmp_path)
+        head = reader.head()
+        assert head is not None
+        assert head.effort == "high"
+        assert reader.verify().ok
+
+    def test_effort_change_breaks_verification(self, tmp_path: Path) -> None:
+        # Persist a step at effort=high, then rewrite the on-disk effort to
+        # "low" without recomputing the hash. Verification must reject it: a
+        # step replayed at a different effort is divergence, not noise.
+        journal = Journal.open(tmp_path)
+        journal.append(input_hash="aa", model="m1", prompt="p1", effort="high")
+        journal.close()
+
+        bucket = tmp_path / "000000.jsonl"
+        rows = [json.loads(line) for line in bucket.read_text().splitlines() if line.strip()]
+        rows[0]["effort"] = "low"  # tamper: effort no longer matches step_hash
+        bucket.write_text(
+            "\n".join(json.dumps(r, sort_keys=True, separators=(",", ":")) for r in rows) + "\n",
+            encoding="utf-8",
+        )
+
+        result = JournalReader(tmp_path).verify()
+        assert not result.ok
+        assert any("step_hash mismatch" in e for e in result.errors)

--- a/tests/unit/test_journal_export.py
+++ b/tests/unit/test_journal_export.py
@@ -116,3 +116,36 @@ class TestExport:
         receipt_path = tmp_path / "receipt.tar"
         with pytest.raises(ReceiptError):
             export_receipt(agent_dir, receipt_path, agent_id="agent-1")
+
+
+class TestExportEffortRoundTrip:
+    """An effort-bearing journal must stay offline-verifiable end to end.
+
+    Regression for the export/publish recompute paths that folded every
+    hashed field except ``effort``: an effort-bearing row's bundled step_hash
+    included effort while the offline walker recomputed without it, so
+    ``verify_receipt`` failed on a chain the local reader accepted.
+    """
+
+    def test_effort_bearing_journal_roundtrips_offline(self, tmp_path: Path) -> None:
+        agent_dir = tmp_path / "agent-effort"
+        journal = Journal.open(agent_dir)
+        journal.append(input_hash="a0", model="m1", prompt="p0", effort="high")
+        journal.append(input_hash="a1", model="m1", prompt="p1", effort="low")
+        journal.close()
+
+        reader = JournalReader(agent_dir)
+        # Local reader must accept the effort-bearing chain.
+        assert reader.verify().ok
+        head = reader.head().step_hash  # type: ignore[union-attr]
+
+        receipt_path = tmp_path / "receipt.tar"
+        result = export_receipt(agent_dir, receipt_path, agent_id="agent-effort")
+        assert result.head_hash == head
+
+        # OFFLINE third-party verify must reproduce the same head_hash from the
+        # bundled bytes, which only holds if the walker folds effort into the
+        # recomputed step hash.
+        verified = verify_receipt(receipt_path, expected_head=head)
+        assert verified.ok, f"offline verify must pass; errors={verified.errors}"
+        assert verified.steps == 2

--- a/tests/unit/test_journal_publish.py
+++ b/tests/unit/test_journal_publish.py
@@ -117,3 +117,35 @@ class TestPublish:
         blob = receipt_path.read_bytes()
         assert b"SECRET_TOKEN_DO_NOT_LEAK" not in blob
         assert b"ALSO_SECRET" not in blob
+
+
+class TestPublishEffortReanchor:
+    """Published receipts must re-anchor over the effort dimension too.
+
+    Regression: the publish recompute path folded every hashed field except
+    ``effort`` when re-anchoring the redacted chain, silently dropping the
+    effort dimension from published receipts while the redacted rows still
+    carried the ``effort`` key.
+    """
+
+    def test_effort_bearing_journal_publishes_and_verifies(self, tmp_path: Path) -> None:
+        agent_dir = tmp_path / "agent-effort"
+        journal = Journal.open(agent_dir)
+        journal.append(input_hash="a0", model="m1", prompt="p0", effort="high")
+        journal.append(input_hash="a1", model="m1", prompt="p1", effort="low")
+        journal.close()
+
+        receipt_path = tmp_path / "redacted.tar"
+        result = publish_receipt(
+            agent_dir,
+            receipt_path,
+            agent_id="agent-effort",
+            policy=RedactionPolicy.default(),
+            opt_in=True,
+        )
+
+        # Offline verify must reproduce the re-anchored head, which only holds
+        # if the re-anchor folds effort into each recomputed step hash.
+        v = verify_receipt(receipt_path, expected_head=result.head_hash)
+        assert v.ok, v.errors
+        assert v.steps == 2

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
New minor release. Three coherent workstreams, each additive/off-by-default (or deny-by-default for the security hole), test-gated, and coupled to a determinism/audit/isolation lever.

## Worker isolation (security)
- Deny embedded agent-team spawning inside workers: the per-adapter env filter strips `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` (and `*_AGENT_TEAMS` variants) by default even from a widened allowlist and after the secrets overlay; the Claude adapter pins it off in the merged worker settings. Explicit host opt-in (`BERNSTEIN_ALLOW_EMBEDDED_AGENT_TEAMS`) records an attestation to the HMAC audit chain. Preserves one-worker-one-audit-trail.
- `bernstein doctor` warns when a discovered adapter CLI is below a known-safe version floor (data-driven advisory map).

## Replay integrity
- Context-compaction state is folded into the step fingerprint so a replay divergence caused by provider-side compaction is detected and attributed; deterministic/hermetic modes additionally make a best-effort request to suppress client-side auto-compaction (the fingerprint is the guarantee, not the suppression).
- Model effort (low/medium/high/max) is now a deterministic routing dimension and part of the versioned step fingerprint. Legacy records without effort verify byte-for-byte across the local reader, the offline receipt verifier, and the redacted-publish re-anchor.

## Standards mapping
- `bernstein audit export --standard owasp-asi | owasp-skills` maps OWASP ASI01-10 and AST01-10 onto real mechanisms and audit events, with honest mapped/partial/todo accounting, alongside the EU AI Act export.
- `bernstein interop a2a conformance` verifies an agent card round-trips (JCS + detached Ed25519 JWS + fields/expiry/issuer), provable offline.

Validated: three parallel implementers, per-branch adversarial review, a fix pass, and an integrated review (all clean); 454-test regression slice green and ruff clean. Bumps 2.11.0 to 2.12.0; notes at `docs/release-notes/v2.12.0.md`. Merge LAST; auto-release tags on green CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OWASP ASI and OWASP Skills compliance exports, including richer coverage reporting.
  * Added an interoperability conformance check for signed capability cards.
  * Added adapter safety checks that flag versions below known safe floors.

* **Bug Fixes**
  * Improved replay and audit fidelity by including reasoning effort in journal hashing and verification.
  * Made environment filtering stricter by default for embedded agent-team spawning, with explicit opt-in support.

* **Documentation**
  * Updated release notes and reference docs to reflect the new checks and supported standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->