### PR TITLE
fix(tests): align retry-consolidation test with the 2-retry hard ceiling

### DIFF
--- a/tests/unit/test_retry_consolidation.py
+++ b/tests/unit/test_retry_consolidation.py
@@ -186,7 +186,9 @@ def test_maybe_retry_ignores_legacy_title_prefix_when_typed_field_disagrees():
     [
         (0, 3, 1, 1),
         (1, 3, 1, 2),
-        (2, 3, 1, 3),
+        # _MAX_REGULAR_TASK_RETRIES=2 hard ceiling: after 2 retries a task
+        # is dead-lettered regardless of task.max_retries or dynamic_limit.
+        (2, 3, 0, None),
         (3, 3, 0, None),  # DLQ: at limit => fail with "Max retries exceeded".
     ],
 )


### PR DESCRIPTION
The 2.14.0 content added a _MAX_REGULAR_TASK_RETRIES=2 hard ceiling (a task is dead-lettered after two retries regardless of task.max_retries or the reason-derived dynamic_limit), but the parametrized retry test still expected a third retry for retry_count=2, so main CI went red on that shard. This aligns the (2,3,...) case with the documented, evidence-backed ceiling (DLQ at retry_count=2).

Unblocks the v2.14.0 release. The max_turns shard failure on the same run was collateral of a known flaky process-rename hang, not a regression (passes deterministically).

## Summary by Sourcery

Tests:
- Update parametrized retry test expectations so tasks are dead-lettered after two retries instead of allowing a third retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified retry behavior at the maximum retry limit: once the configured retry ceiling is reached, tasks now follow the dead-letter/fail path instead of being recreated.
  * Updated regression coverage to reflect that no additional retry attempts are posted and the retry counter does not increment past the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->