### PR TITLE
test(worker): remove stale xfail marks from TestWorkerProcess

### DIFF
--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -10,8 +10,6 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
-import pytest
-
 from bernstein.adapters.base import build_worker_cmd
 
 if TYPE_CHECKING:
@@ -62,7 +60,6 @@ class TestBuildWorkerCmd:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(reason="Shim module loader breaks subprocess imports during decomposition")
 class TestWorkerProcess:
     def test_worker_writes_and_cleans_pid_file(self, tmp_path: Path) -> None:
         """Worker should write PID file on start and remove it on exit."""


### PR DESCRIPTION
## Summary

The five tests in `TestWorkerProcess` (tests/unit/test_worker.py) were marked xfail with reason "Shim module loader breaks subprocess imports during decomposition". They all pass on current main and show up as XPASS, so the mark is stale. This PR removes the class-level xfail mark and the now-unused `pytest` import.

## Verification

- Ran `uv run python -m pytest tests/unit/test_worker.py -q --timeout=180` three consecutive times on a clean checkout of main: `7 passed` on every run.
- `uv run ruff check tests/`: all checks passed.

No production code changes; test-only diff (3 deleted lines).

## Summary by Sourcery

Remove stale xfail marker from TestWorkerProcess tests that now pass reliably.

Tests:
- Remove class-level xfail mark from TestWorkerProcess so its tests run as normal passes.
- Drop unused pytest import from test_worker module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Worker process integration tests now run normally instead of being marked as expected failures.
  * Removed an outdated test dependency and expectation tied to a previously known subprocess import issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->