### PR TITLE
fix: multi-provider orchestration hardening (integrates #2194)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -66,7 +66,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Run trufflehog
-        uses: trufflesecurity/trufflehog@00155c9dc586f34d189adc83d3ac2698c2ec551f  # v3.95.8
+        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334  # v3.95.7
         with:
           # Only report verified secrets - keeps signal-to-noise high and
           # lets the job act as a hard gate. Unknown / unverified results

--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -142,6 +142,13 @@ Environment variables are useful in CI and automation. Common variables:
 | `BERNSTEIN_COMPLIANCE` | Compliance preset override |
 | `BERNSTEIN_QUIET` | Quiet mode (reduced terminal output) |
 | `BERNSTEIN_AUDIT` | Enable extra audit behavior in run flow |
+| `BERNSTEIN_STALL_THRESHOLD_S` | Override the manager-stall deadline (see §4.2 below). Takes precedence over the `tuning.orchestrator.stalled_manager_threshold_s` yaml key. |
+| `BERNSTEIN_MAX_TURNS` | Override the SDK turn ceiling for the openai_agents runner (see §4.1). Takes precedence over `tuning.agent.max_turns`. |
+| `BERNSTEIN_JANITOR_FUZZY_PATHS` | Opt-in fuzzy matching for `path_exists` completion signals. **Default `0` (off)**: exact-path matching is unchanged - the check means exactly the path written in the plan. Set to `1` to enable a fuzzy fallback on a literal miss: a pattern derived from the basename (`**/<stem>*<suffix>`) so a manager-guessed path (e.g. `packages/db/test/foo.test.ts`) can match a worker's repo-idiomatic path (e.g. `packages/db/src/__tests__/foo.test.ts`). A fuzzy match logs a WARNING naming the matched path. Explicit glob syntax written in the criterion itself (`*`, `?`, `[`) is always honored, regardless of this flag. See [TROUBLESHOOTING.md #21](TROUBLESHOOTING.md#21-janitor-path_exists-fails-on-a-correctly-placed-file-acceptance-path-mismatch). |
+| `BERNSTEIN_JANITOR_REOPEN_MAX` | Max janitor-reopen cycles per task before a janitor-FAILed task is permanently failed instead of reopened under the same id. **Default `2`.** A non-numeric value logs a warning and falls back to the default; negative values are clamped to `0` (fail immediately, never reopen). |
+| `BERNSTEIN_QUIESCENCE_SETTLE_S` | Settle delay (seconds) the orchestrator waits after a tick reaches quiescence (all tasks terminal) before the re-check that decides whether to self-stop. **Default `2.0`.** Set `0` to skip the settle sleep entirely (used by tests to avoid a real per-tick delay). |
+| `BERNSTEIN_RUN_COMMAND_DEDUPE_WINDOW_S` | Dedupe window (seconds) for the `run_command` builtin: an identical command (same hash) still in flight or finished within this window reuses the original's result instead of re-executing. **Default `2.0`.** Set `0` to disable the dedupe guard entirely. |
+| `BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE` | Operator lever for the `openai_agents` runner's tool source. Set to `builtin` to make every spawn use the runner's workdir-sandboxed builtin tools (`read_file`/`write_file`/`list_dir`/`run_command`) even when the per-spawn `mcp_config` carries no `tool_source` key. An explicit `mcp_config["tool_source"]` value always wins over this env var. Unset by default. |
 
 ---
 
@@ -155,20 +162,91 @@ tuning:
     tick_interval_s: 5.0
     drain_timeout_s: 120.0
     stale_claim_timeout_s: 1800.0
+    stalled_manager_threshold_s: 300.0
+    max_agent_runtime_s: 3600.0
   spawn:
     spawn_backoff_base_s: 60.0
+  agent:
+    max_turns: 200
+  slo:
+    error_budget_min_failures: 10
 ```
 
 Key default groups:
 
 | Group | Examples |
 |-------|---------|
-| `OrchestratorDefaults` | `tick_interval_s`, `drain_timeout_s`, `max_consecutive_failures`, `stale_claim_timeout_s` |
+| `OrchestratorDefaults` | `tick_interval_s`, `drain_timeout_s`, `max_consecutive_failures`, `stale_claim_timeout_s`, `stalled_manager_threshold_s`, `max_agent_runtime_s` |
 | `SpawnDefaults` | `spawn_backoff_base_s`, `spawn_backoff_max_s`, `max_spawn_failures` |
 | `TaskDefaults` | Retry limits, deadline windows |
-| `AgentDefaults` | Heartbeat intervals, max dead agents kept |
+| `AgentDefaults` | Heartbeat intervals, max dead agents kept, `max_turns` |
+| `SLODefaults` | `error_budget_min_failures` |
+
+### 4.1) Agent run-length limits (SDK turns, error budget, wall-clock)
+
+Three previously-hardcoded ceilings on the `openai_agents` adapter path are
+now tunable, with defaults unchanged so nothing breaks for existing users:
+
+- **`max_turns`** (`AgentDefaults.max_turns`, default `None`) - forwarded to
+  the OpenAI Agents SDK's `Runner.run_sync(..., max_turns=...)` only when
+  set. `None` omits the kwarg entirely, so the SDK's own default (`10`)
+  applies exactly as before. A task that legitimately needs more turns
+  before `MaxTurnsExceeded` (large-repo investigation, multi-file
+  refactors) can raise this via `tuning.agent.max_turns: 200` or the
+  `BERNSTEIN_MAX_TURNS` env var (checked first). `BERNSTEIN_MAX_TURNS` must
+  parse as a positive integer - `0`, a negative value, or a non-numeric
+  string is rejected with a warning and falls through to
+  `tuning.agent.max_turns`/the SDK default, rather than being forwarded to
+  `Runner.run_sync` where it would fail every run on the first turn.
+- **`error_budget_min_failures`** (`SLODefaults.error_budget_min_failures`,
+  default `3`) - the floor `ErrorBudget.budget_total` never goes below,
+  even when `total_tasks * (1 - slo_target)` rounds lower. Raise it via
+  `tuning.slo.error_budget_min_failures` when a run's early failures are
+  infra-death retries (rate limits, transient auth) that shouldn't trip
+  `IncidentManager`'s auto-pause. A negative override is clamped to `0`
+  rather than being allowed to suppress the SLO-target-derived budget.
+- **`max_agent_runtime_s`** (`OrchestratorDefaults.max_agent_runtime_s`,
+  default `1800`) - the starting wall-clock kill deadline for a spawned
+  agent, now sourced through `OrchestratorConfig` via the same
+  `tuning.orchestrator.*` mechanism as `stale_claim_timeout_s`. This is
+  only the *starting* value - the agent lifecycle reaper already
+  self-extends it by 600s per cycle up to a 5400s hard cap while the agent
+  keeps heartbeating.
 
 See `defaults.py` for the full list of parameters and their default values.
+
+### 4.2) Manager-stall deadline
+
+`core/orchestration/stalled_manager.py` aborts a run when the manager agent
+has been alive for `stalled_manager_threshold_s` (default `170.0`) with zero
+child tasks posted to the task server. On a larger codebase, or a goal whose
+acceptance criteria demand root-cause investigation before decomposition, the
+manager can legitimately need longer than that before its first `POST /tasks`
+call. Raise the deadline via either:
+
+```yaml
+tuning:
+  orchestrator:
+    stalled_manager_threshold_s: 900.0
+```
+
+or the `BERNSTEIN_STALL_THRESHOLD_S` env var (checked first, so it overrides
+the yaml value for a single run without editing `bernstein.yaml`). Precedence:
+env var > yaml `tuning.orchestrator.stalled_manager_threshold_s` > the
+`170.0` default. Each tier must resolve to a positive, finite number of
+seconds - an unparseable, zero, negative, `nan`, or `inf` value at a given
+tier is rejected with a warning and falls through to the next tier, rather
+than silently disabling the watchdog (fires on turn one) or making it a
+permanent no-op.
+
+If the resolved threshold reaches or exceeds `AGENT.idle_log_age_threshold_s`
+(`180.0` by default - a separate, currently-unwired idle-agent watchdog), a
+warning is logged, since that watchdog would race the stalled-manager
+diagnostic if it is ever wired into the tick loop. This check runs for the
+env var, yaml, and default resolution paths alike, so raising the threshold
+via `BERNSTEIN_STALL_THRESHOLD_S` - the primary way an operator raises it -
+surfaces the warning too. The resolution (and this check) happens once per
+orchestrator instance, not on every tick.
 
 ---
 

--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -120,6 +120,45 @@ grep -i "rate limit\|429\|hit your limit\|resets" .sdd/runtime/*.log
 - Use the `TierAwareRouter` to balance across multiple providers (Claude + Codex + Gemini).
 - For batch-eligible tasks, set `batch_eligible: true` to route to provider batch APIs at reduced cost.
 
+### 4a. Healthy worker killed as a false-positive rate-limit hit
+
+**Symptom:** A worker that was making normal progress gets killed and the
+run falls back to a more expensive sticky provider, even though the
+provider dashboard shows no throttling. `.sdd/runtime/*.log` shows a
+`_scan_log_for_patterns: matched RISKY pattern ...` line pointing at a
+structured `tool_call`/`tool_result` JSON line, a `"max_tokens": ...`
+manifest dump, or a `"timeout": <n>` tool argument.
+
+**Cause:** `core/observability/rate_limit_tracker.py`'s log-scanning
+classifier (`_scan_log_for_patterns`) infers 429/throttle events from raw
+agent subprocess output. Bare substrings (`"413"`, `"429"`, `"401"`,
+`"403"`, `"504"`) and generic English words (`timeout`, `rate limit`,
+`unauthorized`, ...) previously matched anywhere in the log tail,
+including inside an agent's own JSON tool traffic where those tokens
+carry zero relation to a real provider error (byte counts, arg names,
+target-repo code being read). Fixed 2026-07-02 (#2183): structured
+`tool_call`/`tool_result`/`heartbeat` lines are now skipped entirely, and
+every remaining risky bare token/word only counts as a match when it
+appears on a line that also carries explicit error context
+(`error|status|http|code|exception|failed|failure|traceback`, matched
+with a word boundary via `_ERROR_CONTEXT_RE`).
+
+**Diagnosis:**
+```bash
+# Every classifier match is logged with the matched line - one read
+# tells you whether it was a real provider error or a data false-positive.
+grep "_scan_log_for_patterns: matched" .sdd/runtime/*.log
+```
+
+**Resolution:**
+- If the matched line is agent-produced data (tool JSON, code being
+  read) rather than a real HTTP/provider error, it's a classifier gap -
+  file an issue with the matched line so the pattern/context list can be
+  tightened further.
+- No operator action needed for the fixed patterns above; upgrade to a
+  release containing #2183 if you're still seeing this on unrelated data
+  lines.
+
 ---
 
 ## 5. Budget Exceeded
@@ -224,6 +263,21 @@ git diff main...agent/<session-id>
 - Manually resolve: `git checkout agent/<branch> && git rebase main` then `git checkout main && git merge agent/<branch>`.
 - Prevent future conflicts by adding explicit `owned_files` to tasks in plan YAML files.
 - Increase the `depends_on` declarations between tasks that touch the same code.
+
+**Injected skill files (`.claude/skills/bernstein-*.md`) causing conflicts on
+*every* worker merge:** See [issue #2187](https://github.com/sipyourdrink-ltd/bernstein/issues/2187).
+Each worker's worktree gets its own rendered copy of the always-injected
+skills (`bernstein-completion-protocol.md`, `bernstein-signal-check.md`, plus
+role-specific skills), with session-specific content
+(`{{SESSION_ID}}`/`{{TASK_IDS}}`). If an agent's `git add -A` stages these
+files, every worker merge conflicts on them - not because of real work
+overlap, but because two agents' injected boilerplate collides. As of this
+fix, `inject_skills()` registers each injected path in the target repo's
+`.git/info/exclude` (resolved correctly for worktrees via
+`git rev-parse --git-path info/exclude`), so the skills stay readable by
+Claude Code but are never staged or committed. If you still see this on an
+older Bernstein version, manually run `git rm --cached .claude/skills/bernstein-*.md`
+and add the paths to `.git/info/exclude` to unblock merges.
 
 ---
 
@@ -453,6 +507,51 @@ print(yaml.dump(plan, default_flow_style=False))
 - Stage-level `depends_on: [other_stage]` must reference existing stage names.
 - Step fields: `goal` (required), `role` (required), `priority`, `scope`, `complexity` (optional with defaults).
 - Validate with `python3 -c "from bernstein.core.planning.plan_loader import load_plan; load_plan('plans/my-project.yaml')"`.
+
+---
+
+## 21. Janitor `path_exists` Fails on a Correctly-Placed File (Acceptance-Path Mismatch)
+
+**Symptom:** A task's actual code/test changes are correct and merge cleanly, but the janitor still fails it with `path_exists: <some/guessed/path>`, the task retries and fails again with the identical mismatch, and enough of these in a run trip the `>75% of tasks failing` sev1 orchestration pause. See issue [#2186](https://github.com/sipyourdrink-ltd/bernstein/issues/2186).
+
+**Cause:** The manager's decomposition writes `completion_signals` with exact literal file paths guessed at planning time (e.g. `path_exists: packages/db/test/seed-workers.test.ts`), before any code exists. Workers legitimately place new files at the repo's actual idiomatic location (e.g. `packages/db/src/__tests__/seed-workers-demo-link.test.ts`). The literal path never existed and never will; the check is a coin flip decided before implementation starts, and retries can't fix a decomposition-time guess.
+
+**Diagnosis:**
+```bash
+grep "janitor failed" .sdd/runtime/*.log
+# Look for `path_exists: <path>` entries where the referenced directory
+# convention (e.g. `test/` vs `src/__tests__/`) doesn't match what's
+# actually in the repo:
+find . -name "*<basename-without-extension>*"
+```
+
+**Resolution:**
+- **Default behavior is unchanged**: `path_exists` with a plain literal
+  path still means exactly that path - operators can rely on the check
+  meaning the path they wrote.
+- **Explicit glob syntax always works**: a criterion that itself contains
+  glob characters (e.g. `path_exists: packages/db/**/seed-workers*.test.ts`)
+  is evaluated as a glob pattern. This is opt-in per-check by
+  construction, and the recommended way for plans/decompositions to
+  express "a test file matching this shape exists" without guessing the
+  repo's directory convention.
+- **Opt-in fuzzy fallback**: set `BERNSTEIN_JANITOR_FUZZY_PATHS=1` to make
+  a literal miss fall back to a fuzzy pattern derived from the basename
+  (`**/<stem>*<suffix>`), tolerating a different directory
+  depth/convention. Default OFF. When a fuzzy match satisfies a check, the
+  janitor logs a WARNING (`janitor path_exists: FUZZY MATCH ...`) naming
+  the literal path that missed, the pattern tried, and the path that
+  matched - check `.sdd/runtime/*.log`. See
+  [CONFIG.md](CONFIG.md#3-environment-variables).
+- **Known limitation:** `test_passes` signals (e.g. `pnpm exec vitest run
+  test/seed-workers.test.ts`) still reference the manager's guessed literal
+  path and are not rewritten by this fix - a command-level mismatch there
+  will still fail. If you hit this, prefer directory-wide test commands
+  (`pnpm --filter db test`) in the plan/decomposition rather than a single
+  guessed file path.
+- If the manager's decompositions repeatedly guess paths for a repo with an
+  unusual layout, consider using `glob_exists` (already supported) instead
+  of `path_exists` in hand-authored plan YAML.
 
 ---
 

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -876,6 +876,15 @@ class CLIAdapter(ABC):
     #: lower-cased :meth:`name` is used as a fallback.
     registry_name: str = ""
 
+    #: Provider-identifier aliases this adapter answers to (for example
+    #: ``("codex", "openai", "gpt")``). Consumed by
+    #: :mod:`bernstein.adapters.registry` to build the
+    #: provider-name -> adapter-name lookup table used by
+    #: ``_infer_adapter_name_for_provider`` in ``spawner_core.py``. Empty by
+    #: default: adapters that never need provider-string inference (most of
+    #: the catalog) do not have to declare anything.
+    provides: tuple[str, ...] = ()
+
     def _derive_session_namespace(self) -> str:
         """Return the namespace label used for deterministic session ids."""
         if self.registry_name:

--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -18,6 +18,7 @@ from bernstein.core.semantic_cache import ResponseCacheManager
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.adapters.plugin_sdk import AdapterPluginInfo
     from bernstein.core.models import ModelConfig
 
 logger = logging.getLogger(__name__)
@@ -201,6 +202,21 @@ class CachingAdapter(CLIAdapter):
         """Return inner adapter's name."""
         return self._inner.name()
 
+    def plugin_info(self) -> AdapterPluginInfo:
+        """Delegate plugin metadata to the wrapped adapter.
+
+        Capability gates (e.g. ``ensure_sampling_params_supported``)
+        duck-type on ``plugin_info`` to read declared capabilities, so the
+        caching wrapper must be transparent here or the inner adapter's
+        capabilities become invisible and valid spawns are refused.
+
+        Raises:
+            AttributeError: When the wrapped adapter is not a plugin
+                adapter (has no ``plugin_info``), so callers see exactly
+                the behaviour of the unwrapped adapter.
+        """
+        return self._inner.plugin_info()  # type: ignore[attr-defined]
+
     def is_alive(self, pid: int) -> bool:
         """Delegate to inner adapter (always False for cached PID 0)."""
         if pid == 0:
@@ -216,3 +232,34 @@ class CachingAdapter(CLIAdapter):
     def detect_tier(self) -> Any:
         """Delegate to inner adapter."""
         return self._inner.detect_tier()
+
+    def __getattr__(self, name: str) -> Any:
+        """Fall back to the wrapped adapter for any attribute not found here.
+
+        ``CLIAdapter`` subclasses declare capability flags as plain class
+        attributes (e.g. ``consumes_heartbeat_dir``, and any future
+        capability flag not yet known to this wrapper). Callers duck-type
+        on those attributes via ``getattr(adapter, "flag", False)``.
+        Without this delegation, wrapping an adapter in ``CachingAdapter``
+        silently resets every such flag to its ``getattr`` default because
+        Python attribute lookup never reaches the inner adapter's class -
+        the capability appears to vanish with no error (bug #11: the
+        spawner stopped injecting ``heartbeat_dir`` for every
+        caching-wrapped openai_agents spawn, orphaning heartbeats in the
+        worktree and triggering false ``no_heartbeat`` kills).
+
+        ``__getattr__`` only fires when normal attribute lookup (instance
+        ``__dict__`` plus the ``CachingAdapter``/``CLIAdapter`` MRO) fails,
+        so it never shadows an attribute or method this class already
+        defines - it is a pure fallback, not an override.
+
+        Raises:
+            AttributeError: When the wrapped adapter also lacks the
+                attribute, matching the error Python would give for a
+                direct lookup on this class.
+        """
+        try:
+            inner = self.__dict__["_inner"]
+        except KeyError:
+            raise AttributeError(name) from None
+        return getattr(inner, name)

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -259,6 +259,11 @@ _RATE_LIMIT_COOLDOWN: float = COST.rate_limit_cooldown_s
 class ClaudeCodeAdapter(CLIAdapter):
     """Spawn and monitor Claude Code CLI sessions."""
 
+    # Provider-string aliases this adapter resolves from in
+    # ``_infer_adapter_name_for_provider`` (via the registry's
+    # provider-alias table). Unchanged from the old substring branch.
+    provides = ("claude", "anthropic")
+
     external_endpoints = (("api.anthropic.com", 443),)
     # Surface the upstream provider on the ``bernstein status``
     # rate-limit panel. Anthropic uses HTTP 429 plus structured

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -58,6 +58,14 @@ class CodexAdapter(CLIAdapter):
     """Spawn and monitor OpenAI Codex CLI sessions."""
 
     registry_name = "codex"
+    # Provider-string aliases this adapter resolves from in
+    # ``_infer_adapter_name_for_provider``. NOTE: "openai" and "gpt" are
+    # broad aliases that historically also matched the openai_agents
+    # provider string via substring search (see 042bcbd0). The registry
+    # requires exact provider-name matches, so this alias set only ever
+    # matches a provider literally named "codex", "openai", or "gpt" --
+    # it can no longer swallow "openai_agents".
+    provides = ("codex", "openai", "gpt")
     # Default model when no operator-pinned model reaches this adapter. Read by
     # the spawner to substitute Claude tier names for non-Claude adapters.
     default_model = _DEFAULT_CODEX_MODEL

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -199,6 +199,11 @@ def _inject_multimodal_attachments(prompt: str, multimodal_context: Any) -> str:
 class GeminiAdapter(CLIAdapter):
     """Spawn and monitor Google Gemini / Antigravity CLI sessions."""
 
+    # Provider-string aliases this adapter resolves from in
+    # ``_infer_adapter_name_for_provider`` (via the registry's
+    # provider-alias table). Unchanged from the old substring branch.
+    provides = ("gemini", "google")
+
     external_endpoints = (("generativelanguage.googleapis.com", 443),)
     # Google Generative Language returns HTTP 429 with status
     # ``RESOURCE_EXHAUSTED`` once per-minute quotas are tripped.

--- a/src/bernstein/adapters/mistral.py
+++ b/src/bernstein/adapters/mistral.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import TYPE_CHECKING, Any
 
@@ -12,6 +13,9 @@ if TYPE_CHECKING:
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
+
+logger = logging.getLogger(__name__)
 
 
 class MistralAdapter(CLIAdapter):
@@ -21,6 +25,24 @@ class MistralAdapter(CLIAdapter):
     ``--auto-approve`` for non-interactive execution and accepts the task
     prompt via the ``--prompt`` flag.
     """
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        """Declare the sampling surface MistralAdapter genuinely wires.
+
+        ``vibe`` accepts a ``--temperature`` flag. It has no documented
+        ``--top-p``/``--top-k``/``--max-tokens`` flag, so only the narrow
+        temperature capability is declared -
+        :func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`
+        refuses a spawn requesting the others rather than silently
+        dropping them.
+        """
+        return AdapterPluginInfo(
+            name="mistral",
+            version="0.1.0",
+            author="bernstein",
+            description="Mistral Vibe CLI adapter",
+            capabilities=(AdapterCapability.SUPPORTS_TEMPERATURE,),
+        )
 
     def spawn(
         self,
@@ -65,6 +87,21 @@ class MistralAdapter(CLIAdapter):
             "--prompt",
             prompt,
         ]
+
+        if mcp_config:
+            temperature = mcp_config.get("temperature")
+            if isinstance(temperature, (int, float)) and not isinstance(temperature, bool):
+                logger.debug("mistral adapter: wiring --temperature=%s onto argv", temperature)
+                cmd.extend(["--temperature", str(float(temperature))])
+            for dropped_key in ("top_p", "top_k", "max_tokens"):
+                if mcp_config.get(dropped_key) is not None:
+                    logger.warning(
+                        "mistral adapter: %s=%r requested but not wired (vibe CLI has no "
+                        "matching flag) - ensure_sampling_params_supported should have refused "
+                        "this spawn before reaching here",
+                        dropped_key,
+                        mcp_config.get(dropped_key),
+                    )
 
         pid_dir = workdir / ".sdd" / "runtime" / "pids"
         wrapped_cmd = build_worker_cmd(

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -31,16 +31,20 @@ EU-residency / vLLM note:
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.core.models import ModelConfig
+
+logger = logging.getLogger(__name__)
 
 # Default Ollama API endpoint
 OLLAMA_BASE_URL = "http://localhost:11434"
@@ -130,6 +134,27 @@ class OllamaAdapter(CLIAdapter):
     def eu_residency(self) -> bool:
         """Return whether the EU-residency self-hosted guard is active."""
         return self._eu_residency
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        """Declare the sampling surface OllamaAdapter genuinely wires.
+
+        This adapter drives Aider (see the module docstring), which
+        accepts a ``--temperature`` flag. Aider has no ``--top-p``,
+        ``--top-k``, or completion ``--max-tokens`` CLI flag (its
+        ``--max-chat-history-tokens`` controls a different thing - chat
+        history truncation, not the completion length), so only the
+        narrow temperature capability is declared -
+        :func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`
+        refuses a spawn requesting the others rather than silently
+        dropping them.
+        """
+        return AdapterPluginInfo(
+            name="ollama",
+            version="0.1.0",
+            author="bernstein",
+            description="Ollama / OpenAI-compatible local LLM adapter (via Aider)",
+            capabilities=(AdapterCapability.SUPPORTS_TEMPERATURE,),
+        )
 
     def _resolve_model(self, model_name: str) -> str:
         """Map Bernstein model name to Ollama / OpenAI-compatible model ID."""
@@ -242,6 +267,21 @@ class OllamaAdapter(CLIAdapter):
             "1024",
             "--no-auto-lint",
         ]
+
+        if mcp_config:
+            temperature = mcp_config.get("temperature")
+            if isinstance(temperature, (int, float)) and not isinstance(temperature, bool):
+                logger.debug("ollama adapter: wiring --temperature=%s onto aider argv", temperature)
+                cmd.extend(["--temperature", str(float(temperature))])
+            for dropped_key in ("top_p", "top_k", "max_tokens"):
+                if mcp_config.get(dropped_key) is not None:
+                    logger.warning(
+                        "ollama adapter: %s=%r requested but not wired (aider has no matching "
+                        "CLI flag) - ensure_sampling_params_supported should have refused this "
+                        "spawn before reaching here",
+                        dropped_key,
+                        mcp_config.get(dropped_key),
+                    )
 
         pid_dir = workdir / ".sdd" / "runtime" / "pids"
         wrapped_cmd = build_worker_cmd(

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -67,6 +67,23 @@ _OPENAI_CREDENTIAL_KEYS: tuple[str, ...] = (
 # full list.
 _DEFAULT_SANDBOX_PROVIDER: str = "unix_local"
 
+# Operator lever for the runner's tool source.  When set to ``"builtin"``
+# every openai_agents spawn uses the runner's workdir-sandboxed builtin
+# tools (read_file/write_file/list_dir/run_command) even when the
+# per-spawn ``mcp_config`` carries no ``tool_source`` key.  An explicit
+# ``mcp_config["tool_source"]`` value always wins over the env var.
+# Without this lever nothing in core/ ever populates ``tools`` or sets
+# ``tool_source``, so spawns arrive with ZERO tools: the model answers
+# the prompt with prose, the SDK sees a final output, and the runner
+# exits 0 in seconds having done no work.
+TOOL_SOURCE_ENV_VAR: str = "BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE"
+
+# Kept in sync with ``openai_agents_builtins._ALLOW_RUN_COMMAND_ENV``. The
+# spawn side must resolve this itself because ``build_filtered_env`` strips
+# BERNSTEIN_* control vars from the runner subprocess environment - a
+# parent-env opt-in that is not folded into the manifest simply vanishes.
+_ALLOW_RUN_COMMAND_ENV_VAR: str = "BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND"
+
 # Models the runner accepts.  Used for ``supported_models`` reporting and
 # to map effort tiers back to the cheapest viable SKU.  Entries must
 # also appear in ``bernstein.core.cost.cost.MODEL_COSTS_PER_1M_TOKENS``
@@ -91,6 +108,14 @@ class OpenAIAgentsAdapter(PluginAdapter):
     orchestrator's hot path so users without the optional dependency can
     still import the module for discovery/testing.
     """
+
+    # Provider-string aliases this adapter resolves from in
+    # ``_infer_adapter_name_for_provider``. Must resolve ahead of the bare
+    # "openai" alias on CodexAdapter, otherwise openai_agents spawns are
+    # misrouted to the codex adapter (see 042bcbd0). The registry's
+    # exact-match lookup makes ordering irrelevant going forward, but the
+    # alias set itself is unchanged from the old substring branch.
+    provides = ("openai_agents", "openai-agents")
 
     # The SDK forwards 429s from api.openai.com with the standard
     # ``rate_limit_exceeded`` / ``insufficient_quota`` error codes.
@@ -204,12 +229,31 @@ class OpenAIAgentsAdapter(PluginAdapter):
             if isinstance(provider, str) and provider:
                 sandbox_provider = provider
             # ``tool_source: "builtin"`` opts into the runner's
-            # workdir-sandboxed builtins.  Any other value keeps the default
-            # MCP-gateway path, so the manifest stays byte-identical for
-            # runs that do not request builtins.
+            # workdir-sandboxed builtins.  Any other explicit value keeps
+            # the default MCP-gateway path, so the manifest stays
+            # byte-identical for runs that do not request builtins.
             raw_tool_source = mcp_config.get("tool_source")
             if raw_tool_source == "builtin":
                 tool_source = "builtin"
+        # Operator env-var lever: applies only when mcp_config carries no
+        # explicit ``tool_source`` (an explicit value - builtin or not -
+        # always wins over the environment).
+        _env_tool_source_value = os.environ.get(TOOL_SOURCE_ENV_VAR)
+        _mcp_config_has_tool_source_key = bool(mcp_config) and "tool_source" in mcp_config
+        _env_lever_applies = not _mcp_config_has_tool_source_key and _env_tool_source_value == "builtin"
+        if _env_lever_applies:
+            tool_source = "builtin"
+        logger.info(
+            "_build_manifest tool_source decision session=%s: mcp_config_tool_source=%r, "
+            "env %s=%r, env_lever_applied=%s -> resolved tool_source=%r",
+            session_id,
+            (mcp_config or {}).get("tool_source"),
+            TOOL_SOURCE_ENV_VAR,
+            _env_tool_source_value,
+            _env_lever_applies,
+            tool_source,
+        )
+        if mcp_config:
             raw_tools: object = mcp_config.get("tools")
             if isinstance(raw_tools, list):
                 tools = [cast("dict[str, Any]", t) for t in cast("list[Any]", raw_tools) if isinstance(t, dict)]
@@ -247,7 +291,64 @@ class OpenAIAgentsAdapter(PluginAdapter):
         # value survives, matching the other sampling overrides above.
         overrides.setdefault("max_tokens", int(getattr(model_config, "max_tokens", 200_000)))
 
+        # Control knobs the RUNNER cannot see on its own: the spawner hands
+        # the subprocess a filtered environment (env_isolation strips
+        # BERNSTEIN_* control vars) and the runner never loads the operator
+        # yaml, so these must be resolved HERE - where the parent env and
+        # tuning defaults are both visible - and travel in the manifest.
+        raw_allow = (mcp_config or {}).get("allow_run_command")
+        if isinstance(raw_allow, bool):
+            allow_run_command = raw_allow
+        else:
+            allow_run_command = os.environ.get(_ALLOW_RUN_COMMAND_ENV_VAR) == "1"
+        raw_max_turns = (mcp_config or {}).get("max_turns")
+        if isinstance(raw_max_turns, int) and not isinstance(raw_max_turns, bool) and raw_max_turns > 0:
+            max_turns: int | None = raw_max_turns
+        else:
+            # Spawn-side resolution of env > tuning.agent.max_turns > None,
+            # reusing the runner's own resolver (in this process the env is
+            # the parent env and defaults are the yaml-loaded tuning).
+            from bernstein.adapters.openai_agents_runner import _resolve_max_turns
+
+            max_turns = _resolve_max_turns()
+
+        _tool_names = [str(t.get("name", "<unnamed>")) if isinstance(t, dict) else "<non-dict-tool>" for t in tools]
+        logger.info(
+            "_build_manifest tool assembly session=%s: resolved tool_source=%r, gateway tool_names=%r "
+            "(count=%d), mcp_servers=%r, allow_run_command=%s",
+            session_id,
+            tool_source,
+            _tool_names,
+            len(_tool_names),
+            list(mcp_servers.keys()),
+            allow_run_command,
+        )
+        # ``tool_source == "builtin"`` legitimately reports zero tools here -
+        # the builtin tool objects (read_file/write_file/list_dir, plus
+        # run_command when allow_run_command) are constructed later in the
+        # runner's ``_run_session``, not put into this manifest's ``tools``
+        # list (see openai_agents_runner.py's comment on the builtin path).
+        # A "gateway" spawn with zero tools and no mcp servers, however, has
+        # NO way to get any tool at all - the agent can only emit text. This
+        # is exactly the D2 tools-zero failure mode (silent zero-tools spawn,
+        # see work/bernstein/proofs/d2/tools-zero-diagnosis.md).
+        if tool_source != "builtin" and not tools and not mcp_servers:
+            logger.warning(
+                "_build_manifest session=%s: agent will have zero tools - it can only emit text. "
+                "reason=gateway tool_source selected but no gateway tools/mcpServers configured "
+                "(mcp_config tools=%r, mcpServers=%r; env %s=%r). Set mcp_config['tool_source']='builtin' "
+                "or export %s=builtin to grant workdir-sandboxed builtin tools instead.",
+                session_id,
+                (mcp_config or {}).get("tools"),
+                (mcp_config or {}).get("mcpServers"),
+                TOOL_SOURCE_ENV_VAR,
+                _env_tool_source_value,
+                TOOL_SOURCE_ENV_VAR,
+            )
+
         return overrides | {
+            "allow_run_command": allow_run_command,
+            "max_turns": max_turns,
             "session_id": session_id,
             "prompt": prompt,
             "workdir": str(workdir),
@@ -310,6 +411,25 @@ class OpenAIAgentsAdapter(PluginAdapter):
             system_addendum=system_addendum,
         )
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        # A spawn whose manifest carries tool_source="gateway" with zero
+        # tools gives the model NO function tools at all - it can only
+        # answer with prose and exit "successfully" having done nothing.
+        # Log the effective selection so that failure mode is visible in
+        # the orchestrator log instead of only in the (worktree-local,
+        # cleanup-prone) runner log.
+        logger.info(
+            "openai_agents spawn %s: tool_source=%s, tools=%d, model=%s, "
+            "allow_run_command=%s, max_turns=%s (env %s=%r, mcp_config tool_source=%r)",
+            session_id,
+            manifest["tool_source"],
+            len(manifest["tools"]),
+            manifest["model"],
+            manifest["allow_run_command"],
+            manifest["max_turns"],
+            TOOL_SOURCE_ENV_VAR,
+            os.environ.get(TOOL_SOURCE_ENV_VAR),
+            (mcp_config or {}).get("tool_source"),
+        )
 
         # ``api_key_env`` overrides which env var holds the key; only its
         # NAME is ever recorded, never the value.  The name is validated
@@ -324,6 +444,48 @@ class OpenAIAgentsAdapter(PluginAdapter):
                 "OpenAIAgentsAdapter: %s is not set - spawn will fail",
                 api_key_env,
             )
+
+        # One-line spawn-manifest summary: model/base_url/api_key_env NAME
+        # (never the secret value)/max_tokens/tool_source/tool count, all in
+        # one place so a spawn can be fully characterized from a single log
+        # line without cross-referencing the (worktree-local, cleanup-prone)
+        # manifest JSON file.
+        _max_tokens_val = manifest.get("max_tokens")
+        _max_tokens_str = "default:200000" if _max_tokens_val is None else str(_max_tokens_val)
+        logger.info(
+            "openai_agents spawn_manifest_summary session=%s: model=%s, base_url=%s, "
+            "api_key_env=%s, max_tokens=%s, tool_source=%s, tool_count=%d",
+            session_id,
+            manifest.get("model"),
+            manifest.get("base_url") or "<default>",
+            api_key_env,
+            _max_tokens_str,
+            manifest["tool_source"],
+            len(manifest["tools"]),
+        )
+
+        # [DEEPSEEK-DEBUG] Unconditional diagnostic for the
+        # deepseek/deepseek-chat-via-OpenRouter empty-completion / malformed
+        # tool-call investigation (2026-07-03). Confirms at the SPAWN side
+        # (before the runner subprocess even starts) that: (1) the model
+        # string is forwarded to the runner byte-for-byte with no name
+        # mapping/rewriting anywhere in this adapter, and (2) bernstein never
+        # sets any OpenRouter-recommended extra headers (HTTP-Referer,
+        # X-Title) anywhere in ``_build_manifest``/``spawn`` - grep this repo's
+        # ``src/bernstein/adapters/openai_agents*.py`` for "extra_headers" /
+        # "HTTP-Referer" / "X-Title" to confirm; there are none. If OpenRouter
+        # routing/model behavior depends on those headers being present, this
+        # is the log line proving they are absent for this spawn.
+        logger.info(
+            "[DEEPSEEK-DEBUG] spawn session=%s: model string forwarded verbatim (no "
+            "name mapping) model=%r, base_url=%r, api_key_env=%r (value never logged), "
+            "extra_headers_configured=False (bernstein sets no HTTP-Referer/X-Title/"
+            "any custom header anywhere in this adapter or the runner)",
+            session_id,
+            manifest.get("model"),
+            manifest.get("base_url") or "<default>",
+            api_key_env,
+        )
 
         cmd = [*self._runner_command(), "--manifest", str(manifest_path)]
 

--- a/src/bernstein/adapters/openai_agents_builtins.py
+++ b/src/bernstein/adapters/openai_agents_builtins.py
@@ -15,24 +15,62 @@ MCP-gateway path stays the default; builtins never become the default.
 The builtins split into two confinement tiers - do not conflate them:
 
 * ``read_file`` / ``write_file`` / ``list_dir`` are **workdir-confined at the
-  builtin layer**. Every path argument is resolved against the run workdir;
-  absolute paths and any ``..`` escape are rejected, checked on the real
-  (symlink-resolved) target so a symlinked parent cannot redirect the write.
-  These three are always available under ``tool_source: "builtin"``.
+  builtin layer**. A path argument may be relative (resolved against the run
+  workdir) or absolute; either way it is normalized (symlinks resolved) and
+  then checked for **containment** inside the real workdir - an absolute
+  path is allowed *iff* it resolves inside the workdir root (this is what
+  lets worker/manager heartbeat writes use the runner-issued absolute path,
+  e.g. ``/workspace/.sdd/runtime/heartbeats/<id>.json``, without every
+  absolute-path write being rejected outright). ``..`` traversal and any
+  absolute path that resolves outside the workdir are still rejected. These
+  three are always available under ``tool_source: "builtin"``.
 * ``run_command`` is a **restricted process-exec primitive**, not a
   workdir-sandboxed tool. It runs a child process, and a child process can
-  read and write anywhere the runner process can reach. The builtin layer
-  applies defense-in-depth only: ``argv`` is a list run with ``shell=False``
-  (no shell string, no interpolation), and ``argv[0]`` must be a bare command
-  name - absolute paths, path separators, and known shell/interpreters
-  (``sh``, ``bash``, ``python``, ``env``, ...) are rejected, and the survivor
-  is resolved on ``PATH`` and run by its resolved absolute path. TRUE
-  filesystem confinement for ``run_command`` is the configured OS sandbox
-  (``docker``/``e2b``/``modal``), NOT this builtin. Accordingly it is exposed
+  read and write anywhere the runner process can reach. It accepts EITHER a
+  single command **string** or an **argv list**:
+
+  - A string is executed as ``["/bin/bash", "-lc", <string>]`` - a real
+    shell, so variable substitution (``$FOO``), command substitution
+    (``$(...)``), pipes, redirects, and background jobs (``cmd & disown``)
+    all work exactly as the model expects when it writes ordinary shell
+    snippets (this is required for Bernstein's own manager-role prompt,
+    which instructs agents to authenticate task-API calls with
+    ``Authorization: Bearer $(cat <token-file>)``/``$BERNSTEIN_AUTH_TOKEN`` -
+    a no-shell argv exec cannot expand either). ``argv[0]`` here is always
+    the literal ``/bin/bash`` invoked directly by this module - it never
+    passes through :func:`resolve_command`, so it is **not** subject to the
+    ``argv``-list policy below by construction.
+  - A list is still run with ``shell=False`` - no shell string, no
+    interpolation - and ``argv[0]`` must be a bare command name resolved via
+    :func:`resolve_command`: absolute paths and path separators are
+    rejected (the model must pass a bare name, not a path), the survivor is
+    checked against a short denylist of **genuinely dangerous** operations
+    (privilege escalation, filesystem/partition destruction, system power
+    state - see ``_BLOCKED_COMMANDS``), and then resolved on ``PATH`` and run
+    by its resolved absolute path. Standard toolchain interpreters and
+    runners (``bash``, ``sh``, ``python``, ``python3``, ``pytest``, ``node``,
+    ``npm``, ``pip``, ``git``, ...) are ordinary bare commands here and are
+    **not** denylisted - blocking them provided no real containment once the
+    shell-string form above exists unguarded (a model that wants a shell can
+    already get a full one via the string form), and blocking them made
+    every Python/pytest-driven task structurally unsolvable for a
+    ``run_command``-only worker (see the D2 MiniMax KILL-NOTE).
+
+  TRUE filesystem confinement for ``run_command`` is the configured OS
+  sandbox (``docker``/``e2b``/``modal``), NOT this builtin - the shell string
+  form is exactly as confined (or unconfined) as the list form; the shell
+  itself does not grant the child process any capability an argv list
+  couldn't already reach (arbitrary binary execution) once ``run_command``
+  is exposed at all. Accordingly ``run_command`` (in either form) is exposed
   only when the run has an OS sandbox provider configured, or the operator
   explicitly opts in with ``BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND=1``. Under the
   bare local/worktree path with no opt-in, ``run_command`` is withheld while
   the three file tools remain available.
+
+  Every allow/deny decision made by :func:`resolve_command` and
+  :func:`resolve_in_workdir` is logged at ``INFO`` with the exact command/path
+  and the rule that fired, so a run's audit log alone explains every policy
+  decision without needing to reproduce the run.
 
 Every call is recorded to the runner's event stream (the same line-delimited
 JSON surface the MCP path uses) via an injected event sink, with the tool
@@ -47,14 +85,22 @@ package installed.
 
 from __future__ import annotations
 
+import hashlib
+import itertools
+import logging
 import os
 import shutil
 import subprocess
+import tempfile
+import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+
+logger = logging.getLogger(__name__)
 
 # Output byte caps so a tool call cannot flood the event stream or return an
 # unbounded payload to the model. Deterministic and process-independent.
@@ -73,33 +119,43 @@ BUILTIN_TOOL_NAMES: tuple[str, ...] = (
     "run_command",
 )
 
-# Shell/interpreter command names rejected as ``argv[0]`` for ``run_command``.
-# A bare interpreter name resolves to a real interpreter binary that would
-# re-open the door this builtin is trying to keep shut (``sh -c ...`` runs an
-# arbitrary shell string; ``python -c ...`` runs arbitrary code). These are
-# rejected before PATH resolution so the model cannot smuggle a shell in as a
-# bare name either.
-_BLOCKED_INTERPRETERS: frozenset[str] = frozenset(
+# Bare command names rejected outright as ``argv[0]`` for the argv-LIST form
+# of ``run_command``. This is intentionally short: standard toolchain
+# interpreters/runners (bash, sh, python, python3, pytest, node, npm, pip,
+# git, ...) are NOT here - blocking them provided no real containment (the
+# shell-string form of run_command already gives the model an unrestricted
+# ``/bin/bash -lc`` by design, so denylisting the same interpreters as bare
+# argv[0] names in the list form was security theater that only cost every
+# Python/pytest-driven worker task its full turn budget; see the D2 MiniMax
+# KILL-NOTE). What remains here targets operations that are dangerous
+# regardless of which process invokes them: privilege escalation, partition/
+# filesystem destruction, and host power state.
+_BLOCKED_COMMANDS: frozenset[str] = frozenset(
     {
-        "sh",
-        "bash",
-        "dash",
-        "zsh",
-        "ksh",
-        "fish",
-        "env",
-        "python",
-        "python3",
-        "perl",
-        "ruby",
-        "node",
-        "nodejs",
+        "sudo",
+        "doas",
+        "su",
+        "shutdown",
+        "reboot",
+        "halt",
+        "poweroff",
+        "init",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "dd",
+        "visudo",
     }
 )
 
 # Environment opt-in that exposes ``run_command`` even without an OS sandbox
 # provider. See :func:`run_command_available`.
 _ALLOW_RUN_COMMAND_ENV: str = "BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND"
+
+# Shell used to execute the single-string form of ``run_command``. ``-l``
+# (login) picks up the same PATH/profile a human shell session would have;
+# ``-c`` takes the command string as its sole positional argument.
+_SHELL_ARGV: tuple[str, str] = ("/bin/bash", "-lc")
 
 # Sandbox providers that give ``run_command`` real OS-level filesystem
 # confinement. The bare local/worktree path (``unix_local``) does NOT, so
@@ -110,23 +166,37 @@ _OS_SANDBOX_PROVIDERS: frozenset[str] = frozenset({"docker", "e2b", "modal"})
 class CommandNotAllowedError(ValueError):
     """Raised when ``run_command`` receives an ``argv[0]`` it will not run.
 
-    ``run_command`` is a restricted process-exec primitive: ``argv[0]`` must
-    be a bare command name (no path separator, not an absolute path), must not
-    be a shell/interpreter, and must resolve on the process ``PATH``. This is
-    a defense-in-depth restriction at the builtin layer; true filesystem
-    confinement is the configured OS sandbox, not this check.
+    ``run_command`` (argv-list form) is a restricted process-exec primitive:
+    ``argv[0]`` must be a bare command name (no path separator, not an
+    absolute path), must not name one of a short list of genuinely dangerous
+    operations (see ``_BLOCKED_COMMANDS``), and must resolve on the process
+    ``PATH``. Standard toolchain interpreters (bash, sh, python, python3,
+    pytest, node, ...) are ordinary bare commands and are not rejected here.
+    This is a defense-in-depth restriction at the builtin layer; true
+    filesystem confinement is the configured OS sandbox, not this check.
     """
 
 
 def resolve_command(name: str) -> str:
     """Resolve a bare command *name* to an absolute executable path.
 
-    The model may only pass a bare command name. This function rejects any
-    ``name`` that is an absolute path, contains a path separator (``/`` or the
-    platform ``os.sep``), or names a known shell/interpreter, then resolves the
-    survivor via :func:`shutil.which` against the process ``PATH`` and returns
-    the resolved absolute path. Passing an already-absolute path such as
-    ``/bin/sh`` is therefore rejected before it can run.
+    The model may only pass a bare command name (no absolute path, no path
+    separator) for the argv-LIST form of ``run_command``. This function
+    rejects such malformed names, rejects a short denylist of genuinely
+    dangerous operations (``_BLOCKED_COMMANDS`` - privilege escalation,
+    filesystem/partition destruction, host power state), then resolves the
+    survivor via :func:`shutil.which` against the process ``PATH`` and
+    returns the resolved absolute path. Standard toolchain interpreters and
+    runners (``bash``, ``sh``, ``python``, ``python3``, ``pytest``, ``node``,
+    ``npm``, ``pip``, ``git``, ...) are deliberately NOT denylisted - see the
+    module docstring for why blocking them was both ineffective (the
+    shell-string form of ``run_command`` already grants an unrestricted
+    shell) and actively harmful (it made Python/pytest-driven tasks
+    unsolvable for a ``run_command``-only worker).
+
+    Every decision - allow or deny - is logged at ``INFO`` with the exact
+    ``argv[0]`` and the rule that fired, so the audit log alone explains why
+    a command was let through or refused.
 
     Args:
         name: Candidate ``argv[0]`` from a tool call.
@@ -136,100 +206,138 @@ def resolve_command(name: str) -> str:
 
     Raises:
         CommandNotAllowedError: *name* is empty, absolute, contains a path
-            separator, is a blocked interpreter, or does not resolve on PATH.
+            separator, names a blocked (dangerous) command, or does not
+            resolve on PATH.
     """
     if not name:
+        logger.info("run_command policy: DENY rule=empty_argv0 argv0=%r", name)
         msg = "empty command"
         raise CommandNotAllowedError(msg)
     candidate = Path(name)
     if candidate.is_absolute():
+        logger.info("run_command policy: DENY rule=absolute_path argv0=%r", name)
         msg = f"argv[0] must be a bare command name, not an absolute path: {name!r}"
         raise CommandNotAllowedError(msg)
     if "/" in name or os.sep in name or (os.altsep and os.altsep in name):
+        logger.info("run_command policy: DENY rule=path_separator argv0=%r", name)
         msg = f"argv[0] must be a bare command name without a path separator: {name!r}"
         raise CommandNotAllowedError(msg)
-    if name in _BLOCKED_INTERPRETERS:
-        msg = f"argv[0] names a shell/interpreter, which is not allowed: {name!r}"
+    if name in _BLOCKED_COMMANDS:
+        logger.info("run_command policy: DENY rule=blocked_dangerous_command argv0=%r", name)
+        msg = f"argv[0] names a command this policy blocks as dangerous: {name!r}"
         raise CommandNotAllowedError(msg)
     resolved = shutil.which(name)
     if resolved is None:
+        logger.info("run_command policy: DENY rule=unresolvable_on_path argv0=%r", name)
         msg = f"argv[0] does not resolve to an executable on PATH: {name!r}"
         raise CommandNotAllowedError(msg)
+    logger.info("run_command policy: ALLOW rule=bare_command_resolved argv0=%r resolved=%r", name, resolved)
     return resolved
 
 
-def run_command_available(sandbox_provider: str | None) -> bool:
+def run_command_available(
+    sandbox_provider: str | None,
+    *,
+    allow_run_command: bool | None = None,
+) -> bool:
     """Return whether ``run_command`` should be exposed for this run.
 
     ``run_command`` is a process-exec primitive: its filesystem confinement is
     the OS sandbox, not the builtin layer. So it is exposed only when the run
     has a real OS sandbox provider configured, or when the operator explicitly
-    opts in via the ``BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND=1`` environment
-    variable. Under the bare local/worktree path with no opt-in it is withheld;
+    opts in. The opt-in travels in the runner MANIFEST (``allow_run_command``,
+    resolved by the spawn side) with the ``BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND=1``
+    environment variable as a fallback for direct runner invocations - the
+    spawner filters the subprocess environment (env_isolation), so a parent-env
+    opt-in never survives into an adapter-spawned runner on its own.
+    Under the bare local/worktree path with no opt-in it is withheld;
     ``read_file``/``write_file``/``list_dir`` remain available and confined.
 
     Args:
         sandbox_provider: The manifest sandbox provider, e.g. ``unix_local``,
             ``docker``, ``e2b``, ``modal``.
+        allow_run_command: Manifest-carried opt-in decision. ``True``/``False``
+            wins over the environment fallback; ``None`` means the manifest
+            did not carry the field (direct invocation) and the env applies.
 
     Returns:
         ``True`` when ``run_command`` may be registered, ``False`` otherwise.
     """
     if sandbox_provider in _OS_SANDBOX_PROVIDERS:
         return True
+    if allow_run_command is not None:
+        return allow_run_command
     return os.environ.get(_ALLOW_RUN_COMMAND_ENV) == "1"
 
 
 class WorkdirEscapeError(ValueError):
     """Raised when a path argument would leave the run workdir.
 
-    Covers absolute paths and ``..`` traversal. The message names the
-    offending path but never the resolved absolute target outside the
-    workdir, so error text handed back to the model does not leak host
-    layout.
+    Covers ``..`` traversal and absolute paths that resolve outside the
+    workdir. The message names the offending path but never the resolved
+    absolute target outside the workdir, so error text handed back to the
+    model does not leak host layout.
     """
 
 
 def resolve_in_workdir(workdir: Path, relpath: str) -> Path:
     """Resolve *relpath* against *workdir*, rejecting escapes.
 
-    The returned path is the real (symlink-resolved) location the caller
-    may touch. It is guaranteed to sit inside the real workdir.
+    *relpath* may be relative (joined onto *workdir*) or absolute. Either
+    way, the returned path is the real (symlink-resolved) location the
+    caller may touch, and it is guaranteed to sit inside the real workdir -
+    an absolute path is allowed **iff** it normalizes into the workdir. This
+    is what lets runner-issued absolute paths (e.g. worker/manager heartbeat
+    writes to ``/workspace/.sdd/runtime/heartbeats/<id>.json``) succeed
+    without a blanket ban on every absolute path; escapes are still rejected
+    by the same containment check that already caught ``..`` traversal.
 
-    Rejection rules, both raising :class:`WorkdirEscapeError`:
-
-    * ``relpath`` is absolute (``/etc/passwd``, ``C:\\...``). Builtins only
-      ever address paths relative to the workdir.
-    * The resolved real path is not the workdir itself and is not contained
-      by the real workdir - this catches ``..`` traversal and symlinks that
-      point outside, because containment is checked on the realpath, not on
-      the lexical string.
+    Rejection rule, raising :class:`WorkdirEscapeError`: the resolved real
+    path is not the workdir itself and is not contained by the real workdir.
+    This catches ``..`` traversal, an absolute path outside the workdir root,
+    and symlinks that point outside, because containment is checked on the
+    realpath, not on the lexical string.
 
     Args:
         workdir: The run workdir the sandbox is confined to.
-        relpath: Candidate path from a tool argument.
+        relpath: Candidate path from a tool argument - relative or absolute.
 
     Returns:
         The resolved absolute :class:`Path` inside the workdir.
 
     Raises:
-        WorkdirEscapeError: The path is absolute or escapes the workdir.
+        WorkdirEscapeError: The path escapes the workdir.
     """
     candidate = Path(relpath)
-    if candidate.is_absolute():
-        msg = f"absolute paths are not allowed: {relpath!r}"
-        raise WorkdirEscapeError(msg)
-
     real_workdir = Path(workdir).resolve()
-    # Resolve the joined path. ``strict=False`` so a not-yet-existing target
-    # (e.g. write_file creating a new file) still resolves its parent chain;
-    # ``..`` segments collapse during resolution, so an escape shows up as a
-    # real path outside ``real_workdir`` below.
-    resolved = (real_workdir / candidate).resolve()
+
+    # ``strict=False`` so a not-yet-existing target (e.g. write_file creating
+    # a new file) still resolves its parent chain; ``..`` segments collapse
+    # during resolution, so an escape shows up as a real path outside
+    # ``real_workdir`` below - for both the relative and the absolute case.
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+        rule = "absolute_path"
+    else:
+        resolved = (real_workdir / candidate).resolve()
+        rule = "relative_path"
 
     if resolved != real_workdir and real_workdir not in resolved.parents:
+        logger.info(
+            "resolve_in_workdir policy: DENY rule=%s path=%r resolved=%s workdir=%s",
+            rule,
+            relpath,
+            resolved,
+            real_workdir,
+        )
         msg = f"path escapes the run workdir: {relpath!r}"
         raise WorkdirEscapeError(msg)
+    logger.info(
+        "resolve_in_workdir policy: ALLOW rule=%s path=%r resolved=%s",
+        rule,
+        relpath,
+        resolved,
+    )
     return resolved
 
 
@@ -360,74 +468,316 @@ def list_dir_in_workdir(
     return "\n".join(entries)
 
 
+# ---------------------------------------------------------------------------
+# run_command duplicate-invocation guard (D2 attempt-4 defect 2, 2026-07-02)
+# ---------------------------------------------------------------------------
+# Observed failure: on the openai_agents path against a chat-completions
+# translation endpoint (meridian), the assistant message can arrive with the
+# SAME tool_call duplicated - the SDK then faithfully invokes ``run_command``
+# twice, concurrently, for one logical model call (the manager's
+# ``bash create_tasks.sh`` ran twice and double-POSTed duplicate task pairs,
+# feeding the 15-minute claim-conflict deadlock). The builtin layer itself
+# has always executed exactly once per invocation; this guard makes execution
+# exactly-once per logical call even when the invocation is delivered twice.
+#
+# Mechanism: every invocation gets a monotonic id and a sha256 command hash
+# (both logged at INFO forever, so any double-delivery is visible in logs).
+# If an identical command (same hash) is either still in flight or finished
+# within ``_DEDUPE_WINDOW_S`` seconds, the duplicate does NOT execute - it
+# waits for / reuses the original's result and logs a WARNING with both
+# invocation ids. Duplicates from a duplicated tool_calls array arrive
+# back-to-back (milliseconds apart, often overlapping); a legitimate model
+# retry of the same command requires a full LLM round trip and lands well
+# outside the window. Tunable via ``BERNSTEIN_RUN_COMMAND_DEDUPE_WINDOW_S``
+# (seconds; ``0`` disables the guard entirely).
+_DEDUPE_WINDOW_ENV = "BERNSTEIN_RUN_COMMAND_DEDUPE_WINDOW_S"
+_DEDUPE_WINDOW_DEFAULT_S = 2.0
+
+_invocation_ids = itertools.count(1)
+_dedupe_lock = threading.Lock()
+
+
+class _InvocationRecord:
+    """In-flight/most-recent execution record for one command hash."""
+
+    __slots__ = ("done", "finished_at", "invocation_id", "result")
+
+    def __init__(self, invocation_id: int) -> None:
+        self.invocation_id = invocation_id
+        self.done = threading.Event()
+        self.finished_at: float = 0.0
+        self.result: str = ""
+
+
+_recent_invocations: dict[str, _InvocationRecord] = {}
+
+
+def _dedupe_window_s() -> float:
+    """Return the duplicate-suppression window in seconds (0 disables)."""
+    raw = os.environ.get(_DEDUPE_WINDOW_ENV)
+    if raw is None:
+        return _DEDUPE_WINDOW_DEFAULT_S
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning(
+            "run_command: invalid %s=%r - using default %.1fs",
+            _DEDUPE_WINDOW_ENV,
+            raw,
+            _DEDUPE_WINDOW_DEFAULT_S,
+        )
+        return _DEDUPE_WINDOW_DEFAULT_S
+
+
+def _command_hash(workdir: Path, exec_argv: list[str]) -> str:
+    """Stable hash identifying one logical command in one workdir."""
+    payload = "\x00".join([str(workdir), *exec_argv])
+    return hashlib.sha256(payload.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+def _claim_or_join_invocation(
+    command_hash: str,
+    invocation_id: int,
+    window_s: float,
+) -> tuple[_InvocationRecord, bool]:
+    """Register this invocation, or join an identical recent/in-flight one.
+
+    Returns ``(record, is_duplicate)``. When ``is_duplicate`` is ``True`` the
+    caller must NOT execute; it should wait on ``record.done`` and reuse
+    ``record.result``.
+    """
+    with _dedupe_lock:
+        prev = _recent_invocations.get(command_hash)
+        if window_s > 0 and prev is not None:
+            in_flight = not prev.done.is_set()
+            fresh = prev.done.is_set() and (time.monotonic() - prev.finished_at) <= window_s
+            if in_flight or fresh:
+                return prev, True
+        record = _InvocationRecord(invocation_id)
+        _recent_invocations[command_hash] = record
+        return record, False
+
+
+def _run_captured(
+    exec_argv: list[str],
+    *,
+    cwd: Path,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    """Run *exec_argv*, capturing stdout/stderr via temp files, not pipes.
+
+    ``subprocess.run(capture_output=True)`` backs stdout/stderr with OS
+    pipes. A shell-string command that backgrounds a job (``cmd & disown``,
+    e.g. a heartbeat loop: ``while true; do date > hb; sleep 30; done &``)
+    spawns a grandchild that inherits those pipe write-ends. A pipe only
+    reaches EOF once *every* fd referencing its write end is closed - so
+    ``subprocess.run``'s internal ``communicate()`` blocks reading from the
+    pipe for the full lifetime of the backgrounded grandchild, even though
+    the direct child (the shell) exited immediately after its foreground
+    statements. ``disown`` only detaches job-control/SIGHUP tracking, not
+    stdio, so it does not fix this.
+
+    File-backed capture has no such wait: ``Popen.wait()`` (which is what
+    this function ultimately drives) returns as soon as the *direct* child
+    exits, regardless of what a backgrounded grandchild still holds open,
+    because there is no read-until-EOF loop over a file the way there is
+    over a pipe - we simply seek back and read whatever bytes exist once the
+    direct child is done. ``stdin=DEVNULL`` additionally ensures a
+    backgrounded child never blocks waiting on stdin input it will never
+    receive.
+    """
+    with tempfile.TemporaryFile() as out_f, tempfile.TemporaryFile() as err_f:
+        raw = subprocess.run(
+            exec_argv,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=out_f,
+            stderr=err_f,
+            shell=False,
+            timeout=timeout,
+            check=False,
+        )
+        out_f.seek(0)
+        err_f.seek(0)
+        stdout = out_f.read().decode("utf-8", errors="replace")
+        stderr = err_f.read().decode("utf-8", errors="replace")
+    return subprocess.CompletedProcess(exec_argv, raw.returncode, stdout, stderr)
+
+
 def run_command_in_workdir(
     workdir: Path,
-    argv: Sequence[str],
+    argv: Sequence[str] | str,
     *,
     emit: Callable[[dict[str, Any]], None],
 ) -> str:
-    """Run *argv* inside the workdir with ``shell=False``, recording the call.
+    """Run *argv* inside the workdir, recording the call.
 
-    ``argv`` is a list passed straight to :func:`subprocess.run` with
-    ``shell=False``: there is no shell string and no shell interpolation,
-    so metacharacters (``;``, ``|``, ``$(...)``, ``&&``) in an argument are
-    handed to the program literally rather than interpreted by a shell. The
-    child runs with ``cwd`` set to the resolved workdir.
+    Two calling forms, dispatched on the type of *argv*:
 
-    ``argv[0]`` is restricted to a bare command name resolved via
-    :func:`resolve_command`: absolute paths, path separators, and known
-    shell/interpreters are rejected, and the survivor is resolved on ``PATH``
-    and run by its resolved absolute path. This is a defense-in-depth measure
-    at the builtin layer; ``run_command`` remains a process-exec primitive
-    whose filesystem confinement is the configured OS sandbox, not this check.
+    * A **string** is executed as ``["/bin/bash", "-lc", argv]`` - a real
+      shell. Variable substitution (``$FOO``), command substitution
+      (``$(...)``), pipes, redirects, and background jobs (``cmd &
+      disown``) all work as they would in an interactive shell. This is the
+      form the manager role's task-server auth snippets need (e.g.
+      ``TOKEN=$(cat <token-file>) && curl ... -H "Authorization: Bearer
+      $TOKEN"``).
+    * A **list** is passed straight to a subprocess call with ``shell=False``:
+      there is no shell string and no shell interpolation, so metacharacters
+      (``;``, ``|``, ``$(...)``, ``&&``) in an argument are handed to the
+      program literally rather than interpreted by a shell. ``argv[0]`` is
+      restricted to a bare command name resolved via :func:`resolve_command`:
+      absolute paths and path separators are rejected, and a short denylist
+      of genuinely dangerous operations (``_BLOCKED_COMMANDS``) is checked -
+      standard toolchain interpreters (bash, sh, python, python3, pytest,
+      node, ...) are ordinary bare commands and are **not** denylisted. The
+      survivor is resolved on ``PATH`` and run by its resolved absolute path.
+
+    Both forms capture stdout/stderr via temp files rather than OS pipes
+    (see :func:`_run_captured`), so a shell-string command that backgrounds
+    a job (``cmd & disown``) does not block the call for the job's lifetime.
+
+    The child runs with ``cwd`` set to the resolved workdir in both forms.
+    ``run_command`` remains a process-exec primitive whose true filesystem
+    confinement is the configured OS sandbox, not this function.
     """
-    argv_list = list(argv)
+    invocation_id = next(_invocation_ids)
+    is_shell_form = isinstance(argv, str)
     emit(
         {
             "type": "tool_call",
             "name": "run_command",
-            "args": {"argv": argv_list},
+            "args": {"command": argv} if is_shell_form else {"argv": list(argv)},
             "tool_source": "builtin",
+            "exec_form": "shell_string" if is_shell_form else "argv_list",
+            "invocation_id": invocation_id,
         }
     )
-    if not argv_list:
-        emit(
-            {
-                "type": "tool_result",
-                "name": "run_command",
-                "tool_source": "builtin",
-                "status": "error",
-                "error": "empty argv",
-            }
-        )
-        return "error: empty argv"
-    try:
-        resolved_command = resolve_command(argv_list[0])
-    except CommandNotAllowedError as exc:
-        emit(
-            {
-                "type": "tool_result",
-                "name": "run_command",
-                "tool_source": "builtin",
-                "status": "error",
-                "error": f"{type(exc).__name__}: {exc}",
-            }
-        )
-        return f"error: {exc}"
-    real_workdir = Path(workdir).resolve()
-    exec_argv = [resolved_command, *argv_list[1:]]
-    try:
+
+    if is_shell_form:
+        command_str = argv
+        if not command_str.strip():
+            logger.info(
+                "run_command: exec_form=shell_string cwd=%s exit_code=n/a status=error error=%r",
+                workdir,
+                "empty command string",
+            )
+            emit(
+                {
+                    "type": "tool_result",
+                    "name": "run_command",
+                    "tool_source": "builtin",
+                    "status": "error",
+                    "error": "empty command string",
+                }
+            )
+            return "error: empty command string"
+        exec_argv: list[str] = [*_SHELL_ARGV, command_str]
+        logged_form = f"shell_string command={command_str!r}"
+    else:
+        argv_list = list(argv)
+        if not argv_list:
+            logger.info(
+                "run_command: exec_form=argv_list cwd=%s exit_code=n/a status=error error=%r",
+                workdir,
+                "empty argv",
+            )
+            emit(
+                {
+                    "type": "tool_result",
+                    "name": "run_command",
+                    "tool_source": "builtin",
+                    "status": "error",
+                    "error": "empty argv",
+                }
+            )
+            return "error: empty argv"
+        try:
+            resolved_command = resolve_command(argv_list[0])
+        except CommandNotAllowedError as exc:
+            logger.info(
+                "run_command: exec_form=argv_list cwd=%s argv=%r exit_code=n/a status=error error=%s: %s",
+                workdir,
+                argv_list,
+                type(exc).__name__,
+                exc,
+            )
+            emit(
+                {
+                    "type": "tool_result",
+                    "name": "run_command",
+                    "tool_source": "builtin",
+                    "status": "error",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+            return f"error: {exc}"
         # argv list + shell=False: no shell string, no interpolation.
-        completed = subprocess.run(
+        exec_argv = [resolved_command, *argv_list[1:]]
+        logged_form = f"argv_list exec_argv={exec_argv!r}"
+
+    real_workdir = Path(workdir).resolve()
+
+    # Duplicate-invocation guard (see module comment above _InvocationRecord):
+    # one INFO line per invocation with a monotonic id + command hash, so a
+    # double-delivered tool call is diagnosable from logs alone, forever.
+    command_hash = _command_hash(real_workdir, exec_argv)
+    window_s = _dedupe_window_s()
+    logger.info(
+        "run_command invocation: id=%d command_hash=%s %s cwd=%s",
+        invocation_id,
+        command_hash,
+        logged_form,
+        real_workdir,
+    )
+    record, is_duplicate = _claim_or_join_invocation(command_hash, invocation_id, window_s)
+    if is_duplicate:
+        logger.warning(
+            "run_command DUPLICATE-INVOCATION suppressed: id=%d is a duplicate of "
+            "id=%d (command_hash=%s, window=%.1fs) - executing once, reusing the "
+            "original result (double-delivered tool_call, see D2 defect 2)",
+            invocation_id,
+            record.invocation_id,
+            command_hash,
+            window_s,
+        )
+        # Bounded wait: the original is subject to _RUN_COMMAND_TIMEOUT_S, so
+        # this can never hang the duplicate past that ceiling plus slack.
+        finished = record.done.wait(timeout=_RUN_COMMAND_TIMEOUT_S + 30.0)
+        emit(
+            {
+                "type": "tool_result",
+                "name": "run_command",
+                "tool_source": "builtin",
+                "status": "ok" if finished else "error",
+                "deduped": True,
+                "invocation_id": invocation_id,
+                "duplicate_of": record.invocation_id,
+            }
+        )
+        if not finished:
+            return "error: duplicate invocation timed out waiting for the original execution"
+        return record.result
+
+    def _finish(result: str) -> str:
+        record.result = result
+        record.finished_at = time.monotonic()
+        record.done.set()
+        return result
+
+    try:
+        completed = _run_captured(
             exec_argv,
             cwd=real_workdir,
-            capture_output=True,
-            text=True,
-            shell=False,
             timeout=_RUN_COMMAND_TIMEOUT_S,
-            check=False,
         )
-    except (OSError, subprocess.SubprocessError) as exc:
+    except subprocess.TimeoutExpired as exc:
+        logger.info(
+            "run_command: %s cwd=%s exit_code=n/a status=error error=timeout after %ss stderr_tail=%r",
+            logged_form,
+            real_workdir,
+            _RUN_COMMAND_TIMEOUT_S,
+            (exc.stderr or "")[-2000:] if isinstance(exc.stderr, str) else exc.stderr,
+        )
         emit(
             {
                 "type": "tool_result",
@@ -435,11 +785,50 @@ def run_command_in_workdir(
                 "tool_source": "builtin",
                 "status": "error",
                 "error": f"{type(exc).__name__}: {exc}",
+                "invocation_id": invocation_id,
             }
         )
-        return f"error: {exc}"
+        return _finish(f"error: {exc}")
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.info(
+            "run_command: %s cwd=%s exit_code=n/a status=error error=%s: %s",
+            logged_form,
+            real_workdir,
+            type(exc).__name__,
+            exc,
+        )
+        emit(
+            {
+                "type": "tool_result",
+                "name": "run_command",
+                "tool_source": "builtin",
+                "status": "error",
+                "error": f"{type(exc).__name__}: {exc}",
+                "invocation_id": invocation_id,
+            }
+        )
+        return _finish(f"error: {exc}")
+
     stdout = completed.stdout[:_MAX_CMD_OUTPUT_CHARS]
     stderr = completed.stderr[:_MAX_CMD_OUTPUT_CHARS]
+    if completed.returncode == 0:
+        logger.info(
+            "run_command: %s cwd=%s exit_code=%d status=ok",
+            logged_form,
+            real_workdir,
+            completed.returncode,
+        )
+    else:
+        # Never truncate what we log to the reader's eye beyond the same cap
+        # already applied to the tool-facing stderr - full stderr tail on
+        # nonzero exit is the whole point of this log line.
+        logger.info(
+            "run_command: %s cwd=%s exit_code=%d status=nonzero stderr_tail=%r",
+            logged_form,
+            real_workdir,
+            completed.returncode,
+            stderr[-2000:],
+        )
     emit(
         {
             "type": "tool_result",
@@ -447,21 +836,26 @@ def run_command_in_workdir(
             "tool_source": "builtin",
             "status": "ok",
             "exit_code": completed.returncode,
+            "invocation_id": invocation_id,
         }
     )
-    return f"exit_code={completed.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    return _finish(f"exit_code={completed.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}")
 
 
-def selected_builtin_names(sandbox_provider: str | None) -> tuple[str, ...]:
+def selected_builtin_names(
+    sandbox_provider: str | None,
+    *,
+    allow_run_command: bool | None = None,
+) -> tuple[str, ...]:
     """Return the builtin tool names active for this run.
 
     ``read_file``/``write_file``/``list_dir`` are always present. ``run_command``
     is included only when :func:`run_command_available` is satisfied (an OS
-    sandbox provider or the explicit opt-in). Exported so the runner can log
-    exactly which set is active.
+    sandbox provider, the manifest opt-in, or the env fallback). Exported so
+    the runner can log exactly which set is active.
     """
     names = ["read_file", "write_file", "list_dir"]
-    if run_command_available(sandbox_provider):
+    if run_command_available(sandbox_provider, allow_run_command=allow_run_command):
         names.append("run_command")
     return tuple(names)
 
@@ -471,6 +865,7 @@ def build_builtin_tools(
     emit: Callable[[dict[str, Any]], None],
     *,
     sandbox_provider: str | None = None,
+    allow_run_command: bool | None = None,
 ) -> list[Any]:
     """Return the workdir-confined builtins wrapped as SDK ``@function_tool``.
 
@@ -483,8 +878,9 @@ def build_builtin_tools(
     workdir-confined at the builtin layer. ``run_command`` is a process-exec
     primitive whose filesystem confinement is the configured OS sandbox, so it
     is returned **only** when :func:`run_command_available` is satisfied for
-    *sandbox_provider* (an OS sandbox provider, or the explicit
-    ``BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND=1`` opt-in).
+    *sandbox_provider* (an OS sandbox provider, the manifest-carried
+    *allow_run_command* opt-in, or the ``BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND=1``
+    env fallback for direct invocations).
 
     Args:
         workdir: Run workdir every path is confined to.
@@ -518,11 +914,24 @@ def build_builtin_tools(
 
     tools: list[Any] = [read_file, write_file, list_dir]
 
-    if run_command_available(sandbox_provider):
+    if run_command_available(sandbox_provider, allow_run_command=allow_run_command):
 
         @function_tool
-        def run_command(argv: list[str]) -> str:
-            """Run a bare-name command inside the run workdir (no shell)."""
+        def run_command(argv: str | list[str]) -> str:
+            """Run a command inside the run workdir.
+
+            Pass a single command STRING to get a real shell
+            (``/bin/bash -lc <string>``): variable substitution (``$FOO``),
+            command substitution (``$(...)``), pipes, redirects, and
+            background jobs (``cmd & disown``) all work, e.g.
+            ``"TOKEN=$(cat path/to/token) && curl -H \"Authorization: Bearer $TOKEN\" ..."``.
+
+            Pass an argv LIST (e.g. ``["echo", "hello"]``) to run without a
+            shell: no interpolation, metacharacters in an argument are
+            passed to the program literally, and the first element must be
+            a bare command name resolvable on PATH (no absolute paths, no
+            shell/interpreter names).
+            """
             return run_command_in_workdir(workdir, argv, emit=emit)
 
         tools.append(run_command)

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -26,7 +26,9 @@ tests and downstream cost-tracking code rely on::
     {"type": "tool_call", "name": "file_read", "args": {...}}
     {"type": "tool_result", "name": "file_read", "output": "..."}
     {"type": "progress", "message": "..."}
-    {"type": "usage", "input_tokens": 123, "output_tokens": 456, "tool_calls": 3}
+    {"type": "usage", "input_tokens": 123, "output_tokens": 456, "tool_calls": 3,
+     "model": "gpt-5-mini", "cost_usd": 0.00123, "priced": true,
+     "running_total_usd": 0.00123}
     {"type": "completion", "status": "done", "summary": "..."}
     {"type": "error", "message": "...", "kind": "rate_limit"}
 
@@ -53,12 +55,10 @@ import re
 import sys
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,64 @@ EXIT_GENERIC: int = 1
 EXIT_MANIFEST_ERROR: int = 2
 EXIT_SDK_MISSING: int = 3
 EXIT_RATE_LIMIT: int = 4
+
+# Env var overriding AGENT.max_turns (tuning.agent.max_turns in bernstein.yaml).
+# Checked after the manifest value; an unset/blank/unparseable value falls
+# through to the yaml-tunable default, which itself defaults to 30 (bug 13:
+# the SDK's own default of 10 killed builtin-tool workflows mid-flight).
+MAX_TURNS_ENV_VAR: str = "BERNSTEIN_MAX_TURNS"
+
+
+def _resolve_max_turns(manifest_value: int | None = None) -> int | None:
+    """Resolve the effective ``max_turns`` for ``Runner.run_sync``.
+
+    Precedence: manifest ``max_turns`` (resolved by the spawn side, which
+    sees the operator yaml tuning and the un-filtered environment) >
+    ``BERNSTEIN_MAX_TURNS`` env var (direct-invocation fallback; the
+    spawner's filtered env strips it for adapter-spawned runners) >
+    ``AGENT.max_turns`` (yaml ``tuning.agent.max_turns``) > ``None``
+    (SDK default applies - unchanged behavior for anyone not opting in).
+
+    Logs the effective value and its source at INFO so a wrong turn cap
+    (e.g. the SDK's default 10 killing a multi-tool run) is diagnosable
+    from the runner log alone.
+    """
+    if manifest_value is not None:
+        if isinstance(manifest_value, int) and manifest_value > 0:
+            logger.info("max_turns=%d (source=manifest)", manifest_value)
+            return manifest_value
+        logger.warning(
+            "manifest max_turns=%r must be a positive int; falling back to env/tuning/SDK default",
+            manifest_value,
+        )
+    raw_env = os.environ.get(MAX_TURNS_ENV_VAR)
+    if raw_env is not None and raw_env.strip():
+        try:
+            parsed = int(raw_env)
+        except ValueError:
+            logger.warning(
+                "%s=%r is not a valid int; falling back to tuning.agent.max_turns/SDK default",
+                MAX_TURNS_ENV_VAR,
+                raw_env,
+            )
+        else:
+            if parsed > 0:
+                logger.info("max_turns=%d (source=env %s)", parsed, MAX_TURNS_ENV_VAR)
+                return parsed
+            logger.warning(
+                "%s=%r must be a positive int; falling back to tuning.agent.max_turns/SDK default",
+                MAX_TURNS_ENV_VAR,
+                raw_env,
+            )
+
+    from bernstein.core.defaults import AGENT
+
+    if AGENT.max_turns is not None:
+        logger.info("max_turns=%d (source=default tuning.agent.max_turns)", AGENT.max_turns)
+    else:
+        logger.info("max_turns not configured (source=SDK default)")
+    return AGENT.max_turns
+
 
 # ``api_key_env`` must name a known LLM-provider credential.  The name both
 # widens the filtered environment handed to this subprocess and selects the
@@ -228,6 +286,14 @@ class RunnerManifest:
     base_url: str | None = None
     api_key_env: str | None = None
     heartbeat_dir: str | None = None
+    # Control knobs resolved by the SPAWN side. They must travel in the
+    # manifest because the spawner hands the runner a filtered environment
+    # (env_isolation) that strips BERNSTEIN_* control vars - parent-env
+    # values never reach this subprocess on their own. ``None`` means the
+    # manifest did not carry the field (e.g. a hand-written manifest for a
+    # direct invocation) and the runner's own env/defaults apply.
+    allow_run_command: bool | None = None
+    max_turns: int | None = None
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> RunnerManifest:
@@ -337,20 +403,6 @@ def _build_agent_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
     return kwargs
 
 
-def _build_run_config(manifest: RunnerManifest) -> dict[str, Any]:
-    """Build the SDK ``RunConfig`` / ``SandboxRunConfig`` shape.
-
-    Returns a plain dict so the caller can hand the pieces to the SDK
-    without this module having to import SDK types.
-    """
-    return {
-        "sandbox_provider": manifest.sandbox_provider,
-        "workdir": manifest.workdir,
-        "timeout_seconds": manifest.timeout_seconds,
-        "mcp_servers": manifest.mcp_servers.copy(),
-    }
-
-
 def _build_model_settings_kwargs(
     manifest: RunnerManifest,
     *,
@@ -427,6 +479,322 @@ def _resolve_client_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
             raise RuntimeError(msg)
         kwargs["api_key"] = api_key
     return kwargs
+
+
+def _resolve_tokens_sidecar_path(manifest: RunnerManifest) -> Path:
+    """Return the ``.tokens`` sidecar path the orchestrator actually reads.
+
+    Bug 13 (2026-07-02): the orchestrator's live cost-metering loop
+    (``Orchestrator._record_live_costs``) only prices a session once
+    ``AgentSession.tokens_used`` is non-zero, and that field is populated
+    exclusively by ``TokenGrowthMonitor.read_tokens()`` tailing
+    ``<orchestrator-root>/.sdd/runtime/<session_id>.tokens`` - the same
+    sidecar Claude Code's wrapper script writes (see
+    :mod:`bernstein.adapters.claude_wrapper_script`). Before this fix the
+    openai_agents runner emitted a ``usage`` event to its own stdout/log
+    only, which nothing tails for cost purposes, so
+    ``AgentSession.tokens_used`` stayed ``0`` for the entire run and the
+    live-cost loop skipped the session on every tick - the direct cause of
+    the observed ``spent_usd: 0.0`` / empty ``usages`` run.
+
+    Mirrors :func:`_resolve_heartbeat_dir`'s resolution logic: ``workdir``
+    is a per-session worktree under default isolation, so the sidecar must
+    live under the orchestrator-root ``.sdd/runtime/`` directory (the
+    heartbeat directory's parent), not a worktree-relative path, or the
+    monitor polling the orchestrator root would never see it.
+    """
+    if manifest.heartbeat_dir:
+        runtime_dir = Path(manifest.heartbeat_dir).parent
+    else:
+        runtime_dir = Path(manifest.workdir) / ".sdd" / "runtime"
+    return runtime_dir / f"{manifest.session_id}.tokens"
+
+
+def _append_tokens_sidecar(path: Path, input_tokens: int, output_tokens: int) -> None:
+    """Append one usage record to the ``.tokens`` sidecar file.
+
+    Uses the exact schema Claude Code's wrapper script writes
+    (``{"ts": float, "in": int, "out": int}``) so the orchestrator's
+    generic ``TokenGrowthMonitor.read_tokens()`` - which just tails
+    whatever provider wrote the file - works unchanged for the
+    openai_agents path. Best-effort: a sidecar write failure must never
+    fail the run, only lose live-cost visibility for this call (logged at
+    WARNING so the loss itself is diagnosable).
+
+    Args:
+        path: Absolute sidecar path from :func:`_resolve_tokens_sidecar_path`.
+        input_tokens: Prompt tokens for this call.
+        output_tokens: Completion tokens for this call.
+    """
+    if input_tokens <= 0 and output_tokens <= 0:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = json.dumps({"ts": time.time(), "in": input_tokens, "out": output_tokens})
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(record + "\n")
+    except OSError as exc:
+        logger.warning("failed to write tokens sidecar %s: %s", path, exc)
+
+
+def _extract_usage_tokens(result: Any) -> tuple[int, int, int]:
+    """Extract ``(input_tokens, output_tokens, tool_calls)`` from a result-like object.
+
+    Accepts anything shaped like an SDK run result: ``result.usage`` first
+    (aggregate), then the ``result.raw_responses`` per-call fallback (bug-13
+    follow-up: ``RunResult`` never defines ``usage``, so the fallback is the
+    path that actually fires on real SDK objects). Also accepts the
+    ``run_data`` payload some SDK exceptions carry (e.g. ``MaxTurnsExceeded``
+    exposes the partial run's ``raw_responses`` via ``exc.run_data``), and
+    ``None`` (returns all zeros).
+
+    Args:
+        result: An SDK ``RunResult``, an exception's ``run_data`` object,
+            or ``None``.
+
+    Returns:
+        ``(input_tokens, output_tokens, tool_calls)``. All zero when no
+        usable usage data exists on the object.
+    """
+    usage: Any = getattr(result, "usage", None)
+    input_tokens = int(getattr(usage, "input_tokens", 0) or 0)
+    output_tokens = int(getattr(usage, "output_tokens", 0) or 0)
+    tool_calls = int(getattr(usage, "tool_calls", 0) or 0)
+
+    if input_tokens <= 0 and output_tokens <= 0:
+        raw_responses: Any = getattr(result, "raw_responses", None) or []
+        fallback_input = 0
+        fallback_output = 0
+        for raw_response in raw_responses:
+            raw_usage = getattr(raw_response, "usage", None)
+            fallback_input += int(getattr(raw_usage, "input_tokens", 0) or 0)
+            fallback_output += int(getattr(raw_usage, "output_tokens", 0) or 0)
+        if fallback_input > 0 or fallback_output > 0:
+            input_tokens = fallback_input
+            output_tokens = fallback_output
+
+    return input_tokens, output_tokens, tool_calls
+
+
+def _log_max_turns_exceeded(exc: BaseException, max_turns: int | None) -> None:
+    """Log a WARNING with full context when a session hits the turn cap.
+
+    Bug 13 (D2 minimax attempt-e938bd33): MaxTurnsExceeded was the dominant
+    failure and surfaced only as a generic runtime error - no record of the
+    configured cap, the turns actually burned, or whether the agent had
+    already finished its work (backend hit the cap AFTER committing and
+    POSTing /complete, so the kill wasted completed work). This makes the
+    cap-hit a 2-minute diagnosis from the runner log alone.
+
+    Args:
+        exc: The ``MaxTurnsExceeded`` exception (its ``run_data`` carries the
+            partial run's ``raw_responses``/``new_items`` when the SDK
+            populated them).
+        max_turns: The effective cap forwarded to ``Runner.run_sync``
+            (``None`` = SDK default).
+    """
+    run_data = getattr(exc, "run_data", None)
+    raw_responses = getattr(run_data, "raw_responses", None) or []
+    turns_used: int | str = len(raw_responses) if raw_responses else "unknown"
+    # Best-effort detection of already-completed work: the agent signals
+    # completion by POSTing the task /complete endpoint via the run_command
+    # builtin tool, so a "/complete" string inside any tool-call item of the
+    # partial run means the work was ALREADY done when the cap fired.
+    work_completed = "unknown"
+    try:
+        new_items = getattr(run_data, "new_items", None) or []
+        for item in new_items:
+            raw_item = getattr(item, "raw_item", item)
+            arguments = getattr(raw_item, "arguments", None)
+            if isinstance(arguments, str) and "/complete" in arguments:
+                work_completed = "yes"
+                break
+        else:
+            if new_items:
+                work_completed = "no"
+    except Exception:  # diagnostics only - never mask the real failure
+        work_completed = "unknown"
+    logger.warning(
+        "MaxTurnsExceeded: session hit the turn cap "
+        "(max_turns=%s, turns_used=%s, work_already_completed=%s). "
+        "Raise tuning.agent.max_turns / %s / manifest max_turns if this "
+        "workflow legitimately needs more turns.",
+        max_turns if max_turns is not None else "SDK-default",
+        turns_used,
+        work_completed,
+        MAX_TURNS_ENV_VAR,
+    )
+
+
+def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_desc: str) -> None:
+    """Extract, price, emit, and sidecar the session's token usage.
+
+    Single choke point for usage accounting, callable from BOTH the success
+    path (``usage_source`` = the SDK ``RunResult``) and the exception path
+    (``usage_source`` = the exception's ``run_data`` payload, or ``None``).
+
+    D2 MiniMax attempt-3 (2026-07-03) proof: the usage-extraction block
+    previously lived only after the ``try/except`` around
+    ``Runner.run_sync``, so ANY exception - including ``MaxTurnsExceeded``,
+    a routine condition where the agent has already made up to ``max_turns``
+    real, billable LLM calls - skipped it entirely. Six backend agents each
+    burned 10 real MiniMax turns and emitted zero ``usage`` events; the run's
+    cost file read ``spent_usd: 0.0, usages: []`` despite real spend. This
+    helper makes the extraction reachable from the exception handler: real
+    partial usage is priced and sidecar'd exactly like a successful run's,
+    and when genuinely no data exists a ``usage_missing`` event still fires
+    so downstream sees "unknown", never a silent zero.
+
+    Args:
+        manifest: The runner manifest (model, session id, sidecar path).
+        usage_source: Object to extract usage from - an SDK ``RunResult``,
+            an exception's ``run_data``, or ``None``.
+        source_desc: Human-readable description of where ``usage_source``
+            came from (e.g. ``"result"``, ``"MaxTurnsExceeded.run_data"``),
+            logged so a $0 run names the exact path that produced it.
+    """
+    input_tokens, output_tokens, tool_calls = _extract_usage_tokens(usage_source)
+
+    if input_tokens <= 0 and output_tokens <= 0:
+        # No usable token counts. Never fabricate tokens/cost and never
+        # write the sidecar with zeros - both would poison the
+        # orchestrator's live-cost accounting with fake data. Instead, emit
+        # a usage event flagged ``usage_missing`` (so downstream consumers
+        # can tell "zero spend" apart from "we don't know") and log loudly,
+        # naming the model and source, so a $0.00 run is a 2-minute
+        # diagnosis instead of a silent no-op.
+        logger.warning(
+            "llm_call session=%s model=%s source=%s: SDK returned no usage "
+            "data (usage is None/empty and raw_responses carried no usable "
+            "usage) - cost metering for this call is unavailable, not zero",
+            manifest.session_id,
+            manifest.model,
+            source_desc,
+        )
+        emit_event(
+            {
+                "type": "usage",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "tool_calls": tool_calls,
+                "model": manifest.model,
+                "usage_missing": True,
+                "usage_source": source_desc,
+            },
+        )
+        return
+
+    # Bug 13 fix: price the call (visible $0 + WARNING for unpriced models,
+    # never a silent drop - see price_model_usage docstring), log the
+    # per-call INFO line that would have made the original $0.00 run a
+    # 2-minute diagnosis, and write the .tokens sidecar so the
+    # orchestrator's live cost-metering loop actually sees this session
+    # (see _resolve_tokens_sidecar_path docstring for why the previous
+    # stdout-only "usage" event never reached it).
+    from bernstein.core.cost.model_prices import price_model_usage
+
+    price_result = price_model_usage(manifest.model, input_tokens, output_tokens)
+    # ``Runner.run_sync`` aggregates every internal turn into one cumulative
+    # usage total (whether from ``result.usage``, the ``raw_responses``
+    # fallback sum, or an exception's partial ``run_data``), so this call's
+    # cost *is* the session's running total to this point - there is no
+    # separate accumulator to maintain across multiple SDK calls in-process.
+    running_total_usd = price_result.cost_usd
+    logger.info(
+        "llm_call session=%s model=%s source=%s input_tokens=%d "
+        "output_tokens=%d cost_usd=%.6f priced=%s running_total_usd=%.6f",
+        manifest.session_id,
+        manifest.model,
+        source_desc,
+        input_tokens,
+        output_tokens,
+        price_result.cost_usd,
+        price_result.priced,
+        running_total_usd,
+    )
+
+    emit_event(
+        {
+            "type": "usage",
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "tool_calls": tool_calls,
+            "model": manifest.model,
+            "cost_usd": price_result.cost_usd,
+            "priced": price_result.priced,
+            "running_total_usd": running_total_usd,
+            "usage_source": source_desc,
+        },
+    )
+
+    _append_tokens_sidecar(
+        _resolve_tokens_sidecar_path(manifest),
+        input_tokens,
+        output_tokens,
+    )
+
+
+def _redacted_keys(mapping: Any) -> Any:
+    """Redact a header/body mapping for logging: return only its sorted key
+    names, never the values.
+
+    ``extra_headers``/``extra_body`` are where provider auth
+    (``Authorization: Bearer <key>``, ``X-Api-Key``, OpenRouter keys) is
+    conventionally placed, so their values must never reach the logs. Returns
+    the sorted list of key names for a mapping, ``None`` for ``None`` (nothing
+    configured), and a redacted marker for any non-mapping value so a secret
+    can never be logged verbatim.
+    """
+    if mapping is None:
+        return None
+    if isinstance(mapping, Mapping):
+        return sorted(str(k) for k in mapping)
+    return "<redacted: non-mapping value>"
+
+
+def _deepseek_debug_tool_schema_summary(tools: Any) -> list[dict[str, Any]]:
+    """Best-effort summary of a tool list's name + strict-schema flag.
+
+    [DEEPSEEK-DEBUG] diagnostic helper (2026-07-03): the empty-completion /
+    malformed-tool-call bug on ``deepseek/deepseek-chat`` via OpenRouter is
+    hypothesized to be triggered by the OpenAI Agents SDK's default
+    ``strict_json_schema=True`` on ``FunctionTool`` (see ``agents/tool.py``
+    ``strict_json_schema: bool = True`` and ``function_tool(strict_mode=True)``
+    defaults, and ``Converter.tool_to_openai`` which puts
+    ``"strict": tool.strict_json_schema`` directly into the outbound
+    ``ChatCompletionToolParam``). This walks whatever tool objects/dicts are
+    about to be handed to the SDK and reports, per tool, its name and
+    whatever strict-schema signal is discoverable - without assuming a
+    specific SDK version's exact attribute layout (best-effort; never
+    raises).
+
+    Args:
+        tools: The tool list about to be attached to ``agent_kwargs["tools"]``
+            - either raw dicts (gateway tool_source) or SDK ``Tool``
+            instances (builtin tool_source, built via ``@function_tool``).
+
+    Returns:
+        List of ``{"name": ..., "strict_json_schema": ..., "kind": ...,
+        "params_json_schema": ...}`` summaries. Never raises.
+    """
+    summaries: list[dict[str, Any]] = []
+    try:
+        for tool in tools or []:
+            entry: dict[str, Any] = {"kind": type(tool).__name__}
+            if isinstance(tool, dict):
+                entry["name"] = tool.get("name", "<unnamed-dict-tool>")
+                entry["strict_json_schema"] = tool.get("strict")
+                params = tool.get("parameters") or tool.get("params_json_schema")
+                entry["params_json_schema"] = params
+            else:
+                entry["name"] = getattr(tool, "name", "<unnamed-tool-object>")
+                entry["strict_json_schema"] = getattr(tool, "strict_json_schema", "<attr-absent>")
+                params_schema = getattr(tool, "params_json_schema", None)
+                entry["params_json_schema"] = params_schema
+            summaries.append(entry)
+    except Exception as exc:  # diagnostics only - never mask the real failure
+        summaries.append({"error": f"tool schema summary failed: {type(exc).__name__}: {exc}"})
+    return summaries
 
 
 def _resolve_heartbeat_dir(manifest: RunnerManifest) -> Path:
@@ -587,6 +955,11 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
         )
         return EXIT_GENERIC
 
+    # Set when ``manifest.base_url`` names a custom OpenAI-compatible
+    # endpoint: holds the ``AsyncOpenAI`` client the Agent's model must be
+    # built against explicitly (see the ``explicit_model_client`` usage
+    # below ``_build_agent_kwargs``).
+    explicit_model_client: Any = None
     if client_kwargs:
         # The manifest overrides the endpoint and/or API key.  Hand the SDK
         # a dedicated client instead of letting it read the ambient
@@ -604,6 +977,32 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
                 # authenticated with the third-party key.
                 sdk.set_default_openai_client(client, use_for_tracing=False)
                 sdk.set_default_openai_api("chat_completions")
+                # D1 openrouter fix (2026-07-02): setting the default
+                # client is NOT enough on its own. ``Agent(model=<str>)``
+                # is resolved by ``RunConfig.model_provider`` (a fresh
+                # ``agents.MultiProvider()`` by default -
+                # ``agents/run_config.py:220``) via
+                # ``turn_preparation.get_model()``
+                # (``agents/run_internal/turn_preparation.py:126-135``),
+                # which for a plain string falls through to
+                # ``model_provider.get_model(agent.model)``. ``MultiProvider``
+                # unconditionally splits the model string on the first "/"
+                # to find a provider prefix
+                # (``agents/models/multi_provider.py:154-161``,
+                # ``_get_prefix_and_model_name``) and raises
+                # ``UserError(f"Unknown prefix: {prefix}")`` for anything
+                # that isn't "openai"/"litellm"/"any-llm"/an explicit
+                # provider-map entry (``multi_provider.py:173`` and
+                # ``:221``). OpenRouter model ids legitimately contain a
+                # "vendor/model" slash (e.g. "deepseek/deepseek-chat"), so
+                # the SDK misreads "deepseek" as an SDK provider prefix and
+                # aborts before any tool call. Building the ``Model``
+                # instance ourselves sidesteps this entirely:
+                # ``get_model()`` returns ``agent.model`` directly, with no
+                # prefix parsing, whenever it is already an
+                # ``agents.Model`` instance rather than a string
+                # (``turn_preparation.py:132-133``).
+                explicit_model_client = client
             else:
                 sdk.set_default_openai_client(client)
         except Exception as exc:
@@ -616,8 +1015,27 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
             )
             return EXIT_GENERIC
 
+    # Resolved before the try so the except handler can report the effective
+    # cap even when the exception fires before/inside ``Runner.run_sync``.
+    max_turns: int | None = None
     try:
         agent_kwargs = _build_agent_kwargs(manifest)
+        if explicit_model_client is not None:
+            # Never log the client itself (it carries the API key) - only
+            # the model id and base_url, both non-secret.
+            logger.info(
+                "openai_agents_runner session=%s: routing model=%r through an "
+                "explicit OpenAIChatCompletionsModel bound to base_url=%r "
+                "instead of a bare model string, so the SDK's MultiProvider "
+                "never prefix-parses a vendor/model id from a custom endpoint",
+                manifest.session_id,
+                manifest.model,
+                manifest.base_url,
+            )
+            agent_kwargs["model"] = sdk.OpenAIChatCompletionsModel(
+                model=manifest.model,
+                openai_client=explicit_model_client,
+            )
         if manifest.tool_source == "builtin":
             # Opt-in workdir-sandboxed builtins for runs with no MCP gateway
             # reachable. Every call is recorded to this same event stream via
@@ -627,7 +1045,10 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
                 selected_builtin_names,
             )
 
-            active_names = selected_builtin_names(manifest.sandbox_provider)
+            active_names = selected_builtin_names(
+                manifest.sandbox_provider,
+                allow_run_command=manifest.allow_run_command,
+            )
             emit_event(
                 {
                     "type": "progress",
@@ -639,18 +1060,228 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
                 Path(manifest.workdir),
                 emit_event,
                 sandbox_provider=manifest.sandbox_provider,
+                allow_run_command=manifest.allow_run_command,
             )
+
+            # Disable strict JSON schema for non-OpenAI models (e.g.
+            # deepseek-chat via OpenRouter).  The SDK defaults
+            # strict_json_schema=True on every FunctionTool, which sends
+            # {"strict": true} in the tool schema.  Models that don't
+            # support OpenAI's strict structured-output mode return empty
+            # responses or malformed tool calls when they see this flag.
+            _model_lower = (manifest.model or "").lower()
+            _is_openai_native = any(_model_lower.startswith(p) for p in ("gpt-", "o1-", "o3-", "o4-", "chatgpt-"))
+            if not _is_openai_native:
+                _relaxed_count = 0
+                for tool in agent_kwargs.get("tools", []):
+                    if getattr(tool, "strict_json_schema", None) is True:
+                        tool.strict_json_schema = False
+                        _relaxed_count += 1
+                if _relaxed_count:
+                    logger.info(
+                        "[DEEPSEEK-DEBUG] Relaxed strict_json_schema=False on %d tools "
+                        "for non-OpenAI model %r (strict mode causes empty responses "
+                        "on deepseek-chat and other non-OpenAI models via OpenRouter)",
+                        _relaxed_count,
+                        manifest.model,
+                    )
+
         settings_kwargs = _build_model_settings_kwargs(manifest, model_settings_cls=sdk.ModelSettings)
         if settings_kwargs:
             agent_kwargs["model_settings"] = sdk.ModelSettings(**settings_kwargs)
         agent: Any = agent_cls(**agent_kwargs)
-        run_config = _build_run_config(manifest)
+        # No ``run_config`` is passed: the SDK's ``run_config`` kwarg must
+        # be a real ``agents.RunConfig`` instance - a plain dict crashes
+        # inside ``run.py`` on ``run_config.session_input_callback`` - and
+        # none of the manifest fields the old dict carried
+        # (sandbox_provider, workdir, timeout_seconds, mcp_servers) are
+        # ``RunConfig`` fields anyway. Every per-run knob we need (model,
+        # endpoint client, sampling settings) already rides on the Agent
+        # via ``_build_agent_kwargs``.
+        run_sync_kwargs: dict[str, Any] = {}
+        max_turns = _resolve_max_turns(manifest.max_turns)
+        if max_turns is not None:
+            run_sync_kwargs["max_turns"] = max_turns
+        # [DEEPSEEK-DEBUG] Unconditional (not gated behind a debug flag)
+        # pre-call diagnostic for the deepseek/deepseek-chat-via-OpenRouter
+        # empty-completion / malformed-tool-call investigation (2026-07-03).
+        # Logged at INFO so it is captured on every run without operator
+        # opt-in. Never logs the API key itself - only the env var NAME.
+        _model_settings_obj = agent_kwargs.get("model_settings")
+        _model_settings_repr = (
+            {
+                "temperature": getattr(_model_settings_obj, "temperature", None),
+                "top_p": getattr(_model_settings_obj, "top_p", None),
+                "tool_choice": getattr(_model_settings_obj, "tool_choice", None),
+                "parallel_tool_calls": getattr(_model_settings_obj, "parallel_tool_calls", None),
+                "max_tokens": getattr(_model_settings_obj, "max_tokens", None),
+                "extra_args": getattr(_model_settings_obj, "extra_args", None),
+                # extra_headers/extra_body are the SDK-conventional home for
+                # provider auth (Authorization/api-key). Log only the KEY NAMES,
+                # never the values, so this diagnostic can never leak a secret
+                # if an auth header is ever configured here.
+                "extra_headers_keys": _redacted_keys(getattr(_model_settings_obj, "extra_headers", None)),
+                "extra_body_keys": _redacted_keys(getattr(_model_settings_obj, "extra_body", None)),
+            }
+            if _model_settings_obj is not None
+            else "<no ModelSettings constructed - settings_kwargs was empty>"
+        )
+        _tool_list_for_log = agent_kwargs.get("tools", [])
+        logger.info(
+            "[DEEPSEEK-DEBUG] pre-call session=%s model=%r base_url=%r api_key_env=%r "
+            "explicit_model_client=%s tool_source=%r tool_count=%d max_turns=%s",
+            manifest.session_id,
+            manifest.model,
+            manifest.base_url,
+            manifest.api_key_env,
+            explicit_model_client is not None,
+            manifest.tool_source,
+            len(_tool_list_for_log),
+            max_turns,
+        )
+        logger.info(
+            "[DEEPSEEK-DEBUG] pre-call session=%s model_settings=%s "
+            "(tool_choice/parallel_tool_calls of None means the SDK/provider "
+            "default applies - bernstein never sets these explicitly)",
+            manifest.session_id,
+            _model_settings_repr,
+        )
+        logger.info(
+            "[DEEPSEEK-DEBUG] pre-call session=%s no extra_headers configured by bernstein "
+            "(no HTTP-Referer/X-Title sent to OpenRouter unless the SDK's own default "
+            "HEADERS constant includes them) - client_kwargs base_url=%r",
+            manifest.session_id,
+            client_kwargs.get("base_url"),
+        )
+        try:
+            _tool_schema_summary = _deepseek_debug_tool_schema_summary(_tool_list_for_log)
+            logger.info(
+                "[DEEPSEEK-DEBUG] pre-call session=%s tool_schemas=%s",
+                manifest.session_id,
+                json.dumps(_tool_schema_summary, default=str)[:8000],
+            )
+            _any_strict_true = any(entry.get("strict_json_schema") is True for entry in _tool_schema_summary)
+            if _any_strict_true:
+                logger.warning(
+                    "[DEEPSEEK-DEBUG] pre-call session=%s: at least one tool schema has "
+                    "strict_json_schema=True - the OpenAI Agents SDK sends this as "
+                    "'strict': true in the ChatCompletionToolParam.function block "
+                    "(agents/models/chatcmpl_converter.py Converter.tool_to_openai). "
+                    "This is the leading hypothesis for deepseek-chat-via-OpenRouter "
+                    "empty/malformed tool_calls - deepseek's function calling is not "
+                    "confirmed to fully support OpenAI's strict structured-output mode.",
+                    manifest.session_id,
+                )
+        except Exception as exc:  # diagnostics only - never mask the real failure
+            logger.warning(
+                "[DEEPSEEK-DEBUG] pre-call session=%s: tool schema logging itself failed: %s: %s",
+                manifest.session_id,
+                type(exc).__name__,
+                exc,
+            )
+
         # ``Runner.run_sync`` is the SDK's synchronous API - we avoid
         # ``asyncio.run`` here so the runner stays compatible with
         # environments where the event loop is already running
-        # (e.g. pytest-asyncio tests that import this module).
-        result: Any = runner_cls.run_sync(agent, manifest.prompt, run_config=run_config)
+        # (e.g. pytest-asyncio tests that import this module). ``max_turns``
+        # is only forwarded when configured (env/tuning) - omitting the
+        # kwarg preserves the SDK's own default exactly, as before.
+        result: Any = runner_cls.run_sync(agent, manifest.prompt, **run_sync_kwargs)
+
+        # [DEEPSEEK-DEBUG] Unconditional post-call diagnostic: dump as much
+        # of the raw SDK response shape as is discoverable so an empty
+        # completion (zero usage, empty summary) or a malformed-tool-call
+        # response is a direct log read instead of a re-run-and-guess.
+        try:
+            _raw_responses = getattr(result, "raw_responses", None) or []
+            _raw_summaries: list[dict[str, Any]] = []
+            for _rr in _raw_responses:
+                _rr_usage = getattr(_rr, "usage", None)
+                _output = getattr(_rr, "output", None)
+                _choices = getattr(_rr, "choices", None)
+                _summary: dict[str, Any] = {
+                    "usage": {
+                        "input_tokens": getattr(_rr_usage, "input_tokens", None),
+                        "output_tokens": getattr(_rr_usage, "output_tokens", None),
+                        "raw": str(_rr_usage) if _rr_usage is not None else None,
+                    },
+                }
+                if _choices is not None:
+                    _choice_summaries = []
+                    for _choice in _choices:
+                        _message = getattr(_choice, "message", None)
+                        _choice_summaries.append(
+                            {
+                                "finish_reason": getattr(_choice, "finish_reason", None),
+                                "content": getattr(_message, "content", None) if _message else None,
+                                "refusal": getattr(_message, "refusal", None) if _message else None,
+                                "tool_calls": str(getattr(_message, "tool_calls", None)) if _message else None,
+                            },
+                        )
+                    _summary["choices"] = _choice_summaries
+                if _output is not None:
+                    _summary["output"] = str(_output)[:4000]
+                _raw_summaries.append(_summary)
+            logger.info(
+                "[DEEPSEEK-DEBUG] post-call session=%s model=%s raw_responses_count=%d "
+                "final_output=%r raw_responses=%s",
+                manifest.session_id,
+                manifest.model,
+                len(_raw_responses),
+                str(getattr(result, "final_output", ""))[:2000],
+                json.dumps(_raw_summaries, default=str)[:8000],
+            )
+            _result_usage = getattr(result, "usage", None)
+            logger.info(
+                "[DEEPSEEK-DEBUG] post-call session=%s result.usage=%r "
+                "(RunResult/RunResultBase does not define 'usage' on installed SDK "
+                "0.17.7 per _extract_usage_tokens's docstring - expect None here; "
+                "the raw_responses per-call usage above is the real signal)",
+                manifest.session_id,
+                _result_usage,
+            )
+        except Exception as exc:  # diagnostics only - never mask the real failure
+            logger.warning(
+                "[DEEPSEEK-DEBUG] post-call session=%s: raw response logging itself "
+                "failed (SDK shape may differ from expected): %s: %s",
+                manifest.session_id,
+                type(exc).__name__,
+                exc,
+            )
     except Exception as exc:  # SDK errors are varied - catch broadly
+        # D2 MiniMax attempt-3 (2026-07-03): agents that die on an
+        # exception - especially ``MaxTurnsExceeded``, which by definition
+        # fires AFTER ``max_turns`` real, billable LLM calls - previously
+        # emitted zero usage events, so an entire failed run metered
+        # ``spent_usd: 0.0, usages: []`` despite real provider spend.
+        # SDK exceptions derived from ``AgentsException`` carry the partial
+        # run's state on ``exc.run_data`` (``RunErrorDetails``, with the
+        # same ``raw_responses`` list a successful ``RunResult`` has), so
+        # extract and price whatever usage exists before returning; when
+        # the exception carries no run data, ``_emit_session_usage`` still
+        # emits the ``usage_missing`` marker so downstream sees "unknown",
+        # never a silent zero.
+        #
+        # [DEEPSEEK-DEBUG] Before this fix, everything downstream of this
+        # except block only ever saw ``f"{type(exc).__name__}: {exc}"`` -
+        # the full traceback was silently swallowed. Log it unconditionally
+        # at ERROR so an exception raised mid-call (e.g. a malformed
+        # response the SDK's client-side parsing chokes on) is a direct log
+        # read, not a guess from a one-line message.
+        logger.exception(
+            "[DEEPSEEK-DEBUG] exception in Runner.run_sync session=%s model=%s base_url=%r exc_type=%s",
+            manifest.session_id,
+            manifest.model,
+            manifest.base_url,
+            type(exc).__name__,
+        )
+        _emit_session_usage(
+            manifest,
+            getattr(exc, "run_data", None),
+            source_desc=f"{type(exc).__name__}.run_data",
+        )
+        if type(exc).__name__ == "MaxTurnsExceeded":
+            _log_max_turns_exceeded(exc, max_turns)
         if _is_rate_limit(exc):
             emit_event(
                 {
@@ -669,16 +1300,13 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
         )
         return EXIT_GENERIC
 
-    usage: Any = getattr(result, "usage", None)
-    if usage is not None:
-        emit_event(
-            {
-                "type": "usage",
-                "input_tokens": int(getattr(usage, "input_tokens", 0) or 0),
-                "output_tokens": int(getattr(usage, "output_tokens", 0) or 0),
-                "tool_calls": int(getattr(usage, "tool_calls", 0) or 0),
-            },
-        )
+    # Bug 13 follow-up (2026-07-02): a real MiniMax-M2.7-highspeed smoke run
+    # proved ``result.usage`` is ``None`` on this provider - installed SDK
+    # inspection (openai-agents 0.17.7, ``agents/result.py``) shows
+    # ``RunResult``/``RunResultBase`` never define a ``usage`` attribute at
+    # all, so the ``raw_responses`` fallback inside ``_extract_usage_tokens``
+    # is the path that actually fires on real SDK result objects.
+    _emit_session_usage(manifest, result, source_desc="result")
 
     emit_event(
         {

--- a/src/bernstein/adapters/plugin_sdk.py
+++ b/src/bernstein/adapters/plugin_sdk.py
@@ -57,13 +57,39 @@ class AdapterCapability(Enum):
     RATE_LIMIT_DETECTION = "rate_limit_detection"
     STRUCTURED_OUTPUT = "structured_output"
     BATCH_MODE = "batch_mode"
+    #: Coarse "honours the full SAMPLING_PARAM_KEYS surface" capability.
+    #: Declaring this means every key in :data:`SAMPLING_PARAM_KEYS` -
+    #: temperature, top_p, top_k, base_url, api_key_env - is genuinely
+    #: wired through to the underlying CLI/SDK call. Adapters that only
+    #: wire a subset (for example a CLI that exposes ``--temperature``
+    #: but has no top_p/top_k flag) must declare the narrower
+    #: ``SUPPORTS_TEMPERATURE``/``SUPPORTS_TOP_P``/``SUPPORTS_TOP_K``
+    #: capabilities instead - see :func:`ensure_sampling_params_supported`
+    #: for how the two are reconciled at the spawn-time gate.
     SUPPORTS_SAMPLING_PARAMS = "supports_sampling_params"
+    #: Adapter wires an incoming ``temperature`` override to a real CLI
+    #: flag or SDK parameter (PR3, issue: sampling-fields-plumbing).
+    SUPPORTS_TEMPERATURE = "supports_temperature"
+    #: Adapter wires an incoming ``top_p`` override to a real CLI flag or
+    #: SDK parameter (PR3).
+    SUPPORTS_TOP_P = "supports_top_p"
+    #: Adapter wires an incoming ``top_k`` override to a real CLI flag or
+    #: SDK parameter (PR3).
+    SUPPORTS_TOP_K = "supports_top_k"
+    #: Adapter wires an incoming ``max_tokens`` override to a real CLI flag
+    #: or SDK parameter (PR3). Note ``max_tokens`` is NOT a member of
+    #: :data:`SAMPLING_PARAM_KEYS` (that tuple predates this capability and
+    #: is gated separately) - this capability exists for adapters/callers
+    #: that want to probe max_tokens support specifically.
+    SUPPORTS_MAX_TOKENS = "supports_max_tokens"
 
 
 # Per-spawn keys in ``mcp_config`` that request sampling or endpoint
 # overrides.  An adapter must declare
-# :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS` before any of these
-# are honoured - see :func:`ensure_sampling_params_supported`.
+# :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS` (or, since PR3, the
+# narrower per-key capability - see :data:`_SAMPLING_KEY_CAPABILITY`)
+# before any of these are honoured - see
+# :func:`ensure_sampling_params_supported`.
 SAMPLING_PARAM_KEYS: tuple[str, ...] = (
     "temperature",
     "top_p",
@@ -71,6 +97,20 @@ SAMPLING_PARAM_KEYS: tuple[str, ...] = (
     "base_url",
     "api_key_env",
 )
+
+# Maps a :data:`SAMPLING_PARAM_KEYS` entry to the narrow capability that
+# covers it in isolation. Keys absent from this mapping (``base_url``,
+# ``api_key_env``) have no narrow capability - an adapter that does not
+# declare the coarse :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS` can
+# never honour an endpoint override, regardless of what per-sampling-field
+# capabilities it declares. This reflects reality: swapping the target
+# endpoint is a bigger commitment than accepting one more generation
+# parameter, and no adapter shipped so far wires it half-way.
+_SAMPLING_KEY_CAPABILITY: dict[str, AdapterCapability] = {
+    "temperature": AdapterCapability.SUPPORTS_TEMPERATURE,
+    "top_p": AdapterCapability.SUPPORTS_TOP_P,
+    "top_k": AdapterCapability.SUPPORTS_TOP_K,
+}
 
 
 class SamplingParamsRefusal(RuntimeError):
@@ -111,21 +151,72 @@ def ensure_sampling_params_supported(
     Raises:
         SamplingParamsRefusal: When any sampling/endpoint key is present and
             the adapter does not declare
-            :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS`.
+            :attr:`AdapterCapability.SUPPORTS_SAMPLING_PARAMS`, and (since
+            PR3) does not cover that specific key via a narrower
+            per-sampling-field capability - see
+            :data:`_SAMPLING_KEY_CAPABILITY`.
     """
     if not mcp_config:
+        logger.debug("ensure_sampling_params_supported: no mcp_config, nothing to gate")
         return
     requested = tuple(k for k in SAMPLING_PARAM_KEYS if mcp_config.get(k) is not None)
     if not requested:
+        logger.debug("ensure_sampling_params_supported: mcp_config has no sampling/endpoint keys")
         return
-    if isinstance(adapter, PluginAdapter):
+    adapter_name = adapter.name()
+    logger.debug(
+        "ensure_sampling_params_supported: adapter=%r requested_keys=%s",
+        adapter_name,
+        requested,
+    )
+    # Duck-type on ``plugin_info`` instead of ``isinstance(adapter,
+    # PluginAdapter)``: wrappers such as CachingAdapter are plain
+    # CLIAdapters that forward ``plugin_info()`` to the adapter they wrap,
+    # and an isinstance check would hide the inner adapter's declared
+    # capabilities and refuse spawns it should allow.
+    capabilities: tuple[AdapterCapability, ...] = ()
+    plugin_info = getattr(adapter, "plugin_info", None)
+    if callable(plugin_info):
         try:
-            capabilities = adapter.plugin_info().capabilities
-        except Exception:  # pragma: no cover - defensive against bad plugins
+            capabilities = plugin_info().capabilities
+        except Exception:  # defensive against bad plugins / non-plugin inners
+            logger.warning("ensure_sampling_params_supported: plugin_info() raised for %r", adapter_name, exc_info=True)
             capabilities = ()
-        if AdapterCapability.SUPPORTS_SAMPLING_PARAMS in capabilities:
-            return
-    raise SamplingParamsRefusal(adapter.name(), requested)
+    logger.debug("ensure_sampling_params_supported: adapter=%r declares capabilities=%s", adapter_name, capabilities)
+
+    if AdapterCapability.SUPPORTS_SAMPLING_PARAMS in capabilities:
+        logger.info(
+            "ensure_sampling_params_supported: adapter=%r declares coarse SUPPORTS_SAMPLING_PARAMS, "
+            "honouring all requested keys=%s",
+            adapter_name,
+            requested,
+        )
+        return
+
+    # PR3: no coarse capability, but the adapter may still honour a subset
+    # of the requested keys via a narrow per-field capability (for example
+    # a CLI that wires ``--temperature`` but has no top_p/top_k flag).
+    # ``base_url``/``api_key_env`` have no narrow capability (see
+    # :data:`_SAMPLING_KEY_CAPABILITY`) - they require the coarse flag.
+    unsupported = tuple(k for k in requested if _SAMPLING_KEY_CAPABILITY.get(k) not in capabilities)
+    supported = tuple(k for k in requested if k not in unsupported)
+    if supported:
+        logger.info(
+            "ensure_sampling_params_supported: adapter=%r honours narrow-capability keys=%s via per-field capabilities",
+            adapter_name,
+            supported,
+        )
+    if not unsupported:
+        return
+    logger.warning(
+        "ensure_sampling_params_supported: REFUSING spawn - adapter=%r does not declare capability "
+        "for requested keys=%s (declared capabilities=%s). This was previously a silent-drop bug; "
+        "now a loud, structured refusal.",
+        adapter_name,
+        unsupported,
+        capabilities,
+    )
+    raise SamplingParamsRefusal(adapter_name, unsupported)
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.adapters.plugin_sdk import AdapterCapability, AdapterPluginInfo
 from bernstein.core.llm import LLMSettings
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 # Maps provider key → (tier, requests_per_minute, tokens_per_minute)
@@ -31,6 +35,11 @@ class QwenAdapter(CLIAdapter):
     Qwen CLI is used as a generic OpenAI-compatible coding agent wrapper.
     It passes the provider's base_url and api_key directly to Qwen CLI.
     """
+
+    # Provider-string alias this adapter resolves from in
+    # ``_infer_adapter_name_for_provider`` (via the registry's
+    # provider-alias table). Unchanged from the old substring branch.
+    provides = ("qwen",)
 
     def _detect_provider(self, settings: LLMSettings) -> str:
         """Select provider based on which API keys are configured."""
@@ -74,7 +83,36 @@ class QwenAdapter(CLIAdapter):
         "auto": _QWEN_PLUS_MODEL,
     }
 
-    def _build_command(self, model_name: str, provider: str, settings: LLMSettings) -> list[str]:
+    def plugin_info(self) -> AdapterPluginInfo:
+        """Declare the sampling surface QwenAdapter genuinely wires.
+
+        The ``qwen`` CLI accepts ``--temperature``/``--top-p`` pass-through
+        flags for its OpenAI-compatible generation config (see
+        :meth:`_build_command`). It does not expose a ``--top-k`` or
+        ``--max-tokens`` flag, so those are NOT declared here -
+        :func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`
+        would refuse a spawn requesting them rather than silently drop
+        them.
+        """
+        return AdapterPluginInfo(
+            name="qwen",
+            version="0.1.0",
+            author="bernstein",
+            description="Qwen CLI adapter for OpenAI compatible models",
+            capabilities=(
+                AdapterCapability.SUPPORTS_TEMPERATURE,
+                AdapterCapability.SUPPORTS_TOP_P,
+            ),
+        )
+
+    def _build_command(
+        self,
+        model_name: str,
+        provider: str,
+        settings: LLMSettings,
+        *,
+        mcp_config: dict[str, Any] | None = None,
+    ) -> list[str]:
         """Build the qwen CLI command list (without the final prompt argument).
 
         The Tavily API key is never placed on argv (it would be visible to
@@ -82,6 +120,11 @@ class QwenAdapter(CLIAdapter):
         spawned process via the ``TAVILY_API_KEY`` environment variable in
         :meth:`spawn`. Only the non-sensitive ``--web-search-default``
         selector is added to argv.
+
+        Args:
+            mcp_config: Per-spawn config that may carry ``temperature``/
+                ``top_p`` overrides - the only two sampling fields this
+                adapter's :meth:`plugin_info` declares support for.
         """
         cmd: list[str] = ["qwen", "-y"]
 
@@ -95,6 +138,25 @@ class QwenAdapter(CLIAdapter):
 
         if settings.tavily_api_key:
             cmd.extend(["--web-search-default", "tavily"])
+
+        if mcp_config:
+            temperature = mcp_config.get("temperature")
+            if isinstance(temperature, (int, float)) and not isinstance(temperature, bool):
+                logger.debug("qwen adapter: wiring --temperature=%s onto argv", temperature)
+                cmd.extend(["--temperature", str(float(temperature))])
+            top_p = mcp_config.get("top_p")
+            if isinstance(top_p, (int, float)) and not isinstance(top_p, bool):
+                logger.debug("qwen adapter: wiring --top-p=%s onto argv", top_p)
+                cmd.extend(["--top-p", str(float(top_p))])
+            for dropped_key in ("top_k", "max_tokens"):
+                if mcp_config.get(dropped_key) is not None:
+                    logger.warning(
+                        "qwen adapter: %s=%r requested but not wired (qwen CLI has no matching "
+                        "flag) - ensure_sampling_params_supported should have refused this spawn "
+                        "before reaching here",
+                        dropped_key,
+                        mcp_config.get(dropped_key),
+                    )
 
         return cmd
 
@@ -134,7 +196,7 @@ class QwenAdapter(CLIAdapter):
             env["TAVILY_API_KEY"] = settings.tavily_api_key
 
         # Pass the prompt as a positional argument (one-shot mode) instead of deprecated -p
-        cmd = self._build_command(model_config.model, provider, settings)
+        cmd = self._build_command(model_config.model, provider, settings, mcp_config=mcp_config)
         cmd.append(prompt)
 
         # Wrap with bernstein-worker for process visibility

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -112,6 +112,15 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
 
 _entrypoints_loaded = False
 
+#: provider-alias (lower-cased) -> adapter registry name. Built lazily from
+#: each adapter's ``provides`` class attribute the first time
+#: :func:`adapter_name_for_provider` is called. This is the structural
+#: replacement for the old hand-ordered substring `if`/`elif` chain that
+#: used to live in ``spawner_core._infer_adapter_name_for_provider`` -- see
+#: PR1 of the provider/adapter routing fix ladder.
+_PROVIDER_ALIAS_TABLE: dict[str, str] = {}
+_provider_aliases_built = False
+
 
 def _load_entrypoint_adapters() -> None:
     """Discover and register adapters from the ``bernstein.adapters`` entry-point group.
@@ -226,3 +235,162 @@ def iter_adapter_specs() -> Iterator[tuple[str, type[CLIAdapter] | CLIAdapter]]:
     _load_entrypoint_adapters()
     for name in sorted(_ADAPTERS.keys()):
         yield name, _ADAPTERS[name]
+
+
+def _register_provider_alias(alias: str, adapter_name: str) -> None:
+    """Register a single provider-name alias into the provider alias table.
+
+    Raises ``ValueError`` immediately if ``alias`` is already claimed by a
+    *different* adapter. This is PR1's collision policy: an ambiguous alias
+    fails loudly at table-build time (import/first-use time), never
+    silently at spawn time. This is what actually forecloses the
+    042bcbd0 class of bug (``openai_agents`` silently swallowed by a
+    broader ``openai`` substring match) for good -- a future adapter that
+    tries to claim an alias someone else already owns cannot ship at all.
+
+    Args:
+        alias: Lower-cased provider-name alias, e.g. ``"openai_agents"``.
+        adapter_name: Registry name of the adapter claiming the alias, e.g.
+            ``"openai_agents"``.
+
+    Raises:
+        ValueError: If ``alias`` is already registered to a different
+            adapter name.
+    """
+    existing = _PROVIDER_ALIAS_TABLE.get(alias)
+    if existing is not None and existing != adapter_name:
+        raise ValueError(
+            f"Provider alias {alias!r} is claimed by both adapter {existing!r} "
+            f"and adapter {adapter_name!r}. Provider aliases (the `provides` "
+            "class attribute on each CLIAdapter) must be unique across the "
+            "whole adapter catalog -- rename or narrow one of the "
+            "conflicting `provides` entries before this can load."
+        )
+    _PROVIDER_ALIAS_TABLE[alias] = adapter_name
+    logger.debug("registry: registered provider alias %r -> adapter %r", alias, adapter_name)
+
+
+def _build_provider_alias_table() -> None:
+    """Populate :data:`_PROVIDER_ALIAS_TABLE` from every adapter's ``provides``.
+
+    Idempotent: runs once, guarded by :data:`_provider_aliases_built`.
+    Entry-point adapters are discovered first so third-party adapters'
+    ``provides`` declarations participate in collision detection too.
+
+    Some adapters are registered under more than one ``_ADAPTERS`` key for
+    the *same* underlying class (for example ``GeminiAdapter`` is keyed as
+    both ``"gemini"`` and ``"antigravity"`` during the 2026-06-18
+    dual-binary transition -- see the comment in ``_ADAPTERS`` above). Each
+    distinct adapter object/class must contribute its ``provides`` aliases
+    exactly once, or the second registration would collide with the first
+    under a *different* adapter name and trip the collision guard on a
+    false positive. Entries are grouped by identity first; when a group
+    has more than one registry key, the key that is itself one of the
+    declared aliases (self-referencing / canonical, e.g. ``"gemini"``) is
+    preferred, matching what the old hardcoded substring branch used to
+    return literally.
+    """
+    global _provider_aliases_built
+    if _provider_aliases_built:
+        return
+    logger.info("registry: building provider alias table from %d registered adapters", len(_ADAPTERS))
+    _load_entrypoint_adapters()
+
+    names_by_entry_id: dict[int, list[str]] = {}
+    entry_by_id: dict[int, type[CLIAdapter] | CLIAdapter] = {}
+    for name, entry in _ADAPTERS.items():
+        eid = id(entry)
+        names_by_entry_id.setdefault(eid, []).append(name)
+        entry_by_id[eid] = entry
+
+    for eid, names in names_by_entry_id.items():
+        entry = entry_by_id[eid]
+        provides = getattr(entry, "provides", ()) or ()
+        if not provides:
+            continue
+        canonical = next((n for n in names if n in provides), names[0])
+        if len(names) > 1:
+            logger.debug(
+                "registry: adapter registered under multiple keys %s; using canonical name %r for provides=%s",
+                names,
+                canonical,
+                provides,
+            )
+        for alias in provides:
+            _register_provider_alias(alias.strip().lower(), canonical)
+    _provider_aliases_built = True
+    logger.info(
+        "registry: provider alias table built -- %d aliases across %d adapters: %s",
+        len(_PROVIDER_ALIAS_TABLE),
+        len({v for v in _PROVIDER_ALIAS_TABLE.values()}),
+        _PROVIDER_ALIAS_TABLE,
+    )
+
+
+def adapter_name_for_provider(provider_name: str | None, model: str) -> str | None:
+    """Resolve an adapter registry name from a provider name and/or model string.
+
+    This is the structural replacement for the old
+    ``spawner_core._infer_adapter_name_for_provider`` substring `if`/`elif`
+    chain (Root Cause A: no canonical provider -> adapter table, so any new
+    provider name that happened to be a substring of another's would
+    misroute silently until someone noticed and reordered the branches).
+
+    Resolution order:
+
+    1. **Exact match.** ``provider_name`` (case-insensitive, stripped) is
+       looked up directly against the alias table built from every
+       adapter's ``provides`` declaration. Because
+       :func:`_register_provider_alias` refuses ambiguous aliases at
+       build time, an exact hit here is guaranteed unambiguous.
+    2. **Substring fallback, longest-alias-first.** Some call sites (for
+       example the sampling-capability probe in ``spawner_core.py``, which
+       calls this with ``provider_name=None``) only have a bare model
+       string like ``"gpt-4.1"`` or ``"claude-opus-4"`` to go on. For that
+       case every registered alias is checked as a substring of
+       ``f"{provider_name} {model}"``, longest alias first. Longest-first
+       guarantees a more specific alias (``"openai_agents"``) always wins
+       over a shorter alias it textually contains (``"openai"``) without
+       requiring any hand-maintained ordering -- this is what forecloses
+       the 042bcbd0 bug class structurally rather than only patching the
+       one instance of it.
+
+    Returns:
+        The resolved adapter registry name, or ``None`` if nothing in the
+        alias table matches. Callers apply their own fallback (typically
+        the spawner's currently-active adapter) when ``None`` is returned.
+    """
+    logger.debug("registry.adapter_name_for_provider: provider_name=%r model=%r", provider_name, model)
+    _build_provider_alias_table()
+
+    if provider_name:
+        exact = _PROVIDER_ALIAS_TABLE.get(provider_name.strip().lower())
+        if exact is not None:
+            logger.info(
+                "registry.adapter_name_for_provider: EXACT match provider_name=%r -> adapter=%r",
+                provider_name,
+                exact,
+            )
+            return exact
+
+    text = f"{provider_name or ''} {model}".lower()
+    for alias in sorted(_PROVIDER_ALIAS_TABLE, key=len, reverse=True):
+        if alias in text:
+            adapter_name = _PROVIDER_ALIAS_TABLE[alias]
+            logger.info(
+                "registry.adapter_name_for_provider: SUBSTRING fallback matched "
+                "alias=%r in text=%r -> adapter=%r (provider_name=%r had no exact hit)",
+                alias,
+                text,
+                adapter_name,
+                provider_name,
+            )
+            return adapter_name
+
+    logger.info(
+        "registry.adapter_name_for_provider: NO MATCH for provider_name=%r model=%r; "
+        "caller must apply its own fallback",
+        provider_name,
+        model,
+    )
+    return None

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 import yaml
@@ -34,8 +36,6 @@ from bernstein.core.skills.routing import auto_route_enabled, select_auto_route_
 from bernstein.core.skills.sanitizer import sanitize_skill_body
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from bernstein.core.skills.routing import RoutableTask
 
     class Task(RoutableTask, Protocol):
@@ -82,6 +82,94 @@ ROLE_SKILL_MAP: dict[str, list[str]] = {
     ],
     "security": [],
 }
+
+
+def _resolve_git_exclude_path(workdir: Path) -> Path | None:
+    """Resolve the ``info/exclude`` file for ``workdir``'s git repo.
+
+    Uses ``git rev-parse --git-path info/exclude`` rather than assuming
+    ``workdir/.git/info/exclude`` exists, because inside a ``git worktree``
+    ``.git`` is a *file* containing a ``gitdir: <path>`` pointer to the real
+    gitdir (typically under the main checkout's ``.git/worktrees/<name>/``),
+    not a directory. ``git rev-parse --git-path`` resolves this correctly in
+    both the plain-repo and worktree cases.
+
+    Returns ``None`` (and logs at debug level) if ``workdir`` is not inside a
+    git repository or the ``git`` binary is unavailable - exclusion is a
+    best-effort hardening measure and must never block agent spawn.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-path", "info/exclude"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _logger.debug("Could not resolve git info/exclude for %s: %s", workdir, exc)
+        return None
+
+    exclude_relpath = result.stdout.strip()
+    if not exclude_relpath:
+        _logger.debug("git rev-parse --git-path info/exclude returned empty for %s", workdir)
+        return None
+
+    exclude_path = Path(exclude_relpath)
+    if not exclude_path.is_absolute():
+        exclude_path = workdir / exclude_path
+    return exclude_path
+
+
+def _exclude_injected_paths(workdir: Path, relative_paths: list[str]) -> None:
+    """Idempotently append ``relative_paths`` to ``workdir``'s ``info/exclude``.
+
+    Injected skill files must remain readable by Claude Code (which reads
+    the working tree directly) but must never be staged or committed by an
+    agent's broad ``git add`` - two agents' worktrees render different
+    session-specific content into the same filenames, so committing them
+    causes a merge conflict on every worker merge back to the shared work
+    branch. Writing to ``info/exclude`` (rather than ``.gitignore``) keeps
+    this local-only and out of the tracked tree entirely.
+    """
+    exclude_path = _resolve_git_exclude_path(workdir)
+    if exclude_path is None:
+        _logger.debug(
+            "Skipping git exclude registration for %s - not a git repo or git unavailable",
+            workdir,
+        )
+        return
+
+    try:
+        exclude_path.parent.mkdir(parents=True, exist_ok=True)
+        existing = exclude_path.read_text(encoding="utf-8") if exclude_path.exists() else ""
+    except OSError as exc:
+        _logger.debug("Failed to read git exclude file %s: %s", exclude_path, exc)
+        return
+
+    existing_lines = set(existing.splitlines())
+    new_lines = [path for path in relative_paths if path not in existing_lines]
+    if not new_lines:
+        _logger.debug("All injected paths already excluded in %s", exclude_path)
+        return
+
+    try:
+        with exclude_path.open("a", encoding="utf-8") as fh:
+            if existing and not existing.endswith("\n"):
+                fh.write("\n")
+            for path in new_lines:
+                fh.write(f"{path}\n")
+                _logger.debug("Excluded injected skill from git: %s -> %s", path, exclude_path)
+    except OSError as exc:
+        _logger.debug("Failed to append to git exclude file %s: %s", exclude_path, exc)
+        return
+
+    _logger.debug(
+        "Registered %d injected skill path(s) in git exclude file %s",
+        len(new_lines),
+        exclude_path,
+    )
 
 
 def render_skill_template(
@@ -179,6 +267,7 @@ def inject_skills(
             templates_to_inject.append(candidate.template_name)
             trigger_by_template[candidate.template_name] = "auto-route"
 
+    written_relpaths: list[str] = []
     for template_name in templates_to_inject:
         source_path = skills_source_dir / template_name
         if not source_path.exists():
@@ -209,6 +298,7 @@ def inject_skills(
         try:
             dest_path.write_text(rendered, encoding="utf-8")
             _logger.debug("Injected skill: %s -> %s", template_name, dest_path)
+            written_relpaths.append(str(dest_path.relative_to(workdir)))
         except OSError as exc:
             _logger.debug("Failed to write skill %s: %s", dest_path, exc)
             continue
@@ -249,6 +339,9 @@ def inject_skills(
         except Exception:
             # Never let the activation log block a spawn.
             _logger.debug("activation log append failed for %s", template_name, exc_info=True)
+
+    if written_relpaths:
+        _exclude_injected_paths(workdir, written_relpaths)
 
 
 def _extract_skill_version(content: str) -> str:

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 import os
 import sys
 import time
@@ -19,6 +20,8 @@ import httpx
 from bernstein.cli.first_run_guard import handle_first_run_exception
 from bernstein.cli.helpers import (
     SDD_DIRS,
+    SERVER_URL,
+    auth_headers,
     console,
     find_seed_file,
     print_banner,
@@ -36,6 +39,8 @@ from bernstein.cli.run_preflight import (
 from bernstein.core.cost import estimate_run_cost
 from bernstein.core.manager_parsing import _resolve_depends_on  # pyright: ignore[reportPrivateUsage]
 from bernstein.core.plan_loader import PlanLoadError, load_plan, load_plan_from_yaml
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Plan helpers
@@ -722,6 +727,57 @@ def _init_impl(
     )
 
 
+def _signal_orchestrator_shutdown(*, reason: str = "cli detected run completion") -> None:
+    """Best-effort belt-and-braces graceful-shutdown signal to the orchestrator.
+
+    The orchestrator has its own quiescence self-stop (see
+    ``core/orchestration/orchestrator.py`` tick-quiescence handling) that
+    should already have terminated the run by the time the CLI observes
+    completion. This call exists purely as a backstop: if the self-stop
+    ever fails to fire, the CLI still nudges the server's ``POST /shutdown``
+    route (see ``core/routes/status_lifecycle.py::shutdown_server``) so the
+    run does not hang forever.
+
+    This call is idempotent and never raises: a connection error or 404
+    almost always means the orchestrator already stopped itself, which is
+    treated as success (not a failure of this signal).
+    """
+    target = f"{SERVER_URL}/shutdown"
+    try:
+        resp = httpx.post(
+            target,
+            json={"reason": reason},
+            timeout=3.0,
+            headers=auth_headers(),
+        )
+        if resp.status_code == 404:
+            logger.info(
+                "cli_shutdown_signal: sent target=%s result=already_stopped "
+                "(404 - server likely self-stopped and torn down its routes)",
+                target,
+            )
+            return
+        resp.raise_for_status()
+        logger.info(
+            "cli_shutdown_signal: sent target=%s result=acknowledged response=%s",
+            target,
+            resp.json() if resp.content else None,
+        )
+    except httpx.ConnectError:
+        logger.info(
+            "cli_shutdown_signal: sent target=%s result=already_stopped "
+            "(connection refused - orchestrator process already exited via self-stop)",
+            target,
+        )
+    except Exception as exc:
+        logger.info(
+            "cli_shutdown_signal: sent target=%s result=error error=%s "
+            "(non-fatal - orchestrator quiescence self-stop is the primary path)",
+            target,
+            exc,
+        )
+
+
 def _wait_for_run_completion(
     *,
     poll_interval_s: float = 2.0,
@@ -749,6 +805,15 @@ def _wait_for_run_completion(
             claimed_count = int(status_payload.get("claimed", 0) or 0)
             agent_count = int(health_payload.get("agent_count", 0) or 0)
             if total > 0 and open_count == claimed_count == 0 and (agent_count == 0):
+                logger.info(
+                    "run_completion_detected: total=%d open=%d claimed=%d agent_count=%d "
+                    "- sending belt-and-braces shutdown signal",
+                    total,
+                    open_count,
+                    claimed_count,
+                    agent_count,
+                )
+                _signal_orchestrator_shutdown(reason="cli detected run completion (quiescent)")
                 return status_payload
         time.sleep(poll_interval_s)
     return last_status

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from bernstein.core import heartbeat as heartbeat_protocol
+from bernstein.core.cost import price_model_usage
 from bernstein.core.janitor import verify_task
 from bernstein.core.lifecycle import transition_agent
 from bernstein.core.metrics import get_collector
@@ -43,6 +44,27 @@ if TYPE_CHECKING:
     from bernstein.core.abort_chain import AbortChain, AbortPolicy
 
 logger = logging.getLogger(__name__)
+
+
+def _retry_escalation_context(orch: Any) -> dict[str, Any]:
+    """Build the ``role_model_policy``/``default_adapter_name`` kwargs for
+    :func:`retry_or_fail_task` from the orchestrator's spawner.
+
+    Lets retry escalation (task_lifecycle.py) know whether the retrying
+    role is pinned to a non-Claude provider/model, so it doesn't stamp a
+    Claude tier name ("opus"/"sonnet") onto a task that will spawn against
+    a non-Claude adapter (see task_lifecycle.py's retry-escalation
+    docstring for the run-9 attempt-8 defect this closes). Read-only,
+    best-effort: any missing attribute (older/mock orchestrators in tests)
+    degrades to ``None``, which task_lifecycle.py treats as "assume
+    Claude-compatible" - today's historical behavior, unchanged.
+    """
+    spawner = getattr(orch, "_spawner", None)
+    return {
+        "role_model_policy": getattr(spawner, "role_model_policy", None),
+        "default_adapter_name": getattr(spawner, "default_adapter_name", None),
+    }
+
 
 # ---------------------------------------------------------------------------
 # Abort chain helpers - three-level hierarchy
@@ -207,6 +229,59 @@ def _capture_agent_crash(
 # ---------------------------------------------------------------------------
 
 
+def _preserve_runner_logs(orch: Any, session: Any) -> Path | None:
+    """Copy the session's runner logs out of the worktree before cleanup.
+
+    Adapter runners (e.g. openai_agents) write their transcript to
+    ``<worktree>/.sdd/runtime/<session_id>*.log`` and their manifest to
+    ``<session_id>.manifest.json``. ``cleanup_worktree()`` deletes the
+    whole worktree, so a dead agent's ONLY diagnostic artifacts are
+    destroyed at exactly the moment they are needed. Copy them into the
+    orchestrator's ``.sdd/runtime/agent_logs/<session_id>/`` first.
+
+    All errors are suppressed so the cleanup path is never interrupted.
+
+    Returns:
+        The destination directory when at least one file was preserved,
+        ``None`` otherwise.
+    """
+    import shutil
+
+    try:
+        worktree_path = orch._spawner.get_worktree_path(session.id)
+        if worktree_path is None:
+            return None
+        runtime_dir = Path(worktree_path) / ".sdd" / "runtime"
+        if not runtime_dir.is_dir():
+            return None
+        candidates = [
+            *runtime_dir.glob(f"{session.id}*.log"),
+            *runtime_dir.glob(f"{session.id}.manifest.json"),
+        ]
+        if not candidates:
+            return None
+        dest_dir = Path(orch._workdir) / ".sdd" / "runtime" / "agent_logs" / session.id
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        copied: list[str] = []
+        for src in candidates:
+            with contextlib.suppress(OSError):
+                shutil.copy2(src, dest_dir / src.name)
+                copied.append(src.name)
+        if not copied:
+            return None
+        logger.info(
+            "Preserved %d runner log/manifest file(s) for dead agent %s: %s -> %s",
+            len(copied),
+            session.id,
+            ", ".join(sorted(copied)),
+            dest_dir,
+        )
+        return dest_dir
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Runner log preservation for %s skipped: %s", session.id, exc)
+        return None
+
+
 def _save_partial_work(spawner: Any, session: Any) -> bool:
     """Commit and merge uncommitted agent work before worktree destruction.
 
@@ -226,7 +301,7 @@ def _save_partial_work(spawner: Any, session: Any) -> bool:
 
     wt = str(worktree_path)
     committed = False
-    with contextlib.suppress(Exception):
+    try:
         subprocess.run(
             ["git", "add", "-A"],
             cwd=wt,
@@ -240,10 +315,25 @@ def _save_partial_work(spawner: Any, session: Any) -> bool:
             timeout=10,
         )
         committed = result.returncode == 0
+    except Exception:
+        logger.exception(
+            "Partial-work WIP commit failed during reap (session_id=%s role=%s worktree=%s) - reap continues",
+            session.id,
+            session.role,
+            wt,
+        )
 
     # Try to merge the branch before cleanup
-    with contextlib.suppress(Exception):
+    try:
         spawner.reap_completed_agent(session, skip_merge=False)
+    except Exception:
+        logger.exception(
+            "reap_completed_agent (merge) failed during partial-work save "
+            "(session_id=%s role=%s worktree=%s) - reap continues",
+            session.id,
+            session.role,
+            wt,
+        )
 
     if committed:
         logger.info("Saved partial work for agent %s", session.id)
@@ -283,6 +373,7 @@ def _handle_dead_agent(orch: Any, session: AgentSession, tasks_snapshot: dict[st
     _rl_tracker = getattr(orch, "_rate_limit_tracker", None)
     if _rl_tracker is not None and session.provider:
         _rl_tracker.decrement_active(session.provider)
+    _preserve_runner_logs(orch, session)
     for task_id in session.task_ids:
         orch._crash_counts[task_id] = orch._crash_counts.get(task_id, 0) + 1
         _maybe_preserve_worktree(orch, session, task_id)
@@ -480,6 +571,7 @@ def _try_compact_and_retry(
             retried_task_ids=orch._retried_task_ids,
             tasks_snapshot=tasks_snapshot,
             workdir=getattr(orch, "_workdir", None),
+            **_retry_escalation_context(orch),
         )
         return False
 
@@ -518,6 +610,7 @@ def _try_compact_and_retry(
             retried_task_ids=orch._retried_task_ids,
             tasks_snapshot=tasks_snapshot,
             workdir=getattr(orch, "_workdir", None),
+            **_retry_escalation_context(orch),
         )
         return False
 
@@ -551,6 +644,7 @@ def _try_compact_and_retry(
         retried_task_ids=orch._retried_task_ids,
         tasks_snapshot=tasks_snapshot,
         workdir=getattr(orch, "_workdir", None),
+        **_retry_escalation_context(orch),
     )
 
     # Patch the newly created retry task with compacted description and meta-message.
@@ -739,6 +833,84 @@ def _resolve_agent_log_path(workdir: Path, session: AgentSession) -> Path:
     return log_path
 
 
+def _resolve_tokens_sidecar_path(workdir: Path, session: AgentSession) -> Path:
+    """Return the ``.tokens`` sidecar path for a session.
+
+    Mirrors :func:`bernstein.adapters.openai_agents_runner._resolve_tokens_sidecar_path`
+    and :meth:`bernstein.core.tokens.token_monitor.TokenGrowthMonitor.read_tokens`:
+    the sidecar always lives at the orchestrator-root ``.sdd/runtime/`` directory
+    (never inside a per-task worktree), keyed by session id.
+    """
+    return workdir / ".sdd" / "runtime" / f"{session.id}.tokens"
+
+
+def _read_runner_cost_usd(
+    workdir: Path,
+    session: AgentSession,
+    task_id: str,
+) -> tuple[float, int, int]:
+    """Recover the real LLM cost for a dead agent from its runner cost sidecar.
+
+    Bug (2026-07-03, D2 openrouter FAIL-NOTE): the openai_agents runner prices
+    every LLM call and writes ``{"type": "usage", "cost_usd": ..., "priced": true}``
+    into its own log, and (bug-13) also appends ``{"ts", "in", "out"}`` token
+    records to a ``.tokens`` sidecar file specifically so that cost/usage
+    survives even if the agent process is killed before the orchestrator can
+    read its final log line. The orphan/auto-complete-after-death path
+    (:func:`handle_orphaned_task`) never consulted either source and always
+    recorded ``cost_usd=0.0`` for tasks whose agent died -- this function is
+    the fix: sum the sidecar's token records and price them with the same
+    pricing table the runner itself uses, so a task that a real provider
+    charged real money for is never silently zeroed out.
+
+    Args:
+        workdir: Orchestrator root working directory (``orch._workdir``).
+        session: The dead agent's session (supplies the model for pricing).
+        task_id: Task id, used only for the diagnostic log line.
+
+    Returns:
+        ``(cost_usd, input_tokens, output_tokens)``. All zero if the sidecar
+        is missing, empty, or unreadable -- a missing sidecar is not itself
+        an error (e.g. providers other than openai_agents don't write one).
+    """
+    sidecar_path = _resolve_tokens_sidecar_path(workdir, session)
+    total_in = 0
+    total_out = 0
+    try:
+        raw = sidecar_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0.0, 0, 0
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        total_in += int(rec.get("in", 0) or 0)
+        total_out += int(rec.get("out", 0) or 0)
+
+    if total_in <= 0 and total_out <= 0:
+        return 0.0, 0, 0
+
+    model = session.model_config.model if session.model_config else ""
+    price_result = price_model_usage(model, total_in, total_out)
+    logger.info(
+        "orphan_cost_recovered: task_id=%s agent_id=%s source=%s "
+        "input_tokens=%d output_tokens=%d cost_usd=%.6f priced=%s",
+        task_id,
+        session.id,
+        sidecar_path,
+        total_in,
+        total_out,
+        price_result.cost_usd,
+        price_result.priced,
+    )
+    return price_result.cost_usd, total_in, total_out
+
+
 def _handle_failure_detection(
     orch: Any,
     task: Task,
@@ -754,17 +926,35 @@ def _handle_failure_detection(
         return False
 
     _log_path = _resolve_agent_log_path(orch._workdir, session)
+    logger.debug(
+        "_handle_failure_detection: scanning log_path=%s for session=%s provider=%r task=%s",
+        _log_path,
+        session.id,
+        session.provider,
+        task_id,
+    )
     _failure_type = _rl_tracker.detect_failure_type(_log_path)
     if _failure_type is None:
+        logger.debug(
+            "_handle_failure_detection: no failure pattern found in log_path=%s for session=%s",
+            _log_path,
+            session.id,
+        )
         return False
 
     _rl_tracker.throttle_provider(session.provider, getattr(orch, "_router", None))
+    # Triggering evidence: the specific pattern/excerpt that caused this
+    # throttle decision is logged by RateLimitTracker._scan_log_for_patterns
+    # (matched pattern=..., line_type=..., excerpt=...) immediately before
+    # this line -- log_path here is the pointer that ties the two together.
     logger.warning(
-        "Failure detected (%s) in log for session %s (provider=%r, task=%s)",
+        "Failure detected (%s) in log for session %s (provider=%r, task=%s, log_path=%s) -> throttling provider %r",
         _failure_type,
         session.id,
         session.provider,
         task_id,
+        _log_path,
+        session.provider,
     )
 
     _fallback_model = _run_cascade_fallback(orch, task, task_id, session, _rl_tracker, _failure_type)
@@ -907,20 +1097,256 @@ def _handle_rate_limit_orphan(
     else:
         error_type = "rate_limit_requeue_failed"
 
-    emit_orphan_metrics(orch._workdir, task_id, session, start_ts, success=False, error_type=error_type)
+    _rl_cost_usd, _rl_tokens_in, _rl_tokens_out = _read_runner_cost_usd(orch._workdir, session, task_id)
+    emit_orphan_metrics(
+        orch._workdir,
+        task_id,
+        session,
+        start_ts,
+        success=False,
+        error_type=error_type,
+        cost_usd=_rl_cost_usd,
+        tokens_prompt=_rl_tokens_in,
+        tokens_completion=_rl_tokens_out,
+    )
     orch._record_provider_health(session, success=False)
     if orch._evolution is not None:
         try:
             orch._evolution.record_task_completion(
                 task=task,
                 duration_seconds=round(time.time() - start_ts, 2),
-                cost_usd=0.0,
+                cost_usd=_rl_cost_usd,
                 janitor_passed=False,
                 model=session.model_config.model,
                 provider=session.provider,
+                tokens_prompt=_rl_tokens_in,
+                tokens_completion=_rl_tokens_out,
             )
         except Exception as exc:
             logger.warning("Evolution record_task_completion for orphan %s failed: %s", task_id, exc)
+
+
+# Below this runtime, a clean (exit code 0) agent exit with no file
+# changes, no git commits, and no completion signals is treated as
+# "suspicious" rather than simply healthy no-op work.
+_FAST_EXIT_THRESHOLD_S = 60.0
+# Never truncate the diagnostic beyond this many trailing log lines - this
+# is a display cap for the log file itself, not a cap on what gets logged.
+_FAST_EXIT_LOG_TAIL_LINES = 60
+
+
+def _probe_fast_exit(
+    orch: Any,
+    session: AgentSession,
+    task_id: str,
+) -> dict[str, Any]:
+    """Probe a clean-but-fast agent exit and surface full diagnostic detail.
+
+    Historically a very-short-lived agent that exited cleanly (code 0, no
+    files modified, no commits, no completion signals) was accepted as
+    "no changes needed" with nothing more than a WARNING log line, and
+    callers downstream only ever saw a bare ``bool`` verdict - there was no
+    way to report or act on *why* the exit looked suspicious. Ground truth:
+    run-9 attempt-7's manager exited 0 after ~3s with zero tools and zero
+    child tasks, the orphan handler auto-completed the task, and the run
+    then declared itself healthy (see
+    work/agent-reports/2026-07-02-run9-attempt9-audit.md).
+
+    This probe is unconditional for every clean exit (not just ones under
+    the threshold) so the caller always has the full structured record;
+    ``suspicious`` tells the caller whether the runtime crossed
+    ``_FAST_EXIT_THRESHOLD_S``. Never truncates/swallows anything: the
+    exit code, a manifest path (when a runner manifest was preserved), and
+    the last ``_FAST_EXIT_LOG_TAIL_LINES`` lines of the agent's log are all
+    returned in full and logged at ERROR when suspicious.
+
+    Args:
+        orch: Orchestrator instance.
+        session: The dead agent's session (exit_code, spawn_ts, id must be set).
+        task_id: The orphaned task this exit is being evaluated for.
+
+    Returns:
+        A dict (never a bare bool) with keys: ``suspicious`` (bool),
+        ``runtime_s`` (float), ``exit_code`` (int | None), ``manifest_path``
+        (str | None), ``log_path`` (str | None), ``log_tail`` (list[str]),
+        ``session_id`` (str), ``task_id`` (str).
+    """
+    runtime_s = time.time() - session.spawn_ts if session.spawn_ts > 0 else -1.0
+    suspicious = 0 <= runtime_s < _FAST_EXIT_THRESHOLD_S
+
+    workdir = Path(orch._workdir)
+    log_path = _resolve_agent_log_path(workdir, session)
+    log_tail: list[str] = []
+    log_path_str: str | None = None
+    if log_path.exists():
+        log_path_str = str(log_path)
+        with contextlib.suppress(OSError):
+            log_tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-_FAST_EXIT_LOG_TAIL_LINES:]
+
+    # Runner manifests (e.g. openai_agents_runner.py) are preserved by
+    # _preserve_runner_logs() into agent_logs/<session_id>/ before the
+    # worktree is destroyed - check there first, then fall back to the
+    # (likely already-gone) worktree location for completeness.
+    manifest_path: str | None = None
+    preserved_dir = workdir / ".sdd" / "runtime" / "agent_logs" / session.id
+    with contextlib.suppress(OSError):
+        if preserved_dir.is_dir():
+            manifest_candidates = sorted(preserved_dir.glob(f"{session.id}*.manifest.json"))
+            if manifest_candidates:
+                manifest_path = str(manifest_candidates[0])
+    if manifest_path is None:
+        worktree_path = orch._spawner.get_worktree_path(session.id)
+        if worktree_path is not None:
+            candidate = Path(worktree_path) / ".sdd" / "runtime" / f"{session.id}.manifest.json"
+            with contextlib.suppress(OSError):
+                if candidate.exists():
+                    manifest_path = str(candidate)
+
+    result: dict[str, Any] = {
+        "suspicious": suspicious,
+        "runtime_s": round(runtime_s, 2),
+        "exit_code": session.exit_code,
+        "manifest_path": manifest_path,
+        "log_path": log_path_str,
+        "log_tail": log_tail,
+        "session_id": session.id,
+        "task_id": task_id,
+    }
+
+    if suspicious:
+        logger.error(
+            "FAST EXIT: agent %s (task %s) exited cleanly (exit_code=%s) after only "
+            "%.1fs with no files modified, no commits, and no completion signals - "
+            "likely had no tools or never started real work. manifest=%s log=%s "
+            "log_tail=%r",
+            session.id,
+            task_id,
+            session.exit_code,
+            runtime_s,
+            manifest_path or "<none preserved>",
+            log_path_str or "<none found>",
+            log_tail,
+        )
+        # Pull out any structured (JSON) log lines that carry an explicit
+        # error/type/summary payload and log each one IN FULL (never
+        # truncated) -- log_tail above is already the full untruncated text
+        # of up to _FAST_EXIT_LOG_TAIL_LINES lines, but this makes the
+        # actual error payload impossible to miss when scrolling a long
+        # tail. Ground truth: run-9 attempt-7's manager had a fabricated
+        # "completion" event buried in a 60-line tail that got skimmed past.
+        for _raw_line in log_tail:
+            _stripped = _raw_line.lstrip()
+            if not _stripped.startswith("{"):
+                continue
+            try:
+                _parsed = json.loads(_stripped)
+            except ValueError:
+                continue
+            if not isinstance(_parsed, dict):
+                continue
+            _ptype = _parsed.get("type")
+            if _ptype in ("error", "completion", "progress") or "error" in _parsed:
+                logger.error(
+                    "FAST EXIT structured line: agent %s (task %s) type=%r full_payload=%s",
+                    session.id,
+                    task_id,
+                    _ptype,
+                    json.dumps(_parsed),
+                )
+    else:
+        logger.info(
+            "Fast-exit probe: agent %s (task %s) exited cleanly after %.1fs "
+            "(above %.0fs threshold, not flagged suspicious)",
+            session.id,
+            task_id,
+            runtime_s,
+            _FAST_EXIT_THRESHOLD_S,
+        )
+
+    return result
+
+
+# Below this signal age, an agent must NOT be judged dead even if its tracked
+# PID looks dead/exited or reports a young/wrong start time. Ground truth: D2
+# claude leg attempt4-meridian-fixed FAIL-NOTE defect 4/8 -- manager-48832613
+# was judged dead ("process exited (PID 77, 3s runtime)... died without
+# output") while it had done ~109s of real work (spawned 01:04:47, last tool
+# activity ~01:06, created 4 child tasks server-side). The runner double-forks
+# (or re-execs): the tracked launcher PID exits in seconds while the real
+# worker keeps running with no linkage back to session.pid, so a single-PID
+# liveness check is not trustworthy on its own.
+_ORPHAN_LIVENESS_GRACE_S = 90.0
+
+
+def _mtime_age(path: Path, now: float) -> float | None:
+    """Return seconds since ``path`` was last modified, or None if unreadable/missing."""
+    with contextlib.suppress(OSError):
+        if path.exists():
+            return now - path.stat().st_mtime
+    return None
+
+
+def _probe_liveness_signals(orch: Any, session: AgentSession, now: float) -> dict[str, Any]:
+    """Collect every liveness signal for a possibly-dead agent and log the judgment.
+
+    Never trusts a single tracked PID's reported death as proof the agent is
+    dead -- double-forked/re-exec'd runners break that assumption (see
+    ``_ORPHAN_LIVENESS_GRACE_S`` docstring above). Checks, in order: raw PID
+    liveness, heartbeat file mtime (``.sdd/runtime/heartbeats/<id>.json``,
+    written by the heartbeat loop in ``core/agents/heartbeat.py``), the
+    worktree's runner log mtime, and the worktree ``.git`` mtime (proxy for
+    recent commit/branch activity). ALWAYS logs every input plus the final
+    verdict and why, in one line, never truncated -- a future misjudgment
+    must be diagnosable from this log line alone in under 2 minutes.
+    """
+    pid = session.pid
+    pid_alive = bool(pid) and _is_process_alive(pid)
+
+    heartbeat_path = orch._workdir / ".sdd" / "runtime" / "heartbeats" / f"{session.id}.json"
+    heartbeat_age = _mtime_age(heartbeat_path, now)
+
+    log_path = orch._workdir / ".sdd" / "worktrees" / session.id / ".sdd" / "runtime" / f"{session.id}.log"
+    log_age = _mtime_age(log_path, now)
+
+    git_path = orch._workdir / ".sdd" / "worktrees" / session.id / ".git"
+    git_age = _mtime_age(git_path, now)
+
+    fresh_ages = [a for a in (heartbeat_age, log_age, git_age) if a is not None and a < _ORPHAN_LIVENESS_GRACE_S]
+    has_fresh_signal = bool(fresh_ages)
+    verdict = "ALIVE (fresh signal found)" if has_fresh_signal else "DEAD (no fresh signal)"
+    reason = (
+        "at least one file signal is fresher than the grace window -- a dead-looking/wrong "
+        "tracked pid is not trusted alone"
+        if has_fresh_signal
+        else "pid dead/unknown and every file signal is stale or missing -- judged dead"
+    )
+
+    logger.info(
+        "liveness_judgment: session=%s pid=%s pid_alive=%s heartbeat_path=%s heartbeat_age_s=%s "
+        "log_path=%s log_age_s=%s git_path=%s git_age_s=%s grace_s=%.0f verdict=%s reason=%s",
+        session.id,
+        pid if pid else "unknown",
+        pid_alive,
+        heartbeat_path,
+        f"{heartbeat_age:.1f}" if heartbeat_age is not None else "missing",
+        log_path,
+        f"{log_age:.1f}" if log_age is not None else "missing",
+        git_path,
+        f"{git_age:.1f}" if git_age is not None else "missing",
+        _ORPHAN_LIVENESS_GRACE_S,
+        verdict,
+        reason,
+    )
+
+    return {
+        "pid": pid,
+        "pid_alive": pid_alive,
+        "heartbeat_age_s": heartbeat_age,
+        "log_age_s": log_age,
+        "git_age_s": git_age,
+        "has_fresh_signal": has_fresh_signal,
+        "verdict": verdict,
+    }
 
 
 def _handle_orphan_no_signals(
@@ -946,14 +1372,27 @@ def _handle_orphan_no_signals(
             f"Orphaned task {task_id} auto-completed "
             f"({files_changed} files modified, no signals) after agent {session.id} died"
         )
-        return _try_auto_complete(orch, task_id, base, summary, log_msg)
+        return _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
     if has_commits:
         summary = f"Auto-completed: agent {session.id} made git commits on branch (no signals to verify)"
         log_msg = (
             f"Orphaned task {task_id} auto-completed (git commits detected, no signals) after agent {session.id} died"
         )
-        return _try_auto_complete(orch, task_id, base, summary, log_msg)
+        return _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
     if clean_exit:
+        # A very short-lived "successful" agent that changed nothing is a
+        # defect signal, not health: run-9 attempt-7's manager exited 0
+        # after ~3s with zero tools and zero child tasks, and the
+        # auto-complete below made the run self-declare healthy.
+        # _probe_fast_exit() always runs for a clean exit and returns the
+        # full structured diagnostic (exit code, manifest path, log tail) -
+        # logged at ERROR when suspicious - instead of the bare
+        # WARNING-and-move-on this used to be.
+        # The probe's structured diagnostic is logged internally (ERROR when
+        # suspicious); the auto-complete summary text is left unchanged so
+        # existing consumers of the completion message are unaffected -
+        # operators get the diagnostic from the log, not a mutated summary.
+        _probe_result = _probe_fast_exit(orch, session, task_id)
         summary = (
             f"Auto-completed (no changes needed): agent {session.id} "
             f"exited cleanly with empty diff (exit code 0, no signals to verify)"
@@ -961,7 +1400,43 @@ def _handle_orphan_no_signals(
         log_msg = (
             f"Orphaned task {task_id} auto-completed (no changes needed, clean exit) after agent {session.id} died"
         )
-        return _try_auto_complete(orch, task_id, base, summary, log_msg)
+        _result = _try_auto_complete(orch, task_id, base, summary, log_msg, session=session, start_ts=start_ts)
+        if _probe_result.get("suspicious"):
+            logger.warning(
+                "SUSPICIOUS auto-complete: agent %s auto-completed task %s after only %.1fs "
+                "clean exit with no files modified, no commits, and no completion signals - "
+                "this is a defect signal, not health. See preserved logs under "
+                ".sdd/runtime/agent_logs/%s/ for the full transcript (manifest=%s).",
+                session.id,
+                task_id,
+                _probe_result.get("runtime_s"),
+                session.id,
+                _probe_result.get("manifest_path") or "<none preserved>",
+            )
+        return _result
+
+    # Before declaring "died without output", check every liveness signal --
+    # a double-forked/re-exec'd runner's tracked PID can exit in seconds while
+    # the real work continues untracked (defect 8, D2 claude leg). Never trust
+    # a dead-looking/wrong-pid alone: an agent doing observable work (fresh
+    # heartbeat file / growing log / recent git activity) must NOT be judged
+    # dead just because session.pid looks dead or young.
+    _liveness = _probe_liveness_signals(orch, session, time.time())
+    if _liveness["has_fresh_signal"]:
+        logger.warning(
+            "Deferring death judgment for task %s: agent %s tracked pid=%s looks dead but "
+            "liveness signals are fresh (heartbeat_age_s=%s log_age_s=%s git_age_s=%s, "
+            "grace_s=%.0f) -- NOT failing the task this tick; will re-evaluate on the next "
+            "reap cycle once signals actually go stale.",
+            task_id,
+            session.id,
+            _liveness["pid"] or "unknown",
+            _liveness["heartbeat_age_s"],
+            _liveness["log_age_s"],
+            _liveness["git_age_s"],
+            _ORPHAN_LIVENESS_GRACE_S,
+        )
+        return False, "deferred_liveness_signal_fresh"
 
     # Agent died without output
     runtime = int(time.time() - start_ts)
@@ -974,6 +1449,7 @@ def _handle_orphan_no_signals(
             max_task_retries=orch._config.max_task_retries,
             retried_task_ids=orch._retried_task_ids,
             workdir=getattr(orch, "_workdir", None),
+            **_retry_escalation_context(orch),
         )
         logger.warning(
             "Task '%s' failed - agent died without output. "
@@ -994,11 +1470,25 @@ def _try_auto_complete(
     base: str,
     summary: str,
     log_msg: str,
+    session: AgentSession | None = None,
+    start_ts: float | None = None,
 ) -> tuple[bool, str | None]:
     """Try to auto-complete a task. Returns (success, error_type)."""
     try:
         complete_task(orch._client, base, task_id, summary)
         logger.info(log_msg)
+        if session is not None:
+            _lifetime_s = (time.time() - start_ts) if start_ts is not None else -1.0
+            logger.warning(
+                "orphan_auto_complete: task_id=%s agent_id=%s agent_lifetime_s=%.2f "
+                "exit_reason=%r summary=%r -- task was auto-completed because its "
+                "agent died, not because the agent reported completion itself",
+                task_id,
+                session.id,
+                _lifetime_s,
+                session.exit_code,
+                summary,
+            )
         return True, None
     except httpx.HTTPError as exc:
         logger.error(_ORPHAN_COMPLETE_ERROR, task_id, exc)
@@ -1025,7 +1515,21 @@ def handle_orphaned_task(
         tasks_snapshot: Pre-fetched tasks bucketed by status from this tick.
     """
     base = orch._config.server_url
-    start_ts = session.heartbeat_ts if session.heartbeat_ts > 0 else time.time()
+    # Root-cause fix (defect 8, D2 claude leg attempt4-meridian-fixed): this used
+    # to be `session.heartbeat_ts if session.heartbeat_ts > 0 else time.time()`.
+    # heartbeat_ts is a "last confirmed alive" watermark that freezes the moment
+    # the tracked PID stops being confirmable (e.g. a double-forked/re-exec'd
+    # runner whose tracked launcher PID exits in ~3s while the real worker keeps
+    # running untracked) -- so it is NOT a start time. Every downstream "runtime"
+    # figure derived from it (the "PID %s, %ds runtime" log line and
+    # emit_orphan_metrics' duration_seconds) reported ~3s for an agent that had
+    # actually been alive and working for ~109s. spawn_ts is the true, immutable
+    # start time and must be preferred for any reported runtime/duration.
+    start_ts = (
+        session.spawn_ts
+        if session.spawn_ts > 0
+        else (session.heartbeat_ts if session.heartbeat_ts > 0 else time.time())
+    )
     success = False
     error_type: str | None = None
 
@@ -1125,6 +1629,18 @@ def handle_orphaned_task(
                     task_id,
                     session.id,
                 )
+                _lifetime_s = time.time() - start_ts
+                logger.warning(
+                    "orphan_auto_complete: task_id=%s agent_id=%s agent_lifetime_s=%.2f "
+                    "exit_reason=%r summary=%r -- task was auto-completed because its "
+                    "agent died, not because the agent reported completion itself "
+                    "(janitor verification passed on the completion signals it left behind)",
+                    task_id,
+                    session.id,
+                    _lifetime_s,
+                    session.exit_code,
+                    result_payload["result_summary"],
+                )
             except httpx.HTTPError as exc:
                 logger.error(_ORPHAN_COMPLETE_ERROR, task_id, exc)
                 error_type = "complete_failed"
@@ -1138,6 +1654,7 @@ def handle_orphaned_task(
                     max_task_retries=orch._config.max_task_retries,
                     retried_task_ids=orch._retried_task_ids,
                     workdir=getattr(orch, "_workdir", None),
+                    **_retry_escalation_context(orch),
                 )
                 logger.info(
                     "Orphaned task %s retry/failed (janitor failed: %s) after agent %s died",
@@ -1165,6 +1682,12 @@ def handle_orphaned_task(
         except OSError:
             logger.debug("WAL write failed for orphaned %s %s", _wal_dtype, task_id)
 
+    # Recover the real runner cost from the .tokens cost sidecar *before*
+    # emitting any metrics -- this is a dead agent, so this is the only
+    # remaining source of truth for what it actually spent (see
+    # _read_runner_cost_usd docstring / D2 openrouter FAIL-NOTE 2026-07-03).
+    _orphan_cost_usd, _orphan_tokens_in, _orphan_tokens_out = _read_runner_cost_usd(orch._workdir, session, task_id)
+
     emit_orphan_metrics(
         orch._workdir,
         task_id,
@@ -1172,11 +1695,16 @@ def handle_orphaned_task(
         start_ts,
         success=success,
         error_type=error_type,
+        cost_usd=_orphan_cost_usd,
+        tokens_prompt=_orphan_tokens_in,
+        tokens_completion=_orphan_tokens_out,
     )
     orch._record_provider_health(session, success=success)
 
     # Feed orphaned task outcome to the evolution coordinator so that
-    # failed/timed-out agent runs are visible to trend analysis.
+    # failed/timed-out agent runs are visible to trend analysis, and so the
+    # priced runner cost lands in .sdd/metrics/tasks.jsonl instead of being
+    # silently zeroed out (bug family: bug-13 cost metering).
     if orch._evolution is not None:
         _now = time.time()
         _duration = _now - start_ts
@@ -1184,10 +1712,12 @@ def handle_orphaned_task(
             orch._evolution.record_task_completion(
                 task=task,
                 duration_seconds=round(_duration, 2),
-                cost_usd=0.0,
+                cost_usd=_orphan_cost_usd,
                 janitor_passed=success,
                 model=session.model_config.model,
                 provider=session.provider,
+                tokens_prompt=_orphan_tokens_in,
+                tokens_completion=_orphan_tokens_out,
             )
         except Exception as exc:
             logger.warning(
@@ -1195,6 +1725,35 @@ def handle_orphaned_task(
                 task_id,
                 exc,
             )
+
+    # Also reconcile the observability MetricsCollector's in-memory
+    # TaskMetrics entry (populated at spawn time by collector.start_task()
+    # in task_lifecycle.py). Without this, retrospective.py's cost
+    # aggregation fallback (source=task_metrics) finds this task_id
+    # permanently "started, never finished" with cost_usd stuck at 0.0,
+    # because collector.complete_task() was previously only reachable from
+    # the janitor-verified normal-completion path -- never from this
+    # orphan/auto-complete-after-death path.
+    try:
+        _collector = get_collector(orch._workdir / ".sdd" / "metrics")
+        if _collector.task_metrics.get(task_id) is not None:
+            _collector.complete_task(
+                task_id,
+                success=success,
+                tokens_used=_orphan_tokens_in + _orphan_tokens_out,
+                cost_usd=_orphan_cost_usd,
+                janitor_passed=success,
+            )
+            if _orphan_cost_usd > 0:
+                logger.info(
+                    "orphan_cost_folded_in: task_id=%s agent_id=%s cost_usd=%.6f "
+                    "folded into observability MetricsCollector (retrospective cost aggregation)",
+                    task_id,
+                    session.id,
+                    _orphan_cost_usd,
+                )
+    except Exception as exc:
+        logger.warning("Failed to reconcile observability collector for orphan %s: %s", task_id, exc)
 
 
 # ---------------------------------------------------------------------------
@@ -1210,6 +1769,9 @@ def emit_orphan_metrics(
     *,
     success: bool,
     error_type: str | None,
+    cost_usd: float = 0.0,
+    tokens_prompt: int = 0,
+    tokens_completion: int = 0,
 ) -> None:
     """Write a 14-field MetricsRecord to .sdd/metrics/YYYY-MM-DD.jsonl.
 
@@ -1220,6 +1782,13 @@ def emit_orphan_metrics(
         start_ts: Approximate start timestamp of the agent run.
         success: Whether the orphaned task was auto-completed.
         error_type: Error category, or None on success.
+        cost_usd: Real LLM cost recovered from the runner's cost sidecar
+            (see :func:`_read_runner_cost_usd`), or ``0.0`` if none was
+            found. Previously hardcoded to ``0.0`` unconditionally, which
+            silently dropped real spend for every orphaned/auto-completed
+            task (bug family: bug-13 cost metering).
+        tokens_prompt: Prompt tokens recovered alongside ``cost_usd``.
+        tokens_completion: Completion tokens recovered alongside ``cost_usd``.
     """
     now = time.time()
     record = MetricsRecord(
@@ -1229,8 +1798,8 @@ def emit_orphan_metrics(
         role=session.role,
         model_used=session.model_config.model,
         duration_seconds=round(now - start_ts, 2),
-        token_count=0,
-        cost_usd=0.0,
+        token_count=tokens_prompt + tokens_completion,
+        cost_usd=cost_usd,
         success=success,
         error_type=error_type,
         files_modified=0,
@@ -1425,7 +1994,7 @@ def _reap_wall_clock_timeout(
     _release_task_to_session(orch, session.task_ids)
     collector.end_agent(session.id)
     if orch._evolution is not None:
-        with contextlib.suppress(Exception):
+        try:
             orch._evolution.record_agent_lifetime(
                 agent_id=session.id,
                 role=session.role,
@@ -1433,8 +2002,18 @@ def _reap_wall_clock_timeout(
                 tasks_completed=0,
                 _model=session.model_config.model,
             )
+        except Exception:
+            logger.exception(
+                "record_agent_lifetime failed during wall-clock reap "
+                "(session_id=%s role=%s model=%s lifetime_seconds=%s) - reap continues",
+                session.id,
+                session.role,
+                getattr(session.model_config, "model", None),
+                round(runtime, 2),
+            )
     with contextlib.suppress(OSError):
         orch._signal_mgr.clear_signals(session.id)
+    _preserve_runner_logs(orch, session)
     for task_id in session.task_ids:
         handle_orphaned_task(orch, task_id, session, tasks_snapshot)
     _save_partial_work(orch._spawner, session)
@@ -1464,13 +2043,23 @@ def _reap_heartbeat_timeout(
     _release_task_to_session(orch, session.task_ids)
     collector.end_agent(session.id)
     if orch._evolution is not None:
-        with contextlib.suppress(Exception):
+        try:
             orch._evolution.record_agent_lifetime(
                 agent_id=session.id,
                 role=session.role,
                 lifetime_seconds=round(now - session.spawn_ts, 2),
                 tasks_completed=0,
                 _model=session.model_config.model,
+            )
+        except Exception:
+            logger.exception(
+                "record_agent_lifetime failed during heartbeat-timeout reap "
+                "(session_id=%s role=%s model=%s lifetime_seconds=%s age=%.0fs) - reap continues",
+                session.id,
+                session.role,
+                getattr(session.model_config, "model", None),
+                round(now - session.spawn_ts, 2),
+                age,
             )
     orch._record_provider_health(session, success=False)
     with contextlib.suppress(OSError):
@@ -1497,6 +2086,7 @@ def _reap_heartbeat_timeout(
                 retried_task_ids=orch._retried_task_ids,
                 tasks_snapshot=tasks_snapshot,
                 workdir=getattr(orch, "_workdir", None),
+                **_retry_escalation_context(orch),
             )
         except httpx.HTTPError as exc:
             logger.error("Failed to retry/fail task %s: %s", task_id, exc)

--- a/src/bernstein/core/agents/agent_recycling.py
+++ b/src/bernstein/core/agents/agent_recycling.py
@@ -196,6 +196,24 @@ def _reap_completed_agent(orch: Any, session: AgentSession, completion_file: Pat
         orch._signal_mgr.clear_signals(session.id)
     with contextlib.suppress(OSError):
         completion_file.unlink()
+    # Preserve the runner transcript/manifest BEFORE the worktree (and the
+    # ``.sdd/runtime/<session_id>*.log`` inside it) is destroyed. D2 MiniMax
+    # attempt-3 (2026-07-03): the manager completed cleanly, was reaped via
+    # this idle-recycle path, and its runner log - the only artifact carrying
+    # its usage/usage_missing cost diagnostics - was deleted with the
+    # worktree because only the crash paths in agent_lifecycle.py preserved
+    # logs. Mirrors agent_lifecycle.py's _handle_dead_agent/reap paths.
+    # Imported lazily: agent_lifecycle re-imports this module at its EOF for
+    # back-compat re-exports, so a top-level import here would deepen the
+    # existing agent_recycling <-> agent_lifecycle cycle.
+    from bernstein.core.agents.agent_lifecycle import _preserve_runner_logs
+
+    _preserved_dir = _preserve_runner_logs(orch, session)
+    logger.info(
+        "Runner log preservation before worktree cleanup for completed agent %s: %s",
+        session.id,
+        _preserved_dir if _preserved_dir is not None else "nothing to preserve",
+    )
     with contextlib.suppress(Exception):
         orch._spawner.cleanup_worktree(session.id)
     get_collector().end_agent(session.id)
@@ -243,6 +261,18 @@ def _recycle_or_kill(orch: Any, session: AgentSession, now: float, reason: str) 
         orch._idle_shutdown_ts.pop(session.id, None)
         with contextlib.suppress(OSError):
             orch._signal_mgr.clear_signals(session.id)
+        # Preserve the runner transcript/manifest BEFORE the worktree is
+        # destroyed (same rationale as _reap_completed_agent above; mirrors
+        # agent_lifecycle.py's crash-path preservation). Lazy import: see
+        # _reap_completed_agent for the cycle rationale.
+        from bernstein.core.agents.agent_lifecycle import _preserve_runner_logs
+
+        _preserved_dir = _preserve_runner_logs(orch, session)
+        logger.info(
+            "Runner log preservation before worktree cleanup for recycled agent %s: %s",
+            session.id,
+            _preserved_dir if _preserved_dir is not None else "nothing to preserve",
+        )
         with contextlib.suppress(Exception):
             orch._spawner.cleanup_worktree(session.id)
         get_collector().end_agent(session.id)

--- a/src/bernstein/core/agents/heartbeat.py
+++ b/src/bernstein/core/agents/heartbeat.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
+import signal
+import subprocess
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -83,21 +86,188 @@ class HeartbeatMonitor:
         return [self.check(session_id) for session_id in session_ids]
 
     def inject_heartbeat_instructions(self, session_id: str) -> str:
-        """Return a shell snippet that writes heartbeats in the background."""
-        heartbeat_path = self._workdir / ".sdd" / "runtime" / "heartbeats" / f"{session_id}.json"
+        """Return a shell snippet that writes heartbeats in the background.
+
+        Defect-10 fix (leaked heartbeat shell loop, 2026-07-02/03 Claude leg):
+        a bare ``while true; do ...; done &`` loop had no way to know its
+        parent run had ended, so it survived the run indefinitely as an
+        orphaned host process. The generated loop is now self-terminating:
+        it checks for a run-scoped STOP marker file on every iteration and
+        exits on its own the moment that marker appears. It also records its
+        own PID to a run-scoped pidfile so :meth:`reap_heartbeat_loop` can
+        kill it directly as a belt-and-braces backstop (e.g. if the run
+        crashes before it can write the STOP marker).
+        """
+        heartbeat_dir = self._workdir / ".sdd" / "runtime" / "heartbeats"
+        heartbeat_path = heartbeat_dir / f"{session_id}.json"
+        pid_path = self._heartbeat_pid_path(session_id)
+        stop_path = self._heartbeat_stop_path(session_id)
         escaped_path = str(heartbeat_path)
+        escaped_pid = str(pid_path)
+        escaped_stop = str(stop_path)
+        logger.info(
+            "Heartbeat loop instructions generated for session %s (heartbeat=%s pidfile=%s stopfile=%s)",
+            session_id,
+            escaped_path,
+            escaped_pid,
+            escaped_stop,
+        )
+        # NOTE: mkdir/rm must be their own statements (`;`, not `&&`) -- a
+        # trailing `&` backgrounds the entire preceding `&&` AND-list, which
+        # would race the mkdir against the `echo $! > pidfile` below and
+        # made the pidfile write fail before the directory existed.
+        # Sleep in 1s ticks (up to 15) rather than one `sleep 15` so the
+        # STOP-marker check has sub-second latency instead of waiting out a
+        # full sleep before noticing the run has ended.
         return (
-            f"(mkdir -p '{heartbeat_path.parent}' && "
-            f"while true; do "
+            f"# heartbeat cadence: sleep 15s total, polled in 1s ticks for fast STOP response\n"
+            f"mkdir -p '{heartbeat_dir}'; rm -f '{escaped_stop}'; "
+            f"(while [ ! -f '{escaped_stop}' ]; do "
             f'printf \'{{"timestamp":%s,'
             f'"phase":"implementing",'
             f'"progress_pct":0,'
             f'"current_file":"",'
             f'"message":"working"}}\' '
             f"\"$(date +%s)\" > '{escaped_path}'; "
-            f"sleep 15; "
-            f"done) >/dev/null 2>&1 &"
+            f"_t=0; while [ \"$_t\" -lt 15 ] && [ ! -f '{escaped_stop}' ]; do sleep 1; _t=$((_t+1)); done; "
+            f"done; rm -f '{escaped_pid}') >/dev/null 2>&1 & "
+            f"echo $! > '{escaped_pid}'"
         )
+
+    def _heartbeat_pid_path(self, session_id: str) -> Path:
+        return self._workdir / ".sdd" / "runtime" / "heartbeats" / f"{session_id}.pid"
+
+    def _heartbeat_stop_path(self, session_id: str) -> Path:
+        return self._workdir / ".sdd" / "runtime" / "heartbeats" / f"{session_id}.stop"
+
+    def request_heartbeat_stop(self, session_id: str) -> None:
+        """Write the STOP marker so the loop exits on its next iteration."""
+        stop_path = self._heartbeat_stop_path(session_id)
+        stop_path.parent.mkdir(parents=True, exist_ok=True)
+        stop_path.touch()
+        logger.info("Heartbeat STOP marker written for session %s (%s)", session_id, stop_path)
+
+    def _pid_cmdline(self, pid: int) -> str | None:
+        """Best-effort process command line for *pid*, or None if unavailable.
+
+        Reads ``/proc/<pid>/cmdline`` on Linux; falls back to ``ps`` on
+        platforms without procfs (e.g. macOS). Returns None when the process
+        is gone or the command line cannot be read, so the caller can decide
+        conservatively.
+        """
+        proc_cmdline = Path("/proc") / str(pid) / "cmdline"
+        try:
+            raw = proc_cmdline.read_bytes()
+        except FileNotFoundError:
+            # No procfs (macOS/BSD) or process gone: fall back to ps.
+            try:
+                result = subprocess.run(
+                    ["ps", "-p", str(pid), "-o", "command="],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (OSError, subprocess.SubprocessError):
+                return None
+            if result.returncode != 0:
+                return None
+            return result.stdout.strip() or None
+        except OSError:
+            return None
+        # /proc cmdline args are NUL-separated.
+        return raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip() or None
+
+    def _pid_is_heartbeat_loop(self, pid: int, session_id: str) -> bool | None:
+        """Whether *pid* still looks like this session's heartbeat loop.
+
+        Returns True when the process command line references this session's
+        heartbeat/stop path, False when it clearly does not (a recycled,
+        unrelated PID), and None when identity cannot be determined (command
+        line unreadable) so the caller can choose a conservative default.
+        """
+        cmdline = self._pid_cmdline(pid)
+        if cmdline is None:
+            return None
+        heartbeat_marker = str(self._heartbeat_pid_path(session_id).parent / f"{session_id}")
+        stop_marker = str(self._heartbeat_stop_path(session_id))
+        return heartbeat_marker in cmdline or stop_marker in cmdline
+
+    def reap_heartbeat_loop(self, session_id: str, *, reason: str) -> None:
+        """Belt-and-braces reap: request stop, then kill the recorded pid if still alive.
+
+        Safe to call even if no heartbeat loop was ever spawned for this
+        session (missing pidfile / already-exited pid are both no-ops).
+        Always logged at INFO so a leak is diagnosable from logs alone.
+        """
+        self.request_heartbeat_stop(session_id)
+        pid_path = self._heartbeat_pid_path(session_id)
+        try:
+            raw_pid = pid_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            logger.info(
+                "Heartbeat reap for session %s: no pidfile found (%s) -- nothing to kill",
+                session_id,
+                reason,
+            )
+            return
+        try:
+            pid = int(raw_pid)
+        except ValueError:
+            logger.info("Heartbeat reap for session %s: malformed pidfile contents %r", session_id, raw_pid)
+            return
+
+        # Verify the PID still belongs to this session's heartbeat loop before
+        # signalling it. A run that crashed before writing the STOP marker can
+        # leave a stale pidfile; if the OS recycled that PID to an unrelated
+        # process, an unconditional SIGTERM would kill a foreign process. Skip
+        # the kill on a definitive identity mismatch; proceed (with a warning)
+        # only when identity cannot be determined at all.
+        identity = self._pid_is_heartbeat_loop(pid, session_id)
+        if identity is False:
+            logger.warning(
+                "Heartbeat reap for session %s: pid %d does not match this session's heartbeat "
+                "loop (likely a recycled/unrelated PID) -- NOT signalling it (reason: %s)",
+                session_id,
+                pid,
+                reason,
+            )
+            with contextlib.suppress(OSError):
+                pid_path.unlink()
+            return
+        if identity is None:
+            logger.warning(
+                "Heartbeat reap for session %s: could not verify pid %d identity (command line "
+                "unreadable); proceeding with SIGTERM (reason: %s)",
+                session_id,
+                pid,
+                reason,
+            )
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            logger.info(
+                "Heartbeat reap for session %s: pid %d already exited (reason: %s)",
+                session_id,
+                pid,
+                reason,
+            )
+        except OSError as exc:
+            logger.warning(
+                "Heartbeat reap for session %s: failed to signal pid %d: %s",
+                session_id,
+                pid,
+                exc,
+            )
+        else:
+            logger.info(
+                "Heartbeat reap for session %s: sent SIGTERM to pid %d (reason: %s)",
+                session_id,
+                pid,
+                reason,
+            )
+        with contextlib.suppress(OSError):
+            pid_path.unlink()
 
     def _read_heartbeat(self, session_id: str) -> AgentHeartbeat | None:
         """Read a heartbeat from the primary or fallback location."""
@@ -290,6 +460,22 @@ def _update_stall_count(
     return orch._stall_counts[task_id]
 
 
+def _reap_session_heartbeat_loop(orch: Any, session: Any, reason: str) -> None:
+    """Belt-and-braces: kill any heartbeat shell loop this session spawned.
+
+    Defect-10: heartbeat loops are backgrounded inside the agent's own
+    shell and must not outlive the run. The loop is self-terminating (see
+    HeartbeatMonitor.inject_heartbeat_instructions), but whenever the
+    orchestrator forcibly kills a session it also proactively reaps the
+    heartbeat loop so nothing is left relying on the self-check alone.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if not isinstance(workdir, Path):
+        return
+    with contextlib.suppress(Exception):
+        HeartbeatMonitor(workdir).reap_heartbeat_loop(session.id, reason=reason)
+
+
 def _escalate_stall_simple(
     orch: Any,
     session: Any,
@@ -301,6 +487,7 @@ def _escalate_stall_simple(
     if count >= AGENT.escalation_kill_count:
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
+        _reap_session_heartbeat_loop(orch, session, reason="stall_kill")
         orch._stall_counts[task_id] = 0
     elif count >= AGENT.escalation_high_count:
         with contextlib.suppress(OSError):
@@ -334,6 +521,7 @@ def _escalate_stall_profiled(
         )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
+        _reap_session_heartbeat_loop(orch, session, reason=f"stall_kill:{profile.reason}")
         orch._stall_counts[task_id] = 0
     elif count >= profile.shutdown_threshold:
         logger.warning(

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -6,6 +6,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+import re
 import shutil
 import threading
 import time
@@ -20,7 +21,7 @@ from bernstein.adapters.plugin_sdk import (
     SamplingParamsRefusal,
     ensure_sampling_params_supported,
 )
-from bernstein.adapters.registry import get_adapter
+from bernstein.adapters.registry import adapter_name_for_provider, get_adapter
 from bernstein.adapters.skills_injector import inject_skills
 from bernstein.agents.registry import AgentRegistry, get_registry
 from bernstein.bridges.base import AgentState, BridgeError, RuntimeBridge, SpawnRequest
@@ -197,6 +198,164 @@ def _sanitise_for_log(value: str) -> str:
     return value.replace("\r", "").replace("\n", "") if value else value
 
 
+# ---------------------------------------------------------------------------
+# Error-aware spawn-failure extraction
+# ---------------------------------------------------------------------------
+# Ground truth: work/bernstein/proofs/d2/minimax/FAIL-NOTE.md. Adapter
+# fast-exit probes (``CLIAdapter._probe_fast_exit`` in adapters/base.py)
+# raise a ``SpawnError``/``RateLimitError`` whose message embeds only the
+# LAST LINE of the runner's log (``tail_lines[-1]``). In the D2 MiniMax
+# incident, the openai_agents runner actually died on
+# ``BadRequestError: 400 ... does not support max tokens > 196608``, but
+# the log's last line was a benign, unrelated SDK tracing warning
+# (``OPENAI_API_KEY is not set, skipping trace export``) - the real error
+# sat further up in the per-session runtime log. That masking happened
+# across 7 run attempts before the real defect was found by hand.
+#
+# Fixing the extraction inside adapters/base.py is out of scope for this
+# change (file-ownership boundary - see PR description), so this
+# re-derives a full, error-aware failure reason downstream, in the
+# spawner's own exception handler, by independently re-reading the same
+# per-session log the adapter wrote (``<spawn_cwd>/.sdd/runtime/
+# <session_id>.log`` - see e.g. adapters/openai_agents.py's ``log_path``
+# construction) rather than trusting the already-truncated exception
+# message.
+_TRACEBACK_HEADER = "Traceback (most recent call last):"
+_ERROR_LEVEL_RE = re.compile(r"\b(ERROR|CRITICAL)\b")
+_EXCEPTION_CLASS_RE = re.compile(r"\b\w+(?:Error|Exception)\b")
+_HTTP_STATUS_RE = re.compile(r"\b[45]\d{2}\b")
+_SPAWN_EXIT_CODE_RE = re.compile(r"exited early with code (-?\d+)")
+_FAILURE_REASON_MAX_CHARS = 4000
+_FAILURE_REASON_FALLBACK_LINES = 10
+
+
+def extract_error_aware_reason(log_text: str, max_chars: int = _FAILURE_REASON_MAX_CHARS) -> str:
+    """Extract the LAST genuine error record from a runner's log text.
+
+    Scans (in priority order) for: the last ``Traceback (most recent call
+    last):`` block through to its final exception line; failing that, the
+    last line matching an ERROR/CRITICAL log level, an exception-class
+    pattern (``\\w+Error``/``Exception``), or an HTTP 4xx/5xx status code
+    mention. This deliberately does NOT just grab the log's last line -
+    that naive approach is the exact masking bug this function replaces
+    (see module docstring above and FAIL-NOTE.md).
+
+    Args:
+        log_text: Full contents of the runner's log (stdout/stderr
+            concatenated, or a per-session ``.sdd/runtime/<id>.log``).
+        max_chars: Cap on the returned text, measured from the start of
+            the matched error record (not a truncation of the message
+            body - it's a generous ceiling so pathological logs can't
+            balloon a caller's log line without limit).
+
+    Returns:
+        The full matched error text (traceback or multi-line block from
+        the last matching error line to end of log), capped at
+        ``max_chars``. When no error pattern is found anywhere in the
+        log, returns the last ``_FAILURE_REASON_FALLBACK_LINES`` lines,
+        clearly prefixed with "(no error pattern found, showing last N
+        lines)" so callers can tell a fallback from a real match.
+    """
+    if not log_text or not log_text.strip():
+        return "(no error pattern found, showing last 10 lines): <log empty or unavailable>"
+
+    lines = log_text.splitlines()
+
+    # 1. Traceback blocks are the most authoritative signal - prefer the
+    #    LAST one (a runner may log an earlier, recovered exception too).
+    traceback_starts = [i for i, line in enumerate(lines) if line.strip() == _TRACEBACK_HEADER]
+    if traceback_starts:
+        start = traceback_starts[-1]
+        end = len(lines)
+        for j in range(start + 1, len(lines)):
+            if lines[j].strip() == "":
+                end = j
+                break
+        block = "\n".join(lines[start:end]).strip()
+        if block:
+            return block[:max_chars]
+
+    # 2. Otherwise, find the LAST line matching an ERROR/CRITICAL level,
+    #    an exception-class name, or an HTTP 4xx/5xx status code, and
+    #    return everything from there to the end of the log (full
+    #    multi-line error body, e.g. an HTTP error response payload that
+    #    follows the status-code line).
+    match_idx = None
+    for i, line in enumerate(lines):
+        if _ERROR_LEVEL_RE.search(line) or _EXCEPTION_CLASS_RE.search(line) or _HTTP_STATUS_RE.search(line):
+            match_idx = i
+    if match_idx is not None:
+        block = "\n".join(lines[match_idx:]).strip()
+        if block:
+            return block[:max_chars]
+
+    # 3. No error pattern anywhere in the log - fall back to the last N
+    #    lines, clearly labeled as a fallback (never silently equal to
+    #    just the last line, which is the bug being fixed here).
+    tail = "\n".join(lines[-_FAILURE_REASON_FALLBACK_LINES:]).strip()
+    return f"(no error pattern found, showing last {_FAILURE_REASON_FALLBACK_LINES} lines)\n{tail}"[:max_chars]
+
+
+def _diagnose_spawn_failure(
+    session_id: str,
+    spawn_cwd: Path,
+    adapter_name: str,
+    exc: Exception,
+) -> str:
+    """Re-derive a full, error-aware failure reason for a failed spawn attempt.
+
+    Independently re-reads the runner's per-session log
+    (``<spawn_cwd>/.sdd/runtime/<session_id>.log`` and its
+    ``.stderr.log`` sibling, when present) and runs
+    :func:`extract_error_aware_reason` over it, instead of trusting
+    ``str(exc)`` - which, for adapters that raise via
+    ``CLIAdapter._probe_fast_exit`` (adapters/base.py), only ever embeds
+    the log's last line. Emits a WARNING with the agent id, exit context,
+    the extracted reason, and the log file path so a human can jump
+    straight to the full session log.
+
+    Args:
+        session_id: Agent session id - also the per-session log's stem.
+        spawn_cwd: Worktree cwd the adapter spawned into.
+        adapter_name: Adapter name, for the warning log line.
+        exc: The exception raised by the failed spawn attempt.
+
+    Returns:
+        The error-aware failure reason, or ``str(exc)`` when no
+        per-session log file can be found on disk.
+    """
+    log_path = spawn_cwd / ".sdd" / "runtime" / f"{session_id}.log"
+    stderr_path = log_path.with_suffix(".stderr.log")
+
+    log_text_parts: list[str] = []
+    found_path: Path | None = None
+    for candidate in (log_path, stderr_path):
+        try:
+            log_text_parts.append(candidate.read_text(encoding="utf-8", errors="replace"))
+            found_path = found_path or candidate
+        except OSError:
+            continue
+
+    if not log_text_parts:
+        return str(exc)
+
+    reason = extract_error_aware_reason("\n".join(log_text_parts))
+
+    exit_code_match = _SPAWN_EXIT_CODE_RE.search(str(exc))
+    exit_context = f"exit_code={exit_code_match.group(1)}" if exit_code_match else "exit_code=unknown"
+
+    logger.warning(
+        "Spawn failure reason extracted for agent %s (adapter=%s, %s): %s | log=%s",
+        session_id,
+        adapter_name,
+        exit_context,
+        reason[:2000],
+        found_path,
+    )
+
+    return reason
+
+
 def _render_signal_check(session_id: str) -> str:
     """Return signal-check instructions to append to every agent's system prompt.
 
@@ -251,16 +410,45 @@ def _render_auth_section(token_path: Path) -> str:
         "```bash\n"
         f'-H "Authorization: Bearer $(cat {absolute})"\n'
         "```\n"
-        "Example - creating a subtask:\n"
+        "**Command-form contract - read this before your first request.** Your "
+        "`run_command` tool accepts two call forms:\n"
+        "- a single command **STRING** (e.g. "
+        f'`run_command("curl ... -H \\"Authorization: Bearer $(cat {absolute})\\" ...")`)'
+        "\n  → this runs via a shell, so `$(...)`, `$VAR`, pipes, and `&&` all expand normally.\n"
+        "- an **argv LIST** (e.g. "
+        f'`run_command(["curl", "-H", "Authorization: Bearer $(cat {absolute})", ...])`)'
+        "\n  → this execs the process directly with NO shell involved, so `$(...)` and "
+        "`$VAR` are never expanded. The literal text (including the dollar sign, "
+        "parens, and path) is sent as-is, curl still exits 0, and the task server "
+        "returns 401. There is no visible error other than the HTTP status - it "
+        "looks like success unless you check it.\n\n"
+        "**Every curl below MUST be invoked with `run_command` in the single-STRING "
+        "form whenever it uses `$(...)`, `$VAR`, a pipe, or `&&`.** If you are not "
+        "sure which form your tool call used, re-issue the request as one string "
+        "and re-check the status code.\n\n"
+        "**Do not use the `read_file` tool to obtain your token.** `read_file` is "
+        "confined to your own worktree, and the token file lives outside it - the "
+        "call will fail with a workdir-escape error every time, regardless of the "
+        "token's validity. The only supported way to read the token is through "
+        "`run_command` in string form running `cat <token-path>` (or interpolating "
+        "it into the curl command directly, as shown below).\n\n"
+        "**Always check the HTTP status, not just the command's exit code.** curl "
+        "exits 0 even on a 401 or 500 - the failure is only visible in the response "
+        "body/status line. Add `-w '\\n%{http_code}'` to every call and treat any "
+        "status outside 200-299 as a failure: stop, re-verify you used the string "
+        "form and the correct token path, and retry. Do not report a task as done, "
+        "or give up, based solely on a non-2xx response without first confirming "
+        "the command form was correct.\n"
+        "Example - creating a subtask (pass the whole line to `run_command` as ONE string):\n"
         "```bash\n"
-        f"curl -s -X POST http://127.0.0.1:8052/tasks \\\n"
+        f"curl -sS -w '\\n%{{http_code}}' -X POST http://127.0.0.1:8052/tasks \\\n"
         f'  -H "Authorization: Bearer $(cat {absolute})" \\\n'
         '  -H "Content-Type: application/json" \\\n'
         '  -d \'{"title": "...", "role": "backend", "description": "..."}\'\n'
         "```\n"
-        "Example - marking a task complete:\n"
+        "Example - marking a task complete (pass the whole line to `run_command` as ONE string):\n"
         "```bash\n"
-        f"curl -s -X POST http://127.0.0.1:8052/tasks/<TASK_ID>/complete \\\n"
+        f"curl -sS -w '\\n%{{http_code}}' -X POST http://127.0.0.1:8052/tasks/<TASK_ID>/complete \\\n"
         f'  -H "Authorization: Bearer $(cat {absolute})" \\\n'
         '  -H "Content-Type: application/json" \\\n'
         '  -d \'{"result_summary": "Done"}\'\n'
@@ -1024,6 +1212,24 @@ class AgentSpawner:
         self._rate_limit_tracker: Any = None
 
     @property
+    def role_model_policy(self) -> dict[str, dict[str, Any]]:
+        """Read-only view of the configured ``role_model_policy``.
+
+        Exposed so callers outside this module (task_lifecycle.py's retry
+        escalation, in particular) can determine whether a role has been
+        pinned to a non-Claude provider/model *before* stamping a Claude
+        tier name ("opus"/"sonnet") onto a retried task - see
+        ``_choose_retry_escalation`` for why that matters. Returns a
+        shallow copy; mutating it does not affect spawn behavior.
+        """
+        return dict(self._role_model_policy)
+
+    @property
+    def default_adapter_name(self) -> str:
+        """Name of the spawner's default (run-level) adapter, e.g. ``claude``."""
+        return self._adapter.name()
+
+    @property
     def _identity_store(self) -> Any:
         """Return the AgentIdentityStore, creating it on first access."""
         if self._identity_store_instance is None:
@@ -1551,17 +1757,47 @@ class AgentSpawner:
         reap_subprocess(session, self._procs)
 
     def _infer_adapter_name_for_provider(self, provider_name: str | None, model: str) -> str:
-        """Infer adapter name from provider/model identifiers."""
-        text = f"{provider_name or ''} {model}".lower()
-        if "gemini" in text or "google" in text:
-            return "gemini"
-        if "codex" in text or "openai" in text or "gpt" in text:
-            return "codex"
-        if "qwen" in text:
-            return "qwen"
-        if "claude" in text or "anthropic" in text:
-            return "claude"
-        return self._adapter.name()
+        """Resolve adapter name from provider/model identifiers via the adapter registry.
+
+        Delegates to :func:`bernstein.adapters.registry.adapter_name_for_provider`,
+        which looks the pair up against the ``provider_name -> adapter_name``
+        table built from every adapter's ``provides`` declaration. This
+        replaces the old hand-ordered substring `if`/`elif` chain (Root
+        Cause A of the provider/adapter routing bug ladder): there is no
+        longer any hardcoded branch order to get wrong, and
+        :func:`bernstein.adapters.registry._register_provider_alias` raises
+        loudly at table-build time if two adapters ever claim the same
+        alias, instead of silently misrouting at spawn time.
+
+        Unrecognized provider/model combinations still fall back to
+        ``self._adapter.name()`` -- the currently-active adapter -- exactly
+        as before, so Claude-only / unrecognized-provider operators are
+        unaffected.
+        """
+        logger.debug(
+            "_infer_adapter_name_for_provider: provider_name=%r model=%r current_adapter=%r",
+            provider_name,
+            model,
+            self._adapter.name(),
+        )
+        resolved = adapter_name_for_provider(provider_name, model)
+        if resolved is not None:
+            logger.info(
+                "_infer_adapter_name_for_provider: resolved provider_name=%r model=%r -> adapter=%r",
+                provider_name,
+                model,
+                resolved,
+            )
+            return resolved
+        fallback = self._adapter.name()
+        logger.info(
+            "_infer_adapter_name_for_provider: no registry match for provider_name=%r model=%r; "
+            "falling back to current adapter %r",
+            provider_name,
+            model,
+            fallback,
+        )
+        return fallback
 
     def _get_adapter_by_name(self, adapter_name: str, *, role: str | None = None) -> CLIAdapter:
         """Return cached adapter instance, creating one when needed.
@@ -1629,13 +1865,31 @@ class AgentSpawner:
 
         Adapters without the attribute get ``mcp_config`` back unchanged
         so their MCP config files stay byte-identical.
+
+        Logged at INFO on every call (bug #11): the previous silent
+        skip made a ``CachingAdapter``-wrapped adapter's dropped
+        ``consumes_heartbeat_dir`` flag invisible - workers wrote
+        heartbeats into the worktree, the monitor polled the
+        orchestrator root, and every spawn was killed at the stale
+        threshold with no log line pointing at the cause.
         """
-        if not getattr(adapter, "consumes_heartbeat_dir", False):
+        consumes = getattr(adapter, "consumes_heartbeat_dir", False)
+        injected = bool(consumes)
+        if injected:
+            heartbeat_dir = str(self._workdir / ".sdd" / "runtime" / "heartbeats")
+        logger.info(
+            "heartbeat_dir injection check: adapter=%s consumes_heartbeat_dir=%s injected=%s",
+            adapter.name() if hasattr(adapter, "name") else type(adapter).__name__,
+            consumes,
+            injected,
+        )
+        if not injected:
             return mcp_config
-        heartbeat_dir = str(self._workdir / ".sdd" / "runtime" / "heartbeats")
         return {**(mcp_config or {}), "heartbeat_dir": heartbeat_dir}
 
-    def _primary_adapter_supports_sampling(self, model_config: ModelConfig) -> bool:
+    def _primary_adapter_supports_sampling(
+        self, model_config: ModelConfig, *, provider_name: str | None = None
+    ) -> bool:
         """Best-effort probe: does the adapter for this spawn honour sampling?
 
         Used to decide whether mode-profile sampling params may be folded
@@ -1646,13 +1900,43 @@ class AgentSpawner:
         spawn, so injecting profile defaults there would break otherwise
         valid runs.
 
-        The probe only inspects adapters that are already known - the
-        default adapter and any already-cached instance - and never calls
-        :meth:`_get_adapter_by_name`. Building or caching a new adapter here
-        would perturb the failover loop's own adapter resolution (and its
-        side effects), so the probe stays read-only. An adapter that is not
-        yet known is treated as not supporting sampling, the conservative
-        choice that preserves today's behavior.
+        ``provider_name`` is the per-role/per-spawn provider resolved by the
+        caller (``_apply_sampling_overrides`` passes the same ``provider_name``
+        that ``spawn_for_tasks`` computed from ``role_model_policy``/task
+        ``cli`` and fed into ``_resolve_routing``). Passing it through to
+        :meth:`_infer_adapter_name_for_provider` is what makes this probe
+        target the adapter that will ACTUALLY spawn the role - e.g.
+        ``openai_agents`` for a role pinned via ``role_model_policy.<role>.
+        provider: openai_agents`` - instead of always resolving from
+        ``provider_name=None``, which silently falls back to the *primary*
+        adapter (``self._adapter``, e.g. ``claude`` from ``cli: auto``).
+        That primary-adapter fallback was the root cause of the mode-profile
+        sampling fold (and, before PR3's unconditional role-policy fold, any
+        role-scoped sampling override) being silently skipped whenever the
+        primary adapter did not declare ``SUPPORTS_SAMPLING_PARAMS`` even
+        though the per-role adapter did (see the D2 OpenRouter KILL-NOTE).
+        ``provider_name=None`` (the default) preserves the previous
+        primary-adapter behavior for call sites that have no role context.
+
+        The probe prefers an already-known adapter instance - the default
+        adapter or an already-cached one - to avoid perturbing the failover
+        loop's own adapter resolution/caching. But the per-role adapter is
+        frequently NOT yet cached at this point in ``spawn_for_tasks``
+        (this gate runs before the spawn loop's own
+        :meth:`_get_adapter_by_name` call), which is exactly the scenario
+        that silently starved the mode-profile fold: a cache-miss used to
+        fall straight through to ``self._adapter`` (the primary adapter),
+        never actually checking the per-role adapter's capability at all.
+        To fix that without perturbing the failover loop, an uncached probe
+        instantiates the resolved adapter class directly via
+        :func:`bernstein.adapters.registry.get_adapter` - a plain
+        constructor call, not :meth:`_get_adapter_by_name` (which enforces
+        ``role_adapter_policy`` and writes an audit-log entry as a side
+        effect) - checks its capability, and discards the instance without
+        adding it to ``self._adapter_cache``. Any failure to construct the
+        probe instance (unknown adapter name, missing optional dependency,
+        etc.) is swallowed and treated as "does not support sampling", the
+        conservative choice that preserves today's behavior.
         """
 
         def _supports(adapter: object) -> bool:
@@ -1665,11 +1949,65 @@ class AgentSpawner:
             except Exception:  # pragma: no cover - defensive against bad plugins
                 return False
 
-        adapter_name = self._infer_adapter_name_for_provider(None, model_config.model)
+        adapter_name = self._infer_adapter_name_for_provider(provider_name, model_config.model)
         cached = self._adapter_cache.get(adapter_name)
-        if cached is not None and _supports(cached):
-            return True
-        return _supports(self._adapter)
+        if cached is not None:
+            result = _supports(cached)
+            logger.info(
+                "_primary_adapter_supports_sampling: provider_name=%r model=%r -> "
+                "adapter=%r (cached) supports_sampling=%s",
+                provider_name,
+                model_config.model,
+                adapter_name,
+                result,
+            )
+            return result
+
+        if adapter_name == self._adapter.name():
+            result = _supports(self._adapter)
+            logger.info(
+                "_primary_adapter_supports_sampling: provider_name=%r model=%r -> "
+                "adapter=%r (== primary self._adapter) supports_sampling=%s",
+                provider_name,
+                model_config.model,
+                adapter_name,
+                result,
+            )
+            return result
+
+        # Uncached, non-primary adapter (the common case for a role pinned
+        # to a different provider than the run's primary adapter, e.g.
+        # ``cli: auto`` -> claude primary with a role_model_policy
+        # ``provider: openai_agents`` override): probe it directly via the
+        # registry factory, read-only, without caching or role-policy
+        # enforcement.
+        try:
+            from bernstein.adapters.registry import get_adapter
+
+            probe_adapter = get_adapter(adapter_name)
+        except Exception as exc:
+            logger.info(
+                "_primary_adapter_supports_sampling: provider_name=%r model=%r -> "
+                "adapter=%r could not be probed (%s: %s); treating as supports_sampling=False",
+                provider_name,
+                model_config.model,
+                adapter_name,
+                type(exc).__name__,
+                exc,
+            )
+            return False
+
+        result = _supports(probe_adapter)
+        logger.info(
+            "_primary_adapter_supports_sampling: provider_name=%r model=%r -> "
+            "adapter=%r (uncached probe, primary=%r) supports_sampling=%s",
+            provider_name,
+            model_config.model,
+            adapter_name,
+            self._adapter.name() if hasattr(self._adapter, "name") else type(self._adapter).__name__,
+            result,
+        )
+        return result
 
     def _apply_sampling_overrides(
         self,
@@ -1678,18 +2016,23 @@ class AgentSpawner:
         role_policy: dict[str, Any],
         model_config: ModelConfig,
         tasks: list[Task],
+        provider_name: str | None = None,
     ) -> dict[str, Any] | None:
-        """Fold per-role endpoint and mode-profile sampling params into config.
+        """Fold per-role endpoint/sampling and mode-profile sampling params into config.
 
         Two opt-in sources feed the per-spawn ``mcp_config`` slots the
         adapter manifest reads (see :data:`SAMPLING_PARAM_KEYS`):
 
-        1. ``role_model_policy[role].base_url`` / ``.api_key_env`` - the
-           per-role OpenAI-compatible endpoint override parsed from
-           ``bernstein.yaml``. ``api_key_env`` was already validated at
-           parse time against the fail-closed credential allowlist. These
-           are explicit operator config, so they forward unconditionally;
-           the spawn path's capability gate still guards the target adapter.
+        1. ``role_model_policy[role]`` - the per-role
+           :class:`~bernstein.core.config.config_schema.RoleModelPolicyEntry`
+           parsed from ``bernstein.yaml``: ``base_url``/``api_key_env`` (the
+           OpenAI-compatible endpoint override; ``api_key_env`` was already
+           validated at parse time against the fail-closed credential
+           allowlist) AND, since PR3, ``temperature``/``top_p``/``top_k``/
+           ``max_tokens``/``extra_params``. All of these are explicit
+           operator config, so they forward unconditionally; the spawn
+           path's capability gate (:func:`ensure_sampling_params_supported`)
+           still guards whether the target adapter actually honours them.
         2. The resolved :class:`ModeProfile`'s deterministic sampling params
            (``temperature``, ``top_p``, ``top_k``, ``max_tokens``) via
            :func:`apply_mode_to_spawn`. These are implicit defaults, so they
@@ -1701,12 +2044,25 @@ class AgentSpawner:
         (operator-set) wins over a role-policy value, which wins over a
         mode-profile value. Absent config leaves ``mcp_config`` unchanged,
         so a run without any of these keys is byte-identical to before.
+        (PR3 note: this is the function the design doc referred to as
+        ``_fold_role_and_mode_sampling_params_into_mcp_config`` - it was
+        already implemented and named ``_apply_sampling_overrides`` when
+        this PR started; see the PR3 report for that drift.)
 
         The merge is deterministic: it reads only the parsed config, the
         selected model id, and the task metadata - no wall-clock or random
         input - so two operators with identical state build identical
         manifests.
         """
+        role = tasks[0].role if tasks else None
+        logger.debug(
+            "_apply_sampling_overrides: entry role=%r model=%r provider_name=%r mcp_config_keys=%s role_policy_keys=%s",
+            role,
+            model_config.model,
+            provider_name,
+            sorted((mcp_config or {}).keys()),
+            sorted(role_policy.keys()),
+        )
         derived: dict[str, Any] = {}
 
         # Mode-profile sampling params (lowest precedence). Wiring these here
@@ -1714,8 +2070,13 @@ class AgentSpawner:
         # adapter manifest; the profile object defined them but nothing
         # forwarded them before. Guarded by the target adapter's capability
         # so a default profile temperature never breaks a spawn on an
-        # adapter that cannot honour sampling params.
-        if self._primary_adapter_supports_sampling(model_config):
+        # adapter that cannot honour sampling params. ``provider_name`` is
+        # forwarded so the gate probes the adapter that will ACTUALLY spawn
+        # this role (e.g. openai_agents pinned via role_model_policy), not
+        # always the run's primary adapter (e.g. claude from cli: auto) -
+        # see _primary_adapter_supports_sampling's docstring / the D2
+        # OpenRouter KILL-NOTE this fixes.
+        if self._primary_adapter_supports_sampling(model_config, provider_name=provider_name):
             from bernstein.core.agents.spawner_prompt import apply_mode_to_spawn
 
             bundle = apply_mode_to_spawn(
@@ -1734,6 +2095,17 @@ class AgentSpawner:
                 derived["top_k"] = profile.top_k
             if profile.max_tokens is not None:
                 derived["max_tokens"] = profile.max_tokens
+            logger.debug(
+                "_apply_sampling_overrides: mode-profile %r contributed sampling keys=%s",
+                profile.name,
+                dict(derived),
+            )
+        else:
+            logger.debug(
+                "_apply_sampling_overrides: adapter for model=%r does not declare "
+                "SUPPORTS_SAMPLING_PARAMS, skipping mode-profile sampling defaults",
+                model_config.model,
+            )
 
         # Per-role endpoint override (higher precedence than the profile).
         for key in ("base_url", "api_key_env"):
@@ -1741,15 +2113,72 @@ class AgentSpawner:
             if isinstance(value, str) and value:
                 derived[key] = value
 
+        # PR3: per-role sampling overrides (RoleModelPolicyEntry.temperature/
+        # top_p/top_k/max_tokens/extra_params). Same precedence tier as the
+        # endpoint override above - explicit per-role operator config beats
+        # the mode-profile default for the same key. Each field is validated
+        # for type before folding in so a malformed role_policy entry cannot
+        # inject an unexpected type into the manifest.
+        role_sampling_before = dict(derived)
+        temperature = role_policy.get("temperature")
+        if isinstance(temperature, (int, float)) and not isinstance(temperature, bool):
+            derived["temperature"] = float(temperature)
+        top_p = role_policy.get("top_p")
+        if isinstance(top_p, (int, float)) and not isinstance(top_p, bool):
+            derived["top_p"] = float(top_p)
+        top_k = role_policy.get("top_k")
+        if isinstance(top_k, int) and not isinstance(top_k, bool):
+            derived["top_k"] = top_k
+        max_tokens = role_policy.get("max_tokens")
+        if isinstance(max_tokens, int) and not isinstance(max_tokens, bool):
+            derived["max_tokens"] = max_tokens
+        extra_params = role_policy.get("extra_params")
+        if isinstance(extra_params, dict) and extra_params:
+            derived["extra_params"] = extra_params
+        role_overrode = {
+            k: v for k, v in derived.items() if k not in role_sampling_before or role_sampling_before[k] != v
+        }
+        if role_overrode:
+            logger.info(
+                "_apply_sampling_overrides: role=%r role_model_policy sampling fields=%s take "
+                "precedence over mode-profile defaults for the same key(s)",
+                role,
+                role_overrode,
+            )
+
+        gate_adapter_name = self._infer_adapter_name_for_provider(provider_name, model_config.model)
+
         if not derived:
+            logger.info(
+                "_apply_sampling_overrides: role=%r gate_adapter=%r (provider_name=%r) - no derived "
+                "sampling/endpoint keys, mcp_config unchanged (reason: neither role_model_policy nor "
+                "the resolved mode profile contributed any sampling/endpoint keys for this role)",
+                role,
+                gate_adapter_name,
+                provider_name,
+            )
             return mcp_config
 
         # Operator-set values in ``mcp_config`` always win: only fill slots
         # the caller did not already set.
         merged = dict(mcp_config or {})
+        filled: dict[str, Any] = {}
+        skipped_operator_set: dict[str, Any] = {}
         for key, value in derived.items():
             if merged.get(key) is None:
                 merged[key] = value
+                filled[key] = value
+            else:
+                skipped_operator_set[key] = merged[key]
+        logger.info(
+            "_apply_sampling_overrides: role=%r gate_adapter=%r (provider_name=%r) folded_keys=%s "
+            "into runner manifest%s",
+            role,
+            gate_adapter_name,
+            provider_name,
+            filled,
+            f" (skipped, operator mcp_config already set: {skipped_operator_set})" if skipped_operator_set else "",
+        )
         return merged
 
     def _spawn_via_runtime_bridge(
@@ -1868,6 +2297,14 @@ class AgentSpawner:
                 base_config=model_config,
                 preferred_provider=preferred_provider,
             )
+            logger.info(
+                "Router selected provider for role=%s: provider=%s model=%s/%s (preferred_provider=%s)",
+                tasks[0].role,
+                decision.provider,
+                decision.model_config.model,
+                decision.model_config.effort,
+                preferred_provider,
+            )
             return decision.model_config, decision.provider, "router"
         except RouterError as exc:
             if preferred_provider:
@@ -1889,6 +2326,12 @@ class AgentSpawner:
     def _spawn_for_tasks_internal(self, tasks: list[Task], model_override: str | None = None) -> AgentSession:
         """Actual spawn implementation."""
         if self._shutdown_event is not None and self._shutdown_event.is_set():
+            logger.info(
+                "spawn refused: shutdown_event is set - role=%s task_count=%d task_ids=%s",
+                tasks[0].role if tasks else "<empty>",
+                len(tasks),
+                [t.id for t in tasks],
+            )
             raise ShutdownInProgress("Orchestrator shutting down - refusing new spawn")
 
         # Disk space check: refuse to spawn if less than 1 GB free.
@@ -1993,7 +2436,32 @@ class AgentSpawner:
         # resolved via _infer_adapter_name_for_provider downstream.
         preferred_provider = tasks[0].cli or role_policy.get("provider")
 
-        if not tasks[0].model and role_policy.get("model"):
+        # Retry escalation (task_lifecycle._choose_retry_escalation) stamps
+        # Claude tier names ("opus"/"sonnet"/"haiku") onto ``task.model``.
+        # Those are escalation labels, NOT operator pins - when the operator
+        # pinned this role's model via role_model_policy, a tier-stamped
+        # retry model must not shadow the pin, or the retry is spawned with
+        # e.g. model="opus" against a MiniMax endpoint (400 "unknown model
+        # 'opus'", run-9 attempt-8). The ab-test escape hatch
+        # (metadata["pinned_model"]) still marks a tier name as a genuine
+        # pin. ``metadata`` may be ``None`` on older/partial constructions.
+        task_metadata = tasks[0].metadata or {}
+        task_model_is_pinned = bool(task_metadata.get("pinned_model"))
+        task_model_is_tier_name = tasks[0].model in _CLAUDE_TIER_MODELS
+        task_model_blocks_role_policy = bool(tasks[0].model) and (task_model_is_pinned or not task_model_is_tier_name)
+
+        if not task_model_blocks_role_policy and role_policy.get("model"):
+            if tasks[0].model and tasks[0].model != role_policy["model"]:
+                logger.info(
+                    "Retry model decision for task %s (role=%s, retry_count=%s): "
+                    "keeping operator role_model_policy model=%r, ignoring "
+                    "tier-stamped task.model=%r (escalation label, not an operator pin)",
+                    tasks[0].id,
+                    tasks[0].role,
+                    getattr(tasks[0], "retry_count", None),
+                    role_policy["model"],
+                    tasks[0].model,
+                )
             model_config = ModelConfig(
                 model=role_policy["model"],
                 effort=role_policy.get("effort", base_config.effort),
@@ -2036,11 +2504,9 @@ class AgentSpawner:
         # --model-b sonnet``) stamp ``metadata["pinned_model"] = True`` on
         # the task. Coercing both sides of an A/B test to the same adapter
         # default would silently collapse the comparison into A-vs-A, so
-        # honor the pin and skip coercion. ``metadata`` may be ``None`` on
-        # older/partial Task constructions.
-        task_metadata = tasks[0].metadata or {}
-        task_model_is_pinned = bool(task_metadata.get("pinned_model"))
-        task_model_is_tier_name = tasks[0].model in _CLAUDE_TIER_MODELS
+        # honor the pin and skip coercion. (``task_model_is_pinned`` /
+        # ``task_model_is_tier_name`` are computed above, before the
+        # role-policy model application.)
         if (
             provider_name is None
             and not role_policy.get("model")
@@ -2051,6 +2517,47 @@ class AgentSpawner:
                 model_config,
                 adapter_name=self._adapter.name(),
                 adapter_default_model=self._default_model or getattr(self._adapter, "default_model", None),
+            )
+        elif (
+            provider_name is not None
+            and not role_policy.get("model")
+            and task_model_is_tier_name
+            and not task_model_is_pinned
+        ):
+            # role_model_policy pinned a *provider* for this role but no
+            # *model* (e.g. ``role_model_policy: {backend: {provider:
+            # qwen}}``). ``provider_name`` is therefore non-None here, which
+            # made the branch above a no-op - the tier name stamped by the
+            # heuristic selector or retry escalation (task_lifecycle stamps
+            # "opus"/"sonnet" unconditionally, see task_lifecycle.py's retry
+            # escalation) would otherwise reach a non-Claude adapter
+            # literally (e.g. ``qwen -m opus``). Resolve which adapter this
+            # provider actually maps to (read-only name lookup, no adapter
+            # instantiation / role-policy enforcement side effects - see
+            # ``_primary_adapter_supports_sampling``'s docstring for why
+            # ``_get_adapter_by_name`` is avoided at this point in the spawn
+            # path) and coerce against ITS default model, not
+            # ``self._adapter``'s (the two can differ, e.g.
+            # ``self._adapter=claude``, ``role_policy.provider=qwen``).
+            resolved_adapter_name = self._infer_adapter_name_for_provider(provider_name, model_config.model)
+            before_model = model_config.model
+            model_config = _coerce_model_for_non_claude_adapter(
+                model_config,
+                adapter_name=resolved_adapter_name,
+                adapter_default_model=self._default_model,
+            )
+            logger.info(
+                "Provider-only role_policy coercion for role=%s: provider=%s -> "
+                "resolved_adapter=%s, tier-stamped model=%r %s (task_model=%r, "
+                "role_policy_provider=%r, role_policy_model=%r)",
+                tasks[0].role,
+                provider_name,
+                resolved_adapter_name,
+                before_model,
+                f"coerced to {model_config.model!r}" if model_config.model != before_model else "left unchanged",
+                tasks[0].model,
+                role_policy.get("provider"),
+                role_policy.get("model"),
             )
 
         logger.info(
@@ -2299,6 +2806,7 @@ class AgentSpawner:
             role_policy=role_policy,
             model_config=model_config,
             tasks=tasks,
+            provider_name=provider_name,
         )
 
         log_dir = spawn_cwd / ".sdd" / "logs"
@@ -2545,7 +3053,14 @@ class AgentSpawner:
                             provider_name = None
                     except Exception as exc:
                         categorized = classify_spawn_error(exc, provider=provider_name)
-                        attempt_errors.append(f"{adapter_name}: {exc}")
+                        # Re-derive the failure reason from the runner's own
+                        # per-session log instead of trusting str(exc), which
+                        # for fast-exit-probe failures (adapters/base.py)
+                        # only ever embeds the log's LAST LINE - see
+                        # extract_error_aware_reason()'s module docstring
+                        # and work/bernstein/proofs/d2/minimax/FAIL-NOTE.md.
+                        diagnosed_reason = _diagnose_spawn_failure(session_id, spawn_cwd, adapter_name, exc)
+                        attempt_errors.append(f"{adapter_name}: {diagnosed_reason}")
 
                         # Fail-fast for permanent and operator-fix errors - no
                         # point trying alternate providers when the binary is
@@ -2559,7 +3074,7 @@ class AgentSpawner:
                                 categorized.retry_strategy.value,
                                 session_id,
                                 adapter_name,
-                                exc,
+                                diagnosed_reason,
                             )
                             self._adapter_health.record_failure(adapter_name)
                             break
@@ -2571,7 +3086,7 @@ class AgentSpawner:
                             provider_name,
                             adapter_name,
                             categorized.retry_strategy.value,
-                            exc,
+                            diagnosed_reason,
                         )
                         if self._router is None or provider_name is None:
                             continue

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -143,6 +143,21 @@ def _run_merge_and_push(
         )
 
     merge_start = time.perf_counter()
+    # Provenance: record the call site before invoking the merge so the
+    # log line identifies the WORKER branch + WORKTREE root that triggered
+    # this merge attempt (defect 28: every merge commit must have
+    # provenance -- a decoy with no provenance must be impossible).
+    # Use ``getattr`` so callers passing a minimal stub session
+    # (e.g. ``_Stub`` in test_spawner_merge_queue_wiring) don't crash on
+    # a missing ``role`` attribute -- the log line must NEVER raise.
+    author_role = getattr(session, "role", "<unknown>")
+    logger.info(
+        "merge_preflight: from=<worktree=%s> to=<main=%s> branch=agent/%s author=<spawner:%s> reason=<reap-and-merge>",
+        worktree_root,
+        worktree_root,
+        session.id,
+        author_role,
+    )
     merge_result = merge_worktree_branch_fn(session.id, repo_root=worktree_root)
     merge_duration.observe(time.perf_counter() - merge_start)
 

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -150,6 +150,19 @@ class RoleModelPolicyEntry(BaseModel):
     it is validated against the same fail-closed credential allowlist the
     ``openai_agents`` runner enforces so a repo-carried config cannot
     forward arbitrary host secrets to an arbitrary endpoint.
+
+    ``temperature``/``top_p``/``top_k``/``max_tokens``/``extra_params`` mirror
+    the sampling-field shape already proven on the ``ModelCard`` dataclass
+    (see ``feat/model-cards-phase1``): they are per-role sampling overrides
+    that flow into the per-spawn ``mcp_config`` via
+    :meth:`bernstein.core.agents.spawner_core.AgentSpawner._apply_sampling_overrides`,
+    taking precedence over a resolved :class:`ModeProfile`'s sampling
+    defaults for the same role. The spawn-time capability gate
+    (:func:`bernstein.adapters.plugin_sdk.ensure_sampling_params_supported`)
+    still decides whether the target adapter actually honours them -
+    setting these fields for a role pinned to an adapter that does not
+    declare sampling support raises ``SamplingParamsRefusal`` rather than
+    silently dropping the override.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -160,6 +173,11 @@ class RoleModelPolicyEntry(BaseModel):
     effort: str | None = None
     base_url: str | None = None
     api_key_env: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    max_tokens: int | None = None
+    extra_params: dict[str, Any] = Field(default_factory=dict)
 
 
 class RoleConfigEntry(BaseModel):

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -633,14 +633,14 @@ def _parse_bridge_settings(raw: object) -> BridgeConfigSet | None:
     return BridgeConfigSet(openclaw=_parse_openclaw_runtime_config(data.get("openclaw")))
 
 
-def _parse_role_model_policy(raw: object) -> dict[str, dict[str, str]] | None:
+def _parse_role_model_policy(raw: object) -> dict[str, dict[str, str | int]] | None:
     """Parse optional role-specific provider/model overrides."""
     if raw is None:
         return None
     if not isinstance(raw, dict):
         raise SeedError("role_model_policy must be a mapping of role -> settings")
 
-    parsed: dict[str, dict[str, str]] = {}
+    parsed: dict[str, dict[str, str | int]] = {}
     for role, settings in raw.items():
         if not isinstance(role, str) or not role:
             raise SeedError("role_model_policy keys must be non-empty role strings")
@@ -657,8 +657,17 @@ _ROLE_POLICY_KEYS: tuple[str, ...] = (
     "api_key_env",
 )
 
+# Integer-typed role policy keys, validated and stored separately from the
+# string-typed keys above. ``max_tokens`` is a per-role sampling override
+# (see ``RoleModelPolicyEntry.max_tokens`` in config_schema.py:179) that must
+# flow through the seed parser unchanged so an operator can cap completion
+# length for a role - without this branch a seed file setting
+# ``role_model_policy.<role>.max_tokens`` was rejected at parse time with
+# "unknown keys: max_tokens" (parser/schema divergence fixed here).
+_ROLE_POLICY_INT_KEYS: tuple[str, ...] = ("max_tokens",)
 
-def _parse_single_role_policy(role: str, settings: object) -> dict[str, str]:
+
+def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | int]:
     """Parse and validate a single role's model policy settings.
 
     ``base_url`` and ``api_key_env`` are optional per-role endpoint
@@ -668,17 +677,30 @@ def _parse_single_role_policy(role: str, settings: object) -> dict[str, str]:
     the same fail-closed credential allowlist the ``openai_agents`` runner
     enforces so a repo-carried config cannot forward an unrelated host
     secret to an arbitrary endpoint.
+
+    ``max_tokens`` is an optional per-role integer cap on completion length
+    (see :data:`_ROLE_POLICY_INT_KEYS`); it is validated as a positive int
+    here and flows unchanged into
+    :meth:`bernstein.core.agents.spawner_core.AgentSpawner._apply_sampling_overrides`.
     """
     if not isinstance(settings, dict):
         raise SeedError(f"role_model_policy[{role!r}] must be a mapping")
 
-    normalized: dict[str, str] = {}
+    normalized: dict[str, str | int] = {}
     for key in _ROLE_POLICY_KEYS:
         value = settings.get(key)
         if value is None:
             continue
         if not isinstance(value, str) or not value:
             raise SeedError(f"role_model_policy[{role!r}][{key!r}] must be a non-empty string")
+        normalized[key] = value
+
+    for key in _ROLE_POLICY_INT_KEYS:
+        value = settings.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise SeedError(f"role_model_policy[{role!r}][{key!r}] must be a positive integer")
         normalized[key] = value
 
     # Reuse the adapter's fail-closed credential-name allowlist. Imported
@@ -689,14 +711,15 @@ def _parse_single_role_policy(role: str, settings: object) -> dict[str, str]:
         from bernstein.adapters.openai_agents_runner import validate_api_key_env_name
 
         try:
-            validate_api_key_env_name(normalized["api_key_env"])
+            validate_api_key_env_name(str(normalized["api_key_env"]))
         except RuntimeError as exc:
             raise SeedError(f"role_model_policy[{role!r}][api_key_env]: {exc}") from exc
 
     if "cli" in normalized and "provider" not in normalized:
         normalized["provider"] = normalized["cli"]
 
-    unknown_keys = sorted(set(settings) - set(_ROLE_POLICY_KEYS))
+    allowed_keys = set(_ROLE_POLICY_KEYS) | set(_ROLE_POLICY_INT_KEYS)
+    unknown_keys = sorted(set(settings) - allowed_keys)
     if unknown_keys:
         raise SeedError(f"role_model_policy[{role!r}] has unknown keys: {', '.join(unknown_keys)}")
     return normalized

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -25,8 +25,33 @@ import operator
 import random
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any
 
+# Pricing table + per-call pricing live in the dependency-free leaf
+# ``model_prices`` so adapters can price a call without importing this
+# module (which reaches routing internals); re-exported for existing
+# ``from bernstein.core.cost.cost import ...`` call sites.
+from bernstein.core.cost.model_prices import (
+    MODEL_COSTS_PER_1M_TOKENS as MODEL_COSTS_PER_1M_TOKENS,
+)
+from bernstein.core.cost.model_prices import (
+    MODEL_GEMINI_3_1_PRO as MODEL_GEMINI_3_1_PRO,
+)
+from bernstein.core.cost.model_prices import (
+    MODEL_GPT_5_4 as MODEL_GPT_5_4,
+)
+from bernstein.core.cost.model_prices import (
+    MODEL_GPT_5_5 as MODEL_GPT_5_5,
+)
+from bernstein.core.cost.model_prices import (
+    ModelUsdPer1MTokens as ModelUsdPer1MTokens,
+)
+from bernstein.core.cost.model_prices import (
+    UsagePriceResult as UsagePriceResult,
+)
+from bernstein.core.cost.model_prices import (
+    price_model_usage as price_model_usage,
+)
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus
 
 if TYPE_CHECKING:
@@ -42,62 +67,43 @@ EPSILON: float = 0.1  # 10% explore, 90% exploit
 MIN_OBSERVATIONS: int = 5  # arms trusted only after this many samples
 QUALITY_THRESHOLD: float = 0.80  # minimum success_rate to consider an arm
 
-# Model name constants (used across pricing tables and cache tiers)
-MODEL_GPT_5_4 = "gpt-5.4"
-MODEL_GPT_5_5 = "gpt-5.5"
-MODEL_GEMINI_3_1_PRO = "gemini-3.1-pro"
 
+def read_tokens_sidecar_totals(sidecar_path: Path) -> tuple[int, int]:
+    """Sum cumulative (input, output) tokens from a runner ``.tokens`` sidecar.
 
-class ModelUsdPer1MTokens(TypedDict, total=False):
-    """USD per 1 million tokens (list prices, approximate)."""
+    The openai_agents runner appends one ``{"ts", "in", "out"}`` JSON record
+    per LLM call to ``.sdd/runtime/<session_id>.tokens`` (bug-13) so that
+    token usage survives agent death. This is the SINGLE shared reader for
+    that format: the live-cost tick (``Orchestrator._record_live_costs``) and
+    any recovery path should both price from this same source of truth, so
+    the run ledger's ``spent_usd`` can never diverge from per-task costs.
 
-    input: float
-    output: float
-    cache_read: float | None
-    cache_write: float | None
+    Args:
+        sidecar_path: Path to the ``.tokens`` sidecar file.
 
+    Returns:
+        ``(total_input_tokens, total_output_tokens)`` - ``(0, 0)`` when the
+        sidecar is missing, empty, or unreadable (not an error: providers
+        other than openai_agents don't write one).
+    """
+    try:
+        raw = sidecar_path.read_text(encoding="utf-8")
+    except OSError:
+        return 0, 0
+    total_in = 0
+    total_out = 0
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except ValueError:
+            continue
+        total_in += int(rec.get("in", 0) or 0)
+        total_out += int(rec.get("out", 0) or 0)
+    return total_in, total_out
 
-# Per-model input/output pricing per 1M tokens (USD). Keys match substring checks in ``_model_cost``.
-# Updated 2026-05-05 from official API pricing pages - GPT-5.5 added (announced
-# 2026-04-23, generally available in API on 2026-04-24).
-MODEL_COSTS_PER_1M_TOKENS: dict[str, ModelUsdPer1MTokens] = {
-    "haiku": {"input": 1.0, "output": 5.0, "cache_read": 0.1, "cache_write": 1.25},
-    "sonnet": {"input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.75},
-    "opus": {"input": 5.0, "output": 25.0, "cache_read": 0.5, "cache_write": 6.25},
-    # GPT-5.5: launched 2026-04-24 at GPT-5.4 input parity with cheaper
-    # output (per OpenAI pricing page); GPT-5.4 retained as pinned fallback.
-    MODEL_GPT_5_5: {"input": 2.5, "output": 12.0},
-    "gpt-5.5-mini": {"input": 0.6, "output": 3.0},
-    MODEL_GPT_5_4: {"input": 2.5, "output": 15.0},
-    "gpt-5.4-mini": {"input": 0.75, "output": 4.5},
-    # OpenAI Agents SDK v2 baseline models (oai-001). Launch prices as of
-    # 2026-04-19 - gpt-5 is roughly sonnet-parity on input, cheaper on output;
-    # gpt-5-mini is the default for the runner; o4 is the reasoning tier.
-    "gpt-5": {"input": 2.5, "output": 15.0},
-    "gpt-5-mini": {"input": 0.5, "output": 2.5},
-    "o4": {"input": 3.0, "output": 12.0},
-    "o3": {"input": 2.0, "output": 8.0},
-    "o4-mini": {"input": 1.1, "output": 4.4},
-    "gemini-3": {"input": 3.0, "output": 15.0, "cache_read": 0.1},
-    MODEL_GEMINI_3_1_PRO: {"input": 0.50, "output": 3.00, "cache_read": 0.02},
-    "gemini-3-flash": {"input": 0.15, "output": 1.00, "cache_read": 0.005},
-    "qwen3-coder": {"input": 0.22, "output": 0.9},
-    # DeepSeek V4 family (FEAT deepseek-v4-flash-eu, added 2026-05-07).
-    # Hosted prices from deepseek.com release pages; the structural
-    # arbitrage comes from V4-Flash at ~$1.74/MTok input (CAISI 2026-04
-    # evaluation places the model ~8 months behind frontier - adequate
-    # for the 60-70% of agentic workloads that are not the hardest 30%).
-    # Self-hosted runs (Ollama / vLLM via :class:`OllamaAdapter`) reduce
-    # input cost to electricity; the hosted entries below are the
-    # opportunity-cost reference used by ``CostTracker`` to narrate
-    # "saved $X by self-hosting" in the run summary.
-    "deepseek-v4-flash": {"input": 1.74, "output": 0.20},
-    "deepseek-v4-pro": {"input": 4.50, "output": 1.50},
-    # Blended-only entries in ``_MODEL_COST_USD_PER_1K`` - approximate 40/60 input/output split of total $/1M.
-    "qwen-max": {"input": 0.8, "output": 1.2},
-    "qwen-plus": {"input": 0.4, "output": 0.6},
-    "qwen-turbo": {"input": 0.16, "output": 0.24},
-}
 
 # Approximate cost per 1k tokens (input+output blended average), USD.
 # Updated 2026-03-28 from official API pricing pages.

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -720,6 +720,26 @@ class CostTracker:
             status = self.status()
             envelope_fired = self._maybe_fire_envelope_threshold_locked(envelope)
 
+        # Bug item-7 (2026-07-02): the run ledger's spent_usd sat at 0.0 for
+        # whole runs because nothing fed record() - every ledger mutation now
+        # logs itself so a silent-zero ledger is diagnosable from logs alone.
+        # item 31 (2026-07-02): also tag each mutation with the ORIGIN of its
+        # token counts (via the existing cost_tags channel - no signature
+        # change) so an alive-exit /complete sidecar ingestion is
+        # distinguishable in the logs from an orphan/dead-exit recovery.
+        logger.info(
+            "ledger_update: run_spent_usd=%.6f delta=%.6f source=%s/%s model=%s "
+            "input_tokens=%d output_tokens=%d tokens_sidecar_source=%s",
+            status.spent_usd,
+            cost_usd,
+            task_id,
+            agent_id,
+            model,
+            input_tokens,
+            output_tokens,
+            merged_tags.get("tokens_sidecar_source", ""),
+        )
+
         if evicted is not None:
             self._rotate_evicted(evicted)
         self._emit_threshold_warnings(status)

--- a/src/bernstein/core/cost/model_prices.py
+++ b/src/bernstein/core/cost/model_prices.py
@@ -1,0 +1,191 @@
+"""Model pricing table and per-call pricing (leaf module).
+
+Extracted from :mod:`bernstein.core.cost.cost` so adapters can price a call
+without importing the cost package, which reaches routing/bandit internals.
+Import-linter forbids ``adapters -> scheduler internals``; keeping pricing in
+this dependency-free leaf preserves that contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+# Model name constants (used across pricing tables and cache tiers)
+MODEL_GPT_5_4 = "gpt-5.4"
+MODEL_GPT_5_5 = "gpt-5.5"
+MODEL_GEMINI_3_1_PRO = "gemini-3.1-pro"
+
+
+class ModelUsdPer1MTokens(TypedDict, total=False):
+    """USD per 1 million tokens (list prices, approximate)."""
+
+    input: float
+    output: float
+    cache_read: float | None
+    cache_write: float | None
+
+
+# Per-model input/output pricing per 1M tokens (USD). Keys match substring checks in ``_model_cost``.
+# Updated 2026-05-05 from official API pricing pages - GPT-5.5 added (announced
+# 2026-04-23, generally available in API on 2026-04-24).
+MODEL_COSTS_PER_1M_TOKENS: dict[str, ModelUsdPer1MTokens] = {
+    "haiku": {"input": 1.0, "output": 5.0, "cache_read": 0.1, "cache_write": 1.25},
+    # claude-sonnet-5 (2026-07-02): Shane's Claude legs now run this model via
+    # a local gateway on the openai_agents path, so it is priced by THIS
+    # table rather than Anthropic's own billing. Introductory launch price
+    # (anthropic.com/news/claude-sonnet-5) is $2/$10 per 1M in/out through
+    # 2026-08-31, reverting to standard $3/$15 (== the generic "sonnet" row
+    # below) on 2026-09-01 - revisit this entry then. MUST precede the bare
+    # "sonnet" row below: substring matching in ``price_model_usage`` takes
+    # the first dict-order match, and "sonnet" is a substring of
+    # "claude-sonnet-5" - without this ordering every claude-sonnet-5 call
+    # would silently price at the wrong (generic sonnet) rate.
+    "claude-sonnet-5": {"input": 2.0, "output": 10.0, "cache_read": 0.2, "cache_write": 2.5},
+    "sonnet": {"input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.75},
+    "opus": {"input": 5.0, "output": 25.0, "cache_read": 0.5, "cache_write": 6.25},
+    # GPT-5.5: launched 2026-04-24 at GPT-5.4 input parity with cheaper
+    # output (per OpenAI pricing page); GPT-5.4 retained as pinned fallback.
+    MODEL_GPT_5_5: {"input": 2.5, "output": 12.0},
+    "gpt-5.5-mini": {"input": 0.6, "output": 3.0},
+    MODEL_GPT_5_4: {"input": 2.5, "output": 15.0},
+    "gpt-5.4-mini": {"input": 0.75, "output": 4.5},
+    # OpenAI Agents SDK v2 baseline models (oai-001). Launch prices as of
+    # 2026-04-19 - gpt-5 is roughly sonnet-parity on input, cheaper on output;
+    # gpt-5-mini is the default for the runner; o4 is the reasoning tier.
+    "gpt-5": {"input": 2.5, "output": 15.0},
+    "gpt-5-mini": {"input": 0.5, "output": 2.5},
+    "o4": {"input": 3.0, "output": 12.0},
+    "o3": {"input": 2.0, "output": 8.0},
+    "o4-mini": {"input": 1.1, "output": 4.4},
+    "gemini-3": {"input": 3.0, "output": 15.0, "cache_read": 0.1},
+    MODEL_GEMINI_3_1_PRO: {"input": 0.50, "output": 3.00, "cache_read": 0.02},
+    "gemini-3-flash": {"input": 0.15, "output": 1.00, "cache_read": 0.005},
+    "qwen3-coder": {"input": 0.22, "output": 0.9},
+    # DeepSeek V4 family (FEAT deepseek-v4-flash-eu, added 2026-05-07).
+    # Hosted prices from deepseek.com release pages; the structural
+    # arbitrage comes from V4-Flash at ~$1.74/MTok input (CAISI 2026-04
+    # evaluation places the model ~8 months behind frontier - adequate
+    # for the 60-70% of agentic workloads that are not the hardest 30%).
+    # Self-hosted runs (Ollama / vLLM via :class:`OllamaAdapter`) reduce
+    # input cost to electricity; the hosted entries below are the
+    # opportunity-cost reference used by ``CostTracker`` to narrate
+    # "saved $X by self-hosting" in the run summary.
+    "deepseek-v4-flash": {"input": 1.74, "output": 0.20},
+    "deepseek-v4-pro": {"input": 4.50, "output": 1.50},
+    # OpenRouter "deepseek/deepseek-chat" (D1 openrouter fix, 2026-07-02):
+    # this is the model id the openai_agents runner sends verbatim to
+    # OpenRouter (openrouter.ai/deepseek/deepseek-chat, DeepSeek V3 rates as
+    # of 2026-07). Note per OpenRouter: "deepseek-chat" is slated for
+    # deprecation 2026-07-24 in favor of "deepseek-v4-flash" above - update
+    # the manifest model id and drop this row once that lands. Substring
+    # matching means this single "deepseek-chat" key also matches the full
+    # "deepseek/deepseek-chat" manifest string, so no separate alias entry
+    # is needed.
+    "deepseek-chat": {"input": 0.2002, "output": 0.8001},
+    # Blended-only entries in ``_MODEL_COST_USD_PER_1K`` - approximate 40/60 input/output split of total $/1M.
+    "qwen-max": {"input": 0.8, "output": 1.2},
+    "qwen-plus": {"input": 0.4, "output": 0.6},
+    "qwen-turbo": {"input": 0.16, "output": 0.24},
+    # MiniMax (bug 13, 2026-07-02: a 45-minute MiniMax-M3 run on the
+    # openai_agents provider path metered spent_usd=0.0 because no entry
+    # existed here AND the runner never priced/emitted usage at all - see
+    # price_model_usage() below for the fix that makes unpriced models
+    # visible instead of silently vanishing). Prices approximate MiniMax's
+    # published API rates; keep "minimax-m3" ahead of any future bare
+    # "minimax" stem so substring matching cannot land on the wrong SKU.
+    "minimax-m3": {"input": 0.3, "output": 1.2},
+    "minimax-m2.7": {"input": 0.2, "output": 0.8},
+}
+
+
+@dataclass(frozen=True)
+class UsagePriceResult:
+    """Result of pricing a single LLM call's token usage.
+
+    Attributes:
+        model: The model name that was priced (as given by the caller).
+        input_tokens: Prompt tokens for this call.
+        output_tokens: Completion tokens for this call.
+        cost_usd: Computed cost in USD. Exactly ``0.0`` when ``priced`` is
+            ``False`` - an explicit, visible zero, not a heuristic guess.
+        priced: ``True`` when ``model`` matched an entry in
+            :data:`MODEL_COSTS_PER_1M_TOKENS`. ``False`` means the model is
+            unrecognized: tokens are still counted (see ``input_tokens`` /
+            ``output_tokens``) but the dollar cost is reported as an
+            explicit ``$0`` rather than silently vanishing from totals or
+            being estimated with a heuristic that would look precise but
+            isn't.
+    """
+
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    priced: bool
+
+
+def price_model_usage(model: str, input_tokens: int, output_tokens: int) -> UsagePriceResult:
+    """Price one LLM call's token usage against :data:`MODEL_COSTS_PER_1M_TOKENS`.
+
+    Bug 13 (2026-07-02): a 45-minute MiniMax-M3 run on the ``openai_agents``
+    provider path metered ``spent_usd: 0.0`` with an empty ``usages`` list -
+    budget guards were completely inert because usage was never priced *or*
+    surfaced anywhere the orchestrator's live-cost mechanism could see it.
+    This function is the pricing half of the fix: it is the single place
+    that decides a call's dollar cost, and it never drops a model on the
+    floor silently. An unrecognized model still gets its tokens counted (the
+    caller is expected to log/emit them) but its cost is an explicit ``$0``,
+    tagged ``priced=False``, with a WARNING logged here - so unpriced spend
+    is visible as a token-volume signal instead of disappearing from cost
+    totals entirely ("visibility over false precision").
+
+    Args:
+        model: Model name/id as reported by the provider (e.g.
+            ``"gpt-5-mini"``, ``"MiniMax-M3"``). Matched case-insensitively
+            as a substring against :data:`MODEL_COSTS_PER_1M_TOKENS` keys.
+        input_tokens: Prompt tokens consumed by this call.
+        output_tokens: Completion tokens consumed by this call.
+
+    Returns:
+        A :class:`UsagePriceResult` with the computed cost and whether the
+        model had a pricing-table entry.
+    """
+    model_lower = model.lower()
+    # Match longest key first so a specific variant (e.g. "gpt-5-mini") wins
+    # over its parent stem ("gpt-5"). Dict-order matching would return the
+    # parent for any variant whose stem is listed first, over-pricing the
+    # variant at the parent rate.
+    for key in sorted(MODEL_COSTS_PER_1M_TOKENS, key=len, reverse=True):
+        pricing = MODEL_COSTS_PER_1M_TOKENS[key]
+        if key in model_lower:
+            cost = (input_tokens / 1_000_000.0) * pricing.get("input", 0.0) + (
+                output_tokens / 1_000_000.0
+            ) * pricing.get("output", 0.0)
+            return UsagePriceResult(
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost,
+                priced=True,
+            )
+    logger.warning(
+        "price_model_usage: no pricing-table entry for model %r - metering at "
+        "$0/token so this call's tokens stay visible instead of vanishing from "
+        "cost totals (input_tokens=%d, output_tokens=%d). Add an entry to "
+        "MODEL_COSTS_PER_1M_TOKENS to price this model.",
+        model,
+        input_tokens,
+        output_tokens,
+    )
+    return UsagePriceResult(
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=0.0,
+        priced=False,
+    )

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -107,6 +107,21 @@ class OrchestratorDefaults:
     manager_review_completion_threshold: int = 7  # trigger review every 7 done
     manager_review_stall_s: float = 900.0  # 15 min
 
+    # How long a manager session may run with zero child tasks before
+    # ``core.orchestration.stalled_manager`` declares a stall and aborts the
+    # run. Tunable via ``tuning.orchestrator.stalled_manager_threshold_s`` in
+    # bernstein.yaml, or the ``BERNSTEIN_STALL_THRESHOLD_S`` env var (checked
+    # first). See ``stalled_manager.py`` module docstring for the detection
+    # logic and its relationship to ``AGENT.idle_log_age_threshold_s``.
+    stalled_manager_threshold_s: float = 170.0
+
+    # Starting wall-clock kill deadline for a spawned agent (OrchestratorConfig.
+    # max_agent_runtime_s). Self-extends +600s/tick up to a 5400s hard cap while
+    # the agent is heartbeating (see core/agents/agent_lifecycle.py); this is
+    # only the initial value before any extension. Tunable via
+    # ``tuning.orchestrator.max_agent_runtime_s``.
+    max_agent_runtime_s: int = 1800  # 30 min
+
 
 # ---------------------------------------------------------------------------
 # Spawn / Agent defaults
@@ -141,6 +156,31 @@ class AgentDefaults:
     escalation_med_count: int = 3
 
     zombie_pid_max_age_s: float = 7 * 24 * 3600  # 7 days
+
+    # Max SDK turns forwarded to ``Runner.run_sync`` by the openai_agents
+    # runner (adapters/openai_agents_runner.py). Bug 13 (D2 minimax
+    # attempt-e938bd33, 2026-07-02): the SDK's own default of 10 was the
+    # dominant failure mode for builtin-tool workflows - backend hit
+    # MaxTurnsExceeded AFTER committing + POSTing /complete (wasted-work
+    # kill) and qa hit it 3x mid-exploration. 30 is the saner default for
+    # multi-tool workflows. Override via ``tuning.agent.max_turns``, the
+    # ``BERNSTEIN_MAX_TURNS`` env var, or the runner manifest's
+    # ``max_turns`` field. Set to ``None`` to omit the kwarg and fall back
+    # to the SDK's own default (10).
+    max_turns: int | None = 30
+
+
+@dataclass(frozen=True)
+class SLODefaults:
+    """Error-budget floor for the observability SLO/incident subsystem."""
+
+    # ErrorBudget.budget_total always tolerates at least this many failures,
+    # even when total_tasks * (1 - slo_target) rounds below it (e.g. a small
+    # task count). Raising this delays IncidentManager's auto-pause-on-
+    # error-budget-depletion response, useful when early infra-death retries
+    # (rate limits, transient auth) shouldn't count against a healthy run.
+    # Tunable via ``tuning.slo.error_budget_min_failures``.
+    error_budget_min_failures: int = 3
 
 
 # ---------------------------------------------------------------------------
@@ -680,6 +720,7 @@ SCHEMA_RETRY = SchemaRetryDefaults()
 LINEAGE = LineageDefaults()
 REWORK_LEDGER = ReworkLedgerDefaults()
 COMPACTION = CompactionDefaults()
+SLO = SLODefaults()
 
 # Module-level constant for direct import - preferred when only the
 # numeric cap is needed (no need to import the whole singleton).
@@ -735,6 +776,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "lineage": "LINEAGE",
         "rework_ledger": "REWORK_LEDGER",
         "compaction": "COMPACTION",
+        "slo": "SLO",
     }
 )
 
@@ -765,6 +807,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "LINEAGE": LineageDefaults,
         "REWORK_LEDGER": ReworkLedgerDefaults,
         "COMPACTION": CompactionDefaults,
+        "SLO": SLODefaults,
     }
 )
 

--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -14,10 +14,29 @@ logger = logging.getLogger(__name__)
 _CONVENTIONAL_COMMIT_RE = re.compile(r"^(feat|fix|chore|docs|test|refactor)(\([a-z0-9._/-]+\))?: .+")
 
 # Paths that must NEVER be staged, even via explicit add.
+#
+# Extended (defect 28 - decoy commit / secret leak): the previous list
+# only excluded ``.sdd/runtime/`` and ``.sdd/metrics/``.  The decoy commit
+# ``7e2364e`` on ``main`` (see
+# ``work/bernstein/proofs/d2/minimax/attempt-83808a8a/DIAGNOSIS.md``)
+# swept 83 ``.sdd/*`` files including ``.sdd/attestations/ed25519-signing-key.pem``,
+# ``.sdd/auth/agent_identity_jwt_secret``, ``.sdd/runtime/agent_tokens/``,
+# and ``bernstein.yaml`` into a single commit on a default branch.  The
+# merge-preflight safety guard in :mod:`bernstein.core.git.git_pr` blocks
+# the COMMIT, but to close the gap at the staging layer too we extend the
+# deny list with every prefix that must never reach a default branch.
 _NEVER_STAGE: frozenset[str] = frozenset(
     {
+        ".sdd/",
+        "attestations/",
+        "auth/",
         ".sdd/runtime/",
         ".sdd/metrics/",
+        ".sdd/attestations/",
+        ".sdd/auth/",
+        ".sdd/traces/",
+        "bernstein.yaml",
+        ".claude/mcp.json",
         ".env",
         "*.pid",
         "*.log",

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import time
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from bernstein.core.git.git_basic import GitResult, run_git
@@ -33,12 +33,20 @@ class MergeResult:
         conflicting_files: File paths with merge conflicts (empty on success).
         merge_diff: The diff of merged changes (empty on conflict).
         error: Error message if the merge failed for non-conflict reasons.
+        refused_forbidden_files: When ``success`` is False because the
+            merge-preflight safety guard detected staged files that must
+            never reach the default branch (``.sdd/`` runtime state,
+            ``attestations/`` signing material, or ``auth/`` secrets),
+            this is the list of forbidden paths that were staged.  The
+            merge is aborted and never produces a commit in this case
+            (fix for defect 28, the decoy-commit secret-leak path).
     """
 
     success: bool
     conflicting_files: list[str]
     merge_diff: str = ""
     error: str = ""
+    refused_forbidden_files: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -54,6 +62,115 @@ class PullRequestResult:
     success: bool
     pr_url: str = ""
     error: str = ""
+
+
+# ------------------------------------------------------------------
+# Merge-preflight safety guard (defect 28 - decoy commit / secret leak)
+# ------------------------------------------------------------------
+#
+# The orchestrator used to do ``git add -A && git commit`` in the main
+# checkout as part of the merge-to-main path; that swept the full
+# ``.sdd/*`` runtime tree -- including ``.sdd/attestations/ed25519-signing-key.pem``,
+# ``.sdd/auth/agent_identity_jwt_secret``, ``.sdd/runtime/agent_tokens/``
+# cost sidecars, and ``bernstein.yaml`` -- into a single commit on ``main``
+# under a stolen message.  The path that prevented this from being a
+# self-evident bug was the absence of any guard that said "this kind of
+# file must never reach the protected branch".  The deny list below is
+# the answer: a merge whose staged set touches ANY of these prefixes is
+# REFUSED (merge aborted, no commit, refusal recorded) so a silent leak
+# is impossible.
+_MERGE_DENY_PREFIXES: tuple[str, ...] = (
+    ".sdd/",
+    "attestations/",
+    "auth/",
+)
+# Exact filenames that are runtime artefacts, never part of a deliverable.
+_MERGE_DENY_EXACT: frozenset[str] = frozenset(
+    {
+        "bernstein.yaml",
+        ".claude/mcp.json",
+        ".env",
+    }
+)
+
+
+def _is_forbidden_for_merge(path: str) -> bool:
+    """Return True if *path* must never appear in a merge-to-default commit.
+
+    Uses normalised forward-slash paths.  The deny list is intentionally
+    narrow but ABSOLUTE: any match means the merge is refused, even if the
+    caller "really meant to" (the orchestrator never needs runtime state
+    on a protected branch).
+    """
+    if not path:
+        return False
+    norm = path.replace("\\", "/")
+    # Strip only a leading "./" (POSIX literal `./foo`), NOT a stray
+    # leading dot -- ``lstrip("./")`` would also strip the dot from
+    # ``.sdd/`` and ``.env`` which would let them bypass the deny list.
+    while norm.startswith("./"):
+        norm = norm[2:]
+    for prefix in _MERGE_DENY_PREFIXES:
+        if norm == prefix.rstrip("/") or norm.startswith(prefix):
+            return True
+    return norm in _MERGE_DENY_EXACT
+
+
+def _verify_merge_staging_is_safe(
+    cwd: Path,
+    branch: str,
+) -> list[str]:
+    """Return the list of forbidden staged paths (empty = safe to commit).
+
+    Runs ``git diff --cached --name-only`` against the merge working
+    directory and filters against :data:`_MERGE_DENY_PREFIXES` and
+    :data:`_MERGE_DENY_EXACT`.  Emits a single ``merge_preflight`` log
+    line so every merge -- successful or refused -- has provenance in the
+    orchestrator log (fix for defect 28's house-rule-2 requirement:
+    no silent decoy commits).
+
+    Args:
+        cwd: Repository root where the merge has been staged.
+        branch: The branch being merged in (for provenance logging only).
+
+    Returns:
+        List of staged paths that are forbidden on a default-branch commit.
+        Empty list means the staged set is safe to commit.
+    """
+    try:
+        staged_r = run_git(
+            ["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            cwd,
+            timeout=15,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        # If we cannot read the index we MUST refuse rather than fall
+        # through -- a verification failure is not a clean bill of health.
+        logger.warning(
+            "merge_preflight: STAGED-READ-FAILED cwd=%s branch=%s error=%s -- refusing merge as fail-closed",
+            cwd,
+            branch,
+            exc,
+        )
+        return ["<staged-read-failed>"]
+
+    staged_paths = [p.strip() for p in staged_r.stdout.splitlines() if p.strip()]
+    forbidden = [p for p in staged_paths if _is_forbidden_for_merge(p)]
+
+    # Provenance log -- house-rule-2 corollary says every merge commit must
+    # log INFO with author/reason/added; even a refused merge must be
+    # auditable.  Single line, fixed schema.
+    logger.info(
+        "merge_preflight: cwd=%s branch=%s staged_count=%d forbidden_count=%d added=%s reason=%s",
+        cwd,
+        branch,
+        len(staged_paths),
+        len(forbidden),
+        ",".join(staged_paths) if staged_paths else "<empty>",
+        "deny-list-match" if forbidden else "all-files-deliverable",
+    )
+
+    return forbidden
 
 
 # ------------------------------------------------------------------
@@ -165,6 +282,41 @@ def merge_with_conflict_detection(
                 success=False,
                 conflicting_files=[],
                 error=f"Python syntax errors blocked merge: {error_summary}",
+            )
+
+        # Pre-commit safety guard (defect 28): refuse the merge if the
+        # staged set touches ANY path the orchestrator must never put on a
+        # default branch (.sdd/* runtime state, attestations/* signing
+        # material, auth/* secrets, bernstein.yaml).  This blocks the
+        # decoy-commit / secret-leak path where a ``git add -A`` upstream
+        # swept runtime artefacts into the merge's staged set.  The merge
+        # is aborted -- no commit is ever produced.  See
+        # :func:`_verify_merge_staging_is_safe` for the deny list and
+        # provenance logging.
+        forbidden = _verify_merge_staging_is_safe(cwd, branch)
+        if forbidden:
+            run_git(["merge", "--abort"], cwd, timeout=10)
+            forbidden_str = ", ".join(forbidden[:5])
+            more = f" (+{len(forbidden) - 5} more)" if len(forbidden) > 5 else ""
+            logger.error(
+                "Refusing merge of %s into %s: staged set contains %d forbidden "
+                "path(s) -- refusing to commit runtime state / secrets to a "
+                "default branch (defect 28 decoy-commit guard). forbidden=%s%s",
+                branch,
+                cwd,
+                len(forbidden),
+                forbidden_str,
+                more,
+            )
+            return MergeResult(
+                success=False,
+                conflicting_files=[],
+                error=(
+                    f"merge-preflight safety guard refused: {len(forbidden)} "
+                    f"forbidden path(s) staged (.sdd/, attestations/, auth/, "
+                    f"bernstein.yaml). First: {forbidden_str}{more}"
+                ),
+                refused_forbidden_files=list(forbidden),
             )
 
         # Clean merge - commit it

--- a/src/bernstein/core/git/salvage.py
+++ b/src/bernstein/core/git/salvage.py
@@ -239,8 +239,15 @@ def _try_salvage_branch(
     # 1. Stage everything (including untracked files, skipping .gitignore).
     add_r = run_git(["add", "-A"], worktree_path, timeout=_SALVAGE_TIMEOUT_S)
     if not add_r.ok:
+        logger.warning(
+            "salvage step 1/4 FAILED (git add -A): session=%s worktree=%s stderr=%s",
+            session_id,
+            worktree_path,
+            add_r.stderr.strip(),
+        )
         errors.append(f"git add -A: {add_r.stderr.strip()}")
         return None, False, errors
+    logger.info("salvage step 1/4 ok (git add -A): session=%s worktree=%s", session_id, worktree_path)
 
     # 2. Commit.  --allow-empty so we leave a breadcrumb even when the diff
     #    is purely whitespace or already staged-and-reverted.
@@ -260,14 +267,29 @@ def _try_salvage_branch(
         timeout=_SALVAGE_TIMEOUT_S,
     )
     if not commit_r.ok:
+        logger.warning(
+            "salvage step 2/4 FAILED (git commit): session=%s worktree=%s stderr=%s",
+            session_id,
+            worktree_path,
+            commit_r.stderr.strip(),
+        )
         errors.append(f"git commit: {commit_r.stderr.strip()}")
         return None, False, errors
+    logger.info("salvage step 2/4 ok (git commit %r): session=%s", msg, session_id)
 
     # 3. Rename current branch to salvage/<id>.
     rename_r = run_git(["branch", "-M", branch], worktree_path, timeout=_SALVAGE_TIMEOUT_S)
     if not rename_r.ok:
+        logger.warning(
+            "salvage step 3/4 FAILED (git branch -M %s): session=%s worktree=%s stderr=%s",
+            branch,
+            session_id,
+            worktree_path,
+            rename_r.stderr.strip(),
+        )
         errors.append(f"git branch -M {branch}: {rename_r.stderr.strip()}")
         return None, False, errors
+    logger.info("salvage step 3/4 ok (branch renamed to %s): session=%s", branch, session_id)
 
     # 4. Push best-effort.
     push_r = run_git(
@@ -277,7 +299,17 @@ def _try_salvage_branch(
     )
     pushed = push_r.ok
     if not pushed:
+        logger.warning(
+            "salvage step 4/4 FAILED (git push origin %s): session=%s worktree=%s stderr=%s "
+            "-- branch is committed locally but not pushed; filesystem patch fallback still applies",
+            branch,
+            session_id,
+            worktree_path,
+            push_r.stderr.strip(),
+        )
         errors.append(f"git push origin {branch}: {push_r.stderr.strip()}")
+    else:
+        logger.info("salvage step 4/4 ok (pushed %s to origin): session=%s", branch, session_id)
 
     return branch, pushed, errors
 

--- a/src/bernstein/core/observability/rate_limit_tracker.py
+++ b/src/bernstein/core/observability/rate_limit_tracker.py
@@ -14,8 +14,10 @@ Implements:
 from __future__ import annotations
 
 import enum
+import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +51,12 @@ class RequestPriority(enum.Enum):
 
 # Text patterns that indicate a rate-limit / 429 event in agent logs.
 # Checked case-insensitively against the last 500 lines of the log.
+#
+# NOTE: "429" is a *risky bare token* (see _RISKY_BARE_TOKENS below) - a bare
+# number matches freely inside structured JSON log data (byte counts, task
+# IDs, timestamps) that has nothing to do with a rate-limit event. It is only
+# treated as a hit when it appears on a line that ALSO contains explicit
+# error context (see _ERROR_CONTEXT_RE).
 _RATE_LIMIT_PATTERNS: tuple[str, ...] = (
     "rate limit",
     "rate_limit",
@@ -76,7 +84,7 @@ _TIMEOUT_PATTERNS: tuple[str, ...] = (
     "TimeoutError",
     "ConnectTimeoutError",
     "ReadTimeoutError",
-    "504",
+    "504",  # risky bare token - see _RISKY_BARE_TOKENS
     "gateway timeout",
 )
 
@@ -97,6 +105,7 @@ _API_ERROR_PATTERNS: tuple[str, ...] = (
 )
 
 # Text patterns that indicate an authentication error (401, 403) in agent logs.
+# "401"/"403" are risky bare tokens - see _RISKY_BARE_TOKENS.
 _AUTH_ERROR_PATTERNS: tuple[str, ...] = (
     "401",
     "403",
@@ -110,13 +119,21 @@ _AUTH_ERROR_PATTERNS: tuple[str, ...] = (
 )
 
 # Text patterns that indicate a context-overflow / prompt-too-long (413) error.
+#
+# "413" and "context window" are risky bare/generic tokens (see
+# _RISKY_BARE_TOKENS) - they match freely inside structured JSON tool-result
+# and manifest dumps that have nothing to do with a real provider error.
+# "max_tokens" was REMOVED outright (not just demoted to risky): it is a
+# completely ordinary field name in request/response manifests and provides
+# no error signal even with context words nearby - see 2026-07-02 incident
+# (runs 4/5/6 killed by healthy MiniMax-M3 workers whose JSON logs contained
+# `"max_tokens": 16384` and numbers containing 413/429).
 _CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
     "413",
     "prompt is too long",
     "prompt too long",
     "context window",
     "context_length_exceeded",
-    "max_tokens",
     "maximum context length",
     "token limit exceeded",
     "request too large",
@@ -126,6 +143,72 @@ _CONTEXT_OVERFLOW_PATTERNS: tuple[str, ...] = (
     "context length exceeded",
     "PromptTooLongError",
 )
+
+# Bare numbers / generic words that are common in structured JSON log data
+# (tool-call results, manifest dumps, byte counts, task IDs) and therefore
+# cannot be trusted as failure signals on their own. A risky token only
+# counts as a match when it appears with a word boundary on a line that ALSO
+# contains explicit error context (see _ERROR_CONTEXT_RE) - e.g.
+# "Error code: 413 - request too large" matches, but a JSON blob containing
+# `"max_tokens": 16384` (which incidentally contains the digits 4-1-3 nowhere,
+# but DOES contain other risky substrings like "429" in unrelated counters)
+# does not. See 2026-07-02 false-positive incident (runs 4/5/6 killed).
+_RISKY_BARE_TOKENS: frozenset[str] = frozenset(
+    {
+        # bare HTTP codes - match inside byte counts / ids / timestamps
+        "413",
+        "429",
+        "401",
+        "403",
+        "504",
+        # generic words/phrases - appear freely in tool output, target-repo code
+        # being read, and test stdout (2026-07-02 run 7: `"timeout": 5` in a
+        # tool-call JSON killed a healthy manager)
+        "context window",
+        "timeout",
+        "timed out",
+        "time out",
+        "request timeout",
+        "connect timeout",
+        "read timeout",
+        "gateway timeout",
+        "rate limit",
+        "rate_limit",
+        "ratelimit",
+        "overloaded",
+        "hit your limit",
+        "usage cap",
+        "unauthorized",
+        "forbidden",
+        "invalid_client",
+        "invalid_token",
+        "expired_token",
+        "connection refused",
+        "connection reset",
+        "econnrefused",
+        "econnreset",
+        "api_error",
+    }
+)
+
+# Structured agent-log lines that carry DATA (tool traffic, heartbeats), not
+# provider errors. Never scanned: a tool result legitimately contains target
+# repo code/output with words like "unauthorized" or "TimeoutError" in it.
+#
+# "completion" and "progress" were added 2026-07-02 (D2 tools-zero diagnosis,
+# work/bernstein/proofs/d2/tools-zero-diagnosis.md Q5): both carry raw
+# model-authored free text (a completion's ``summary`` field, a progress
+# event's narration) that legitimately contains words like "timeout" in
+# prose ("I set a 10s timeout on the curl call") without any real failure
+# having occurred. Excluding them from substring scanning closes that
+# false-positive hole; risky-bare-token matches on OTHER line types still
+# require same-line error context via ``_ERROR_CONTEXT_RE``.
+_DATA_LINE_TYPES: frozenset[str] = frozenset({"tool_call", "tool_result", "heartbeat", "completion", "progress"})
+
+# Words that indicate a line is plausibly describing a real provider/HTTP
+# error, rather than incidental structured data. Deliberately narrow -
+# broadening this list re-opens the false-positive hole this patch closes.
+_ERROR_CONTEXT_RE = re.compile(r"\b(error|status|http|code|exception|failed|failure|traceback)\b", re.IGNORECASE)
 
 _BASE_THROTTLE_S: float = 60.0
 _MAX_THROTTLE_S: float = 3600.0
@@ -448,12 +531,25 @@ class RateLimitTracker:
     def _scan_log_for_patterns(self, log_path: Path, patterns: tuple[str, ...]) -> bool:
         """Scan the tail of *log_path* for any of the given patterns.
 
+        Patterns in ``_RISKY_BARE_TOKENS`` (bare numbers like "413"/"429" and
+        generic phrases like "context window") are NOT matched by plain
+        substring containment - structured JSON log lines (tool results,
+        manifest dumps) are full of numbers and common words that would
+        otherwise false-positive-kill a healthy worker (2026-07-02 incident:
+        runs 4/5/6 killed by this exact failure mode). A risky token only
+        counts as a match when (a) it appears with a real word boundary, AND
+        (b) the SAME line also contains explicit error context per
+        ``_ERROR_CONTEXT_RE``. All other patterns keep the original
+        case-insensitive substring behaviour, scanned line-by-line so the
+        matched line can be logged for diagnosis.
+
         Args:
             log_path: Path to the agent's subprocess log file.
             patterns: Tuple of strings to search for (case-insensitive).
 
         Returns:
-            True if any pattern was found, False otherwise.
+            True if any pattern was found, False otherwise (including
+            when the file does not exist or cannot be read).
         """
         if not log_path.exists():
             return False
@@ -464,8 +560,58 @@ class RateLimitTracker:
             return False
 
         lines = text.splitlines()[-_LOG_SCAN_TAIL_LINES:]
-        snippet = "\n".join(lines).lower()
-        return any(pat.lower() in snippet for pat in patterns)
+        for line in lines:
+            stripped = line.lstrip()
+            _line_type: str | None = None
+            if stripped.startswith("{"):
+                try:
+                    _obj = json.loads(stripped)
+                except ValueError:
+                    _obj = None
+                if isinstance(_obj, dict):
+                    _raw_type = _obj.get("type")
+                    _line_type = _raw_type if isinstance(_raw_type, str) else None
+                    if _line_type in _DATA_LINE_TYPES:
+                        logger.debug(
+                            "_scan_log_for_patterns: skipping data-line type=%r in %s (not scanned)",
+                            _line_type,
+                            log_path,
+                        )
+                        continue
+            lower_line = line.lower()
+            for pat in patterns:
+                pat_lower = pat.lower()
+                # log-line type for the matched line: the JSON "type" field
+                # when the line parsed as JSON, else "unstructured" -- this
+                # is the field that let a "completion" line's fabricated
+                # "timeout" text through before the _DATA_LINE_TYPES fix
+                # above (2026-07-02 D2 tools-zero diagnosis).
+                _matched_line_type = _line_type or "unstructured"
+                _excerpt = line.strip()[:120]
+                if pat_lower in _RISKY_BARE_TOKENS:
+                    if not re.search(rf"\b{re.escape(pat_lower)}\b", lower_line):
+                        continue
+                    if not _ERROR_CONTEXT_RE.search(lower_line):
+                        continue
+                    logger.info(
+                        "_scan_log_for_patterns: matched RISKY pattern=%r line_type=%r "
+                        "(with error context) in %s, excerpt=%r",
+                        pat,
+                        _matched_line_type,
+                        log_path,
+                        _excerpt,
+                    )
+                    return True
+                elif pat_lower in lower_line:
+                    logger.info(
+                        "_scan_log_for_patterns: matched pattern=%r line_type=%r in %s, excerpt=%r",
+                        pat,
+                        _matched_line_type,
+                        log_path,
+                        _excerpt,
+                    )
+                    return True
+        return False
 
 
 # ------------------------------------------------------------------

--- a/src/bernstein/core/observability/slo.py
+++ b/src/bernstein/core/observability/slo.py
@@ -119,12 +119,20 @@ class ErrorBudget:
     def budget_total(self) -> int:
         """Total allowed failures given current task count.
 
-        Always allows at least 3 failures to avoid false depletion when
-        only a few tasks have completed (e.g. 2 * 0.10 rounds to 0).
+        Always allows at least ``SLO.error_budget_min_failures`` (default 3)
+        failures to avoid false depletion when only a few tasks have
+        completed (e.g. 2 * 0.10 rounds to 0). Tunable via
+        ``tuning.slo.error_budget_min_failures`` in bernstein.yaml.
         """
+        from bernstein.core.defaults import SLO
+
         if self.total_tasks == 0:
             return 0
-        return max(3, round(self.total_tasks * (1.0 - self.slo_target)))
+        # Clamp a misconfigured (e.g. negative) tuning.slo.error_budget_min_failures
+        # to 0 rather than letting a pathological floor suppress the budget below
+        # what the raw SLO-target computation would allow.
+        min_failures = max(0, SLO.error_budget_min_failures)
+        return max(min_failures, round(self.total_tasks * (1.0 - self.slo_target)))
 
     @property
     def budget_remaining(self) -> int:

--- a/src/bernstein/core/observability/watchdog.py
+++ b/src/bernstein/core/observability/watchdog.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from bernstein.core.agent_log_aggregator import AgentLogAggregator
 from bernstein.core.heartbeat import HeartbeatMonitor, compute_stall_profile
+from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -46,6 +47,11 @@ class WatchdogFinding:
     summary: str
     detail: str
     role: str = "reviewer"
+    # Title of the task this finding is about. Used by AutoSpawnGuard to
+    # compute ancestry depth (e.g. a finding about a task whose title already
+    # starts with "Watchdog triage:" is itself depth-1, so a new triage task
+    # about it would be depth 2 and gets refused).
+    task_title: str = ""
 
 
 @dataclass
@@ -101,6 +107,7 @@ def _check_session_findings(
                     f"Adaptive profile: wakeup={profile.wakeup_threshold}, "
                     f"shutdown={profile.shutdown_threshold}, kill={profile.kill_threshold} ({profile.reason})."
                 ),
+                task_title=str(title),
             )
             return
 
@@ -133,6 +140,7 @@ def _check_heartbeat_findings(
                     f"Tier-1 watchdog found no heartbeat file and no log activity for {runtime_s:.0f}s "
                     f"while task {task_id} remains active."
                 ),
+                task_title=str(title),
             )
         return
 
@@ -150,6 +158,7 @@ def _check_heartbeat_findings(
                 f"Tier-1 watchdog observed heartbeat age {hb_status.age_seconds:.0f}s "
                 f"for task {task_id} (timeout={timeout_s:.0f}s, phase={hb_status.phase or 'unknown'})."
             ),
+            task_title=str(title),
         )
 
 
@@ -178,6 +187,7 @@ def _check_log_growth_findings(
             f"Tier-1 watchdog saw no new log lines for {no_growth_ticks} consecutive ticks "
             f"(current_line={current_line}, runtime={runtime_s:.0f}s) on task {task_id}."
         ),
+        task_title=str(title),
     )
 
 
@@ -270,6 +280,7 @@ class WatchdogManager:
         *,
         notify: Callable[..., None] | None = None,
         post_bulletin: Callable[[str, str], None] | None = None,
+        max_auto_spawns_per_run: int = 3,
     ) -> None:
         self._workdir = workdir
         self._client = client
@@ -278,6 +289,7 @@ class WatchdogManager:
         self._post_bulletin = post_bulletin
         self._state_path = workdir / ".sdd" / "runtime" / "watchdog_state.json"
         self._events_path = workdir / ".sdd" / "runtime" / "watchdog_incidents.jsonl"
+        self._auto_spawn_guard = AutoSpawnGuard(workdir, max_auto_spawns_per_run=max_auto_spawns_per_run)
 
     def sync(self, findings: list[WatchdogFinding]) -> None:
         """Sync current findings into persisted incident state."""
@@ -302,6 +314,15 @@ class WatchdogManager:
                     last_seen_ts=now,
                 )
                 self._append_event("detected", incident)
+                logger.warning(
+                    "watchdog TIER1 detected: key=%s source=%s severity=%s task=%s session=%s summary=%s",
+                    incident.key,
+                    incident.source,
+                    incident.severity,
+                    incident.task_id,
+                    incident.session_id,
+                    incident.summary,
+                )
             else:
                 incident.count += 1
                 incident.last_seen_ts = now
@@ -311,12 +332,29 @@ class WatchdogManager:
                 incident.detail = finding.detail
 
             if incident.triage_task_id is None:
-                triage_task_id = self._create_triage_task(finding)
+                existing_open_titles = [
+                    f"Watchdog triage: {other.summary}"
+                    for other in state.values()
+                    if other.triage_task_id is not None and other.key != finding.key
+                ]
+                triage_task_id = self._create_triage_task(finding, existing_open_titles)
                 if triage_task_id:
                     incident.triage_task_id = triage_task_id
                     self._append_event("triage_created", incident)
 
             if not incident.escalated and incident.count >= _human_escalation_threshold(incident.severity):
+                threshold = _human_escalation_threshold(incident.severity)
+                logger.warning(
+                    "watchdog TIER3 escalating to human: key=%s count=%d threshold=%d severity=%s "
+                    "task=%s session=%s triage_task_id=%s",
+                    incident.key,
+                    incident.count,
+                    threshold,
+                    incident.severity,
+                    incident.task_id,
+                    incident.session_id,
+                    incident.triage_task_id or "n/a",
+                )
                 self._escalate_human(incident)
                 incident.escalated = True
                 self._append_event("human_escalated", incident)
@@ -325,10 +363,30 @@ class WatchdogManager:
 
         self._save_state(active)
 
-    def _create_triage_task(self, finding: WatchdogFinding) -> str | None:
-        """Create a Tier-2 reviewer task for AI triage."""
+    def _create_triage_task(self, finding: WatchdogFinding, existing_open_titles: list[str]) -> str | None:
+        """Create a Tier-2 reviewer task for AI triage.
+
+        Gated by :class:`AutoSpawnGuard` to prevent the "watchdog triage of
+        watchdog triage" recursion and unbounded triage-task growth observed
+        in production (see module docstring of ``auto_spawn_guard``).
+        """
+        title = f"Watchdog triage: {finding.summary}"
+        decision = self._auto_spawn_guard.evaluate(
+            kind="watchdog_triage",
+            title=title,
+            source_title=finding.task_title,
+            existing_open_titles=existing_open_titles,
+        )
+        if not decision.allowed:
+            logger.info(
+                "watchdog TIER2 triage suppressed by AutoSpawnGuard: key=%s title=%r reason=%s",
+                finding.key,
+                title,
+                getattr(decision, "reason", "<no reason attr>"),
+            )
+            return None
         payload = {
-            "title": f"Watchdog triage: {finding.summary}",
+            "title": title,
             "description": (
                 "Tier-2 watchdog triage.\n\n"
                 "A Tier-1 mechanical watchdog detected a live agent problem before merge.\n"

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -339,11 +339,38 @@ class Orchestrator:
         # Track spawn failures per batch for backoff: task_ids -> (fail_count, last_fail_ts)
         self._spawn_failures: dict[frozenset[str], tuple[int, float]] = {}
         self._spawn_failure_history: dict[frozenset[str], list[Any]] = {}
+        # Bug 1 (2026-07-02, claim-conflict-churn): per-task-id claim-conflict
+        # episode counter + backoff deadline. A "conflict episode" is one
+        # tick's bounded burst of re-fetch-and-retry attempts against a 409
+        # (see task_lifecycle._claim_task_with_conflict_retry). Without this,
+        # a task stuck in perpetual 409 (stale file lock, unmet dependency,
+        # etc.) got re-attempted every tick forever -- 144 consecutive
+        # identical `claim?expected_version=1` -> 409 requests were observed
+        # from a single session in work/bernstein/proofs/d2/claim-loop-evidence.
+        # task_id -> (episode_count, backoff_until_epoch_s)
+        self._claim_conflict_state: dict[str, tuple[int, float]] = {}
         self._latest_tasks_by_id: dict[str, Task] = {}
         # Track last backlog replenishment timestamp
         self._last_replenish_ts: float = 0.0
         # Run completion summary state
         self._summary_written: bool = False
+        # Guards the FINAL (shutdown-final) retrospective regeneration so it
+        # only ever runs once per process, regardless of which terminal path
+        # triggers it (tick-loop drain in run(), or the tick-level
+        # quiescence self-stop in _tick_internal's "8b" block). See
+        # _regenerate_final_retrospective.
+        self._final_retrospective_regenerated: bool = False
+        # Defect 29 (2026-07-02, work/bernstein/proofs/d2/minimax/attempt-83808a8a):
+        # self-stop ordering race. The run-summary MUST NOT fire until the
+        # post-/complete chain (task_done -> reap_completed_agent ->
+        # merge_worktree_branch -> _apply_janitor_verdict_action) has drained
+        # for every completed task. We track each terminal task from the
+        # moment we first see it in done/failed state and only decrement the
+        # counter once the task has been through ``process_completed_tasks``
+        # AND its session is no longer alive. The 8b summary block gates
+        # ``_generate_run_summary`` on this counter reaching zero.
+        self._pending_post_complete_count: int = 0
+        self._post_complete_seen_task_ids: set[str] = set()
         self._run_start_ts: float = time.time()
         self._agent_failure_timestamps: dict[str, float] = {}  # adapter_name -> last failure ts
         self._shutting_down = threading.Event()
@@ -1682,13 +1709,229 @@ class Orchestrator:
         # 8. Replenish backlog in evolve mode when tasks run out
         self._replenish_backlog(result)
 
-        # 8b. Generate run completion summary for non-evolve runs (reuse cached tasks)
-        if (
-            not self._config.evolve_mode
-            and result.open_tasks == result.active_agents == 0
-            and not self._summary_written
-        ):
-            self._generate_run_summary(tasks_by_status["done"], tasks_by_status["failed"])
+        # 8b. Generate run completion summary for non-evolve runs.
+        #
+        # Bug (2026-07-02 D2 openrouter final leg,
+        # work/bernstein/proofs/d2/openrouter/attempt-final-f15a2a9e):
+        # `tasks_by_status` here is the snapshot fetched at the TOP of this
+        # tick (step 1, above), before `reap_dead_agents` (step 5, above)
+        # can synchronously auto-complete/fail a task within this SAME
+        # tick (e.g. an orphan auto-complete after its agent died mid-run).
+        # Passing that stale snapshot to `_generate_run_summary` made a
+        # task that had JUST been auto-completed look like it never
+        # happened: `compute_run_health([])` is vacuously HEALTHY with
+        # every TERMINATOR_* count at 0, even though spawner.log had
+        # already logged the `orphan_auto_complete` event for that exact
+        # task earlier in this same tick. Fix: refetch immediately before
+        # generating the summary so it reflects whatever reap_dead_agents
+        # just did.
+        # Regression (2026-07-02 D2 minimax leg,
+        # work/bernstein/proofs/d2/minimax/attempt-e938bd33): this block was
+        # previously ALSO gated on `not self._summary_written`. On that run,
+        # tick #7 detected quiescence, wrote the summary + interim
+        # retrospective (setting `_summary_written = True`), and the settle
+        # window then correctly said "run continues" (a retry task had
+        # appeared: open=1). But once `_summary_written` was True, every
+        # LATER quiescent tick skipped this entire block - so the
+        # tick-quiescence self-stop and its shutdown-final retrospective
+        # regeneration could never fire again. The run's final quiescence
+        # (last retry permanently failed at 01:57:15) passed silently and
+        # the process was torn down with the stale tick-7 INTERIM
+        # retrospective on disk (3 tasks/$0.0174 vs the real 5/$0.0375).
+        # Fix: the `_summary_written` one-shot guard now wraps ONLY the
+        # summary generation below; quiescence detection, the settle-window
+        # check, the self-stop, and shutdown-final regeneration re-run on
+        # every quiescent tick until confirmed.
+        if not self._config.evolve_mode and result.open_tasks == result.active_agents == 0:
+            refreshed_tasks_by_status = tasks_by_status
+            try:
+                refreshed_tasks_by_status = fetch_all_tasks(self._client, base)
+                logger.info(
+                    "8b quiescence detected (tick #%d): refetched tasks before run-summary "
+                    "generation to capture any same-tick reap_dead_agents completions "
+                    "(done %d->%d, failed %d->%d)",
+                    self._tick_count,
+                    len(tasks_by_status["done"]),
+                    len(refreshed_tasks_by_status["done"]),
+                    len(tasks_by_status["failed"]),
+                    len(refreshed_tasks_by_status["failed"]),
+                )
+            except httpx.HTTPError:
+                logger.exception(
+                    "8b quiescence refetch failed (tick #%d) - falling back to the "
+                    "pre-reap snapshot for run-summary generation; the interim "
+                    "retrospective may undercount tasks reap_dead_agents completed "
+                    "this tick",
+                    self._tick_count,
+                )
+
+            # Defect 29 (2026-07-02, work/bernstein/proofs/d2/minimax/attempt-83808a8a):
+            # process_completed_tasks (the post-/complete chain) ran at step
+            # 1c above, BEFORE the refetch. Any task that became terminal
+            # during this same tick - e.g. via reap_dead_agents' orphan
+            # auto-complete at step 5, or via a /complete POST that landed
+            # between step 1 and step 8b - was NOT in process_completed_tasks'
+            # input list. Drive the chain for those newly-terminal tasks here
+            # so the 8b summary gate (``_pending_post_complete_count == 0``)
+            # can fire on this tick instead of waiting one full poll cycle.
+            _newly_terminal_for_chain: list[Task] = []
+            for bucket in ("done", "failed"):
+                for task in refreshed_tasks_by_status.get(bucket, []):
+                    if task.id not in self._processed_done_tasks:
+                        _newly_terminal_for_chain.append(task)
+            if _newly_terminal_for_chain:
+                logger.info(
+                    "8b pre-summary chain processing (tick #%d): %d newly-terminal "
+                    "task(s) added to process_completed_tasks: %s",
+                    self._tick_count,
+                    len(_newly_terminal_for_chain),
+                    ", ".join(t.id for t in _newly_terminal_for_chain),
+                )
+                try:
+                    _chain_result = TickResult()
+                    # Pass both done and failed - process_completed_tasks
+                    # filters to ``_processed_done_tasks`` itself so a
+                    # failed task gets registered the same way as a done
+                    # task. A pure done-only filter here would strand
+                    # failed tasks in the drain tracker.
+                    process_completed_tasks(
+                        self,
+                        list(_newly_terminal_for_chain),
+                        _chain_result,
+                    )
+                except Exception as exc:
+                    logger.exception(
+                        "8b pre-summary process_completed_tasks raised (tick #%d): %s",
+                        self._tick_count,
+                        exc,
+                    )
+
+            # Defect 29: refresh the drain tracker against the latest snapshot,
+            # then log the run-end decision with all its inputs so a 2-minute
+            # diagnosis from logs alone is possible (house rule 2).
+            _pending_post_complete = self._refresh_drain_tracker(refreshed_tasks_by_status)
+            if _pending_post_complete > 0:
+                _still_pending = sorted(
+                    tid
+                    for tid in self._post_complete_seen_task_ids
+                    if tid not in set(self._processed_done_tasks.keys())
+                )
+                _action = "defer_summary"
+                logger.info(
+                    "run_end_check: tick=#%d open=%d active=%d pending_post_complete=%d "
+                    "summary_written=%s -> action=%s (waiting for post-/complete chain "
+                    "on tasks: %s)",
+                    self._tick_count,
+                    result.open_tasks,
+                    result.active_agents,
+                    _pending_post_complete,
+                    self._summary_written,
+                    _action,
+                    _still_pending or "<none>",
+                )
+            elif not self._summary_written:
+                _action = "fire_summary"
+                logger.info(
+                    "run_end_check: tick=#%d open=%d active=%d pending_post_complete=%d "
+                    "summary_written=%s -> action=%s (all terminal tasks drained)",
+                    self._tick_count,
+                    result.open_tasks,
+                    result.active_agents,
+                    _pending_post_complete,
+                    self._summary_written,
+                    _action,
+                )
+                self._generate_run_summary(refreshed_tasks_by_status["done"], refreshed_tasks_by_status["failed"])
+            else:
+                _action = "summary_already_written"
+                logger.info(
+                    "run_end_check: tick=#%d open=%d active=%d pending_post_complete=%d "
+                    "summary_written=%s -> action=%s (proceeding to settle-window "
+                    "self-stop check; shutdown-final regeneration still pending)",
+                    self._tick_count,
+                    result.open_tasks,
+                    result.active_agents,
+                    _pending_post_complete,
+                    self._summary_written,
+                    _action,
+                )
+
+            # Only self-stop once real work has actually happened (at least
+            # one task has reached a terminal state). A brand-new/empty
+            # backlog reading open=0/agents=0 on tick #1 is not "the run
+            # finished" - it's "nothing has been scheduled yet" (e.g. a
+            # server that hasn't ingested its seed task yet, or a test
+            # harness driving tick() directly against an empty transport).
+            # Self-stopping in that case would end the orchestrator before
+            # it ever does anything.
+            _had_any_terminal_task = bool(refreshed_tasks_by_status["done"] or refreshed_tasks_by_status["failed"])
+            if not _had_any_terminal_task:
+                logger.debug(
+                    "8b quiescence (tick #%d) with zero terminal tasks - not eligible "
+                    "for self-stop yet (nothing has actually run)",
+                    self._tick_count,
+                )
+
+            # Confirm this quiescence is real rather than a momentary gap
+            # before more child tasks appear (see the A5 stale-retrospective
+            # bug this module already guards against: a run reported
+            # 100%/HEALTHY at T+58s and 2 more tasks subsequently failed).
+            # A short settle window catches that race without waiting a
+            # full poll interval.
+            #
+            # This self-stop is also what makes shutdown-final retrospective
+            # regeneration actually fire for runs that end via a `--quiet` /
+            # wait-for-completion CLI path (cli/run_bootstrap.py's
+            # `_wait_for_run_completion`, which polls this process's HTTP
+            # server from a SEPARATE CLI process and never sends this
+            # process a stop signal). This orchestrator subprocess is
+            # launched detached (`start_new_session=True` in
+            # server_launch._start_spawner), so without self-stopping here
+            # it just idles until the container's PID-namespace teardown
+            # SIGKILLs it - unmaskable, no Python cleanup code runs, and
+            # `run()`'s post-tick-loop shutdown-final regeneration never
+            # gets a chance to execute.
+            if _had_any_terminal_task:
+                # Overridable via env var so tests (and any operator who
+                # wants a tighter/looser margin) don't have to eat a real
+                # 2s sleep per quiescent tick.
+                _settle_s = float(os.environ.get("BERNSTEIN_QUIESCENCE_SETTLE_S", "2.0"))
+                if _settle_s > 0:
+                    time.sleep(_settle_s)
+                try:
+                    settled = fetch_all_tasks(self._client, base)
+                except httpx.HTTPError:
+                    logger.exception(
+                        "Quiescence settle re-check failed (tick #%d) after %.1fs - not "
+                        "self-stopping; relying on the normal tick loop or an external "
+                        "stop signal instead",
+                        self._tick_count,
+                        _settle_s,
+                    )
+                    settled = None
+                if settled is not None:
+                    settled_open = len(settled["open"])
+                    settled_agents = sum(1 for a in self._agents.values() if a.status != "dead")
+                    if settled_open == 0 and settled_agents == 0:
+                        logger.info(
+                            "Quiescence confirmed after %.1fs settle window (tick #%d, "
+                            "open=%d agents=%d) - self-stopping",
+                            _settle_s,
+                            self._tick_count,
+                            settled_open,
+                            settled_agents,
+                        )
+                        self._regenerate_final_retrospective(trigger_path="tick-quiescence-self-stop")
+                        self._running = False
+                    else:
+                        logger.info(
+                            "Quiescence NOT confirmed after %.1fs settle window (tick #%d): "
+                            "open=%d agents=%d - run continues",
+                            _settle_s,
+                            self._tick_count,
+                            settled_open,
+                            settled_agents,
+                        )
 
         # 9. Log summary
         self._log_summary(result)
@@ -1819,6 +2062,70 @@ class Orchestrator:
                 reason=reason,
             )
             logger.info("Workflow approval granted for phase %r via file", phase_name)
+
+    def _regenerate_final_retrospective(self, trigger_path: str) -> None:
+        """Regenerate the FINAL retrospective by re-reading final event state.
+
+        Idempotent and safe to call from more than one terminal path
+        (tick-loop drain, tick-level quiescence self-stop, future
+        interrupt/kill paths) - only the first caller actually writes;
+        later callers just log which path was skipped and why. This is the
+        single source of truth for "what triggered shutdown-final
+        regeneration" so a `grep` of the logs always finds an explicit
+        answer (logging-is-the-debugging-interface rule).
+
+        Args:
+            trigger_path: Human-readable name of the terminal path that
+                invoked this (e.g. "tick-loop-drain",
+                "tick-quiescence-self-stop"). Logged at INFO so a run's
+                actual shutdown path is always visible in the logs.
+        """
+        if self._config.evolve_mode:
+            logger.warning(
+                "shutdown-final regeneration skipped via %s: evolve_mode is on",
+                trigger_path,
+            )
+            return
+        if self._final_retrospective_regenerated:
+            logger.info(
+                "shutdown-final regeneration already performed by an earlier terminal "
+                "path - skipping duplicate run triggered via %s",
+                trigger_path,
+            )
+            return
+        logger.info("shutdown-final regeneration triggered via %s", trigger_path)
+        try:
+            # Re-fetch FINAL event state here rather than reusing any
+            # previously-cached task snapshot. This is the fix for the
+            # sibling bug found alongside the "never fires" bug (same
+            # ground-truth run): the 8b tick-level mid-run summary was
+            # feeding generate_retrospective() a snapshot fetched BEFORE
+            # reap_dead_agents() (tick step 5) synchronously auto-completed
+            # an orphaned task within that same tick, so the retrospective
+            # vacuously reported 0 done / 0 failed / HEALTHY while
+            # spawner.log had already logged the orphan_auto_complete event.
+            # Fetching fresh here, at the moment of actual shutdown, is the
+            # only way to guarantee every such in-tick completion is
+            # reflected.
+            final_tasks = fetch_all_tasks(self._client, self._config.server_url)
+            status_histogram = {status: len(tasks) for status, tasks in final_tasks.items()}
+            runtime_dir = self._workdir / ".sdd" / "runtime"
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+            generate_retrospective(
+                done_tasks=final_tasks.get("done", []),
+                failed_tasks=final_tasks.get("failed", []),
+                collector=get_collector(self._workdir / ".sdd" / "metrics"),
+                runtime_dir=runtime_dir,
+                run_start_ts=self._run_start_ts,
+                trigger_reason="shutdown-final",
+                full_status_counts=status_histogram,
+            )
+            self._final_retrospective_regenerated = True
+        except Exception:
+            logger.exception(
+                "Final retrospective regeneration failed at shutdown via %s (non-fatal)",
+                trigger_path,
+            )
 
     def run(self) -> None:
         """Run the orchestrator loop until stopped.
@@ -1955,6 +2262,39 @@ class Orchestrator:
 
         self._drain_before_cleanup()
         self._cleanup()
+
+        # A5 fix: unconditionally regenerate the FINAL retrospective here, at
+        # true orchestrator shutdown (the tick loop has actually exited),
+        # overwriting any earlier "mid-run" snapshot written by
+        # _generate_run_summary()'s tick-level "queue looks empty" heuristic.
+        # This is the only point where every task has had the chance to
+        # reach a terminal state, so it's the only point a HEALTHY verdict
+        # can be trusted (see canary A5 stale-retrospective bug: a run
+        # reported 100%/HEALTHY at T+58s while 2 of 3 tasks subsequently
+        # failed, and the report was never refreshed).
+        #
+        # Regression (2026-07-02 D2 openrouter final leg,
+        # work/bernstein/proofs/d2/openrouter/attempt-final-f15a2a9e): this
+        # block only runs if the tick loop actually exits via `self._running`
+        # going False, i.e. someone called `.stop()` (normally the SIGINT/
+        # SIGTERM handler installed around `orchestrator.run()` in this
+        # module's __main__ block). But `bernstein run --quiet` /
+        # `_wait_for_run_completion()` (cli/run_bootstrap.py) never signals
+        # this process - it just polls the task server's HTTP /status
+        # endpoint from an entirely separate CLI process and returns once
+        # quiescent. This orchestrator subprocess is launched detached
+        # (`start_new_session=True` in server_launch._start_spawner), so
+        # when the CLI process then exits and the container's PID namespace
+        # tears down, the kernel SIGKILLs every process in the namespace
+        # unconditionally - no Python code here ever runs. See
+        # `_regenerate_final_retrospective` / the tick()-level
+        # "tick-quiescence-self-stop" path below for the self-triggered
+        # fix that covers that terminal path too; this call is now a no-op
+        # (guarded by `_final_retrospective_regenerated`) whenever that path
+        # already handled it, and remains the sole trigger for interrupt/
+        # kill-signal shutdowns where `.stop()` IS called.
+        self._regenerate_final_retrospective(trigger_path="tick-loop-drain")
+
         self._post_bulletin("status", "run stopped")
         self._recorder.record(
             "run_completed",
@@ -2732,11 +3072,45 @@ class Orchestrator:
                     )
 
     def _record_live_costs(self) -> None:
-        """Update live cost tracker from active agent token usage."""
+        """Update live cost tracker from active agent token usage.
+
+        Bug item-7 (2026-07-02, D2 claude FAIL-NOTE): ``session.tokens_used``
+        is never populated on the openai_agents provider path, so this tick
+        skipped every live agent and the run ledger's ``spent_usd`` stayed
+        0.0 for the entire run - budget guards were unenforceable while real
+        cost accumulated only in the ``.tokens`` sidecars. Fix: read each
+        live session's cumulative sidecar totals (the same source of truth
+        the orphan-recovery path prices dead agents from) and feed them to
+        the delta-safe ``record_cumulative``. ``session.tokens_used`` remains
+        the fallback for providers that don't write a sidecar.
+        """
+        from bernstein.core.cost.cost import read_tokens_sidecar_totals  # local: avoid import cycle
+
         any_change = False
         for session in self._agents.values():
-            if session.status == "dead" or session.tokens_used <= 0:
+            if session.status == "dead":
                 continue
+
+            # Same sidecar location contract as the openai_agents runner and
+            # the orphan-recovery path: .sdd/runtime/<session_id>.tokens at
+            # the orchestrator root (never inside a per-task worktree).
+            sidecar_path = self._workdir / ".sdd" / "runtime" / f"{session.id}.tokens"
+            sidecar_in, sidecar_out = read_tokens_sidecar_totals(sidecar_path)
+            if sidecar_in > 0 or sidecar_out > 0:
+                total_in, total_out = sidecar_in, sidecar_out
+                token_source = str(sidecar_path)
+            elif session.tokens_used > 0:
+                total_in, total_out = session.tokens_used, 0
+                token_source = "session.tokens_used"
+            else:
+                continue
+            logger.debug(
+                "live_cost_tick: session=%s tokens_in=%d tokens_out=%d source=%s",
+                session.id,
+                total_in,
+                total_out,
+                token_source,
+            )
 
             model_name = session.model_config.model if session.model_config else "sonnet"
             task_id = session.task_ids[0] if session.task_ids else f"live-{session.id}"
@@ -2747,8 +3121,8 @@ class Orchestrator:
                 agent_id=session.id,
                 task_id=task_id,
                 model=model_name,
-                total_input_tokens=session.tokens_used,
-                total_output_tokens=0,
+                total_input_tokens=total_in,
+                total_output_tokens=total_out,
                 role=role_label,
             )
             if delta_cost > 0:
@@ -2898,6 +3272,8 @@ class Orchestrator:
                     max_task_retries=self._config.max_task_retries,
                     retried_task_ids=self._retried_task_ids,
                     workdir=self._workdir,
+                    role_model_policy=getattr(self._spawner, "role_model_policy", None),
+                    default_adapter_name=getattr(self._spawner, "default_adapter_name", None),
                 )
 
     def _enforce_budget_killswitch(self) -> None:
@@ -3331,6 +3707,8 @@ class Orchestrator:
             retried_task_ids=self._retried_task_ids,
             tasks_snapshot=tasks_snapshot,
             workdir=self._workdir,
+            role_model_policy=getattr(self._spawner, "role_model_policy", None),
+            default_adapter_name=getattr(self._spawner, "default_adapter_name", None),
         )
 
     def _check_file_overlap(self, batch: list[Task]) -> bool:
@@ -3696,6 +4074,62 @@ class Orchestrator:
 
     # -- Run summary --------------------------------------------------------
 
+    def _refresh_drain_tracker(self, refreshed_tasks_by_status: dict[str, list[Task]]) -> int:
+        """Update the post-/complete drain counter against freshly-fetched tasks.
+
+        Defect 29 (2026-07-02, work/bernstein/proofs/d2/minimax/attempt-83808a8a):
+        the run-summary used to fire the moment ``open_tasks == active_agents == 0``
+        held, with no check that the post-/complete chain (task_done ->
+        ``_reap_and_cleanup_session`` -> ``_apply_janitor_verdict_action``)
+        had actually run for the just-completed tasks. On MiniMax-M2.7-highspeed
+        ~40 s child runtimes that race always lost - janitor never fired,
+        ``generate_retrospective`` was skipped because the chain never registered
+        the completion in ``_processed_done_tasks``, and no merge-to-main
+        happened before the orchestrator self-stopped.
+
+        Definition of "drained" for a single task:
+
+        * Its id is in ``self._processed_done_tasks`` (the orchestrator's
+          ``process_completed_tasks`` step has at least started the chain), AND
+        * Its session is either absent (``_find_session_for_task`` returns
+          ``None`` -- the agent never had a worktree, or it was cleaned up)
+          or its session.status == ``"dead"`` (the reap step inside
+          ``_reap_and_cleanup_session`` transitioned it).
+
+        The function returns the current pending count after the refresh.
+
+        Args:
+            refreshed_tasks_by_status: Latest task buckets from the refetch
+                inside the step 8b block.
+
+        Returns:
+            The number of tasks whose post-/complete chain has NOT yet drained.
+        """
+        terminal_ids: set[str] = set()
+        for bucket in ("done", "failed"):
+            terminal_ids.update(t.id for t in refreshed_tasks_by_status.get(bucket, []))
+
+        # Increment for any newly-observed terminal task.
+        for tid in terminal_ids:
+            if tid not in self._post_complete_seen_task_ids:
+                self._pending_post_complete_count += 1
+                self._post_complete_seen_task_ids.add(tid)
+
+        # Decrement for tasks whose chain has fully drained. We iterate over
+        # a snapshot because we mutate the set below.
+        for tid in list(self._post_complete_seen_task_ids):
+            if tid not in self._processed_done_tasks:
+                # process_completed_tasks hasn't started the chain for this
+                # task yet (e.g. auto-complete-by-reap happened in this tick
+                # AFTER process_completed_tasks ran). Leave the counter alone.
+                continue
+            session = self._find_session_for_task(tid)
+            if session is None or session.status == "dead":
+                self._pending_post_complete_count -= 1
+                self._post_complete_seen_task_ids.discard(tid)
+
+        return self._pending_post_complete_count
+
     def _generate_run_summary(
         self,
         done_tasks: list[Task],
@@ -3713,6 +4147,22 @@ class Orchestrator:
         collector = get_collector(self._workdir / ".sdd" / "metrics")
         total_cost = collector.get_total_cost()
         files_modified: int = sum(getattr(m, "files_modified", 0) for m in collector.task_metrics.values())
+
+        # Defect 29 firing log: every input that the run-end decision was
+        # made against, so a 2-minute diagnosis from logs alone is possible.
+        logger.info(
+            "run_summary_firing: tick=#%d tasks_completed=%d tasks_failed=%d "
+            "files_modified=%d cost_usd=%.4f wall_clock_s=%.1f "
+            "pending_post_complete=%d processed_done_tasks=%d -> action=fire_summary",
+            self._tick_count,
+            total_completed,
+            total_failed,
+            files_modified,
+            total_cost,
+            wall_clock_s,
+            self._pending_post_complete_count,
+            len(self._processed_done_tasks),
+        )
 
         task_lines: list[str] = [f"- [x] {task.title}" for task in sorted(done_tasks, key=lambda t: t.title)]
         for task in sorted(failed_tasks, key=lambda t: t.title):
@@ -3775,12 +4225,19 @@ class Orchestrator:
             duration=duration_str,
         )
 
+        # NOTE: _generate_run_summary() is invoked from the tick-level "queue
+        # looks empty" heuristic (see 8b in tick()), not true orchestrator
+        # shutdown - child tasks can still fail afterwards (janitor rejection,
+        # etc.). Mark this retrospective INTERIM; run() re-generates the
+        # FINAL retrospective, unconditionally overwriting this one, once the
+        # tick loop actually exits (see A5 stale-retrospective bug).
         generate_retrospective(
             done_tasks=done_tasks,
             failed_tasks=failed_tasks,
             collector=collector,
             runtime_dir=runtime_dir,
             run_start_ts=self._run_start_ts,
+            trigger_reason="mid-run",
         )
 
         # Auto-PR: create a GitHub PR if BERNSTEIN_AUTO_PR is set

--- a/src/bernstein/core/orchestration/orchestrator_evolve.py
+++ b/src/bernstein/core/orchestration/orchestrator_evolve.py
@@ -18,9 +18,10 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from bernstein.core.models import TaskType
+from bernstein.core.models import TaskStatus, TaskType
 from bernstein.core.orchestration.evolution import UpgradeStatus
 from bernstein.core.platform_compat import kill_process_group
+from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard
 
 if TYPE_CHECKING:
     from bernstein.core.orchestration.tick_pipeline import (
@@ -44,6 +45,19 @@ _EVOLVE_FOCUS_AREAS: list[str] = [
 
 _REPLENISH_COOLDOWN_S: float = 60.0
 _REPLENISH_MAX_TASKS: int = 5
+
+# Statuses that count as "still open" for auto-spawn dedupe purposes -- a
+# terminal task (done/closed/failed/cancelled/abandoned) shouldn't block a
+# fresh upgrade task with the same title.
+_OPEN_TASK_STATUSES = {
+    TaskStatus.PLANNED,
+    TaskStatus.OPEN,
+    TaskStatus.CLAIMED,
+    TaskStatus.IN_PROGRESS,
+    TaskStatus.WAITING_FOR_SUBTASKS,
+    TaskStatus.PENDING_APPROVAL,
+    TaskStatus.BLOCKED,
+}
 
 
 def _run_governance_step(
@@ -749,13 +763,37 @@ def run_evolution_cycle(orch: Any, result: Any) -> None:
 
 
 def _create_upgrade_tasks(orch: Any, proposals: list[Any], result: Any) -> None:
-    """Create tasks from eligible upgrade proposals."""
+    """Create tasks from eligible upgrade proposals.
+
+    Gated by AutoSpawnGuard to prevent unbounded duplicate "Upgrade: ..."
+    tasks (e.g. the same low-success-rate opportunity being re-proposed every
+    analysis cycle with no dedupe or cap -- see
+    work/agent-reports/2026-07-02-run9-attempt9-audit.md).
+    """
     _task_eligible_statuses = {UpgradeStatus.PENDING, UpgradeStatus.APPROVED}
     base = orch._config.server_url
+    guard = AutoSpawnGuard(orch._workdir)
+    latest_tasks_raw = getattr(orch, "_latest_tasks_by_id", {})
+    latest_tasks = latest_tasks_raw if isinstance(latest_tasks_raw, dict) else {}
+    existing_open_titles = [
+        task.title
+        for task in latest_tasks.values()
+        if getattr(task, "task_type", None) == TaskType.UPGRADE_PROPOSAL
+        and getattr(task, "status", None) in _OPEN_TASK_STATUSES
+    ]
     for proposal in proposals:
         if proposal.status not in _task_eligible_statuses:
             continue
         try:
+            title = f"Upgrade: {proposal.title}"
+            decision = guard.evaluate(
+                kind="upgrade_proposal",
+                title=title,
+                source_title=None,
+                existing_open_titles=existing_open_titles,
+            )
+            if not decision.allowed:
+                continue
             target_files = proposal.risk_assessment.affected_components
             diff_estimate = max(len(proposal.proposed_change) // 10, 10)
             risk_score = orch._risk_scorer.score_proposal(
@@ -765,7 +803,7 @@ def _create_upgrade_tasks(orch: Any, proposals: list[Any], result: Any) -> None:
             )
             is_high = orch._risk_scorer.is_high_risk(risk_score)
             task_body = {
-                "title": f"Upgrade: {proposal.title}",
+                "title": title,
                 "description": proposal.description,
                 "role": "backend",
                 "priority": 1 if is_high else 2,
@@ -776,6 +814,7 @@ def _create_upgrade_tasks(orch: Any, proposals: list[Any], result: Any) -> None:
             }
             resp = orch._client.post(f"{base}/tasks", json=task_body)
             resp.raise_for_status()
+            existing_open_titles.append(title)
             logger.info(
                 "Created upgrade task for proposal %s: %s (risk=%.2f)",
                 proposal.id,

--- a/src/bernstein/core/orchestration/orchestrator_summary.py
+++ b/src/bernstein/core/orchestration/orchestrator_summary.py
@@ -108,12 +108,18 @@ def generate_run_summary(
         duration=duration_str,
     )
 
+    # NOTE: this generate_run_summary() entry point fires from a tick-level
+    # "queue looks empty" heuristic, not true orchestrator shutdown - tasks
+    # spawned just before this point can still fail afterwards. Mark the
+    # retrospective INTERIM so a stale HEALTHY snapshot is never mistaken
+    # for the final report (see A5 stale-retrospective bug).
     generate_retrospective(
         done_tasks=done_tasks,
         failed_tasks=failed_tasks,
         collector=collector,
         runtime_dir=runtime_dir,
         run_start_ts=orch._run_start_ts,
+        trigger_reason="mid-run",
     )
 
     emit_summary_card(

--- a/src/bernstein/core/orchestration/stalled_manager.py
+++ b/src/bernstein/core/orchestration/stalled_manager.py
@@ -29,12 +29,16 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import operator
+import os
 import time
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from bernstein.core import defaults as _defaults
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +50,19 @@ logger = logging.getLogger(__name__)
 # race that idle-kill instead of firing before it, so this stays a few
 # seconds under it to guarantee the stalled-manager detector reports the
 # real cause first.
-STALL_THRESHOLD_S: float = 170.0
+#
+# This is only reached when ``orch._config`` is unset entirely (bare test
+# doubles) - production always carries a value via
+# ``OrchestratorConfig.stalled_manager_threshold_s``'s ``default_factory``.
+# Derived from ``core.defaults.ORCHESTRATOR`` rather than a second hardcoded
+# literal so there is exactly one authoritative default to tune.
+STALL_THRESHOLD_S: float = _defaults.ORCHESTRATOR.stalled_manager_threshold_s
+
+# Env var checked ahead of ``OrchestratorConfig.stalled_manager_threshold_s``
+# (which itself defaults from ``tuning.orchestrator.stalled_manager_threshold_s``
+# in bernstein.yaml, see core.defaults.OrchestratorDefaults). Precedence:
+# env var > yaml-tunable config field > the module constant above.
+STALL_THRESHOLD_ENV_VAR: str = "BERNSTEIN_STALL_THRESHOLD_S"
 
 # Path to the operator-facing remediation doc. A sibling effort owns the
 # actual document; if it already lives elsewhere we still emit a pointer so
@@ -82,12 +98,35 @@ class StalledManagerDiagnostic:
     remediation: str = REMEDIATION_DOC
 
     def message(self) -> str:
-        """Return the one-line operator-facing console message."""
+        """Return the one-line operator-facing console message.
+
+        ``hook_event_count`` is sourced from the hook sidecar file
+        (``.sdd/runtime/hooks/{session_id}.jsonl``), a different telemetry
+        channel from the manager's own per-session activity log. A manager
+        can be genuinely alive and working (reading files, planning) for
+        the full stall window while that sidecar still reads 0 events, so
+        ``hook_event_count == 0`` does not by itself prove the manager
+        never authenticated to the task server - only that this specific
+        channel saw nothing. Only assert an auth failure when there is
+        corroborating evidence (a nonzero hook-event count).
+        """
+        if self.hook_event_count == 0 and not self.last_bash_commands:
+            explanation = (
+                "manager active but no child tasks yet - NOT confirmed as an auth failure; "
+                "hook_event_count is a separate telemetry channel from the manager's own "
+                "activity log and can read 0 even while the manager is working. The stall "
+                "threshold may simply be too low for this codebase's decomposition time - see "
+                f"{STALL_THRESHOLD_ENV_VAR} / tuning.orchestrator.stalled_manager_threshold_s"
+            )
+        else:
+            explanation = (
+                f"this is NOT a generic server timeout - the manager likely cannot authenticate "
+                f"to the task server ({self.hook_event_count} hook event(s) recorded)"
+            )
         return (
             f"Manager session {self.session_id} ran for {self.runtime_s:.0f}s without "
             f"creating any child tasks ({self.hook_event_count} hook event(s) recorded). "
-            f"This is NOT a generic server timeout - the manager likely cannot authenticate "
-            f"to the task server. See {self.remediation} for remediation."
+            f"{explanation}. See {self.remediation} for remediation."
         )
 
     def to_record(self) -> dict[str, Any]:
@@ -234,6 +273,108 @@ def build_diagnostic(
     )
 
 
+def _is_sane_threshold(value: float) -> bool:
+    """A stall threshold must be a positive, finite number of seconds.
+
+    ``0``/negative would fire the watchdog on the very first tick after
+    spawn for every manager session. ``nan``/``inf`` would make the
+    ``runtime < threshold`` comparison in :func:`detect_stalled_manager`
+    permanently false/true, silently disabling or permanently no-op'ing the
+    watchdog with no operator-visible signal - a real risk once this value
+    can come from an operator-typable env var.
+    """
+    return math.isfinite(value) and value > 0
+
+
+def _resolve_stall_threshold_s(orch: Any) -> float:
+    """Resolve the effective stall threshold, cached once per orchestrator.
+
+    Precedence: ``BERNSTEIN_STALL_THRESHOLD_S`` env var > ``OrchestratorConfig.
+    stalled_manager_threshold_s`` (yaml-tunable via ``tuning.orchestrator.
+    stalled_manager_threshold_s``, see ``core.defaults.OrchestratorDefaults``)
+    > the ``STALL_THRESHOLD_S`` module default. An unparseable, non-positive,
+    or non-finite value at any tier falls through to the next tier with a
+    warning rather than crashing or silently disabling the watchdog.
+
+    The resolved value is cached on ``orch`` so env/config are only
+    re-parsed - and the resolution + race-check logged - once per
+    orchestrator instance, instead of on every tick for the lifetime of the
+    manager session (``detect_stalled_manager`` is called every tick while
+    the manager is alive and below threshold).
+    """
+    cached = getattr(orch, "_stalled_manager_threshold_cache", None)
+    if cached is not None:
+        return cached
+
+    resolved: float | None = None
+    raw_env = os.environ.get(STALL_THRESHOLD_ENV_VAR)
+    if raw_env is not None and raw_env.strip():
+        try:
+            env_value = float(raw_env)
+        except ValueError:
+            logger.warning(
+                "%s=%r is not a valid float; falling back to config/default stall threshold",
+                STALL_THRESHOLD_ENV_VAR,
+                raw_env,
+            )
+        else:
+            if _is_sane_threshold(env_value):
+                logger.info(
+                    "stalled_manager: threshold resolved to %.1fs from env %s=%r",
+                    env_value,
+                    STALL_THRESHOLD_ENV_VAR,
+                    raw_env,
+                )
+                resolved = env_value
+            else:
+                logger.warning(
+                    "%s=%r must be a positive, finite number of seconds; "
+                    "falling back to config/default stall threshold",
+                    STALL_THRESHOLD_ENV_VAR,
+                    raw_env,
+                )
+
+    if resolved is None:
+        config_value = getattr(getattr(orch, "_config", None), "stalled_manager_threshold_s", None)
+        if config_value is not None and _is_sane_threshold(float(config_value)):
+            resolved = float(config_value)
+        else:
+            if config_value is not None:
+                logger.warning(
+                    "tuning.orchestrator.stalled_manager_threshold_s=%r must be a positive, "
+                    "finite number of seconds; falling back to the %.1fs default",
+                    config_value,
+                    STALL_THRESHOLD_S,
+                )
+            resolved = STALL_THRESHOLD_S
+
+    # Race-check runs for every resolution path (env, config, and default),
+    # not just the config/default fallback - env is the primary way an
+    # operator raises the threshold, so it's the path that most needs this.
+    _warn_if_races_idle_kill(resolved)
+    orch._stalled_manager_threshold_cache = resolved
+    return resolved
+
+
+def _warn_if_races_idle_kill(threshold_s: float) -> None:
+    """Warn when the stall threshold has been raised past the idle-agent deadline.
+
+    ``detect_idle_agents`` (``core.agents.heartbeat``) has no call site in the
+    orchestrator tick loop today, so this is not a live race - but the two
+    deadlines' 170-vs-180s spacing is intentional, and a raised threshold
+    should still surface if that watchdog is ever wired up later.
+    """
+    idle_threshold = float(_defaults.AGENT.idle_log_age_threshold_s)
+    if threshold_s >= idle_threshold:
+        logger.warning(
+            "stalled_manager_threshold_s (%.0fs) >= AGENT.idle_log_age_threshold_s (%.0fs); "
+            "if idle-log-kill is ever wired into the tick loop it may fire before the "
+            "stalled-manager diagnostic can produce its more specific message",
+            threshold_s,
+            idle_threshold,
+        )
+
+
 def detect_stalled_manager(orch: Any) -> StalledManagerDiagnostic | None:
     """Return a diagnostic if a manager session has stalled, else ``None``.
 
@@ -255,7 +396,7 @@ def detect_stalled_manager(orch: Any) -> StalledManagerDiagnostic | None:
         return None
 
     runtime = max(now - float(getattr(session, "spawn_ts", now)), 0.0)
-    threshold = float(getattr(getattr(orch, "_config", None), "stalled_manager_threshold_s", STALL_THRESHOLD_S))
+    threshold = _resolve_stall_threshold_s(orch)
     if runtime < threshold:
         return None
 

--- a/src/bernstein/core/orchestration/watchdog.py
+++ b/src/bernstein/core/orchestration/watchdog.py
@@ -304,6 +304,14 @@ def _try_recover_safety_prompt(
         delivered = False
     outcome_event = "watchdog.recover.succeeded" if delivered else "watchdog.recover.failed"
     _emit_audit_event(audit_path, outcome_event, base_payload.copy())
+    logger.info(
+        "watchdog recovery %s: session=%s rule=%s action=%s recovery_id=%s",
+        "SUCCEEDED" if delivered else "FAILED",
+        session.session_id,
+        recovery.rule,
+        recovery.action,
+        recovery.recovery_id,
+    )
     return recovery
 
 
@@ -337,13 +345,35 @@ def tick(
 
     recoveries: list[RecoveryAction] = []
     skipped: list[str] = []
+    sessions = list(sessions)
+    paused_count = sum(1 for s in sessions if s.is_paused)
+    logger.debug(
+        "watchdog tick: probing %d session(s), %d paused",
+        len(sessions),
+        paused_count,
+    )
 
     for session in sessions:
         if not session.is_paused:
             continue
         kind = classify_prompt(session.recent_output)
+        # Every paused-session probe conclusion, logged with the classifier
+        # input (last line) and verdict -- this is the decision that
+        # determines auto-answer vs. escalate vs. no-op.
+        logger.info(
+            "watchdog probe: session=%s is_paused=True classified=%s last_line=%r approved_classes=%s",
+            session.session_id,
+            kind,
+            _last_line(session.recent_output),
+            sorted(session.approved_prompt_classes),
+        )
         if kind == "model_question":
             skipped.append(session.session_id)
+            logger.warning(
+                "watchdog: session=%s prompt classified as model_question -- "
+                "auto-answer suppressed, escalating to operator",
+                session.session_id,
+            )
             _emit_audit_event(
                 audit_path,
                 "watchdog.recover.skipped",
@@ -360,6 +390,11 @@ def tick(
         if recovery is not None:
             recoveries.append(recovery)
 
+    logger.info(
+        "watchdog tick complete: %d recoveries attempted, %d model-question escalations",
+        len(recoveries),
+        len(skipped),
+    )
     return WatchdogResult(
         recoveries=tuple(recoveries),
         skipped_model_questions=tuple(skipped),

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import glob as globmod
 import json
 import logging
+import os
 import re
 import subprocess
 import uuid
@@ -47,6 +48,172 @@ JUDGE_CONFIDENCE_THRESHOLD = 0.7  # Below this, flag for human review
 _JUDGE_RETRY_RE = re.compile(r"\[judge_retry:(\d+)\]")
 _JUDGE_TEMPLATE_PATH = _BUNDLED_TEMPLATES_DIR / "prompts" / "judge.md"
 
+# --- Attribution (item 15 + S2 family) ---
+#
+# The janitor historically judged a task purely by evaluating its completion
+# signals against the SHARED repo state. Two failure modes fell out of that
+# (proofs/d2/minimax/attempt-e938bd33 + S2 orphan family):
+#   1. Misattribution: a 0-file manager task got janitor_passed=true because a
+#      CHILD task's landed work satisfied the manager's signals, while the
+#      backend task that made the real green commit (b9574d9) was judged
+#      against the wrong repo snapshot and failed.
+#   2. Rubber-stamped orphans: crash-recovery auto-completions with an empty
+#      diff ($0 / 0 tokens, no commits) were accepted because "no failing
+#      signal" was treated as "passed".
+#
+# Fix: before accepting, attribute concrete work to THE TASK BEING JUDGED --
+# commits whose message references the task id, falling back to changed files
+# in the task's owned_files -- and REJECT any non-no-op task with an empty
+# attributed diff. Attribution inputs/outputs are logged on every verdict so
+# a future misattribution is a log read, not a proof-archive autopsy.
+
+# Task types that legitimately produce no diff (research/exploration output
+# lives in task notes, not the repo). Everything else must show work.
+_NOOP_TASK_TYPES = frozenset({TaskType.RESEARCH})
+
+_ATTRIBUTION_MAX_COMMITS = 50
+
+# Completion-signal types that constitute real evidence a task did work
+# (as opposed to a bare path_exists / glob_exists that a rubber-stamp could
+# trivially satisfy). A passing signal of one of these types lets the janitor
+# accept a task whose diff is not attributable (empty-diff warn path) instead
+# of hard-rejecting it.
+_NONTRIVIAL_SIGNAL_TYPES = frozenset({"test_passes", "file_contains", "llm_review", "llm_judge"})
+
+
+def _has_nontrivial_passing_signal(task: Task, signal_results: list[tuple[str, bool, str]]) -> bool:
+    """True if the task has at least one passing non-trivial completion signal.
+
+    ``signal_results`` entries are ``(desc, passed, detail)`` where ``desc`` is
+    ``f"{signal.type}: {signal.value}"`` (see :func:`_collect_signal_results`),
+    so the type is the text before the first ``": "``. A passing signal of a
+    :data:`_NONTRIVIAL_SIGNAL_TYPES` type is treated as evidence real work
+    happened, which lets an unattributable-diff task be accepted with a warning
+    rather than hard-rejected.
+    """
+    for desc, passed, _detail in signal_results:
+        if not passed:
+            continue
+        signal_type = desc.split(":", 1)[0].strip()
+        if signal_type in _NONTRIVIAL_SIGNAL_TYPES:
+            return True
+    return False
+
+
+def _is_git_repo(workdir: Path) -> bool:
+    """True when *workdir* is inside a git work tree (attribution possible)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("janitor attribution: git repo detection failed in %s: %s", workdir, exc)
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _attribute_task_work(task: Task, workdir: Path) -> tuple[list[str], list[str], str]:
+    """Attribute concrete repo work to *the task being judged*.
+
+    Resolution order (each step logged):
+      1. Commits on HEAD whose message contains the task id (fixed-string
+         ``git log --grep``) -- the strongest signal that a commit belongs to
+         this task. Changed files are the union across those commits.
+      2. Fallback: files changed in the last commit, restricted to the
+         task's ``owned_files`` when set. This is explicitly weaker (it can
+         see another task's landing commit) and the returned reason says so.
+
+    Args:
+        task: The task under judgment.
+        workdir: Project root (must already be a verified git repo).
+
+    Returns:
+        Tuple of (attributed commit shas, attributed changed files, human
+        reason describing HOW attribution was decided).
+    """
+    try:
+        log_result = subprocess.run(
+            [
+                "git",
+                "log",
+                f"--max-count={_ATTRIBUTION_MAX_COMMITS}",
+                "--format=%H",
+                "--fixed-strings",
+                f"--grep={task.id}",
+            ],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("janitor attribution: git log --grep failed for task=%s: %s", task.id, exc)
+        log_result = None
+
+    if log_result is not None and log_result.returncode == 0:
+        commits = [line.strip() for line in log_result.stdout.splitlines() if line.strip()]
+        if commits:
+            files: list[str] = []
+            for sha in commits:
+                try:
+                    show = subprocess.run(
+                        ["git", "show", "--name-only", "--format=", sha],
+                        cwd=workdir,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                except (subprocess.TimeoutExpired, OSError) as exc:
+                    logger.warning("janitor attribution: git show %s failed: %s", sha, exc)
+                    continue
+                if show.returncode == 0:
+                    files.extend(line.strip() for line in show.stdout.splitlines() if line.strip())
+            unique_files = sorted(set(files))
+            reason = (
+                f"commit-message match: {len(commits)} commit(s) reference task id {task.id!r} "
+                f"({[c[:12] for c in commits]}), {len(unique_files)} changed file(s)"
+            )
+            return commits, unique_files, reason
+
+    # Fallback: last-commit diff scoped to owned_files. Weaker attribution --
+    # says the repo moved in this task's file territory, not that THIS task
+    # moved it. WITHOUT owned_files there is no territory to scope to: an
+    # unscoped last-commit diff would attribute ANOTHER task's landing commit
+    # to this one (exactly the archived manager rubber-stamp), so we
+    # deliberately attribute nothing in that case.
+    if not task.owned_files:
+        return (
+            [],
+            [],
+            f"no commit references task id {task.id!r} and task has no owned_files -- "
+            "nothing attributable to this task (unscoped last-commit diff would "
+            "misattribute another task's work)",
+        )
+    cmd = ["git", "diff", "HEAD~1", "--name-only", "--", *task.owned_files]
+    try:
+        diff_result = subprocess.run(
+            cmd,
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("janitor attribution: fallback diff failed for task=%s: %s", task.id, exc)
+        return [], [], f"attribution failed: no task-id commits and fallback diff errored ({exc})"
+
+    files = [line.strip() for line in diff_result.stdout.splitlines() if line.strip()]
+    scope = f"owned_files={task.owned_files}" if task.owned_files else "all files (no owned_files)"
+    reason = (
+        f"fallback last-commit diff over {scope}: {len(files)} changed file(s); "
+        f"NO commit references task id {task.id!r} -- weak attribution"
+    )
+    return [], sorted(set(files)), reason
+
 
 def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]:
     """Evaluate a single completion signal against the filesystem.
@@ -60,13 +227,13 @@ def evaluate_signal(signal: CompletionSignal, workdir: Path) -> tuple[bool, str]
     """
     match signal.type:
         case "path_exists":
-            ok = _check_path_exists(signal.value, workdir)
-            return ok, "exists" if ok else "not found"
+            return _check_path_exists(signal.value, workdir)
         case "glob_exists":
             ok = _check_glob_exists(signal.value, workdir)
             return ok, "matched" if ok else "no matches"
         case "test_passes":
-            ok = _check_test_passes(signal.value, workdir)
+            command = _resolve_branch_check_command(signal.value, workdir)
+            ok = _check_test_passes(command, workdir)
             return ok, "exit 0" if ok else "non-zero exit"
         case "file_contains":
             ok = _check_file_contains(signal.value, workdir)
@@ -322,6 +489,10 @@ async def run_janitor(
     """
     _guardrails = guardrails_config if guardrails_config is not None else GuardrailsConfig()
     _bypass_guardrails = permission_mode == "bypass"
+    # Attribution needs a git repo; detect once per janitor pass. Non-git
+    # workdirs (unit tests, dry runs) skip the empty-diff guard entirely --
+    # signals-only judgment there is unchanged behavior.
+    _attribution_possible = _is_git_repo(workdir)
     results: list[JanitorResult] = []
     for task in tasks:
         if not task.completion_signals:
@@ -340,7 +511,65 @@ async def run_janitor(
             all_passed = all(passed for _, passed, _ in signal_results)
             failed_descs = [desc for desc, passed, _ in signal_results if not passed]
 
-        diff = _get_git_diff(task, workdir)
+        # Empty-diff guard + attribution (item 15 / S2): a non-no-op task
+        # with zero attributable changed files must NOT pass -- catches both
+        # the 0-file manager rubber-stamp and crash-recovery orphan
+        # auto-completions with no diff.
+        attributed_commits: list[str] = []
+        attributed_files: list[str] = []
+        attribution_reason = "attribution skipped: workdir is not a git repo"
+        if _attribution_possible:
+            attributed_commits, attributed_files, attribution_reason = _attribute_task_work(task, workdir)
+            logger.info(
+                "janitor attribution: task=%s commits=%s files=%s reason=%s",
+                task.id,
+                [c[:12] for c in attributed_commits],
+                attributed_files,
+                attribution_reason,
+            )
+            if not attributed_files and task.task_type not in _NOOP_TASK_TYPES:
+                # An empty attributable diff normally means a 0-file
+                # rubber-stamp or a crash-recovery orphan auto-completion and
+                # must be rejected. BUT a task can legitimately land real work
+                # in a commit whose message omits the task id and which carries
+                # no owned_files (attribution then returns empty even though
+                # work happened). To avoid false-rejecting such a real
+                # completion, only hard-reject when the task has NOT already
+                # proven work via a non-trivial passing signal (a passing
+                # test_passes / file_contains / llm_review / llm_judge). When
+                # such proof exists and all signals passed, downgrade to a
+                # warn-and-flag for review instead of failing the task.
+                has_nontrivial_pass = all_passed and _has_nontrivial_passing_signal(task, signal_results)
+                if has_nontrivial_pass:
+                    warn_detail = f"empty diff but non-trivial completion signals passed: {attribution_reason}"
+                    signal_results.append(("attribution:empty_diff_warn", True, warn_detail))
+                    logger.warning(
+                        "janitor WARN (empty diff, flagged for review): task=%s task_type=%s -- no "
+                        "changed files attributable to this task (attribution: %s), but non-trivial "
+                        "completion signals passed, so accepting rather than rejecting; stamp the "
+                        "task id into the landing commit or set owned_files to make attribution "
+                        "explicit",
+                        task.id,
+                        task.task_type.value,
+                        attribution_reason,
+                    )
+                else:
+                    all_passed = False
+                    empty_diff_detail = f"empty diff: {attribution_reason}"
+                    signal_results.append(("attribution:empty_diff", False, empty_diff_detail))
+                    failed_descs.append(f"attribution:empty_diff: {empty_diff_detail}")
+                    logger.warning(
+                        "janitor REJECT (empty diff): task=%s task_type=%s -- no changed files "
+                        "attributable to this task (attribution: %s); a task with zero changed "
+                        "files must not be accepted unless it is an explicit no-op task type %s "
+                        "or it has a non-trivial passing completion signal",
+                        task.id,
+                        task.task_type.value,
+                        attribution_reason,
+                        sorted(t.value for t in _NOOP_TASK_TYPES),
+                    )
+
+        diff = _get_git_diff(task, workdir, attributed_commits=attributed_commits)
         guardrail_results: list[GuardrailResult] = run_guardrails(
             diff,
             task,
@@ -355,6 +584,11 @@ async def run_janitor(
             for gr in blocked_guards:
                 signal_results.append((f"guardrail:{gr.check}", False, gr.detail))
                 failed_descs.append(f"guardrail:{gr.check}: {gr.detail}")
+            logger.warning(
+                "janitor REJECT (guardrail): task=%s blocked_checks=%s",
+                task.id,
+                [(gr.check, gr.detail) for gr in blocked_guards],
+            )
 
         fix_task_ids = await _create_fix_tasks_if_needed(
             task,
@@ -364,6 +598,31 @@ async def run_janitor(
             server_url,
             workdir,
         )
+
+        # Single-line accept/reject decision with WHY -- inputs (signal
+        # results) and the verdict, so the janitor's per-task disposition is
+        # visible from the log alone without cross-referencing JanitorResult.
+        if all_passed:
+            logger.info(
+                "janitor ACCEPT: task=%s signals=%s attributed_commits=%s attributed_files=%s attribution=%s",
+                task.id,
+                [(desc, ok) for desc, ok, _ in signal_results],
+                [c[:12] for c in attributed_commits],
+                attributed_files,
+                attribution_reason,
+            )
+        else:
+            logger.warning(
+                "janitor REJECT: task=%s failed_signals=%s fix_tasks_created=%s judge_verdict=%s "
+                "attributed_commits=%s attributed_files=%s attribution=%s",
+                task.id,
+                failed_descs,
+                fix_task_ids,
+                judge_verdict.verdict if judge_verdict else None,
+                [c[:12] for c in attributed_commits],
+                attributed_files,
+                attribution_reason,
+            )
 
         results.append(
             JanitorResult(
@@ -484,12 +743,25 @@ def _get_judge_retry_count(task: Task) -> int:
     return int(match.group(1)) if match else 0
 
 
-def _get_git_diff(task: Task, workdir: Path) -> str:
-    """Get git diff for the task's owned files, truncated for cost control."""
+def _get_git_diff(task: Task, workdir: Path, *, attributed_commits: list[str] | None = None) -> str:
+    """Get git diff for the task's work, truncated for cost control.
+
+    When *attributed_commits* is provided (commits whose message references
+    the task id), the diff is the content of exactly those commits -- the
+    work belonging to THE TASK BEING JUDGED. Otherwise falls back to the
+    historical behavior (last-commit diff over owned_files), which can show
+    another task's landing commit and is only used when no attribution
+    exists.
+    """
     try:
-        cmd = ["git", "diff", "HEAD~1", "--"]
-        if task.owned_files:
-            cmd.extend(task.owned_files)
+        if attributed_commits:
+            # The commits themselves are already attributed to this task --
+            # no owned_files path filter, their full content IS the work.
+            cmd = ["git", "show", "--format=", *attributed_commits]
+        else:
+            cmd = ["git", "diff", "HEAD~1", "--"]
+            if task.owned_files:
+                cmd.extend(task.owned_files)
         result = subprocess.run(
             cmd,
             cwd=workdir,
@@ -719,9 +991,135 @@ def _resolve(path_str: str, workdir: Path) -> Path:
     return workdir / p
 
 
-def _check_path_exists(path_str: str, workdir: Path) -> bool:
-    """Check if a file or directory exists."""
-    return _resolve(path_str, workdir).exists()
+_GLOB_CHARS = frozenset("*?[")
+
+
+def _fuzzy_paths_enabled() -> bool:
+    """Whether the OPT-IN fuzzy basename fallback for ``path_exists`` is active.
+
+    Issue #2186: manager decompositions guess exact file paths at planning
+    time (e.g. ``packages/db/test/seed-workers.test.ts``), before any code
+    exists. Workers legitimately place files at repo-idiomatic paths (e.g.
+    ``packages/db/src/__tests__/seed-workers-demo-link.test.ts``). A literal
+    miss then fails the janitor, drains the retry/error budget, and can
+    trip a sev1 orchestration pause even though the work was done correctly.
+
+    Default OFF: exact-path matching is the contract operators rely on --
+    "the check means exactly the path I wrote." Set
+    ``BERNSTEIN_JANITOR_FUZZY_PATHS=1`` to opt in to the fuzzy basename
+    fallback for runs where the manager's decomposition guesses paths.
+    Explicit glob syntax in the criterion itself (``*``, ``?``, ``[``) is
+    honored regardless of this flag -- that's opt-in per-check by
+    construction.
+    """
+    raw = os.environ.get("BERNSTEIN_JANITOR_FUZZY_PATHS", "0").strip().lower()
+    enabled = raw in {"1", "true", "yes", "on"}
+    if raw not in {"0", "1", "false", "true", "no", "yes", "off", "on"}:
+        logger.warning(
+            "BERNSTEIN_JANITOR_FUZZY_PATHS=%r not recognized; fuzzy path matching stays disabled",
+            raw,
+        )
+    return enabled
+
+
+def _check_path_exists(path_str: str, workdir: Path) -> tuple[bool, str]:
+    """Check if a file or directory exists.
+
+    Matching is conservative (issue #2186):
+      1. Literal path, resolved against ``workdir`` -- the default and
+         only out-of-the-box behavior, unchanged: the check means exactly
+         the path the plan author wrote.
+      2. If the literal path does NOT exist AND the criterion contains
+         explicit glob syntax (``*``/``?``/``[``), it is evaluated as a glob
+         pattern. Literal semantics take precedence: a literal path that
+         happens to contain a metacharacter (e.g. a Next.js dynamic-route
+         file ``app/users/[id]/page.tsx`` or a fixture ``foo[1].json``) is
+         matched literally first and is never silently reinterpreted as a
+         glob when it exists on disk.
+      3. OPT-IN fuzzy fallback (``BERNSTEIN_JANITOR_FUZZY_PATHS=1``,
+         default off): on a literal miss, try a pattern derived from the
+         basename (``**/<stem>*<suffix>``) to tolerate a manager guessing
+         the wrong directory convention (e.g. ``test/`` vs
+         ``src/__tests__/``) for a file the worker did create. When it
+         fires, a WARNING log names the literal miss, the pattern, and the
+         path that satisfied the check.
+
+    Returns:
+        (passed, detail). ``detail`` is "exists"/"not found" for the
+        literal case (unchanged wire format) and a longer message
+        identifying the matched path when a glob or fuzzy match passed.
+    """
+    has_glob_syntax = any(c in _GLOB_CHARS for c in path_str)
+
+    # Literal-first: a literal path always wins, even when it contains a glob
+    # metacharacter. This preserves literal-path semantics for real files like
+    # ``app/users/[id]/page.tsx`` or ``foo[1].json`` so they are never silently
+    # reinterpreted as a glob when they exist on disk.
+    literal = _resolve(path_str, workdir)
+    if literal.exists():
+        return True, "exists"
+
+    if has_glob_syntax:
+        # Literal miss AND the criterion contains explicit glob syntax: honor
+        # it as a glob pattern (opt-in per-check by construction).
+        glob_pattern = str(workdir / path_str)
+        glob_matches = sorted(globmod.glob(glob_pattern, recursive=True))
+        if glob_matches:
+            matched = glob_matches[0]
+            logger.info(
+                "janitor path_exists: glob pattern %r matched %r",
+                path_str,
+                matched,
+            )
+            return True, f"exists: glob pattern matched {matched}"
+        logger.info(
+            "janitor path_exists: glob pattern %r matched nothing under %s",
+            path_str,
+            workdir,
+        )
+        return False, "not found"
+
+    if not _fuzzy_paths_enabled():
+        return False, "not found"
+
+    # Opt-in fuzzy basename fallback. Split the basename on the FIRST dot,
+    # not the last: multi-part suffixes like ".test.ts" / ".spec.tsx" are
+    # common in this exact scenario (a manager guessing
+    # "seed-workers.test.ts" vs. a worker naming it
+    # "seed-workers-demo-link.test.ts") and Path.stem/.suffix would only
+    # peel off ".ts", leaving ".test" glued onto a stem that then fails to
+    # prefix-match the worker's actual filename.
+    name = Path(path_str).name
+    name_parts = name.split(".", 1)
+    stem = name_parts[0]
+    suffix = f".{name_parts[1]}" if len(name_parts) > 1 else ""
+    if not stem:
+        logger.info(
+            "janitor path_exists: literal miss for %r and no basename to fuzzy-match",
+            path_str,
+        )
+        return False, "not found"
+    fuzzy_pattern = f"**/{stem}*{suffix}" if suffix else f"**/{stem}*"
+    full_fuzzy_pattern = str(workdir / fuzzy_pattern)
+    fuzzy_matches = sorted(globmod.glob(full_fuzzy_pattern, recursive=True))
+    if fuzzy_matches:
+        matched = fuzzy_matches[0]
+        logger.warning(
+            "janitor path_exists: FUZZY MATCH (BERNSTEIN_JANITOR_FUZZY_PATHS=1): "
+            "literal path %r not found; fuzzy pattern %r matched %r -- "
+            "the check passed on a fuzzy match, not the exact path written in the plan",
+            path_str,
+            fuzzy_pattern,
+            matched,
+        )
+        return True, f"exists via fuzzy fallback: matched {matched} (basename pattern: {fuzzy_pattern})"
+
+    logger.info(
+        "janitor path_exists: no match for %r (tried literal and fuzzy %r; fuzzy matching enabled)",
+        path_str,
+        fuzzy_pattern,
+    )
+    return False, "not found"
 
 
 def _check_glob_exists(pattern: str, workdir: Path) -> bool:
@@ -729,6 +1127,186 @@ def _check_glob_exists(pattern: str, workdir: Path) -> bool:
     full_pattern = str(workdir / pattern)
     matches = globmod.glob(full_pattern, recursive=True)
     return len(matches) > 0
+
+
+# --- bug 12: janitor branch-check acceptance signals vs actual pushed branch ---
+#
+# Task acceptance signals of type ``test_passes`` are sometimes generated as
+# git branch/commit checks, e.g. ``git rev-parse --verify fix-905-x`` or
+# ``git log -1 --format=%s fix-905-x | grep -q '#905'``. The branch name
+# baked into the signal comes from a slugifier at task-generation time
+# (hyphen-separated), while the agent that actually does the work is free to
+# choose its own branch name and conventionally uses a slash after the type
+# prefix (``fix/905-x``, ``feat/905-x``). When the two diverge, the literal
+# shell command fails even though the agent's work (including the pushed
+# branch and PR) is real -- bernstein records its own success as a failure
+# and DLQs the task. See work/agent-reports/2026-07-02-run9-attempt9-audit.md
+# (task d56c18f2fc08): expected ``fix-905-demo-worker-record`` (hyphens),
+# agent pushed ``fix/905-demo-worker-record`` (slash); PR #965 was open and
+# real the entire time.
+#
+# Fix: for git branch/commit-check commands, resolve the referenced token
+# against branches that actually exist (local + remote-tracking), tolerant
+# of slash-vs-hyphen drift, and rewrite the command to the ref that was
+# actually found before running it. Every resolution attempt is logged at
+# INFO with the expected ref(s), the branches actually found, and the
+# verdict + reason, so a future mismatch is a log read, not a DLQ mystery.
+
+_GIT_REF_CHECK_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^\s*git\s+rev-parse\s+--verify\s"),
+    re.compile(r"^\s*git\s+log\s+-1\b"),
+)
+
+# Well-known refs that are never task-specific branch names -- never rewrite
+# these even if they happen to appear as the trailing bare token.
+_SPECIAL_REFS = {"HEAD", "head", "main", "master", "trunk", "develop", "@"}
+
+
+def _extract_branch_ref(command: str) -> str | None:
+    """Best-effort extraction of a branch/ref token from a git test_passes command.
+
+    Only fires for the two acceptance-signal shapes bernstein's task
+    generator emits to verify a task pushed a branch: ``git rev-parse
+    --verify <ref>`` and ``git log -1 ... <ref> | ...``. The ref is taken as
+    the last whitespace-separated, non-flag token in the segment before any
+    pipe (flags like ``--format=%s`` are excluded because they start with
+    ``-``).
+
+    Args:
+        command: The raw ``test_passes`` shell command.
+
+    Returns:
+        The extracted ref, or None if the command doesn't look like a
+        branch/commit check, or the trailing token is a well-known special
+        ref (HEAD/main/master/...) rather than a task-specific branch name.
+    """
+    if not any(pattern.match(command) for pattern in _GIT_REF_CHECK_PATTERNS):
+        return None
+    first_segment = command.split("|", 1)[0]
+    tokens = first_segment.split()
+    candidates = [tok for tok in tokens[2:] if tok and not tok.startswith("-")]
+    if not candidates:
+        return None
+    ref = candidates[-1]
+    if ref in _SPECIAL_REFS:
+        return None
+    return ref
+
+
+def _list_git_branches(workdir: Path) -> list[str]:
+    """Return every local and remote-tracking branch name visible in *workdir*."""
+    try:
+        result = subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname:short)", "refs/heads/", "refs/remotes/"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("janitor: git for-each-ref failed in %s: %s", workdir, exc)
+        return []
+    if result.returncode != 0:
+        logger.warning(
+            "janitor: git for-each-ref exited %s in %s: %s",
+            result.returncode,
+            workdir,
+            result.stderr.strip(),
+        )
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _normalize_branch_token(name: str) -> str:
+    """Collapse ``/`` to ``-`` so slash- and hyphen-style branch names compare equal."""
+    return name.replace("/", "-")
+
+
+def _resolve_branch_ref(expected: str, workdir: Path) -> tuple[str | None, list[str]]:
+    """Resolve *expected* against the branches that actually exist in *workdir*.
+
+    Tries, in order: exact local/remote-tracking match, ``origin/<expected>``,
+    then a slash-vs-hyphen-normalized fuzzy match against every branch found
+    (this is what recovers bug 12: signal expects ``fix-905-x``, agent pushed
+    ``fix/905-x``).
+
+    Args:
+        expected: The branch/ref token pulled from the acceptance command.
+        workdir: Project root to inspect for branches.
+
+    Returns:
+        Tuple of (resolved ref name or None if nothing matched, the full
+        list of branches found -- for logging).
+    """
+    branches = _list_git_branches(workdir)
+    if expected in branches:
+        return expected, branches
+    remote_exact = f"origin/{expected}"
+    if remote_exact in branches:
+        return remote_exact, branches
+    target_norm = _normalize_branch_token(expected)
+    for branch in branches:
+        bare = branch.split("/", 1)[1] if branch.startswith("origin/") else branch
+        if _normalize_branch_token(bare) == target_norm:
+            return branch, branches
+    return None, branches
+
+
+def _resolve_branch_check_command(command: str, workdir: Path) -> str:
+    """Rewrite a branch-check ``test_passes`` command to the ref that actually exists.
+
+    No-op for commands that aren't recognized branch/commit checks. For
+    recognized checks, logs the expected ref, every branch found in
+    *workdir*, and the verdict (exact match / rewritten / not found) before
+    returning the (possibly rewritten) command for execution.
+
+    Args:
+        command: The raw ``test_passes`` shell command from the completion signal.
+        workdir: Project root the command will run in.
+
+    Returns:
+        The original command, or the same command with the expected ref
+        token replaced by the actually-existing branch name.
+    """
+    expected = _extract_branch_ref(command)
+    if expected is None:
+        return command
+
+    resolved, branches = _resolve_branch_ref(expected, workdir)
+
+    if resolved == expected:
+        logger.info(
+            "janitor acceptance check: branch ref %r matched exactly in %s "
+            "(branches found: %s) - verdict: PASS-eligible, running command as-is",
+            expected,
+            workdir,
+            branches,
+        )
+        return command
+
+    if resolved is not None:
+        logger.info(
+            "janitor acceptance check: branch ref %r not found verbatim, but "
+            "%r matched under slash/hyphen normalization in %s (branches "
+            "found: %s) - verdict: rewriting command to use the "
+            "actually-pushed ref (bug 12: hyphen-vs-slash naming drift "
+            "between task generation and agent-side branch naming)",
+            expected,
+            resolved,
+            workdir,
+            branches,
+        )
+        return command.replace(expected, resolved, 1)
+
+    logger.info(
+        "janitor acceptance check: branch ref %r not found (exact, "
+        "origin/-prefixed, or slash/hyphen variant) in %s (branches found: "
+        "%s) - verdict: will FAIL, running original command for an honest error",
+        expected,
+        workdir,
+        branches,
+    )
+    return command
 
 
 def _check_test_passes(command: str, workdir: Path) -> bool:
@@ -752,8 +1330,31 @@ def _check_test_passes(command: str, workdir: Path) -> bool:
             capture_output=True,
             timeout=120,
         )
+        if result.returncode != 0:
+            logger.info(
+                "janitor test_passes FAIL: command=%r cwd=%s exit=%d stderr=%s stdout=%s",
+                command,
+                workdir,
+                result.returncode,
+                result.stderr.decode("utf-8", errors="replace")[-2000:],
+                result.stdout.decode("utf-8", errors="replace")[-2000:],
+            )
         return result.returncode == 0
-    except (subprocess.TimeoutExpired, OSError):
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "janitor test_passes TIMEOUT: command=%r cwd=%s timeout=120s exc=%s",
+            command,
+            workdir,
+            exc,
+        )
+        return False
+    except OSError as exc:
+        logger.warning(
+            "janitor test_passes ERROR: command=%r cwd=%s exc=%s",
+            command,
+            workdir,
+            exc,
+        )
         return False
 
 

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -13,12 +13,90 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from bernstein.core.models import Complexity, Task
+from bernstein.core.models import Complexity, Task, TaskStatus
 
 if TYPE_CHECKING:
     from bernstein.core.metrics import MetricsCollector, TaskMetrics
 
 logger = logging.getLogger(__name__)
+
+
+def _read_persisted_task_costs(runtime_dir: Path) -> dict[str, float]:
+    """Read per-task cost_usd from the durable ``.sdd/metrics/tasks.jsonl`` sidecar.
+
+    This file is appended to by the evolution aggregator's
+    ``record_task_completion()`` call, which fires from BOTH the normal
+    janitor-verified completion path AND the orphan/auto-completed-after-
+    death path (agent_lifecycle.py ``handle_orphaned_task`` ->
+    ``orch._evolution.record_task_completion(...)``). It is therefore a
+    more durable record of "what cost actually happened" than the
+    in-memory ``MetricsCollector`` passed into this function: the collector
+    reflects only what has been folded in by the moment THIS call fires,
+    while the jsonl file reflects everything persisted to disk up to now
+    regardless of whether this retrospective call runs in the same process
+    tick as the fold-in, a later tick, or (in principle) a separate process
+    reading .sdd/ off disk.
+
+    Ground truth (2026-07-03, D2 minimax attempt-e938bd33): a mid-run
+    retrospective fired at 01:55:26 and correctly reported $0.0174 from 3
+    task rows -- that was an accurate snapshot AT THAT MOMENT. Two more
+    orphan-cost fold-ins landed at 01:56:21 and 01:57:15 (+$0.009627,
+    +$0.010522), but the run's "shutdown-final" regeneration never fired
+    again afterward (that gap is an orchestrator.py shutdown-sequencing
+    issue, out of this module's ownership), so the stale $0.0174 INTERIM
+    retrospective was the last one ever written even though
+    .sdd/metrics/tasks.jsonl on disk had the complete $0.0375 across 5
+    rows. Cross-checking against the persisted file here means that ANY
+    future retrospective generation -- whenever it happens to fire --
+    reports the fullest picture available on disk at that instant, rather
+    than being limited to whatever the in-memory collector had folded in
+    by that exact tick.
+
+    Args:
+        runtime_dir: The ``.sdd/runtime`` directory passed to
+            :func:`generate_retrospective`. The metrics sidecar lives at
+            the sibling path ``.sdd/metrics/tasks.jsonl``.
+
+    Returns:
+        Mapping of task_id -> most-recently-written cost_usd for that
+        task_id (last write wins, so a retried task's final recorded cost
+        is used rather than double-counting each attempt).
+    """
+    metrics_path = runtime_dir.parent / "metrics" / "tasks.jsonl"
+    costs: dict[str, float] = {}
+    if not metrics_path.exists():
+        logger.debug(
+            "cost_aggregation: persisted sidecar not found at %s -- skipping durable cross-check",
+            metrics_path,
+        )
+        return costs
+    try:
+        with metrics_path.open() as f:
+            for line_no, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "cost_aggregation: skipping malformed line %d in %s: %s",
+                        line_no,
+                        metrics_path,
+                        exc,
+                    )
+                    continue
+                task_id = record.get("task_id")
+                if not task_id:
+                    continue
+                cost_usd = record.get("cost_usd")
+                if cost_usd is None:
+                    continue
+                costs[task_id] = float(cost_usd)  # last write wins (final retry outcome)
+    except OSError as exc:
+        logger.warning("cost_aggregation: failed to read %s: %s", metrics_path, exc)
+        return {}
+    return costs
 
 
 def _count_by_field(tasks: list[Task], field: str) -> dict[str, int]:
@@ -29,6 +107,255 @@ def _count_by_field(tasks: list[Task], field: str) -> dict[str, int]:
         key = val.value if hasattr(val, "value") else str(val)
         counts[key] += 1
     return counts
+
+
+# ---------------------------------------------------------------------------
+# Run-health honesty
+# ---------------------------------------------------------------------------
+#
+# Bug: a run could be reported "healthy" (completion_rate high, 0
+# recommendations, "No issues detected; run looks healthy.") even when
+# almost every task's terminal state was FORCED by watchdog/timeout/janitor
+# machinery rather than an agent genuinely finishing its own work. Ground
+# truth: 2026-07-02 run9-attempt9 - 21 spawns / 19 merge refusals / 746
+# SHUTDOWN(no_heartbeat) signals in 40 minutes, driven by a heartbeat-dir
+# bug (see work/agent-reports/2026-07-02-run9-attempt9-audit.md) - and
+# nothing in the retrospective would have surfaced this as unhealthy.
+#
+# There is NO dedicated "who/what terminated this task" field on ``Task``
+# today. ``Task.terminal_reason`` (bernstein/core/tasks/models.py:422) is a
+# narrow categorical field written only for a handful of agent-reported
+# outcomes (see the match statement in
+# bernstein/core/tasks/task_lifecycle.py:342, values like
+# "error_max_turns" / "error_max_budget_usd" / "model_error" /
+# "blocking_limit") - it is never populated for orchestrator-forced kills.
+#
+# The actual forcing-reason text for orchestrator-forced kills DOES exist,
+# but only as free-text written into ``Task.result_summary`` at the call
+# sites that force a termination:
+#   - watchdog/heartbeat kill: "Agent {id} reaped (heartbeat timeout)"
+#     (bernstein/core/agents/agent_lifecycle.py:_reap_heartbeat_timeout,
+#     ~line 1567)
+#   - janitor rejection: "Agent {id} died; janitor failed: {signals}"
+#     (bernstein/core/agents/agent_lifecycle.py:handle_orphaned_task,
+#     ~line 1208)
+#   - retry-budget exhaustion / DLQ: "Max retries exceeded: {reason}"
+#     (bernstein/core/tasks/task_lifecycle.py:retry_or_fail_task, ~line 819)
+#   - orphaned-with-no-signal death: "Agent {id} died; no completion
+#     signals and no files modified" (agent_lifecycle.py:_handle_orphan_no_signals)
+#   - auto-completion inferred (not agent-reported) after the agent process
+#     already died: "Auto-completed ..." / "... after agent {id} died"
+#     (agent_lifecycle.py:handle_orphaned_task /
+#     _handle_orphan_no_signals)
+#
+# Rather than inventing a new field that every one of those call sites
+# would need to start writing (out of scope for this fix, and those call
+# sites are owned by other concurrently-edited branches per the wave plan
+# collision rules), this module derives a best-effort terminator category
+# by keyword-matching the EXISTING ``result_summary`` / ``terminal_reason``
+# text. This is a proxy, not ground truth: if the free-text wording at any
+# of the call sites above changes, these markers must be updated too.
+_WATCHDOG_MARKERS: tuple[str, ...] = ("heartbeat timeout", "reaped (heartbeat", "reaped stale agent")
+_JANITOR_MARKERS: tuple[str, ...] = ("janitor failed", "janitor rejected", "janitor:")
+_TIMEOUT_MARKERS: tuple[str, ...] = ("wall-clock", "exceeded timeout", "timeout)", "max turns", "max_turns")
+_AUTO_COMPLETED_MARKERS: tuple[str, ...] = ("auto-completed", "after agent")
+_FORCED_OTHER_MARKERS: tuple[str, ...] = (
+    "max retries exceeded",
+    "died; no completion signals",
+    "died; escalating",
+    "sibling_aborted",
+    "parent_aborted",
+    "shutdown_signal",
+    "kill_requested",
+)
+
+# Categories, in the priority order they are matched (most-specific first).
+TERMINATOR_WATCHDOG_KILLED = "watchdog_killed"
+TERMINATOR_JANITOR_REJECTED = "janitor_rejected"
+TERMINATOR_TIMEOUT_KILLED = "timeout_killed"
+TERMINATOR_OTHER_FORCED = "other_forced"
+TERMINATOR_AUTO_COMPLETED_AFTER_DEATH = "auto_completed_after_death"
+TERMINATOR_AGENT_COMPLETED = "agent_completed"
+# A task whose terminal status is FAILED but whose result_summary/
+# terminal_reason text did not match any of the forced-kill marker sets
+# above (e.g. a provider error surfaced directly, a non-retryable API
+# failure). Bug this closes: such a task used to fall through to the
+# TERMINATOR_AGENT_COMPLETED default -- a FAILED task counted as a genuine
+# completion -- which let compute_run_health's non-agent-fraction check
+# miss it entirely. Ground truth: 2026-07-02 D2 openrouter leg
+# (work/bernstein/proofs/d2/openrouter/KILL-NOTE.md) -- 1/1 tasks failed
+# (deepseek max_tokens context-length BadRequestError, no forced-kill
+# keyword anywhere in the text) and the retrospective still printed
+# "Verdict: HEALTHY" / "Agent-completed: 1".
+TERMINATOR_AGENT_REPORTED_FAILURE = "agent_reported_failure"
+
+# Categories that do NOT represent a genuine agent-reported outcome. A run
+# where most terminations fall in this set is not "healthy" no matter how
+# high the raw completion_rate looks.
+_NON_AGENT_CATEGORIES: frozenset[str] = frozenset(
+    {
+        TERMINATOR_WATCHDOG_KILLED,
+        TERMINATOR_JANITOR_REJECTED,
+        TERMINATOR_TIMEOUT_KILLED,
+        TERMINATOR_OTHER_FORCED,
+        TERMINATOR_AUTO_COMPLETED_AFTER_DEATH,
+        TERMINATOR_AGENT_REPORTED_FAILURE,
+    }
+)
+
+# A run is UNHEALTHY when more than this fraction of task terminations were
+# non-agent-caused (watchdog/timeout/janitor/other-forced/auto-completed).
+_UNHEALTHY_NON_AGENT_FRACTION = 0.5
+
+
+def classify_task_terminator(task: Task) -> str:
+    """Classify how a task's terminal state was reached.
+
+    Best-effort proxy derived from ``task.result_summary`` /
+    ``task.terminal_reason`` free text - see the module-level comment
+    above for exactly what is and is not tracked today. Returns one of
+    the ``TERMINATOR_*`` constants.
+    """
+    text = f"{task.result_summary or ''} {task.terminal_reason or ''}".lower()
+    if any(m in text for m in _WATCHDOG_MARKERS):
+        return TERMINATOR_WATCHDOG_KILLED
+    if any(m in text for m in _JANITOR_MARKERS):
+        return TERMINATOR_JANITOR_REJECTED
+    if any(m in text for m in _TIMEOUT_MARKERS):
+        return TERMINATOR_TIMEOUT_KILLED
+    if any(m in text for m in _FORCED_OTHER_MARKERS):
+        return TERMINATOR_OTHER_FORCED
+    if any(m in text for m in _AUTO_COMPLETED_MARKERS):
+        # Read-side confirmation for the orphan_auto_complete WARNING logged
+        # by agent_lifecycle.py's _try_auto_complete/handle_orphaned_task at
+        # write time: this classification is derived entirely from
+        # task.result_summary text those call sites write (e.g.
+        # "Auto-completed: agent {id} ..." / "Auto-completed after agent
+        # {id} died; janitor passed"). If this log line's task_id never has
+        # a matching orphan_auto_complete WARNING in the same run, the two
+        # ends have drifted out of sync.
+        matched = next((m for m in _AUTO_COMPLETED_MARKERS if m in text), None)
+        logger.debug(
+            "classify_task_terminator: task_id=%s -> auto_completed_after_death (matched_marker=%r, result_summary=%r)",
+            task.id,
+            matched,
+            task.result_summary,
+        )
+        return TERMINATOR_AUTO_COMPLETED_AFTER_DEATH
+    if task.status == TaskStatus.FAILED:
+        return TERMINATOR_AGENT_REPORTED_FAILURE
+    return TERMINATOR_AGENT_COMPLETED
+
+
+def compute_run_health(all_tasks: list[Task], n_unresolved: int = 0) -> tuple[bool, dict[str, int]]:
+    """Compute the run-health verdict and per-terminator-category counts.
+
+    Args:
+        all_tasks: Every task considered for this run's retrospective
+            (done + failed).
+        n_unresolved: Count of tasks the metrics collector saw started but
+            that never reconciled to either ``all_tasks`` or a
+            ``collector.complete_task()`` call (see
+            ``generate_retrospective``'s reconciliation block). Treated as
+            additional non-agent-verified terminations for health purposes.
+
+    Returns:
+        Tuple of ``(healthy, counts)`` where ``counts`` maps each
+        ``TERMINATOR_*`` category to the number of tasks in it.
+
+        Hard rule (bug fix): ``healthy`` is ``False`` whenever ANY task
+        has status FAILED, or ``n_unresolved > 0``, or there is at least
+        one ``TERMINATOR_AUTO_COMPLETED_AFTER_DEATH`` -- regardless of the
+        text-pattern classification below. This does not depend on
+        ``classify_task_terminator`` finding a forced-kill marker in the
+        task's free text, because that classification is a best-effort
+        proxy that can miss real failures (e.g. a provider error with no
+        forced-kill keyword -- see TERMINATOR_AGENT_REPORTED_FAILURE).
+        Absent any hard-rule trigger, ``healthy`` is ``False`` when more
+        than ``_UNHEALTHY_NON_AGENT_FRACTION`` of terminations were
+        non-agent-caused (watchdog/timeout/janitor/other-forced/
+        auto-completed-after-death/agent-reported-failure). An empty task
+        list with no unresolved tasks is vacuously healthy.
+    """
+    counts: dict[str, int] = defaultdict(int)
+    for t in all_tasks:
+        counts[classify_task_terminator(t)] += 1
+
+    total = len(all_tasks) + n_unresolved
+    if total == 0:
+        return True, dict(counts)
+
+    n_failed = sum(1 for t in all_tasks if t.status == TaskStatus.FAILED)
+    auto_completed = counts.get(TERMINATOR_AUTO_COMPLETED_AFTER_DEATH, 0)
+    if n_failed > 0 or auto_completed > 0 or n_unresolved > 0:
+        return False, dict(counts)
+
+    non_agent = sum(counts.get(cat, 0) for cat in _NON_AGENT_CATEGORIES)
+    healthy = (non_agent / total) <= _UNHEALTHY_NON_AGENT_FRACTION
+    return healthy, dict(counts)
+
+
+def _write_run_health_section(
+    lines: list[str],
+    all_tasks: list[Task],
+    n_unresolved: int = 0,
+) -> tuple[bool, dict[str, int]]:
+    """Write the Run Health section and return (healthy, counts) for reuse in Recommendations."""
+    healthy, counts = compute_run_health(all_tasks, n_unresolved=n_unresolved)
+    total = len(all_tasks) + n_unresolved
+    agent_completed = counts.get(TERMINATOR_AGENT_COMPLETED, 0)
+    watchdog_killed = counts.get(TERMINATOR_WATCHDOG_KILLED, 0)
+    janitor_rejected = counts.get(TERMINATOR_JANITOR_REJECTED, 0)
+    timeout_killed = counts.get(TERMINATOR_TIMEOUT_KILLED, 0)
+    other_forced = counts.get(TERMINATOR_OTHER_FORCED, 0)
+    auto_completed = counts.get(TERMINATOR_AUTO_COMPLETED_AFTER_DEATH, 0)
+    agent_reported_failure = counts.get(TERMINATOR_AGENT_REPORTED_FAILURE, 0)
+
+    verdict = "HEALTHY" if healthy else "UNHEALTHY"
+    logger.info(
+        "run health: %d/%d agent-completed, %d watchdog-killed, %d janitor-rejected, "
+        "%d timeout-killed, %d other-forced, %d auto-completed-after-death, "
+        "%d agent-reported-failure, %d unresolved-in-metrics -> %s",
+        agent_completed,
+        total,
+        watchdog_killed,
+        janitor_rejected,
+        timeout_killed,
+        other_forced,
+        auto_completed,
+        agent_reported_failure,
+        n_unresolved,
+        verdict,
+    )
+
+    lines.extend(("## Run Health", ""))
+    lines.append(f"- **Verdict:** {verdict}")
+    lines.extend(
+        (
+            "",
+            "| Terminator category | Count |",
+            "|----------------------|-------|",
+            f"| Agent-completed | {agent_completed} |",
+            f"| Agent-reported failure | {agent_reported_failure} |",
+            f"| Watchdog-killed | {watchdog_killed} |",
+            f"| Janitor-rejected | {janitor_rejected} |",
+            f"| Timeout-killed | {timeout_killed} |",
+            f"| Auto-completed after agent death | {auto_completed} |",
+            f"| Other forced termination | {other_forced} |",
+            f"| Unresolved in metrics (started, outcome never reconciled) | {n_unresolved} |",
+            "",
+        )
+    )
+    if not healthy:
+        lines.append(
+            f"- **Warning:** {total - agent_completed}/{total} task terminations were NOT genuine "
+            "agent completions (failed/watchdog/timeout/janitor/other-forced/auto-completed/"
+            "unresolved) - the completion rate above does not reflect real progress. Investigate "
+            "the dominant non-agent category before trusting this run's outcome."
+        )
+        lines.append("")
+
+    return healthy, counts
 
 
 def _write_rate_table(
@@ -248,6 +575,9 @@ def generate_retrospective(
     collector: MetricsCollector,
     runtime_dir: Path,
     run_start_ts: float,
+    *,
+    trigger_reason: str = "shutdown-final",
+    full_status_counts: dict[str, int] | None = None,
 ) -> None:
     """Write a run retrospective to .sdd/runtime/retrospective.md.
 
@@ -255,29 +585,217 @@ def generate_retrospective(
     breakdown by model/role, agent failure patterns, and produces
     actionable recommendations.
 
+    IMPORTANT (A5 stale-retrospective fix): this function unconditionally
+    OVERWRITES any prior retrospective.md. Callers that invoke this from a
+    tick-level "queue looks empty" heuristic rather than true orchestrator
+    shutdown MUST pass ``trigger_reason="mid-run"`` so the report is
+    labeled INTERIM and is never mistaken for the final verdict. Ground
+    truth: a canary run's retrospective reported "100% completion,
+    HEALTHY" at T+58s (right after the manager task alone finished), and
+    2 of the run's 3 total tasks subsequently failed (janitor-rejected)
+    without the report ever being regenerated - the run health honesty
+    logic above (``compute_run_health`` / ``TERMINATOR_*``) is correct but
+    was never re-run against the final task list. Only the true
+    orchestrator-shutdown call site should use the default
+    ``"shutdown-final"``, and it must always pass the FINAL done/failed
+    task lists.
+
     Args:
         done_tasks: Tasks with status 'done'.
         failed_tasks: Tasks with status 'failed'.
         collector: Live MetricsCollector instance for in-memory metrics.
         runtime_dir: Directory where retrospective.md is written.
         run_start_ts: Unix timestamp when the run started.
+        trigger_reason: Why this generation fired - "mid-run" for a
+            tick-level heuristic that may not reflect the final run state,
+            or "shutdown-final" (default) for the true end-of-run call.
+        full_status_counts: Optional full task-state histogram (including
+            non-terminal statuses like "open"/"claimed") for the log line.
+            Falls back to a done/failed/unresolved-only histogram when
+            not provided.
     """
     runtime_dir.mkdir(parents=True, exist_ok=True)
     retro_path = runtime_dir / "retrospective.md"
 
     all_tasks = done_tasks + failed_tasks
-    total = len(all_tasks)
-    n_done = len(done_tasks)
-    n_failed = len(failed_tasks)
-    completion_rate = (n_done / total * 100) if total else 0.0
-
     wall_clock_s = time.time() - run_start_ts
     task_metrics: dict[str, TaskMetrics] = collector._task_metrics  # type: ignore[reportPrivateUsage]
+    agent_metrics = collector._agent_metrics  # type: ignore[reportPrivateUsage]
+
+    # ------------------------------------------------------------------
+    # Ground-truth reconciliation against collector.task_metrics
+    # ------------------------------------------------------------------
+    #
+    # Bug: done_tasks/failed_tasks are handed to this function by the
+    # orchestrator's caller, which can be stale. Per-tick, the orchestrator
+    # fetches a `tasks_by_status` snapshot once at the START of the tick
+    # (orchestrator.py:1120, `fetch_all_tasks`) and only refreshes it via
+    # local mutation; but reap_dead_agents / handle_orphaned_task
+    # (agent_lifecycle.py, steps 5/5b run LATER in the SAME tick) persist
+    # task outcomes straight to the task server over HTTP and never write
+    # back into that same snapshot dict. `_generate_run_summary` is then
+    # called with the now-stale snapshot at orchestrator.py:1691 -- so
+    # tasks that failed or auto-completed during this tick's own
+    # lifecycle-management steps are invisible to done_tasks/failed_tasks.
+    # Ground truth: 2026-07-02 D2 claude/sdd-snapshot (attempt 2) -- 4
+    # failed manager attempts and a CLI final tally of "Failed: 4", but
+    # done_tasks/failed_tasks arrived here empty (0 done / 0 total).
+    # Diagnosed but NOT fixed here (out of this module's ownership --
+    # owned files are src/bernstein/core/quality/retrospective.py only);
+    # see the handoff report for the orchestrator.py/agent_lifecycle.py fix.
+    #
+    # `collector.task_metrics` is populated by `collector.start_task()`
+    # at agent-spawn time (task_lifecycle.py:1976) independently of the
+    # tasks_by_status snapshot above, so it is a second, less-stale source
+    # of "this task_id existed and something happened to it". However,
+    # `collector.complete_task()` is only called from the janitor-verified
+    # normal-completion path (task_lifecycle.py:2656) and from a couple of
+    # narrow batch/fast-path call sites -- NOT from the retry/fail path
+    # (task_lifecycle.py:retry_or_fail_task) or the orphan / auto-complete-
+    # after-death path (agent_lifecycle.py:handle_orphaned_task, ~line
+    # 1394, which posts completion to the task server and to a *separate*
+    # `.sdd/metrics/*.jsonl` MetricsRecord file via emit_orphan_metrics(),
+    # bypassing the collector entirely). So a task that failed via retry
+    # exhaustion, or was auto-completed after its agent died, shows up in
+    # `collector.task_metrics` as PERMANENTLY "started, never finished"
+    # (`end_time is None`, `success` stuck at its `False` default) -- and
+    # if it also never lands in done_tasks/failed_tasks (the staleness bug
+    # above), it disappears from the retrospective entirely. Ground truth:
+    # 2026-07-02 D2 claude/attempt1-tools-zero -- a genuine auto-completed-
+    # after-death event and real cost $0.031996, retrospective said
+    # "HEALTHY" / "$0.0000" / "Auto-completed after agent death: 0".
+    #
+    # Treat any such "unresolved" task_metrics entry not already accounted
+    # for in all_tasks as a suspect/failed outcome for retrospective
+    # purposes: we cannot prove it succeeded, so counting it as healthy-by-
+    # omission is exactly the dishonesty this module exists to prevent.
+    _known_task_ids = {t.id for t in all_tasks}
+    unresolved_task_ids = sorted(
+        tid for tid, tm in task_metrics.items() if tid not in _known_task_ids and tm.end_time is None
+    )
+    n_unresolved = len(unresolved_task_ids)
+    if unresolved_task_ids:
+        logger.warning(
+            "retrospective: %d task(s) present in collector.task_metrics (started via "
+            "start_task()) but absent from both done_tasks and failed_tasks AND never "
+            "reached collector.complete_task() (end_time is None) -- ids=%s. Counting "
+            "these as unresolved/failed for retrospective honesty rather than silently "
+            "dropping them (see reconciliation comment in generate_retrospective).",
+            n_unresolved,
+            unresolved_task_ids,
+        )
+
+    n_done = len(done_tasks)
+    n_failed = len(failed_tasks) + n_unresolved
+    total = len(all_tasks) + n_unresolved
+    completion_rate = (n_done / total * 100) if total else 0.0
+
+    _status_histogram = full_status_counts if full_status_counts is not None else {"done": n_done, "failed": n_failed}
+    logger.info(
+        "Generating retrospective (trigger=%s): status_histogram=%s",
+        trigger_reason,
+        _status_histogram,
+    )
+
     # get_total_cost() sums agent_metrics; when only task_metrics are populated
     # (e.g. bernstein retro reading from archive) fall back to summing task costs.
+    #
+    # Every cost record consumed here is logged so a case where a real
+    # per-runner cost (e.g. $0.031996 in a runner log) vanishes into a
+    # $0.0000 summary becomes visible in the retrospective-generation log
+    # instead of only in the retrospective.md output (2026-07-02 D2
+    # claude/attempt-1: retrospective said "HEALTHY" / cost $0.0000 while
+    # the runner log recorded $0.031996 -- the source mismatch was
+    # invisible without this).
+    _agent_cost_total = sum(am.total_cost_usd for am in agent_metrics.values())
+    logger.info(
+        "cost_aggregation: source=agent_metrics records_found=%d total=$%.6f",
+        len(agent_metrics),
+        _agent_cost_total,
+    )
+    for _am in agent_metrics.values():
+        logger.debug(
+            "cost_aggregation: record source=agent_metrics agent_id=%s role=%s cost_usd=%.6f",
+            _am.agent_id,
+            _am.role,
+            _am.total_cost_usd,
+        )
     total_cost = collector.get_total_cost()
     if abs(total_cost) < 1e-9 and task_metrics:
-        total_cost = sum(tm.cost_usd for tm in task_metrics.values())
+        _parsed = 0
+        _skipped = 0
+        _fallback_total = 0.0
+        for _task_id, _tm in task_metrics.items():
+            if _tm.cost_usd:
+                _parsed += 1
+                _fallback_total += _tm.cost_usd
+                logger.debug(
+                    "cost_aggregation: record source=task_metrics task_id=%s role=%s cost_usd=%.6f",
+                    _task_id,
+                    _tm.role,
+                    _tm.cost_usd,
+                )
+            else:
+                _skipped += 1
+        total_cost = _fallback_total
+        logger.info(
+            "cost_aggregation: agent_metrics total was $0.0000, falling back to source=task_metrics: "
+            "N=%d records found, M=%d parsed (cost_usd>0), K=%d skipped (reasons=cost_usd==0), "
+            "fallback_total=$%.6f",
+            len(task_metrics),
+            _parsed,
+            _skipped,
+            _fallback_total,
+        )
+    elif abs(total_cost) < 1e-9:
+        logger.warning(
+            "cost_aggregation: agent_metrics total=$0.0000 AND task_metrics is empty (N=0 records) -- "
+            "total_cost will report as $0.0000 in the retrospective. If any runner actually incurred "
+            "cost this run, this is a wiring gap between whatever recorded that cost and this "
+            "MetricsCollector instance."
+        )
+
+    # ------------------------------------------------------------------
+    # Durable cross-check against .sdd/metrics/tasks.jsonl
+    # ------------------------------------------------------------------
+    #
+    # The in-memory collector (agent_metrics / task_metrics above) only
+    # reflects whatever has been folded in by the exact moment this
+    # function is called. The persisted tasks.jsonl sidecar is written by
+    # the evolution aggregator's record_task_completion() from BOTH the
+    # normal completion path and the orphan/auto-completed-after-death
+    # path, so it can be strictly more complete than the in-memory view
+    # (e.g. a fold-in landed after the last retrospective tick, or this
+    # call is racing a fold-in in another tick). Reconcile per-task_id so
+    # both the Overview total AND the by-model/by-role cost breakdown
+    # (which reads task_metrics directly) reflect the fullest picture.
+    _persisted_costs = _read_persisted_task_costs(runtime_dir)
+    _reconciled = 0
+    _reconciled_total_added = 0.0
+    for _task_id, _persisted_cost in _persisted_costs.items():
+        _tm = task_metrics.get(_task_id)
+        if _tm is not None and abs(_tm.cost_usd) < 1e-9 and _persisted_cost > 0:
+            _tm.cost_usd = _persisted_cost
+            _reconciled += 1
+            _reconciled_total_added += _persisted_cost
+            logger.info(
+                "cost_aggregation: reconciled task_id=%s cost_usd=%.6f from persisted "
+                "source=.sdd/metrics/tasks.jsonl (in-memory collector had $0.0000 for this task)",
+                _task_id,
+                _persisted_cost,
+            )
+    if _reconciled:
+        total_cost += _reconciled_total_added
+    logger.info(
+        "retrospective_cost_aggregation: source=%s rows=%d total_usd=%.6f "
+        "(persisted_sidecar_rows=%d, reconciled_from_sidecar=%d)",
+        "agent_metrics+task_metrics+persisted_sidecar" if _reconciled else "agent_metrics+task_metrics",
+        len(task_metrics),
+        total_cost,
+        len(_persisted_costs),
+        _reconciled,
+    )
+    logger.info("cost_aggregation: final total_cost=$%.6f (used in retrospective.md)", total_cost)
 
     lines: list[str] = []
     _section = lines.append
@@ -288,6 +806,13 @@ def generate_retrospective(
     ts_str = time.strftime("%Y-%m-%d %H:%M:%S")
     _section("# Run Retrospective")
     _section("")
+    if trigger_reason != "shutdown-final":
+        _section(
+            f"**INTERIM - run in progress** (trigger: {trigger_reason}). This snapshot was "
+            "generated before all tasks reached a terminal state and will be overwritten by "
+            "the final retrospective at orchestrator shutdown."
+        )
+        _section("")
     _section(f"Generated: {ts_str}")
     _section("")
 
@@ -311,6 +836,8 @@ def generate_retrospective(
     _section(f"- **Wall-clock duration:** {duration_str}")
     _section("")
 
+    run_healthy, terminator_counts = _write_run_health_section(lines, all_tasks, n_unresolved=n_unresolved)
+
     _write_failure_analysis(lines, done_tasks, failed_tasks)
     _write_performance_section(lines, task_metrics, all_tasks)
     _write_cost_breakdown(lines, task_metrics)
@@ -329,16 +856,24 @@ def generate_retrospective(
         cx_failed=cx_failed,
         total_cost=total_cost,
         wall_clock_s=wall_clock_s,
+        run_healthy=run_healthy,
+        terminator_counts=terminator_counts,
     )
     if recommendations:
         for rec in recommendations:
             _section(f"- {rec}")
-    else:
+    elif run_healthy:
         _section("- No issues detected; run looks healthy.")
     _section("")
 
     retro_path.write_text("\n".join(lines))
-    logger.info("Retrospective written to .sdd/runtime/retrospective.md")
+    logger.info(
+        "Retrospective written to .sdd/runtime/retrospective.md (trigger=%s, done=%d, failed=%d, healthy=%s)",
+        trigger_reason,
+        n_done,
+        n_failed,
+        run_healthy,
+    )
 
     sdd_dir = runtime_dir.parent
     goal = all_tasks[0].title if all_tasks else "Unknown goal"
@@ -379,6 +914,8 @@ def _build_recommendations(
     cx_failed: dict[str, int],
     total_cost: float,
     wall_clock_s: float,
+    run_healthy: bool = True,
+    terminator_counts: dict[str, int] | None = None,
 ) -> list[str]:
     """Return a list of recommendation strings based on run metrics.
 
@@ -390,6 +927,11 @@ def _build_recommendations(
         cx_failed: Count of failures per complexity level.
         total_cost: Total cost in USD.
         wall_clock_s: Wall-clock duration in seconds.
+        run_healthy: Result of :func:`compute_run_health` - False means most
+            task terminations were non-agent-caused (watchdog/timeout/
+            janitor/other-forced/auto-completed).
+        terminator_counts: Per-category counts from :func:`compute_run_health`,
+            used to name the dominant non-agent cause in the recommendation.
 
     Returns:
         List of recommendation strings (may be empty).
@@ -399,6 +941,16 @@ def _build_recommendations(
     total = n_done + n_failed
     if total == 0:
         return recs
+
+    if not run_healthy:
+        counts = terminator_counts or {}
+        non_agent = {k: v for k, v in counts.items() if k != TERMINATOR_AGENT_COMPLETED and v > 0}
+        dominant = max(non_agent, key=lambda k: non_agent[k]) if non_agent else "unknown"
+        recs.append(
+            f"UNHEALTHY: most task terminations were non-agent-caused (dominant cause: "
+            f"{dominant}, see Run Health table) - do not trust the completion rate; "
+            "diagnose the forcing mechanism (watchdog/timeout/janitor) before re-running."
+        )
 
     overall_fail_rate = n_failed / total
     if overall_fail_rate >= 0.5:

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import subprocess
 import time
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -58,6 +59,7 @@ from bernstein.core.server import (
     TaskFailRequest,
     TaskPatchRequest,
     TaskProgressRequest,
+    TaskReopenRequest,
     TaskResponse,
     TaskSelfCreate,
     TaskStore,
@@ -107,6 +109,11 @@ def _get_direct_channel(request: Request) -> DirectChannel:
 
 def _get_runtime_dir(request: Request) -> Path:
     return request.app.state.runtime_dir  # type: ignore[no-any-return]
+
+
+def _get_workdir(request: Request) -> Path:
+    """Return the repository root from application state."""
+    return request.app.state.workdir  # type: ignore[no-any-return]
 
 
 def _get_gate_report_path(request: Request, task_id: str) -> Path:
@@ -196,6 +203,310 @@ def _evict_realtime_session(request: Request, session_id: str | None) -> None:
 
         if isinstance(monitor, RealtimeBehaviorMonitor):
             monitor.evict_session(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Auto-commit pre-/complete hook (defect 33)
+# ---------------------------------------------------------------------------
+#
+# Workers were previously expected to ``git commit`` before POSTing
+# /complete (the prompt contract landed in 59fdc178/88611aab).  This hook
+# moves the obligation from "remember to commit" to "the route commits for
+# you" so a worker that forgets still has its work delivered.  Failures are
+# swallowed: the orchestrator's janitor still observes a 0-diff task on
+# /complete's branch and can FAIL it, which the bounded-reopen path
+# (test_janitor_reopen) handles.  See defect 33 in the scoreboard.
+
+_AUTO_COMMIT_DENY_DIR_PREFIXES: tuple[str, ...] = (
+    ".sdd/",
+    "attestations/",
+    "auth/",
+)
+_AUTO_COMMIT_DENY_EXACT: tuple[str, ...] = (
+    "bernstein.yaml",
+    ".claude/mcp.json",
+)
+_AUTO_COMMIT_DENY_GLOBS: tuple[str, ...] = (".env", ".env.*")
+
+
+def _is_auto_commit_denied(path: str) -> bool:
+    """Return True when *path* matches the auto-commit deny list.
+
+    Rules:
+      * Path starts with any prefix in ``_AUTO_COMMIT_DENY_DIR_PREFIXES``
+        (matched against forward-slash separators).
+      * Path equals any exact entry in ``_AUTO_COMMIT_DENY_EXACT``.
+      * Path matches any glob in ``_AUTO_COMMIT_DENY_GLOBS`` (.env,
+        .env.<anything>).
+    """
+    p = path.replace("\\", "/")
+    if p in _AUTO_COMMIT_DENY_EXACT:
+        return True
+    for prefix in _AUTO_COMMIT_DENY_DIR_PREFIXES:
+        if p.startswith(prefix):
+            return True
+    for glob in _AUTO_COMMIT_DENY_GLOBS:
+        if glob.endswith(".*"):
+            stem = glob[:-2]
+            if p == stem or p.startswith(stem + "."):
+                return True
+        elif glob in p:
+            return True
+    return False
+
+
+def _is_salvage_branch(branch_name: str | None) -> bool:
+    """Return True when *branch_name* is a salvage/graveyard branch.
+
+    The existing convention (bernstein.core.git.salvage) uses
+    ``salvage/<session-id>`` branches.  We also defend against any branch
+    containing ``bernstein-salvage`` as a backstop in case future tooling
+    changes the prefix.
+    """
+    if not branch_name:
+        return False
+    if branch_name.startswith("salvage/"):
+        return True
+    return "bernstein-salvage" in branch_name
+
+
+def _run_auto_commit_pre_complete(
+    request: Request,
+    task: Task,
+) -> None:
+    """Auto-commit any uncommitted changes in the worker's worktree.
+
+    Runs AFTER the worker reports done via /complete, BEFORE the task
+    transitions to done in the store.  Operates only on the worker's
+    primary worktree (``.sdd/worktrees/<session-id>``) and on the
+    worker's ``agent/<session-id>`` branch.  Salvage / graveyard
+    branches are skipped.
+
+    Logging contract (house rule 2 - full logging, never silent):
+
+      * ``auto_commit_pre_complete: task=<id> session=<s> reason=already_committed``
+      * ``auto_commit_pre_complete: task=<id> session=<s> reason=skipped_salvage_branch branch=<name>``
+      * ``auto_commit_pre_complete: task=<id> session=<s> reason=nothing_to_commit``
+      * ``auto_commit_pre_complete: task=<id> session=<s> files=<list> reason=uncommitted_changes_at_complete``
+      * ``auto_commit_pre_complete_failed: task=<id> session=<s> error=<msg> files=<list>`` (WARN)
+
+    All errors are swallowed (fail-open) so the orchestrator's lifecycle
+    machinery still observes a /complete - see spec step 6.
+    """
+    session_id = task.claimed_by_session
+    if not session_id:
+        logger.info(
+            "auto_commit_pre_complete: task=%s session=None reason=no_session",
+            task.id,
+        )
+        return
+
+    workdir = _get_workdir(request)
+    worktree_path = workdir / ".sdd" / "worktrees" / session_id
+
+    if not worktree_path.exists() or not worktree_path.is_dir():
+        logger.info(
+            "auto_commit_pre_complete: task=%s session=%s reason=no_worktree path=%s",
+            task.id,
+            session_id,
+            str(worktree_path),
+        )
+        return
+
+    branch_name: str | None = None
+    try:
+        branch_proc = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if branch_proc.returncode == 0:
+            branch_name = branch_proc.stdout.strip() or None
+    except Exception as exc:  # pragma: no cover  # intentional-broad-except: branch lookup is best-effort
+        logger.debug(
+            "auto_commit_pre_complete: task=%s session=%s branch_lookup_error=%s",
+            task.id,
+            session_id,
+            exc,
+        )
+
+    if _is_salvage_branch(branch_name):
+        logger.info(
+            "auto_commit_pre_complete: task=%s session=%s reason=skipped_salvage_branch branch=%s",
+            task.id,
+            session_id,
+            branch_name or "",
+        )
+        return
+
+    try:
+        already = subprocess.run(
+            ["git", "log", "-50", f"--grep={task.id}", "--fixed-strings"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if already.returncode == 0 and already.stdout.strip():
+            logger.info(
+                "auto_commit_pre_complete: task=%s session=%s reason=already_committed",
+                task.id,
+                session_id,
+            )
+            return
+    except Exception as exc:  # intentional-broad-except: already-committed check is best-effort
+        logger.warning(
+            "auto_commit_pre_complete_failed: task=%s session=%s error=%s stage=already_committed_check",
+            task.id,
+            session_id,
+            exc,
+        )
+
+    files_to_commit: list[str] = []
+    try:
+        merge_base_proc = subprocess.run(
+            ["git", "merge-base", "HEAD", "origin/main"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if merge_base_proc.returncode == 0 and merge_base_proc.stdout.strip():
+            base = merge_base_proc.stdout.strip().splitlines()[0]
+            diff_proc = subprocess.run(
+                ["git", "diff", "--name-only", f"{base}..HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            if diff_proc.returncode == 0:
+                files_to_commit.extend(line.strip() for line in diff_proc.stdout.splitlines() if line.strip())
+
+        status_proc = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=all"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+        if status_proc.returncode == 0:
+            for line in status_proc.stdout.splitlines():
+                if len(line) < 4:
+                    continue
+                path = line[3:].strip()
+                if " -> " in path:
+                    path = path.split(" -> ", 1)[1].strip()
+                if path and not _is_auto_commit_denied(path):
+                    files_to_commit.append(path)
+    except Exception as exc:  # intentional-broad-except: file enumeration is best-effort
+        logger.warning(
+            "auto_commit_pre_complete_failed: task=%s session=%s error=%s stage=file_enumeration",
+            task.id,
+            session_id,
+            exc,
+        )
+        return
+
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for p in files_to_commit:
+        if p not in seen:
+            seen.add(p)
+            deduped.append(p)
+    files_to_commit = deduped
+
+    if not files_to_commit:
+        logger.info(
+            "auto_commit_pre_complete: task=%s session=%s reason=nothing_to_commit",
+            task.id,
+            session_id,
+        )
+        return
+
+    try:
+        commit_set = [p for p in files_to_commit if not _is_auto_commit_denied(p)]
+        if not commit_set:
+            logger.info(
+                "auto_commit_pre_complete: task=%s session=%s reason=nothing_to_commit (deny-list excluded all)",
+                task.id,
+                session_id,
+            )
+            return
+
+        add_proc = subprocess.run(
+            ["git", "add", "--", *commit_set],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+        if add_proc.returncode != 0:
+            logger.warning(
+                "auto_commit_pre_complete_failed: task=%s session=%s error=%s files=%s stage=git_add",
+                task.id,
+                session_id,
+                (add_proc.stderr or add_proc.stdout or "").strip()[:500],
+                commit_set,
+            )
+            return
+
+        commit_message = f"auto: {task.id} pre-/complete"
+        commit_proc = subprocess.run(
+            ["git", "commit", "-m", commit_message],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+        )
+        if commit_proc.returncode != 0:
+            stderr = (commit_proc.stderr or commit_proc.stdout or "").strip()
+            if "nothing to commit" in stderr or "no changes added" in stderr:
+                logger.info(
+                    "auto_commit_pre_complete: task=%s session=%s reason=already_committed (raced-during-stage)",
+                    task.id,
+                    session_id,
+                )
+                return
+            logger.warning(
+                "auto_commit_pre_complete_failed: task=%s session=%s error=%s files=%s stage=git_commit",
+                task.id,
+                session_id,
+                stderr[:500],
+                commit_set,
+            )
+            return
+
+        logger.info(
+            "auto_commit_pre_complete: task=%s session=%s files=%s reason=uncommitted_changes_at_complete",
+            task.id,
+            session_id,
+            commit_set,
+        )
+    except Exception as exc:  # intentional-broad-except: auto-commit is best-effort, never blocks completion
+        logger.warning(
+            "auto_commit_pre_complete_failed: task=%s session=%s error=%s files=%s",
+            task.id,
+            session_id,
+            exc,
+            files_to_commit,
+        )
 
 
 def _try_check_realtime_anomaly(
@@ -626,6 +937,12 @@ async def next_task(
         parent_session_id=parent_session_id,
     )
     if task is None:
+        logger.info(
+            "task.next 404: role=%s claimed_by_session=%s parent_session_id=%s no open tasks",
+            role,
+            claimed_by_session,
+            parent_session_id,
+        )
         raise HTTPException(status_code=404, detail=f"No open tasks for role '{role}'")
     return task_to_response(task)
 
@@ -650,6 +967,14 @@ async def claim_batch(body: BatchClaimRequest, request: Request) -> BatchClaimRe
             claimed_by_session=body.claimed_by_session,
             tenant_id=tenant_id,
         )
+        if failed:
+            logger.warning(
+                "task.claim_batch partial failure: agent_id=%s requested=%d claimed=%d failed=%s",
+                body.agent_id,
+                len(body.task_ids),
+                len(claimed),
+                failed,
+            )
         return BatchClaimResponse(claimed=claimed, failed=failed)
 
 
@@ -688,16 +1013,42 @@ async def claim_task(
             if task is None:
                 raise KeyError
             _require_task_access(task, request)
+            pre_claim_status = task.status.value
+            pre_claim_version = task.version
             task = await store.claim_by_id(
                 task_id,
                 expected_version=expected_version,
                 claimed_by_session=claimed_by_session,
             )
         except KeyError:
+            logger.warning(
+                "task.claim 404: task_id=%s not found (claimed_by_session=%s)",
+                task_id,
+                claimed_by_session,
+            )
             raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
         except ValueError as exc:
+            # This is the single most important line for diagnosing claim-conflict
+            # churn: log expected vs. actual version/status so a retry storm is
+            # visible from the server log alone, without needing client-side traces.
+            logger.warning(
+                "task.claim 409: task_id=%s expected_version=%s actual_version=%s "
+                "pre_claim_status=%s claimed_by_session=%s reason=%s",
+                task_id,
+                expected_version,
+                pre_claim_version,
+                pre_claim_status,
+                claimed_by_session,
+                exc,
+            )
             raise HTTPException(status_code=409, detail=str(exc)) from None
         sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "claimed"}))
+        logger.info(
+            "task.claim ok: task_id=%s new_version=%s claimed_by_session=%s",
+            task.id,
+            task.version,
+            claimed_by_session,
+        )
         return task_to_response(task)
 
 
@@ -728,7 +1079,19 @@ async def complete_task(task_id: str, body: TaskCompleteRequest, request: Reques
             # Auto-claim if task reverted to "open" (e.g. after orchestrator
             # restart reconciliation).  Prevents agents from looping on 409.
             if task.status.value == "open":
+                logger.info(
+                    "task.complete auto-claim: task_id=%s reverted to open, re-claiming before complete",
+                    task_id,
+                )
                 await store.claim_by_id(task_id)
+            # Defect 33: auto-commit the worker's uncommitted work BEFORE
+            # the store transitions the task to done, so the commit message
+            # is visible to the janitor (which reads ``git log`` after
+            # /complete lands).  Failures are swallowed - the orchestrator
+            # will catch a 0-diff task on /complete's branch and trigger
+            # the bounded-reopen path.  Logging contract in
+            # ``_run_auto_commit_pre_complete``.
+            _run_auto_commit_pre_complete(request, task)
             task = await store.complete(task_id, body.result_summary)
         except KeyError:
             raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
@@ -798,6 +1161,12 @@ async def wait_for_subtasks(task_id: str, body: TaskWaitForSubtasksRequest, requ
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
     except IllegalTransitionError as exc:
+        logger.warning(
+            "task.wait_for_subtasks 409: task_id=%s current_status=%s reason=%s",
+            task_id,
+            existing_task.status.value if existing_task is not None else "unknown",
+            exc,
+        )
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     sse_bus.publish("task_update", json.dumps({"id": task.id, "status": task.status.value}))
     return task_to_response(task)
@@ -818,11 +1187,21 @@ async def fail_task(task_id: str, body: TaskFailRequest, request: Request) -> Ta
         _require_task_access(existing_task, request)
         # Auto-claim if task reverted to "open" (same rationale as /complete).
         if existing_task.status.value == "open":
+            logger.info(
+                "task.fail auto-claim: task_id=%s reverted to open, re-claiming before fail",
+                task_id,
+            )
             await store.claim_by_id(task_id)
         task = await store.fail(task_id, body.reason)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
     except IllegalTransitionError as exc:
+        logger.warning(
+            "task.fail 409: task_id=%s current_status=%s reason=%s",
+            task_id,
+            existing_task.status.value if existing_task is not None else "unknown",
+            exc,
+        )
         raise HTTPException(status_code=409, detail=str(exc)) from None
     sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "failed"}))
     get_plugin_manager().fire_task_failed(task_id=task.id, role=task.role, error=body.reason)
@@ -830,6 +1209,45 @@ async def fail_task(task_id: str, body: TaskFailRequest, request: Request) -> Ta
     # Update per-file health scores with failure outcome (fire-and-forget)
     _update_file_health(request, task.id, list(task.owned_files), "failure")
 
+    return task_to_response(task)
+
+
+@router.post(
+    "/tasks/{task_id}/reopen",
+    responses={404: {"description": "Task not found"}, 409: {"description": "Invalid state transition"}},
+)
+async def reopen_task(task_id: str, body: TaskReopenRequest, request: Request) -> TaskResponse:
+    """Reopen a done task that failed janitor verification (same task id).
+
+    Transitions DONE -> OPEN and increments
+    ``metadata['janitor_reopen_count']``. The orchestrator enforces the
+    reopen budget; this endpoint only performs the state transition.
+    """
+    store = _get_store(request)
+    sse_bus = _get_sse_bus(request)
+    try:
+        existing_task = store.get_task(task_id)
+        if existing_task is None:
+            raise KeyError
+        _require_task_access(existing_task, request)
+        task = await store.reopen(task_id, body.reason)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
+    except IllegalTransitionError as exc:
+        logger.warning(
+            "task.reopen 409: task_id=%s current_status=%s reason=%s",
+            task_id,
+            existing_task.status.value if existing_task is not None else "unknown",
+            exc,
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+    logger.info(
+        "task.reopen: task_id=%s reopen_count=%s reason=%s",
+        task_id,
+        task.metadata.get("janitor_reopen_count"),
+        body.reason,
+    )
+    sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "open"}))
     return task_to_response(task)
 
 
@@ -850,6 +1268,12 @@ async def close_task(task_id: str, request: Request) -> TaskResponse:
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
     except IllegalTransitionError as exc:
+        logger.warning(
+            "task.close 409: task_id=%s current_status=%s reason=%s",
+            task_id,
+            existing_task.status.value if existing_task is not None else "unknown",
+            exc,
+        )
         raise HTTPException(status_code=409, detail=str(exc)) from None
     sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "closed"}))
     return task_to_response(task)
@@ -891,6 +1315,12 @@ async def cancel_task(task_id: str, body: TaskCancelRequest, request: Request) -
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
     except ValueError as exc:
+        logger.warning(
+            "task.cancel 409: task_id=%s current_status=%s reason=%s",
+            task_id,
+            existing_task.status.value if existing_task is not None else "unknown",
+            exc,
+        )
         raise HTTPException(status_code=409, detail=str(exc)) from None
 
     # Publish an SSE event for every cancelled task (root + descendants) so
@@ -921,6 +1351,12 @@ async def block_task(task_id: str, body: TaskBlockRequest, request: Request) -> 
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
     except IllegalTransitionError as exc:
+        logger.warning(
+            "task.block 409: task_id=%s current_status=%s reason=%s",
+            task_id,
+            existing_task.status.value if existing_task is not None else "unknown",
+            exc,
+        )
         raise HTTPException(status_code=409, detail=str(exc)) from None
     sse_bus.publish("task_update", json.dumps({"id": task.id, "status": "blocked"}))
     return task_to_response(task)

--- a/src/bernstein/core/security/approval.py
+++ b/src/bernstein/core/security/approval.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+import traceback
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -237,6 +238,13 @@ class ApprovalGate:
         For ``pr``: immediately returns a non-approved, non-rejected result
             (caller should call :meth:`create_pr` separately).
 
+        FAIL-CLOSED: any unexpected exception raised while resolving the
+        decision (including inside ``_review``) is caught here, logged at
+        ERROR with the full traceback and the inputs under evaluation, and
+        turned into a REJECTED result. Callers must never see an exception
+        escape this method and must never treat "gate raised" as "gate
+        approved" -- see house lesson on ApprovalGate fail-open drift.
+
         Args:
             task: The completed task to review.
             session_id: Agent session ID (used for logging).
@@ -249,26 +257,65 @@ class ApprovalGate:
         Returns:
             :class:`ApprovalResult` describing the decision.
         """
-        if bypass_enabled:
-            logger.info("Approval gate: bypassing review for task %s", task.id)
-            return ApprovalResult(approved=True)
+        try:
+            if bypass_enabled:
+                logger.info(
+                    "Approval gate decision: task=%s session=%s decision=approved reason=bypass_enabled",
+                    task.id,
+                    session_id,
+                )
+                return ApprovalResult(approved=True)
 
-        mode = override_mode if override_mode is not None else self._mode
-        if mode == ApprovalMode.AUTO:
-            return ApprovalResult(approved=True)
+            mode = override_mode if override_mode is not None else self._mode
+            if mode == ApprovalMode.AUTO:
+                logger.info(
+                    "Approval gate decision: task=%s session=%s decision=approved reason=mode_auto",
+                    task.id,
+                    session_id,
+                )
+                return ApprovalResult(approved=True)
 
-        if mode == ApprovalMode.PR:
-            return ApprovalResult(approved=False, rejected=False)
+            if mode == ApprovalMode.PR:
+                logger.info(
+                    "Approval gate decision: task=%s session=%s decision=pending_pr reason=mode_pr",
+                    task.id,
+                    session_id,
+                )
+                return ApprovalResult(approved=False, rejected=False)
 
-        # REVIEW mode
-        return self._review(task, session_id=session_id, diff=diff, test_summary=test_summary, timeout_s=timeout_s)
+            # REVIEW mode
+            result = self._review(
+                task, session_id=session_id, diff=diff, test_summary=test_summary, timeout_s=timeout_s
+            )
+            logger.info(
+                "Approval gate decision: task=%s session=%s decision=%s reason=review_mode_poll",
+                task.id,
+                session_id,
+                "rejected" if result.rejected else "approved",
+            )
+            return result
+        except Exception:
+            logger.error(
+                "Approval gate evaluate() raised -- FAIL-CLOSED to rejected (not auto-merge). "
+                "task=%s session=%s override_mode=%s timeout_s=%s bypass_enabled=%s diff_len=%d "
+                "test_summary=%r\n%s",
+                task.id,
+                session_id,
+                override_mode,
+                timeout_s,
+                bypass_enabled,
+                len(diff),
+                test_summary,
+                traceback.format_exc(),
+            )
+            return ApprovalResult(approved=False, rejected=True)
 
     def create_pr(
         self,
         task: Task,
         *,
         worktree_path: Path,
-        session_id: str,
+        session_id: str = "",
         base_branch: str = "main",
         labels: list[str] | None = None,
         _role: str = "",
@@ -283,21 +330,78 @@ class ApprovalGate:
         then creates a PR with a structured body including task metadata, cost,
         test results, and the agent role/model.
 
+        NOTE ON PARAMETER NAMES: ``session_id``/``model``/``cost_usd`` are the
+        public keyword names accepted for logging/metadata parity with other
+        gate call sites; ``_role`` is underscore-prefixed by convention because
+        it is "part of the interface" but not required for PR construction
+        itself. Do NOT rename the public names without updating every caller --
+        a prior signature drift where this method briefly accepted
+        ``_session_id``/``_model``/``_cost_usd`` broke pre-existing callers and
+        tests that pass ``session_id``/``model``/``cost_usd`` with
+        ``TypeError: create_pr() got an unexpected keyword argument
+        'session_id'``. This method fail-closes internally (below) so that even
+        a *future* drift cannot escape as a bypass.
+
         Args:
             task: The task whose work should become a PR.
             worktree_path: Path to the agent's git worktree.
-            _session_id: Agent session ID (part of interface).
+            session_id: Agent session ID (part of interface).
             base_branch: Target branch for the PR.
             labels: GitHub labels to attach (defaults to ["bernstein", "auto-generated"]).
             _role: Agent role (part of interface).
-            _model: Model name (part of interface).
-            _cost_usd: Cost in USD (part of interface).
+            model: Model name (part of interface).
+            cost_usd: Cost in USD (part of interface).
             test_summary: One-line test result summary (e.g. ``"12 passed, 0 failed"``).
 
         Returns:
-            PR URL on success, empty string on failure.
+            PR URL on success, empty string on failure (failure -- including
+            an internal exception -- must NEVER be treated by the caller as
+            "approved"; it means no PR exists and merge must stay skipped).
         """
-        _ = session_id  # Part of interface
+        try:
+            return self._create_pr_inner(
+                task,
+                worktree_path=worktree_path,
+                session_id=session_id,
+                base_branch=base_branch,
+                labels=labels,
+                role=_role,
+                model=model,
+                cost_usd=cost_usd,
+                test_summary=test_summary,
+            )
+        except Exception:
+            logger.error(
+                "Approval gate create_pr() raised -- FAIL-CLOSED, returning no PR (caller must NOT "
+                "treat this as approved/auto-merge). task=%s session=%s role=%s model=%s cost_usd=%s "
+                "base_branch=%s worktree_path=%s\n%s",
+                task.id,
+                session_id,
+                _role,
+                model,
+                cost_usd,
+                base_branch,
+                worktree_path,
+                traceback.format_exc(),
+            )
+            return ""
+
+    def _create_pr_inner(
+        self,
+        task: Task,
+        *,
+        worktree_path: Path,
+        session_id: str,
+        base_branch: str,
+        labels: list[str] | None,
+        role: str,
+        model: str,
+        cost_usd: float,
+        test_summary: str,
+    ) -> str:
+        """Do the actual push+PR-creation work. Exceptions propagate to create_pr()."""
+        _ = session_id  # Part of interface (logging/metadata parity)
+        _ = role  # Part of interface
         _ = model  # Part of interface
         _ = cost_usd  # Part of interface
         from bernstein.core.git_ops import PullRequestResult, create_github_pr, push_head_as
@@ -312,13 +416,17 @@ class ApprovalGate:
 
         if _has_no_diff(worktree_path, base_branch):
             logger.info(
-                "Approval gate: no diff vs %s for task %s - skipping PR (agent made no changes)",
-                base_branch,
+                "Approval gate decision: task=%s decision=no_pr reason=no_diff_vs_%s",
                 task.id,
+                base_branch,
             )
             return ""
 
         if not _push_with_retry(push_fn, worktree_path, pr_branch, task.id):
+            logger.info(
+                "Approval gate decision: task=%s decision=no_pr reason=push_failed",
+                task.id,
+            )
             return ""
 
         diff_stats = self._get_diff_stats(worktree_path, base_branch)
@@ -332,10 +440,18 @@ class ApprovalGate:
             labels=effective_labels,
         )
         if not pr_result.success:
-            logger.warning("Approval gate: PR creation failed for task %s: %s", task.id, pr_result.error)
+            logger.warning(
+                "Approval gate decision: task=%s decision=no_pr reason=pr_create_failed error=%s",
+                task.id,
+                pr_result.error,
+            )
             return ""
 
-        logger.info("Approval gate: PR created for task %s: %s", task.id, pr_result.pr_url)
+        logger.info(
+            "Approval gate decision: task=%s decision=pr_created pr_url=%s",
+            task.id,
+            pr_result.pr_url,
+        )
         if self._auto_merge and pr_result.pr_url:
             _try_enable_auto_merge(self._workdir, pr_result.pr_url)
         return pr_result.pr_url

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -254,6 +254,12 @@ class TaskFailRequest(BaseModel):
     reason: str = ""
 
 
+class TaskReopenRequest(BaseModel):
+    """Body for POST /tasks/{task_id}/reopen."""
+
+    reason: str = ""
+
+
 class TaskCancelRequest(BaseModel):
     """Body for POST /tasks/{task_id}/cancel."""
 

--- a/src/bernstein/core/tasks/auto_spawn_guard.py
+++ b/src/bernstein/core/tasks/auto_spawn_guard.py
@@ -1,0 +1,346 @@
+"""Recursion/dedupe/cap guard for auto-spawned meta-tasks.
+
+Guards against the "recursive junk task" production incident: with no limits,
+the evolution loop's "Upgrade: ..." proposal tasks and the watchdog's
+"Watchdog triage: ..." tasks can spawn unboundedly, including meta-tasks
+*about* other meta-tasks (e.g. "Watchdog triage of watchdog triage" - a triage
+task created because a previous triage task itself stalled). A single real
+run degenerated into ~19 "Upgrade: Improve task success rate" duplicates plus
+recursive watchdog-triage-of-watchdog-triage chains with zero forward
+progress. See work/agent-reports/2026-07-02-run9-attempt9-audit.md.
+
+This module is shared by both known auto-spawn sites:
+- ``bernstein.core.orchestration.orchestrator_evolve._create_upgrade_tasks``
+- ``bernstein.core.observability.watchdog.WatchdogManager._create_triage_task``
+
+Guard order (first hit wins, cheapest checks first):
+1. Ancestry depth: refuse spawning a meta-task ABOUT a task that is itself an
+   auto-spawned meta-task (its title already carries a known meta-task
+   prefix). This caps recursion at depth 1: normal-task -> meta-task is
+   allowed, meta-task -> meta-task-about-a-meta-task is refused.
+2. Dedupe: refuse spawning a meta-task whose (normalized) title matches an
+   already-open auto-spawned task. Normalization: lowercase, collapse
+   whitespace, strip a trailing id-like suffix (e.g. "(abc123)"); a match is
+   either an exact normalized match or one title containing the other (both
+   at least 8 characters) - good enough to catch cosmetic drift like an
+   appended session id without conflating unrelated short titles.
+3. Cap: refuse once the number of ALLOWED auto-spawns for this run has
+   reached ``max_auto_spawns_per_run``. State is a small JSON counter
+   persisted under the run's ``.sdd/runtime/`` directory so multiple call
+   sites (and process restarts within the same run) share one cap.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Title prefixes produced by known auto-spawn sites. A source task whose title
+# starts with one of these is itself an auto-spawned meta-task.
+META_TASK_PREFIXES: tuple[str, ...] = ("Upgrade:", "Watchdog triage:")
+
+DEFAULT_MAX_ANCESTRY_DEPTH = 1
+DEFAULT_MAX_AUTO_SPAWNS_PER_RUN = 3
+
+_STATE_RELATIVE_PATH = Path(".sdd") / "runtime" / "auto_spawn_guard.json"
+
+_TRAILING_ID_RE = re.compile(r"[\[(][0-9a-f-]{6,}[\])]\s*$")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class AutoSpawnDecision:
+    """Result of an :meth:`AutoSpawnGuard.evaluate` call."""
+
+    allowed: bool
+    reason: str  # "allowed" | "depth" | "dedupe" | "cap"
+    ancestry_depth: int
+    current_count: int
+    cap: int
+
+
+def meta_task_kind(title: str | None) -> str | None:
+    """Return the matched ``META_TASK_PREFIXES`` category for ``title``, or ``None``.
+
+    This is the "title-CLASS" used for category-based dedupe: two meta-task
+    titles in the same category (e.g. both ``"Upgrade: ..."``) are treated as
+    the same class of auto-spawn even when their specific wording differs
+    (e.g. "Upgrade: Improve task success rate" vs. "Upgrade: Improve token
+    budget") -- see :func:`_titles_match`.
+    """
+    if not title:
+        return None
+    for prefix in META_TASK_PREFIXES:
+        if prefix in title:
+            return prefix
+    return None
+
+
+def compute_ancestry_depth(source_title: str | None) -> int:
+    """Ancestry depth of a meta-task that would be created ABOUT ``source_title``.
+
+    A meta-task about an ordinary task has depth 1. If the source task's own
+    title already carries a known meta-task prefix (i.e. the source is itself
+    an auto-spawned meta-task), the new meta-task would be depth 2 -- exactly
+    the "triage of triage" / "upgrade of upgrade" shape observed in
+    production.
+    """
+    depth = 1
+    if not source_title:
+        return depth
+    for prefix in META_TASK_PREFIXES:
+        if prefix in source_title:
+            depth += 1
+            break
+    return depth
+
+
+def _normalize_title(title: str) -> str:
+    normalized = title.strip().lower()
+    normalized = _WHITESPACE_RE.sub(" ", normalized)
+    normalized = _TRAILING_ID_RE.sub("", normalized).strip()
+    return normalized
+
+
+def _titles_match(candidate: str, existing: str) -> bool:
+    """Dedupe match: exact (normalized) match, or one title containing the other.
+
+    History: an earlier version of this function additionally treated ANY
+    two titles sharing the same known meta-task prefix (e.g. both starting
+    with "Upgrade:") as duplicates regardless of content, to catch a real
+    incident where "Upgrade: Improve task success rate" survived as three
+    sequential, differently-worded task rows. That title-CLASS rule was too
+    coarse: it also refused genuinely distinct, unrelated proposals that
+    merely shared a prefix (e.g. "Upgrade: Proposal One" vs "Upgrade:
+    Proposal Two" from two independent evolution findings in the same
+    cycle) -- see tests/unit/test_orchestrator.py::
+    test_happy_path_creates_http_task_per_proposal, which regressed under
+    the coarse rule (2026-07-02).
+
+    The dedupe key is now purely content-based: normalize both titles
+    (lowercase, collapse whitespace, strip a trailing id-like suffix such as
+    "(abc123)"), then match on exact equality or containment (gated on both
+    normalized titles being at least 8 characters so short generic titles
+    like "Fix bug" don't spuriously collide). This still catches true
+    resurrection-duplicates -- the retry/resurrection path always copies the
+    title verbatim or with only a cosmetic id-suffix change -- while letting
+    two differently-worded, independently-generated proposals coexist even
+    when they share a category prefix.
+    """
+    normalized_candidate = _normalize_title(candidate)
+    normalized_existing = _normalize_title(existing)
+    if not normalized_candidate or not normalized_existing:
+        return False
+    if normalized_candidate == normalized_existing:
+        return True
+    if len(normalized_candidate) >= 8 and len(normalized_existing) >= 8:
+        return normalized_candidate in normalized_existing or normalized_existing in normalized_candidate
+    return False
+
+
+class AutoSpawnGuard:
+    """Shared cap/dedupe/depth guard for auto-spawned meta-tasks.
+
+    The allowed-spawn counter is persisted to
+    ``<workdir>/.sdd/runtime/auto_spawn_guard.json`` so every call site in the
+    same run (and across process restarts within that run) shares a single
+    cap, rather than each site independently allowing up to its own cap.
+    """
+
+    def __init__(
+        self,
+        workdir: Path,
+        *,
+        max_ancestry_depth: int = DEFAULT_MAX_ANCESTRY_DEPTH,
+        max_auto_spawns_per_run: int = DEFAULT_MAX_AUTO_SPAWNS_PER_RUN,
+    ) -> None:
+        self._workdir = workdir
+        self._max_ancestry_depth = max_ancestry_depth
+        self._max_auto_spawns_per_run = max_auto_spawns_per_run
+        self._state_path = workdir / _STATE_RELATIVE_PATH
+
+    def evaluate(
+        self,
+        *,
+        kind: str,
+        title: str,
+        source_title: str | None,
+        existing_open_titles: list[str],
+    ) -> AutoSpawnDecision:
+        """Decide whether an auto-spawn of ``title`` (of type ``kind``) is allowed.
+
+        Args:
+            kind: Caller-supplied label for the auto-spawn site, used only for
+                logging (e.g. "upgrade_proposal", "watchdog_triage",
+                "retry:upgrade_proposal" for a retry-path recreation of a
+                meta-task).
+            title: The title of the meta-task that would be created.
+            source_title: Title of the task/finding this meta-task would be
+                about, if any. Used to compute ancestry depth.
+            existing_open_titles: Titles of currently-open (open or claimed)
+                auto-spawned tasks, for dedupe comparison.
+
+        Every call - allowed or refused - is logged at INFO with the full
+        decision inputs (reason, dedupe key, ancestry depth); this is the
+        primary debugging surface for auto-spawn behaviour, so the log line
+        is never truncated or downgraded to DEBUG.
+        """
+        # Content-based dedupe key (normalized title) -- see _titles_match's
+        # docstring for why this is no longer just the meta-task prefix
+        # (that coarser key falsely collided distinct proposals sharing a
+        # category, e.g. "Upgrade: Proposal One" vs "Upgrade: Proposal Two").
+        dedupe_key = _normalize_title(title)
+        depth = compute_ancestry_depth(source_title)
+        count = self._load_count()
+
+        if depth > self._max_ancestry_depth:
+            decision = AutoSpawnDecision(
+                allowed=False,
+                reason="depth",
+                ancestry_depth=depth,
+                current_count=count,
+                cap=self._max_auto_spawns_per_run,
+            )
+            logger.warning(
+                "Auto-spawn refused (depth): kind=%s title=%r ancestry_depth=%d max_ancestry_depth=%d "
+                "source_title=%r dedupe_key=%r",
+                kind,
+                title,
+                depth,
+                self._max_ancestry_depth,
+                source_title,
+                dedupe_key,
+            )
+            self._log_decision(
+                kind=kind,
+                title=title,
+                source_title=source_title,
+                dedupe_key=dedupe_key,
+                decision=decision,
+            )
+            return decision
+
+        for existing in existing_open_titles:
+            is_match = _titles_match(title, existing)
+            # Every candidate/existing comparison is logged at INFO with the
+            # dedupe key and verdict -- "log every dedupe decision with the
+            # key + verdict + reason" (not just the final refusal/allow).
+            logger.info(
+                "auto_spawn_dedupe_check kind=%s dedupe_key=%r candidate=%r existing=%r match=%s",
+                kind,
+                dedupe_key,
+                title,
+                existing,
+                is_match,
+            )
+            if is_match:
+                decision = AutoSpawnDecision(
+                    allowed=False,
+                    reason="dedupe",
+                    ancestry_depth=depth,
+                    current_count=count,
+                    cap=self._max_auto_spawns_per_run,
+                )
+                logger.warning(
+                    "Auto-spawn refused (dedupe): kind=%s title=%r duplicates existing open task %r dedupe_key=%r",
+                    kind,
+                    title,
+                    existing,
+                    dedupe_key,
+                )
+                self._log_decision(
+                    kind=kind, title=title, source_title=source_title, dedupe_key=dedupe_key, decision=decision
+                )
+                return decision
+
+        if count >= self._max_auto_spawns_per_run:
+            decision = AutoSpawnDecision(
+                allowed=False,
+                reason="cap",
+                ancestry_depth=depth,
+                current_count=count,
+                cap=self._max_auto_spawns_per_run,
+            )
+            logger.warning(
+                "Auto-spawn refused (cap): kind=%s title=%r current_count=%d cap=%d dedupe_key=%r",
+                kind,
+                title,
+                count,
+                self._max_auto_spawns_per_run,
+                dedupe_key,
+            )
+            self._log_decision(
+                kind=kind,
+                title=title,
+                source_title=source_title,
+                dedupe_key=dedupe_key,
+                decision=decision,
+            )
+            return decision
+
+        new_count = count + 1
+        self._save_count(new_count)
+        decision = AutoSpawnDecision(
+            allowed=True,
+            reason="allowed",
+            ancestry_depth=depth,
+            current_count=new_count,
+            cap=self._max_auto_spawns_per_run,
+        )
+        self._log_decision(kind=kind, title=title, source_title=source_title, dedupe_key=dedupe_key, decision=decision)
+        return decision
+
+    def _log_decision(
+        self,
+        *,
+        kind: str,
+        title: str,
+        source_title: str | None,
+        dedupe_key: str,
+        decision: AutoSpawnDecision,
+    ) -> None:
+        """Uniform INFO-level record of every auto-spawn decision (allowed or refused).
+
+        This is intentionally separate from (and in addition to) the
+        per-branch WARNING logs above: those are for operator alerting on
+        refusals, this is the single always-on debugging trail - never
+        truncated, always includes the exact dedupe key and ancestry depth
+        used, per the "logging IS the debugging interface" rule.
+        """
+        logger.info(
+            "auto_spawn_decision kind=%s title=%r source_title=%r allowed=%s reason=%s dedupe_key=%r "
+            "ancestry_depth=%d current_count=%d cap=%d",
+            kind,
+            title,
+            source_title,
+            decision.allowed,
+            decision.reason,
+            dedupe_key,
+            decision.ancestry_depth,
+            decision.current_count,
+            decision.cap,
+        )
+
+    def _load_count(self) -> int:
+        if not self._state_path.exists():
+            return 0
+        try:
+            raw = json.loads(self._state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            logger.warning("Auto-spawn guard state unreadable, resetting: %s", self._state_path)
+            return 0
+        if not isinstance(raw, dict):
+            return 0
+        count = raw.get("count", 0)
+        return count if isinstance(count, int) else 0
+
+    def _save_count(self, count: int) -> None:
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"count": count, "updated_at": time.time()}
+        self._state_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/bernstein/core/tasks/lifecycle.py
+++ b/src/bernstein/core/tasks/lifecycle.py
@@ -190,6 +190,10 @@ TASK_TRANSITIONS: dict[tuple[TaskStatus, TaskStatus], Callable[[Task], bool]] = 
     # Verification gate (orchestrator closes after janitor + merge)
     (TaskStatus.DONE, TaskStatus.CLOSED): _always,
     (TaskStatus.DONE, TaskStatus.FAILED): _always,
+    # Janitor reopen (bounded): a done task that fails janitor verification
+    # is re-queued under the SAME id for another attempt. The reopen budget
+    # is enforced by the orchestrator via metadata['janitor_reopen_count'].
+    (TaskStatus.DONE, TaskStatus.OPEN): _always,
     # Abandon primitive (#1350) - agent-initiated structured exit.
     # ABANDONED is a terminal state distinct from FAILED so dashboards can
     # split intentional vs. unintentional exits. Downstream consumers move

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -28,6 +28,27 @@ def _default_poll_interval_s() -> int:
     return int(_defaults.ORCHESTRATOR.tick_interval_s)
 
 
+def _default_stalled_manager_threshold_s() -> float:
+    """Return the current canonical stalled-manager deadline.
+
+    Reads from :mod:`bernstein.core.defaults` each call (same pattern as
+    :func:`_default_poll_interval_s`) so that ``tuning.orchestrator.
+    stalled_manager_threshold_s`` overrides from ``bernstein.yaml`` are
+    honoured. See ``core.orchestration.stalled_manager`` for the consumer.
+    """
+    return float(_defaults.ORCHESTRATOR.stalled_manager_threshold_s)
+
+
+def _default_max_agent_runtime_s() -> int:
+    """Return the current canonical agent wall-clock kill starting value.
+
+    Reads from :mod:`bernstein.core.defaults` each call (same pattern as
+    :func:`_default_poll_interval_s`) so that ``tuning.orchestrator.
+    max_agent_runtime_s`` overrides are honoured.
+    """
+    return int(_defaults.ORCHESTRATOR.max_agent_runtime_s)
+
+
 class TaskStoreUnavailable(Exception):
     """Raised when the task store cannot operate after exhausting retries.
 
@@ -1225,7 +1246,16 @@ class OrchestratorConfig:
     # Deployments that explicitly relied on the 900s value must set this field explicitly.
     heartbeat_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_stale_s))
     heartbeat_enabled: bool = True
-    max_agent_runtime_s: int = 1800  # 30 min wall-clock kill (agents need time for complex tasks)
+    # Derived from ORCHESTRATOR.max_agent_runtime_s (canonical) so
+    # ``tuning.orchestrator.max_agent_runtime_s`` overrides the starting
+    # wall-clock kill deadline (agents need time for complex tasks; this
+    # self-extends up to a 5400s hard cap while heartbeating, see
+    # core/agents/agent_lifecycle.py - this is only the starting value).
+    max_agent_runtime_s: int = field(default_factory=_default_max_agent_runtime_s)
+    # Derived from ORCHESTRATOR.stalled_manager_threshold_s (canonical) so
+    # ``tuning.orchestrator.stalled_manager_threshold_s`` overrides actually
+    # change the manager-stall deadline. See core.orchestration.stalled_manager.
+    stalled_manager_threshold_s: float = field(default_factory=_default_stalled_manager_threshold_s)
     max_tasks_per_agent: int = 2  # batch 2 same-role tasks per agent to reduce context overhead
     server_url: str = "http://localhost:8052"
     evolution_enabled: bool = True

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -11,9 +11,11 @@ import asyncio
 import contextlib
 import logging
 import math
+import os
 import re
 import time
 from collections import defaultdict
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
@@ -40,6 +42,7 @@ from bernstein.core.metrics import get_collector
 from bernstein.core.router import RouterError
 from bernstein.core.rule_enforcer import RulesConfig, load_rules_config, run_rule_enforcement
 from bernstein.core.spawn_analyzer import SpawnAnalyzer, SpawnFailureAnalysis
+from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard, meta_task_kind
 from bernstein.core.tasks.lifecycle import transition_agent
 from bernstein.core.tasks.models import (
     AgentSession,
@@ -64,6 +67,37 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _XL_ROLES = frozenset({"architect", "security", "manager"})
+
+# Bug 1 (2026-07-02, fix/claim-conflict-churn): bounds for the claim-conflict
+# recovery loop in ``_claim_task_with_conflict_retry`` / ``claim_and_spawn_batches``.
+# See that function's docstring for the full root-cause writeup.
+_CLAIM_CONFLICT_MAX_ATTEMPTS = 5  # hard cap on re-fetch+retry attempts within one episode
+_CLAIM_CONFLICT_BACKOFF_BASE_S = 5.0  # first cross-tick backoff after an exhausted episode
+_CLAIM_CONFLICT_BACKOFF_MAX_S = 300.0  # cap so a permanently-stuck task backs off at most 5 min
+_CLAIM_TERMINAL_STATUSES = frozenset(
+    {
+        TaskStatus.DONE,
+        TaskStatus.CLOSED,
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        TaskStatus.ABANDONED,
+    }
+)
+
+# Bug 2 (2026-07-02, fix/claim-conflict-churn): hard retry ceiling applied to
+# EVERY task lineage in ``retry_or_fail_task`` (meta-tasks additionally go
+# through AutoSpawnGuard's ancestry/dedupe/cap checks (see below) and
+# normally never reach this ceiling at all). Evidence
+# (work/bernstein/proofs/d2/claim-loop-evidence/d2-minimax-final-snap.tar,
+# tasks.jsonl) showed "Add test for hello subcommand" and "Commit changes on
+# feature branch" each respawn 3x (retry_count 0, 1, 2) inside one 12-minute
+# run with zero forward progress -- the prior effective limit
+# (min(task.max_retries=3, dynamic_limit=3) = 3) allowed up to 4 total
+# attempts per lineage before permanent failure. Capping the retry ceiling to
+# 2 (3 total attempts) cuts one full churn cycle off every structurally-dead
+# task lineage, regardless of what ``task.max_retries`` or the
+# reason-derived ``dynamic_limit`` would otherwise allow.
+_MAX_REGULAR_TASK_RETRIES = 2
 
 
 # ---------------------------------------------------------------------------
@@ -533,6 +567,48 @@ _TRANSIENT_MARKERS = (
 _FATAL_MARKERS = ("syntaxerror", "syntax error", "fatal")
 
 
+_META_TASK_OPEN_STATUSES: frozenset[TaskStatus] = frozenset(
+    {
+        TaskStatus.PLANNED,
+        TaskStatus.OPEN,
+        TaskStatus.CLAIMED,
+        TaskStatus.IN_PROGRESS,
+        TaskStatus.WAITING_FOR_SUBTASKS,
+        TaskStatus.PENDING_APPROVAL,
+    }
+)
+
+
+def _collect_open_meta_task_titles(
+    tasks_snapshot: dict[str, list[Task]] | None,
+    *,
+    exclude_task_id: str,
+) -> list[str]:
+    """Titles of currently open/claimed auto-spawned meta-tasks, for AutoSpawnGuard dedupe.
+
+    Mirrors the open-status set ``orchestrator_evolve._create_upgrade_tasks``
+    uses at the meta-task creation site, so the retry path's dedupe view is
+    consistent with the creation-time dedupe view. ``exclude_task_id`` omits
+    the task currently being retried/failed (it is about to leave these
+    statuses regardless of the guard's decision).
+    """
+    if not tasks_snapshot:
+        return []
+    titles: list[str] = []
+    seen_ids: set[str] = set()
+    for bucket in tasks_snapshot.values():
+        for candidate in bucket:
+            if candidate.id == exclude_task_id or candidate.id in seen_ids:
+                continue
+            if getattr(candidate, "status", None) not in _META_TASK_OPEN_STATUSES:
+                continue
+            if meta_task_kind(candidate.title) is None:
+                continue
+            seen_ids.add(candidate.id)
+            titles.append(candidate.title)
+    return titles
+
+
 def _dynamic_retry_limit(reason: str, default_max: int) -> int:
     """Determine the retry limit based on failure reason keywords."""
     reason_lower = reason.lower()
@@ -657,6 +733,8 @@ def retry_or_fail_task(
     retried_task_ids: set[str],
     tasks_snapshot: dict[str, list[Task]] | None = None,
     workdir: Path | None = None,
+    role_model_policy: dict[str, dict[str, Any]] | None = None,
+    default_adapter_name: str | None = None,
 ) -> None:
     """Re-queue a task for retry, or fail it permanently if max retries reached.
 
@@ -683,6 +761,19 @@ def retry_or_fail_task(
             Queue under ``<workdir>/.sdd/runtime/dlq.jsonl``.
             Callers without a workdir (e.g. ad-hoc scripts or legacy tests)
             fall back to the historical behaviour of plain failure.
+        role_model_policy: Optional ``AgentSpawner.role_model_policy`` snapshot.
+            When the retrying task's role has a non-Claude ``provider``/``model``
+            pinned here, retry escalation stamps ``effort``/``max_output_tokens``
+            only and leaves ``model`` alone instead of stamping a Claude tier
+            name ("opus"/"sonnet") that is meaningless to that adapter. Callers
+            that omit this (e.g. legacy tests, ad-hoc scripts) get the
+            historical Claude-tier-name-always behavior, which is correct for
+            Claude-only runs and was never wrong until a non-Claude adapter
+            entered the picture.
+        default_adapter_name: The spawner's default adapter name (e.g.
+            ``AgentSpawner.default_adapter_name``), used as the fallback
+            Claude-compatibility check when the retrying role has no
+            role_model_policy entry of its own.
     """
     base = server_url
     dynamic_limit = _dynamic_retry_limit(reason, max_task_retries)
@@ -718,7 +809,81 @@ def retry_or_fail_task(
     # source of truth is ``task.retry_count`` (typed field).
     retry_count = task.retry_count
     per_task_limit = task.max_retries if task.max_retries > 0 else max_task_retries
-    effective_limit = min(per_task_limit, dynamic_limit)
+    # Bug 2 hard ceiling (see _MAX_REGULAR_TASK_RETRIES docstring above):
+    # applies to every lineage regardless of task.max_retries or the
+    # reason-derived dynamic_limit, so a structurally-dead task (e.g. its
+    # agent keeps dying for an environment reason no retry can fix) burns at
+    # most 2 retries before permanent failure instead of riding whatever
+    # higher ceiling those other two knobs would otherwise allow.
+    effective_limit = min(per_task_limit, dynamic_limit, _MAX_REGULAR_TASK_RETRIES)
+    _original_task_id = task.metadata.get("original_task_id", task.id) if isinstance(task.metadata, dict) else task.id
+    logger.info(
+        "retry_or_fail_task decision inputs: task=%s original_task_id=%s retry_count=%d "
+        "per_task_limit=%d dynamic_limit=%d hard_cap=%d -> effective_limit=%d reason=%r",
+        task_id,
+        _original_task_id,
+        retry_count,
+        per_task_limit,
+        dynamic_limit,
+        _MAX_REGULAR_TASK_RETRIES,
+        effective_limit,
+        reason,
+    )
+
+    # Auto-spawn guard: this generic retry path is a SECOND spawn site for
+    # auto-spawned meta-tasks (e.g. an evolution-loop "Upgrade: ..." proposal
+    # or a watchdog "Watchdog triage: ..." task) - it recreates a brand-new
+    # open task row with the same title whenever the meta-task's own agent
+    # dies, completely bypassing the AutoSpawnGuard that
+    # ``orchestrator_evolve._create_upgrade_tasks`` / the watchdog's
+    # ``_create_triage_task`` consult at CREATION time. Left unguarded, a
+    # meta-task that structurally cannot succeed (e.g. the environment
+    # defect it exists to work around) gets re-spawned via retry up to
+    # ``max_retries`` times with zero forward progress - the exact
+    # "9 Upgrade: Improve task success rate" rows seen in
+    # work/bernstein/proofs/d2/minimax/sdd-snapshot/runtime/tasks.jsonl,
+    # where 2 of the 3 real-lineage recreations went through THIS function,
+    # never through the guarded creation site, so the guard's dedupe/cap
+    # counter never even saw them.
+    #
+    # Retrying a meta-task is itself an auto-spawn "about" that same
+    # meta-task, so ``source_title=task.title`` deterministically computes
+    # ancestry depth 2 (the source title already carries a
+    # ``META_TASK_PREFIXES`` prefix) -- refused by the depth<=1 cap. Net
+    # effect: a meta-task gets its normal first attempt, but a failed
+    # meta-task is routed straight to permanent-fail/DLQ instead of being
+    # resurrected under a new task id.
+    meta_kind = meta_task_kind(task.title)
+    if meta_kind is not None and retry_count < effective_limit:
+        if workdir is not None:
+            existing_open_titles = _collect_open_meta_task_titles(tasks_snapshot, exclude_task_id=task.id)
+            guard = AutoSpawnGuard(workdir)
+            decision = guard.evaluate(
+                kind=f"retry:{meta_kind.rstrip(':')}",
+                title=task.title,
+                source_title=task.title,
+                existing_open_titles=existing_open_titles,
+            )
+            if not decision.allowed:
+                logger.info(
+                    "Refusing to re-spawn meta-task %s (title=%r) via retry: auto-spawn guard reason=%s "
+                    "ancestry_depth=%d current_count=%d cap=%d - routing to permanent failure instead of "
+                    "creating a new task row",
+                    task_id,
+                    task.title,
+                    decision.reason,
+                    decision.ancestry_depth,
+                    decision.current_count,
+                    decision.cap,
+                )
+                retry_count = effective_limit  # force the permanent-fail/DLQ branch below
+        else:
+            logger.info(
+                "Auto-spawn guard skipped for retry of meta-task %s (title=%r): no workdir supplied "
+                "(legacy/ad-hoc caller) - falling back to historical unguarded retry behaviour",
+                task_id,
+                task.title,
+            )
 
     if retry_count < effective_limit:
         # Escalate model on retry: large/architect/security always opus/max;
@@ -726,15 +891,68 @@ def retry_or_fail_task(
         from bernstein.core.tasks.models import Scope as _Scope
 
         _high_stakes_roles = ("architect", "security")
+
+        # Historically this block stamped a Claude tier name ("opus"/
+        # "sonnet") onto the retried task.model unconditionally - correct
+        # for Claude-only runs, but for a role pinned to a non-Claude
+        # provider/model (role_model_policy) or running against a
+        # non-Claude default adapter, a tier name is meaningless and gets
+        # spawned literally (e.g. `qwen -m opus`, the run-9 attempt-8 class
+        # of bug: retry stamped model="opus" against a MiniMax endpoint).
+        # Determine Claude-compatibility for the retrying role BEFORE
+        # choosing retry_model so the escalation itself never produces a
+        # value that has to be coerced/papered over downstream in
+        # spawner_core.py. Callers that don't pass role_model_policy /
+        # default_adapter_name (legacy tests, ad-hoc scripts) get
+        # ``adapter_for_role is None`` -> treated as Claude-compatible,
+        # i.e. today's historical behavior, unchanged.
+        role_policy_entry = role_model_policy.get(task.role, {}) if isinstance(role_model_policy, dict) else {}
+        pinned_model = role_policy_entry.get("model") if isinstance(role_policy_entry, dict) else None
+        adapter_for_role = (
+            role_policy_entry.get("provider") if isinstance(role_policy_entry, dict) else None
+        ) or default_adapter_name
+        adapter_is_claude_compatible = True
+        if isinstance(adapter_for_role, str) and adapter_for_role:
+            from bernstein.core.bandit_router import BanditRouter
+
+            adapter_is_claude_compatible = BanditRouter.router_applicable(adapter_for_role)
+        logger.info(
+            "Retry escalation adapter check for task %s (role=%s): "
+            "role_policy_provider=%r role_policy_model=%r default_adapter_name=%r "
+            "-> adapter_for_role=%r claude_compatible=%s",
+            task_id,
+            task.role,
+            role_policy_entry.get("provider"),
+            pinned_model,
+            default_adapter_name,
+            adapter_for_role,
+            adapter_is_claude_compatible,
+        )
+
         if task.scope == _Scope.LARGE or task.role in _high_stakes_roles:
-            retry_model = "opus"
+            retry_model = "opus" if adapter_is_claude_compatible else (pinned_model or task.model)
             retry_effort = "max"
         elif retry_count >= 1:
-            retry_model = "opus"
+            retry_model = "opus" if adapter_is_claude_compatible else (pinned_model or task.model)
             retry_effort = "high"
         else:
-            retry_model = task.model or "sonnet"
+            retry_model = (task.model or "sonnet") if adapter_is_claude_compatible else (pinned_model or task.model)
             retry_effort = task.effort or "high"
+
+        logger.info(
+            "Retry model decision for task %s (role=%s, retry_count=%s, scope=%s): "
+            "model=%r effort=%r (claude_compatible=%s, pinned_model=%r, prior_task_model=%r, reason=%r)",
+            task_id,
+            task.role,
+            retry_count,
+            task.scope,
+            retry_model,
+            retry_effort,
+            adapter_is_claude_compatible,
+            pinned_model,
+            task.model,
+            reason,
+        )
 
         # Max output tokens escalation (T415)
         new_max_output_tokens = task.max_output_tokens
@@ -800,8 +1018,9 @@ def retry_or_fail_task(
         try:
             client.post(f"{base}/tasks", json=task_body).raise_for_status()
             logger.info(
-                "Retrying task %s (attempt %d/%d): %s",
+                "retry_or_fail_task verdict=retry task=%s original_task_id=%s attempt=%d/%d reason=%r",
                 task_id,
+                _original_task_id,
                 retry_count + 1,
                 effective_limit,
                 reason,
@@ -826,6 +1045,14 @@ def retry_or_fail_task(
         # retry budget exhausted - move to Dead Letter Queue
         # before marking the task failed so permanently-failed work is not
         # silently dropped.
+        logger.info(
+            "retry_or_fail_task verdict=permanent_fail task=%s original_task_id=%s attempt=%d/%d reason=%r",
+            task_id,
+            _original_task_id,
+            retry_count + 1,
+            effective_limit,
+            reason,
+        )
         _enqueue_dlq_if_workdir(
             workdir=workdir,
             task=task,
@@ -1250,6 +1477,205 @@ def _apply_fair_scheduling(orch: Any, batches: list[list[Task]]) -> list[list[Ta
     return ordered
 
 
+def _refetch_task_for_claim_conflict(client: httpx.Client, base: str, task_id: str) -> Task | None:
+    """Re-GET a single task after a claim 409 to discover its current state.
+
+    Returns ``None`` if the task no longer exists (404) or the re-fetch
+    itself fails -- callers must treat that as "stop claiming, move on"
+    rather than retry against data we no longer trust.
+    """
+    try:
+        resp = client.get(f"{base}/tasks/{task_id}")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return Task.from_dict(resp.json())
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "claim-conflict re-GET of task %s failed: %s -- treating as unclaimable this attempt",
+            task_id,
+            exc,
+        )
+        return None
+    except (KeyError, ValueError, TypeError) as exc:
+        # A 2xx response whose body is missing/malformed (not a well-formed
+        # task dict) is a re-fetch failure just like an HTTP error: we no
+        # longer trust the data, so stop claiming and move on rather than
+        # crashing the whole tick.
+        logger.warning(
+            "claim-conflict re-GET of task %s returned an unparseable body: %s -- treating as unclaimable this attempt",
+            task_id,
+            exc,
+        )
+        return None
+
+
+def _claim_task_with_conflict_retry(
+    orch: Any,
+    task: Task,
+    base: str,
+    session_id: str | None,
+) -> tuple[httpx.Response | None, str | None]:
+    """POST ``/tasks/{id}/claim``, recovering from stale-version 409s instead of looping forever.
+
+    Root cause (Bug 1, 2026-07-02, evidence in
+    ``work/bernstein/proofs/d2/claim-loop-evidence``): the original call site
+    sent one CAS claim attempt and, on 409, gave up for the current tick --
+    but ``batches`` is recomputed fresh every tick from ``fetch_all_tasks``,
+    and if the task's server-side state never actually changes (e.g. a
+    dependency check or a stale file-ownership lock from a dead agent keeps
+    failing the claim for a reason that has nothing to do with the version),
+    the exact same stale ``expected_version`` gets resubmitted every tick,
+    forever. Server log evidence: 144 consecutive identical
+    ``POST /tasks/109ba3616f03/claim?expected_version=1`` -> 409 responses
+    from one session against one task across an entire run, with the worker
+    for that task never spawning.
+
+    On every 409 this now:
+      1. Re-GETs the task to discover its CURRENT version/status.
+      2. If the task is gone (404) or has reached a terminal status
+         (done/closed/failed/cancelled/abandoned) -> stop; there is nothing
+         left to claim.
+      3. If another session now holds a non-open claim on it -> stop and
+         move on; retrying cannot help.
+      4. Otherwise (still OPEN) -> retry with the freshly observed version,
+         whether or not it actually moved -- a same-version 409 means some
+         OTHER precondition (role mismatch, unmet dependency, file-ownership
+         overlap) is blocking the claim, and that also deserves a few
+         bounded retries rather than an infinite tight loop.
+    Retries within one call are capped at ``_CLAIM_CONFLICT_MAX_ATTEMPTS``.
+
+    Every attempt is logged at INFO with task_id, version sent, response
+    code, the current version/status discovered on re-fetch, and the
+    decision taken -- so a repeat of this bug shows up as readable log
+    lines instead of a silent multi-hundred-line loop.
+
+    Returns:
+        ``(response, None)`` on a successful (non-409) response -- caller
+        must still check ``response.status_code`` for 404/5xx as before.
+        ``(last_response, reason)`` when claiming this task was abandoned.
+    """
+    attempts = 0
+    current_task = task
+    resp: httpx.Response | None = None
+    while True:
+        attempts += 1
+        params: dict[str, Any] = {"expected_version": current_task.version}
+        if session_id is not None:
+            params["claimed_by_session"] = session_id
+        resp = orch._client.post(f"{base}/tasks/{current_task.id}/claim", params=params)
+        logger.info(
+            "claim attempt %d/%d task=%s sent_version=%s -> HTTP %d",
+            attempts,
+            _CLAIM_CONFLICT_MAX_ATTEMPTS,
+            current_task.id,
+            current_task.version,
+            resp.status_code,
+        )
+        if resp.status_code != 409:
+            if attempts > 1:
+                logger.info(
+                    "claim conflict for task %s resolved after %d attempt(s)",
+                    current_task.id,
+                    attempts,
+                )
+            return resp, None
+
+        if attempts >= _CLAIM_CONFLICT_MAX_ATTEMPTS:
+            logger.warning(
+                "claim conflict cap reached for task %s after %d attempts (last sent version=%s, "
+                "detail=%r) -- giving up on this task this episode",
+                current_task.id,
+                attempts,
+                current_task.version,
+                resp.text[:300] if resp is not None else None,
+            )
+            return resp, f"CAS conflict, gave up after {attempts} attempts"
+
+        refreshed = _refetch_task_for_claim_conflict(orch._client, base, current_task.id)
+        if refreshed is None:
+            logger.info(
+                "claim conflict for task %s: re-GET found task gone (404 or fetch error) -- stopping, nothing to claim",
+                current_task.id,
+            )
+            return resp, "task no longer exists or unfetchable"
+
+        if refreshed.status in _CLAIM_TERMINAL_STATUSES:
+            logger.info(
+                "claim conflict for task %s: re-fetch shows terminal status=%s -- stopping, work is done",
+                current_task.id,
+                refreshed.status.value,
+            )
+            return resp, f"task reached terminal status {refreshed.status.value}"
+
+        if refreshed.status != TaskStatus.OPEN:
+            other_session = refreshed.claimed_by_session
+            if other_session is not None and other_session != session_id:
+                logger.info(
+                    "claim conflict for task %s: now held by a different session %s (status=%s) -- "
+                    "moving on, not retrying",
+                    current_task.id,
+                    other_session,
+                    refreshed.status.value,
+                )
+                return resp, f"claimed by another session {other_session}"
+            logger.info(
+                "claim conflict for task %s: status=%s (not open, no foreign session to blame) -- "
+                "stopping this episode",
+                current_task.id,
+                refreshed.status.value,
+            )
+            return resp, f"task not open (status={refreshed.status.value})"
+
+        # Still OPEN. Whether or not the version actually moved, retry with
+        # the freshest known version rather than resubmitting stale data.
+        logger.info(
+            "claim conflict for task %s: re-fetch shows status=OPEN, version %s -> %s -- retrying (attempt %d/%d)",
+            current_task.id,
+            current_task.version,
+            refreshed.version,
+            attempts + 1,
+            _CLAIM_CONFLICT_MAX_ATTEMPTS,
+        )
+        current_task = refreshed
+        task.version = refreshed.version  # keep caller's Task object in sync
+        time.sleep(min(0.05 * (2 ** (attempts - 1)), 0.5))
+
+
+def _claim_conflict_backoff_active(orch: Any, task_id: str) -> bool:
+    """True if ``task_id`` is still within its cross-tick claim-conflict backoff window."""
+    state: dict[str, tuple[int, float]] = getattr(orch, "_claim_conflict_state", None) or {}
+    _episode_count, backoff_until = state.get(task_id, (0, 0.0))
+    return time.time() < backoff_until
+
+
+def _record_claim_conflict_episode(orch: Any, task_id: str) -> None:
+    """Record one exhausted claim-conflict episode and set the next backoff window."""
+    if not hasattr(orch, "_claim_conflict_state") or not isinstance(orch._claim_conflict_state, dict):
+        orch._claim_conflict_state = {}
+    episode_count, _ = orch._claim_conflict_state.get(task_id, (0, 0.0))
+    episode_count += 1
+    backoff_s = min(
+        _CLAIM_CONFLICT_BACKOFF_BASE_S * (2 ** (episode_count - 1)),
+        _CLAIM_CONFLICT_BACKOFF_MAX_S,
+    )
+    backoff_until = time.time() + backoff_s
+    orch._claim_conflict_state[task_id] = (episode_count, backoff_until)
+    logger.warning(
+        "claim-conflict episode %d for task %s -- backing off %.1fs before the next attempt",
+        episode_count,
+        task_id,
+        backoff_s,
+    )
+
+
+def _clear_claim_conflict_state(orch: Any, task_id: str) -> None:
+    """Drop claim-conflict bookkeeping for a task once it claims successfully."""
+    state = getattr(orch, "_claim_conflict_state", None)
+    if isinstance(state, dict):
+        state.pop(task_id, None)
+
+
 def claim_and_spawn_batches(
     orch: Any,  # Orchestrator instance (avoids circular import)
     batches: list[list[Task]],
@@ -1557,27 +1983,49 @@ def claim_and_spawn_batches(
         # Claim tasks BEFORE spawning to prevent duplicate agents.
         # Pass expected_version for CAS (compare-and-swap) to prevent two
         # distributed nodes from claiming the same task simultaneously.
-        # Abort on server errors (5xx), CAS conflicts (409), or transport failures.
+        # Abort on server errors (5xx), CAS conflicts (409, with bounded
+        # re-fetch-and-retry -- see _claim_task_with_conflict_retry), or
+        # transport failures.
+        #
+        # Bug 1b (2026-07-02, claim-then-never-spawn deadlock): a
+        # multi-task batch used to be all-or-nothing -- if task N claimed
+        # successfully but a LATER task in the same batch failed to claim,
+        # the whole batch aborted via `continue`, leaving the already
+        # server-side-claimed earlier task(s) claimed with no agent spawned
+        # and no failure recorded. Evidence
+        # (work/bernstein/proofs/d2/claude/attempt4-meridian-fixed/FAIL-NOTE.md):
+        # duplicate-titled task pairs (created by an unrelated upstream
+        # double-execution bug) meant one twin claimed fine while its
+        # sibling's claim was rejected by the file-ownership-overlap check
+        # (surfaced generically as a 409, misread as a version race); the
+        # claimed twin then sat blocking the dependency graph for the full
+        # 15-minute stale-claim-reaper window with `agents=0 spawned=0`.
+        # Fix: track which tasks actually claimed and shrink ``batch`` to
+        # that subset before spawning, instead of discarding the whole
+        # batch -- a claimed task with no path to a worker is a worse
+        # failure mode than a partially-sized agent batch. Tasks that never
+        # claimed stay open and are retried (bounded, backed off) on a
+        # later tick via the same claim-conflict machinery above.
         claim_failed = False
+        claimed_tasks: list[Task] = []
         _orch_session_id: str | None = getattr(orch, "session_id", None)
         for task in batch:
-            try:
-                _claim_params: dict[str, Any] = {"expected_version": task.version}
-                if _orch_session_id is not None:
-                    _claim_params["claimed_by_session"] = _orch_session_id
-                resp = orch._client.post(
-                    f"{base}/tasks/{task.id}/claim",
-                    params=_claim_params,
+            if _claim_conflict_backoff_active(orch, task.id):
+                logger.debug(
+                    "Skipping claim for task %s: still within claim-conflict backoff window",
+                    task.id,
                 )
-                if resp.status_code == 409:
-                    logger.info(
-                        "CAS conflict claiming task %s (version %d) -- another node claimed it",
-                        task.id,
-                        task.version,
-                    )
-                    result.errors.append(f"claim:{task.id}: CAS conflict (version {task.version})")
+                result.errors.append(f"claim:{task.id}: in claim-conflict backoff")
+                claim_failed = True
+                break
+            try:
+                resp, conflict_reason = _claim_task_with_conflict_retry(orch, task, base, _orch_session_id)
+                if conflict_reason is not None:
+                    _record_claim_conflict_episode(orch, task.id)
+                    result.errors.append(f"claim:{task.id}: {conflict_reason}")
                     claim_failed = True
                     break
+                assert resp is not None  # conflict_reason is None only on a real response
                 if resp.status_code >= 500:
                     logger.error(
                         "Server error %d claiming task %s -- aborting spawn",
@@ -1587,6 +2035,8 @@ def claim_and_spawn_batches(
                     result.errors.append(f"claim:{task.id}: server error {resp.status_code}")
                     claim_failed = True
                     break
+                _clear_claim_conflict_state(orch, task.id)
+                claimed_tasks.append(task)
             except httpx.TransportError as exc:
                 logger.error(
                     "Server unreachable claiming task %s: %s -- aborting spawn",
@@ -1597,7 +2047,18 @@ def claim_and_spawn_batches(
                 claim_failed = True
                 break
         if claim_failed:
-            continue
+            if not claimed_tasks:
+                continue
+            logger.warning(
+                "Partial batch-claim failure: %d/%d task(s) claimed before the failure "
+                "(%s) -- spawning for the claimed subset %s instead of leaving them "
+                "claimed with no agent (claim-then-never-spawn deadlock)",
+                len(claimed_tasks),
+                len(batch),
+                result.errors[-1] if result.errors else "unknown reason",
+                [t.id for t in claimed_tasks],
+            )
+            batch = claimed_tasks
 
         # Response cache: if a functionally identical task was already completed,
         # return the cached result without spawning an agent (20-40% savings target).
@@ -2303,7 +2764,14 @@ def _evaluate_approval_gate(
             _create_approval_pr(orch, task, session, completion_data)
             return True
     except Exception:
-        logger.exception("Approval gate failed for task %s -- defaulting to auto-merge", task.id)
+        logger.exception(
+            "approval_decision: task=%s session=%s decision=held FAIL-CLOSED (outer exception) -- "
+            "exception raised in approval-gate evaluation flow (gate check or pre-gate step such as "
+            "_resolve_approval_workflow); holding for approval, NOT auto-merging",
+            task.id,
+            session.id,
+        )
+        return True
     return False
 
 
@@ -2359,11 +2827,11 @@ def _create_approval_pr(
     pr_url = orch._approval_gate.create_pr(
         task,
         worktree_path=worktree_path,
-        _session_id=session.id,
+        session_id=session.id,
         labels=orch._config.pr_labels,
         _role=session.role,
-        _model=session.model_config.model,
-        _cost_usd=cost_usd,
+        model=session.model_config.model,
+        cost_usd=cost_usd,
         test_summary=test_summary,
     )
     if pr_url:
@@ -2532,8 +3000,15 @@ def _record_cost_and_convergence(
     task_m: Any,
     cost_usd: float,
     janitor_passed: bool,
+    tokens_sidecar_source: str = "",
 ) -> None:
-    """Record cost tracking, convergence, and completion budget."""
+    """Record cost tracking, convergence, and completion budget.
+
+    ``tokens_sidecar_source`` (item 31, 2026-07-02) rides the ledger mutation
+    so the emitted ``ledger_update:`` line records whether these token counts
+    came from an alive-exit /complete sidecar ingestion (``alive_exit``) vs a
+    dead-session recovery (``dead_exit``) vs the collector metrics (``""``).
+    """
     agent_id = session.id if session else "unknown"
     model = session.model_config.model if session else "unknown"
     tokens_in = task_m.tokens_prompt if task_m else 0
@@ -2546,6 +3021,7 @@ def _record_cost_and_convergence(
         total_output_tokens=tokens_out,
         total_cost_usd=cost_usd if cost_usd > 0 else None,
         tenant_id=task.tenant_id,
+        cost_tags={"tokens_sidecar_source": tokens_sidecar_source} if tokens_sidecar_source else None,
     )
     try:
         orch._cost_tracker.save(orch._workdir / ".sdd")
@@ -2583,9 +3059,99 @@ def _record_completion_metrics(
     collector = get_collector(orch._workdir / ".sdd" / "metrics")
     task_m = collector.task_metrics.get(task.id)
     cost_usd = task_m.cost_usd if task_m else 0.0
+    tokens_prompt = task_m.tokens_prompt if task_m else 0
+    tokens_completion = task_m.tokens_completion if task_m else 0
+    cost_source = "collector.task_metrics"
 
-    _record_cost_and_convergence(orch, task, session, task_m, cost_usd, janitor_passed)
-    collector.complete_task(task.id, success=janitor_passed, janitor_passed=janitor_passed, cost_usd=cost_usd)
+    # D2 canary-host-99d0eac0 (2026-07-03): ``task_m.cost_usd`` is populated
+    # by nothing on the normal-completion path - the live-cost loop
+    # (orchestrator._record_live_costs) feeds CostTracker only and never
+    # writes back into collector.task_metrics - so normally-completed tasks
+    # with REAL spend (e.g. canary qa task 325c200e1985, whose .tokens
+    # sidecar carried 51,880/1,401 tokens) recorded ``cost_usd: 0.0`` in
+    # ``.sdd/metrics/tasks.jsonl``. The runner writes its priced usage to
+    # the orchestrator-root ``.tokens`` sidecar BEFORE its process exits
+    # (including on exception paths since the MaxTurnsExceeded fix), so at
+    # completion time the sidecar is ground truth for what the session
+    # actually spent - reading it here also closes the race where the
+    # sidecar lands after the live-cost loop's last tick. Prefer it
+    # whenever it knows more than the (typically zero) collector figure.
+    # Lazy import: agent_lifecycle imports this module at its top, so a
+    # top-level import here would be circular.
+    # Bug 14 (D2 minimax attempt-e938bd33, 2026-07-02): when the agent died
+    # BEFORE the completion sweep processed its task (MaxTurnsExceeded fires
+    # a nonzero exit and the reaper drops the session from _agents /
+    # _task_to_session), _find_session_for_task returns None here, the
+    # sidecar branch below never ran, and the metrics row recorded $0
+    # (task 7bb98dc57345: sidecar carried 54,003/1,026 tokens ~ $0.0116,
+    # row said cost_usd=0.0, model=null). The sidecar file itself survives
+    # (keyed by agent id at .sdd/runtime/<agent_id>.tokens), and
+    # task.assigned_agent still names the dead agent, so reconstruct a
+    # minimal session-shaped shim (id + model from the collector's
+    # AgentMetrics, recorded at spawn) and read the sidecar anyway.
+    sidecar_session: Any = session
+    if session is None and getattr(task, "assigned_agent", None):
+        agent_id = task.assigned_agent
+        agent_m = collector.agent_metrics.get(agent_id) if hasattr(collector, "agent_metrics") else None
+        dead_model = getattr(agent_m, "model", "") or ""
+        sidecar_session = SimpleNamespace(
+            id=agent_id,
+            model_config=SimpleNamespace(model=dead_model),
+        )
+        logger.info(
+            "completion_cost_fallback: task_id=%s session gone (agent reaped before "
+            "completion sweep) - reading sidecar via task.assigned_agent=%s model=%r",
+            task.id,
+            agent_id,
+            dead_model,
+        )
+    if sidecar_session is not None:
+        from bernstein.core.agents.agent_lifecycle import _read_runner_cost_usd
+
+        sidecar_cost, sidecar_in, sidecar_out = _read_runner_cost_usd(orch._workdir, sidecar_session, task.id)
+        if sidecar_cost > cost_usd or (cost_usd <= 0.0 and (sidecar_in > 0 or sidecar_out > 0)):
+            cost_usd = sidecar_cost
+            tokens_prompt = sidecar_in
+            tokens_completion = sidecar_out
+            cost_source = "tokens_sidecar" if session is not None else "tokens_sidecar_dead_session"
+            if task_m is not None:
+                # Reconcile the in-memory record too: retrospective.py's
+                # cost-aggregation fallback reads collector._task_metrics
+                # directly, and _record_cost_and_convergence below reads
+                # task_m.tokens_prompt/tokens_completion for CostTracker.
+                task_m.cost_usd = cost_usd
+                task_m.tokens_prompt = sidecar_in
+                task_m.tokens_completion = sidecar_out
+                task_m.tokens_used = sidecar_in + sidecar_out
+    logger.info(
+        "completion_cost_source: task_id=%s agent_id=%s source=%s cost_usd=%.6f tokens_prompt=%d tokens_completion=%d",
+        task.id,
+        session.id if session else getattr(sidecar_session, "id", "none") if sidecar_session else "none",
+        cost_source,
+        cost_usd,
+        tokens_prompt,
+        tokens_completion,
+    )
+
+    # item 31 (2026-07-02): classify the ledger ingestion origin so the
+    # alive-exit /complete path is distinguishable from an orphan/dead-exit
+    # recovery in the ledger_update: log line. cost_source is already the
+    # authoritative selector chosen above.
+    if cost_source == "tokens_sidecar":
+        tokens_sidecar_source = "alive_exit"
+    elif cost_source == "tokens_sidecar_dead_session":
+        tokens_sidecar_source = "dead_exit"
+    else:
+        tokens_sidecar_source = ""
+
+    _record_cost_and_convergence(orch, task, session, task_m, cost_usd, janitor_passed, tokens_sidecar_source)
+    collector.complete_task(
+        task.id,
+        success=janitor_passed,
+        janitor_passed=janitor_passed,
+        cost_usd=cost_usd,
+        tokens_used=tokens_prompt + tokens_completion,
+    )
 
     if session is not None:
         collector.complete_agent_task(session.id, success=janitor_passed)
@@ -2737,6 +3303,11 @@ def _record_evolution_completion(
                 janitor_passed=janitor_passed,
                 model=session.model_config.model if session else None,
                 provider=session.provider if session else None,
+                # task_m was reconciled with the runner's .tokens sidecar in
+                # _record_completion_metrics, so these carry the real token
+                # counts into .sdd/metrics/tasks.jsonl alongside cost_usd.
+                tokens_prompt=task_m.tokens_prompt if task_m else 0,
+                tokens_completion=task_m.tokens_completion if task_m else 0,
             )
         except Exception as exc:
             logger.warning("Evolution record_task_completion failed: %s", exc)
@@ -2787,6 +3358,111 @@ def _verify_via_janitor(task: Task, workdir: Path, server_url: str | None) -> tu
     return janitor_result.passed, failed_descs
 
 
+def _enqueue_alive_exit_janitor_pass(
+    orch: Any,
+    task: Task,
+    *,
+    reason: str,
+) -> concurrent.futures.Future[tuple[bool, list[str]]] | None:
+    """Enqueue a janitor pass for a task whose worker exited via /complete.
+
+    Mirrors the dead-exit scheduling in
+    ``bernstein.core.agents.agent_lifecycle.handle_orphaned_task``: that path
+    runs ``verify_task`` synchronously, then issues ``POST /complete`` or
+    ``retry_or_fail_task``. The alive-exit path has been wired through
+    ``process_completed_tasks`` + ``_process_single_completed_task`` for
+    months, but in practice it can be skipped when the orchestrator
+    self-stops before the next tick (item 30 defect evidence:
+    attempt-83808a8a - backend/qa tasks had ``metrics/tasks.jsonl`` rows
+    missing because ``_apply_janitor_verdict_action`` was never invoked).
+    This helper makes the enqueue observable and reachable from callers
+    outside the orchestrator's main tick (drain, retry, manual invocations).
+
+    Log shape mirrors the dead-exit path: every enqueue emits ``janitor:
+    enqueued pass task=... session=... role=... reason=...`` at INFO so a
+    silent no-op in the tick loop is impossible to overlook.
+
+    Args:
+        orch: Orchestrator instance (or any object exposing ``_executor``
+            and ``_processed_done_tasks``).
+        task: The just-done task whose worker exited via ``/complete``.
+        reason: Short string describing WHY the janitor pass is being
+            scheduled (e.g. ``"alive_exit_tick"``, ``"alive_exit_drain"``).
+
+    Returns:
+        The future tracking the verify_task result, or None if the
+        task has no completion signals (a no-op enqueue; a subsequent
+        process_completed_tasks iteration can still process it as
+        auto-verified).
+    """
+    if not task.completion_signals:
+        logger.info(
+            "janitor: enqueued pass task=%s session=%s role=%s reason=%s "
+            "no_completion_signals=true (will be marked verified by default)",
+            task.id,
+            getattr(orch, "_task_to_session", {}).get(task.id, "<none>"),
+            task.role,
+            reason,
+        )
+        return None
+
+    session_id = None
+    try:
+        _find_session = getattr(orch, "_find_session_for_task", None)
+        if callable(_find_session):
+            sess = _find_session(task.id)
+            if sess is not None:
+                session_id = sess.id
+    except Exception:
+        session_id = None
+
+    logger.info(
+        "janitor: enqueued pass task=%s session=%s role=%s reason=%s",
+        task.id,
+        session_id or "<none>",
+        task.role,
+        reason,
+    )
+
+    server_url: str | None = getattr(getattr(orch, "_config", None), "server_url", None)
+    executor = getattr(orch, "_executor", None)
+    if executor is None:
+        # Defensive: if the orchestrator has no executor we still want a
+        # synchronous verify so the task does not silently vanish.
+        try:
+            return _JanitorSyncFuture(verify_task(task, orch._workdir))
+        except Exception as exc:  # pragma: no cover - defensive only
+            logger.warning(
+                "janitor: sync-verify failed for task=%s reason=%s exc=%s",
+                task.id,
+                reason,
+                exc,
+            )
+            return None
+
+    if _has_llm_judge_signal(task):
+        return executor.submit(_verify_via_janitor, task, orch._workdir, server_url)
+    return executor.submit(verify_task, task, orch._workdir)
+
+
+class _JanitorSyncFuture:
+    """Backport of ``concurrent.futures.Future``-like used when no executor exists.
+
+    Holds a pre-computed verify_task result and exposes ``result()`` /
+    ``done()`` to look like a Future, so the rest of the pipeline can
+    treat it uniformly.
+    """
+
+    def __init__(self, value: tuple[bool, list[str]]) -> None:
+        self._value = value
+
+    def result(self, timeout: float | None = None) -> tuple[bool, list[str]]:
+        return self._value
+
+    def done(self) -> bool:
+        return True
+
+
 def process_completed_tasks(
     orch: Any,  # Orchestrator instance
     done_tasks: list[Task],
@@ -2821,18 +3497,23 @@ def process_completed_tasks(
     if not new_tasks:
         return
 
-    server_url: str | None = getattr(orch._config, "server_url", None)
-
     # Fan-out: submit verification calls in parallel. llm_judge signals need
     # the async run_janitor pipeline; everything else uses verify_task.
+    #
+    # DEFECT 30 FIX: previously the alive-exit janitor enqueue was implicit
+    # in the executor.submit() call below; an ops decision (premature
+    # self-stop predicate fires BEFORE this iteration can append a row
+    # to .sdd/metrics/tasks.jsonl, the orchestrator exits, and the worker
+    # task vanishes from janitor's view). The explicit
+    # ``_enqueue_alive_exit_janitor_pass`` helper now both logs the
+    # enqueue (so a silent no-op is impossible) and exposes a reusable
+    # janitor pass entrypoint that drain and retry paths can call outside
+    # the orchestrator tick.
     verify_futures: dict[str, concurrent.futures.Future[tuple[bool, list[str]]]] = {}
     for task in new_tasks:
-        if not task.completion_signals:
-            continue
-        if _has_llm_judge_signal(task):
-            verify_futures[task.id] = orch._executor.submit(_verify_via_janitor, task, orch._workdir, server_url)
-        else:
-            verify_futures[task.id] = orch._executor.submit(verify_task, task, orch._workdir)
+        future = _enqueue_alive_exit_janitor_pass(orch, task, reason="alive_exit_tick")
+        if future is not None:
+            verify_futures[task.id] = future
 
     # Fan-in: collect results then run sequential post-verification steps.
     for task in new_tasks:
@@ -2873,6 +3554,27 @@ def _process_single_completed_task(
     cache_verified = False
     cache_diff_lines = 0
     qg_result: Any = None
+
+    # DEFECT 30 FIX: the alive-exit /complete path runs the janitor+verdict
+    # action here. Log at INFO so a silent no-op in the orchestrator tick
+    # is impossible to overlook (attempt-83808a8a had zero janitor
+    # log lines because the tick exited before this ever ran).
+    _proc_session = None
+    try:
+        _find_session = getattr(orch, "_find_session_for_task", None)
+        if callable(_find_session):
+            _proc_session = _find_session(task.id)
+    except Exception:
+        _proc_session = None
+    _proc_session_id = _proc_session.id if _proc_session is not None else "<none>"
+    _proc_alive = bool(_proc_session is not None and _proc_session.status != "dead")
+    logger.info(
+        "janitor: alive-exit pass starting task=%s session=%s alive_session=%s role=%s",
+        task.id,
+        _proc_session_id,
+        _proc_alive,
+        task.role,
+    )
 
     janitor_passed = _resolve_janitor_result(task, verify_futures, result)
 
@@ -2934,6 +3636,116 @@ def _process_single_completed_task(
             logger.warning("append_decision failed for task %s: %s", task.id, exc)
 
     _record_evolution_completion(orch, task, session, task_m, cost_usd, janitor_passed)
+
+    _apply_janitor_verdict_action(orch, task, janitor_passed)
+
+
+_JANITOR_REOPEN_MAX_DEFAULT = 2
+
+
+def _janitor_reopen_max() -> int:
+    """Max janitor-reopen cycles per task (env BERNSTEIN_JANITOR_REOPEN_MAX, default 2)."""
+    raw = os.environ.get("BERNSTEIN_JANITOR_REOPEN_MAX", "")
+    try:
+        value = int(raw) if raw else _JANITOR_REOPEN_MAX_DEFAULT
+    except ValueError:
+        logger.warning(
+            "janitor_verdict_action: invalid BERNSTEIN_JANITOR_REOPEN_MAX=%r, using default %d",
+            raw,
+            _JANITOR_REOPEN_MAX_DEFAULT,
+        )
+        return _JANITOR_REOPEN_MAX_DEFAULT
+    return max(0, value)
+
+
+def _apply_janitor_verdict_action(orch: Any, task: Task, janitor_passed: bool) -> None:
+    """Act on the janitor verdict for a completed task.
+
+    A task the janitor FAILed must not stay silently ``done``:
+
+    * If the task's janitor-reopen budget (default 2 cycles, override via
+      ``BERNSTEIN_JANITOR_REOPEN_MAX``) is not exhausted, the task is
+      reopened under the SAME id via ``POST /tasks/{id}/reopen`` and will
+      be re-claimed by the normal scheduling path (AutoSpawnGuard and the
+      retry machinery are untouched - no new task is created).
+    * Otherwise it is permanently failed via ``POST /tasks/{id}/fail``.
+
+    Every decision is logged as ``janitor_verdict_action: ...`` with its
+    inputs so a silent no-op is impossible.
+
+    Args:
+        orch: Orchestrator instance.
+        task: The completed task whose janitor verdict was just resolved.
+        janitor_passed: Final janitor + verification-gate verdict.
+    """
+    if janitor_passed:
+        logger.debug("janitor_verdict_action: task=%s verdict=PASS action=none", task.id)
+        return
+
+    server_url: str | None = getattr(orch._config, "server_url", None)
+    if not server_url:
+        logger.warning(
+            "janitor_verdict_action: task=%s verdict=FAIL action=skip reason=no_server_url",
+            task.id,
+        )
+        return
+
+    max_cycles = _janitor_reopen_max()
+    prior_cycles = int(task.metadata.get("janitor_reopen_count", 0) or 0)
+
+    if prior_cycles < max_cycles:
+        cycle = prior_cycles + 1
+        try:
+            resp = orch._client.post(
+                f"{server_url}/tasks/{task.id}/reopen",
+                json={"reason": f"janitor verification failed (reopen cycle {cycle}/{max_cycles})"},
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.warning(
+                "janitor_verdict_action: task=%s verdict=FAIL action=reopen cycle=%d/%d FAILED: %s",
+                task.id,
+                cycle,
+                max_cycles,
+                exc,
+            )
+            return
+        # Allow the re-completed task to be janitor-verified again on the
+        # next completion instead of being skipped as already-processed.
+        try:
+            orch._processed_done_tasks.pop(task.id, None)
+        except Exception:  # pragma: no cover - defensive, dict-like expected
+            logger.debug("janitor_verdict_action: could not clear processed marker for %s", task.id)
+        logger.info(
+            "janitor_verdict_action: task=%s verdict=FAIL action=reopen cycle=%d/%d",
+            task.id,
+            cycle,
+            max_cycles,
+        )
+    else:
+        try:
+            resp = orch._client.post(
+                f"{server_url}/tasks/{task.id}/fail",
+                json={
+                    "reason": (
+                        f"reopen_budget_exhausted: janitor verification failed after "
+                        f"{prior_cycles} reopen cycle(s) (max {max_cycles})"
+                    )
+                },
+            )
+            resp.raise_for_status()
+        except Exception as exc:
+            logger.warning(
+                "janitor_verdict_action: task=%s verdict=FAIL action=permanent_fail "
+                "reason=reopen_budget_exhausted FAILED: %s",
+                task.id,
+                exc,
+            )
+            return
+        logger.info(
+            "janitor_verdict_action: task=%s verdict=FAIL action=permanent_fail reason=reopen_budget_exhausted",
+            task.id,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1496,6 +1496,50 @@ class TaskStore:
             await self._append_archive(task, completed_at)
             return task
 
+    async def reopen(self, task_id: str, reason: str) -> Task:
+        """Reopen a done task that failed janitor verification.
+
+        Transitions DONE -> OPEN so the SAME task (same id) is re-claimed and
+        re-attempted - no new task is created. Increments
+        ``metadata['janitor_reopen_count']`` so the orchestrator can bound the
+        number of reopen cycles before permanent failure.
+
+        Args:
+            task_id: Task identifier.
+            reason: Why the task is being reopened (e.g. failed janitor signals).
+
+        Returns:
+            The updated Task.
+
+        Raises:
+            KeyError: If task_id does not exist.
+            IllegalTransitionError: If the task is not in DONE status.
+        """
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise KeyError(task_id)
+            self._index_remove(task)
+            transition_task(task, TaskStatus.OPEN, actor="task_store", reason=reason)
+            reopen_count = int(task.metadata.get("janitor_reopen_count", 0) or 0) + 1
+            task.metadata["janitor_reopen_count"] = reopen_count
+            task.claimed_at = None
+            task.claimed_by_session = None
+            task.assigned_agent = None
+            task.completed_at = None
+            task.result_summary = None
+            task.priority = 0
+            task.version += 1
+            self._index_add(task)
+            await self._append_jsonl(self._task_to_record(task))
+            logger.info(
+                "task.reopen: task_id=%s reopen_count=%d reason=%s",
+                task_id,
+                reopen_count,
+                reason,
+            )
+            return task
+
     async def abandon(
         self,
         task_id: str,

--- a/src/bernstein/evolution/__init__.py
+++ b/src/bernstein/evolution/__init__.py
@@ -12,6 +12,7 @@ are hash-locked and cannot be modified by the evolution system.
 
 from __future__ import annotations
 
+import logging
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -97,6 +98,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from bernstein.core.models import Task
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "AgentMetrics",
@@ -403,8 +406,27 @@ class EvolutionCoordinator:
         janitor_passed: bool,
         model: str | None = None,
         provider: str | None = None,
+        tokens_prompt: int = 0,
+        tokens_completion: int = 0,
     ) -> None:
-        """Record metrics for a completed task."""
+        """Record metrics for a completed task.
+
+        Args:
+            task: The completed task.
+            duration_seconds: Wall-clock duration of the agent run.
+            cost_usd: Real LLM cost for this task, if known. Callers must
+                thread through the actual runner-priced cost (e.g. recovered
+                from a cost sidecar for orphaned/auto-completed tasks) rather
+                than hardcoding ``0.0`` -- a hardcoded zero here is exactly
+                the bug-13-family defect where ``.sdd/metrics/tasks.jsonl``
+                shows ``cost_usd: 0.0`` for tasks the provider actually
+                charged real money for.
+            janitor_passed: Whether janitor verification passed.
+            model: Model used, if known.
+            provider: Provider used, if known.
+            tokens_prompt: Prompt tokens consumed, if known.
+            tokens_completion: Completion tokens consumed, if known.
+        """
         metrics = TaskMetrics(
             timestamp=time.time(),
             task_id=task.id,
@@ -414,6 +436,8 @@ class EvolutionCoordinator:
             duration_seconds=duration_seconds,
             cost_usd=cost_usd,
             janitor_passed=janitor_passed,
+            tokens_prompt=tokens_prompt,
+            tokens_completion=tokens_completion,
         )
         self.collector.record_task_metrics(metrics)
 
@@ -423,18 +447,46 @@ class EvolutionCoordinator:
         role: str,
         lifetime_seconds: float,
         tasks_completed: int,
+        _model: str | None = None,
         model: str | None = None,
     ) -> None:
         """Record agent session lifetime metrics when an agent ends.
+
+        API-drift fix (defect 22): the real callers in
+        ``core/tasks/task_lifecycle.py`` and ``core/agents/agent_lifecycle.py``
+        invoke this with the underscore-prefixed ``_model`` kwarg, while this
+        signature historically only accepted ``model``. That mismatch raised
+        ``TypeError: record_agent_lifetime() got an unexpected keyword
+        argument '_model'`` on every call, which was silently swallowed by a
+        broad ``except Exception`` (task_lifecycle.py, logged at WARNING) or a
+        bare ``contextlib.suppress(Exception)`` (agent_lifecycle.py's
+        wall-clock and heartbeat reap paths - no log at all). Net effect: the
+        evolution system's agents.jsonl metrics stream never received a
+        single agent-lifetime record, starving role/model retirement analysis
+        of its primary input with zero visible signal in the reap paths.
+
+        Both spellings are accepted so this also stays compatible with any
+        caller (including existing tests) still passing the un-prefixed
+        ``model`` kwarg.
 
         Args:
             agent_id: Unique agent session identifier.
             role: Role the agent was assigned.
             lifetime_seconds: Total wall-clock time the agent was alive.
             tasks_completed: Number of tasks the agent successfully completed.
-            _model: Model used by the agent (part of interface).
+            _model: Model used by the agent, as passed by the real orchestrator
+                callers (underscore-prefixed).
+            model: Same field, accepted un-prefixed for backward compatibility.
         """
-        _ = model  # Part of interface
+        resolved_model = _model if _model is not None else model
+        logger.info(
+            "record_agent_lifetime: agent_id=%s role=%s model=%s lifetime_seconds=%.2f tasks_completed=%d",
+            agent_id,
+            role,
+            resolved_model,
+            lifetime_seconds,
+            tasks_completed,
+        )
         metrics = AgentMetrics(
             timestamp=time.time(),
             agent_id=agent_id,

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -25,9 +25,39 @@ Read the `## Task Server Authentication` section appended to this prompt for the
 absolute path to your token file, then include the `Authorization` header on **every**
 request. Without that header the server returns 401 and no task is created.
 
+**Command-form contract - read this before your first request.** Your `run_command`
+tool accepts two call forms:
+- a single command **STRING** (e.g. `run_command("curl ... -H \"Authorization: Bearer $(cat /path/to/token)\" ...")`)
+  → this runs via a shell, so `$(...)`, `$VAR`, pipes, and `&&` all expand normally.
+- an **argv LIST** (e.g. `run_command(["curl", "-H", "Authorization: Bearer $(cat /path/to/token)", ...])`)
+  → this execs the process directly with NO shell involved, so `$(...)` and `$VAR`
+  are never expanded. The literal text (including the dollar sign, parens, and
+  path) is sent as-is, curl still exits 0, and the task server returns 401.
+  There is no visible error other than the HTTP status - it looks like success
+  unless you check it.
+
+**Every curl below - including the ones in the appended `## Task Server Authentication`
+section - MUST be invoked with `run_command` in the single-STRING form whenever it uses
+`$(...)`, `$VAR`, a pipe, or `&&`.** If you are not sure which form your tool call used,
+re-issue the request as one string and re-check the status code.
+
+**Do not use the `read_file` tool to obtain your token.** `read_file` is confined to
+your own worktree, and the token file lives outside it - the call will fail with a
+workdir-escape error every time, regardless of the token's validity. The only
+supported way to read the token is through `run_command` in string form running
+`cat <token-path>` (or interpolating it into the curl command directly, as shown
+below).
+
+**Always check the HTTP status, not just the command's exit code.** curl exits 0 even
+on a 401 or 500 - the failure is only visible in the response body/status line. Add
+`-w '\n%{http_code}'` to every call and treat any status outside 200-299 as a failure:
+stop, re-verify you used the string form and the correct token path, and retry. Do not
+report a task as done, or give up, based solely on a non-2xx response without first
+confirming the command form was correct.
+
 ```bash
 TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -s -X POST http://127.0.0.1:8052/tasks \
+curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -44,6 +74,10 @@ curl -s -X POST http://127.0.0.1:8052/tasks \
     ]
   }'
 ```
+
+The command above must be passed to `run_command` as ONE string (the whole multi-line
+`TOKEN=... curl ...` sequence joined with `&&` or `;`, or run as a single-line
+equivalent) - never as an argv list, or `$TOKEN` will never be substituted.
 
 **Priority**: 1=critical, 2=normal, 3=nice-to-have
 **Scope**: small (<30min), medium (30-120min), large (2-8h)
@@ -77,14 +111,18 @@ Programmatic surface lives at `bernstein.core.memory.cross_task_kb.CrossTaskKB`.
 
 ## When done planning
 
-Mark your own task as complete (remember the `Authorization` header):
+Mark your own task as complete (remember the `Authorization` header, the single-STRING
+`run_command` form, and to check the trailing HTTP status code):
 
 ```bash
 TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -s -X POST http://127.0.0.1:8052/tasks/{YOUR_TASK_ID}/complete \
+curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{YOUR_TASK_ID}/complete \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"result_summary": "Created N tasks to achieve goal: ..."}'
 ```
+
+If the trailing status code is not 2xx, do not treat the task as complete - re-verify
+you used the string form of `run_command` and retry before exiting.
 
 Then exit.

--- a/templates/roles/manager/task_prompt.md
+++ b/templates/roles/manager/task_prompt.md
@@ -28,9 +28,19 @@ section appended below for the absolute token file path. Every POST needs the
 `Authorization: Bearer $(cat …)` header (or `Authorization: Bearer $BERNSTEIN_AUTH_TOKEN`
 as a fallback).
 
+**Call form matters.** These commands rely on `$(...)`/`$VAR` shell expansion, which
+only happens when `run_command` is invoked with a single command **STRING**. If
+`run_command` is invoked with an argv **LIST** instead, no shell runs, `$(...)`/`$VAR`
+are sent as literal text, curl still exits 0, and the server returns 401 with no other
+visible error. Always pass these commands to `run_command` as one string. Do not read
+the token via the `read_file` tool - the token file lives outside your worktree and
+`read_file` cannot reach it; use `run_command` string-form `cat <token-path>` instead.
+Always inspect the trailing HTTP status code (`-w '\n%{http_code}'` below) and treat
+any non-2xx response as a failure to fix and retry, not as a reason to give up.
+
 ```bash
 TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -s -X POST http://127.0.0.1:8052/tasks \
+curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -48,8 +58,11 @@ curl -s -X POST http://127.0.0.1:8052/tasks \
 ## Done signal
 ```bash
 TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete \
+curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"result_summary": "{{TASK_TITLE}}: created N tasks"}'
 ```
+
+Pass the whole command above to `run_command` as ONE string - never as an argv list -
+and confirm the trailing status code is 2xx before considering the task done.

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 import sys
 import threading
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,20 +17,23 @@ from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
 from bernstein.adapters import openai_agents as adapter_module
 from bernstein.adapters import openai_agents_runner as runner_module
-from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
+from bernstein.adapters.openai_agents import TOOL_SOURCE_ENV_VAR, OpenAIAgentsAdapter
 from bernstein.adapters.openai_agents_runner import (
     EXIT_GENERIC,
     EXIT_MANIFEST_ERROR,
     EXIT_OK,
     EXIT_RATE_LIMIT,
     EXIT_SDK_MISSING,
+    MAX_TURNS_ENV_VAR,
     RunnerManifest,
+    _append_tokens_sidecar,
     _build_agent_kwargs,
     _build_model_settings_kwargs,
-    _build_run_config,
     _is_rate_limit,
     _resolve_client_kwargs,
     _resolve_heartbeat_dir,
+    _resolve_max_turns,
+    _resolve_tokens_sidecar_path,
     _start_heartbeat,
     emit_event,
     load_manifest,
@@ -265,6 +270,90 @@ class TestSpawnCommand:
             (tmp_path / ".sdd" / "runtime" / "oai-tsb.manifest.json").read_text(),
         )
         assert manifest["tool_source"] == "builtin"
+
+    def test_env_var_enables_builtin_tool_source(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE=builtin flips the default."""
+        monkeypatch.setenv(TOOL_SOURCE_ENV_VAR, "builtin")
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1106)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-tse",
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-tse.manifest.json").read_text(),
+        )
+        assert manifest["tool_source"] == "builtin"
+
+    def test_env_var_applies_when_mcp_config_lacks_tool_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(TOOL_SOURCE_ENV_VAR, "builtin")
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1107)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-tsf",
+                mcp_config={"sandbox_provider": "e2b"},
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-tsf.manifest.json").read_text(),
+        )
+        assert manifest["tool_source"] == "builtin"
+
+    def test_explicit_mcp_config_tool_source_wins_over_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit mcp_config tool_source beats the env var."""
+        monkeypatch.setenv(TOOL_SOURCE_ENV_VAR, "builtin")
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1108)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-tsx",
+                mcp_config={"tool_source": "gateway"},
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-tsx.manifest.json").read_text(),
+        )
+        assert manifest["tool_source"] == "gateway"
+
+    def test_non_builtin_env_value_keeps_gateway(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(TOOL_SOURCE_ENV_VAR, "gateway")
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1109)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="run tests",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id="oai-tsy",
+            )
+        manifest = json.loads(
+            (tmp_path / ".sdd" / "runtime" / "oai-tsy.manifest.json").read_text(),
+        )
+        assert manifest["tool_source"] == "gateway"
 
     def test_manifest_includes_sampling_overrides(self, tmp_path: Path) -> None:
         adapter = OpenAIAgentsAdapter()
@@ -880,22 +969,148 @@ class TestRunnerHelpers:
         kwargs = _build_agent_kwargs(manifest)
         assert kwargs["tools"] == [{"name": "file_read"}]
 
-    def test_build_run_config_copies_mcp_servers(self) -> None:
+    def test_run_sync_not_called_with_dict_run_config(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Regression: a plain-dict ``run_config`` crashes the SDK.
+
+        ``agents.run`` accesses ``run_config.session_input_callback`` on
+        whatever is passed, so handing it a dict raised AttributeError on
+        every spawn. The runner must not pass ``run_config`` at all unless
+        it is a real ``agents.RunConfig`` instance.
+        """
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
         manifest = RunnerManifest(
             session_id="s",
             prompt="p",
             workdir="/abs",
-            model="gpt-5",
+            model="MiniMax-M3",
             sandbox_provider="e2b",
             mcp_servers={"bernstein": {"command": "python"}},
         )
-        cfg = _build_run_config(manifest)
-        assert cfg["sandbox_provider"] == "e2b"
-        assert cfg["workdir"] == "/abs"
-        assert cfg["mcp_servers"] == {"bernstein": {"command": "python"}}
-        # Defensive copy - mutating the output must not mutate manifest state.
-        cfg["mcp_servers"]["other"] = {"command": "x"}
-        assert "other" not in manifest.mcp_servers
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        _, kwargs = fake_runner.run_sync.call_args
+        assert not isinstance(kwargs.get("run_config"), dict), (
+            "run_config must never be a plain dict - the SDK requires a real agents.RunConfig instance"
+        )
+        assert "run_config" not in kwargs
+
+    def test_resolve_max_turns_defaults_to_30(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bug 13: the SDK default of 10 killed builtin-tool workflows - the
+        shipped default is now 30 (tuning.agent.max_turns)."""
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        core_defaults.reset()
+        assert _resolve_max_turns() == 30
+
+    def test_resolve_max_turns_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        assert _resolve_max_turns() == 200
+
+    def test_resolve_max_turns_tuning_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        core_defaults.override("agent", {"max_turns": 80})
+        try:
+            assert _resolve_max_turns() == 80
+        finally:
+            core_defaults.reset()
+
+    def test_resolve_max_turns_env_beats_tuning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.override("agent", {"max_turns": 80})
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        try:
+            assert _resolve_max_turns() == 200
+        finally:
+            core_defaults.reset()
+
+    def test_resolve_max_turns_unparseable_env_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.reset()
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "notanumber")
+        assert _resolve_max_turns() == 30
+
+    def test_resolve_max_turns_zero_env_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A 0 max_turns would fail every run on turn one - reject, don't forward."""
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.reset()
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "0")
+        assert _resolve_max_turns() == 30
+
+    def test_resolve_max_turns_negative_env_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core import defaults as core_defaults
+
+        core_defaults.reset()
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "-5")
+        assert _resolve_max_turns() == 30
+
+    def test_resolve_max_turns_negative_env_falls_back_to_tuning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-positive env value falls through to tuning.agent.max_turns, not just None."""
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "-5")
+        core_defaults.override("agent", {"max_turns": 80})
+        try:
+            assert _resolve_max_turns() == 80
+        finally:
+            core_defaults.reset()
+
+    def test_log_max_turns_exceeded_reports_turns_and_completed_work(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Bug 13: hitting the cap must WARN with the configured cap, turns
+        actually used, and whether the agent had already POSTed /complete."""
+        from types import SimpleNamespace
+
+        from bernstein.adapters.openai_agents_runner import _log_max_turns_exceeded
+
+        run_data = SimpleNamespace(
+            raw_responses=[SimpleNamespace(usage=None) for _ in range(10)],
+            new_items=[
+                SimpleNamespace(
+                    raw_item=SimpleNamespace(
+                        arguments='{"command": "curl -X POST http://localhost:8052/tasks/abc/complete"}'
+                    )
+                )
+            ],
+        )
+        exc = RuntimeError("Max turns (10) exceeded")
+        exc.run_data = run_data  # type: ignore[attr-defined]
+
+        with caplog.at_level("WARNING", logger="bernstein.adapters.openai_agents_runner"):
+            _log_max_turns_exceeded(exc, 10)
+
+        assert any(
+            "max_turns=10" in rec.getMessage()
+            and "turns_used=10" in rec.getMessage()
+            and "work_already_completed=yes" in rec.getMessage()
+            for rec in caplog.records
+        ), f"missing/incomplete MaxTurns warning: {[r.getMessage() for r in caplog.records]}"
+
+    def test_log_max_turns_exceeded_handles_missing_run_data(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No run_data on the exception must still produce a WARNING with
+        unknowns, never a crash."""
+        from bernstein.adapters.openai_agents_runner import _log_max_turns_exceeded
+
+        with caplog.at_level("WARNING", logger="bernstein.adapters.openai_agents_runner"):
+            _log_max_turns_exceeded(RuntimeError("Max turns (30) exceeded"), None)
+
+        assert any(
+            "max_turns=SDK-default" in rec.getMessage()
+            and "turns_used=unknown" in rec.getMessage()
+            and "work_already_completed=unknown" in rec.getMessage()
+            for rec in caplog.records
+        )
 
     def test_build_model_settings_kwargs_empty_when_absent(self) -> None:
         manifest = RunnerManifest(
@@ -1108,9 +1323,30 @@ class _FakeUsage:
 
 
 class _FakeResult:
-    def __init__(self, summary: str = "done", usage: _FakeUsage | None = None) -> None:
+    def __init__(
+        self,
+        summary: str = "done",
+        usage: _FakeUsage | None = None,
+        raw_responses: list[Any] | None = None,
+    ) -> None:
         self.final_output = summary
         self.usage = usage
+        self.raw_responses = raw_responses if raw_responses is not None else []
+
+
+class _FakeRawResponseUsage:
+    """Mimics ``agents.usage.Usage`` as embedded on ``ModelResponse.usage``."""
+
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class _FakeRawResponse:
+    """Mimics ``agents.items.ModelResponse`` - the ``result.raw_responses`` element."""
+
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.usage = _FakeRawResponseUsage(input_tokens, output_tokens)
 
 
 class TestRunnerRun:
@@ -1146,19 +1382,67 @@ class TestRunnerRun:
         assert usage_event["output_tokens"] == 20
         assert usage_event["tool_calls"] == 1
 
-    def test_run_without_usage_still_emits_completion(
+    def test_run_forwards_max_turns_30_by_default(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        """Bug 13: unset BERNSTEIN_MAX_TURNS / tuning -> the shipped default
+        of 30 is forwarded (the SDK's own default of 10 killed builtin-tool
+        workflows mid-flight)."""
+        from bernstein.core import defaults as core_defaults
+
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        core_defaults.reset()
+        fake_agent = MagicMock()
         fake_runner = MagicMock()
-        fake_runner.run_sync.return_value = _FakeResult(summary="ok", usage=None)
-        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
         with patch.dict(sys.modules, {"agents": fake_sdk}):
             rc = run(self._manifest())
         assert rc == EXIT_OK
+        _, kwargs = fake_runner.run_sync.call_args
+        assert kwargs["max_turns"] == 30
+
+    def test_run_forwards_max_turns_from_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(self._manifest())
+        assert rc == EXIT_OK
+        _, kwargs = fake_runner.run_sync.call_args
+        assert kwargs["max_turns"] == 200
+
+    def test_run_without_usage_still_emits_completion(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``result.usage`` is None AND there is no ``raw_responses`` fallback data:
+        a usage_missing event fires (not a silently dropped usage event) and a
+        WARNING is logged - see the raw_responses-fallback tests below for the
+        bug-13-followup fallback path itself."""
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok", usage=None)
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with caplog.at_level(logging.WARNING):
+            with patch.dict(sys.modules, {"agents": fake_sdk}):
+                rc = run(self._manifest())
+        assert rc == EXIT_OK
         events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
         assert any(e["type"] == "completion" for e in events)
-        assert not any(e["type"] == "usage" for e in events)
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 0
+        assert usage_event["output_tokens"] == 0
+        assert usage_event["usage_missing"] is True
+        assert any("no usage data" in rec.message for rec in caplog.records)
 
     def test_run_emits_sdk_missing_when_import_fails(
         self,
@@ -1437,6 +1721,108 @@ class TestRunnerRun:
             run(self._manifest())
         fake_sdk.set_default_openai_client.assert_not_called()
 
+    def test_run_builds_explicit_model_for_slash_containing_id_with_base_url(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """D1 openrouter fix: OpenRouter model ids like 'deepseek/deepseek-chat'
+        contain a vendor/model slash. Passed as a bare string, the SDK's
+        ``MultiProvider`` (the default ``RunConfig.model_provider``) parses
+        everything before the first '/' as an SDK provider prefix and raises
+        ``UserError: Unknown prefix: deepseek`` before any tool call
+        (agents/models/multi_provider.py:154-173,221 in the installed SDK).
+        The fix must build an explicit ``OpenAIChatCompletionsModel`` bound
+        to the manifest's endpoint client and hand THAT to ``Agent(model=...)``
+        instead - never the bare string - since the SDK never re-resolves
+        (and never prefix-parses) a model that is already a ``Model``
+        instance (agents/run_internal/turn_preparation.py:126-135)."""
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="deepseek/deepseek-chat",
+            base_url="https://openrouter.ai/api/v1",
+            api_key_env="OPENROUTER_API_KEY",
+        )
+        client_sentinel = object()
+        explicit_model_sentinel = object()
+        fake_agent_cls = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_chat_model_cls = MagicMock(return_value=explicit_model_sentinel)
+        fake_sdk = MagicMock(
+            Agent=fake_agent_cls,
+            Runner=fake_runner,
+            OpenAIChatCompletionsModel=fake_chat_model_cls,
+        )
+        fake_openai = MagicMock(AsyncOpenAI=MagicMock(return_value=client_sentinel))
+        with (
+            patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-proxy"}, clear=True),
+            caplog.at_level("INFO"),
+        ):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        # The SDK's own prefix-parsing path (a bare model string handed to
+        # MultiProvider) must never be exercised: the Agent is built with
+        # the pre-resolved Model instance, not "deepseek/deepseek-chat".
+        fake_chat_model_cls.assert_called_once_with(
+            model="deepseek/deepseek-chat",
+            openai_client=client_sentinel,
+        )
+        assert fake_agent_cls.call_args.kwargs["model"] is explicit_model_sentinel
+        assert any(
+            "deepseek/deepseek-chat" in rec.message and "https://openrouter.ai/api/v1" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_run_uses_bare_model_string_without_base_url(self) -> None:
+        """No ``base_url`` override: existing behavior (bare model string,
+        resolved by whatever ``model_provider`` the SDK defaults to) is
+        unchanged - the runner must not construct an explicit
+        ``OpenAIChatCompletionsModel`` when there is no custom endpoint."""
+        fake_agent_cls = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=fake_agent_cls, Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(self._manifest())
+        assert rc == EXIT_OK
+        assert fake_agent_cls.call_args.kwargs["model"] == "gpt-5-mini"
+        fake_sdk.OpenAIChatCompletionsModel.assert_not_called()
+
+    def test_run_builds_explicit_model_even_without_slash_when_base_url_set(self) -> None:
+        """A custom endpoint always gets an explicit Model, slash or not -
+        the manifest's model id is still whatever the endpoint expects, and
+        relying on the SDK's default-client wiring alone previously left
+        model resolution to MultiProvider, which is only safe for ids the
+        SDK's built-in prefixes happen to tolerate."""
+        manifest = RunnerManifest(
+            session_id="abc",
+            prompt="hello",
+            workdir="/workspace",
+            model="gpt-5-mini",
+            base_url="http://localhost:8000/v1",
+            api_key_env="OPENROUTER_API_KEY",
+        )
+        client_sentinel = object()
+        fake_agent_cls = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=fake_agent_cls, Runner=fake_runner)
+        fake_openai = MagicMock(AsyncOpenAI=MagicMock(return_value=client_sentinel))
+        with (
+            patch.dict(sys.modules, {"agents": fake_sdk, "openai": fake_openai}),
+            patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-proxy"}, clear=True),
+        ):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        fake_sdk.OpenAIChatCompletionsModel.assert_called_once_with(
+            model="gpt-5-mini",
+            openai_client=client_sentinel,
+        )
+        assert fake_agent_cls.call_args.kwargs["model"] is fake_sdk.OpenAIChatCompletionsModel.return_value
+
     def test_run_fails_loudly_when_api_key_env_var_missing(
         self,
         capsys: pytest.CaptureFixture[str],
@@ -1659,3 +2045,528 @@ class TestPricing:
 class TestModuleSurface:
     def test_module_exports_adapter_class(self) -> None:
         assert hasattr(adapter_module, "OpenAIAgentsAdapter")
+
+
+# ---------------------------------------------------------------------------
+# Manifest-carried control knobs (allow_run_command / max_turns)
+# ---------------------------------------------------------------------------
+
+
+class TestManifestControlKnobs:
+    """Control env vars are filtered from the runner env; they must ride the manifest."""
+
+    def _spawn_and_read_manifest(
+        self,
+        tmp_path: Path,
+        *,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        adapter = OpenAIAgentsAdapter()
+        proc_mock = _make_popen_mock(pid=1200)
+        with patch(
+            "bernstein.adapters.openai_agents.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="do work",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5", effort="high"),
+                session_id=session_id,
+                mcp_config=mcp_config,
+            )
+        return json.loads((tmp_path / ".sdd" / "runtime" / f"{session_id}.manifest.json").read_text())
+
+    def test_allow_run_command_from_parent_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", "1")
+        manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-arc1")
+        assert manifest["allow_run_command"] is True
+
+    def test_allow_run_command_false_when_env_unset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", raising=False)
+        manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-arc2")
+        assert manifest["allow_run_command"] is False
+
+    def test_explicit_mcp_config_allow_run_command_wins_over_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", "1")
+        manifest = self._spawn_and_read_manifest(
+            tmp_path, session_id="oai-arc3", mcp_config={"allow_run_command": False}
+        )
+        assert manifest["allow_run_command"] is False
+
+    def test_max_turns_from_mcp_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-mt1", mcp_config={"max_turns": 40})
+        assert manifest["max_turns"] == 40
+
+    def test_max_turns_from_parent_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "77")
+        manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-mt2")
+        assert manifest["max_turns"] == 77
+
+    def test_runner_manifest_parses_control_knobs(self) -> None:
+        manifest = RunnerManifest.from_dict(
+            {
+                "session_id": "s",
+                "prompt": "p",
+                "workdir": "/abs",
+                "model": "MiniMax-M3",
+                "allow_run_command": True,
+                "max_turns": 40,
+            }
+        )
+        assert manifest.allow_run_command is True
+        assert manifest.max_turns == 40
+
+    def test_runner_manifest_defaults_to_none(self) -> None:
+        manifest = RunnerManifest.from_dict({"session_id": "s", "prompt": "p", "workdir": "/abs", "model": "gpt-5"})
+        assert manifest.allow_run_command is None
+        assert manifest.max_turns is None
+
+    def test_resolve_max_turns_manifest_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        assert _resolve_max_turns(40) == 40
+
+    def test_resolve_max_turns_invalid_manifest_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "200")
+        assert _resolve_max_turns(0) == 200
+
+    def test_run_forwards_manifest_max_turns_to_run_sync(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.delenv(MAX_TURNS_ENV_VAR, raising=False)
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(summary="ok")
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        manifest = RunnerManifest(
+            session_id="s",
+            prompt="p",
+            workdir="/abs",
+            model="MiniMax-M3",
+            max_turns=40,
+        )
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+        _, kwargs = fake_runner.run_sync.call_args
+        assert kwargs["max_turns"] == 40
+
+
+# ---------------------------------------------------------------------------
+# Bug 13: cost metering on the openai_agents path.
+#
+# Root cause: the runner captured SDK usage and emitted a bare "usage" event
+# to its own stdout/log, but never priced it and never wrote the ``.tokens``
+# sidecar file (``<orchestrator-root>/.sdd/runtime/<session_id>.tokens``)
+# that ``TokenGrowthMonitor.read_tokens()`` tails to populate
+# ``AgentSession.tokens_used``. The orchestrator's live cost loop
+# (``Orchestrator._record_live_costs``) skips any session whose
+# ``tokens_used`` is 0, so the session's spend never reached CostTracker at
+# all - a 45-minute MiniMax-M3 run recorded ``spent_usd: 0.0`` with an empty
+# ``usages`` list. These tests pin: (1) a fake SDK usage payload flows
+# through to a correctly priced + aggregated "usage" event and a populated
+# tokens sidecar, and (2) an unrecognized model is priced at an explicit $0
+# with a WARNING logged and its tokens still counted, not dropped.
+# ---------------------------------------------------------------------------
+
+
+class TestBug13CostMetering:
+    def _manifest(
+        self, *, model: str, heartbeat_dir: str | None = None, session_id: str = "sess-bug13"
+    ) -> RunnerManifest:
+        return RunnerManifest(
+            session_id=session_id,
+            prompt="hello",
+            workdir="/workspace",
+            model=model,
+            heartbeat_dir=heartbeat_dir,
+        )
+
+    def test_priced_model_usage_flows_to_usage_event_and_sidecar(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A fake SDK usage payload for a priced model computes a nonzero
+        cost, emits it on the "usage" event, and lands in the .tokens
+        sidecar the orchestrator's live cost loop actually reads."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        # Uses the model from the actual bug-13 incident (MiniMax-M3) rather
+        # than a "gpt-5" family name: several gpt-5* keys are substrings of
+        # each other in MODEL_COSTS_PER_1M_TOKENS insertion order (a
+        # pre-existing, separate issue from bug 13), which would make this
+        # test's expected cost depend on dict iteration order.
+        manifest = self._manifest(model="MiniMax-M3", heartbeat_dir=str(heartbeat_dir))
+
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(
+            summary="ok",
+            usage=_FakeUsage(input_tokens=10_000, output_tokens=2_000, tool_calls=3),
+        )
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 10_000
+        assert usage_event["output_tokens"] == 2_000
+        assert usage_event["model"] == "MiniMax-M3"
+        assert usage_event["priced"] is True
+        # minimax-m3: $0.30/$1.20 per 1M -> (10000/1e6)*0.3 + (2000/1e6)*1.2
+        expected_cost = (10_000 / 1_000_000.0) * 0.3 + (2_000 / 1_000_000.0) * 1.2
+        assert usage_event["cost_usd"] == pytest.approx(expected_cost)
+        assert usage_event["cost_usd"] > 0.0
+        assert usage_event["running_total_usd"] == pytest.approx(expected_cost)
+
+        # The bug-13 fix: the tokens sidecar must exist and carry the same
+        # counts, at the orchestrator-root path (heartbeat_dir's parent),
+        # NOT under the per-session worktree.
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert sidecar.exists()
+        record = json.loads(sidecar.read_text().strip().splitlines()[-1])
+        assert record["in"] == 10_000
+        assert record["out"] == 2_000
+        assert "ts" in record
+
+    def test_unpriced_model_logs_warning_and_meters_zero_without_dropping_tokens(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A model with no pricing-table entry must not vanish from cost
+        totals: cost is an explicit $0, a WARNING is logged, and the token
+        counts still flow through to the usage event and the sidecar."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(model="totally-unknown-model-xyz", heartbeat_dir=str(heartbeat_dir))
+
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(
+            summary="ok",
+            usage=_FakeUsage(input_tokens=5_000, output_tokens=1_000, tool_calls=0),
+        )
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with caplog.at_level("WARNING"):
+            with patch.dict(sys.modules, {"agents": fake_sdk}):
+                rc = run(manifest)
+        assert rc == EXIT_OK
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        usage_event = next(e for e in events if e["type"] == "usage")
+        # Tokens are still visible even though the model is unpriced.
+        assert usage_event["input_tokens"] == 5_000
+        assert usage_event["output_tokens"] == 1_000
+        assert usage_event["priced"] is False
+        assert usage_event["cost_usd"] == 0.0
+        assert usage_event["running_total_usd"] == 0.0
+
+        assert any(
+            "no pricing-table entry" in rec.message and "totally-unknown-model-xyz" in rec.message
+            for rec in caplog.records
+            if rec.levelname == "WARNING"
+        )
+
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert sidecar.exists()
+        record = json.loads(sidecar.read_text().strip().splitlines()[-1])
+        assert record["in"] == 5_000
+        assert record["out"] == 1_000
+
+    def test_none_usage_falls_back_to_raw_responses(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Bug-13 follow-up (2026-07-02): a real MiniMax-M2.7-highspeed run
+        proved ``result.usage`` is None on some providers (in fact, the
+        installed SDK's ``RunResult`` never has a ``usage`` attribute at
+        all). Usage must be recovered by summing ``result.raw_responses``
+        (each a fake ``agents.items.ModelResponse`` carrying its own
+        ``usage``), priced correctly, and written to the sidecar exactly as
+        the primary path does."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(model="MiniMax-M3", heartbeat_dir=str(heartbeat_dir))
+
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(
+            summary="ok",
+            usage=None,
+            raw_responses=[
+                _FakeRawResponse(input_tokens=3_000, output_tokens=500),
+                _FakeRawResponse(input_tokens=2_000, output_tokens=300),
+            ],
+        )
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(manifest)
+        assert rc == EXIT_OK
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 5_000
+        assert usage_event["output_tokens"] == 800
+        assert usage_event["priced"] is True
+        assert "usage_missing" not in usage_event
+        expected_cost = (5_000 / 1_000_000.0) * 0.3 + (800 / 1_000_000.0) * 1.2
+        assert usage_event["cost_usd"] == pytest.approx(expected_cost)
+
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert sidecar.exists()
+        record = json.loads(sidecar.read_text().strip().splitlines()[-1])
+        assert record["in"] == 5_000
+        assert record["out"] == 800
+
+    def test_none_usage_and_empty_raw_responses_emits_usage_missing_no_sidecar(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Both ``result.usage`` and the ``raw_responses`` fallback yield
+        nothing: a WARNING naming the model must fire, a usage event with
+        ``usage_missing: true`` must be emitted, and NOTHING may be written
+        to the cost sidecar (no fabricated tokens/cost)."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(model="MiniMax-M2.7-highspeed", heartbeat_dir=str(heartbeat_dir))
+
+        fake_agent = MagicMock()
+        fake_runner = MagicMock()
+        fake_runner.run_sync.return_value = _FakeResult(
+            summary="ok",
+            usage=None,
+            raw_responses=[_FakeRawResponse(input_tokens=0, output_tokens=0)],
+        )
+        fake_sdk = MagicMock(Agent=MagicMock(return_value=fake_agent), Runner=fake_runner)
+        with caplog.at_level(logging.WARNING):
+            with patch.dict(sys.modules, {"agents": fake_sdk}):
+                rc = run(manifest)
+        assert rc == EXIT_OK
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 0
+        assert usage_event["output_tokens"] == 0
+        assert usage_event["usage_missing"] is True
+        assert "cost_usd" not in usage_event
+
+        assert any(
+            "no usage data" in rec.message and "MiniMax-M2.7-highspeed" in rec.message
+            for rec in caplog.records
+            if rec.levelname == "WARNING"
+        )
+
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert not sidecar.exists()
+
+    def test_resolve_tokens_sidecar_path_uses_heartbeat_dir_parent(self, tmp_path: Path) -> None:
+        heartbeat_dir = tmp_path / "orchestrator-root" / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(model="gpt-5", heartbeat_dir=str(heartbeat_dir), session_id="s1")
+        path = _resolve_tokens_sidecar_path(manifest)
+        assert path == heartbeat_dir.parent / "s1.tokens"
+
+    def test_resolve_tokens_sidecar_path_falls_back_to_workdir(self, tmp_path: Path) -> None:
+        manifest = RunnerManifest(
+            session_id="s2",
+            prompt="p",
+            workdir=str(tmp_path / "worktree"),
+            model="gpt-5",
+        )
+        path = _resolve_tokens_sidecar_path(manifest)
+        assert path == tmp_path / "worktree" / ".sdd" / "runtime" / "s2.tokens"
+
+    def test_append_tokens_sidecar_skips_zero_usage(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / "s3.tokens"
+        _append_tokens_sidecar(sidecar, 0, 0)
+        assert not sidecar.exists()
+
+    def test_append_tokens_sidecar_survives_unwritable_path(self, caplog: pytest.LogCaptureFixture) -> None:
+        # A path under a location that cannot be created (root-owned or
+        # already a file) must log a warning, never raise - a sidecar
+        # failure must not fail the run.
+        unwritable = Path("/this/path/should/not/be/creatable/by/tests") / "s4.tokens"
+        with caplog.at_level("WARNING"):
+            _append_tokens_sidecar(unwritable, 10, 10)
+        assert any("failed to write tokens sidecar" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# D2 MiniMax attempt-3 regression (2026-07-03): usage extraction must be
+# reachable on exception paths. Six backend agents each burned 10 real
+# MiniMax turns, died on MaxTurnsExceeded, and emitted ZERO usage events -
+# the run's cost file read `spent_usd: 0.0, usages: []` despite real spend,
+# because the extraction block lived only after the try/except around
+# Runner.run_sync. These tests pin: (1) an exception carrying partial run
+# data (exc.run_data.raw_responses) still prices and sidecars the real
+# usage; (2) an exception with no run data still emits the usage_missing
+# marker (downstream sees "unknown", never a silent zero); (3) the
+# rate-limit exception branch behaves the same way.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunData:
+    """Mimics ``agents.exceptions.RunErrorDetails`` as carried on
+    ``AgentsException.run_data`` - same ``raw_responses`` shape as a
+    successful ``RunResult``."""
+
+    def __init__(self, raw_responses: list[Any]) -> None:
+        self.raw_responses = raw_responses
+
+
+class _FakeMaxTurnsExceeded(Exception):
+    """Stands in for ``agents.exceptions.MaxTurnsExceeded``: an SDK
+    exception that carries the partial run's state on ``run_data``."""
+
+    def __init__(self, message: str, run_data: Any = None) -> None:
+        super().__init__(message)
+        self.run_data = run_data
+
+
+class TestUsageOnExceptionPaths:
+    def _manifest(self, *, heartbeat_dir: str, session_id: str = "sess-exc") -> RunnerManifest:
+        return RunnerManifest(
+            session_id=session_id,
+            prompt="hello",
+            workdir="/workspace",
+            model="MiniMax-M3",
+            heartbeat_dir=heartbeat_dir,
+        )
+
+    def test_max_turns_exceeded_with_run_data_prices_and_sidecars_partial_usage(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The exact D2 MiniMax attempt-3 shape: run_sync raises
+        MaxTurnsExceeded after real billable turns. The partial usage on
+        exc.run_data.raw_responses must be priced, emitted as a usage
+        event, and written to the .tokens sidecar - AND the error event +
+        EXIT_GENERIC contract must be preserved."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(heartbeat_dir=str(heartbeat_dir))
+
+        exc = _FakeMaxTurnsExceeded(
+            "Max turns (10) exceeded",
+            run_data=_FakeRunData(
+                raw_responses=[
+                    _FakeRawResponse(input_tokens=5_000, output_tokens=700),
+                    _FakeRawResponse(input_tokens=6_000, output_tokens=900),
+                ],
+            ),
+        )
+        fake_runner = MagicMock()
+        fake_runner.run_sync.side_effect = exc
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with caplog.at_level(logging.INFO):
+            with patch.dict(sys.modules, {"agents": fake_sdk}):
+                rc = run(manifest)
+        assert rc == EXIT_GENERIC
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        # The error contract is unchanged...
+        error_event = next(e for e in events if e["type"] == "error")
+        assert error_event["kind"] == "runtime"
+        assert "Max turns" in error_event["message"]
+        # ...but a real usage event now precedes it.
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 11_000
+        assert usage_event["output_tokens"] == 1_600
+        assert usage_event["priced"] is True
+        expected_cost = (11_000 / 1_000_000.0) * 0.3 + (1_600 / 1_000_000.0) * 1.2
+        assert usage_event["cost_usd"] == pytest.approx(expected_cost)
+        assert usage_event["cost_usd"] > 0.0
+        assert usage_event["usage_source"] == "_FakeMaxTurnsExceeded.run_data"
+        # Usage event must be emitted before the error event (extraction
+        # happens before the early return).
+        assert events.index(usage_event) < events.index(error_event)
+        # No completion event on the exception path.
+        assert not any(e["type"] == "completion" for e in events)
+
+        # The sidecar carries the recovered partial usage.
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert sidecar.exists()
+        record = json.loads(sidecar.read_text().strip().splitlines()[-1])
+        assert record["in"] == 11_000
+        assert record["out"] == 1_600
+
+        # The INFO line names what was recovered and from where.
+        assert any(
+            "llm_call" in rec.message and "_FakeMaxTurnsExceeded.run_data" in rec.message
+            for rec in caplog.records
+            if rec.levelname == "INFO"
+        )
+
+    def test_exception_without_run_data_emits_usage_missing_marker(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A plain exception with no run_data: no fabricated tokens, no
+        sidecar, but a usage_missing event fires so downstream can tell
+        "unknown" from "zero"."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(heartbeat_dir=str(heartbeat_dir))
+
+        fake_runner = MagicMock()
+        fake_runner.run_sync.side_effect = RuntimeError("something else")
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with caplog.at_level(logging.WARNING):
+            with patch.dict(sys.modules, {"agents": fake_sdk}):
+                rc = run(manifest)
+        assert rc == EXIT_GENERIC
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 0
+        assert usage_event["output_tokens"] == 0
+        assert usage_event["usage_missing"] is True
+        assert usage_event["usage_source"] == "RuntimeError.run_data"
+        assert "cost_usd" not in usage_event
+        assert any(e["type"] == "error" and e["kind"] == "runtime" for e in events)
+
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert not sidecar.exists()
+
+        assert any("no usage data" in rec.message for rec in caplog.records if rec.levelname == "WARNING")
+
+    def test_rate_limit_exception_with_run_data_recovers_usage_and_keeps_exit_code(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A rate-limit abort mid-run still recovers the spend already
+        incurred and still returns EXIT_RATE_LIMIT."""
+        heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+        manifest = self._manifest(heartbeat_dir=str(heartbeat_dir))
+
+        exc = _FakeMaxTurnsExceeded(
+            "HTTP 429 rate limit",
+            run_data=_FakeRunData(raw_responses=[_FakeRawResponse(input_tokens=2_000, output_tokens=300)]),
+        )
+        fake_runner = MagicMock()
+        fake_runner.run_sync.side_effect = exc
+        fake_sdk = MagicMock(Agent=MagicMock(), Runner=fake_runner)
+        with patch.dict(sys.modules, {"agents": fake_sdk}):
+            rc = run(manifest)
+        assert rc == EXIT_RATE_LIMIT
+
+        events = [json.loads(line) for line in capsys.readouterr().out.strip().splitlines()]
+        assert any(e["type"] == "error" and e["kind"] == "rate_limit" for e in events)
+        usage_event = next(e for e in events if e["type"] == "usage")
+        assert usage_event["input_tokens"] == 2_000
+        assert usage_event["output_tokens"] == 300
+        assert usage_event["cost_usd"] > 0.0
+
+        sidecar = heartbeat_dir.parent / f"{manifest.session_id}.tokens"
+        assert sidecar.exists()

--- a/tests/unit/adapters/test_openai_agents_builtins.py
+++ b/tests/unit/adapters/test_openai_agents_builtins.py
@@ -4,14 +4,21 @@ These cover the hard conditions the builtins must satisfy:
 
 1. Path confinement (file tools): absolute paths and ``..`` escapes are
    rejected; an in-workdir path is accepted.
-2. ``run_command`` uses an argv list with ``shell=False`` - a metacharacter
-   in an argument is passed literally, never interpreted by a shell.
+2. ``run_command`` given an argv LIST still uses ``shell=False`` - a
+   metacharacter in an argument is passed literally, never interpreted by a
+   shell.
 3. ``run_command`` rejects absolute / path-separator / shell-interpreter
    ``argv[0]`` (the proven filesystem-escape vectors) and only runs bare
-   commands resolved on ``PATH``.
+   commands resolved on ``PATH`` when given the argv-list form.
 4. ``run_command`` is only exposed (registered) under an OS sandbox provider
    or the explicit opt-in.
 5. Every builtin call emits an audit event to the run event stream.
+6. ``run_command`` given a single command STRING runs it through a real
+   shell (``/bin/bash -lc``), so variable/command substitution, pipes, and
+   background jobs work - this is the regression coverage for the D2
+   OpenRouter FAIL-NOTE: the manager prompt's task-server auth headers
+   (``$(cat <token-file>)`` / ``$BERNSTEIN_AUTH_TOKEN``) only resolve when
+   ``run_command`` is given the shell-string form.
 """
 
 from __future__ import annotations
@@ -55,9 +62,17 @@ class TestPathConfinement:
     def test_workdir_root_itself_accepted(self, tmp_path: Path) -> None:
         assert resolve_in_workdir(tmp_path, ".") == tmp_path.resolve()
 
-    def test_absolute_path_rejected(self, tmp_path: Path) -> None:
-        with pytest.raises(WorkdirEscapeError, match="absolute"):
+    def test_absolute_path_outside_workdir_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(WorkdirEscapeError, match="escapes"):
             resolve_in_workdir(tmp_path, "/etc/passwd")
+
+    def test_absolute_path_inside_workdir_allowed(self, tmp_path: Path) -> None:
+        # Runner-issued absolute paths (e.g. heartbeat writes to
+        # /workspace/.sdd/runtime/heartbeats/<id>.json) must resolve when
+        # they normalize inside the workdir - only escapes are rejected.
+        absolute_inside = tmp_path / "sub" / "file.txt"
+        resolved = resolve_in_workdir(tmp_path, str(absolute_inside))
+        assert resolved == absolute_inside.resolve()
 
     def test_parent_escape_rejected(self, tmp_path: Path) -> None:
         with pytest.raises(WorkdirEscapeError, match="escapes"):
@@ -84,6 +99,31 @@ class TestPathConfinement:
         write_file_in_workdir(tmp_path, "a/b.txt", "hello", emit=emit)
         assert (tmp_path / "a" / "b.txt").read_text() == "hello"
         assert read_file_in_workdir(tmp_path, "a/b.txt", emit=emit) == "hello"
+
+    def test_write_file_absolute_path_inside_workdir_succeeds(self, tmp_path: Path) -> None:
+        # Defect B regression: worker/manager heartbeat writes use an
+        # absolute path under the workspace root (e.g.
+        # /workspace/.sdd/runtime/heartbeats/<id>.json). A blanket
+        # absolute-path ban made every such write fail with
+        # WorkdirEscapeError; only escapes outside the workdir must fail.
+        heartbeat = tmp_path / ".sdd" / "runtime" / "heartbeats" / "backend-1.json"
+        _events, emit = _sink()
+        out = write_file_in_workdir(tmp_path, str(heartbeat), '{"ts": 1}', emit=emit)
+        assert out.startswith("wrote")
+        assert heartbeat.read_text() == '{"ts": 1}'
+
+    def test_write_file_absolute_path_outside_workdir_rejected(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / "outside-heartbeat.json"
+        _events, emit = _sink()
+        out = write_file_in_workdir(tmp_path, str(outside), "x", emit=emit)
+        assert out.startswith("error:")
+        assert not outside.exists()
+
+    def test_write_file_dotdot_traversal_still_rejected(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = write_file_in_workdir(tmp_path, "../../etc/evil.txt", "x", emit=emit)
+        assert out.startswith("error:")
+        assert not (tmp_path.parent.parent / "etc" / "evil.txt").exists()
 
 
 class TestRunCommandNoShell:
@@ -117,6 +157,194 @@ class TestRunCommandNoShell:
         assert out.startswith("error:")
 
 
+class TestRunCommandShellString:
+    """A single command STRING gets a real shell (``/bin/bash -lc``).
+
+    Regression coverage for the D2 OpenRouter FAIL-NOTE root cause: the
+    manager prompt asks the agent to resolve ``$(cat <token-file>)`` and
+    ``$BERNSTEIN_AUTH_TOKEN`` into an Authorization header. Both require
+    shell substitution; an argv-list call (``shell=False``) cannot do this.
+    """
+
+    def test_command_substitution_resolves(self, tmp_path: Path) -> None:
+        token_file = tmp_path / "manager.token"
+        token_file.write_text("secret-token-value")
+        _events, emit = _sink()
+        out = run_command_in_workdir(
+            tmp_path,
+            "echo Bearer $(cat manager.token)",
+            emit=emit,
+        )
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "Bearer secret-token-value"
+
+    def test_env_var_fallback_resolves(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_AUTH_TOKEN", "env-fallback-token")
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, "echo Bearer $BERNSTEIN_AUTH_TOKEN", emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "Bearer env-fallback-token"
+
+    def test_arithmetic_substitution(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, "echo $((2+2))", emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "4"
+
+    def test_pipe_works(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, "echo hello | tr a-z A-Z", emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "HELLO"
+
+    def test_runs_in_workdir(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, "pwd", emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == str(tmp_path.resolve())
+
+    def test_nonzero_exit_surfaces_stderr(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(
+            tmp_path,
+            "echo boom-error-message 1>&2; exit 1",
+            emit=emit,
+        )
+        assert out.startswith("exit_code=1")
+        stderr = out.split("stderr:\n", 1)[1]
+        assert "boom-error-message" in stderr
+
+    def test_empty_string_rejected(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, "   ", emit=emit)
+        assert out.startswith("error:")
+
+    def test_shell_string_form_was_never_subject_to_the_denylist(self, tmp_path: Path) -> None:
+        # Finding: the shell-string form builds exec_argv as
+        # ["/bin/bash", "-lc", <string>] directly - "/bin/bash" never passes
+        # through resolve_command, so it was never blockable by the old
+        # interpreter denylist (which rejected bare "bash"/"sh"/"python"...
+        # only on the argv-LIST path). The D2 MiniMax outage was entirely on
+        # the argv-list path; this pins down that the shell fix from
+        # 0be0dd2e was never dead-on-arrival for its own callers.
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, "python3 -c 'print(1+1)'", emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "2"
+
+    def test_bare_pytest_argv0_resolves_when_on_path(self, tmp_path: Path) -> None:
+        import shutil as _shutil
+
+        if _shutil.which("pytest") is None:
+            pytest.skip("pytest not on PATH in this test environment")
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, ["pytest", "--version"], emit=emit)
+        assert not out.startswith("error:")
+
+    def test_argv_list_form_unaffected_by_shell_support(self, tmp_path: Path) -> None:
+        """List form still runs with no shell - no regression from adding string support."""
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, ["echo", "hello"], emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "hello"
+
+    def test_background_job_does_not_hang_the_call(self, tmp_path: Path) -> None:
+        """A backgrounded job (heartbeat-loop shape) must not block the tool call.
+
+        Previously an OPEN xfail: ``subprocess.run(capture_output=True)``
+        backs stdout/stderr with OS pipes, and a backgrounded grandchild
+        (``sleep 30 & disown``) inherits those pipe fds even though
+        ``disown`` detaches job-control/SIGHUP tracking, not stdio - so the
+        pipe never reaches EOF and the call blocked for the full 30s.
+        Fixed by capturing via temp files (:func:`_run_captured`): the direct
+        child (bash) exits immediately after the foreground statement, and
+        ``Popen.wait()`` returns without waiting on the backgrounded
+        grandchild's fds the way a pipe-based read-until-EOF would.
+        """
+        import time
+
+        start = time.monotonic()
+        _events, emit = _sink()
+        out = run_command_in_workdir(
+            tmp_path,
+            "sleep 30 & disown; echo started",
+            emit=emit,
+        )
+        elapsed = time.monotonic() - start
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "started"
+        assert elapsed < 10, f"run_command took {elapsed:.1f}s - background job blocked the call"
+
+    def test_heartbeat_loop_shape_does_not_hang_the_call(self, tmp_path: Path) -> None:
+        """The manager's actual heartbeat-loop shape must return promptly.
+
+        The command shape mirrors a real backgrounded heartbeat loop (a
+        subshell that forks a loop and detaches), but with two safety nets so
+        this test never leaks an orphaned process onto the host:
+          1. The loop is bounded (``seq 1 5`` + ``sleep 1``) instead of
+             ``while true`` + ``sleep 30`` - even if cleanup below fails, the
+             spawned process self-terminates in ~5s instead of running
+             forever.
+          2. The subshell records its own pid (via ``$!``) to a pidfile in
+             the test's ``tmp_path``, and a unique per-test marker string is
+             embedded directly in the shell command line (the process's own
+             argv, not its stdout - so it never pollutes the captured
+             output) so it can be found/reaped with ``pgrep -f``/``pkill -f``
+             regardless of whether the pidfile write raced the loop's exit.
+        The try/finally guarantees the kill runs even if an assertion below
+        fails.
+        """
+        import os
+        import signal
+        import subprocess
+        import time
+        import uuid
+
+        marker = f"hb-loop-test-{uuid.uuid4().hex}"
+        pidfile = tmp_path / "hb_loop.pid"
+        start = time.monotonic()
+        _events, emit = _sink()
+        try:
+            out = run_command_in_workdir(
+                tmp_path,
+                # The marker appears only in the process's own command line
+                # (via the ``{marker}.txt`` redirect target) - never echoed
+                # to stdout - so it doesn't affect the captured output while
+                # still being greppable via `ps`/`pgrep -f`.
+                f"(for i in $(seq 1 5); do date +%s > {marker}.txt; "
+                f"sleep 1; done & echo $! > {pidfile}) ; echo started",
+                emit=emit,
+            )
+            elapsed = time.monotonic() - start
+            stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+            assert stdout == "started"
+            assert elapsed < 10, f"run_command took {elapsed:.1f}s - heartbeat loop blocked the call"
+        finally:
+            # Belt-and-braces cleanup: kill by recorded pid, then sweep by
+            # marker in case the pidfile write lost the race with process
+            # exit. Never let this loop outlive the test.
+            if pidfile.exists():
+                try:
+                    pid = int(pidfile.read_text().strip())
+                    os.kill(pid, signal.SIGTERM)
+                except (ValueError, ProcessLookupError, OSError):
+                    pass
+            subprocess.run(["pkill", "-f", marker], check=False)
+
+    def test_normal_foreground_output_capture_unaffected(self, tmp_path: Path) -> None:
+        """File-backed capture must preserve exact stdout/stderr for normal calls."""
+        _events, emit = _sink()
+        out = run_command_in_workdir(
+            tmp_path,
+            "echo out-line; echo err-line 1>&2",
+            emit=emit,
+        )
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        stderr = out.split("stderr:\n", 1)[1].strip()
+        assert stdout == "out-line"
+        assert stderr == "err-line"
+
+
 class TestRunCommandArgvRestriction:
     """The two proven escapes must now fail closed at the builtin layer."""
 
@@ -143,10 +371,36 @@ class TestRunCommandArgvRestriction:
         assert out.startswith("error:")
         assert not outside.exists()
 
-    def test_bare_shell_name_rejected(self, tmp_path: Path) -> None:
-        # Even a bare interpreter name (resolvable on PATH) is blocked.
+    def test_bare_basic_toolchain_interpreters_allowed(self, tmp_path: Path) -> None:
+        # Defect A regression: bare standard-toolchain interpreter names
+        # (bash, sh, python, python3, ...) used to be denylisted outright,
+        # making every Python/pytest-driven run_command-only task
+        # structurally unsolvable (D2 MiniMax KILL-NOTE). They are ordinary
+        # bare commands now - the shell-string form already grants an
+        # unrestricted shell, so denylisting them here added no real
+        # containment.
         _events, emit = _sink()
         out = run_command_in_workdir(tmp_path, ["sh", "-c", "echo hi"], emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "hi"
+
+    def test_bare_bash_argv0_allowed(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, ["bash", "-c", "echo bash-ok"], emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "bash-ok"
+
+    def test_bare_python3_argv0_allowed(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, ["python3", "-c", "print(1)"], emit=emit)
+        stdout = out.split("stdout:\n", 1)[1].split("\nstderr:", 1)[0].strip()
+        assert stdout == "1"
+
+    def test_dangerous_command_still_rejected(self, tmp_path: Path) -> None:
+        # The rework shrank the denylist to genuinely dangerous operations -
+        # confirm at least one of those still fails closed.
+        _events, emit = _sink()
+        out = run_command_in_workdir(tmp_path, ["sudo", "true"], emit=emit)
         assert out.startswith("error:")
 
     def test_relative_path_separator_argv0_rejected(self, tmp_path: Path) -> None:
@@ -207,6 +461,30 @@ class TestRunCommandGating:
         assert "run_command" in names
         assert set(names) == set(BUILTIN_TOOL_NAMES)
 
+    def test_manifest_opt_in_enables_run_command_without_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Manifest allow_run_command=True must not depend on the (filtered) env."""
+        monkeypatch.delenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", raising=False)
+        assert run_command_available("unix_local", allow_run_command=True) is True
+        names = selected_builtin_names("unix_local", allow_run_command=True)
+        assert "run_command" in names
+
+    def test_manifest_opt_out_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Manifest allow_run_command=False beats the env fallback."""
+        monkeypatch.setenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", "1")
+        assert run_command_available("unix_local", allow_run_command=False) is False
+        names = selected_builtin_names("unix_local", allow_run_command=False)
+        assert "run_command" not in names
+
+    def test_manifest_none_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """allow_run_command=None (direct invocation) keeps the env behavior."""
+        monkeypatch.setenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", "1")
+        assert run_command_available("unix_local", allow_run_command=None) is True
+
+    def test_os_sandbox_still_wins_over_manifest_opt_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An OS sandbox provider confines run_command regardless of the flag."""
+        monkeypatch.delenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", raising=False)
+        assert run_command_available("docker", allow_run_command=False) is True
+
 
 class TestAuditEvents:
     def test_read_emits_call_and_result(self, tmp_path: Path) -> None:
@@ -250,3 +528,75 @@ class TestAuditEvents:
         run_command_in_workdir(tmp_path, ["true"], emit=emit)
         recorded = {e["name"] for e in events if e["type"] == "tool_call"}
         assert recorded == set(BUILTIN_TOOL_NAMES)
+
+
+class TestRunCommandDuplicateSuppression:
+    """Regression: D2 attempt-4 defect 2 - double-delivered tool_calls.
+
+    A chat-completions translation endpoint delivered the SAME tool_call
+    twice per assistant message; the SDK invoked ``run_command`` twice, so
+    ``bash create_tasks.sh`` double-POSTed duplicate task pairs. These tests
+    count REAL executions (a command that appends to a file) and assert
+    exactly-once for a duplicated invocation, in both calling forms.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_dedupe_state(self) -> Any:
+        from bernstein.adapters import openai_agents_builtins as mod
+
+        mod._recent_invocations.clear()
+        yield
+        mod._recent_invocations.clear()
+
+    def test_single_shell_string_executes_exactly_once(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        run_command_in_workdir(tmp_path, "echo run >> marker.txt", emit=emit)
+        assert (tmp_path / "marker.txt").read_text().count("run") == 1
+
+    def test_single_argv_executes_exactly_once(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        run_command_in_workdir(tmp_path, ["bash", "-c", "echo run >> marker.txt"], emit=emit)
+        assert (tmp_path / "marker.txt").read_text().count("run") == 1
+
+    def test_duplicate_shell_string_executes_exactly_once(self, tmp_path: Path) -> None:
+        events, emit = _sink()
+        first = run_command_in_workdir(tmp_path, "echo run >> marker.txt", emit=emit)
+        second = run_command_in_workdir(tmp_path, "echo run >> marker.txt", emit=emit)
+        assert (tmp_path / "marker.txt").read_text().count("run") == 1
+        assert second == first
+        results = [e for e in events if e["type"] == "tool_result"]
+        assert results[1].get("deduped") is True
+        assert results[1]["duplicate_of"] == results[0]["invocation_id"]
+
+    def test_duplicate_argv_executes_exactly_once(self, tmp_path: Path) -> None:
+        events, emit = _sink()
+        argv = ["bash", "-c", "echo run >> marker.txt"]
+        first = run_command_in_workdir(tmp_path, argv, emit=emit)
+        second = run_command_in_workdir(tmp_path, argv, emit=emit)
+        assert (tmp_path / "marker.txt").read_text().count("run") == 1
+        assert second == first
+        results = [e for e in events if e["type"] == "tool_result"]
+        assert results[1].get("deduped") is True
+
+    def test_distinct_commands_both_execute(self, tmp_path: Path) -> None:
+        _events, emit = _sink()
+        run_command_in_workdir(tmp_path, "echo a >> marker.txt", emit=emit)
+        run_command_in_workdir(tmp_path, "echo b >> marker.txt", emit=emit)
+        text = (tmp_path / "marker.txt").read_text()
+        assert "a" in text
+        assert "b" in text
+
+    def test_window_zero_disables_suppression(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_RUN_COMMAND_DEDUPE_WINDOW_S", "0")
+        _events, emit = _sink()
+        run_command_in_workdir(tmp_path, "echo run >> marker.txt", emit=emit)
+        run_command_in_workdir(tmp_path, "echo run >> marker.txt", emit=emit)
+        assert (tmp_path / "marker.txt").read_text().count("run") == 2
+
+    def test_invocation_id_and_events_carry_ids(self, tmp_path: Path) -> None:
+        events, emit = _sink()
+        run_command_in_workdir(tmp_path, ["true"], emit=emit)
+        call = next(e for e in events if e["type"] == "tool_call")
+        result = next(e for e in events if e["type"] == "tool_result")
+        assert isinstance(call["invocation_id"], int)
+        assert result["invocation_id"] == call["invocation_id"]

--- a/tests/unit/agents/test_agent_lifecycle_helpers.py
+++ b/tests/unit/agents/test_agent_lifecycle_helpers.py
@@ -350,3 +350,118 @@ def test_emit_orphan_metrics_appends_failure_record(tmp_path: Path) -> None:
     assert failure["success"] is False
     assert failure["test_pass_rate"] == 0.0
     assert failure["error_type"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# _preserve_runner_logs
+# ---------------------------------------------------------------------------
+
+
+def test_preserve_runner_logs_copies_logs_and_manifest(tmp_path: Path) -> None:
+    """Runner logs + manifest are copied out of the worktree before cleanup."""
+    from bernstein.core.agents.agent_lifecycle import _preserve_runner_logs
+
+    worktree = tmp_path / "wt"
+    runtime = worktree / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "A-1.log").write_text("runner transcript")
+    (runtime / "A-1.events.log").write_text("events")
+    (runtime / "A-1.manifest.json").write_text("{}")
+    (runtime / "OTHER-SESSION.log").write_text("not ours")
+    orch_dir = tmp_path / "orch"
+    orch_dir.mkdir()
+    orch = SimpleNamespace(
+        _spawner=SimpleNamespace(get_worktree_path=lambda sid: worktree),
+        _workdir=orch_dir,
+    )
+
+    dest = _preserve_runner_logs(orch, _session())
+
+    assert dest == orch_dir / ".sdd" / "runtime" / "agent_logs" / "A-1"
+    names = sorted(p.name for p in dest.iterdir())
+    assert names == ["A-1.events.log", "A-1.log", "A-1.manifest.json"]
+    assert (dest / "A-1.log").read_text() == "runner transcript"
+
+
+def test_preserve_runner_logs_none_without_worktree(tmp_path: Path) -> None:
+    from bernstein.core.agents.agent_lifecycle import _preserve_runner_logs
+
+    orch = SimpleNamespace(
+        _spawner=SimpleNamespace(get_worktree_path=lambda sid: None),
+        _workdir=tmp_path,
+    )
+    assert _preserve_runner_logs(orch, _session()) is None
+
+
+def test_preserve_runner_logs_none_when_no_matching_files(tmp_path: Path) -> None:
+    from bernstein.core.agents.agent_lifecycle import _preserve_runner_logs
+
+    worktree = tmp_path / "wt"
+    (worktree / ".sdd" / "runtime").mkdir(parents=True)
+    orch = SimpleNamespace(
+        _spawner=SimpleNamespace(get_worktree_path=lambda sid: worktree),
+        _workdir=tmp_path / "orch",
+    )
+    assert _preserve_runner_logs(orch, _session()) is None
+    assert not (tmp_path / "orch" / ".sdd" / "runtime" / "agent_logs" / "A-1").exists()
+
+
+# ---------------------------------------------------------------------------
+# suspicious short-lived clean-exit auto-complete warning
+# ---------------------------------------------------------------------------
+
+
+def _orphan_orch(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        _workdir=tmp_path,
+        _client=MagicMock(),
+        _spawner=SimpleNamespace(get_worktree_path=lambda sid: None),
+    )
+
+
+def test_short_lived_clean_exit_auto_complete_warns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A <60s 'no changes needed' auto-complete emits a defect-signal WARNING."""
+    import logging
+    import time as _time
+
+    import bernstein.core.agents.agent_lifecycle as al
+
+    monkeypatch.setattr(al, "collect_completion_data", lambda workdir, session: {"files_modified": []})
+    monkeypatch.setattr(al, "complete_task", lambda client, base, task_id, summary: None)
+    session = _session(exit_code=0)
+    session.spawn_ts = _time.time() - 3.0
+    with caplog.at_level(logging.WARNING):
+        success, error_type = al._handle_orphan_no_signals(
+            _orphan_orch(tmp_path), MagicMock(), "T-1", session, "http://srv", _time.time()
+        )
+    assert success is True
+    assert error_type is None
+    warning = next(r for r in caplog.records if "SUSPICIOUS auto-complete" in r.message)
+    assert "A-1" in warning.message
+    assert "agent_logs" in warning.message
+
+
+def test_long_lived_clean_exit_auto_complete_does_not_warn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+    import time as _time
+
+    import bernstein.core.agents.agent_lifecycle as al
+
+    monkeypatch.setattr(al, "collect_completion_data", lambda workdir, session: {"files_modified": []})
+    monkeypatch.setattr(al, "complete_task", lambda client, base, task_id, summary: None)
+    session = _session(exit_code=0)
+    session.spawn_ts = _time.time() - 300.0
+    with caplog.at_level(logging.WARNING):
+        success, _ = al._handle_orphan_no_signals(
+            _orphan_orch(tmp_path), MagicMock(), "T-1", session, "http://srv", _time.time()
+        )
+    assert success is True
+    assert not any("SUSPICIOUS auto-complete" in r.message for r in caplog.records)

--- a/tests/unit/agents/test_agent_recycling_paths.py
+++ b/tests/unit/agents/test_agent_recycling_paths.py
@@ -355,3 +355,109 @@ def test_check_loops_recovers_deadlock_victim(tmp_path: Path) -> None:
     check_loops_and_deadlocks(orch)
     lock_mgr.release.assert_called_with("A-9")
     detector.clear_wait.assert_called_with("A-9")
+
+
+# ---------------------------------------------------------------------------
+# Runner-log preservation on the idle/clean-reap paths (D2 MiniMax
+# attempt-3 regression, 2026-07-03): the manager completed cleanly, was
+# reaped via _reap_completed_agent, and its runner transcript - the only
+# artifact carrying its usage/cost diagnostics - was deleted with the
+# worktree because these paths (unlike agent_lifecycle's crash paths)
+# never called _preserve_runner_logs before cleanup_worktree.
+# ---------------------------------------------------------------------------
+
+
+def test_reap_completed_agent_preserves_runner_logs_before_worktree_cleanup(tmp_path: Path) -> None:
+    """_reap_completed_agent must copy the runner transcript out of the
+    worktree BEFORE cleanup_worktree destroys it."""
+    completion_file = tmp_path / "completed" / "A-1"
+    completion_file.parent.mkdir(parents=True)
+    completion_file.write_text("")
+    session = _session("A-1")
+
+    # A real worktree with a real runner log inside it, so the actual
+    # _preserve_runner_logs implementation runs end to end.
+    worktree = tmp_path / "worktrees" / "A-1"
+    wt_runtime = worktree / ".sdd" / "runtime"
+    wt_runtime.mkdir(parents=True)
+    (wt_runtime / "A-1.log").write_text('{"type": "usage", "input_tokens": 10, "output_tokens": 5}\n')
+    (wt_runtime / "A-1.manifest.json").write_text("{}")
+
+    call_order: list[str] = []
+    spawner = MagicMock()
+    spawner.get_worktree_path.return_value = worktree
+    spawner.cleanup_worktree.side_effect = lambda sid: call_order.append("cleanup")
+
+    orch = SimpleNamespace(
+        _workdir=tmp_path,
+        _spawner=spawner,
+        _signal_mgr=MagicMock(),
+        _idle_shutdown_ts={},
+    )
+
+    import bernstein.core.agents.agent_lifecycle as al
+
+    original_preserve = al._preserve_runner_logs
+
+    def _tracking_preserve(orch_arg, session_arg):  # type: ignore[no-untyped-def]
+        call_order.append("preserve")
+        return original_preserve(orch_arg, session_arg)
+
+    with (
+        patch.object(ar, "_save_partial_work"),
+        patch.object(ar, "_propagate_abort_to_children"),
+        patch("bernstein.core.metrics.get_collector", return_value=MagicMock()),
+        patch.object(al, "_preserve_runner_logs", side_effect=_tracking_preserve),
+    ):
+        ar._reap_completed_agent(orch, session, completion_file)
+
+    # Preservation happened, and strictly before worktree cleanup.
+    assert call_order == ["preserve", "cleanup"]
+    preserved_log = tmp_path / ".sdd" / "runtime" / "agent_logs" / "A-1" / "A-1.log"
+    assert preserved_log.exists()
+    assert "usage" in preserved_log.read_text()
+    preserved_manifest = tmp_path / ".sdd" / "runtime" / "agent_logs" / "A-1" / "A-1.manifest.json"
+    assert preserved_manifest.exists()
+
+
+def test_recycle_or_kill_after_grace_preserves_runner_logs_before_cleanup(tmp_path: Path) -> None:
+    """The grace-elapsed force-kill branch must also preserve runner logs
+    before destroying the worktree."""
+    session = _session("A-1")
+
+    worktree = tmp_path / "worktrees" / "A-1"
+    wt_runtime = worktree / ".sdd" / "runtime"
+    wt_runtime.mkdir(parents=True)
+    (wt_runtime / "A-1.log").write_text('{"type": "error", "kind": "runtime", "message": "x"}\n')
+
+    call_order: list[str] = []
+    spawner = MagicMock()
+    spawner.get_worktree_path.return_value = worktree
+    spawner.cleanup_worktree.side_effect = lambda sid: call_order.append("cleanup")
+
+    orch = SimpleNamespace(
+        _workdir=tmp_path,
+        _spawner=spawner,
+        _signal_mgr=MagicMock(),
+        _idle_shutdown_ts={"A-1": 1000.0},
+    )
+
+    import bernstein.core.agents.agent_lifecycle as al
+
+    original_preserve = al._preserve_runner_logs
+
+    def _tracking_preserve(orch_arg, session_arg):  # type: ignore[no-untyped-def]
+        call_order.append("preserve")
+        return original_preserve(orch_arg, session_arg)
+
+    with (
+        patch.object(ar, "_save_partial_work"),
+        patch.object(ar, "_propagate_abort_to_children"),
+        patch("bernstein.core.metrics.get_collector", return_value=MagicMock()),
+        patch.object(al, "_preserve_runner_logs", side_effect=_tracking_preserve),
+    ):
+        ar._recycle_or_kill(orch, session, now=1000.0 + _IDLE_GRACE_S + 1, reason="role_drained")
+
+    assert call_order == ["preserve", "cleanup"]
+    preserved_log = tmp_path / ".sdd" / "runtime" / "agent_logs" / "A-1" / "A-1.log"
+    assert preserved_log.exists()

--- a/tests/unit/agents/test_heartbeat_paths.py
+++ b/tests/unit/agents/test_heartbeat_paths.py
@@ -13,6 +13,8 @@ tests so the real escalation code runs end to end.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -339,4 +341,139 @@ def test_stalled_tasks_no_new_snapshot_is_noop(tmp_path: Path) -> None:
     with patch("bernstein.core.agents.heartbeat.time.time", return_value=300.0):
         check_stalled_tasks(orch)
     orch._spawner.kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Defect-10: leaked heartbeat shell loop -- self-termination + reap
+# ---------------------------------------------------------------------------
+
+
+def test_inject_heartbeat_instructions_is_self_terminating(tmp_path: Path) -> None:
+    """The generated loop checks a STOP marker and records its own pid."""
+    monitor = HeartbeatMonitor(tmp_path)
+    snippet = monitor.inject_heartbeat_instructions("SID-1")
+
+    assert "SID-1.stop" in snippet
+    assert "SID-1.pid" in snippet
+    assert "while [ ! -f" in snippet  # self-terminating condition, not `while true`
+    assert "while true" not in snippet
+    assert "echo $!" in snippet  # records loop pid for belt-and-braces reap
+
+
+def test_heartbeat_loop_actually_self_terminates_on_stop_marker(tmp_path: Path) -> None:
+    """End-to-end: run the real generated snippet, request stop, prove no leaked process.
+
+    This is the direct regression test for the observed defect: a bernstein
+    run left a heartbeat shell loop running on the HOST after the run ended.
+    """
+    monitor = HeartbeatMonitor(tmp_path)
+    snippet = monitor.inject_heartbeat_instructions("SID-2")
+
+    # Run the exact generated snippet the way an agent shell would.
+    subprocess.run(["/bin/sh", "-c", snippet], check=True, timeout=10)
+
+    pid_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / "SID-2.pid"
+    heartbeat_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / "SID-2.json"
+
+    # Loop should have started and written at least one heartbeat + its pidfile.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not (pid_path.exists() and heartbeat_path.exists()):
+        time.sleep(0.1)
+    assert pid_path.exists(), "heartbeat loop never wrote its pidfile"
+    pid = int(pid_path.read_text(encoding="utf-8").strip())
+
+    def _alive(p: int) -> bool:
+        try:
+            os.kill(p, 0)
+        except ProcessLookupError:
+            return False
+        else:
+            return True
+
+    assert _alive(pid), "loop pid should still be running before STOP is requested"
+
+    # This is the fix under test: request stop instead of leaving it running forever.
+    monitor.request_heartbeat_stop("SID-2")
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and _alive(pid):
+        time.sleep(0.2)
+
+    assert not _alive(pid), "heartbeat loop leaked past its STOP marker -- defect-10 regression"
+
+
+def _spawn_fake_heartbeat_loop(tmp_path: Path, session_id: str) -> subprocess.Popen[bytes]:
+    """Spawn a long-lived process whose command line looks like this session's
+    heartbeat loop (it references the session's stop-marker path), so the reap
+    identity check recognizes it as the real loop."""
+    stop_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / f"{session_id}.stop"
+    return subprocess.Popen(
+        ["sh", "-c", f"while [ ! -f '{stop_path}' ]; do sleep 1; done"],
+    )
+
+
+def test_reap_heartbeat_loop_kills_recorded_pid(tmp_path: Path) -> None:
+    """reap_heartbeat_loop is a belt-and-braces kill-by-pid, safe when nothing was spawned."""
+    monitor = HeartbeatMonitor(tmp_path)
+
+    # No heartbeat loop ever spawned for this session: must be a safe no-op.
+    monitor.reap_heartbeat_loop("NEVER-SPAWNED", reason="test_noop")
+
+    # Simulate an orphaned loop by recording a real long-lived process's pid
+    # whose command line identifies it as this session's heartbeat loop.
+    proc = _spawn_fake_heartbeat_loop(tmp_path, "SID-3")
+    pid_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / "SID-3.pid"
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(proc.pid), encoding="utf-8")
+
+    monitor.reap_heartbeat_loop("SID-3", reason="test_kill")
+    proc.wait(timeout=5)
+
+    assert proc.returncode is not None
+    assert not pid_path.exists()
+    stop_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / "SID-3.stop"
+    assert stop_path.exists()
+
+
+def test_reap_heartbeat_loop_spares_recycled_foreign_pid(tmp_path: Path) -> None:
+    """A stale pidfile whose PID was recycled to an unrelated process must NOT
+    be signalled: the reap verifies the process still looks like this session's
+    heartbeat loop before killing it."""
+    monitor = HeartbeatMonitor(tmp_path)
+
+    # A foreign process that has nothing to do with this session's heartbeat.
+    proc = subprocess.Popen(["sleep", "30"])
+    try:
+        pid_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / "SID-FOREIGN.pid"
+        pid_path.parent.mkdir(parents=True, exist_ok=True)
+        pid_path.write_text(str(proc.pid), encoding="utf-8")
+
+        monitor.reap_heartbeat_loop("SID-FOREIGN", reason="test_recycled")
+
+        # The foreign process must still be alive (not signalled).
+        assert proc.poll() is None, "reap killed a recycled/unrelated PID"
+        # Stale pidfile is cleaned up even though we did not kill the process.
+        assert not pid_path.exists()
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_stall_kill_reaps_heartbeat_loop(tmp_path: Path) -> None:
+    """Killing a stalled agent also reaps any heartbeat loop it spawned (belt-and-braces)."""
+    orch = _stall_orch(tmp_path, start_count=4)  # next count -> 5 -> kill
+
+    # Simulate a heartbeat loop the killed session had spawned (command line
+    # identifies it as A-1's heartbeat loop so the reap identity check matches).
+    proc = _spawn_fake_heartbeat_loop(tmp_path, "A-1")
+    pid_path = tmp_path / ".sdd" / "runtime" / "heartbeats" / "A-1.pid"
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(proc.pid), encoding="utf-8")
+
+    with patch("bernstein.core.agents.heartbeat.time.time", return_value=300.0):
+        check_stalled_tasks(orch)
+
+    orch._spawner.kill.assert_called_once()
+    proc.wait(timeout=5)
+    assert proc.returncode is not None, "heartbeat loop for the killed session was not reaped"
     orch._signal_mgr.write_wakeup.assert_not_called()

--- a/tests/unit/agents/test_spawner_core_helpers.py
+++ b/tests/unit/agents/test_spawner_core_helpers.py
@@ -88,6 +88,54 @@ def test_render_auth_section_does_not_embed_token_value() -> None:
     assert "$(cat /tmp/tok.jwt)" in out
 
 
+def test_render_auth_section_mirrors_manager_template_shell_contract() -> None:
+    """Mirrors the e2da807d manager-prompt auth contract (see templates/roles/manager).
+
+    The rendered section must:
+    - mandate run_command's single-STRING shell form for the auth curls,
+    - warn that the argv-list form silently drops ``$(...)``/``$VAR`` expansion,
+    - require checking the trailing HTTP status via ``-w '\\n%{http_code}'``
+      and retrying on non-2xx,
+    - contain the string-form curl with ``$(cat <token path>)``.
+    """
+    out = _render_auth_section(Path("/tmp/tok.jwt"))
+    # Single-STRING form mandate + argv-list expansion warning.
+    assert "single command **STRING**" in out
+    assert "argv LIST" in out
+    assert "never expanded" in out
+    assert "single-STRING" in out
+    # String-form curl example interpolating the token path.
+    assert '-H "Authorization: Bearer $(cat /tmp/tok.jwt)"' in out
+    assert "ONE string" in out
+    # HTTP status check + retry-on-non-2xx instruction.
+    assert "-w '\\n%{http_code}'" in out
+    assert "200-299" in out
+    assert "retry" in out
+    # Example curls carry the status-code write-out.
+    assert "curl -sS -w '\\n%{http_code}'" in out
+
+
+def test_render_auth_section_has_no_read_file_token_fallback() -> None:
+    """The unreachable read_file-token fallback is gone; read_file is prohibited.
+
+    e2da807d removed the read_file fallback from the manager templates because
+    read_file is confined to the agent worktree and the token lives outside it.
+    The rendered section must not instruct agents to read the token via
+    read_file - the only read_file mention allowed is the explicit prohibition.
+    """
+    out = _render_auth_section(Path("/tmp/tok.jwt"))
+    assert "**Do not use the `read_file` tool to obtain your token.**" in out
+    # Every read_file mention must be part of the prohibition paragraph,
+    # never a fallback instruction.
+    prohibition_start = out.index("**Do not use the `read_file` tool")
+    prohibition_end = out.index("\n\n", prohibition_start)
+    outside = out[:prohibition_start] + out[prohibition_end:]
+    assert "read_file" not in outside
+    # No fallback phrasing anywhere.
+    assert "fall back to `read_file`" not in out
+    assert "use the `read_file` tool to read" not in out
+
+
 # ---------------------------------------------------------------------------
 # _render_signal_check
 # ---------------------------------------------------------------------------
@@ -231,6 +279,35 @@ def test_set_shutdown_event_stores_event(tmp_path: Path) -> None:
     event = threading.Event()
     spawner.set_shutdown_event(event)
     assert spawner._shutdown_event is event
+
+
+def test_spawn_refused_during_shutdown_is_logged(tmp_path: Path, make_task: Any, caplog: Any) -> None:
+    """Logging gap: a spawn attempt during shutdown raised
+    ``ShutdownInProgress`` with no log line -- an operator reading only the
+    server-side log (not the orchestrator's exception traceback) had no way
+    to see that a spawn was refused and why. Assert the refusal logs the
+    role, task count, and task ids being refused."""
+    import logging
+
+    from bernstein.core.orchestration.orchestrator import ShutdownInProgress
+
+    caplog.set_level(logging.INFO, logger="bernstein.core.agents.spawner_core")
+    spawner = _spawner(tmp_path)
+    event = threading.Event()
+    event.set()
+    spawner.set_shutdown_event(event)
+
+    task = make_task(id="task-shutdown-1")
+    try:
+        spawner.spawn_for_tasks([task])
+        raise AssertionError("expected ShutdownInProgress")
+    except ShutdownInProgress:
+        pass
+
+    messages = [r.message for r in caplog.records]
+    assert any("spawn refused" in m and "shutdown_event is set" in m and "task-shutdown-1" in m for m in messages), (
+        messages
+    )
 
 
 def test_set_merge_queue_stores_queue(tmp_path: Path) -> None:

--- a/tests/unit/security/test_approval_gate_fail_closed.py
+++ b/tests/unit/security/test_approval_gate_fail_closed.py
@@ -1,0 +1,238 @@
+"""Regression tests for ApprovalGate fail-open defect (defect item 9).
+
+Background: an API-drift TypeError inside ``ApprovalGate.create_pr`` (a
+signature mismatch between the public keyword names ``session_id``/``model``/
+``cost_usd`` and a caller) escaped as an exception, was swallowed by the
+caller's broad ``except Exception: ... defaulting to auto-merge``, and
+silently bypassed the approval gate -- work got auto-merged without ever
+passing review. See
+work/bernstein/proofs/d2/claude/attempt4-meridian-fixed/FAIL-NOTE.md.
+
+These tests verify:
+  (a) the documented public call signature (``session_id``, ``_role``,
+      ``model``, ``cost_usd`` keywords) works against ``create_pr``.
+  (b) an injected exception inside gate evaluation (``evaluate`` and
+      ``create_pr``) results in a REJECT/no-PR outcome, never an approval.
+  (c) every gate decision path emits a log record so a future bypass is
+      impossible to miss in logs.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import Task
+
+from bernstein.core.security.approval import ApprovalGate, ApprovalMode, ApprovalResult
+
+
+def _make_task(task_id: str = "t1") -> Task:
+    return Task(
+        id=task_id,
+        title="Add hello subcommand",
+        description="test task",
+        role="backend",
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) previously-drifting call signature now works
+# ---------------------------------------------------------------------------
+
+
+def test_create_pr_accepts_public_kwargs(tmp_path: Path) -> None:
+    """The documented public call shape must work.
+
+    Regression for: TypeError: ApprovalGate.create_pr() got an unexpected
+    keyword argument 'session_id'.
+    """
+
+    def fake_push(worktree_path: Path, branch: str) -> object:
+        class _Result:
+            ok = True
+
+        return _Result()
+
+    def fake_create_pr(**kwargs: object) -> object:
+        class _Result:
+            success = True
+            pr_url = "https://example.com/pr/1"
+            error = ""
+
+        return _Result()
+
+    gate = ApprovalGate(
+        mode=ApprovalMode.PR,
+        workdir=tmp_path,
+        auto_merge=False,
+        _push_branch_fn=fake_push,
+        _create_pr_fn=fake_create_pr,
+    )
+
+    # Simulate a real diff existing so create_pr doesn't short-circuit on
+    # "no diff" before reaching the drifted-kwarg call surface.
+    import bernstein.core.security.approval as approval_mod
+
+    monkeypatch_no_diff = approval_mod._has_no_diff
+    approval_mod._has_no_diff = lambda *_a, **_k: False  # type: ignore[assignment]
+    try:
+        task = _make_task()
+        pr_url = gate.create_pr(
+            task,
+            worktree_path=tmp_path,
+            session_id="session-abc",
+            labels=["bernstein"],
+            _role="backend",
+            model="claude-sonnet-5",
+            cost_usd=0.12,
+            test_summary="2 passed",
+        )
+    finally:
+        approval_mod._has_no_diff = monkeypatch_no_diff
+
+    assert pr_url == "https://example.com/pr/1"
+
+
+# ---------------------------------------------------------------------------
+# (b) injected exception -> REJECT / no-PR, never approve
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_fail_closed_on_internal_exception(tmp_path: Path) -> None:
+    """An exception raised while resolving a decision must reject, not approve."""
+
+    def boom(*_args: object, **_kwargs: object) -> str:
+        raise RuntimeError("injected failure inside poll_decision")
+
+    gate = ApprovalGate(
+        mode=ApprovalMode.REVIEW,
+        workdir=tmp_path,
+        _poll_decision=boom,
+    )
+
+    result = gate.evaluate(_make_task(), session_id="session-abc")
+
+    assert isinstance(result, ApprovalResult)
+    assert result.approved is False
+    assert result.rejected is True
+
+
+def test_create_pr_fail_closed_on_internal_exception(tmp_path: Path) -> None:
+    """An exception raised while pushing/creating the PR must return no-PR ("")."""
+
+    def boom_push(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("injected failure inside push_fn")
+
+    gate = ApprovalGate(
+        mode=ApprovalMode.PR,
+        workdir=tmp_path,
+        _push_branch_fn=boom_push,
+    )
+
+    import bernstein.core.security.approval as approval_mod
+
+    monkeypatch_no_diff = approval_mod._has_no_diff
+    approval_mod._has_no_diff = lambda *_a, **_k: False  # type: ignore[assignment]
+    try:
+        pr_url = gate.create_pr(
+            _make_task(),
+            worktree_path=tmp_path,
+            session_id="session-abc",
+            _role="backend",
+            model="claude-sonnet-5",
+            cost_usd=0.0,
+        )
+    finally:
+        approval_mod._has_no_diff = monkeypatch_no_diff
+
+    assert pr_url == ""
+
+
+def test_create_pr_fail_closed_with_wrong_kwargs_still_never_raises(tmp_path: Path) -> None:
+    """Even a *future* signature drift must not escape as an unhandled exception.
+
+    Calling with an unexpected keyword still raises TypeError at the call
+    boundary (Python's normal behavior) -- but that is on the caller. What
+    this test guards is that create_pr's *internal* logic path (once
+    reached) never lets an exception propagate past its own try/except;
+    combined with the caller-shape test above, the known drift is closed.
+    """
+    gate = ApprovalGate(mode=ApprovalMode.PR, workdir=tmp_path)
+
+    with pytest.raises(TypeError):
+        gate.create_pr(  # type: ignore[call-arg]
+            _make_task(),
+            worktree_path=tmp_path,
+            this_kwarg_does_not_exist="x",
+        )
+
+
+# ---------------------------------------------------------------------------
+# (c) decision logging emits
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_logs_decision_for_auto_mode(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    gate = ApprovalGate(mode=ApprovalMode.AUTO, workdir=tmp_path)
+    with caplog.at_level(logging.INFO, logger="bernstein.core.security.approval"):
+        result = gate.evaluate(_make_task(), session_id="session-abc")
+
+    assert result.approved is True
+    assert any("Approval gate decision" in r.message and "decision=approved" in r.message for r in caplog.records)
+
+
+def test_evaluate_logs_error_with_traceback_on_fail_closed(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    def boom(*_args: object, **_kwargs: object) -> str:
+        raise ValueError("boom for logging test")
+
+    gate = ApprovalGate(mode=ApprovalMode.REVIEW, workdir=tmp_path, _poll_decision=boom)
+
+    with caplog.at_level(logging.ERROR, logger="bernstein.core.security.approval"):
+        result = gate.evaluate(_make_task("t-log"), session_id="session-xyz")
+
+    assert result.rejected is True
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "expected an ERROR log on fail-closed path"
+    combined = "\n".join(r.getMessage() for r in error_records)
+    assert "FAIL-CLOSED" in combined
+    assert "t-log" in combined
+    assert "ValueError" in combined or "boom for logging test" in combined
+
+
+def test_create_pr_logs_decision_on_success(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    def fake_push(worktree_path: Path, branch: str) -> object:
+        class _Result:
+            ok = True
+
+        return _Result()
+
+    def fake_create_pr(**kwargs: object) -> object:
+        class _Result:
+            success = True
+            pr_url = "https://example.com/pr/2"
+            error = ""
+
+        return _Result()
+
+    gate = ApprovalGate(
+        mode=ApprovalMode.PR,
+        workdir=tmp_path,
+        auto_merge=False,
+        _push_branch_fn=fake_push,
+        _create_pr_fn=fake_create_pr,
+    )
+
+    import bernstein.core.security.approval as approval_mod
+
+    monkeypatch_no_diff = approval_mod._has_no_diff
+    approval_mod._has_no_diff = lambda *_a, **_k: False  # type: ignore[assignment]
+    try:
+        with caplog.at_level(logging.INFO, logger="bernstein.core.security.approval"):
+            pr_url = gate.create_pr(_make_task(), worktree_path=tmp_path, session_id="s1")
+    finally:
+        approval_mod._has_no_diff = monkeypatch_no_diff
+
+    assert pr_url == "https://example.com/pr/2"
+    assert any("decision=pr_created" in r.message for r in caplog.records)

--- a/tests/unit/tasks/test_auto_spawn_guard.py
+++ b/tests/unit/tasks/test_auto_spawn_guard.py
@@ -1,0 +1,239 @@
+"""Regression tests for AutoSpawnGuard (recursion/dedupe/cap for meta-tasks).
+
+Covers the production incident in
+work/agent-reports/2026-07-02-run9-attempt9-audit.md: unbounded
+"Upgrade: ..." duplicates and recursive "Watchdog triage of watchdog
+triage" tasks with no depth/dedupe/cap guard.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard, compute_ancestry_depth, meta_task_kind
+
+
+def test_allowed_spawn_passes_all_guards_and_persists_count(tmp_path: Path) -> None:
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=3)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve task success rate",
+        source_title=None,
+        existing_open_titles=[],
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "allowed"
+    assert decision.ancestry_depth == 1
+    assert decision.current_count == 1
+    assert decision.cap == 3
+
+    state_path = tmp_path / ".sdd" / "runtime" / "auto_spawn_guard.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["count"] == 1
+
+
+def test_depth_refusal_blocks_meta_task_about_a_meta_task(tmp_path: Path) -> None:
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    # Source task is itself a watchdog-triage meta-task -> would be depth 2.
+    decision = guard.evaluate(
+        kind="watchdog_triage",
+        title="Watchdog triage: Heartbeat stale for task Watchdog triage: Heartbeat stale for task X",
+        source_title="Watchdog triage: Heartbeat stale for task X",
+        existing_open_titles=[],
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "depth"
+    assert decision.ancestry_depth == 2
+
+    # Refused spawns must not consume the cap.
+    state_path = tmp_path / ".sdd" / "runtime" / "auto_spawn_guard.json"
+    assert not state_path.exists()
+
+
+def test_compute_ancestry_depth_baseline_and_nested() -> None:
+    assert compute_ancestry_depth(None) == 1
+    assert compute_ancestry_depth("Fix the login bug") == 1
+    assert compute_ancestry_depth("Upgrade: Improve task success rate") == 2
+    assert compute_ancestry_depth("Watchdog triage: Heartbeat stale for task X") == 2
+
+
+def test_dedupe_refusal_blocks_duplicate_title(tmp_path: Path) -> None:
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve task success rate",
+        source_title=None,
+        existing_open_titles=["Upgrade: Improve task success rate"],
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "dedupe"
+
+
+def test_dedupe_refusal_matches_close_enough_titles(tmp_path: Path) -> None:
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve task success rate  ",
+        source_title=None,
+        existing_open_titles=["upgrade: improve task success rate (abc123)"],
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "dedupe"
+
+
+def test_cap_refusal_blocks_once_limit_reached(tmp_path: Path) -> None:
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=2)
+
+    first = guard.evaluate(kind="k", title="Upgrade: A", source_title=None, existing_open_titles=[])
+    second = guard.evaluate(kind="k", title="Upgrade: B", source_title=None, existing_open_titles=[])
+    third = guard.evaluate(kind="k", title="Upgrade: C", source_title=None, existing_open_titles=[])
+
+    assert first.allowed is True
+    assert second.allowed is True
+    assert third.allowed is False
+    assert third.reason == "cap"
+    assert third.current_count == 2
+
+
+def test_cap_state_is_shared_across_guard_instances(tmp_path: Path) -> None:
+    """Two call sites (e.g. evolution loop + watchdog) sharing one workdir
+    must share the same cap counter."""
+    guard_a = AutoSpawnGuard(tmp_path, max_auto_spawns_per_run=1)
+    guard_b = AutoSpawnGuard(tmp_path, max_auto_spawns_per_run=1)
+
+    first = guard_a.evaluate(kind="a", title="Upgrade: A", source_title=None, existing_open_titles=[])
+    second = guard_b.evaluate(kind="b", title="Watchdog triage: B", source_title=None, existing_open_titles=[])
+
+    assert first.allowed is True
+    assert second.allowed is False
+    assert second.reason == "cap"
+
+
+def test_meta_task_kind_matches_known_prefixes_only() -> None:
+    assert meta_task_kind("Upgrade: Improve task success rate") == "Upgrade:"
+    assert meta_task_kind("Watchdog triage: Heartbeat stale for task X") == "Watchdog triage:"
+    assert meta_task_kind("Implement hello subcommand in cli.py") is None
+    assert meta_task_kind(None) is None
+    assert meta_task_kind("") is None
+
+
+def test_dedupe_does_not_collide_distinct_titles_sharing_a_prefix(tmp_path: Path) -> None:
+    """Regression (2026-07-02, fix/claim-conflict-churn): an earlier version
+    of the dedupe rule treated ANY two titles sharing a known meta-task
+    prefix (e.g. both "Upgrade: ...") as automatic duplicates, regardless of
+    content. That was too coarse -- it silently rejected genuinely distinct,
+    independently-generated proposals from the same evolution cycle, e.g.
+    "Upgrade: Proposal One" and "Upgrade: Proposal Two", which must both be
+    allowed to spawn (see tests/unit/test_orchestrator.py::
+    TestRunEvolutionCycle::test_happy_path_creates_http_task_per_proposal).
+    Dedupe is now purely content-based (normalized-title exact/containment
+    match), so two proposals with unrelated remainders must NOT collide even
+    though they share the "Upgrade:" category.
+    """
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve token budget accounting",
+        source_title=None,
+        existing_open_titles=["Upgrade: Improve task success rate"],
+    )
+
+    assert decision.allowed is True
+    assert decision.reason == "allowed"
+
+
+def test_dedupe_still_catches_true_resurrection_duplicates(tmp_path: Path) -> None:
+    """Control: a true resurrection (identical title, or identical modulo a
+    trailing id-like suffix) must still be refused -- the content-based
+    dedupe key is stricter than the old prefix-class rule, not a no-op."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    decision = guard.evaluate(
+        kind="upgrade_proposal",
+        title="Upgrade: Improve task success rate",
+        source_title=None,
+        existing_open_titles=["Upgrade: Improve task success rate (abc123)"],
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "dedupe"
+
+
+def test_dedupe_check_logs_key_verdict_and_reason_for_every_candidate(tmp_path: Path, caplog) -> None:
+    """Every candidate/existing-title comparison must be logged with the
+    dedupe key and verdict, not just the final allow/refuse decision."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.auto_spawn_guard"):
+        decision = guard.evaluate(
+            kind="upgrade_proposal",
+            title="Upgrade: Improve task success rate",
+            source_title=None,
+            existing_open_titles=["Upgrade: Proposal One", "Upgrade: Improve task success rate"],
+        )
+
+    assert decision.allowed is False
+    assert decision.reason == "dedupe"
+    check_lines = [r.getMessage() for r in caplog.records if "auto_spawn_dedupe_check" in r.getMessage()]
+    assert any("existing='Upgrade: Proposal One'" in line and "match=False" in line for line in check_lines)
+    assert any("existing='Upgrade: Improve task success rate'" in line and "match=True" in line for line in check_lines)
+
+
+def test_evaluate_logs_info_decision_line_for_allowed_spawn(tmp_path: Path, caplog) -> None:
+    """Every decision -- including an ALLOWED spawn -- must emit an INFO-level
+    line carrying reason, dedupe key, and ancestry depth (logging IS the
+    debugging interface)."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=3)
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.auto_spawn_guard"):
+        decision = guard.evaluate(
+            kind="upgrade_proposal",
+            title="Upgrade: Improve task success rate",
+            source_title=None,
+            existing_open_titles=[],
+        )
+
+    assert decision.allowed is True
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    decision_lines = [r.getMessage() for r in info_records if "auto_spawn_decision" in r.getMessage()]
+    assert decision_lines, f"no auto_spawn_decision INFO line found in {[r.getMessage() for r in info_records]}"
+    assert any("allowed=True" in line and "reason=allowed" in line for line in decision_lines)
+    assert any("dedupe_key='upgrade: improve task success rate'" in line for line in decision_lines)
+    assert any("ancestry_depth=1" in line for line in decision_lines)
+
+
+def test_evaluate_logs_info_decision_line_for_refused_spawn(tmp_path: Path, caplog) -> None:
+    """A refused (depth) decision must ALSO emit the uniform INFO decision
+    line, not just the WARNING alert -- the audit-3 evidence flagged that
+    "no auto-spawn/ancestry depth log lines" were found for the run that
+    produced the junk tasks, so suppressed decisions must be just as
+    visible as allowed ones."""
+    guard = AutoSpawnGuard(tmp_path, max_ancestry_depth=1, max_auto_spawns_per_run=10)
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.auto_spawn_guard"):
+        decision = guard.evaluate(
+            kind="retry:Upgrade",
+            title="Upgrade: Improve task success rate",
+            source_title="Upgrade: Improve task success rate",
+            existing_open_titles=[],
+        )
+
+    assert decision.allowed is False
+    assert decision.reason == "depth"
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    decision_lines = [r.getMessage() for r in info_records if "auto_spawn_decision" in r.getMessage()]
+    assert decision_lines, f"no auto_spawn_decision INFO line found in {[r.getMessage() for r in info_records]}"
+    assert any(
+        "allowed=False" in line and "reason=depth" in line and "ancestry_depth=2" in line for line in decision_lines
+    )

--- a/tests/unit/tasks/test_claim_conflict_retry.py
+++ b/tests/unit/tasks/test_claim_conflict_retry.py
@@ -1,0 +1,208 @@
+"""Regression tests for Bug 1 (2026-07-02, fix/claim-conflict-churn).
+
+Root cause: the claim call site sent one CAS claim attempt and, on 409, gave
+up for the tick -- but since ``batches`` is recomputed fresh every tick from
+the same stale server state, the identical ``expected_version`` got
+resubmitted every tick forever. Evidence: 144 consecutive identical
+``POST /tasks/109ba3616f03/claim?expected_version=1`` -> 409 responses from
+one session against one task in
+``work/bernstein/proofs/d2/claim-loop-evidence/d2-minimax-final-snap.tar``.
+
+These tests exercise ``_claim_task_with_conflict_retry`` directly against a
+mocked httpx client so the three required behaviours are pinned down without
+needing a live server:
+  1. 409 -> re-GET shows a fresh version, still OPEN -> retries succeed.
+  2. 409 -> re-GET shows the task claimed by a foreign session -> stop,
+     don't retry.
+  3. 409 forever (stale lock / unmet precondition, version never resolves)
+     -> capped at ``_CLAIM_CONFLICT_MAX_ATTEMPTS`` attempts, then gives up
+     with a reason instead of looping unboundedly.
+Plus the cross-tick backoff bookkeeping (episode counter + backoff window).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import httpx
+
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_lifecycle import (
+    _CLAIM_CONFLICT_MAX_ATTEMPTS,
+    _claim_conflict_backoff_active,
+    _claim_task_with_conflict_retry,
+    _clear_claim_conflict_state,
+    _record_claim_conflict_episode,
+)
+
+
+def _make_task(task_id: str = "task-1", version: int = 1, status: TaskStatus = TaskStatus.OPEN) -> Task:
+    return Task(
+        id=task_id,
+        title="Commit changes on feature branch",
+        description="desc",
+        role="devops",
+        version=version,
+        status=status,
+    )
+
+
+def _resp(status_code: int, json_body: dict | None = None, text: str = "") -> httpx.Response:
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status_code
+    r.json.return_value = json_body or {}
+    r.text = text
+    r.raise_for_status = MagicMock()
+    return r
+
+
+class _FakeOrch:
+    """Minimal orchestrator stand-in exposing only ``_client``."""
+
+    def __init__(self, client: MagicMock) -> None:
+        self._client = client
+
+
+# ---------------------------------------------------------------------------
+# 1. 409 -> re-fetch shows a fresh version, still OPEN -> retry succeeds.
+# ---------------------------------------------------------------------------
+
+
+def test_409_then_refetch_fresh_version_retries_and_succeeds():
+    client = MagicMock(spec=httpx.Client)
+    orch = _FakeOrch(client)
+    task = _make_task(version=1)
+
+    stale_claim_409 = _resp(409, text="Version conflict: task task-1 is at version 2, expected 1")
+    refetch_open_v2 = _resp(
+        200, {"id": "task-1", "title": "t", "description": "d", "role": "devops", "version": 2, "status": "open"}
+    )
+    fresh_claim_200 = _resp(
+        200, {"id": "task-1", "title": "t", "description": "d", "role": "devops", "version": 3, "status": "claimed"}
+    )
+
+    client.post.side_effect = [stale_claim_409, fresh_claim_200]
+    client.get.side_effect = [refetch_open_v2]
+
+    resp, reason = _claim_task_with_conflict_retry(orch, task, "http://test", "session-a")
+
+    assert reason is None
+    assert resp is not None
+    assert resp.status_code == 200
+    # Second POST must have used the freshly observed version (2), not the stale 1.
+    second_call_params = client.post.call_args_list[1].kwargs["params"]
+    assert second_call_params["expected_version"] == 2
+    # The caller's Task object is kept in sync with the refreshed version.
+    assert task.version == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. 409 -> re-fetch shows a foreign session now holds the claim -> stop.
+# ---------------------------------------------------------------------------
+
+
+def test_409_then_foreign_claimant_stops_without_retry():
+    client = MagicMock(spec=httpx.Client)
+    orch = _FakeOrch(client)
+    task = _make_task(version=1)
+
+    conflict_409 = _resp(409)
+    refetch_claimed_by_other = _resp(
+        200,
+        {
+            "id": "task-1",
+            "title": "t",
+            "description": "d",
+            "role": "devops",
+            "version": 2,
+            "status": "claimed",
+            "claimed_by_session": "some-other-session",
+        },
+    )
+    client.post.side_effect = [conflict_409]
+    client.get.side_effect = [refetch_claimed_by_other]
+
+    _result, reason = _claim_task_with_conflict_retry(orch, task, "http://test", "session-a")
+
+    assert reason is not None
+    assert "another session" in reason
+    assert client.post.call_count == 1  # never retried
+
+
+# ---------------------------------------------------------------------------
+# 3. Persistent 409 (e.g. stale lock) never resolves -> capped, doesn't loop forever.
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_conflict_is_capped_not_infinite():
+    client = MagicMock(spec=httpx.Client)
+    orch = _FakeOrch(client)
+    task = _make_task(version=1)
+
+    always_409 = _resp(409)
+    still_open_same_version = _resp(
+        200,
+        {"id": "task-1", "title": "t", "description": "d", "role": "devops", "version": 1, "status": "open"},
+    )
+
+    client.post.side_effect = [always_409] * _CLAIM_CONFLICT_MAX_ATTEMPTS
+    client.get.side_effect = [still_open_same_version] * (_CLAIM_CONFLICT_MAX_ATTEMPTS - 1)
+
+    _result, reason = _claim_task_with_conflict_retry(orch, task, "http://test", "session-a")
+
+    assert reason is not None
+    assert "gave up" in reason
+    assert client.post.call_count == _CLAIM_CONFLICT_MAX_ATTEMPTS  # bounded, not 144
+
+
+# ---------------------------------------------------------------------------
+# 4. Terminal status on re-fetch (task already done elsewhere) -> stop.
+# ---------------------------------------------------------------------------
+
+
+def test_409_then_terminal_status_stops():
+    client = MagicMock(spec=httpx.Client)
+    orch = _FakeOrch(client)
+    task = _make_task(version=1)
+
+    conflict_409 = _resp(409)
+    refetch_done = _resp(
+        200,
+        {"id": "task-1", "title": "t", "description": "d", "role": "devops", "version": 5, "status": "done"},
+    )
+    client.post.side_effect = [conflict_409]
+    client.get.side_effect = [refetch_done]
+
+    _result, reason = _claim_task_with_conflict_retry(orch, task, "http://test", "session-a")
+
+    assert reason is not None
+    assert "terminal status" in reason
+    assert client.post.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-tick backoff bookkeeping.
+# ---------------------------------------------------------------------------
+
+
+def test_claim_conflict_episode_sets_backoff_and_clears_on_success():
+    orch = _FakeOrch(MagicMock(spec=httpx.Client))
+    assert not _claim_conflict_backoff_active(orch, "task-1")
+
+    _record_claim_conflict_episode(orch, "task-1")
+    assert _claim_conflict_backoff_active(orch, "task-1")
+    count, backoff_until = orch._claim_conflict_state["task-1"]
+    assert count == 1
+    assert backoff_until > time.time()
+
+    # A second episode escalates the backoff window further into the future.
+    first_backoff_until = backoff_until
+    _record_claim_conflict_episode(orch, "task-1")
+    count2, backoff_until2 = orch._claim_conflict_state["task-1"]
+    assert count2 == 2
+    assert backoff_until2 >= first_backoff_until
+
+    _clear_claim_conflict_state(orch, "task-1")
+    assert "task-1" not in orch._claim_conflict_state
+    assert not _claim_conflict_backoff_active(orch, "task-1")

--- a/tests/unit/test_adapter_inference.py
+++ b/tests/unit/test_adapter_inference.py
@@ -1,0 +1,145 @@
+"""Unit tests for provider -> adapter name resolution.
+
+PR1 of the provider/adapter routing fix ladder replaced the hand-ordered
+substring `if`/`elif` chain that used to live directly in
+``AgentSpawner._infer_adapter_name_for_provider`` with a real registry
+lookup (:func:`bernstein.adapters.registry.adapter_name_for_provider`),
+built from each adapter's declared ``provides`` aliases.
+
+Original regression coverage (kept, still exercised end-to-end through
+``AgentSpawner``): the bare "openai" check used to match before
+"openai_agents" was considered, so every role_model_policy entry with
+provider: openai_agents was misrouted to the codex adapter instead of its
+own adapter (fixed structurally here, fixed as a point-fix in 042bcbd0).
+
+New coverage added in PR1: the registry module directly, including one
+assertion per currently-registered adapter alias (so a future ambiguous
+alias addition fails at test time, not silently at spawn time) and the
+collision-at-registration-time guarantee itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters import registry
+
+
+def _make_spawner(tmp_path: Path) -> AgentSpawner:
+    adapter = MagicMock()
+    adapter.name.return_value = "test-adapter"
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(adapter, templates_dir, tmp_path)
+
+
+def test_openai_agents_provider_routes_to_openai_agents_adapter(tmp_path: Path) -> None:
+    """provider='openai_agents' must not be swallowed by the 'openai' check."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider("openai_agents", "MiniMax-M3")
+    assert result == "openai_agents"
+
+
+def test_bare_gpt_model_with_no_provider_routes_to_codex(tmp_path: Path) -> None:
+    """provider=None + a gpt-family model name still routes to codex."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider(None, "gpt-5.5")
+    assert result == "codex"
+
+
+def test_bare_openai_provider_routes_to_codex(tmp_path: Path) -> None:
+    """provider='openai' (not openai_agents) keeps its existing codex routing."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider("openai", "some-model")
+    assert result == "codex"
+
+
+def test_unrecognized_provider_falls_back_to_current_adapter(tmp_path: Path) -> None:
+    """Unrecognized provider/model still falls back to self._adapter.name(),
+    exactly as the old substring chain did -- Claude-only / unrecognized
+    provider operators must see unchanged behavior."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider("totally-unknown-provider", "totally-unknown-model")
+    assert result == "test-adapter"
+
+
+# --- registry.adapter_name_for_provider: direct unit coverage ---------------
+
+
+def test_registry_exact_match_openai_agents() -> None:
+    """Exact provider-name match: 'openai_agents' resolves to its own adapter,
+    not the broader 'openai'/'codex' alias -- this is the core regression the
+    registry replacement exists to make structurally impossible to reintroduce."""
+    assert registry.adapter_name_for_provider("openai_agents", "MiniMax-M3") == "openai_agents"
+
+
+def test_registry_substring_fallback_prefers_longest_alias() -> None:
+    """provider_name=None, model text contains both 'openai' and would-be
+    'openai_agents' style text: longest-alias-first must still resolve to the
+    more specific adapter, matching what the old hand-ordered chain achieved
+    by putting the openai_agents check first."""
+    assert registry.adapter_name_for_provider(None, "openai_agents runner build") == "openai_agents"
+
+
+def test_registry_unknown_provider_and_model_returns_none() -> None:
+    """No match in the alias table returns None; callers apply their own
+    fallback (AgentSpawner falls back to self._adapter.name())."""
+    assert registry.adapter_name_for_provider("totally-unknown-provider", "totally-unknown-model") is None
+
+
+def test_registry_all_registered_adapter_aliases_resolve_correctly() -> None:
+    """One assertion per registered adapter alias.
+
+    Walks the live provider-alias table (built from every adapter's
+    ``provides`` declaration) and asserts each alias resolves back to its
+    owning adapter by exact match. A future adapter that declares an alias
+    already claimed by another adapter fails loudly at
+    ``_register_provider_alias`` time (see
+    ``test_registry_ambiguous_alias_raises_at_registration_time`` below)
+    long before this test would even run -- this test instead guards
+    against a *correct-but-wrong-target* regression, e.g. someone
+    accidentally repointing an alias at the wrong adapter name.
+    """
+    registry._build_provider_alias_table()
+    alias_table = dict(registry._PROVIDER_ALIAS_TABLE)
+    assert alias_table, "expected at least one adapter to declare `provides` aliases"
+    for alias, expected_adapter_name in alias_table.items():
+        resolved = registry.adapter_name_for_provider(alias, "irrelevant-model")
+        assert resolved == expected_adapter_name, (
+            f"alias {alias!r} resolved to adapter {resolved!r}, expected {expected_adapter_name!r}"
+        )
+
+
+def test_registry_ambiguous_alias_raises_at_registration_time() -> None:
+    """Collision policy: two adapters claiming the same alias must fail
+    loudly at registration time, not silently misroute at spawn time.
+
+    This is what actually forecloses the 042bcbd0 bug class going forward:
+    it is no longer possible to ship two adapters with an overlapping
+    ``provides`` alias without the table failing to build.
+    """
+    test_alias = "__pr1_collision_test_alias__"
+    registry._register_provider_alias(test_alias, "adapter-a")
+    try:
+        with pytest.raises(ValueError, match="claimed by both"):
+            registry._register_provider_alias(test_alias, "adapter-b")
+    finally:
+        # Don't leak test-only state into the shared module-level table.
+        registry._PROVIDER_ALIAS_TABLE.pop(test_alias, None)
+
+
+def test_registry_same_alias_same_adapter_is_not_a_collision() -> None:
+    """Re-registering the identical (alias, adapter_name) pair is a no-op,
+    not a collision -- this is what makes the dual-binary gemini/antigravity
+    registration (same class under two ``_ADAPTERS`` keys) safe."""
+    test_alias = "__pr1_idempotent_test_alias__"
+    try:
+        registry._register_provider_alias(test_alias, "adapter-a")
+        registry._register_provider_alias(test_alias, "adapter-a")  # must not raise
+        assert registry._PROVIDER_ALIAS_TABLE[test_alias] == "adapter-a"
+    finally:
+        registry._PROVIDER_ALIAS_TABLE.pop(test_alias, None)

--- a/tests/unit/test_adapter_mistral.py
+++ b/tests/unit/test_adapter_mistral.py
@@ -9,6 +9,7 @@ import pytest
 from bernstein.core.models import ModelConfig
 
 from bernstein.adapters.mistral import MistralAdapter
+from bernstein.adapters.plugin_sdk import AdapterCapability
 from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
 
 if TYPE_CHECKING:
@@ -54,3 +55,64 @@ class TestMistralAdapterSpawn:
 class TestMistralAdapterName:
     def test_name(self) -> None:
         assert MistralAdapter().name() == "Mistral Vibe"
+
+
+class TestMistralAdapterPluginInfo:
+    def test_declares_temperature_only(self) -> None:
+        info = MistralAdapter().plugin_info()
+        assert set(info.capabilities) == {AdapterCapability.SUPPORTS_TEMPERATURE}
+
+    def test_does_not_declare_coarse_or_others(self) -> None:
+        info = MistralAdapter().plugin_info()
+        assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TOP_P not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TOP_K not in info.capabilities
+        assert AdapterCapability.SUPPORTS_MAX_TOKENS not in info.capabilities
+
+
+class TestMistralAdapterSamplingParams:
+    """mcp_config temperature must reach the built CLI argv."""
+
+    def test_temperature_reaches_argv(self, tmp_path: Path) -> None:
+        adapter = MistralAdapter()
+        proc_mock = make_popen_mock(pid=701)
+        with patch("bernstein.adapters.mistral.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="mistral-large", effort="high"),
+                session_id="mistral-sampling1",
+                mcp_config={"temperature": 0.4},
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--temperature" in inner
+        assert inner[inner.index("--temperature") + 1] == "0.4"
+
+    def test_no_mcp_config_omits_temperature_flag(self, tmp_path: Path) -> None:
+        adapter = MistralAdapter()
+        proc_mock = make_popen_mock(pid=702)
+        with patch("bernstein.adapters.mistral.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="mistral-large", effort="high"),
+                session_id="mistral-sampling2",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert inner == ["vibe", "--auto-approve", "--prompt", "fix the bug"]
+
+    def test_top_p_top_k_max_tokens_never_reach_argv(self, tmp_path: Path) -> None:
+        adapter = MistralAdapter()
+        proc_mock = make_popen_mock(pid=703)
+        with patch("bernstein.adapters.mistral.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="mistral-large", effort="high"),
+                session_id="mistral-sampling3",
+                mcp_config={"top_p": 0.9, "top_k": 40, "max_tokens": 4096},
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--top-p" not in inner
+        assert "--top-k" not in inner
+        assert "--max-tokens" not in inner

--- a/tests/unit/test_adapter_ollama.py
+++ b/tests/unit/test_adapter_ollama.py
@@ -1,0 +1,109 @@
+"""Unit tests for OllamaAdapter spawn/name/plugin_info.
+
+No test file previously existed for this adapter (verified via
+``find tests -iname '*ollama*'`` before writing this file). Pattern
+matched from ``test_adapter_qwen.py`` / ``test_adapter_mistral.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.ollama import OllamaAdapter
+from bernstein.adapters.plugin_sdk import AdapterCapability
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+class TestOllamaAdapterSpawn:
+    """OllamaAdapter.spawn() builds the expected aider command."""
+
+    def test_spawn_builds_aider_command(self, tmp_path: Path) -> None:
+        adapter = OllamaAdapter()
+        proc_mock = make_popen_mock(pid=800)
+        with patch("bernstein.adapters.ollama.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen2.5-coder:7b", effort="high"),
+                session_id="ollama-s1",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert inner[0] == "aider"
+        assert "--model" in inner
+        assert inner[inner.index("--model") + 1] == "ollama/qwen2.5-coder:7b"
+        assert "--message" in inner
+        assert inner[inner.index("--message") + 1] == "fix the bug"
+
+    def test_name(self) -> None:
+        assert OllamaAdapter().name() == "Ollama (local)"
+
+
+class TestOllamaAdapterPluginInfo:
+    def test_declares_temperature_only(self) -> None:
+        info = OllamaAdapter().plugin_info()
+        assert set(info.capabilities) == {AdapterCapability.SUPPORTS_TEMPERATURE}
+
+    def test_does_not_declare_coarse_or_others(self) -> None:
+        info = OllamaAdapter().plugin_info()
+        assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TOP_P not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TOP_K not in info.capabilities
+        assert AdapterCapability.SUPPORTS_MAX_TOKENS not in info.capabilities
+
+
+class TestOllamaAdapterSamplingParams:
+    """mcp_config temperature must reach the built aider argv."""
+
+    def test_temperature_reaches_argv(self, tmp_path: Path) -> None:
+        adapter = OllamaAdapter()
+        proc_mock = make_popen_mock(pid=801)
+        with patch("bernstein.adapters.ollama.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen2.5-coder:7b", effort="high"),
+                session_id="ollama-sampling1",
+                mcp_config={"temperature": 0.15},
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--temperature" in inner
+        assert inner[inner.index("--temperature") + 1] == "0.15"
+
+    def test_no_mcp_config_omits_temperature_flag(self, tmp_path: Path) -> None:
+        adapter = OllamaAdapter()
+        proc_mock = make_popen_mock(pid=802)
+        with patch("bernstein.adapters.ollama.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen2.5-coder:7b", effort="high"),
+                session_id="ollama-sampling2",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--temperature" not in inner
+
+    def test_top_p_top_k_max_tokens_never_reach_argv(self, tmp_path: Path) -> None:
+        adapter = OllamaAdapter()
+        proc_mock = make_popen_mock(pid=803)
+        with patch("bernstein.adapters.ollama.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen2.5-coder:7b", effort="high"),
+                session_id="ollama-sampling3",
+                mcp_config={"top_p": 0.9, "top_k": 40, "max_tokens": 4096},
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--top-p" not in inner
+        assert "--top-k" not in inner
+        assert "--max-tokens" not in inner

--- a/tests/unit/test_adapter_plugin_sdk.py
+++ b/tests/unit/test_adapter_plugin_sdk.py
@@ -152,6 +152,13 @@ class TestAdapterCapability:
             "STRUCTURED_OUTPUT",
             "BATCH_MODE",
             "SUPPORTS_SAMPLING_PARAMS",
+            # PR3: narrow per-sampling-field capabilities so adapters that
+            # only wire a subset of SAMPLING_PARAM_KEYS via real CLI flags
+            # (ollama/qwen/mistral) don't have to fake the coarse flag.
+            "SUPPORTS_TEMPERATURE",
+            "SUPPORTS_TOP_P",
+            "SUPPORTS_TOP_K",
+            "SUPPORTS_MAX_TOKENS",
         }
         assert set(AdapterCapability.__members__.keys()) == expected
 
@@ -434,4 +441,104 @@ class TestEnsureSamplingParamsSupported:
         ensure_sampling_params_supported(
             _SamplingStubAdapter(),
             {"temperature": 0.2, "top_p": 0.9, "api_key_env": "MY_PROXY_KEY"},
+        )
+
+    def test_caching_wrapper_forwards_supporting_capability(self, tmp_path: Path) -> None:
+        """A CachingAdapter must not hide the inner adapter's capability."""
+        from bernstein.adapters.caching_adapter import CachingAdapter
+
+        wrapped = CachingAdapter(_SamplingStubAdapter(), tmp_path)
+        ensure_sampling_params_supported(
+            wrapped,
+            {"base_url": "http://localhost:8000/v1", "api_key_env": "MY_PROXY_KEY"},
+        )
+
+    def test_caching_wrapper_still_refuses_non_supporting_inner(self, tmp_path: Path) -> None:
+        """Wrapping must not grant a capability the inner adapter lacks."""
+        from bernstein.adapters.caching_adapter import CachingAdapter
+
+        wrapped = CachingAdapter(_StubPluginAdapter(), tmp_path)
+        with pytest.raises(SamplingParamsRefusal, match="base_url"):
+            ensure_sampling_params_supported(
+                wrapped,
+                {"base_url": "http://localhost:8000/v1"},
+            )
+
+
+class _TemperatureOnlyStubAdapter(_StubPluginAdapter):
+    """Stub adapter that only declares the narrow SUPPORTS_TEMPERATURE
+    capability - mirrors the ollama/mistral shape shipped in PR3."""
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        return AdapterPluginInfo(
+            name="temperature-only-stub",
+            version="1.0.0",
+            capabilities=(AdapterCapability.SUPPORTS_TEMPERATURE,),
+        )
+
+
+class _TemperatureAndTopPStubAdapter(_StubPluginAdapter):
+    """Stub adapter declaring SUPPORTS_TEMPERATURE + SUPPORTS_TOP_P - mirrors
+    the qwen shape shipped in PR3."""
+
+    def plugin_info(self) -> AdapterPluginInfo:
+        return AdapterPluginInfo(
+            name="temp-and-top-p-stub",
+            version="1.0.0",
+            capabilities=(AdapterCapability.SUPPORTS_TEMPERATURE, AdapterCapability.SUPPORTS_TOP_P),
+        )
+
+
+class TestEnsureSamplingParamsSupportedNarrowCapabilities:
+    """PR3: an adapter that declares only a narrow per-field capability
+    (not the coarse SUPPORTS_SAMPLING_PARAMS) should be allowed to honour
+    exactly the keys it declares, and refused only for the rest."""
+
+    def test_narrow_capability_passes_for_covered_key(self) -> None:
+        ensure_sampling_params_supported(
+            _TemperatureOnlyStubAdapter(),
+            {"temperature": 0.2},
+        )
+
+    def test_narrow_capability_refuses_uncovered_key(self) -> None:
+        with pytest.raises(SamplingParamsRefusal) as excinfo:
+            ensure_sampling_params_supported(
+                _TemperatureOnlyStubAdapter(),
+                {"top_p": 0.9},
+            )
+        assert excinfo.value.requested_keys == ("top_p",)
+
+    def test_narrow_capability_partial_request_refuses_only_uncovered_subset(self) -> None:
+        """Requesting both a covered and an uncovered key must refuse with
+        ONLY the uncovered key, not the full requested set - this is the
+        behavior change from the pre-PR3 all-or-nothing gate."""
+        with pytest.raises(SamplingParamsRefusal) as excinfo:
+            ensure_sampling_params_supported(
+                _TemperatureOnlyStubAdapter(),
+                {"temperature": 0.2, "top_k": 40},
+            )
+        assert excinfo.value.requested_keys == ("top_k",)
+
+    def test_narrow_capability_never_covers_base_url_or_api_key_env(self) -> None:
+        """base_url/api_key_env have no narrow capability - only the coarse
+        SUPPORTS_SAMPLING_PARAMS flag covers an endpoint override."""
+        with pytest.raises(SamplingParamsRefusal) as excinfo:
+            ensure_sampling_params_supported(
+                _TemperatureOnlyStubAdapter(),
+                {"temperature": 0.2, "base_url": "http://localhost:8000/v1"},
+            )
+        assert excinfo.value.requested_keys == ("base_url",)
+
+    def test_two_narrow_capabilities_both_covered(self) -> None:
+        ensure_sampling_params_supported(
+            _TemperatureAndTopPStubAdapter(),
+            {"temperature": 0.2, "top_p": 0.9},
+        )
+
+    def test_coarse_capability_still_wins_over_all_keys(self) -> None:
+        """Backward-compat: an adapter with the coarse flag is unaffected
+        by the narrow-capability gate logic."""
+        ensure_sampling_params_supported(
+            _SamplingStubAdapter(),
+            {"temperature": 0.2, "top_p": 0.9, "top_k": 40, "base_url": "x", "api_key_env": "Y"},
         )

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -11,6 +11,7 @@ import pytest
 from bernstein.core.llm import LLMSettings
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
+from bernstein.adapters.plugin_sdk import AdapterCapability
 from bernstein.adapters.qwen import QwenAdapter
 
 if TYPE_CHECKING:
@@ -292,6 +293,128 @@ class TestQwenAdapterSpawn:
                 session_id="my-qwen-session",
             )
         assert result.log_path.name == "my-qwen-session.log"
+
+
+# ---------------------------------------------------------------------------
+# PR3: sampling params (temperature/top_p) wired via mcp_config
+# ---------------------------------------------------------------------------
+
+
+class TestQwenAdapterPluginInfo:
+    def test_declares_temperature_and_top_p_only(self) -> None:
+        info = QwenAdapter().plugin_info()
+        assert set(info.capabilities) == {
+            AdapterCapability.SUPPORTS_TEMPERATURE,
+            AdapterCapability.SUPPORTS_TOP_P,
+        }
+
+    def test_does_not_declare_coarse_or_top_k_or_max_tokens(self) -> None:
+        info = QwenAdapter().plugin_info()
+        assert AdapterCapability.SUPPORTS_SAMPLING_PARAMS not in info.capabilities
+        assert AdapterCapability.SUPPORTS_TOP_K not in info.capabilities
+        assert AdapterCapability.SUPPORTS_MAX_TOKENS not in info.capabilities
+
+
+class TestQwenAdapterSamplingParams:
+    """mcp_config temperature/top_p must reach the built CLI argv."""
+
+    def test_temperature_reaches_argv(self, tmp_path: Path) -> None:
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=300)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-sampling1",
+                mcp_config={"temperature": 0.3},
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--temperature" in inner
+        assert inner[inner.index("--temperature") + 1] == "0.3"
+
+    def test_top_p_reaches_argv(self, tmp_path: Path) -> None:
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=301)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-sampling2",
+                mcp_config={"top_p": 0.85},
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--top-p" in inner
+        assert inner[inner.index("--top-p") + 1] == "0.85"
+
+    def test_both_reach_argv_together(self, tmp_path: Path) -> None:
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=302)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-sampling3",
+                mcp_config={"temperature": 0.1, "top_p": 0.95},
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner[inner.index("--temperature") + 1] == "0.1"
+        assert inner[inner.index("--top-p") + 1] == "0.95"
+
+    def test_no_mcp_config_omits_sampling_flags(self, tmp_path: Path) -> None:
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=303)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-sampling4",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--temperature" not in inner
+        assert "--top-p" not in inner
+
+    def test_top_k_and_max_tokens_never_reach_argv(self, tmp_path: Path) -> None:
+        """Not declared in plugin_info -> not wired, even if present in
+        mcp_config (the spawn-time gate is expected to have refused this
+        spawn upstream; this test proves the adapter itself never fakes
+        support for a flag the real CLI does not have)."""
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=304)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-sampling5",
+                mcp_config={"top_k": 40, "max_tokens": 4096},
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--top-k" not in inner
+        assert "--max-tokens" not in inner
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -9,6 +10,8 @@ from unittest.mock import MagicMock, patch
 from bernstein.core.agent_reaping import _has_git_commits_on_branch, handle_orphaned_task
 from bernstein.core.cascade import CascadeDecision, CascadeExhausted
 from bernstein.core.models import AgentSession, Complexity, ModelConfig, Scope, Task, TaskStatus, TaskType
+
+from bernstein.core.agents.agent_lifecycle import _probe_fast_exit
 
 
 def _make_task(task_id: str = "T-1") -> Task:
@@ -323,3 +326,445 @@ def test_orphaned_task_files_modified_takes_priority(tmp_path: Path) -> None:
     call_args = mock_complete.call_args
     assert "modified 1 files" in call_args[0][3]
     mock_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Defect 8 (D2 claude leg, attempt4-meridian-fixed FAIL-NOTE): dead-agent
+# misjudgment on double-forked runners. A tracked launcher PID can exit in
+# ~3s while the real worker keeps running untracked; the death judgment must
+# not fire while a fresher liveness signal (heartbeat file / runner log /
+# worktree git activity) says otherwise.
+# ---------------------------------------------------------------------------
+
+
+def test_orphaned_task_not_judged_dead_when_heartbeat_fresh_despite_dead_pid(tmp_path: Path, caplog) -> None:  # type: ignore[no-untyped-def]
+    """Regression for defect 8: fresh heartbeat file must block the death verdict.
+
+    Ground truth: manager-48832613 was declared dead ("PID 77, 3s runtime ...
+    died without output") after ~109s of real work because the tracked
+    launcher PID had already exited (double-fork). A fresh heartbeat file
+    is exactly the signal that must override a dead-looking/wrong pid.
+    """
+    import logging
+
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-doubleforked",
+        role="manager",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        pid=77,  # tracked launcher pid -- already exited (double-fork)
+        exit_code=1,
+        spawn_ts=1000.0,
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+
+    heartbeat_dir = tmp_path / ".sdd" / "runtime" / "heartbeats"
+    heartbeat_dir.mkdir(parents=True)
+    (heartbeat_dir / f"{session.id}.json").write_text("{}")  # freshly written -- mtime is "now"
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+        caplog.at_level(logging.INFO, logger="bernstein.core.agents.agent_lifecycle"),
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    # The agent must NOT be judged dead: no fail/retry and no auto-complete
+    # (the task is simply deferred to the next tick).
+    mock_retry.assert_not_called()
+    mock_complete.assert_not_called()
+    assert any("Deferring death judgment" in r.message for r in caplog.records)
+
+
+def test_orphaned_task_judged_dead_when_all_signals_stale(tmp_path: Path) -> None:
+    """Case (b): genuinely dead agent (stale/missing heartbeat, dead pid, no output) IS judged dead."""
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-genuinely-dead",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+        pid=99999999,
+        exit_code=1,
+        spawn_ts=1000.0,
+    )
+    orch = _make_orch_no_ratelimit(tmp_path)
+    # No heartbeat/log/git files created at all -- every signal is "missing".
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task") as mock_complete,
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry,
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    mock_complete.assert_not_called()
+    mock_retry.assert_called_once()
+
+
+def test_liveness_judgment_log_line_contains_all_inputs(tmp_path: Path, caplog) -> None:
+    """The liveness_judgment log line must carry every input plus the verdict and why.
+
+    A future misjudgment must be diagnosable from this log line alone, per
+    house logging rules -- never a truncated payload.
+    """
+    import logging
+
+    from bernstein.core.agents.agent_lifecycle import _probe_liveness_signals
+
+    orch = SimpleNamespace(_workdir=tmp_path)
+    session = AgentSession(
+        id="sess-log-check",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=["T-1"],
+        pid=123,
+        spawn_ts=1000.0,
+    )
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False),
+        caplog.at_level(logging.INFO, logger="bernstein.core.agents.agent_lifecycle"),
+    ):
+        result = _probe_liveness_signals(orch, session, now=1500.0)
+
+    assert result["has_fresh_signal"] is False
+    records = [r for r in caplog.records if "liveness_judgment" in r.message]
+    assert len(records) == 1
+    msg = records[0].message
+    for expected in (
+        "session=sess-log-check",
+        "pid=123",
+        "pid_alive=False",
+        "heartbeat_age_s=",
+        "log_age_s=",
+        "git_age_s=",
+        "grace_s=",
+        "verdict=",
+        "reason=",
+    ):
+        assert expected in msg, f"missing {expected!r} in log line: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# _probe_fast_exit: structured diagnostics for a suspiciously fast agent death
+# ---------------------------------------------------------------------------
+
+
+def test_probe_fast_exit_returns_structured_dict_for_fast_death(tmp_path: Path) -> None:
+    """A synthetic failing/fast process must yield a structured dict with
+    exit code, log tail, and manifest path - not a bare boolean."""
+    session = AgentSession(
+        id="sess-fast-death",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=["T-1"],
+        exit_code=0,
+    )
+    # Simulate an agent that has been "alive" for only 2 seconds.
+    session.spawn_ts = __import__("time").time() - 2.0
+
+    # Log file the process wrote before dying.
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True)
+    log_path = runtime_dir / f"{session.id}.log"
+    log_lines = [f"line {i}" for i in range(100)]
+    log_path.write_text("\n".join(log_lines) + "\n")
+
+    # Preserved runner manifest (written by _preserve_runner_logs before
+    # this probe would ever run in production).
+    preserved_dir = runtime_dir / "agent_logs" / session.id
+    preserved_dir.mkdir(parents=True)
+    manifest_path = preserved_dir / f"{session.id}.manifest.json"
+    manifest_path.write_text("{}")
+
+    orch = SimpleNamespace()
+    orch._workdir = tmp_path
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = None
+
+    result = _probe_fast_exit(orch, session, "T-1")
+
+    assert isinstance(result, dict)
+    assert result["suspicious"] is True
+    assert result["exit_code"] == 0
+    assert result["manifest_path"] == str(manifest_path)
+    assert result["log_path"] == str(log_path)
+    # Log tail must contain real content, not be swallowed/truncated to nothing.
+    assert result["log_tail"], "log_tail must not be empty when a log file exists"
+    assert result["log_tail"][-1] == "line 99"
+    assert len(result["log_tail"]) <= 60
+    assert result["session_id"] == "sess-fast-death"
+    assert result["task_id"] == "T-1"
+
+
+def test_probe_fast_exit_not_suspicious_for_long_lived_agent(tmp_path: Path) -> None:
+    """An agent that ran well past the fast-exit threshold is not flagged."""
+    session = AgentSession(
+        id="sess-normal",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=["T-1"],
+        exit_code=0,
+    )
+    session.spawn_ts = __import__("time").time() - 600.0  # ran for 10 minutes
+
+    orch = SimpleNamespace()
+    orch._workdir = tmp_path
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = None
+
+    result = _probe_fast_exit(orch, session, "T-1")
+
+    assert result["suspicious"] is False
+    assert result["exit_code"] == 0
+    assert result["log_tail"] == []
+    assert result["manifest_path"] is None
+
+
+def test_probe_fast_exit_falls_back_to_worktree_manifest(tmp_path: Path) -> None:
+    """When no preserved manifest exists, fall back to the (still-live) worktree copy."""
+    session = AgentSession(
+        id="sess-wt",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=["T-1"],
+        exit_code=0,
+    )
+    session.spawn_ts = __import__("time").time() - 1.0
+
+    worktree_runtime = tmp_path / "worktree" / ".sdd" / "runtime"
+    worktree_runtime.mkdir(parents=True)
+    wt_manifest = worktree_runtime / f"{session.id}.manifest.json"
+    wt_manifest.write_text("{}")
+
+    orch = SimpleNamespace()
+    orch._workdir = tmp_path
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = tmp_path / "worktree"
+
+    result = _probe_fast_exit(orch, session, "T-1")
+
+    assert result["suspicious"] is True
+    assert result["manifest_path"] == str(wt_manifest)
+
+
+# ---------------------------------------------------------------------------
+# Cost propagation regression: orphan/auto-complete-after-death path must
+# recover real runner cost instead of silently recording $0.0
+# (D2 openrouter FAIL-NOTE, 2026-07-03: runner priced the manager's session
+# at $0.0038789583 but .sdd/metrics/tasks.jsonl recorded cost_usd: 0.0 and
+# retrospective's cost_aggregation fallback logged "K=1 skipped
+# (reasons=cost_usd==0), final total_cost=$0.000000").
+# ---------------------------------------------------------------------------
+
+
+def _write_tokens_sidecar(tmp_path: Path, session_id: str, input_tokens: int, output_tokens: int) -> Path:
+    """Write a runner cost sidecar (.sdd/runtime/<session_id>.tokens) with one usage record.
+
+    Mirrors the schema written by bernstein.adapters.openai_agents_runner's
+    _append_tokens_sidecar(): one JSON object per line, {"ts", "in", "out"}.
+    """
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    sidecar_path = runtime_dir / f"{session_id}.tokens"
+    with sidecar_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"ts": 1783037874.0, "in": input_tokens, "out": output_tokens}) + "\n")
+    return sidecar_path
+
+
+def test_orphaned_task_folds_in_real_runner_cost_from_sidecar(tmp_path: Path) -> None:
+    """Reproduces the D2 openrouter FAIL-NOTE: an agent that made real, priced
+    LLM calls dies before self-reporting completion. The orphan/auto-complete
+    path picks the task up, finds a clean exit + empty diff (exactly the
+    manager's outcome in the FAIL-NOTE), and must fold the runner's real cost
+    (recovered from the .tokens sidecar) into both:
+
+      1. .sdd/metrics/tasks.jsonl (via EvolutionCoordinator.record_task_completion)
+      2. the observability MetricsCollector's in-memory task_metrics entry,
+         which is what retrospective.py's cost_aggregation fallback reads.
+
+    Before the fix, both of these hardcoded cost_usd=0.0 on this path.
+    """
+    from bernstein.core.observability import metric_collector as metric_collector_mod
+    from bernstein.core.quality.retrospective import generate_retrospective
+    from bernstein.evolution import EvolutionCoordinator
+
+    task = _make_task(task_id="c504cea0632a")
+    task.status = TaskStatus.CLAIMED
+    task.role = "manager"
+    session = AgentSession(
+        id="manager-1d73fe26",
+        role="manager",
+        provider="openai_agents",
+        model_config=ModelConfig("deepseek/deepseek-chat", "high"),
+        task_ids=[task.id],
+        exit_code=0,  # Clean exit, exactly like the FAIL-NOTE manager
+    )
+
+    # Real runner cost: 14136 input / 1311 output tokens on deepseek/deepseek-chat
+    # (the exact figures quoted in the D2 openrouter FAIL-NOTE).
+    _write_tokens_sidecar(tmp_path, session.id, input_tokens=14136, output_tokens=1311)
+
+    # Reset the observability MetricsCollector global singleton so this test
+    # doesn't leak state from/into other tests, then register the task the
+    # way task_lifecycle.py's spawn path does (collector.start_task()).
+    metric_collector_mod._default_collector = None
+    obs_collector = metric_collector_mod.get_collector(tmp_path / ".sdd" / "metrics")
+    obs_collector.start_task(task.id, role="manager", model="deepseek/deepseek-chat", provider="openai_agents")
+
+    orch = _make_orch_no_ratelimit(tmp_path)
+    orch._evolution = EvolutionCoordinator(state_dir=tmp_path / ".sdd")
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle.collect_completion_data", return_value={"files_modified": []}),
+        patch("bernstein.core.agents.agent_lifecycle._has_git_commits_on_branch", return_value=False),
+        patch("bernstein.core.agents.agent_lifecycle.complete_task"),
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task"),
+    ):
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    # 1. .sdd/metrics/tasks.jsonl must carry the real, nonzero cost.
+    tasks_jsonl = tmp_path / ".sdd" / "metrics" / "tasks.jsonl"
+    assert tasks_jsonl.exists(), "tasks.jsonl was never written"
+    records = [json.loads(line) for line in tasks_jsonl.read_text().splitlines() if line.strip()]
+    task_records = [r for r in records if r["task_id"] == task.id]
+    assert task_records, f"no tasks.jsonl record for {task.id}"
+    assert task_records[-1]["cost_usd"] > 0.0, f"cost_usd was not folded in: {task_records[-1]}"
+    assert task_records[-1]["tokens_prompt"] == 14136
+    assert task_records[-1]["tokens_completion"] == 1311
+
+    # 2. Retrospective's cost aggregation (which reads the observability
+    #    collector's in-memory task_metrics, not tasks.jsonl) must also see
+    #    the real cost, not "$0.000000" / "K=1 skipped (cost_usd==0)".
+    generate_retrospective(
+        done_tasks=[],
+        failed_tasks=[],
+        collector=obs_collector,
+        runtime_dir=tmp_path / ".sdd" / "runtime",
+        run_start_ts=1783037874.0,
+    )
+    retro_text = (tmp_path / ".sdd" / "runtime" / "retrospective.md").read_text()
+    total_cost = obs_collector.get_total_cost()
+    fallback_total = sum(tm.cost_usd for tm in obs_collector.task_metrics.values())
+    assert total_cost > 0.0 or fallback_total > 0.0, (
+        f"retrospective cost aggregation still sees $0 total (total_cost={total_cost}, "
+        f"fallback_total={fallback_total}); retrospective.md:\n{retro_text}"
+    )
+
+    metric_collector_mod._default_collector = None
+
+
+def test_reap_wall_clock_timeout_logs_and_continues_when_evolution_raises(tmp_path: Path, caplog) -> None:  # type: ignore[no-untyped-def]
+    """Item 25: reap paths must not swallow exceptions from best-effort
+    evolution/metrics recording silently. record_agent_lifetime raising
+    (e.g. the item-22 TypeError) must produce a logged ERROR with a
+    traceback and the session id, and the reap must still complete
+    (result.reaped populated, spawner.kill called)."""
+    import logging
+
+    from bernstein.core.agents.agent_lifecycle import _reap_wall_clock_timeout
+
+    session = AgentSession(
+        id="agent-x1",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("claude-3", "high"),
+        task_ids=["T-1"],
+    )
+
+    orch = SimpleNamespace()
+    orch._spawner = MagicMock()
+    orch._spawner.get_worktree_path.return_value = "/tmp/worktree-agent-x1"
+    orch._signal_mgr = MagicMock()
+    orch._evolution = MagicMock()
+    orch._evolution.record_agent_lifetime.side_effect = TypeError("boom: unexpected keyword")
+    orch._preserved_worktrees = {}
+
+    result = SimpleNamespace(reaped=[])
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle._propagate_abort_to_children"),
+        patch("bernstein.core.agents.agent_lifecycle._release_file_ownership"),
+        patch("bernstein.core.agents.agent_lifecycle._release_task_to_session"),
+        patch("bernstein.core.agents.agent_lifecycle._preserve_runner_logs"),
+        patch("bernstein.core.agents.agent_lifecycle.handle_orphaned_task"),
+        patch("bernstein.core.agents.agent_lifecycle._save_partial_work", return_value=False),
+        caplog.at_level(logging.ERROR),
+    ):
+        _reap_wall_clock_timeout(orch, session, result, {}, runtime=42.0)
+
+    # Reap must still complete despite the evolution-recording exception.
+    assert result.reaped == [session.id]
+    orch._spawner.kill.assert_called_once()
+    orch._spawner.cleanup_worktree.assert_called_once_with(session.id)
+
+    # The failure must be loud: ERROR level, with the session id, and a
+    # traceback (logger.exception attaches exc_info).
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "expected an ERROR log for the swallowed exception, found none"
+    assert any(session.id in r.getMessage() for r in error_records), caplog.text
+    assert any("record_agent_lifetime" in r.getMessage() for r in error_records), caplog.text
+    assert any(r.exc_info for r in error_records), "expected logger.exception to attach a traceback"
+
+
+def test_reap_heartbeat_timeout_logs_and_continues_when_evolution_raises(tmp_path: Path, caplog) -> None:  # type: ignore[no-untyped-def]
+    """Same as above for the heartbeat-timeout reap path."""
+    import logging
+
+    from bernstein.core.agents.agent_lifecycle import _reap_heartbeat_timeout
+
+    session = AgentSession(
+        id="agent-x2",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("claude-3", "high"),
+        task_ids=["T-2"],
+        spawn_ts=1000.0,
+    )
+
+    orch = SimpleNamespace()
+    orch._spawner = MagicMock()
+    orch._signal_mgr = MagicMock()
+    orch._evolution = MagicMock()
+    orch._evolution.record_agent_lifetime.side_effect = TypeError("boom: unexpected keyword")
+    orch._record_provider_health = MagicMock()
+    orch._wal_writer = None
+    orch._client = MagicMock()
+    orch._config = SimpleNamespace(server_url="http://server", max_task_retries=3)
+    orch._retried_task_ids = set()
+    orch._workdir = tmp_path
+
+    result = SimpleNamespace(reaped=[])
+
+    with (
+        patch("bernstein.core.agents.agent_lifecycle._propagate_abort_to_children"),
+        patch("bernstein.core.agents.agent_lifecycle._release_file_ownership"),
+        patch("bernstein.core.agents.agent_lifecycle._release_task_to_session"),
+        patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task"),
+        caplog.at_level(logging.ERROR),
+    ):
+        _reap_heartbeat_timeout(orch, session, result, {}, now=1100.0, age=100.0)
+
+    assert result.reaped == [session.id]
+    orch._spawner.kill.assert_called_once()
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "expected an ERROR log for the swallowed exception, found none"
+    assert any(session.id in r.getMessage() for r in error_records), caplog.text
+    assert any("record_agent_lifetime" in r.getMessage() for r in error_records), caplog.text
+    assert any(r.exc_info for r in error_records), "expected logger.exception to attach a traceback"

--- a/tests/unit/test_approval_gate_outer_fail_closed.py
+++ b/tests/unit/test_approval_gate_outer_fail_closed.py
@@ -1,0 +1,110 @@
+"""Targeted tests for the outer fail-closed behavior of ``_evaluate_approval_gate``.
+
+Defect: on ANY exception in the evaluate+create_pr flow -- including one raised
+by a pre-gate step like ``_resolve_approval_workflow`` -- the outer except in
+``task_lifecycle._evaluate_approval_gate`` used to default to a value that let
+the merge proceed (fail OPEN). The fix must fail CLOSED: on any exception,
+return ``True`` (skip_merge=True, i.e. hold for approval) and log at ERROR
+with the full traceback.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from bernstein.core.models import AgentSession, ModelConfig, Task
+
+from bernstein.core.tasks.task_lifecycle import _evaluate_approval_gate
+
+
+def _task(task_id: str = "t-1") -> Task:
+    return Task(id=task_id, title="do the thing", description="desc", role="engineer")
+
+
+def _session(task_id: str = "t-1") -> AgentSession:
+    return AgentSession(
+        id="sess-1",
+        role="engineer",
+        task_ids=[task_id],
+        model_config=ModelConfig(model="test-model", effort="medium"),
+    )
+
+
+def _orch_with_gate(gate: Any) -> Any:
+    return SimpleNamespace(_approval_gate=gate, _config=SimpleNamespace(approval_workflow=None))
+
+
+def test_exception_in_resolve_approval_workflow_holds_for_approval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pre-gate exception (in _resolve_approval_workflow) must HOLD, not auto-merge."""
+    gate = MagicMock()
+    orch = _orch_with_gate(gate)
+
+    def _boom(_orch: Any, _task: Task) -> tuple[Any, float | None]:
+        raise RuntimeError("boom from pre-gate step")
+
+    monkeypatch.setattr(
+        "bernstein.core.tasks.task_lifecycle._resolve_approval_workflow",
+        _boom,
+    )
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is True, "exception in pre-gate step must fail CLOSED (hold for approval)"
+    gate.evaluate.assert_not_called()
+
+
+def test_exception_in_gate_evaluate_holds_for_approval() -> None:
+    """An exception raised inside gate.evaluate() itself must also HOLD."""
+    gate = MagicMock()
+    gate.evaluate.side_effect = RuntimeError("boom from gate.evaluate")
+    orch = _orch_with_gate(gate)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is True, "exception in gate.evaluate() must fail CLOSED (hold for approval)"
+
+
+def test_happy_path_approved_is_unchanged() -> None:
+    """No exception, gate approves -- merge proceeds (skip_merge=False)."""
+    gate = MagicMock()
+    gate.evaluate.return_value = SimpleNamespace(approved=True, rejected=False)
+    orch = _orch_with_gate(gate)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is False
+
+
+def test_happy_path_rejected_is_unchanged() -> None:
+    """No exception, gate rejects -- merge is held (skip_merge=True), same as before."""
+    gate = MagicMock()
+    gate.evaluate.return_value = SimpleNamespace(approved=False, rejected=True)
+    orch = _orch_with_gate(gate)
+
+    result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is True
+
+
+def test_error_log_emitted_on_outer_exception(caplog: pytest.LogCaptureFixture) -> None:
+    """The failure path must emit an ERROR-level log with the exception/traceback."""
+    gate = MagicMock()
+    gate.evaluate.side_effect = RuntimeError("boom for logging check")
+    orch = _orch_with_gate(gate)
+
+    with caplog.at_level(logging.ERROR, logger="bernstein.core.tasks.task_lifecycle"):
+        result = _evaluate_approval_gate(orch, _task(), _session(), None, janitor_passed=True)
+
+    assert result is True
+    assert any(record.levelno >= logging.ERROR for record in caplog.records), "expected an ERROR-level log record"
+    error_text = "\n".join(record.getMessage() for record in caplog.records if record.levelno >= logging.ERROR)
+    assert "FAIL-CLOSED" in error_text
+    assert any(record.exc_info for record in caplog.records if record.levelno >= logging.ERROR), (
+        "expected the ERROR log to carry exception info (logger.exception / traceback)"
+    )

--- a/tests/unit/test_auto_commit_on_complete.py
+++ b/tests/unit/test_auto_commit_on_complete.py
@@ -1,0 +1,490 @@
+"""Tests for the /complete auto-commit hook (defect 33).
+
+The hook (``_run_auto_commit_pre_complete`` in
+``bernstein.core.routes.task_crud``) auto-commits a worker's uncommitted
+work BEFORE ``store.complete`` transitions the task to done, so a worker
+that forgets to commit still has its work delivered.  Failures are
+swallowed (fail-open) - see defect 33 spec.
+
+These tests run foreground-only per the lessons.md rule 5 (background
+pytest is a stall trap for delegated agents).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from bernstein.core.routes.task_crud import (
+    _is_auto_commit_denied,
+    _is_salvage_branch,
+    _run_auto_commit_pre_complete,
+)
+from bernstein.core.server import create_app
+from bernstein.core.tasks.models import Task, TaskStatus
+
+# ---------------------------------------------------------------------------
+# Pure-function tests (deny list / salvage detection)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".sdd/runtime/pids/spawner.pid",
+        ".sdd/metrics/foo.jsonl",
+        ".sdd/traces/session.jsonl",
+        "attestations/abc.sig",
+        "auth/secrets.yaml",
+        "bernstein.yaml",
+        ".claude/mcp.json",
+        ".env",
+        ".env.local",
+        ".env.production",
+    ],
+)
+def test_is_auto_commit_denied_true(path: str) -> None:
+    assert _is_auto_commit_denied(path), f"expected {path!r} to be denied"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/bernstein/core/routes/task_crud.py",
+        "tests/unit/test_auto_commit_on_complete.py",
+        "templates/roles/backend/system_prompt.md",
+        "README.md",
+        "docs/operations/runbook.md",
+    ],
+)
+def test_is_auto_commit_denied_false(path: str) -> None:
+    assert not _is_auto_commit_denied(path), f"expected {path!r} to be allowed"
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "salvage/session-abc",
+        "salvage/anything",
+        "bernstein-salvage-2026",
+    ],
+)
+def test_is_salvage_branch_true(branch: str) -> None:
+    assert _is_salvage_branch(branch)
+
+
+@pytest.mark.parametrize(
+    "branch",
+    [
+        "agent/A-1234",
+        "main",
+        "fix/auto-commit-on-complete",
+        None,
+        "",
+    ],
+)
+def test_is_salvage_branch_false(branch: str | None) -> None:
+    assert not _is_salvage_branch(branch)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fake Request with workdir set
+# ---------------------------------------------------------------------------
+
+
+class _FakeAppState:
+    """Minimal stand-in for ``starlette.applications.Starlette.state``."""
+
+    def __init__(self, workdir: Path) -> None:
+        self.workdir = workdir
+
+
+class _FakeApp:
+    """Minimal stand-in for ``starlette.requests.Request.app``.
+
+    The hook reads ``request.app.state.workdir`` - so ``app`` exposes
+    ``state`` whose attribute is the workdir Path.
+    """
+
+    def __init__(self, workdir: Path) -> None:
+        self.state = _FakeAppState(workdir)
+
+
+class _FakeRequest:
+    """Minimal stand-in for the bits of Request that the hook reads."""
+
+    def __init__(self, workdir: Path) -> None:
+        self.app = _FakeApp(workdir)
+
+
+def _make_task(task_id: str, session_id: str | None) -> Task:
+    return Task(
+        id=task_id,
+        title="Test task",
+        description="",
+        role="backend",
+        status=TaskStatus.CLAIMED,
+        claimed_by_session=session_id,
+    )
+
+
+def _init_git_repo(repo: Path, initial_commit_message: str = "init") -> str:
+    """Initialise a git repo at *repo* and return HEAD sha."""
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "README.md").write_text("init\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", initial_commit_message], cwd=repo, check=True)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return sha
+
+
+def _setup_workdir_with_worktree(workdir: Path, session_id: str) -> Path:
+    """Build a workdir/<.sdd/worktrees/<session_id>/> git worktree.
+
+    Returns the worktree path.  The worktree is on its own
+    ``agent/<session_id>`` branch and is a fully working git checkout
+    (separate HEAD but tracked by the same .git).
+    """
+    workdir.mkdir(parents=True, exist_ok=True)
+    _init_git_repo(workdir)
+    wt = workdir / ".sdd" / "worktrees" / session_id
+    wt.parent.mkdir(parents=True, exist_ok=True)
+    branch_name = f"agent/{session_id}"
+    subprocess.run(
+        [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            str(wt),
+        ],
+        cwd=workdir,
+        check=True,
+    )
+    # Configure user.email/user.name inside the worktree too.
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=wt, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=wt, check=True)
+    return wt
+
+
+# ---------------------------------------------------------------------------
+# (a) worker has uncommitted deliverable → auto-commit happens
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_creates_commit_for_uncommitted_changes(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "A-1"
+    task = _make_task("T-100", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+
+    # Worker leaves a staged-and-unstaged mixed state: a new file plus a
+    # modification to README.md.
+    (wt / "src" / "new_module.py").parent.mkdir(parents=True, exist_ok=True)
+    (wt / "src" / "new_module.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    (wt / "README.md").write_text("updated contents\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=wt, check=True)
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    # /complete still succeeds (we never raised).  Verify the commit landed.
+    log_out = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "auto: T-100 pre-/complete" in log_out, f"expected auto-commit in log:\n{log_out}"
+    # Status should now be clean.
+    status_proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert status_proc.stdout.strip() == "", f"expected clean status, got:\n{status_proc.stdout}"
+
+    reason_logs = [
+        r.message
+        for r in caplog.records
+        if "auto_commit_pre_complete" in r.message and "reason=uncommitted_changes_at_complete" in r.message
+    ]
+    assert reason_logs, f"expected uncommitted_changes log; got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# (b) worker has already committed → no-op
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_skips_when_already_committed(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "A-2"
+    task = _make_task("T-200", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+
+    # Worker already committed with the task id in the message - this is
+    # the success path from 88611aab's prompt contract.
+    (wt / "delivered.txt").write_text("worker deliverable\n", encoding="utf-8")
+    subprocess.run(["git", "add", "delivered.txt"], cwd=wt, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "T-200: shipped feature"],
+        cwd=wt,
+        check=True,
+    )
+
+    log_count_before = len(caplog.records)
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    # No new commit was created (we expect init + the worker's commit).
+    log_out = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert log_out.count("\n") == 2, f"expected exactly 2 commits (init + worker), got:\n{log_out}"
+    assert "auto: T-200 pre-/complete" not in log_out
+
+    # Log records reflect the already-committed reason.
+    new_records = caplog.records[log_count_before:]
+    reasons = [r.message for r in new_records if "auto_commit_pre_complete" in r.message]
+    assert any("reason=already_committed" in m for m in reasons), reasons
+
+
+# ---------------------------------------------------------------------------
+# (c) salvage branch → skipped
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_skips_salvage_branch(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "A-3"
+    task = _make_task("T-300", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+
+    # Switch the worktree onto a salvage branch with dirty state.
+    subprocess.run(["git", "checkout", "-q", "-b", "salvage/legacy"], cwd=wt, check=True)
+    (wt / "salvaged.txt").write_text("rescued state\n", encoding="utf-8")
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    # No commit was created on the salvage branch.
+    log_out = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "auto: T-300 pre-/complete" not in log_out
+
+    reasons = [
+        r.message
+        for r in caplog.records
+        if "auto_commit_pre_complete" in r.message and "skipped_salvage_branch" in r.message
+    ]
+    assert reasons, f"expected salvage skip log; got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# (d) only deny-listed uncommitted files → nothing_to_commit
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_skips_when_only_deny_listed_changes_exist(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "A-4"
+    task = _make_task("T-400", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+
+    # Worker accidentally left a .env file and a runtime artifact.
+    (wt / ".env").write_text("SECRET=should-not-commit\n", encoding="utf-8")
+    (wt / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+    (wt / ".sdd" / "runtime" / "scratch.log").write_text("noise\n", encoding="utf-8")
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    # No commit was created.
+    log_out = subprocess.run(
+        ["git", "log", "--oneline"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "auto: T-400 pre-/complete" not in log_out
+
+    reasons = [
+        r.message
+        for r in caplog.records
+        if "auto_commit_pre_complete" in r.message and "reason=nothing_to_commit" in r.message
+    ]
+    assert reasons, f"expected nothing_to_commit log; got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# (e) mix of allow + deny → only allowed files committed, deny excluded
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_excludes_deny_listed_files_even_with_real_work(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "A-5"
+    task = _make_task("T-500", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+
+    (wt / "real_work.py").write_text("print('real')\n", encoding="utf-8")
+    (wt / ".env.local").write_text("SECRET=excluded\n", encoding="utf-8")
+    (wt / "bernstein.yaml").write_text("config: leaked\n", encoding="utf-8")
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    # Only the allowed file should have been staged and committed.
+    log_out = subprocess.run(
+        ["git", "show", "--name-only", "HEAD"],
+        cwd=wt,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "real_work.py" in log_out, log_out
+    assert ".env.local" not in log_out, log_out
+    assert "bernstein.yaml" not in log_out, log_out
+
+
+# ---------------------------------------------------------------------------
+# (f) git error during commit (mocked) → /complete still succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_swallows_git_errors(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    session_id = "A-6"
+    task = _make_task("T-600", session_id)
+    wt = _setup_workdir_with_worktree(tmp_path, session_id)
+
+    # Create a real dirty state so the hook tries to commit.
+    (wt / "deliverable.py").write_text("print('hi')\n", encoding="utf-8")
+
+    # Force git commit to fail by patching subprocess.run inside the hook.
+    # The hook reads ``subprocess.run`` from the module-level import - we
+    # patch ``subprocess.run`` itself so the hook sees the failure too.
+    real_run = subprocess.run
+
+    def failing_run(*args: Any, **kwargs: Any) -> Any:
+        if (
+            args
+            and isinstance(args[0], list)
+            and args[0][:1] == ["git"]
+            and len(args[0]) >= 2
+            and args[0][1:2] == ["commit"]
+        ):
+            return subprocess.CompletedProcess(
+                args=args[0],
+                returncode=128,
+                stdout="",
+                stderr="fatal: simulated commit failure",
+            )
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", failing_run)
+
+    request = _FakeRequest(tmp_path)
+    # Must NOT raise.
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    warn_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "auto_commit_pre_complete_failed" in r.message
+    ]
+    assert warn_records, f"expected warn log on simulated git error; got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# (g) no session attached → log no-op, return without raising
+# ---------------------------------------------------------------------------
+
+
+def test_auto_commit_skips_when_no_session(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    task = _make_task("T-700", None)
+
+    request = _FakeRequest(tmp_path)
+    _run_auto_commit_pre_complete(request, task)  # type: ignore[arg-type]
+
+    log_lines = [r.message for r in caplog.records if "auto_commit_pre_complete" in r.message]
+    assert any("reason=no_session" in m for m in log_lines), log_lines
+
+
+# ---------------------------------------------------------------------------
+# (h) /complete end-to-end via TestClient - works on a tiny task
+#     (regression: existing /complete path stays green).
+# ---------------------------------------------------------------------------
+
+
+def test_complete_endpoint_still_responds_200(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/tasks",
+            json={
+                "title": "Trivial task",
+                "description": "Smoke.",
+                "role": "backend",
+                "priority": 1,
+                "scope": "small",
+                "complexity": "low",
+                "estimated_minutes": 5,
+            },
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        task_id = create_resp.json()["id"]
+        # Claim and complete - no worker session, so the hook should
+        # no-op cleanly with reason=no_session.
+        assert client.post(f"/tasks/{task_id}/claim").status_code == 200
+        resp = client.post(
+            f"/tasks/{task_id}/complete",
+            json={"result_summary": "Done."},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "done"
+
+    # The no_session log line must have been emitted.
+    lines = [r.message for r in caplog.records if "auto_commit_pre_complete" in r.message]
+    assert any("reason=no_session" in m for m in lines), lines

--- a/tests/unit/test_caching_adapter.py
+++ b/tests/unit/test_caching_adapter.py
@@ -218,6 +218,43 @@ def test_spawn_forwards_budget_multiplier_and_system_addendum(
     assert kwargs["task_scope"] == "medium"
 
 
+def test_forwards_consumes_heartbeat_dir_flag_from_inner(tmp_path: Path) -> None:
+    """Regression for bug #11: capability flags must survive the wrapper.
+
+    ``CachingAdapter`` previously exposed only the attributes/methods it
+    explicitly defined, so ``getattr(wrapped, "consumes_heartbeat_dir",
+    False)`` always returned the default ``False`` even when the wrapped
+    adapter declared ``consumes_heartbeat_dir = True`` (e.g. openai_agents).
+    That silently disabled heartbeat_dir injection for every caching-wrapped
+    spawn, orphaning heartbeats in the worktree and causing false
+    no_heartbeat kills. ``__getattr__`` delegation must make the flag
+    visible through the wrapper.
+    """
+    inner = MagicMock(spec=CLIAdapter)
+    inner.name.return_value = "mock-adapter"
+    inner.consumes_heartbeat_dir = True
+
+    wrapped = CachingAdapter(inner, tmp_path)
+
+    assert getattr(wrapped, "consumes_heartbeat_dir", False) is True
+
+
+def test_does_not_forward_flag_when_inner_lacks_it(tmp_path: Path) -> None:
+    """Adapters that never declared the flag still default to False."""
+    inner = MagicMock(spec=CLIAdapter)
+    inner.name.return_value = "mock-adapter"
+
+    wrapped = CachingAdapter(inner, tmp_path)
+
+    assert getattr(wrapped, "consumes_heartbeat_dir", False) is False
+
+
+def test_unknown_attribute_still_raises_attribute_error(adapter: CachingAdapter) -> None:
+    """__getattr__ delegation must not swallow genuinely missing attributes."""
+    with pytest.raises(AttributeError):
+        _ = adapter.definitely_not_a_real_attribute
+
+
 def test_concurrency_safe_spawns(adapter: CachingAdapter, mock_inner: MagicMock) -> None:
     """Verify that multiple threads can safely spawn through the adapter."""
     import threading

--- a/tests/unit/test_cascade_v2.py
+++ b/tests/unit/test_cascade_v2.py
@@ -479,8 +479,11 @@ class TestExpandedErrorDetection:
         assert tracker.scan_log_for_api_error(log)
 
     def test_detect_connection_refused(self, tmp_path: Path) -> None:
+        # "connection refused"/"ECONNREFUSED" are risky-bare tokens (they also
+        # appear in benign prose/JSON), so a real detection requires same-line
+        # error context -- exactly how a genuine connection failure is logged.
         log = tmp_path / "agent.log"
-        log.write_text("ECONNREFUSED: connection refused by remote host\n")
+        log.write_text("Error: ECONNREFUSED connection refused by remote host\n")
         tracker = RateLimitTracker()
         assert tracker.scan_log_for_api_error(log)
 
@@ -499,15 +502,22 @@ class TestExpandedErrorDetection:
 
 class TestDetectFailureType:
     def test_rate_limit_takes_priority(self, tmp_path: Path) -> None:
-        """Rate limit is detected before timeout or API error."""
+        """Rate limit is detected before timeout or API error.
+
+        "rate limit" and "timeout" are risky-bare tokens (they appear in
+        benign prose/JSON), so a real detection requires same-line error
+        context -- present here on a genuine provider-error line.
+        """
         log = tmp_path / "agent.log"
-        log.write_text("rate limit exceeded and then timeout occurred\n")
+        log.write_text("Error: rate limit exceeded and then timeout occurred\n")
         tracker = RateLimitTracker()
         assert tracker.detect_failure_type(log) == "rate_limit"
 
     def test_timeout_detected(self, tmp_path: Path) -> None:
+        # "timed out" is a risky-bare token; a real timeout is logged with
+        # error context, which is what a genuine failure line carries.
         log = tmp_path / "agent.log"
-        log.write_text("connection timed out\n")
+        log.write_text("Error: connection timed out\n")
         tracker = RateLimitTracker()
         assert tracker.detect_failure_type(log) == "timeout"
 

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -109,6 +109,67 @@ class TestCFGPydanticModel:
         assert cfg.role_model_policy["manager"].effort == "max"
         assert cfg.role_model_policy["backend"].model == "sonnet"
 
+    def test_role_model_policy_sampling_fields_round_trip(self) -> None:
+        """PR3: temperature/top_p/top_k/max_tokens/extra_params on
+        RoleModelPolicyEntry must survive a parse -> dump -> re-parse cycle
+        (mirrors the ModelCard round-trip proven on feat/model-cards-phase1)."""
+        data = _minimal_config(
+            role_model_policy={
+                "backend": {
+                    "model": "deepseek/deepseek-v4-flash",
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "temperature": 0.2,
+                    "top_p": 0.9,
+                    "top_k": 40,
+                    "max_tokens": 4096,
+                    "extra_params": {"reasoning_effort": "low"},
+                }
+            }
+        )
+        cfg = BernsteinConfig(**data)
+        entry = cfg.role_model_policy["backend"]
+        assert entry.temperature == 0.2
+        assert entry.top_p == 0.9
+        assert entry.top_k == 40
+        assert entry.max_tokens == 4096
+        assert entry.extra_params == {"reasoning_effort": "low"}
+
+        # Round-trip through dict serialization (the shape spawner_core's
+        # role_model_policy consumer receives).
+        dumped = cfg.model_dump()
+        reparsed = BernsteinConfig(**dumped)
+        reentry = reparsed.role_model_policy["backend"]
+        assert reentry.temperature == 0.2
+        assert reentry.top_p == 0.9
+        assert reentry.top_k == 40
+        assert reentry.max_tokens == 4096
+        assert reentry.extra_params == {"reasoning_effort": "low"}
+
+    def test_role_model_policy_sampling_fields_default_to_none_or_empty(self) -> None:
+        """Every new field must be optional so existing configs keep working."""
+        data = _minimal_config(role_model_policy={"backend": {"model": "sonnet"}})
+        cfg = BernsteinConfig(**data)
+        entry = cfg.role_model_policy["backend"]
+        assert entry.temperature is None
+        assert entry.top_p is None
+        assert entry.top_k is None
+        assert entry.max_tokens is None
+        assert entry.extra_params == {}
+
+    def test_role_model_policy_extra_params_default_not_shared_between_instances(self) -> None:
+        """default_factory=dict guard - mutating one entry's extra_params must
+        not leak into a sibling entry constructed without the field."""
+        data = _minimal_config(
+            role_model_policy={
+                "backend": {"model": "sonnet"},
+                "manager": {"model": "opus"},
+            }
+        )
+        cfg = BernsteinConfig(**data)
+        cfg.role_model_policy["backend"].extra_params["leak"] = True
+        assert "leak" not in cfg.role_model_policy["manager"].extra_params
+
     def test_nested_worktree_setup(self) -> None:
         data = _minimal_config(
             worktree_setup={

--- a/tests/unit/test_conflict_resolution.py
+++ b/tests/unit/test_conflict_resolution.py
@@ -103,6 +103,7 @@ class TestMergeWithConflictDetection:
         mock.side_effect = [
             GitResult(0, "", ""),  # merge --no-commit --no-ff
             GitResult(0, "", ""),  # _check_python_syntax: diff --cached --name-only
+            GitResult(0, "src/foo.py\n", ""),  # _verify_merge_staging_is_safe: staged files
             GitResult(0, "", ""),  # commit -m <msg>
             GitResult(0, "1 file changed\n", ""),  # diff HEAD~1 --stat
         ]
@@ -116,12 +117,14 @@ class TestMergeWithConflictDetection:
         mock.side_effect = [
             GitResult(0, "", ""),  # merge --no-commit --no-ff
             GitResult(0, "", ""),  # _check_python_syntax
+            GitResult(0, "src/foo.py\n", ""),  # _verify_merge_staging_is_safe
             GitResult(0, "", ""),  # commit
             GitResult(0, "", ""),  # diff --stat
         ]
         merge_with_conflict_detection(REPO, "feature/x", message="Custom merge msg")
-        # Verify the commit used the custom message (index 2: merge, syntax, commit)
-        commit_call = mock.call_args_list[2]
+        # Verify the commit used the custom message. Sequence: merge (0),
+        # syntax-check (1), safety-guard (2), commit (3).
+        commit_call = mock.call_args_list[3]
         assert "Custom merge msg" in commit_call[0][0]
 
     @patch("bernstein.core.git.git_pr.run_git")
@@ -156,6 +159,7 @@ class TestMergeWithConflictDetection:
         mock.side_effect = [
             GitResult(0, "", ""),  # merge --no-commit --no-ff
             GitResult(0, "", ""),  # _check_python_syntax
+            GitResult(0, "", ""),  # _verify_merge_staging_is_safe: nothing staged -> safe
             GitResult(1, "", "nothing to commit"),  # commit fails
             GitResult(0, "", ""),  # merge --abort (fallback)
         ]

--- a/tests/unit/test_cost_price_model_usage.py
+++ b/tests/unit/test_cost_price_model_usage.py
@@ -1,0 +1,124 @@
+"""Unit tests for ``bernstein.core.cost.cost.price_model_usage`` (bug 13).
+
+Bug 13: a 45-minute MiniMax-M3 run on the openai_agents provider path
+metered ``spent_usd: 0.0`` because usage was never priced. This module is
+the pricing primitive the openai_agents_runner fix
+(``src/bernstein/adapters/openai_agents_runner.py``) uses per LLM call:
+it must always return a concrete cost for a priced model and an explicit,
+loudly-logged $0 - never a silent drop - for an unrecognized one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.cost.cost import MODEL_COSTS_PER_1M_TOKENS, UsagePriceResult, price_model_usage
+
+
+class TestPriceModelUsage:
+    def test_priced_model_returns_nonzero_cost(self) -> None:
+        result = price_model_usage("minimax-m3", input_tokens=10_000, output_tokens=2_000)
+        assert isinstance(result, UsagePriceResult)
+        assert result.priced is True
+        assert result.model == "minimax-m3"
+        assert result.input_tokens == 10_000
+        assert result.output_tokens == 2_000
+        expected = (10_000 / 1_000_000.0) * 0.3 + (2_000 / 1_000_000.0) * 1.2
+        assert result.cost_usd == pytest.approx(expected)
+        assert result.cost_usd > 0.0
+
+    def test_matching_is_case_insensitive_substring(self) -> None:
+        result = price_model_usage("MiniMax-M3", input_tokens=1_000, output_tokens=1_000)
+        assert result.priced is True
+        assert result.cost_usd > 0.0
+
+    def test_unknown_model_is_explicit_zero_not_dropped(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            result = price_model_usage(
+                "some-brand-new-model-nobody-priced-yet", input_tokens=7_000, output_tokens=3_000
+            )
+
+        assert result.priced is False
+        assert result.cost_usd == 0.0
+        # Tokens are still visible on the result even though cost is $0.
+        assert result.input_tokens == 7_000
+        assert result.output_tokens == 3_000
+
+        assert any(rec.levelname == "WARNING" and "no pricing-table entry" in rec.message for rec in caplog.records)
+
+    def test_zero_tokens_prices_to_zero_for_known_model(self) -> None:
+        result = price_model_usage("gpt-5-mini", input_tokens=0, output_tokens=0)
+        assert result.priced is True
+        assert result.cost_usd == 0.0
+
+    def test_deepseek_chat_openrouter_id_prices_nonzero(self) -> None:
+        """D1 openrouter fix: 'deepseek/deepseek-chat' (the manifest model id
+        sent verbatim to OpenRouter) must match the 'deepseek-chat' pricing
+        row by substring and price above $0 - proving cost is no longer
+        silently metered at $0 for this model."""
+        result = price_model_usage("deepseek/deepseek-chat", input_tokens=10_000, output_tokens=2_000)
+        assert result.priced is True
+        expected = (10_000 / 1_000_000.0) * 0.2002 + (2_000 / 1_000_000.0) * 0.8001
+        assert result.cost_usd == pytest.approx(expected)
+        assert result.cost_usd > 0.0
+
+    def test_deepseek_chat_bare_alias_prices_nonzero(self) -> None:
+        result = price_model_usage("deepseek-chat", input_tokens=1_000, output_tokens=1_000)
+        assert result.priced is True
+        assert result.cost_usd > 0.0
+
+    def test_claude_sonnet_5_prices_at_its_own_rate_not_generic_sonnet(self) -> None:
+        """Substring-ordering hazard: 'sonnet' is a substring of
+        'claude-sonnet-5', so 'claude-sonnet-5' MUST be declared before the
+        generic 'sonnet' row in MODEL_COSTS_PER_1M_TOKENS or every
+        claude-sonnet-5 call would silently price at the wrong (generic
+        sonnet) rate instead of its own."""
+        result = price_model_usage("claude-sonnet-5", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert result.priced is True
+        expected = 2.0 + 10.0  # $2/$10 per 1M in/out at the introductory rate
+        assert result.cost_usd == pytest.approx(expected)
+        # Would be 3.0 + 15.0 if it fell through to the generic "sonnet" row.
+        assert result.cost_usd != pytest.approx(3.0 + 15.0)
+
+    def test_generic_sonnet_unaffected_by_claude_sonnet_5_entry(self) -> None:
+        result = price_model_usage("sonnet", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert result.priced is True
+        assert result.cost_usd == pytest.approx(3.0 + 15.0)
+
+    def test_mini_flash_variants_price_at_own_rate_not_parent(self) -> None:
+        """Longest-key-first matching hazard: the parent stems 'gpt-5', 'o4',
+        and 'gemini-3' are substrings of their 'gpt-5-mini', 'o4-mini', and
+        'gemini-3-flash' variants. Dict-order-first matching returned the
+        (more expensive) parent, over-pricing the variant. Matching must pick
+        the longest key so each variant prices at its own rate."""
+        # gpt-5-mini: own rate $0.5/$2.5, NOT parent gpt-5 $2.5/$15.
+        gpt5_mini = price_model_usage("gpt-5-mini", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert gpt5_mini.priced is True
+        assert gpt5_mini.cost_usd == pytest.approx(0.5 + 2.5)
+        assert gpt5_mini.cost_usd != pytest.approx(2.5 + 15.0)
+
+        # o4-mini: own rate $1.1/$4.4, NOT parent o4 $3.0/$12.
+        o4_mini = price_model_usage("o4-mini", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert o4_mini.priced is True
+        assert o4_mini.cost_usd == pytest.approx(1.1 + 4.4)
+        assert o4_mini.cost_usd != pytest.approx(3.0 + 12.0)
+
+        # gemini-3-flash: own rate $0.15/$1.0, NOT parent gemini-3 $3.0/$15.
+        gemini_flash = price_model_usage("gemini-3-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert gemini_flash.priced is True
+        assert gemini_flash.cost_usd == pytest.approx(0.15 + 1.0)
+        assert gemini_flash.cost_usd != pytest.approx(3.0 + 15.0)
+
+    def test_every_pricing_table_entry_is_self_priceable(self) -> None:
+        """Every key in the table must price itself as a positive number
+        for nonzero tokens - guards against a future entry with a typo'd
+        rate (e.g. accidentally 0.0) reintroducing a silent-$0 bug."""
+        for key, pricing in MODEL_COSTS_PER_1M_TOKENS.items():
+            result = price_model_usage(key, input_tokens=1_000_000, output_tokens=1_000_000)
+            assert result.priced is True, f"{key} did not match itself"
+            assert result.cost_usd >= 0.0
+            if pricing.get("input", 0.0) > 0 or pricing.get("output", 0.0) > 0:
+                assert result.cost_usd > 0.0, f"{key} priced to exactly zero"

--- a/tests/unit/test_cost_tracker.py
+++ b/tests/unit/test_cost_tracker.py
@@ -299,6 +299,35 @@ class TestCostTrackerLogging:
         exceeded_messages = [r.message for r in caplog.records if "BUDGET EXCEEDED" in r.message]
         assert len(exceeded_messages) == 2
 
+    def test_ledger_update_logs_tokens_sidecar_source(self, caplog: pytest.LogCaptureFixture) -> None:
+        """item 31: the ledger_update: mutation line carries the origin marker
+        so an alive-exit /complete ingestion is distinguishable from an
+        orphan/dead-exit recovery in the logs."""
+        tracker = CostTracker(run_id="run-1", budget_usd=10.0)
+        with caplog.at_level("INFO"):
+            tracker.record(
+                agent_id="a1",
+                task_id="t1",
+                model="sonnet",
+                input_tokens=51_880,
+                output_tokens=1_401,
+                cost_usd=0.5,
+                cost_tags={"tokens_sidecar_source": "alive_exit"},
+            )
+        ledger_lines = [r.message for r in caplog.records if r.message.startswith("ledger_update:")]
+        assert len(ledger_lines) == 1
+        assert "tokens_sidecar_source=alive_exit" in ledger_lines[0]
+
+    def test_ledger_update_source_empty_when_untagged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A record with no origin tag (e.g. live-cost tick) logs an empty marker,
+        never crashes on the missing tag."""
+        tracker = CostTracker(run_id="run-1", budget_usd=10.0)
+        with caplog.at_level("INFO"):
+            tracker.record(agent_id="a1", task_id="t1", model="sonnet", input_tokens=1, output_tokens=1, cost_usd=0.1)
+        ledger_lines = [r.message for r in caplog.records if r.message.startswith("ledger_update:")]
+        assert len(ledger_lines) == 1
+        assert "tokens_sidecar_source=" in ledger_lines[0]
+
 
 # ---------------------------------------------------------------------------
 # CostTracker - persistence

--- a/tests/unit/test_evolution.py
+++ b/tests/unit/test_evolution.py
@@ -1026,3 +1026,44 @@ class TestRecordAgentLifetime:
 
         recent = coordinator.collector.get_recent_agent_metrics(hours=1)
         assert len(recent) == 3
+
+    def test_real_caller_kwarg_shape_underscore_model(self, tmp_path: Path) -> None:
+        """API-drift regression (defect 22): real orchestrator callers
+        (task_lifecycle._record_agent_lifetime, agent_lifecycle's wall-clock
+        and heartbeat reap paths) invoke this with ``_model=`` rather than
+        ``model=``. Before the fix this raised TypeError and was silently
+        swallowed by the caller's except-Exception / suppress(Exception).
+        """
+        coordinator = EvolutionCoordinator(tmp_path)
+
+        # Must not raise -- this is the exact kwarg shape the orchestrator uses.
+        coordinator.record_agent_lifetime(
+            agent_id="agent-underscore",
+            role="backend",
+            lifetime_seconds=42.0,
+            tasks_completed=1,
+            _model="sonnet",
+        )
+
+        recent = coordinator.collector.get_recent_agent_metrics(hours=1)
+        assert len(recent) == 1
+        assert recent[0].agent_id == "agent-underscore"
+
+    def test_record_agent_lifetime_logs_info(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Every record_agent_lifetime call emits an INFO line with
+        session/role/model/lifetime so the data flow is visible in logs."""
+        coordinator = EvolutionCoordinator(tmp_path)
+
+        with caplog.at_level("INFO", logger="bernstein.evolution"):
+            coordinator.record_agent_lifetime(
+                agent_id="agent-logged",
+                role="qa",
+                lifetime_seconds=99.5,
+                tasks_completed=4,
+                _model="haiku",
+            )
+
+        messages = [r.message for r in caplog.records if r.name == "bernstein.evolution"]
+        assert any("agent-logged" in m and "qa" in m and "haiku" in m and "99.5" in m for m in messages), (
+            f"expected INFO log with session/role/model/lifetime, got: {messages}"
+        )

--- a/tests/unit/test_failure_reduction.py
+++ b/tests/unit/test_failure_reduction.py
@@ -64,8 +64,9 @@ def _make_task(
     )
 
 
-def _mock_adapter(pid: int = 42) -> MagicMock:
+def _mock_adapter(pid: int = 42, name: str = "claude") -> MagicMock:
     adapter = MagicMock(spec=CLIAdapter)
+    adapter.name.return_value = name
     adapter.spawn.return_value = SpawnResult(pid=pid, log_path=Path("/tmp/test.log"))
     adapter.is_alive.return_value = True
     adapter.is_rate_limited.return_value = False
@@ -78,6 +79,8 @@ def _build_orchestrator(
     task: Task,
     *,
     max_retries: int = 2,
+    adapter_name: str = "claude",
+    role_model_policy: dict[str, dict] | None = None,
 ) -> tuple[Orchestrator, list[dict]]:
     """Return (orchestrator, captured_post_bodies) with task-specific mock transport."""
     posted: list[dict] = []
@@ -122,10 +125,10 @@ def _build_orchestrator(
         server_url="http://testserver",
         max_task_retries=max_retries,
     )
-    adp = _mock_adapter()
+    adp = _mock_adapter(name=adapter_name)
     templates_dir = tmp_path / "templates" / "roles"
     templates_dir.mkdir(parents=True)
-    spawner = AgentSpawner(adp, templates_dir, tmp_path)
+    spawner = AgentSpawner(adp, templates_dir, tmp_path, role_model_policy=role_model_policy)
     client = httpx.Client(transport=transport, base_url="http://testserver")
     return Orchestrator(cfg, spawner, tmp_path, client=client), posted
 
@@ -250,6 +253,66 @@ class TestLargeScopeOpusMaxOnRetry:
         assert len(posted) == 1
         # First retry of medium scope: effort bumped, but not opus/max
         assert posted[0]["effort"] != "max" or posted[0]["model"] != "opus"
+
+
+class TestRetryEscalationAdapterAwareness:
+    """PR2 (provider-agnostic precedence): retry escalation must not stamp a
+    Claude tier name ("opus") onto a task that will spawn against a
+    non-Claude adapter - see task_lifecycle.py's ``retry_or_fail_task``
+    docstring for the run-9 attempt-8 defect this closes."""
+
+    def test_claude_adapter_high_stakes_retry_still_escalates_to_opus(self, tmp_path: Path) -> None:
+        """(a) No regression: a Claude-compatible run still gets opus/max
+        for high-stakes roles on retry."""
+        task = _make_task(
+            id="T-arch-claude",
+            role="architect",
+            description="Design the system.",
+        )
+        orch, posted = _build_orchestrator(tmp_path, task, adapter_name="claude")
+
+        orch._retry_or_fail_task("T-arch-claude", "agent died")
+
+        assert len(posted) == 1
+        assert posted[0]["model"] == "opus"
+        assert posted[0]["effort"] == "max"
+
+    def test_non_claude_default_adapter_high_stakes_retry_leaves_model_unchanged(self, tmp_path: Path) -> None:
+        """(b) A non-Claude default adapter (no role_model_policy at all):
+        high-stakes retry must escalate effort only, never stamp "opus"."""
+        task = _make_task(
+            id="T-arch-qwen",
+            role="architect",
+            description="Design the system.",
+        )
+        orch, posted = _build_orchestrator(tmp_path, task, adapter_name="qwen")
+
+        orch._retry_or_fail_task("T-arch-qwen", "agent died")
+
+        assert len(posted) == 1
+        assert posted[0]["model"] != "opus"
+        assert posted[0]["effort"] == "max"
+
+    def test_operator_pinned_non_claude_model_survives_retry(self, tmp_path: Path) -> None:
+        """(c) role_model_policy pins a non-Claude model for this role; a
+        high-stakes retry must escalate to THAT model, never "opus"."""
+        task = _make_task(
+            id="T-arch-pinned",
+            role="architect",
+            description="Design the system.",
+        )
+        orch, posted = _build_orchestrator(
+            tmp_path,
+            task,
+            adapter_name="claude",  # default adapter is Claude...
+            role_model_policy={"architect": {"provider": "qwen", "model": "MiniMax-M3"}},
+        )
+
+        orch._retry_or_fail_task("T-arch-pinned", "agent died")
+
+        assert len(posted) == 1
+        assert posted[0]["model"] == "MiniMax-M3"
+        assert posted[0]["effort"] == "max"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -35,6 +35,168 @@ def test_merge_with_conflict_detection_aborts_and_reports_files(
     assert ["merge", "--abort"] in calls
 
 
+# ---------------------------------------------------------------------------
+# Defect 28 -- decoy-commit / secret-leak regression tests.
+#
+# A merge-to-main whose staged set contains .sdd/* runtime state,
+# attestations/* signing material, auth/* secrets, bernstein.yaml, or any
+# other runtime artefact must be REFUSED.  No commit is produced, the
+# merge is aborted, and the refusal is recorded on the result.
+# ---------------------------------------------------------------------------
+
+
+def _make_clean_merge_fake(staged_files: list[str]) -> object:
+    """Return a fake ``run_git`` that simulates a clean merge that has
+    staged the supplied set of files (post ``git merge --no-commit``).
+
+    Records every args list it sees so tests can assert what was called.
+    """
+
+    seen: list[list[str]] = []
+
+    def _fake(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
+        seen.append(args)
+        # Simulate the safety-guard stage seeing the staged files.
+        if args[:3] == ["diff", "--cached", "--name-only"]:
+            return GitResult(returncode=0, stdout="\n".join(staged_files) + "\n", stderr="")
+        if args[:3] == ["merge", "--no-commit", "--no-ff"]:
+            return GitResult(returncode=0, stdout="", stderr="")
+        if args[:2] == ["merge", "--abort"]:
+            return GitResult(returncode=0, stdout="", stderr="")
+        if args[:1] == ["commit"]:
+            # Never called when the guard is in effect, but handle
+            # benignly for sanity.
+            return GitResult(returncode=0, stdout="", stderr="")
+        # Catch-all -- any unexpected call returns ok so we can assert
+        # the call site, not the side effect.
+        return GitResult(returncode=0, stdout="", stderr="")
+
+    _fake.seen = seen  # type: ignore[attr-defined]
+    return _fake
+
+
+def test_merge_with_conflict_detection_refuses_sdd_runtime_in_staged_set(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Decoy commit regression: a merge whose staged set contains any
+    ``.sdd/*`` file (runtime state, attestations, auth secrets) must be
+    REFUSED -- no commit produced, merge aborted, refusal recorded."""
+    staged = [
+        ".sdd/runtime/agent_tokens/backend-74bcd752.token",
+        ".sdd/attestations/ed25519-signing-key.pem",
+        ".sdd/auth/agent_identity_jwt_secret",
+    ]
+    fake = _make_clean_merge_fake(staged)
+    monkeypatch.setattr(git_pr, "run_git", fake)
+
+    result = git_pr.merge_with_conflict_detection(tmp_path, "agent/qa-aa55cebb")
+
+    # The merge is refused -- not silent, not committed.
+    assert result.success is False
+    assert result.refused_forbidden_files, "guard must populate refused_forbidden_files with the offending paths"
+    assert ".sdd/runtime/agent_tokens/backend-74bcd752.token" in result.refused_forbidden_files
+    assert ".sdd/attestations/ed25519-signing-key.pem" in result.refused_forbidden_files
+    assert ".sdd/auth/agent_identity_jwt_secret" in result.refused_forbidden_files
+    assert "forbidden" in result.error.lower() or "refused" in result.error.lower()
+
+    # The merge MUST have been aborted (no commit ever produced).
+    assert ["merge", "--abort"] in fake.seen
+    # The actual ``commit`` invocation must NOT appear -- a refused merge
+    # never produces a commit, that is the whole point of the guard.
+    commit_calls = [a for a in fake.seen if a[:1] == ["commit"]]
+    assert commit_calls == [], f"refused merge must not run ``git commit``; saw: {commit_calls}"
+
+
+def test_merge_with_conflict_detection_refuses_bernstein_yaml_in_staged_set(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``bernstein.yaml`` is a runtime config and must never land on a
+    default branch via a worker merge."""
+    staged = ["bernstein.yaml"]
+    fake = _make_clean_merge_fake(staged)
+    monkeypatch.setattr(git_pr, "run_git", fake)
+
+    result = git_pr.merge_with_conflict_detection(tmp_path, "agent/backend-74bcd752")
+
+    assert result.success is False
+    assert "bernstein.yaml" in result.refused_forbidden_files
+
+
+def test_merge_with_conflict_detection_refuses_attestations_and_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Top-level ``attestations/`` and ``auth/`` directories are deny-listed
+    at the repo root, not just under ``.sdd/``."""
+    staged = ["attestations/ed25519-signing-key.pem", "auth/jwt_secret"]
+    fake = _make_clean_merge_fake(staged)
+    monkeypatch.setattr(git_pr, "run_git", fake)
+
+    result = git_pr.merge_with_conflict_detection(tmp_path, "agent/qa-aa55cebb")
+
+    assert result.success is False
+    assert "attestations/ed25519-signing-key.pem" in result.refused_forbidden_files
+    assert "auth/jwt_secret" in result.refused_forbidden_files
+
+
+def test_merge_with_conflict_detection_allows_pure_deliverable_staged_set(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A clean merge that only staged deliverable files (cli.py,
+    test_cli.py) must NOT be refused -- the guard must not block legitimate
+    merges."""
+    staged = ["src/bernstein/cli/cli.py", "tests/unit/test_cli.py"]
+    fake = _make_clean_merge_fake(staged)
+    # Override commit handler to return ok so the merge succeeds.
+    orig_fake = fake
+
+    def _fake_with_commit(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
+        if args[:1] == ["commit"]:
+            return GitResult(returncode=0, stdout="", stderr="")
+        return orig_fake(args, cwd, timeout=timeout, **kwargs)
+
+    _fake_with_commit.seen = orig_fake.seen  # type: ignore[attr-defined]
+    monkeypatch.setattr(git_pr, "run_git", _fake_with_commit)
+
+    result = git_pr.merge_with_conflict_detection(tmp_path, "agent/qa-aa55cebb")
+
+    assert result.success is True
+    assert result.refused_forbidden_files == []
+
+
+def test_is_forbidden_for_merge_matches_deny_list() -> None:
+    """Unit-level coverage of the deny-list predicate.  This is the
+    cheap "no ``git add -A`` in main repo" canary: every path that the
+    orchestrator's merge must reject is enumerated here."""
+    # Forbidden
+    for path in [
+        ".sdd/runtime/agent_tokens/x.token",
+        ".sdd/attestations/ed25519-signing-key.pem",
+        ".sdd/auth/agent_identity_jwt_secret",
+        ".sdd/cost/ledger.jsonl",
+        ".sdd/metrics/tasks.jsonl",
+        ".sdd/.schema_version",
+        "attestations/x.pem",
+        "auth/jwt_secret",
+        "bernstein.yaml",
+        ".claude/mcp.json",
+        ".env",
+    ]:
+        assert git_pr._is_forbidden_for_merge(path) is True, f"path {path!r} should be forbidden"
+    # Allowed
+    for path in [
+        "src/bernstein/cli/cli.py",
+        "tests/unit/test_cli.py",
+        "src/bernstein/core/orchestrator.py",
+        "docs/operations/merge.md",
+        "scripts/run_tests.py",
+    ]:
+        assert git_pr._is_forbidden_for_merge(path) is False, f"path {path!r} should NOT be forbidden"
+
+
 def test_create_task_branch_delegates_to_git(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     seen: list[str] = []
 

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -10,15 +11,18 @@ from unittest.mock import patch
 
 import pytest
 from bernstein.core.janitor import (
+    _extract_branch_ref,
     _get_judge_retry_count,
     _parse_judge_response,
+    _resolve_branch_check_command,
+    _resolve_branch_ref,
     create_fix_tasks,
     evaluate_signal,
     judge_task,
     run_janitor,
     verify_task,
 )
-from bernstein.core.models import CompletionSignal, Task
+from bernstein.core.models import CompletionSignal, Task, TaskType
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -73,6 +77,186 @@ class TestPathExists:
         signal = CompletionSignal(type="path_exists", value=str(target))
         passed, _ = evaluate_signal(signal, tmp_path)
         assert passed is True
+
+
+class TestPathExistsGlobAndFuzzy:
+    """Issue #2186: manager-guessed literal paths vs. worker-chosen
+    repo-idiomatic paths. Conservative matching contract:
+      - exact-path matching is the default, unchanged;
+      - explicit glob syntax in the criterion always works (opt-in
+        per-check by construction);
+      - the fuzzy basename fallback is opt-in via
+        BERNSTEIN_JANITOR_FUZZY_PATHS=1, default OFF."""
+
+    _GUESSED = "packages/db/test/seed-workers.test.ts"
+
+    def _write_idiomatic_file(self, tmp_path: Path) -> None:
+        """Worker output at the repo's actual convention -- a fuzzy (but
+        not literal or glob) match for the manager's guessed path."""
+        actual_dir = tmp_path / "packages" / "db" / "src" / "__tests__"
+        actual_dir.mkdir(parents=True)
+        (actual_dir / "seed-workers-demo-link.test.ts").write_text("x")
+
+    def test_literal_hit_unaffected(self, tmp_path: Path) -> None:
+        """A literal hit keeps the original ("exists") detail string --
+        no behavior change for the common case."""
+        (tmp_path / "foo.py").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="foo.py")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert detail == "exists"
+
+    def test_fuzzy_off_by_default(self, tmp_path: Path) -> None:
+        """DEFAULT behavior: a literal miss FAILS even when a would-be
+        fuzzy match exists -- exact-path matching is the contract
+        operators rely on."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        env = {k: v for k, v in os.environ.items() if k != "BERNSTEIN_JANITOR_FUZZY_PATHS"}
+        with patch.dict("os.environ", env, clear=True):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_fuzzy_explicit_zero_also_off(self, tmp_path: Path) -> None:
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_explicit_glob_works_without_flag(self, tmp_path: Path) -> None:
+        """Explicit glob syntax in the criterion is honored regardless of
+        the fuzzy flag -- opt-in per-check by construction."""
+        nested = tmp_path / "packages" / "db"
+        nested.mkdir(parents=True)
+        (nested / "seed-workers.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "glob pattern matched" in detail
+        assert "seed-workers.test.ts" in detail
+
+    def test_explicit_glob_recursive_different_depth(self, tmp_path: Path) -> None:
+        """A `**` glob written in the criterion matches at any depth,
+        with the fuzzy flag off."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value="packages/db/**/seed-workers*.test.ts")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "seed-workers-demo-link.test.ts" in detail
+
+    def test_explicit_glob_no_match_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "unrelated.txt").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/**/seed-workers*.test.ts")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_fuzzy_opt_in_hits_at_different_depth(self, tmp_path: Path) -> None:
+        """The exact #2186 repro with BERNSTEIN_JANITOR_FUZZY_PATHS=1:
+        manager guesses `packages/db/test/...`, worker writes to
+        `packages/db/src/__tests__/...` -- a different directory depth
+        and name suffix. The opt-in fuzzy basename fallback finds it."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "fuzzy fallback" in detail
+        assert "seed-workers-demo-link.test.ts" in detail
+
+    def test_fuzzy_opt_in_true_miss_still_fails(self, tmp_path: Path) -> None:
+        """With fuzzy enabled, a path with no literal or fuzzy match
+        anywhere under workdir must still fail -- the fallback is not a
+        rubber stamp."""
+        (tmp_path / "unrelated.txt").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert detail == "not found"
+
+    def test_fuzzy_match_logs_loudly_with_matched_path(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """When the fuzzy fallback satisfies a check it must WARN, naming
+        the literal miss, the pattern, and the matched path (logging is
+        the debugging interface -- see #2186 postmortem)."""
+        self._write_idiomatic_file(tmp_path)
+
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}), caplog.at_level("WARNING"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        fuzzy_warnings = [rec for rec in caplog.records if rec.levelname == "WARNING" and "FUZZY MATCH" in rec.message]
+        assert fuzzy_warnings, "expected a WARNING log for the fuzzy match"
+        assert any(self._GUESSED in rec.message for rec in fuzzy_warnings)
+        assert any("seed-workers-demo-link.test.ts" in rec.message for rec in fuzzy_warnings)
+
+    def test_glob_match_logs_matched_path(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        nested = tmp_path / "packages" / "db"
+        nested.mkdir(parents=True)
+        (nested / "seed-workers.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
+        with caplog.at_level("INFO"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert any("glob pattern" in rec.message and "seed-workers.test.ts" in rec.message for rec in caplog.records)
+
+    def test_fuzzy_true_miss_logs_patterns_tried(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        signal = CompletionSignal(type="path_exists", value=self._GUESSED)
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "1"}), caplog.at_level("INFO"):
+            passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        assert any("no match" in rec.message and "seed-workers" in rec.message for rec in caplog.records)
+
+    def test_literal_path_with_glob_metachar_matched_literally(self, tmp_path: Path) -> None:
+        """A real file whose literal path contains a glob metacharacter (e.g.
+        a Next.js dynamic-route file `app/users/[id]/page.tsx`) must be
+        matched literally, NOT silently reinterpreted as a glob pattern that
+        would fail to match its own brackets."""
+        route_dir = tmp_path / "app" / "users" / "[id]"
+        route_dir.mkdir(parents=True)
+        (route_dir / "page.tsx").write_text("export default 1")
+
+        signal = CompletionSignal(type="path_exists", value="app/users/[id]/page.tsx")
+        with patch.dict("os.environ", {"BERNSTEIN_JANITOR_FUZZY_PATHS": "0"}):
+            passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert detail == "exists"
+
+    def test_literal_path_with_bracket_fixture_matched_literally(self, tmp_path: Path) -> None:
+        """`foo[1].json` on disk must satisfy a literal `foo[1].json` check;
+        glob would read `[1]` as a character class and miss the real file."""
+        (tmp_path / "foo[1].json").write_text("{}")
+
+        signal = CompletionSignal(type="path_exists", value="foo[1].json")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert detail == "exists"
+
+    def test_glob_still_honored_when_literal_missing(self, tmp_path: Path) -> None:
+        """When no literal file matches, a criterion with glob syntax still
+        falls through to glob interpretation (opt-in per-check)."""
+        nested = tmp_path / "packages" / "db"
+        nested.mkdir(parents=True)
+        (nested / "seed-workers.test.ts").write_text("x")
+
+        signal = CompletionSignal(type="path_exists", value="packages/*/seed-workers.test.ts")
+        passed, detail = evaluate_signal(signal, tmp_path)
+        assert passed is True
+        assert "glob pattern matched" in detail
 
 
 # --- glob_exists ---
@@ -131,6 +315,150 @@ class TestTestPasses:
         )
         passed, _ = evaluate_signal(signal, tmp_path)
         assert passed is False
+
+    def test_nonzero_exit_logs_failure_detail(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """Logging gap: a failing test_passes command used to fail silently
+        (no log line at all).  Assert the FAIL log line fires with the
+        command, exit code, and captured stderr/stdout."""
+        caplog.set_level("INFO", logger="bernstein.core.quality.janitor")
+        signal = CompletionSignal(
+            type="test_passes",
+            value=f"{sys.executable} -c \"import sys; sys.stderr.write('boom'); raise SystemExit(1)\"",
+        )
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+        fail_records = [r for r in caplog.records if "test_passes FAIL" in r.message]
+        assert fail_records, f"expected a test_passes FAIL log line, got: {[r.message for r in caplog.records]}"
+        assert "exit=1" in fail_records[0].message
+        assert "boom" in fail_records[0].message
+
+
+# --- bug 12: branch-check acceptance signals vs actual pushed branch ---
+#
+# Regression coverage for work/agent-reports/2026-07-02-run9-attempt9-audit.md
+# (task d56c18f2fc08): the janitor's acceptance signal expected the branch
+# ``fix-905-demo-worker-record`` (hyphens) but the agent actually pushed
+# ``fix/905-demo-worker-record`` (slash) -- a real, delivered PR was recorded
+# as a DLQ'd failure.
+
+
+def _run_git(args: list[str], cwd: Path) -> None:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+
+
+def _init_git_repo_with_branch(tmp_path: Path, branch_name: str) -> Path:
+    """Create a throwaway git repo at *tmp_path* with a commit on *branch_name*."""
+    _run_git(["init", "-q"], tmp_path)
+    _run_git(["config", "user.email", "test@example.com"], tmp_path)
+    _run_git(["config", "user.name", "Test"], tmp_path)
+    (tmp_path / "README.md").write_text("seed\n")
+    _run_git(["add", "README.md"], tmp_path)
+    _run_git(["commit", "-q", "-m", "seed"], tmp_path)
+    _run_git(["checkout", "-q", "-b", branch_name], tmp_path)
+    (tmp_path / "work.txt").write_text("work\n")
+    _run_git(["add", "work.txt"], tmp_path)
+    _run_git(["commit", "-q", "-m", "fix: demo worker record (#905)"], tmp_path)
+    _run_git(["checkout", "-q", "-"], tmp_path)  # back to the initial branch
+    return tmp_path
+
+
+class TestExtractBranchRef:
+    def test_extracts_ref_from_rev_parse_verify(self) -> None:
+        assert _extract_branch_ref("git rev-parse --verify fix-905-demo-worker-record") == "fix-905-demo-worker-record"
+
+    def test_extracts_ref_from_git_log_with_pipe(self) -> None:
+        command = "git log -1 --format=%s fix-905-demo-worker-record | grep -q '#905'"
+        assert _extract_branch_ref(command) == "fix-905-demo-worker-record"
+
+    def test_ignores_special_refs(self) -> None:
+        assert _extract_branch_ref("git rev-parse --verify HEAD") is None
+        assert _extract_branch_ref("git rev-parse --verify main") is None
+
+    def test_ignores_non_branch_commands(self) -> None:
+        assert _extract_branch_ref("pytest tests/unit/test_foo.py -x") is None
+
+
+class TestResolveBranchRef:
+    def test_resolves_hyphenated_expectation_to_slash_branch(self, tmp_path: Path) -> None:
+        # Signal expects hyphens; agent actually pushed with a slash.
+        _init_git_repo_with_branch(tmp_path, "fix/905-demo-worker-record")
+        resolved, branches = _resolve_branch_ref("fix-905-demo-worker-record", tmp_path)
+        assert resolved == "fix/905-demo-worker-record"
+        assert "fix/905-demo-worker-record" in branches
+
+    def test_resolves_slash_expectation_to_hyphen_branch(self, tmp_path: Path) -> None:
+        # The reverse drift direction also resolves.
+        _init_git_repo_with_branch(tmp_path, "fix-905-demo-worker-record")
+        resolved, _ = _resolve_branch_ref("fix/905-demo-worker-record", tmp_path)
+        assert resolved == "fix-905-demo-worker-record"
+
+    def test_exact_match_wins_without_fuzzing(self, tmp_path: Path) -> None:
+        _init_git_repo_with_branch(tmp_path, "fix-905-demo-worker-record")
+        resolved, _ = _resolve_branch_ref("fix-905-demo-worker-record", tmp_path)
+        assert resolved == "fix-905-demo-worker-record"
+
+    def test_returns_none_when_branch_truly_absent(self, tmp_path: Path) -> None:
+        _init_git_repo_with_branch(tmp_path, "feat/unrelated-branch")
+        resolved, branches = _resolve_branch_ref("fix-905-demo-worker-record", tmp_path)
+        assert resolved is None
+        assert "feat/unrelated-branch" in branches
+
+
+class TestBranchCheckAcceptanceEndToEnd:
+    """Exercises the actual bug-12 scenario through evaluate_signal()."""
+
+    def test_janitor_accepts_slash_branch_when_signal_expects_hyphens(self, tmp_path: Path) -> None:
+        _init_git_repo_with_branch(tmp_path, "fix/905-demo-worker-record")
+        signal = CompletionSignal(
+            type="test_passes",
+            value="git rev-parse --verify fix-905-demo-worker-record",
+        )
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+
+    def test_janitor_accepts_commit_message_check_across_naming_drift(self, tmp_path: Path) -> None:
+        _init_git_repo_with_branch(tmp_path, "fix/905-demo-worker-record")
+        signal = CompletionSignal(
+            type="test_passes",
+            value="git log -1 --format=%s fix-905-demo-worker-record | grep -q '#905'",
+        )
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is True
+
+    def test_janitor_still_fails_when_branch_never_pushed(self, tmp_path: Path) -> None:
+        _init_git_repo_with_branch(tmp_path, "feat/unrelated-branch")
+        signal = CompletionSignal(
+            type="test_passes",
+            value="git rev-parse --verify fix-905-demo-worker-record",
+        )
+        passed, _ = evaluate_signal(signal, tmp_path)
+        assert passed is False
+
+    def test_logs_expected_and_found_branches_with_verdict(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _init_git_repo_with_branch(tmp_path, "fix/905-demo-worker-record")
+        signal = CompletionSignal(
+            type="test_passes",
+            value="git rev-parse --verify fix-905-demo-worker-record",
+        )
+        with caplog.at_level("INFO", logger="bernstein.core.quality.janitor"):
+            evaluate_signal(signal, tmp_path)
+        combined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "fix-905-demo-worker-record" in combined
+        assert "fix/905-demo-worker-record" in combined
+        assert "rewriting command" in combined
+
+    def test_resolve_branch_check_command_is_noop_for_non_git_commands(self, tmp_path: Path) -> None:
+        command = f'{sys.executable} -c "raise SystemExit(0)"'
+        assert _resolve_branch_check_command(command, tmp_path) == command
 
 
 # --- file_contains ---
@@ -403,6 +731,26 @@ class TestRunJanitor:
         assert len(sr) == 2
         assert sr[0] == ("path_exists: a.py", True, "exists")
         assert sr[1] == ("path_exists: missing.py", False, "not found")
+
+    @pytest.mark.asyncio
+    async def test_accept_and_reject_verdicts_are_logged(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Logging gap: run_janitor's accept/reject disposition for each task
+        was only visible via the returned JanitorResult, not the logs. Assert
+        an ACCEPT line for the passing task and a REJECT line (with the
+        failed signals) for the failing task."""
+        caplog.set_level("INFO", logger="bernstein.core.quality.janitor")
+        (tmp_path / "a.py").write_text("x")
+
+        t_pass = _make_task(id="T-PASS", signals=[CompletionSignal(type="path_exists", value="a.py")])
+        t_fail = _make_task(id="T-FAIL", signals=[CompletionSignal(type="path_exists", value="missing.py")])
+        await run_janitor([t_pass, t_fail], tmp_path)
+
+        accept_records = [r.message for r in caplog.records if "janitor ACCEPT" in r.message]
+        reject_records = [r.message for r in caplog.records if "janitor REJECT" in r.message]
+        assert any("T-PASS" in m for m in accept_records), accept_records
+        assert any("T-FAIL" in m and "missing.py" in m for m in reject_records), reject_records
 
 
 # --- create_fix_tasks ---
@@ -899,3 +1247,169 @@ class TestRunJanitorWithJudge:
         assert results[0].passed is True
         assert results[0].judge_verdict is not None
         assert results[0].judge_verdict.flagged_for_review is True
+
+
+# --- Empty-diff guard + attribution (item 15 / S2 family) ---
+
+
+def _init_git_repo(repo: Path) -> None:
+    """Create a git repo with one baseline commit (base.txt)."""
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+    _git("init", "-q")
+    _git("config", "user.email", "janitor-test@example.com")
+    _git("config", "user.name", "Janitor Test")
+    (repo / "base.txt").write_text("baseline\n")
+    _git("add", "base.txt")
+    _git("commit", "-q", "-m", "baseline commit")
+
+
+class TestEmptyDiffGuardAndAttribution:
+    """Regressions for the archived misattribution run (attempt-e938bd33):
+    janitor_passed=true on a 0-file manager task while the worker with the
+    real commit was rejected; S2 orphans with empty diffs rubber-stamped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_manager_zero_file_task_rejected(self, tmp_path: Path) -> None:
+        """A task with no commits and no owned_files must NOT pass, even if
+        its signals are satisfied by repo state another task created."""
+        _init_git_repo(tmp_path)
+        task = _make_task(
+            id="MGR-0FILE",
+            signals=[CompletionSignal(type="path_exists", value="base.txt")],
+        )
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        empty_diff = [d for d, ok, _ in results[0].signal_results if d == "attribution:empty_diff"]
+        assert empty_diff, f"expected attribution:empty_diff signal, got {results[0].signal_results}"
+
+    @pytest.mark.asyncio
+    async def test_worker_with_real_commit_accepted(self, tmp_path: Path) -> None:
+        """A worker whose commit message references its task id (the b9574d9
+        pattern: '[WIP] qa-5a36fe2a partial work') is attributed and accepted."""
+        _init_git_repo(tmp_path)
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "cli.py").write_text("print('hello, world')\n")
+        subprocess.run(["git", "add", "src/cli.py"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "[WIP] WKR-REAL partial work"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        task = Task(
+            id="WKR-REAL",
+            title="Implement hello CLI",
+            description="Add cli.py with a hello command.",
+            role="backend",
+            completion_signals=[CompletionSignal(type="path_exists", value="src/cli.py")],
+            owned_files=["src/cli.py"],
+        )
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is True, f"signal_results={results[0].signal_results}"
+
+    @pytest.mark.asyncio
+    async def test_crash_recovery_orphan_empty_diff_rejected(self, tmp_path: Path) -> None:
+        """S2 family: crash-recovery auto-completion with owned_files it never
+        touched (empty diff, no commits) must be rejected, not rubber-stamped."""
+        _init_git_repo(tmp_path)
+        task = Task(
+            id="ORPHAN-S2",
+            title="Orphan recovered after crash",
+            description="Auto-completed by crash recovery; no work happened.",
+            role="backend",
+            completion_signals=[CompletionSignal(type="path_exists", value="base.txt")],
+            owned_files=["orphan.py"],
+        )
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        failed = [d for d, ok, _ in results[0].signal_results if not ok]
+        assert any("empty_diff" in d for d in failed), f"failed={failed}"
+
+    @pytest.mark.asyncio
+    async def test_unattributable_diff_with_nontrivial_signal_accepted_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A task that landed real work in a commit whose message omits the
+        task id and which has no owned_files (attribution returns empty) must
+        NOT be hard-rejected when it has a passing non-trivial completion
+        signal (a passing test_passes). Instead it is accepted and flagged for
+        review, so real completions are not false-rejected just because the
+        commit did not stamp the task id."""
+        _init_git_repo(tmp_path)
+        # A real landing commit whose message does NOT reference the task id.
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "feature.py").write_text("VALUE = 1\n")
+        subprocess.run(["git", "add", "src/feature.py"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "add feature"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        task = _make_task(
+            id="NOSTAMP-1",
+            signals=[
+                CompletionSignal(
+                    type="test_passes",
+                    value=f'{sys.executable} -c "raise SystemExit(0)"',
+                )
+            ],
+        )
+
+        with caplog.at_level("WARNING"):
+            results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is True, f"signal_results={results[0].signal_results}"
+        # Not hard-rejected: no failing empty_diff signal.
+        failed = [d for d, ok, _ in results[0].signal_results if not ok]
+        assert not any("empty_diff" in d and "warn" not in d for d in failed), f"failed={failed}"
+        assert any("empty diff, flagged for review" in rec.message for rec in caplog.records), (
+            "expected an empty-diff WARN log flagging the task for review"
+        )
+
+    @pytest.mark.asyncio
+    async def test_research_noop_task_type_exempt(self, tmp_path: Path) -> None:
+        """Explicit no-op task types (research) legitimately have no diff."""
+        _init_git_repo(tmp_path)
+        task = Task(
+            id="RSRCH-1",
+            title="Research task",
+            description="Exploration; output lives in notes, not the repo.",
+            role="backend",
+            completion_signals=[CompletionSignal(type="path_exists", value="base.txt")],
+            task_type=TaskType.RESEARCH,
+        )
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_non_git_workdir_guard_skipped(self, tmp_path: Path) -> None:
+        """Outside a git repo, attribution is impossible; signals-only
+        judgment (historical behavior) is preserved."""
+        task = _make_task(
+            id="NOGIT-1",
+            signals=[CompletionSignal(type="path_exists", value="plain.txt")],
+        )
+        (tmp_path / "plain.txt").write_text("x")
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is True

--- a/tests/unit/test_janitor_alive_exit.py
+++ b/tests/unit/test_janitor_alive_exit.py
@@ -1,0 +1,306 @@
+"""Tests for alive-exit /complete -> janitor pass enqueueing (defect item 30).
+
+Before the fix the alive-exit path only ran ``verify_task`` via the
+orchestrator tick's ``process_completed_tasks`` -> ``_process_single_completed_task``
+chain. When the orchestrator self-stopped before the next tick, no janitor
+row ever landed in ``.sdd/metrics/tasks.jsonl`` and no
+``janitor_verdict_action`` log line was emitted. Attempt 83808a8a is the
+canonical evidence: ``tasks.jsonl`` contained exactly one row (the manager,
+which went through the dead-agent path).
+
+After the fix:
+
+* ``_enqueue_alive_exit_janitor_pass`` is a clearly-named standalone
+  entry point that emits ``janitor: enqueued pass task=... role=...`` at
+  INFO and submits ``verify_task`` (or ``run_janitor`` for ``llm_judge``
+  signals) to ``orch._executor`` (or returns a sync-Future if no executor
+  exists).
+* ``process_completed_tasks`` calls the helper, so every tick sees the
+  alive-exit janitor log line.
+* ``_process_single_completed_task`` logs ``janitor: alive-exit pass
+  starting`` at INFO so a silent no-op is impossible.
+* The dead-exit ``handle_orphaned_task`` path is untouched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from bernstein.core.models import CompletionSignal, Task, TaskType
+
+from bernstein.core.tasks import task_lifecycle
+from bernstein.core.tasks.task_lifecycle import (
+    _enqueue_alive_exit_janitor_pass,
+    _process_single_completed_task,
+    process_completed_tasks,
+)
+
+
+def _make_task(
+    task_id: str = "alive-task-1",
+    *,
+    signals: list[CompletionSignal] | None = None,
+    role: str = "backend",
+) -> Task:
+    task = Task(
+        id=task_id,
+        title="Implement cli.py hello",
+        description="Add a hello subcommand to cli.py",
+        role=role,
+        task_type=TaskType.STANDARD,
+        status=task_lifecycle.TaskStatus.DONE,
+    )
+    if signals is not None:
+        task.completion_signals = signals
+    return task
+
+
+class _FakeExecutor:
+    """Mimics ``concurrent.futures.ThreadPoolExecutor.submit`` for tests."""
+
+    def __init__(self) -> None:
+        self.submitted: list[tuple[Any, tuple[Any, ...]]] = []
+
+    def submit(self, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        self.submitted.append((fn, args, kwargs))
+        return SimpleNamespace(_fn=fn, _args=args, _kwargs=kwargs)
+
+
+def test_enqueue_alive_exit_janitor_logs_and_submits(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A janitor pass IS enqueued when ``/complete`` is processed for an alive task.
+
+    This is the core property for defect 30: the alive-exit path MUST
+    schedule a janitor pass just like the dead-exit path schedules
+    ``verify_task`` synchronously in ``handle_orphaned_task``.
+    """
+    executor = _FakeExecutor()
+    orch: Any = SimpleNamespace(
+        _executor=executor,
+        _processed_done_tasks={},
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _task_to_session={},
+        _workdir=Path("/tmp"),
+    )
+    signals = [
+        CompletionSignal(type="path_exists", value="src/bernstein/cli.py"),
+    ]
+    task = _make_task(signals=signals)
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        future = _enqueue_alive_exit_janitor_pass(orch, task, reason="alive_exit_tick")
+
+    assert future is not None, "janitor future must be returned for tasks with completion_signals"
+    # Executor got a verify_task or run_janitor submission.
+    assert len(executor.submitted) == 1
+    fn, args, _ = executor.submitted[0]
+    # Either verify_task (sync) or _verify_via_janitor (async) is acceptable.
+    from bernstein.core.janitor import verify_task
+
+    assert fn in (verify_task, task_lifecycle._verify_via_janitor)
+    if fn is verify_task:
+        # verify_task(task, workdir)
+        assert args[0] is task
+    else:
+        # _verify_via_janitor(task, workdir, server_url)
+        assert args[0] is task
+    # Log line must mention task, role, reason -- visible evidence the
+    # alive-exit janitor pass was scheduled.
+    assert any(
+        "janitor: enqueued pass" in rec.message
+        and "task=alive-task-1" in rec.message
+        and "role=backend" in rec.message
+        and "reason=alive_exit_tick" in rec.message
+        for rec in caplog.records
+    ), caplog.text
+
+
+def test_enqueue_alive_exit_no_signals_returns_none_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tasks without completion_signals return None and log a no_signals marker.
+
+    Matches the existing pre-fix behavior in ``process_completed_tasks``
+    (``if not task.completion_signals: continue``). The new helper returns
+    None so the caller can take a different path (auto-verify) and still
+    has a log line for the alive-exit enqueue observation.
+    """
+    executor = _FakeExecutor()
+    orch: Any = SimpleNamespace(
+        _executor=executor,
+        _processed_done_tasks={},
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _task_to_session={},
+    )
+    task = _make_task(signals=[])
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        future = _enqueue_alive_exit_janitor_pass(orch, task, reason="alive_exit_drain")
+
+    assert future is None
+    assert len(executor.submitted) == 0
+    assert any("no_completion_signals=true" in rec.message for rec in caplog.records), caplog.text
+
+
+def test_enqueue_alive_exit_without_executor_returns_sync_future() -> None:
+    """If ``orch._executor`` is missing, run verify_task inline and wrap it.
+
+    This protects against the orchestrator self-stopping before the
+    tick has scheduled a future -- the janitor still gets a synchronous
+    pass and a Future-shaped result back so the caller can treat it
+    identically to the executor path.
+    """
+    orch: Any = SimpleNamespace(
+        _executor=None,
+        _processed_done_tasks={},
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _task_to_session={},
+        _workdir=Path("/tmp"),
+    )
+    task = _make_task(
+        signals=[CompletionSignal(type="path_exists", value="nonexistent_path_xyz123")],
+    )
+
+    future = _enqueue_alive_exit_janitor_pass(orch, task, reason="alive_exit_no_executor")
+    assert future is not None
+    passed, failed = future.result()
+    assert passed is False
+    assert any("path_exists" in s for s in failed)
+
+
+def test_process_completed_tasks_invokes_helper_for_alive_exits(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``process_completed_tasks`` MUST route through the helper for each alive-exit task.
+
+    Defends against a future refactor accidentally bypassing the new
+    helper and reintroducing the silent skip.
+    """
+    executor = _FakeExecutor()
+    orch: Any = SimpleNamespace(
+        _executor=executor,
+        _processed_done_tasks={},
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _task_to_session={},
+        _workdir=Path("/tmp"),
+        # Stub the post-enqueue hooks so the test focuses only on the
+        # helper routing through `process_completed_tasks`.
+        _find_session_for_task=lambda _: None,
+        _wal_writer=None,
+        _spawner=SimpleNamespace(
+            get_worktree_path=lambda _: None,
+            reap_completed_agent=lambda *a, **k: None,
+            cleanup_worktree=lambda _: None,
+        ),
+        _record_provider_health=lambda *a, **k: None,
+        _cost_tracker=SimpleNamespace(spent_usd=0.0),
+        _evolution=None,
+    )
+    task = _make_task(
+        task_id="alive-process-task",
+        signals=[CompletionSignal(type="path_exists", value="irrelevant")],
+    )
+    result = SimpleNamespace(
+        verified=[],
+        verification_failures=[],
+        spawned=[],
+        reaped=[],
+        retried=[],
+        errors=[],
+        dry_run_planned=[],
+        open_tasks=0,
+    )
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        # The post-enqueue path may fail on the minimal mock; the test
+        # asserts the helper was invoked, not that it ran cleanly.
+        with contextlib.suppress(Exception):
+            process_completed_tasks(orch, [task], result)
+
+    # _enqueue_alive_exit_janitor_pass ran via the helper path; the
+    # helper itself submits to the executor exactly once.
+    assert len(executor.submitted) == 1, executor.submitted
+
+
+def test_process_single_completed_task_logs_alive_exit_start(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``_process_single_completed_task`` must log the alive-exit pass START line.
+
+    This is the top-of-function INFO log that makes the alive-exit
+    janitor pass observable even if every downstream step (WAL write,
+    metrics, reap) is skipped.
+    """
+    executor = _FakeExecutor()
+    orch: Any = SimpleNamespace(
+        _executor=executor,
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _task_to_session={},
+        _find_session_for_task=lambda _: None,  # no live session
+        _wal_writer=None,  # skip WAL writes -- out of scope for this test
+        _spawner=SimpleNamespace(
+            get_worktree_path=lambda _: None,
+            reap_completed_agent=lambda *a, **k: None,
+            cleanup_worktree=lambda _: None,
+        ),
+        _record_provider_health=lambda *a, **k: None,
+        _cost_tracker=SimpleNamespace(spent_usd=0.0),
+        _workdir=Path("/tmp"),
+        _evolution=None,  # skip evolution
+        _processed_done_tasks={},
+    )
+    task = _make_task(
+        task_id="alive-start-task",
+        signals=[CompletionSignal(type="path_exists", value="never")],
+    )
+
+    # Pre-submit a verify_task future so _resolve_janitor_result can use it.
+    from bernstein.core.janitor import verify_task
+
+    verify_future = executor.submit(verify_task, task, "/tmp")
+    verify_futures = {task.id: verify_future}
+
+    result = SimpleNamespace(
+        verified=[],
+        verification_failures=[],
+        spawned=[],
+        reaped=[],
+        retried=[],
+        errors=[],
+        dry_run_planned=[],
+        open_tasks=0,
+    )
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        # After the top-of-function log any unrelated failures (no orch
+        # subclasses hooked up) should not affect the pass test.
+        with contextlib.suppress(Exception):
+            _process_single_completed_task(orch, task, verify_futures, result)
+
+    assert any(
+        "janitor: alive-exit pass starting" in rec.message
+        and "task=alive-start-task" in rec.message
+        and "role=backend" in rec.message
+        for rec in caplog.records
+    ), caplog.text
+
+
+def test_dead_path_janitor_pass_unchanged() -> None:
+    """Sanity: the dead-exit ``verify_task`` call site is untouched.
+
+    Regresses the safe carve-out: item 30 must NOT modify
+    ``handle_orphaned_task`` (read-only territory).
+    """
+    import inspect
+
+    from bernstein.core.agents import agent_lifecycle
+
+    src = inspect.getsource(agent_lifecycle.handle_orphaned_task)
+    # The synchronous verify_task call must still be present.
+    assert "passed, failed_signals = verify_task(task, orch._workdir)" in src

--- a/tests/unit/test_janitor_reopen.py
+++ b/tests/unit/test_janitor_reopen.py
@@ -1,0 +1,171 @@
+"""Tests for bounded janitor reopen-on-FAIL (commit-before-complete follow-up).
+
+Covers the janitor-verdict action wiring in ``task_lifecycle``:
+
+* done task + janitor FAIL -> reopened once (same id), logged
+* FAIL with exhausted reopen budget -> permanent fail, logged
+* janitor PASS -> stays done, no state change
+
+Plus the ``TaskStore.reopen`` DONE -> OPEN transition itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_lifecycle import _apply_janitor_verdict_action
+from bernstein.core.tasks.task_store import TaskStore
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeClient:
+    """Records POSTs made by the orchestrator janitor-verdict action."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, url: str, json: dict[str, Any] | None = None, **_kwargs: Any) -> _FakeResponse:
+        self.posts.append((url, json or {}))
+        return _FakeResponse()
+
+
+def _make_task(task_id: str = "task123", reopen_count: int = 0) -> Task:
+    task = Task(
+        id=task_id,
+        title="Implement hello subcommand",
+        description="Add a hello subcommand to cli.py",
+        role="backend",
+        status=TaskStatus.DONE,
+    )
+    if reopen_count:
+        task.metadata["janitor_reopen_count"] = reopen_count
+    return task
+
+
+def _make_orch(client: _FakeClient) -> SimpleNamespace:
+    return SimpleNamespace(
+        _config=SimpleNamespace(server_url="http://127.0.0.1:8052"),
+        _client=client,
+        _processed_done_tasks={"task123": None},
+    )
+
+
+def test_janitor_fail_reopens_task_and_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """First janitor FAIL on a done task reopens it (same id) and logs cycle 1/2."""
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        _apply_janitor_verdict_action(orch, task, janitor_passed=False)
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url.endswith("/tasks/task123/reopen")
+    assert "janitor verification failed" in body["reason"]
+    # Processed marker cleared so the re-completed task gets re-verified.
+    assert "task123" not in orch._processed_done_tasks
+    assert "janitor_verdict_action: task=task123 verdict=FAIL action=reopen cycle=1/2" in caplog.text
+
+
+def test_janitor_fail_budget_exhausted_permanent_fails(caplog: pytest.LogCaptureFixture) -> None:
+    """Janitor FAIL after the reopen budget is spent permanently fails the task."""
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task(reopen_count=2)  # default budget of 2 already spent
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        _apply_janitor_verdict_action(orch, task, janitor_passed=False)
+
+    assert len(client.posts) == 1
+    url, body = client.posts[0]
+    assert url.endswith("/tasks/task123/fail")
+    assert "reopen_budget_exhausted" in body["reason"]
+    assert (
+        "janitor_verdict_action: task=task123 verdict=FAIL action=permanent_fail reason=reopen_budget_exhausted"
+    ) in caplog.text
+
+
+def test_second_fail_with_budget_one_permanent_fails(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With BERNSTEIN_JANITOR_REOPEN_MAX=1: first FAIL reopens, second FAIL is permanent."""
+    monkeypatch.setenv("BERNSTEIN_JANITOR_REOPEN_MAX", "1")
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+
+    with caplog.at_level(logging.INFO, logger="bernstein.core.tasks.task_lifecycle"):
+        # First FAIL -> reopen cycle 1/1.
+        _apply_janitor_verdict_action(orch, task, janitor_passed=False)
+        # Simulate the server-side counter bump from the reopen.
+        task.metadata["janitor_reopen_count"] = 1
+        # Second FAIL -> budget exhausted -> permanent fail.
+        _apply_janitor_verdict_action(orch, task, janitor_passed=False)
+
+    assert client.posts[0][0].endswith("/tasks/task123/reopen")
+    assert client.posts[1][0].endswith("/tasks/task123/fail")
+    assert "action=reopen cycle=1/1" in caplog.text
+    assert "action=permanent_fail reason=reopen_budget_exhausted" in caplog.text
+
+
+def test_janitor_pass_leaves_task_done() -> None:
+    """Janitor PASS makes no state change and no HTTP call."""
+    client = _FakeClient()
+    orch = _make_orch(client)
+    task = _make_task()
+
+    _apply_janitor_verdict_action(orch, task, janitor_passed=True)
+
+    assert client.posts == []
+    assert task.status is TaskStatus.DONE
+    assert "task123" in orch._processed_done_tasks
+
+
+def test_store_reopen_done_task_keeps_id_and_increments_counter(tmp_path: Path) -> None:
+    """TaskStore.reopen transitions DONE -> OPEN under the same task id."""
+
+    async def _run() -> None:
+        store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")
+        task = _make_task()
+        task.status = TaskStatus.DONE
+        store._tasks[task.id] = task
+        store._index_add(task)
+
+        reopened = await store.reopen("task123", "janitor verification failed")
+
+        assert reopened.id == "task123"
+        assert reopened.status is TaskStatus.OPEN
+        assert reopened.metadata["janitor_reopen_count"] == 1
+        assert reopened.claimed_by_session is None
+        assert reopened.result_summary is None
+
+    asyncio.run(_run())
+
+
+def test_store_reopen_rejects_non_done_task(tmp_path: Path) -> None:
+    """Reopening a task that is not DONE raises IllegalTransitionError."""
+    from bernstein.core.tasks.lifecycle import IllegalTransitionError
+
+    async def _run() -> None:
+        store = TaskStore(jsonl_path=tmp_path / "tasks.jsonl", archive_path=tmp_path / "archive.jsonl")
+        task = _make_task()
+        task.status = TaskStatus.OPEN
+        store._tasks[task.id] = task
+        store._index_add(task)
+
+        with pytest.raises(IllegalTransitionError):
+            await store.reopen("task123", "should not work")
+
+    asyncio.run(_run())

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -139,6 +139,8 @@ def test_transition_task_terminal_statuses() -> None:
         transition_task(task, TaskStatus.DONE)
         assert task.status == TaskStatus.DONE
 
-        # Once DONE, no more transitions should be possible
+        # Once DONE, only the explicitly-allowed exits are possible. DONE ->
+        # OPEN is intentionally legal now (bounded janitor reopen), so assert
+        # a transition that remains illegal (DONE -> IN_PROGRESS).
         with pytest.raises(IllegalTransitionError):
-            transition_task(task, TaskStatus.OPEN)
+            transition_task(task, TaskStatus.IN_PROGRESS)

--- a/tests/unit/test_max_output_tokens_escalation.py
+++ b/tests/unit/test_max_output_tokens_escalation.py
@@ -28,8 +28,13 @@ def test_task_serialization_includes_max_output_tokens():
     assert task_default.max_output_tokens is None
 
 
-def test_agent_lifecycle_detects_max_output_tokens_finish_reason():
+def test_agent_lifecycle_detects_max_output_tokens_finish_reason(tmp_path):
     orch = MagicMock()
+    # Real workdir Path so the orphan-liveness probe (which stats
+    # heartbeat/log/git files under _workdir) sees genuinely-missing files and
+    # returns no fresh signal, instead of a MagicMock path whose stat() mtime
+    # cannot be compared against the grace window.
+    orch._workdir = tmp_path
     session = AgentSession(
         id="A1",
         role="backend",

--- a/tests/unit/test_mutation_setup.py
+++ b/tests/unit/test_mutation_setup.py
@@ -113,10 +113,12 @@ class TestKeyMutationScenarios:
 
         from bernstein.core.tasks.lifecycle import IllegalTransitionError, transition_task
 
-        # DONE -> OPEN should be illegal (mutant might allow all transitions)
+        # DONE -> IN_PROGRESS should be illegal (mutant might allow all
+        # transitions). Note DONE -> OPEN is intentionally legal now (bounded
+        # janitor reopen), so this guard uses a transition that stays illegal.
         task = Task(id="mut-1", title="t", description="d", role="r", status=TaskStatus.DONE)
         with pytest.raises(IllegalTransitionError):
-            transition_task(task, TaskStatus.OPEN)
+            transition_task(task, TaskStatus.IN_PROGRESS)
 
     def test_env_expansion_blocked_vars(self) -> None:
         """Blocked env vars must stay blocked (mutant might remove the check)."""

--- a/tests/unit/test_orchestration_watchdog.py
+++ b/tests/unit/test_orchestration_watchdog.py
@@ -128,6 +128,32 @@ def test_tick_auto_answers_safety_prompt(tmp_path: Path) -> None:
     assert events[0]["recovery_id"] == events[1]["recovery_id"] == recovery.recovery_id
 
 
+def test_tick_logs_probe_conclusion_and_summary(tmp_path: Path, caplog) -> None:
+    """Logging gap: the watchdog's per-session probe decision (which prompt
+    kind was classified, and why auto-answer did or didn't fire) was only
+    visible via the audit JSONL for skipped model-questions -- successful
+    safety-prompt probes and the tick-level summary were invisible in logs.
+    Assert both the per-probe INFO line and the tick-summary INFO line."""
+    caplog.set_level("INFO", logger="bernstein.core.orchestration.watchdog")
+    captured: list[tuple[str, str]] = []
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="some agent log\nContinue? [y/N]",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    tick([snapshot], _record_calls(captured), audit, env=env)
+
+    messages = [r.message for r in caplog.records]
+    probe_lines = [m for m in messages if "watchdog probe" in m]
+    assert any("session=s1" in m and "classified=safety" in m for m in probe_lines), probe_lines
+    assert any("watchdog recovery SUCCEEDED" in m and "session=s1" in m for m in messages), messages
+    assert any("watchdog tick complete" in m for m in messages), messages
+
+
 def test_tick_skips_session_without_safety_approval(tmp_path: Path) -> None:
     captured: list[tuple[str, str]] = []
     snapshot = SessionSnapshot(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections
 import json
+import logging
 import subprocess
 import time
 from pathlib import Path
@@ -4069,6 +4070,278 @@ class TestRunCompletionSummary:
         assert "**Files modified:**" in content
 
 
+class TestShutdownFinalOnQuiescenceSelfStop:
+    """Regression for the D2 openrouter final leg (2026-07-02,
+    work/bernstein/proofs/d2/openrouter/attempt-final-f15a2a9e).
+
+    Ground truth from that run: a lone manager task's agent died cleanly
+    with an empty diff; `reap_dead_agents` orphan-auto-completed the task
+    within the SAME tick that detected the death (spawner.log:
+    ``orphan_auto_complete: task_id=d6c31deb34f7 ...``). But:
+
+    1. The 8b "queue looks empty" mid-run retrospective read
+       `tasks_by_status` fetched at the TOP of that tick - before the
+       orphan auto-complete ran - so it vacuously reported "HEALTHY" /
+       "Auto-completed after agent death: 0" even though the event had
+       already happened moments earlier in the same tick.
+    2. The A5 shutdown-final regeneration (added in aac43032) only runs
+       from `run()`'s post-tick-loop code, which only executes once
+       something calls `orchestrator.stop()`. But this run exited via
+       `bernstein run --quiet`'s `_wait_for_run_completion()`
+       (cli/run_bootstrap.py), which polls this process's HTTP server from
+       a SEPARATE process and never signals it - so the orchestrator
+       subprocess (launched detached via `start_new_session=True` in
+       server_launch._start_spawner) just idled until the container's
+       PID-namespace teardown SIGKILLed it, running no shutdown code at
+       all. The final retrospective was never regenerated.
+
+    This test drives the exact same shape through the real
+    `reap_dead_agents` / orphan-auto-complete code path (like
+    `TestOrphanMetrics` above) via a single `orch.tick()` call - the same
+    call `orchestrator.run()`'s tick loop makes internally regardless of
+    which CLI surface is waiting on it - and asserts both bugs are fixed.
+    """
+
+    def _build_manager_dies_orphan_transport(self, task_id: str) -> tuple[httpx.MockTransport, dict[str, Any]]:
+        """A stateful mock server: GET reflects current state, POST .../complete mutates it.
+
+        This lets a single tick() exercise the real race: the bulk GET
+        /tasks fetched at the top of the tick sees "claimed" (pre-reap),
+        while a later refetch in the SAME tick (after reap_dead_agents
+        posts the completion) must see "done".
+        """
+        state: dict[str, Any] = {
+            "id": task_id,
+            "title": "Decompose goal",
+            "description": "Break down the goal into child tasks.",
+            "role": "manager",
+            "priority": 1,
+            "scope": "medium",
+            "complexity": "medium",
+            "estimated_minutes": 5,
+            "status": "claimed",
+            "depends_on": [],
+            "owned_files": [],
+            "assigned_agent": "manager-e7bfd5e6",
+            "result_summary": None,
+            "task_type": "standard",
+            "retry_count": 0,
+            "max_retries": 3,
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = request.url
+            if request.method == "GET" and url.path == "/tasks":
+                return _tasks_response(url, [dict(state)])
+            if request.method == "GET" and url.path == f"/tasks/{task_id}":
+                return httpx.Response(200, json=dict(state))
+            if request.method == "GET" and url.path == f"/tasks/{task_id}/snapshots":
+                return httpx.Response(200, json=[])
+            if request.method == "POST" and url.path == f"/tasks/{task_id}/complete":
+                state["status"] = "done"
+                state["result_summary"] = (
+                    "Auto-completed (no changes needed): agent manager-e7bfd5e6 exited "
+                    "cleanly with empty diff (exit code 0, no signals to verify) -- task "
+                    "was auto-completed because its agent died, not because the agent "
+                    "reported completion itself"
+                )
+                return httpx.Response(200, json={})
+            return httpx.Response(200, json={})
+
+        return httpx.MockTransport(handler), state
+
+    def test_orphan_auto_complete_self_stop_produces_unhealthy_final_retrospective(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No need to eat the real 2s settle window in a unit test.
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        task_id = "d6c31deb34f7"
+        transport, state = self._build_manager_dies_orphan_transport(task_id)
+        adapter = _mock_adapter()
+        adapter.is_alive.return_value = False  # agent already dead when tick() runs
+        cfg = OrchestratorConfig(
+            server_url="http://testserver",
+            evolve_mode=False,
+            evolution_enabled=False,
+        )
+        orch = _build_orchestrator(tmp_path, transport, adapter=adapter, config=cfg)
+        session = AgentSession(
+            id="manager-e7bfd5e6",
+            role="manager",
+            pid=99,
+            task_ids=[task_id],
+            status="working",
+            exit_code=0,  # clean exit -> "auto-completed, no changes needed" path
+        )
+        orch._agents["manager-e7bfd5e6"] = session
+
+        orch.tick()
+
+        # The orphan auto-complete must have actually fired within this tick.
+        assert state["status"] == "done", "reap_dead_agents should have auto-completed the task"
+        assert "auto-completed" in (state["result_summary"] or "").lower()
+
+        # Bug 1 fix: the mid-run summary (8b) must reflect the SAME-TICK
+        # completion, not the pre-reap "claimed" snapshot fetched at the
+        # top of the tick.
+        summary_content = (tmp_path / ".sdd" / "runtime" / "summary.md").read_text()
+        assert "**Total completed:** 1" in summary_content
+
+        # Bug 2 fix: quiescence self-stop must fire so shutdown-final
+        # regeneration actually runs on this terminal path, without
+        # depending on an external stop signal that the --quiet CLI path
+        # never sends.
+        assert orch._running is False, "orchestrator should self-stop once quiescence is confirmed"
+        assert orch._final_retrospective_regenerated is True
+
+        retro_content = (tmp_path / ".sdd" / "runtime" / "retrospective.md").read_text()
+        assert "INTERIM" not in retro_content, "the FINAL retrospective must not be labeled interim"
+        assert "**Verdict:** UNHEALTHY" in retro_content
+        assert "Auto-completed after agent death | 1" in retro_content, (
+            "the auto-completed-after-death task must be counted, not undercounted as 0"
+        )
+        assert "No issues detected; run looks healthy." not in retro_content
+
+    def test_regeneration_is_not_duplicated_by_run_post_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_regenerate_final_retrospective` must be idempotent: calling it again
+        (as run()'s post-tick-loop code does on every normal exit) after the
+        tick-level self-stop already wrote the final report must be a no-op,
+        not a second write."""
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        task_id = "d6c31deb34f7"
+        transport, _state = self._build_manager_dies_orphan_transport(task_id)
+        adapter = _mock_adapter()
+        adapter.is_alive.return_value = False
+        cfg = OrchestratorConfig(
+            server_url="http://testserver",
+            evolve_mode=False,
+            evolution_enabled=False,
+        )
+        orch = _build_orchestrator(tmp_path, transport, adapter=adapter, config=cfg)
+        orch._agents["manager-e7bfd5e6"] = AgentSession(
+            id="manager-e7bfd5e6",
+            role="manager",
+            pid=99,
+            task_ids=[task_id],
+            status="working",
+            exit_code=0,
+        )
+
+        orch.tick()
+        retro_path = tmp_path / ".sdd" / "runtime" / "retrospective.md"
+        first_mtime = retro_path.stat().st_mtime
+
+        # Simulate run()'s post-tick-loop call after the while loop exits
+        # because orch._running is now False.
+        orch._regenerate_final_retrospective(trigger_path="tick-loop-drain")
+
+        assert retro_path.stat().st_mtime == first_mtime, "second call must not rewrite the report"
+
+    def test_regeneration_fires_on_later_quiescence_after_unconfirmed_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Regression for the D2 minimax leg (2026-07-02,
+        work/bernstein/proofs/d2/minimax/attempt-e938bd33).
+
+        Archived shape: tick #7 detected quiescence and wrote the summary +
+        INTERIM retrospective; the settle-window refetch then found a retry
+        task (open=1) so the run correctly continued. But because the whole
+        8b block was gated on `not self._summary_written`, every LATER
+        quiescent tick skipped quiescence handling entirely - the self-stop
+        and shutdown-final regeneration never fired again, and the run
+        exited with the stale tick-7 interim retrospective on disk
+        (3 tasks/$0.0174 vs the real 5 rows/$0.0375).
+
+        This test drives that exact shape: tick 1 quiesces but the settle
+        refetch reveals a new open (retry) task; tick 2 quiesces for real.
+        The FINAL retrospective must be regenerated on tick 2, must differ
+        from the interim, and the explicit trigger log line must fire.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        def _mk(task_id: str, title: str, status: str) -> dict[str, Any]:
+            return {
+                "id": task_id,
+                "title": title,
+                "description": title,
+                "role": "qa",
+                "priority": 1,
+                "scope": "small",
+                "complexity": "low",
+                "estimated_minutes": 5,
+                "status": status,
+                "depends_on": [],
+                "owned_files": [],
+                "assigned_agent": None,
+                "result_summary": "done" if status == "done" else None,
+                "task_type": "standard",
+                "retry_count": 0,
+                "max_retries": 3,
+            }
+
+        done_task = _mk("aaaa11112222", "Implement hello subcommand", "done")
+        retry_task_open = _mk("bbbb33334444", "Add test for hello subcommand (retry)", "open")
+        retry_task_failed = dict(retry_task_open, status="failed")
+
+        phase = {"n": 1, "tasks_calls": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                phase["tasks_calls"] += 1
+                if phase["n"] == 1:
+                    # Fetches 1 (top-of-tick) and 2 (8b refetch) see a
+                    # quiescent queue; fetch 3 (settle re-check) reveals the
+                    # retry task that appeared during the settle window.
+                    if phase["tasks_calls"] >= 3:
+                        return _tasks_response(request.url, [done_task, retry_task_open])
+                    return _tasks_response(request.url, [done_task])
+                # Phase 2: the retry permanently failed; queue is truly quiescent.
+                return _tasks_response(request.url, [done_task, retry_task_failed])
+            return httpx.Response(200, json={})
+
+        cfg = OrchestratorConfig(
+            server_url="http://testserver",
+            evolve_mode=False,
+            evolution_enabled=False,
+        )
+        orch = _build_orchestrator(tmp_path, httpx.MockTransport(handler), config=cfg)
+        orch._running = True  # as run() sets before its tick loop
+
+        with caplog.at_level(logging.INFO):
+            # Tick 1: quiescence detected -> summary + INTERIM retro written,
+            # settle window finds the retry task -> run continues.
+            orch.tick()
+
+        retro_path = tmp_path / ".sdd" / "runtime" / "retrospective.md"
+        assert orch._summary_written is True, "tick 1 must have written the run summary"
+        assert orch._running is True, "tick 1 settle check must NOT self-stop (open retry task)"
+        assert orch._final_retrospective_regenerated is False
+        interim_content = retro_path.read_text()
+        assert "INTERIM" in interim_content, "tick 1 writes the interim snapshot"
+        assert "shutdown-final regeneration triggered" not in caplog.text
+
+        with caplog.at_level(logging.INFO):
+            # Tick 2: truly quiescent. Before the fix this tick skipped the
+            # entire 8b block (summary already written) and the final
+            # retrospective was never regenerated.
+            phase["n"] = 2
+            orch.tick()
+
+        assert orch._running is False, "tick 2 must self-stop on confirmed quiescence"
+        assert orch._final_retrospective_regenerated is True
+        assert "shutdown-final regeneration triggered via tick-quiescence-self-stop" in caplog.text, (
+            "the explicit trigger log line must fire (this missing line hid the bug twice)"
+        )
+
+        final_content = retro_path.read_text()
+        assert final_content != interim_content, "final retrospective must overwrite the interim snapshot"
+        assert "INTERIM" not in final_content, "the FINAL retrospective must not be labeled interim"
+
+
 # --- DryRun ---
 
 
@@ -5786,6 +6059,72 @@ def test_record_live_costs_enforces_max_cost_per_agent(tmp_path: Path) -> None:
     mock_retry.assert_called_once()
 
 
+def test_record_live_costs_accumulates_from_tokens_sidecar(tmp_path: Path) -> None:
+    """Ledger spent_usd must accumulate from the .tokens sidecar (bug item-7).
+
+    openai_agents sessions never populate ``session.tokens_used``; before the
+    fix the run ledger's spent_usd stayed 0.0 all run. Simulated session cost
+    (sidecar rows) must flow into the tracker: spent_usd > 0 and equal to the
+    priced sum of the sidecar tokens, delta-safe across repeated ticks.
+    """
+    from bernstein.core.cost.cost_tracker import estimate_cost
+
+    transport = _mock_transport({})
+    orch = _build_orchestrator(tmp_path, transport=transport)
+    session = AgentSession(
+        id="agent-sidecar",
+        role="backend",
+        task_ids=["task-sidecar"],
+        status="working",
+    )
+    assert session.tokens_used == 0  # openai_agents path: never populated
+    orch._agents[session.id] = session
+
+    sidecar = tmp_path / ".sdd" / "runtime" / f"{session.id}.tokens"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(
+        '{"ts": 1.0, "in": 1000, "out": 500}\n{"ts": 2.0, "in": 2000, "out": 1500}\n',
+        encoding="utf-8",
+    )
+
+    orch._record_live_costs()
+    expected = estimate_cost("sonnet", 3000, 2000)
+    assert expected > 0
+    status = orch._cost_tracker.status()
+    assert status.spent_usd > 0
+    assert status.spent_usd == pytest.approx(expected)
+
+    # Delta-safe: a second tick over the same sidecar adds nothing.
+    orch._record_live_costs()
+    assert orch._cost_tracker.status().spent_usd == pytest.approx(expected)
+
+    # New sidecar rows increment by exactly the newly-priced delta.
+    with sidecar.open("a", encoding="utf-8") as fh:
+        fh.write('{"ts": 3.0, "in": 500, "out": 250}\n')
+    orch._record_live_costs()
+    expected_total = estimate_cost("sonnet", 3500, 2250)
+    assert orch._cost_tracker.status().spent_usd == pytest.approx(expected_total)
+
+
+def test_record_live_costs_falls_back_to_session_tokens(tmp_path: Path) -> None:
+    """Providers without a sidecar still meter via session.tokens_used."""
+    from bernstein.core.cost.cost_tracker import estimate_cost
+
+    transport = _mock_transport({})
+    orch = _build_orchestrator(tmp_path, transport=transport)
+    session = AgentSession(
+        id="agent-legacy",
+        role="backend",
+        task_ids=["task-legacy"],
+        status="working",
+    )
+    session.tokens_used = 4000
+    orch._agents[session.id] = session
+
+    orch._record_live_costs()
+    assert orch._cost_tracker.status().spent_usd == pytest.approx(estimate_cost("sonnet", 4000, 0))
+
+
 def test_build_notification_manager_includes_seed_webhooks() -> None:
     """Seed-level webhooks should be threaded into NotificationManager targets."""
     from bernstein.core.orchestrator import _build_notification_manager
@@ -5818,3 +6157,257 @@ def test_build_notification_manager_includes_desktop_target() -> None:
     assert manager is not None
     targets = manager._targets  # pyright: ignore[reportPrivateUsage]
     assert any(t.type == "desktop" and t.events == ["task.completed", "task.failed"] for t in targets)
+
+
+# --- Defect 29: self-stop ordering race (D2 MiniMax re-proof) -------------
+
+
+class TestSelfStopOrderingDrain:
+    """Defect 29 (2026-07-02, work/bernstein/proofs/d2/minimax/attempt-83808a8a).
+
+    Regression for the run-summary firing BEFORE the post-/complete chain
+    (task_done -> ``_reap_and_cleanup_session`` -> ``_apply_janitor_verdict_action``)
+    had drained for the just-completed tasks. On MiniMax-M2.7-highspeed's
+    ~40 s child runtimes, the orchestrator's ``open_tasks == active_agents == 0``
+    predicate fired the run-summary in the same poll cycle that first
+    detected quiescence, but before ``process_completed_tasks`` had run the
+    chain for the children - so ``generate_retrospective`` was skipped (no
+    chain-registered completion) and no merge-to-main happened before
+    self-stop.
+
+    The fix introduces a drain counter (incremented when a task is first
+    seen in done/failed state, decremented once ``_processed_done_tasks``
+    contains it AND its session is dead/None). The summary gate now waits
+    on that counter reaching zero.
+    """
+
+    def _build(
+        self,
+        tmp_path: Path,
+        *,
+        done_tasks: list[dict] | None = None,
+        failed_tasks: list[dict] | None = None,
+    ) -> Orchestrator:
+        _done = done_tasks or []
+        _failed = failed_tasks or []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = request.url
+            if request.method == "GET" and url.path == "/tasks":
+                return _tasks_response(url, _done + _failed)
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        cfg = OrchestratorConfig(
+            server_url="http://testserver",
+            evolve_mode=False,
+            evolution_enabled=False,
+        )
+        return _build_orchestrator(tmp_path, transport, config=cfg)
+
+    def test_summary_defers_when_post_complete_chain_not_yet_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defect 29 (a) regression: terminal tasks visible, but
+        ``process_completed_tasks`` has not registered them in
+        ``_processed_done_tasks`` yet (e.g. a /complete POST landed AFTER
+        the tick-1 snapshot was taken, and the step-1c call already ran
+        against the pre-/complete snapshot). The drain counter is
+        positive, so the run summary MUST NOT be written.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        done = [_task_as_dict(_make_task(id="T-1", title="Backend feature", status="done"))]
+        failed = [_task_as_dict(_make_task(id="T-2", title="QA test", status="failed"))]
+        orch = self._build(tmp_path, done_tasks=done, failed_tasks=failed)
+
+        # Simulate "chain not yet run": patch ``process_completed_tasks`` to
+        # a no-op so it never adds the task ids to ``_processed_done_tasks``.
+        # This is the exact shape the fix targets: tasks are terminal in the
+        # server, the orchestrator can see them, but the chain that drains
+        # them has not run yet (or has been bypassed).
+        import bernstein.core.orchestration.orchestrator as orch_mod
+
+        monkeypatch.setattr(
+            orch_mod,
+            "process_completed_tasks",
+            lambda *_args, **_kwargs: None,
+        )
+
+        orch.tick()
+
+        summary_path = tmp_path / ".sdd" / "runtime" / "summary.md"
+        assert not summary_path.exists(), (
+            "defect 29 regression: summary.md MUST NOT be written while "
+            "pending_post_complete_count > 0; the post-/complete chain "
+            "has not drained for the terminal tasks yet"
+        )
+        assert orch._pending_post_complete_count >= 1, (
+            "drain tracker should still report pending tasks; tick should "
+            "have re-evaluated and either processed or deferred"
+        )
+
+    def test_summary_fires_when_post_complete_chain_drains(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defect 29 (b) positive: once every terminal task is in
+        ``_processed_done_tasks`` AND its session is dead (or None), the
+        drain counter reaches zero and the run summary fires.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        done = [_task_as_dict(_make_task(id="T-1", title="Backend feature", status="done"))]
+        failed = [_task_as_dict(_make_task(id="T-2", title="QA test", status="failed"))]
+        orch = self._build(tmp_path, done_tasks=done, failed_tasks=failed)
+
+        orch.tick()
+
+        summary_path = tmp_path / ".sdd" / "runtime" / "summary.md"
+        assert summary_path.exists(), (
+            "summary.md should fire once the post-/complete chain has "
+            "drained: _processed_done_tasks has both task ids, no sessions "
+            "are alive for them"
+        )
+        assert orch._pending_post_complete_count == 0
+        assert orch._summary_written is True
+
+    def test_summary_defers_until_session_transitions_to_dead(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defect 29 (a) tighter: chain HAS run (``_processed_done_tasks``
+        has the task id) but the session is still alive (status != dead).
+        The drain counter MUST stay positive until the session is dead.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        task_id = "T-1"
+        done = [_task_as_dict(_make_task(id=task_id, title="Live work", status="done"))]
+        orch = self._build(tmp_path, done_tasks=done)
+
+        orch._processed_done_tasks[task_id] = None
+        orch._post_complete_seen_task_ids.add(task_id)
+        orch._pending_post_complete_count = 1
+        orch._agents["backend-xyz"] = AgentSession(
+            id="backend-xyz",
+            role="backend",
+            pid=12345,
+            task_ids=[task_id],
+            status="working",
+            exit_code=None,
+        )
+        orch._task_to_session[task_id] = "backend-xyz"
+
+        orch.tick()
+
+        summary_path = tmp_path / ".sdd" / "runtime" / "summary.md"
+        assert not summary_path.exists(), (
+            "defect 29 regression: summary.md MUST NOT fire while the "
+            "agent session is still alive (reap step inside "
+            "_reap_and_cleanup_session has not transitioned it to dead)"
+        )
+        assert orch._pending_post_complete_count == 1, (
+            "drain tracker should still report the live-session task as "
+            "pending - the chain ran but the session has not been reaped"
+        )
+
+        orch._agents["backend-xyz"].status = "dead"
+
+        orch.tick()
+
+        assert summary_path.exists(), (
+            "summary.md should fire once the session is dead and _processed_done_tasks has the task id (chain drained)"
+        )
+        assert orch._pending_post_complete_count == 0
+
+    def test_run_end_check_log_emitted_with_all_inputs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Defect 29 (c): the run-end decision MUST log every input that
+        drove it (open, active, pending_post_complete, summary_written,
+        action) so a 2-minute diagnosis from logs alone is possible.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        done = [_task_as_dict(_make_task(id="T-1", title="Real work", status="done"))]
+        orch = self._build(tmp_path, done_tasks=done)
+
+        logging.getLogger().setLevel(logging.INFO)
+        with caplog.at_level(logging.INFO):
+            orch.tick()
+
+        run_end_lines = [
+            rec
+            for rec in caplog.records
+            if rec.name == "bernstein.core.orchestration.orchestrator" and rec.getMessage().startswith("run_end_check:")
+        ]
+        assert run_end_lines, (
+            f"run_end_check log line MUST be emitted on the quiescent tick; "
+            f"got {len(caplog.records)} records total. Records:"
+            + "\n".join(r.getMessage()[:120] for r in caplog.records)
+        )
+        msg = run_end_lines[-1].getMessage()
+        assert "tick=#" in msg
+        assert "open=" in msg
+        assert "active=" in msg
+        assert "pending_post_complete=" in msg
+        assert "summary_written=" in msg
+        assert "-> action=" in msg
+        action = msg.split("-> action=")[1].split(" ")[0].strip()
+        assert action in {"fire_summary", "defer_summary", "wait"}, f"unexpected action value {action!r}"
+
+    def test_run_summary_firing_log_emitted_with_all_inputs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Defect 29 (c): the firing log line MUST emit every input that
+        the run-summary generation saw, so logs alone diagnose the run.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        done = [_task_as_dict(_make_task(id="T-1", title="Work A", status="done"))]
+        orch = self._build(tmp_path, done_tasks=done)
+
+        with caplog.at_level(logging.INFO):
+            orch.tick()
+
+        firing_lines = [rec for rec in caplog.records if rec.getMessage().startswith("run_summary_firing:")]
+        assert firing_lines, (
+            "run_summary_firing log line MUST be emitted at the top of _generate_run_summary with all inputs"
+        )
+        msg = firing_lines[-1].getMessage()
+        assert "tick=#" in msg
+        assert "tasks_completed=" in msg
+        assert "tasks_failed=" in msg
+        assert "files_modified=" in msg
+        assert "cost_usd=" in msg
+        assert "wall_clock_s=" in msg
+        assert "pending_post_complete=" in msg
+        assert "processed_done_tasks=" in msg
+        assert "-> action=fire_summary" in msg
+
+    def test_defer_summary_log_lists_pending_task_ids(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Defect 29 (c): when the action is defer_summary, the log MUST
+        list the task ids whose post-/complete chain is still pending.
+        """
+        monkeypatch.setenv("BERNSTEIN_QUIESCENCE_SETTLE_S", "0")
+
+        done = [_task_as_dict(_make_task(id="T-stuck", title="Stuck work", status="done"))]
+        orch = self._build(tmp_path, done_tasks=done)
+
+        import bernstein.core.orchestration.orchestrator as orch_mod
+
+        monkeypatch.setattr(
+            orch_mod,
+            "process_completed_tasks",
+            lambda *_args, **_kwargs: None,
+        )
+
+        with caplog.at_level(logging.INFO):
+            orch.tick()
+
+        run_end_lines = [rec for rec in caplog.records if rec.getMessage().startswith("run_end_check:")]
+        assert run_end_lines
+        msg = run_end_lines[-1].getMessage()
+        assert "defer_summary" in msg
+        assert "T-stuck" in msg, "defer_summary log MUST include the task ids still pending the post-/complete chain"

--- a/tests/unit/test_orchestrator_config_stale_claim.py
+++ b/tests/unit/test_orchestrator_config_stale_claim.py
@@ -52,3 +52,45 @@ def test_reset_restores_original_stale_claim_timeout() -> None:
     cfg = OrchestratorConfig()
     assert cfg.stale_claim_timeout_s == pytest.approx(900.0)
     assert cfg.drain_timeout_s == pytest.approx(60.0)
+
+
+def test_stalled_manager_threshold_defaults_match_singleton() -> None:
+    """Regression test for #2179: stalled_manager_threshold_s must flow the same way."""
+    cfg = OrchestratorConfig()
+    assert cfg.stalled_manager_threshold_s == pytest.approx(
+        defaults.ORCHESTRATOR.stalled_manager_threshold_s,
+    )
+    assert cfg.stalled_manager_threshold_s == pytest.approx(170.0)
+
+
+def test_override_flows_into_new_stalled_manager_threshold() -> None:
+    override("orchestrator", {"stalled_manager_threshold_s": 300.0})
+    cfg = OrchestratorConfig()
+    assert cfg.stalled_manager_threshold_s == pytest.approx(300.0)
+
+
+def test_reset_restores_original_stalled_manager_threshold() -> None:
+    override("orchestrator", {"stalled_manager_threshold_s": 42.0})
+    reset()
+    cfg = OrchestratorConfig()
+    assert cfg.stalled_manager_threshold_s == pytest.approx(170.0)
+
+
+def test_max_agent_runtime_defaults_match_singleton() -> None:
+    """Same gap class: max_agent_runtime_s was a plain hardcoded field, not tuning-backed."""
+    cfg = OrchestratorConfig()
+    assert cfg.max_agent_runtime_s == defaults.ORCHESTRATOR.max_agent_runtime_s
+    assert cfg.max_agent_runtime_s == 1800
+
+
+def test_override_flows_into_new_max_agent_runtime() -> None:
+    override("orchestrator", {"max_agent_runtime_s": 3600})
+    cfg = OrchestratorConfig()
+    assert cfg.max_agent_runtime_s == 3600
+
+
+def test_reset_restores_original_max_agent_runtime() -> None:
+    override("orchestrator", {"max_agent_runtime_s": 60})
+    reset()
+    cfg = OrchestratorConfig()
+    assert cfg.max_agent_runtime_s == 1800

--- a/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
+++ b/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
@@ -1,0 +1,108 @@
+"""Regression tests for _create_upgrade_tasks' AutoSpawnGuard wiring.
+
+Covers the production incident (work/agent-reports/2026-07-02-run9-attempt9-audit.md)
+where the same "Upgrade: Improve task success rate" opportunity was
+re-proposed every analysis cycle with no dedupe or cap, producing ~19
+duplicate meta-tasks with zero forward progress.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from bernstein.core.models import Task, TaskStatus, TaskType
+
+from bernstein.core.orchestration.evolution import UpgradeStatus
+from bernstein.core.orchestration.orchestrator_evolve import _create_upgrade_tasks
+
+
+def _proposal(
+    proposal_id: str,
+    title: str,
+    *,
+    status: UpgradeStatus = UpgradeStatus.PENDING,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=proposal_id,
+        title=title,
+        description="desc",
+        status=status,
+        proposed_change="x" * 100,
+        risk_assessment=SimpleNamespace(affected_components=["model_routing"]),
+    )
+
+
+def _orch(workdir: Path, *, latest_tasks: dict[str, Task] | None = None) -> SimpleNamespace:
+    client = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    client.post.return_value = resp
+
+    risk_scorer = SimpleNamespace(
+        score_proposal=lambda **kwargs: SimpleNamespace(composite_risk=0.2),
+        is_high_risk=lambda score: False,
+    )
+
+    return SimpleNamespace(
+        _workdir=workdir,
+        _config=SimpleNamespace(server_url="http://server"),
+        _client=client,
+        _risk_scorer=risk_scorer,
+        _latest_tasks_by_id=latest_tasks or {},
+    )
+
+
+def test_allowed_upgrade_task_is_created_and_posted(tmp_path: Path) -> None:
+    orch = _orch(tmp_path)
+    result = SimpleNamespace(errors=[])
+
+    _create_upgrade_tasks(orch, [_proposal("p1", "Improve task success rate")], result)
+
+    assert orch._client.post.call_count == 1
+    _, kwargs = orch._client.post.call_args
+    assert kwargs["json"]["title"] == "Upgrade: Improve task success rate"
+    assert result.errors == []
+
+
+def test_dedupe_refuses_upgrade_task_matching_existing_open_task(tmp_path: Path) -> None:
+    existing = Task(
+        id="t1",
+        title="Upgrade: Improve task success rate",
+        description="desc",
+        role="backend",
+        task_type=TaskType.UPGRADE_PROPOSAL,
+        status=TaskStatus.OPEN,
+    )
+    orch = _orch(tmp_path, latest_tasks={existing.id: existing})
+    result = SimpleNamespace(errors=[])
+
+    _create_upgrade_tasks(orch, [_proposal("p1", "Improve task success rate")], result)
+
+    assert orch._client.post.call_count == 0
+
+
+def test_cap_refuses_upgrade_tasks_beyond_configured_limit(tmp_path: Path) -> None:
+    # Pre-seed the shared guard state at the cap (default 3) so the very next
+    # evaluation in this run is refused.
+    state_path = tmp_path / ".sdd" / "runtime" / "auto_spawn_guard.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"count": 3}), encoding="utf-8")
+
+    orch = _orch(tmp_path)
+    result = SimpleNamespace(errors=[])
+
+    _create_upgrade_tasks(orch, [_proposal("p1", "Improve task success rate")], result)
+
+    assert orch._client.post.call_count == 0
+
+
+def test_non_eligible_proposal_status_is_skipped_before_guard(tmp_path: Path) -> None:
+    orch = _orch(tmp_path)
+    result = SimpleNamespace(errors=[])
+
+    _create_upgrade_tasks(orch, [_proposal("p1", "Applied already", status=UpgradeStatus.APPLIED)], result)
+
+    assert orch._client.post.call_count == 0

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -292,3 +292,191 @@ class TestRouterRateLimitIntegration:
         # With success_rate=1.0 and zero active agents, spreading term = 1.0 * 0.10
         # health=1.0*0.35 + cost=1.0*0.25 + free=0*0.2 + latency=1.0*0.10 + spread=1.0*0.10 = 0.80
         assert abs(score - 0.80) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Regression: risky bare-substring patterns must not false-positive on
+# structured JSON log data (2026-07-02 incident - runs 4/5/6 killed).
+# ---------------------------------------------------------------------------
+
+
+class TestRiskyBareTokenFalsePositives:
+    """Structured JSON tool-result / manifest lines must NOT trigger a
+    failure classification just because they contain a risky bare number or
+    generic phrase like "max_tokens", "413", or "429" with no error context.
+    """
+
+    def test_no_context_overflow_on_json_manifest_line(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "tool_result", "tool": "spawn", "manifest": '
+            '{"max_tokens": 16384, "model": "MiniMax-M3", "batch_id": 413}}\n'
+        )
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_context_overflow(log)
+
+    def test_no_rate_limit_on_json_counters_line(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text('{"type": "tool_result", "bytes_written": 429, "duration_ms": 129413}\n')
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_429(log)
+
+    def test_no_auth_error_on_json_status_code_line(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text('{"type": "tool_result", "port": 401, "queue_depth": 403}\n')
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_auth_error(log)
+
+    def test_no_failure_type_detected_on_healthy_worker_json_log(self, tmp_path: Path) -> None:
+        """The exact incident shape: a healthy worker's structured log full
+        of tool results and a manifest dump must classify as no failure."""
+        log = tmp_path / "agent.log"
+        log.write_text(
+            "\n".join(
+                [
+                    '{"type": "tool_call", "name": "Read", "input": {"path": "x.py"}}',
+                    '{"type": "tool_result", "manifest": {"max_tokens": 16384}}',
+                    '{"type": "tool_result", "bytes": 413129, "count": 429}',
+                    '{"type": "assistant", "text": "Task complete."}',
+                ]
+            )
+        )
+        tracker = RateLimitTracker()
+        assert tracker.detect_failure_type(log) is None
+
+    def test_max_tokens_removed_outright_even_with_error_context(self, tmp_path: Path) -> None:
+        """max_tokens was removed from the pattern list entirely, not just
+        demoted to risky - it must not fire even next to the word "error"."""
+        log = tmp_path / "agent.log"
+        log.write_text('{"error": "none", "max_tokens": 16384}\n')
+        tracker = RateLimitTracker()
+        assert not tracker.scan_log_for_context_overflow(log)
+
+
+class TestRiskyBareTokenTruePositives:
+    """Genuine provider errors with real error context must still be
+    detected - the fix must not blind the classifier entirely."""
+
+    def test_detects_413_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("Error code: 413 - request too large\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_context_overflow(log)
+
+    def test_detects_context_length_exceeded_phrase(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("openai.BadRequestError: context_length_exceeded\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_context_overflow(log)
+
+    def test_detects_429_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("HTTP status 429 received from provider\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_429(log)
+
+    def test_detects_401_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("Request failed with HTTP error 401 Unauthorized\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_auth_error(log)
+
+    def test_detects_504_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("gateway returned status 504\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_timeout(log)
+
+    def test_detects_context_window_with_error_context(self, tmp_path: Path) -> None:
+        log = tmp_path / "agent.log"
+        log.write_text("Error: context window exceeded for this request\n")
+        tracker = RateLimitTracker()
+        assert tracker.scan_log_for_context_overflow(log)
+
+
+class TestDataLineAndGenericWordFalsePositives:
+    """2026-07-02 run-7 regression: healthy agents killed by generic words in
+    structured JSON log lines (`"timeout": 5` in a tool_call payload)."""
+
+    def _tracker(self):
+        from bernstein.core.observability.rate_limit_tracker import RateLimitTracker
+
+        return RateLimitTracker()
+
+    def test_tool_traffic_lines_never_match(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "tool_call", "name": "run_command", "args": {"argv": ["pnpm", "test"], "timeout": 5}}\n'
+            '{"type": "tool_result", "name": "read_file", "ok": true, "result": {"bytes": 64133, "preview": "if (unauthorized) throw new Error(\'forbidden\'); // rate limit retry"}}\n'
+            '{"type": "tool_result", "name": "run_command", "ok": false, "result": {"stderr_preview": "Error: connect ECONNREFUSED 127.0.0.1:5432 - test timed out"}}\n'
+            '{"type": "heartbeat", "phase": "running", "timeout": 429}\n'
+            '{"type": "tool_result", "name": "read_file", "result": {"preview": "max_tokens: 16384, TimeoutError handling, status 413 code"}}\n'
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_generic_words_without_error_context_never_match(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text(
+            "setting request timeout to 30s for provider\n"
+            "the rate limit configuration was loaded\n"
+            "unauthorized users are redirected to login\n"
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_real_provider_errors_still_detected(self, tmp_path):
+        cases = {
+            "rate_limit": '{"type": "error", "kind": "api", "message": "Error code: 429 - rate limit exceeded"}\n',
+            "timeout": "openai.APITimeoutError: HTTP request failed: read timeout\n",
+            "context_overflow": '{"type": "error", "message": "Error code: 413 - request too large: maximum context length exceeded"}\n',
+            "auth_error": "openai.AuthenticationError: Error code: 401 - invalid api key\n",
+            "api_error": "httpx.ConnectError: connection refused (APIConnectionError) - request failed\n",
+        }
+        for expected, line in cases.items():
+            log = tmp_path / f"{expected}.log"
+            log.write_text(line)
+            assert self._tracker().detect_failure_type(log) == expected, expected
+
+
+class TestCompletionProgressSkipSet:
+    """2026-07-02 D2 tools-zero diagnosis (Q5): a hallucinated agent's own
+    fabricated JSON tool-call text leaked "timeout" into a "completion"-type
+    event's free-text summary, tripping the false-positive cascade fallback.
+    "completion" and "progress" were added to _DATA_LINE_TYPES so model
+    free-text prose in those event types is never substring-scanned."""
+
+    def _tracker(self):
+        from bernstein.core.observability.rate_limit_tracker import RateLimitTracker
+
+        return RateLimitTracker()
+
+    def test_completion_type_prose_with_timeout_does_not_match(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "completion", "summary": "<tool_call>{\\"name\\": \\"bash\\", '
+            '\\"arguments\\": {\\"command\\": \\"pnpm test\\", \\"timeout\\": 10}}</tool_call>"}\n'
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_progress_type_prose_with_timeout_does_not_match(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text('{"type": "progress", "message": "I set a 10s timeout on the curl call and it succeeded"}\n')
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_bare_timeout_without_error_context_does_not_match(self, tmp_path):
+        """ "timeout" is a _RISKY_BARE_TOKENS entry: even on an unstructured
+        line (not completion/progress), a bare mention with no error-context
+        word on the same line must not trigger a match."""
+        log = tmp_path / "agent.log"
+        log.write_text("setting request timeout to 30s for provider\n")
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_completion_type_with_real_error_elsewhere_still_detected(self, tmp_path):
+        """Sanity check: the skip-set only covers completion/progress lines
+        themselves -- a genuine error on a different, non-data line type is
+        still detected."""
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "completion", "summary": "the task finished after a brief timeout delay"}\n'
+            '{"type": "error", "message": "Error code: 429 - rate limit exceeded"}\n'
+        )
+        assert self._tracker().detect_failure_type(log) == "rate_limit"

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -289,10 +289,13 @@ class TestTaskStateTransitions:
         assert event.entity_type == "task"
 
     def test_illegal_task_transition_raises(self) -> None:
-        """DONE -> OPEN is not in the transition table."""
+        """DONE -> IN_PROGRESS is not in the transition table.
+
+        (DONE -> OPEN is intentionally legal now: bounded janitor reopen.)
+        """
         task = _make_task(id="T-bad", status="done")
         with pytest.raises(IllegalTransitionError):
-            transition_task(task, TaskStatus.OPEN)
+            transition_task(task, TaskStatus.IN_PROGRESS)
 
     def test_illegal_agent_transition_raises(self) -> None:
         """dead -> working is not allowed."""

--- a/tests/unit/test_retrospective.py
+++ b/tests/unit/test_retrospective.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
+import json
 import time
 from typing import TYPE_CHECKING
 
 from bernstein.core.metrics import MetricsCollector
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus, TaskType
-from bernstein.core.retrospective import _build_recommendations, _fmt_seconds, generate_retrospective
+from bernstein.core.retrospective import (
+    TERMINATOR_AGENT_COMPLETED,
+    TERMINATOR_AGENT_REPORTED_FAILURE,
+    TERMINATOR_AUTO_COMPLETED_AFTER_DEATH,
+    TERMINATOR_JANITOR_REJECTED,
+    TERMINATOR_WATCHDOG_KILLED,
+    _build_recommendations,
+    _fmt_seconds,
+    classify_task_terminator,
+    compute_run_health,
+    generate_retrospective,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -24,6 +36,8 @@ def _make_task(
     role: str = "backend",
     complexity: str = "medium",
     status: str = "done",
+    result_summary: str | None = None,
+    terminal_reason: str | None = None,
 ) -> Task:
     return Task(
         id=id,
@@ -34,6 +48,8 @@ def _make_task(
         complexity=Complexity(complexity),
         status=TaskStatus(status),
         task_type=TaskType.STANDARD,
+        result_summary=result_summary,
+        terminal_reason=terminal_reason,
     )
 
 
@@ -292,3 +308,466 @@ class TestGenerateRetrospective:
         content = (tmp_path / "runtime" / "retrospective.md").read_text()
         assert "# Run Retrospective" in content
         assert "0%" in content or "0 done" in content
+
+
+# ---------------------------------------------------------------------------
+# classify_task_terminator / compute_run_health - run-health honesty
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTaskTerminator:
+    def test_genuine_completion_with_no_result_summary(self) -> None:
+        task = _make_task(status="done")
+        assert classify_task_terminator(task) == TERMINATOR_AGENT_COMPLETED
+
+    def test_watchdog_heartbeat_kill(self) -> None:
+        task = _make_task(
+            status="failed",
+            result_summary="Retried: Agent sess-1 reaped (heartbeat timeout)",
+        )
+        assert classify_task_terminator(task) == TERMINATOR_WATCHDOG_KILLED
+
+    def test_janitor_rejection(self) -> None:
+        task = _make_task(
+            status="failed",
+            result_summary="Agent sess-1 died; janitor failed: ['test_passes: ...']",
+        )
+        assert classify_task_terminator(task) == TERMINATOR_JANITOR_REJECTED
+
+    def test_auto_completed_after_death(self) -> None:
+        task = _make_task(
+            status="done",
+            result_summary="Auto-completed: agent sess-1 made git commits on branch (no signals to verify)",
+        )
+        assert classify_task_terminator(task) == TERMINATOR_AUTO_COMPLETED_AFTER_DEATH
+
+    def test_agent_completed_ignores_unrelated_summary_text(self) -> None:
+        task = _make_task(status="done", result_summary="Implemented the widget factory as requested.")
+        assert classify_task_terminator(task) == TERMINATOR_AGENT_COMPLETED
+
+    def test_failed_task_with_no_matching_marker_is_agent_reported_failure_not_completed(self) -> None:
+        """A FAILED task must never be classified as TERMINATOR_AGENT_COMPLETED,
+        even when its result_summary text doesn't match any forced-kill
+        marker. Ground truth: D2 openrouter leg -- a raw provider
+        BadRequestError (deepseek max_tokens > context cap) had none of the
+        watchdog/janitor/timeout/other-forced/auto-completed keywords and
+        fell through to the "genuine completion" default."""
+        task = _make_task(
+            status="failed",
+            result_summary="BadRequestError: maximum context length is 163840 tokens",
+        )
+        assert classify_task_terminator(task) == TERMINATOR_AGENT_REPORTED_FAILURE
+
+
+class TestComputeRunHealth:
+    def test_empty_is_vacuously_healthy(self) -> None:
+        healthy, counts = compute_run_health([])
+        assert healthy is True
+        assert counts == {}
+
+    def test_all_agent_completed_is_healthy(self) -> None:
+        tasks = [_make_task(id=f"T-{i}", status="done") for i in range(5)]
+        healthy, counts = compute_run_health(tasks)
+        assert healthy is True
+        assert counts[TERMINATOR_AGENT_COMPLETED] == 5
+
+    def test_majority_watchdog_killed_is_unhealthy(self) -> None:
+        """Ground truth: run-9 attempt-9 had 21 spawns / 19 merge refusals driven by
+        SHUTDOWN(no_heartbeat) kills, yet the run was never flagged unhealthy."""
+        watchdog_killed = [
+            _make_task(
+                id=f"T-wd-{i}",
+                status="failed",
+                result_summary=f"Retried: Agent sess-{i} reaped (heartbeat timeout)",
+            )
+            for i in range(19)
+        ]
+        genuine = [_make_task(id=f"T-ok-{i}", status="done") for i in range(2)]
+        healthy, counts = compute_run_health(watchdog_killed + genuine)
+        assert healthy is False
+        assert counts[TERMINATOR_WATCHDOG_KILLED] == 19
+        assert counts[TERMINATOR_AGENT_COMPLETED] == 2
+
+    def test_minority_forced_terminations_still_healthy_when_no_task_actually_failed(self) -> None:
+        """The fraction-based heuristic only gets a chance to run when the
+        hard rule (any FAILED-status task, any auto-completed-after-death,
+        any unresolved-in-metrics) does not already fire. A stray
+        forced-kill-shaped marker on an otherwise DONE task (e.g. leftover
+        text from an earlier retry that later succeeded) below the 50%
+        threshold should not sink the verdict."""
+        stale_marker_but_done = [
+            _make_task(
+                id="T-wd-1",
+                status="done",
+                result_summary="Retried: Agent sess-1 reaped (heartbeat timeout); retried and succeeded",
+            )
+        ]
+        genuine = [_make_task(id=f"T-ok-{i}", status="done") for i in range(9)]
+        healthy, counts = compute_run_health(stale_marker_but_done + genuine)
+        assert healthy is True
+        assert counts[TERMINATOR_WATCHDOG_KILLED] == 1
+
+    def test_any_failed_task_forces_unhealthy_hard_rule(self) -> None:
+        """Regression for the D2 openrouter leg (KILL-NOTE.md, 2026-07-02):
+        a single failed task whose result_summary/terminal_reason text does
+        not match ANY forced-kill marker (e.g. a raw provider BadRequestError)
+        used to fall through classify_task_terminator's default and count as
+        TERMINATOR_AGENT_COMPLETED, so compute_run_health never saw it and
+        reported HEALTHY for a 100%-failure run. The hard rule (n_failed > 0)
+        must catch this regardless of text-pattern matching."""
+        failed = [
+            _make_task(
+                id="T-1",
+                status="failed",
+                result_summary=(
+                    "BadRequestError: Error code: 400 - \"This endpoint's maximum context "
+                    'length is 163840 tokens. However, you requested about 201099 tokens."'
+                ),
+            )
+        ]
+        healthy, counts = compute_run_health(failed)
+        assert healthy is False
+        assert counts[TERMINATOR_AGENT_REPORTED_FAILURE] == 1
+        assert counts.get(TERMINATOR_AGENT_COMPLETED, 0) == 0
+
+    def test_unresolved_in_metrics_forces_unhealthy(self) -> None:
+        healthy, _counts = compute_run_health([_make_task(id="T-ok", status="done")], n_unresolved=1)
+        assert healthy is False
+
+
+class TestRunHealthInRecommendations:
+    def _call(self, **kwargs: object) -> list[str]:
+        defaults = {
+            "n_done": 10,
+            "n_failed": 0,
+            "role_failed": {},
+            "role_done": {"backend": 10},
+            "cx_failed": {},
+            "total_cost": 0.5,
+            "wall_clock_s": 300.0,
+        }
+        defaults.update(kwargs)
+        return _build_recommendations(**defaults)  # type: ignore[arg-type]
+
+    def test_unhealthy_run_always_produces_a_recommendation(self) -> None:
+        recs = self._call(
+            run_healthy=False,
+            terminator_counts={TERMINATOR_WATCHDOG_KILLED: 19, TERMINATOR_AGENT_COMPLETED: 2},
+        )
+        assert any("UNHEALTHY" in r for r in recs)
+        assert any(TERMINATOR_WATCHDOG_KILLED in r for r in recs)
+
+    def test_healthy_run_with_no_other_issues_stays_empty(self) -> None:
+        assert self._call(run_healthy=True) == []
+
+
+class TestGenerateRetrospectiveRunHealth:
+    def test_healthy_run_reports_healthy_verdict(self, tmp_path: Path) -> None:
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        done = [_make_task(id=f"T-{i}") for i in range(5)]
+        generate_retrospective(
+            done_tasks=done,
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 10,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "## Run Health" in content
+        assert "**Verdict:** HEALTHY" in content
+        assert "No issues detected; run looks healthy." in content
+
+    def test_watchdog_killed_majority_reports_unhealthy_not_healthy(self, tmp_path: Path) -> None:
+        """The core regression: a run where most terminations are watchdog
+        kills must NOT be reported as healthy, even with a high nominal
+        completion rate on the surviving tasks."""
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        failed = [
+            _make_task(
+                id=f"T-wd-{i}",
+                status="failed",
+                result_summary=f"Retried: Agent sess-{i} reaped (heartbeat timeout)",
+            )
+            for i in range(19)
+        ]
+        done = [_make_task(id=f"T-ok-{i}") for i in range(2)]
+        generate_retrospective(
+            done_tasks=done,
+            failed_tasks=failed,
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 60,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "**Verdict:** UNHEALTHY" in content
+        assert "No issues detected; run looks healthy." not in content
+        assert "UNHEALTHY" in content
+        assert "Watchdog-killed | 19" in content
+
+    def test_case1_stale_snapshot_reconciles_4_failed_from_metrics(self, tmp_path: Path) -> None:
+        """Regression for D2 claude/sdd-snapshot attempt 2 (2026-07-02): the
+        orchestrator's done_tasks/failed_tasks arrived here EMPTY (stale
+        tasks_by_status snapshot fetched before this tick's own reaping
+        persisted the 4 failures), yet the CLI's own final tally said
+        "Failed: 4" and collector.task_metrics has 4 started-but-never-
+        completed manager attempts (retry_or_fail_task never calls
+        collector.complete_task()). The retrospective must reconcile from
+        task_metrics ground truth: 4 failed, 0 done, 4 total, UNHEALTHY --
+        not "0 done / 0 total ... HEALTHY" as it did before this fix."""
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        for i in range(4):
+            collector.start_task(f"mgr-attempt-{i}", "manager", "claude-sonnet-5", "claude")
+        run_start = time.time() - 382  # 6m22s, matching the ground-truth wall clock
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=run_start,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "**Completion rate:** 0% (0 done / 4 total)" in content
+        assert "**Failed tasks:** 4" in content
+        assert "**Verdict:** UNHEALTHY" in content
+        assert "6m 22s" in content
+        assert "No issues detected; run looks healthy." not in content
+
+    def test_case3_auto_completed_after_death_counted_when_task_object_available(self, tmp_path: Path) -> None:
+        """Regression for D2 claude/attempt1-tools-zero (2026-07-02): a task
+        that was auto-completed after its agent died (result_summary
+        written by agent_lifecycle.py's orphan-handling path) must be
+        classified as TERMINATOR_AUTO_COMPLETED_AFTER_DEATH and must force
+        the verdict to UNHEALTHY, never silently folded into a healthy
+        "0 auto-completed" count."""
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        done = [
+            _make_task(
+                id="mgr-orphan-1",
+                status="done",
+                result_summary="Auto-completed after agent sess-1 died; janitor passed",
+            )
+        ]
+        generate_retrospective(
+            done_tasks=done,
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 53,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "**Verdict:** UNHEALTHY" in content
+        assert "Auto-completed after agent death | 1" in content
+        assert "No issues detected; run looks healthy." not in content
+
+
+class TestRetrospectiveRegeneration:
+    """Regression for the A5 stale-retrospective bug: a canary run's
+    retrospective reported "100% completion, HEALTHY" at T+58s (generated
+    right after the manager's own task finished), and 2 of the run's 3
+    total tasks subsequently failed (janitor-rejected) without the report
+    ever being regenerated. The fix requires that (1) a mid-run generation
+    is labeled INTERIM and (2) a later "shutdown-final" generation for the
+    same retrospective.md path always overwrites it with the true final
+    state, never leaving the stale HEALTHY snapshot in place."""
+
+    def test_final_generation_overwrites_stale_mid_run_healthy_snapshot(self, tmp_path: Path) -> None:
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        runtime_dir = tmp_path / "runtime"
+
+        # T+58s: manager task alone has finished. Mid-run heuristic fires
+        # with only the 1 completed task visible - 100%/HEALTHY.
+        manager_task = _make_task(id="mgr-1", title="Decompose goal", role="manager", status="done")
+        generate_retrospective(
+            done_tasks=[manager_task],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=runtime_dir,
+            run_start_ts=time.time() - 58,
+            trigger_reason="mid-run",
+        )
+        interim_content = (runtime_dir / "retrospective.md").read_text()
+        assert "INTERIM" in interim_content
+        assert "**Verdict:** HEALTHY" in interim_content
+        assert "**Completion rate:** 100% (1 done / 1 total)" in interim_content
+
+        # T+3min: the 2 child tasks (backend, qa) subsequently fail
+        # (janitor-rejected). True orchestrator shutdown regenerates the
+        # retrospective with the FINAL task lists, overwriting the stale
+        # snapshot above.
+        backend_task = _make_task(
+            id="backend-1",
+            title="Add hello subcommand to cli.py",
+            role="backend",
+            status="failed",
+            result_summary="Agent backend-1 died; janitor failed: ['test_passes: ...']",
+        )
+        qa_task = _make_task(
+            id="qa-1",
+            title="Add test for hello subcommand",
+            role="qa",
+            status="failed",
+            result_summary="Agent qa-1 died; janitor failed: ['test_passes: ...']",
+        )
+        generate_retrospective(
+            done_tasks=[manager_task],
+            failed_tasks=[backend_task, qa_task],
+            collector=collector,
+            runtime_dir=runtime_dir,
+            run_start_ts=time.time() - 180,
+        )
+        final_content = (runtime_dir / "retrospective.md").read_text()
+
+        # The stale HEALTHY snapshot must be gone, not merely appended to.
+        assert "INTERIM" not in final_content
+        assert "**Verdict:** UNHEALTHY" in final_content
+        assert "**Completion rate:** 33% (1 done / 3 total)" in final_content
+        assert "**Failed tasks:** 2" in final_content
+        assert "Add hello subcommand to cli.py" in final_content
+        assert "Add test for hello subcommand" in final_content
+        assert "No issues detected; run looks healthy." not in final_content
+
+    def test_mid_run_generation_is_labeled_interim(self, tmp_path: Path) -> None:
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        generate_retrospective(
+            done_tasks=[_make_task(id="T-1")],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 10,
+            trigger_reason="mid-run",
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "INTERIM" in content
+        assert "mid-run" in content
+
+    def test_shutdown_final_generation_has_no_interim_label(self, tmp_path: Path) -> None:
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        generate_retrospective(
+            done_tasks=[_make_task(id="T-1")],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 10,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "INTERIM" not in content
+
+
+class TestUnresolvedMetricsEntry:
+    def test_unresolved_metrics_entry_reconciles_into_failed_count(self, tmp_path: Path) -> None:
+        """A task_metrics entry the collector started but that never reached
+        done_tasks/failed_tasks nor collector.complete_task() (end_time is
+        None) must be counted as failed/unresolved rather than silently
+        dropped -- this is the generalised proxy for both the auto-complete-
+        after-death and stale-snapshot failure modes when no Task object
+        with result_summary text is available at all."""
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        collector.start_task("orphan-task-1", "manager", "claude-sonnet-5", "claude")
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 53,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "**Failed tasks:** 1" in content
+        assert "**Verdict:** UNHEALTHY" in content
+        assert "Unresolved in metrics (started, outcome never reconciled) | 1" in content
+
+
+class TestPersistedCostReconciliation:
+    """Cover the retrospective's cross-check against the durable
+    .sdd/metrics/tasks.jsonl sidecar (see _read_persisted_task_costs).
+
+    Ground truth: orphan-recovery fold-ins (agent_lifecycle.py
+    orphan_cost_folded_in) can land in the persisted sidecar without ever
+    reaching the in-memory MetricsCollector's task_metrics entry for that
+    task_id by the time generate_retrospective() is called -- the
+    retrospective must not silently report $0 in that case.
+    """
+
+    def _write_sidecar(self, tmp_path: Path, rows: list[dict[str, object]]) -> None:
+        metrics_dir = tmp_path / "metrics"
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        sidecar = metrics_dir / "tasks.jsonl"
+        with sidecar.open("w") as f:
+            for row in rows:
+                f.write(json.dumps(row) + "\n")
+
+    def test_zero_in_memory_cost_reconciled_from_sidecar(self, tmp_path: Path) -> None:
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        # Task started via start_task() (as agent_lifecycle.py does at spawn
+        # time) but its cost was never folded into the collector -- cost_usd
+        # stays at the dataclass default of 0.0.
+        collector.start_task("T-orphan", "qa", "MiniMax-M2.7-highspeed", "openai_agents")
+        # But the durable sidecar (written by the evolution aggregator from
+        # the orphan/auto-complete path) DOES have the real recorded cost.
+        self._write_sidecar(tmp_path, [{"task_id": "T-orphan", "cost_usd": 0.009851}])
+
+        done = [_make_task(id="T-orphan", role="qa", status="failed")]
+        generate_retrospective(
+            done_tasks=[],
+            failed_tasks=done,
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 30,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "**Total cost:** $0.0099" in content
+
+    def test_no_sidecar_file_does_not_crash(self, tmp_path: Path) -> None:
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        collector.start_task("T-1", "backend", "claude-sonnet-5", "claude")
+        generate_retrospective(
+            done_tasks=[_make_task(id="T-1")],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 10,
+        )
+        retro = tmp_path / "runtime" / "retrospective.md"
+        assert retro.exists()
+        assert "**Total cost:** $0.0000" in retro.read_text()
+
+    def test_nonzero_in_memory_cost_not_overwritten_by_sidecar(self, tmp_path: Path) -> None:
+        """If the collector already has a real recorded cost for a task,
+        the sidecar cross-check must not clobber it (only $0.0 entries are
+        eligible for reconciliation)."""
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        m = collector.start_task("T-1", "backend", "claude-sonnet-5", "claude")
+        m.end_time = m.start_time + 5.0
+        m.success = True
+        m.cost_usd = 0.05
+        # Sidecar disagrees (e.g. stale/partial write) -- in-memory wins
+        # because it is non-zero.
+        self._write_sidecar(tmp_path, [{"task_id": "T-1", "cost_usd": 999.0}])
+
+        generate_retrospective(
+            done_tasks=[_make_task(id="T-1")],
+            failed_tasks=[],
+            collector=collector,
+            runtime_dir=tmp_path / "runtime",
+            run_start_ts=time.time() - 10,
+        )
+        content = (tmp_path / "runtime" / "retrospective.md").read_text()
+        assert "**Total cost:** $0.0500" in content
+
+    def test_cost_aggregation_log_line_emitted(self, tmp_path: Path, caplog: object) -> None:
+        import logging
+
+        collector = MetricsCollector(metrics_dir=tmp_path / "metrics")
+        collector.start_task("T-orphan", "qa", "MiniMax-M2.7-highspeed", "openai_agents")
+        self._write_sidecar(tmp_path, [{"task_id": "T-orphan", "cost_usd": 0.009851}])
+
+        with caplog.at_level(logging.INFO, logger="bernstein.core.quality.retrospective"):  # type: ignore[attr-defined]
+            generate_retrospective(
+                done_tasks=[],
+                failed_tasks=[_make_task(id="T-orphan", role="qa", status="failed")],
+                collector=collector,
+                runtime_dir=tmp_path / "runtime",
+                run_start_ts=time.time() - 30,
+            )
+        messages = [r.message for r in caplog.records]  # type: ignore[attr-defined]
+        assert any(m.startswith("retrospective_cost_aggregation: source=") for m in messages)
+        assert any("reconciled_from_sidecar=1" in m for m in messages)

--- a/tests/unit/test_retry_or_fail_task.py
+++ b/tests/unit/test_retry_or_fail_task.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock
 
 import httpx
@@ -22,9 +23,9 @@ class MockTaskType:
 
 
 class MockTask:
-    def __init__(self, task_id, description=""):
+    def __init__(self, task_id, description="", title="Test Task"):
         self.id = task_id
-        self.title = "Test Task"
+        self.title = title
         self.description = description
         self.role = "backend"
         self.priority = 1
@@ -102,3 +103,250 @@ def test_retry_or_fail_task_permanent(retry_func):
     # Actually fail_task does a PUT or POST to fail it. Let's just check that `task_body` wasn't posted to `/tasks`.
     call_args = mock_client.post.call_args_list
     assert not any(call[0][0].endswith("/tasks") for call in call_args)
+
+
+# ---------------------------------------------------------------------------
+# Auto-spawn guard regression tests.
+#
+# Root cause: retry_or_fail_task is a SECOND spawn site for auto-spawned
+# meta-tasks (evolution-loop "Upgrade: ..." proposals, watchdog
+# "Watchdog triage: ..." tasks) that completely bypassed AutoSpawnGuard --
+# only the CREATION-time call sites (orchestrator_evolve, watchdog) consulted
+# the guard. See work/bernstein/proofs/d2/minimax/sdd-snapshot/runtime/
+# tasks.jsonl (attempt-3 evidence): a single "Upgrade: Improve task success
+# rate" proposal recreated itself twice more via THIS function
+# (b66d312a1b4c -> b711648c45a0 -> 4e816f62948b), never touching the guard.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_retry_of_meta_task_is_suppressed_by_ancestry_cap(retry_func, tmp_path):
+    """(ii) Ancestry cap: retrying a task whose OWN title already carries a
+    known meta-task prefix ("Upgrade:") is a depth-2 auto-spawn (a meta-task
+    about itself) and must be refused -- the task is routed straight to
+    permanent failure instead of a new task row being POSTed to /tasks.
+    This is the "grandchild" auto-spawn the ancestry cap exists to block:
+    without it, a structurally-unsolvable meta-task recreates itself up to
+    max_retries times with zero forward progress.
+    """
+    mock_client = MagicMock(spec=httpx.Client)
+
+    task = MockTask("meta-1", title="Upgrade: Improve task success rate")
+    tasks_snapshot = {"active": [task]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="meta-1",
+        reason="Agent backend-abc died; no completion signals and no files modified",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+        workdir=tmp_path,
+    )
+
+    # No new "Upgrade: ..." task row was created via POST /tasks.
+    post_calls = mock_client.post.call_args_list
+    assert not any(call[0][0].endswith("/tasks") for call in post_calls), (
+        f"retry of a meta-task must not recreate it via POST /tasks, got: {post_calls}"
+    )
+    # It was routed to permanent failure instead.
+    assert any(call[0][0].endswith("/meta-1/fail") for call in post_calls), (
+        f"expected a /tasks/meta-1/fail call, got: {post_calls}"
+    )
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_retry_of_non_meta_task_is_unaffected_by_guard(retry_func, tmp_path):
+    """Control: an ordinary (non meta-task) retry is unaffected by the guard
+    even when a workdir is supplied -- the guard only intercepts titles
+    matching a known auto-spawn prefix."""
+    mock_client = MagicMock(spec=httpx.Client)
+
+    task = MockTask("normal-1", title="Implement hello subcommand in cli.py")
+    tasks_snapshot = {"active": [task]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="normal-1",
+        reason="Agent backend-abc died; no completion signals and no files modified",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+        workdir=tmp_path,
+    )
+
+    post_calls = mock_client.post.call_args_list
+    assert any(call[0][0].endswith("/tasks") for call in post_calls)
+
+
+def test_retry_of_meta_task_logs_info_refusal_line(caplog):
+    """(iii) The refusal must be logged at INFO with the reason and ancestry
+    depth -- logging IS the debugging interface, per team convention."""
+    mock_client = MagicMock(spec=httpx.Client)
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        task = MockTask("meta-2", title="Upgrade: Improve task success rate")
+        tasks_snapshot = {"active": [task]}
+        retried_ids: set[str] = set()
+
+        with caplog.at_level(logging.INFO):
+            retry_lifecycle(
+                task_id="meta-2",
+                reason="Agent backend-xyz died; no completion signals and no files modified",
+                client=mock_client,
+                server_url="http://test",
+                max_task_retries=3,
+                retried_task_ids=retried_ids,
+                tasks_snapshot=tasks_snapshot,
+                workdir=Path(tmp),
+            )
+
+    messages = [r.getMessage() for r in caplog.records]
+    refusal_lines = [m for m in messages if "Refusing to re-spawn meta-task" in m]
+    assert refusal_lines, f"expected a refusal log line, got: {messages}"
+    assert any("reason=depth" in m and "ancestry_depth=2" in m for m in refusal_lines)
+    # The guard's own uniform decision line must also be present.
+    assert any("auto_spawn_decision" in m for m in messages)
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_retry_of_meta_task_without_workdir_falls_back_to_legacy_behavior(retry_func):
+    """Callers that omit workdir (ad-hoc scripts, legacy tests) keep the
+    historical unguarded retry behaviour -- the guard requires a workdir to
+    persist its cap counter."""
+    mock_client = MagicMock(spec=httpx.Client)
+
+    task = MockTask("meta-3", title="Upgrade: Improve task success rate")
+    tasks_snapshot = {"active": [task]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="meta-3",
+        reason="Agent backend-abc died; no completion signals and no files modified",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+        # workdir intentionally omitted
+    )
+
+    post_calls = mock_client.post.call_args_list
+    assert any(call[0][0].endswith("/tasks") for call in post_calls)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 (2026-07-02, fix/claim-conflict-churn): hard retry-count cap for
+# REGULAR (non-meta) task lineages.
+#
+# Root cause: with task.max_retries=3 and a "died" (transient) failure
+# reason resolving dynamic_limit to 3, retry_or_fail_task allowed retry_count
+# to climb 0 -> 1 -> 2 -> 3 before permanent failure -- 4 total attempts.
+# Evidence (work/bernstein/proofs/d2/claim-loop-evidence/d2-minimax-final-snap.tar,
+# tasks.jsonl) showed "Add test for hello subcommand" and "Commit changes on
+# feature branch" each respawning 3x inside one 12-minute run with zero
+# forward progress (every agent died for the same underlying reason). The
+# fix caps the effective retry ceiling at 2 (3 total attempts) for every
+# task lineage, independent of task.max_retries / the reason-derived
+# dynamic_limit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_regular_task_retry_capped_at_two_then_permanent_fail(retry_func):
+    """A non-meta task with retry_count already at 2 (its 3rd attempt just
+    failed) must be permanently failed, not retried a 4th time -- even
+    though task.max_retries=3 and the failure reason is transient (which
+    would otherwise raise dynamic_limit to 3, allowing one more retry)."""
+    mock_client = MagicMock(spec=httpx.Client)
+
+    task = MockTask("regular-1", title="Commit changes on feature branch")
+    task.retry_count = 2  # already retried twice (0 -> 1 -> 2)
+    task.max_retries = 3  # would normally allow one more retry
+    tasks_snapshot = {"active": [task]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="regular-1",
+        reason="Agent devops-abc died; janitor failed: ['test_passes: git log --oneline -1 | grep -q hello']",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+    )
+
+    post_calls = mock_client.post.call_args_list
+    # No new task row created -- the lineage must not respawn a 4th time.
+    assert not any(call[0][0].endswith("/tasks") for call in post_calls), (
+        f"expected no retry POST /tasks once the hard cap is reached, got: {post_calls}"
+    )
+    # Routed to permanent failure instead.
+    assert any(call[0][0].endswith("/regular-1/fail") for call in post_calls), (
+        f"expected a /tasks/regular-1/fail call, got: {post_calls}"
+    )
+
+
+@pytest.mark.parametrize("retry_func", [retry_lifecycle, retry_completion])
+def test_regular_task_retry_allowed_below_hard_cap(retry_func):
+    """Control: a task with retry_count=1 (2nd attempt just failed) is still
+    under the hard cap of 2 and gets one more retry."""
+    mock_client = MagicMock(spec=httpx.Client)
+
+    task = MockTask("regular-2", title="Add test for hello subcommand")
+    task.retry_count = 1
+    task.max_retries = 3
+    tasks_snapshot = {"active": [task]}
+    retried_ids: set[str] = set()
+
+    retry_func(
+        task_id="regular-2",
+        reason="Agent qa-abc died; janitor failed: ['test_passes: pytest test_cli.py -k hello']",
+        client=mock_client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=retried_ids,
+        tasks_snapshot=tasks_snapshot,
+    )
+
+    post_calls = mock_client.post.call_args_list
+    assert any(call[0][0].endswith("/tasks") for call in post_calls), (
+        f"expected one more retry POST /tasks under the hard cap, got: {post_calls}"
+    )
+
+
+def test_retry_cap_decision_is_logged_with_original_task_id(caplog):
+    """LOG every retry decision: original task id, attempt number, reason, verdict."""
+    mock_client = MagicMock(spec=httpx.Client)
+
+    task = MockTask("regular-3", title="Commit changes on feature branch")
+    task.retry_count = 2
+    task.max_retries = 3
+    task.metadata = {"original_task_id": "orig-root-task"}
+    tasks_snapshot = {"active": [task]}
+    retried_ids: set[str] = set()
+
+    with caplog.at_level(logging.INFO):
+        retry_lifecycle(
+            task_id="regular-3",
+            reason="Agent devops-abc died",
+            client=mock_client,
+            server_url="http://test",
+            max_task_retries=3,
+            retried_task_ids=retried_ids,
+            tasks_snapshot=tasks_snapshot,
+        )
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("retry_or_fail_task decision inputs" in m and "orig-root-task" in m for m in messages), (
+        f"expected a decision-inputs log line with the original_task_id, got: {messages}"
+    )
+    assert any("verdict=permanent_fail" in m and "orig-root-task" in m for m in messages), (
+        f"expected a permanent_fail verdict log line, got: {messages}"
+    )

--- a/tests/unit/test_run_cmd_track_b.py
+++ b/tests/unit/test_run_cmd_track_b.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+from bernstein.cli.run_bootstrap import _signal_orchestrator_shutdown
 from bernstein.cli.run_cmd import (
     RunCostEstimate,
     _emit_preflight_runtime_warnings,
@@ -75,10 +76,80 @@ def test_wait_for_run_completion_returns_quiescent_status() -> None:
         patch("bernstein.cli.run_bootstrap.server_get", side_effect=_fake_server_get),
         patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
         patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown") as shutdown_signal,
     ):
         result = _wait_for_run_completion(timeout_s=5.0)
 
     assert result == {"total": 2, "open": 0, "claimed": 0}
+    # Defect-3 fix: completion detection must invoke the belt-and-braces
+    # shutdown signal exactly once, as a backstop to the orchestrator's own
+    # quiescence self-stop.
+    shutdown_signal.assert_called_once()
+
+
+def test_wait_for_run_completion_timeout_does_not_signal_shutdown() -> None:
+    """If quiescence is never observed (timeout), no shutdown signal should fire --
+    we only know completion happened when total > 0 and open == claimed == 0."""
+    clock = {"now": 0.0}
+
+    def _fake_time() -> float:
+        clock["now"] += 10.0
+        return clock["now"]
+
+    with (
+        patch("bernstein.cli.run_bootstrap.server_get", return_value={"total": 2, "open": 1, "claimed": 0}),
+        patch("bernstein.cli.run_bootstrap.time.sleep", return_value=None),
+        patch("bernstein.cli.run_bootstrap.time.time", side_effect=_fake_time),
+        patch("bernstein.cli.run_bootstrap._signal_orchestrator_shutdown") as shutdown_signal,
+    ):
+        _wait_for_run_completion(timeout_s=5.0)
+
+    shutdown_signal.assert_not_called()
+
+
+def test_signal_orchestrator_shutdown_posts_to_shutdown_endpoint() -> None:
+    """Happy path: orchestrator still up, POST /shutdown is sent and acknowledged."""
+    fake_response = type(
+        "FakeResponse",
+        (),
+        {
+            "status_code": 200,
+            "content": b'{"status": "shutting_down"}',
+            "json": lambda self: {"status": "shutting_down"},
+            "raise_for_status": lambda self: None,
+        },
+    )()
+
+    with patch("bernstein.cli.run_bootstrap.httpx.post", return_value=fake_response) as post:
+        _signal_orchestrator_shutdown(reason="test")
+
+    post.assert_called_once()
+    called_kwargs = post.call_args.kwargs
+    assert called_kwargs["json"] == {"reason": "test"}
+
+
+def test_signal_orchestrator_shutdown_treats_connection_refused_as_success() -> None:
+    """The orchestrator's own quiescence self-stop may already have torn the
+    server down by the time the CLI signals -- connection-refused must be
+    logged and treated as success, never raised."""
+    import httpx
+
+    with patch("bernstein.cli.run_bootstrap.httpx.post", side_effect=httpx.ConnectError("refused")):
+        # Must not raise.
+        _signal_orchestrator_shutdown(reason="test")
+
+
+def test_signal_orchestrator_shutdown_treats_404_as_success() -> None:
+    """A 404 (route torn down after self-stop) is also treated as success."""
+    fake_response = type(
+        "FakeResponse",
+        (),
+        {"status_code": 404, "content": b"", "json": lambda self: None, "raise_for_status": lambda self: None},
+    )()
+
+    with patch("bernstein.cli.run_bootstrap.httpx.post", return_value=fake_response):
+        # Must not raise.
+        _signal_orchestrator_shutdown(reason="test")
 
 
 def test_finalize_run_output_quiet_uses_summary_only() -> None:

--- a/tests/unit/test_seed_parser_mutation_kill.py
+++ b/tests/unit/test_seed_parser_mutation_kill.py
@@ -27,6 +27,8 @@ from bernstein.core.config.seed_parser import (
     _parse_network_config,  # pyright: ignore[reportPrivateUsage]
     _parse_rate_limit_bucket,  # pyright: ignore[reportPrivateUsage]
     _parse_rate_limit_config,  # pyright: ignore[reportPrivateUsage]
+    _parse_role_model_policy,  # pyright: ignore[reportPrivateUsage]
+    _parse_single_role_policy,  # pyright: ignore[reportPrivateUsage]
     _parse_string_list,  # pyright: ignore[reportPrivateUsage]
     _parse_team,  # pyright: ignore[reportPrivateUsage]
     _parse_tenants,  # pyright: ignore[reportPrivateUsage]
@@ -724,3 +726,51 @@ def test_parse_network_config_empty_dict_yields_empty_allowed_ips() -> None:
     cfg = _parse_network_config({})
     assert isinstance(cfg, NetworkConfig)
     assert cfg.allowed_ips == ()
+
+
+# ---------------------------------------------------------------------------
+# role_model_policy.<role>.max_tokens (D2 OpenRouter KILL-NOTE regression):
+# a seed file setting this key used to be rejected at parse time with
+# "unknown keys: max_tokens" because _ROLE_POLICY_KEYS never listed it even
+# though config_schema.py's RoleModelPolicyEntry and the spawner fold both
+# already supported it (parser/schema divergence). Pin that it now parses
+# and lands correctly typed (as an int, not a string) on the normalized
+# role-policy dict that flows into AgentSpawner.role_model_policy.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_single_role_policy_accepts_max_tokens() -> None:
+    """A role policy with max_tokens=8000 must parse, not raise SeedError."""
+    normalized = _parse_single_role_policy("adversary", {"provider": "openai_agents", "max_tokens": 8000})
+    assert normalized["max_tokens"] == 8000
+    assert isinstance(normalized["max_tokens"], int)
+    assert not isinstance(normalized["max_tokens"], bool)
+    assert normalized["provider"] == "openai_agents"
+
+
+def test_parse_single_role_policy_max_tokens_only() -> None:
+    """max_tokens alone (no other keys) is a valid, minimal role policy."""
+    normalized = _parse_single_role_policy("backend", {"max_tokens": 4096})
+    assert normalized == {"max_tokens": 4096}
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, "8000", 3.5, True])
+def test_parse_single_role_policy_rejects_invalid_max_tokens(bad_value: object) -> None:
+    """max_tokens must be a positive int - not zero/negative/string/float/bool."""
+    with pytest.raises(SeedError, match="max_tokens.*positive integer"):
+        _parse_single_role_policy("qa", {"max_tokens": bad_value})
+
+
+def test_parse_role_model_policy_max_tokens_round_trip() -> None:
+    """Full role_model_policy section with max_tokens round-trips through
+    the public entry point _parse_role_model_policy (what the seed loader
+    actually calls), matching the seed-file shape from the KILL-NOTE:
+    ``role_model_policy: {adversary: {provider: openai_agents, max_tokens: 8000}}``.
+    """
+    parsed = _parse_role_model_policy(
+        {"adversary": {"provider": "openai_agents", "model": "deepseek/deepseek-chat", "max_tokens": 8000}}
+    )
+    assert parsed is not None
+    assert parsed["adversary"]["max_tokens"] == 8000
+    assert parsed["adversary"]["provider"] == "openai_agents"
+    assert parsed["adversary"]["model"] == "deepseek/deepseek-chat"

--- a/tests/unit/test_skills_injector.py
+++ b/tests/unit/test_skills_injector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from bernstein.core.models import Task
@@ -216,6 +217,163 @@ class TestInjectSkills:
             assert "name:" in content, f"{skill_file.name} missing 'name' field"
             assert "description:" in content, f"{skill_file.name} missing 'description' field"
             assert "whenToUse:" in content, f"{skill_file.name} missing 'whenToUse' field"
+
+
+class TestGitExcludeRegistration:
+    """Injected skills must be excluded from git so agents never commit them.
+
+    See https://github.com/sipyourdrink-ltd/bernstein/issues/2187 - every
+    worker's rendered copy differs (session id, task ids), so committing
+    them causes a merge conflict on every worker merge back to the shared
+    work branch.
+    """
+
+    def _make_skills_dir(self, tmp_path: Path) -> Path:
+        skills_dir = tmp_path / "templates" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "bernstein-completion-protocol.md").write_text(
+            "---\nname: bernstein-completion-protocol\n"
+            "description: Report task completion\n"
+            "whenToUse: When finished\n---\n"
+            "Complete tasks: {{COMPLETE_CMDS}}\n",
+            encoding="utf-8",
+        )
+        (skills_dir / "bernstein-signal-check.md").write_text(
+            "---\nname: bernstein-signal-check\n"
+            "description: Check signals\n"
+            "whenToUse: Periodically\n---\n"
+            "Signals at {{SESSION_ID}}\n",
+            encoding="utf-8",
+        )
+        return tmp_path / "templates" / "roles"
+
+    def _init_git_repo(self, path: Path) -> None:
+        subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+
+    def test_injection_adds_exclude_entries(self, tmp_path: Path) -> None:
+        templates_dir = self._make_skills_dir(tmp_path)
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        self._init_git_repo(workdir)
+
+        inject_skills(
+            workdir=workdir,
+            role="docs",
+            tasks=[],
+            session_id="s-1",
+            templates_dir=templates_dir,
+        )
+
+        exclude_file = workdir / ".git" / "info" / "exclude"
+        assert exclude_file.exists()
+        content = exclude_file.read_text()
+        assert ".claude/skills/bernstein-completion-protocol.md" in content
+        assert ".claude/skills/bernstein-signal-check.md" in content
+
+    def test_reinjection_does_not_duplicate_exclude_entries(self, tmp_path: Path) -> None:
+        templates_dir = self._make_skills_dir(tmp_path)
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        self._init_git_repo(workdir)
+
+        for session in ("s-1", "s-2"):
+            inject_skills(
+                workdir=workdir,
+                role="docs",
+                tasks=[],
+                session_id=session,
+                templates_dir=templates_dir,
+            )
+
+        exclude_file = workdir / ".git" / "info" / "exclude"
+        content = exclude_file.read_text()
+        assert content.count(".claude/skills/bernstein-completion-protocol.md") == 1
+        assert content.count(".claude/skills/bernstein-signal-check.md") == 1
+
+    def test_works_when_git_is_a_gitfile_worktree(self, tmp_path: Path) -> None:
+        """In a git worktree, ``.git`` is a file pointing at the real gitdir."""
+        templates_dir = self._make_skills_dir(tmp_path)
+        main_repo = tmp_path / "main-repo"
+        main_repo.mkdir()
+        self._init_git_repo(main_repo)
+        (main_repo / "README.md").write_text("hello\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=main_repo, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=main_repo, check=True)
+
+        worktree_path = tmp_path / "agent-worktree"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "agent-branch", str(worktree_path)],
+            cwd=main_repo,
+            check=True,
+        )
+
+        assert (worktree_path / ".git").is_file(), "worktree .git must be a gitfile, not a dir"
+
+        inject_skills(
+            workdir=worktree_path,
+            role="docs",
+            tasks=[],
+            session_id="s-worktree",
+            templates_dir=templates_dir,
+        )
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-path", "info/exclude"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        exclude_file = Path(result.stdout.strip())
+        if not exclude_file.is_absolute():
+            exclude_file = worktree_path / exclude_file
+
+        assert exclude_file.exists()
+        content = exclude_file.read_text()
+        assert ".claude/skills/bernstein-completion-protocol.md" in content
+        # `info/exclude` is repo-wide, resolved via the main repo's real
+        # gitdir rather than a naively-assumed `worktree_path/.git/info/exclude`
+        # (which does not exist - `.git` in a worktree is a file, not a dir).
+        assert str(exclude_file) != str(worktree_path / ".git" / "info" / "exclude")
+        assert not (worktree_path / ".git").is_dir()
+
+    def test_injected_skills_still_readable_after_exclusion(self, tmp_path: Path) -> None:
+        templates_dir = self._make_skills_dir(tmp_path)
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        self._init_git_repo(workdir)
+
+        inject_skills(
+            workdir=workdir,
+            role="docs",
+            tasks=[],
+            session_id="s-1",
+            templates_dir=templates_dir,
+        )
+
+        skill_file = workdir / ".claude" / "skills" / "bernstein-completion-protocol.md"
+        assert skill_file.exists()
+        assert "Complete tasks" in skill_file.read_text()
+
+    def test_non_git_workdir_does_not_raise(self, tmp_path: Path) -> None:
+        """Missing git repo must not block skill injection (best-effort)."""
+        templates_dir = self._make_skills_dir(tmp_path)
+        workdir = tmp_path / "workdir"
+        workdir.mkdir()
+        # Deliberately not a git repo.
+
+        inject_skills(
+            workdir=workdir,
+            role="docs",
+            tasks=[],
+            session_id="s-1",
+            templates_dir=templates_dir,
+        )
+
+        assert (workdir / ".claude" / "skills" / "bernstein-completion-protocol.md").exists()
+        assert not (workdir / ".git").exists()
 
 
 class TestRoleSkillMap:

--- a/tests/unit/test_slo.py
+++ b/tests/unit/test_slo.py
@@ -41,6 +41,45 @@ def test_error_budget_remediation() -> None:
     assert tracker.error_budget.status == SLOStatus.RED
 
 
+def test_error_budget_floor_defaults_to_three() -> None:
+    """Regression test: budget_total floor is tunable, default unchanged at 3."""
+    from bernstein.core import defaults
+    from bernstein.core.observability.slo import ErrorBudget
+
+    defaults.reset()
+    budget = ErrorBudget(total_tasks=10, failed_tasks=0)
+    assert budget.budget_total == 3
+
+
+def test_error_budget_floor_honors_tuning_override() -> None:
+    """tuning.slo.error_budget_min_failures raises the tolerated-failure floor (#run5 audit)."""
+    from bernstein.core import defaults
+    from bernstein.core.observability.slo import ErrorBudget
+
+    defaults.override("slo", {"error_budget_min_failures": 20})
+    try:
+        budget = ErrorBudget(total_tasks=10, failed_tasks=10)
+        assert budget.budget_total == 20
+        assert not budget.is_depleted
+    finally:
+        defaults.reset()
+
+
+def test_error_budget_floor_clamps_negative_override() -> None:
+    """A misconfigured negative error_budget_min_failures must not suppress the
+    SLO-target-derived budget below what an unset floor would allow."""
+    from bernstein.core import defaults
+    from bernstein.core.observability.slo import ErrorBudget
+
+    defaults.override("slo", {"error_budget_min_failures": -5})
+    try:
+        budget = ErrorBudget(total_tasks=10, failed_tasks=0)
+        # round(10 * (1 - 0.90)) == 1, clamped floor of 0 must not pull this below 1.
+        assert budget.budget_total == 1
+    finally:
+        defaults.reset()
+
+
 def test_slo_tracker_update_from_collector() -> None:
     """Test updating SLO values from metrics collector."""
     tracker = SLOTracker()

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -354,6 +354,27 @@ class TestSpawnerWithRouter:
         assert session.provider == "test_provider"
         assert session.pid == 300
 
+    def test_router_selection_is_logged(
+        self, tmp_path: Path, make_task, mock_adapter_factory, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Logging gap: a successful router decision (provider + model chosen
+        for a task) was silent -- only the skip/fallback paths logged. Assert
+        the routing decision (inputs: role; output: provider/model) is
+        visible from the log alone."""
+        caplog.set_level("INFO", logger="bernstein.core.agents.spawner_core")  # actual module for the alias
+        adapter = mock_adapter_factory(pid=300)
+        adapter.name.return_value = "claude"
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        router = _make_router()
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False)
+
+        task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
+        spawner.spawn_for_tasks([task])
+
+        messages = [r.message for r in caplog.records]
+        assert any("Router selected provider" in m and "provider=test_provider" in m for m in messages), messages
+
     def test_router_skipped_for_non_claude_adapter(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
         """Router is skipped when adapter is not Claude-compatible (e.g. qwen, gemini).
 
@@ -498,6 +519,79 @@ class TestSpawnerWithRouter:
         assert session.provider == "codex"
         assert session.model_config.model == "openai/gpt-5.4-mini"
         assert session.pid == 777
+
+    def _pinned_spawner(self, tmp_path: Path, mock_adapter_factory) -> tuple[AgentSpawner, Any]:
+        """Spawner with a role_model_policy-pinned backend model (bug-10 harness)."""
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        pinned_adapter = mock_adapter_factory(pid=888)
+        pinned_adapter.name.return_value = "openai_agents"
+        # The real ``openai_agents`` adapter declares SUPPORTS_SAMPLING_PARAMS
+        # (see OpenAIAgentsAdapter.plugin_info in src/bernstein/adapters/
+        # openai_agents.py). _primary_adapter_supports_sampling now probes the
+        # REAL registry-resolved adapter class for an uncached, non-primary
+        # provider name (max-tokens-config fix) - so this mock must declare
+        # the same capability its claimed identity has, or the mode-profile
+        # sampling fold's default temperature gets refused by this mock at
+        # spawn time even though the real adapter it stands in for would
+        # honour it.
+        # ``plugin_info`` is not part of CLIAdapter's spec (it's a
+        # PluginAdapter-only method), so it must be assigned directly rather
+        # than via ``.plugin_info.return_value = ...`` (attribute access
+        # first, which the spec would reject).
+        pinned_adapter.plugin_info = MagicMock(
+            return_value=AdapterPluginInfo(
+                name="openai_agents",
+                version="1.0.0",
+                capabilities=(AdapterCapability.SUPPORTS_SAMPLING_PARAMS,),
+            )
+        )
+        spawner = AgentSpawner(
+            mock_adapter_factory(pid=123),
+            templates_dir,
+            tmp_path,
+            role_model_policy={"backend": {"provider": "openai_agents", "model": "MiniMax-M3"}},
+            use_worktrees=False,
+        )
+        return spawner, pinned_adapter
+
+    def test_retry_tier_stamp_does_not_override_operator_model(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Regression (run-9 attempt-8): retry escalation stamped task.model="opus",
+        which shadowed the operator-pinned MiniMax-M3 and produced a spawn with
+        model=opus against the MiniMax endpoint (400 "unknown model 'opus'").
+        A tier-named task.model is an escalation label, not an operator pin."""
+        spawner, pinned_adapter = self._pinned_spawner(tmp_path, mock_adapter_factory)
+        task = make_task(role="backend")
+        task.model = "opus"
+        task.retry_count = 1
+        with patch.object(spawner, "_get_adapter_by_name", return_value=pinned_adapter):
+            session = spawner.spawn_for_tasks([task])
+        assert session.model_config.model == "MiniMax-M3"
+
+    def test_pinned_tier_model_still_wins_over_role_policy(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """metadata["pinned_model"] marks a tier name as a genuine pin (ab-test)."""
+        spawner, pinned_adapter = self._pinned_spawner(tmp_path, mock_adapter_factory)
+        task = make_task(role="backend")
+        task.model = "opus"
+        task.metadata = {"pinned_model": True}
+        with patch.object(spawner, "_get_adapter_by_name", return_value=pinned_adapter):
+            session = spawner.spawn_for_tasks([task])
+        assert session.model_config.model != "MiniMax-M3"
+
+    def test_non_tier_task_model_still_wins_over_role_policy(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """A concrete (non-tier) task.model is a genuine pin and beats role policy."""
+        spawner, pinned_adapter = self._pinned_spawner(tmp_path, mock_adapter_factory)
+        task = make_task(role="backend")
+        task.model = "MiniMax-M2.7-highspeed"
+        with patch.object(spawner, "_get_adapter_by_name", return_value=pinned_adapter):
+            session = spawner.spawn_for_tasks([task])
+        assert session.model_config.model != "MiniMax-M3"
 
     def test_per_step_cli_overrides_default_adapter(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
         """Task.cli (per-step `cli:` from plan YAML) drives adapter selection,
@@ -689,6 +783,81 @@ class TestNonClaudeAdapterModelCoercionGuard:
         task.metadata = {"pinned_model": True}
         session = spawner.spawn_for_tasks([task])
 
+        assert session.model_config.model == "opus"
+
+
+# --- Provider-only role_model_policy coercion (issue: role_policy pins a
+# provider but no model; tier-stamped model still leaked through because
+# ``provider_name`` was non-None, which short-circuited the coercion guard
+# above -- the guard's ``provider_name is None`` condition assumed the only
+# way to get a non-Claude adapter was via ``self._adapter`` itself) ---
+
+
+class TestProviderOnlyRolePolicyCoercionGuard:
+    def _pinned_provider_spawner(
+        self, tmp_path: Path, mock_adapter_factory, *, default_model: str | None
+    ) -> tuple[AgentSpawner, Any]:
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True, exist_ok=True)
+        default_adapter = mock_adapter_factory(pid=1)
+        default_adapter.name.return_value = "claude"
+        target_adapter = mock_adapter_factory(pid=2)
+        target_adapter.name.return_value = "qwen"
+        spawner = AgentSpawner(
+            default_adapter,
+            templates_dir,
+            tmp_path,
+            role_model_policy={"backend": {"provider": "qwen"}},
+            use_worktrees=False,
+            default_model=default_model,
+        )
+        return spawner, target_adapter
+
+    def test_tier_stamp_coerced_when_role_policy_pins_provider_only(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Regression: role_model_policy sets {provider: qwen} with no
+        model. A retry-escalated tier name ("opus") on task.model must not
+        reach the qwen adapter literally - it should coerce to the run's
+        default_model, same as the self._adapter-is-qwen case already
+        covered by TestNonClaudeAdapterModelCoercionGuard."""
+        spawner, target_adapter = self._pinned_provider_spawner(
+            tmp_path, mock_adapter_factory, default_model="MiniMax-M3"
+        )
+        task = make_task(role="backend")
+        task.model = "opus"
+        task.retry_count = 1
+        with patch.object(spawner, "_get_adapter_by_name", return_value=target_adapter):
+            session = spawner.spawn_for_tasks([task])
+        assert session.model_config.model == "MiniMax-M3"
+
+    def test_genuine_pin_left_untouched_when_role_policy_pins_provider_only(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """A genuine (non-tier-name) task.model pin must survive even when
+        role_model_policy only pins a provider."""
+        spawner, target_adapter = self._pinned_provider_spawner(
+            tmp_path, mock_adapter_factory, default_model="MiniMax-M3"
+        )
+        task = make_task(role="backend")
+        task.model = "MiniMax-Text-01"
+        with patch.object(spawner, "_get_adapter_by_name", return_value=target_adapter):
+            session = spawner.spawn_for_tasks([task])
+        assert session.model_config.model == "MiniMax-Text-01"
+
+    def test_tier_stamp_left_unchanged_when_no_default_model_known(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Consistent with the pre-existing provider_name-is-None coercion
+        branch: with no run-level default_model configured, there is no
+        known non-Claude substitute, so the tier name is left as-is rather
+        than guessing."""
+        spawner, target_adapter = self._pinned_provider_spawner(tmp_path, mock_adapter_factory, default_model=None)
+        task = make_task(role="backend")
+        task.model = "opus"
+        task.retry_count = 1
+        with patch.object(spawner, "_get_adapter_by_name", return_value=target_adapter):
+            session = spawner.spawn_for_tasks([task])
         assert session.model_config.model == "opus"
 
 
@@ -1446,6 +1615,7 @@ class _SamplingCapableAdapter(PluginAdapter):
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
+        multimodal_context: Any | None = None,
     ) -> SpawnResult:
         self.seen_mcp_config = mcp_config
         return SpawnResult(pid=4242, log_path=workdir / "stub.log")
@@ -1487,6 +1657,33 @@ class TestSamplingParamsSpawnPath:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+
+        spawner.spawn_for_tasks([make_task()])
+
+        assert adapter.seen_mcp_config is not None
+        assert adapter.seen_mcp_config["heartbeat_dir"] == str(tmp_path / ".sdd" / "runtime" / "heartbeats")
+
+    def test_heartbeat_dir_injected_through_caching_adapter_wrapper(self, tmp_path: Path, make_task) -> None:
+        """Regression for bug #11: caching must not swallow heartbeat_dir injection.
+
+        Production always spawns with ``enable_caching=True`` (see
+        ``orchestrator.py``'s ``AgentSpawner`` construction), which wraps
+        every adapter - including the primary one - in ``CachingAdapter``.
+        ``CachingAdapter`` did not forward the ``consumes_heartbeat_dir``
+        capability flag, so ``_mcp_config_for_adapter``'s
+        ``getattr(adapter, "consumes_heartbeat_dir", False)`` gate silently
+        evaluated to ``False`` for every openai_agents spawn, and no
+        ``heartbeat_dir`` key ever reached the manifest. Workers then wrote
+        heartbeats into the worktree while the ``HeartbeatMonitor`` polled
+        the orchestrator root, killing every worker at the 120s stale
+        threshold (746 ``no_heartbeat`` SHUTDOWNs in one 40-minute run).
+        This test spawns through a caching-wrapped adapter and asserts the
+        manifest the adapter receives still contains ``heartbeat_dir``.
+        """
+        adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, enable_caching=True)
 
         spawner.spawn_for_tasks([make_task()])
 
@@ -1585,3 +1782,340 @@ class TestSamplingParamsSpawnPath:
         assert adapter.seen_mcp_config["top_p"] == pytest.approx(0.8)
         assert adapter.seen_mcp_config["top_k"] == 25
         assert adapter.seen_mcp_config["max_tokens"] == 1234
+
+    def test_role_policy_sampling_params_reach_adapter(self, tmp_path: Path, make_task) -> None:
+        """PR3: RoleModelPolicyEntry.temperature/top_p/top_k/max_tokens/
+        extra_params must reach the adapter mcp_config, same as the
+        base_url/api_key_env endpoint override already proven above."""
+        adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            role_model_policy={
+                "backend": {
+                    "temperature": 0.2,
+                    "top_p": 0.9,
+                    "top_k": 40,
+                    "max_tokens": 4096,
+                    "extra_params": {"reasoning_effort": "low"},
+                }
+            },
+        )
+
+        spawner.spawn_for_tasks([make_task(role="backend")])
+
+        assert adapter.seen_mcp_config is not None
+        assert adapter.seen_mcp_config["temperature"] == pytest.approx(0.2)
+        assert adapter.seen_mcp_config["top_p"] == pytest.approx(0.9)
+        assert adapter.seen_mcp_config["top_k"] == 40
+        assert adapter.seen_mcp_config["max_tokens"] == 4096
+        assert adapter.seen_mcp_config["extra_params"] == {"reasoning_effort": "low"}
+
+    def test_role_policy_sampling_params_take_precedence_over_mode_profile(self, tmp_path: Path, make_task) -> None:
+        """PR3: when both a role_model_policy sampling field and a
+        ModeProfile sampling field are set for the same role/key, the
+        role-policy value must win - matching the docstring's stated
+        precedence order (operator mcp_config > role policy > mode profile).
+        """
+        from bernstein.core.routing.mode_profile import ModeProfile
+
+        adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            role_model_policy={
+                "backend": {
+                    "temperature": 0.9,
+                    "top_k": 99,
+                }
+            },
+        )
+
+        profile_only_max_tokens = ModeProfile(
+            name="deep",
+            system_prompt_preamble="",
+            temperature=0.1,
+            top_p=0.5,
+            top_k=10,
+            max_tokens=500,
+        )
+        with patch("bernstein.core.agents.spawner_prompt.select_mode", return_value=profile_only_max_tokens):
+            spawner.spawn_for_tasks([make_task(role="backend")])
+
+        assert adapter.seen_mcp_config is not None
+        # Role policy wins for temperature and top_k (set on both sources).
+        assert adapter.seen_mcp_config["temperature"] == pytest.approx(0.9)
+        assert adapter.seen_mcp_config["top_k"] == 99
+        # top_p and max_tokens are only on the mode profile, so they still
+        # flow through unopposed.
+        assert adapter.seen_mcp_config["top_p"] == pytest.approx(0.5)
+        assert adapter.seen_mcp_config["max_tokens"] == 500
+
+    def test_operator_mcp_config_wins_over_role_policy_sampling(self, tmp_path: Path, make_task) -> None:
+        """An explicit mcp_config sampling value must not be replaced by
+        role_model_policy - same rule as the endpoint-override test above,
+        extended to the PR3 sampling fields."""
+        adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            mcp_config={"temperature": 0.01},
+            role_model_policy={"backend": {"temperature": 0.99}},
+        )
+
+        spawner.spawn_for_tasks([make_task(role="backend")])
+
+        assert adapter.seen_mcp_config is not None
+        assert adapter.seen_mcp_config["temperature"] == pytest.approx(0.01)
+
+    def test_mode_profile_max_tokens_reaches_manifest_for_openai_agents_role_with_claude_primary(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Regression (D2 OpenRouter KILL-NOTE, max-tokens-config fix):
+        ``_apply_sampling_overrides``'s mode-profile fold used to gate on
+        ``_primary_adapter_supports_sampling(model_config)`` called with no
+        provider context, which always resolved to the run's PRIMARY
+        adapter (e.g. ``claude`` from ``cli: auto``). A role pinned to a
+        DIFFERENT provider via ``role_model_policy.<role>.provider`` (e.g.
+        ``openai_agents``, which DOES declare SUPPORTS_SAMPLING_PARAMS) never
+        got the mode profile's max_tokens folded in when the primary adapter
+        didn't declare the capability - so bernstein's much larger default
+        max_tokens reached the runner manifest instead, 400ing on models
+        with a smaller completion cap (e.g. deepseek/deepseek-chat on
+        OpenRouter: 163840-token cap; KILL-NOTE
+        work/bernstein/proofs/d2/openrouter/KILL-NOTE.md).
+
+        This test pins a primary adapter named "claude" (a bare CLIAdapter
+        mock with no ``plugin_info``/SUPPORTS_SAMPLING_PARAMS) alongside a
+        role_model_policy provider override of "openai_agents" (the real,
+        registry-resolvable adapter class, which DOES declare the
+        capability) and asserts the resolved ModeProfile's max_tokens
+        reaches the adapter's mcp_config even though the primary adapter
+        cannot honour it.
+        """
+        from bernstein.core.routing.mode_profile import ModeProfile
+
+        primary_adapter = mock_adapter_factory(pid=1)
+        primary_adapter.name.return_value = "claude"
+
+        # Stands in for the real openai_agents adapter at actual spawn time;
+        # the capability GATE itself probes the real registry-resolved
+        # OpenAIAgentsAdapter class (uncached, non-primary provider path),
+        # not this mock - this mock only needs to declare the same
+        # capability so the post-fold ensure_sampling_params_supported()
+        # check at the real spawn site doesn't refuse the call.
+        spawn_time_adapter = _SamplingCapableAdapter()
+
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            primary_adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            role_model_policy={"backend": {"provider": "openai_agents"}},
+        )
+
+        profile = ModeProfile(name="deep", system_prompt_preamble="", max_tokens=8000)
+        with (
+            patch("bernstein.core.agents.spawner_prompt.select_mode", return_value=profile),
+            patch.object(spawner, "_get_adapter_by_name", return_value=spawn_time_adapter),
+        ):
+            spawner.spawn_for_tasks([make_task(role="backend")])
+
+        assert spawn_time_adapter.seen_mcp_config is not None
+        assert spawn_time_adapter.seen_mcp_config["max_tokens"] == 8000
+
+    def test_role_policy_max_tokens_reaches_manifest_with_claude_primary(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Companion to the mode-profile regression above: an EXPLICIT
+        role_model_policy.<role>.max_tokens must reach the manifest for an
+        openai_agents-provider role even when the primary adapter is
+        claude. Unlike the mode-profile fold, this path is unconditional in
+        ``_apply_sampling_overrides`` (explicit operator config always
+        forwards), but the seed-parser half of the KILL-NOTE fix
+        (``_ROLE_POLICY_KEYS``) is what makes this value reach
+        ``AgentSpawner.role_model_policy`` at all from a real seed file -
+        this test pins the spawner-side half of that same end-to-end path.
+        """
+        primary_adapter = mock_adapter_factory(pid=1)
+        primary_adapter.name.return_value = "claude"
+
+        spawn_time_adapter = _SamplingCapableAdapter()
+
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            primary_adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            role_model_policy={"backend": {"provider": "openai_agents", "max_tokens": 4096}},
+        )
+
+        with patch.object(spawner, "_get_adapter_by_name", return_value=spawn_time_adapter):
+            spawner.spawn_for_tasks([make_task(role="backend")])
+
+        assert spawn_time_adapter.seen_mcp_config is not None
+        assert spawn_time_adapter.seen_mcp_config["max_tokens"] == 4096
+
+
+# --- Error-aware spawn-failure extraction (D2 MiniMax masking bug) ---
+#
+# Ground truth: work/bernstein/proofs/d2/minimax/FAIL-NOTE.md. A real
+# openai_agents runner died on a 400 BadRequestError ("does not support max
+# tokens > 196608"), but the fast-exit probe reported only the log's LAST
+# LINE - a benign, unrelated SDK tracing warning
+# ("OPENAI_API_KEY is not set, skipping trace export") - across 7 run
+# attempts, hiding the real root cause that sat further up in the log.
+
+
+class TestExtractErrorAwareReason:
+    """Regression tests for spawner_core.extract_error_aware_reason()."""
+
+    def _minimax_style_log(self) -> str:
+        """Build a fake runner log matching the D2 MiniMax incident shape:
+        a multi-line BadRequestError traceback buried mid-log, followed by
+        an unrelated benign warning as the actual last line."""
+        return "\n".join(
+            [
+                "[runner] booting openai_agents session abc123",
+                "[runner] loading manifest",
+                "Traceback (most recent call last):",
+                '  File "openai_agents_runner.py", line 274, in run',
+                "    response = client.responses.create(**kwargs)",
+                '  File "openai/_client.py", line 812, in create',
+                "    raise self._make_status_error_from_response(response)",
+                "openai.BadRequestError: Error code: 400 - {'error': {'message': "
+                '"invalid params, model[MiniMax-M2.7-highspeed] does not support '
+                "max tokens > 196608 (2013)\", 'type': 'bad_request_error'}}",
+                "",
+                "OPENAI_API_KEY is not set, skipping trace export",
+            ]
+        )
+
+    def test_extracts_traceback_not_last_line(self) -> None:
+        """The extracted reason must surface the real 400/BadRequestError,
+        not the benign tracing warning that happens to be the last line."""
+        from bernstein.core.agents.spawner_core import extract_error_aware_reason
+
+        log_text = self._minimax_style_log()
+        reason = extract_error_aware_reason(log_text)
+
+        assert "400" in reason
+        assert "BadRequestError" in reason
+        # This is the exact defect being fixed: naive last-line extraction
+        # would return ONLY the benign warning below, masking the real error.
+        assert reason != "OPENAI_API_KEY is not set, skipping trace export"
+        assert reason.strip() != "OPENAI_API_KEY is not set, skipping trace export"
+
+    def test_extracts_full_traceback_block(self) -> None:
+        """The full traceback (not just the exception's final line) is returned."""
+        from bernstein.core.agents.spawner_core import extract_error_aware_reason
+
+        reason = extract_error_aware_reason(self._minimax_style_log())
+
+        assert "Traceback (most recent call last):" in reason
+        assert "openai_agents_runner.py" in reason
+
+    def test_error_level_line_without_traceback(self) -> None:
+        """A log with no traceback but an ERROR-level line still surfaces
+        that line (and what follows) instead of an unrelated last line."""
+        from bernstein.core.agents.spawner_core import extract_error_aware_reason
+
+        log_text = "\n".join(
+            [
+                "[runner] starting",
+                "ERROR: connection refused to provider endpoint (500)",
+                "[runner] cleaning up",
+                "OPENAI_API_KEY is not set, skipping trace export",
+            ]
+        )
+        reason = extract_error_aware_reason(log_text)
+
+        assert "connection refused" in reason
+        assert "500" in reason
+
+    def test_falls_back_to_last_lines_when_no_error_pattern(self) -> None:
+        """When nothing in the log looks like an error, fall back to the
+        last N lines - but clearly labeled as a fallback."""
+        from bernstein.core.agents.spawner_core import extract_error_aware_reason
+
+        log_text = "\n".join(f"benign startup line {i}" for i in range(20))
+        reason = extract_error_aware_reason(log_text)
+
+        assert "no error pattern found" in reason
+        assert "benign startup line 19" in reason
+
+    def test_caps_extracted_text_length(self) -> None:
+        """The extracted text is capped, even for a pathologically long
+        traceback, to keep a single log line bounded."""
+        from bernstein.core.agents.spawner_core import extract_error_aware_reason
+
+        long_body = "\n".join(f"    frame {i} irrelevant noise" for i in range(2000))
+        log_text = f"Traceback (most recent call last):\n{long_body}\nValueError: boom"
+        reason = extract_error_aware_reason(log_text, max_chars=500)
+
+        assert len(reason) <= 500
+
+
+class TestDiagnoseSpawnFailure:
+    """Regression tests for spawner_core._diagnose_spawn_failure()."""
+
+    def test_reads_runner_session_log_and_surfaces_real_error(self, tmp_path: Path) -> None:
+        """End-to-end: given the on-disk per-session log an openai_agents
+        adapter actually writes to (<spawn_cwd>/.sdd/runtime/<session_id>.log),
+        the diagnosed reason must contain the real error, not the benign
+        last-line warning the raw exception message embeds."""
+        from bernstein.core.agents.spawner_core import _diagnose_spawn_failure
+
+        session_id = "backend-minimax-abc123"
+        runtime_dir = tmp_path / ".sdd" / "runtime"
+        runtime_dir.mkdir(parents=True)
+        log_path = runtime_dir / f"{session_id}.log"
+        log_path.write_text(
+            "\n".join(
+                [
+                    "[runner] booting openai_agents session",
+                    "Traceback (most recent call last):",
+                    '  File "openai_agents_runner.py", line 274, in run',
+                    "    response = client.responses.create(**kwargs)",
+                    "openai.BadRequestError: Error code: 400 - does not support max tokens > 196608",
+                    "",
+                    "OPENAI_API_KEY is not set, skipping trace export",
+                ]
+            )
+        )
+
+        # The exception the fast-exit probe would have raised - its message
+        # embeds ONLY the log's last line (the bug being fixed).
+        exc = SpawnError("openai_agents exited early with code 1: OPENAI_API_KEY is not set, skipping trace export")
+
+        reason = _diagnose_spawn_failure(session_id, tmp_path, "openai_agents", exc)
+
+        assert "400" in reason
+        assert "BadRequestError" in reason
+        assert reason != "OPENAI_API_KEY is not set, skipping trace export"
+
+    def test_falls_back_to_exception_string_when_no_log_found(self, tmp_path: Path) -> None:
+        """When no per-session log file exists on disk, fall back to
+        str(exc) rather than raising or returning an empty reason."""
+        from bernstein.core.agents.spawner_core import _diagnose_spawn_failure
+
+        exc = SpawnError("adapter exited early with code 1: some message")
+        reason = _diagnose_spawn_failure("no-such-session", tmp_path, "openai_agents", exc)
+
+        assert reason == str(exc)

--- a/tests/unit/test_stalled_manager.py
+++ b/tests/unit/test_stalled_manager.py
@@ -13,9 +13,11 @@ from bernstein.core.models import AgentSession, ModelConfig, Task
 
 from bernstein.core.orchestration.stalled_manager import (
     REMEDIATION_DOC,
+    STALL_THRESHOLD_ENV_VAR,
     STALL_THRESHOLD_S,
     StalledManagerDiagnostic,
     _redact_env,
+    _resolve_stall_threshold_s,
     build_diagnostic,
     detect_stalled_manager,
     handle_stalled_manager,
@@ -281,3 +283,130 @@ def test_build_diagnostic_picks_last_five_bash_commands(tmp_path: Path) -> None:
     diag = build_diagnostic(tmp_path, session, now=time.time())
     assert diag.last_bash_commands == ["cmd-3", "cmd-4", "cmd-5", "cmd-6", "cmd-7"]
     assert diag.hook_event_count == 8
+
+
+def test_diagnostic_message_does_not_assert_auth_failure_with_zero_evidence() -> None:
+    """hook_event_count==0 with no bash commands must not assert an auth failure (#2179)."""
+    diag = StalledManagerDiagnostic(
+        session_id="manager-run2",
+        manager_task_id="task-1",
+        runtime_s=174.0,
+        hook_event_count=0,
+        last_bash_commands=[],
+    )
+    msg = diag.message()
+    assert "NOT confirmed as an auth failure" in msg
+    assert "likely cannot authenticate" not in msg
+    assert STALL_THRESHOLD_ENV_VAR in msg
+
+
+# ---------------------------------------------------------------------------
+# Threshold resolution (#2179): CLI/env > yaml-tunable config > default
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_threshold_uses_config_when_no_env(monkeypatch: Any) -> None:
+    monkeypatch.delenv(STALL_THRESHOLD_ENV_VAR, raising=False)
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=300.0))
+    assert _resolve_stall_threshold_s(orch) == 300.0
+
+
+def test_resolve_threshold_falls_back_to_default_without_config(monkeypatch: Any) -> None:
+    monkeypatch.delenv(STALL_THRESHOLD_ENV_VAR, raising=False)
+    orch = SimpleNamespace(_config=None)
+    assert _resolve_stall_threshold_s(orch) == STALL_THRESHOLD_S
+
+
+def test_resolve_threshold_env_beats_config(monkeypatch: Any) -> None:
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "250")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=900.0))
+    assert _resolve_stall_threshold_s(orch) == 250.0
+
+
+def test_resolve_threshold_unparseable_env_falls_back_with_warning(monkeypatch: Any, caplog: Any) -> None:
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "notanumber")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=222.0))
+    with caplog.at_level("WARNING"):
+        result = _resolve_stall_threshold_s(orch)
+    assert result == 222.0
+    assert "not a valid float" in caplog.text
+
+
+def test_resolve_threshold_warns_when_it_would_race_idle_kill(monkeypatch: Any, caplog: Any) -> None:
+    monkeypatch.delenv(STALL_THRESHOLD_ENV_VAR, raising=False)
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=200.0))
+    with caplog.at_level("WARNING"):
+        result = _resolve_stall_threshold_s(orch)
+    assert result == 200.0
+    assert "idle_log_age_threshold_s" in caplog.text
+
+
+def test_resolve_threshold_env_path_also_warns_when_it_would_race_idle_kill(monkeypatch: Any, caplog: Any) -> None:
+    """The race-check must fire for the env override too, not just the config/default path -
+    BERNSTEIN_STALL_THRESHOLD_S is the primary way an operator raises the threshold (#2179)."""
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "250")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=90.0))
+    with caplog.at_level("WARNING"):
+        result = _resolve_stall_threshold_s(orch)
+    assert result == 250.0
+    assert "idle_log_age_threshold_s" in caplog.text
+
+
+def test_resolve_threshold_zero_env_falls_back_to_config_with_warning(monkeypatch: Any, caplog: Any) -> None:
+    """A 0/negative env value must not silently disable the watchdog (fires on turn one)."""
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "0")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=222.0))
+    with caplog.at_level("WARNING"):
+        result = _resolve_stall_threshold_s(orch)
+    assert result == 222.0
+    assert "positive, finite" in caplog.text
+
+
+def test_resolve_threshold_negative_env_falls_back(monkeypatch: Any) -> None:
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "-5")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=222.0))
+    assert _resolve_stall_threshold_s(orch) == 222.0
+
+
+def test_resolve_threshold_nan_env_falls_back(monkeypatch: Any) -> None:
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "nan")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=222.0))
+    assert _resolve_stall_threshold_s(orch) == 222.0
+
+
+def test_resolve_threshold_inf_env_falls_back(monkeypatch: Any) -> None:
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "inf")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=222.0))
+    assert _resolve_stall_threshold_s(orch) == 222.0
+
+
+def test_resolve_threshold_non_positive_config_falls_back_to_default(monkeypatch: Any, caplog: Any) -> None:
+    monkeypatch.delenv(STALL_THRESHOLD_ENV_VAR, raising=False)
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=-10.0))
+    with caplog.at_level("WARNING"):
+        result = _resolve_stall_threshold_s(orch)
+    assert result == STALL_THRESHOLD_S
+    assert "positive, finite" in caplog.text
+
+
+def test_resolve_threshold_caches_per_orchestrator_instance(monkeypatch: Any, caplog: Any) -> None:
+    """Resolution + its log lines must happen once per orchestrator, not once per tick."""
+    monkeypatch.setenv(STALL_THRESHOLD_ENV_VAR, "250")
+    orch = SimpleNamespace(_config=SimpleNamespace(stalled_manager_threshold_s=90.0))
+    with caplog.at_level("INFO"):
+        first = _resolve_stall_threshold_s(orch)
+        caplog.clear()
+        second = _resolve_stall_threshold_s(orch)
+    assert first == second == 250.0
+    assert caplog.text == ""
+
+
+def test_detect_stalled_manager_honors_raised_threshold_via_config(monkeypatch: Any, tmp_path: Path) -> None:
+    """A manager alive past the old 170s default but under a raised threshold is not aborted."""
+    monkeypatch.delenv(STALL_THRESHOLD_ENV_VAR, raising=False)
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 250.0)  # past old default, under raised threshold
+    orch = _build_orch(tmp_path, session=session)
+    orch._config = SimpleNamespace(stalled_manager_threshold_s=300.0)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        assert detect_stalled_manager(orch) is None

--- a/tests/unit/test_task_completion.py
+++ b/tests/unit/test_task_completion.py
@@ -172,8 +172,18 @@ def test_process_completed_tasks_creates_fix_task_for_cross_model_review(tmp_pat
         process_completed_tasks(orch, [task], result)
 
     assert result.verification_failures == [("T-review", ["cross_model_review:Add regression coverage"])]
-    payload = orch._client.post.call_args.kwargs["json"]
-    assert payload["title"].startswith("[REVIEW-FIX] Refine prompt")
+    # The janitor-verdict action posts a /reopen after the fix-task creation,
+    # so locate the fix-task POST among all calls instead of assuming last.
+    posted_urls = [call.args[0] for call in orch._client.post.call_args_list if call.args]
+    fix_task_payloads = [
+        call.kwargs["json"]
+        for call in orch._client.post.call_args_list
+        if call.args and call.args[0].endswith("/tasks")
+    ]
+    assert fix_task_payloads, f"no fix-task POST found among {posted_urls}"
+    assert fix_task_payloads[0]["title"].startswith("[REVIEW-FIX] Refine prompt")
+    # Failed janitor verdict must also reopen the task (bounded).
+    assert any(url.endswith("/tasks/T-review/reopen") for url in posted_urls)
 
 
 def test_process_completed_tasks_blocks_on_formal_verification_violation(tmp_path: Path, make_task: Any) -> None:

--- a/tests/unit/test_task_crud_claim_conflict_logging.py
+++ b/tests/unit/test_task_crud_claim_conflict_logging.py
@@ -1,0 +1,73 @@
+"""Logging-gap smoke test for the /tasks/{id}/claim 409 path (task_crud.py).
+
+Before this change, a claim conflict (stale ``expected_version`` or a task
+already claimed) raised HTTPException(409) with no server-side log line --
+the only visibility was the client's own HTTP response, which is invisible
+in the orchestrator's server-side log stream.  On 2026-07-02 a 144-iteration
+claim-retry loop against this exact endpoint left the operator with a bare
+401/409 storm and no way to tell WHY the conflicts were happening (expected
+vs. actual version) from the server log alone.
+
+This test drives the real FastAPI route (not the store layer directly) via
+TestClient so it exercises exactly the code path that fired the loop, and
+asserts the new WARNING log line carries the expected/actual version and
+status needed to diagnose a churn loop from the server log alone.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+from starlette.testclient import TestClient
+
+from bernstein.core.server import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_claim_version_conflict_logs_expected_vs_actual(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bernstein.core.routes.task_crud")
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    with TestClient(app) as client:
+        create_resp = client.post(
+            "/tasks",
+            json={
+                "title": "Do the thing",
+                "description": "Some work.",
+                "role": "backend",
+                "priority": 1,
+                "scope": "small",
+                "complexity": "low",
+                "estimated_minutes": 10,
+            },
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        task_id = create_resp.json()["id"]
+
+        # First claim succeeds and bumps the version.
+        first = client.post(f"/tasks/{task_id}/claim")
+        assert first.status_code == 200, first.text
+
+        # Second claim against a stale expected_version=1 must 409 -- the
+        # task is already claimed (version bumped past 1 by the first claim).
+        second = client.post(f"/tasks/{task_id}/claim", params={"expected_version": 1})
+        assert second.status_code == 409, second.text
+
+    conflict_records = [
+        r.message
+        for r in caplog.records
+        if "task.claim 409" in r.message  # type: ignore[attr-defined]
+    ]
+    assert conflict_records, f"expected a task.claim 409 log line, got: {caplog.text}"  # type: ignore[attr-defined]
+    line = conflict_records[0]
+    assert task_id in line
+    assert "expected_version=1" in line
+    assert "actual_version=" in line
+    assert "pre_claim_status=" in line
+
+    ok_records = [r.message for r in caplog.records if "task.claim ok" in r.message]  # type: ignore[attr-defined]
+    assert any(task_id in m for m in ok_records), "expected a task.claim ok line for the first successful claim"

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -870,3 +870,318 @@ def test_formal_verification_gate_swallows_runner_exception(tmp_path: Path, make
 
     assert passed is True
     assert result.verification_failures == []
+
+
+# ---------------------------------------------------------------------------
+# Normal-completion cost sourcing (D2 canary-host-99d0eac0 regression,
+# 2026-07-03): task_m.cost_usd is populated by nothing on the normal
+# completion path (the live-cost loop feeds CostTracker only), so tasks
+# whose runner wrote a real .tokens sidecar (canary qa task 325c200e1985:
+# 51,880/1,401 tokens) still recorded cost_usd 0.0 in metrics/tasks.jsonl.
+# _record_completion_metrics must fall back to the sidecar.
+# ---------------------------------------------------------------------------
+
+
+def _write_tokens_sidecar(workdir: Path, session_id: str, input_tokens: int, output_tokens: int) -> Path:
+    """Write a runner cost sidecar with one usage record (runner schema)."""
+    import json as _json
+
+    runtime_dir = workdir / ".sdd" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    sidecar = runtime_dir / f"{session_id}.tokens"
+    with sidecar.open("a", encoding="utf-8") as fh:
+        fh.write(_json.dumps({"ts": 1783039683.9, "in": input_tokens, "out": output_tokens}) + "\n")
+    return sidecar
+
+
+def test_record_completion_metrics_sources_cost_from_tokens_sidecar(tmp_path: Path, make_task: Any) -> None:
+    """A normally-completed task whose collector entry has cost_usd=0 but
+    whose session wrote a real .tokens sidecar must record the sidecar's
+    priced cost (and token counts), not 0.0."""
+    from bernstein.core.tasks.task_lifecycle import _record_completion_metrics
+
+    task = make_task(id="T-cost", title="qa task", description="d", status=TaskStatus.DONE)
+    session = _session_for(task.id, exit_code=0)
+    orch = _process_orch(tmp_path, session)
+
+    # Collector entry exists (start_task ran at spawn) but nothing ever
+    # populated its cost - the exact canary state.
+    collector = MagicMock()
+    task_m = SimpleNamespace(
+        cost_usd=0.0,
+        tokens_prompt=0,
+        tokens_completion=0,
+        tokens_used=0,
+        start_time=10.0,
+        end_time=15.0,
+    )
+    collector.task_metrics = {task.id: task_m}
+    collector.agent_metrics = {session.id: SimpleNamespace(tasks_completed=1)}
+
+    # The canary qa task's real figures.
+    _write_tokens_sidecar(tmp_path, session.id, input_tokens=51_880, output_tokens=1_401)
+
+    with patch("bernstein.core.tasks.task_lifecycle.get_collector", return_value=collector):
+        returned_task_m, cost_usd = _record_completion_metrics(
+            orch,
+            task,
+            session,
+            janitor_passed=True,
+            qg_result=None,
+            completion_data=None,
+            agent_just_reaped=False,
+        )
+
+    # Sidecar cost was folded in (sonnet is a priced model).
+    assert cost_usd > 0.0, "cost_usd must come from the sidecar, not the never-populated collector figure"
+    assert returned_task_m is task_m
+    # The in-memory record was reconciled (what retrospective's fallback reads).
+    assert task_m.cost_usd == cost_usd
+    assert task_m.tokens_prompt == 51_880
+    assert task_m.tokens_completion == 1_401
+    assert task_m.tokens_used == 53_281
+    # complete_task received the real figures.
+    _, complete_kwargs = collector.complete_task.call_args
+    assert complete_kwargs["cost_usd"] == cost_usd
+    assert complete_kwargs["tokens_used"] == 53_281
+    # CostTracker got the same cost.
+    _, cumulative_kwargs = orch._cost_tracker.record_cumulative.call_args
+    assert cumulative_kwargs["total_cost_usd"] == cost_usd
+    assert cumulative_kwargs["total_input_tokens"] == 51_880
+
+
+def test_record_completion_metrics_tags_alive_exit_sidecar_source(tmp_path: Path, make_task: Any) -> None:
+    """item 31: an alive-exit /complete that sources cost from the sidecar must
+    tag the ledger mutation with tokens_sidecar_source=alive_exit so the run
+    ledger entry is distinguishable from an orphan/dead-exit recovery."""
+    from bernstein.core.tasks.task_lifecycle import _record_completion_metrics
+
+    task = make_task(id="T-alive", title="qa task", description="d", status=TaskStatus.DONE)
+    session = _session_for(task.id, exit_code=0)
+    orch = _process_orch(tmp_path, session)
+
+    collector = MagicMock()
+    task_m = SimpleNamespace(
+        cost_usd=0.0,
+        tokens_prompt=0,
+        tokens_completion=0,
+        tokens_used=0,
+        start_time=10.0,
+        end_time=15.0,
+    )
+    collector.task_metrics = {task.id: task_m}
+    collector.agent_metrics = {session.id: SimpleNamespace(tasks_completed=1)}
+
+    _write_tokens_sidecar(tmp_path, session.id, input_tokens=51_880, output_tokens=1_401)
+
+    with patch("bernstein.core.tasks.task_lifecycle.get_collector", return_value=collector):
+        _record_completion_metrics(
+            orch,
+            task,
+            session,
+            janitor_passed=True,
+            qg_result=None,
+            completion_data=None,
+            agent_just_reaped=False,
+        )
+
+    _, cumulative_kwargs = orch._cost_tracker.record_cumulative.call_args
+    assert cumulative_kwargs["cost_tags"] == {"tokens_sidecar_source": "alive_exit"}
+
+
+def test_record_completion_metrics_keeps_collector_cost_when_it_knows_more(tmp_path: Path, make_task: Any) -> None:
+    """When the collector already carries a real (higher) cost, the sidecar
+    must not clobber it."""
+    from bernstein.core.tasks.task_lifecycle import _record_completion_metrics
+
+    task = make_task(id="T-keep", title="t", description="d", status=TaskStatus.DONE)
+    session = _session_for(task.id, exit_code=0)
+    orch = _process_orch(tmp_path, session)
+    collector = _collector_for(task.id, session.id)  # cost_usd=2.5 pre-populated
+
+    # A tiny sidecar that prices below the collector figure.
+    _write_tokens_sidecar(tmp_path, session.id, input_tokens=10, output_tokens=5)
+
+    with patch("bernstein.core.tasks.task_lifecycle.get_collector", return_value=collector):
+        _, cost_usd = _record_completion_metrics(
+            orch,
+            task,
+            session,
+            janitor_passed=True,
+            qg_result=None,
+            completion_data=None,
+            agent_just_reaped=False,
+        )
+
+    assert cost_usd == 2.5
+
+
+def test_record_completion_metrics_recovers_sidecar_cost_when_session_reaped(tmp_path: Path, make_task: Any) -> None:
+    """Bug 14 (D2 minimax attempt-e938bd33): the agent died on MaxTurnsExceeded
+    and was reaped BEFORE the completion sweep processed its /complete'd task,
+    so _find_session_for_task returned None and the metrics row recorded $0
+    despite a .tokens sidecar carrying 54,003/1,026 real tokens. With
+    session=None but task.assigned_agent set, the sidecar must still be read
+    (model recovered from the collector's AgentMetrics) and the real cost
+    recorded."""
+    from bernstein.core.tasks.task_lifecycle import _record_completion_metrics
+
+    task = make_task(id="T-dead", title="backend task", description="d", status=TaskStatus.DONE)
+    task.assigned_agent = "backend-ae800d98"
+    # Orch stub: session object irrelevant - we pass session=None directly.
+    orch = _process_orch(tmp_path, _session_for(task.id, exit_code=1))
+
+    collector = MagicMock()
+    task_m = SimpleNamespace(
+        cost_usd=0.0,
+        tokens_prompt=0,
+        tokens_completion=0,
+        tokens_used=0,
+        start_time=10.0,
+        end_time=15.0,
+    )
+    collector.task_metrics = {task.id: task_m}
+    # AgentMetrics recorded at spawn carries the model used for pricing.
+    collector.agent_metrics = {"backend-ae800d98": SimpleNamespace(tasks_completed=0, model="sonnet")}
+
+    # The real figures from the failing run's sidecar.
+    _write_tokens_sidecar(tmp_path, "backend-ae800d98", input_tokens=54_003, output_tokens=1_026)
+
+    with patch("bernstein.core.tasks.task_lifecycle.get_collector", return_value=collector):
+        returned_task_m, cost_usd = _record_completion_metrics(
+            orch,
+            task,
+            None,  # session already reaped - the exact bug-14 state
+            janitor_passed=True,
+            qg_result=None,
+            completion_data=None,
+            agent_just_reaped=False,
+        )
+
+    assert cost_usd > 0.0, "MaxTurns-reaped session's sidecar cost must not be zeroed"
+    assert returned_task_m is task_m
+    assert task_m.tokens_prompt == 54_003
+    assert task_m.tokens_completion == 1_026
+    assert task_m.cost_usd == cost_usd
+    _, complete_kwargs = collector.complete_task.call_args
+    assert complete_kwargs["cost_usd"] == cost_usd
+    assert complete_kwargs["tokens_used"] == 55_029
+
+
+def test_record_completion_metrics_no_session_no_assigned_agent_stays_zero(tmp_path: Path, make_task: Any) -> None:
+    """Without a session AND without task.assigned_agent there is no sidecar
+    key to read - the function must not crash and must record the collector
+    figures unchanged."""
+    from bernstein.core.tasks.task_lifecycle import _record_completion_metrics
+
+    task = make_task(id="T-nokey", title="t", description="d", status=TaskStatus.DONE)
+    task.assigned_agent = None
+    orch = _process_orch(tmp_path, _session_for(task.id, exit_code=1))
+    collector = _collector_for(task.id, "A-1")  # cost_usd=2.5 pre-populated
+
+    with patch("bernstein.core.tasks.task_lifecycle.get_collector", return_value=collector):
+        _, cost_usd = _record_completion_metrics(
+            orch,
+            task,
+            None,
+            janitor_passed=False,
+            qg_result=None,
+            completion_data=None,
+            agent_just_reaped=False,
+        )
+
+    assert cost_usd == 2.5
+
+
+def test_record_evolution_completion_passes_reconciled_tokens(tmp_path: Path, make_task: Any) -> None:
+    """The evolution tasks.jsonl writer receives the reconciled token counts
+    from task_m alongside cost_usd."""
+    from bernstein.core.tasks.task_lifecycle import _record_evolution_completion
+
+    task = make_task(id="T-evo", title="t", description="d", status=TaskStatus.DONE)
+    session = _session_for(task.id, exit_code=0)
+    orch = _process_orch(tmp_path, session)
+    orch._evolution = MagicMock()
+    orch._latest_tasks_by_id = {}
+
+    task_m = SimpleNamespace(
+        cost_usd=0.0123,
+        tokens_prompt=51_880,
+        tokens_completion=1_401,
+        tokens_used=53_281,
+        start_time=10.0,
+        end_time=15.0,
+    )
+
+    _record_evolution_completion(orch, task, session, task_m, cost_usd=0.0123, janitor_passed=True)
+
+    _, kwargs = orch._evolution.record_task_completion.call_args
+    assert kwargs["cost_usd"] == 0.0123
+    assert kwargs["tokens_prompt"] == 51_880
+    assert kwargs["tokens_completion"] == 1_401
+
+
+# ---------------------------------------------------------------------------
+# Bug 1b (2026-07-02, fix/claim-conflict-churn): claim-then-never-spawn
+# deadlock. Root cause: in a multi-task batch, if an EARLIER task claimed
+# successfully but a LATER task in the same batch failed to claim, the whole
+# batch used to abort via `continue`, leaving the already-claimed task
+# server-side claimed with no agent ever spawned for it -- rescued only by
+# the 15-minute stale-claim reaper. Evidence:
+# work/bernstein/proofs/d2/claude/attempt4-meridian-fixed/FAIL-NOTE.md
+# (duplicate-titled task pair, one twin claimed while its sibling's claim
+# was rejected, claimed twin blocked the dependency graph for 15 minutes
+# with agents=0 spawned=0).
+# ---------------------------------------------------------------------------
+
+
+def test_claim_and_spawn_batches_spawns_claimed_subset_on_partial_claim_failure(tmp_path: Path, make_task: Any) -> None:
+    """A batch where task A claims successfully but task B's claim is
+    rejected (409, and B turns out to be claimed by a foreign session on
+    re-fetch) must still spawn an agent for A -- not leave A claimed with no
+    worker."""
+    orch = _claim_orch(tmp_path)
+    task_a = make_task(id="T-a", role="backend")
+    task_b = make_task(id="T-b", role="backend")
+    session = AgentSession(
+        id="A-partial", role="backend", task_ids=[task_a.id], model_config=ModelConfig("sonnet", "high")
+    )
+    orch._spawner.spawn_for_tasks.return_value = session
+
+    def _post_side_effect(url: str, **kwargs: Any) -> SimpleNamespace:
+        if url.endswith("/T-a/claim"):
+            return SimpleNamespace(status_code=200)
+        if url.endswith("/T-b/claim"):
+            return SimpleNamespace(status_code=409, text="task T-b is not open")
+        raise AssertionError(f"unexpected POST {url}")
+
+    def _get_side_effect(url: str, **kwargs: Any) -> SimpleNamespace:
+        assert url.endswith("/tasks/T-b")
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "id": "T-b",
+                "title": task_b.title,
+                "description": task_b.description,
+                "role": "backend",
+                "version": 2,
+                "status": "claimed",
+                "claimed_by_session": "some-other-session",
+            },
+            raise_for_status=lambda: None,
+        )
+
+    orch._client.post.side_effect = _post_side_effect
+    orch._client.get.side_effect = _get_side_effect
+    result = TickResult()
+
+    claim_and_spawn_batches(
+        orch, [[task_a, task_b]], alive_count=0, assigned_task_ids=set(), done_ids=set(), result=result
+    )
+
+    # The agent was spawned for the claimed subset (task A only).
+    orch._spawner.spawn_for_tasks.assert_called_once()
+    spawned_batch = orch._spawner.spawn_for_tasks.call_args[0][0]
+    assert [t.id for t in spawned_batch] == ["T-a"]
+    # Task B's claim failure is recorded, but does not block A.
+    assert any("T-b" in e for e in result.errors)

--- a/tests/unit/test_watchdog.py
+++ b/tests/unit/test_watchdog.py
@@ -162,3 +162,101 @@ def test_watchdog_manager_escalates_repeated_high_severity_incident(tmp_path: Pa
     assert notifications[0]["event"] == "approval.needed"
     assert len(bulletins) == 1
     assert bulletins[0][0] == "alert"
+
+
+def test_watchdog_manager_logs_detection_and_escalation(tmp_path: Path, caplog) -> None:
+    """Logging gap: WatchdogManager.sync() persisted new-incident and
+    human-escalation events to JSONL, but never logged them -- an operator
+    tailing the process log saw nothing until the triage-task-created line,
+    which only fires when the triage HTTP call succeeds. Assert the TIER1
+    detected line fires on first sight, and the TIER3 escalation line fires
+    once the incident crosses its threshold."""
+    caplog.set_level("WARNING", logger="bernstein.core.observability.watchdog")
+    client = MagicMock()
+    client.post.return_value = _response("triage-2")
+    manager = WatchdogManager(tmp_path, client, "http://server")
+    finding = WatchdogFinding(
+        key="heartbeat:sess-1:task-1",
+        session_id="sess-1",
+        task_id="task-1",
+        source="heartbeat",
+        severity="high",
+        summary="Heartbeat stale for task task-1",
+        detail="Heartbeat age exceeded the wakeup threshold.",
+    )
+
+    with patch("bernstein.core.observability.watchdog.time.time", return_value=200.0):
+        manager.sync([finding])
+        manager.sync([finding])
+
+    messages = [r.message for r in caplog.records]
+    assert any("watchdog TIER1 detected" in m and "heartbeat:sess-1:task-1" in m for m in messages), messages
+    assert any("watchdog TIER3 escalating to human" in m and "heartbeat:sess-1:task-1" in m for m in messages), messages
+
+
+def test_watchdog_manager_refuses_triage_of_triage(tmp_path: Path) -> None:
+    """Regression test for the 2026-07-02 production incident: a watchdog
+    triage task that itself stalls must NOT spawn a second triage task about
+    it ("Watchdog triage of watchdog triage"). See
+    work/agent-reports/2026-07-02-run9-attempt9-audit.md.
+    """
+    client = MagicMock()
+    client.post.return_value = _response("triage-3")
+    manager = WatchdogManager(tmp_path, client, "http://server")
+
+    # The finding's task_title is itself an existing "Watchdog triage: ..."
+    # meta-task -- i.e. this finding is ABOUT a previously auto-spawned
+    # triage task, which would make a new triage task depth 2.
+    finding = WatchdogFinding(
+        key="heartbeat:sess-2:triage-task-1",
+        session_id="sess-2",
+        task_id="triage-task-1",
+        source="heartbeat",
+        severity="high",
+        summary="Heartbeat stale for task Watchdog triage: Heartbeat stale for task X",
+        detail="Heartbeat age exceeded the wakeup threshold.",
+        task_title="Watchdog triage: Heartbeat stale for task X",
+    )
+
+    with patch("bernstein.core.observability.watchdog.time.time", return_value=300.0):
+        manager.sync([finding])
+
+    assert client.post.call_count == 0
+    state_path = tmp_path / ".sdd" / "runtime" / "watchdog_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state[finding.key]["triage_task_id"] is None
+
+
+def test_watchdog_manager_dedupes_triage_tasks_across_incidents(tmp_path: Path) -> None:
+    """Two distinct incidents that would create identically-worded triage
+    tasks must only spawn one."""
+    client = MagicMock()
+    client.post.return_value = _response("triage-4")
+    manager = WatchdogManager(tmp_path, client, "http://server")
+
+    finding_a = WatchdogFinding(
+        key="heartbeat:sess-a:task-a",
+        session_id="sess-a",
+        task_id="task-a",
+        source="heartbeat",
+        severity="high",
+        summary="Heartbeat stale for task Fix API",
+        detail="detail-a",
+        task_title="Fix API",
+    )
+    finding_b = WatchdogFinding(
+        key="heartbeat:sess-b:task-b",
+        session_id="sess-b",
+        task_id="task-b",
+        source="heartbeat",
+        severity="high",
+        summary="Heartbeat stale for task Fix API",
+        detail="detail-b",
+        task_title="Fix API",
+    )
+
+    with patch("bernstein.core.observability.watchdog.time.time", return_value=300.0):
+        manager.sync([finding_a])
+        manager.sync([finding_b])
+
+    assert client.post.call_count == 1

--- a/tests/unit/test_worktree_salvage.py
+++ b/tests/unit/test_worktree_salvage.py
@@ -135,6 +135,31 @@ def test_salvage_creates_branch_and_filesystem_fallback(
     assert result.branch_pushed is False
 
 
+def test_salvage_logs_each_branch_step(
+    repo_with_worktree: tuple[Path, Path, str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Logging gap: ``_try_salvage_branch``'s 4 git steps (add/commit/rename/
+    push) previously only surfaced failures via a returned errors list --
+    nothing was logged per-step, so a stuck salvage looked identical to a
+    silent one in the logs. Assert each step logs its own line, and that a
+    push failure (no remote configured in this fixture) logs a WARNING
+    rather than staying silent."""
+    caplog.set_level("INFO", logger="bernstein.core.git.salvage")
+    repo_root, worktree_path, session_id = repo_with_worktree
+    _dirty_the_worktree(worktree_path)
+
+    result = salvage_worktree(repo_root, worktree_path, session_id, push=True)
+
+    assert result.salvaged is True
+    messages = [r.message for r in caplog.records]
+    assert any("salvage step 1/4 ok (git add -A)" in m for m in messages), messages
+    assert any("salvage step 2/4 ok (git commit" in m for m in messages), messages
+    assert any("salvage step 3/4 ok (branch renamed" in m for m in messages), messages
+    # No remote is configured in the fixture, so push must fail loudly.
+    assert any("salvage step 4/4 FAILED (git push" in m for m in messages), messages
+
+
 def test_salvage_diff_is_recoverable_from_branch(
     repo_with_worktree: tuple[Path, Path, str],
 ) -> None:

--- a/tunnels-test.json
+++ b/tunnels-test.json
@@ -1,0 +1,32 @@
+{
+  "tunnels": [
+    {
+      "name": "cloudflared-bf7e68d1",
+      "provider": "cloudflared",
+      "port": 8052,
+      "public_url": "https://fake-cloudflared.example.com",
+      "pid": 41001
+    },
+    {
+      "name": "cloudflared-e2668e08",
+      "provider": "cloudflared",
+      "port": 8052,
+      "public_url": "https://fake-cloudflared.example.com",
+      "pid": 41001
+    },
+    {
+      "name": "cloudflared-aaf5bf4a",
+      "provider": "cloudflared",
+      "port": 8052,
+      "public_url": "https://fake-cloudflared.example.com",
+      "pid": 41001
+    },
+    {
+      "name": "cloudflared-c7a533f8",
+      "provider": "cloudflared",
+      "port": 8052,
+      "public_url": "https://fake-cloudflared.example.com",
+      "pid": 41001
+    }
+  ]
+}


### PR DESCRIPTION
Integration of @shanemmattner's #2194 ('22 defect fixes for multi-provider agent orchestration', + the strict_json_schema follow-up), brought to green and finished to the project bar. This consolidates the granular issue PRs #2182/#2185/#2188/#2189/#2184 (their fixes are all contained here) and closes #2179, #2183, #2186, #2187.

## Contributor's fixes (22)
Watchdog auth-misdiagnosis, failure-classifier bare-substring false positives, janitor exact-path vs idiomatic-path acceptance, injected-skills gitignore, tunable run-length limits, strict_json_schema disable for non-OpenAI models, per-call pricing/metering, and more across adapters, tasks, cost, routing, quality, and observability.

## Finishing work done on top (to reach green + our bar)
- Restored the public create_pr API (session_id/model/cost_usd) that a rename had broken, repairing 9 pre-existing tests and back-compat.
- Fixed model pricing to match the longest key first, so mini/flash variants (gpt-5-mini, o4-mini, gemini-3-flash) price at their own rate instead of the parent stem that feeds the budget guards.
- Redacted a diagnostic pre-call log that dumped request headers/body verbatim.
- Tightened the janitor empty-diff guard and made the path_exists glob behavior non-silent; added a process-identity check before the heartbeat reaper os.kills a pidfile PID.
- Extracted the pricing table into a dependency-free cost.model_prices leaf so the runner can price a call without the adapter reaching scheduler internals (import-linter contract).
- Replaced all unicode dashes with ASCII across the added templates/docs/code; documented four new config env vars; resolved every ruff finding.

## Validation
Ruff clean, import-linter 3 kept / 0 broken. 47/48 tests/unit subdirectories green (~5300 tests, 0 failures) plus all 51 touched top-level test files (1754 passed). The remaining loose top-level batch showed 0 failures while running; the full sharded suite runs here on this maintainer branch.

Thank you @shanemmattner - excellent, well-validated work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reopening completed tasks in bounded cases.
  * Expanded task/agent handling to better preserve logs, track usage, and record more accurate cost and token totals.
  * Improved provider and adapter selection, including broader model/provider alias matching.

* **Bug Fixes**
  * Reduced false positives in rate-limit, timeout, and shutdown detection.
  * Improved handling of stalled runs, cleanup, merge safety, and completion verification.
  * Made command execution, heartbeat cleanup, and retry behavior more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->