### PR TITLE
chore(release): 2.14.0

### DIFF
--- a/docs/release-notes/v2.14.0.md
+++ b/docs/release-notes/v2.14.0.md
@@ -1,0 +1,20 @@
+# v2.14.0
+
+Released 2026-07-04.
+
+Multi-provider orchestration hardening. A large batch of correctness and run-safety fixes for real-codebase runs across mixed providers (Claude, OpenAI, OpenRouter, DeepSeek, MiniMax, Qwen, Gemini), contributed by @shanemmattner and finished to green.
+
+## Fixes
+- Stalled-manager watchdog no longer misdiagnoses a healthy manager as an auth failure: a manager doing real root-cause investigation before it POSTs its first child task is no longer killed at a hardcoded deadline, the config override is honored, and the failure record names the real cause. (#2179)
+- Failure classifier stops false-positive-killing healthy workers: bare-substring patterns (413, 429, 401, max_tokens, context window) no longer match structured tool-call log data; detection is anchored to real error shapes. (#2183)
+- Janitor acceptance checks tolerate idiomatic worker paths: path_exists honors explicit globs and an opt-in fuzzy basename fallback, so a run where workers placed correct output at repo-idiomatic paths is not cascaded to a false sev1. (#2186)
+- Injected .claude/skills/bernstein-*.md files are excluded from work-branch commits, so they stop causing a merge conflict on every worker merge. (#2187)
+- Per-call token usage is priced and surfaced on the openai_agents provider path, so budget guards are no longer inert on non-Claude runs. Model pricing matches the most specific key first, so mini and flash variants price at their own rate instead of the parent model rate.
+- strict_json_schema is disabled for non-OpenAI models that reject it, with diagnostic logging.
+- Plus the rest of the 22-fix batch across adapters, tasks, cost, routing, quality, and observability.
+
+## Features
+- Tunable agent run-length limits: max_turns, an error-budget floor, and max_agent_runtime_s, configurable per run.
+
+## Internal
+- Pricing table extracted into a dependency-free cost.model_prices leaf so adapters can price a call without reaching scheduler internals; public create_pr API preserved; a diagnostic pre-call log that dumped request headers/body verbatim is now redacted.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.13.0"
+version = "2.14.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.13.0"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Release bump for the multi-provider orchestration hardening that landed via #2198.

- Fixes for #2179 (stalled-manager auth-misdiagnosis), #2183 (classifier false positives), #2186 (janitor path matching), #2187 (injected-skills gitignore), plus per-call pricing/metering on the openai_agents path and the rest of the batch.
- Feature: tunable run-length limits (max_turns, error-budget floor, max_agent_runtime_s).

Bumps 2.13.0 to 2.14.0; notes at `docs/release-notes/v2.14.0.md`. Merge LAST; auto-release tags on green CI.

## Summary by Sourcery

Bump the project to version 2.14.0 and record the associated release notes for this release.

Build:
- Update project version from 2.13.0 to 2.14.0 in build metadata and lockfile.

Documentation:
- Add release-notes document for v2.14.0 describing orchestration hardening fixes, pricing updates, and new tunable run-length limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable agent run limits, including turn count, runtime limits, and error-budget controls.
  * Improved pricing visibility for AI agent calls.

* **Bug Fixes**
  * Reduced false positive failure classifications.
  * Improved watchdog health detection and worker path checks.
  * Prevented injected skill content from being included in work-branch commits.
  * Disabled unsupported JSON schema enforcement for compatible models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->