### PR TITLE
feat: tunable agent run-length limits (max_turns, error-budget floor, max_agent_runtime_s)

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -142,6 +142,7 @@ Environment variables are useful in CI and automation. Common variables:
 | `BERNSTEIN_COMPLIANCE` | Compliance preset override |
 | `BERNSTEIN_QUIET` | Quiet mode (reduced terminal output) |
 | `BERNSTEIN_AUDIT` | Enable extra audit behavior in run flow |
+| `BERNSTEIN_MAX_TURNS` | Override the SDK turn ceiling for the openai_agents runner (see §4.1). Takes precedence over `tuning.agent.max_turns`. |
 
 ---
 
@@ -155,18 +156,50 @@ tuning:
     tick_interval_s: 5.0
     drain_timeout_s: 120.0
     stale_claim_timeout_s: 1800.0
+    max_agent_runtime_s: 3600.0
   spawn:
     spawn_backoff_base_s: 60.0
+  agent:
+    max_turns: 200
+  slo:
+    error_budget_min_failures: 10
 ```
 
 Key default groups:
 
 | Group | Examples |
 |-------|---------|
-| `OrchestratorDefaults` | `tick_interval_s`, `drain_timeout_s`, `max_consecutive_failures`, `stale_claim_timeout_s` |
+| `OrchestratorDefaults` | `tick_interval_s`, `drain_timeout_s`, `max_consecutive_failures`, `stale_claim_timeout_s`, `max_agent_runtime_s` |
 | `SpawnDefaults` | `spawn_backoff_base_s`, `spawn_backoff_max_s`, `max_spawn_failures` |
 | `TaskDefaults` | Retry limits, deadline windows |
-| `AgentDefaults` | Heartbeat intervals, max dead agents kept |
+| `AgentDefaults` | Heartbeat intervals, max dead agents kept, `max_turns` |
+| `SLODefaults` | `error_budget_min_failures` |
+
+### 4.1) Agent run-length limits (SDK turns, error budget, wall-clock)
+
+Three previously-hardcoded ceilings on the `openai_agents` adapter path are
+now tunable, with defaults unchanged so nothing breaks for existing users:
+
+- **`max_turns`** (`AgentDefaults.max_turns`, default `None`) — forwarded to
+  the OpenAI Agents SDK's `Runner.run_sync(..., max_turns=...)` only when
+  set. `None` omits the kwarg entirely, so the SDK's own default (`10`)
+  applies exactly as before. A task that legitimately needs more turns
+  before `MaxTurnsExceeded` (large-repo investigation, multi-file
+  refactors) can raise this via `tuning.agent.max_turns: 200` or the
+  `BERNSTEIN_MAX_TURNS` env var (checked first).
+- **`error_budget_min_failures`** (`SLODefaults.error_budget_min_failures`,
+  default `3`) — the floor `ErrorBudget.budget_total` never goes below,
+  even when `total_tasks * (1 - slo_target)` rounds lower. Raise it via
+  `tuning.slo.error_budget_min_failures` when a run's early failures are
+  infra-death retries (rate limits, transient auth) that shouldn't trip
+  `IncidentManager`'s auto-pause.
+- **`max_agent_runtime_s`** (`OrchestratorDefaults.max_agent_runtime_s`,
+  default `1800`) — the starting wall-clock kill deadline for a spawned
+  agent, now sourced through `OrchestratorConfig` via the same
+  `tuning.orchestrator.*` mechanism as `stale_claim_timeout_s`. This is
+  only the *starting* value — the agent lifecycle reaper already
+  self-extends it by 600s per cycle up to a 5400s hard cap while the agent
+  keeps heartbeating.
 
 See `defaults.py` for the full list of parameters and their default values.
 

--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -186,13 +186,18 @@ now tunable, with defaults unchanged so nothing breaks for existing users:
   applies exactly as before. A task that legitimately needs more turns
   before `MaxTurnsExceeded` (large-repo investigation, multi-file
   refactors) can raise this via `tuning.agent.max_turns: 200` or the
-  `BERNSTEIN_MAX_TURNS` env var (checked first).
+  `BERNSTEIN_MAX_TURNS` env var (checked first). `BERNSTEIN_MAX_TURNS` must
+  parse as a positive integer — `0`, a negative value, or a non-numeric
+  string is rejected with a warning and falls through to
+  `tuning.agent.max_turns`/the SDK default, rather than being forwarded to
+  `Runner.run_sync` where it would fail every run on the first turn.
 - **`error_budget_min_failures`** (`SLODefaults.error_budget_min_failures`,
   default `3`) — the floor `ErrorBudget.budget_total` never goes below,
   even when `total_tasks * (1 - slo_target)` rounds lower. Raise it via
   `tuning.slo.error_budget_min_failures` when a run's early failures are
   infra-death retries (rate limits, transient auth) that shouldn't trip
-  `IncidentManager`'s auto-pause.
+  `IncidentManager`'s auto-pause. A negative override is clamped to `0`
+  rather than being allowed to suppress the SLO-target-derived budget.
 - **`max_agent_runtime_s`** (`OrchestratorDefaults.max_agent_runtime_s`,
   default `1800`) — the starting wall-clock kill deadline for a spawned
   agent, now sourced through `OrchestratorConfig` via the same

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -87,10 +87,18 @@ def _resolve_max_turns() -> int | None:
     raw_env = os.environ.get(MAX_TURNS_ENV_VAR)
     if raw_env is not None and raw_env.strip():
         try:
-            return int(raw_env)
+            parsed = int(raw_env)
         except ValueError:
             logger.warning(
                 "%s=%r is not a valid int; falling back to tuning.agent.max_turns/SDK default",
+                MAX_TURNS_ENV_VAR,
+                raw_env,
+            )
+        else:
+            if parsed > 0:
+                return parsed
+            logger.warning(
+                "%s=%r must be a positive int; falling back to tuning.agent.max_turns/SDK default",
                 MAX_TURNS_ENV_VAR,
                 raw_env,
             )
@@ -98,6 +106,7 @@ def _resolve_max_turns() -> int | None:
     from bernstein.core.defaults import AGENT
 
     return AGENT.max_turns
+
 
 # ``api_key_env`` must name a known LLM-provider credential.  The name both
 # widens the filtered environment handed to this subprocess and selects the

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -70,6 +70,35 @@ EXIT_MANIFEST_ERROR: int = 2
 EXIT_SDK_MISSING: int = 3
 EXIT_RATE_LIMIT: int = 4
 
+# Env var overriding AGENT.max_turns (tuning.agent.max_turns in bernstein.yaml).
+# Checked first; an unset/blank/unparseable value falls through to the
+# yaml-tunable default, which itself defaults to ``None`` (SDK default of 10
+# applies, unchanged from prior behavior).
+MAX_TURNS_ENV_VAR: str = "BERNSTEIN_MAX_TURNS"
+
+
+def _resolve_max_turns() -> int | None:
+    """Resolve the effective ``max_turns`` for ``Runner.run_sync``.
+
+    Precedence: ``BERNSTEIN_MAX_TURNS`` env var > ``AGENT.max_turns`` (yaml
+    ``tuning.agent.max_turns``) > ``None`` (SDK default applies - unchanged
+    behavior for anyone not opting in).
+    """
+    raw_env = os.environ.get(MAX_TURNS_ENV_VAR)
+    if raw_env is not None and raw_env.strip():
+        try:
+            return int(raw_env)
+        except ValueError:
+            logger.warning(
+                "%s=%r is not a valid int; falling back to tuning.agent.max_turns/SDK default",
+                MAX_TURNS_ENV_VAR,
+                raw_env,
+            )
+
+    from bernstein.core.defaults import AGENT
+
+    return AGENT.max_turns
+
 # ``api_key_env`` must name a known LLM-provider credential.  The name both
 # widens the filtered environment handed to this subprocess and selects the
 # secret sent as the bearer key to ``base_url``, so an unconstrained value
@@ -645,11 +674,17 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
             agent_kwargs["model_settings"] = sdk.ModelSettings(**settings_kwargs)
         agent: Any = agent_cls(**agent_kwargs)
         run_config = _build_run_config(manifest)
+        run_sync_kwargs: dict[str, Any] = {"run_config": run_config}
+        max_turns = _resolve_max_turns()
+        if max_turns is not None:
+            run_sync_kwargs["max_turns"] = max_turns
         # ``Runner.run_sync`` is the SDK's synchronous API - we avoid
         # ``asyncio.run`` here so the runner stays compatible with
         # environments where the event loop is already running
-        # (e.g. pytest-asyncio tests that import this module).
-        result: Any = runner_cls.run_sync(agent, manifest.prompt, run_config=run_config)
+        # (e.g. pytest-asyncio tests that import this module). ``max_turns``
+        # is only forwarded when configured (env/tuning) - omitting the
+        # kwarg preserves the SDK's own default exactly, as before.
+        result: Any = runner_cls.run_sync(agent, manifest.prompt, **run_sync_kwargs)
     except Exception as exc:  # SDK errors are varied - catch broadly
         if _is_rate_limit(exc):
             emit_event(

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -107,6 +107,13 @@ class OrchestratorDefaults:
     manager_review_completion_threshold: int = 7  # trigger review every 7 done
     manager_review_stall_s: float = 900.0  # 15 min
 
+    # Starting wall-clock kill deadline for a spawned agent (OrchestratorConfig.
+    # max_agent_runtime_s). Self-extends +600s/tick up to a 5400s hard cap while
+    # the agent is heartbeating (see core/agents/agent_lifecycle.py); this is
+    # only the initial value before any extension. Tunable via
+    # ``tuning.orchestrator.max_agent_runtime_s``.
+    max_agent_runtime_s: int = 1800  # 30 min
+
 
 # ---------------------------------------------------------------------------
 # Spawn / Agent defaults
@@ -141,6 +148,27 @@ class AgentDefaults:
     escalation_med_count: int = 3
 
     zombie_pid_max_age_s: float = 7 * 24 * 3600  # 7 days
+
+    # Max SDK turns forwarded to ``Runner.run_sync`` by the openai_agents
+    # runner (adapters/openai_agents_runner.py). ``None`` preserves prior
+    # behavior exactly: the kwarg is omitted and the OpenAI Agents SDK's own
+    # default (10) applies. Set via ``tuning.agent.max_turns`` or the
+    # ``BERNSTEIN_MAX_TURNS`` env var when a task needs more turns than the
+    # SDK default allows before ``MaxTurnsExceeded``.
+    max_turns: int | None = None
+
+
+@dataclass(frozen=True)
+class SLODefaults:
+    """Error-budget floor for the observability SLO/incident subsystem."""
+
+    # ErrorBudget.budget_total always tolerates at least this many failures,
+    # even when total_tasks * (1 - slo_target) rounds below it (e.g. a small
+    # task count). Raising this delays IncidentManager's auto-pause-on-
+    # error-budget-depletion response, useful when early infra-death retries
+    # (rate limits, transient auth) shouldn't count against a healthy run.
+    # Tunable via ``tuning.slo.error_budget_min_failures``.
+    error_budget_min_failures: int = 3
 
 
 # ---------------------------------------------------------------------------
@@ -680,6 +708,7 @@ SCHEMA_RETRY = SchemaRetryDefaults()
 LINEAGE = LineageDefaults()
 REWORK_LEDGER = ReworkLedgerDefaults()
 COMPACTION = CompactionDefaults()
+SLO = SLODefaults()
 
 # Module-level constant for direct import - preferred when only the
 # numeric cap is needed (no need to import the whole singleton).
@@ -735,6 +764,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "lineage": "LINEAGE",
         "rework_ledger": "REWORK_LEDGER",
         "compaction": "COMPACTION",
+        "slo": "SLO",
     }
 )
 
@@ -765,6 +795,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "LINEAGE": LineageDefaults,
         "REWORK_LEDGER": ReworkLedgerDefaults,
         "COMPACTION": CompactionDefaults,
+        "SLO": SLODefaults,
     }
 )
 

--- a/src/bernstein/core/observability/slo.py
+++ b/src/bernstein/core/observability/slo.py
@@ -128,7 +128,11 @@ class ErrorBudget:
 
         if self.total_tasks == 0:
             return 0
-        return max(SLO.error_budget_min_failures, round(self.total_tasks * (1.0 - self.slo_target)))
+        # Clamp a misconfigured (e.g. negative) tuning.slo.error_budget_min_failures
+        # to 0 rather than letting a pathological floor suppress the budget below
+        # what the raw SLO-target computation would allow.
+        min_failures = max(0, SLO.error_budget_min_failures)
+        return max(min_failures, round(self.total_tasks * (1.0 - self.slo_target)))
 
     @property
     def budget_remaining(self) -> int:

--- a/src/bernstein/core/observability/slo.py
+++ b/src/bernstein/core/observability/slo.py
@@ -119,12 +119,16 @@ class ErrorBudget:
     def budget_total(self) -> int:
         """Total allowed failures given current task count.
 
-        Always allows at least 3 failures to avoid false depletion when
-        only a few tasks have completed (e.g. 2 * 0.10 rounds to 0).
+        Always allows at least ``SLO.error_budget_min_failures`` (default 3)
+        failures to avoid false depletion when only a few tasks have
+        completed (e.g. 2 * 0.10 rounds to 0). Tunable via
+        ``tuning.slo.error_budget_min_failures`` in bernstein.yaml.
         """
+        from bernstein.core.defaults import SLO
+
         if self.total_tasks == 0:
             return 0
-        return max(3, round(self.total_tasks * (1.0 - self.slo_target)))
+        return max(SLO.error_budget_min_failures, round(self.total_tasks * (1.0 - self.slo_target)))
 
     @property
     def budget_remaining(self) -> int:

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -28,6 +28,16 @@ def _default_poll_interval_s() -> int:
     return int(_defaults.ORCHESTRATOR.tick_interval_s)
 
 
+def _default_max_agent_runtime_s() -> int:
+    """Return the current canonical agent wall-clock kill starting value.
+
+    Reads from :mod:`bernstein.core.defaults` each call (same pattern as
+    :func:`_default_poll_interval_s`) so that ``tuning.orchestrator.
+    max_agent_runtime_s`` overrides are honoured.
+    """
+    return int(_defaults.ORCHESTRATOR.max_agent_runtime_s)
+
+
 class TaskStoreUnavailable(Exception):
     """Raised when the task store cannot operate after exhausting retries.
 
@@ -1225,7 +1235,12 @@ class OrchestratorConfig:
     # Deployments that explicitly relied on the 900s value must set this field explicitly.
     heartbeat_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_stale_s))
     heartbeat_enabled: bool = True
-    max_agent_runtime_s: int = 1800  # 30 min wall-clock kill (agents need time for complex tasks)
+    # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical) so
+    # ``tuning.orchestrator.max_agent_runtime_s`` overrides the starting
+    # wall-clock kill deadline (agents need time for complex tasks; this
+    # self-extends up to a 5400s hard cap while heartbeating, see
+    # core/agents/agent_lifecycle.py - this is only the starting value).
+    max_agent_runtime_s: int = field(default_factory=_default_max_agent_runtime_s)
     max_tasks_per_agent: int = 2  # batch 2 same-role tasks per agent to reduce context overhead
     server_url: str = "http://localhost:8052"
     evolution_enabled: bool = True

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -22,6 +22,7 @@ from bernstein.adapters.openai_agents_runner import (
     EXIT_OK,
     EXIT_RATE_LIMIT,
     EXIT_SDK_MISSING,
+    MAX_TURNS_ENV_VAR,
     RunnerManifest,
     _build_agent_kwargs,
     _build_model_settings_kwargs,
@@ -29,6 +30,7 @@ from bernstein.adapters.openai_agents_runner import (
     _is_rate_limit,
     _resolve_client_kwargs,
     _resolve_heartbeat_dir,
+    _resolve_max_turns,
     _start_heartbeat,
     emit_event,
     load_manifest,
@@ -897,6 +899,45 @@ class TestRunnerHelpers:
         cfg["mcp_servers"]["other"] = {"command": "x"}
         assert "other" not in manifest.mcp_servers
 
+    def test_resolve_max_turns_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default preserves prior behavior exactly: no kwarg, SDK default (10) applies."""
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        core_defaults.reset()
+        assert _resolve_max_turns() is None
+
+    def test_resolve_max_turns_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        assert _resolve_max_turns() == 200
+
+    def test_resolve_max_turns_tuning_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        core_defaults.override("agent", {"max_turns": 80})
+        try:
+            assert _resolve_max_turns() == 80
+        finally:
+            core_defaults.reset()
+
+    def test_resolve_max_turns_env_beats_tuning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.override("agent", {"max_turns": 80})
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        try:
+            assert _resolve_max_turns() == 200
+        finally:
+            core_defaults.reset()
+
+    def test_resolve_max_turns_unparseable_env_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.reset()
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "notanumber")
+        assert _resolve_max_turns() is None
+
     def test_build_model_settings_kwargs_empty_when_absent(self) -> None:
         manifest = RunnerManifest(
             session_id="s",
@@ -1145,6 +1186,42 @@ class TestRunnerRun:
         assert usage_event["input_tokens"] == 10
         assert usage_event["output_tokens"] == 20
         assert usage_event["tool_calls"] == 1
+
+    def test_run_omits_max_turns_kwarg_by_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Unset BERNSTEIN_MAX_TURNS / tuning -> no kwarg -> SDK default (10) applies unchanged."""
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        core_defaults.reset()
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(self._manifest())
+        assert rc == EXIT_OK
+        _, kwargs = fake_runner.run_sync.call_args
+        assert "max_turns" not in kwargs
+
+    def test_run_forwards_max_turns_from_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(self._manifest())
+        assert rc == EXIT_OK
+        _, kwargs = fake_runner.run_sync.call_args
+        assert kwargs["max_turns"] == 200
 
     def test_run_without_usage_still_emits_completion(
         self,

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -938,6 +938,32 @@ class TestRunnerHelpers:
         monkeypatch.setenv(MAX_TURNS_ENV_VAR, "notanumber")
         assert _resolve_max_turns() is None
 
+    def test_resolve_max_turns_zero_env_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A 0 max_turns would fail every run on turn one - reject, don't forward."""
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.reset()
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "0")
+        assert _resolve_max_turns() is None
+
+    def test_resolve_max_turns_negative_env_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.reset()
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "-5")
+        assert _resolve_max_turns() is None
+
+    def test_resolve_max_turns_negative_env_falls_back_to_tuning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-positive env value falls through to tuning.agent.max_turns, not just None."""
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "-5")
+        core_defaults.override("agent", {"max_turns": 80})
+        try:
+            assert _resolve_max_turns() == 80
+        finally:
+            core_defaults.reset()
+
     def test_build_model_settings_kwargs_empty_when_absent(self) -> None:
         manifest = RunnerManifest(
             session_id="s",

--- a/tests/unit/test_orchestrator_config_stale_claim.py
+++ b/tests/unit/test_orchestrator_config_stale_claim.py
@@ -52,3 +52,23 @@ def test_reset_restores_original_stale_claim_timeout() -> None:
     cfg = OrchestratorConfig()
     assert cfg.stale_claim_timeout_s == pytest.approx(900.0)
     assert cfg.drain_timeout_s == pytest.approx(60.0)
+
+
+def test_max_agent_runtime_defaults_match_singleton() -> None:
+    """Same gap class: max_agent_runtime_s was a plain hardcoded field, not tuning-backed."""
+    cfg = OrchestratorConfig()
+    assert cfg.max_agent_runtime_s == defaults.ORCHESTRATOR.max_agent_runtime_s
+    assert cfg.max_agent_runtime_s == 1800
+
+
+def test_override_flows_into_new_max_agent_runtime() -> None:
+    override("orchestrator", {"max_agent_runtime_s": 3600})
+    cfg = OrchestratorConfig()
+    assert cfg.max_agent_runtime_s == 3600
+
+
+def test_reset_restores_original_max_agent_runtime() -> None:
+    override("orchestrator", {"max_agent_runtime_s": 60})
+    reset()
+    cfg = OrchestratorConfig()
+    assert cfg.max_agent_runtime_s == 1800

--- a/tests/unit/test_slo.py
+++ b/tests/unit/test_slo.py
@@ -41,6 +41,30 @@ def test_error_budget_remediation() -> None:
     assert tracker.error_budget.status == SLOStatus.RED
 
 
+def test_error_budget_floor_defaults_to_three() -> None:
+    """Regression test: budget_total floor is tunable, default unchanged at 3."""
+    from bernstein.core import defaults
+    from bernstein.core.observability.slo import ErrorBudget
+
+    defaults.reset()
+    budget = ErrorBudget(total_tasks=10, failed_tasks=0)
+    assert budget.budget_total == 3
+
+
+def test_error_budget_floor_honors_tuning_override() -> None:
+    """tuning.slo.error_budget_min_failures raises the tolerated-failure floor (#run5 audit)."""
+    from bernstein.core import defaults
+    from bernstein.core.observability.slo import ErrorBudget
+
+    defaults.override("slo", {"error_budget_min_failures": 20})
+    try:
+        budget = ErrorBudget(total_tasks=10, failed_tasks=10)
+        assert budget.budget_total == 20
+        assert not budget.is_depleted
+    finally:
+        defaults.reset()
+
+
 def test_slo_tracker_update_from_collector() -> None:
     """Test updating SLO values from metrics collector."""
     tracker = SLOTracker()

--- a/tests/unit/test_slo.py
+++ b/tests/unit/test_slo.py
@@ -65,6 +65,21 @@ def test_error_budget_floor_honors_tuning_override() -> None:
         defaults.reset()
 
 
+def test_error_budget_floor_clamps_negative_override() -> None:
+    """A misconfigured negative error_budget_min_failures must not suppress the
+    SLO-target-derived budget below what an unset floor would allow."""
+    from bernstein.core import defaults
+    from bernstein.core.observability.slo import ErrorBudget
+
+    defaults.override("slo", {"error_budget_min_failures": -5})
+    try:
+        budget = ErrorBudget(total_tasks=10, failed_tasks=0)
+        # round(10 * (1 - 0.90)) == 1, clamped floor of 0 must not pull this below 1.
+        assert budget.budget_total == 1
+    finally:
+        defaults.reset()
+
+
 def test_slo_tracker_update_from_collector() -> None:
     """Test updating SLO values from metrics collector."""
     tracker = SLOTracker()


### PR DESCRIPTION
## Summary

Real-repo orchestration runs hit three ceilings on the `openai_agents`
adapter path that had no operator-facing override — a small companion
to #2182 (also from today's production evidence, see linked audit below).

1. **`Runner.run_sync` had no `max_turns` kwarg at all** — the SDK's own
   default (10) applied silently. A manager doing legitimate
   root-cause investigation before decomposing, or a worker on a
   multi-file refactor, can exceed 10 turns easily and hits
   `MaxTurnsExceeded`, losing all progress on re-queue.
2. **`ErrorBudget.budget_total` floor was `max(3, ...)` inline** — 3
   tolerated failures is too tight when early failures are infra-death
   retries (rate limits, transient auth) rather than real task
   failures; `IncidentManager` auto-pauses the run.
3. **`OrchestratorConfig.max_agent_runtime_s` was a plain `int = 1800`
   field**, not wired through the `tuning:` mechanism the way
   `stale_claim_timeout_s` already is — so `tuning.orchestrator.
   max_agent_runtime_s` silently did nothing.

## Changes — all three defaults are UNCHANGED, this only adds an override surface

- `AgentDefaults.max_turns: int | None = None` (`defaults.py`). `None`
  omits the `max_turns` kwarg entirely, so the SDK's own default (10)
  applies exactly as before. `openai_agents_runner._resolve_max_turns()`
  resolves `BERNSTEIN_MAX_TURNS` env (checked first) >
  `tuning.agent.max_turns` > `None`, with a `logger.warning` (not a
  crash) on an unparseable env value.
- `SLODefaults.error_budget_min_failures: int = 3` — new dataclass +
  `tuning:` section (registered in `_SECTION_TO_ATTR`/`_ATTR_TO_FACTORY`
  alongside the 23 existing sections). `ErrorBudget.budget_total` now
  reads this instead of the inline literal `3`. Override via
  `tuning.slo.error_budget_min_failures`.
- `OrchestratorDefaults.max_agent_runtime_s: int = 1800` (new field),
  `OrchestratorConfig.max_agent_runtime_s` now sourced via
  `default_factory` from it, mirroring the existing
  `poll_interval_s`/`stale_claim_timeout_s` pattern.

## Test plan

- [x] New tests: `max_turns` resolution precedence (env / tuning /
  None-default / unparseable-env-fallback), end-to-end `run_sync` kwarg
  forwarding (both omitted-by-default and forwarded-when-set), error-budget
  floor default + tuning override + `is_depleted` behavior,
  `OrchestratorConfig` default/override/reset triad for
  `max_agent_runtime_s` (mirroring the existing `stale_claim_timeout_s`
  regression test in `test_orchestrator_config_stale_claim.py`).
- [x] `uv run --python 3.13.6 --isolated pytest tests/unit/adapters/test_openai_agents.py tests/unit/test_slo.py tests/unit/test_orchestrator_config_stale_claim.py tests/unit/test_slo_extended.py tests/unit/test_slo_burndown.py tests/unit/test_slo_cmd.py -x -q` — 181 passed (all pre-existing tests green unmodified, since the default behavior is byte-for-byte unchanged).
- [x] `uv run --python 3.13.6 --isolated pytest tests/unit/test_defaults.py -x -q` — 15 passed (no regression in the `override`/`reset` machinery from the new `SLO` section).
- [x] `uv run ruff check` clean on all touched files.
- [x] `uv run lint-imports` — 3 kept, 0 broken.

Docs: `docs/operations/CONFIG.md` §4.1 (new) + env var table entry.

## Summary by Sourcery

Make agent run-length and SLO/error-budget limits configurable while preserving existing default behaviors.

New Features:
- Allow overriding the OpenAI Agents runner turn ceiling via the BERNSTEIN_MAX_TURNS environment variable and tuning.agent.max_turns.
- Introduce a tunable SLO error budget minimum failure floor via tuning.slo.error_budget_min_failures.
- Make OrchestratorConfig.max_agent_runtime_s derive from OrchestratorDefaults so it can be configured via tuning.orchestrator.max_agent_runtime_s.

Documentation:
- Document the new agent run-length configuration options and BERNSTEIN_MAX_TURNS in CONFIG.md, including examples of tuning overrides.

Tests:
- Add tests for max_turns resolution and forwarding to Runner.run_sync, SLO error budget floor defaults and overrides, and orchestrator max_agent_runtime_s default/override/reset behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `BERNSTEIN_MAX_TURNS` to override effective agent turn limits, with clear precedence over tuning defaults.
  * Introduced tunable agent wall-clock runtime start deadline (`orchestrator.max_agent_runtime_s`).
  * Added tunable SLO minimum failure floor (`tuning.slo.error_budget_min_failures`).
* **Bug Fixes**
  * Invalid or non-positive `BERNSTEIN_MAX_TURNS` no longer breaks behavior; it falls back safely.
  * Negative minimum-failure tuning is clamped to prevent unintended budget suppression.
* **Documentation**
  * Updated configuration docs with the new variable, precedence, and runtime semantics.
* **Tests**
  * Expanded unit coverage for turn resolution, runtime defaults/overrides, and SLO budget floor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->