### PR TITLE
fix: apply critical-path priority boost on the first spawn batch

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1199,7 +1199,13 @@ class Orchestrator:
         # The server returns tasks matching the requested status; apply the
         # dependency filter here for "open" tasks.
         done_tasks = tasks_by_status["done"]
-        done_ids = {t.id for t in done_tasks}
+        # A dependency is satisfied by any terminal-success status, not just
+        # "done": once a done task's agent is reaped and its branch merged,
+        # the task moves to "closed" (the store soft-archives via status).
+        # Checking "done" alone re-blocked dependents forever after that
+        # transition, so lower-priority independent tasks were claimed ahead
+        # of a high-priority task whose dependency had already completed.
+        done_ids = {t.id for t in done_tasks} | {t.id for t in tasks_by_status.get("closed", [])}
         now = time.time()
         open_tasks = [
             t
@@ -1330,8 +1336,16 @@ class Orchestrator:
             except OSError as exc:
                 logger.debug("Failed to save task graph: %s", exc)
         else:
-            # Fast tick: reuse cached critical path IDs from last normal tick
-            critical_path_ids = getattr(self, "_cached_critical_path_ids", set())
+            # Fast tick: skip the expensive graph analysis, validation and
+            # snapshot persistence, but still recompute the critical path -
+            # it is a cheap O(V+E) traversal and claim ordering depends on
+            # it. The very first tick is always a fast tick (_tick_count is
+            # incremented to 1 before the phase check, and 1 % phase != 0),
+            # so reusing only the cache from the last normal tick left the
+            # first spawn batch without the critical-path priority boost
+            # and served stale boosts to tasks created between normal ticks.
+            critical_path_ids = set(DependencyValidator().critical_path(all_tasks))
+            self._cached_critical_path_ids = critical_path_ids
 
         # 3. Count alive agents, spawn if capacity (capped by graph parallel width)
         # 2b. Rate-limit recovery: restore providers whose throttle window expired.

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -866,15 +866,21 @@ class TaskStore:
         return dfs(new_task.id)
 
     def _dependencies_satisfied(self, task: Task) -> bool:
-        done_ids = {done_task.id for done_task in self._by_status[TaskStatus.DONE].values()}
+        # A dependency is satisfied by either terminal-success status: tasks
+        # move from "done" to "closed" once their agent is reaped and its
+        # branch merged (the store soft-archives via status). Accepting only
+        # "done" here rejected claims of dependents whose dependency had
+        # already completed and been closed.
+        completed_tasks = list(self._by_status[TaskStatus.DONE].values()) + list(
+            self._by_status[TaskStatus.CLOSED].values()
+        )
+        done_ids = {done_task.id for done_task in completed_tasks}
         if not all(dep in done_ids for dep in task.depends_on):
             return False
         if task.depends_on_repo is None:
             return True
         if not task.depends_on:
-            return any(
-                done_task.repo == task.depends_on_repo for done_task in self._by_status[TaskStatus.DONE].values()
-            )
+            return any(done_task.repo == task.depends_on_repo for done_task in completed_tasks)
         return all(
             (self._tasks.get(dep_id) is not None and self._tasks[dep_id].repo == task.depends_on_repo)
             for dep_id in task.depends_on

--- a/tests/integration/test_critical_path_priority.py
+++ b/tests/integration/test_critical_path_priority.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="critical-path boost not applied on first batch; tracked in #2226")
 async def test_critical_path_priority(test_client: TestClient, orchestrator_factory, integration_sdd: Path):
     # 1. Create tasks
     # Task A: low priority, but dependency for B

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -3228,6 +3228,53 @@ class TestAssignedTaskIdDoubleSpawn:
         assert len(non_dead) == 1
 
 
+class TestCriticalPathBoostFirstBatch:
+    """The critical-path priority boost must feed the very first spawn batch.
+
+    Tick 1 is a fast tick (the tick counter is incremented to 1 before the
+    normal-phase modulo check, and 1 % normal_tick_phase != 0), so the
+    critical path must be recomputed on fast ticks too. Before the fix the
+    first batch saw an empty critical-path cache and ordered a low-priority
+    dependency of a high-priority task behind unrelated fillers.
+    """
+
+    def test_first_tick_claims_critical_path_dependency_first(self, tmp_path: Path) -> None:
+        """With one agent slot, tick 1 must claim the dependency of the P1 task."""
+        # Filler ids sort lexicographically BEFORE the dependency id, so
+        # without the boost the priority tie (all 3s) would break on task id
+        # and a filler would be claimed first.
+        dep = _make_task(id="T-z-dep", title="Dependency", priority=3)
+        blocked = _make_task(id="T-z-blocked", title="Critical path", priority=1)
+        blocked.depends_on = ["T-z-dep"]
+        fillers = [_make_task(id=f"T-a-filler-{i}", title=f"Filler {i}", priority=3) for i in range(3)]
+        all_tasks = [_task_as_dict(t) for t in [dep, blocked, *fillers]]
+
+        claimed_order: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            url = request.url
+            if request.method == "GET" and url.path == "/tasks":
+                return _tasks_response(url, all_tasks)
+            if request.method == "POST" and url.path.endswith("/claim"):
+                claimed_order.append(url.path.split("/")[2])
+                return httpx.Response(200, json={})
+            return httpx.Response(200, json={})
+
+        config = OrchestratorConfig(
+            max_agents=1,
+            max_tasks_per_agent=1,
+            poll_interval_s=1,
+            heartbeat_timeout_s=120,
+            server_url="http://testserver",
+        )
+        orch = _build_orchestrator(tmp_path, httpx.MockTransport(handler), config=config)
+
+        result = orch.tick()
+
+        assert len(result.spawned) == 1
+        assert claimed_order and claimed_order[0] == "T-z-dep"
+
+
 class TestEvolveAutoCommitRuntimeExclusion:
     """_evolve_auto_commit stages all changes then unstages .sdd/runtime/ and .sdd/metrics/."""
 

--- a/tests/unit/test_task_store.py
+++ b/tests/unit/test_task_store.py
@@ -151,6 +151,30 @@ async def test_list_tasks_filters_open_tasks_by_completed_dependencies(tmp_path:
 
 
 @pytest.mark.anyio
+async def test_closed_dependency_still_satisfies_dependents(tmp_path: Path) -> None:
+    """A dependency that moved done -> closed keeps its dependents claimable.
+
+    Done tasks transition to closed once their agent is reaped and its branch
+    merged (soft-archive via status). Dependents must stay visible in the
+    open listing and remain claimable after that transition.
+    """
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    dependency = await store.create(_task_request(title="dependency"))
+    blocked = await store.create(_task_request(title="blocked", depends_on=[dependency.id]))
+
+    await store.claim_by_id(dependency.id, expected_version=dependency.version)
+    await store.complete(dependency.id, "done")
+    await store.close(dependency.id)
+
+    open_ids = {task.id for task in store.list_tasks(status="open")}
+    assert blocked.id in open_ids
+
+    claimed = await store.claim_by_id(blocked.id, expected_version=blocked.version)
+    assert claimed.status == TaskStatus.CLAIMED
+
+
+@pytest.mark.anyio
 async def test_status_summary_reports_counts_by_status(tmp_path: Path) -> None:
     """status_summary aggregates task counts and per-role breakdowns."""
     store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")


### PR DESCRIPTION
## Symptom

tests/integration/test_critical_path_priority.py fails on main: Task A (priority 3) is a dependency of Task B (priority 1), so the critical-path rule says A must be claimed first, but an unrelated filler task spawns first. The test was skip-marked referencing #2226.

## Root cause

Two independent scheduler defects combined to produce the symptom:

1. First spawn batch never saw the boost. The tick counter is incremented to 1 before the normal-phase modulo check (1 % normal_tick_phase != 0), so tick 1 is always a fast tick. Fast ticks reused the cached critical-path IDs from the last normal tick, and that cache starts empty; the first normal tick is tick 6, but the first spawn happens on tick 1. With an empty override map the dependency tied with the fillers at priority 3 and lost the claim ordering on the task-id tie-break. git log -S shows the cache and the gating landed together, so the boost never fed the first batch (no later regression).

2. Dependents re-blocked after done -> closed. Once the dependency completed and its agent was reaped and merged, the task transitioned from done to closed (soft-archive via status). Both the orchestrator's dependency filter and TaskStore._dependencies_satisfied only accepted done, so the high-priority dependent became unclaimable again and fillers kept winning the remaining slots.

## Fix

- Orchestrator fast ticks now recompute the critical path itself (a cheap O(V+E) traversal, no file IO); the expensive graph analysis, dependency validation and snapshot persistence remain gated behind normal ticks. Deterministic, no LLM involvement.
- Dependency satisfaction accepts either terminal-success status (done or closed) in both the orchestrator tick filter and the task store claim checks.
- Removed the skip mark from test_critical_path_priority; the rest of the test is unchanged.

## Tests

- tests/integration/test_critical_path_priority.py passes (skip removed).
- New unit test TestCriticalPathBoostFirstBatch in tests/unit/test_orchestrator.py: tick 1 must claim the critical-path dependency ahead of same-priority fillers whose ids would win the tie-break. Verified to fail on the unfixed scheduler.
- New unit test test_closed_dependency_still_satisfies_dependents in tests/unit/test_task_store.py: dependents stay listed and claimable after the dependency moves done -> closed. Verified to fail on the unfixed store.
- Regression: tests/unit/test_task_lifecycle.py, test_orchestrator.py, test_regression_orchestrator.py, test_deterministic_run.py: 371 passed, 7 skipped. Store/graph neighbors (test_task_store*.py, test_task_batching.py, test_dep_validator.py, test_task_graph.py): 108 passed. tests/integration/test_sequential_dependency.py still passes.
- ruff check src/ tests/ and ruff format --check on touched files pass.

Fixes #2226