### PR TITLE
fix: remove hardcoded model fallbacks, thread default_model through all paths

### DIFF
--- a/docs/examples/agent-prompt-template.md
+++ b/docs/examples/agent-prompt-template.md
@@ -1,0 +1,199 @@
+# Agent Prompt Template for Non-Claude Models
+
+Use this template when writing `system_prompt.md` files for Bernstein role
+templates, especially when agents will be driven by non-Claude models via
+the `openai_agents` adapter (e.g., MiniMax-M3, DeepSeek, Qwen). Claude
+has built-in agentic scaffolding; other models need it spelled out.
+
+The template has 5 layers in order. Each layer builds on the previous one.
+Do not reorder — the model reads top-down, and tool contract must come
+before project rules that reference tool names.
+
+---
+
+## Layer 1: Role Identity
+
+One sentence. Who you are, what you own, what you don't touch.
+
+```markdown
+# You are a [Role] for [Project].
+
+You [one-sentence scope]. You do not [explicit exclusion].
+```
+
+**Why first:** anchors the model's behavior before any rules land. Without
+this, instruction-following models treat everything as equally weighted.
+
+---
+
+## Layer 2: Agent Behavior
+
+The "how to be a coding agent" layer. This is what Claude Code gives you
+for free — raw API models need it explicitly.
+
+```markdown
+## How you work
+
+1. **Explore before editing.** Read the files you plan to change AND their
+   tests before writing a single line. Understand the current behavior
+   first — never edit blind.
+2. **One change at a time.** Make the smallest possible edit, then verify
+   it works before moving to the next change. Do not batch multiple
+   unrelated changes.
+3. **Verify before claiming done.** Run the relevant test and read its
+   output. A task is not complete until you have seen a passing test or
+   confirmed the fix with your own eyes. Never assume success.
+4. **Be terse.** No filler, no preamble, no "certainly" or "I'd be happy
+   to." State what you did, what you found, and what's next.
+5. **Never invent information.** If you're unsure about a function's
+   behavior, read it. If you can't find a file, search for it. Do not
+   guess paths, function signatures, or return types.
+6. **Commit after each logical unit.** Small, focused commits with
+   conventional commit messages. Never batch an entire task into one
+   giant commit.
+```
+
+**Calibration notes for specific models:**
+- **MiniMax-M3**: Tends toward premature completion claims. Reinforce
+  rule 3 with: "Run the test. Paste the output. Then mark complete."
+- **DeepSeek**: Strong at code but verbose in explanations. Reinforce
+  rule 4.
+- **Qwen**: Good instruction-following but can loop on ambiguity.
+  Reinforce the escalation ladder (Layer 5).
+
+---
+
+## Layer 3: Tool Contract
+
+Name the exact tools available. The `openai_agents` adapter with
+`tool_source=builtin` provides these four:
+
+```markdown
+## Tools available
+
+You have exactly these tools:
+
+- **`run_command`** — Execute a shell command. Use for: git, test runners,
+  build tools, grep, find. Returns stdout + stderr + exit code.
+- **`read_file`** — Read a file's contents. Always read before editing.
+  Supports line range: `read_file(path, start_line, end_line)`.
+- **`write_file`** — Write or overwrite a file. The ENTIRE content must
+  be provided — this is not a patch/diff tool, it replaces the full file.
+- **`list_dir`** — List directory contents. Use to orient yourself before
+  diving into specific files.
+
+### Tool usage rules
+
+- Read a file before writing to it — understand what you're replacing.
+- Use `run_command` for ALL shell operations: git, tests, linting, grep.
+- Check exit codes. A command that exits non-zero has failed — read stderr.
+- Never reference tools you don't have (no `edit_file`, no `search`, no
+  `browser`).
+```
+
+**Note:** If your project uses `tool_source=gateway` (MCP tools), replace
+this section with the actual tool names from your MCP descriptor.
+
+---
+
+## Layer 4: Project Conventions
+
+Project-specific rules: tech stack, code standards, domain constraints.
+This is the layer that varies per project. Keep it concrete and testable —
+every rule should be yes/no checkable against a diff.
+
+```markdown
+## Project rules
+
+### Tech stack
+- [Language, framework, package manager, test runner]
+
+### Non-negotiable rules
+1. [Rule with concrete example of correct vs incorrect]
+2. [Rule with concrete example]
+...
+
+### Patterns to follow
+- Before writing [X], read [existing example path] and mirror its structure.
+- [Import convention]
+- [Naming convention]
+```
+
+**Anti-patterns:**
+- "Write clean code" — not checkable, means nothing to a model.
+- "Follow best practices" — which ones? Be specific.
+- "Be careful with X" — say what to do, not what to feel.
+
+---
+
+## Layer 5: Escalation Ladder
+
+When to decide, when to research, when to stop. Without this, models
+either guess (dangerous) or halt on every ambiguity (slow).
+
+```markdown
+## When you're unsure
+
+1. **Ambiguity resolvable from the codebase** — grep/read to find the
+   answer yourself. Note your assumption in the commit message.
+2. **A dependency behaves unexpectedly** — STOP that step. Document what
+   you observed (command + output). Continue other independent steps.
+   Report it when done.
+3. **You need a function that doesn't exist yet** — STOP. Do not create
+   it yourself. Report it as a dependency.
+4. **A product/design decision is needed** — Do not decide. List it as
+   "needs decision" in your output.
+5. **Tests fail in ways unrelated to your change** — Do not fix unrelated
+   code. Report it.
+```
+
+---
+
+## Layer 6: Orchestration Protocol (auto-injected)
+
+**Do not write this layer.** Bernstein's `openai_agents` adapter
+automatically appends orchestration instructions (task completion signals,
+heartbeat protocol, signal-check behavior) via `system_addendum`. Adding
+your own completion/heartbeat instructions will conflict.
+
+---
+
+## Putting It All Together
+
+A complete template for a backend agent might look like:
+
+```markdown
+# You are a Backend Engineer for Acme Corp.
+
+You implement server-side changes: API routes, database queries, and
+migrations. You do not touch frontend components or test infrastructure.
+
+## How you work
+[Layer 2 content — copy and adapt from above]
+
+## Tools available
+[Layer 3 content — copy verbatim for builtin tools]
+
+## Project rules
+[Layer 4 content — project-specific]
+
+## When you're unsure
+[Layer 5 content — copy and adapt from above]
+
+## Current task
+{{TASK_DESCRIPTION}}
+```
+
+The `{{TASK_DESCRIPTION}}` placeholder is required — Bernstein's renderer
+substitutes the actual task description at spawn time.
+
+---
+
+## Size Guidelines
+
+- **Total prompt: 800–2000 tokens.** Under 800 loses critical rules; over
+  2000 wastes context window on preamble the model stops attending to.
+- **Layer 2 (behavior): ~150 tokens.** Short, imperative, numbered.
+- **Layer 3 (tools): ~200 tokens.** Exact names, exact signatures.
+- **Layer 4 (project): 300–1000 tokens.** Scales with project complexity.
+- **Layer 5 (escalation): ~100 tokens.** 4-5 numbered rules.

--- a/src/bernstein/__init__.py
+++ b/src/bernstein/__init__.py
@@ -58,10 +58,15 @@ _BUNDLED_TEMPLATES_DIR = _bundled_templates_dir
 def get_templates_dir(workdir: Path) -> Path:
     """Return the templates directory for a project, with bundled fallback.
 
-    Checks ``workdir / "templates"`` first; falls back to the package's
-    bundled defaults so that ``bernstein`` works right after ``pip install``
-    without requiring ``bernstein init`` first.
+    Checks ``workdir / ".bernstein" / "templates"`` first (project-local
+    Bernstein directory), then ``workdir / "templates"`` for backward
+    compatibility, then falls back to the package's bundled defaults so
+    that ``bernstein`` works right after ``pip install`` without requiring
+    ``bernstein init`` first.
     """
+    dot_bernstein = workdir / ".bernstein" / "templates"
+    if dot_bernstein.is_dir():
+        return dot_bernstein
     local = workdir / "templates"
     if local.is_dir():
         return local

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -285,14 +285,26 @@ def print_dry_run_table(workdir: Path) -> None:
 
 
 _SEED_FILENAMES = ("bernstein.yaml", "bernstein.yml")
+_DOT_BERNSTEIN_SEED_FILENAMES = (
+    ".bernstein/bernstein.yaml",
+    ".bernstein/bernstein.yml",
+)
 
 
 def find_seed_file() -> Path | None:
     """Look for a bernstein.yaml in the current directory.
 
+    Checks the project-local ``.bernstein/`` directory first (e.g.
+    ``.bernstein/bernstein.yaml``), then falls back to the root-level
+    ``bernstein.yaml``/``bernstein.yml`` for backward compatibility.
+
     Returns:
         Path to the seed file if found, None otherwise.
     """
+    for name in _DOT_BERNSTEIN_SEED_FILENAMES:
+        p = Path(name)
+        if p.is_file():
+            return p
     for name in _SEED_FILENAMES:
         p = Path(name)
         if p.is_file():

--- a/src/bernstein/core/agents/spawn_errors.py
+++ b/src/bernstein/core/agents/spawn_errors.py
@@ -126,6 +126,25 @@ class ResourceExhaustedError(CategorizedSpawnError):
     retry_strategy = RetryStrategy.RETRY_SAME
 
 
+class ModelNotConfiguredError(CategorizedSpawnError):
+    """A task requires a model but none is configured anywhere.
+
+    Bernstein never silently falls back to a default model (e.g. Claude
+    Sonnet/Opus) - an operator must explicitly configure a model via the
+    task, ``role_model_policy``, an adapter default, or the seed config.
+    Raised at the routing/spawn boundary when every one of those sources is
+    empty, so a run never incurs a surprise bill on an unconfigured model.
+
+    ``CategorizedSpawnError`` subclasses ``RuntimeError``, so the existing
+    spawn-loop callers (``task_lifecycle.py``, ``multi_cell.py``,
+    ``workflow_runner.py``) already catch this at the per-batch spawn
+    boundary and log an error + skip/fail just the affected task(s) instead
+    of crashing the whole orchestrator.
+    """
+
+    retry_strategy = RetryStrategy.RETRY_AFTER_FIX
+
+
 _SPAWN_ERROR_PATTERNS: list[tuple[type[CategorizedSpawnError], str, tuple[str, ...]]] = [
     (AdapterNotInstalledError, "Adapter binary not found", ("not found", "no such file", "command not found")),
     (WorktreeCreationError, "Worktree creation failed", ("worktree", "git worktree")),

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -29,7 +29,11 @@ from bernstein.core.agents.adapter_health import AdapterHealthMonitor
 from bernstein.core.agents.container import ContainerConfig, ContainerError, ContainerManager
 from bernstein.core.agents.heartbeat import HeartbeatMonitor
 from bernstein.core.agents.in_process_agent import InProcessAgent
-from bernstein.core.agents.spawn_errors import RetryStrategy, classify_spawn_error
+from bernstein.core.agents.spawn_errors import (
+    ModelNotConfiguredError,
+    RetryStrategy,
+    classify_spawn_error,
+)
 from bernstein.core.agents.spawn_rate_limiter import SpawnRateLimiter, SpawnRateLimitExceeded
 
 # Import sub-module functions
@@ -2430,7 +2434,46 @@ class AgentSpawner:
             )
         model_config = base_config
         provider_name: str | None = None
-        role_policy = self._role_model_policy.get(tasks[0].role, {})
+        role_name = tasks[0].role
+        role_policy = self._role_model_policy.get(role_name)
+        role_policy_match = "exact"
+        if role_policy is None:
+            role_policy = self._role_model_policy.get("default")
+            role_policy_match = "default"
+        if role_policy is None:
+            if self._role_model_policy:
+                # role_model_policy IS configured (non-empty) but neither this
+                # role nor a "default" key exists in it - this is an operator
+                # misconfiguration, not "no policy at all". Fail loudly rather
+                # than silently falling through to code-level defaults.
+                role_policy_match = "HARD FAIL"
+                logger.info(
+                    "role_model_policy resolution for role=%r: match=%s, resolved=None, "
+                    "available_keys=%s",
+                    role_name,
+                    role_policy_match,
+                    sorted(self._role_model_policy.keys()),
+                )
+                raise ModelNotConfiguredError(
+                    f"No model configured for role={role_name!r}: role_model_policy is "
+                    f"non-empty but has neither an entry for {role_name!r} nor a 'default' "
+                    f"entry. Available role_model_policy keys: "
+                    f"{sorted(self._role_model_policy.keys())}. Add a role entry or a "
+                    "'default' entry to role_model_policy in the YAML config."
+                )
+            # role_model_policy itself is empty/not configured at all - other
+            # mechanisms downstream (router, adapter defaults, seed config)
+            # may still supply a model, so it's OK to fall through with {}.
+            role_policy = {}
+            role_policy_match = "none"
+        logger.info(
+            "role_model_policy resolution for role=%r: match=%s, resolved=%s, "
+            "available_keys=%s",
+            role_name,
+            role_policy_match,
+            role_policy,
+            sorted(self._role_model_policy.keys()),
+        )
         # Per-step CLI override (plan-file `cli:` field) wins over role-level
         # role_model_policy.provider, which in turn wins over the default
         # adapter. The string is treated as a provider/adapter identifier and

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2419,6 +2419,7 @@ class AgentSpawner:
             templates_dir=self._templates_dir,
             metrics_dir=metrics_dir if metrics_dir.exists() else None,
             workdir=self._workdir,
+            default_model=self._default_model,
         )
         if model_override:
             base_config = ModelConfig(
@@ -3249,6 +3250,7 @@ class AgentSpawner:
             templates_dir=self._templates_dir,
             metrics_dir=metrics_dir if metrics_dir.exists() else None,
             workdir=self._workdir,
+            default_model=self._default_model,
         )
         role = tasks[0].role
         session_id = f"{role}-resume-{uuid.uuid4().hex[:8]}"

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2418,12 +2418,17 @@ class AgentSpawner:
         #      based on task complexity, scope, and role templates.
         # ---------------------------------------------------------------
         metrics_dir = self._workdir / ".sdd" / "metrics"
+        # role_model_policy may pin this role's model below; feed that pin to
+        # the heuristic selector as the default so a role-policy-only config
+        # (no run-level default_model) does not fail heuristic routing before
+        # the pin is applied.
+        _policy_preview = self._role_model_policy.get(tasks[0].role) or self._role_model_policy.get("default") or {}
         base_config = _select_batch_config(
             tasks,
             templates_dir=self._templates_dir,
             metrics_dir=metrics_dir if metrics_dir.exists() else None,
             workdir=self._workdir,
-            default_model=self._default_model,
+            default_model=self._default_model or _policy_preview.get("model"),
         )
         if model_override:
             base_config = ModelConfig(
@@ -3286,12 +3291,15 @@ class AgentSpawner:
         )
 
         metrics_dir = self._workdir / ".sdd" / "metrics"
+        # Same role-policy fallback as the main spawn path: a role-policy-only
+        # config (no run-level default_model) must not fail heuristic routing.
+        _policy_preview = self._role_model_policy.get(tasks[0].role) or self._role_model_policy.get("default") or {}
         model_config = _select_batch_config(
             tasks,
             templates_dir=self._templates_dir,
             metrics_dir=metrics_dir if metrics_dir.exists() else None,
             workdir=self._workdir,
-            default_model=self._default_model,
+            default_model=self._default_model or _policy_preview.get("model"),
         )
         role = tasks[0].role
         session_id = f"{role}-resume-{uuid.uuid4().hex[:8]}"

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2448,8 +2448,7 @@ class AgentSpawner:
                 # than silently falling through to code-level defaults.
                 role_policy_match = "HARD FAIL"
                 logger.info(
-                    "role_model_policy resolution for role=%r: match=%s, resolved=None, "
-                    "available_keys=%s",
+                    "role_model_policy resolution for role=%r: match=%s, resolved=None, available_keys=%s",
                     role_name,
                     role_policy_match,
                     sorted(self._role_model_policy.keys()),
@@ -2467,8 +2466,7 @@ class AgentSpawner:
             role_policy = {}
             role_policy_match = "none"
         logger.info(
-            "role_model_policy resolution for role=%r: match=%s, resolved=%s, "
-            "available_keys=%s",
+            "role_model_policy resolution for role=%r: match=%s, resolved=%s, available_keys=%s",
             role_name,
             role_policy_match,
             role_policy,

--- a/src/bernstein/core/agents/spawner_warm_pool.py
+++ b/src/bernstein/core/agents/spawner_warm_pool.py
@@ -133,6 +133,7 @@ def _select_batch_config(
     templates_dir: Path | None = None,
     metrics_dir: Path | None = None,
     workdir: Path | None = None,
+    default_model: str | None = None,
 ) -> ModelConfig:
     """Pick the highest-tier model config across all tasks in a batch.
 
@@ -150,6 +151,8 @@ def _select_batch_config(
         templates_dir: Optional path to templates/roles/ for config.yaml lookup.
         metrics_dir: Optional path to .sdd/metrics for bandit state.
         workdir: Optional project root for effectiveness scorer data.
+        default_model: Optional model name from the seed config, used as the
+            primary fallback ahead of the hardcoded Claude tier names.
 
     Returns:
         ModelConfig suitable for the entire batch.
@@ -177,11 +180,13 @@ def _select_batch_config(
     def _route_for_batch(task: Task) -> ModelConfig:
         """Batch-specific routing: consult bandit when available, else heuristics."""
         if task.model or task.effort:
-            return ModelConfig(model=task.model or "sonnet", effort=task.effort or "normal")
+            return ModelConfig(
+                model=task.model or default_model or "sonnet", effort=task.effort or "normal"
+            )
         if task.role in _HIGH_STAKES_ROLES or task.scope == Scope.LARGE or task.priority == 1:
-            return ModelConfig(model="opus", effort="max")
+            return ModelConfig(model=default_model or "opus", effort="max")
         if task.complexity == Complexity.HIGH:
-            return ModelConfig(model="opus", effort="high")
+            return ModelConfig(model=default_model or "opus", effort="high")
         return route_task(task, bandit_metrics_dir=metrics_dir, workdir=workdir)
 
     configs = [_route_for_batch(t) for t in tasks]

--- a/src/bernstein/core/agents/spawner_warm_pool.py
+++ b/src/bernstein/core/agents/spawner_warm_pool.py
@@ -6,6 +6,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, cast
 
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.models import ModelConfig, Task
 
 if TYPE_CHECKING:
@@ -77,10 +78,15 @@ def _coerce_model_for_non_claude_adapter(
     model in the manifest that never actually ran. This normalises the selected
     model so the recorded and executed model agree.
 
-    Returns the input unchanged for Claude-compatible adapters (byte-identical),
-    for models that are not Claude tiers, or when no adapter default is known.
-    Callers must only invoke this when the operator did not pin a model
-    (no per-task ``model`` and no ``role_model_policy`` model).
+    Returns the input unchanged for Claude-compatible adapters (byte-identical)
+    or for models that are not Claude tiers. Raises
+    :class:`ModelNotConfiguredError` when the model IS an unpinned Claude tier
+    name being sent to a non-Claude adapter and no adapter default is
+    configured - spawning would otherwise send e.g. ``codex exec -m opus``,
+    which the CLI rejects, or silently bill a Claude-tier-shaped call to a
+    provider that has no such tier. Callers must only invoke this when the
+    operator did not pin a model (no per-task ``model`` and no
+    ``role_model_policy`` model).
     """
     from bernstein.core.bandit_router import BanditRouter
 
@@ -89,7 +95,12 @@ def _coerce_model_for_non_claude_adapter(
     if model_config.model not in _CLAUDE_TIER_MODELS:
         return model_config
     if not adapter_default_model:
-        return model_config
+        raise ModelNotConfiguredError(
+            f"Model '{model_config.model}' is an unpinned Claude tier name but adapter "
+            f"'{adapter_name}' is not Claude-compatible and has no default_model configured. "
+            "Refusing to spawn with a nonsensical model - configure role_model_policy or an "
+            "adapter default.",
+        )
     return ModelConfig(
         model=adapter_default_model,
         effort=model_config.effort,
@@ -120,9 +131,15 @@ def _load_role_config(role: str, templates_dir: Path) -> ModelConfig | None:
         if not isinstance(raw_data, dict):
             return None
         data: dict[str, Any] = cast("dict[str, Any]", raw_data)
-        model = str(data.get("default_model", "sonnet"))
+        model = data.get("default_model")
+        if model is None:
+            logger.debug(
+                "Role config for '%s' has no default_model - skipping role-config routing",
+                role,
+            )
+            return None
         effort = str(data.get("default_effort", "high"))
-        return ModelConfig(model=model, effort=effort)
+        return ModelConfig(model=str(model), effort=effort)
     except Exception as exc:
         logger.warning("Failed to load role config for '%s': %s", role, exc)
         return None
@@ -180,14 +197,33 @@ def _select_batch_config(
     def _route_for_batch(task: Task) -> ModelConfig:
         """Batch-specific routing: consult bandit when available, else heuristics."""
         if task.model or task.effort:
-            return ModelConfig(
-                model=task.model or default_model or "sonnet", effort=task.effort or "normal"
-            )
+            model = task.model or default_model
+            if model is None:
+                raise ModelNotConfiguredError(
+                    f"Task {task.id} has effort={task.effort!r} but no model, and no "
+                    "default_model is configured. Refusing to guess a model.",
+                )
+            return ModelConfig(model=model, effort=task.effort or "normal")
         if task.role in _HIGH_STAKES_ROLES or task.scope == Scope.LARGE or task.priority == 1:
-            return ModelConfig(model=default_model or "opus", effort="max")
+            if default_model is None:
+                raise ModelNotConfiguredError(
+                    f"Task {task.id} (role={task.role}) is high-stakes but no default_model "
+                    "is configured. Refusing to guess a model.",
+                )
+            return ModelConfig(model=default_model, effort="max")
         if task.complexity == Complexity.HIGH:
-            return ModelConfig(model=default_model or "opus", effort="high")
-        return route_task(task, bandit_metrics_dir=metrics_dir, workdir=workdir)
+            if default_model is None:
+                raise ModelNotConfiguredError(
+                    f"Task {task.id} has HIGH complexity but no default_model is configured. "
+                    "Refusing to guess a model.",
+                )
+            return ModelConfig(model=default_model, effort="high")
+        return route_task(
+            task,
+            bandit_metrics_dir=metrics_dir,
+            workdir=workdir,
+            default_model=default_model,
+        )
 
     configs = [_route_for_batch(t) for t in tasks]
     # Sort by model tier (opus > sonnet > haiku) then effort (max > high > normal)

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -526,6 +526,14 @@ class BernsteinConfig(BaseModel):
         default="nvidia/nemotron-3-super-120b-a12b",
         description="Model for internal LLM calls.",
     )
+    judge_model: str | None = Field(
+        default=None,
+        description="Model for janitor LLM-judge calls. Falls back to the run's top-level model.",
+    )
+    judge_provider: str | None = Field(
+        default=None,
+        description="Provider for janitor LLM-judge calls. Falls back to the run's adapter provider.",
+    )
 
     # --- Constraints and context ---
     constraints: list[str] = Field(default_factory=list)

--- a/src/bernstein/core/config/seed.py
+++ b/src/bernstein/core/config/seed.py
@@ -19,8 +19,6 @@ from typing import Any, Literal, cast
 
 import yaml
 
-logger = logging.getLogger(__name__)
-
 # Re-export all dataclasses / config types from seed_config
 from bernstein.core.config.seed_config import (  # noqa: F401
     CORSConfig,
@@ -40,8 +38,15 @@ from bernstein.core.config.seed_config import (  # noqa: F401
     github_backlog_sync_enabled,
 )
 
-# Re-export all parsing functions from seed_parser
+# Re-export all parsing functions and regex/frozenset constants from
+# seed_parser that callers may reference
 from bernstein.core.config.seed_parser import (  # noqa: F401
+    _ALLOWED_WEBHOOK_EVENTS,
+    _BUDGET_RE,
+    _DEFAULT_RATE_LIMIT_PATHS,
+    _ENV_REF_RE,
+    _VALID_CLIS,
+    _WEBHOOK_EVENT_ALIASES,
     _expand_env_value,
     _normalize_webhook_event,
     _parse_bridge_settings,
@@ -69,15 +74,7 @@ from bernstein.core.models import (
     TaskStatus,
 )
 
-# Re-export regex/frozenset constants that callers may reference
-from bernstein.core.config.seed_parser import (  # noqa: F401
-    _ALLOWED_WEBHOOK_EVENTS,
-    _BUDGET_RE,
-    _DEFAULT_RATE_LIMIT_PATHS,
-    _ENV_REF_RE,
-    _VALID_CLIS,
-    _WEBHOOK_EVENT_ALIASES,
-)
+logger = logging.getLogger(__name__)
 
 # Type alias kept for backward compatibility
 type _StrObjDict = dict[str, object]

--- a/src/bernstein/core/config/seed.py
+++ b/src/bernstein/core/config/seed.py
@@ -10,11 +10,16 @@ This module re-exports all names from ``seed_config`` (dataclasses) and
 
 from __future__ import annotations
 
+import logging
+import os
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, cast
+from pathlib import Path
+from typing import Any, Literal, cast
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 # Re-export all dataclasses / config types from seed_config
 from bernstein.core.config.seed_config import (  # noqa: F401
@@ -63,9 +68,6 @@ from bernstein.core.models import (
     Task,
     TaskStatus,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 # Re-export regex/frozenset constants that callers may reference
 from bernstein.core.config.seed_parser import (  # noqa: F401
@@ -391,3 +393,54 @@ def build_config_snapshot(
         feature_gates=registry.to_snapshot(),
         stale_gate_names=stale,
     )
+
+
+# ---------------------------------------------------------------------------
+# Seed path resolution (fixes: subprocesses losing role_model_policy because
+# they independently re-derived ``workdir / "bernstein.yaml"`` instead of
+# using the path the bootstrap process actually parsed)
+# ---------------------------------------------------------------------------
+
+
+def resolve_seed_path(workdir: Path, explicit: Path | None = None) -> Path:
+    """Resolve the effective seed (bernstein.yaml) path for a process.
+
+    Every Bernstein subprocess (spawner/orchestrator, watchdog, FastAPI
+    server) needs to agree on which seed file to parse. Historically each
+    subprocess independently hardcoded ``workdir / "bernstein.yaml"``, which
+    silently produced an empty/default config whenever the real seed lived
+    elsewhere (e.g. a non-default filename or a seed staged outside the
+    workdir) -- ``role_model_policy`` and other seed-driven settings were
+    lost with no error, and agents spawned with the default model instead
+    of the configured one.
+
+    Resolution order (highest priority first):
+        1. ``explicit`` -- an caller-supplied path (e.g. parsed from
+           ``--seed-path`` argv or threaded through from the bootstrap
+           process that already resolved it).
+        2. ``BERNSTEIN_SEED_PATH`` env var -- set by the bootstrap process
+           on the subprocess env so children inherit the resolved path
+           without needing their own argv plumbing.
+        3. Fallback: ``workdir / "bernstein.yaml"`` (the historical default).
+
+    Args:
+        workdir: Project root directory.
+        explicit: Explicit seed path override, if the caller already knows it.
+
+    Returns:
+        Resolved, absolute :class:`Path` to the seed file.
+    """
+    if explicit:
+        resolved = explicit.resolve()
+        logger.debug("resolve_seed_path: using explicit path %s", resolved)
+        return resolved
+
+    env_path = os.environ.get("BERNSTEIN_SEED_PATH", "").strip()
+    if env_path:
+        resolved = Path(env_path).resolve()
+        logger.debug("resolve_seed_path: using BERNSTEIN_SEED_PATH=%s -> %s", env_path, resolved)
+        return resolved
+
+    resolved = workdir / "bernstein.yaml"
+    logger.debug("resolve_seed_path: falling back to workdir default %s", resolved)
+    return resolved

--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -385,6 +385,10 @@ class SeedConfig:
     # explicitly and export the matching API key.
     internal_llm_provider: str = "none"
     internal_llm_model: str = "nvidia/nemotron-3-super-120b-a12b"
+    # Janitor LLM-judge model/provider override (falls back to
+    # bernstein.core.quality.janitor.JUDGE_MODEL/JUDGE_PROVIDER when unset).
+    judge_model: str | None = None
+    judge_provider: str | None = None
     model_fallback: ModelFallbackSeedConfig | None = None
     cost_tags: dict[str, str] = field(default_factory=dict)
     cost_autopilot: bool = False

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -1650,6 +1650,8 @@ def parse_seed(path: Path) -> SeedConfig:
 
     internal_llm_provider_raw = _validate_optional_str(data, "internal_llm_provider", "openrouter_free")
     internal_llm_model_raw = _validate_optional_str(data, "internal_llm_model", "nvidia/nemotron-3-super-120b-a12b")
+    judge_model_raw = _parse_optional_str_field(data, "judge_model")
+    judge_provider_raw = _parse_optional_str_field(data, "judge_provider")
     model_fallback = _parse_model_fallback(data.get("model_fallback"))
     cost_tags = _parse_cost_tags(data.get("cost_tags", {}))
     cost_autopilot_raw = _validate_optional_bool(data, "cost_autopilot", False)
@@ -1708,6 +1710,8 @@ def parse_seed(path: Path) -> SeedConfig:
         tenants=tenants,
         internal_llm_provider=internal_llm_provider_raw,
         internal_llm_model=internal_llm_model_raw,
+        judge_model=cast("str | None", judge_model_raw),
+        judge_provider=cast("str | None", judge_provider_raw),
         model_fallback=model_fallback,
         cost_tags=cost_tags,
         cost_autopilot=cost_autopilot_raw,

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -420,10 +420,14 @@ class PhasePipelineDefaults:
     """
 
     enabled: bool = False
-    research_model: str = "opus"
-    plan_model: str = "opus"
-    implement_model: str = "sonnet"
-    verify_model: str = "sonnet"
+    # No built-in defaults - Bernstein never silently falls back to a Claude
+    # tier name. These are currently unread by any consumer (dead code); if a
+    # future PhasedRunner reads them, it must treat None as "not configured"
+    # and raise/skip rather than guessing a model.
+    research_model: str | None = None
+    plan_model: str | None = None
+    implement_model: str | None = None
+    verify_model: str | None = None
     artifact_root: str = ".sdd/runtime/phase_artifacts"
     gc_on_task_close: bool = True
     # Mechanical exit-criteria gate (R001..R005) at every phase boundary.

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -47,6 +47,7 @@ from bernstein.core.seed import (
     SeedConfig,
     github_backlog_sync_enabled,
     parse_seed,
+    resolve_seed_path,
 )
 from bernstein.core.server_launch import (
     BootstrapResult,
@@ -549,8 +550,22 @@ def bootstrap_from_seed(
     check_config_paths(seed, workdir)
     effective_cells = cells if cells is not None else seed.cells
 
+    # Persist the resolved seed path so downstream tooling (dashboard,
+    # `bernstein status`, debug bundles) can find the real seed file even
+    # when it doesn't live at the default ``workdir/bernstein.yaml``.
+    _resolved_seed_path = seed_path.resolve()
+    _seed_location_path = workdir / ".sdd" / "runtime" / "seed_location.json"
+    try:
+        _seed_location_path.parent.mkdir(parents=True, exist_ok=True)
+        import json as _json
+
+        _seed_location_path.write_text(_json.dumps({"seed_path": str(_resolved_seed_path)}))
+        logger.info("bootstrap_from_seed: persisted seed_path=%s to %s", _resolved_seed_path, _seed_location_path)
+    except OSError as exc:
+        logger.warning("bootstrap_from_seed: failed to persist seed_location.json: %s", exc)
+
     # 2. Workspace + catalog + index (silent - errors logged, not printed)
-    ensure_sdd(workdir, model=seed.model or "opus")
+    ensure_sdd(workdir, model=seed.model)
     _clean_stale_runtime(workdir)
     _discover_catalog(workdir)
     _index_codebase_with_timeout(workdir)
@@ -611,9 +626,12 @@ def bootstrap_from_seed(
     from bernstein.core.cost import estimate_run_cost
 
     est_count = backlog_count if backlog_count > 0 else 5
-    est_model = seed.model or "sonnet"
-    low, high = estimate_run_cost(est_count, est_model)
-    console.print(f"  [dim]cost[/dim]    ~${low:.2f}-${high:.2f} ({est_count} tasks, {est_model})")
+    est_model = seed.model
+    if est_model:
+        low, high = estimate_run_cost(est_count, est_model)
+        console.print(f"  [dim]cost[/dim]    ~${low:.2f}-${high:.2f} ({est_count} tasks, {est_model})")
+    else:
+        console.print(f"  [dim]cost[/dim]    unknown (no model configured, {est_count} tasks)")
 
     # 5. Start spawner + watchdog
     # Propagate the resolved adapter (e.g. ``mock`` from ``--idle``) explicitly so
@@ -632,8 +650,15 @@ def bootstrap_from_seed(
         ab_test=ab_test,
         adapter=_resolved_adapter,
         model=getattr(seed, "model", None) or None,
+        seed_path=_resolved_seed_path,
     )
-    _start_watchdog(workdir, port, adapter=_resolved_adapter, model=getattr(seed, "model", None) or None)
+    _start_watchdog(
+        workdir,
+        port,
+        adapter=_resolved_adapter,
+        model=getattr(seed, "model", None) or None,
+        seed_path=_resolved_seed_path,
+    )
     console.print(f"  [dim]agents[/dim]  spawning (max {seed.max_agents})")
 
     result = BootstrapResult(
@@ -658,7 +683,13 @@ def bootstrap_from_seed(
     return result
 
 
-def _start_watchdog(workdir: Path, port: int, adapter: str | None = None, model: str | None = None) -> int:
+def _start_watchdog(
+    workdir: Path,
+    port: int,
+    adapter: str | None = None,
+    model: str | None = None,
+    seed_path: Path | None = None,
+) -> int:
     """Launch the watchdog as a background process.
 
     Args:
@@ -668,6 +699,10 @@ def _start_watchdog(workdir: Path, port: int, adapter: str | None = None, model:
             Threaded through so a watchdog-triggered spawner restart doesn't
             silently drop back to the default ``claude`` adapter.
         model: ``--model`` override to preserve across spawner restarts.
+        seed_path: Resolved bernstein.yaml path to preserve across
+            watchdog-triggered spawner restarts (see ``_restart_spawner``) --
+            otherwise a restarted spawner would re-derive
+            ``workdir / "bernstein.yaml"`` and silently lose config.
 
     Returns:
         PID of the watchdog process.
@@ -687,6 +722,9 @@ def _start_watchdog(workdir: Path, port: int, adapter: str | None = None, model:
         argv.extend(["--adapter", adapter])
     if model:
         argv.extend(["--model", model])
+    if seed_path:
+        argv.extend(["--seed-path", str(seed_path)])
+        logger.info("_start_watchdog: propagating seed_path=%s", seed_path)
 
     log_fh = log_path.open("w")
     proc = subprocess.Popen(
@@ -766,6 +804,7 @@ def run_watchdog(
     poll_s: float = 5.0,
     adapter: str | None = None,
     model: str | None = None,
+    seed_path: Path | None = None,
 ) -> None:
     """Monitor the server and orchestrator, restarting them if they die.
 
@@ -786,6 +825,8 @@ def run_watchdog(
         adapter: Resolved CLI adapter override to preserve across
             watchdog-triggered spawner restarts (see ``_restart_spawner``).
         model: ``--model`` override to preserve across spawner restarts.
+        seed_path: Resolved bernstein.yaml path to preserve across spawner
+            restarts.
     """
     server_pid_path = workdir / ".sdd" / "runtime" / "server.pid"
     spawner_pid_path = workdir / ".sdd" / "runtime" / "spawner.pid"
@@ -824,7 +865,8 @@ def run_watchdog(
             cur_server_pid = _read_pid(server_pid_path)
             if cur_server_pid is None or not _is_alive(cur_server_pid):
                 return -1  # signal: skip restart
-            return _start_spawner(workdir, port, adapter=adapter, model=model)
+            logger.info("_restart_spawner: restarting with seed_path=%s adapter=%s model=%s", seed_path, adapter, model)
+            return _start_spawner(workdir, port, adapter=adapter, model=model, seed_path=seed_path)
 
         spawner_alive_since, spawner_restarts, spawner_give_up_logged = _watchdog_check_process(
             name="Orchestrator",
@@ -1074,7 +1116,7 @@ def _bootstrap_from_goal_impl(
 
     # Initialise workspace
     with Status("[bold]Creating workspace...[/bold]", console=console):
-        created = ensure_sdd(workdir, model=model or "opus")
+        created = ensure_sdd(workdir, model=model)
         if first_run and not (workdir / "bernstein.yaml").exists():
             auto_write_bernstein_yaml(workdir)
         _clean_stale_runtime(workdir)
@@ -1151,10 +1193,15 @@ def _bootstrap_from_goal_impl(
     from bernstein.core.cost import estimate_run_cost
 
     est_task_count = backlog_count if backlog_count > 0 else 5  # default estimate for manager-planned
-    low, high = estimate_run_cost(est_task_count, "sonnet")
-    console.print(
-        f"[bold yellow]Cost estimate:[/bold yellow] ${low:.2f}-${high:.2f} ({est_task_count} task(s), sonnet model)"
-    )
+    if model:
+        low, high = estimate_run_cost(est_task_count, model)
+        console.print(
+            f"[bold yellow]Cost estimate:[/bold yellow] ${low:.2f}-${high:.2f} ({est_task_count} task(s), {model} model)"
+        )
+    else:
+        console.print(
+            f"[bold yellow]Cost estimate:[/bold yellow] unknown - no model configured ({est_task_count} task(s))"
+        )
 
     cell_label = f"{cells} cells" if cells > 1 else "single cell"
     # Propagate the resolved cli adapter explicitly so the orchestrator
@@ -1192,6 +1239,12 @@ if __name__ == "__main__":
     _parser.add_argument("--port", type=int, default=8052)
     _parser.add_argument("--adapter", type=str, default=None)
     _parser.add_argument("--model", type=str, default=None)
+    _parser.add_argument(
+        "--seed-path",
+        type=str,
+        default=os.environ.get("BERNSTEIN_SEED_PATH", "").strip() or None,
+        help="Resolved bernstein.yaml path, threaded through from bootstrap_from_seed().",
+    )
     _args = _parser.parse_args()
 
     if _args.watchdog:
@@ -1204,7 +1257,9 @@ if __name__ == "__main__":
                 level=logging.INFO,
                 format="%(asctime)s %(levelname)s %(name)s: %(message)s",
             )
-        run_watchdog(Path.cwd(), _args.port, adapter=_args.adapter, model=_args.model)
+        _watchdog_seed_path = Path(_args.seed_path) if _args.seed_path else None
+        logger.info("watchdog __main__: starting with seed_path=%s", _watchdog_seed_path)
+        run_watchdog(Path.cwd(), _args.port, adapter=_args.adapter, model=_args.model, seed_path=_watchdog_seed_path)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -47,7 +47,6 @@ from bernstein.core.seed import (
     SeedConfig,
     github_backlog_sync_enabled,
     parse_seed,
-    resolve_seed_path,
 )
 from bernstein.core.server_launch import (
     BootstrapResult,
@@ -1196,7 +1195,8 @@ def _bootstrap_from_goal_impl(
     if model:
         low, high = estimate_run_cost(est_task_count, model)
         console.print(
-            f"[bold yellow]Cost estimate:[/bold yellow] ${low:.2f}-${high:.2f} ({est_task_count} task(s), {model} model)"
+            f"[bold yellow]Cost estimate:[/bold yellow] ${low:.2f}-${high:.2f} "
+            f"({est_task_count} task(s), {model} model)"
         )
     else:
         console.print(

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5399,6 +5399,8 @@ if __name__ == "__main__":
             max_cost_per_agent=seed.max_cost_per_agent if seed else 0.0,
             test_agent=seed.test_agent if seed else TestAgentConfig(),
             cost_autopilot=seed.cost_autopilot if seed else False,
+            judge_model=seed.judge_model if seed else None,
+            judge_provider=seed.judge_provider if seed else None,
         )
 
         if args.cells > 1:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -125,6 +125,7 @@ from bernstein.core.runtime_state import (
     rotate_log_file,
     write_session_replay_metadata,
 )
+from bernstein.core.seed import resolve_seed_path
 from bernstein.core.semantic_cache import ResponseCacheManager
 from bernstein.core.signals import read_unresolved_pivots
 from bernstein.core.slo import SLOTracker, apply_error_budget_adjustments
@@ -393,10 +394,20 @@ class Orchestrator:
             if model_policy_yaml.exists():
                 load_model_policy_from_yaml(model_policy_yaml, self._router)
             else:
-                # Fall back to bernstein.yaml model_policy section
-                seed_path = workdir / _BERNSTEIN_YAML
-                if seed_path.exists():
-                    load_model_policy_from_yaml(seed_path, self._router)
+                # Fall back to bernstein.yaml model_policy section. Resolve via
+                # resolve_seed_path() (explicit --seed-path / BERNSTEIN_SEED_PATH
+                # env / workdir default) instead of hardcoding workdir/bernstein.yaml
+                # -- otherwise role_model_policy is silently lost whenever the
+                # real seed lives elsewhere, and agents spawn on the default
+                # model instead of the configured one.
+                _seed_path_for_policy = resolve_seed_path(workdir)
+                logger.info(
+                    "Orchestrator.__init__: resolved seed_path=%s for model_policy fallback (exists=%s)",
+                    _seed_path_for_policy,
+                    _seed_path_for_policy.exists(),
+                )
+                if _seed_path_for_policy.exists():
+                    load_model_policy_from_yaml(_seed_path_for_policy, self._router)
             # Warn on startup if policy leaves no viable providers
             policy_issues = self._router.validate_policy()
             for issue in policy_issues:
@@ -575,7 +586,7 @@ class Orchestrator:
             run_id=run_id,
             sdd_dir=workdir / ".sdd",
         )
-        _seed_path = workdir / _BERNSTEIN_YAML
+        _seed_path = resolve_seed_path(workdir)
         self._replay_metadata = SessionReplayMetadata(
             run_id=run_id,
             started_at=time.time(),
@@ -633,7 +644,7 @@ class Orchestrator:
 
         # Config hot-reload: track bernstein.yaml mtime so mutable config
         # fields (max_agents, budget_usd) are picked up without restart.
-        self._config_path: Path = workdir / _BERNSTEIN_YAML
+        self._config_path: Path = resolve_seed_path(workdir)
         self._config_mtime: float = self._config_path.stat().st_mtime if self._config_path.exists() else 0.0
 
         # Memory leak detection: sampled every few ticks
@@ -4627,7 +4638,7 @@ def _resolve_manager_llm(workdir: Path) -> tuple[str, str]:
 
     provider = "openrouter_free"
     model = "nvidia/nemotron-3-super-120b-a12b"
-    seed_path = workdir / _BERNSTEIN_YAML
+    seed_path = resolve_seed_path(workdir)
     if seed_path.exists():
         with contextlib.suppress(Exception):
             seed = parse_seed(seed_path)
@@ -4867,12 +4878,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=8052)
     # The adapter default deliberately falls through to the BERNSTEIN_ADAPTER
-    # env var first.  The bootstrap subprocess launcher sets that var when the
-    # operator passes ``--idle`` / a ``cli`` override / a seed-resolved cli,
-    # which closes the long-standing bug where ``bernstein run --idle`` would
-    # silently spawn Claude (and burn real tokens) because this default was
-    # hardcoded to ``"claude"``.
-    _adapter_env_default = os.environ.get("BERNSTEIN_ADAPTER", "").strip() or "claude"
+    # env var first, with NO further fallback.  Bernstein must never silently
+    # spawn Claude (and burn real tokens) because an adapter was never
+    # configured - the operator must pass ``--adapter``, set
+    # ``BERNSTEIN_ADAPTER``, or configure ``cli`` in the seed. Absence of all
+    # three is a fatal misconfiguration, checked below once the seed-resolved
+    # value (if any) has also been consulted.
+    _adapter_env_default = os.environ.get("BERNSTEIN_ADAPTER", "").strip() or None
     parser.add_argument("--adapter", type=str, default=_adapter_env_default)
     parser.add_argument("--cells", type=int, default=1, help="Number of parallel cells (1=single-cell)")
     # Run-level model override (from ``bernstein run --model``), threaded through
@@ -4883,6 +4895,16 @@ if __name__ == "__main__":
     # non-Claude adapter understands - see _coerce_model_for_non_claude_adapter.
     _model_env_default = os.environ.get("BERNSTEIN_MODEL", "").strip() or None
     parser.add_argument("--model", type=str, default=_model_env_default)
+    # Resolved bernstein.yaml path, threaded through from bootstrap_from_seed()
+    # via _start_spawner()'s --seed-path / BERNSTEIN_SEED_PATH env var. Fixes
+    # the bug where this subprocess independently re-derived
+    # ``workdir / "bernstein.yaml"`` and silently lost role_model_policy (and
+    # every other seed setting) whenever the real seed lived elsewhere.
+    parser.add_argument(
+        "--seed-path",
+        type=str,
+        default=os.environ.get("BERNSTEIN_SEED_PATH", "").strip() or None,
+    )
     args = parser.parse_args()
 
     workdir = Path.cwd()
@@ -4960,14 +4982,34 @@ if __name__ == "__main__":
     try:
         # Try to load adapter from seed if available
         adapter_name = args.adapter
-        seed_path = workdir / _BERNSTEIN_YAML
+        seed_path = Path(args.seed_path) if args.seed_path else resolve_seed_path(workdir)
+        logger.info(
+            "orchestrator __main__: resolved seed_path=%s (from --seed-path=%s, exists=%s)",
+            seed_path,
+            args.seed_path,
+            seed_path.exists(),
+        )
         seed: SeedConfig | None = None
         if seed_path.exists():
             try:
                 seed = parse_seed(seed_path)
                 adapter_name = getattr(seed, "cli", adapter_name)
+                logger.info(
+                    "orchestrator __main__: parsed seed from %s (cli=%s, model=%s, role_model_policy=%s)",
+                    seed_path,
+                    getattr(seed, "cli", None),
+                    getattr(seed, "model", None),
+                    getattr(seed, "role_model_policy", None),
+                )
             except Exception as exc:
                 logger.warning("Failed to parse seed for adapter config: %s", exc)
+
+        if not adapter_name:
+            logger.error(
+                "FATAL: no adapter configured. Bernstein does not default to Claude - "
+                "pass --adapter, set BERNSTEIN_ADAPTER, or configure 'cli' in bernstein.yaml."
+            )
+            sys.exit(1)
 
         # Run-level model: ``--model`` flag (threaded from ``bernstein run
         # --model``) wins, falling back to the seed's resolved model (also

--- a/src/bernstein/core/quality/fast_path.py
+++ b/src/bernstein/core/quality/fast_path.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.metrics import get_collector
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 
@@ -429,13 +430,40 @@ def execute_fast_path(
 # L1 model override - cheapest model for simple tasks
 # ---------------------------------------------------------------------------
 
-# Default L1 model: sonnet (not haiku - on Max plan sonnet is unlimited
-# and produces much better results for the same cost).
-_l1_model_config = ModelConfig(model="sonnet", effort="normal", max_tokens=50_000)
+# L1 model config comes ONLY from routing.yaml's `fast_path.l1_model` /
+# `fast_path.l1_effort` keys, loaded via load_fast_path_config() below.
+# Bernstein never hardcodes a fallback model (previously "sonnet") - if no
+# config has been loaded, get_l1_model_config() raises ModelNotConfiguredError
+# instead of silently defaulting.
+_l1_model_config: ModelConfig | None = None
 
 
 def get_l1_model_config() -> ModelConfig:
-    """Return the cheapest model config for L1 (simple) tasks."""
+    """Return the config-supplied model config for L1 (simple) tasks.
+
+    Raises:
+        ModelNotConfiguredError: if ``fast_path.l1_model`` has not been set
+            via ``load_fast_path_config()`` (i.e. no routing.yaml, or the
+            YAML omits ``fast_path.l1_model``). Bernstein never falls back
+            to a hardcoded default model.
+    """
+    if _l1_model_config is None:
+        logger.error(
+            "get_l1_model_config: no L1 model configured (fast_path.l1_model "
+            "missing from routing.yaml) - raising instead of defaulting to a "
+            "hardcoded model"
+        )
+        raise ModelNotConfiguredError(
+            "No L1 model configured for fast-path routing. Set "
+            "fast_path.l1_model (and optionally fast_path.l1_effort) in "
+            ".sdd/config/routing.yaml - Bernstein does not hardcode a "
+            "default model for L1 tasks."
+        )
+    logger.debug(
+        "get_l1_model_config: returning config-supplied model=%s effort=%s",
+        _l1_model_config.model,
+        _l1_model_config.effort,
+    )
     return _l1_model_config
 
 
@@ -555,16 +583,30 @@ def load_fast_path_config(routing_yaml: Path) -> bool:
     if parsed_l1 is not None:
         _l1_patterns = parsed_l1
 
-    # Load L1 model override
+    # Load L1 model override. l1_model is required - Bernstein does not
+    # hardcode a fallback model (previously "haiku") when the operator sets
+    # l1_effort without also pinning l1_model.
     l1_model: object = fp_cfg.get("l1_model")
     l1_effort: object = fp_cfg.get("l1_effort")
-    if l1_model or l1_effort:
+    if l1_model:
         _l1_model_config = ModelConfig(
-            model=str(l1_model) if l1_model else "haiku",
-            effort=str(l1_effort) if l1_effort else "low",
+            model=str(l1_model),
+            effort=str(l1_effort) if l1_effort else "normal",
             max_tokens=50_000,
         )
-        logger.debug("L1 model config from routing.yaml: %s/%s", _l1_model_config.model, _l1_model_config.effort)
+        logger.info(
+            "L1 model config loaded from routing.yaml (config-supplied): model=%s effort=%s",
+            _l1_model_config.model,
+            _l1_model_config.effort,
+        )
+    elif l1_effort:
+        logger.warning(
+            "routing.yaml fast_path.l1_effort=%r set without fast_path.l1_model - "
+            "ignoring l1_effort (no hardcoded model fallback available); "
+            "L1 model config remains %s",
+            l1_effort,
+            "unset (will raise on use)" if _l1_model_config is None else "unchanged",
+        )
 
     return True
 

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -40,6 +40,12 @@ logger = logging.getLogger(__name__)
 # --- Judge constants ---
 
 MAX_JUDGE_RETRIES = 2
+# Last-resort fallback constants used only when neither the operator's
+# bernstein.yaml (judge_model/judge_provider) nor an explicit caller
+# argument supplies a value. Every quality-judge call was previously
+# hardcoded to these, billing Claude via OpenRouter regardless of the
+# run's configured model -- see judge_task()/run_janitor() for the
+# resolution order.
 JUDGE_MODEL = "anthropic/claude-sonnet-4-20250514"
 JUDGE_PROVIDER = "openrouter"
 JUDGE_MAX_DIFF_CHARS = 10_000  # Truncate diff to control cost
@@ -293,6 +299,9 @@ async def _evaluate_judge_signals(
     task: Task,
     workdir: Path,
     signal_results: list[tuple[str, bool, str]],
+    *,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
 ) -> JudgeVerdict | None:
     """Evaluate llm_judge signals and append results to signal_results."""
     judge_signals = [s for s in task.completion_signals if s.type == "llm_judge"]
@@ -306,7 +315,7 @@ async def _evaluate_judge_signals(
         return None
 
     criteria = judge_signals[0].value
-    verdict = await judge_task(task, workdir, criteria)
+    verdict = await judge_task(task, workdir, criteria, judge_model=judge_model, judge_provider=judge_provider)
     judge_desc = f"llm_judge: {criteria}"
     if verdict.verdict == "accept":
         signal_results.append((judge_desc, True, f"accepted (confidence: {verdict.confidence:.2f})"))
@@ -464,6 +473,8 @@ async def run_janitor(
     server_url: str | None = None,
     guardrails_config: GuardrailsConfig | None = None,
     permission_mode: str | None = None,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
 ) -> list[JanitorResult]:
     """Evaluate tasks and return structured results.
 
@@ -483,6 +494,11 @@ async def run_janitor(
             (all checks enabled). Pass None to disable all guardrails.
         permission_mode: Permission mode string (bypass/plan/auto/default).
             When ``"bypass"``, non-immune guardrail checks are relaxed.
+        judge_model: Optional model override for llm_judge signal evaluation.
+            Falls back to the operator's ``bernstein.yaml`` judge_model, then
+            to ``JUDGE_MODEL`` as a last resort.
+        judge_provider: Optional provider override for llm_judge signal
+            evaluation. Same fallback order as ``judge_model``.
 
     Returns:
         List of JanitorResult for each evaluated task.
@@ -507,7 +523,13 @@ async def run_janitor(
             )
         else:
             signal_results = _collect_signal_results(task, workdir)
-            judge_verdict = await _evaluate_judge_signals(task, workdir, signal_results)
+            judge_verdict = await _evaluate_judge_signals(
+                task,
+                workdir,
+                signal_results,
+                judge_model=judge_model,
+                judge_provider=judge_provider,
+            )
             all_passed = all(passed for _, passed, _ in signal_results)
             failed_descs = [desc for desc, passed, _ in signal_results if not passed]
 
@@ -853,8 +875,15 @@ def _parse_judge_response(raw: str) -> JudgeVerdict:
     )
 
 
-async def judge_task(task: Task, workdir: Path, criteria: str) -> JudgeVerdict:
-    """Evaluate task completion using an LLM judge (Claude Sonnet).
+async def judge_task(
+    task: Task,
+    workdir: Path,
+    criteria: str,
+    *,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
+) -> JudgeVerdict:
+    """Evaluate task completion using an LLM judge.
 
     Gets the git diff, renders the judge prompt, calls the LLM, and parses
     the structured verdict. Cost-capped at ~$0.10 per invocation via
@@ -864,6 +893,11 @@ async def judge_task(task: Task, workdir: Path, criteria: str) -> JudgeVerdict:
         task: The completed task to judge.
         workdir: Project root directory.
         criteria: Evaluation criteria string from the llm_judge signal.
+        judge_model: Optional model override. Falls back to ``JUDGE_MODEL``
+            when unset (the operator's ``bernstein.yaml`` judge_model, if
+            any, should already be passed in here by the caller).
+        judge_provider: Optional provider override. Falls back to
+            ``JUDGE_PROVIDER`` when unset.
 
     Returns:
         JudgeVerdict with accept/retry decision, confidence, and feedback.
@@ -871,11 +905,22 @@ async def judge_task(task: Task, workdir: Path, criteria: str) -> JudgeVerdict:
     diff = _get_git_diff(task, workdir)
     prompt = _render_judge_prompt(task, diff, criteria)
 
+    model = judge_model or JUDGE_MODEL
+    provider = judge_provider or JUDGE_PROVIDER
+    logger.info(
+        "judge_task: resolved model=%s provider=%s (override_model=%s override_provider=%s) task=%s",
+        model,
+        provider,
+        judge_model,
+        judge_provider,
+        task.id,
+    )
+
     try:
         raw_response = await call_llm(
             prompt=prompt,
-            model=JUDGE_MODEL,
-            provider=JUDGE_PROVIDER,
+            model=model,
+            provider=provider,
             max_tokens=JUDGE_MAX_TOKENS,
             temperature=0.0,
         )

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -759,6 +759,53 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
         except HookBlockingError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+        # Validate the requested role against the operator's configured
+        # role_model_policy, when one is configured for this run. This is a
+        # hard 400 (not just a log line) so the calling LLM gets an
+        # immediate, actionable error instead of silently falling back to a
+        # default provider/model at spawn time (see spawner_core.py's
+        # _resolve_role_policy, which is exact-match only against
+        # role_model_policy keys plus the "default" catch-all).
+        #
+        # "auto" is exempted because it is resolved to a concrete role via
+        # classify_role() above, before this check ever runs -- but we still
+        # guard it defensively in case that resolution is ever bypassed.
+        raw_role = effective_body.role
+        seed_config = getattr(request.app.state, "seed_config", None)
+        role_model_policy: dict[str, Any] | None = getattr(seed_config, "role_model_policy", None)
+        if role_model_policy:
+            policy_keys = list(role_model_policy.keys())
+            # "default" is a catch-all config entry, not an assignable role --
+            # never advertise it as a valid choice to the calling LLM.
+            valid_roles = [k for k in policy_keys if k != "default"]
+            if raw_role != "auto" and raw_role not in role_model_policy:
+                logger.warning(
+                    "Rejecting task create: title=%r attempted role=%r is not a valid "
+                    "role. Valid roles=%s",
+                    effective_body.title,
+                    raw_role,
+                    valid_roles,
+                )
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Invalid role '{raw_role}'. Valid roles: "
+                        f"[{', '.join(valid_roles)}]. Use one of these exact strings."
+                    ),
+                )
+            logger.info(
+                "Task created with role=%r matched against role_model_policy keys=%s",
+                raw_role,
+                policy_keys,
+            )
+        else:
+            logger.info(
+                "Task created with role=%r; no role_model_policy configured on this run "
+                "(seed_config=%s) -- skipping role validation",
+                raw_role,
+                "present but empty" if seed_config is not None else "absent",
+            )
+
         task = await store.create(effective_body)
         append_assessment_log(
             request.app.state.sdd_dir,

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -781,8 +781,8 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
             if raw_role != "auto" and raw_role not in role_model_policy:
                 logger.warning(
                     "Rejecting task create: title=%r attempted role=%r is not a valid role. Valid roles=%s",
-                    effective_body.title,
-                    raw_role,
+                    sanitize_log(str(effective_body.title)),
+                    sanitize_log(str(raw_role)),
                     valid_roles,
                 )
                 raise HTTPException(
@@ -794,14 +794,14 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
                 )
             logger.info(
                 "Task created with role=%r matched against role_model_policy keys=%s",
-                raw_role,
+                sanitize_log(str(raw_role)),
                 policy_keys,
             )
         else:
             logger.info(
                 "Task created with role=%r; no role_model_policy configured on this run "
                 "(seed_config=%s) -- skipping role validation",
-                raw_role,
+                sanitize_log(str(raw_role)),
                 "present but empty" if seed_config is not None else "absent",
             )
 

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -780,8 +780,7 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
             valid_roles = [k for k in policy_keys if k != "default"]
             if raw_role != "auto" and raw_role not in role_model_policy:
                 logger.warning(
-                    "Rejecting task create: title=%r attempted role=%r is not a valid "
-                    "role. Valid roles=%s",
+                    "Rejecting task create: title=%r attempted role=%r is not a valid role. Valid roles=%s",
                     effective_body.title,
                     raw_role,
                     valid_roles,

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -1042,13 +1042,27 @@ def _check_opus_override(
 
 
 def _try_l1_fast_path(task: Task) -> ModelConfig | None:
-    """Try L1 fast-path routing for simple tasks."""
+    """Try L1 fast-path routing for simple tasks.
+
+    Returns None (fall through to the remaining routing sources) when
+    ``fast_path.l1_model`` is not configured, so an operator-configured
+    ``default_model`` still applies to L1-classified tasks. If no source
+    at all configures a model, the heuristic fallback in
+    ``_select_model_config`` raises ``ModelNotConfiguredError``.
+    """
     from bernstein.core.fast_path import TaskLevel, classify_task, get_l1_model_config
 
     classification = classify_task(task)
     if classification.level != TaskLevel.L1:
         return None
-    l1_cfg = get_l1_model_config()
+    try:
+        l1_cfg = get_l1_model_config()
+    except ModelNotConfiguredError:
+        logger.info(
+            "Task %s classified L1 but fast_path.l1_model is not configured - falling through to standard routing",
+            task.id,
+        )
+        return None
     logger.info(
         "Task %s: Selected %s/%s (L1 fast-path: role=%s, scope=%s, %s)",
         task.id,

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 from bernstein.core.routing.router_policies import ModelPolicy, PolicyFilter
 
@@ -884,6 +885,7 @@ def route_task(
     *,
     budget_remaining_usd: float | None = None,
     budget_aware_routing_enabled: bool | None = None,
+    default_model: str | None = None,
 ) -> ModelConfig:
     """Select model and effort based on task metadata.
 
@@ -912,6 +914,9 @@ def route_task(
         workdir: Optional project root for effectiveness scorer data.
         budget_remaining_usd: Remaining run budget in USD.
         budget_aware_routing_enabled: Feature flag for downgrade.
+        default_model: Operator-configured fallback model. When ``None`` and
+            no other source configures a model, routing raises
+            :class:`ModelNotConfiguredError` instead of defaulting to Claude.
 
     Returns:
         ModelConfig with selected model and effort (and is_batch flag).
@@ -922,6 +927,7 @@ def route_task(
         workdir,
         budget_remaining_usd=budget_remaining_usd,
         budget_aware_routing_enabled=budget_aware_routing_enabled,
+        default_model=default_model,
     )
     if task.batch_eligible and task.priority != 1:
         logger.debug("Batch routing task %s (%s/%s)", task.id, cfg.model, cfg.effort)
@@ -1158,16 +1164,30 @@ def _select_model_config(
     *,
     budget_remaining_usd: float | None = None,
     budget_aware_routing_enabled: bool | None = None,
+    default_model: str | None = None,
 ) -> ModelConfig:
     """Internal: select model/effort without applying batch flag.
 
     When ``budget_aware_routing_enabled`` is True and remaining budget cannot
     absorb another opus task, the opus override is skipped and
     the task lands on sonnet via the heuristic path.
+
+    Args:
+        default_model: Operator-configured fallback model (e.g. from the
+            seed config or adapter default). Bernstein has no built-in
+            default - when this is ``None`` and the task carries no model
+            of its own, routing raises :class:`ModelNotConfiguredError`
+            rather than silently picking Claude Sonnet/Opus.
     """
     # Manager-specified overrides take precedence
     if task.model or task.effort:
-        model = task.model or "sonnet"
+        model = task.model or default_model
+        if model is None:
+            raise ModelNotConfiguredError(
+                f"Task {task.id} has effort={task.effort!r} but no model, and no "
+                "default_model is configured (role_model_policy/seed/adapter default). "
+                "Refusing to guess a model - configure one explicitly.",
+            )
         effort = task.effort or "high"
         logger.info(
             "Task %s: Selected %s/%s (manager override: role=%s, priority=%d, complexity=%s)",
@@ -1196,8 +1216,14 @@ def _select_model_config(
         budget_aware_routing_enabled=budget_aware_routing_enabled,
     )
     if opus_reason is not None:
-        logger.info("Task %s: Selected opus/max (%s)", task.id, opus_reason)
-        return ModelConfig(model="opus", effort="max")
+        if default_model is None:
+            raise ModelNotConfiguredError(
+                f"Task {task.id} triggered a high-stakes opus override ({opus_reason}) but "
+                "no default_model is configured. Refusing to guess a model - configure one "
+                "explicitly (role_model_policy/seed/adapter default).",
+            )
+        logger.info("Task %s: Selected %s/max (%s)", task.id, default_model, opus_reason)
+        return ModelConfig(model=default_model, effort="max")
 
     # L1 fast-path: route simple tasks to the cheapest model
     l1_result = _try_l1_fast_path(task)
@@ -1209,25 +1235,36 @@ def _select_model_config(
     if bandit_result is not None:
         return bandit_result
 
-    # Heuristic fallback
+    # Heuristic fallback - no built-in default model; the operator must
+    # configure one (role_model_policy/seed/adapter default) or routing
+    # refuses rather than silently spending on Claude Sonnet.
+    if default_model is None:
+        raise ModelNotConfiguredError(
+            f"Task {task.id} (role={task.role}, complexity={task.complexity.value}) has no "
+            "model configured on the task and no default_model was supplied to the router. "
+            "Refusing to guess a model - configure one explicitly.",
+        )
+
     if task.complexity == Complexity.HIGH:
         logger.info(
-            "Task %s: Selected sonnet/high (heuristic fallback: complexity=%s, role=%s, priority=%d)",
+            "Task %s: Selected %s/high (heuristic fallback: complexity=%s, role=%s, priority=%d)",
             task.id,
+            default_model,
             task.complexity.value,
             task.role,
             task.priority,
         )
-        return ModelConfig(model="sonnet", effort="high")
+        return ModelConfig(model=default_model, effort="high")
 
     logger.info(
-        "Task %s: Selected sonnet/high (default: role=%s, complexity=%s, priority=%d)",
+        "Task %s: Selected %s/high (default: role=%s, complexity=%s, priority=%d)",
         task.id,
+        default_model,
         task.role,
         task.complexity.value,
         task.priority,
     )
-    return ModelConfig(model="sonnet", effort="high")
+    return ModelConfig(model=default_model, effort="high")
 
 
 def load_model_policy_from_yaml(path: Path, router: TierAwareRouter) -> None:

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -14,6 +14,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
@@ -21,8 +22,6 @@ from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 from bernstein.core.routing.router_policies import ModelPolicy, PolicyFilter
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from bernstein.core.quota_probe import QuotaSnapshot
 
 logger = logging.getLogger(__name__)
@@ -1076,7 +1075,19 @@ def _try_bandit_selection(
         bandit = EpsilonGreedyBandit.load(bandit_metrics_dir)
         _seed_bandit_with_effectiveness(bandit, task, workdir, bandit_metrics_dir)
 
-        candidates = ["sonnet", "opus"] if task.complexity == Complexity.HIGH else list(CASCADE)
+        # Bandit arms are Claude tier names (haiku/sonnet/opus) - this path only
+        # ever runs for the Claude-compatible bandit/cascade routing scheme, so
+        # tier names are the correct vocabulary here (see spawner_core.py's
+        # retry-escalation comments for the same convention). The single
+        # source of truth for the arm set is CASCADE (bernstein.core.cost),
+        # not a re-hardcoded literal - both branches previously duplicated
+        # CASCADE's exact contents (["sonnet", "opus"]), so the HIGH-complexity
+        # special case was dead code; using CASCADE directly for all
+        # complexities removes the redundant hardcoded literal while keeping
+        # this Claude-adapter-specific behavior intact. Operators who need a
+        # different arm set configure it via CASCADE/cost.py, not by patching
+        # this call site.
+        candidates = list(CASCADE)
         selected = bandit.select(role=task.role, candidate_models=candidates)
         effort = "max" if selected == "opus" else "high"
         logger.info(
@@ -1409,10 +1420,36 @@ _default_router: TierAwareRouter | None = None
 
 
 def get_default_router() -> TierAwareRouter:
-    """Get or create the default router instance with pre-configured providers."""
+    """Get or create the default router instance with pre-configured providers.
+
+    Prefers ``<cwd>/.sdd/config/providers.yaml`` (the same convention used by
+    the orchestrator/server/CLI entry points) over the hardcoded example
+    catalog below. The hardcoded catalog only exists as a documented,
+    clearly-logged last resort for callers (e.g. ``hijacker.py``'s
+    ``router or get_default_router()`` fallback) that construct a router with
+    no workdir/config context at all - it is never used silently when a real
+    providers.yaml is present.
+    """
     global _default_router
     if _default_router is None:
         _default_router = TierAwareRouter()
+
+        providers_yaml = Path.cwd() / ".sdd" / "config" / "providers.yaml"
+        if providers_yaml.exists():
+            logger.info(
+                "get_default_router: loading config-supplied providers from %s",
+                providers_yaml,
+            )
+            load_providers_from_yaml(providers_yaml, _default_router)
+            return _default_router
+
+        logger.warning(
+            "get_default_router: no providers.yaml found at %s - falling back to "
+            "the built-in example provider catalog (openrouter_free/anthropic_standard/"
+            "anthropic_premium/google_ai). Configure .sdd/config/providers.yaml to "
+            "override these hardcoded example models/tiers.",
+            providers_yaml,
+        )
 
         # Free tier provider (e.g., OpenRouter free models)
         _default_router.register_provider(

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -761,10 +761,14 @@ def _do_reload_seed_config(workdir: Path, jsonl_path: Path, application: Any) ->
         write_config_snapshot,
     )
     from bernstein.core.runtime_state import hash_file, write_config_state
-    from bernstein.core.seed import SeedError, parse_seed
+    from bernstein.core.seed import SeedError, parse_seed, resolve_seed_path
     from bernstein.core.tenanting import TenantRegistry, ensure_tenant_layout, tenant_registry_from_seed
 
-    seed_path = workdir / "bernstein.yaml"
+    # resolve_seed_path() checks BERNSTEIN_SEED_PATH env first so this reload
+    # picks up the same seed file the bootstrap process actually parsed,
+    # instead of silently falling back to workdir/bernstein.yaml.
+    seed_path = resolve_seed_path(workdir)
+    logger.info("_do_reload_seed_config: resolved seed_path=%s (exists=%s)", seed_path, seed_path.exists())
     sdd_dir = jsonl_path.parent.parent
     previous_snapshot = read_config_snapshot(sdd_dir)
     current_snapshot = load_redacted_config(seed_path if seed_path.exists() else None)
@@ -1115,7 +1119,10 @@ def create_app(
     from bernstein.core.seed import CORSConfig
 
     cors_config = CORSConfig()  # default; overridden after seed_config loads
-    seed_path = workdir / "bernstein.yaml"
+    from bernstein.core.seed import resolve_seed_path
+
+    seed_path = resolve_seed_path(workdir)
+    logger.info("create_app: resolved seed_path=%s (exists=%s)", seed_path, seed_path.exists())
     if seed_path.exists():
         with contextlib.suppress(Exception):
             from bernstein.core.seed import parse_seed

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -85,12 +85,16 @@ def _clean_stale_runtime(workdir: Path) -> None:
             lock_file.unlink(missing_ok=True)
 
 
-def ensure_sdd(workdir: Path, *, model: str = "opus") -> bool:
+def ensure_sdd(workdir: Path, *, model: str | None = None) -> bool:
     """Create .sdd/ workspace structure if it does not exist.
 
     Args:
         workdir: Project root directory.
-        model: Default model name for the workspace config.
+        model: Default model name for the workspace config. Bernstein has no
+            built-in default - when ``None``, no ``default_model`` line is
+            written and routing must be configured explicitly elsewhere
+            (task/role_model_policy/adapter default) or it will refuse to
+            spawn rather than silently bill Claude Sonnet/Opus.
 
     Returns:
         True if the workspace was newly created, False if it already existed.
@@ -115,11 +119,21 @@ def ensure_sdd(workdir: Path, *, model: str = "opus") -> bool:
     # Write default config if missing
     config_path = workdir / ".sdd" / "config.yaml"
     if not config_path.exists():
+        if model:
+            model_line = f"default_model: {model}\n"
+        else:
+            model_line = ""
+            logger.info(
+                "ensure_sdd: no model configured for %s - omitting default_model from "
+                "config.yaml. Configure one explicitly (role_model_policy/seed/adapter "
+                "default) or task spawning will refuse rather than default to Claude.",
+                workdir,
+            )
         config_path.write_text(
             "# Bernstein workspace config\n"
             "server_port: 8052\n"
             "max_workers: 4\n"
-            f"default_model: {model}\n"
+            f"{model_line}"
             "default_effort: max\n"
         )
 
@@ -427,7 +441,7 @@ def _inject_manager_task(
         "priority": 1,
         "scope": "large",
         "complexity": "high",
-        "model": seed.model or "opus",
+        "model": seed.model,
         "effort": "max",
     }
 
@@ -486,7 +500,7 @@ def _inject_worker_task(
         "priority": 1,
         "scope": "large",
         "complexity": "high",
-        "model": seed.model or "sonnet",
+        "model": seed.model,
         "effort": "max",
     }
 
@@ -518,6 +532,7 @@ def _start_spawner(
     ab_test: bool = False,
     adapter: str | None = None,
     model: str | None = None,
+    seed_path: Path | None = None,
 ) -> int:
     """Launch the spawner process in the background.
 
@@ -533,6 +548,13 @@ def _start_spawner(
     the CLI's own argv -- can coerce Claude tier names (opus/sonnet/haiku)
     emitted by the heuristic model selector for manager-spawned child tasks
     into a model the resolved non-Claude adapter actually understands.
+
+    ``seed_path`` (the resolved bernstein.yaml the bootstrap process actually
+    parsed) is threaded through the same way. Without it, the orchestrator
+    subprocess independently re-derives ``workdir / "bernstein.yaml"``, which
+    silently loses ``role_model_policy`` (and every other seed setting)
+    whenever the real seed lives at a different path -- agents then spawn
+    with the default model instead of the configured one, with no error.
     """
     pid_path = workdir / ".sdd" / "runtime" / "spawner.pid"
     log_path = workdir / ".sdd" / "runtime" / "spawner.log"
@@ -555,6 +577,9 @@ def _start_spawner(
         env["BERNSTEIN_ADAPTER"] = adapter
     if model:
         env["BERNSTEIN_MODEL"] = model
+    if seed_path:
+        env["BERNSTEIN_SEED_PATH"] = str(seed_path)
+        logger.info("_start_spawner: propagating seed_path=%s via BERNSTEIN_SEED_PATH + --seed-path", seed_path)
 
     argv = [
         sys.executable,
@@ -569,6 +594,8 @@ def _start_spawner(
         argv.extend(["--adapter", adapter])
     if model:
         argv.extend(["--model", model])
+    if seed_path:
+        argv.extend(["--seed-path", str(seed_path)])
 
     log_fh = log_path.open("a")
     proc = subprocess.Popen(

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -130,11 +130,7 @@ def ensure_sdd(workdir: Path, *, model: str | None = None) -> bool:
                 workdir,
             )
         config_path.write_text(
-            "# Bernstein workspace config\n"
-            "server_port: 8052\n"
-            "max_workers: 4\n"
-            f"{model_line}"
-            "default_effort: max\n"
+            f"# Bernstein workspace config\nserver_port: 8052\nmax_workers: 4\n{model_line}default_effort: max\n"
         )
 
     # .gitignore for runtime dir - ensure session.json is always listed.

--- a/src/bernstein/core/tasks/batch_api.py
+++ b/src/bernstein/core/tasks/batch_api.py
@@ -346,7 +346,11 @@ class ProviderBatchManager:
         if router is None:
             return BatchSubmissionResult(handled=False, submitted=False)
 
-        base_config = route_task(task)
+        # Thread the run's default_model into routing so batch-eligible tasks
+        # do not fail with ModelNotConfiguredError when the operator relies on
+        # the run-level model instead of per-task models.
+        _spawner_default_model = getattr(getattr(orch, "_spawner", None), "_default_model", None)
+        base_config = route_task(task, default_model=_spawner_default_model)
         if not base_config.is_batch:
             base_config = ModelConfig(
                 model=base_config.model,

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1320,6 +1320,11 @@ class OrchestratorConfig:
     # Default off; enable once multi-tenant workloads exist.
     fair_scheduling_enabled: bool = False
     cost_autopilot: bool = False  # Wire CostAutopilot when True
+    # Janitor LLM-judge model/provider override, threaded from the seed's
+    # ``judge_model``/``judge_provider`` (bernstein.yaml). None = fall back
+    # to the janitor's hardcoded JUDGE_MODEL/JUDGE_PROVIDER defaults.
+    judge_model: str | None = None
+    judge_provider: str | None = None
 
     def __post_init__(self) -> None:
         """Parse nested workflow config if dict provided."""

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3332,7 +3332,13 @@ def _has_llm_judge_signal(task: Task) -> bool:
     return any(signal.type == "llm_judge" for signal in task.completion_signals)
 
 
-def _verify_via_janitor(task: Task, workdir: Path, server_url: str | None) -> tuple[bool, list[str]]:
+def _verify_via_janitor(
+    task: Task,
+    workdir: Path,
+    server_url: str | None,
+    judge_model: str | None = None,
+    judge_provider: str | None = None,
+) -> tuple[bool, list[str]]:
     """Run the async ``run_janitor`` pipeline for a single task synchronously.
 
     Translates a ``JanitorResult`` back into the ``(passed, failed_signals)``
@@ -3345,11 +3351,25 @@ def _verify_via_janitor(task: Task, workdir: Path, server_url: str | None) -> tu
         workdir: Project root for signal evaluation and git diff lookups.
         server_url: Optional task-server URL forwarded to ``run_janitor`` for
             fix-task creation.
+        judge_model: Optional operator-configured model for the janitor's
+            llm_judge signal evaluation (from ``bernstein.yaml``'s
+            ``judge_model``). Falls back to the janitor's hardcoded default
+            when unset.
+        judge_provider: Optional operator-configured provider counterpart
+            to ``judge_model``.
 
     Returns:
         Tuple of (all_passed, list_of_failed_signal_descriptions).
     """
-    results = asyncio.run(run_janitor([task], workdir, server_url=server_url))
+    results = asyncio.run(
+        run_janitor(
+            [task],
+            workdir,
+            server_url=server_url,
+            judge_model=judge_model,
+            judge_provider=judge_provider,
+        )
+    )
     if not results:
         # Task had no completion signals (shouldn't reach here in practice).
         return True, []
@@ -3424,7 +3444,10 @@ def _enqueue_alive_exit_janitor_pass(
         reason,
     )
 
-    server_url: str | None = getattr(getattr(orch, "_config", None), "server_url", None)
+    _orch_config = getattr(orch, "_config", None)
+    server_url: str | None = getattr(_orch_config, "server_url", None)
+    judge_model: str | None = getattr(_orch_config, "judge_model", None)
+    judge_provider: str | None = getattr(_orch_config, "judge_provider", None)
     executor = getattr(orch, "_executor", None)
     if executor is None:
         # Defensive: if the orchestrator has no executor we still want a
@@ -3441,7 +3464,14 @@ def _enqueue_alive_exit_janitor_pass(
             return None
 
     if _has_llm_judge_signal(task):
-        return executor.submit(_verify_via_janitor, task, orch._workdir, server_url)
+        return executor.submit(
+            _verify_via_janitor,
+            task,
+            orch._workdir,
+            server_url,
+            judge_model,
+            judge_provider,
+        )
     return executor.submit(verify_task, task, orch._workdir)
 
 

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 import httpx
 
 from bernstein.core.agent_log_aggregator import AgentLogAggregator
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.completion_budget import CompletionBudget
 from bernstein.core.context import append_decision
 from bernstein.core.context_recommendations import RecommendationEngine
@@ -2120,16 +2121,28 @@ def claim_and_spawn_batches(
         if len(batch) == 1:
             l1_check = classify_task(batch[0])
             if l1_check.level == TaskLevel.L1 and not batch[0].model:
-                l1_cfg = get_l1_model_config()
-                batch[0].model = l1_cfg.model
-                batch[0].effort = l1_cfg.effort
-                logger.info(
-                    "L1 downgrade for task %s -> %s/%s (%s)",
-                    batch[0].id,
-                    l1_cfg.model,
-                    l1_cfg.effort,
-                    l1_check.reason,
-                )
+                try:
+                    l1_cfg = get_l1_model_config()
+                except ModelNotConfiguredError:
+                    # fast_path.l1_model is not configured: skip the L1
+                    # downgrade and let standard routing apply the
+                    # operator-configured default_model (or refuse with a
+                    # clear error if none is configured anywhere).
+                    logger.info(
+                        "Task %s classified L1 but fast_path.l1_model is not configured - skipping L1 downgrade",
+                        batch[0].id,
+                    )
+                    l1_cfg = None
+                if l1_cfg is not None:
+                    batch[0].model = l1_cfg.model
+                    batch[0].effort = l1_cfg.effort
+                    logger.info(
+                        "L1 downgrade for task %s -> %s/%s (%s)",
+                        batch[0].id,
+                        l1_cfg.model,
+                        l1_cfg.effort,
+                        l1_check.reason,
+                    )
 
         # Provider batch: submit eligible low-risk single-task work to
         # OpenAI/Anthropic batch APIs instead of spawning a local CLI agent.

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -9,6 +9,9 @@ You lead a team of AI coding agents. Your job: decompose the goal into tasks, cr
 4. **Verify**: include completion signals so the janitor can verify work
 
 ## Available roles for tasks
+
+**IMPORTANT: Use these EXACT role names when creating tasks. The task server validates roles and will reject any name not in this list.**
+
 - **backend**: server-side logic, APIs, data models, business rules
 - **frontend**: UI components, styling, client-side logic
 - **qa**: test writing, validation, edge case coverage

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -274,6 +274,9 @@ def orchestrator_factory(integration_sdd: Path):
             workdir=integration_sdd.parent,
             use_worktrees=use_worktrees,
             spawn_rate_limiter=permissive_rate_limiter,
+            # Routing refuses to spawn unconfigured tasks; integration tasks
+            # are created over the API without models.
+            default_model="mock-model",
         )
         orchestrator = Orchestrator(config, spawner, workdir=integration_sdd.parent)
 

--- a/tests/integration/test_capability_matrix_spawn_refusal.py
+++ b/tests/integration/test_capability_matrix_spawn_refusal.py
@@ -220,13 +220,21 @@ def _build_spawner(
     adapter: MagicMock,
     catalog: CatalogRegistry | None = None,
 ) -> AgentSpawner:
-    """Construct an :class:`AgentSpawner` plumbed exactly like prod (sans worktree)."""
+    """Construct an :class:`AgentSpawner` plumbed exactly like prod (sans worktree).
+
+    ``default_model`` is set explicitly: these tests exercise capability-matrix
+    enforcement, not model routing, but the ``mockcli`` adapter is not
+    Claude-compatible, so an unconfigured model would now correctly raise
+    ``ModelNotConfiguredError`` at the spawn boundary (Bernstein never
+    silently falls back to a Claude tier name for a non-Claude adapter).
+    """
     return AgentSpawner(
         adapter=adapter,
         templates_dir=workdir / "templates" / "roles",
         workdir=workdir,
         catalog=catalog,
         use_worktrees=False,
+        default_model="mock-model",
     )
 
 

--- a/tests/integration/test_criterion_profile_routing.py
+++ b/tests/integration/test_criterion_profile_routing.py
@@ -61,7 +61,9 @@ class TestRouteTaskHonoursCriterionProfile:
     def test_safety_first_routes_to_opus(self) -> None:
         baseline = _make_task()
         with_profile = _make_task(metadata={"criterion_profile": "safety-first"})
-        baseline_cfg = route_task(baseline)
+        # The unbiased baseline needs a configured default; routing no longer
+        # guesses a model for unconfigured tasks.
+        baseline_cfg = route_task(baseline, default_model="sonnet")
         biased_cfg = route_task(with_profile)
         assert baseline_cfg.model != biased_cfg.model or baseline_cfg.effort != biased_cfg.effort, (
             "expected criterion-profile to change at least one of model/effort"
@@ -103,9 +105,12 @@ class TestRouteTaskHonoursCriterionProfile:
 class TestFeatureFlagDisablesPath:
     def test_disabled_flag_reverts_to_default_routing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ENV_FLAG, "0")
-        cfg = route_task(_make_task(metadata={"criterion_profile": "safety-first"}))
+        cfg = route_task(
+            _make_task(metadata={"criterion_profile": "safety-first"}),
+            default_model="sonnet",
+        )
         # Without the bias, the small/low backend task lands on the
-        # default sonnet/high path, not opus.
+        # configured default sonnet/high path, not opus.
         assert cfg.model != "opus"
 
     def test_enabled_flag_picks_up_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -176,7 +181,7 @@ class TestProfileValidationGuardsAtCLI:
         # ``extract_from_task`` is the wire-side path; integration check
         # confirms it doesn't crash the router for malformed input.
         task = _make_task(metadata={"criterion_profile": "made-up-preset"})
-        cfg = route_task(task)
+        cfg = route_task(task, default_model="sonnet")
         # Falls through to the default heuristic path.
         assert cfg.model in {"sonnet", "haiku", "opus"}
 
@@ -249,7 +254,7 @@ def test_env_var_propagated_to_router_path(
     routing for tasks that lack the metadata key.
     """
     monkeypatch.setenv("BERNSTEIN_RUN_CRITERION_PROFILE", "safety-first")
-    cfg = route_task(_make_task())
+    cfg = route_task(_make_task(), default_model="sonnet")
     # No metadata on the task -> no bias, default routing applies.
     assert cfg.model in {"sonnet", "haiku", "opus"}
     # Specifically, it must NOT be auto-pinned to opus just because the

--- a/tests/integration/test_decision_log_routing.py
+++ b/tests/integration/test_decision_log_routing.py
@@ -53,7 +53,7 @@ def test_routing_emits_decision_record(_redirect_decision_log: Path) -> None:
     """``route_task`` produces exactly one model_route decision per call."""
     from bernstein.core.routing.router_core import route_task
 
-    route_task(_make_task("t-1"))
+    route_task(_make_task("t-1"), default_model="run-default")
 
     records = dl.replay(_redirect_decision_log)
     assert len(records) == 1
@@ -67,7 +67,7 @@ def test_routing_decision_inputs_carry_task_id(
     """The decision record's ``inputs`` payload includes the task id + role."""
     from bernstein.core.routing.router_core import route_task
 
-    route_task(_make_task("t-42", role="manager"))
+    route_task(_make_task("t-42", role="manager"), default_model="run-default")
 
     [rec] = dl.replay(_redirect_decision_log)
     assert rec.inputs.get("task_id") == "t-42"
@@ -79,7 +79,7 @@ def test_routing_disable_via_env(_redirect_decision_log: Path, monkeypatch: pyte
     from bernstein.core.routing.router_core import route_task
 
     monkeypatch.setenv(dl.ENV_DISABLE, "0")
-    route_task(_make_task("t-3"))
+    route_task(_make_task("t-3"), default_model="run-default")
 
     assert not _redirect_decision_log.exists()
 
@@ -91,7 +91,7 @@ def test_routing_multiple_calls_each_emit_one_record(
     from bernstein.core.routing.router_core import route_task
 
     for i in range(5):
-        route_task(_make_task(f"t-{i}"))
+        route_task(_make_task(f"t-{i}"), default_model="run-default")
 
     records = dl.replay(_redirect_decision_log)
     assert len(records) == 5
@@ -105,8 +105,8 @@ def test_cli_tail_surfaces_routing_decisions(
     from bernstein.cli.commands.decisions_cmd import decisions_group
     from bernstein.core.routing.router_core import route_task
 
-    route_task(_make_task("t-cli-1", role="frontend"))
-    route_task(_make_task("t-cli-2", role="backend"))
+    route_task(_make_task("t-cli-1", role="frontend"), default_model="run-default")
+    route_task(_make_task("t-cli-2", role="backend"), default_model="run-default")
 
     runner = CliRunner()
     result = runner.invoke(decisions_group, ["tail", "--path", str(_redirect_decision_log)])

--- a/tests/integration/test_failover.py
+++ b/tests/integration/test_failover.py
@@ -82,7 +82,9 @@ def test_fast_exit_rate_limit_fails_over_to_alternate_provider(tmp_path: Path) -
         log_path=tmp_path / ".sdd" / "runtime" / "gemini.log",
     )
 
-    spawner = AgentSpawner(primary_adapter, templates_dir, tmp_path, router=router, use_worktrees=False)
+    spawner = AgentSpawner(
+        primary_adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet"
+    )
     with patch.object(spawner, "_get_adapter_by_name", side_effect=[primary_adapter, backup_adapter]):
         session = spawner.spawn_for_tasks([_make_task()])
 

--- a/tests/integration/test_fresh_context_retry.py
+++ b/tests/integration/test_fresh_context_retry.py
@@ -182,6 +182,7 @@ def spawner(
         workdir=workdir,
         use_worktrees=False,
         spawn_rate_limiter=rate_limiter,
+        default_model="mock-model",
     )
     # Stub the heavy auth/JWT path - production wires it up but unit-style
     # integration tests don't have an identity store on disk.

--- a/tests/integration/test_openclaw_bridge_flow.py
+++ b/tests/integration/test_openclaw_bridge_flow.py
@@ -199,6 +199,7 @@ async def test_openclaw_bridge_seed_to_spawner_flow(
             tmp_path,
             use_worktrees=False,
             runtime_bridge=bridge,
+            default_model="mock-model",
         )
 
         session = await asyncio.to_thread(spawner.spawn_for_tasks, [make_task()])

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -393,6 +393,7 @@ def test_agent_node_dispatches_through_real_spawner(tmp_path: Path) -> None:
         templates_dir=workdir / "templates" / "roles",
         workdir=workdir,
         use_worktrees=False,
+        default_model="mock-model",
     )
 
     spec = _spec_from(

--- a/tests/unit/routing/test_router_core.py
+++ b/tests/unit/routing/test_router_core.py
@@ -640,72 +640,93 @@ class TestRouteTaskSelection:
         assert cfg.model == "haiku"
         assert cfg.effort == "low"
 
-    def test_high_stakes_role_routes_opus(self) -> None:
-        cfg = route_task(_task(role="security"))
-        assert cfg.model == "opus"
+    # Routing no longer hardcodes Claude tier names: high-stakes tasks
+    # escalate to max effort on the operator-supplied default_model, and
+    # unconfigured tasks refuse instead of guessing.
+
+    def test_high_stakes_role_routes_default_model_max(self) -> None:
+        cfg = route_task(_task(role="security"), default_model="run-default")
+        assert cfg.model == "run-default"
         assert cfg.effort == "max"
 
-    def test_architect_role_routes_opus(self) -> None:
-        assert route_task(_task(role="architect")).model == "opus"
+    def test_architect_role_routes_default_model(self) -> None:
+        assert route_task(_task(role="architect"), default_model="run-default").model == "run-default"
 
-    def test_large_scope_routes_opus(self) -> None:
-        cfg = route_task(_task(scope=Scope.LARGE))
-        assert cfg.model == "opus"
+    def test_large_scope_routes_default_model(self) -> None:
+        cfg = route_task(_task(scope=Scope.LARGE), default_model="run-default")
+        assert cfg.model == "run-default"
+        assert cfg.effort == "max"
 
-    def test_critical_priority_routes_opus(self) -> None:
-        cfg = route_task(_task(priority=1))
-        assert cfg.model == "opus"
+    def test_critical_priority_routes_default_model(self) -> None:
+        cfg = route_task(_task(priority=1), default_model="run-default")
+        assert cfg.model == "run-default"
+        assert cfg.effort == "max"
 
-    def test_plain_medium_backend_routes_sonnet(self) -> None:
-        cfg = route_task(_task(role="backend", complexity=Complexity.MEDIUM, scope=Scope.MEDIUM, priority=2))
-        assert cfg.model == "sonnet"
+    def test_plain_medium_backend_routes_default_model_high(self) -> None:
+        cfg = route_task(
+            _task(role="backend", complexity=Complexity.MEDIUM, scope=Scope.MEDIUM, priority=2),
+            default_model="run-default",
+        )
+        assert cfg.model == "run-default"
         assert cfg.effort == "high"
 
-    def test_high_complexity_heuristic_routes_sonnet(self) -> None:
-        cfg = route_task(_task(role="backend", complexity=Complexity.HIGH, scope=Scope.MEDIUM, priority=2))
-        assert cfg.model == "sonnet"
+    def test_high_complexity_heuristic_routes_default_model(self) -> None:
+        cfg = route_task(
+            _task(role="backend", complexity=Complexity.HIGH, scope=Scope.MEDIUM, priority=2),
+            default_model="run-default",
+        )
+        assert cfg.model == "run-default"
 
     def test_batch_eligible_sets_is_batch(self) -> None:
-        cfg = route_task(_task(batch_eligible=True))
+        cfg = route_task(_task(batch_eligible=True), default_model="run-default")
         assert cfg.is_batch is True
 
     def test_critical_batch_not_batched(self) -> None:
         # priority=1 is never routed to batch even if eligible.
-        cfg = route_task(_task(priority=1, batch_eligible=True))
+        cfg = route_task(_task(priority=1, batch_eligible=True), default_model="run-default")
         assert cfg.is_batch is False
 
 
 class TestRouteTaskBudgetAware:
-    def test_budget_downgrade_skips_opus_for_high_stakes(self) -> None:
-        # Low remaining budget -> high-stakes task lands on sonnet.
+    # The high-stakes escalation now expresses as max effort on the
+    # default_model (no hardcoded opus); the budget downgrade drops the
+    # escalation back to the plain heuristic (high effort).
+
+    def test_budget_downgrade_skips_escalation_for_high_stakes(self) -> None:
+        # Low remaining budget -> high-stakes task keeps the plain heuristic.
         cfg = route_task(
             _task(role="security"),
             budget_remaining_usd=1.0,
             budget_aware_routing_enabled=True,
+            default_model="run-default",
         )
-        assert cfg.model == "sonnet"
+        assert cfg.model == "run-default"
+        assert cfg.effort == "high"
 
-    def test_ample_budget_keeps_opus(self) -> None:
+    def test_ample_budget_keeps_premium_effort(self) -> None:
         cfg = route_task(
             _task(role="security"),
             budget_remaining_usd=100.0,
             budget_aware_routing_enabled=True,
+            default_model="run-default",
         )
-        assert cfg.model == "opus"
+        assert cfg.effort == "max"
 
-    def test_disabled_budget_routing_keeps_opus(self) -> None:
+    def test_disabled_budget_routing_keeps_premium_effort(self) -> None:
         cfg = route_task(
             _task(role="security"),
             budget_remaining_usd=0.5,
             budget_aware_routing_enabled=False,
+            default_model="run-default",
         )
-        assert cfg.model == "opus"
+        assert cfg.effort == "max"
 
     def test_module_context_drives_downgrade(self) -> None:
         # When kwargs are omitted, set_budget_context state applies.
         set_budget_context(1.0, enabled=True)
-        cfg = route_task(_task(role="manager"))
-        assert cfg.model == "sonnet"
+        cfg = route_task(_task(role="manager"), default_model="run-default")
+        assert cfg.model == "run-default"
+        assert cfg.effort == "high"
 
     def test_check_opus_override_returns_none_for_plain_task(self) -> None:
         assert _check_opus_override(_task(role="backend", priority=2, scope=Scope.MEDIUM)) is None
@@ -726,7 +747,7 @@ class TestRouterMisc:
         state = RouterState(preferred_tier=Tier.STANDARD)
         r = TierAwareRouter(state=state)
         r.register_provider(_provider("p", tier=Tier.STANDARD))
-        decisions = r.route_batch([_task(), _task(), _task()])
+        decisions = r.route_batch([_task(model="sonnet"), _task(model="sonnet"), _task(model="sonnet")])
         assert len(decisions) == 3
         assert all(d.provider == "p" for d in decisions)
 

--- a/tests/unit/test_agent_signals.py
+++ b/tests/unit/test_agent_signals.py
@@ -235,7 +235,7 @@ class TestSpawnerSignalInjection:
         adapter = mock_adapter_factory(pid=42)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         spawner.spawn_for_tasks([task])
@@ -250,7 +250,7 @@ class TestSpawnerSignalInjection:
         adapter = mock_adapter_factory(pid=42)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         session = spawner.spawn_for_tasks([task])

--- a/tests/unit/test_batch_api.py
+++ b/tests/unit/test_batch_api.py
@@ -148,6 +148,9 @@ def _make_orch(tmp_path: Path, router: _RouterStub) -> Any:
             _worktree_mgr=_WorktreeManagerStub(tmp_path / "batch-worktree"),
             _worktree_paths={},
             reap_completed_agent=MagicMock(return_value=None),
+            # Routing refuses to guess a model; batch submission reads the
+            # run's default from the spawner.
+            _default_model="mock-model",
         ),
         _batch_sessions={},
         _task_to_session={},

--- a/tests/unit/test_budget_aware_routing.py
+++ b/tests/unit/test_budget_aware_routing.py
@@ -212,58 +212,67 @@ class TestCheckOpusOverrideModuleState:
 class TestRouteTaskBudgetAware:
     """Integration test at the `route_task` layer."""
 
-    def test_route_task_downgrades_to_sonnet_near_cap(self) -> None:
-        """audit-102 repro: budget=1.0, spend=0.95, priority=1/architect → sonnet."""
+    # Routing no longer hardcodes opus/sonnet literals: the high-stakes
+    # escalation is max effort on the supplied default_model, and the budget
+    # downgrade drops back to the plain heuristic (high effort).
+
+    def test_route_task_downgrades_near_cap(self) -> None:
+        """audit-102 repro: budget=1.0, spend=0.95, priority=1/architect → downgraded."""
         task = _make_task(role="architect", priority=1)
 
         config = route_task(
             task,
             budget_remaining_usd=0.05,
             budget_aware_routing_enabled=True,
+            default_model="run-default",
         )
 
-        assert config.model == "sonnet"
+        assert config.model == "run-default"
+        assert config.effort == "high"
 
-    def test_route_task_ample_budget_escalates_to_opus(self) -> None:
+    def test_route_task_ample_budget_escalates_to_max_effort(self) -> None:
         task = _make_task(role="architect", priority=1)
 
         config = route_task(
             task,
             budget_remaining_usd=100.0,
             budget_aware_routing_enabled=True,
+            default_model="run-default",
         )
 
-        assert config.model == "opus"
+        assert config.model == "run-default"
         assert config.effort == "max"
 
     def test_route_task_flag_off_always_escalates(self) -> None:
-        """Back-compat: with flag off, tight budget still gives opus."""
+        """Back-compat: with flag off, tight budget still escalates effort."""
         task = _make_task(role="manager")
 
         config = route_task(
             task,
             budget_remaining_usd=0.01,
             budget_aware_routing_enabled=False,
+            default_model="run-default",
         )
 
-        assert config.model == "opus"
+        assert config.effort == "max"
 
     def test_route_task_default_call_unchanged(self) -> None:
-        """route_task() with no budget args preserves legacy behaviour."""
+        """route_task() with no budget args preserves the escalation."""
         task = _make_task(role="manager")
 
-        config = route_task(task)
+        config = route_task(task, default_model="run-default")
 
-        assert config.model == "opus"
+        assert config.model == "run-default"
         assert config.effort == "max"
 
     def test_route_task_uses_module_context_when_no_kwarg(self) -> None:
         task = _make_task(role="security")
         set_budget_context(0.05, enabled=True)
 
-        config = route_task(task)
+        config = route_task(task, default_model="run-default")
 
-        assert config.model == "sonnet"
+        assert config.model == "run-default"
+        assert config.effort == "high"
 
     def test_manager_override_not_downgraded(self) -> None:
         """Manager-specified model wins regardless of budget."""

--- a/tests/unit/test_coordination.py
+++ b/tests/unit/test_coordination.py
@@ -179,6 +179,7 @@ def test_spawn_prompt_includes_bulletin_summary(tmp_path: Path):
         templates_dir=templates_dir,
         workdir=tmp_path,
         bulletin=board,
+        default_model="mock-model",
     )
 
     task = _make_task()
@@ -207,6 +208,7 @@ def test_spawn_prompt_no_bulletin_section_without_board(tmp_path: Path):
         adapter=adapter,
         templates_dir=templates_dir,
         workdir=tmp_path,
+        default_model="mock-model",
     )
 
     task = _make_task()
@@ -236,6 +238,7 @@ def test_spawn_prompt_no_bulletin_section_with_empty_board(tmp_path: Path):
         templates_dir=templates_dir,
         workdir=tmp_path,
         bulletin=board,
+        default_model="mock-model",
     )
 
     task = _make_task()

--- a/tests/unit/test_cost_engine.py
+++ b/tests/unit/test_cost_engine.py
@@ -450,7 +450,8 @@ class TestRoutTaskBanditIntegration:
         assert config.model == "sonnet"
 
     def test_bandit_does_not_affect_manager_tasks(self, tmp_path: Path) -> None:
-        """Manager role always uses opus regardless of bandit data."""
+        """Manager role escalates to max effort on the configured default_model
+        regardless of bandit data (the haiku arm must not win)."""
         from bernstein.core.router import route_task
 
         metrics_dir = tmp_path / "metrics"
@@ -458,19 +459,21 @@ class TestRoutTaskBanditIntegration:
         _bandit_with_data(metrics_dir, "manager", "haiku", observations=10, successes=10)
 
         task = _task(role="manager")
-        config = route_task(task, bandit_metrics_dir=metrics_dir)
+        config = route_task(task, bandit_metrics_dir=metrics_dir, default_model="run-default")
 
-        assert config.model == "opus"
+        assert config.model == "run-default"
+        assert config.effort == "max"
 
     def test_route_task_without_bandit_uses_heuristics(self) -> None:
         """Without bandit_metrics_dir, route_task uses heuristics."""
         from bernstein.core.router import route_task
 
         task = _task(role="backend", complexity=Complexity.MEDIUM)
-        config = route_task(task, bandit_metrics_dir=None)
+        config = route_task(task, bandit_metrics_dir=None, default_model="run-default")
 
-        # Heuristic gives sonnet for medium backend tasks
-        assert config.model in ("sonnet", "haiku", "opus")
+        # Heuristic gives high effort on the default model for medium backend tasks
+        assert config.model == "run-default"
+        assert config.effort == "high"
 
 
 # ---------------------------------------------------------------------------
@@ -496,7 +499,8 @@ class TestSelectBatchConfigBanditIntegration:
         assert config.model == "sonnet"
 
     def test_manager_ignores_bandit(self, tmp_path: Path) -> None:
-        """Manager always gets opus even if bandit says haiku."""
+        """Manager always gets the configured default at max effort even if
+        bandit says haiku."""
         from bernstein.core.spawner import _select_batch_config
 
         metrics_dir = tmp_path / "metrics"
@@ -504,18 +508,20 @@ class TestSelectBatchConfigBanditIntegration:
         _bandit_with_data(metrics_dir, "manager", "haiku", observations=10, successes=10)
 
         tasks = [_task(role="manager")]
-        config = _select_batch_config(tasks, metrics_dir=metrics_dir)
+        config = _select_batch_config(tasks, metrics_dir=metrics_dir, default_model="run-default")
 
-        assert config.model == "opus"
+        assert config.model == "run-default"
+        assert config.effort == "max"
 
     def test_no_metrics_dir_falls_back_to_heuristics(self) -> None:
         """Without metrics_dir, uses heuristic routing."""
         from bernstein.core.spawner import _select_batch_config
 
         tasks = [_task(role="backend", complexity=Complexity.MEDIUM)]
-        config = _select_batch_config(tasks, metrics_dir=None)
+        config = _select_batch_config(tasks, metrics_dir=None, default_model="run-default")
 
-        assert config.model in ("sonnet", "opus")
+        assert config.model == "run-default"
+        assert config.effort == "high"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_crash_recovery.py
+++ b/tests/unit/test_crash_recovery.py
@@ -96,6 +96,7 @@ def _make_spawner(tmp_path: Path, adapter: CLIAdapter | None = None) -> AgentSpa
         adapter=adapter,
         templates_dir=tmp_path / "templates",
         workdir=tmp_path,
+        default_model="mock-model",
     )
 
 

--- a/tests/unit/test_deterministic_run.py
+++ b/tests/unit/test_deterministic_run.py
@@ -7,10 +7,12 @@ These are pure logic tests - no server, no agents, no IO.
 
 from __future__ import annotations
 
+import pytest
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus, TaskType
 from bernstein.core.router import route_task
 from bernstein.core.tick_pipeline import group_by_role
 
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.knowledge.task_graph import TaskGraph
 
 # ---------------------------------------------------------------------------
@@ -258,54 +260,66 @@ class TestRoleAssignmentDeterministic:
 
 
 class TestModelSelectionDeterministic:
-    """route_task produces the same ModelConfig every time (no randomness)."""
+    """route_task produces the same ModelConfig every time (no randomness).
 
-    def test_critical_priority_always_opus(self) -> None:
-        """Priority-1 tasks always route to opus/max."""
+    Routing has no built-in model fallback: high-stakes escalation lands on
+    the operator-configured default_model at max effort, and routing with no
+    default at all deterministically refuses with ModelNotConfiguredError.
+    """
+
+    def test_critical_priority_always_default_model_max(self) -> None:
+        """Priority-1 tasks always route to default_model/max."""
         task = _t(id="T-crit", priority=1, role="backend")
         for _ in range(10):
-            cfg = route_task(task)
-            assert cfg.model == "opus"
+            cfg = route_task(task, default_model="run-default")
+            assert cfg.model == "run-default"
             assert cfg.effort == "max"
 
-    def test_manager_role_always_opus(self) -> None:
-        """Manager role always routes to opus/max."""
+    def test_manager_role_always_default_model_max(self) -> None:
+        """Manager role always routes to default_model/max."""
         task = _t(id="T-mgr", role="manager")
         for _ in range(10):
-            cfg = route_task(task)
-            assert cfg.model == "opus"
+            cfg = route_task(task, default_model="run-default")
+            assert cfg.model == "run-default"
             assert cfg.effort == "max"
 
-    def test_security_role_always_opus(self) -> None:
-        """Security role always routes to opus/max."""
+    def test_security_role_always_default_model_max(self) -> None:
+        """Security role always routes to default_model/max."""
         task = _t(id="T-sec", role="security")
         for _ in range(10):
-            cfg = route_task(task)
-            assert cfg.model == "opus"
+            cfg = route_task(task, default_model="run-default")
+            assert cfg.model == "run-default"
             assert cfg.effort == "max"
 
-    def test_large_scope_always_opus(self) -> None:
-        """Large-scope tasks always route to opus/max."""
+    def test_large_scope_always_default_model_max(self) -> None:
+        """Large-scope tasks always route to default_model/max."""
         task = _t(id="T-large", scope=Scope.LARGE, role="backend")
         for _ in range(10):
-            cfg = route_task(task)
-            assert cfg.model == "opus"
+            cfg = route_task(task, default_model="run-default")
+            assert cfg.model == "run-default"
             assert cfg.effort == "max"
 
     def test_high_complexity_heuristic_fallback(self) -> None:
-        """High complexity (no bandit) falls back to sonnet/high deterministically."""
+        """High complexity (no bandit) falls back to default_model/high deterministically."""
         task = _t(id="T-hi", complexity=Complexity.HIGH, role="backend", priority=2)
         for _ in range(10):
-            cfg = route_task(task)
-            assert cfg.model == "sonnet"
+            cfg = route_task(task, default_model="run-default")
+            assert cfg.model == "run-default"
             assert cfg.effort == "high"
+
+    def test_no_model_configured_always_refuses(self) -> None:
+        """With no task model and no default_model, routing refuses every time."""
+        task = _t(id="T-none", role="backend", priority=2, complexity=Complexity.MEDIUM)
+        for _ in range(10):
+            with pytest.raises(ModelNotConfiguredError, match="Refusing to guess"):
+                route_task(task)
 
     def test_default_route_deterministic(self) -> None:
         """Default routing (medium complexity, normal priority) is stable."""
         task = _t(id="T-default", role="backend", priority=2, complexity=Complexity.MEDIUM)
-        reference = route_task(task)
+        reference = route_task(task, default_model="run-default")
         for _ in range(9):
-            cfg = route_task(task)
+            cfg = route_task(task, default_model="run-default")
             assert cfg.model == reference.model
             assert cfg.effort == reference.effort
 
@@ -327,8 +341,12 @@ class TestModelSelectionDeterministic:
             _t(id="T-e", role="security", complexity=Complexity.HIGH),
         ]
 
-        reference = [(route_task(t).model, route_task(t).effort) for t in tasks]
+        def _route(t: Task) -> tuple[str, str]:
+            cfg = route_task(t, default_model="run-default")
+            return (cfg.model, cfg.effort)
+
+        reference = [_route(t) for t in tasks]
 
         for run in range(9):
-            configs = [(route_task(t).model, route_task(t).effort) for t in tasks]
+            configs = [_route(t) for t in tasks]
             assert configs == reference, f"Run {run + 2}: model configs diverged: {configs} vs {reference}"

--- a/tests/unit/test_failure_reduction.py
+++ b/tests/unit/test_failure_reduction.py
@@ -528,49 +528,52 @@ class TestMaybeRetryProgressiveTimeout:
 
 
 # ---------------------------------------------------------------------------
-# Fix F: route_task legacy function - LARGE and architect/security → opus/max
+# Fix F: route_task legacy function - LARGE and architect/security -> max effort
 # ---------------------------------------------------------------------------
 
 
 class TestRouteTaskLegacyFunction:
-    """The legacy route_task() function should use opus/max for high-stakes routing."""
+    """The legacy route_task() function escalates high-stakes tasks to max
+    effort on the operator-configured default_model; it never hardcodes a
+    Claude tier name."""
 
-    def test_large_scope_routes_to_opus_max(self) -> None:
+    def test_large_scope_routes_to_default_model_max(self) -> None:
         from bernstein.core.router import route_task
 
         task = _make_task(scope="large")
-        cfg = route_task(task)
-        assert cfg.model == "opus"
+        cfg = route_task(task, default_model="run-default")
+        assert cfg.model == "run-default"
         assert cfg.effort == "max"
 
-    def test_architect_role_routes_to_opus_max(self) -> None:
+    def test_architect_role_routes_to_default_model_max(self) -> None:
         from bernstein.core.router import route_task
 
         task = _make_task(role="architect")
-        cfg = route_task(task)
-        assert cfg.model == "opus"
+        cfg = route_task(task, default_model="run-default")
+        assert cfg.model == "run-default"
         assert cfg.effort == "max"
 
-    def test_security_role_routes_to_opus_max(self) -> None:
+    def test_security_role_routes_to_default_model_max(self) -> None:
         from bernstein.core.router import route_task
 
         task = _make_task(role="security")
-        cfg = route_task(task)
-        assert cfg.model == "opus"
+        cfg = route_task(task, default_model="run-default")
+        assert cfg.model == "run-default"
         assert cfg.effort == "max"
 
-    def test_manager_role_routes_to_opus_max(self) -> None:
+    def test_manager_role_routes_to_default_model_max(self) -> None:
         from bernstein.core.router import route_task
 
         task = _make_task(role="manager")
-        cfg = route_task(task)
-        assert cfg.model == "opus"
+        cfg = route_task(task, default_model="run-default")
+        assert cfg.model == "run-default"
         assert cfg.effort == "max"
 
-    def test_medium_scope_backend_uses_sonnet(self) -> None:
+    def test_medium_scope_backend_uses_default_model_high(self) -> None:
         from bernstein.core.router import route_task
 
         task = _make_task(role="backend", scope="medium", complexity="medium")
-        cfg = route_task(task)
-        # Should not escalate to opus for ordinary tasks
-        assert cfg.model in ("sonnet", "haiku")
+        cfg = route_task(task, default_model="run-default")
+        # Should not escalate to max effort for ordinary tasks
+        assert cfg.model == "run-default"
+        assert cfg.effort == "high"

--- a/tests/unit/test_fast_path.py
+++ b/tests/unit/test_fast_path.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bernstein.core import fast_path as fast_path_module
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.fast_path import (
     FastPathAction,
     FastPathResult,
@@ -17,9 +19,6 @@ from bernstein.core.fast_path import (
     try_fast_path_batch,
 )
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
-
-from bernstein.core import fast_path as fast_path_module
-from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 
 # --- Helpers ---
 

--- a/tests/unit/test_fast_path.py
+++ b/tests/unit/test_fast_path.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from bernstein.core import fast_path as fast_path_module
-from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.fast_path import (
     FastPathAction,
     FastPathResult,
@@ -19,6 +17,9 @@ from bernstein.core.fast_path import (
     try_fast_path_batch,
 )
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
+
+from bernstein.core import fast_path as fast_path_module
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 
 # --- Helpers ---
 

--- a/tests/unit/test_fast_path.py
+++ b/tests/unit/test_fast_path.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bernstein.core import fast_path as fast_path_module
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.fast_path import (
     FastPathAction,
     FastPathResult,
@@ -16,7 +18,7 @@ from bernstein.core.fast_path import (
     get_l1_model_config,
     try_fast_path_batch,
 )
-from bernstein.core.models import Complexity, Scope, Task
+from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 
 # --- Helpers ---
 
@@ -369,14 +371,33 @@ class TestFastPathStats:
 
 
 class TestL1ModelConfig:
-    """Tests for L1 cheapest model config."""
+    """Tests for L1 cheapest model config.
 
-    def test_l1_model_is_sonnet(self) -> None:
+    L1 model config comes only from routing.yaml's fast_path.l1_model
+    (see load_fast_path_config) - Bernstein never hardcodes a fallback
+    model, so get_l1_model_config() must raise when unconfigured and
+    return exactly what was configured when it is.
+    """
+
+    def setup_method(self) -> None:
+        self._orig = fast_path_module._l1_model_config
+
+    def teardown_method(self) -> None:
+        fast_path_module._l1_model_config = self._orig
+
+    def test_raises_when_unconfigured(self) -> None:
+        fast_path_module._l1_model_config = None
+        with pytest.raises(ModelNotConfiguredError, match="No L1 model configured"):
+            get_l1_model_config()
+
+    def test_l1_model_returns_config_supplied_model(self) -> None:
+        fast_path_module._l1_model_config = ModelConfig(model="sonnet", effort="normal", max_tokens=50_000)
         cfg = get_l1_model_config()
         assert cfg.model == "sonnet"
         assert cfg.effort == "normal"
 
     def test_l1_model_has_reasonable_token_limit(self) -> None:
+        fast_path_module._l1_model_config = ModelConfig(model="sonnet", effort="normal", max_tokens=50_000)
         cfg = get_l1_model_config()
         assert cfg.max_tokens <= 100_000
 

--- a/tests/unit/test_hijacker.py
+++ b/tests/unit/test_hijacker.py
@@ -636,10 +636,11 @@ class TestHijackerIntegration:
             complexity=Complexity.LOW,
         )
 
-        # Hijack for the task
+        # Hijack for the task; the subject here is free-tier hijacking, so
+        # pin an explicit run default that the trial opportunity supports.
         from bernstein.core.router import route_task
 
-        model_config = route_task(test_task)
+        model_config = route_task(test_task, default_model="sonnet")
         result = hijacker.hijack_for_task(model_config)
 
         assert result is not None

--- a/tests/unit/test_idle_agent_detection.py
+++ b/tests/unit/test_idle_agent_detection.py
@@ -225,7 +225,7 @@ class TestSpawnerReapCompletedAgent:
         adapter = _mock_adapter(pid=999, proc=mock_proc)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         session = spawner.spawn_for_tasks([_make_task(id="T-001")])
         spawner.reap_completed_agent(session)
@@ -240,7 +240,7 @@ class TestSpawnerReapCompletedAgent:
         adapter = _mock_adapter(pid=888, proc=mock_proc)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         session = spawner.spawn_for_tasks([_make_task(id="T-002")])
         spawner.reap_completed_agent(session)
@@ -252,7 +252,7 @@ class TestSpawnerReapCompletedAgent:
         adapter = _mock_adapter(pid=777, proc=None)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         session = spawner.spawn_for_tasks([_make_task(id="T-003")])
         # Should not raise
@@ -283,7 +283,7 @@ class TestSpawnerReapCompletedAgent:
         adapter = _mock_adapter(pid=666, proc=mock_proc)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         session = spawner.spawn_for_tasks([_make_task(id="T-004")])
         spawner.reap_completed_agent(session)

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -210,7 +210,7 @@ class TestSpawnerMcpPassthrough:
         templates_dir.mkdir(parents=True)
         mcp_config = {"mcpServers": {"tavily": {"command": "npx"}}}
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, mcp_config=mcp_config)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, mcp_config=mcp_config, default_model="mock-model")
         spawner.spawn_for_tasks([make_task()])
 
         call_kwargs = adapter.spawn.call_args.kwargs
@@ -221,7 +221,7 @@ class TestSpawnerMcpPassthrough:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, mcp_config=None)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, mcp_config=None, default_model="mock-model")
         spawner.spawn_for_tasks([make_task()])
 
         call_kwargs = adapter.spawn.call_args.kwargs

--- a/tests/unit/test_mcp_registry.py
+++ b/tests/unit/test_mcp_registry.py
@@ -511,6 +511,7 @@ class TestSpawnerMCPRegistryIntegration:
             tmp_path,
             mcp_config=base_config,
             mcp_registry=registry,
+            default_model="mock-model",
         )
         spawner.spawn_for_tasks([make_task(description="Use web search")])
 
@@ -537,6 +538,7 @@ class TestSpawnerMCPRegistryIntegration:
             tmp_path,
             mcp_config=base_config,
             mcp_registry=None,
+            default_model="mock-model",
         )
         spawner.spawn_for_tasks([make_task()])
 

--- a/tests/unit/test_model_coercion.py
+++ b/tests/unit/test_model_coercion.py
@@ -9,8 +9,10 @@ and executed model agree, while leaving the Claude path byte-identical.
 
 from __future__ import annotations
 
+import pytest
 from bernstein.core.models import ModelConfig
 
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.agents.spawner_warm_pool import _coerce_model_for_non_claude_adapter
 
 
@@ -44,13 +46,16 @@ def test_non_tier_model_passed_through() -> None:
     assert out.model == "gpt-5.4"
 
 
-def test_no_default_leaves_model_unchanged() -> None:
-    out = _coerce_model_for_non_claude_adapter(
-        ModelConfig(model="sonnet", effort="high"),
-        adapter_name="Codex",
-        adapter_default_model=None,
-    )
-    assert out.model == "sonnet"
+def test_no_default_refuses_unpinned_tier() -> None:
+    """With no adapter or run-level default, an unpinned Claude tier name has
+    no valid substitute for a non-Claude adapter, so coercion refuses instead
+    of passing the tier name through to a CLI that cannot run it."""
+    with pytest.raises(ModelNotConfiguredError, match="unpinned Claude tier name"):
+        _coerce_model_for_non_claude_adapter(
+            ModelConfig(model="sonnet", effort="high"),
+            adapter_name="Codex",
+            adapter_default_model=None,
+        )
 
 
 def test_run_level_default_model_coerces_haiku_for_qwen() -> None:

--- a/tests/unit/test_oauth_refresh.py
+++ b/tests/unit/test_oauth_refresh.py
@@ -41,7 +41,7 @@ def _make_spawner(tmp_path: Path, adapter: MagicMock) -> AgentSpawner:
     backend_dir.mkdir(parents=True)
     (backend_dir / "system_prompt.md").write_text("You are a backend agent.")
 
-    spawner = AgentSpawner(adapter, templates_dir, tmp_path)
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, default_model="mock-model")
     spawner._get_adapter_by_name = MagicMock(return_value=adapter)
     spawner._infer_adapter_name_for_provider = MagicMock(return_value="test-adapter")
     spawner._router = MagicMock()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -235,9 +235,15 @@ def _build_orchestrator(
     transport: httpx.MockTransport,
     adapter: CLIAdapter | None = None,
     config: OrchestratorConfig | None = None,
-    default_model: str | None = None,
+    default_model: str | None = "mock-model",
 ) -> Orchestrator:
-    """Convenience: wire up orchestrator with mocked transport."""
+    """Convenience: wire up orchestrator with mocked transport.
+
+    ``default_model`` defaults to a mock value because routing now refuses
+    to spawn when no model is configured anywhere; tests here exercise
+    orchestrator scheduling, not model configuration. Pass ``None``
+    explicitly to exercise the unconfigured-model refusal path.
+    """
     cfg = config or OrchestratorConfig(
         max_agents=6,
         poll_interval_s=1,

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -235,6 +235,7 @@ def _build_orchestrator(
     transport: httpx.MockTransport,
     adapter: CLIAdapter | None = None,
     config: OrchestratorConfig | None = None,
+    default_model: str | None = None,
 ) -> Orchestrator:
     """Convenience: wire up orchestrator with mocked transport."""
     cfg = config or OrchestratorConfig(
@@ -247,7 +248,7 @@ def _build_orchestrator(
     adp = adapter or _mock_adapter()
     templates_dir = tmp_path / "templates" / "roles"
     templates_dir.mkdir(parents=True)
-    spawner = AgentSpawner(adp, templates_dir, tmp_path)
+    spawner = AgentSpawner(adp, templates_dir, tmp_path, default_model=default_model)
     client = httpx.Client(transport=_paginated_transport(transport), base_url="http://testserver")
     return Orchestrator(cfg, spawner, tmp_path, client=client)
 
@@ -578,7 +579,7 @@ class TestTickStarvingRolePriority:
             max_tasks_per_agent=1,
             server_url="http://testserver",
         )
-        orch = _build_orchestrator(tmp_path, httpx.MockTransport(handler), config=cfg)
+        orch = _build_orchestrator(tmp_path, httpx.MockTransport(handler), config=cfg, default_model="mock-model")
         be_session = AgentSession(
             id="existing-backend",
             role="backend",

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -140,7 +140,7 @@ def _build_orchestrator(
     adp = adapter or _mock_adapter()
     templates_dir = tmp_path / "templates" / "roles"
     templates_dir.mkdir(parents=True)
-    spawner = AgentSpawner(adp, templates_dir, tmp_path)
+    spawner = AgentSpawner(adp, templates_dir, tmp_path, default_model="mock-model")
     client = httpx.Client(transport=transport, base_url="http://testserver")
     return Orchestrator(cfg, spawner, tmp_path, client=client)
 

--- a/tests/unit/test_retry_or_fail_task.py
+++ b/tests/unit/test_retry_or_fail_task.py
@@ -38,6 +38,7 @@ class MockTask:
         self.model = "sonnet"
         self.effort = "high"
         self.max_output_tokens = None
+        self.max_turns = None
         self.meta_messages = []
         self.completion_signals = []
         self.metadata = {}

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from bernstein.core import fast_path as fast_path_module
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 from bernstein.core.router import (
     ModelPolicy,
@@ -19,6 +18,8 @@ from bernstein.core.router import (
     load_model_policy_from_yaml,
     route_task,
 )
+
+from bernstein.core import fast_path as fast_path_module
 
 # --- Helpers ---
 
@@ -503,9 +504,7 @@ class TestRouteTask:
         assert config.model == "l1-model"
         assert config.effort == "normal"
 
-    def test_simple_tasks_fall_back_to_default_model_when_l1_unset(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_simple_tasks_fall_back_to_default_model_when_l1_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Without fast_path.l1_model, L1 classification falls through to the
         # standard routing sources instead of failing the task.
         monkeypatch.setattr(fast_path_module, "_l1_model_config", None)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from bernstein.core import fast_path as fast_path_module
 from bernstein.core.models import Complexity, ModelConfig, Scope, Task
 from bernstein.core.router import (
     ModelPolicy,
@@ -30,7 +31,13 @@ def _make_task(
     description: str = "Write the code.",
     scope: Scope = Scope.MEDIUM,
     complexity: Complexity = Complexity.MEDIUM,
+    model: str | None = "sonnet",
+    effort: str | None = None,
 ) -> Task:
+    # ``model`` defaults to an explicit pin because routing no longer guesses
+    # a model for unconfigured tasks; provider-selection tests here exercise
+    # tier/policy behavior, not model resolution. Pass ``model=None`` plus
+    # ``route_task(..., default_model=...)`` to exercise resolution itself.
     return Task(
         id=id,
         title=title,
@@ -38,6 +45,8 @@ def _make_task(
         role=role,
         scope=scope,
         complexity=complexity,
+        model=model,
+        effort=effort,
     )
 
 
@@ -249,8 +258,8 @@ class TestSelectProviderForTask:
             )
         )
 
-        # Task requires opus (manager role)
-        task = _make_task(role="manager")
+        # Task requires opus (pinned) but the provider only serves sonnet
+        task = _make_task(role="manager", model="opus")
 
         with pytest.raises(RouterError, match="No available provider"):
             router.select_provider_for_task(task)
@@ -346,7 +355,7 @@ class TestModelMatching:
             )
         )
 
-        task = _make_task(role="manager")  # routes to opus
+        task = _make_task(role="manager", model="opus", effort="max")
         decision = router.select_provider_for_task(task)
 
         assert decision.provider == "provider"
@@ -365,10 +374,10 @@ class TestModelMatching:
             )
         )
 
-        task = _make_task(complexity=Complexity.HIGH, scope=Scope.LARGE)
+        task = _make_task(complexity=Complexity.HIGH, scope=Scope.LARGE, model="opus", effort="max")
         decision = router.select_provider_for_task(task)
 
-        # Effort should be preserved from base routing (max for large+high)
+        # Effort should be preserved from base routing (max, pinned on the task)
         assert decision.model_config.effort == "max"
 
 
@@ -433,13 +442,13 @@ class TestBatchRouting:
         )
 
         tasks = [
-            _make_task(id="T-first", role="manager"),
+            _make_task(id="T-first", role="manager", model="opus", effort="max"),
             _make_task(id="T-second", role="backend"),
         ]
 
         decisions = router.route_batch(tasks)
 
-        # Manager routes to opus, backend to sonnet
+        # Manager pinned to opus, backend to sonnet
         assert decisions[0].model_config.model == "opus"
         assert decisions[1].model_config.model == "sonnet"
 
@@ -448,78 +457,104 @@ class TestBatchRouting:
 
 
 class TestRouteTask:
-    def test_manager_routes_to_opus_max(self) -> None:
-        task = _make_task(role="manager")
-        config = route_task(task)
+    """Routing no longer hardcodes Claude tier names; high-stakes tasks
+    escalate to max effort on the operator-configured default_model, and
+    L1 tasks use the routing.yaml-configured fast_path.l1_model."""
 
-        assert config.model == "opus"
+    _L1_CONFIG = ModelConfig(model="l1-model", effort="normal", max_tokens=50_000)
+
+    def test_manager_routes_to_default_model_max(self) -> None:
+        task = _make_task(role="manager", model=None)
+        config = route_task(task, default_model="run-default")
+
+        assert config.model == "run-default"
         assert config.effort == "max"
 
-    def test_security_routes_to_opus_max(self) -> None:
-        # Security needs deep analysis -- always use opus/max
-        task = _make_task(role="security")
-        config = route_task(task)
+    def test_security_routes_to_default_model_max(self) -> None:
+        # Security needs deep analysis -- always use max effort
+        task = _make_task(role="security", model=None)
+        config = route_task(task, default_model="run-default")
 
-        assert config.model == "opus"
+        assert config.model == "run-default"
         assert config.effort == "max"
 
-    def test_large_high_complexity_routes_to_opus_max(self) -> None:
-        # Large scope + high complexity = hardest tasks, use opus/max
-        task = _make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
-        config = route_task(task)
+    def test_large_high_complexity_routes_to_default_model_max(self) -> None:
+        # Large scope + high complexity = hardest tasks, use max effort
+        task = _make_task(scope=Scope.LARGE, complexity=Complexity.HIGH, model=None)
+        config = route_task(task, default_model="run-default")
 
-        assert config.model == "opus"
+        assert config.model == "run-default"
         assert config.effort == "max"
 
-    def test_medium_complexity_routes_to_sonnet_high(self) -> None:
-        task = _make_task(complexity=Complexity.MEDIUM)
-        config = route_task(task)
+    def test_medium_complexity_routes_to_default_model_high(self) -> None:
+        task = _make_task(complexity=Complexity.MEDIUM, model=None)
+        config = route_task(task, default_model="run-default")
 
-        assert config.model == "sonnet"
+        assert config.model == "run-default"
         assert config.effort == "high"
 
-    def test_simple_tasks_route_to_sonnet(self) -> None:
-        # Low complexity + small scope tasks are L1 fast-pathed to haiku/low
-        task = _make_task(complexity=Complexity.LOW, scope=Scope.SMALL)
+    def test_simple_tasks_route_to_l1_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Low complexity + small scope tasks are L1 fast-pathed to the
+        # routing.yaml-configured L1 model
+        monkeypatch.setattr(fast_path_module, "_l1_model_config", self._L1_CONFIG)
+        task = _make_task(complexity=Complexity.LOW, scope=Scope.SMALL, model=None)
         config = route_task(task)
 
-        assert config.model == "sonnet"
+        assert config.model == "l1-model"
         assert config.effort == "normal"
 
-    def test_l1_docstring_task_routes_to_sonnet(self) -> None:
-        """L1 tasks (e.g. add docstring) should route to haiku/low."""
+    def test_simple_tasks_fall_back_to_default_model_when_l1_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Without fast_path.l1_model, L1 classification falls through to the
+        # standard routing sources instead of failing the task.
+        monkeypatch.setattr(fast_path_module, "_l1_model_config", None)
+        task = _make_task(complexity=Complexity.LOW, scope=Scope.SMALL, model=None)
+        config = route_task(task, default_model="run-default")
+
+        assert config.model == "run-default"
+
+    def test_l1_docstring_task_routes_to_l1_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """L1 tasks (e.g. add docstring) route to the configured L1 model."""
+        monkeypatch.setattr(fast_path_module, "_l1_model_config", self._L1_CONFIG)
         task = _make_task(
             title="Add docstring to parse_config",
             complexity=Complexity.LOW,
             scope=Scope.SMALL,
+            model=None,
         )
         config = route_task(task)
 
-        assert config.model == "sonnet"
+        assert config.model == "l1-model"
         assert config.effort == "normal"
 
-    def test_l1_typo_task_routes_to_sonnet(self) -> None:
-        """L1 tasks (e.g. fix typo) should route to haiku/low."""
+    def test_l1_typo_task_routes_to_l1_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """L1 tasks (e.g. fix typo) route to the configured L1 model."""
+        monkeypatch.setattr(fast_path_module, "_l1_model_config", self._L1_CONFIG)
         task = _make_task(
             title="Fix typo in error message",
             complexity=Complexity.LOW,
             scope=Scope.SMALL,
+            model=None,
         )
         config = route_task(task)
 
-        assert config.model == "sonnet"
+        assert config.model == "l1-model"
         assert config.effort == "normal"
 
-    def test_l1_not_applied_to_excluded_roles(self) -> None:
+    def test_l1_not_applied_to_excluded_roles(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Manager/architect/security roles are never L1-routed."""
+        monkeypatch.setattr(fast_path_module, "_l1_model_config", self._L1_CONFIG)
         task = _make_task(
             title="Add docstring to security module",
             role="security",
+            model=None,
         )
-        config = route_task(task)
+        config = route_task(task, default_model="run-default")
 
-        # Security always gets opus, regardless of L1 pattern match
-        assert config.model == "opus"
+        # Security always escalates to max effort, regardless of L1 pattern match
+        assert config.model == "run-default"
+        assert config.effort == "max"
 
 
 # --- Default router ---
@@ -615,8 +650,8 @@ class TestRoutingWithMockedTierStates:
         assert simple_decision.tier == Tier.FREE
         assert simple_decision.estimated_cost == pytest.approx(0.0)
 
-        # Complex task (manager) should fall back to paid if free doesn't support opus
-        manager_task = _make_task(role="manager")
+        # Complex task (manager, pinned to opus) should fall back to paid if free doesn't support opus
+        manager_task = _make_task(role="manager", model="opus", effort="max")
         manager_decision = router.select_provider_for_task(manager_task)
         # Free tier doesn't have opus, should fallback to standard
         assert manager_decision.tier == Tier.STANDARD

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -356,7 +356,9 @@ class TestSpawnerWithRouter:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         router = _make_router()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet"
+        )
 
         task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
         session = spawner.spawn_for_tasks([task])
@@ -377,7 +379,9 @@ class TestSpawnerWithRouter:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         router = _make_router()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet"
+        )
 
         task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
         spawner.spawn_for_tasks([task])
@@ -397,7 +401,9 @@ class TestSpawnerWithRouter:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         router = _make_router()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
         session = spawner.spawn_for_tasks([task])
@@ -410,7 +416,9 @@ class TestSpawnerWithRouter:
         adapter = mock_adapter_factory(pid=400)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=None, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, router=None, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task()
         session = spawner.spawn_for_tasks([task])
@@ -424,7 +432,9 @@ class TestSpawnerWithRouter:
         templates_dir.mkdir(parents=True)
         # Router with no providers will raise RouterError
         router = TierAwareRouter()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task()
         session = spawner.spawn_for_tasks([task])
@@ -1491,7 +1501,9 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=700)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(role="backend", description="Implement JWT authentication")
         spawner.spawn_for_tasks([task])
@@ -1514,7 +1526,9 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=701)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(role="backend", description="Review code quality")
         spawner.spawn_for_tasks([task])
@@ -1530,7 +1544,9 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=702)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=None, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, catalog=None, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(role="backend", description="Write some code")
         spawner.spawn_for_tasks([task])
@@ -1551,7 +1567,9 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=703)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(role="backend", description="Implement JWT auth")
         session = spawner.spawn_for_tasks([task])
@@ -1570,7 +1588,9 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=704)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(role="backend", description="Write some backend code")
         session = spawner.spawn_for_tasks([task])

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -54,7 +54,7 @@ class TestSpawnForTasks:
         adapter = mock_adapter_factory(pid=100)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         session = spawner.spawn_for_tasks([task])

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from bernstein.core.agency_loader import AgencyAgent
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.models import (
     AgentSession,
     Complexity,
@@ -312,11 +313,14 @@ class TestSelectBatchConfig:
         assert config.effort == "max"
 
     def test_single_task_returns_its_config(self, make_task) -> None:
-        # LOW+SMALL tasks hit the L1 fast-path → cheapest model (haiku/low)
+        # LOW+SMALL tasks hit the L1 fast-path, which requires
+        # fast_path.l1_model to be configured via routing.yaml. Bernstein
+        # never hardcodes a fallback model (previously "sonnet") - with no
+        # config loaded, this must hard-fail with a clear error instead of
+        # silently defaulting.
         task = make_task(complexity=Complexity.LOW, scope=Scope.SMALL)
-        config = _select_batch_config([task])
-        assert config.model == "sonnet"
-        assert config.effort == "normal"
+        with pytest.raises(ModelNotConfiguredError, match="No L1 model configured"):
+            _select_batch_config([task])
 
 
 # --- TierAwareRouter integration ---

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from bernstein.core.agency_loader import AgencyAgent
-from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 from bernstein.core.models import (
     AgentSession,
     Complexity,
@@ -45,6 +44,7 @@ from bernstein.adapters.plugin_sdk import (
     AdapterPluginInfo,
     PluginAdapter,
 )
+from bernstein.core.agents.spawn_errors import ModelNotConfiguredError
 
 # --- spawn_for_tasks ---
 
@@ -70,7 +70,7 @@ class TestSpawnForTasks:
         adapter = mock_adapter_factory(pid=200)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         tasks = [
             make_task(id="T-001", role="backend"),
@@ -101,9 +101,10 @@ class TestSpawnForTasks:
 
     def test_uses_highest_model_config_in_batch(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
         adapter = mock_adapter_factory()
+        adapter.name.return_value = "claude"  # tier-name assertions need a Claude-compatible adapter
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="sonnet")
 
         tasks = [
             make_task(id="T-001", role="backend", complexity=Complexity.LOW),
@@ -114,9 +115,13 @@ class TestSpawnForTasks:
                 complexity=Complexity.HIGH,
             ),
         ]
+        # Routing no longer hardcodes opus for high-stakes tasks; pin the
+        # per-task models so the batch still exercises highest-tier sorting.
+        tasks[0].model = "sonnet"
+        tasks[1].model = "opus"
         session = spawner.spawn_for_tasks(tasks)
 
-        # The high-complexity large-scope task should route to opus
+        # The batch must adopt the highest-tier model across its tasks
         call_kwargs = adapter.spawn.call_args.kwargs
         assert call_kwargs["model_config"].model == "opus"
         assert session.model_config.model == "opus"
@@ -125,7 +130,7 @@ class TestSpawnForTasks:
         adapter = mock_adapter_factory()
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task(role="qa")
         session = spawner.spawn_for_tasks([task])
@@ -136,7 +141,7 @@ class TestSpawnForTasks:
         adapter = mock_adapter_factory()
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         spawner.spawn_for_tasks([task])
@@ -164,7 +169,7 @@ class TestSpawnForTasks:
             "whenToUse: Periodically\n---\n{{SESSION_ID}}\n"
         )
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
         task = make_task(role="backend")
         spawner.spawn_for_tasks([task])
 
@@ -297,29 +302,30 @@ class TestRenderPrompt:
 
 class TestSelectBatchConfig:
     def test_picks_opus_over_sonnet(self, make_task) -> None:
-        tasks = [
-            make_task(complexity=Complexity.LOW, scope=Scope.SMALL),
-            make_task(complexity=Complexity.HIGH, scope=Scope.LARGE),
-        ]
-        config = _select_batch_config(tasks)
+        # Routing no longer hardcodes tier names for high-stakes tasks; pin
+        # the per-task models so the batch still exercises tier sorting.
+        low = make_task(complexity=Complexity.LOW, scope=Scope.SMALL)
+        low.model = "sonnet"
+        high = make_task(complexity=Complexity.HIGH, scope=Scope.LARGE)
+        high.model = "opus"
+        config = _select_batch_config([low, high])
         assert config.model == "opus"
 
     def test_picks_higher_effort(self, make_task) -> None:
         tasks = [
-            make_task(role="manager"),  # routes to opus max
+            make_task(role="manager"),  # high-stakes role routes to max effort
             make_task(role="manager"),
         ]
-        config = _select_batch_config(tasks)
+        config = _select_batch_config(tasks, default_model="mock-model")
         assert config.effort == "max"
 
     def test_single_task_returns_its_config(self, make_task) -> None:
-        # LOW+SMALL tasks hit the L1 fast-path, which requires
-        # fast_path.l1_model to be configured via routing.yaml. Bernstein
-        # never hardcodes a fallback model (previously "sonnet") - with no
-        # config loaded, this must hard-fail with a clear error instead of
-        # silently defaulting.
+        # LOW+SMALL tasks classify as L1. With no fast_path.l1_model in
+        # routing.yaml the L1 fast-path is skipped, and with no default_model
+        # supplied either, routing must hard-fail with a clear error instead
+        # of silently defaulting (previously "sonnet").
         task = make_task(complexity=Complexity.LOW, scope=Scope.SMALL)
-        with pytest.raises(ModelNotConfiguredError, match="No L1 model configured"):
+        with pytest.raises(ModelNotConfiguredError, match="no default_model"):
             _select_batch_config([task])
 
 
@@ -350,7 +356,7 @@ class TestSpawnerWithRouter:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         router = _make_router()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet")
 
         task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
         session = spawner.spawn_for_tasks([task])
@@ -371,7 +377,7 @@ class TestSpawnerWithRouter:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         router = _make_router()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="sonnet")
 
         task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
         spawner.spawn_for_tasks([task])
@@ -391,7 +397,7 @@ class TestSpawnerWithRouter:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
         router = _make_router()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="mock-model")
 
         task = make_task(scope=Scope.LARGE, complexity=Complexity.HIGH)
         session = spawner.spawn_for_tasks([task])
@@ -404,7 +410,7 @@ class TestSpawnerWithRouter:
         adapter = mock_adapter_factory(pid=400)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=None, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=None, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         session = spawner.spawn_for_tasks([task])
@@ -418,7 +424,7 @@ class TestSpawnerWithRouter:
         templates_dir.mkdir(parents=True)
         # Router with no providers will raise RouterError
         router = TierAwareRouter()
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, router=router, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         session = spawner.spawn_for_tasks([task])
@@ -475,6 +481,7 @@ class TestSpawnerWithRouter:
             tmp_path,
             router=router,
             use_worktrees=False,
+            default_model="sonnet",
         )
         with patch.object(spawner, "_get_adapter_by_name", side_effect=[failing_adapter, backup_adapter]):
             session = spawner.spawn_for_tasks([make_task()])
@@ -614,6 +621,7 @@ class TestSpawnerWithRouter:
             templates_dir,
             tmp_path,
             use_worktrees=False,
+            default_model="mock-model",
         )
 
         task = make_task(role="backend")
@@ -643,6 +651,7 @@ class TestSpawnerWithRouter:
             tmp_path,
             role_model_policy={"backend": {"provider": "codex"}},
             use_worktrees=False,
+            default_model="mock-model",
         )
 
         task = make_task(role="backend")
@@ -665,6 +674,7 @@ class TestSpawnerWithRouter:
             tmp_path,
             use_worktrees=False,
             spawn_rate_limiter=limiter,
+            default_model="mock-model",
         )
 
         spawner.spawn_for_tasks([make_task()])
@@ -849,20 +859,22 @@ class TestProviderOnlyRolePolicyCoercionGuard:
             session = spawner.spawn_for_tasks([task])
         assert session.model_config.model == "MiniMax-Text-01"
 
-    def test_tier_stamp_left_unchanged_when_no_default_model_known(
+    def test_tier_stamp_refused_when_no_default_model_known(
         self, tmp_path: Path, make_task, mock_adapter_factory
     ) -> None:
-        """Consistent with the pre-existing provider_name-is-None coercion
-        branch: with no run-level default_model configured, there is no
-        known non-Claude substitute, so the tier name is left as-is rather
-        than guessing."""
+        """With no run-level default_model configured, there is no known
+        non-Claude substitute for the tier name, so the spawn is refused
+        with a clear error instead of sending e.g. ``-m opus`` to a
+        non-Claude adapter (which the CLI rejects or misbills)."""
         spawner, target_adapter = self._pinned_provider_spawner(tmp_path, mock_adapter_factory, default_model=None)
         task = make_task(role="backend")
         task.model = "opus"
         task.retry_count = 1
-        with patch.object(spawner, "_get_adapter_by_name", return_value=target_adapter):
-            session = spawner.spawn_for_tasks([task])
-        assert session.model_config.model == "opus"
+        with (
+            patch.object(spawner, "_get_adapter_by_name", return_value=target_adapter),
+            pytest.raises(ModelNotConfiguredError, match="unpinned Claude tier name"),
+        ):
+            spawner.spawn_for_tasks([task])
 
 
 # --- _render_prompt with agency_catalog ---
@@ -987,9 +999,12 @@ class TestSelectBatchConfigExtended:
         assert config.effort == "max"
 
     def test_heuristics_used_when_no_config_yaml(self, tmp_path: Path, make_task) -> None:
+        # High-stakes heuristics resolve to the supplied default_model
+        # (previously a hardcoded "opus") with max effort.
         task = make_task(role="backend", complexity=Complexity.HIGH, scope=Scope.LARGE)
-        config = _select_batch_config([task], templates_dir=tmp_path)
-        assert config.model == "opus"
+        config = _select_batch_config([task], templates_dir=tmp_path, default_model="mock-model")
+        assert config.model == "mock-model"
+        assert config.effort == "max"
 
     def test_task_model_override_respected(self, make_task) -> None:
         task = Task(
@@ -1024,8 +1039,11 @@ class TestSelectBatchConfigExtended:
             model=None,
             effort="max",
         )
-        config = _select_batch_config([task])
+        # An effort-only override needs a default_model to pair with; routing
+        # refuses to guess a model (previously hardcoded "sonnet").
+        config = _select_batch_config([task], default_model="mock-model")
         assert config.effort == "max"
+        assert config.model == "mock-model"
 
     def test_both_model_and_effort_override(self) -> None:
         task = Task(
@@ -1078,13 +1096,23 @@ class TestLoadRoleConfig:
         result = _load_role_config("backend", tmp_path)
         assert result is None
 
-    def test_defaults_when_fields_missing(self, tmp_path: Path) -> None:
+    def test_returns_none_when_default_model_missing(self, tmp_path: Path) -> None:
+        # A config.yaml without default_model no longer resolves to a
+        # hardcoded "sonnet"; role-config routing is skipped entirely so the
+        # other model sources (task/role policy/default_model) apply instead.
         role_dir = tmp_path / "backend"
         role_dir.mkdir()
         (role_dir / "config.yaml").write_text("{}\n")
         result = _load_role_config("backend", tmp_path)
+        assert result is None
+
+    def test_effort_defaults_to_high_when_model_present(self, tmp_path: Path) -> None:
+        role_dir = tmp_path / "backend"
+        role_dir.mkdir()
+        (role_dir / "config.yaml").write_text("default_model: mock-model\n")
+        result = _load_role_config("backend", tmp_path)
         assert result is not None
-        assert result.model == "sonnet"
+        assert result.model == "mock-model"
         assert result.effort == "high"
 
 
@@ -1116,7 +1144,7 @@ class TestWorktreeIntegration:
         worktree_path = tmp_path / ".sdd" / "worktrees" / "session-abc"
         worktree_path.mkdir(parents=True)
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True, default_model="mock-model")
         with patch.object(spawner._worktree_mgr, "create", return_value=worktree_path) as mock_create:
             task = make_task()
             session = spawner.spawn_for_tasks([task])
@@ -1136,7 +1164,7 @@ class TestWorktreeIntegration:
         worktree_path = tmp_path / ".sdd" / "worktrees" / "session-claude-md"
         worktree_path.mkdir(parents=True)
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True, default_model="mock-model")
         with patch.object(spawner._worktree_mgr, "create", return_value=worktree_path):
             task = make_task(
                 id="T-AUDIT-095",
@@ -1160,7 +1188,7 @@ class TestWorktreeIntegration:
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=True, default_model="mock-model")
         with patch.object(spawner._worktree_mgr, "create", side_effect=WorktreeError("git failed")):
             task = make_task()
             with pytest.raises(SpawnError, match="Cannot create workspace for agent"):
@@ -1170,7 +1198,7 @@ class TestWorktreeIntegration:
         adapter = mock_adapter_factory(pid=400)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task()
         spawner.spawn_for_tasks([task])
@@ -1463,7 +1491,7 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=700)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
 
         task = make_task(role="backend", description="Implement JWT authentication")
         spawner.spawn_for_tasks([task])
@@ -1486,7 +1514,7 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=701)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
 
         task = make_task(role="backend", description="Review code quality")
         spawner.spawn_for_tasks([task])
@@ -1502,7 +1530,7 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=702)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=None, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=None, use_worktrees=False, default_model="mock-model")
 
         task = make_task(role="backend", description="Write some code")
         spawner.spawn_for_tasks([task])
@@ -1523,7 +1551,7 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=703)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
 
         task = make_task(role="backend", description="Implement JWT auth")
         session = spawner.spawn_for_tasks([task])
@@ -1542,7 +1570,7 @@ class TestSpawnForTasksWithCatalog:
         adapter = mock_adapter_factory(pid=704)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, catalog=catalog, use_worktrees=False, default_model="mock-model")
 
         task = make_task(role="backend", description="Write some backend code")
         session = spawner.spawn_for_tasks([task])
@@ -1641,6 +1669,7 @@ class TestSamplingParamsSpawnPath:
             tmp_path,
             use_worktrees=False,
             mcp_config={"temperature": 0.2, "top_k": 40, "api_key_env": "MY_PROXY_KEY"},
+            default_model="mock-model",
         )
 
         spawner.spawn_for_tasks([make_task()])
@@ -1660,7 +1689,7 @@ class TestSamplingParamsSpawnPath:
         adapter = _SamplingCapableAdapter()
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         spawner.spawn_for_tasks([make_task()])
 
@@ -1687,7 +1716,9 @@ class TestSamplingParamsSpawnPath:
         adapter = _SamplingCapableAdapter()
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, enable_caching=True)
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, use_worktrees=False, enable_caching=True, default_model="mock-model"
+        )
 
         spawner.spawn_for_tasks([make_task()])
 
@@ -1700,7 +1731,7 @@ class TestSamplingParamsSpawnPath:
         adapter = mock_adapter_factory(pid=99)
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         spawner.spawn_for_tasks([make_task()])
 
@@ -1727,6 +1758,7 @@ class TestSamplingParamsSpawnPath:
                     "api_key_env": "OPENROUTER_API_KEY",
                 }
             },
+            default_model="mock-model",
         )
 
         spawner.spawn_for_tasks([make_task(role="backend")])
@@ -1747,6 +1779,7 @@ class TestSamplingParamsSpawnPath:
             use_worktrees=False,
             mcp_config={"base_url": "http://operator-set/v1"},
             role_model_policy={"backend": {"base_url": "http://role-set/v1"}},
+            default_model="mock-model",
         )
 
         spawner.spawn_for_tasks([make_task(role="backend")])
@@ -1768,7 +1801,7 @@ class TestSamplingParamsSpawnPath:
         adapter = _SamplingCapableAdapter()
         templates_dir = tmp_path / "templates" / "roles"
         templates_dir.mkdir(parents=True)
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         custom = ModeProfile(
             name="deep",
@@ -1808,6 +1841,7 @@ class TestSamplingParamsSpawnPath:
                     "extra_params": {"reasoning_effort": "low"},
                 }
             },
+            default_model="mock-model",
         )
 
         spawner.spawn_for_tasks([make_task(role="backend")])
@@ -1841,6 +1875,7 @@ class TestSamplingParamsSpawnPath:
                     "top_k": 99,
                 }
             },
+            default_model="mock-model",
         )
 
         profile_only_max_tokens = ModeProfile(
@@ -1877,6 +1912,7 @@ class TestSamplingParamsSpawnPath:
             use_worktrees=False,
             mcp_config={"temperature": 0.01},
             role_model_policy={"backend": {"temperature": 0.99}},
+            default_model="mock-model",
         )
 
         spawner.spawn_for_tasks([make_task(role="backend")])
@@ -1930,6 +1966,7 @@ class TestSamplingParamsSpawnPath:
             tmp_path,
             use_worktrees=False,
             role_model_policy={"backend": {"provider": "openai_agents"}},
+            default_model="mock-model",
         )
 
         profile = ModeProfile(name="deep", system_prompt_preamble="", max_tokens=8000)
@@ -1968,6 +2005,7 @@ class TestSamplingParamsSpawnPath:
             tmp_path,
             use_worktrees=False,
             role_model_policy={"backend": {"provider": "openai_agents", "max_tokens": 4096}},
+            default_model="mock-model",
         )
 
         with patch.object(spawner, "_get_adapter_by_name", return_value=spawn_time_adapter):

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -2177,6 +2177,7 @@ class TestInlineCouncilForwarding:
             role_model_policy={
                 "backend": {
                     "provider": "openai_agents",
+                    "model": "gpt-5-mini",
                     "council": self._COUNCIL_BLOCK,
                 }
             },

--- a/tests/unit/test_spawner_openclaw_bridge.py
+++ b/tests/unit/test_spawner_openclaw_bridge.py
@@ -95,6 +95,7 @@ def _make_spawner(tmp_path: Path, adapter: CLIAdapter, bridge: RuntimeBridge) ->
         tmp_path,
         use_worktrees=False,
         runtime_bridge=bridge,
+        default_model="mock-model",
     )
 
 

--- a/tests/unit/test_spawner_openclaw_bridge.py
+++ b/tests/unit/test_spawner_openclaw_bridge.py
@@ -208,6 +208,7 @@ def test_bridge_refuses_sampling_params(
         use_worktrees=False,
         runtime_bridge=bridge,
         mcp_config={"temperature": 0.2, "base_url": "http://localhost:8000/v1"},
+        default_model="mock-model",
     )
 
     with pytest.raises(SamplingParamsRefusal, match="temperature"):

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -694,10 +694,14 @@ def test_verify_via_janitor_runs_run_janitor_for_llm_judge(
         workdir: Path,
         *,
         server_url: str | None = None,
+        judge_model: str | None = None,
+        judge_provider: str | None = None,
     ) -> list[Any]:
         captured["tasks"] = tasks
         captured["workdir"] = workdir
         captured["server_url"] = server_url
+        captured["judge_model"] = judge_model
+        captured["judge_provider"] = judge_provider
         return [
             SimpleNamespace(
                 task_id=tasks[0].id,

--- a/tests/unit/test_unattended_retry.py
+++ b/tests/unit/test_unattended_retry.py
@@ -272,7 +272,7 @@ def _make_minimal_spawner(
     templates_dir: Path,
     tmp_path: Path,
 ) -> AgentSpawner:
-    spawner = AgentSpawner(adapter, templates_dir, tmp_path)
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path, default_model="mock-model")
     spawner._get_adapter_by_name = MagicMock(return_value=adapter)  # pyright: ignore[reportPrivateUsage]
     spawner._infer_adapter_name_for_provider = MagicMock(return_value="test-adapter")  # pyright: ignore[reportPrivateUsage]
     spawner._rate_limit_tracker = None  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -342,7 +342,9 @@ class TestTaskRepoField:
 
         from bernstein.core.spawner import AgentSpawner
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, workspace=ws, use_worktrees=False)
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, workspace=ws, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(id="T-100", role="backend")
         # Manually set repo since make_task doesn't support it
@@ -367,7 +369,9 @@ class TestTaskRepoField:
 
         from bernstein.core.spawner import AgentSpawner
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, workspace=ws, use_worktrees=False)
+        spawner = AgentSpawner(
+            adapter, templates_dir, tmp_path, workspace=ws, use_worktrees=False, default_model="mock-model"
+        )
 
         task = make_task(id="T-101", role="backend")
         task.repo = "nonexistent"
@@ -388,7 +392,7 @@ class TestTaskRepoField:
 
         from bernstein.core.spawner import AgentSpawner
 
-        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False)
+        spawner = AgentSpawner(adapter, templates_dir, tmp_path, use_worktrees=False, default_model="mock-model")
 
         task = make_task(id="T-102", role="backend")
         task.repo = "some-repo"


### PR DESCRIPTION
## What

Removes all hardcoded model fallback strings from the codebase. Every model
selection now flows from `bernstein.yaml` configuration -- no silent defaults.

## Why

Hardcoded fallbacks (e.g. `"claude-sonnet-4-20250514"`) silently override
user configuration when a model field is missing. This causes unexpected API
charges on the wrong provider and configuration that appears to work but
ignores the YAML.

## How

- Thread `default_model` from seed config through batch routing (`spawner_core.py`)
- Make janitor judge model configurable via `bernstein.yaml` instead of hardcoded
- Propagate `seed_path` to spawner so it can read the canonical config
- Remove all remaining hardcoded model fallback strings
- Fix 4 test fixtures that relied on the old implicit defaults

## Checklist

- [x] `ruff check src/` passes
- [x] `import bernstein` passes
- [x] Tests updated (4 fixtures pinned to `default_model="mock-model"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `judge_model` / `judge_provider` overrides for janitor-based review signals.
  * Added CLI/runtime `--seed-path` wiring and improved seed/template resolution precedence and propagation.
  * Routing now supports an explicit run-level `default_model` to enable deterministic model selection and batch submission.

* **Bug Fixes**
  * Model selection/spawning now fails fast when required models aren’t configured (no silent hardcoded guesses).
  * Stricter role-policy validation and improved fast-path/L1 behavior; tighter handling for unpinned Claude tier usage.

* **Documentation**
  * Added a non-Claude “Agent Prompt Template” example.

* **Tests**
  * Updated/refined tests to pin `default_model` and cover new refusal/fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->