### PR TITLE
fix(tests): reap leaked timeout-watchdog timers between unit tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -53,3 +53,47 @@ def _block_real_network(request: pytest.FixtureRequest) -> Iterator[None]:
         return
     with block_network():
         yield
+
+
+@pytest.fixture(autouse=True)
+def _reap_leaked_timeout_watchdogs():
+    """Cancel any timeout-watchdog Timer a spawn test leaves running.
+
+    ``CLIAdapter._start_timeout_watchdog`` starts a ``threading.Timer`` that
+    production code cancels when the agent is reaped. Adapter unit tests
+    routinely discard the ``SpawnResult`` (they only assert on the manifest
+    or log), so each spawn leaks a live Timer that sleeps for the full
+    timeout. Across a shard's worth of adapter tests these accumulate until
+    the process can no longer start new threads
+    (``RuntimeError: can't start new thread``), which flakes an unrelated
+    later test in the same shard. Cancel any that survive a test so worker
+    threads never pile up.
+    """
+    yield
+    import threading
+
+    for thread in threading.enumerate():
+        if isinstance(thread, threading.Timer) and thread.name.startswith("timeout-watchdog"):
+            thread.cancel()
+
+
+@pytest.fixture(autouse=True)
+def _reap_leaked_timeout_watchdogs():
+    """Cancel any timeout-watchdog Timer a spawn test leaves running.
+
+    ``CLIAdapter._start_timeout_watchdog`` starts a ``threading.Timer`` that
+    production code cancels when the agent is reaped. Adapter unit tests
+    routinely discard the ``SpawnResult`` (they only assert on the manifest
+    or log), so each spawn leaks a live Timer that sleeps for the full
+    timeout. Across a shard's worth of adapter tests these accumulate until
+    the process can no longer start new threads
+    (``RuntimeError: can't start new thread``), which flakes an unrelated
+    later test in the same shard. Cancel any that survive a test so worker
+    threads never pile up.
+    """
+    yield
+    import threading
+
+    for thread in threading.enumerate():
+        if isinstance(thread, threading.Timer) and thread.name.startswith("timeout-watchdog"):
+            thread.cancel()


### PR DESCRIPTION
Fixes the shard-3 CI flake where an unrelated test failed with `RuntimeError: can't start new thread`.

Root cause: `CLIAdapter._start_timeout_watchdog` starts a `threading.Timer` per spawn that production code cancels on reap, but adapter unit tests discard the SpawnResult, leaking a live Timer each time. With the ~26 openai_agents spawn tests added recently, a shard accumulated enough leaked timers to exhaust the thread limit, flaking whichever test ran when the ceiling was hit.

Fix: an autouse fixture in `tests/unit/conftest.py` cancels any surviving `timeout-watchdog` Timer after each unit test. Verified: running `tests/unit/adapters/test_openai_agents.py` leaked 26 threads before, 0 after. Unblocks the v2.14.0 release.

## Summary by Sourcery

Tests:
- Introduce a global unit-test fixture that cancels any surviving timeout-watchdog threading.Timer after each test to avoid cross-test thread leakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unit test reliability by automatically cleaning up leaked timeout watchdog timers between test runs.
  * Reduced intermittent test failures caused by accumulated background timers across the test environment.
* **Tests**
  * Added/updated an automatic fixture to reap and cancel lingering timeout watchdog threads after each unit test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->