### PR TITLE
fix: janitor path_exists honors explicit globs + opt-in fuzzy basename fallback (#2186)

### DIFF
--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -142,7 +142,7 @@ Environment variables are useful in CI and automation. Common variables:
 | `BERNSTEIN_COMPLIANCE` | Compliance preset override |
 | `BERNSTEIN_QUIET` | Quiet mode (reduced terminal output) |
 | `BERNSTEIN_AUDIT` | Enable extra audit behavior in run flow |
-| `BERNSTEIN_JANITOR_FUZZY_PATH_MATCH` | `path_exists` completion-signal matching. Default `1` (on): a literal miss falls back to interpreting the value as a glob, then to a fuzzy basename pattern (`**/<stem>*<suffix>`), so a manager-guessed path (e.g. `packages/db/test/foo.test.ts`) still matches a worker's repo-idiomatic path (e.g. `packages/db/src/__tests__/foo.test.ts`). Set to `0`/`false`/`no`/`off` to require an exact literal path match (pre-#2186 behavior). See [TROUBLESHOOTING.md #21](TROUBLESHOOTING.md#21-janitor-path_exists-fails-on-a-correctly-placed-file-acceptance-path-mismatch). |
+| `BERNSTEIN_JANITOR_FUZZY_PATHS` | Opt-in fuzzy matching for `path_exists` completion signals. **Default `0` (off)**: exact-path matching is unchanged — the check means exactly the path written in the plan. Set to `1` to enable a fuzzy fallback on a literal miss: a pattern derived from the basename (`**/<stem>*<suffix>`) so a manager-guessed path (e.g. `packages/db/test/foo.test.ts`) can match a worker's repo-idiomatic path (e.g. `packages/db/src/__tests__/foo.test.ts`). A fuzzy match logs a WARNING naming the matched path. Explicit glob syntax written in the criterion itself (`*`, `?`, `[`) is always honored, regardless of this flag. See [TROUBLESHOOTING.md #21](TROUBLESHOOTING.md#21-janitor-path_exists-fails-on-a-correctly-placed-file-acceptance-path-mismatch). |
 
 ---
 

--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -142,6 +142,7 @@ Environment variables are useful in CI and automation. Common variables:
 | `BERNSTEIN_COMPLIANCE` | Compliance preset override |
 | `BERNSTEIN_QUIET` | Quiet mode (reduced terminal output) |
 | `BERNSTEIN_AUDIT` | Enable extra audit behavior in run flow |
+| `BERNSTEIN_JANITOR_FUZZY_PATH_MATCH` | `path_exists` completion-signal matching. Default `1` (on): a literal miss falls back to interpreting the value as a glob, then to a fuzzy basename pattern (`**/<stem>*<suffix>`), so a manager-guessed path (e.g. `packages/db/test/foo.test.ts`) still matches a worker's repo-idiomatic path (e.g. `packages/db/src/__tests__/foo.test.ts`). Set to `0`/`false`/`no`/`off` to require an exact literal path match (pre-#2186 behavior). See [TROUBLESHOOTING.md #21](TROUBLESHOOTING.md#21-janitor-path_exists-fails-on-a-correctly-placed-file-acceptance-path-mismatch). |
 
 ---
 

--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -472,16 +472,22 @@ find . -name "*<basename-without-extension>*"
 ```
 
 **Resolution:**
-- As of this fix, `path_exists` no longer fails on a pure literal miss. It
-  falls back, in order: (1) the literal path, (2) the same string
-  interpreted as a glob pattern, (3) a fuzzy pattern derived from the
-  basename (`**/<stem>*<suffix>`) that tolerates a different directory
-  depth/convention. Every fallback match (or a true miss) is logged at INFO
-  level naming the pattern tried and the path that satisfied it — check
-  `.sdd/runtime/*.log` for `janitor path_exists:` lines.
-- The fuzzy fallback is on by default. To pin the old literal-only
-  behavior (e.g. if a project intentionally wants `path_exists` to reject
-  near-miss paths), set `BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0`. See
+- **Default behavior is unchanged**: `path_exists` with a plain literal
+  path still means exactly that path — operators can rely on the check
+  meaning the path they wrote.
+- **Explicit glob syntax always works**: a criterion that itself contains
+  glob characters (e.g. `path_exists: packages/db/**/seed-workers*.test.ts`)
+  is evaluated as a glob pattern. This is opt-in per-check by
+  construction, and the recommended way for plans/decompositions to
+  express "a test file matching this shape exists" without guessing the
+  repo's directory convention.
+- **Opt-in fuzzy fallback**: set `BERNSTEIN_JANITOR_FUZZY_PATHS=1` to make
+  a literal miss fall back to a fuzzy pattern derived from the basename
+  (`**/<stem>*<suffix>`), tolerating a different directory
+  depth/convention. Default OFF. When a fuzzy match satisfies a check, the
+  janitor logs a WARNING (`janitor path_exists: FUZZY MATCH ...`) naming
+  the literal path that missed, the pattern tried, and the path that
+  matched — check `.sdd/runtime/*.log`. See
   [CONFIG.md](CONFIG.md#3-environment-variables).
 - **Known limitation:** `test_passes` signals (e.g. `pnpm exec vitest run
   test/seed-workers.test.ts`) still reference the manager's guessed literal

--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -456,6 +456,45 @@ print(yaml.dump(plan, default_flow_style=False))
 
 ---
 
+## 21. Janitor `path_exists` Fails on a Correctly-Placed File (Acceptance-Path Mismatch)
+
+**Symptom:** A task's actual code/test changes are correct and merge cleanly, but the janitor still fails it with `path_exists: <some/guessed/path>`, the task retries and fails again with the identical mismatch, and enough of these in a run trip the `>75% of tasks failing` sev1 orchestration pause. See issue [#2186](https://github.com/sipyourdrink-ltd/bernstein/issues/2186).
+
+**Cause:** The manager's decomposition writes `completion_signals` with exact literal file paths guessed at planning time (e.g. `path_exists: packages/db/test/seed-workers.test.ts`), before any code exists. Workers legitimately place new files at the repo's actual idiomatic location (e.g. `packages/db/src/__tests__/seed-workers-demo-link.test.ts`). The literal path never existed and never will; the check is a coin flip decided before implementation starts, and retries can't fix a decomposition-time guess.
+
+**Diagnosis:**
+```bash
+grep "janitor failed" .sdd/runtime/*.log
+# Look for `path_exists: <path>` entries where the referenced directory
+# convention (e.g. `test/` vs `src/__tests__/`) doesn't match what's
+# actually in the repo:
+find . -name "*<basename-without-extension>*"
+```
+
+**Resolution:**
+- As of this fix, `path_exists` no longer fails on a pure literal miss. It
+  falls back, in order: (1) the literal path, (2) the same string
+  interpreted as a glob pattern, (3) a fuzzy pattern derived from the
+  basename (`**/<stem>*<suffix>`) that tolerates a different directory
+  depth/convention. Every fallback match (or a true miss) is logged at INFO
+  level naming the pattern tried and the path that satisfied it — check
+  `.sdd/runtime/*.log` for `janitor path_exists:` lines.
+- The fuzzy fallback is on by default. To pin the old literal-only
+  behavior (e.g. if a project intentionally wants `path_exists` to reject
+  near-miss paths), set `BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0`. See
+  [CONFIG.md](CONFIG.md#3-environment-variables).
+- **Known limitation:** `test_passes` signals (e.g. `pnpm exec vitest run
+  test/seed-workers.test.ts`) still reference the manager's guessed literal
+  path and are not rewritten by this fix — a command-level mismatch there
+  will still fail. If you hit this, prefer directory-wide test commands
+  (`pnpm --filter db test`) in the plan/decomposition rather than a single
+  guessed file path.
+- If the manager's decompositions repeatedly guess paths for a repo with an
+  unusual layout, consider using `glob_exists` (already supported) instead
+  of `path_exists` in hand-authored plan YAML.
+
+---
+
 ## Quick Reference: Exit Codes
 
 | Exit code | Meaning | Likely cause |

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -719,8 +719,11 @@ def _resolve(path_str: str, workdir: Path) -> Path:
     return workdir / p
 
 
-def _fuzzy_path_match_enabled() -> bool:
-    """Whether the fuzzy basename fallback for ``path_exists`` is active.
+_GLOB_CHARS = frozenset("*?[")
+
+
+def _fuzzy_paths_enabled() -> bool:
+    """Whether the OPT-IN fuzzy basename fallback for ``path_exists`` is active.
 
     Issue #2186: manager decompositions guess exact file paths at planning
     time (e.g. ``packages/db/test/seed-workers.test.ts``), before any code
@@ -729,72 +732,80 @@ def _fuzzy_path_match_enabled() -> bool:
     miss then fails the janitor, drains the retry/error budget, and can
     trip a sev1 orchestration pause even though the work was done correctly.
 
-    Default ON: the glob and fuzzy-basename fallbacks below are strictly
-    more permissive than a bare literal check, so this is safe to leave on.
-    Set ``BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0`` to pin the old
-    literal-path-only behavior (e.g. if a project relies on path_exists
-    rejecting near-miss paths).
+    Default OFF: exact-path matching is the contract operators rely on --
+    "the check means exactly the path I wrote." Set
+    ``BERNSTEIN_JANITOR_FUZZY_PATHS=1`` to opt in to the fuzzy basename
+    fallback for runs where the manager's decomposition guesses paths.
+    Explicit glob syntax in the criterion itself (``*``, ``?``, ``[``) is
+    honored regardless of this flag -- that's opt-in per-check by
+    construction.
     """
-    raw = os.environ.get("BERNSTEIN_JANITOR_FUZZY_PATH_MATCH", "1").strip().lower()
-    enabled = raw not in {"0", "false", "no", "off"}
+    raw = os.environ.get("BERNSTEIN_JANITOR_FUZZY_PATHS", "0").strip().lower()
+    enabled = raw in {"1", "true", "yes", "on"}
     if raw not in {"0", "1", "false", "true", "no", "yes", "off", "on"}:
         logger.warning(
-            "BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=%r not recognized; defaulting to enabled",
+            "BERNSTEIN_JANITOR_FUZZY_PATHS=%r not recognized; fuzzy path matching stays disabled",
             raw,
         )
     return enabled
 
 
 def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
-    """Check if a file or directory exists, tolerating path-guess drift.
+    """Check if a file or directory exists.
 
-    Three attempts, in order (issue #2186):
-      1. Literal path, resolved against ``workdir`` -- the original,
-         backwards-compatible behavior.
-      2. The same string interpreted as a glob pattern -- covers a manager
-         guessing a wildcard-shaped path.
-      3. A fuzzy fallback pattern derived from the path's basename
-         (``**/<stem>*<suffix>``) -- covers a manager guessing the wrong
-         directory convention (e.g. ``test/`` vs ``src/__tests__/``) for a
-         file the worker did create. Gated by
-         ``BERNSTEIN_JANITOR_FUZZY_PATH_MATCH`` (default on).
-
-    Every fallback match is logged with the literal miss, the pattern
-    tried, and the path that satisfied it, so a janitor failure (or a
-    fallback rescue) is diagnosable from logs alone.
+    Matching is conservative (issue #2186):
+      1. Literal path, resolved against ``workdir`` -- the default and
+         only out-of-the-box behavior, unchanged: the check means exactly
+         the path the plan author wrote.
+      2. If the criterion itself contains explicit glob syntax
+         (``*``/``?``/``[``), it is evaluated as a glob pattern. This is
+         opt-in per-check by construction -- a plain literal path is never
+         reinterpreted.
+      3. OPT-IN fuzzy fallback (``BERNSTEIN_JANITOR_FUZZY_PATHS=1``,
+         default off): on a literal miss, try a pattern derived from the
+         basename (``**/<stem>*<suffix>``) to tolerate a manager guessing
+         the wrong directory convention (e.g. ``test/`` vs
+         ``src/__tests__/``) for a file the worker did create. When it
+         fires, a WARNING log names the literal miss, the pattern, and the
+         path that satisfied the check.
 
     Returns:
         (passed, detail). ``detail`` is "exists"/"not found" for the
         literal case (unchanged wire format) and a longer message
-        identifying the matched path when a fallback is what passed.
+        identifying the matched path when a glob or fuzzy match passed.
     """
-    literal = _resolve(path_str, workdir)
-    if literal.exists():
-        return True, "exists"
+    has_glob_syntax = any(c in _GLOB_CHARS for c in path_str)
 
-    glob_pattern = str(workdir / path_str)
-    glob_matches = sorted(globmod.glob(glob_pattern, recursive=True))
-    if glob_matches:
-        matched = glob_matches[0]
+    if not has_glob_syntax:
+        literal = _resolve(path_str, workdir)
+        if literal.exists():
+            return True, "exists"
+    else:
+        # Explicit glob syntax in the criterion: honor it unconditionally.
+        glob_pattern = str(workdir / path_str)
+        glob_matches = sorted(globmod.glob(glob_pattern, recursive=True))
+        if glob_matches:
+            matched = glob_matches[0]
+            logger.info(
+                "janitor path_exists: glob pattern %r matched %r",
+                path_str,
+                matched,
+            )
+            return True, f"exists: glob pattern matched {matched}"
         logger.info(
-            "janitor path_exists: literal miss for %r; glob pattern %r matched %r",
+            "janitor path_exists: glob pattern %r matched nothing under %s",
             path_str,
-            glob_pattern,
-            matched,
-        )
-        return True, f"exists via glob fallback: matched {matched} (pattern: {path_str})"
-
-    if not _fuzzy_path_match_enabled():
-        logger.info(
-            "janitor path_exists: no match for %r (literal + glob both missed; "
-            "fuzzy fallback disabled via BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0)",
-            path_str,
+            workdir,
         )
         return False, "not found"
 
-    # Split on the FIRST dot, not the last: multi-part suffixes like
-    # ".test.ts" / ".spec.tsx" are common in this exact scenario (a manager
-    # guessing "seed-workers.test.ts" vs. a worker naming it
+    if not _fuzzy_paths_enabled():
+        return False, "not found"
+
+    # Opt-in fuzzy basename fallback. Split the basename on the FIRST dot,
+    # not the last: multi-part suffixes like ".test.ts" / ".spec.tsx" are
+    # common in this exact scenario (a manager guessing
+    # "seed-workers.test.ts" vs. a worker naming it
     # "seed-workers-demo-link.test.ts") and Path.stem/.suffix would only
     # peel off ".ts", leaving ".test" glued onto a stem that then fails to
     # prefix-match the worker's actual filename.
@@ -804,7 +815,7 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
     suffix = f".{name_parts[1]}" if len(name_parts) > 1 else ""
     if not stem:
         logger.info(
-            "janitor path_exists: no match for %r (literal + glob missed; no basename to fuzzy-match)",
+            "janitor path_exists: literal miss for %r and no basename to fuzzy-match",
             path_str,
         )
         return False, "not found"
@@ -813,8 +824,10 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
     fuzzy_matches = sorted(globmod.glob(full_fuzzy_pattern, recursive=True))
     if fuzzy_matches:
         matched = fuzzy_matches[0]
-        logger.info(
-            "janitor path_exists: literal+glob miss for %r; fuzzy pattern %r matched %r",
+        logger.warning(
+            "janitor path_exists: FUZZY MATCH (BERNSTEIN_JANITOR_FUZZY_PATHS=1): "
+            "literal path %r not found; fuzzy pattern %r matched %r -- "
+            "the check passed on a fuzzy match, not the exact path written in the plan",
             path_str,
             fuzzy_pattern,
             matched,
@@ -822,9 +835,8 @@ def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
         return True, f"exists via fuzzy fallback: matched {matched} (basename pattern: {fuzzy_pattern})"
 
     logger.info(
-        "janitor path_exists: no match for %r (tried literal, glob %r, fuzzy %r)",
+        "janitor path_exists: no match for %r (tried literal and fuzzy %r; fuzzy matching enabled)",
         path_str,
-        glob_pattern,
         fuzzy_pattern,
     )
     return False, "not found"

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import glob as globmod
 import json
 import logging
+import os
 import re
 import subprocess
 import uuid
@@ -60,8 +61,7 @@ def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]
     """
     match signal.type:
         case "path_exists":
-            ok = _check_path_exists(signal.value, workdir)
-            return ok, "exists" if ok else "not found"
+            return _check_path_exists(signal.value, workdir)
         case "glob_exists":
             ok = _check_glob_exists(signal.value, workdir)
             return ok, "matched" if ok else "no matches"
@@ -719,9 +719,115 @@ def _resolve(path_str: str, workdir: Path) -> Path:
     return workdir / p
 
 
-def _check_path_exists(path_str: str, workdir: Path) -> bool:
-    """Check if a file or directory exists."""
-    return _resolve(path_str, workdir).exists()
+def _fuzzy_path_match_enabled() -> bool:
+    """Whether the fuzzy basename fallback for ``path_exists`` is active.
+
+    Issue #2186: manager decompositions guess exact file paths at planning
+    time (e.g. ``packages/db/test/seed-workers.test.ts``), before any code
+    exists. Workers legitimately place files at repo-idiomatic paths (e.g.
+    ``packages/db/src/__tests__/seed-workers-demo-link.test.ts``). A literal
+    miss then fails the janitor, drains the retry/error budget, and can
+    trip a sev1 orchestration pause even though the work was done correctly.
+
+    Default ON: the glob and fuzzy-basename fallbacks below are strictly
+    more permissive than a bare literal check, so this is safe to leave on.
+    Set ``BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0`` to pin the old
+    literal-path-only behavior (e.g. if a project relies on path_exists
+    rejecting near-miss paths).
+    """
+    raw = os.environ.get("BERNSTEIN_JANITOR_FUZZY_PATH_MATCH", "1").strip().lower()
+    enabled = raw not in {"0", "false", "no", "off"}
+    if raw not in {"0", "1", "false", "true", "no", "yes", "off", "on"}:
+        logger.warning(
+            "BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=%r not recognized; defaulting to enabled",
+            raw,
+        )
+    return enabled
+
+
+def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
+    """Check if a file or directory exists, tolerating path-guess drift.
+
+    Three attempts, in order (issue #2186):
+      1. Literal path, resolved against ``workdir`` -- the original,
+         backwards-compatible behavior.
+      2. The same string interpreted as a glob pattern -- covers a manager
+         guessing a wildcard-shaped path.
+      3. A fuzzy fallback pattern derived from the path's basename
+         (``**/<stem>*<suffix>``) -- covers a manager guessing the wrong
+         directory convention (e.g. ``test/`` vs ``src/__tests__/``) for a
+         file the worker did create. Gated by
+         ``BERNSTEIN_JANITOR_FUZZY_PATH_MATCH`` (default on).
+
+    Every fallback match is logged with the literal miss, the pattern
+    tried, and the path that satisfied it, so a janitor failure (or a
+    fallback rescue) is diagnosable from logs alone.
+
+    Returns:
+        (passed, detail). ``detail`` is "exists"/"not found" for the
+        literal case (unchanged wire format) and a longer message
+        identifying the matched path when a fallback is what passed.
+    """
+    literal = _resolve(path_str, workdir)
+    if literal.exists():
+        return True, "exists"
+
+    glob_pattern = str(workdir / path_str)
+    glob_matches = sorted(globmod.glob(glob_pattern, recursive=True))
+    if glob_matches:
+        matched = glob_matches[0]
+        logger.info(
+            "janitor path_exists: literal miss for %r; glob pattern %r matched %r",
+            path_str,
+            glob_pattern,
+            matched,
+        )
+        return True, f"exists via glob fallback: matched {matched} (pattern: {path_str})"
+
+    if not _fuzzy_path_match_enabled():
+        logger.info(
+            "janitor path_exists: no match for %r (literal + glob both missed; "
+            "fuzzy fallback disabled via BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0)",
+            path_str,
+        )
+        return False, "not found"
+
+    # Split on the FIRST dot, not the last: multi-part suffixes like
+    # ".test.ts" / ".spec.tsx" are common in this exact scenario (a manager
+    # guessing "seed-workers.test.ts" vs. a worker naming it
+    # "seed-workers-demo-link.test.ts") and Path.stem/.suffix would only
+    # peel off ".ts", leaving ".test" glued onto a stem that then fails to
+    # prefix-match the worker's actual filename.
+    name = Path(path_str).name
+    name_parts = name.split(".", 1)
+    stem = name_parts[0]
+    suffix = f".{name_parts[1]}" if len(name_parts) > 1 else ""
+    if not stem:
+        logger.info(
+            "janitor path_exists: no match for %r (literal + glob missed; no basename to fuzzy-match)",
+            path_str,
+        )
+        return False, "not found"
+    fuzzy_pattern = f"**/{stem}*{suffix}" if suffix else f"**/{stem}*"
+    full_fuzzy_pattern = str(workdir / fuzzy_pattern)
+    fuzzy_matches = sorted(globmod.glob(full_fuzzy_pattern, recursive=True))
+    if fuzzy_matches:
+        matched = fuzzy_matches[0]
+        logger.info(
+            "janitor path_exists: literal+glob miss for %r; fuzzy pattern %r matched %r",
+            path_str,
+            fuzzy_pattern,
+            matched,
+        )
+        return True, f"exists via fuzzy fallback: matched {matched} (basename pattern: {fuzzy_pattern})"
+
+    logger.info(
+        "janitor path_exists: no match for %r (tried literal, glob %r, fuzzy %r)",
+        path_str,
+        glob_pattern,
+        fuzzy_pattern,
+    )
+    return False, "not found"
 
 
 def _check_glob_exists(pattern: str, workdir: Path) -> bool:

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -75,6 +75,105 @@ class TestPathExists:
         assert passed is True
 
 
+class TestPathExistsFallback:
+    """Issue #2186: manager-guessed literal paths vs. worker-chosen
+    repo-idiomatic paths. path_exists should fall back to glob, then a
+    fuzzy basename match, before failing."""
+
+    def test_literal_hit_unaffected(self, tmp_path: Path) -> None:
+        """A literal hit keeps the original ("exists") detail string --
+        no behavior change for the common case."""
+        (tmp_path / "foo.py").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="foo.py")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert detail == "exists"
+
+    def test_literal_miss_glob_hit(self, tmp_path: Path) -> None:
+        """Literal path string with a glob-shaped guess matches via the
+        glob fallback."""
+        nested = tmp_path / "packages" / "db"
+        nested.mkdir(parents=True)
+        (nested / "seed-workers.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "glob fallback" in detail
+        assert "seed-workers.test.ts" in detail
+
+    def test_literal_miss_fuzzy_hit_different_depth(self, tmp_path: Path) -> None:
+        """The exact #2186 repro: manager guesses `packages/db/test/...`,
+        worker writes to `packages/db/src/__tests__/...` -- a different
+        directory depth and name suffix. The fuzzy basename fallback
+        should still find it."""
+        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
+        actual_dir.mkdir(parents=True)
+        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "fuzzy fallback" in detail
+        assert "seed-workers-demo-link.test.ts" in detail
+
+    def test_true_miss_still_fails(self, tmp_path: Path) -> None:
+        """No literal, glob, or fuzzy match anywhere under workdir --
+        must still fail; the fallback must not become a rubber stamp."""
+        (tmp_path / "unrelated.txt").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_fuzzy_fallback_can_be_disabled_via_env(self, tmp_path: Path) -> None:
+        """BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0 pins the old
+        literal(+glob)-only behavior."""
+        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
+        actual_dir.mkdir(parents=True)
+        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATH_MATCH": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_glob_fallback_logs_literal_miss_and_match(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """The janitor must log which path satisfied a glob-fallback match
+        (logging is the debugging interface -- see #2186 postmortem)."""
+        nested = tmp_path / "packages" / "db"
+        nested.mkdir(parents=True)
+        (nested / "seed-workers.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
+        with caplog.at_level("INFO"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert any("literal miss" in rec.message for rec in caplog.records)
+        assert any("seed-workers.test.ts" in rec.message for rec in caplog.records)
+
+    def test_fuzzy_fallback_logs_named_match(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
+        actual_dir.mkdir(parents=True)
+        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
+        with caplog.at_level("INFO"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert any("seed-workers-demo-link.test.ts" in rec.message and "fuzzy" in rec.message for rec in caplog.records)
+
+    def test_true_miss_logs_all_patterns_tried(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
+        with caplog.at_level("INFO"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert any("no match" in rec.message and "seed-workers" in rec.message for rec in caplog.records)
+
+
 # --- glob_exists ---
 
 

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -75,10 +76,23 @@ class TestPathExists:
         assert passed is True
 
 
-class TestPathExistsFallback:
+class TestPathExistsGlobAndFuzzy:
     """Issue #2186: manager-guessed literal paths vs. worker-chosen
-    repo-idiomatic paths. path_exists should fall back to glob, then a
-    fuzzy basename match, before failing."""
+    repo-idiomatic paths. Conservative matching contract:
+      - exact-path matching is the default, unchanged;
+      - explicit glob syntax in the criterion always works (opt-in
+        per-check by construction);
+      - the fuzzy basename fallback is opt-in via
+        BERNSTEIN_JANITOR_FUZZY_PATHS=1, default OFF."""
+
+    _GUESSED = "packages/db/test/seed-workers.test.ts"
+
+    def _write_idiomatic_file(self, tmp_path: Path) -> None:
+        """Worker output at the repo's actual convention -- a fuzzy (but
+        not literal or glob) match for the manager's guessed path."""
+        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
+        actual_dir.mkdir(parents=True)
+        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
 
     def test_literal_hit_unaffected(self, tmp_path: Path) -> None:
         """A literal hit keeps the original ("exists") detail string --
@@ -90,60 +104,103 @@ class TestPathExistsFallback:
         assert passed is True
         assert detail == "exists"
 
-    def test_literal_miss_glob_hit(self, tmp_path: Path) -> None:
-        """Literal path string with a glob-shaped guess matches via the
-        glob fallback."""
-        nested = tmp_path / "packages" / "db"
-        nested.mkdir(parents=True)
-        (nested / "seed-workers.test.ts").write_text("x")
+    def test_fuzzy_off_by_default(self, tmp_path: Path) -> None:
+        """DEFAULT behavior: a literal miss FAILS even when a would-be
+        fuzzy match exists -- exact-path matching is the contract
+        operators rely on."""
+        self._write_idiomatic_file(tmp_path)
 
-        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
-        passed, detail = evaluate_signal(signal, tmp_path)
-        assert passed is True
-        assert "glob fallback" in detail
-        assert "seed-workers.test.ts" in detail
-
-    def test_literal_miss_fuzzy_hit_different_depth(self, tmp_path: Path) -> None:
-        """The exact #2186 repro: manager guesses `packages/db/test/...`,
-        worker writes to `packages/db/src/__tests__/...` -- a different
-        directory depth and name suffix. The fuzzy basename fallback
-        should still find it."""
-        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
-        actual_dir.mkdir(parents=True)
-        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
-
-        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
-        passed, detail = evaluate_signal(signal, tmp_path)
-        assert passed is True
-        assert "fuzzy fallback" in detail
-        assert "seed-workers-demo-link.test.ts" in detail
-
-    def test_true_miss_still_fails(self, tmp_path: Path) -> None:
-        """No literal, glob, or fuzzy match anywhere under workdir --
-        must still fail; the fallback must not become a rubber stamp."""
-        (tmp_path / "unrelated.txt").write_text("x")
-
-        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
-        passed, detail = evaluate_signal(signal, tmp_path)
-        assert passed is False
-        assert detail == "not found"
-
-    def test_fuzzy_fallback_can_be_disabled_via_env(self, tmp_path: Path) -> None:
-        """BERNSTEIN_JANITOR_FUZZY_PATH_MATCH=0 pins the old
-        literal(+glob)-only behavior."""
-        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
-        actual_dir.mkdir(parents=True)
-        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
-
-        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
-        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATH_MATCH": "0"}):
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        env = {k: v for k, v in os.environ.items() if k != "BERNSTEIN_JANITOR_FUZZY_PATHS"}
+        with patch.dict("os.environ", env, clear=True):
             passed, detail = evaluate_signal(signal, tmp_path)
         assert passed is False
         assert detail == "not found"
 
-    def test_glob_fallback_logs_literal_miss_and_match(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """The janitor must log which path satisfied a glob-fallback match
-        (logging is the debugging interface -- see #2186 postmortem)."""
+    def test_fuzzy_explicit_zero_also_off(self, tmp_path: Path) -> None:
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_explicit_glob_works_without_flag(self, tmp_path: Path) -> None:
+        """Explicit glob syntax in the criterion is honored regardless of
+        the fuzzy flag -- opt-in per-check by construction."""
+        nested = tmp_path / "packages" / "db"
+        nested.mkdir(parents=True)
+        (nested / "seed-workers.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "glob pattern matched" in detail
+        assert "seed-workers.test.ts" in detail
+
+    def test_explicit_glob_recursive_different_depth(self, tmp_path: Path) -> None:
+        """A `**` glob written in the criterion matches at any depth,
+        with the fuzzy flag off."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value="packages/db/**/seed-workers*.test.ts")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "seed-workers-demo-link.test.ts" in detail
+
+    def test_explicit_glob_no_match_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "unrelated.txt").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/**/seed-workers*.test.ts")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_fuzzy_opt_in_hits_at_different_depth(self, tmp_path: Path) -> None:
+        """The exact #2186 repro with BERNSTEIN_JANITOR_FUZZY_PATHS=1:
+        manager guesses `packages/db/test/...`, worker writes to
+        `packages/db/src/__tests__/...` -- a different directory depth
+        and name suffix. The opt-in fuzzy basename fallback finds it."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "fuzzy fallback" in detail
+        assert "seed-workers-demo-link.test.ts" in detail
+
+    def test_fuzzy_opt_in_true_miss_still_fails(self, tmp_path: Path) -> None:
+        """With fuzzy enabled, a path with no literal or fuzzy match
+        anywhere under workdir must still fail -- the fallback is not a
+        rubber stamp."""
+        (tmp_path / "unrelated.txt").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_fuzzy_match_logs_loudly_with_matched_path(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """When the fuzzy fallback satisfies a check it must WARN, naming
+        the literal miss, the pattern, and the matched path (logging is
+        the debugging interface -- see #2186 postmortem)."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}), caplog.at_level("WARNING"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        fuzzy_warnings = [rec for rec in caplog.records if rec.levelname == "WARNING" and "FUZZY MATCH" in rec.message]
+        assert fuzzy_warnings, "expected a WARNING log for the fuzzy match"
+        assert any(self._GUESSED in rec.message for rec in fuzzy_warnings)
+        assert any("seed-workers-demo-link.test.ts" in rec.message for rec in fuzzy_warnings)
+
+    def test_glob_match_logs_matched_path(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         nested = tmp_path / "packages" / "db"
         nested.mkdir(parents=True)
         (nested / "seed-workers.test.ts").write_text("x")
@@ -152,23 +209,11 @@ class TestPathExistsFallback:
         with caplog.at_level("INFO"):
             passed, _ = evaluate_signal(signal, tmp_path)
         assert passed is True
-        assert any("literal miss" in rec.message for rec in caplog.records)
-        assert any("seed-workers.test.ts" in rec.message for rec in caplog.records)
+        assert any("glob pattern" in rec.message and "seed-workers.test.ts" in rec.message for rec in caplog.records)
 
-    def test_fuzzy_fallback_logs_named_match(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
-        actual_dir.mkdir(parents=True)
-        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
-
-        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
-        with caplog.at_level("INFO"):
-            passed, _ = evaluate_signal(signal, tmp_path)
-        assert passed is True
-        assert any("seed-workers-demo-link.test.ts" in rec.message and "fuzzy" in rec.message for rec in caplog.records)
-
-    def test_true_miss_logs_all_patterns_tried(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        signal = CompletionSignal(type="path_exists", value="packages/db/test/seed-workers.test.ts")
-        with caplog.at_level("INFO"):
+    def test_fuzzy_true_miss_logs_patterns_tried(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}), caplog.at_level("INFO"):
             passed, _ = evaluate_signal(signal, tmp_path)
         assert passed is False
         assert any("no match" in rec.message and "seed-workers" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Addresses #2186 as a conservative first step. A run where every worker did
real, correct work still cascaded to a sev1 (`>75% of tasks failing —
orchestration pause requested`) because the manager's decomposition encoded
**exact literal file paths** in janitor `path_exists` acceptance checks,
guessed at planning time before any code existed. Workers legitimately
placed their output at the repo's actual idiomatic path instead, the
janitor failed deterministically, retries hit the identical mismatch, and
the error budget drained.

Real evidence (`evidence-2026-07-02-run8/spawner.log:201`):

```
janitor failed: ['path_exists: packages/db/test/seed-workers.test.ts',
  'path_exists: apps/web/test/actions/get-available-shifts-for-worker.test.ts',
  'path_exists: apps/web/test/actions/get-my-schedule.test.ts',
  'test_passes: pnpm --filter db exec vitest run test/seed-workers.test.ts', ...]
```

The worker had written a 327-line test at
`packages/db/src/__tests__/seed-workers-demo-link.test.ts` — correct,
merged, just not at the guessed path. Two retries later this task hit
`max_retries_exceeded` and contributed to the failure-rate that triggered
`INC-1783019879-001 [sev1]`.

## Design: conservative matching contract

We deliberately kept this small and default-safe; the matching behavior in
`_check_path_exists` (`src/bernstein/core/quality/janitor.py`) is now:

1. **Exact-path matching stays the DEFAULT, unchanged from upstream.** A
   plain literal path means exactly the path the plan author wrote —
   operators can continue to rely on "the check means exactly the path I
   wrote." No implicit reinterpretation on a miss.
2. **Explicit glob syntax in the criterion always works.** If the check
   itself contains glob characters (e.g. `path_exists:
   packages/db/**/seed-workers*.test.ts`), it is evaluated as a recursive
   glob. This is opt-in per-check by construction, and gives
   decompositions a sanctioned way to say "a test file matching this shape
   exists" without guessing the repo's directory convention.
3. **Fuzzy basename fallback is OPT-IN, default OFF**, behind
   `BERNSTEIN_JANITOR_FUZZY_PATHS=1` (env-flag style consistent with
   `BERNSTEIN_STALL_THRESHOLD_S` from #2182). On a literal miss it tries a
   pattern derived from the basename, `**/<stem>*<suffix>`, splitting on
   the *first* dot so multi-part suffixes like `.test.ts` survive
   (verified against the exact repro: `seed-workers.test.ts` → pattern
   `**/seed-workers*.test.ts`, which matches
   `seed-workers-demo-link.test.ts`). When it fires, the janitor logs a
   **WARNING** naming the literal path that missed, the pattern tried, and
   the path that satisfied the check, so a fuzzy rescue is never silent.
   Setting the flag to `0` (or leaving it unset) turns fuzzy behavior off
   completely.

**We'd genuinely welcome maintainer feedback on the default.** We
considered defaulting the fuzzy fallback on (it is strictly more
permissive), but chose default-off so this PR changes nothing for existing
operators; if you'd prefer a different gate (config key vs env var, or a
per-signal opt-in syntax), happy to adjust. We're also posting a
design-feedback comment on #2186 with the broader options (e.g.
worker-declared artifact paths, and distinguishing acceptance-mismatch
from agent failure in failure-rate accounting).

### Known limitation

`test_passes` signals that embed the manager's guessed literal path inside
a shell command (e.g. `pnpm --filter db exec vitest run
test/seed-workers.test.ts`) are **not** rewritten by this fix — rewriting
arbitrary shell commands safely is out of scope for a surgical change.
Documented in `docs/operations/TROUBLESHOOTING.md` §21 with a workaround
(prefer directory-wide test commands like `pnpm --filter db test` in the
plan/decomposition rather than a single guessed file path).

## Changes

- `src/bernstein/core/quality/janitor.py` — `_check_path_exists`: honor
  explicit glob syntax; opt-in fuzzy-basename fallback via
  `_fuzzy_paths_enabled()` (`BERNSTEIN_JANITOR_FUZZY_PATHS`, default off);
  WARNING-level logging when a fuzzy match satisfies a check.
- `tests/unit/test_janitor.py` — 11 new tests: literal hit unaffected
  (backward-compat detail string), **fuzzy OFF by default** (literal miss
  + would-be fuzzy hit still FAILS, env var explicitly absent), fuzzy
  explicitly `0` also off, explicit glob works with the flag off (flat and
  `**` recursive at a different depth), glob no-match fails, fuzzy opt-in
  hits at a different directory depth (the exact #2186 repro paths), fuzzy
  opt-in true miss still fails, WARNING log names the literal miss + the
  matched path, glob match log names the matched path, true-miss log lists
  patterns tried.
- `docs/operations/CONFIG.md` — new `BERNSTEIN_JANITOR_FUZZY_PATHS` env
  var row (documents default-off and the always-on explicit-glob rule).
- `docs/operations/TROUBLESHOOTING.md` — new §21 "Janitor `path_exists`
  Fails on a Correctly-Placed File (Acceptance-Path Mismatch)".

## Test plan

- [x] `python3 -m pytest tests/unit/test_janitor.py -q` — 66 passed (11 new).
- [x] `uv run ruff format --check src/bernstein/core/quality/janitor.py tests/unit/test_janitor.py` — clean.
- [x] `uv run ruff check` on the same files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
