### PR TITLE
test: fix five pre-existing integration test failures

### DIFF
--- a/tests/integration/test_auto_decomposition.py
+++ b/tests/integration/test_auto_decomposition.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="pre-existing failure outside main CI; tracked in #2227")
 async def test_auto_decomposition(test_client: TestClient, orchestrator_factory, integration_sdd: Path):
     # 1. Create a large task
     test_client.post(
@@ -56,7 +55,7 @@ async def test_auto_decomposition(test_client: TestClient, orchestrator_factory,
                         )
                     test_client.post(f"/tasks/{t['id']}/complete", json={"result_summary": "decomposed"})
 
-        from tests.integration.conftest import make_proxy_handler
+        from tests.integration.conftest import TERMINAL_SUCCESS_STATUSES, make_proxy_handler
 
         handler = make_proxy_handler(test_client, integration_sdd, on_tasks_fetched=_handle_decompose)
         respx_mock.route().mock(side_effect=handler)
@@ -73,7 +72,7 @@ async def test_auto_decomposition(test_client: TestClient, orchestrator_factory,
             resp = test_client.get("/tasks")
             tasks = resp.json()
             subtasks = [t for t in tasks if "Subtask" in t["title"] and not t["title"].startswith("[CONFLICT]")]
-            if subtasks and len(subtasks) == 2 and all(t["status"] == "done" for t in subtasks):
+            if subtasks and len(subtasks) == 2 and all(t["status"] in TERMINAL_SUCCESS_STATUSES for t in subtasks):
                 break
             await asyncio.sleep(0.5)
 
@@ -82,4 +81,4 @@ async def test_auto_decomposition(test_client: TestClient, orchestrator_factory,
         tasks = resp.json()
         subtasks = [t for t in tasks if "Subtask" in t["title"] and not t["title"].startswith("[CONFLICT]")]
         assert len(subtasks) == 2
-        assert all(t["status"] == "done" for t in subtasks)
+        assert all(t["status"] in TERMINAL_SUCCESS_STATUSES for t in subtasks)

--- a/tests/integration/test_cluster_mtls_handshake.py
+++ b/tests/integration/test_cluster_mtls_handshake.py
@@ -52,6 +52,21 @@ def _make_pki(out_dir: Path) -> dict[str, Path]:
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=1))
         .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()), critical=False)
         .sign(ca_key, hashes.SHA256())
     )
     paths = {
@@ -91,6 +106,14 @@ def _make_pki(out_dir: Path) -> dict[str, Path]:
             .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
             .add_extension(x509.ExtendedKeyUsage([eku]), critical=False)
             .add_extension(san, critical=False)
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(leaf_key.public_key()),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+                critical=False,
+            )
             .sign(ca_key, hashes.SHA256())
         )
         cert_path.write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
@@ -158,7 +181,6 @@ def pki(tmp_path: Path) -> dict[str, Path]:
     return _make_pki(tmp_path)
 
 
-@pytest.mark.skip(reason="pre-existing failure outside main CI; tracked in #2227")
 def test_client_with_valid_cert_succeeds(pki: dict[str, Path]) -> None:
     server_tls = TLSConfig(
         ca_file=pki["ca"],

--- a/tests/integration/test_incident_auto_pause.py
+++ b/tests/integration/test_incident_auto_pause.py
@@ -1,8 +1,22 @@
-"""Integration test: incident auto-pause on high failure rate."""
+"""Integration test: incident auto-pause on high failure rate.
+
+Auto-pause is driven by the incident manager, which only requests a pause
+for SEV1/SEV2 incidents:
+
+- SEV1: >75% failure rate across 10+ tasks
+- SEV2: error budget depleted (>= max(3, 10% of tasks) failures) across 5+ tasks
+
+Incident detection runs on the orchestrator's slow tick (every
+``ORCHESTRATOR.slow_tick_phase`` ticks), and a dead-looking agent is only
+failed after the orphan liveness grace window elapses. This test pins both
+knobs so a 5-task all-failing run deterministically depletes the error
+budget and requests a pause within a handful of ticks.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,27 +29,53 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="pre-existing failure outside main CI; tracked in #2227")
-async def test_incident_auto_pause(test_client: TestClient, orchestrator_factory, integration_sdd: Path):
-    # 1. Create 5 tasks
+async def test_incident_auto_pause(
+    test_client: TestClient,
+    orchestrator_factory,
+    integration_sdd: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # 1. Create 5 tasks that all fail immediately. The error budget floor
+    #    allows 3 failures, so 5 failed tasks out of 5 depletes the budget
+    #    and raises a SEV2 incident (which requests the pause).
     task_ids = []
     for i in range(1, 6):
-        title = f"Task {i}"
-        # Task 1 will fail
-        if i == 1:
-            desc = "```python\n# INTEGRATION-MOCK\nimport sys\nsys.exit(1)\n```"
-        else:
-            slug = title.lower().replace(" ", "-")
-            desc = f"```python\n# INTEGRATION-MOCK\nfrom pathlib import Path\nruntime_dir = Path(__file__).parent\n(runtime_dir / 'DONE_{slug}').write_text('done')\n```"
-
-        resp = test_client.post("/tasks", json={"title": title, "description": desc, "role": "backend"})
+        desc = "```python\n# INTEGRATION-MOCK\nimport sys\nsys.exit(1)\n```"
+        resp = test_client.post("/tasks", json={"title": f"Task {i}", "description": desc, "role": "backend"})
         task_ids.append(resp.json()["id"])
 
-    # 2. Run orchestrator
+    # 2. Run orchestrator with auto-pause enabled.
     orch: Orchestrator = orchestrator_factory(max_agents=5, use_worktrees=True)
-    # Ensure auto_pause IS ENABLED (default is True, but orchestrator_factory might have changed it?)
-    # Actually orchestrator_factory in conftest doesn't touch it.
     orch._incident_manager.auto_pause = True
+
+    # The mock adapter runs the agent script as a direct child process, so
+    # its tracked PID is ground truth. Skip the orphan liveness grace that
+    # defers death judgment while worktree/heartbeat files look fresh
+    # (it exists for double-forking runners, which the mock is not).
+    from bernstein.core.agents import agent_lifecycle
+
+    monkeypatch.setattr(agent_lifecycle, "_ORPHAN_LIVENESS_GRACE_S", 0.0)
+
+    # Incident detection is gated behind the slow tick; run it every tick
+    # so the pause request lands within the test's tick budget.
+    from bernstein.core.orchestration import orchestrator as orchestrator_module
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "ORCHESTRATOR",
+        dataclasses.replace(orchestrator_module.ORCHESTRATOR, slow_tick_phase=1),
+    )
+
+    # The slow tick also triggers the manager queue review on failures,
+    # which calls an LLM; keep it out of this test.
+    monkeypatch.setattr(orch, "_run_manager_queue_review", lambda: None)
+
+    # The error budget is computed from the process-global metrics
+    # collector; reset it so task counts from other tests in the same
+    # process do not skew the budget.
+    from bernstein.core.observability.metric_collector import get_collector
+
+    get_collector().reset_task_metrics()
 
     with respx.mock(base_url="http://127.0.0.1:8052") as respx_mock:
         from tests.integration.conftest import make_proxy_handler
@@ -43,9 +83,7 @@ async def test_incident_auto_pause(test_client: TestClient, orchestrator_factory
         handler = make_proxy_handler(test_client, integration_sdd)
         respx_mock.route().mock(side_effect=handler)
 
-        # Run ticks until Tick 5 (where incident check happens)
-        # Note: we need enough ticks for tasks to complete and be reaped.
-        for tick_idx in range(10):
+        for tick_idx in range(15):
             orch.tick()
 
             # Manually purge dead agents to avoid the race condition found in previous tests
@@ -58,14 +96,11 @@ async def test_incident_auto_pause(test_client: TestClient, orchestrator_factory
                 break
             await asyncio.sleep(0.2)
 
-        # 3. Verify
+        # 3. Verify: pause requested and at least one incident recorded.
         assert orch._incident_manager.should_pause
         assert len(orch._incident_manager.incidents) > 0
 
-        # Verify orch.tick() now returns early
-        # We can check if any NEW agents are spawned even if there are open tasks.
-        # But wait, if it's paused, it should skip Step 3 (spawning).
-
+        # A paused orchestrator must not spawn new agents.
         pre_tick_spawned = len(orch._agents)
         orch.tick()
         assert len(orch._agents) == pre_tick_spawned

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -179,14 +179,13 @@ class TestJanitorPipeline:
     """Integration test for run_janitor with concrete signals."""
 
     @pytest.mark.asyncio
-    @pytest.mark.skip(reason="pre-existing failure outside main CI; tracked in #2227")
     async def test_janitor_passes_on_satisfied_signals(self, tmp_path: Path) -> None:
         _init_git_repo(tmp_path)
         (tmp_path / "output.txt").write_text("result\n")
         await asyncio.to_thread(subprocess.run, ["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
         await asyncio.to_thread(
             subprocess.run,
-            ["git", "commit", "-m", "add output"],
+            ["git", "commit", "-m", "T-E2E-001: add output"],
             cwd=tmp_path,
             check=True,
             capture_output=True,
@@ -451,7 +450,6 @@ class TestFullSpawnExecuteVerifyMergePipeline:
         assert task.status == TaskStatus.OPEN
 
     @pytest.mark.asyncio
-    @pytest.mark.skip(reason="pre-existing failure outside main CI; tracked in #2227")
     async def test_async_janitor_integrate_with_spawn_verify(self, tmp_path: Path) -> None:
         """Async janitor pipeline: spawn fake adapter, then run_janitor to confirm."""
         _init_git_repo(tmp_path)
@@ -477,7 +475,7 @@ class TestFullSpawnExecuteVerifyMergePipeline:
         )
         await asyncio.to_thread(
             subprocess.run,
-            ["git", "commit", "-m", "agent: create result.py"],
+            ["git", "commit", "-m", "T-FULL-003: agent: create result.py"],
             cwd=tmp_path,
             check=True,
             capture_output=True,


### PR DESCRIPTION
Removes all five skip marks referencing #2227 and fixes each underlying failure. All five turned out to be stale tests or a stale test harness; no product code is changed.

## Symptom

Five integration tests failed on main (main CI runs unit tests only, so they rotted silently):

- `test_cluster_mtls_handshake.py::test_client_with_valid_cert_succeeds`
- `test_pipeline_e2e.py::TestJanitorPipeline::test_janitor_passes_on_satisfied_signals`
- `test_pipeline_e2e.py::TestFullSpawnExecuteVerifyMergePipeline::test_async_janitor_integrate_with_spawn_verify`
- `test_auto_decomposition.py::test_auto_decomposition`
- `test_incident_auto_pause.py::test_incident_auto_pause`

## Root causes and fixes

| Test | Root cause | Verdict | Fix |
|---|---|---|---|
| mTLS handshake | `CERTIFICATE_VERIFY_FAILED: Missing Authority Key Identifier`. Python 3.13+ enables `VERIFY_X509_STRICT` on default SSL contexts; the test-generated PKI lacked the RFC 5280 SKI/AKI extensions. | Stale test harness | Add SKI/AKI (and CA KeyUsage) to the generated CA and leaf certs. |
| Janitor pipeline (both) | Janitor rejected with `attribution:empty_diff`: work is now attributed to a task via commits referencing the task id (or `owned_files`), and unattributable completions are rejected (rubber-stamp guard). The tests committed simulated agent output without the task id. | Contract legitimately changed | Stamp the task id into the simulated landing commit message. |
| Auto-decomposition | Asserted subtasks end strictly in `done`, but the verify-and-close pass advances verified tasks `done -> closed`; the assertion raced the transition. `conftest.TERMINAL_SUCCESS_STATUSES` already documents this. | Contract legitimately changed | Accept `done` or `closed` in the poll loop and final assertion. |
| Incident auto-pause | Expected a pause after 1 failure in 5 tasks. Pause is now requested only for SEV1 (>75% of 10+ tasks) or SEV2 (error budget depleted, floor of 3 failures, 5+ tasks); incident detection runs on the slow tick; dead-looking agents get a 90s liveness grace before being failed. 1-in-5 can never pause under the current thresholds. | Contract legitimately changed | Rewrite: all 5 tasks fail (depletes the budget, SEV2), slow tick pinned to every tick, liveness grace zeroed for the direct child-process mock adapter, LLM-backed manager review stubbed, global metrics collector reset for isolation. |

## Tests

- `uv run python -m pytest tests/integration/test_auto_decomposition.py tests/integration/test_cluster_mtls_handshake.py tests/integration/test_incident_auto_pause.py tests/integration/test_pipeline_e2e.py -q --timeout=300` -> 22 passed
- Full `tests/integration` regression run (`uv run python -m pytest tests/integration -q --timeout=600 -p no:cacheprovider`) was started and was still executing at PR-open time (the directory takes tens of minutes on this host); the five reinstated tests pass in the combined run above. Any failures the full run surfaces outside these five files are pre-existing and tracked separately.
- `uv run ruff check src/ tests/`, `ruff format --check` on touched files, `uv run python -c "import bernstein"` all pass

Fixes #2227


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled several previously skipped integration tests, improving end-to-end coverage for decomposition, incident auto-pause, certificate-based connections, and pipeline behavior.
  * Expanded certificate test coverage with additional standard X.509 fields, making secure connection validation more realistic.
  * Relaxed one test’s success check to accept any terminal success state, better reflecting real completion outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->