### PR TITLE
feat: explicit max_turns on TaskCreate, wired through spawn path

### DIFF
--- a/docs/operations/MAX_TURNS.md
+++ b/docs/operations/MAX_TURNS.md
@@ -1,0 +1,64 @@
+# Explicit `max_turns` on task create
+
+By default, an agent's turn budget is computed from task complexity, model
+speed, and the task timeout (`compute_max_turns` in
+`bernstein.core.agents.claude_max_turns`): higher complexity gets more turns,
+and a fast model gets more turns than a slow one within the same timeout
+window. `TaskCreate.max_turns` lets an API caller bypass that computation
+entirely and pin an exact turn count.
+
+## When to use it
+
+- You know from experience that a task type needs more (or fewer) turns than
+  the complexity-based default.
+- You're running a benchmark or eval and need a deterministic, reproducible
+  turn budget across runs regardless of which model handles the task.
+- You want to hard-cap runaway agents on a specific task without changing
+  the global `max_turns_cap`.
+
+## Usage
+
+```json
+POST /tasks
+{
+  "title": "...",
+  "description": "...",
+  "role": "backend",
+  "max_turns": 60
+}
+```
+
+Leave `max_turns` unset (the default, `null`) to keep the automatic
+complexity/model/timeout computation.
+
+## Behavior
+
+When `max_turns` is set on the task:
+
+- `compute_max_turns(explicit_max_turns=...)` returns that value verbatim —
+  complexity, model tier, and timeout are still recorded on the
+  `MaxTurnsConfig` for logging, but none of them affect the number.
+- `constrained_by_timeout` is always `False` for an explicit value (the
+  caller is assumed to have already accounted for timeout).
+- The spawner threads the value through as `explicit_max_turns` to the
+  active adapter, but only if that adapter's `spawn()` signature accepts an
+  `explicit_max_turns` parameter. Adapters that don't support it log a
+  warning and silently fall back to auto-computed turns — the task still
+  runs, just without the explicit cap. Check the adapter's `spawn()`
+  signature if you need to confirm support before relying on this for a
+  hard limit.
+
+## Schema
+
+`max_turns: int | None` on `TaskCreate` (`src/bernstein/core/server/server_models.py`)
+and on the internal `Task` dataclass (`src/bernstein/core/tasks/models.py`).
+`None` means "use the automatic computation."
+
+## Code pointers
+
+| File | What it does |
+|------|--------------|
+| `src/bernstein/core/agents/claude_max_turns.py` | `compute_max_turns`, `MaxTurnsConfig` |
+| `src/bernstein/core/server/server_models.py` | `TaskCreate.max_turns` field |
+| `src/bernstein/core/tasks/models.py` | `Task.max_turns` field, dict round-trip |
+| `src/bernstein/core/agents/spawner_core.py` | Threads `explicit_max_turns` to the adapter if supported |

--- a/docs/operations/MAX_TURNS.md
+++ b/docs/operations/MAX_TURNS.md
@@ -31,6 +31,10 @@ POST /tasks
 Leave `max_turns` unset (the default, `null`) to keep the automatic
 complexity/model/timeout computation.
 
+Accepted values are 1 to 10000 inclusive; zero, negative, and larger
+values are rejected at request validation time because the number is
+passed verbatim to the CLI `--max-turns` flag.
+
 ## Behavior
 
 When `max_turns` is set on the task:

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -377,6 +377,7 @@ class ClaudeCodeAdapter(CLIAdapter):
         batch_mode: bool = False,
         task_scope: str = "medium",
         budget_multiplier: float = 1.0,
+        explicit_max_turns: int | None = None,
     ) -> list[str]:
         """Build the claude CLI command with effort mapping.
 
@@ -408,12 +409,30 @@ class ClaudeCodeAdapter(CLIAdapter):
             budget_multiplier: Additional multiplier applied on top of the
                 scope-based budget (e.g. 2.0 when retrying after hitting the
                 budget cap in a previous attempt).
+            explicit_max_turns: When set (e.g. from ``Task.max_turns``), used
+                verbatim for ``--max-turns``, bypassing the batch_mode /
+                scope_multiplier / effort-based computation below entirely.
         """
         model_id = _MODEL_MAP.get(model_config.model, model_config.model)
         effort = getattr(model_config, "effort", "high")
-        base_turns = COST.effort_base_turns.get(effort, 50)
-        scope_multiplier = self._SCOPE_MULTIPLIERS.get(task_scope, 1.5)
-        max_turns = self.BATCH_MAX_TURNS if batch_mode else int(base_turns * scope_multiplier)
+        if explicit_max_turns is not None:
+            max_turns = explicit_max_turns
+            _logger.info(
+                "_build_command: max_turns=%d (explicit override; bypassing batch_mode/scope_multiplier computation)",
+                max_turns,
+            )
+        else:
+            base_turns = COST.effort_base_turns.get(effort, 50)
+            scope_multiplier = self._SCOPE_MULTIPLIERS.get(task_scope, 1.5)
+            max_turns = self.BATCH_MAX_TURNS if batch_mode else int(base_turns * scope_multiplier)
+            _logger.info(
+                "_build_command: max_turns=%d (computed: batch_mode=%s effort=%s task_scope=%s scope_multiplier=%s)",
+                max_turns,
+                batch_mode,
+                effort,
+                task_scope,
+                scope_multiplier,
+            )
         claude_effort = ({"max": "max", "high": "high", "medium": "medium", "normal": "medium", "low": "low"}).get(
             effort, "high"
         )
@@ -716,6 +735,7 @@ class ClaudeCodeAdapter(CLIAdapter):
         budget_multiplier: float = 1.0,
         system_addendum: str = "",
         multimodal_context: Any | None = None,
+        explicit_max_turns: int | None = None,
     ) -> SpawnResult:
         self.enforce_network_policy()
         # Issue #1797: encode any attached images into the prompt body
@@ -759,6 +779,13 @@ class ClaudeCodeAdapter(CLIAdapter):
             _logger.info("Batch mode detected for session %s - using %d max-turns", session_id, self.BATCH_MAX_TURNS)
 
         agents_json = build_agents_json(role)
+        if explicit_max_turns is not None:
+            _logger.info(
+                "spawn: session=%s explicit_max_turns=%d supplied - will bypass batch_mode/scope_multiplier "
+                "max_turns computation in _build_command",
+                session_id,
+                explicit_max_turns,
+            )
         cmd = self._build_command(
             model_config,
             effective_mcp,
@@ -770,6 +797,7 @@ class ClaudeCodeAdapter(CLIAdapter):
             batch_mode=batch_mode,
             task_scope=task_scope,
             budget_multiplier=budget_multiplier,
+            explicit_max_turns=explicit_max_turns,
         )
 
         # Wrap with bernstein-worker for process visibility

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -134,6 +134,20 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         # reporting never reaches the central server.  It is a URL, not a
         # credential, so passing it through is safe.
         "BERNSTEIN_SERVER_URL",
+        # ``BERNSTEIN_RUN_ID`` (wave 3, per-agent instrumentation) is set by
+        # the orchestrator on ``os.environ`` at run start (see
+        # ``Orchestrator.__init__`` right after ``self._run_id`` is
+        # generated) and read back by
+        # ``bernstein.core.instrumentation.init_instrumenter`` /
+        # ``bernstein.adapters.openai_agents_runner.run`` inside the spawned
+        # agent subprocess so its LLM-call/tool-call/conversation JSONL logs
+        # land under the SAME ``.sdd/runs/<run_id>/...`` tree wave 2's
+        # phase/task timing writes to. Without it in the allowlist a
+        # filtered subprocess env silently drops it and every agent falls
+        # back to a literal "unknown" run id, scattering its instrumentation
+        # outside the run it belongs to. It is a plain identifier, not a
+        # credential, so passing it through is safe.
+        "BERNSTEIN_RUN_ID",
     }
 )
 

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -284,6 +284,14 @@ class OpenAIAgentsAdapter(PluginAdapter):
             heartbeat_dir = mcp_config.get("heartbeat_dir")
             if isinstance(heartbeat_dir, str) and heartbeat_dir:
                 overrides["heartbeat_dir"] = heartbeat_dir
+            # Wave 3 (per-agent instrumentation): task id injected by
+            # spawner_core so the runner's RunInstrumenter can write under
+            # .sdd/runs/<run_id>/tasks/<task_id>/agents/<session_id>/.
+            # Absent on hand-written manifests (e.g. direct-invocation
+            # tests) - the runner falls back to "unknown" in that case.
+            task_id = mcp_config.get("task_id")
+            if isinstance(task_id, str) and task_id:
+                overrides["task_id"] = task_id
 
         # ``max_tokens`` from ``mcp_config`` (mode-profile override) wins; the
         # model_config value is only the fallback when the override is absent.

--- a/src/bernstein/core/agents/claude_max_turns.py
+++ b/src/bernstein/core/agents/claude_max_turns.py
@@ -126,7 +126,9 @@ def compute_max_turns(
             timeout_s=timeout_s,
             turns_per_minute=_TURNS_PER_MINUTE.get(_classify_model_tier(model), DEFAULT_TURNS_PER_MINUTE),
             constrained_by_timeout=False,
-            reasoning=f"Explicit max_turns={explicit_max_turns} supplied by caller; complexity-based computation bypassed.",
+            reasoning=(
+                f"Explicit max_turns={explicit_max_turns} supplied by caller; complexity-based computation bypassed."
+            ),
         )
 
     base = _BASE_TURNS.get(complexity, _BASE_TURNS["medium"])

--- a/src/bernstein/core/agents/claude_max_turns.py
+++ b/src/bernstein/core/agents/claude_max_turns.py
@@ -95,6 +95,7 @@ def compute_max_turns(
     timeout_s: int = 1800,
     min_turns: int = 5,
     max_turns_cap: int = 200,
+    explicit_max_turns: int | None = None,
 ) -> MaxTurnsConfig:
     """Compute optimal max_turns based on complexity, model, and timeout.
 
@@ -109,10 +110,25 @@ def compute_max_turns(
         timeout_s: Task timeout in seconds.
         min_turns: Absolute minimum turns.
         max_turns_cap: Absolute maximum turns.
+        explicit_max_turns: When set (e.g. from ``TaskCreate.max_turns``), bypasses
+            all complexity/model/timeout math below and is used verbatim. This lets
+            API callers take exact control over agent turn budgets.
 
     Returns:
-        MaxTurnsConfig with the computed value and reasoning.
+        MaxTurnsConfig with the computed (or explicit) value and reasoning.
     """
+    if explicit_max_turns is not None:
+        logger.info("max_turns=%s (explicit)", explicit_max_turns)
+        return MaxTurnsConfig(
+            max_turns=explicit_max_turns,
+            complexity=complexity,
+            model=model,
+            timeout_s=timeout_s,
+            turns_per_minute=_TURNS_PER_MINUTE.get(_classify_model_tier(model), DEFAULT_TURNS_PER_MINUTE),
+            constrained_by_timeout=False,
+            reasoning=f"Explicit max_turns={explicit_max_turns} supplied by caller; complexity-based computation bypassed.",
+        )
+
     base = _BASE_TURNS.get(complexity, _BASE_TURNS["medium"])
 
     tier = _classify_model_tier(model)

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2946,6 +2946,20 @@ class AgentSpawner:
                     # adapter never inherits another adapter's extras.
                     attempt_mcp = self._mcp_config_for_adapter(target_adapter, effective_mcp)
 
+                    # Wave 3 (per-agent instrumentation): tell the
+                    # openai_agents runner subprocess which task it is
+                    # working so its RunInstrumenter writes to
+                    # .sdd/runs/<run_id>/tasks/<task_id>/agents/<agent_id>/
+                    # instead of an "unknown" task bucket. Scoped to the
+                    # openai_agents adapter only: other adapters pass
+                    # mcp_config through to their own CLI flags verbatim,
+                    # and a stray top-level "task_id" key there is an
+                    # unnecessary risk for no benefit (those adapters are
+                    # not instrumented in this wave).
+                    if "openai_agents" in adapter_name and tasks:
+                        attempt_mcp = dict(attempt_mcp or {})
+                        attempt_mcp.setdefault("task_id", tasks[0].id)
+
                     try:
                         # Apply OS-level resource limits to non-sandboxed spawns.
                         target_adapter.set_resource_limits(self._resource_limits)

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import inspect
 import json
 import logging
 import re
@@ -3020,6 +3021,26 @@ class AgentSpawner:
                             # Extract budget_multiplier from task metadata
                             # (set by retry logic when previous attempt hit budget cap).
                             _budget_mult = max(float(t.metadata.get("budget_multiplier", 1.0)) for t in tasks)
+                            # Explicit per-task max_turns override (Task.max_turns):
+                            # thread it to the adapter as explicit_max_turns, but
+                            # only when its spawn() signature accepts the
+                            # parameter. Adapters without support keep their own
+                            # auto-computed turn budget; warn so the operator
+                            # knows the cap was not applied. When several grouped
+                            # tasks carry a value the largest wins, mirroring
+                            # budget_multiplier above.
+                            _extra_spawn_kwargs: dict[str, Any] = {}
+                            _explicit_turns = max((t.max_turns for t in tasks if t.max_turns is not None), default=None)
+                            if _explicit_turns is not None:
+                                if "explicit_max_turns" in inspect.signature(target_adapter.spawn).parameters:
+                                    _extra_spawn_kwargs["explicit_max_turns"] = _explicit_turns
+                                else:
+                                    logger.warning(
+                                        "Adapter %s spawn() does not accept explicit_max_turns; "
+                                        "task max_turns=%d ignored, falling back to adapter-computed turns",
+                                        adapter_name,
+                                        _explicit_turns,
+                                    )
                             # Cacheable prefix extraction is deferred to adapters
                             # that support provider-specific caching.
                             result = target_adapter.spawn(
@@ -3031,6 +3052,7 @@ class AgentSpawner:
                                 task_scope=max_scope,
                                 budget_multiplier=_budget_mult,
                                 system_addendum="",
+                                **_extra_spawn_kwargs,
                             )
                         spawn_duration = time.perf_counter() - spawn_start
                         agent_spawn_duration.labels(adapter=provider_name or adapter_name).observe(spawn_duration)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -489,6 +489,20 @@ class Orchestrator:
         # ``.sdd/cost/ledger.jsonl``.
         run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
         self._run_id = run_id
+        # Wave 3 (per-agent instrumentation): export the run id onto the
+        # process environment so it threads through
+        # ``bernstein.adapters.env_isolation.build_filtered_env`` into every
+        # spawned agent subprocess, letting each agent's
+        # ``RunInstrumenter`` (bernstein.core.instrumentation) write its
+        # llm-calls/tool-calls/conversation JSONL under this same
+        # ``.sdd/runs/<run_id>/...`` tree wave 2's timing data lives in.
+        # Best-effort: os.environ writes essentially never fail, but this
+        # must never be allowed to abort orchestrator startup either way.
+        try:
+            os.environ["BERNSTEIN_RUN_ID"] = run_id
+            logger.info("Exported BERNSTEIN_RUN_ID=%s for spawned-agent instrumentation", run_id)
+        except Exception as exc:  # noqa: BLE001 - defensive, must never block startup
+            logger.warning("Failed to export BERNSTEIN_RUN_ID=%s to process env: %s", run_id, exc)
         hard_budget_usd = 0.0
         _raw_hard = os.environ.get("BERNSTEIN_HARD_BUDGET_USD", "").strip()
         if _raw_hard:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -501,7 +501,7 @@ class Orchestrator:
         try:
             os.environ["BERNSTEIN_RUN_ID"] = run_id
             logger.info("Exported BERNSTEIN_RUN_ID=%s for spawned-agent instrumentation", run_id)
-        except Exception as exc:  # noqa: BLE001 - defensive, must never block startup
+        except Exception as exc:  # intentional-broad-except: defensive, must never block startup
             logger.warning("Failed to export BERNSTEIN_RUN_ID=%s to process env: %s", run_id, exc)
         hard_budget_usd = 0.0
         _raw_hard = os.environ.get("BERNSTEIN_HARD_BUDGET_USD", "").strip()

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -321,6 +321,7 @@ def task_to_response(task: Task) -> TaskResponse:
         terminal_reason=task.terminal_reason,
         max_output_tokens=task.max_output_tokens,
         meta_messages=list(task.meta_messages),
+        max_turns=task.max_turns,
     )
 
 
@@ -1230,6 +1231,7 @@ def create_app(
     from bernstein.core.routes.hooks import router as hooks_router
     from bernstein.core.routes.identities import router as identities_router
     from bernstein.core.routes.mcp_bot_tools import router as mcp_bot_tools_router
+    from bernstein.core.routes.orchestrator_holds import router as orchestrator_holds_router
     from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
     from bernstein.core.routes.plans import router as plans_router
     from bernstein.core.routes.predictive import router as predictive_router
@@ -1301,6 +1303,7 @@ def create_app(
         well_known_router,
         mcp_bot_tools_router,
         session_peek_router,
+        orchestrator_holds_router,
     ]
 
     for r in all_routers:

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1231,7 +1231,6 @@ def create_app(
     from bernstein.core.routes.hooks import router as hooks_router
     from bernstein.core.routes.identities import router as identities_router
     from bernstein.core.routes.mcp_bot_tools import router as mcp_bot_tools_router
-    from bernstein.core.routes.orchestrator_holds import router as orchestrator_holds_router
     from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
     from bernstein.core.routes.plans import router as plans_router
     from bernstein.core.routes.predictive import router as predictive_router
@@ -1303,7 +1302,6 @@ def create_app(
         well_known_router,
         mcp_bot_tools_router,
         session_peek_router,
-        orchestrator_holds_router,
     ]
 
     for r in all_routers:

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -156,7 +156,9 @@ class TaskCreate(BaseModel):
     # Explicit override for compute_max_turns()'s complexity-based auto-computation.
     # When set, callers get exact control over how many turns a Claude agent spawn
     # gets, bypassing scope/complexity math entirely (see claude_max_turns.py).
-    max_turns: int | None = None
+    # Bounded because the value reaches the CLI --max-turns flag verbatim: 0 or a
+    # negative would break the spawn, and an unbounded value defeats turn budgeting.
+    max_turns: int | None = Field(default=None, ge=1, le=10_000)
 
     @field_validator("scope", "complexity", "task_type")
     @classmethod

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -153,6 +153,10 @@ class TaskCreate(BaseModel):
     terminal_reason: str | None = Field(default=None, max_length=_MAX_DESCRIPTION_LEN)
     max_output_tokens: int | None = None  # Per-task output-token cap (escalated on retry)
     meta_messages: list[str] | None = Field(default=None, max_length=_MAX_LIST_LEN)
+    # Explicit override for compute_max_turns()'s complexity-based auto-computation.
+    # When set, callers get exact control over how many turns a Claude agent spawn
+    # gets, bypassing scope/complexity math entirely (see claude_max_turns.py).
+    max_turns: int | None = None
 
     @field_validator("scope", "complexity", "task_type")
     @classmethod
@@ -252,6 +256,7 @@ class TaskResponse(BaseModel):
     terminal_reason: str | None = None
     max_output_tokens: int | None = None
     meta_messages: list[str] = Field(default_factory=list)
+    max_turns: int | None = None
 
 
 class WebhookTaskResponse(BaseModel):

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -452,6 +452,11 @@ class Task:
     # that report ``is_multimodal_capable() == False`` MUST refuse spawns
     # carrying a non-empty list before any process is launched.
     attachments: list[str] = field(default_factory=list[str])
+    # Explicit override for compute_max_turns()'s complexity-based auto-computation
+    # (see bernstein.core.agents.claude_max_turns.compute_max_turns). When set,
+    # this value is used verbatim for the Claude adapter's --max-turns flag,
+    # bypassing all scope/complexity-derived math. None = auto-compute as before.
+    max_turns: int | None = None
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Task:
@@ -553,6 +558,7 @@ class Task:
             parallel_safe=bool(raw.get("parallel_safe", False)),
             story_id=(str(raw["story_id"]) if raw.get("story_id") else None),
             attachments=_normalize_attachments(raw.get("attachments")),
+            max_turns=(lambda v: None if v is None else int(v))(raw.get("max_turns")),
         )
 
 

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -525,7 +525,16 @@ def maybe_retry_task(
         "metadata": retry_metadata,
         "meta_messages": list(task.meta_messages),
         "max_output_tokens": task.max_output_tokens,
+        # Carry forward the explicit max_turns override (if any) so a retry
+        # spawn doesn't silently fall back to complexity-based auto-computation.
+        "max_turns": task.max_turns,
     }
+    logger.info(
+        "maybe_retry_task: carrying max_turns=%r forward from task %s to retry %d",
+        task.max_turns,
+        task.id,
+        next_retry,
+    )
 
     try:
         resp = client.post(f"{server_url}/tasks", json=payload)
@@ -1011,7 +1020,17 @@ def retry_or_fail_task(
             "retry_count": retry_count + 1,
             "max_retries": task.max_retries,
             "retry_delay_s": task.retry_delay_s,
+            # Carry forward the explicit max_turns override (if any) so the
+            # retry spawn doesn't silently fall back to complexity-based
+            # auto-computation in compute_max_turns().
+            "max_turns": task.max_turns,
         }
+        logger.info(
+            "retry_or_fail_task: carrying max_turns=%r forward from task %s to retry %d",
+            task.max_turns,
+            task_id,
+            retry_count + 1,
+        )
         # Preserve completion signals on retry
         if task.completion_signals:
             task_body["completion_signals"] = [{"type": s.type, "value": s.value} for s in task.completion_signals]

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -95,6 +95,9 @@ class TaskRecord(TypedDict):
     max_output_tokens: NotRequired[int | None]
     meta_messages: NotRequired[list[str]]
     metadata: NotRequired[dict[str, Any]]
+    # Explicit compute_max_turns() override (see claude_max_turns.py). Optional
+    # for backward compat with records written before this field existed.
+    max_turns: NotRequired[int | None]
 
 
 class ArchiveRecord(TypedDict):
@@ -195,6 +198,7 @@ class TaskCreateRequest(Protocol):
     retry_delay_s: float | None
     terminal_reason: str | None
     max_output_tokens: int | None
+    max_turns: int | None
 
     @property
     def meta_messages(self) -> Sequence[str] | None: ...
@@ -820,6 +824,7 @@ class TaskStore:
             "max_output_tokens": task.max_output_tokens,
             "meta_messages": list(task.meta_messages),
             "metadata": dict(task.metadata),
+            "max_turns": task.max_turns,
         }
 
     # -- public API ---------------------------------------------------------
@@ -914,6 +919,12 @@ class TaskStore:
         max_retries_raw = getattr(req, "max_retries", None)
         retry_delay_raw = getattr(req, "retry_delay_s", None)
         meta_messages_raw = getattr(req, "meta_messages", None)
+        max_turns_raw = getattr(req, "max_turns", None)
+        logger.info(
+            "TaskStore.create: max_turns=%r for title=%r (None => auto-computed at spawn time)",
+            max_turns_raw,
+            req.title,
+        )
 
         task = Task(
             id=uuid.uuid4().hex[:12],
@@ -951,6 +962,7 @@ class TaskStore:
             terminal_reason=getattr(req, "terminal_reason", None),
             max_output_tokens=getattr(req, "max_output_tokens", None),
             meta_messages=list(meta_messages_raw) if meta_messages_raw is not None else [],
+            max_turns=int(max_turns_raw) if max_turns_raw is not None else None,
         )
         async with self._lock:
             if task.depends_on:

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -923,7 +923,7 @@ class TaskStore:
         logger.info(
             "TaskStore.create: max_turns=%r for title=%r (None => auto-computed at spawn time)",
             max_turns_raw,
-            req.title,
+            sanitize_log(req.title),
         )
 
         task = Task(

--- a/tests/golden/cli_snapshots/task_response.json
+++ b/tests/golden/cli_snapshots/task_response.json
@@ -18,6 +18,7 @@
   "id": "task-001",
   "max_output_tokens": null,
   "max_retries": 3,
+  "max_turns": null,
   "meta_messages": [],
   "metadata": {},
   "model": null,

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -169,8 +169,32 @@ class TestAdapterContract:
         assert callable(adapter.detect_tier)
 
     def test_spawn_signature_matches_base(self, name: str, factory: Any) -> None:
+        """Every base parameter must be untouched; adapter-specific extras
+        must be keyword-only with a default.
+
+        The spawner threads optional capabilities (e.g. ``explicit_max_turns``)
+        to adapters by inspecting ``spawn()`` signatures, so adapters may
+        extend the base contract - but only in a way that keeps every
+        base-shaped call site working unchanged.
+        """
         adapter = factory()
-        assert inspect.signature(type(adapter).spawn) == inspect.signature(CLIAdapter.spawn)
+        base_sig = inspect.signature(CLIAdapter.spawn)
+        adapter_sig = inspect.signature(type(adapter).spawn)
+        assert adapter_sig.return_annotation == base_sig.return_annotation, (
+            f"{name}.spawn() changed the return annotation"
+        )
+        for pname, param in base_sig.parameters.items():
+            assert pname in adapter_sig.parameters, f"{name}.spawn() is missing base parameter {pname!r}"
+            assert adapter_sig.parameters[pname] == param, f"{name}.spawn() altered base parameter {pname!r}"
+        for pname, param in adapter_sig.parameters.items():
+            if pname in base_sig.parameters:
+                continue
+            assert param.kind is inspect.Parameter.KEYWORD_ONLY, (
+                f"{name}.spawn() extra parameter {pname!r} must be keyword-only"
+            )
+            assert param.default is not inspect.Parameter.empty, (
+                f"{name}.spawn() extra parameter {pname!r} must have a default"
+            )
 
     def test_spawn_returns_spawn_result(self, name: str, factory: Any, tmp_path: Path) -> None:
         adapter = factory()

--- a/tests/unit/test_dlq_retry_integration.py
+++ b/tests/unit/test_dlq_retry_integration.py
@@ -52,6 +52,7 @@ class _MockTask:
         self.model = "sonnet"
         self.effort = "high"
         self.max_output_tokens = None
+        self.max_turns = None
         self.meta_messages: list[str] = []
         self.completion_signals: list[object] = []
         self.metadata: dict[str, object] = {}


### PR DESCRIPTION
## What

Adds an explicit `max_turns` field to `TaskCreate` so workflow drivers can
set per-task turn budgets directly in the API, bypassing `compute_max_turns()`.

## Why

The complexity-based `compute_max_turns()` calculation is a black box for
external workflow drivers. When running phased workflows (triage/implement/review),
each phase has different turn budget needs that the driver knows better than
the heuristic. This lets the YAML config control it directly.

## How

- Add `max_turns: int | None = None` to `TaskCreate`, `TaskResponse`, `Task`, `TaskRecord`
- Wire through `spawner_core.py` -> `claude.py` adapter's `_build_command` and `spawn`
- When set, bypasses `scope_multiplier` math entirely
- Retries carry `max_turns` forward via `task_lifecycle.py`
- Operator docs: `docs/operations/MAX_TURNS.md`

## Checklist

- [x] `ruff check src/` passes
- [x] `import bernstein` passes
- [x] Docs included (`MAX_TURNS.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-task `max_turns` with automatic computation by default and explicit override support.
  * Task API responses now return the per-task `max_turns`, and retries preserve the original setting.
* **Documentation**
  * Documented how turn limits are computed and when/why to use explicit `max_turns`.
* **Bug Fixes**
  * Improved spawned agent instrumentation and run identification so child processes receive the correct run/task context.
* **Tests**
  * Tightened adapter `spawn()` signature validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->