### PR TITLE
chore(release): 2.15.0

### DIFF
--- a/docs/release-notes/v2.15.0.md
+++ b/docs/release-notes/v2.15.0.md
@@ -1,0 +1,22 @@
+# v2.15.0
+
+Released 2026-07-05.
+
+Feature release built around five community contributions by Shane Mattner (@shanemmattner), plus scheduler and test-infrastructure fixes.
+
+## Features
+- Hold/release API (`/orchestrator/holds`): heartbeat-renewed leases that keep the spawner alive while an external workflow driver is active, replacing the fixed quiescence settle timer. TTL is a grace window; expired holds release on their own. Operator docs in `docs/operations/HOLDS.md`. (#2218, thanks @shanemmattner)
+- Explicit `max_turns` on `TaskCreate`: per-task turn budgets flow end to end to the adapter spawn, bypassing the complexity heuristic when set; bounded 1..10000 at the schema boundary; retries carry the value forward. Docs in `docs/operations/MAX_TURNS.md`. (#2217, thanks @shanemmattner)
+- Per-agent run instrumentation: JSONL records for every LLM call, tool call, and conversation message, captured in real time via SDK hooks and anchored to the project root (not the per-task worktree). Docs in `docs/operations/INSTRUMENTATION.md`. (#2219, thanks @shanemmattner)
+- Council-of-agents redesign: per-member cost attribution, judge synthesis over candidate outputs, `enable_thinking=false` injected for Qwen models served from Alibaba Cloud endpoints (hostname-suffix detection), and `BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND` passthrough in env isolation. (#2220, thanks @shanemmattner)
+- Inline `role_model_policy.<role>.council` seed blocks now forward into the runner manifest, behaving identically to the `councils/*.yaml` file convention. (#2231)
+
+## Fixes
+- Model selection no longer falls back to hardcoded model strings: every selection flows from configuration, and unconfigured paths raise `ModelNotConfiguredError` instead of silently guessing. (#2216, thanks @shanemmattner)
+- Critical-path priority boost applies on the first spawn batch, so a low-priority dependency of a high-priority task is claimed first. (#2233)
+- Worker exit codes: when the whole process group receives SIGINT, the worker no longer re-forwards the signal into the child's interpreter shutdown window, so it reports the child handler's exit code instead of 130. (#2238)
+- Five integration tests repaired and re-enabled after root-causing failures that predated this cycle. (#2232)
+
+## Internal
+- Unit coverage for the council runner path. (#2230)
+- Log-injection sanitization on hold fields; scanner findings resolved across instrumentation and council logging. (#2229)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.14.1"
+version = "2.15.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.14.1"
+version = "2.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump to 2.15.0 with release notes.

Highlights: hold/release API for spawner lifecycle, explicit per-task max_turns, per-agent run instrumentation, council redesign with per-member cost attribution and Qwen thinking-mode handling, configuration-only model selection (no hardcoded fallbacks), critical-path priority fix, worker SIGINT exit-code fix, five integration tests repaired and re-enabled.

Full notes in docs/release-notes/v2.15.0.md.

## Summary by Sourcery

Bump project version to 2.15.0 and document the release highlights and internal changes.

New Features:
- Introduce hold/release API for orchestrator spawner lifecycle to keep workers alive under external workflow control.
- Add explicit per-task max_turns configuration that propagates through execution while enforcing bounded limits.
- Add per-agent run instrumentation that records LLM calls, tool calls, and conversation messages to JSONL logs.
- Redesign council-of-agents behavior with per-member cost attribution, judge synthesis, Qwen thinking-mode handling, and support for inline council seed blocks.

Bug Fixes:
- Ensure model selection is driven purely by configuration and raises ModelNotConfiguredError when no configured model exists instead of guessing.
- Fix critical-path priority boosting so dependencies of high-priority tasks are scheduled first on the initial spawn batch.
- Correct worker exit-code reporting under SIGINT so the child handler’s exit code is preserved instead of returning 130.
- Repair and re-enable five previously failing integration tests.

Enhancements:
- Add unit test coverage for the council runner path to strengthen reliability.
- Sanitize log injection across hold-related fields, instrumentation, and council logging to resolve scanner findings.

Documentation:
- Add detailed release notes for v2.15.0, including operator documentation for holds, max_turns, and instrumentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for holding and releasing operations, along with more detailed agent run tracking.
  * Improved multi-agent coordination behavior and forwarding of seed-related context.

* **Bug Fixes**
  * Fixed model selection to avoid unexpected fallback behavior.
  * Improved task prioritization, worker interrupt handling, and integration test reliability.

* **Chores**
  * Updated the project version to **v2.15.0** and published release notes for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->