### PR TITLE
feat: hold/release API for spawner lifecycle management

### DIFF
--- a/docs/operations/HOLDS.md
+++ b/docs/operations/HOLDS.md
@@ -1,0 +1,94 @@
+# Orchestrator holds
+
+The orchestrator self-stops on quiescence: when `open_tasks == 0` and
+`active_agents == 0` for a settle window, it exits. The hold/release API lets
+an external caller (a dashboard, a human-in-the-loop workflow, a scheduler
+like `run.py`) prevent that self-stop while it still has work planned, even
+though the orchestrator looks idle right now.
+
+A hold is a lightweight, TTL-bounded lease: acquire it before a gap in task
+submission, release it when you're done. If the caller crashes or forgets to
+release, the hold expires on its own and the orchestrator can self-stop
+again.
+
+---
+
+## Endpoints
+
+All endpoints are under `/orchestrator/holds` on the running task server.
+
+### `POST /orchestrator/holds`
+
+Acquire a hold.
+
+```json
+{
+  "reason": "waiting on human approval for phase 2",
+  "ttl_seconds": 300
+}
+```
+
+`ttl_seconds` is optional; the server default is 300s (`DEFAULT_TTL_SECONDS`
+in `bernstein.core.orchestration.holds`). Response:
+
+```json
+{
+  "id": "3f9c2b1a...",
+  "reason": "waiting on human approval for phase 2",
+  "created_at": 1751600000.0,
+  "ttl_seconds": 300.0,
+  "expires_at": 1751600300.0
+}
+```
+
+### `DELETE /orchestrator/holds/{hold_id}`
+
+Release a hold by id. Returns `{"released": true}`, or `404` if the hold was
+already released or has expired.
+
+### `GET /orchestrator/holds`
+
+List all currently active (non-expired) holds:
+
+```json
+{"holds": [...], "count": 1}
+```
+
+---
+
+## TTL behavior
+
+- Holds expire automatically at `created_at + ttl_seconds`. There is no
+  renewal call — a caller that needs a hold to last longer must release and
+  re-acquire, or use a larger `ttl_seconds` up front.
+- Expiry is lazy: a hold is purged the next time `list_active()` runs (every
+  quiescence check and every `GET`/`POST` call), not on a background timer.
+- While at least one hold is active, the orchestrator's quiescence
+  self-stop check is skipped for that tick and logged as
+  `"Quiescence detected but N active hold(s) present ... skipping self-stop"`.
+
+## Usage pattern
+
+A driver script that submits work in phases, with a gap between phases where
+no tasks exist yet:
+
+```python
+hold = acquire_hold("phase-2 prep", ttl_seconds=600)
+try:
+    # ... do phase-1 wrap-up, decide phase-2 tasks ...
+    submit_phase_2_tasks()
+finally:
+    release_hold(hold.id)
+```
+
+Backward compatibility: `BERNSTEIN_QUIESCENCE_SETTLE_S` still applies for
+runs that never acquire a hold — this API is additive, not a replacement for
+non-driven runs.
+
+## Code pointers
+
+| File | What it does |
+|------|--------------|
+| `src/bernstein/core/orchestration/holds.py` | `HoldRegistry`, `Hold`, module-level singleton |
+| `src/bernstein/core/routes/orchestrator_holds.py` | FastAPI routes |
+| `src/bernstein/core/orchestration/tick_pipeline.py` | `fetch_active_holds` — consulted before self-stop |

--- a/docs/operations/HOLDS.md
+++ b/docs/operations/HOLDS.md
@@ -6,10 +6,12 @@ an external caller (a dashboard, a human-in-the-loop workflow, a scheduler
 like `run.py`) prevent that self-stop while it still has work planned, even
 though the orchestrator looks idle right now.
 
-A hold is a lightweight, TTL-bounded lease: acquire it before a gap in task
-submission, release it when you're done. If the caller crashes or forgets to
-release, the hold expires on its own and the orchestrator can self-stop
-again.
+A hold is a lightweight, heartbeat-renewed lease: acquire it before a gap in
+task submission, renew it periodically while you still need it, release it
+when you're done. `ttl_seconds` is a grace window, not a run-duration
+estimate: if the caller crashes or stops heartbeating, the hold expires on
+its own once the grace window elapses since the last renewal, and the
+orchestrator can self-stop again.
 
 ---
 
@@ -28,8 +30,8 @@ Acquire a hold.
 }
 ```
 
-`ttl_seconds` is optional; the server default is 300s (`DEFAULT_TTL_SECONDS`
-in `bernstein.core.orchestration.holds`). Response:
+`ttl_seconds` is the grace window and is optional; the server default is 45s
+(`DEFAULT_TTL_SECONDS` in `bernstein.core.orchestration.holds`). Response:
 
 ```json
 {
@@ -37,9 +39,16 @@ in `bernstein.core.orchestration.holds`). Response:
   "reason": "waiting on human approval for phase 2",
   "created_at": 1751600000.0,
   "ttl_seconds": 300.0,
-  "expires_at": 1751600300.0
+  "expires_at": 1751600300.0,
+  "last_renewed_at": null
 }
 ```
+
+### `POST /orchestrator/holds/{hold_id}/renew`
+
+Heartbeat-renew a hold, pushing `expires_at` out to `now + ttl_seconds`.
+Returns the updated hold (with `last_renewed_at` set), or `404` if the hold
+never existed, was already released, or has already expired.
 
 ### `DELETE /orchestrator/holds/{hold_id}`
 
@@ -58,14 +67,21 @@ List all currently active (non-expired) holds:
 
 ## TTL behavior
 
-- Holds expire automatically at `created_at + ttl_seconds`. There is no
-  renewal call — a caller that needs a hold to last longer must release and
-  re-acquire, or use a larger `ttl_seconds` up front.
+- `ttl_seconds` is a grace window: a hold expires at
+  `created_at + ttl_seconds`, or at `last_renewed_at + ttl_seconds` once it
+  has been renewed. A long-running caller keeps its hold alive by calling
+  the renew endpoint more often than the grace window; a caller with a
+  known, bounded gap can instead use a larger `ttl_seconds` up front and
+  never renew.
 - Expiry is lazy: a hold is purged the next time `list_active()` runs (every
-  quiescence check and every `GET`/`POST` call), not on a background timer.
+  quiescence check and every `GET` call), not on a background timer.
 - While at least one hold is active, the orchestrator's quiescence
   self-stop check is skipped for that tick and logged as
   `"Quiescence detected but N active hold(s) present ... skipping self-stop"`.
+- The hold check fails open: if the orchestrator cannot fetch the hold list
+  (endpoint unreachable, malformed response), it logs a warning and treats
+  the tick as having no active holds. A hold is advisory, never a hard lock
+  that can wedge shutdown.
 
 ## Usage pattern
 
@@ -76,13 +92,14 @@ no tasks exist yet:
 hold = acquire_hold("phase-2 prep", ttl_seconds=600)
 try:
     # ... do phase-1 wrap-up, decide phase-2 tasks ...
+    # (or heartbeat with renew_hold(hold.id) if the gap is open-ended)
     submit_phase_2_tasks()
 finally:
     release_hold(hold.id)
 ```
 
 Backward compatibility: `BERNSTEIN_QUIESCENCE_SETTLE_S` still applies for
-runs that never acquire a hold — this API is additive, not a replacement for
+runs that never acquire a hold - this API is additive, not a replacement for
 non-driven runs.
 
 ## Code pointers
@@ -91,4 +108,4 @@ non-driven runs.
 |------|--------------|
 | `src/bernstein/core/orchestration/holds.py` | `HoldRegistry`, `Hold`, module-level singleton |
 | `src/bernstein/core/routes/orchestrator_holds.py` | FastAPI routes |
-| `src/bernstein/core/orchestration/tick_pipeline.py` | `fetch_active_holds` — consulted before self-stop |
+| `src/bernstein/core/orchestration/tick_pipeline.py` | `fetch_active_holds` - consulted before self-stop |

--- a/src/bernstein/core/orchestration/holds.py
+++ b/src/bernstein/core/orchestration/holds.py
@@ -44,7 +44,7 @@ DEFAULT_TTL_SECONDS: float = 45.0
 
 
 @dataclass(frozen=True, slots=True)
-class Hold(object):
+class Hold:
     """A single active hold preventing orchestrator self-stop.
 
     Attributes:

--- a/src/bernstein/core/orchestration/holds.py
+++ b/src/bernstein/core/orchestration/holds.py
@@ -1,0 +1,182 @@
+"""Orchestrator hold/release registry.
+
+Supplements the orchestrator's quiescence settle-timer self-stop logic
+(``open_tasks == 0 and active_agents == 0``) with an explicit "hold" primitive
+so external callers (dashboards, long-running human-in-the-loop workflows,
+external schedulers) can prevent the orchestrator from self-stopping even
+when it looks idle.
+
+A caller acquires a :class:`Hold` via ``acquire_hold(reason, ttl_seconds)``,
+does whatever work needs the orchestrator to stay up, then calls
+``release_hold(hold_id)`` when done. Holds also expire automatically after
+their TTL so a caller that crashes or forgets to release doesn't wedge the
+orchestrator open forever.
+
+Thread-safe: backed by a single ``threading.Lock`` since this registry is
+read/written from both the FastAPI request-handling threads (via
+``orchestrator_holds`` routes) and the orchestrator's own tick loop (via
+``tick_pipeline.fetch_active_holds`` -> HTTP -> this module, or in-process
+callers that import the singleton directly).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS: float = 300.0
+
+
+@dataclass(frozen=True, slots=True)
+class Hold(object):
+    """A single active hold preventing orchestrator self-stop.
+
+    Attributes:
+        id: uuid4 hex identifier for this hold.
+        reason: Human-readable reason the hold was acquired (surfaced in logs
+            and in the "skipping self-stop" orchestrator message).
+        created_at: Epoch seconds when the hold was acquired.
+        ttl_seconds: How long the hold stays active before auto-expiring.
+        expires_at: Epoch seconds when the hold expires (created_at + ttl_seconds).
+    """
+
+    id: str
+    reason: str
+    created_at: float
+    ttl_seconds: float = DEFAULT_TTL_SECONDS
+    expires_at: float = field(default=0.0)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-safe dict for API responses."""
+        return {
+            "id": self.id,
+            "reason": self.reason,
+            "created_at": self.created_at,
+            "ttl_seconds": self.ttl_seconds,
+            "expires_at": self.expires_at,
+        }
+
+
+def _make_hold(reason: str, ttl_seconds: float) -> Hold:
+    created_at = time.time()
+    return Hold(
+        id=uuid.uuid4().hex,
+        reason=reason,
+        created_at=created_at,
+        ttl_seconds=ttl_seconds,
+        expires_at=created_at + ttl_seconds,
+    )
+
+
+class HoldRegistry:
+    """Thread-safe registry of active orchestrator holds."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._holds: dict[str, Hold] = {}
+        logger.info("HoldRegistry initialized")
+
+    def acquire(self, reason: str, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Hold:
+        """Create and store a new hold.
+
+        Args:
+            reason: Why the caller wants the orchestrator to stay up.
+            ttl_seconds: Auto-expiry window; defaults to 5 minutes so a caller
+                that crashes without releasing doesn't wedge the orchestrator
+                open indefinitely.
+
+        Returns:
+            The newly created Hold.
+        """
+        hold = _make_hold(reason, ttl_seconds)
+        with self._lock:
+            self._holds[hold.id] = hold
+        logger.info(
+            "HoldRegistry.acquire: id=%s reason=%r ttl_seconds=%.1f expires_at=%.1f (active_count=%d)",
+            hold.id,
+            reason,
+            ttl_seconds,
+            hold.expires_at,
+            len(self._holds),
+        )
+        return hold
+
+    def release(self, hold_id: str) -> bool:
+        """Remove a hold by id.
+
+        Args:
+            hold_id: The id of the hold to release.
+
+        Returns:
+            True if a hold with that id was found and removed, False otherwise.
+        """
+        with self._lock:
+            hold = self._holds.pop(hold_id, None)
+        if hold is None:
+            logger.warning("HoldRegistry.release: hold_id=%s not found (already released or expired?)", hold_id)
+            return False
+        logger.info(
+            "HoldRegistry.release: id=%s reason=%r (held for %.1fs)",
+            hold_id,
+            hold.reason,
+            time.time() - hold.created_at,
+        )
+        return True
+
+    def list_active(self) -> list[Hold]:
+        """Purge expired holds and return the remaining active ones.
+
+        Returns:
+            List of Hold objects that have not yet expired.
+        """
+        now = time.time()
+        with self._lock:
+            expired_ids = [hid for hid, h in self._holds.items() if h.expires_at < now]
+            for hid in expired_ids:
+                expired = self._holds.pop(hid, None)
+                if expired is not None:
+                    logger.info(
+                        "HoldRegistry: hold id=%s reason=%r expired at %.1f (ttl_seconds=%.1f)",
+                        expired.id,
+                        expired.reason,
+                        expired.expires_at,
+                        expired.ttl_seconds,
+                    )
+            active = list(self._holds.values())
+        return active
+
+    def has_active(self) -> bool:
+        """Convenience wrapper: True if any non-expired hold exists."""
+        return len(self.list_active()) > 0
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton + convenience functions
+# ---------------------------------------------------------------------------
+
+_registry = HoldRegistry()
+
+
+def acquire_hold(reason: str, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Hold:
+    """Acquire a hold on the module-level singleton registry."""
+    return _registry.acquire(reason, ttl_seconds)
+
+
+def release_hold(hold_id: str) -> bool:
+    """Release a hold on the module-level singleton registry."""
+    return _registry.release(hold_id)
+
+
+def list_active_holds() -> list[Hold]:
+    """List active holds on the module-level singleton registry."""
+    return _registry.list_active()
+
+
+def has_active_holds() -> bool:
+    """True if the module-level singleton registry has any active hold."""
+    return _registry.has_active()

--- a/src/bernstein/core/orchestration/holds.py
+++ b/src/bernstein/core/orchestration/holds.py
@@ -30,6 +30,8 @@ import time
 import uuid
 from dataclasses import dataclass, field, replace
 
+from bernstein.core.security.sanitize import sanitize_log
+
 logger = logging.getLogger(__name__)
 
 # Grace-window semantics: as of the heartbeat-renewal model, holds are no
@@ -118,7 +120,7 @@ class HoldRegistry:
         logger.info(
             "HoldRegistry.acquire: id=%s reason=%r ttl_seconds=%.1f expires_at=%.1f (active_count=%d)",
             hold.id,
-            reason,
+            sanitize_log(reason),
             ttl_seconds,
             hold.expires_at,
             len(self._holds),
@@ -137,12 +139,14 @@ class HoldRegistry:
         with self._lock:
             hold = self._holds.pop(hold_id, None)
         if hold is None:
-            logger.warning("HoldRegistry.release: hold_id=%s not found (already released or expired?)", hold_id)
+            logger.warning(
+                "HoldRegistry.release: hold_id=%s not found (already released or expired?)", sanitize_log(hold_id)
+            )
             return False
         logger.info(
             "HoldRegistry.release: id=%s reason=%r (held for %.1fs)",
-            hold_id,
-            hold.reason,
+            sanitize_log(hold_id),
+            sanitize_log(hold.reason),
             time.time() - hold.created_at,
         )
         return True
@@ -163,7 +167,7 @@ class HoldRegistry:
             if hold is None:
                 logger.warning(
                     "HoldRegistry.renew: hold_id=%s not found (never existed, already released, or already expired)",
-                    hold_id,
+                    sanitize_log(hold_id),
                 )
                 return False
             if hold.expires_at < now:
@@ -171,7 +175,7 @@ class HoldRegistry:
                 self._holds.pop(hold_id, None)
                 logger.warning(
                     "HoldRegistry.renew: hold_id=%s found but already expired at %.1f (now=%.1f) - dropping",
-                    hold_id,
+                    sanitize_log(hold_id),
                     hold.expires_at,
                     now,
                 )
@@ -181,7 +185,7 @@ class HoldRegistry:
             self._holds[hold_id] = renewed
         logger.info(
             "hold %s renewed, new expires_at=%.1f (ttl_seconds=%.1f, last_renewed_at=%.1f)",
-            hold_id,
+            sanitize_log(hold_id),
             new_expires_at,
             renewed.ttl_seconds,
             now,
@@ -197,7 +201,7 @@ class HoldRegistry:
         """
         with self._lock:
             hold = self._holds.get(hold_id)
-        logger.info("HoldRegistry.get: hold_id=%s found=%s", hold_id, hold is not None)
+        logger.info("HoldRegistry.get: hold_id=%s found=%s", sanitize_log(hold_id), hold is not None)
         return hold
 
     def list_active(self) -> list[Hold]:
@@ -215,7 +219,7 @@ class HoldRegistry:
                     logger.info(
                         "HoldRegistry: hold id=%s reason=%r expired at %.1f (ttl_seconds=%.1f)",
                         expired.id,
-                        expired.reason,
+                        sanitize_log(expired.reason),
                         expired.expires_at,
                         expired.ttl_seconds,
                     )

--- a/src/bernstein/core/orchestration/holds.py
+++ b/src/bernstein/core/orchestration/holds.py
@@ -7,10 +7,13 @@ external schedulers) can prevent the orchestrator from self-stopping even
 when it looks idle.
 
 A caller acquires a :class:`Hold` via ``acquire_hold(reason, ttl_seconds)``,
-does whatever work needs the orchestrator to stay up, then calls
-``release_hold(hold_id)`` when done. Holds also expire automatically after
-their TTL so a caller that crashes or forgets to release doesn't wedge the
-orchestrator open forever.
+then periodically calls ``renew_hold(hold_id)`` (a heartbeat) for as long as
+it needs the orchestrator to stay up, then calls ``release_hold(hold_id)``
+when done. ``ttl_seconds`` is a grace window, not a run-duration estimate:
+each renewal pushes ``expires_at`` out by another ``ttl_seconds`` from "now".
+A caller that crashes or stops heartbeating has its hold auto-expire once the
+grace window elapses since the last renewal (or since acquisition, if never
+renewed) - so it doesn't wedge the orchestrator open forever.
 
 Thread-safe: backed by a single ``threading.Lock`` since this registry is
 read/written from both the FastAPI request-handling threads (via
@@ -25,11 +28,19 @@ import logging
 import threading
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TTL_SECONDS: float = 300.0
+# Grace-window semantics: as of the heartbeat-renewal model, holds are no
+# longer sized to a caller's estimated run duration. A driver acquires a hold
+# once, then calls HoldRegistry.renew(hold_id) periodically (heartbeat) to
+# keep it alive. DEFAULT_TTL_SECONDS is now the GRACE WINDOW: how long the
+# hold survives after the *last* renewal (or after acquire, if never renewed)
+# before it is considered abandoned and expires. A short grace window means a
+# crashed/hung driver stops blocking orchestrator self-stop quickly, while a
+# live driver just needs to heartbeat more often than this window.
+DEFAULT_TTL_SECONDS: float = 45.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,8 +52,13 @@ class Hold(object):
         reason: Human-readable reason the hold was acquired (surfaced in logs
             and in the "skipping self-stop" orchestrator message).
         created_at: Epoch seconds when the hold was acquired.
-        ttl_seconds: How long the hold stays active before auto-expiring.
-        expires_at: Epoch seconds when the hold expires (created_at + ttl_seconds).
+        ttl_seconds: Grace window - how long the hold survives after the last
+            heartbeat renewal (or since creation, if never renewed) before
+            auto-expiring.
+        expires_at: Epoch seconds when the hold expires (created_at + ttl_seconds,
+            or last_renewed_at + ttl_seconds after a renewal).
+        last_renewed_at: Epoch seconds of the most recent heartbeat renewal, or
+            None if the hold has never been renewed since acquisition.
     """
 
     id: str
@@ -50,6 +66,7 @@ class Hold(object):
     created_at: float
     ttl_seconds: float = DEFAULT_TTL_SECONDS
     expires_at: float = field(default=0.0)
+    last_renewed_at: float | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Serialize to a JSON-safe dict for API responses."""
@@ -59,6 +76,7 @@ class Hold(object):
             "created_at": self.created_at,
             "ttl_seconds": self.ttl_seconds,
             "expires_at": self.expires_at,
+            "last_renewed_at": self.last_renewed_at,
         }
 
 
@@ -86,9 +104,10 @@ class HoldRegistry:
 
         Args:
             reason: Why the caller wants the orchestrator to stay up.
-            ttl_seconds: Auto-expiry window; defaults to 5 minutes so a caller
-                that crashes without releasing doesn't wedge the orchestrator
-                open indefinitely.
+            ttl_seconds: Grace-window auto-expiry; defaults to
+                DEFAULT_TTL_SECONDS (45s) so a caller that crashes without
+                releasing (and without heartbeating via renew()) doesn't wedge
+                the orchestrator open indefinitely.
 
         Returns:
             The newly created Hold.
@@ -127,6 +146,59 @@ class HoldRegistry:
             time.time() - hold.created_at,
         )
         return True
+
+    def renew(self, hold_id: str) -> bool:
+        """Heartbeat-renew a hold, pushing its expiry out by another grace window.
+
+        Args:
+            hold_id: The id of the hold to renew.
+
+        Returns:
+            True if the hold was found (and not already expired) and renewed,
+            False if the hold is unknown or has already expired.
+        """
+        now = time.time()
+        with self._lock:
+            hold = self._holds.get(hold_id)
+            if hold is None:
+                logger.warning(
+                    "HoldRegistry.renew: hold_id=%s not found (never existed, already released, or already expired)",
+                    hold_id,
+                )
+                return False
+            if hold.expires_at < now:
+                # Already expired but not yet purged by list_active(); treat as gone.
+                self._holds.pop(hold_id, None)
+                logger.warning(
+                    "HoldRegistry.renew: hold_id=%s found but already expired at %.1f (now=%.1f) - dropping",
+                    hold_id,
+                    hold.expires_at,
+                    now,
+                )
+                return False
+            new_expires_at = now + hold.ttl_seconds
+            renewed = replace(hold, expires_at=new_expires_at, last_renewed_at=now)
+            self._holds[hold_id] = renewed
+        logger.info(
+            "hold %s renewed, new expires_at=%.1f (ttl_seconds=%.1f, last_renewed_at=%.1f)",
+            hold_id,
+            new_expires_at,
+            renewed.ttl_seconds,
+            now,
+        )
+        return True
+
+    def get(self, hold_id: str) -> Hold | None:
+        """Look up a single hold by id without purging expired entries.
+
+        Returns:
+            The Hold if present (even if technically expired but not yet
+            purged), or None if it was never registered / already released.
+        """
+        with self._lock:
+            hold = self._holds.get(hold_id)
+        logger.info("HoldRegistry.get: hold_id=%s found=%s", hold_id, hold is not None)
+        return hold
 
     def list_active(self) -> list[Hold]:
         """Purge expired holds and return the remaining active ones.
@@ -170,6 +242,16 @@ def acquire_hold(reason: str, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> Hold:
 def release_hold(hold_id: str) -> bool:
     """Release a hold on the module-level singleton registry."""
     return _registry.release(hold_id)
+
+
+def renew_hold(hold_id: str) -> bool:
+    """Heartbeat-renew a hold on the module-level singleton registry."""
+    return _registry.renew(hold_id)
+
+
+def get_hold(hold_id: str) -> Hold | None:
+    """Look up a single hold on the module-level singleton registry."""
+    return _registry.get(hold_id)
 
 
 def list_active_holds() -> list[Hold]:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -126,6 +126,7 @@ from bernstein.core.runtime_state import (
     rotate_log_file,
     write_session_replay_metadata,
 )
+from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.semantic_cache import ResponseCacheManager
 from bernstein.core.signals import read_unresolved_pivots
 from bernstein.core.slo import SLOTracker, apply_error_budget_adjustments
@@ -1934,7 +1935,7 @@ class Orchestrator:
                             )
                             _active_holds = []
                         if _active_holds:
-                            _hold_reasons = [str(h.get("reason", "<no reason>")) for h in _active_holds]
+                            _hold_reasons = [sanitize_log(str(h.get("reason", "<no reason>"))) for h in _active_holds]
                             logger.info(
                                 "Quiescence detected but %d active hold(s) present (tick #%d) - skipping self-stop: %s",
                                 len(_active_holds),

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1925,7 +1925,7 @@ class Orchestrator:
                         # this instant still prevents the stop for this tick.
                         try:
                             _active_holds = fetch_active_holds(self._client, base)
-                        except Exception as exc:  # noqa: BLE001 - defensive, must never crash the tick loop
+                        except Exception as exc:  # intentional-broad-except: must never crash the tick loop
                             logger.warning(
                                 "fetch_active_holds raised during quiescence self-stop check (tick #%d): %s "
                                 "- treating as no active holds",
@@ -1936,8 +1936,7 @@ class Orchestrator:
                         if _active_holds:
                             _hold_reasons = [str(h.get("reason", "<no reason>")) for h in _active_holds]
                             logger.info(
-                                "Quiescence detected but %d active hold(s) present (tick #%d) - skipping "
-                                "self-stop: %s",
+                                "Quiescence detected but %d active hold(s) present (tick #%d) - skipping self-stop: %s",
                                 len(_active_holds),
                                 self._tick_count,
                                 _hold_reasons,

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -99,6 +99,7 @@ from bernstein.core.orchestration.tick_pipeline import (
     block_task,
     complete_task,
     fail_task,
+    fetch_active_holds,
     fetch_all_tasks,
     group_by_role,
     parse_backlog_file,
@@ -1913,16 +1914,45 @@ class Orchestrator:
                     settled_open = len(settled["open"])
                     settled_agents = sum(1 for a in self._agents.values() if a.status != "dead")
                     if settled_open == settled_agents == 0:
-                        logger.info(
-                            "Quiescence confirmed after %.1fs settle window (tick #%d, "
-                            "open=%d agents=%d) - self-stopping",
-                            _settle_s,
-                            self._tick_count,
-                            settled_open,
-                            settled_agents,
-                        )
-                        self._regenerate_final_retrospective(trigger_path="tick-quiescence-self-stop")
-                        self._running = False
+                        # Hold/release API (supplements the settle-timer
+                        # self-stop above): external callers can call
+                        # POST /orchestrator/holds to keep this orchestrator
+                        # alive even when it looks fully quiescent - e.g. a
+                        # dashboard mid-review, or an external scheduler about
+                        # to enqueue follow-up tasks that hasn't posted them
+                        # yet. Checked here, right before the actual
+                        # self-stop, so a hold acquired at any point up to
+                        # this instant still prevents the stop for this tick.
+                        try:
+                            _active_holds = fetch_active_holds(self._client, base)
+                        except Exception as exc:  # noqa: BLE001 - defensive, must never crash the tick loop
+                            logger.warning(
+                                "fetch_active_holds raised during quiescence self-stop check (tick #%d): %s "
+                                "- treating as no active holds",
+                                self._tick_count,
+                                exc,
+                            )
+                            _active_holds = []
+                        if _active_holds:
+                            _hold_reasons = [str(h.get("reason", "<no reason>")) for h in _active_holds]
+                            logger.info(
+                                "Quiescence detected but %d active hold(s) present (tick #%d) - skipping "
+                                "self-stop: %s",
+                                len(_active_holds),
+                                self._tick_count,
+                                _hold_reasons,
+                            )
+                        else:
+                            logger.info(
+                                "Quiescence confirmed after %.1fs settle window (tick #%d, "
+                                "open=%d agents=%d, no active holds) - self-stopping",
+                                _settle_s,
+                                self._tick_count,
+                                settled_open,
+                                settled_agents,
+                            )
+                            self._regenerate_final_retrospective(trigger_path="tick-quiescence-self-stop")
+                            self._running = False
                     else:
                         logger.info(
                             "Quiescence NOT confirmed after %.1fs settle window (tick #%d): "

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -257,6 +257,36 @@ def block_task(client: httpx.Client, base_url: str, task_id: str, reason: str) -
     client.post(f"{base_url}/tasks/{task_id}/block", json={"reason": reason}).raise_for_status()
 
 
+def fetch_active_holds(client: httpx.Client, base_url: str) -> list[dict[str, Any]]:
+    """GET /orchestrator/holds and return the active hold list.
+
+    Used by the orchestrator's quiescence check (``orchestrator.py``) to
+    decide whether to skip a self-stop even when ``open_tasks == 0`` and
+    ``active_agents == 0`` - see ``bernstein.core.orchestration.holds`` for
+    the hold/release registry this reads from.
+
+    Args:
+        client: httpx client.
+        base_url: Server base URL.
+
+    Returns:
+        List of hold dicts (``{id, reason, created_at, ttl_seconds,
+        expires_at}``). Empty list on any error - a hold-fetch failure must
+        never itself block the orchestrator's quiescence decision; it just
+        means holds are treated as absent for this tick.
+    """
+    try:
+        resp = client.get(f"{base_url}/orchestrator/holds")
+        resp.raise_for_status()
+        body = resp.json()
+        holds = cast("list[dict[str, Any]]", body.get("holds", []))
+        logger.debug("fetch_active_holds: %d active hold(s)", len(holds))
+        return holds
+    except Exception as exc:  # noqa: BLE001 - defensive, must never block the tick loop
+        logger.warning("fetch_active_holds: failed to fetch holds from %s (%s) - treating as no active holds", base_url, exc)
+        return []
+
+
 def close_task(client: httpx.Client, base_url: str, task_id: str) -> None:
     """POST /tasks/{task_id}/close to mark a verified task as closed.
 

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -282,8 +282,10 @@ def fetch_active_holds(client: httpx.Client, base_url: str) -> list[dict[str, An
         holds = cast("list[dict[str, Any]]", body.get("holds", []))
         logger.debug("fetch_active_holds: %d active hold(s)", len(holds))
         return holds
-    except Exception as exc:  # noqa: BLE001 - defensive, must never block the tick loop
-        logger.warning("fetch_active_holds: failed to fetch holds from %s (%s) - treating as no active holds", base_url, exc)
+    except Exception as exc:  # intentional-broad-except: must never block the tick loop
+        logger.warning(
+            "fetch_active_holds: failed to fetch holds from %s (%s) - treating as no active holds", base_url, exc
+        )
         return []
 
 

--- a/src/bernstein/core/routes/orchestrator_holds.py
+++ b/src/bernstein/core/routes/orchestrator_holds.py
@@ -1,0 +1,91 @@
+"""Orchestrator hold/release API.
+
+Lets external callers (dashboards, human-in-the-loop workflows, external
+schedulers) prevent the orchestrator from self-stopping on quiescence
+(``open_tasks == 0 and active_agents == 0``) by acquiring a "hold". See
+``bernstein.core.orchestration.holds`` for the registry implementation and
+``bernstein.core.orchestration.orchestrator`` for where holds are consulted
+before a self-stop decision.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from bernstein.core.orchestration.holds import acquire_hold, list_active_holds, release_hold
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/orchestrator/holds", tags=["orchestrator-holds"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+
+class HoldCreateRequest(BaseModel):
+    """Body for POST /orchestrator/holds."""
+
+    reason: str = Field(..., description="Why the caller wants the orchestrator to stay up")
+    ttl_seconds: float | None = Field(default=None, description="Auto-expiry window; server default if omitted")
+
+
+class HoldResponse(BaseModel):
+    """Serialised hold in API responses."""
+
+    id: str
+    reason: str
+    created_at: float
+    ttl_seconds: float
+    expires_at: float
+
+
+class HoldListResponse(BaseModel):
+    """Response for GET /orchestrator/holds."""
+
+    holds: list[HoldResponse]
+    count: int
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=HoldResponse, responses={200: {"description": "Hold acquired"}})
+def create_hold(body: HoldCreateRequest) -> HoldResponse:
+    """Acquire a new hold, preventing orchestrator self-stop while active."""
+    logger.info("POST /orchestrator/holds: reason=%r ttl_seconds=%r", body.reason, body.ttl_seconds)
+    if body.ttl_seconds is not None:
+        hold = acquire_hold(body.reason, ttl_seconds=body.ttl_seconds)
+    else:
+        hold = acquire_hold(body.reason)
+    return HoldResponse(**hold.to_dict())  # type: ignore[arg-type]
+
+
+@router.delete(
+    "/{hold_id}",
+    responses={404: {"description": "Hold not found (already released or expired)"}},
+)
+def delete_hold(hold_id: str) -> dict[str, bool]:
+    """Release a hold by id."""
+    logger.info("DELETE /orchestrator/holds/%s", hold_id)
+    released = release_hold(hold_id)
+    if not released:
+        raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
+    return {"released": True}
+
+
+@router.get("", response_model=HoldListResponse)
+def get_holds() -> HoldListResponse:
+    """List all currently active (non-expired) holds."""
+    holds = list_active_holds()
+    logger.info("GET /orchestrator/holds: %d active", len(holds))
+    return HoldListResponse(
+        holds=[HoldResponse(**h.to_dict()) for h in holds],  # type: ignore[arg-type]
+        count=len(holds),
+    )

--- a/src/bernstein/core/routes/orchestrator_holds.py
+++ b/src/bernstein/core/routes/orchestrator_holds.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
-from bernstein.core.orchestration.holds import acquire_hold, list_active_holds, release_hold
+from bernstein.core.orchestration.holds import acquire_hold, get_hold, list_active_holds, release_hold, renew_hold
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +30,14 @@ router = APIRouter(prefix="/orchestrator/holds", tags=["orchestrator-holds"])
 class HoldCreateRequest(BaseModel):
     """Body for POST /orchestrator/holds."""
 
+    # extra="forbid": reject unknown fields (e.g. a caller sending "ttl_s"
+    # instead of "ttl_seconds") with a 422 instead of silently dropping them
+    # and falling back to the default TTL. Silent field-name drift here is
+    # exactly the bug that killed a prior test run - fail loud instead.
+    model_config = ConfigDict(extra="forbid")
+
     reason: str = Field(..., description="Why the caller wants the orchestrator to stay up")
-    ttl_seconds: float | None = Field(default=None, description="Auto-expiry window; server default if omitted")
+    ttl_seconds: float | None = Field(default=None, description="Grace-window auto-expiry; server default if omitted")
 
 
 class HoldResponse(BaseModel):
@@ -42,6 +48,7 @@ class HoldResponse(BaseModel):
     created_at: float
     ttl_seconds: float
     expires_at: float
+    last_renewed_at: float | None = None
 
 
 class HoldListResponse(BaseModel):
@@ -78,6 +85,31 @@ def delete_hold(hold_id: str) -> dict[str, bool]:
     if not released:
         raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
     return {"released": True}
+
+
+@router.post(
+    "/{hold_id}/renew",
+    response_model=HoldResponse,
+    responses={404: {"description": "Hold not found (never existed, released, or already expired)"}},
+)
+def renew_hold_endpoint(hold_id: str) -> HoldResponse:
+    """Heartbeat-renew a hold, extending its expiry by another grace window."""
+    logger.info("POST /orchestrator/holds/%s/renew", hold_id)
+    renewed = renew_hold(hold_id)
+    if not renewed:
+        logger.warning("POST /orchestrator/holds/%s/renew: not found or already expired", hold_id)
+        raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
+    hold = get_hold(hold_id)
+    if hold is None:
+        # Should not happen (renew() just succeeded), but guard defensively.
+        logger.error("POST /orchestrator/holds/%s/renew: renew succeeded but get_hold returned None", hold_id)
+        raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
+    logger.info(
+        "POST /orchestrator/holds/%s/renew: success, new expires_at=%.1f",
+        hold_id,
+        hold.expires_at,
+    )
+    return HoldResponse(**hold.to_dict())  # type: ignore[arg-type]
 
 
 @router.get("", response_model=HoldListResponse)

--- a/src/bernstein/core/routes/orchestrator_holds.py
+++ b/src/bernstein/core/routes/orchestrator_holds.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
 from bernstein.core.orchestration.holds import acquire_hold, get_hold, list_active_holds, release_hold, renew_hold
+from bernstein.core.security.sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class HoldListResponse(BaseModel):
 @router.post("", response_model=HoldResponse, responses={200: {"description": "Hold acquired"}})
 def create_hold(body: HoldCreateRequest) -> HoldResponse:
     """Acquire a new hold, preventing orchestrator self-stop while active."""
-    logger.info("POST /orchestrator/holds: reason=%r ttl_seconds=%r", body.reason, body.ttl_seconds)
+    logger.info("POST /orchestrator/holds: reason=%r ttl_seconds=%r", sanitize_log(body.reason), body.ttl_seconds)
     if body.ttl_seconds is not None:
         hold = acquire_hold(body.reason, ttl_seconds=body.ttl_seconds)
     else:
@@ -80,7 +81,7 @@ def create_hold(body: HoldCreateRequest) -> HoldResponse:
 )
 def delete_hold(hold_id: str) -> dict[str, bool]:
     """Release a hold by id."""
-    logger.info("DELETE /orchestrator/holds/%s", hold_id)
+    logger.info("DELETE /orchestrator/holds/%s", sanitize_log(hold_id))
     released = release_hold(hold_id)
     if not released:
         raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
@@ -94,19 +95,21 @@ def delete_hold(hold_id: str) -> dict[str, bool]:
 )
 def renew_hold_endpoint(hold_id: str) -> HoldResponse:
     """Heartbeat-renew a hold, extending its expiry by another grace window."""
-    logger.info("POST /orchestrator/holds/%s/renew", hold_id)
+    logger.info("POST /orchestrator/holds/%s/renew", sanitize_log(hold_id))
     renewed = renew_hold(hold_id)
     if not renewed:
-        logger.warning("POST /orchestrator/holds/%s/renew: not found or already expired", hold_id)
+        logger.warning("POST /orchestrator/holds/%s/renew: not found or already expired", sanitize_log(hold_id))
         raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
     hold = get_hold(hold_id)
     if hold is None:
         # Should not happen (renew() just succeeded), but guard defensively.
-        logger.error("POST /orchestrator/holds/%s/renew: renew succeeded but get_hold returned None", hold_id)
+        logger.error(
+            "POST /orchestrator/holds/%s/renew: renew succeeded but get_hold returned None", sanitize_log(hold_id)
+        )
         raise HTTPException(status_code=404, detail=f"Hold {hold_id} not found")
     logger.info(
         "POST /orchestrator/holds/%s/renew: success, new expires_at=%.1f",
-        hold_id,
+        sanitize_log(hold_id),
         hold.expires_at,
     )
     return HoldResponse(**hold.to_dict())  # type: ignore[arg-type]

--- a/src/bernstein/core/routes/orchestrator_holds.py
+++ b/src/bernstein/core/routes/orchestrator_holds.py
@@ -38,7 +38,16 @@ class HoldCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     reason: str = Field(..., description="Why the caller wants the orchestrator to stay up")
-    ttl_seconds: float | None = Field(default=None, description="Grace-window auto-expiry; server default if omitted")
+    # gt=0 / allow_inf_nan=False: a NaN TTL would make expires_at NaN, and
+    # since NaN comparisons are always False the hold would never expire and
+    # never be purged - silently defeating the auto-expiry guarantee. Zero
+    # and negative TTLs are instantly-expired no-ops; reject them loudly too.
+    ttl_seconds: float | None = Field(
+        default=None,
+        gt=0.0,
+        allow_inf_nan=False,
+        description="Grace-window auto-expiry; server default if omitted",
+    )
 
 
 class HoldResponse(BaseModel):

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1230,6 +1230,7 @@ def create_app(
     from bernstein.core.routes.hooks import router as hooks_router
     from bernstein.core.routes.identities import router as identities_router
     from bernstein.core.routes.mcp_bot_tools import router as mcp_bot_tools_router
+    from bernstein.core.routes.orchestrator_holds import router as orchestrator_holds_router
     from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
     from bernstein.core.routes.plans import router as plans_router
     from bernstein.core.routes.predictive import router as predictive_router
@@ -1301,6 +1302,7 @@ def create_app(
         well_known_router,
         mcp_bot_tools_router,
         session_peek_router,
+        orchestrator_holds_router,
     ]
 
     for r in all_routers:

--- a/tests/unit/test_orchestrator_holds_routes.py
+++ b/tests/unit/test_orchestrator_holds_routes.py
@@ -74,3 +74,23 @@ def test_hold_create_rejects_unknown_fields(client: TestClient) -> None:
     """extra="forbid" - a misspelled TTL field must 422, not silently default."""
     resp = client.post("/orchestrator/holds", json={"reason": "x", "ttl_s": 5})
     assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("bad_ttl", ["-5", "0", "NaN", "Infinity"])
+def test_hold_create_rejects_non_positive_or_non_finite_ttl(client: TestClient, bad_ttl: str) -> None:
+    """A NaN TTL makes expires_at NaN, so the hold would never expire or purge.
+
+    Negative/zero TTLs reject with a clean 422. Non-finite TTLs are also
+    rejected before any hold is created, but FastAPI cannot serialise the
+    offending float back into the 422 body, so the crash guard converts
+    those to a 500 - either way the request must fail and no hold may be
+    registered.
+    """
+    before = client.get("/orchestrator/holds").json()["count"]
+    resp = client.post(
+        "/orchestrator/holds",
+        content=f'{{"reason": "x", "ttl_seconds": {bad_ttl}}}',
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code >= 400, (bad_ttl, resp.status_code, resp.text)
+    assert client.get("/orchestrator/holds").json()["count"] == before

--- a/tests/unit/test_orchestrator_holds_routes.py
+++ b/tests/unit/test_orchestrator_holds_routes.py
@@ -1,0 +1,76 @@
+"""Tests for the orchestrator hold/release routes (/orchestrator/holds).
+
+Regression coverage for router registration: the holds feature only works if
+the ``orchestrator_holds`` router is actually mounted on the server app -
+``fetch_active_holds`` treats any error (including a 404 from an unmounted
+router) as "no active holds", so a missing registration silently disables
+the whole feature instead of failing loudly.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.server import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setitem(os.environ, "BERNSTEIN_AUTH_DISABLED", "1")
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    return TestClient(app)
+
+
+def test_holds_router_is_mounted(client: TestClient) -> None:
+    """GET /orchestrator/holds must be a real route, not a 404."""
+    resp = client.get("/orchestrator/holds")
+    assert resp.status_code == 200
+    body = resp.json()
+    # The registry is a module-level singleton shared across app instances,
+    # so assert shape rather than exact emptiness.
+    assert body["count"] == len(body["holds"])
+
+
+def test_holds_router_is_mounted_under_api_v1(client: TestClient) -> None:
+    resp = client.get("/api/v1/orchestrator/holds")
+    assert resp.status_code == 200
+
+
+def test_hold_lifecycle_acquire_renew_release(client: TestClient) -> None:
+    resp = client.post("/orchestrator/holds", json={"reason": "test hold", "ttl_seconds": 30})
+    assert resp.status_code == 200
+    hold = resp.json()
+    assert hold["reason"] == "test hold"
+    assert hold["ttl_seconds"] == 30.0
+    assert hold["last_renewed_at"] is None
+    hold_id = hold["id"]
+
+    listing = client.get("/orchestrator/holds").json()
+    assert listing["count"] == 1
+    assert listing["holds"][0]["id"] == hold_id
+
+    renewed = client.post(f"/orchestrator/holds/{hold_id}/renew")
+    assert renewed.status_code == 200
+    assert renewed.json()["last_renewed_at"] is not None
+    assert renewed.json()["expires_at"] >= hold["expires_at"]
+
+    released = client.delete(f"/orchestrator/holds/{hold_id}")
+    assert released.status_code == 200
+    assert released.json() == {"released": True}
+
+    assert client.delete(f"/orchestrator/holds/{hold_id}").status_code == 404
+    assert client.post(f"/orchestrator/holds/{hold_id}/renew").status_code == 404
+    assert client.get("/orchestrator/holds").json()["count"] == 0
+
+
+def test_hold_create_rejects_unknown_fields(client: TestClient) -> None:
+    """extra="forbid" - a misspelled TTL field must 422, not silently default."""
+    resp = client.post("/orchestrator/holds", json={"reason": "x", "ttl_s": 5})
+    assert resp.status_code == 422


### PR DESCRIPTION
## What

Adds a hold/release API (`/orchestrator/holds`) that prevents the spawner
from self-stopping while an external workflow driver is active, replacing
the fragile quiescence settle timer.

## Why

The quiescence settle timer (`BERNSTEIN_QUIESCENCE_SETTLE_S`) is a fixed
timeout that can't adapt to variable-length workflows. A phased driver
(triage -> implement -> review) has gaps between phases where zero tasks are
open, causing the spawner to self-stop mid-workflow. Holds keep the spawner
alive as long as the driver is alive.

## How

- `holds.py`: Thread-safe in-memory `HoldRegistry` with TTL-based expiry
- `orchestrator_holds.py`: FastAPI router -- POST/DELETE/GET `/orchestrator/holds`, POST `/{id}/renew`
- Heartbeat-renewed design: 45s grace window TTL, driver renews every 15s
- Orchestrator checks holds before quiescence self-stop (two check points)
- Pydantic models use `extra="forbid"` to catch field name mismatches
- Operator docs: `docs/operations/HOLDS.md`

## Checklist

- [x] `ruff check src/` passes
- [x] `import bernstein` passes
- [x] Docs included (`HOLDS.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added orchestrator holds to prevent automatic self-stop when external work is still active.
  * Introduced a REST API to acquire, renew, release, and list holds, including TTL-based expiration.
* **Bug Fixes**
  * Improved shutdown behavior to re-check active holds before stopping; resilient handling when hold status can’t be retrieved.
* **Documentation**
  * Added a guide describing hold behavior, TTLs, expiration rules, and recommended usage.
* **Tests**
  * Added coverage for holds API mounting and the full hold lifecycle, including validation and “not found” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->