### PR TITLE
fix(observability): classifier false positives on tool-traffic data (#2183)

### DIFF
--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -120,6 +120,45 @@ grep -i "rate limit\|429\|hit your limit\|resets" .sdd/runtime/*.log
 - Use the `TierAwareRouter` to balance across multiple providers (Claude + Codex + Gemini).
 - For batch-eligible tasks, set `batch_eligible: true` to route to provider batch APIs at reduced cost.
 
+### 4a. Healthy worker killed as a false-positive rate-limit hit
+
+**Symptom:** A worker that was making normal progress gets killed and the
+run falls back to a more expensive sticky provider, even though the
+provider dashboard shows no throttling. `.sdd/runtime/*.log` shows a
+`_scan_log_for_patterns: matched RISKY pattern ...` line pointing at a
+structured `tool_call`/`tool_result` JSON line, a `"max_tokens": ...`
+manifest dump, or a `"timeout": <n>` tool argument.
+
+**Cause:** `core/observability/rate_limit_tracker.py`'s log-scanning
+classifier (`_scan_log_for_patterns`) infers 429/throttle events from raw
+agent subprocess output. Bare substrings (`"413"`, `"429"`, `"401"`,
+`"403"`, `"504"`) and generic English words (`timeout`, `rate limit`,
+`unauthorized`, ...) previously matched anywhere in the log tail,
+including inside an agent's own JSON tool traffic where those tokens
+carry zero relation to a real provider error (byte counts, arg names,
+target-repo code being read). Fixed 2026-07-02 (#2183): structured
+`tool_call`/`tool_result`/`heartbeat` lines are now skipped entirely, and
+every remaining risky bare token/word only counts as a match when it
+appears on a line that also carries explicit error context
+(`error|status|http|code|exception|failed|failure|traceback`, matched
+with a word boundary via `_ERROR_CONTEXT_RE`).
+
+**Diagnosis:**
+```bash
+# Every classifier match is logged with the matched line - one read
+# tells you whether it was a real provider error or a data false-positive.
+grep "_scan_log_for_patterns: matched" .sdd/runtime/*.log
+```
+
+**Resolution:**
+- If the matched line is agent-produced data (tool JSON, code being
+  read) rather than a real HTTP/provider error, it's a classifier gap -
+  file an issue with the matched line so the pattern/context list can be
+  tightened further.
+- No operator action needed for the fixed patterns above; upgrade to a
+  release containing #2183 if you're still seeing this on unrelated data
+  lines.
+
 ---
 
 ## 5. Budget Exceeded

--- a/src/bernstein/core/observability/rate_limit_tracker.py
+++ b/src/bernstein/core/observability/rate_limit_tracker.py
@@ -14,6 +14,7 @@ Implements:
 from __future__ import annotations
 
 import enum
+import json
 import logging
 import os
 import re
@@ -152,7 +153,27 @@ _CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
 # `"max_tokens": 16384` (which incidentally contains the digits 4-1-3 nowhere,
 # but DOES contain other risky substrings like "429" in unrelated counters)
 # does not. See 2026-07-02 false-positive incident (runs 4/5/6 killed).
-_RISKY_BARE_TOKENS: frozenset[str] = frozenset({"413", "429", "401", "403", "504", "context window"})
+_RISKY_BARE_TOKENS: frozenset[str] = frozenset({
+    # bare HTTP codes — match inside byte counts / ids / timestamps
+    "413", "429", "401", "403", "504",
+    # generic words/phrases — appear freely in tool output, target-repo code
+    # being read, and test stdout (2026-07-02 run 7: `"timeout": 5` in a
+    # tool-call JSON killed a healthy manager)
+    "context window",
+    "timeout", "timed out", "time out",
+    "request timeout", "connect timeout", "read timeout", "gateway timeout",
+    "rate limit", "rate_limit", "ratelimit", "overloaded",
+    "hit your limit", "usage cap",
+    "unauthorized", "forbidden",
+    "invalid_client", "invalid_token", "expired_token",
+    "connection refused", "connection reset", "econnrefused", "econnreset",
+    "api_error",
+})
+
+# Structured agent-log lines that carry DATA (tool traffic, heartbeats), not
+# provider errors. Never scanned: a tool result legitimately contains target
+# repo code/output with words like "unauthorized" or "TimeoutError" in it.
+_DATA_LINE_TYPES: frozenset[str] = frozenset({"tool_call", "tool_result", "heartbeat"})
 
 # Words that indicate a line is plausibly describing a real provider/HTTP
 # error, rather than incidental structured data. Deliberately narrow —
@@ -512,6 +533,14 @@ class RateLimitTracker:
 
         lines = text.splitlines()[-_LOG_SCAN_TAIL_LINES:]
         for line in lines:
+            stripped = line.lstrip()
+            if stripped.startswith("{"):
+                try:
+                    _obj = json.loads(stripped)
+                except ValueError:
+                    _obj = None
+                if isinstance(_obj, dict) and _obj.get("type") in _DATA_LINE_TYPES:
+                    continue
             lower_line = line.lower()
             for pat in patterns:
                 pat_lower = pat.lower()

--- a/src/bernstein/core/observability/rate_limit_tracker.py
+++ b/src/bernstein/core/observability/rate_limit_tracker.py
@@ -153,22 +153,43 @@ _CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
 # `"max_tokens": 16384` (which incidentally contains the digits 4-1-3 nowhere,
 # but DOES contain other risky substrings like "429" in unrelated counters)
 # does not. See 2026-07-02 false-positive incident (runs 4/5/6 killed).
-_RISKY_BARE_TOKENS: frozenset[str] = frozenset({
-    # bare HTTP codes — match inside byte counts / ids / timestamps
-    "413", "429", "401", "403", "504",
-    # generic words/phrases — appear freely in tool output, target-repo code
-    # being read, and test stdout (2026-07-02 run 7: `"timeout": 5` in a
-    # tool-call JSON killed a healthy manager)
-    "context window",
-    "timeout", "timed out", "time out",
-    "request timeout", "connect timeout", "read timeout", "gateway timeout",
-    "rate limit", "rate_limit", "ratelimit", "overloaded",
-    "hit your limit", "usage cap",
-    "unauthorized", "forbidden",
-    "invalid_client", "invalid_token", "expired_token",
-    "connection refused", "connection reset", "econnrefused", "econnreset",
-    "api_error",
-})
+_RISKY_BARE_TOKENS: frozenset[str] = frozenset(
+    {
+        # bare HTTP codes — match inside byte counts / ids / timestamps
+        "413",
+        "429",
+        "401",
+        "403",
+        "504",
+        # generic words/phrases — appear freely in tool output, target-repo code
+        # being read, and test stdout (2026-07-02 run 7: `"timeout": 5` in a
+        # tool-call JSON killed a healthy manager)
+        "context window",
+        "timeout",
+        "timed out",
+        "time out",
+        "request timeout",
+        "connect timeout",
+        "read timeout",
+        "gateway timeout",
+        "rate limit",
+        "rate_limit",
+        "ratelimit",
+        "overloaded",
+        "hit your limit",
+        "usage cap",
+        "unauthorized",
+        "forbidden",
+        "invalid_client",
+        "invalid_token",
+        "expired_token",
+        "connection refused",
+        "connection reset",
+        "econnrefused",
+        "econnreset",
+        "api_error",
+    }
+)
 
 # Structured agent-log lines that carry DATA (tool traffic, heartbeats), not
 # provider errors. Never scanned: a tool result legitimately contains target
@@ -178,9 +199,7 @@ _DATA_LINE_TYPES: frozenset[str] = frozenset({"tool_call", "tool_result", "heart
 # Words that indicate a line is plausibly describing a real provider/HTTP
 # error, rather than incidental structured data. Deliberately narrow —
 # broadening this list re-opens the false-positive hole this patch closes.
-_ERROR_CONTEXT_RE = re.compile(
-    r"\b(error|status|http|code|exception|failed|failure|traceback)\b", re.IGNORECASE
-)
+_ERROR_CONTEXT_RE = re.compile(r"\b(error|status|http|code|exception|failed|failure|traceback)\b", re.IGNORECASE)
 
 _BASE_THROTTLE_S: float = 60.0
 _MAX_THROTTLE_S: float = 3600.0
@@ -550,8 +569,7 @@ class RateLimitTracker:
                     if not _ERROR_CONTEXT_RE.search(lower_line):
                         continue
                     logger.info(
-                        "_scan_log_for_patterns: matched RISKY pattern %r "
-                        "(with error context) in %s, line: %s",
+                        "_scan_log_for_patterns: matched RISKY pattern %r (with error context) in %s, line: %s",
                         pat,
                         log_path,
                         line.strip()[:300],

--- a/src/bernstein/core/observability/rate_limit_tracker.py
+++ b/src/bernstein/core/observability/rate_limit_tracker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import enum
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +50,12 @@ class RequestPriority(enum.Enum):
 
 # Text patterns that indicate a rate-limit / 429 event in agent logs.
 # Checked case-insensitively against the last 500 lines of the log.
+#
+# NOTE: "429" is a *risky bare token* (see _RISKY_BARE_TOKENS below) — a bare
+# number matches freely inside structured JSON log data (byte counts, task
+# IDs, timestamps) that has nothing to do with a rate-limit event. It is only
+# treated as a hit when it appears on a line that ALSO contains explicit
+# error context (see _ERROR_CONTEXT_RE).
 _RATE_LIMIT_PATTERNS: tuple[str, ...] = (
     "rate limit",
     "rate_limit",
@@ -76,7 +83,7 @@ _TIMEOUT_PATTERNS: tuple[str, ...] = (
     "TimeoutError",
     "ConnectTimeoutError",
     "ReadTimeoutError",
-    "504",
+    "504",  # risky bare token — see _RISKY_BARE_TOKENS
     "gateway timeout",
 )
 
@@ -97,6 +104,7 @@ _API_ERROR_PATTERNS: tuple[str, ...] = (
 )
 
 # Text patterns that indicate an authentication error (401, 403) in agent logs.
+# "401"/"403" are risky bare tokens — see _RISKY_BARE_TOKENS.
 _AUTH_ERROR_PATTERNS: tuple[str, ...] = (
     "401",
     "403",
@@ -110,13 +118,21 @@ _AUTH_ERROR_PATTERNS: tuple[str, ...] = (
 )
 
 # Text patterns that indicate a context-overflow / prompt-too-long (413) error.
+#
+# "413" and "context window" are risky bare/generic tokens (see
+# _RISKY_BARE_TOKENS) — they match freely inside structured JSON tool-result
+# and manifest dumps that have nothing to do with a real provider error.
+# "max_tokens" was REMOVED outright (not just demoted to risky): it is a
+# completely ordinary field name in request/response manifests and provides
+# no error signal even with context words nearby — see 2026-07-02 incident
+# (runs 4/5/6 killed by healthy MiniMax-M3 workers whose JSON logs contained
+# `"max_tokens": 16384` and numbers containing 413/429).
 _CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
     "413",
     "prompt is too long",
     "prompt too long",
     "context window",
     "context_length_exceeded",
-    "max_tokens",
     "maximum context length",
     "token limit exceeded",
     "request too large",
@@ -125,6 +141,24 @@ _CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
     "prompt_too_long",
     "context length exceeded",
     "PromptTooLongError",
+)
+
+# Bare numbers / generic words that are common in structured JSON log data
+# (tool-call results, manifest dumps, byte counts, task IDs) and therefore
+# cannot be trusted as failure signals on their own. A risky token only
+# counts as a match when it appears with a word boundary on a line that ALSO
+# contains explicit error context (see _ERROR_CONTEXT_RE) — e.g.
+# "Error code: 413 - request too large" matches, but a JSON blob containing
+# `"max_tokens": 16384` (which incidentally contains the digits 4-1-3 nowhere,
+# but DOES contain other risky substrings like "429" in unrelated counters)
+# does not. See 2026-07-02 false-positive incident (runs 4/5/6 killed).
+_RISKY_BARE_TOKENS: frozenset[str] = frozenset({"413", "429", "401", "403", "504", "context window"})
+
+# Words that indicate a line is plausibly describing a real provider/HTTP
+# error, rather than incidental structured data. Deliberately narrow —
+# broadening this list re-opens the false-positive hole this patch closes.
+_ERROR_CONTEXT_RE = re.compile(
+    r"\b(error|status|http|code|exception|failed|failure|traceback)\b", re.IGNORECASE
 )
 
 _BASE_THROTTLE_S: float = 60.0
@@ -448,12 +482,25 @@ class RateLimitTracker:
     def _scan_log_for_patterns(self, log_path: Path, patterns: tuple[str, ...]) -> bool:
         """Scan the tail of *log_path* for any of the given patterns.
 
+        Patterns in ``_RISKY_BARE_TOKENS`` (bare numbers like "413"/"429" and
+        generic phrases like "context window") are NOT matched by plain
+        substring containment — structured JSON log lines (tool results,
+        manifest dumps) are full of numbers and common words that would
+        otherwise false-positive-kill a healthy worker (2026-07-02 incident:
+        runs 4/5/6 killed by this exact failure mode). A risky token only
+        counts as a match when (a) it appears with a real word boundary, AND
+        (b) the SAME line also contains explicit error context per
+        ``_ERROR_CONTEXT_RE``. All other patterns keep the original
+        case-insensitive substring behaviour, scanned line-by-line so the
+        matched line can be logged for diagnosis.
+
         Args:
             log_path: Path to the agent's subprocess log file.
             patterns: Tuple of strings to search for (case-insensitive).
 
         Returns:
-            True if any pattern was found, False otherwise.
+            True if any pattern was found, False otherwise (including
+            when the file does not exist or cannot be read).
         """
         if not log_path.exists():
             return False
@@ -464,8 +511,32 @@ class RateLimitTracker:
             return False
 
         lines = text.splitlines()[-_LOG_SCAN_TAIL_LINES:]
-        snippet = "\n".join(lines).lower()
-        return any(pat.lower() in snippet for pat in patterns)
+        for line in lines:
+            lower_line = line.lower()
+            for pat in patterns:
+                pat_lower = pat.lower()
+                if pat_lower in _RISKY_BARE_TOKENS:
+                    if not re.search(rf"\b{re.escape(pat_lower)}\b", lower_line):
+                        continue
+                    if not _ERROR_CONTEXT_RE.search(lower_line):
+                        continue
+                    logger.info(
+                        "_scan_log_for_patterns: matched RISKY pattern %r "
+                        "(with error context) in %s, line: %s",
+                        pat,
+                        log_path,
+                        line.strip()[:300],
+                    )
+                    return True
+                elif pat_lower in lower_line:
+                    logger.info(
+                        "_scan_log_for_patterns: matched pattern %r in %s, line: %s",
+                        pat,
+                        log_path,
+                        line.strip()[:300],
+                    )
+                    return True
+        return False
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -292,3 +292,109 @@ class TestRouterRateLimitIntegration:
         # With success_rate=1.0 and zero active agents, spreading term = 1.0 * 0.10
         # health=1.0*0.35 + cost=1.0*0.25 + free=0*0.2 + latency=1.0*0.10 + spread=1.0*0.10 = 0.80
         assert abs(score - 0.80) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Regression: risky bare-substring patterns must not false-positive on
+# structured JSON log data (2026-07-02 incident — runs 4/5/6 killed).
+# ---------------------------------------------------------------------------
+
+
+class TestRiskyBareTokenFalsePositives:
+    """Structured JSON tool-result / manifest lines must NOT trigger a
+    failure classification just because they contain a risky bare number or
+    generic phrase like "max_tokens", "413", or "429" with no error context.
+    """
+
+    def test_no_context_overflow_on_json_manifest_line(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "tool_result", "tool": "spawn", "manifest": '
+            '{"max_tokens": 16384, "model": "MiniMax-M3", "batch_id": 413}}\n'
+        )
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_context_overflow(log)
+
+    def test_no_rate_limit_on_json_counters_line(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "tool_result", "bytes_written": 429, "duration_ms": 129413}\n'
+        )
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_429(log)
+
+    def test_no_auth_error_on_json_status_code_line(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text('{"type": "tool_result", "port": 401, "queue_depth": 403}\n')
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_auth_error(log)
+
+    def test_no_failure_type_detected_on_healthy_worker_json_log(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact incident shape: a healthy worker's structured log full
+        of tool results and a manifest dump must classify as no failure."""
+        log = tmp_path / "agent.log"
+        log.write_text(
+            "\n".join(
+                [
+                    '{"type": "tool_call", "name": "Read", "input": {"path": "x.py"}}',
+                    '{"type": "tool_result", "manifest": {"max_tokens": 16384}}',
+                    '{"type": "tool_result", "bytes": 413129, "count": 429}',
+                    '{"type": "assistant", "text": "Task complete."}',
+                ]
+            )
+        )
+        tracker = RateLimitTracker()
+        assert tracker.detect_failure_type(log) is None
+
+    def test_max_tokens_removed_outright_even_with_error_context(
+        self, tmp_path: Path
+    ) -> None:
+        """max_tokens was removed from the pattern list entirely, not just
+        demoted to risky — it must not fire even next to the word "error"."""
+        log = tmp_path / "agent.log"
+        log.write_text('{"error": "none", "max_tokens": 16384}\n')
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_context_overflow(log)
+
+
+class TestRiskyBareTokenTruePositives:
+    """Genuine provider errors with real error context must still be
+    detected — the fix must not blind the classifier entirely."""
+
+    def test_detects_413_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("Error code: 413 - request too large\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_context_overflow(log)
+
+    def test_detects_context_length_exceeded_phrase(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("openai.BadRequestError: context_length_exceeded\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_context_overflow(log)
+
+    def test_detects_429_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("HTTP status 429 received from provider\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_429(log)
+
+    def test_detects_401_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("Request failed with HTTP error 401 Unauthorized\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_auth_error(log)
+
+    def test_detects_504_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("gateway returned status 504\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_timeout(log)
+
+    def test_detects_context_window_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("Error: context window exceeded for this request\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_context_overflow(log)

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -317,9 +317,7 @@ class TestRiskyBareTokenFalsePositives:
 
     def test_no_rate_limit_on_json_counters_line(self, tmp_path: Path) -> None:
         log = tmp_path / "agent.log"
-        log.write_text(
-            '{"type": "tool_result", "bytes_written": 429, "duration_ms": 129413}\n'
-        )
+        log.write_text('{"type": "tool_result", "bytes_written": 429, "duration_ms": 129413}\n')
         tracker = RateLimitTracker()
         assert not tracker.scan_log_for_429(log)
 
@@ -329,9 +327,7 @@ class TestRiskyBareTokenFalsePositives:
         tracker = RateLimitTracker()
         assert not tracker.scan_log_for_auth_error(log)
 
-    def test_no_failure_type_detected_on_healthy_worker_json_log(
-        self, tmp_path: Path
-    ) -> None:
+    def test_no_failure_type_detected_on_healthy_worker_json_log(self, tmp_path: Path) -> None:
         """The exact incident shape: a healthy worker's structured log full
         of tool results and a manifest dump must classify as no failure."""
         log = tmp_path / "agent.log"
@@ -348,9 +344,7 @@ class TestRiskyBareTokenFalsePositives:
         tracker = RateLimitTracker()
         assert tracker.detect_failure_type(log) is None
 
-    def test_max_tokens_removed_outright_even_with_error_context(
-        self, tmp_path: Path
-    ) -> None:
+    def test_max_tokens_removed_outright_even_with_error_context(self, tmp_path: Path) -> None:
         """max_tokens was removed from the pattern list entirely, not just
         demoted to risky — it must not fire even next to the word "error"."""
         log = tmp_path / "agent.log"
@@ -406,6 +400,7 @@ class TestDataLineAndGenericWordFalsePositives:
 
     def _tracker(self):
         from bernstein.core.observability.rate_limit_tracker import RateLimitTracker
+
         return RateLimitTracker()
 
     def test_tool_traffic_lines_never_match(self, tmp_path):

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -398,3 +398,45 @@ class TestRiskyBareTokenTruePositives:
         log.write_text("Error: context window exceeded for this request\n")
         tracker = RateLimitTracker()
         assert tracker.scan_log_for_context_overflow(log)
+
+
+class TestDataLineAndGenericWordFalsePositives:
+    """2026-07-02 run-7 regression: healthy agents killed by generic words in
+    structured JSON log lines (`"timeout": 5` in a tool_call payload)."""
+
+    def _tracker(self):
+        from bernstein.core.observability.rate_limit_tracker import RateLimitTracker
+        return RateLimitTracker()
+
+    def test_tool_traffic_lines_never_match(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "tool_call", "name": "run_command", "args": {"argv": ["pnpm", "test"], "timeout": 5}}\n'
+            '{"type": "tool_result", "name": "read_file", "ok": true, "result": {"bytes": 64133, "preview": "if (unauthorized) throw new Error(\'forbidden\'); // rate limit retry"}}\n'
+            '{"type": "tool_result", "name": "run_command", "ok": false, "result": {"stderr_preview": "Error: connect ECONNREFUSED 127.0.0.1:5432 — test timed out"}}\n'
+            '{"type": "heartbeat", "phase": "running", "timeout": 429}\n'
+            '{"type": "tool_result", "name": "read_file", "result": {"preview": "max_tokens: 16384, TimeoutError handling, status 413 code"}}\n'
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_generic_words_without_error_context_never_match(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text(
+            "setting request timeout to 30s for provider\n"
+            "the rate limit configuration was loaded\n"
+            "unauthorized users are redirected to login\n"
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_real_provider_errors_still_detected(self, tmp_path):
+        cases = {
+            "rate_limit": '{"type": "error", "kind": "api", "message": "Error code: 429 - rate limit exceeded"}\n',
+            "timeout": "openai.APITimeoutError: HTTP request failed: read timeout\n",
+            "context_overflow": '{"type": "error", "message": "Error code: 413 - request too large: maximum context length exceeded"}\n',
+            "auth_error": "openai.AuthenticationError: Error code: 401 - invalid api key\n",
+            "api_error": "httpx.ConnectError: connection refused (APIConnectionError) — request failed\n",
+        }
+        for expected, line in cases.items():
+            log = tmp_path / f"{expected}.log"
+            log.write_text(line)
+            assert self._tracker().detect_failure_type(log) == expected, expected


### PR DESCRIPTION
## Summary

Fixes #2183. The failure classifier in `core/observability/rate_limit_tracker.py`
(`_scan_log_for_patterns`) infers 429/throttle events from raw agent
subprocess log tails. Its pattern list mixed unambiguous multi-word phrases
with bare substrings (`"413"`, `"429"`, `"401"`, `"403"`, `"504"`) and the
fully generic field name `"max_tokens"`, matched case-insensitively against
the entire log tail — including an agent's own structured tool-call/
tool-result JSON, which routinely contains those exact tokens with zero
relation to a real provider error (byte counts, arg values, target-repo
code being read).

This false-positive-killed healthy MiniMax-M3 workers in 4 consecutive
orchestration runs today (runs 4-7, 2026-07-02):

- Runs 4-6: `"max_tokens": 16384` in a manifest dump, and byte
  counts/ids containing the digit sequences `413`/`429`, matched with no
  error context.
- Run 7: a `"timeout": 5` tool-call argument in structured tool JSON
  matched the generic word `timeout`.

Each false kill cascaded the run to the more expensive sticky-fallback
provider, silently multiplying cost with no operator-visible signal
beyond a terse classifier match.

## Changes

- `_RISKY_BARE_TOKENS`: removed `"max_tokens"` outright (pure noise, no
  signal even with error context).
- Remaining risky bare tokens (HTTP codes) and previously-unconditional
  generic words (`timeout`, `rate limit`, `unauthorized`, `forbidden`,
  `connection refused`, ...) now only count as a match when they appear
  with a word boundary on a line that **also** carries explicit error
  context, via a new `_ERROR_CONTEXT_RE` matching
  `error|status|http|code|exception|failed|failure|traceback`.
  Unambiguous multi-word patterns (e.g. `"invalid_token"`) keep their
  original substring behavior unchanged.
- Structured agent-log lines typed `tool_call`/`tool_result`/`heartbeat`
  are now skipped entirely before pattern scanning — they are agent DATA
  (target-repo code, test stdout, tool arg payloads), never provider
  errors, and no context-requirement can safely rescue every case (e.g. a
  file literally named `429.txt` inside a `tool_result`).
- Every match is now logged with the matched line
  (`_scan_log_for_patterns: matched ... in <path>, line: <line>`) for
  one-read diagnosis of future false positives, per this repo's logging
  policy.
- Docs: `docs/operations/TROUBLESHOOTING.md` §4a (new) — symptom, root
  cause, one-line diagnostic grep, and resolution guidance for operators
  who hit this failure mode.

## Test plan

- [x] `uv run --python 3.13.6 --isolated pytest tests/unit/test_rate_limit_tracker.py -q` — 45 passed (regression coverage for both fixes: tool-traffic-line skip, context-required bare tokens/words, `max_tokens` removal).
- [x] `uv run ruff format --check src/ tests/` — clean.
- [x] `uv run ruff check src/ tests/` — clean.

## Evidence

Healthy MiniMax-M3 workers killed by false-positive rate-limit
classification in 4 consecutive orchestration runs
(`work/agent-reports/evidence-2026-07-02-run6/spawner.log` and the run-7
regression referenced in the second cherry-picked commit) before the
worker had actually hit any real provider throttle — confirmed against
provider dashboards showing no throttling at the time of each kill.

## Summary by Sourcery

Tighten the log-based failure classifier to avoid false-positive rate-limit and error detections on structured tool traffic while preserving detection of genuine provider errors.

Bug Fixes:
- Prevent false-positive rate-limit, timeout, and auth-error classifications caused by bare status codes and generic words appearing inside structured JSON tool logs.
- Exclude tool_call, tool_result, and heartbeat JSON lines from failure classification to avoid misinterpreting normal tool traffic as provider failures.
- Remove max_tokens from context-overflow patterns so common manifest fields no longer trigger spurious overflow detection, even when near error-like text.

Enhancements:
- Require risky bare tokens and generic phrases to appear with word boundaries and explicit error context before they count as classifier matches, and log the specific matching line for diagnosis.
- Add targeted unit tests to cover both false-positive regressions and true-positive detection of rate-limit, timeout, context-overflow, auth, and API errors.

Documentation:
- Extend troubleshooting documentation with guidance on diagnosing and resolving false-positive rate-limit classifications caused by log pattern matching.