### PR TITLE
style: resolve refurb FURB123 and FURB184 findings

### DIFF
--- a/src/bernstein/adapters/openai_agents_builtins.py
+++ b/src/bernstein/adapters/openai_agents_builtins.py
@@ -381,7 +381,7 @@ def run_command_in_workdir(
     at the builtin layer; ``run_command`` remains a process-exec primitive
     whose filesystem confinement is the configured OS sandbox, not this check.
     """
-    argv_list = [str(a) for a in argv]
+    argv_list = list(argv)
     emit(
         {
             "type": "tool_call",

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -934,8 +934,7 @@ def _parse_github(raw: object) -> GithubConfig:
         return GithubConfig()
     if not isinstance(raw, dict):
         raise SeedError(f"github must be a mapping, got: {type(raw).__name__}")
-    github_dict: dict[str, object] = cast("_StrObjDict", raw)
-    sync_raw: object = github_dict.get("sync_backlog", False)
+    sync_raw: object = cast("_StrObjDict", raw).get("sync_backlog", False)
     if not isinstance(sync_raw, bool):
         raise SeedError(f"github.sync_backlog must be a bool, got: {type(sync_raw).__name__}")
     return GithubConfig(sync_backlog=sync_raw)


### PR DESCRIPTION
Two behavior-preserving refurb cleanups on the 2.13.0 additions: `list(argv)` for the already-typed builtin argv, and an inlined cast in the github seed parser.

## Summary by Sourcery

Apply behavior-preserving refurb style cleanups to recent additions.

Enhancements:
- Inline the cast when reading github sync_backlog in the seed parser for clearer, more direct access.
- Simplify argv handling in the OpenAI agents builtin command runner by using list(argv) on the already-typed sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of command inputs when running tasks in a working directory, making command execution more reliable.
  * Refined parsing of GitHub-related configuration so sync settings are processed more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->