### PR TITLE
feat(tokens): refuse credential-shaped content in compaction summaries

### DIFF
--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -471,6 +471,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "semantic_graph": "bernstein.core.knowledge.ast_symbol_graph",
     "sensitive_data": "bernstein.core.security.sensitive_data",
     "sensitive_file_detector": "bernstein.core.security.sensitive_file_detector",
+    "sensitive_gate": "bernstein.core.tokens.sensitive_gate",
     "server_app": "bernstein.core.server.server_app",
     "server_launch": "bernstein.core.server.server_launch",
     "server_middleware": "bernstein.core.server.server_middleware",

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -592,12 +592,21 @@ def _try_compact_and_retry(
         except Exception as _be:
             logger.debug("Budget pre-compaction snapshot failed for %s: %s", task_id, _be)
 
+    # Resolve the audit chain for sensitive-gate events from the run
+    # workdir so gate refusals and redactions land in the operator chain.
+    from bernstein.core.tokens.sensitive_gate import resolve_default_chain
+
+    _gate_workdir = getattr(orch, "_workdir", None)
+    _gate_chain = resolve_default_chain(Path(_gate_workdir)) if _gate_workdir else resolve_default_chain()
+
     try:
         result = pipeline.execute(
             session_id=session.id,
             context_text=description_text,
             tokens_before=tokens_before,
             reason="provider_413",
+            task_id=task_id,
+            audit_chain=_gate_chain,
         )
     except Exception as exc:
         logger.error("Compaction pipeline failed for task %s: %s", task_id, exc)
@@ -613,6 +622,17 @@ def _try_compact_and_retry(
             **_retry_escalation_context(orch),
         )
         return False
+
+    if result.gate_action == "refused":
+        # The sensitive gate found credential-shaped content it could not
+        # safely delimit: nothing was sent to the model and the description
+        # is unchanged. The refusal is already in the audit chain; surface
+        # it to the operator log too.
+        logger.warning(
+            "Compaction for task %s skipped by sensitive gate (rules: %s)",
+            task_id,
+            ", ".join(result.gate_rule_ids),
+        )
 
     # Reconcile post-compaction budget now that we know how many tokens were saved.
     if _budget_mgr is not None:

--- a/src/bernstein/core/compat_redirect_ledger.py
+++ b/src/bernstein/core/compat_redirect_ledger.py
@@ -39,7 +39,7 @@ REDIRECT_LEDGER_POLICY: Final[RedirectLedgerPolicy] = RedirectLedgerPolicy(
     ),
 )
 
-REVIEWED_REDIRECT_MAP_DIGEST: Final[str] = "d35096b8ee9932b42510e4e704a60b276c9188855107c1e4d735f30ef9a13567"
+REVIEWED_REDIRECT_MAP_DIGEST: Final[str] = "7739633119917414455f337b5550be737e9aed29c19f7a441e8bbf6dd0b74c57"
 
 
 def redirect_map_digest(redirects: Mapping[str, str]) -> str:

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -695,6 +695,17 @@ class CompactionDefaults:
     max_block_age_turns: int = 5
     # Shared token estimator: characters per token for English text.
     chars_per_token: int = 4
+    # Sensitive-content gate over compaction input (bernstein.yaml tuning
+    # section ``compaction``, keys ``sensitive_gate_*``). The gate refuses
+    # to forward credential-shaped content to the LLM summary stage.
+    sensitive_gate_enabled: bool = True
+    # Extra operator-supplied deny patterns (regex strings). Hits are
+    # redacted with a typed placeholder.
+    sensitive_gate_extra_deny: tuple[str, ...] = ()
+    # Allowlist entries: a rule id (``content.aws-access-key``) or a rule
+    # id plus the first 8 hex chars of the span hash
+    # (``content.aws-access-key:1a2b3c4d``). Suppressions are audit-logged.
+    sensitive_gate_allow: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -54,6 +54,13 @@ from bernstein.core.security.audit import (
 #: digest.
 EVENT_MULTIMODAL_ATTACH = "multimodal.attach"
 
+#: Issue #2242 -- emitted whenever the compaction sensitive-content gate
+#: redacts a credential-shaped span, refuses a compaction outright, or
+#: suppresses a rule via an operator allowlist entry. The event records
+#: the task id, the rule id, the action taken, and the SHA-256 of the
+#: offending span -- never the span content itself.
+EVENT_COMPACTION_SENSITIVE_GATE = "compaction.sensitive_gate"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -242,10 +249,49 @@ def record_multimodal_attach(
     )
 
 
+def record_sensitive_gate(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    rule_id: str,
+    action: str,
+    span_hash: str,
+) -> AuditEvent:
+    """Append a ``compaction.sensitive_gate`` event into *chain*.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        task_id: Task (or session) whose compaction input was gated.
+        rule_id: Identifier of the deny rule that fired (e.g.
+            ``content.pem-private-key``).
+        action: One of ``redacted``, ``refused``, or ``suppressed``.
+        span_hash: Hex SHA-256 of the offending span bytes. The hash is
+            the only trace of the span -- content is never recorded.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest``
+        embedded in its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_COMPACTION_SENSITIVE_GATE,
+        actor=task_id,
+        resource_type="compaction",
+        resource_id=task_id,
+        details={
+            "task_id": task_id,
+            "rule_id": rule_id,
+            "action": action,
+            "span_hash": span_hash,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
+    "EVENT_COMPACTION_SENSITIVE_GATE",
     "EVENT_MULTIMODAL_ATTACH",
     "AuditChainStore",
     "MultimodalAttachDetails",
     "record_multimodal_attach",
+    "record_sensitive_gate",
 ]

--- a/src/bernstein/core/tokens/compaction_pipeline.py
+++ b/src/bernstein/core/tokens/compaction_pipeline.py
@@ -1,8 +1,12 @@
 """Compaction pipeline - structured context compaction with typed hooks.
 
 Implements a stage pipeline:
-    pre-compact hooks → strip media → LLM summary → boundary marker → reinject
-    → post-compact hooks
+    pre-compact hooks → sensitive gate → strip media → LLM summary
+    → boundary marker → reinject → post-compact hooks
+
+The sensitive gate (:mod:`bernstein.core.tokens.sensitive_gate`) redacts
+credential-shaped spans before anything reaches the LLM summary stage and
+refuses the whole compaction when a hit is not safely delimitable.
 
 Each stage is independently testable and optional hooks fail safe with logging.
 """
@@ -15,10 +19,16 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.tokens.failed_action_retention import (
     FailedActionBlock,
     split_retained_blocks,
     tag_failed_actions,
+)
+from bernstein.core.tokens.sensitive_gate import (
+    GateConfig,
+    emit_gate_audit,
+    scan_for_sensitive_content,
 )
 
 if TYPE_CHECKING:
@@ -86,6 +96,11 @@ class CompactionResult:
         pre_hook_ok: Whether all pre-compact hooks succeeded.
         post_hook_ok: Whether all post-compact hooks ran (even if some warned).
         reason: Compaction trigger reason.
+        gate_action: Sensitive-gate outcome: ``allow`` (clean input),
+            ``redacted`` (spans replaced before summarization), or
+            ``refused`` (compaction skipped; ``compacted_text`` is the
+            unmodified input and nothing was sent to the model).
+        gate_rule_ids: Deny-rule ids that fired, in span order.
     """
 
     correlation_id: str
@@ -96,6 +111,8 @@ class CompactionResult:
     pre_hook_ok: bool
     post_hook_ok: bool
     reason: str
+    gate_action: str = "allow"
+    gate_rule_ids: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +184,7 @@ class CompactionPipeline:
 
     Each stage is independently testable:
     1. Pre-compact hooks - plugins can modify/observe context before compaction.
+    1.5. Sensitive gate - redact credential-shaped spans or refuse outright.
     2. Strip media - remove images/documents that waste token budget.
     3. LLM summary - generate a compact summary for reinjection.
     4. Boundary marker - caller records the trace marker.
@@ -193,6 +211,9 @@ class CompactionPipeline:
         keep_failed_actions: bool = False,
         retained_failures: Sequence[FailedActionBlock] | None = None,
         current_turn: int = 0,
+        sensitive_gate: bool | None = None,
+        task_id: str | None = None,
+        audit_chain: Any | None = None,
     ) -> CompactionResult:
         """Run the full compaction pipeline.
 
@@ -203,6 +224,14 @@ class CompactionPipeline:
             reason: Why compaction was triggered.
             llm_call: Optional async callable for LLM summary.
             strip_media: Whether to strip media blocks before summarizing.
+            sensitive_gate: Per-call override for the sensitive-content
+                gate; ``None`` follows the ``compaction`` defaults
+                (enabled by default). When the gate refuses, the summary
+                stage is skipped and the input is returned unchanged.
+            task_id: Task id recorded on gate audit events; falls back
+                to *session_id*.
+            audit_chain: Optional ``AuditChainStore`` receiving gate
+                events; resolved from ``./.sdd/audit`` when omitted.
             keep_failed_actions: When ``True`` (Manus harness pattern #5),
                 tagged failure blocks already in *context_text* are carved
                 out and re-appended verbatim after summarisation, and any
@@ -227,6 +256,43 @@ class CompactionPipeline:
             tokens_before,
             reason,
         )
+
+        # Stage 1.5: sensitive-content gate. Credential-shaped spans are
+        # redacted before anything is forwarded to the summary stage;
+        # non-delimitable hits refuse the whole compaction.
+        gate_action = "allow"
+        gate_rule_ids: tuple[str, ...] = ()
+        gate_config = GateConfig.from_defaults()
+        gate_enabled = gate_config.enabled if sensitive_gate is None else sensitive_gate
+        if gate_enabled:
+            decision = scan_for_sensitive_content(working_text, config=gate_config)
+            emit_gate_audit(
+                decision,
+                chain=audit_chain,
+                task_id=task_id,
+                session_id=session_id,
+            )
+            gate_action = decision.action
+            gate_rule_ids = tuple(finding.rule_id for finding in decision.findings)
+            if decision.action == "refused":
+                logger.warning(
+                    "Compaction refused by sensitive gate for session %s (%d findings)",
+                    sanitize_log(session_id),
+                    len(decision.findings),
+                )
+                return CompactionResult(
+                    correlation_id=correlation_id,
+                    tokens_before=tokens_before,
+                    tokens_after=tokens_before,
+                    tokens_saved=0,
+                    compacted_text=context_text,
+                    pre_hook_ok=pre_hook_ok,
+                    post_hook_ok=True,  # No compaction happened; hooks skipped.
+                    reason=reason,
+                    gate_action=gate_action,
+                    gate_rule_ids=gate_rule_ids,
+                )
+            working_text = decision.text
 
         # Stage 1b (Manus #5): carve out tagged failure blocks before media
         # stripping / summary so they survive verbatim. Off by default.
@@ -265,6 +331,8 @@ class CompactionPipeline:
             pre_hook_ok=pre_hook_ok,
             post_hook_ok=False,  # Updated below
             reason=reason,
+            gate_action=gate_action,
+            gate_rule_ids=gate_rule_ids,
         )
 
         # Stage 5: Post-compact hooks

--- a/src/bernstein/core/tokens/sensitive_gate.py
+++ b/src/bernstein/core/tokens/sensitive_gate.py
@@ -1,0 +1,531 @@
+"""Deny gate for credential-shaped content in compaction input.
+
+The compaction pipeline forwards slices of worker context to a model API
+to produce summaries. Worker contexts routinely contain file reads, so a
+context that includes ``.env`` contents, private keys, or cloud
+credentials would otherwise be shipped to an external API. This module
+scans compaction input before the summary stage and either redacts the
+offending span or refuses the whole compaction.
+
+Design rules
+------------
+* **Pure and deterministic.** :func:`scan_for_sensitive_content` performs
+  no IO and yields identical verdicts for identical input on every
+  platform. Audit emission is a separate, explicit step
+  (:func:`emit_gate_audit`).
+* **Redact when safely delimitable, refuse otherwise.** Content patterns
+  with a well-defined span (a complete PEM block, an AWS access key id, a
+  ``ghp_`` token) are replaced with a typed placeholder
+  ``[REDACTED:<rule-id>:<sha256[:8] of original>]``. Path-shaped tokens
+  (``.env``, ``id_rsa``, ``*.pem``, ``.ssh/`` ...) signal that credential
+  *file contents* may surround the token in ways the gate cannot
+  delimit, so any such hit refuses the compaction outright. An
+  unterminated PEM header likewise refuses.
+* **Hash only, never content.** Findings carry the SHA-256 of the span;
+  the span text itself is never stored on a finding or an audit event.
+
+Entropy heuristic
+-----------------
+The generic assignment rule fires only when ALL of the following hold:
+
+* the assigned name normalizes (separators stripped, lower-cased, so
+  ``api-key`` -> ``apikey``) to contain a sensitive keyword
+  (``key``, ``secret``, ``token``, ``passwd``, ``password``,
+  ``credential``);
+* the value is at least :data:`ENTROPY_MIN_VALUE_LENGTH` (24) characters;
+* the Shannon entropy of the value is STRICTLY above
+  :data:`ENTROPY_MIN_BITS_PER_CHAR` (4.0 bits/char).
+
+The strict 4.0-bit threshold is deliberately conservative (prefer false
+negatives over noise): a pure-hex value draws from a 16-symbol alphabet
+whose entropy is capped at ``log2(16) == 4.0``, so SHA/MD5 digests and
+UUIDs are structurally incapable of crossing it, while real secrets
+(mixed-case base64-ish material) comfortably exceed it at 24+ chars.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from bernstein.core.security.sanitize import sanitize_log
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Entropy heuristic constants (documented above)
+# ---------------------------------------------------------------------------
+
+#: Minimum Shannon entropy (bits per character, strict) for the generic
+#: assignment rule. Pure-hex values cannot exceed 4.0, so digests and
+#: UUIDs never fire this rule.
+ENTROPY_MIN_BITS_PER_CHAR: float = 4.0
+
+#: Minimum value length for the generic assignment rule.
+ENTROPY_MIN_VALUE_LENGTH: int = 24
+
+#: Sensitive keywords matched against the normalized assignment name.
+_SENSITIVE_NAME_KEYWORDS: tuple[str, ...] = (
+    "key",
+    "secret",
+    "token",
+    "passwd",
+    "password",
+    "credential",
+)
+
+# ---------------------------------------------------------------------------
+# Rule table
+# ---------------------------------------------------------------------------
+
+_PEM_HEADER = r"-----BEGIN [A-Z][A-Z0-9 ]*PRIVATE KEY(?: BLOCK)?-----"
+_PEM_FOOTER = r"-----END [A-Z][A-Z0-9 ]*PRIVATE KEY(?: BLOCK)?-----"
+
+
+@dataclass(frozen=True)
+class _Rule:
+    """A single deny rule: id, compiled pattern, and delimitability."""
+
+    rule_id: str
+    pattern: re.Pattern[str]
+    delimitable: bool
+    #: Regex group whose span is the offending content (0 = whole match).
+    group: int = 0
+
+
+#: Content rules with safely delimitable spans -> redact on hit.
+_CONTENT_RULES: tuple[_Rule, ...] = (
+    _Rule(
+        rule_id="content.pem-private-key",
+        pattern=re.compile(_PEM_HEADER + r".*?" + _PEM_FOOTER, re.DOTALL),
+        delimitable=True,
+    ),
+    _Rule(
+        rule_id="content.aws-access-key",
+        pattern=re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        delimitable=True,
+    ),
+    _Rule(
+        rule_id="content.github-token",
+        pattern=re.compile(r"\bghp_[A-Za-z0-9]{36,}\b"),
+        delimitable=True,
+    ),
+    _Rule(
+        rule_id="content.anthropic-key",
+        pattern=re.compile(r"\bsk-ant-[A-Za-z0-9_-]{24,}\b"),
+        delimitable=True,
+    ),
+)
+
+#: A PEM header without a matching footer: the key material extends past
+#: anything the gate can delimit -> refuse.
+_PEM_UNTERMINATED_RULE = _Rule(
+    rule_id="content.pem-unterminated",
+    pattern=re.compile(_PEM_HEADER),
+    delimitable=False,
+)
+
+#: Path-shaped tokens: the token itself is harmless, but its presence
+#: signals surrounding credential file contents that the gate cannot
+#: safely delimit -> refuse the whole compaction.
+_PATH_RULES: tuple[_Rule, ...] = (
+    _Rule(
+        rule_id="path.env",
+        pattern=re.compile(r"""(?:^|[\s"'=(/])(\.env(?:\.\w[\w.-]*)?)(?=["'):,;\s]|\Z)"""),
+        delimitable=False,
+        group=1,
+    ),
+    _Rule(
+        rule_id="path.id-rsa",
+        pattern=re.compile(r"\bid_rsa\b(?!\.pub\b)"),
+        delimitable=False,
+    ),
+    _Rule(
+        rule_id="path.pem",
+        pattern=re.compile(r"\b[\w.~-]+\.pem\b"),
+        delimitable=False,
+    ),
+    _Rule(
+        rule_id="path.credentials",
+        pattern=re.compile(r"[\w.~-]*/credentials\b|(?<![\w.-])credentials\.(?:json|csv|ini|xml|ya?ml|txt)\b"),
+        delimitable=False,
+    ),
+    _Rule(rule_id="path.ssh-dir", pattern=re.compile(r"\.ssh/"), delimitable=False),
+    _Rule(rule_id="path.aws-dir", pattern=re.compile(r"\.aws/"), delimitable=False),
+    _Rule(rule_id="path.gnupg-dir", pattern=re.compile(r"\.gnupg/"), delimitable=False),
+    _Rule(rule_id="path.kube-dir", pattern=re.compile(r"\.kube/"), delimitable=False),
+)
+
+#: Generic assignment: ``<name> = <value>`` / ``<name>: <value>``.
+#: Group 1 is the name (checked against the keyword set after
+#: normalization), group 2 the value (checked against the entropy
+#: heuristic). Only the value span is redacted.
+_ASSIGNMENT_PATTERN = re.compile(
+    r"""([A-Za-z][A-Za-z0-9_.\-]{0,40})\s*[:=]\s*["']?([A-Za-z0-9+/=_\-]{24,})""",
+)
+
+#: Value shapes excluded from the entropy rule regardless of entropy:
+#: UUIDs and pure-hex digests are identifiers, not secrets. (Belt and
+#: braces -- the 4.0-bit threshold already excludes them structurally.)
+_UUID_PATTERN = re.compile(r"\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\Z")
+_HEX_PATTERN = re.compile(r"\A[0-9a-fA-F]+\Z")
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GateConfig:
+    """Configuration for the sensitive-content gate.
+
+    Attributes:
+        enabled: Master switch; when ``False`` the gate allows everything.
+        extra_deny: Operator-supplied regex strings. Hits are redacted
+            under a synthetic ``extra.<sha256[:8] of pattern>`` rule id.
+            Invalid patterns are logged and skipped.
+        allow: Allowlist entries. Each entry is either a rule id
+            (suppresses every hit of that rule) or ``<rule-id>:<hash8>``
+            (suppresses only the span whose SHA-256 starts with those 8
+            hex chars). Suppressions are audit-logged.
+    """
+
+    enabled: bool = True
+    extra_deny: tuple[str, ...] = ()
+    allow: tuple[str, ...] = ()
+
+    @classmethod
+    def from_defaults(cls) -> GateConfig:
+        """Build a config from the ``compaction`` defaults section."""
+        from bernstein.core import defaults
+
+        return cls(
+            enabled=defaults.COMPACTION.sensitive_gate_enabled,
+            extra_deny=tuple(defaults.COMPACTION.sensitive_gate_extra_deny),
+            allow=tuple(defaults.COMPACTION.sensitive_gate_allow),
+        )
+
+
+@dataclass(frozen=True)
+class GateFinding:
+    """A single deny-rule hit. Carries the span hash, never the content.
+
+    Attributes:
+        rule_id: Identifier of the rule that fired.
+        span_hash: Hex SHA-256 of the offending span bytes (UTF-8).
+        start: Span start offset in the scanned text.
+        end: Span end offset in the scanned text.
+        delimitable: Whether the span can be safely replaced in place.
+    """
+
+    rule_id: str
+    span_hash: str
+    start: int
+    end: int
+    delimitable: bool
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Outcome of a gate scan.
+
+    Attributes:
+        action: ``allow`` (clean or fully suppressed), ``redacted``
+            (all hits replaced with typed placeholders), or ``refused``
+            (at least one non-delimitable hit; ``text`` is untouched and
+            the caller MUST NOT forward it to a model API).
+        text: The gated text. Original input for ``allow`` and
+            ``refused``; placeholder-substituted for ``redacted``.
+        findings: Non-suppressed hits, ordered by span start.
+        suppressed: Hits suppressed by allowlist entries.
+    """
+
+    action: Literal["allow", "redacted", "refused"]
+    text: str
+    findings: tuple[GateFinding, ...] = ()
+    suppressed: tuple[GateFinding, ...] = field(default=())
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def shannon_entropy(value: str) -> float:
+    """Return the Shannon entropy of *value* in bits per character."""
+    if not value:
+        return 0.0
+    counts = Counter(value)
+    total = len(value)
+    return -sum((n / total) * math.log2(n / total) for n in counts.values())
+
+
+def _span_hash(text: str, start: int, end: int) -> str:
+    return hashlib.sha256(text[start:end].encode("utf-8")).hexdigest()
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize an assignment name for keyword matching (``api-key`` -> ``apikey``)."""
+    return re.sub(r"[-_.]", "", name).lower()
+
+
+def _extra_rules(config: GateConfig) -> tuple[_Rule, ...]:
+    """Compile operator-supplied deny patterns; skip invalid ones."""
+    rules: list[_Rule] = []
+    for raw in config.extra_deny:
+        try:
+            pattern = re.compile(raw)
+        except re.error as exc:
+            logger.warning(
+                "sensitive gate: skipping invalid extra_deny pattern (%s)",
+                sanitize_log(str(exc)),
+            )
+            continue
+        rule_id = f"extra.{hashlib.sha256(raw.encode('utf-8')).hexdigest()[:8]}"
+        rules.append(_Rule(rule_id=rule_id, pattern=pattern, delimitable=True))
+    return tuple(rules)
+
+
+def _collect_raw_findings(text: str, config: GateConfig) -> list[GateFinding]:
+    """Run every rule over *text* and return all hits (may overlap)."""
+    findings: list[GateFinding] = []
+
+    complete_pem_spans: list[tuple[int, int]] = []
+    for rule in _CONTENT_RULES + _PATH_RULES + _extra_rules(config):
+        for match in rule.pattern.finditer(text):
+            start, end = match.span(rule.group)
+            findings.append(
+                GateFinding(
+                    rule_id=rule.rule_id,
+                    span_hash=_span_hash(text, start, end),
+                    start=start,
+                    end=end,
+                    delimitable=rule.delimitable,
+                )
+            )
+            if rule.rule_id == "content.pem-private-key":
+                complete_pem_spans.append((start, end))
+
+    # PEM headers not inside a complete block are unterminated -> refuse.
+    for match in _PEM_UNTERMINATED_RULE.pattern.finditer(text):
+        start, end = match.span()
+        inside_complete = any(s <= start and end <= e for s, e in complete_pem_spans)
+        if not inside_complete:
+            findings.append(
+                GateFinding(
+                    rule_id=_PEM_UNTERMINATED_RULE.rule_id,
+                    span_hash=_span_hash(text, start, end),
+                    start=start,
+                    end=end,
+                    delimitable=False,
+                )
+            )
+
+    # Generic high-entropy assignment heuristic.
+    for match in _ASSIGNMENT_PATTERN.finditer(text):
+        name, value = match.group(1), match.group(2)
+        if not any(kw in _normalize_name(name) for kw in _SENSITIVE_NAME_KEYWORDS):
+            continue
+        if len(value) < ENTROPY_MIN_VALUE_LENGTH:
+            continue
+        if _UUID_PATTERN.match(value) or _HEX_PATTERN.match(value):
+            continue
+        if shannon_entropy(value) <= ENTROPY_MIN_BITS_PER_CHAR:
+            continue
+        start, end = match.span(2)
+        findings.append(
+            GateFinding(
+                rule_id="content.entropy-assignment",
+                span_hash=_span_hash(text, start, end),
+                start=start,
+                end=end,
+                delimitable=True,
+            )
+        )
+
+    return findings
+
+
+def _dedupe_overlaps(findings: list[GateFinding]) -> list[GateFinding]:
+    """Resolve overlapping spans deterministically.
+
+    Sort by (start, longest-first, rule id) and greedily keep spans that
+    do not overlap an already-accepted span. Non-delimitable hits are
+    always kept: they force refusal regardless of span geometry.
+    """
+    ordered = sorted(findings, key=lambda f: (f.start, -(f.end - f.start), f.rule_id))
+    accepted: list[GateFinding] = []
+    for finding in ordered:
+        if not finding.delimitable:
+            accepted.append(finding)
+            continue
+        overlaps = any(f.delimitable and finding.start < f.end and f.start < finding.end for f in accepted)
+        if not overlaps:
+            accepted.append(finding)
+    return sorted(accepted, key=lambda f: (f.start, f.rule_id))
+
+
+def _is_suppressed(finding: GateFinding, allow: tuple[str, ...]) -> bool:
+    """Return whether an allowlist entry suppresses *finding*."""
+    specific = f"{finding.rule_id}:{finding.span_hash[:8]}"
+    return finding.rule_id in allow or specific in allow
+
+
+def _redact(text: str, findings: list[GateFinding]) -> str:
+    """Replace each finding span with its typed placeholder, right to left."""
+    result = text
+    for finding in sorted(findings, key=lambda f: f.start, reverse=True):
+        placeholder = f"[REDACTED:{finding.rule_id}:{finding.span_hash[:8]}]"
+        result = result[: finding.start] + placeholder + result[finding.end :]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public scan entrypoint
+# ---------------------------------------------------------------------------
+
+
+def scan_for_sensitive_content(text: str, *, config: GateConfig | None = None) -> GateDecision:
+    """Scan *text* for credential-shaped content. Pure and deterministic.
+
+    Args:
+        text: The compaction input to scan.
+        config: Gate configuration; defaults to the ``compaction``
+            defaults section when omitted.
+
+    Returns:
+        A :class:`GateDecision`. ``refused`` decisions return the
+        original text untouched -- the caller must not forward it.
+    """
+    if config is None:
+        config = GateConfig.from_defaults()
+    if not config.enabled or not text:
+        return GateDecision(action="allow", text=text)
+
+    raw = _collect_raw_findings(text, config)
+    deduped = _dedupe_overlaps(raw)
+
+    active: list[GateFinding] = []
+    suppressed: list[GateFinding] = []
+    for finding in deduped:
+        if _is_suppressed(finding, config.allow):
+            suppressed.append(finding)
+        else:
+            active.append(finding)
+
+    if not active:
+        return GateDecision(action="allow", text=text, suppressed=tuple(suppressed))
+
+    if any(not finding.delimitable for finding in active):
+        return GateDecision(
+            action="refused",
+            text=text,
+            findings=tuple(active),
+            suppressed=tuple(suppressed),
+        )
+
+    return GateDecision(
+        action="redacted",
+        text=_redact(text, active),
+        findings=tuple(active),
+        suppressed=tuple(suppressed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit emission (explicitly separate from the pure scan)
+# ---------------------------------------------------------------------------
+
+
+def resolve_default_chain(base_dir: Path | None = None) -> AuditChainStore | None:
+    """Return an audit chain rooted at ``<base_dir>/.sdd/audit`` if present.
+
+    Never creates the directory: callers outside an initialized install
+    (unit tests, ad-hoc scripts) get ``None`` and emission is skipped.
+    """
+    root = base_dir if base_dir is not None else Path.cwd()
+    audit_dir = root / ".sdd" / "audit"
+    if not audit_dir.is_dir():
+        return None
+    try:
+        from bernstein.core.security.audit_chain import AuditChainStore
+
+        return AuditChainStore(audit_dir)
+    except Exception as exc:
+        logger.warning("sensitive gate: audit chain unavailable (%s)", sanitize_log(str(exc)))
+        return None
+
+
+def emit_gate_audit(
+    decision: GateDecision,
+    *,
+    chain: AuditChainStore | None = None,
+    task_id: str | None = None,
+    session_id: str = "",
+) -> None:
+    """Record every redaction, refusal, and suppression in the audit chain.
+
+    Each event carries ``{task_id, rule_id, action, span_hash}`` -- the
+    hash only, never the span content. Emission failures are logged and
+    never abort the caller: the protective redact/refuse outcome stands
+    regardless of audit availability.
+
+    Args:
+        decision: The scan outcome to record.
+        chain: Audit chain store; resolved from ``./.sdd/audit`` when
+            omitted, and emission is skipped when no chain is available.
+        task_id: Task whose compaction input was gated; falls back to
+            *session_id* for callers without a task id.
+        session_id: Agent session id (fallback actor).
+    """
+    if not decision.findings and not decision.suppressed:
+        return
+    if chain is None:
+        chain = resolve_default_chain()
+    if chain is None:
+        logger.debug("sensitive gate: no audit chain available; skipping event emission")
+        return
+
+    from bernstein.core.security.audit_chain import record_sensitive_gate
+
+    actor = task_id or session_id or "unknown"
+    records = [(finding, decision.action) for finding in decision.findings]
+    records.extend((finding, "suppressed") for finding in decision.suppressed)
+    for finding, action in records:
+        try:
+            record_sensitive_gate(
+                chain=chain,
+                task_id=actor,
+                rule_id=finding.rule_id,
+                action=action,
+                span_hash=finding.span_hash,
+            )
+        except Exception as exc:
+            logger.warning(
+                "sensitive gate: audit emission failed for %s (%s)",
+                sanitize_log(actor),
+                sanitize_log(str(exc)),
+            )
+
+
+__all__ = [
+    "ENTROPY_MIN_BITS_PER_CHAR",
+    "ENTROPY_MIN_VALUE_LENGTH",
+    "GateConfig",
+    "GateDecision",
+    "GateFinding",
+    "emit_gate_audit",
+    "resolve_default_chain",
+    "scan_for_sensitive_content",
+    "shannon_entropy",
+]

--- a/tests/unit/test_compaction_pipeline.py
+++ b/tests/unit/test_compaction_pipeline.py
@@ -170,6 +170,106 @@ class TestCompactionPipeline:
         assert result.pre_hook_ok is False
 
 
+class TestSensitiveGateIntegration:
+    """The pipeline refuses to forward credential-shaped content to the LLM."""
+
+    PEM_BLOCK = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA7bq7wmiCPDlKcQXn3pg9qF4mUJVjcMZLxQ2R8aTnW1sBvKd0\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+
+    def test_pem_block_never_reaches_summary_boundary(self) -> None:
+        """Acceptance: fixture PEM content is absent from the outbound payload."""
+        pipeline = CompactionPipeline(plugin_manager=None)
+        context = f"# Notes\nkey file contents:\n{self.PEM_BLOCK}\nmore notes"
+        summary_mock = MagicMock(return_value="[summary]")
+        with patch(
+            "bernstein.core.tokens.compaction_pipeline.summarize_context",
+            summary_mock,
+        ):
+            result = pipeline.execute(
+                session_id="s-gate-1",
+                context_text=context,
+                tokens_before=500,
+            )
+        assert result.gate_action == "redacted"
+        summary_mock.assert_called_once()
+        outbound_text = summary_mock.call_args.args[0]
+        assert "PRIVATE KEY" not in outbound_text
+        assert "MIIEowIBAAKCAQEA" not in outbound_text
+        assert "[REDACTED:content.pem-private-key:" in outbound_text
+
+    def test_refusal_skips_summary_and_keeps_original(self) -> None:
+        pipeline = CompactionPipeline(plugin_manager=None)
+        context = "$ cat .env\nAWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCyEXAMPLEKEY\n"
+        summary_mock = MagicMock(return_value="[summary]")
+        with patch(
+            "bernstein.core.tokens.compaction_pipeline.summarize_context",
+            summary_mock,
+        ):
+            result = pipeline.execute(
+                session_id="s-gate-2",
+                context_text=context,
+                tokens_before=500,
+            )
+        summary_mock.assert_not_called()
+        assert result.gate_action == "refused"
+        assert result.compacted_text == context
+        assert result.tokens_saved == 0
+
+    def test_gate_can_be_disabled_per_call(self) -> None:
+        pipeline = CompactionPipeline(plugin_manager=None)
+        summary_mock = MagicMock(return_value="[summary]")
+        with patch(
+            "bernstein.core.tokens.compaction_pipeline.summarize_context",
+            summary_mock,
+        ):
+            result = pipeline.execute(
+                session_id="s-gate-3",
+                context_text=f"x\n{self.PEM_BLOCK}\ny",
+                tokens_before=500,
+                sensitive_gate=False,
+            )
+        assert result.gate_action == "allow"
+        assert "PRIVATE KEY" in summary_mock.call_args.args[0]
+
+    def test_gate_events_land_in_injected_audit_chain(self, tmp_path: object) -> None:
+        from pathlib import Path
+
+        from bernstein.core.security.audit_chain import (
+            EVENT_COMPACTION_SENSITIVE_GATE,
+            AuditChainStore,
+        )
+
+        chain = AuditChainStore(Path(str(tmp_path)) / "audit", key=b"k" * 32)
+        pipeline = CompactionPipeline(plugin_manager=None)
+        result = pipeline.execute(
+            session_id="s-gate-4",
+            context_text=f"x\n{self.PEM_BLOCK}\ny",
+            tokens_before=500,
+            task_id="task-42",
+            audit_chain=chain,
+        )
+        assert result.gate_action == "redacted"
+        events = chain.query(event_type=EVENT_COMPACTION_SENSITIVE_GATE)
+        assert len(events) == 1
+        assert events[0].details["task_id"] == "task-42"
+        assert events[0].details["action"] == "redacted"
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_gate_result_defaults_to_allow_for_clean_context(self) -> None:
+        pipeline = CompactionPipeline(plugin_manager=None)
+        result = pipeline.execute(
+            session_id="s-gate-5",
+            context_text="# Header\nnormal notes\n",
+            tokens_before=100,
+        )
+        assert result.gate_action == "allow"
+        assert result.gate_rule_ids == ()
+
+
 class TestPayloads:
     def test_pre_compact_payload_fields(self) -> None:
         payload = PreCompactPayload(

--- a/tests/unit/test_sensitive_gate.py
+++ b/tests/unit/test_sensitive_gate.py
@@ -1,0 +1,368 @@
+"""Tests for the compaction sensitive-content gate.
+
+Covers the acceptance criteria for the deny gate over compaction input:
+
+1. Pure and deterministic verdicts over a fixture corpus.
+2. Credential-shaped spans are redacted with typed placeholders or the
+   whole compaction is refused when the span is not safely delimitable.
+3. Every redaction, refusal, and allowlist suppression is recorded in the
+   HMAC audit chain (span hash only, never content) and the chain verifies.
+4. Allowlist entries suppress rules and the suppression is audit-logged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from bernstein.core.security.audit_chain import (
+    EVENT_COMPACTION_SENSITIVE_GATE,
+    AuditChainStore,
+)
+from bernstein.core.tokens.sensitive_gate import (
+    ENTROPY_MIN_BITS_PER_CHAR,
+    ENTROPY_MIN_VALUE_LENGTH,
+    GateConfig,
+    GateDecision,
+    emit_gate_audit,
+    scan_for_sensitive_content,
+    shannon_entropy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture corpus - positives
+# ---------------------------------------------------------------------------
+
+PEM_BLOCK = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "MIIEowIBAAKCAQEA7bq7wmiCPDlKcQXn3pg9qF4mUJVjcMZLxQ2R8aTnW1sBvKd0\n"
+    "Zx9YpH3mN6cRqLtE5uWvGf8kAoJdSyXbCePiMnrTz4hQjV2wKgUmBaN7lDxOsF1e\n"
+    "-----END RSA PRIVATE KEY-----"
+)
+
+ID_RSA_CONTENT = (
+    "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdz\n"
+    "c2gtcnNhAAAAAwEAAQAAAQEAy8kVpTfW2nQxJmH0dGeLcU4bRaZoP7iM9sBvE1uY\n"
+    "-----END OPENSSH PRIVATE KEY-----"
+)
+
+AKIA_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+GHP_TOKEN = "ghp_A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"
+
+ANTHROPIC_KEY = "sk-ant-api03-Zx9YpH3mN6cRqLtE5uWvGf8kAoJdSyXbCePiMnrTz4hQ"
+
+ENV_FILE_DUMP = (
+    "$ cat .env\n"
+    "DATABASE_URL=postgres://user:pass@host/db\n"
+    "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCyEXAMPLEKEY\n"
+)
+
+ENTROPY_ASSIGNMENT = 'api-key: "9fXq2LmZv8RbT4wKpN6yHs3JdA7eUcGh"'
+
+POSITIVES = [
+    pytest.param(PEM_BLOCK, id="pem-block"),
+    pytest.param(ID_RSA_CONTENT, id="id-rsa-content"),
+    pytest.param(f"found key {AKIA_KEY} in config", id="akia-key"),
+    pytest.param(f"token is {GHP_TOKEN}", id="ghp-token"),
+    pytest.param(f"use {ANTHROPIC_KEY} for the call", id="anthropic-key"),
+    pytest.param(ENV_FILE_DUMP, id="env-file-dump"),
+    pytest.param(ENTROPY_ASSIGNMENT, id="entropy-assignment"),
+]
+
+# ---------------------------------------------------------------------------
+# Fixture corpus - negatives
+# ---------------------------------------------------------------------------
+
+UUID_TEXT = 'request_id = "550e8400-e29b-41d4-a716-446655440000"'
+
+SHA256_TEXT = 'digest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"'
+
+BASE64_IMAGE = "![img](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk)"
+
+NORMAL_CODE = (
+    "def resolve(env_name: str) -> str:\n"
+    '    """Look up a value from the environment."""\n'
+    "    return os.environ.get(env_name, '')\n"
+)
+
+HEX_DIGEST_WITH_SENSITIVE_NAME = 'token_digest = "9b74c9897bac770ffc029102a200c5de1bc1e9cc292e1cadd07f4a8256a2b0ac"'
+
+NEGATIVES = [
+    pytest.param(UUID_TEXT, id="uuid"),
+    pytest.param(SHA256_TEXT, id="sha256-hash"),
+    pytest.param(BASE64_IMAGE, id="base64-image"),
+    pytest.param(NORMAL_CODE, id="normal-code"),
+    pytest.param(HEX_DIGEST_WITH_SENSITIVE_NAME, id="hex-digest-sensitive-name"),
+    pytest.param("plain prose about deployment pipelines", id="prose"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Determinism and verdicts (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+
+class TestVerdicts:
+    @pytest.mark.parametrize("text", POSITIVES)
+    def test_positive_is_flagged(self, text: str) -> None:
+        decision = scan_for_sensitive_content(text)
+        assert decision.action in ("redacted", "refused")
+        assert decision.findings
+
+    @pytest.mark.parametrize("text", NEGATIVES)
+    def test_negative_is_allowed(self, text: str) -> None:
+        decision = scan_for_sensitive_content(text)
+        assert decision.action == "allow"
+        assert decision.text == text
+        assert not decision.findings
+
+    @pytest.mark.parametrize("text", POSITIVES + NEGATIVES)
+    def test_deterministic_across_runs(self, text: str) -> None:
+        first = scan_for_sensitive_content(text)
+        second = scan_for_sensitive_content(text)
+        assert first == second
+
+    def test_empty_input_allows(self) -> None:
+        decision = scan_for_sensitive_content("")
+        assert decision.action == "allow"
+        assert decision.text == ""
+
+
+# ---------------------------------------------------------------------------
+# Redaction behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    def test_akia_key_redacted_with_typed_placeholder(self) -> None:
+        text = f"before {AKIA_KEY} after"
+        decision = scan_for_sensitive_content(text)
+        assert decision.action == "redacted"
+        assert AKIA_KEY not in decision.text
+        span_hash = hashlib.sha256(AKIA_KEY.encode("utf-8")).hexdigest()
+        assert f"[REDACTED:content.aws-access-key:{span_hash[:8]}]" in decision.text
+        assert "before" in decision.text
+        assert "after" in decision.text
+
+    def test_complete_pem_block_redacted(self) -> None:
+        text = f"file contents:\n{PEM_BLOCK}\ndone"
+        decision = scan_for_sensitive_content(text)
+        assert decision.action == "redacted"
+        assert "PRIVATE KEY" not in decision.text.replace("REDACTED", "")
+        assert "MIIEowIBAAKCAQEA" not in decision.text
+        assert "[REDACTED:content.pem-private-key:" in decision.text
+
+    def test_ghp_and_anthropic_tokens_redacted(self) -> None:
+        text = f"a={GHP_TOKEN} b={ANTHROPIC_KEY}"
+        decision = scan_for_sensitive_content(text)
+        assert decision.action == "redacted"
+        assert GHP_TOKEN not in decision.text
+        assert ANTHROPIC_KEY not in decision.text
+        assert "[REDACTED:content.github-token:" in decision.text
+        assert "[REDACTED:content.anthropic-key:" in decision.text
+
+    def test_finding_carries_span_hash_not_content(self) -> None:
+        decision = scan_for_sensitive_content(f"x {AKIA_KEY} y")
+        finding = decision.findings[0]
+        assert finding.span_hash == hashlib.sha256(AKIA_KEY.encode("utf-8")).hexdigest()
+        assert AKIA_KEY not in repr(decision.findings)
+
+
+# ---------------------------------------------------------------------------
+# Refusal behaviour (non-delimitable spans)
+# ---------------------------------------------------------------------------
+
+
+class TestRefusal:
+    def test_env_file_dump_refuses_compaction(self) -> None:
+        decision = scan_for_sensitive_content(ENV_FILE_DUMP)
+        assert decision.action == "refused"
+        assert decision.text == ENV_FILE_DUMP  # untouched: caller must not forward it
+
+    def test_unterminated_pem_refuses(self) -> None:
+        text = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA7bq7wmiCPDlK"
+        decision = scan_for_sensitive_content(text)
+        assert decision.action == "refused"
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "id_rsa",
+            "secrets.pem",
+            "~/.ssh/known_hosts",
+            "~/.aws/credentials",
+            "~/.gnupg/secring.gpg",
+            "~/.kube/config",
+        ],
+    )
+    def test_path_shaped_tokens_refuse(self, token: str) -> None:
+        decision = scan_for_sensitive_content(f"reading {token} now")
+        assert decision.action == "refused"
+
+    def test_public_key_path_not_refused(self) -> None:
+        decision = scan_for_sensitive_content("copy id_rsa.pub to the server")
+        assert decision.action == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Entropy heuristic (conservative: prefer false negatives)
+# ---------------------------------------------------------------------------
+
+
+class TestEntropyHeuristic:
+    def test_threshold_is_documented_and_conservative(self) -> None:
+        # Strictly above 4.0 bits/char: a pure-hex value (16 symbols) can
+        # never exceed log2(16) == 4.0, so digests are structurally excluded.
+        assert ENTROPY_MIN_BITS_PER_CHAR == 4.0
+        assert ENTROPY_MIN_VALUE_LENGTH == 24
+
+    def test_shannon_entropy_of_uniform_hex_is_at_most_four(self) -> None:
+        assert shannon_entropy("0123456789abcdef" * 4) <= 4.0
+
+    def test_normalized_name_matching(self) -> None:
+        # api-key normalizes to apikey and matches the sensitive-name set.
+        decision = scan_for_sensitive_content(ENTROPY_ASSIGNMENT)
+        assert decision.action == "redacted"
+        assert decision.findings[0].rule_id == "content.entropy-assignment"
+
+    def test_non_sensitive_name_with_random_value_is_allowed(self) -> None:
+        decision = scan_for_sensitive_content('cache_id = "9fXq2LmZv8RbT4wKpN6yHs3JdA7eUcGh"')
+        assert decision.action == "allow"
+
+    def test_sensitive_name_with_low_entropy_value_is_allowed(self) -> None:
+        decision = scan_for_sensitive_content('session-token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"')
+        assert decision.action == "allow"
+
+    def test_sensitive_name_with_short_value_is_allowed(self) -> None:
+        decision = scan_for_sensitive_content('api-key = "9fXq2LmZv8RbT4w"')
+        assert decision.action == "allow"
+
+
+# ---------------------------------------------------------------------------
+# Config: extra deny rules and allowlist (acceptance criterion 4)
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_disabled_gate_allows_everything(self) -> None:
+        config = GateConfig(enabled=False)
+        decision = scan_for_sensitive_content(PEM_BLOCK, config=config)
+        assert decision.action == "allow"
+
+    def test_extra_deny_pattern_redacts(self) -> None:
+        config = GateConfig(extra_deny=("INTERNAL-[0-9]{6}",))
+        decision = scan_for_sensitive_content("ref INTERNAL-123456 here", config=config)
+        assert decision.action == "redacted"
+        assert "INTERNAL-123456" not in decision.text
+        assert decision.findings[0].rule_id.startswith("extra.")
+
+    def test_invalid_extra_deny_pattern_is_skipped(self) -> None:
+        config = GateConfig(extra_deny=("[unclosed",))
+        decision = scan_for_sensitive_content("harmless text", config=config)
+        assert decision.action == "allow"
+
+    def test_allowlist_by_rule_id_suppresses(self) -> None:
+        config = GateConfig(allow=("content.aws-access-key",))
+        decision = scan_for_sensitive_content(f"x {AKIA_KEY} y", config=config)
+        assert decision.action == "allow"
+        assert decision.text == f"x {AKIA_KEY} y"
+        assert not decision.findings
+        assert decision.suppressed
+        assert decision.suppressed[0].rule_id == "content.aws-access-key"
+
+    def test_allowlist_by_rule_and_span_hash_suppresses(self) -> None:
+        span_hash8 = hashlib.sha256(AKIA_KEY.encode("utf-8")).hexdigest()[:8]
+        config = GateConfig(allow=(f"content.aws-access-key:{span_hash8}",))
+        decision = scan_for_sensitive_content(f"x {AKIA_KEY} y", config=config)
+        assert decision.action == "allow"
+        assert decision.suppressed
+
+    def test_allowlist_span_hash_does_not_suppress_other_spans(self) -> None:
+        config = GateConfig(allow=("content.aws-access-key:00000000",))
+        decision = scan_for_sensitive_content(f"x {AKIA_KEY} y", config=config)
+        assert decision.action == "redacted"
+        assert not decision.suppressed
+
+    def test_from_defaults_reads_compaction_defaults(self) -> None:
+        from bernstein.core import defaults
+
+        config = GateConfig.from_defaults()
+        assert config.enabled == defaults.COMPACTION.sensitive_gate_enabled
+        assert config.extra_deny == defaults.COMPACTION.sensitive_gate_extra_deny
+        assert config.allow == defaults.COMPACTION.sensitive_gate_allow
+
+
+# ---------------------------------------------------------------------------
+# Audit-chain emission (acceptance criterion 3)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEmission:
+    def _chain(self, tmp_path: object) -> AuditChainStore:
+        from pathlib import Path
+
+        return AuditChainStore(Path(str(tmp_path)) / "audit", key=b"k" * 32)
+
+    def test_redaction_emits_verifiable_event(self, tmp_path: object) -> None:
+        chain = self._chain(tmp_path)
+        decision = scan_for_sensitive_content(f"x {AKIA_KEY} y")
+        emit_gate_audit(decision, chain=chain, task_id="task-1", session_id="s-1")
+
+        events = chain.query(event_type=EVENT_COMPACTION_SENSITIVE_GATE)
+        assert len(events) == 1
+        details = events[0].details
+        assert details["task_id"] == "task-1"
+        assert details["rule_id"] == "content.aws-access-key"
+        assert details["action"] == "redacted"
+        assert details["span_hash"] == hashlib.sha256(AKIA_KEY.encode("utf-8")).hexdigest()
+        assert AKIA_KEY not in str(details)
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_refusal_emits_event_per_finding(self, tmp_path: object) -> None:
+        chain = self._chain(tmp_path)
+        decision = scan_for_sensitive_content(ENV_FILE_DUMP)
+        assert decision.action == "refused"
+        emit_gate_audit(decision, chain=chain, task_id="task-2", session_id="s-2")
+
+        events = chain.query(event_type=EVENT_COMPACTION_SENSITIVE_GATE)
+        assert events
+        assert all(e.details["action"] == "refused" for e in events)
+        assert all("wJalrXUtnFEMI" not in str(e.details) for e in events)
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_suppression_is_audit_logged(self, tmp_path: object) -> None:
+        chain = self._chain(tmp_path)
+        config = GateConfig(allow=("content.aws-access-key",))
+        decision = scan_for_sensitive_content(f"x {AKIA_KEY} y", config=config)
+        emit_gate_audit(decision, chain=chain, task_id="task-3", session_id="s-3")
+
+        events = chain.query(event_type=EVENT_COMPACTION_SENSITIVE_GATE)
+        assert len(events) == 1
+        assert events[0].details["action"] == "suppressed"
+        assert events[0].details["rule_id"] == "content.aws-access-key"
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_allow_decision_emits_nothing(self, tmp_path: object) -> None:
+        chain = self._chain(tmp_path)
+        decision = scan_for_sensitive_content("plain text")
+        emit_gate_audit(decision, chain=chain, task_id="task-4", session_id="s-4")
+        assert not chain.query(event_type=EVENT_COMPACTION_SENSITIVE_GATE)
+
+
+# ---------------------------------------------------------------------------
+# Decision dataclass surface
+# ---------------------------------------------------------------------------
+
+
+class TestGateDecision:
+    def test_decision_is_frozen(self) -> None:
+        decision = scan_for_sensitive_content("plain")
+        assert isinstance(decision, GateDecision)
+        with pytest.raises(AttributeError):
+            decision.action = "refused"  # type: ignore[misc]


### PR DESCRIPTION
## Problem

The compaction pipeline forwards slices of worker context to a model API to produce summaries. Worker contexts routinely contain file reads, and nothing prevented a context that includes `.env` contents, private keys, or cloud credentials from being shipped to an external API as part of a summary request. The refusal or redaction also needs to be recorded so an operator can see that a compaction was skipped and why.

## What was built

**New module `src/bernstein/core/tokens/sensitive_gate.py`** - a pure, deterministic deny gate over compaction input:

- Content rules with safely delimitable spans are redacted with a typed placeholder `[REDACTED:<rule-id>:<sha256[:8] of original>]`: complete PEM private-key blocks, `AKIA[0-9A-Z]{16}`, `ghp_` tokens, `sk-ant-` keys, operator-supplied `extra_deny` regexes, and a generic high-entropy assignment heuristic.
- Path-shaped tokens (`.env*`, `id_rsa` (excluding `.pub`), `*.pem`, `credentials` files, `.ssh/`, `.aws/`, `.gnupg/`, `.kube/` components) and unterminated PEM headers refuse the whole compaction: the token itself is delimitable but the surrounding file contents are not, so redacting only the token would still leak the material.
- Normalized-name matching (`api-key` -> `apikey`) drives the assignment heuristic. The heuristic is conservative by construction: it fires only when the name normalizes to a sensitive keyword, the value is 24+ chars, and its Shannon entropy is strictly above 4.0 bits/char. A pure-hex value is capped at `log2(16) == 4.0`, so SHA/MD5 digests and UUIDs are structurally incapable of triggering it (documented in the module).

**Pipeline integration** - the gate runs inside `CompactionPipeline.execute` between the pre-compact hooks and the media-strip/summary stages, so every summary call site (auto tier, session-memory tier, the reactive provider-413 path, and any future proactive path) is covered by the same rules. A refused scan skips the summary stage entirely and returns the input unchanged with `gate_action="refused"` on the result.

**Audit** - every redaction, refusal, and allowlist suppression appends a `compaction.sensitive_gate` event to the HMAC audit chain with `{task_id, rule_id, action, span_hash}` - the hash only, never the content. The reactive 413 path resolves the chain from the run workdir and logs a warning when a compaction is skipped.

**Config** - the `compaction` defaults section gains `sensitive_gate_enabled` (default true), `sensitive_gate_extra_deny`, and `sensitive_gate_allow`. Allowlist entries are a rule id or `<rule-id>:<hash8>` for a single span; suppressions are audit-logged.

## Deviations from the issue text

- The issue sketches the config as a nested `compaction.sensitive_gate: {enabled, extra_deny, allow}` block. The existing `tuning:` override mechanism maps flat dataclass fields per section, so the keys land as `sensitive_gate_*` under the `compaction` section, following the established convention.
- The issue suggests hooking via the pre-hook slot. The pluggy pre-compact hooks are observe-only (their payload mutations do not feed back into the pipeline), so the gate is implemented as a first-class stage at the same position instead - this also keeps it active when no plugin manager is configured.
- The existing `sensitive_file_detector` (SEC-017) covers the commit-prevention path with file-level verdicts; it has no span offsets, redaction, or refusal semantics, so the gate is a separate module as specified rather than a retrofit.

## How it is tested

- `tests/unit/test_sensitive_gate.py` (58 tests): fixture corpus of positives (PEM block, OPENSSH `id_rsa` content, AKIA key, `ghp_` token, `sk-ant-` key, `.env` dump, high-entropy assignment) and negatives (UUIDs, sha256 digests, base64 images, normal code, hex digest under a sensitive name); determinism across repeated runs; redaction placeholder format and span hashes; refusal for non-delimitable hits; entropy-threshold documentation tests; allowlist suppression by rule id and by span hash; audit-chain emission with `verify()` passing and content-absence assertions.
- `tests/unit/test_compaction_pipeline.py::TestSensitiveGateIntegration`: asserts with a mock at the summary boundary that a fixture PEM block never appears in the outbound payload, that refusal skips the summary call and keeps the original text, that gate events land in an injected audit chain and verify, and that the per-call disable switch works.
- Full runs of the compaction, memory-tier, agent-lifecycle, audit-chain, and defaults suites (385 tests) pass, plus `ruff check`, `ruff format --check`, `lint-imports`, and the routes broad-except check.

Fixes #2242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sensitive-content gate to compaction: redact detectable secrets before summarization, or refuse compaction when findings can’t be safely handled.
  * Added configurable gate controls (enable/disable plus allow/deny tuning) to compaction defaults.
  * Added audit tracking for gate decisions, including redaction/refusal/suppression details.
* **Bug Fixes**
  * Compaction retries now honor gate outcomes and avoid forwarding sensitive content after a refusal.
* **Tests**
  * Added unit and integration coverage for redaction, refusal, gate disabling, and audit event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->