### PR TITLE
fix(spawner): forward inline role_model_policy council block into runner manifest

### DIFF
--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -209,8 +209,9 @@ class OpenAIAgentsAdapter(PluginAdapter):
             mcp_config: Optional MCP servers, sandbox provider choice,
                 sampling/endpoint overrides (``temperature``, ``top_p``,
                 ``top_k``, ``base_url``, ``api_key_env``), the tool source
-                selector (``tool_source``), and the spawner-injected
-                ``heartbeat_dir``.
+                selector (``tool_source``), the spawner-injected
+                ``heartbeat_dir``, and the optional task-level ``council``
+                block forwarded from ``role_model_policy.<role>.council``.
             timeout_seconds: Hard timeout forwarded to the runner.
             task_scope: "small" | "medium" | "large".
             budget_multiplier: Retry multiplier applied to the scope budget.
@@ -304,6 +305,16 @@ class OpenAIAgentsAdapter(PluginAdapter):
             instrumentation_root = mcp_config.get("instrumentation_root")
             if isinstance(instrumentation_root, str) and instrumentation_root:
                 overrides["instrumentation_root"] = instrumentation_root
+            # Task-level council override injected by spawner_core from an
+            # inline ``role_model_policy.<role>.council`` block (already
+            # parsed/validated by the seed parser). Forwarded verbatim so
+            # ``RunnerManifest.council`` is populated exactly the way the
+            # ``model: councils/<name>.yaml`` file convention populates it
+            # via ``_load_council_config`` - both paths drive the same
+            # ``manifest.council`` branch in the runner.
+            council = mcp_config.get("council")
+            if isinstance(council, dict) and council:
+                overrides["council"] = council
 
         # ``max_tokens`` from ``mcp_config`` (mode-profile override) wins; the
         # model_config value is only the fallback when the override is absent.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -2982,6 +2982,30 @@ class AgentSpawner:
                         attempt_mcp = dict(attempt_mcp or {})
                         attempt_mcp.setdefault("task_id", tasks[0].id)
 
+                    # Inline per-role council block
+                    # (``role_model_policy.<role>.council``, parsed and
+                    # validated by ``seed_parser._parse_council``): forward
+                    # it so the runner manifest gets the same ``council``
+                    # payload the ``model: councils/<name>.yaml`` file
+                    # convention produces via ``_load_council_config``.
+                    # Scoped to the openai_agents adapter only - its runner
+                    # is the sole consumer of ``manifest.council``, and
+                    # other adapters treat unknown top-level mcp_config
+                    # keys as MCP server entries (see claude.py's
+                    # bare-servers fallback). An operator-set
+                    # ``mcp_config["council"]`` always wins (setdefault).
+                    if "openai_agents" in adapter_name:
+                        role_council = role_policy.get("council")
+                        if isinstance(role_council, dict) and role_council:
+                            attempt_mcp = dict(attempt_mcp or {})
+                            attempt_mcp.setdefault("council", role_council)
+                            logger.info(
+                                "spawn_for_tasks: role=%r inline role_model_policy council block "
+                                "forwarded into the runner manifest (candidates=%d)",
+                                tasks[0].role if tasks else None,
+                                len(role_council.get("candidates") or ()),
+                            )
+
                     try:
                         # Apply OS-level resource limits to non-sandboxed spawns.
                         target_adapter.set_resource_limits(self._resource_limits)

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -1973,6 +1973,158 @@ class TestSamplingParamsSpawnPath:
         assert spawn_time_adapter.seen_mcp_config["max_tokens"] == 4096
 
 
+class TestInlineCouncilForwarding:
+    """An inline ``role_model_policy.<role>.council`` block must reach the
+    runner manifest with the exact payload the ``model: councils/<name>.yaml``
+    file convention produces - previously the inline block parsed and
+    validated but was silently dropped on the spawn path."""
+
+    _COUNCIL_BLOCK: dict[str, Any] = {
+        "candidates": [
+            {"model": "gpt-5-mini"},
+            {"model": "gpt-5"},
+        ],
+        "judge": {"model": "gpt-5"},
+        "timeout": 45.0,
+    }
+
+    def _spawn_and_capture(
+        self,
+        tmp_path: Path,
+        make_task,
+        mock_adapter_factory,
+        role_policy: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Spawn one backend task pinned to openai_agents and return the
+        mcp_config the spawn-time adapter received."""
+        primary_adapter = mock_adapter_factory(pid=1)
+        primary_adapter.name.return_value = "claude"
+        spawn_time_adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            primary_adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            role_model_policy={"backend": role_policy},
+        )
+        with patch.object(spawner, "_get_adapter_by_name", return_value=spawn_time_adapter):
+            spawner.spawn_for_tasks([make_task(role="backend")])
+        assert spawn_time_adapter.seen_mcp_config is not None
+        return spawn_time_adapter.seen_mcp_config
+
+    def _build_manifest(self, tmp_path: Path, mcp_config: dict[str, Any]) -> dict[str, Any]:
+        from types import SimpleNamespace
+
+        from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
+
+        return OpenAIAgentsAdapter._build_manifest(
+            prompt="do the task",
+            workdir=tmp_path,
+            model_config=SimpleNamespace(model="gpt-5-mini", effort="high", max_tokens=200_000),
+            session_id="sess-council",
+            mcp_config=mcp_config,
+            timeout_seconds=60,
+            task_scope="medium",
+            budget_multiplier=1.0,
+            system_addendum="",
+        )
+
+    def test_inline_council_round_trips_to_manifest_like_council_file(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Round trip: a seed-parsed inline council block must land in the
+        runner manifest and resolve through ``_load_council_config`` to the
+        exact same dict an equivalent ``councils/*.yaml`` file produces."""
+        import yaml
+
+        from bernstein.adapters.openai_agents_runner import (
+            RunnerManifest,
+            _load_council_config,
+        )
+        from bernstein.core.config.seed_parser import _parse_single_role_policy
+
+        role_policy = _parse_single_role_policy(
+            "backend",
+            {
+                "provider": "openai_agents",
+                "model": "gpt-5-mini",
+                "council": self._COUNCIL_BLOCK,
+            },
+        )
+        mcp_config = self._spawn_and_capture(tmp_path, make_task, mock_adapter_factory, role_policy)
+        assert mcp_config["council"] == self._COUNCIL_BLOCK
+
+        manifest = self._build_manifest(tmp_path, mcp_config)
+        assert manifest["council"] == self._COUNCIL_BLOCK
+
+        # File convention: the same block written as councils/roundtrip.yaml
+        # and referenced via ``model:`` must resolve to an identical config.
+        councils_dir = tmp_path / ".bernstein" / "councils"
+        councils_dir.mkdir(parents=True)
+        (councils_dir / "roundtrip.yaml").write_text(
+            yaml.safe_dump(self._COUNCIL_BLOCK),
+            encoding="utf-8",
+        )
+        file_manifest = RunnerManifest(
+            session_id="sess-file",
+            prompt="do the task",
+            workdir=str(tmp_path),
+            model="councils/roundtrip.yaml",
+        )
+        file_council = _load_council_config(file_manifest)
+        inline_council = _load_council_config(RunnerManifest.from_dict(manifest))
+        assert inline_council == file_council == self._COUNCIL_BLOCK
+
+    def test_no_council_in_role_policy_leaves_manifest_unchanged(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """Regression: a role policy without a council block must not put a
+        ``council`` key anywhere on the spawn path."""
+        from bernstein.adapters.openai_agents_runner import RunnerManifest
+
+        role_policy: dict[str, Any] = {"provider": "openai_agents", "model": "gpt-5-mini"}
+        mcp_config = self._spawn_and_capture(tmp_path, make_task, mock_adapter_factory, role_policy)
+        assert "council" not in mcp_config
+
+        manifest = self._build_manifest(tmp_path, mcp_config)
+        assert "council" not in manifest
+        assert RunnerManifest.from_dict(manifest).council is None
+
+    def test_operator_mcp_config_council_wins_over_role_policy(
+        self, tmp_path: Path, make_task, mock_adapter_factory
+    ) -> None:
+        """An explicit mcp_config council must not be replaced by the
+        role-policy block - same precedence rule as the sampling fields."""
+        operator_council: dict[str, Any] = {
+            "candidates": [{"model": "gpt-5"}],
+            "judge": {"model": "gpt-5"},
+        }
+        primary_adapter = mock_adapter_factory(pid=1)
+        primary_adapter.name.return_value = "claude"
+        spawn_time_adapter = _SamplingCapableAdapter()
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+        spawner = AgentSpawner(
+            primary_adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+            mcp_config={"council": operator_council},
+            role_model_policy={
+                "backend": {
+                    "provider": "openai_agents",
+                    "council": self._COUNCIL_BLOCK,
+                }
+            },
+        )
+        with patch.object(spawner, "_get_adapter_by_name", return_value=spawn_time_adapter):
+            spawner.spawn_for_tasks([make_task(role="backend")])
+        assert spawn_time_adapter.seen_mcp_config is not None
+        assert spawn_time_adapter.seen_mcp_config["council"] == operator_council
+
+
 # --- Error-aware spawn-failure extraction (D2 MiniMax masking bug) ---
 #
 # Ground truth: work/bernstein/proofs/d2/minimax/FAIL-NOTE.md. A real


### PR DESCRIPTION
## Symptom

A seed-level `role_model_policy.<role>.council` block parses and validates (seed parser and config schema both accept it), but the role still runs as a plain single-model session. Only the `model: councils/<name>.yaml` file convention produced a council run; the inline block was silently inert.

## Root cause

`spawner_core` never forwarded the parsed `council` dict from the role policy into the per-spawn `mcp_config`, and `OpenAIAgentsAdapter._build_manifest` had no `council` passthrough, so `RunnerManifest.council` stayed `None` and `_load_council_config` fell back to the model-suffix file convention.

## Fix

- `spawner_core.spawn_for_tasks`: inject `role_policy["council"]` into the per-attempt mcp_config, scoped to the openai_agents adapter (mirrors the existing `task_id` injection; other adapters treat unknown top-level mcp_config keys as MCP server entries). An operator-set `mcp_config["council"]` wins via `setdefault`.
- `openai_agents._build_manifest`: serialize `mcp_config["council"]` into the manifest, populating `RunnerManifest.council` exactly the way `_load_council_config` populates it from a council file, so both conventions drive the same `manifest.council` branch in the runner.

## Tests

- Round-trip: a seed-parsed inline council block reaches the manifest and resolves through `_load_council_config` byte-identically to an equivalent `councils/roundtrip.yaml` file.
- Regression: a role policy without a council block adds no `council` key anywhere on the spawn path.
- Precedence: an explicit operator `mcp_config["council"]` is not replaced by the role-policy block.
- `uv run python -m pytest tests/unit/test_spawner.py tests/unit/test_mcp_config.py -q --timeout=300`: 129 passed.
- `uv run lint-imports`: 3 contracts kept (adapters do not import scheduler internals).

Fixes #2222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline council settings are now carried through from task configuration into the agent runner when using the OpenAI Agents path.
  * Existing council settings from operator-provided configuration continue to take precedence when already set.

* **Bug Fixes**
  * Fixed missing council data in spawned tasks so the final runner manifest now includes the expected council configuration.
  * Added regression coverage for cases where council is omitted, ensuring no unexpected council data appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->