### PR TITLE
chore: neutral credential label in adapter dispatch logs

### DIFF
--- a/src/bernstein/adapters/council_runner.py
+++ b/src/bernstein/adapters/council_runner.py
@@ -344,7 +344,7 @@ async def _run_judge(
 
     run_kwargs: dict[str, Any] = {} if max_turns is None else {"max_turns": max_turns}
     logger.info(
-        "run_council._run_judge: dispatching judge model=%r base_url=%r (api_key_env=%r) "
+        "run_council._run_judge: dispatching judge model=%r base_url=%r (credential env var=%r) "
         "timeout=%.1fs max_turns=%s over %d candidate output(s) - full judge prompt follows:\n%s",
         model_id,
         judge_member.get("base_url") or "<default>",

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -488,7 +488,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
         _max_tokens_str = "default:200000" if _max_tokens_val is None else str(_max_tokens_val)
         logger.info(
             "openai_agents spawn_manifest_summary session=%s: model=%s, base_url=%s, "
-            "api_key_env=%s, max_tokens=%s, tool_source=%s, tool_count=%d",
+            "credential env var=%s, max_tokens=%s, tool_source=%s, tool_count=%d",
             session_id,
             manifest.get("model"),
             manifest.get("base_url") or "<default>",
@@ -512,7 +512,7 @@ class OpenAIAgentsAdapter(PluginAdapter):
         # is the log line proving they are absent for this spawn.
         logger.info(
             "[DEEPSEEK-DEBUG] spawn session=%s: model string forwarded verbatim (no "
-            "name mapping) model=%r, base_url=%r, api_key_env=%r (value never logged), "
+            "name mapping) model=%r, base_url=%r, credential env var=%r (value never logged), "
             "extra_headers_configured=False (bernstein sets no HTTP-Referer/X-Title/"
             "any custom header anywhere in this adapter or the runner)",
             session_id,

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -2126,7 +2126,7 @@ def _run_session(manifest: RunnerManifest, client_kwargs: dict[str, Any]) -> int
             # never the secret value it resolves to.
             _key_env_name_for_log = manifest.api_key_env
             logger.info(
-                "[DEEPSEEK-DEBUG] pre-call session=%s model=%r base_url=%r api_key_env=%r "
+                "[DEEPSEEK-DEBUG] pre-call session=%s model=%r base_url=%r credential env var=%r "
                 "explicit_model_client=%s tool_source=%r tool_count=%d max_turns=%s",
                 manifest.session_id,
                 manifest.model,


### PR DESCRIPTION
Credential-heuristic scanners match the literal api_key token inside log format strings even when only the env var NAME is logged (latest: alert 2676 on the council judge dispatch line). This rewords all four remaining sites in one pass so sibling findings stop surfacing one scan at a time.

Log content unchanged: the same env var name is logged under a neutral label. No behavior change.