### PR TITLE
feat: council-of-agents redesign + Qwen/env isolation fixes

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -104,6 +104,7 @@ alwaysApply: false
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |
+| `council_runner.py`         | Task-level "council of agents" runner |
 | `cursor.py`                 | Cursor Agent CLI adapter |
 | `devin_terminal.py`         | Devin for Terminal (Cognition) CLI adapter |
 | `droid.py`                  | Droid (Factory AI) CLI adapter |

--- a/.goosehints
+++ b/.goosehints
@@ -105,6 +105,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |
+| `council_runner.py`         | Task-level "council of agents" runner |
 | `cursor.py`                 | Cursor Agent CLI adapter |
 | `devin_terminal.py`         | Devin for Terminal (Cognition) CLI adapter |
 | `droid.py`                  | Droid (Factory AI) CLI adapter |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |
+| `council_runner.py`         | Task-level "council of agents" runner |
 | `cursor.py`                 | Cursor Agent CLI adapter |
 | `devin_terminal.py`         | Devin for Terminal (Cognition) CLI adapter |
 | `droid.py`                  | Droid (Factory AI) CLI adapter |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |
+| `council_runner.py`         | Task-level "council of agents" runner |
 | `cursor.py`                 | Cursor Agent CLI adapter |
 | `devin_terminal.py`         | Devin for Terminal (Cognition) CLI adapter |
 | `droid.py`                  | Droid (Factory AI) CLI adapter |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -105,6 +105,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `conformance.py`            | Adapter tool contract conformance suite harness |
 | `continue_dev.py`           | Continue.dev CLI adapter |
 | `copilot.py`                | GitHub Copilot CLI adapter |
+| `council_runner.py`         | Task-level "council of agents" runner |
 | `cursor.py`                 | Cursor Agent CLI adapter |
 | `devin_terminal.py`         | Devin for Terminal (Cognition) CLI adapter |
 | `droid.py`                  | Droid (Factory AI) CLI adapter |

--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -202,8 +202,7 @@ async def _run_candidate(
 
     run_kwargs: dict[str, Any] = {} if max_turns is None else {"max_turns": max_turns}
     logger.info(
-        "run_council._run_candidate: dispatching %s base_url=%r (api_key_env=%r) "
-        "timeout=%.1fs max_turns=%s",
+        "run_council._run_candidate: dispatching %s base_url=%r (api_key_env=%r) timeout=%.1fs max_turns=%s",
         label,
         member.get("base_url") or "<default>",
         member.get("api_key_env") or "<ambient OPENAI_API_KEY>",
@@ -224,7 +223,7 @@ async def _run_candidate(
             timeout,
         )
         return None
-    except Exception as exc:  # noqa: BLE001 - one bad candidate must never kill the council
+    except Exception as exc:  # intentional-broad-except: one bad candidate must never kill the council
         logger.warning(
             "run_council._run_candidate: %s FAILED after %.2fs: %s: %s - excluding it "
             "from judge synthesis, continuing with remaining candidates",
@@ -389,10 +388,7 @@ async def _run_council_async(
     # itself catches everything and returns ``None`` for a dead candidate
     # instead of letting the exception escape to ``gather``.
     candidate_results = await asyncio.gather(
-        *(
-            _run_candidate(i, member, agent, prompt, timeout, max_turns)
-            for i, member in enumerate(raw_candidates)
-        ),
+        *(_run_candidate(i, member, agent, prompt, timeout, max_turns) for i, member in enumerate(raw_candidates)),
     )
 
     live: list[tuple[str, str, Any]] = [r for r in candidate_results if r is not None]
@@ -414,9 +410,7 @@ async def _run_council_async(
         [label for label, _, _ in live],
     )
 
-    candidate_outputs = [
-        (label, str(getattr(result, "final_output", ""))) for label, _model_id, result in live
-    ]
+    candidate_outputs = [(label, str(getattr(result, "final_output", ""))) for label, _model_id, result in live]
     judge_result = await _run_judge(judge_member, prompt, candidate_outputs, timeout, agent, max_turns)
 
     # Aggregate cost accounting (back-compat fallback only - see

--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -195,15 +195,31 @@ async def _run_candidate(
 
     model_id = member.get("model")
     label = f"candidates[{index}]={model_id}"
-    client_kwargs = _resolve_member_client_kwargs(member)
-    client = AsyncOpenAI(**client_kwargs)
+    # Setup failures (a missing/invalid ``api_key_env`` variable, client
+    # construction, the clone) must ALSO only exclude this one candidate:
+    # anything escaping this coroutine propagates through the caller's
+    # ``asyncio.gather`` and cancels every sibling candidate, violating the
+    # one-bad-candidate-must-never-kill-the-council contract documented on
+    # this function and relied on at the gather call site.
+    try:
+        client_kwargs = _resolve_member_client_kwargs(member)
+        client = AsyncOpenAI(**client_kwargs)
 
-    candidate_model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
-    candidate_model_settings = _build_member_model_settings(agent, member, label=label)
-    clone_kwargs: dict[str, Any] = {"model": candidate_model}
-    if candidate_model_settings is not None:
-        clone_kwargs["model_settings"] = candidate_model_settings
-    candidate_agent = agent.clone(**clone_kwargs)
+        candidate_model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
+        candidate_model_settings = _build_member_model_settings(agent, member, label=label)
+        clone_kwargs: dict[str, Any] = {"model": candidate_model}
+        if candidate_model_settings is not None:
+            clone_kwargs["model_settings"] = candidate_model_settings
+        candidate_agent = agent.clone(**clone_kwargs)
+    except Exception as exc:  # intentional-broad-except: one bad candidate must never kill the council
+        logger.warning(
+            "run_council._run_candidate: %s SETUP FAILED before dispatch: %s: %s - "
+            "excluding it from judge synthesis, continuing with remaining candidates",
+            label,
+            type(exc).__name__,
+            sanitize_log(str(exc)),
+        )
+        return None
 
     run_kwargs: dict[str, Any] = {} if max_turns is None else {"max_turns": max_turns}
     logger.info(

--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -45,14 +45,19 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.sanitize import sanitize_log
+
 if TYPE_CHECKING:
     from bernstein.adapters.openai_agents_runner import RunnerManifest
 
 logger = logging.getLogger(__name__)
 
 # Default per-candidate (and per-judge) wall-clock budget when the council
-# config does not set its own ``timeout``. Matches
-# ``config_schema.CouncilConfig.timeout``'s Pydantic default.
+# config does not set its own ``timeout``. Deliberately more generous than
+# ``config_schema.CouncilConfig.timeout``'s Pydantic default (60.0): this
+# fallback only fires for a council YAML file that omits ``timeout``
+# entirely, and each member drives a WHOLE multi-turn task run here, not a
+# single call.
 DEFAULT_TIMEOUT_SECONDS = 120.0
 
 
@@ -230,17 +235,22 @@ async def _run_candidate(
             label,
             time.monotonic() - started,
             type(exc).__name__,
-            exc,
+            # Provider exception messages can embed response fragments -
+            # sanitize so a crafted payload cannot forge log lines.
+            sanitize_log(str(exc)),
         )
         return None
 
     elapsed = time.monotonic() - started
     output_text = str(getattr(result, "final_output", ""))
     logger.info(
-        "run_council._run_candidate: %s responded in %.2fs - FULL output follows:\n%s",
+        "run_council._run_candidate: %s responded in %.2fs - FULL output follows "
+        "(newlines escaped, never truncated):\n%s",
         label,
         elapsed,
-        output_text,
+        # Model output is external input: escape newlines so a crafted
+        # completion cannot forge log entries, while keeping every byte.
+        sanitize_log(output_text),
     )
     return label, str(model_id), result
 
@@ -326,7 +336,9 @@ async def _run_judge(
         timeout,
         max_turns if max_turns is not None else "SDK-default",
         len(candidate_outputs),
-        judge_prompt,
+        # The judge prompt embeds the task prompt and candidate outputs -
+        # both external input - so escape newlines before logging.
+        sanitize_log(judge_prompt),
     )
     started = time.monotonic()
     judge_result = await asyncio.wait_for(
@@ -336,9 +348,11 @@ async def _run_judge(
     elapsed = time.monotonic() - started
     output_text = str(getattr(judge_result, "final_output", ""))
     logger.info(
-        "run_council._run_judge: judge responded in %.2fs - FULL synthesis output follows:\n%s",
+        "run_council._run_judge: judge responded in %.2fs - FULL synthesis output "
+        "follows (newlines escaped, never truncated):\n%s",
         elapsed,
-        output_text,
+        # Model output is external input - escape newlines before logging.
+        sanitize_log(output_text),
     )
     return judge_result
 
@@ -362,7 +376,12 @@ async def _run_council_async(
         logger.error(msg)
         raise RuntimeError(msg)
     timeout_value = council_cfg.get("timeout")
-    timeout = float(timeout_value) if isinstance(timeout_value, (int, float)) else DEFAULT_TIMEOUT_SECONDS
+    # Reject bools explicitly (bool is an int subclass, so ``timeout: true``
+    # in a council YAML file would otherwise silently become 1.0s).
+    if isinstance(timeout_value, (int, float)) and not isinstance(timeout_value, bool):
+        timeout = float(timeout_value)
+    else:
+        timeout = DEFAULT_TIMEOUT_SECONDS
 
     # Reuse the runner's own max_turns resolution (manifest field > env var >
     # yaml tuning default > SDK default) so a council role gets the exact

--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -80,10 +80,25 @@ class CouncilRunResult:
             ``_extract_usage_tokens``'s existing fallback path sums real
             token usage across the WHOLE council (every candidate that
             actually ran, plus the judge), not just the winner's slice.
+            Retained as a back-compat aggregate fallback; the caller
+            should prefer ``member_usage`` for cost attribution (see
+            below) since pricing the aggregate under a single model id
+            is wrong when candidates use different real models.
+        member_usage: One entry per live candidate plus the judge -
+            ``{"model": <real model id>, "label": <diagnostic label>,
+            "result": <that member's own RunResult-like object>}``. The
+            caller (``openai_agents_runner._run_session``) feeds each
+            entry's ``result`` back through the normal
+            ``_extract_usage_tokens``/``price_model_usage`` path with
+            ``model`` overriding ``manifest.model`` - which would
+            otherwise be the council's ``.yaml`` file path, not a real,
+            priceable model id. This is the fix for council cost
+            tracking metering at $0 under the yaml path.
     """
 
     final_output: str
     raw_responses: list[Any] = dataclasses.field(default_factory=list)
+    member_usage: list[dict[str, Any]] = dataclasses.field(default_factory=list)
 
 
 def _resolve_member_client_kwargs(member: dict[str, Any]) -> dict[str, Any]:
@@ -113,13 +128,16 @@ async def _run_candidate(
     prompt: str,
     timeout: float,
     max_turns: int | None,
-) -> tuple[str, Any] | None:
+) -> tuple[str, str, Any] | None:
     """Run one candidate's FULL task to completion, independently.
 
     Returns:
-        ``(label, RunResult)`` on success, or ``None`` when the candidate
-        timed out or raised - the caller excludes it from judging but
-        continues with whatever candidates DID survive.
+        ``(label, model_id, RunResult)`` on success, or ``None`` when the
+        candidate timed out or raised - the caller excludes it from
+        judging but continues with whatever candidates DID survive. The
+        real ``model_id`` (not just the diagnostic ``label`` it's embedded
+        in) is returned separately so the caller can attribute cost
+        accounting to it - see ``CouncilRunResult.member_usage``.
     """
     from agents import OpenAIChatCompletionsModel, Runner  # type: ignore[import-not-found]
     from openai import AsyncOpenAI  # type: ignore[import-not-found]
@@ -175,7 +193,7 @@ async def _run_candidate(
         elapsed,
         output_text,
     )
-    return label, result
+    return label, str(model_id), result
 
 
 async def _run_judge(
@@ -323,7 +341,7 @@ async def _run_council_async(
         ),
     )
 
-    live: list[tuple[str, Any]] = [r for r in candidate_results if r is not None]
+    live: list[tuple[str, str, Any]] = [r for r in candidate_results if r is not None]
     if not live:
         msg = (
             f"run_council: session={manifest.session_id}: all {len(raw_candidates)} "
@@ -339,33 +357,57 @@ async def _run_council_async(
         manifest.session_id,
         len(live),
         len(raw_candidates),
-        [label for label, _ in live],
+        [label for label, _, _ in live],
     )
 
-    candidate_outputs = [(label, str(getattr(result, "final_output", ""))) for label, result in live]
+    candidate_outputs = [
+        (label, str(getattr(result, "final_output", ""))) for label, _model_id, result in live
+    ]
     judge_result = await _run_judge(judge_member, prompt, candidate_outputs, timeout, agent, max_turns)
 
-    # Aggregate cost accounting: concatenate every live candidate's
-    # ``raw_responses`` with the judge's own so the existing
+    # Aggregate cost accounting (back-compat fallback only - see
+    # ``member_usage`` below for the actual fix): concatenate every live
+    # candidate's ``raw_responses`` with the judge's own so the existing
     # ``_extract_usage_tokens`` fallback (which sums ``.usage`` off each
-    # ``raw_responses`` entry - see ``CouncilRunResult`` docstring) prices
-    # the WHOLE council's real spend, not just the judge's slice of it.
+    # ``raw_responses`` entry) still reflects the WHOLE council's real
+    # token spend if a caller reads ``.raw_responses`` directly instead of
+    # ``member_usage``.
     aggregated_raw_responses: list[Any] = []
-    for _, result in live:
+    for _, _model_id, result in live:
         aggregated_raw_responses.extend(getattr(result, "raw_responses", None) or [])
     aggregated_raw_responses.extend(getattr(judge_result, "raw_responses", None) or [])
+
+    # Per-member cost attribution: one entry per live candidate plus the
+    # judge, each carrying its OWN real model id and its OWN result object
+    # - so the caller can price each member under its actual model instead
+    # of the council's ``.yaml`` file path (which is not in the pricing
+    # table and previously metered the whole council at $0). See
+    # ``CouncilRunResult.member_usage`` docstring for the full rationale.
+    member_usage: list[dict[str, Any]] = [
+        {"model": model_id, "label": label, "result": result} for label, model_id, result in live
+    ]
+    judge_model_id = str(judge_member.get("model"))
+    member_usage.append(
+        {"model": judge_model_id, "label": f"judge={judge_model_id}", "result": judge_result},
+    )
 
     final_output = str(getattr(judge_result, "final_output", ""))
     logger.info(
         "run_council: session=%s EXIT - council run complete in %.2fs: %d/%d candidates "
-        "live, %d aggregated raw_responses entries carried forward for usage accounting",
+        "live, %d member_usage entries (candidates+judge) for per-model cost accounting, "
+        "%d aggregated raw_responses entries carried forward as a back-compat fallback",
         manifest.session_id,
         time.monotonic() - started,
         len(live),
         len(raw_candidates),
+        len(member_usage),
         len(aggregated_raw_responses),
     )
-    return CouncilRunResult(final_output=final_output, raw_responses=aggregated_raw_responses)
+    return CouncilRunResult(
+        final_output=final_output,
+        raw_responses=aggregated_raw_responses,
+        member_usage=member_usage,
+    )
 
 
 def run_council(

--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -121,6 +121,52 @@ def _resolve_member_client_kwargs(member: dict[str, Any]) -> dict[str, Any]:
     return _resolve_council_member_client_kwargs(member)
 
 
+def _build_member_model_settings(agent: Any, member: dict[str, Any], *, label: str) -> Any | None:
+    """Build a per-member ``ModelSettings`` override for Alibaba Cloud endpoints.
+
+    Each council candidate/judge may target a different ``base_url``, so
+    the Alibaba ``enable_thinking: False`` injection (see
+    ``openai_agents_runner._inject_alibaba_enable_thinking`` - Qwen 3.x
+    otherwise reasons its way out of tool calls) must be evaluated per
+    member rather than once on the shared base agent. Starts from the base
+    agent's OWN ``model_settings`` (so any top-level temperature/top_p/etc.
+    the manifest already resolved onto it survives the clone) and only adds
+    ``extra_body.enable_thinking`` on top - never replaces the whole object.
+
+    Returns:
+        A ``ModelSettings`` instance to pass to ``agent.clone(model_settings=...)``,
+        or ``None`` when this member's endpoint is not Alibaba Cloud (the
+        caller should omit ``model_settings`` entirely so ``clone()`` keeps
+        the base agent's settings unchanged).
+    """
+    from agents import ModelSettings  # type: ignore[import-not-found]
+
+    from bernstein.adapters.openai_agents_runner import (
+        _inject_alibaba_enable_thinking,
+        _is_alibaba_cloud_endpoint,
+    )
+
+    base_url = member.get("base_url")
+    if not _is_alibaba_cloud_endpoint(base_url):
+        return None
+
+    base_model_settings = getattr(agent, "model_settings", None)
+    existing_kwargs: dict[str, Any] = {}
+    if base_model_settings is not None:
+        for f in dataclasses.fields(base_model_settings):
+            value = getattr(base_model_settings, f.name)
+            if value is not None:
+                existing_kwargs[f.name] = value
+
+    merged_kwargs = _inject_alibaba_enable_thinking(
+        existing_kwargs,
+        base_url,
+        context=f"run_council member {label}",
+    )
+    model_settings_cls = type(base_model_settings) if base_model_settings is not None else ModelSettings
+    return model_settings_cls(**merged_kwargs)
+
+
 async def _run_candidate(
     index: int,
     member: dict[str, Any],
@@ -148,7 +194,11 @@ async def _run_candidate(
     client = AsyncOpenAI(**client_kwargs)
 
     candidate_model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
-    candidate_agent = agent.clone(model=candidate_model)
+    candidate_model_settings = _build_member_model_settings(agent, member, label=label)
+    clone_kwargs: dict[str, Any] = {"model": candidate_model}
+    if candidate_model_settings is not None:
+        clone_kwargs["model_settings"] = candidate_model_settings
+    candidate_agent = agent.clone(**clone_kwargs)
 
     run_kwargs: dict[str, Any] = {} if max_turns is None else {"max_turns": max_turns}
     logger.info(
@@ -238,10 +288,14 @@ async def _run_judge(
     client_kwargs = _resolve_member_client_kwargs(judge_member)
     client = AsyncOpenAI(**client_kwargs)
     judge_model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
+    judge_model_settings = _build_member_model_settings(agent, judge_member, label=f"judge={model_id}")
     # Strip tools/handoffs: the judge only ever reads text and produces
     # text - it must never attempt to call a tool the original task agent
     # had access to.
-    judge_agent = agent.clone(model=judge_model, tools=[], handoffs=[])
+    judge_clone_kwargs: dict[str, Any] = {"model": judge_model, "tools": [], "handoffs": []}
+    if judge_model_settings is not None:
+        judge_clone_kwargs["model_settings"] = judge_model_settings
+    judge_agent = agent.clone(**judge_clone_kwargs)
 
     candidate_sections = "\n\n".join(
         f"### Candidate: {label}\n{output_text}" for label, output_text in candidate_outputs

--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -1,0 +1,431 @@
+"""Task-level "council of agents" runner.
+
+Unlike the retired ``bernstein.adapters.council_model.CouncilModel`` (a
+per-turn ``agents.Model`` subclass that fanned out EVERY individual LLM
+call inside a single agent's tool-use loop - far too fine-grained and
+expensive), this module runs the council exactly ONCE per task/run: each
+candidate model independently drives the ENTIRE task to completion (its
+own full multi-turn ``Runner.run`` session, with its own tool calls), and
+only then does a judge model see the candidates' final outputs and
+synthesize one improved answer from them.
+
+Entry point: :func:`run_council`, called from
+``bernstein.adapters.openai_agents_runner._run_session`` exactly where a
+plain single-model run would otherwise call ``Runner.run_sync(agent,
+prompt)`` - see the ``if manifest.council:`` branch there. The manifest's
+``council`` dict is produced by
+``openai_agents_runner._load_council_config`` when a role's
+``model_field`` value in ``role_model_policy`` ends in ``.yaml``/``.yml``
+(that file is parsed into the same
+``{"candidates": [...], "judge": {...}, "timeout": <float>}`` shape
+documented on :class:`bernstein.core.config.config_schema.CouncilConfig`).
+
+Per the repo's logging house rule ("log everything, prune later"), every
+decision point here is logged: which candidate is dispatched and to what
+endpoint, each candidate's FULL output (never truncated) before the judge
+ever sees it, which candidates timed out/errored (and why) with the
+remaining candidates continuing unaffected, the judge's full synthesis
+input and output, and the aggregated cost accounting handed back to the
+caller.
+
+This module is only ever imported lazily from inside
+``openai_agents_runner._run_session``'s ``manifest.council is not None``
+branch - by that point the caller has already confirmed ``import agents``
+succeeds (see that module's own lazy-import comment), so importing the
+``agents``/``openai`` SDKs unconditionally inside the functions below is
+safe despite this codebase's usual lazy-SDK-import convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import dataclasses
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.adapters.openai_agents_runner import RunnerManifest
+
+logger = logging.getLogger(__name__)
+
+# Default per-candidate (and per-judge) wall-clock budget when the council
+# config does not set its own ``timeout``. Matches
+# ``config_schema.CouncilConfig.timeout``'s Pydantic default.
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+
+@dataclasses.dataclass
+class CouncilRunResult:
+    """Minimal duck-typed stand-in for an SDK ``RunResult``.
+
+    ``openai_agents_runner._run_session`` only ever touches two things on
+    whatever ``Runner.run_sync``/``run_council`` hands back: ``final_output``
+    (for the ``completion`` event's ``summary`` field) and usage data via
+    ``_extract_usage_tokens`` - which reads ``result.usage`` first, then
+    falls back to summing ``usage`` off every entry of ``result.raw_responses``
+    (see that function's docstring: the real SDK ``RunResult`` never
+    actually populates ``.usage``, so the ``raw_responses`` fallback is the
+    path that fires in practice). Reproducing the SDK's full ``RunResult``
+    dataclass (20+ fields, several private/internal) would be both fragile
+    and unnecessary - this object only needs to satisfy the two attributes
+    those two call sites actually read.
+
+    Attributes:
+        final_output: The judge's synthesized text - the council's answer
+            for this task/run.
+        raw_responses: Every live candidate's ``RunResult.raw_responses``
+            entries concatenated with the judge's own, so
+            ``_extract_usage_tokens``'s existing fallback path sums real
+            token usage across the WHOLE council (every candidate that
+            actually ran, plus the judge), not just the winner's slice.
+    """
+
+    final_output: str
+    raw_responses: list[Any] = dataclasses.field(default_factory=list)
+
+
+def _resolve_member_client_kwargs(member: dict[str, Any]) -> dict[str, Any]:
+    """Delegate to the runner's existing per-member endpoint resolver.
+
+    Imported lazily (rather than at module level) to avoid a circular
+    import: ``openai_agents_runner`` imports :func:`run_council` from this
+    module, so this module cannot import back from
+    ``openai_agents_runner`` at load time.
+
+    Raises:
+        RuntimeError: ``api_key_env`` is set but fails validation, or the
+            named environment variable is missing/empty - see
+            ``openai_agents_runner._resolve_council_member_client_kwargs``.
+    """
+    from bernstein.adapters.openai_agents_runner import (
+        _resolve_council_member_client_kwargs,
+    )
+
+    return _resolve_council_member_client_kwargs(member)
+
+
+async def _run_candidate(
+    index: int,
+    member: dict[str, Any],
+    agent: Any,
+    prompt: str,
+    timeout: float,
+    max_turns: int | None,
+) -> tuple[str, Any] | None:
+    """Run one candidate's FULL task to completion, independently.
+
+    Returns:
+        ``(label, RunResult)`` on success, or ``None`` when the candidate
+        timed out or raised - the caller excludes it from judging but
+        continues with whatever candidates DID survive.
+    """
+    from agents import OpenAIChatCompletionsModel, Runner  # type: ignore[import-not-found]
+    from openai import AsyncOpenAI  # type: ignore[import-not-found]
+
+    model_id = member.get("model")
+    label = f"candidates[{index}]={model_id}"
+    client_kwargs = _resolve_member_client_kwargs(member)
+    client = AsyncOpenAI(**client_kwargs)
+
+    candidate_model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
+    candidate_agent = agent.clone(model=candidate_model)
+
+    run_kwargs: dict[str, Any] = {} if max_turns is None else {"max_turns": max_turns}
+    logger.info(
+        "run_council._run_candidate: dispatching %s base_url=%r (api_key_env=%r) "
+        "timeout=%.1fs max_turns=%s",
+        label,
+        member.get("base_url") or "<default>",
+        member.get("api_key_env") or "<ambient OPENAI_API_KEY>",
+        timeout,
+        max_turns if max_turns is not None else "SDK-default",
+    )
+    started = time.monotonic()
+    try:
+        result = await asyncio.wait_for(
+            Runner.run(candidate_agent, prompt, **run_kwargs),
+            timeout=timeout,
+        )
+    except TimeoutError:
+        logger.warning(
+            "run_council._run_candidate: %s TIMED OUT after %.1fs - excluding it from "
+            "judge synthesis, continuing with remaining candidates",
+            label,
+            timeout,
+        )
+        return None
+    except Exception as exc:  # noqa: BLE001 - one bad candidate must never kill the council
+        logger.warning(
+            "run_council._run_candidate: %s FAILED after %.2fs: %s: %s - excluding it "
+            "from judge synthesis, continuing with remaining candidates",
+            label,
+            time.monotonic() - started,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+    elapsed = time.monotonic() - started
+    output_text = str(getattr(result, "final_output", ""))
+    logger.info(
+        "run_council._run_candidate: %s responded in %.2fs - FULL output follows:\n%s",
+        label,
+        elapsed,
+        output_text,
+    )
+    return label, result
+
+
+async def _run_judge(
+    judge_member: dict[str, Any],
+    task_prompt: str,
+    candidate_outputs: list[tuple[str, str]],
+    timeout: float,
+    agent: Any,
+    max_turns: int | None,
+) -> Any:
+    """Ask the judge model to SYNTHESIZE one improved answer from every candidate.
+
+    Unlike the retired ``CouncilModel``, which restricted its judge to
+    picking one candidate's response verbatim (see that module's
+    docstring for why - tool-call structural risk at the per-turn level),
+    a task-level judge only ever sees plain TEXT (each candidate's final
+    output after its own full run completed), so there is no structured
+    tool-call payload to corrupt. The judge is explicitly instructed to
+    combine the best insights from every candidate and correct any errors
+    it spots, not to just pick a winner.
+
+    Args:
+        judge_member: The council config's ``judge`` entry
+            (``{"model": ..., "base_url": ..., "api_key_env": ...}``).
+        task_prompt: The original task prompt, included so the judge can
+            evaluate candidate outputs against the actual task.
+        candidate_outputs: ``(label, full_output_text)`` for every candidate
+            that survived (i.e. did not time out or error).
+        timeout: Wall-clock budget for the judge call itself.
+        agent: The base agent definition (used only for ``.clone()`` so the
+            judge inherits the same ``name``/``instructions`` prefix
+            conventions as the candidates; its ``tools``/``handoffs`` are
+            stripped since the judge only ever produces text).
+
+    Returns:
+        The judge's ``RunResult``.
+    """
+    from agents import OpenAIChatCompletionsModel, Runner  # type: ignore[import-not-found]
+    from openai import AsyncOpenAI  # type: ignore[import-not-found]
+
+    model_id = judge_member.get("model")
+    client_kwargs = _resolve_member_client_kwargs(judge_member)
+    client = AsyncOpenAI(**client_kwargs)
+    judge_model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
+    # Strip tools/handoffs: the judge only ever reads text and produces
+    # text - it must never attempt to call a tool the original task agent
+    # had access to.
+    judge_agent = agent.clone(model=judge_model, tools=[], handoffs=[])
+
+    candidate_sections = "\n\n".join(
+        f"### Candidate: {label}\n{output_text}" for label, output_text in candidate_outputs
+    )
+    judge_prompt = (
+        "You are synthesizing the best answer from multiple AI agents who each "
+        "analyzed the same task independently. Each candidate below completed "
+        "the ENTIRE task on its own (its own full multi-step run) and produced "
+        "a final output.\n\n"
+        f"## Original task\n{task_prompt}\n\n"
+        f"## Candidate outputs\n{candidate_sections}\n\n"
+        "## Your job\n"
+        "Combine the best insights, approaches, and correctness from EVERY "
+        "candidate above into ONE unified, improved response. Correct any "
+        "errors you notice in any candidate's output. Do NOT simply pick one "
+        "candidate's answer verbatim and repeat it - genuinely synthesize a "
+        "response that is better than any single candidate's output on its "
+        "own. Output only the final synthesized response - no meta-commentary "
+        "about the synthesis process, no mention of 'candidate 1/2/3'."
+    )
+
+    run_kwargs: dict[str, Any] = {} if max_turns is None else {"max_turns": max_turns}
+    logger.info(
+        "run_council._run_judge: dispatching judge model=%r base_url=%r (api_key_env=%r) "
+        "timeout=%.1fs max_turns=%s over %d candidate output(s) - full judge prompt follows:\n%s",
+        model_id,
+        judge_member.get("base_url") or "<default>",
+        judge_member.get("api_key_env") or "<ambient OPENAI_API_KEY>",
+        timeout,
+        max_turns if max_turns is not None else "SDK-default",
+        len(candidate_outputs),
+        judge_prompt,
+    )
+    started = time.monotonic()
+    judge_result = await asyncio.wait_for(
+        Runner.run(judge_agent, judge_prompt, **run_kwargs),
+        timeout=timeout,
+    )
+    elapsed = time.monotonic() - started
+    output_text = str(getattr(judge_result, "final_output", ""))
+    logger.info(
+        "run_council._run_judge: judge responded in %.2fs - FULL synthesis output follows:\n%s",
+        elapsed,
+        output_text,
+    )
+    return judge_result
+
+
+async def _run_council_async(
+    agent: Any,
+    prompt: str,
+    council_cfg: dict[str, Any],
+    manifest: RunnerManifest,
+) -> CouncilRunResult:
+    """Async implementation backing :func:`run_council` - see its docstring."""
+    started = time.monotonic()
+    raw_candidates = council_cfg.get("candidates")
+    if not isinstance(raw_candidates, list) or not raw_candidates:
+        msg = "run_council: council_cfg.candidates must be a non-empty list"
+        logger.error(msg)
+        raise RuntimeError(msg)
+    judge_member = council_cfg.get("judge")
+    if not isinstance(judge_member, dict):
+        msg = "run_council: council_cfg.judge is required and must be a mapping"
+        logger.error(msg)
+        raise RuntimeError(msg)
+    timeout_value = council_cfg.get("timeout")
+    timeout = float(timeout_value) if isinstance(timeout_value, (int, float)) else DEFAULT_TIMEOUT_SECONDS
+
+    # Reuse the runner's own max_turns resolution (manifest field > env var >
+    # yaml tuning default > SDK default) so a council role gets the exact
+    # same turn-cap behavior a single-model role would - imported lazily to
+    # avoid a circular import at module load (see module docstring).
+    from bernstein.adapters.openai_agents_runner import _resolve_max_turns
+
+    max_turns = _resolve_max_turns(manifest.max_turns)
+
+    logger.info(
+        "run_council: session=%s ENTER - task-level council run starting: %d candidates, "
+        "timeout=%.1fs per candidate/judge call, max_turns=%s",
+        manifest.session_id,
+        len(raw_candidates),
+        timeout,
+        max_turns if max_turns is not None else "SDK-default",
+    )
+
+    # Every candidate runs its OWN full task end-to-end, in parallel. One
+    # candidate hanging or erroring must never block/kill the others -
+    # ``asyncio.gather`` without ``return_exceptions`` would propagate the
+    # first exception and cancel every sibling task, so ``_run_candidate``
+    # itself catches everything and returns ``None`` for a dead candidate
+    # instead of letting the exception escape to ``gather``.
+    candidate_results = await asyncio.gather(
+        *(
+            _run_candidate(i, member, agent, prompt, timeout, max_turns)
+            for i, member in enumerate(raw_candidates)
+        ),
+    )
+
+    live: list[tuple[str, Any]] = [r for r in candidate_results if r is not None]
+    if not live:
+        msg = (
+            f"run_council: session={manifest.session_id}: all {len(raw_candidates)} "
+            f"candidates failed or timed out (timeout={timeout}s) - see WARNING logs "
+            f"above for each candidate's exact failure. No output exists for the judge "
+            f"to synthesize from."
+        )
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    logger.info(
+        "run_council: session=%s: %d/%d candidates survived: %s - proceeding to judge synthesis",
+        manifest.session_id,
+        len(live),
+        len(raw_candidates),
+        [label for label, _ in live],
+    )
+
+    candidate_outputs = [(label, str(getattr(result, "final_output", ""))) for label, result in live]
+    judge_result = await _run_judge(judge_member, prompt, candidate_outputs, timeout, agent, max_turns)
+
+    # Aggregate cost accounting: concatenate every live candidate's
+    # ``raw_responses`` with the judge's own so the existing
+    # ``_extract_usage_tokens`` fallback (which sums ``.usage`` off each
+    # ``raw_responses`` entry - see ``CouncilRunResult`` docstring) prices
+    # the WHOLE council's real spend, not just the judge's slice of it.
+    aggregated_raw_responses: list[Any] = []
+    for _, result in live:
+        aggregated_raw_responses.extend(getattr(result, "raw_responses", None) or [])
+    aggregated_raw_responses.extend(getattr(judge_result, "raw_responses", None) or [])
+
+    final_output = str(getattr(judge_result, "final_output", ""))
+    logger.info(
+        "run_council: session=%s EXIT - council run complete in %.2fs: %d/%d candidates "
+        "live, %d aggregated raw_responses entries carried forward for usage accounting",
+        manifest.session_id,
+        time.monotonic() - started,
+        len(live),
+        len(raw_candidates),
+        len(aggregated_raw_responses),
+    )
+    return CouncilRunResult(final_output=final_output, raw_responses=aggregated_raw_responses)
+
+
+def run_council(
+    agent: Any,
+    prompt: str,
+    council_cfg: dict[str, Any],
+    manifest: RunnerManifest,
+) -> CouncilRunResult:
+    """Run a task-level council: N candidates run the FULL task in parallel,
+    each wrapped in a per-candidate timeout, then a judge synthesizes one
+    unified answer from whichever candidates survived.
+
+    Call-site compatible with ``Runner.run_sync(agent, prompt)`` - see the
+    ``if manifest.council:`` branch in
+    ``openai_agents_runner._run_session`` that calls this instead. The
+    returned :class:`CouncilRunResult` duck-types the two attributes that
+    caller actually reads off its ``result`` (``final_output`` and, via the
+    existing ``_extract_usage_tokens`` fallback, ``raw_responses``).
+
+    Args:
+        agent: The base ``agents.Agent`` definition built by
+            ``openai_agents_runner._build_agent_kwargs``/``agent_cls(...)``
+            (name, instructions, tools). Each candidate/judge gets its own
+            ``.clone(model=...)`` off this same definition - only the
+            model differs per member.
+        prompt: The task prompt, forwarded verbatim to every candidate and
+            included in the judge's synthesis prompt.
+        council_cfg: Parsed council config -
+            ``{"candidates": [{"model", "base_url"?, "api_key_env"?}, ...],
+            "judge": {...}, "timeout"?: float}`` - see
+            ``bernstein.core.config.config_schema.CouncilConfig``.
+        manifest: The parsed ``RunnerManifest`` (used for session-id log
+            correlation only).
+
+    Returns:
+        A :class:`CouncilRunResult` whose ``final_output`` is the judge's
+        synthesized text.
+
+    Raises:
+        RuntimeError: ``council_cfg`` is malformed, or every candidate
+            failed/timed out (the full per-candidate failure reason is
+            logged at WARNING before this is raised).
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # Common case: ``_run_session`` calls this from plain synchronous
+        # code with no event loop running in this thread yet - safe to
+        # drive our own with ``asyncio.run``.
+        logger.info("run_council: no event loop running in this thread - using asyncio.run()")
+        return asyncio.run(_run_council_async(agent, prompt, council_cfg, manifest))
+
+    # A loop IS already running in this thread (e.g. pytest-asyncio tests
+    # that exercise this module directly) - ``asyncio.run()`` would raise
+    # "cannot be called from a running event loop". Drive the whole council
+    # coroutine from a dedicated thread with its own fresh loop instead.
+    logger.info(
+        "run_council: an event loop is already running in this thread - driving the "
+        "council coroutine from a dedicated worker thread instead of asyncio.run()"
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(asyncio.run, _run_council_async(agent, prompt, council_cfg, manifest))
+        return future.result()

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -148,6 +148,12 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         # pass through build_filtered_env() or the runner falls back to a
         # default tool source instead of the one the operator configured.
         "BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE",
+        # ``BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND`` opts the spawned openai_agents
+        # runner into registering the builtin run_command tool. Set alongside
+        # BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE=builtin in run.py; without it in
+        # the passthrough set the filtered env drops it and the manager agent's
+        # run_command calls fail with ModelBehaviorError: Tool run_command not found.
+        "BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND",
     }
 )
 

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -134,6 +134,20 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         # reporting never reaches the central server.  It is a URL, not a
         # credential, so passing it through is safe.
         "BERNSTEIN_SERVER_URL",
+        # ``BERNSTEIN_ALLOWED_API_KEY_ENVS`` must propagate to the spawned
+        # runner subprocess: the runner's own ``validate_api_key_env_name()``
+        # reads this allowlist to accept operator-defined credential
+        # variable names (e.g. ``ALIBABA_CLOUD_API_KEY``). Without it in the
+        # passthrough set, the filtered env silently drops the allowlist and
+        # the runner rejects any non-standard API key env name it wasn't
+        # hardcoded to recognize.
+        "BERNSTEIN_ALLOWED_API_KEY_ENVS",
+        # ``BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE`` is set by run.py before
+        # spawning the openai_agents runner subprocess, telling it which
+        # tool source (e.g. built-in vs MCP-provided) to wire up. It must
+        # pass through build_filtered_env() or the runner falls back to a
+        # default tool source instead of the one the operator configured.
+        "BERNSTEIN_OPENAI_AGENTS_TOOL_SOURCE",
     }
 )
 

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -58,12 +58,9 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import yaml
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -744,8 +741,7 @@ def _load_council_config(manifest: RunnerManifest) -> dict[str, Any] | None:
         raise RuntimeError(msg)
 
     logger.info(
-        "openai_agents_runner session=%s: council file %s parsed OK: %d candidates, "
-        "judge model=%r, timeout=%r",
+        "openai_agents_runner session=%s: council file %s parsed OK: %d candidates, judge model=%r, timeout=%r",
         manifest.session_id,
         config_path,
         len(raw_candidates),

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -814,12 +814,29 @@ def _log_max_turns_exceeded(exc: BaseException, max_turns: int | None) -> None:
     )
 
 
-def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_desc: str) -> None:
+def _emit_session_usage(
+    manifest: RunnerManifest,
+    usage_source: Any,
+    *,
+    source_desc: str,
+    model: str | None = None,
+) -> None:
     """Extract, price, emit, and sidecar the session's token usage.
 
     Single choke point for usage accounting, callable from BOTH the success
     path (``usage_source`` = the SDK ``RunResult``) and the exception path
     (``usage_source`` = the exception's ``run_data`` payload, or ``None``).
+
+    A task-level council run (``manifest.council is not None``) calls this
+    once PER council member (each live candidate, plus the judge) instead
+    of once for the whole session, passing that member's own ``result``
+    object as ``usage_source`` and its real model id as ``model`` - see
+    ``bernstein.adapters.council_runner.CouncilRunResult.member_usage``.
+    Without the ``model`` override every council member would be priced
+    under ``manifest.model``, which for a council role is the ``.yaml``
+    config file path, not a real model id - that path isn't in the pricing
+    table, so ``price_model_usage`` fell back to $0 with a warning for
+    every council run. Passing each member's real model id here is the fix.
 
     D2 MiniMax attempt-3 (2026-07-03) proof: the usage-extraction block
     previously lived only after the ``try/except`` around
@@ -840,7 +857,13 @@ def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_d
         source_desc: Human-readable description of where ``usage_source``
             came from (e.g. ``"result"``, ``"MaxTurnsExceeded.run_data"``),
             logged so a $0 run names the exact path that produced it.
+        model: The real model id to price/report usage under. Defaults to
+            ``manifest.model`` - pass this explicitly for a council member
+            (its real candidate/judge model id), since ``manifest.model``
+            for a council role names the ``.yaml`` config file, not a
+            priceable model.
     """
+    model_id = model if model is not None else manifest.model
     input_tokens, output_tokens, tool_calls = _extract_usage_tokens(usage_source)
 
     if input_tokens <= 0 and output_tokens <= 0:
@@ -856,7 +879,7 @@ def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_d
             "data (usage is None/empty and raw_responses carried no usable "
             "usage) - cost metering for this call is unavailable, not zero",
             manifest.session_id,
-            manifest.model,
+            model_id,
             source_desc,
         )
         emit_event(
@@ -865,7 +888,7 @@ def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_d
                 "input_tokens": 0,
                 "output_tokens": 0,
                 "tool_calls": tool_calls,
-                "model": manifest.model,
+                "model": model_id,
                 "usage_missing": True,
                 "usage_source": source_desc,
             },
@@ -881,7 +904,7 @@ def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_d
     # stdout-only "usage" event never reached it).
     from bernstein.core.cost.model_prices import price_model_usage
 
-    price_result = price_model_usage(manifest.model, input_tokens, output_tokens)
+    price_result = price_model_usage(model_id, input_tokens, output_tokens)
     # ``Runner.run_sync`` aggregates every internal turn into one cumulative
     # usage total (whether from ``result.usage``, the ``raw_responses``
     # fallback sum, or an exception's partial ``run_data``), so this call's
@@ -892,7 +915,7 @@ def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_d
         "llm_call session=%s model=%s source=%s input_tokens=%d "
         "output_tokens=%d cost_usd=%.6f priced=%s running_total_usd=%.6f",
         manifest.session_id,
-        manifest.model,
+        model_id,
         source_desc,
         input_tokens,
         output_tokens,
@@ -907,7 +930,7 @@ def _emit_session_usage(manifest: RunnerManifest, usage_source: Any, *, source_d
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "tool_calls": tool_calls,
-            "model": manifest.model,
+            "model": model_id,
             "cost_usd": price_result.cost_usd,
             "priced": price_result.priced,
             "running_total_usd": running_total_usd,
@@ -1566,7 +1589,28 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
     # ``RunResult``/``RunResultBase`` never define a ``usage`` attribute at
     # all, so the ``raw_responses`` fallback inside ``_extract_usage_tokens``
     # is the path that actually fires on real SDK result objects.
-    _emit_session_usage(manifest, result, source_desc="result")
+    #
+    # Council fix: ``manifest.model`` for a council role names the
+    # ``.yaml`` config file, not a real model id, so pricing the whole
+    # council under it looked up the yaml path in the pricing table and
+    # metered at $0 with a warning. When the council ran, ``result`` is a
+    # ``CouncilRunResult`` carrying ``member_usage`` - one entry per live
+    # candidate plus the judge, each with its own real model id and its
+    # own result object (see
+    # ``bernstein.adapters.council_runner.CouncilRunResult``). Emit one
+    # usage event per member, priced under that member's real model,
+    # instead of one aggregate event priced under the yaml path.
+    member_usage = getattr(result, "member_usage", None) if manifest.council is not None else None
+    if member_usage:
+        for member in member_usage:
+            _emit_session_usage(
+                manifest,
+                member.get("result"),
+                source_desc=f"council:{member.get('label')}",
+                model=member.get("model"),
+            )
+    else:
+        _emit_session_usage(manifest, result, source_desc="result")
 
     emit_event(
         {

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -449,10 +449,83 @@ def _build_agent_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
     return kwargs
 
 
+# Alibaba Cloud (DashScope/MaaS) OpenAI-compatible endpoints. Substring match
+# against ``base_url`` - covers both the public DashScope host
+# (``dashscope.aliyuncs.com``) and the MaaS variant
+# (``maas.aliyuncs.com``) mentioned in Alibaba's own function-calling docs.
+_ALIBABA_BASE_URL_MARKERS: tuple[str, ...] = ("aliyuncs.com",)
+
+
+def _is_alibaba_cloud_endpoint(base_url: str | None) -> bool:
+    """Return whether *base_url* points at an Alibaba Cloud endpoint.
+
+    Qwen 3.x models served via Alibaba Cloud (DashScope/MaaS) default to
+    "thinking" mode, which makes the model reason its way out of calling
+    tools and write ad-hoc scripts instead - Alibaba's own function-calling
+    docs show ``extra_body={"enable_thinking": False}`` on every
+    tool-calling request as the fix. Detection is a simple substring match
+    so both the public DashScope host and any ``*.aliyuncs.com`` MaaS
+    variant are covered without hardcoding a specific hostname.
+    """
+    return bool(base_url) and any(marker in cast("str", base_url) for marker in _ALIBABA_BASE_URL_MARKERS)
+
+
+def _inject_alibaba_enable_thinking(
+    kwargs: dict[str, Any],
+    base_url: str | None,
+    *,
+    context: str,
+) -> dict[str, Any]:
+    """Merge ``extra_body={"enable_thinking": False}`` into *kwargs* for Alibaba endpoints.
+
+    No-op when *base_url* is not an Alibaba Cloud endpoint (see
+    :func:`_is_alibaba_cloud_endpoint`) or when ``enable_thinking`` is
+    already present in an existing ``extra_body`` (an explicit manifest
+    value always wins over this auto-injection). Mutates and returns
+    *kwargs* in place for convenient call-site chaining.
+
+    Args:
+        kwargs: The in-progress ``ModelSettings`` kwargs dict.
+        base_url: The endpoint this call is bound for.
+        context: Human-readable label (session id / council member) logged
+            alongside the injection so it is diagnosable from the runner
+            log alone (lessons.md rule 2).
+
+    Returns:
+        *kwargs*, with ``extra_body.enable_thinking`` set to ``False`` when
+        applicable.
+    """
+    if not _is_alibaba_cloud_endpoint(base_url):
+        return kwargs
+    extra_body: dict[str, Any] = dict(kwargs.get("extra_body") or {})
+    if "enable_thinking" in extra_body:
+        logger.info(
+            "%s: base_url=%r is Alibaba Cloud but extra_body.enable_thinking=%r is "
+            "already set - leaving the explicit value in place",
+            context,
+            base_url,
+            extra_body["enable_thinking"],
+        )
+        return kwargs
+    extra_body["enable_thinking"] = False
+    kwargs["extra_body"] = extra_body
+    logger.info(
+        "%s: base_url=%r matches Alibaba Cloud (aliyuncs.com) - injecting "
+        "extra_body={'enable_thinking': False} so tool calling is reliable "
+        "(Qwen 3.x reasons its way out of tool calls and writes ad-hoc "
+        "scripts instead when thinking mode is left on for function-calling "
+        "requests - see Alibaba's own function-calling docs)",
+        context,
+        base_url,
+    )
+    return kwargs
+
+
 def _build_model_settings_kwargs(
     manifest: RunnerManifest,
     *,
     model_settings_cls: type[Any] | None = None,
+    base_url: str | None = None,
 ) -> dict[str, Any]:
     """Translate optional sampling params into ``ModelSettings`` kwargs.
 
@@ -467,6 +540,16 @@ def _build_model_settings_kwargs(
     when ``None`` the field is not forwarded (the SDK is not loaded, e.g. in
     unit tests), keeping the kwargs SDK-version safe.
 
+    Args:
+        base_url: The single-model endpoint this run is bound for (``None``
+            for the default OpenAI endpoint, or when a council role is
+            active - council members resolve their OWN per-member
+            ``base_url`` in :mod:`bernstein.adapters.council_runner`
+            instead, since each candidate/judge may target a different
+            endpoint). When set and it is an Alibaba Cloud endpoint,
+            ``extra_body={"enable_thinking": False}`` is injected - see
+            :func:`_inject_alibaba_enable_thinking`.
+
     Returns:
         Kwargs for ``agents.ModelSettings``, possibly empty.
     """
@@ -479,6 +562,11 @@ def _build_model_settings_kwargs(
         kwargs["extra_args"] = {"top_k": manifest.top_k}
     if manifest.max_tokens and _model_settings_accepts(model_settings_cls, "max_tokens"):
         kwargs["max_tokens"] = manifest.max_tokens
+    kwargs = _inject_alibaba_enable_thinking(
+        kwargs,
+        base_url,
+        context=f"openai_agents_runner session={manifest.session_id}",
+    )
     return kwargs
 
 
@@ -1346,7 +1434,18 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
                         manifest.model,
                     )
 
-        settings_kwargs = _build_model_settings_kwargs(manifest, model_settings_cls=sdk.ModelSettings)
+        # Council roles resolve their own per-member base_url independently
+        # (see council_runner._run_candidate/_run_judge) since each
+        # candidate/judge may target a different endpoint - the top-level
+        # manifest.base_url must not be applied to the shared base agent in
+        # that case, or every council member would inherit the enable_thinking
+        # override intended for only one of them.
+        settings_base_url = None if manifest.council is not None else manifest.base_url
+        settings_kwargs = _build_model_settings_kwargs(
+            manifest,
+            model_settings_cls=sdk.ModelSettings,
+            base_url=settings_base_url,
+        )
         if settings_kwargs:
             agent_kwargs["model_settings"] = sdk.ModelSettings(**settings_kwargs)
         agent: Any = agent_cls(**agent_kwargs)

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -58,7 +58,12 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -294,6 +299,37 @@ class RunnerManifest:
     # direct invocation) and the runner's own env/defaults apply.
     allow_run_command: bool | None = None
     max_turns: int | None = None
+    # Optional TASK-LEVEL "council of agents" fan-out/judge override (see
+    # ``bernstein.adapters.council_runner.run_council`` and
+    # ``bernstein.core.config.config_schema.CouncilConfig``). Shape::
+    #
+    #     {"candidates": [{"model": "...", "base_url": "...", "api_key_env": "..."}, ...],
+    #      "judge": {"model": "...", "base_url": "...", "api_key_env": "..."},
+    #      "timeout": 60.0}
+    #
+    # ``base_url``/``api_key_env`` are optional per-member endpoint
+    # overrides, resolved through the exact same
+    # ``_resolve_client_kwargs``/``validate_api_key_env_name`` path as the
+    # top-level ``base_url``/``api_key_env`` fields above.
+    #
+    # This field is usually populated INDIRECTLY: when ``model`` (above)
+    # names a ``.yaml``/``.yml`` file (the ``role_model_policy.<role>.model:
+    # "councils/foo.yaml"`` convention), :func:`_load_council_config`
+    # resolves that file relative to ``.bernstein/`` in ``workdir``, parses
+    # it into this exact shape, and :func:`run` rebuilds the manifest with
+    # this field populated before ``_run_session`` runs. A caller MAY also
+    # set this field directly (e.g. a hand-written manifest for a direct
+    # invocation/test) - it is then used as-is and ``model``'s ``.yaml``
+    # suffix is not re-checked.
+    #
+    # When set (by either path), each candidate runs the WHOLE task to
+    # completion independently (its own full ``Runner.run``), then a judge
+    # model synthesizes one improved answer from every candidate's final
+    # output - see :func:`run_council <bernstein.adapters.council_runner.run_council>`
+    # for the task-level implementation the ``manifest.council`` branch in
+    # :func:`_run_session` calls instead of ``Runner.run_sync``. ``None``
+    # (the default) preserves today's single-model behavior exactly.
+    council: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> RunnerManifest:
@@ -391,7 +427,17 @@ def _build_agent_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
     instructions = manifest.system_addendum or None
     kwargs: dict[str, Any] = {
         "name": f"bernstein-{manifest.session_id}",
-        "model": manifest.model,
+        # A council role's ``model`` only ever names a council YAML file
+        # path (already resolved into ``manifest.council`` by
+        # ``_load_council_config`` before this is called) - it is never a
+        # real model id, so it must never be handed to ``Agent(model=...)``
+        # (the SDK would try to resolve the literal path string as a
+        # provider/model id and fail). Leaving it ``None`` here is safe:
+        # this base ``Agent`` definition is only ever used as a
+        # ``.clone(model=...)`` template inside
+        # ``bernstein.adapters.council_runner.run_council`` - it is never
+        # itself passed to ``Runner.run``/``Runner.run_sync``.
+        "model": None if manifest.council is not None else manifest.model,
     }
     if instructions:
         kwargs["instructions"] = instructions
@@ -479,6 +525,146 @@ def _resolve_client_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
             raise RuntimeError(msg)
         kwargs["api_key"] = api_key
     return kwargs
+
+
+def _resolve_council_member_client_kwargs(member: Mapping[str, Any]) -> dict[str, Any]:
+    """Build ``AsyncOpenAI(...)`` kwargs for one council candidate/judge member.
+
+    Mirrors :func:`_resolve_client_kwargs` but reads ``base_url``/
+    ``api_key_env`` from a single council member dict (one entry of
+    ``manifest.council["candidates"]`` or ``manifest.council["judge"]``)
+    instead of the top-level manifest fields, since each council member
+    may target a different endpoint/credential.
+
+    Raises:
+        RuntimeError: ``api_key_env`` is set but fails
+            :func:`validate_api_key_env_name`, or the named environment
+            variable is missing or empty.
+    """
+    kwargs: dict[str, Any] = {}
+    base_url = member.get("base_url")
+    if base_url:
+        kwargs["base_url"] = base_url
+    api_key_env = member.get("api_key_env")
+    if api_key_env:
+        validate_api_key_env_name(api_key_env)
+        api_key = os.environ.get(api_key_env)
+        if not api_key:
+            msg = (
+                f"council member {member.get('model')!r} names api_key_env "
+                f"{api_key_env!r} but it is not set. Export {api_key_env} before "
+                f"spawning the openai_agents runner."
+            )
+            raise RuntimeError(msg)
+        kwargs["api_key"] = api_key
+    return kwargs
+
+
+def _resolve_council_config_path(manifest: RunnerManifest, council_path: str) -> Path:
+    """Resolve a council YAML file reference relative to ``.bernstein/`` in the workdir.
+
+    Args:
+        manifest: The parsed manifest (only ``workdir`` is used).
+        council_path: The raw ``.yaml``/``.yml`` string from
+            ``manifest.model`` (e.g. ``"councils/planning.yaml"``).
+
+    Returns:
+        Absolute path: ``council_path`` unchanged if already absolute,
+        otherwise ``<workdir>/.bernstein/<council_path>``.
+    """
+    candidate = Path(council_path)
+    if candidate.is_absolute():
+        return candidate
+    return Path(manifest.workdir) / ".bernstein" / candidate
+
+
+def _load_council_config(manifest: RunnerManifest) -> dict[str, Any] | None:
+    """Resolve the effective council config for this run, if any.
+
+    Two ways a run ends up with a council config:
+
+    1. ``manifest.council`` is already populated (e.g. a hand-written
+       manifest for a direct invocation/test) - returned unchanged,
+       ``manifest.model`` is not inspected.
+    2. ``manifest.model`` names a ``.yaml``/``.yml`` file (the
+       ``role_model_policy.<role>.model: "councils/foo.yaml"`` convention -
+       see :class:`RunnerManifest`'s ``council`` field docstring). The file
+       is resolved relative to ``.bernstein/`` in ``manifest.workdir`` (see
+       :func:`_resolve_council_config_path`), parsed as YAML, and validated
+       to have a non-empty ``candidates`` list and a ``judge`` mapping -
+       the same shape :func:`bernstein.adapters.council_runner.run_council`
+       expects (mirrors
+       :class:`bernstein.core.config.config_schema.CouncilConfig`).
+
+    Returns:
+        The parsed council config dict, or ``None`` when neither applies -
+        the ordinary single-model path (unchanged behavior).
+
+    Raises:
+        RuntimeError: ``manifest.model`` ends in ``.yaml``/``.yml`` but the
+            referenced file does not exist, is not valid YAML, is not a
+            mapping, or is missing a non-empty ``candidates`` list / a
+            ``judge`` mapping. Surfaced to :func:`run`'s existing
+            ``config_invalid`` error path exactly like any other
+            manifest-time misconfiguration.
+    """
+    if manifest.council is not None:
+        logger.info(
+            "openai_agents_runner session=%s: manifest.council already populated - "
+            "using it as-is (manifest.model=%r is not inspected for a .yaml suffix)",
+            manifest.session_id,
+            manifest.model,
+        )
+        return manifest.council
+
+    if not (manifest.model.endswith(".yaml") or manifest.model.endswith(".yml")):
+        return None
+
+    config_path = _resolve_council_config_path(manifest, manifest.model)
+    logger.info(
+        "openai_agents_runner session=%s: manifest.model=%r ends in .yaml/.yml - "
+        "loading it as a council definition file from %s",
+        manifest.session_id,
+        manifest.model,
+        config_path,
+    )
+    if not config_path.exists():
+        msg = (
+            f"manifest.model {manifest.model!r} looks like a council definition file "
+            f"(ends in .yaml/.yml) but {config_path} does not exist"
+        )
+        raise RuntimeError(msg)
+
+    try:
+        raw_text = config_path.read_text(encoding="utf-8")
+        parsed: object = yaml.safe_load(raw_text)
+    except (OSError, yaml.YAMLError) as exc:
+        msg = f"failed to read/parse council file {config_path}: {type(exc).__name__}: {exc}"
+        raise RuntimeError(msg) from exc
+
+    if not isinstance(parsed, dict):
+        msg = f"council file {config_path} must be a YAML mapping, got {type(parsed).__name__}"
+        raise RuntimeError(msg)
+
+    raw_candidates = parsed.get("candidates")
+    if not isinstance(raw_candidates, list) or not raw_candidates:
+        msg = f"council file {config_path}: 'candidates' must be a non-empty list"
+        raise RuntimeError(msg)
+    raw_judge = parsed.get("judge")
+    if not isinstance(raw_judge, dict):
+        msg = f"council file {config_path}: 'judge' is required and must be a mapping"
+        raise RuntimeError(msg)
+
+    logger.info(
+        "openai_agents_runner session=%s: council file %s parsed OK: %d candidates, "
+        "judge model=%r, timeout=%r",
+        manifest.session_id,
+        config_path,
+        len(raw_candidates),
+        raw_judge.get("model"),
+        parsed.get("timeout"),
+    )
+    return cast("dict[str, Any]", parsed)
 
 
 def _resolve_tokens_sidecar_path(manifest: RunnerManifest) -> Path:
@@ -893,6 +1079,27 @@ def run(manifest: RunnerManifest) -> int:
         },
     )
 
+    # Resolve a task-level council config BEFORE any other SDK work, so a
+    # malformed council YAML file (missing/unreadable/missing
+    # candidates-or-judge) fails loudly at startup instead of mid-session.
+    # When ``manifest.model`` names a council file this REPLACES ``manifest``
+    # with a copy carrying ``council`` populated - every downstream read of
+    # ``manifest.council`` (here and in ``_run_session``) sees the resolved
+    # config from this point on.
+    try:
+        council_cfg = _load_council_config(manifest)
+    except RuntimeError as exc:
+        emit_event(
+            {
+                "type": "error",
+                "kind": "config_invalid",
+                "message": str(exc),
+            },
+        )
+        return EXIT_MANIFEST_ERROR
+    if council_cfg is not None and manifest.council is None:
+        manifest = dataclasses.replace(manifest, council=council_cfg)
+
     # Resolve the endpoint override before any SDK work so a missing key
     # env var fails loudly at startup instead of mid-session.
     try:
@@ -962,7 +1169,14 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
     # built against explicitly (see the ``explicit_model_client`` usage
     # below ``_build_agent_kwargs``).
     explicit_model_client: Any = None
-    if client_kwargs:
+    if client_kwargs and manifest.council is None:
+        # Skipped when ``manifest.council`` is set: a council role builds
+        # one dedicated ``AsyncOpenAI`` client PER council member (see
+        # ``bernstein.adapters.council_runner.run_council``), so the single
+        # top-level client/default-client dance here does not apply - each
+        # member resolves its own endpoint independently of the role's
+        # top-level ``base_url``/``api_key_env``.
+        #
         # The manifest overrides the endpoint and/or API key.  Hand the SDK
         # a dedicated client instead of letting it read the ambient
         # OPENAI_* environment.
@@ -1022,7 +1236,28 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
     max_turns: int | None = None
     try:
         agent_kwargs = _build_agent_kwargs(manifest)
-        if explicit_model_client is not None:
+        if manifest.council is not None:
+            # TASK-LEVEL council override: this role's ENTIRE task run is
+            # driven by N candidate models running the whole task
+            # independently in parallel, then a judge model synthesizes one
+            # improved answer from their outputs - see
+            # ``bernstein.adapters.council_runner.run_council``, called
+            # below instead of ``Runner.run_sync``. ``_build_agent_kwargs``
+            # already left this base agent's ``model`` unset (``None``) for
+            # a council role (manifest.model only ever names the council
+            # YAML file, never a real model id) - ``run_council`` builds
+            # each candidate/judge's own model via
+            # ``agent.clone(model=...)`` off this same base definition, so
+            # no model needs to be set on ``agent_kwargs`` here.
+            logger.info(
+                "openai_agents_runner session=%s: council enabled for this role (%d "
+                "candidates configured) - manifest.model=%r names the council file, "
+                "not a real model id",
+                manifest.session_id,
+                len(manifest.council.get("candidates", [])),
+                manifest.model,
+            )
+        elif explicit_model_client is not None:
             # Never log the client itself (it carries the API key) - only
             # the model id and base_url, both non-secret.
             logger.info(
@@ -1104,155 +1339,175 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
         max_turns = _resolve_max_turns(manifest.max_turns)
         if max_turns is not None:
             run_sync_kwargs["max_turns"] = max_turns
-        # [DEEPSEEK-DEBUG] Unconditional (not gated behind a debug flag)
-        # pre-call diagnostic for the deepseek/deepseek-chat-via-OpenRouter
-        # empty-completion / malformed-tool-call investigation (2026-07-03).
-        # Logged at INFO so it is captured on every run without operator
-        # opt-in. Never logs the API key itself - only the env var NAME.
-        _model_settings_obj = agent_kwargs.get("model_settings")
-        _model_settings_repr = (
-            {
-                "temperature": getattr(_model_settings_obj, "temperature", None),
-                "top_p": getattr(_model_settings_obj, "top_p", None),
-                "tool_choice": getattr(_model_settings_obj, "tool_choice", None),
-                "parallel_tool_calls": getattr(_model_settings_obj, "parallel_tool_calls", None),
-                "max_tokens": getattr(_model_settings_obj, "max_tokens", None),
-                "extra_args": getattr(_model_settings_obj, "extra_args", None),
-                # extra_headers/extra_body are the SDK-conventional home for
-                # provider auth (Authorization/api-key). Log only the KEY NAMES,
-                # never the values, so this diagnostic can never leak a secret
-                # if an auth header is ever configured here.
-                "extra_headers_keys": _redacted_keys(getattr(_model_settings_obj, "extra_headers", None)),
-                "extra_body_keys": _redacted_keys(getattr(_model_settings_obj, "extra_body", None)),
-            }
-            if _model_settings_obj is not None
-            else "<no ModelSettings constructed - settings_kwargs was empty>"
-        )
-        _tool_list_for_log = agent_kwargs.get("tools", [])
-        # Only the NAME of the credential environment variable is logged here,
-        # never the secret value it resolves to.
-        _key_env_name_for_log = manifest.api_key_env
-        logger.info(
-            "[DEEPSEEK-DEBUG] pre-call session=%s model=%r base_url=%r api_key_env=%r "
-            "explicit_model_client=%s tool_source=%r tool_count=%d max_turns=%s",
-            manifest.session_id,
-            manifest.model,
-            manifest.base_url,
-            _key_env_name_for_log,
-            explicit_model_client is not None,
-            manifest.tool_source,
-            len(_tool_list_for_log),
-            max_turns,
-        )
-        logger.info(
-            "[DEEPSEEK-DEBUG] pre-call session=%s model_settings=%s "
-            "(tool_choice/parallel_tool_calls of None means the SDK/provider "
-            "default applies - bernstein never sets these explicitly)",
-            manifest.session_id,
-            _model_settings_repr,
-        )
-        logger.info(
-            "[DEEPSEEK-DEBUG] pre-call session=%s no extra_headers configured by bernstein "
-            "(no HTTP-Referer/X-Title sent to OpenRouter unless the SDK's own default "
-            "HEADERS constant includes them) - client_kwargs base_url=%r",
-            manifest.session_id,
-            client_kwargs.get("base_url"),
-        )
-        try:
-            _tool_schema_summary = _deepseek_debug_tool_schema_summary(_tool_list_for_log)
+        if manifest.council is not None:
+            # Task-level council: run N candidates through the WHOLE task
+            # in parallel, then a judge synthesizes one answer from their
+            # outputs. Imported lazily (not at module top level) to match
+            # this module's existing lazy-SDK-adjacent-import convention
+            # for optional adapter subsystems (see the
+            # ``bernstein.adapters.openai_agents_builtins`` import elsewhere
+            # in this function). ``run_council`` resolves its own
+            # ``max_turns`` internally (mirrors this same
+            # ``_resolve_max_turns`` call), so it is not forwarded here.
+            from bernstein.adapters.council_runner import run_council
+
             logger.info(
-                "[DEEPSEEK-DEBUG] pre-call session=%s tool_schemas=%s",
+                "openai_agents_runner session=%s: running task-level council instead of "
+                "a single Runner.run_sync call (%d candidates configured)",
                 manifest.session_id,
-                json.dumps(_tool_schema_summary, default=str)[:8000],
+                len(manifest.council.get("candidates", [])),
             )
-            _any_strict_true = any(entry.get("strict_json_schema") is True for entry in _tool_schema_summary)
-            if _any_strict_true:
-                logger.warning(
-                    "[DEEPSEEK-DEBUG] pre-call session=%s: at least one tool schema has "
-                    "strict_json_schema=True - the OpenAI Agents SDK sends this as "
-                    "'strict': true in the ChatCompletionToolParam.function block "
-                    "(agents/models/chatcmpl_converter.py Converter.tool_to_openai). "
-                    "This is the leading hypothesis for deepseek-chat-via-OpenRouter "
-                    "empty/malformed tool_calls - deepseek's function calling is not "
-                    "confirmed to fully support OpenAI's strict structured-output mode.",
-                    manifest.session_id,
-                )
-        except Exception as exc:  # diagnostics only - never mask the real failure
-            logger.warning(
-                "[DEEPSEEK-DEBUG] pre-call session=%s: tool schema logging itself failed: %s: %s",
-                manifest.session_id,
-                type(exc).__name__,
-                exc,
-            )
-
-        # ``Runner.run_sync`` is the SDK's synchronous API - we avoid
-        # ``asyncio.run`` here so the runner stays compatible with
-        # environments where the event loop is already running
-        # (e.g. pytest-asyncio tests that import this module). ``max_turns``
-        # is only forwarded when configured (env/tuning) - omitting the
-        # kwarg preserves the SDK's own default exactly, as before.
-        result: Any = runner_cls.run_sync(agent, manifest.prompt, **run_sync_kwargs)
-
-        # [DEEPSEEK-DEBUG] Unconditional post-call diagnostic: dump as much
-        # of the raw SDK response shape as is discoverable so an empty
-        # completion (zero usage, empty summary) or a malformed-tool-call
-        # response is a direct log read instead of a re-run-and-guess.
-        try:
-            _raw_responses = getattr(result, "raw_responses", None) or []
-            _raw_summaries: list[dict[str, Any]] = []
-            for _rr in _raw_responses:
-                _rr_usage = getattr(_rr, "usage", None)
-                _output = getattr(_rr, "output", None)
-                _choices = getattr(_rr, "choices", None)
-                _summary: dict[str, Any] = {
-                    "usage": {
-                        "input_tokens": getattr(_rr_usage, "input_tokens", None),
-                        "output_tokens": getattr(_rr_usage, "output_tokens", None),
-                        "raw": str(_rr_usage) if _rr_usage is not None else None,
-                    },
+            result: Any = run_council(agent, manifest.prompt, manifest.council, manifest)
+        else:
+            # [DEEPSEEK-DEBUG] Unconditional (not gated behind a debug flag)
+            # pre-call diagnostic for the deepseek/deepseek-chat-via-OpenRouter
+            # empty-completion / malformed-tool-call investigation (2026-07-03).
+            # Logged at INFO so it is captured on every run without operator
+            # opt-in. Never logs the API key itself - only the env var NAME.
+            _model_settings_obj = agent_kwargs.get("model_settings")
+            _model_settings_repr = (
+                {
+                    "temperature": getattr(_model_settings_obj, "temperature", None),
+                    "top_p": getattr(_model_settings_obj, "top_p", None),
+                    "tool_choice": getattr(_model_settings_obj, "tool_choice", None),
+                    "parallel_tool_calls": getattr(_model_settings_obj, "parallel_tool_calls", None),
+                    "max_tokens": getattr(_model_settings_obj, "max_tokens", None),
+                    "extra_args": getattr(_model_settings_obj, "extra_args", None),
+                    # extra_headers/extra_body are the SDK-conventional home for
+                    # provider auth (Authorization/api-key). Log only the KEY NAMES,
+                    # never the values, so this diagnostic can never leak a secret
+                    # if an auth header is ever configured here.
+                    "extra_headers_keys": _redacted_keys(getattr(_model_settings_obj, "extra_headers", None)),
+                    "extra_body_keys": _redacted_keys(getattr(_model_settings_obj, "extra_body", None)),
                 }
-                if _choices is not None:
-                    _choice_summaries = []
-                    for _choice in _choices:
-                        _message = getattr(_choice, "message", None)
-                        _choice_summaries.append(
-                            {
-                                "finish_reason": getattr(_choice, "finish_reason", None),
-                                "content": getattr(_message, "content", None) if _message else None,
-                                "refusal": getattr(_message, "refusal", None) if _message else None,
-                                "tool_calls": str(getattr(_message, "tool_calls", None)) if _message else None,
-                            },
-                        )
-                    _summary["choices"] = _choice_summaries
-                if _output is not None:
-                    _summary["output"] = str(_output)[:4000]
-                _raw_summaries.append(_summary)
+                if _model_settings_obj is not None
+                else "<no ModelSettings constructed - settings_kwargs was empty>"
+            )
+            _tool_list_for_log = agent_kwargs.get("tools", [])
+            # Only the NAME of the credential environment variable is logged here,
+            # never the secret value it resolves to.
+            _key_env_name_for_log = manifest.api_key_env
             logger.info(
-                "[DEEPSEEK-DEBUG] post-call session=%s model=%s raw_responses_count=%d "
-                "final_output=%r raw_responses=%s",
+                "[DEEPSEEK-DEBUG] pre-call session=%s model=%r base_url=%r api_key_env=%r "
+                "explicit_model_client=%s tool_source=%r tool_count=%d max_turns=%s",
                 manifest.session_id,
                 manifest.model,
-                len(_raw_responses),
-                str(getattr(result, "final_output", ""))[:2000],
-                json.dumps(_raw_summaries, default=str)[:8000],
+                manifest.base_url,
+                _key_env_name_for_log,
+                explicit_model_client is not None,
+                manifest.tool_source,
+                len(_tool_list_for_log),
+                max_turns,
             )
-            _result_usage = getattr(result, "usage", None)
             logger.info(
-                "[DEEPSEEK-DEBUG] post-call session=%s result.usage=%r "
-                "(RunResult/RunResultBase does not define 'usage' on installed SDK "
-                "0.17.7 per _extract_usage_tokens's docstring - expect None here; "
-                "the raw_responses per-call usage above is the real signal)",
+                "[DEEPSEEK-DEBUG] pre-call session=%s model_settings=%s "
+                "(tool_choice/parallel_tool_calls of None means the SDK/provider "
+                "default applies - bernstein never sets these explicitly)",
                 manifest.session_id,
-                _result_usage,
+                _model_settings_repr,
             )
-        except Exception as exc:  # diagnostics only - never mask the real failure
-            logger.warning(
-                "[DEEPSEEK-DEBUG] post-call session=%s: raw response logging itself "
-                "failed (SDK shape may differ from expected): %s: %s",
+            logger.info(
+                "[DEEPSEEK-DEBUG] pre-call session=%s no extra_headers configured by bernstein "
+                "(no HTTP-Referer/X-Title sent to OpenRouter unless the SDK's own default "
+                "HEADERS constant includes them) - client_kwargs base_url=%r",
                 manifest.session_id,
-                type(exc).__name__,
-                exc,
+                client_kwargs.get("base_url"),
             )
+            try:
+                _tool_schema_summary = _deepseek_debug_tool_schema_summary(_tool_list_for_log)
+                logger.info(
+                    "[DEEPSEEK-DEBUG] pre-call session=%s tool_schemas=%s",
+                    manifest.session_id,
+                    json.dumps(_tool_schema_summary, default=str)[:8000],
+                )
+                _any_strict_true = any(entry.get("strict_json_schema") is True for entry in _tool_schema_summary)
+                if _any_strict_true:
+                    logger.warning(
+                        "[DEEPSEEK-DEBUG] pre-call session=%s: at least one tool schema has "
+                        "strict_json_schema=True - the OpenAI Agents SDK sends this as "
+                        "'strict': true in the ChatCompletionToolParam.function block "
+                        "(agents/models/chatcmpl_converter.py Converter.tool_to_openai). "
+                        "This is the leading hypothesis for deepseek-chat-via-OpenRouter "
+                        "empty/malformed tool_calls - deepseek's function calling is not "
+                        "confirmed to fully support OpenAI's strict structured-output mode.",
+                        manifest.session_id,
+                    )
+            except Exception as exc:  # diagnostics only - never mask the real failure
+                logger.warning(
+                    "[DEEPSEEK-DEBUG] pre-call session=%s: tool schema logging itself failed: %s: %s",
+                    manifest.session_id,
+                    type(exc).__name__,
+                    exc,
+                )
+
+            # ``Runner.run_sync`` is the SDK's synchronous API - we avoid
+            # ``asyncio.run`` here so the runner stays compatible with
+            # environments where the event loop is already running
+            # (e.g. pytest-asyncio tests that import this module). ``max_turns``
+            # is only forwarded when configured (env/tuning) - omitting the
+            # kwarg preserves the SDK's own default exactly, as before.
+            result = runner_cls.run_sync(agent, manifest.prompt, **run_sync_kwargs)
+
+            # [DEEPSEEK-DEBUG] Unconditional post-call diagnostic: dump as much
+            # of the raw SDK response shape as is discoverable so an empty
+            # completion (zero usage, empty summary) or a malformed-tool-call
+            # response is a direct log read instead of a re-run-and-guess.
+            try:
+                _raw_responses = getattr(result, "raw_responses", None) or []
+                _raw_summaries: list[dict[str, Any]] = []
+                for _rr in _raw_responses:
+                    _rr_usage = getattr(_rr, "usage", None)
+                    _output = getattr(_rr, "output", None)
+                    _choices = getattr(_rr, "choices", None)
+                    _summary: dict[str, Any] = {
+                        "usage": {
+                            "input_tokens": getattr(_rr_usage, "input_tokens", None),
+                            "output_tokens": getattr(_rr_usage, "output_tokens", None),
+                            "raw": str(_rr_usage) if _rr_usage is not None else None,
+                        },
+                    }
+                    if _choices is not None:
+                        _choice_summaries = []
+                        for _choice in _choices:
+                            _message = getattr(_choice, "message", None)
+                            _choice_summaries.append(
+                                {
+                                    "finish_reason": getattr(_choice, "finish_reason", None),
+                                    "content": getattr(_message, "content", None) if _message else None,
+                                    "refusal": getattr(_message, "refusal", None) if _message else None,
+                                    "tool_calls": str(getattr(_message, "tool_calls", None)) if _message else None,
+                                },
+                            )
+                        _summary["choices"] = _choice_summaries
+                    if _output is not None:
+                        _summary["output"] = str(_output)[:4000]
+                    _raw_summaries.append(_summary)
+                logger.info(
+                    "[DEEPSEEK-DEBUG] post-call session=%s model=%s raw_responses_count=%d "
+                    "final_output=%r raw_responses=%s",
+                    manifest.session_id,
+                    manifest.model,
+                    len(_raw_responses),
+                    str(getattr(result, "final_output", ""))[:2000],
+                    json.dumps(_raw_summaries, default=str)[:8000],
+                )
+                _result_usage = getattr(result, "usage", None)
+                logger.info(
+                    "[DEEPSEEK-DEBUG] post-call session=%s result.usage=%r "
+                    "(RunResult/RunResultBase does not define 'usage' on installed SDK "
+                    "0.17.7 per _extract_usage_tokens's docstring - expect None here; "
+                    "the raw_responses per-call usage above is the real signal)",
+                    manifest.session_id,
+                    _result_usage,
+                )
+            except Exception as exc:  # diagnostics only - never mask the real failure
+                logger.warning(
+                    "[DEEPSEEK-DEBUG] post-call session=%s: raw response logging itself "
+                    "failed (SDK shape may differ from expected): %s: %s",
+                    manifest.session_id,
+                    type(exc).__name__,
+                    exc,
+                )
     except Exception as exc:  # SDK errors are varied - catch broadly
         # D2 MiniMax attempt-3 (2026-07-03): agents that die on an
         # exception - especially ``MaxTurnsExceeded``, which by definition

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -59,6 +59,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse
 
 import yaml
 
@@ -446,9 +447,9 @@ def _build_agent_kwargs(manifest: RunnerManifest) -> dict[str, Any]:
     return kwargs
 
 
-# Alibaba Cloud (DashScope/MaaS) OpenAI-compatible endpoints. Substring match
-# against ``base_url`` - covers both the public DashScope host
-# (``dashscope.aliyuncs.com``) and the MaaS variant
+# Alibaba Cloud (DashScope/MaaS) OpenAI-compatible endpoints. Host-suffix
+# match against ``base_url``'s hostname - covers both the public DashScope
+# host (``dashscope.aliyuncs.com``) and the MaaS variant
 # (``maas.aliyuncs.com``) mentioned in Alibaba's own function-calling docs.
 _ALIBABA_BASE_URL_MARKERS: tuple[str, ...] = ("aliyuncs.com",)
 
@@ -460,11 +461,19 @@ def _is_alibaba_cloud_endpoint(base_url: str | None) -> bool:
     "thinking" mode, which makes the model reason its way out of calling
     tools and write ad-hoc scripts instead - Alibaba's own function-calling
     docs show ``extra_body={"enable_thinking": False}`` on every
-    tool-calling request as the fix. Detection is a simple substring match
-    so both the public DashScope host and any ``*.aliyuncs.com`` MaaS
-    variant are covered without hardcoding a specific hostname.
+    tool-calling request as the fix. Detection matches the URL's hostname
+    (exact or dot-suffix) so both the public DashScope host and any
+    ``*.aliyuncs.com`` MaaS variant are covered without hardcoding a
+    specific hostname - and so a URL that merely CONTAINS the marker in
+    its path or in an unrelated hostname (e.g. ``notaliyuncs.com``) never
+    triggers the injection on another provider.
     """
-    return bool(base_url) and any(marker in cast("str", base_url) for marker in _ALIBABA_BASE_URL_MARKERS)
+    if not base_url or not isinstance(base_url, str):
+        return False
+    # ``urlparse`` only populates ``hostname`` when a netloc is present;
+    # prefix ``//`` for scheme-less values so a bare host still parses.
+    host = urlparse(base_url if "//" in base_url else f"//{base_url}").hostname or ""
+    return any(host == marker or host.endswith(f".{marker}") for marker in _ALIBABA_BASE_URL_MARKERS)
 
 
 def _inject_alibaba_enable_thinking(

--- a/src/bernstein/core/agents/spawner_warm_pool.py
+++ b/src/bernstein/core/agents/spawner_warm_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.models import ModelConfig, Task
@@ -176,6 +177,15 @@ def _select_batch_config(
 
     def _route_for_batch(task: Task) -> ModelConfig:
         """Batch-specific routing: consult bandit when available, else heuristics."""
+        print(
+            f"[SPAWNER-DEBUG] _route_for_batch: task.id={task.id!r}, task.role={task.role!r}, "
+            f"task.model={task.model!r}, task.effort={task.effort!r}. "
+            "NOTE: role_model_policy is not passed into _select_batch_config/_route_for_batch's "
+            "scope - the caller (spawner_core.py) resolves role_model_policy separately via "
+            "self._role_model_policy.get(task.role, {}) after this function returns.",
+            file=sys.stderr,
+            flush=True,
+        )
         if task.model or task.effort:
             return ModelConfig(model=task.model or "sonnet", effort=task.effort or "normal")
         if task.role in _HIGH_STAKES_ROLES or task.scope == Scope.LARGE or task.priority == 1:

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -159,7 +159,7 @@ class CouncilCandidateConfig(BaseModel):
 
 
 class CouncilConfig(BaseModel):
-    """"Council of agents" fan-out/judge configuration for one role.
+    """ "Council of agents" fan-out/judge configuration for one role.
 
     When set on a :class:`RoleModelPolicyEntry` (or loaded from a
     ``role_model_policy.<role>.model: "*.yaml"`` council definition file -

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -139,6 +139,48 @@ class QualityGatesSchema(BaseModel):
     verify_citations_allowed_hosts: list[str] | None = None
 
 
+class CouncilCandidateConfig(BaseModel):
+    """One candidate (or judge) endpoint in a ``council`` block.
+
+    Mirrors the subset of :class:`RoleModelPolicyEntry`'s endpoint fields
+    a single council member needs: which model, and optionally which
+    OpenAI-compatible endpoint/credential to reach it through. ``base_url``
+    /``api_key_env`` follow the exact same semantics and fail-closed
+    credential-allowlist validation as the top-level role policy fields of
+    the same name (see :class:`RoleModelPolicyEntry`) - ``api_key_env`` is
+    always the NAME of an environment variable, never a literal key.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model: str
+    base_url: str | None = None
+    api_key_env: str | None = None
+
+
+class CouncilConfig(BaseModel):
+    """"Council of agents" fan-out/judge configuration for one role.
+
+    When set on a :class:`RoleModelPolicyEntry` (or loaded from a
+    ``role_model_policy.<role>.model: "*.yaml"`` council definition file -
+    see ``openai_agents_runner._load_council_config``), the role's ENTIRE
+    task run is driven by a task-level council instead of a single model:
+    every ``candidates`` entry runs the WHOLE task independently in
+    parallel (its own full multi-turn run), then ``judge`` synthesizes one
+    improved answer from whichever candidates survived. See
+    ``src/bernstein/adapters/council_runner.py`` (``run_council``) for the
+    runtime implementation and ``openai_agents_runner._run_session``'s
+    ``manifest.council`` branch for how this config drives a run instead of
+    a single ``Runner.run_sync`` call.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    candidates: list[CouncilCandidateConfig]
+    judge: CouncilCandidateConfig
+    timeout: float = 60.0
+
+
 class RoleModelPolicyEntry(BaseModel):
     """Per-role model/provider policy.
 
@@ -178,6 +220,12 @@ class RoleModelPolicyEntry(BaseModel):
     top_k: int | None = None
     max_tokens: int | None = None
     extra_params: dict[str, Any] = Field(default_factory=dict)
+    # Optional "council of agents" fan-out/judge override (see
+    # ``CouncilConfig``). When set, this role's ENTIRE task run is driven by
+    # a task-level council (``bernstein.adapters.council_runner.run_council``)
+    # instead of a single model; ``model``/``base_url``/``api_key_env`` above
+    # are then ignored in favor of the council's own per-candidate endpoints.
+    council: CouncilConfig | None = None
 
 
 class RoleConfigEntry(BaseModel):

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -710,9 +710,7 @@ def _parse_council_candidate(role: str, member: str, raw: object) -> dict[str, s
 
     unknown_keys = sorted(set(raw) - set(_COUNCIL_CANDIDATE_KEYS))
     if unknown_keys:
-        raise SeedError(
-            f"role_model_policy[{role!r}].council.{member} has unknown keys: {', '.join(unknown_keys)}"
-        )
+        raise SeedError(f"role_model_policy[{role!r}].council.{member} has unknown keys: {', '.join(unknown_keys)}")
     return parsed
 
 
@@ -741,9 +739,7 @@ def _parse_council(role: str, raw: object) -> dict[str, object]:
     raw_candidates = raw.get("candidates")
     if not isinstance(raw_candidates, list) or not raw_candidates:
         raise SeedError(f"role_model_policy[{role!r}].council.candidates must be a non-empty list")
-    candidates = [
-        _parse_council_candidate(role, f"candidates[{i}]", entry) for i, entry in enumerate(raw_candidates)
-    ]
+    candidates = [_parse_council_candidate(role, f"candidates[{i}]", entry) for i, entry in enumerate(raw_candidates)]
 
     raw_judge = raw.get("judge")
     if raw_judge is None:

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -633,14 +633,14 @@ def _parse_bridge_settings(raw: object) -> BridgeConfigSet | None:
     return BridgeConfigSet(openclaw=_parse_openclaw_runtime_config(data.get("openclaw")))
 
 
-def _parse_role_model_policy(raw: object) -> dict[str, dict[str, str | int]] | None:
+def _parse_role_model_policy(raw: object) -> dict[str, dict[str, str | int | dict[str, object]]] | None:
     """Parse optional role-specific provider/model overrides."""
     if raw is None:
         return None
     if not isinstance(raw, dict):
         raise SeedError("role_model_policy must be a mapping of role -> settings")
 
-    parsed: dict[str, dict[str, str | int]] = {}
+    parsed: dict[str, dict[str, str | int | dict[str, object]]] = {}
     for role, settings in raw.items():
         if not isinstance(role, str) or not role:
             raise SeedError("role_model_policy keys must be non-empty role strings")
@@ -666,8 +666,105 @@ _ROLE_POLICY_KEYS: tuple[str, ...] = (
 # "unknown keys: max_tokens" (parser/schema divergence fixed here).
 _ROLE_POLICY_INT_KEYS: tuple[str, ...] = ("max_tokens",)
 
+# ``council`` is parsed and validated separately (its value is a nested
+# mapping, not a scalar string/int like every other role-policy key), so it
+# is carved out of the unknown-keys check in ``_parse_single_role_policy``
+# rather than added to ``_ROLE_POLICY_KEYS``.
+_ROLE_POLICY_COUNCIL_KEY = "council"
 
-def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | int]:
+_COUNCIL_CANDIDATE_KEYS: tuple[str, ...] = ("model", "base_url", "api_key_env")
+
+
+def _parse_council_candidate(role: str, member: str, raw: object) -> dict[str, str]:
+    """Parse one ``candidates[]`` entry or the ``judge`` entry of a council block.
+
+    ``member`` is a human-readable label (``"candidates[0]"`` or
+    ``"judge"``) used only for error messages. ``model`` is required;
+    ``base_url``/``api_key_env`` are optional and follow the same
+    fail-closed ``api_key_env`` credential-allowlist validation as the
+    top-level role policy fields of the same name.
+    """
+    if not isinstance(raw, dict):
+        raise SeedError(f"role_model_policy[{role!r}].council.{member} must be a mapping")
+
+    model = raw.get("model")
+    if not isinstance(model, str) or not model:
+        raise SeedError(f"role_model_policy[{role!r}].council.{member}.model must be a non-empty string")
+    parsed: dict[str, str] = {"model": model}
+
+    for key in ("base_url", "api_key_env"):
+        value = raw.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value:
+            raise SeedError(f"role_model_policy[{role!r}].council.{member}.{key} must be a non-empty string")
+        parsed[key] = value
+
+    if "api_key_env" in parsed:
+        from bernstein.adapters.openai_agents_runner import validate_api_key_env_name
+
+        try:
+            validate_api_key_env_name(parsed["api_key_env"])
+        except RuntimeError as exc:
+            raise SeedError(f"role_model_policy[{role!r}].council.{member}.api_key_env: {exc}") from exc
+
+    unknown_keys = sorted(set(raw) - set(_COUNCIL_CANDIDATE_KEYS))
+    if unknown_keys:
+        raise SeedError(
+            f"role_model_policy[{role!r}].council.{member} has unknown keys: {', '.join(unknown_keys)}"
+        )
+    return parsed
+
+
+def _parse_council(role: str, raw: object) -> dict[str, object]:
+    """Parse the optional ``council:`` block of a role's model policy.
+
+    Shape (mirrors :class:`bernstein.core.config.config_schema.CouncilConfig`)::
+
+        council:
+          candidates:
+            - model: gpt-5-mini
+            - model: deepseek/deepseek-v4-flash
+              base_url: https://openrouter.ai/api/v1
+              api_key_env: OPENROUTER_API_KEY
+          judge:
+            model: gpt-5
+          timeout: 60.0
+
+    ``candidates`` must be a non-empty list; ``judge`` is required.
+    ``timeout`` is optional and defaults to 60.0 seconds (matching
+    ``CouncilConfig.timeout``'s Pydantic default) when absent.
+    """
+    if not isinstance(raw, dict):
+        raise SeedError(f"role_model_policy[{role!r}].council must be a mapping")
+
+    raw_candidates = raw.get("candidates")
+    if not isinstance(raw_candidates, list) or not raw_candidates:
+        raise SeedError(f"role_model_policy[{role!r}].council.candidates must be a non-empty list")
+    candidates = [
+        _parse_council_candidate(role, f"candidates[{i}]", entry) for i, entry in enumerate(raw_candidates)
+    ]
+
+    raw_judge = raw.get("judge")
+    if raw_judge is None:
+        raise SeedError(f"role_model_policy[{role!r}].council.judge is required")
+    judge = _parse_council_candidate(role, "judge", raw_judge)
+
+    parsed: dict[str, object] = {"candidates": candidates, "judge": judge}
+
+    raw_timeout = raw.get("timeout")
+    if raw_timeout is not None:
+        if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, (int, float)) or raw_timeout <= 0:
+            raise SeedError(f"role_model_policy[{role!r}].council.timeout must be a positive number")
+        parsed["timeout"] = float(raw_timeout)
+
+    unknown_keys = sorted(set(raw) - {"candidates", "judge", "timeout"})
+    if unknown_keys:
+        raise SeedError(f"role_model_policy[{role!r}].council has unknown keys: {', '.join(unknown_keys)}")
+    return parsed
+
+
+def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | int | dict[str, object]]:
     """Parse and validate a single role's model policy settings.
 
     ``base_url`` and ``api_key_env`` are optional per-role endpoint
@@ -682,11 +779,30 @@ def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | in
     (see :data:`_ROLE_POLICY_INT_KEYS`); it is validated as a positive int
     here and flows unchanged into
     :meth:`bernstein.core.agents.spawner_core.AgentSpawner._apply_sampling_overrides`.
+
+    ``council`` is an optional "council of agents" fan-out/judge block (see
+    :func:`_parse_council` and
+    :class:`bernstein.core.config.config_schema.CouncilConfig`). When
+    present, it is parsed into a nested dict and carried under the
+    ``"council"`` key alongside the scalar fields above - the adapter/spawn
+    path is responsible for using it to drive a TASK-LEVEL council run
+    (``bernstein.adapters.council_runner.run_council``) instead of a single
+    model for this role.
+
+    A separate, simpler convention also produces a council run: setting
+    ``model`` itself to a ``.yaml``/``.yml`` path (e.g.
+    ``"councils/planning.yaml"``) instead of a real model id. That path is
+    stored here completely unresolved/unvalidated - deliberately, so a seed
+    file with a council-file reference for a role parses successfully even
+    when the file's contents are only meaningful at run time, in the
+    worktree, relative to ``.bernstein/``. The runner
+    (``openai_agents_runner._load_council_config``) is what actually
+    resolves and loads it, at spawn/run time, not here.
     """
     if not isinstance(settings, dict):
         raise SeedError(f"role_model_policy[{role!r}] must be a mapping")
 
-    normalized: dict[str, str | int] = {}
+    normalized: dict[str, str | int | dict[str, object]] = {}
     for key in _ROLE_POLICY_KEYS:
         value = settings.get(key)
         if value is None:
@@ -718,7 +834,11 @@ def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | in
     if "cli" in normalized and "provider" not in normalized:
         normalized["provider"] = normalized["cli"]
 
-    allowed_keys = set(_ROLE_POLICY_KEYS) | set(_ROLE_POLICY_INT_KEYS)
+    raw_council = settings.get(_ROLE_POLICY_COUNCIL_KEY)
+    if raw_council is not None:
+        normalized[_ROLE_POLICY_COUNCIL_KEY] = _parse_council(role, raw_council)
+
+    allowed_keys = set(_ROLE_POLICY_KEYS) | set(_ROLE_POLICY_INT_KEYS) | {_ROLE_POLICY_COUNCIL_KEY}
     unknown_keys = sorted(set(settings) - allowed_keys)
     if unknown_keys:
         raise SeedError(f"role_model_policy[{role!r}] has unknown keys: {', '.join(unknown_keys)}")

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4858,6 +4858,7 @@ def _collect_smtp_targets(seed: Any, targets: list[NotificationTarget]) -> None:
 if __name__ == "__main__":
     import argparse
     import sys
+    import traceback
     from pathlib import Path
 
     from bernstein.adapters.registry import get_adapter
@@ -4884,6 +4885,21 @@ if __name__ == "__main__":
     _model_env_default = os.environ.get("BERNSTEIN_MODEL", "").strip() or None
     parser.add_argument("--model", type=str, default=_model_env_default)
     args = parser.parse_args()
+
+    print(f"[SPAWNER-DEBUG] orchestrator __main__: parsed CLI args={vars(args)!r}", file=sys.stderr, flush=True)
+    print(
+        f"[SPAWNER-DEBUG] orchestrator __main__: BERNSTEIN_SEED_PATH env var="
+        f"{os.environ.get('BERNSTEIN_SEED_PATH', '<unset>')!r}",
+        file=sys.stderr,
+        flush=True,
+    )
+    print(
+        f"[SPAWNER-DEBUG] orchestrator __main__: BERNSTEIN_ADAPTER env var="
+        f"{os.environ.get('BERNSTEIN_ADAPTER', '<unset>')!r}, BERNSTEIN_MODEL env var="
+        f"{os.environ.get('BERNSTEIN_MODEL', '<unset>')!r}",
+        file=sys.stderr,
+        flush=True,
+    )
 
     workdir = Path.cwd()
 
@@ -4957,17 +4973,71 @@ if __name__ == "__main__":
         # the real store is set after the orchestrator assigns its run_id below.
         pass  # store will be set after orchestrator is instantiated
 
+    print("[SPAWNER-DEBUG] orchestrator __main__: entering top-level try block", file=sys.stderr, flush=True)
     try:
         # Try to load adapter from seed if available
         adapter_name = args.adapter
         seed_path = workdir / _BERNSTEIN_YAML
+        logger.info(
+            "orchestrator __main__: resolved seed_path=%s (exists=%s)",
+            seed_path,
+            seed_path.exists(),
+        )
         seed: SeedConfig | None = None
         if seed_path.exists():
+            print(
+                f"[SPAWNER-DEBUG] orchestrator __main__: seed file exists at {seed_path}, "
+                "attempting parse_seed()",
+                file=sys.stderr,
+                flush=True,
+            )
             try:
                 seed = parse_seed(seed_path)
                 adapter_name = getattr(seed, "cli", adapter_name)
+                _seed_role_model_policy = getattr(seed, "role_model_policy", None)
+                if not _seed_role_model_policy:
+                    print(
+                        "[SPAWNER-DEBUG] orchestrator __main__: role_model_policy is None/empty "
+                        f"after seed parse (seed_path={seed_path})",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                else:
+                    print(
+                        "[SPAWNER-DEBUG] orchestrator __main__: parsed role_model_policy="
+                        f"{json.dumps(_seed_role_model_policy, default=str)}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                print(
+                    "[SPAWNER-DEBUG] orchestrator __main__: seed parse SUCCESS - cli="
+                    f"{getattr(seed, 'cli', None)!r}, top-level model="
+                    f"{getattr(seed, 'model', None)!r}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                logger.info(
+                    "orchestrator __main__: parsed seed from %s (cli=%s, model=%s, role_model_policy=%s)",
+                    seed_path,
+                    getattr(seed, "cli", None),
+                    getattr(seed, "model", None),
+                    getattr(seed, "role_model_policy", None),
+                )
             except Exception as exc:
+                print(
+                    f"[SPAWNER-DEBUG] orchestrator __main__: seed parse FAILED for {seed_path}: "
+                    f"{exc!r}\n{traceback.format_exc()}",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 logger.warning("Failed to parse seed for adapter config: %s", exc)
+        else:
+            print(
+                f"[SPAWNER-DEBUG] orchestrator __main__: seed file does NOT exist at {seed_path} "
+                "- role_model_policy and model will be unset from seed",
+                file=sys.stderr,
+                flush=True,
+            )
 
         # Run-level model: ``--model`` flag (threaded from ``bernstein run
         # --model``) wins, falling back to the seed's resolved model (also
@@ -4976,6 +5046,13 @@ if __name__ == "__main__":
         # so child-task spawns can coerce Claude tier names for non-Claude
         # adapters instead of passing them through literally.
         run_model: str | None = args.model or (getattr(seed, "model", None) if seed else None)
+        print(
+            f"[SPAWNER-DEBUG] orchestrator __main__: resolved run_model={run_model!r} "
+            f"(args.model={args.model!r}, seed.model="
+            f"{getattr(seed, 'model', None) if seed else '<no seed>'!r})",
+            file=sys.stderr,
+            flush=True,
+        )
 
         if adapter_name == "auto":
             # Auto mode: default to Claude Code (primary), others used via routing
@@ -5284,6 +5361,14 @@ if __name__ == "__main__":
             ),
         )
 
+        _spawner_role_model_policy = seed.role_model_policy if seed else None
+        print(
+            "[SPAWNER-DEBUG] orchestrator __main__: constructing AgentSpawner with "
+            f"role_model_policy={json.dumps(_spawner_role_model_policy, default=str) if _spawner_role_model_policy else '<None/empty>'}, "
+            f"default_model={run_model!r}, adapter={adapter_inst!r}",
+            file=sys.stderr,
+            flush=True,
+        )
         spawner = AgentSpawner(
             adapter=adapter_inst,
             templates_dir=get_templates_dir(workdir) / "roles",
@@ -5484,7 +5569,24 @@ if __name__ == "__main__":
                 if mcp_manager is not None:
                     mcp_manager.stop_all()
     except Exception:
+        _crash_tb = traceback.format_exc()
+        print(f"[SPAWNER-DEBUG] orchestrator __main__: FATAL uncaught exception:\n{_crash_tb}", file=sys.stderr, flush=True)
         logger.exception("Orchestrator crashed")
+        try:
+            _crash_log_dir = workdir / ".sdd" / "runtime"
+            os.makedirs(_crash_log_dir, exist_ok=True)
+            _crash_log_path = _crash_log_dir / "spawner_crash.log"
+            with open(_crash_log_path, "a", encoding="utf-8") as _crash_fh:
+                _crash_fh.write(f"\n=== spawner crash at {datetime.now(UTC).isoformat()} ===\n")
+                _crash_fh.write(_crash_tb)
+                _crash_fh.write("\n")
+            print(f"[SPAWNER-DEBUG] orchestrator __main__: crash traceback appended to {_crash_log_path}", file=sys.stderr, flush=True)
+        except Exception as _log_exc:  # pragma: no cover - crash logging must never itself crash the reporting path
+            print(
+                f"[SPAWNER-DEBUG] orchestrator __main__: FAILED to write spawner_crash.log: {_log_exc!r}",
+                file=sys.stderr,
+                flush=True,
+            )
         sys.exit(1)
 # ---------------------------------------------------------------------------
 # Meta-messages for orchestrator nudges (T567)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -5580,9 +5580,9 @@ if __name__ == "__main__":
         logger.exception("Orchestrator crashed")
         try:
             _crash_log_dir = workdir / ".sdd" / "runtime"
-            os.makedirs(_crash_log_dir, exist_ok=True)
+            _crash_log_dir.mkdir(parents=True, exist_ok=True)
             _crash_log_path = _crash_log_dir / "spawner_crash.log"
-            with open(_crash_log_path, "a", encoding="utf-8") as _crash_fh:
+            with _crash_log_path.open("a", encoding="utf-8") as _crash_fh:
                 _crash_fh.write(f"\n=== spawner crash at {datetime.now(UTC).isoformat()} ===\n")
                 _crash_fh.write(_crash_tb)
                 _crash_fh.write("\n")

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4986,8 +4986,7 @@ if __name__ == "__main__":
         seed: SeedConfig | None = None
         if seed_path.exists():
             print(
-                f"[SPAWNER-DEBUG] orchestrator __main__: seed file exists at {seed_path}, "
-                "attempting parse_seed()",
+                f"[SPAWNER-DEBUG] orchestrator __main__: seed file exists at {seed_path}, attempting parse_seed()",
                 file=sys.stderr,
                 flush=True,
             )
@@ -5362,9 +5361,12 @@ if __name__ == "__main__":
         )
 
         _spawner_role_model_policy = seed.role_model_policy if seed else None
+        _spawner_policy_repr = (
+            json.dumps(_spawner_role_model_policy, default=str) if _spawner_role_model_policy else "<None/empty>"
+        )
         print(
             "[SPAWNER-DEBUG] orchestrator __main__: constructing AgentSpawner with "
-            f"role_model_policy={json.dumps(_spawner_role_model_policy, default=str) if _spawner_role_model_policy else '<None/empty>'}, "
+            f"role_model_policy={_spawner_policy_repr}, "
             f"default_model={run_model!r}, adapter={adapter_inst!r}",
             file=sys.stderr,
             flush=True,
@@ -5570,7 +5572,11 @@ if __name__ == "__main__":
                     mcp_manager.stop_all()
     except Exception:
         _crash_tb = traceback.format_exc()
-        print(f"[SPAWNER-DEBUG] orchestrator __main__: FATAL uncaught exception:\n{_crash_tb}", file=sys.stderr, flush=True)
+        print(
+            f"[SPAWNER-DEBUG] orchestrator __main__: FATAL uncaught exception:\n{_crash_tb}",
+            file=sys.stderr,
+            flush=True,
+        )
         logger.exception("Orchestrator crashed")
         try:
             _crash_log_dir = workdir / ".sdd" / "runtime"
@@ -5580,7 +5586,11 @@ if __name__ == "__main__":
                 _crash_fh.write(f"\n=== spawner crash at {datetime.now(UTC).isoformat()} ===\n")
                 _crash_fh.write(_crash_tb)
                 _crash_fh.write("\n")
-            print(f"[SPAWNER-DEBUG] orchestrator __main__: crash traceback appended to {_crash_log_path}", file=sys.stderr, flush=True)
+            print(
+                f"[SPAWNER-DEBUG] orchestrator __main__: crash traceback appended to {_crash_log_path}",
+                file=sys.stderr,
+                flush=True,
+            )
         except Exception as _log_exc:  # pragma: no cover - crash logging must never itself crash the reporting path
             print(
                 f"[SPAWNER-DEBUG] orchestrator __main__: FAILED to write spawner_crash.log: {_log_exc!r}",

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -916,6 +917,15 @@ def route_task(
     Returns:
         ModelConfig with selected model and effort (and is_batch flag).
     """
+    print(
+        f"[SPAWNER-DEBUG] route_task: ENTRY task.id={getattr(task, 'id', '?')!r}, "
+        f"task.role={getattr(task, 'role', '?')!r}, task.model={getattr(task, 'model', None)!r}, "
+        f"task.effort={getattr(task, 'effort', None)!r}, bandit_metrics_dir={bandit_metrics_dir!r}, "
+        f"workdir={workdir!r}, budget_remaining_usd={budget_remaining_usd!r}, "
+        f"budget_aware_routing_enabled={budget_aware_routing_enabled!r}",
+        file=sys.stderr,
+        flush=True,
+    )
     cfg = _select_model_config(
         task,
         bandit_metrics_dir,
@@ -1165,6 +1175,15 @@ def _select_model_config(
     absorb another opus task, the opus override is skipped and
     the task lands on sonnet via the heuristic path.
     """
+    print(
+        f"[SPAWNER-DEBUG] _select_model_config: ENTRY task.id={getattr(task, 'id', '?')!r}, "
+        f"task.role={getattr(task, 'role', '?')!r}, task.model={getattr(task, 'model', None)!r}, "
+        f"task.effort={getattr(task, 'effort', None)!r}, task.scope={getattr(task, 'scope', None)!r}, "
+        f"task.priority={getattr(task, 'priority', None)!r}, "
+        f"task.complexity={getattr(task, 'complexity', None)!r}",
+        file=sys.stderr,
+        flush=True,
+    )
     # Manager-specified overrides take precedence
     if task.model or task.effort:
         model = task.model or "sonnet"

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -2,10 +2,16 @@
 
 You lead a team of AI coding agents. Your job: decompose the goal into tasks, create them on the task server, and ensure quality.
 
+**CRITICAL — tool-use rules (read before doing anything else):**
+- You EXECUTE commands by calling `run_command` with the command string. Every curl command in this document must be run via `run_command` immediately.
+- You do NOT write shell scripts, .sh files, or any files to disk. You have no reason to call `write_file` ever. If you find yourself about to write a script file, STOP — call `run_command` with that exact command string instead.
+- You do NOT produce plans as documents. You produce tasks by EXECUTING `run_command` with curl POST commands against the task server API.
+- Your workflow: (1) read the codebase with `read_file`/`list_dir`, (2) plan in your reasoning, (3) EXECUTE `run_command("curl ...")` to create each task, (4) EXECUTE `run_command("curl ...")` to mark yourself complete.
+
 ## Your responsibilities
 1. **Analyze**: read the codebase to understand current state
 2. **Plan**: break the goal into specific, actionable tasks with clear acceptance criteria
-3. **Create tasks**: POST each task to the task server API
+3. **Create tasks**: POST each task to the task server API by calling `run_command`
 4. **Verify**: include completion signals so the janitor can verify work
 
 ## Available roles for tasks
@@ -55,27 +61,11 @@ stop, re-verify you used the string form and the correct token path, and retry. 
 report a task as done, or give up, based solely on a non-2xx response without first
 confirming the command form was correct.
 
-```bash
-TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "Implement feature X",
-    "role": "backend",
-    "description": "Detailed description with acceptance criteria",
-    "priority": 2,
-    "scope": "medium",
-    "complexity": "medium",
-    "owned_files": ["src/path/to/file.py"],
-    "completion_signals": [
-      {"type": "path_exists", "value": "src/path/to/file.py"},
-      {"type": "test_passes", "value": "uv run pytest tests/unit/test_file.py -x -q"}
-    ]
-  }'
-```
+Call `run_command` with this exact string (adapt title/role/description for each task):
 
-The command above must be passed to `run_command` as ONE string (the whole multi-line
+    TOKEN=$(cat <absolute-token-path-from-auth-section>) && curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"title": "Implement feature X", "role": "backend", "description": "Detailed description with acceptance criteria", "priority": 2, "scope": "medium", "complexity": "medium", "owned_files": ["src/path/to/file.py"], "completion_signals": [{"type": "path_exists", "value": "src/path/to/file.py"}, {"type": "test_passes", "value": "uv run pytest tests/unit/test_file.py -x -q"}]}'
+
+This command MUST be passed to `run_command` as ONE string (the whole
 `TOKEN=... curl ...` sequence joined with `&&` or `;`, or run as a single-line
 equivalent) - never as an argv list, or `$TOKEN` will never be substituted.
 
@@ -111,16 +101,9 @@ Programmatic surface lives at `bernstein.core.memory.cross_task_kb.CrossTaskKB`.
 
 ## When done planning
 
-Mark your own task as complete (remember the `Authorization` header, the single-STRING
-`run_command` form, and to check the trailing HTTP status code):
+Mark your own task as complete by calling `run_command` with this string:
 
-```bash
-TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{YOUR_TASK_ID}/complete \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"result_summary": "Created N tasks to achieve goal: ..."}'
-```
+    TOKEN=$(cat <absolute-token-path-from-auth-section>) && curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{YOUR_TASK_ID}/complete -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"result_summary": "Created N tasks to achieve goal: ..."}'
 
 If the trailing status code is not 2xx, do not treat the task as complete - re-verify
 you used the string form of `run_command` and retry before exiting.

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -2,9 +2,9 @@
 
 You lead a team of AI coding agents. Your job: decompose the goal into tasks, create them on the task server, and ensure quality.
 
-**CRITICAL — tool-use rules (read before doing anything else):**
+**CRITICAL - tool-use rules (read before doing anything else):**
 - You EXECUTE commands by calling `run_command` with the command string. Every curl command in this document must be run via `run_command` immediately.
-- You do NOT write shell scripts, .sh files, or any files to disk. You have no reason to call `write_file` ever. If you find yourself about to write a script file, STOP — call `run_command` with that exact command string instead.
+- You do NOT write shell scripts, .sh files, or any files to disk. You have no reason to call `write_file` ever. If you find yourself about to write a script file, STOP - call `run_command` with that exact command string instead.
 - You do NOT produce plans as documents. You produce tasks by EXECUTING `run_command` with curl POST commands against the task server API.
 - Your workflow: (1) read the codebase with `read_file`/`list_dir`, (2) plan in your reasoning, (3) EXECUTE `run_command("curl ...")` to create each task, (4) EXECUTE `run_command("curl ...")` to mark yourself complete.
 

--- a/templates/roles/manager/task_prompt.md
+++ b/templates/roles/manager/task_prompt.md
@@ -14,19 +14,20 @@
 {{/IF}}
 
 ## Instructions
-1. Read the codebase and `.sdd/backlog/open/` before planning to understand current state
+
+**You EXECUTE commands — you do NOT write files.** Every task is created by calling `run_command` with a curl command string. Do not write shell scripts, do not call `write_file`, do not produce plan documents. Your output is API calls, not files.
+
+1. Read the codebase and `.sdd/backlog/open/` using `read_file`/`list_dir` to understand current state
 2. Decompose this goal into tasks of 30-60 min each (max 120 min)
 3. Assign each task the right role; every implementation task needs a paired QA task or inline tests
 4. Set `completion_signals` on every task so the janitor can verify completion
 5. Never assign two tasks to overlapping `owned_files`
-6. Post tasks to the task server, then mark your own task complete
+6. Create each task by calling `run_command` with the curl command below, then mark yourself complete the same way
 
 ## Task creation
 
-The task server requires bearer-token auth - see the `## Task Server Authentication`
-section appended below for the absolute token file path. Every POST needs the
-`Authorization: Bearer $(cat …)` header (or `Authorization: Bearer $BERNSTEIN_AUTH_TOKEN`
-as a fallback).
+The task server requires bearer-token auth — see the `## Task Server Authentication`
+section appended below for the absolute token file path.
 
 **Call form matters.** These commands rely on `$(...)`/`$VAR` shell expansion, which
 only happens when `run_command` is invoked with a single command **STRING**. If
@@ -38,31 +39,15 @@ the token via the `read_file` tool - the token file lives outside your worktree 
 Always inspect the trailing HTTP status code (`-w '\n%{http_code}'` below) and treat
 any non-2xx response as a failure to fix and retry, not as a reason to give up.
 
-```bash
-TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "title": "...",
-    "role": "backend",
-    "description": "...",
-    "priority": 2,
-    "scope": "medium",
-    "complexity": "medium",
-    "owned_files": [...],
-    "completion_signals": [...]
-  }'
-```
+For each task, call `run_command` with this string (adapt title/role/description):
+
+    TOKEN=$(cat <absolute-token-path-from-auth-section>) && curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"title": "...", "role": "backend", "description": "...", "priority": 2, "scope": "medium", "complexity": "medium", "owned_files": [...], "completion_signals": [...]}'
 
 ## Done signal
-```bash
-TOKEN=$(cat <absolute-token-path-from-auth-section>)
-curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"result_summary": "{{TASK_TITLE}}: created N tasks"}'
-```
+
+When all tasks are created, call `run_command` with this string:
+
+    TOKEN=$(cat <absolute-token-path-from-auth-section>) && curl -sS -w '\n%{http_code}' -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"result_summary": "{{TASK_TITLE}}: created N tasks"}'
 
 Pass the whole command above to `run_command` as ONE string - never as an argv list -
 and confirm the trailing status code is 2xx before considering the task done.

--- a/templates/roles/manager/task_prompt.md
+++ b/templates/roles/manager/task_prompt.md
@@ -15,7 +15,7 @@
 
 ## Instructions
 
-**You EXECUTE commands — you do NOT write files.** Every task is created by calling `run_command` with a curl command string. Do not write shell scripts, do not call `write_file`, do not produce plan documents. Your output is API calls, not files.
+**You EXECUTE commands - you do NOT write files.** Every task is created by calling `run_command` with a curl command string. Do not write shell scripts, do not call `write_file`, do not produce plan documents. Your output is API calls, not files.
 
 1. Read the codebase and `.sdd/backlog/open/` using `read_file`/`list_dir` to understand current state
 2. Decompose this goal into tasks of 30-60 min each (max 120 min)
@@ -26,7 +26,7 @@
 
 ## Task creation
 
-The task server requires bearer-token auth — see the `## Task Server Authentication`
+The task server requires bearer-token auth - see the `## Task Server Authentication`
 section appended below for the absolute token file path.
 
 **Call form matters.** These commands rely on `$(...)`/`$VAR` shell expansion, which


### PR DESCRIPTION
## What

Redesigns the council-of-agents runner and fixes several env isolation issues
affecting Qwen models and builtin tool policies.

## Why

- Council runner had no cost tracking -- impossible to attribute spend
- Qwen3 models need `enable_thinking=false` for non-thinking mode but the
  adapter wasn't injecting it
- `BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND` was stripped by env isolation,
  silently disabling the run command builtin for all agents

## How

- Council redesign with proper cost tracking and manager prompt directives
- Inject `enable_thinking=false` for Alibaba Cloud / Qwen endpoints
- Add `BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND` to env isolation allowlist
- Debug logging throughout council execution path

## Checklist

- [x] `ruff check src/` passes
- [x] `import bernstein` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional multi-model “council” workflow, letting a task run across multiple candidates and then produce a single combined answer.
  * Expanded configuration so council-based behavior can be defined per role and recognized in startup parsing.

* **Bug Fixes**
  * Improved usage and cost reporting so council runs and error paths are accounted for more accurately.
  * Added better handling for certain compatible cloud endpoints and related model settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->