### PR TITLE
Wire per-role response-style profiles into the worker spawn path

### DIFF
--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -132,6 +132,18 @@ def claim_backlog(
     ),
 )
 @click.option(
+    "--mode",
+    "mode",
+    default=None,
+    type=click.Choice(["verbose", "balanced", "terse", "fast", "smart", "deep"]),
+    help=(
+        "Response-style profile for the worker handling this task. Accepts a "
+        "style name (verbose/balanced/terse) or a mode-profile name "
+        "(fast/smart/deep); stamped as metadata['mode'], the top-priority "
+        "input of the spawn-time style resolution."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Print the JSON payload that would be sent without actually calling the API.",
@@ -147,6 +159,7 @@ def add_task(
     complexity: str,
     depends_on: tuple[str, ...],
     criterion_profile: str | None,
+    mode: str | None,
     dry_run: bool,
 ) -> None:
     """Add a task to the running server.
@@ -175,6 +188,9 @@ def add_task(
         except CriterionProfileError as exc:
             raise click.UsageError(f"--criterion-profile {criterion_profile!r}: {exc}") from None
         payload.setdefault("metadata", {})["criterion_profile"] = criterion_profile
+
+    if mode is not None:
+        payload.setdefault("metadata", {})["mode"] = mode
 
     if dry_run:
         if is_json():

--- a/src/bernstein/core/agents/response_style.py
+++ b/src/bernstein/core/agents/response_style.py
@@ -1,0 +1,280 @@
+"""Per-spawn response-style profiles (issue #2243).
+
+Operators running many parallel workers need per-role control over worker
+output verbosity. This module resolves a declared response style for every
+spawn and renders the system-prompt addendum that carries it, so a reviewer
+role can run terse while an investigator role runs verbose - without
+hand-editing role templates.
+
+Design constraints (load-bearing):
+
+- **Deterministic resolution.** ``Task.metadata['mode']`` > role policy
+  ``response_style`` > seed default (the ``role_model_policy.default``
+  entry) > built-in ``"balanced"``. Same inputs always resolve to the same
+  style and the same rendered addendum (snapshot-testable).
+- **No new prompt dialect.** The addendum body is the mode-profile
+  preamble from ``templates/mode_profiles/{fast,smart,deep}.yaml``; the
+  style vocabulary (``verbose``/``balanced``/``terse``) is the conciseness
+  vocabulary already defined by
+  :class:`bernstein.core.agents.claude_model_prompts.PromptStrategy`.
+- **Backward compatibility.** ``balanced`` is the neutral house style and
+  renders an EMPTY addendum, so a spawn with no explicit profile is
+  byte-identical to a pre-change spawn (the spawner previously hardcoded
+  ``system_addendum=""``).
+- **Typed failure.** A style whose mapped template file is missing from the
+  resolved profile directory raises :class:`ResponseStyleTemplateError`
+  instead of silently falling back to in-code defaults.
+
+The rendered addendum's SHA-256 (:func:`addendum_sha256`) is recorded in
+the task's cost ledger entry and audit trail, and is folded into the task
+identity of the deterministic schedule projection when a profile is
+explicitly declared (see ``orchestration/schedule_projection.py``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein import _BUNDLED_TEMPLATES_DIR  # type: ignore[reportPrivateUsage]
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from pathlib import Path
+
+#: Style vocabulary. Mirrors ``PromptStrategy.conciseness`` in
+#: ``claude_model_prompts.py`` - tested for alignment, not re-derived, so
+#: the two modules cannot silently diverge.
+ResponseStyle = Literal["verbose", "balanced", "terse"]
+
+RESPONSE_STYLES: tuple[str, ...] = ("verbose", "balanced", "terse")
+
+#: The neutral default. Renders an empty addendum so unset-profile spawns
+#: stay byte-identical to pre-change spawns.
+DEFAULT_RESPONSE_STYLE: str = "balanced"
+
+#: Style -> mode-profile template stem under ``templates/mode_profiles/``.
+STYLE_TO_MODE_PROFILE: dict[str, str] = {
+    "terse": "fast",
+    "balanced": "smart",
+    "verbose": "deep",
+}
+
+#: Mode-profile name -> style, so ``Task.metadata['mode']`` values that
+#: carry the existing fast/smart/deep vocabulary resolve deterministically.
+MODE_PROFILE_TO_STYLE: dict[str, str] = {v: k for k, v in STYLE_TO_MODE_PROFILE.items()}
+
+#: Carve-outs baked into every non-empty addendum: content categories that
+#: are never style-compressed regardless of the declared style.
+_CARVE_OUTS = (
+    "### Style carve-outs (verbatim zones)\n"
+    "The response style applies to prose only. Never compress, truncate, or\n"
+    "restyle code blocks, commit messages, error text, or completion API JSON\n"
+    "payloads; reproduce them in full."
+)
+
+
+class ResponseStyleTemplateError(ValueError):
+    """A declared response style references a missing or malformed template.
+
+    Raised when the mode-profile template file mapped to a style cannot be
+    read from the resolved profile directory. Config validation (the seed
+    parser) surfaces this at parse time; the spawner surfaces it as a spawn
+    failure if the file disappears between validation and spawn.
+    """
+
+
+@dataclass(frozen=True)
+class ResolvedStyle:
+    """Outcome of the deterministic style resolution.
+
+    Attributes:
+        style: One of :data:`RESPONSE_STYLES`.
+        source: Which input supplied the style: ``"task_metadata"``,
+            ``"role_policy"``, ``"seed_default"``, or ``"builtin_default"``.
+        explicit: True when the style came from an operator-declared input
+            (anything other than the built-in default). Only explicit
+            profiles are folded into deterministic task identity.
+    """
+
+    style: str
+    source: str
+    explicit: bool
+
+
+def _style_from_metadata_mode(value: object) -> str | None:
+    """Map a ``Task.metadata['mode']`` value onto a style name, or ``None``."""
+    if not isinstance(value, str):
+        return None
+    if value in RESPONSE_STYLES:
+        return value
+    return MODE_PROFILE_TO_STYLE.get(value)
+
+
+def resolve_response_style(
+    *,
+    task_metadata: Mapping[str, Any],
+    role_policy: Mapping[str, Any],
+    default_policy: Mapping[str, Any],
+) -> ResolvedStyle:
+    """Resolve the response style for a spawn.
+
+    Resolution order (deterministic, documented):
+
+    1. ``task_metadata['mode']`` - accepts style names directly
+       (``verbose``/``balanced``/``terse``) or the existing mode-profile
+       names (``fast``/``smart``/``deep``) via :data:`MODE_PROFILE_TO_STYLE`.
+    2. ``role_policy['response_style']`` - the per-role config entry.
+    3. ``default_policy['response_style']`` - the seed-level default (the
+       ``role_model_policy.default`` entry).
+    4. :data:`DEFAULT_RESPONSE_STYLE` (``"balanced"``).
+
+    Unknown values fall through to the next source rather than raising, so
+    a stale metadata value cannot block a spawn; config-level typos are
+    rejected earlier by the seed parser.
+
+    Args:
+        task_metadata: The task's metadata mapping (may be empty).
+        role_policy: The resolved role policy entry for the task's role.
+        default_policy: The ``role_model_policy.default`` entry (or empty).
+
+    Returns:
+        A :class:`ResolvedStyle` - never ``None``.
+    """
+    from_task = _style_from_metadata_mode(task_metadata.get("mode"))
+    if from_task is not None:
+        return ResolvedStyle(style=from_task, source="task_metadata", explicit=True)
+
+    role_style = role_policy.get("response_style")
+    if isinstance(role_style, str) and role_style in RESPONSE_STYLES:
+        return ResolvedStyle(style=role_style, source="role_policy", explicit=True)
+
+    seed_style = default_policy.get("response_style")
+    if isinstance(seed_style, str) and seed_style in RESPONSE_STYLES:
+        return ResolvedStyle(style=seed_style, source="seed_default", explicit=True)
+
+    return ResolvedStyle(style=DEFAULT_RESPONSE_STYLE, source="builtin_default", explicit=False)
+
+
+def _profiles_dir(workdir: Path | None) -> Path:
+    """Return the profile directory: workdir override first, else bundled.
+
+    Mirrors ``spawner_prompt._profiles_dir`` without importing the spawner
+    stack (this module must stay light enough for the config layer).
+    """
+    if workdir is not None:
+        candidate = workdir / "templates" / "mode_profiles"
+        if candidate.is_dir():
+            return candidate
+    return _BUNDLED_TEMPLATES_DIR / "mode_profiles"
+
+
+def style_template_path(style: str, workdir: Path | None = None) -> Path:
+    """Return the template file path a style renders from.
+
+    Raises:
+        ValueError: If *style* is not in :data:`RESPONSE_STYLES`.
+    """
+    profile_name = STYLE_TO_MODE_PROFILE.get(style)
+    if profile_name is None:
+        raise ValueError(f"unknown response style {style!r}; expected one of {RESPONSE_STYLES}")
+    return _profiles_dir(workdir) / f"{profile_name}.yaml"
+
+
+def _load_preamble(style: str, workdir: Path | None) -> str:
+    """Read the mode-profile preamble the style maps to.
+
+    Reads the YAML file directly (no global registry mutation) so the
+    rendered addendum is a pure function of the template bytes on disk.
+
+    Raises:
+        ResponseStyleTemplateError: If the file is missing or malformed.
+    """
+    path = style_template_path(style, workdir)
+    if not path.is_file():
+        raise ResponseStyleTemplateError(
+            f"response style {style!r} maps to template {path.name!r} which is missing from {path.parent}"
+        )
+    import yaml
+
+    try:
+        raw: object = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError) as exc:
+        raise ResponseStyleTemplateError(f"cannot read response-style template {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ResponseStyleTemplateError(f"response-style template {path} must contain a YAML mapping")
+    preamble = raw.get("system_prompt_preamble")
+    if not isinstance(preamble, str) or not preamble.strip():
+        raise ResponseStyleTemplateError(f"response-style template {path} has no 'system_prompt_preamble'")
+    return preamble
+
+
+def render_style_addendum(style: str, *, workdir: Path | None = None) -> str:
+    """Render the system-prompt addendum for *style*.
+
+    ``balanced`` renders an empty string: it declares the neutral house
+    style, and an empty addendum keeps unset-profile spawns byte-identical
+    to pre-change spawns (the spawner previously hardcoded
+    ``system_addendum=""``).
+
+    ``terse``/``verbose`` render the mapped mode-profile preamble plus the
+    fixed carve-out block. Given identical template files the output is
+    byte-identical across machines (snapshot-tested).
+
+    Args:
+        style: One of :data:`RESPONSE_STYLES`.
+        workdir: Project root used to locate ``templates/mode_profiles/``;
+            ``None`` uses the bundled templates.
+
+    Returns:
+        The rendered addendum ("" for ``balanced``).
+
+    Raises:
+        ValueError: If *style* is unknown.
+        ResponseStyleTemplateError: If the mapped template is missing or
+            malformed (AC4 - typed error, no silent fallback).
+    """
+    if style not in RESPONSE_STYLES:
+        raise ValueError(f"unknown response style {style!r}; expected one of {RESPONSE_STYLES}")
+    if style == DEFAULT_RESPONSE_STYLE:
+        return ""
+    preamble = _load_preamble(style, workdir)
+    return f"## Response style: {style}\n\n{preamble.rstrip()}\n\n{_CARVE_OUTS}"
+
+
+def addendum_sha256(addendum: str) -> str:
+    """SHA-256 hex digest of the rendered addendum's UTF-8 bytes."""
+    return hashlib.sha256(addendum.encode("utf-8")).hexdigest()
+
+
+def validate_style_templates(styles: Iterable[str], *, workdir: Path | None = None) -> None:
+    """Validate that every style in *styles* can be rendered.
+
+    Config-validation entry point (AC4): called by the seed parser so a
+    role policy that declares a style whose template file is missing fails
+    at parse time with a typed error rather than at spawn time.
+
+    Raises:
+        ValueError: If a style name is unknown.
+        ResponseStyleTemplateError: If a mapped template file is missing or
+            malformed.
+    """
+    for style in sorted(set(styles)):
+        render_style_addendum(style, workdir=workdir)
+
+
+__all__ = [
+    "DEFAULT_RESPONSE_STYLE",
+    "MODE_PROFILE_TO_STYLE",
+    "RESPONSE_STYLES",
+    "STYLE_TO_MODE_PROFILE",
+    "ResolvedStyle",
+    "ResponseStyle",
+    "ResponseStyleTemplateError",
+    "addendum_sha256",
+    "render_style_addendum",
+    "resolve_response_style",
+    "style_template_path",
+    "validate_style_templates",
+]

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -30,6 +30,12 @@ from bernstein.core.agents.adapter_health import AdapterHealthMonitor
 from bernstein.core.agents.container import ContainerConfig, ContainerError, ContainerManager
 from bernstein.core.agents.heartbeat import HeartbeatMonitor
 from bernstein.core.agents.in_process_agent import InProcessAgent
+from bernstein.core.agents.response_style import (
+    ResponseStyleTemplateError,
+    addendum_sha256,
+    render_style_addendum,
+    resolve_response_style,
+)
 from bernstein.core.agents.spawn_errors import (
     ModelNotConfiguredError,
     RetryStrategy,
@@ -1745,6 +1751,55 @@ class AgentSpawner:
                 exc,
             )
 
+    def _emit_response_profile_audit(
+        self,
+        *,
+        task_ids: list[str],
+        style: str,
+        source: str,
+        profile_content_sha256: str,
+    ) -> None:
+        """Append a ``task_response_profile`` event to the audit chain.
+
+        Every spawn declares a response-style profile; recording the profile
+        name and the rendered-addendum hash per task keeps the audit trail
+        aligned with the cost ledger entry written at completion. Audit
+        failures (key permission, disk full) never mask the spawn: they are
+        logged and swallowed.
+
+        Args:
+            task_ids: IDs of the tasks in this spawn batch.
+            style: Resolved response style (``verbose``/``balanced``/``terse``).
+            source: Which input supplied the style (resolution provenance).
+            profile_content_sha256: SHA-256 of the rendered style addendum.
+        """
+        try:
+            from bernstein.core.security.audit import (
+                TASK_RESPONSE_PROFILE,
+                AuditLog,
+            )
+
+            audit = AuditLog(audit_dir=self._workdir / ".sdd" / "audit")
+            for task_id in task_ids:
+                audit.log(
+                    event_type=TASK_RESPONSE_PROFILE,
+                    actor="spawner",
+                    resource_type="task",
+                    resource_id=task_id,
+                    details={
+                        "task_id": task_id,
+                        "response_profile": style,
+                        "style_source": source,
+                        "profile_content_sha256": profile_content_sha256,
+                    },
+                )
+        except Exception as exc:  # audit must never block the spawn
+            logger.warning(
+                "Could not emit task_response_profile audit event for tasks %s: %s",
+                task_ids,
+                exc,
+            )
+
     def _reap_openclaw(self, session: AgentSession) -> None:
         """Sync logs from the remote bridge for an OpenClaw session."""
         reap_openclaw(session, self._runtime_bridge, self._run_bridge_call)
@@ -2732,6 +2787,46 @@ class AgentSpawner:
         elif self._use_worktrees:
             isolation_mode = IsolationMode.WORKTREE
 
+        # Resolve the per-spawn response-style profile.
+        # Resolution is deterministic (task metadata > role policy > seed
+        # default > "balanced") and the rendered addendum flows to the
+        # adapter via ``system_addendum`` - the rendered prompt itself is
+        # untouched, so a spawn whose resolution lands on the neutral
+        # "balanced" style (empty addendum) is byte-identical to a
+        # pre-change spawn. The profile name and addendum hash are stamped
+        # on the session and task metadata so the completion-time cost
+        # ledger entry and the audit trail can attribute spend per profile.
+        style_resolution = resolve_response_style(
+            task_metadata=task_metadata,
+            role_policy=role_policy,
+            default_policy=self._role_model_policy.get("default") or {},
+        )
+        try:
+            style_addendum = render_style_addendum(style_resolution.style, workdir=self._workdir)
+        except ResponseStyleTemplateError as exc:
+            raise SpawnError(
+                f"Response-style profile {style_resolution.style!r} for role {role!r} "
+                f"(source={style_resolution.source}) cannot be rendered: {exc}"
+            ) from exc
+        profile_content_sha = addendum_sha256(style_addendum)
+        for _t in tasks:
+            if isinstance(_t.metadata, dict):
+                _t.metadata["response_profile"] = style_resolution.style
+                _t.metadata["profile_content_sha256"] = profile_content_sha
+        logger.info(
+            "Response-style profile for role=%s: style=%s source=%s addendum_sha256=%s",
+            role,
+            style_resolution.style,
+            style_resolution.source,
+            profile_content_sha,
+        )
+        self._emit_response_profile_audit(
+            task_ids=[t.id for t in tasks],
+            style=style_resolution.style,
+            source=style_resolution.source,
+            profile_content_sha256=profile_content_sha,
+        )
+
         session = AgentSession(
             id=session_id,
             role=role,
@@ -2743,6 +2838,8 @@ class AgentSpawner:
             isolation=isolation_mode.value,
             token_budget=task_token_budget,
             meta_messages=meta_messages,
+            response_profile=style_resolution.style,
+            profile_content_sha256=profile_content_sha,
         )
 
         # Zero-trust: issue a short-lived, task-scoped JWT for this agent.
@@ -3143,7 +3240,7 @@ class AgentSpawner:
                                 mcp_config=attempt_mcp,
                                 task_scope=max_scope,
                                 budget_multiplier=_budget_mult,
-                                system_addendum="",
+                                system_addendum=style_addendum,
                                 **_extra_spawn_kwargs,
                             )
                         spawn_duration = time.perf_counter() - spawn_start

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -220,6 +220,13 @@ class RoleModelPolicyEntry(BaseModel):
     top_k: int | None = None
     max_tokens: int | None = None
     extra_params: dict[str, Any] = Field(default_factory=dict)
+    # Per-role response-style profile applied at spawn
+    # (``bernstein.core.agents.response_style``). Resolution order is
+    # deterministic and documented there: ``Task.metadata['mode']`` > this
+    # entry > the ``role_model_policy.default`` entry > ``"balanced"``.
+    # ``balanced`` renders an empty style addendum, keeping unset-profile
+    # spawns byte-identical to pre-change spawns.
+    response_style: Literal["verbose", "balanced", "terse"] | None = None
     # Optional "council of agents" fan-out/judge override (see
     # ``CouncilConfig``). When set, this role's ENTIRE task run is driven by
     # a task-level council (``bernstein.adapters.council_runner.run_council``)

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -846,8 +846,7 @@ def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | in
         if not isinstance(raw_style, str) or raw_style not in RESPONSE_STYLES:
             allowed = ", ".join(RESPONSE_STYLES)
             raise SeedError(
-                f"role_model_policy[{role!r}][{_ROLE_POLICY_STYLE_KEY!r}] must be one of: {allowed} "
-                f"(got {raw_style!r})"
+                f"role_model_policy[{role!r}][{_ROLE_POLICY_STYLE_KEY!r}] must be one of: {allowed} (got {raw_style!r})"
             )
         normalized[_ROLE_POLICY_STYLE_KEY] = raw_style
 

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -666,6 +666,15 @@ _ROLE_POLICY_KEYS: tuple[str, ...] = (
 # "unknown keys: max_tokens" (parser/schema divergence fixed here).
 _ROLE_POLICY_INT_KEYS: tuple[str, ...] = ("max_tokens",)
 
+# ``response_style`` declares the per-role response-style profile
+# (``verbose``/``balanced``/``terse``) applied at spawn time (see
+# ``bernstein.core.agents.response_style``). The value is validated against
+# the closed style vocabulary in ``_parse_single_role_policy``; the mapped
+# mode-profile template file is validated for existence in ``parse_seed``
+# so a dangling template reference fails at config-validation time with a
+# typed ``ResponseStyleTemplateError``, not at spawn time.
+_ROLE_POLICY_STYLE_KEY = "response_style"
+
 # ``council`` is parsed and validated separately (its value is a nested
 # mapping, not a scalar string/int like every other role-policy key), so it
 # is carved out of the unknown-keys check in ``_parse_single_role_policy``
@@ -830,11 +839,25 @@ def _parse_single_role_policy(role: str, settings: object) -> dict[str, str | in
     if "cli" in normalized and "provider" not in normalized:
         normalized["provider"] = normalized["cli"]
 
+    raw_style = settings.get(_ROLE_POLICY_STYLE_KEY)
+    if raw_style is not None:
+        from bernstein.core.agents.response_style import RESPONSE_STYLES
+
+        if not isinstance(raw_style, str) or raw_style not in RESPONSE_STYLES:
+            allowed = ", ".join(RESPONSE_STYLES)
+            raise SeedError(
+                f"role_model_policy[{role!r}][{_ROLE_POLICY_STYLE_KEY!r}] must be one of: {allowed} "
+                f"(got {raw_style!r})"
+            )
+        normalized[_ROLE_POLICY_STYLE_KEY] = raw_style
+
     raw_council = settings.get(_ROLE_POLICY_COUNCIL_KEY)
     if raw_council is not None:
         normalized[_ROLE_POLICY_COUNCIL_KEY] = _parse_council(role, raw_council)
 
-    allowed_keys = set(_ROLE_POLICY_KEYS) | set(_ROLE_POLICY_INT_KEYS) | {_ROLE_POLICY_COUNCIL_KEY}
+    allowed_keys = (
+        set(_ROLE_POLICY_KEYS) | set(_ROLE_POLICY_INT_KEYS) | {_ROLE_POLICY_COUNCIL_KEY, _ROLE_POLICY_STYLE_KEY}
+    )
     unknown_keys = sorted(set(settings) - allowed_keys)
     if unknown_keys:
         raise SeedError(f"role_model_policy[{role!r}] has unknown keys: {', '.join(unknown_keys)}")
@@ -1725,6 +1748,28 @@ def parse_seed(path: Path) -> SeedConfig:
     constraints = _parse_string_list(data.get("constraints"), "constraints")
     context_files = _parse_string_list(data.get("context_files"), "context_files")
     role_model_policy = _parse_role_model_policy(data.get("role_model_policy"))
+
+    # AC4: every declared response_style
+    # must be renderable from the mode-profile templates visible from the
+    # seed file's directory. A workdir override directory that lacks the
+    # mapped template file fails here with the typed template error instead
+    # of surfacing as a spawn failure mid-run.
+    if role_model_policy:
+        declared_styles = [
+            str(entry[_ROLE_POLICY_STYLE_KEY])
+            for entry in role_model_policy.values()
+            if _ROLE_POLICY_STYLE_KEY in entry
+        ]
+        if declared_styles:
+            from bernstein.core.agents.response_style import (
+                ResponseStyleTemplateError,
+                validate_style_templates,
+            )
+
+            try:
+                validate_style_templates(declared_styles, workdir=path.parent)
+            except ResponseStyleTemplateError as exc:
+                raise SeedError(f"role_model_policy response_style validation failed: {exc}") from exc
 
     agent_catalog_raw = _parse_optional_str_field(data, "agent_catalog")
     mcp_servers_raw = _parse_mcp_servers(data)

--- a/src/bernstein/core/orchestration/schedule_projection.py
+++ b/src/bernstein/core/orchestration/schedule_projection.py
@@ -188,6 +188,8 @@ def project_schedule_fire(
     last_state: Mapping[str, Any] | None,
     goal: str = "",
     scenario_id: str = "",
+    response_profile: str = "",
+    profile_content_sha256: str = "",
 ) -> ProjectionResult:
     """Project ``(schedule_id, fire_time, last_state)`` onto a task graph.
 
@@ -210,6 +212,16 @@ def project_schedule_fire(
             contract is honoured by the function signature.
         goal: Free-form goal text from the registered schedule.
         scenario_id: Optional named scenario id.
+        response_profile: Optional response-style profile declared on the
+            schedule. When non-empty it is folded
+            into the task identity seed and the canonical payload, so the
+            profile is an input to the task hash rather than a logged
+            field. Empty (the default, and the state of every pre-change
+            schedule) keeps the seed, payload, and hash byte-identical to
+            prior revs - the fold is deliberately conditional so replay of
+            existing audit chains is unaffected.
+        profile_content_sha256: SHA-256 of the rendered style addendum the
+            profile resolves to; folded alongside ``response_profile``.
 
     Returns:
         A ProjectionResult with the canonical task graph and its hash.
@@ -234,17 +246,21 @@ def project_schedule_fire(
     description = "\n".join(description_lines)
 
     # The task_id MUST be deterministic. Derive it from the canonical
-    # tuple so two operators recompute the same id.
-    task_id_seed = json.dumps(
-        {
-            "schedule_id": schedule_id,
-            "fire_time": fire_time,
-            "state_digest": state_digest,
-            "kind": "root",
-            "rev": SCHEDULE_PROJECTION_REV,
-        },
-        sort_keys=True,
-    ).encode()
+    # tuple so two operators recompute the same id. The response profile
+    # is folded in ONLY when explicitly declared: adding the keys
+    # unconditionally would fork the task identity of every profile-less
+    # schedule against previously recorded audit chains.
+    task_id_seed_obj: dict[str, Any] = {
+        "schedule_id": schedule_id,
+        "fire_time": fire_time,
+        "state_digest": state_digest,
+        "kind": "root",
+        "rev": SCHEDULE_PROJECTION_REV,
+    }
+    if response_profile:
+        task_id_seed_obj["response_profile"] = response_profile
+        task_id_seed_obj["profile_content_sha256"] = profile_content_sha256
+    task_id_seed = json.dumps(task_id_seed_obj, sort_keys=True).encode()
     task_id = "sched-task-" + hashlib.sha256(task_id_seed).hexdigest()[:16]
 
     metadata: tuple[tuple[str, str], ...] = (
@@ -255,6 +271,16 @@ def project_schedule_fire(
     )
     if scenario_id:
         metadata = (*metadata, ("scenario_id", scenario_id))
+    if response_profile:
+        # ``mode`` rides the node metadata so a task created from this node
+        # resolves the same profile at spawn time
+        # (``Task.metadata['mode']`` is the top-priority resolution input).
+        metadata = (
+            *metadata,
+            ("mode", response_profile),
+            ("response_profile", response_profile),
+            ("profile_content_sha256", profile_content_sha256),
+        )
 
     role = "manager"
     title = f"Scheduled goal: {(goal or scenario_id or schedule_id)[:120]}"
@@ -269,7 +295,7 @@ def project_schedule_fire(
     )
 
     nodes = _canonical_nodes([root])
-    canonical_obj = {
+    canonical_obj: dict[str, Any] = {
         "rev": SCHEDULE_PROJECTION_REV,
         "schedule_id": schedule_id,
         "fire_time": fire_time,
@@ -278,6 +304,9 @@ def project_schedule_fire(
         "scenario_id": scenario_id,
         "nodes": [_node_to_dict(n) for n in nodes],
     }
+    if response_profile:
+        canonical_obj["response_profile"] = response_profile
+        canonical_obj["profile_content_sha256"] = profile_content_sha256
     canonical_bytes = json.dumps(
         canonical_obj,
         sort_keys=True,

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -383,6 +383,53 @@ class ScheduleSupervisor:
 
         return receipts
 
+    @staticmethod
+    def _resolve_response_profile(schedule: Schedule) -> tuple[str, str]:
+        """Resolve the schedule's declared response-style profile, if any.
+
+        A schedule can declare
+        ``extra: {response_profile: <verbose|balanced|terse>}``; the profile
+        and the SHA-256 of its rendered addendum are then folded into the
+        projected task identity. Schedules without the key (every pre-change
+        schedule) return ``("", "")`` so their projection stays byte-identical
+        to prior revs. Unknown style names are logged and ignored rather than
+        blocking the fire - config-level typos are rejected earlier by the
+        seed parser.
+
+        The addendum is rendered from the bundled templates (no workdir
+        context exists at supervisor level); the spawn-time ledger entry
+        records the hash of the addendum actually rendered in the run's
+        workdir, which may differ when the operator overrides templates.
+        """
+        raw = schedule.extra.get("response_profile")
+        if not isinstance(raw, str) or not raw:
+            return "", ""
+        from bernstein.core.agents.response_style import (
+            RESPONSE_STYLES,
+            ResponseStyleTemplateError,
+            addendum_sha256,
+            render_style_addendum,
+        )
+
+        if raw not in RESPONSE_STYLES:
+            logger.warning(
+                "Schedule %s declares unknown response_profile %r; ignoring",
+                schedule.id,
+                raw,
+            )
+            return "", ""
+        try:
+            profile_sha = addendum_sha256(render_style_addendum(raw))
+        except ResponseStyleTemplateError as exc:
+            logger.warning(
+                "Schedule %s response_profile %r cannot be rendered (%s); ignoring",
+                schedule.id,
+                raw,
+                exc,
+            )
+            return "", ""
+        return raw, profile_sha
+
     def _fire(
         self,
         schedule: Schedule,
@@ -391,12 +438,15 @@ class ScheduleSupervisor:
         counterfactual: bool,
     ) -> FireReceipt:
         """Build the projection, dispatch the trigger event, and chain it."""
+        response_profile, profile_sha = self._resolve_response_profile(schedule)
         projection = project_schedule_fire(
             schedule_id=schedule.id,
             fire_time=fire_epoch,
             last_state=None,
             goal=schedule.goal,
             scenario_id=schedule.scenario_id,
+            response_profile=response_profile,
+            profile_content_sha256=profile_sha,
         )
 
         prev_chain = self._chain.chain_tail if self._chain is not None else ""

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -412,10 +412,12 @@ class ScheduleSupervisor:
         )
 
         if raw not in RESPONSE_STYLES:
+            from bernstein.core.security.sanitize import sanitize_log
+
             logger.warning(
                 "Schedule %s declares unknown response_profile %r; ignoring",
                 schedule.id,
-                raw,
+                sanitize_log(raw),
             )
             return "", ""
         try:

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -63,6 +63,11 @@ _REQUIRED_KEY_MODE = 0o600
 #: ``agent_restart_between_retries``.
 AGENT_FRESH_RESTART_ON_RETRY = "agent_fresh_restart_on_retry"
 
+#: Emitted once per spawn with the resolved response-style profile and the
+#: SHA-256 of the rendered style addendum, so the profile applied to a task
+#: is reconstructable from the audit chain alongside its cost ledger entry.
+TASK_RESPONSE_PROFILE = "task_response_profile"
+
 #: Issue #1799 - emitted once per step appended to an agent's hash-chained
 #: replay journal. Carries the step ``seq`` and ``step_hash`` in details so
 #: the audit-slice extractor can correlate audit events to journal entries

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -933,6 +933,12 @@ class AgentSession:
     abort_detail: str = ""
     finish_reason: str = ""
     meta_messages: list[str] = field(default_factory=list[str])  # Operational nudges/hints (T423)
+    # Response-style profile applied at spawn. The profile name and the
+    # SHA-256 of the rendered style addendum are stamped here so the cost
+    # ledger entry written at task completion can attribute spend per
+    # profile without re-resolving config.
+    response_profile: str = ""
+    profile_content_sha256: str = ""
 
 
 class IsolationMode(StrEnum):

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -3040,11 +3040,30 @@ def _record_cost_and_convergence(
     so the emitted ``ledger_update:`` line records whether these token counts
     came from an alive-exit /complete sidecar ingestion (``alive_exit``) vs a
     dead-session recovery (``dead_exit``) vs the collector metrics (``""``).
+
+    The response-style profile applied at spawn also
+    rides the ledger entry (``response_profile`` + ``profile_content_sha256``
+    cost tags) so downstream cost analysis can group spend per profile. The
+    session carries the authoritative stamp; when the session is already
+    gone (dead-exit recovery), the copy stamped on ``task.metadata`` at
+    spawn is used instead. Pre-change sessions carry neither, keeping the
+    ledger mutation byte-identical for them.
     """
     agent_id = session.id if session else "unknown"
     model = session.model_config.model if session else "unknown"
     tokens_in = task_m.tokens_prompt if task_m else 0
     tokens_out = task_m.tokens_completion if task_m else 0
+    cost_tags: dict[str, str] = {}
+    if tokens_sidecar_source:
+        cost_tags["tokens_sidecar_source"] = tokens_sidecar_source
+    response_profile = getattr(session, "response_profile", "") if session else ""
+    profile_sha = getattr(session, "profile_content_sha256", "") if session else ""
+    if not response_profile and isinstance(task.metadata, dict):
+        response_profile = str(task.metadata.get("response_profile") or "")
+        profile_sha = str(task.metadata.get("profile_content_sha256") or "")
+    if response_profile:
+        cost_tags["response_profile"] = response_profile
+        cost_tags["profile_content_sha256"] = profile_sha
     orch._cost_tracker.record_cumulative(
         agent_id=agent_id,
         task_id=task.id,
@@ -3053,7 +3072,7 @@ def _record_cost_and_convergence(
         total_output_tokens=tokens_out,
         total_cost_usd=cost_usd if cost_usd > 0 else None,
         tenant_id=task.tenant_id,
-        cost_tags={"tokens_sidecar_source": tokens_sidecar_source} if tokens_sidecar_source else None,
+        cost_tags=cost_tags or None,
     )
     try:
         orch._cost_tracker.save(orch._workdir / ".sdd")

--- a/tests/unit/agents/test_response_style.py
+++ b/tests/unit/agents/test_response_style.py
@@ -1,0 +1,241 @@
+"""Tests for the per-spawn response-style profile resolver (issue #2243).
+
+Covers the deterministic resolution order (task metadata > role policy >
+seed default > built-in ``balanced``), byte-stable addendum rendering
+(AC1), the empty-addendum guarantee for ``balanced`` that keeps
+no-profile spawns byte-identical to pre-change spawns (AC3), and the
+typed missing-template error (AC4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.agents.response_style import (
+    DEFAULT_RESPONSE_STYLE,
+    RESPONSE_STYLES,
+    STYLE_TO_MODE_PROFILE,
+    ResponseStyleTemplateError,
+    addendum_sha256,
+    render_style_addendum,
+    resolve_response_style,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestVocabulary:
+    def test_styles_match_conciseness_strategy_vocabulary(self) -> None:
+        """The style names reuse the conciseness vocabulary from
+        ``claude_model_prompts.PromptStrategy`` - no new prompt dialect."""
+        from bernstein.core.agents.claude_model_prompts import (
+            HAIKU_STRATEGY,
+            OPUS_STRATEGY,
+            SONNET_STRATEGY,
+        )
+
+        strategy_vocab = {
+            OPUS_STRATEGY.conciseness,
+            SONNET_STRATEGY.conciseness,
+            HAIKU_STRATEGY.conciseness,
+        }
+        assert set(RESPONSE_STYLES) == strategy_vocab
+
+    def test_every_style_maps_to_a_bundled_mode_profile(self) -> None:
+        assert set(STYLE_TO_MODE_PROFILE) == set(RESPONSE_STYLES)
+        assert set(STYLE_TO_MODE_PROFILE.values()) == {"fast", "smart", "deep"}
+
+    def test_default_style_is_balanced(self) -> None:
+        assert DEFAULT_RESPONSE_STYLE == "balanced"
+
+
+# ---------------------------------------------------------------------------
+# Resolution order (deterministic, documented)
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionOrder:
+    def test_builtin_default_when_nothing_is_set(self) -> None:
+        resolved = resolve_response_style(task_metadata={}, role_policy={}, default_policy={})
+        assert resolved.style == "balanced"
+        assert resolved.source == "builtin_default"
+        assert resolved.explicit is False
+
+    def test_seed_default_beats_builtin(self) -> None:
+        resolved = resolve_response_style(
+            task_metadata={},
+            role_policy={},
+            default_policy={"response_style": "terse"},
+        )
+        assert resolved.style == "terse"
+        assert resolved.source == "seed_default"
+        assert resolved.explicit is True
+
+    def test_role_policy_beats_seed_default(self) -> None:
+        resolved = resolve_response_style(
+            task_metadata={},
+            role_policy={"response_style": "verbose"},
+            default_policy={"response_style": "terse"},
+        )
+        assert resolved.style == "verbose"
+        assert resolved.source == "role_policy"
+
+    def test_task_metadata_mode_beats_role_policy(self) -> None:
+        resolved = resolve_response_style(
+            task_metadata={"mode": "terse"},
+            role_policy={"response_style": "verbose"},
+            default_policy={},
+        )
+        assert resolved.style == "terse"
+        assert resolved.source == "task_metadata"
+
+    @pytest.mark.parametrize(
+        ("mode_name", "expected_style"),
+        [("fast", "terse"), ("smart", "balanced"), ("deep", "verbose")],
+    )
+    def test_task_metadata_accepts_mode_profile_names(self, mode_name: str, expected_style: str) -> None:
+        """``Task.metadata['mode']`` already carries fast/smart/deep for the
+        mode-profile layer; those names map deterministically onto styles."""
+        resolved = resolve_response_style(
+            task_metadata={"mode": mode_name},
+            role_policy={},
+            default_policy={},
+        )
+        assert resolved.style == expected_style
+        assert resolved.source == "task_metadata"
+
+    def test_unknown_metadata_mode_falls_through(self) -> None:
+        resolved = resolve_response_style(
+            task_metadata={"mode": "warp-speed"},
+            role_policy={"response_style": "terse"},
+            default_policy={},
+        )
+        assert resolved.style == "terse"
+        assert resolved.source == "role_policy"
+
+    def test_unknown_role_policy_style_falls_through(self) -> None:
+        resolved = resolve_response_style(
+            task_metadata={},
+            role_policy={"response_style": "shouty"},
+            default_policy={},
+        )
+        assert resolved.style == "balanced"
+        assert resolved.source == "builtin_default"
+
+    def test_same_inputs_always_resolve_identically(self) -> None:
+        args = {
+            "task_metadata": {"mode": "verbose"},
+            "role_policy": {"response_style": "terse"},
+            "default_policy": {"response_style": "balanced"},
+        }
+        first = resolve_response_style(**args)
+        second = resolve_response_style(**args)
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Rendering (AC1: byte-identical snapshot; AC3: balanced renders empty)
+# ---------------------------------------------------------------------------
+
+_EXPECTED_TERSE_ADDENDUM = (
+    "## Response style: terse\n"
+    "\n"
+    "## Mode: fast (terse, minimal tool use)\n"
+    "You operate in fast mode. Produce the shortest correct answer.\n"
+    "Avoid exploratory tool calls; prefer a single well-targeted action.\n"
+    "\n"
+    "### Style carve-outs (verbatim zones)\n"
+    "The response style applies to prose only. Never compress, truncate, or\n"
+    "restyle code blocks, commit messages, error text, or completion API JSON\n"
+    "payloads; reproduce them in full."
+)
+
+_EXPECTED_VERBOSE_ADDENDUM = (
+    "## Response style: verbose\n"
+    "\n"
+    "## Mode: deep (long autonomous research)\n"
+    "You operate in deep autonomous mode. Plan thoroughly before acting,\n"
+    "minimise external chatter, and only surface findings when you have a\n"
+    "complete answer. Use tools sparingly and prefer reasoning.\n"
+    "\n"
+    "### Style carve-outs (verbatim zones)\n"
+    "The response style applies to prose only. Never compress, truncate, or\n"
+    "restyle code blocks, commit messages, error text, or completion API JSON\n"
+    "payloads; reproduce them in full."
+)
+
+
+class TestRendering:
+    def test_terse_addendum_snapshot(self) -> None:
+        """AC1: given identical config, the rendered addendum is
+        byte-identical (frozen snapshot of the bundled template render)."""
+        assert render_style_addendum("terse") == _EXPECTED_TERSE_ADDENDUM
+
+    def test_verbose_addendum_snapshot(self) -> None:
+        assert render_style_addendum("verbose") == _EXPECTED_VERBOSE_ADDENDUM
+
+    def test_balanced_renders_empty(self) -> None:
+        """AC3: balanced is the neutral default; it renders no addendum so
+        spawns without a profile stay byte-identical to pre-change spawns."""
+        assert render_style_addendum("balanced") == ""
+
+    def test_render_is_stable_across_calls(self) -> None:
+        assert render_style_addendum("terse") == render_style_addendum("terse")
+
+    def test_workdir_template_overrides_bundled(self, tmp_path: Path) -> None:
+        profiles = tmp_path / "templates" / "mode_profiles"
+        profiles.mkdir(parents=True)
+        (profiles / "fast.yaml").write_text(
+            "name: fast\nsystem_prompt_preamble: |\n  Custom terse preamble.\n",
+            encoding="utf-8",
+        )
+        rendered = render_style_addendum("terse", workdir=tmp_path)
+        assert "Custom terse preamble." in rendered
+        assert rendered.startswith("## Response style: terse\n")
+
+    def test_unknown_style_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="unknown response style"):
+            render_style_addendum("shouty")
+
+    def test_missing_template_raises_typed_error(self, tmp_path: Path) -> None:
+        """AC4: a workdir profile dir that lacks the mapped template file
+        fails with the typed error instead of silently falling back."""
+        profiles = tmp_path / "templates" / "mode_profiles"
+        profiles.mkdir(parents=True)
+        (profiles / "deep.yaml").write_text(
+            "name: deep\nsystem_prompt_preamble: |\n  Deep preamble.\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ResponseStyleTemplateError, match="fast.yaml"):
+            render_style_addendum("terse", workdir=tmp_path)
+
+    def test_malformed_template_raises_typed_error(self, tmp_path: Path) -> None:
+        profiles = tmp_path / "templates" / "mode_profiles"
+        profiles.mkdir(parents=True)
+        (profiles / "fast.yaml").write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+        with pytest.raises(ResponseStyleTemplateError):
+            render_style_addendum("terse", workdir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Hashing
+# ---------------------------------------------------------------------------
+
+
+class TestHashing:
+    def test_sha256_of_rendered_addendum(self) -> None:
+        rendered = render_style_addendum("terse")
+        expected = hashlib.sha256(rendered.encode("utf-8")).hexdigest()
+        assert addendum_sha256(rendered) == expected
+
+    def test_empty_addendum_hash_is_sha256_of_empty_bytes(self) -> None:
+        assert addendum_sha256("") == hashlib.sha256(b"").hexdigest()

--- a/tests/unit/agents/test_spawner_response_style.py
+++ b/tests/unit/agents/test_spawner_response_style.py
@@ -20,7 +20,6 @@ from bernstein.core.agents.spawner_core import AgentSpawner
 
 if TYPE_CHECKING:
     from pathlib import Path
-
     from unittest.mock import MagicMock
 
 

--- a/tests/unit/agents/test_spawner_response_style.py
+++ b/tests/unit/agents/test_spawner_response_style.py
@@ -1,0 +1,167 @@
+"""Spawn-path wiring tests for response-style profiles (issue #2243).
+
+Verifies that ``spawn_for_tasks`` resolves the style deterministically,
+hands the rendered addendum to the adapter via ``system_addendum``, stamps
+the profile and its content hash onto the session and task metadata for
+the cost ledger, and - critically - that a spawn with NO profile set is
+byte-identical to a pre-change spawn (golden-prompt regression, AC3).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.agents.response_style import (
+    addendum_sha256,
+    render_style_addendum,
+)
+from bernstein.core.agents.spawner_core import AgentSpawner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from unittest.mock import MagicMock
+
+
+def _build_spawner(
+    tmp_path: Path,
+    adapter: MagicMock,
+    *,
+    role_model_policy: dict[str, dict[str, Any]] | None = None,
+) -> AgentSpawner:
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(
+        adapter,
+        templates_dir,
+        tmp_path,
+        use_worktrees=False,
+        default_model="mock-model",
+        role_model_policy=role_model_policy,
+    )
+
+
+def _spawn_kwargs(adapter: MagicMock) -> dict[str, Any]:
+    assert adapter.spawn.call_count == 1
+    return adapter.spawn.call_args.kwargs
+
+
+class TestGoldenPromptRegression:
+    """AC3: a role with no style set behaves byte-identically to pre-change
+    spawns - empty addendum, untouched prompt."""
+
+    def test_no_profile_spawn_passes_empty_system_addendum(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        adapter = mock_adapter_factory()
+        spawner = _build_spawner(tmp_path, adapter)
+        spawner.spawn_for_tasks([make_task()])
+        kwargs = _spawn_kwargs(adapter)
+        # The pre-change spawner hardcoded system_addendum="" - byte-equal.
+        assert kwargs["system_addendum"] == ""
+
+    def test_no_profile_prompt_matches_profiled_spawn_prompt(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        """The addendum travels ONLY via ``system_addendum``: the rendered
+        prompt of a terse spawn is byte-identical to a no-profile spawn of
+        the same task (modulo the per-spawn session id and workdir)."""
+        workdir_plain = tmp_path / "plain"
+        workdir_terse = tmp_path / "terse"
+        workdir_plain.mkdir()
+        workdir_terse.mkdir()
+
+        adapter_plain = mock_adapter_factory()
+        spawner_plain = _build_spawner(workdir_plain, adapter_plain)
+        session_plain = spawner_plain.spawn_for_tasks([make_task()])
+        prompt_plain = _spawn_kwargs(adapter_plain)["prompt"]
+
+        adapter_terse = mock_adapter_factory()
+        spawner_terse = _build_spawner(
+            workdir_terse,
+            adapter_terse,
+            role_model_policy={"backend": {"model": "mock-model", "response_style": "terse"}},
+        )
+        session_terse = spawner_terse.spawn_for_tasks([make_task()])
+        prompt_terse = _spawn_kwargs(adapter_terse)["prompt"]
+
+        def _normalize(prompt: str, session_id: str, workdir: Path) -> str:
+            return prompt.replace(session_id, "SESSION").replace(str(workdir), "WORKDIR")
+
+        assert _normalize(prompt_plain, session_plain.id, workdir_plain) == _normalize(
+            prompt_terse, session_terse.id, workdir_terse
+        )
+
+    def test_no_profile_spawn_still_records_balanced_profile(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        """Every spawn carries a declared profile - unset resolves to the
+        neutral ``balanced`` and the hash of the empty addendum."""
+        adapter = mock_adapter_factory()
+        spawner = _build_spawner(tmp_path, adapter)
+        task = make_task()
+        session = spawner.spawn_for_tasks([task])
+        assert session.response_profile == "balanced"
+        assert session.profile_content_sha256 == hashlib.sha256(b"").hexdigest()
+        assert task.metadata["response_profile"] == "balanced"
+        assert task.metadata["profile_content_sha256"] == hashlib.sha256(b"").hexdigest()
+
+
+class TestProfiledSpawn:
+    def test_role_policy_terse_flows_into_system_addendum(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        adapter = mock_adapter_factory()
+        spawner = _build_spawner(
+            tmp_path,
+            adapter,
+            role_model_policy={"backend": {"model": "mock-model", "response_style": "terse"}},
+        )
+        task = make_task()
+        session = spawner.spawn_for_tasks([task])
+
+        expected = render_style_addendum("terse", workdir=tmp_path)
+        assert expected != ""
+        kwargs = _spawn_kwargs(adapter)
+        assert kwargs["system_addendum"] == expected
+        # AC2: ledger coupling inputs are stamped on session + task metadata.
+        assert session.response_profile == "terse"
+        assert session.profile_content_sha256 == addendum_sha256(expected)
+        assert task.metadata["response_profile"] == "terse"
+        assert task.metadata["profile_content_sha256"] == addendum_sha256(expected)
+
+    def test_task_metadata_mode_overrides_role_policy(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        adapter = mock_adapter_factory()
+        spawner = _build_spawner(
+            tmp_path,
+            adapter,
+            role_model_policy={"backend": {"model": "mock-model", "response_style": "terse"}},
+        )
+        task = make_task()
+        task.metadata["mode"] = "verbose"
+        session = spawner.spawn_for_tasks([task])
+        expected = render_style_addendum("verbose", workdir=tmp_path)
+        assert _spawn_kwargs(adapter)["system_addendum"] == expected
+        assert session.response_profile == "verbose"
+
+    def test_seed_default_entry_supplies_style(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        adapter = mock_adapter_factory()
+        spawner = _build_spawner(
+            tmp_path,
+            adapter,
+            role_model_policy={
+                "default": {"model": "mock-model", "response_style": "terse"},
+                "backend": {"model": "mock-model"},
+            },
+        )
+        session = spawner.spawn_for_tasks([make_task()])
+        assert session.response_profile == "terse"
+
+    def test_rendered_addendum_is_deterministic_across_spawns(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        """AC1 at the spawn seam: two spawns with identical config and task
+        metadata hand the adapter byte-identical addenda."""
+        addenda: list[str] = []
+        for _ in range(2):
+            adapter = mock_adapter_factory()
+            spawner = _build_spawner(
+                tmp_path,
+                adapter,
+                role_model_policy={"backend": {"model": "mock-model", "response_style": "verbose"}},
+            )
+            spawner.spawn_for_tasks([make_task()])
+            addenda.append(_spawn_kwargs(adapter)["system_addendum"])
+        assert addenda[0] == addenda[1]
+        assert addenda[0].startswith("## Response style: verbose\n")

--- a/tests/unit/cli/test_task_cmd_mode.py
+++ b/tests/unit/cli/test_task_cmd_mode.py
@@ -1,0 +1,46 @@
+"""Tests for the ``--mode`` passthrough on task creation (issue #2243).
+
+``bernstein compose --mode <style>`` stamps ``metadata['mode']`` on the
+task payload; the spawner's response-style resolver treats that key as the
+top-priority resolution input. Both the style vocabulary
+(``verbose``/``balanced``/``terse``) and the mode-profile vocabulary
+(``fast``/``smart``/``deep``) are accepted.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.task_cmd import add_task
+
+
+def _payload_from_dry_run(output: str) -> dict:
+    """Extract the JSON payload printed by ``--dry-run``."""
+    start = output.index("{")
+    end = output.rindex("}") + 1
+    return json.loads(output[start:end])
+
+
+class TestAddTaskModeOption:
+    @pytest.mark.parametrize("mode", ["verbose", "balanced", "terse", "fast", "smart", "deep"])
+    def test_mode_lands_in_metadata(self, mode: str) -> None:
+        runner = CliRunner()
+        result = runner.invoke(add_task, ["My task", "--mode", mode, "--dry-run"])
+        assert result.exit_code == 0, result.output
+        payload = _payload_from_dry_run(result.output)
+        assert payload["metadata"]["mode"] == mode
+
+    def test_no_mode_leaves_payload_unchanged(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(add_task, ["My task", "--dry-run"])
+        assert result.exit_code == 0, result.output
+        payload = _payload_from_dry_run(result.output)
+        assert "metadata" not in payload or "mode" not in payload.get("metadata", {})
+
+    def test_unknown_mode_rejected_before_submission(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(add_task, ["My task", "--mode", "shouty", "--dry-run"])
+        assert result.exit_code != 0

--- a/tests/unit/test_schedule_projection.py
+++ b/tests/unit/test_schedule_projection.py
@@ -387,3 +387,55 @@ class TestProjectionPurity:
             if previous is None:
                 previous = result.canonical_bytes
             assert result.canonical_bytes == previous
+
+
+class TestResponseProfileFold:
+    """The response-style profile is an input to task identity when (and
+    only when) a profile is explicitly declared."""
+
+    def _fire(self, **overrides):
+        kwargs = {
+            "schedule_id": "sched_style",
+            "fire_time": 1_700_000_000,
+            "last_state": None,
+            "goal": "Nightly triage",
+        }
+        kwargs.update(overrides)
+        return project_schedule_fire(**kwargs)
+
+    def test_no_profile_is_byte_identical_to_pre_change_shape(self) -> None:
+        """Backward compatibility: with no profile declared, the canonical
+        payload contains no profile keys and the task hash is unchanged."""
+        result = self._fire()
+        payload = json.loads(result.canonical_bytes.decode())
+        assert "response_profile" not in payload
+        assert "profile_content_sha256" not in payload
+        node_metadata_keys = {k for k, _v in [tuple(item) for item in payload["nodes"][0]["metadata"]]}
+        assert "response_profile" not in node_metadata_keys
+
+    def test_profile_folds_into_task_identity(self) -> None:
+        plain = self._fire()
+        profiled = self._fire(response_profile="terse", profile_content_sha256="c" * 64)
+        assert plain.projection_hash != profiled.projection_hash
+        assert plain.nodes[0].task_id != profiled.nodes[0].task_id
+
+    def test_profile_fold_is_deterministic(self) -> None:
+        a = self._fire(response_profile="terse", profile_content_sha256="c" * 64)
+        b = self._fire(response_profile="terse", profile_content_sha256="c" * 64)
+        assert a.canonical_bytes == b.canonical_bytes
+        assert a.projection_hash == b.projection_hash
+
+    def test_different_profile_hash_forks_identity(self) -> None:
+        a = self._fire(response_profile="terse", profile_content_sha256="c" * 64)
+        b = self._fire(response_profile="terse", profile_content_sha256="d" * 64)
+        assert a.projection_hash != b.projection_hash
+        assert a.nodes[0].task_id != b.nodes[0].task_id
+
+    def test_profile_lands_in_canonical_payload_and_node_metadata(self) -> None:
+        result = self._fire(response_profile="verbose", profile_content_sha256="e" * 64)
+        payload = json.loads(result.canonical_bytes.decode())
+        assert payload["response_profile"] == "verbose"
+        assert payload["profile_content_sha256"] == "e" * 64
+        metadata = {k: v for k, v in [tuple(item) for item in payload["nodes"][0]["metadata"]]}
+        assert metadata["response_profile"] == "verbose"
+        assert metadata["mode"] == "verbose"

--- a/tests/unit/test_schedule_supervisor.py
+++ b/tests/unit/test_schedule_supervisor.py
@@ -429,3 +429,45 @@ class TestProjectionPersistenceAlignment:
 
 def test_default_catch_up_limit_is_positive() -> None:
     assert DEFAULT_CATCH_UP_LIMIT > 0
+
+
+class TestResponseProfileProjectionFold:
+    """A schedule-declared response profile forks the projected task identity."""
+
+    def test_declared_profile_changes_projection_hash(self, tmp_path: Path) -> None:
+        store = ScheduleStore(tmp_path)
+        schedule = store.add(cron="* * * * *", goal="Nightly triage")
+        sup = ScheduleSupervisor(store, lambda _e: None, _StubAuditLog())
+        epoch = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+
+        plain = sup._fire(schedule, epoch, counterfactual=True)
+        schedule.extra["response_profile"] = "terse"
+        profiled = sup._fire(schedule, epoch, counterfactual=True)
+
+        assert plain.projection_hash != profiled.projection_hash
+
+    def test_unknown_profile_is_ignored(self, tmp_path: Path) -> None:
+        store = ScheduleStore(tmp_path)
+        schedule = store.add(cron="* * * * *", goal="Nightly triage")
+        sup = ScheduleSupervisor(store, lambda _e: None, _StubAuditLog())
+        epoch = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+
+        plain = sup._fire(schedule, epoch, counterfactual=True)
+        schedule.extra["response_profile"] = "shouty"
+        ignored = sup._fire(schedule, epoch, counterfactual=True)
+
+        assert plain.projection_hash == ignored.projection_hash
+
+    def test_balanced_profile_still_folds_declared_identity(self, tmp_path: Path) -> None:
+        # An EXPLICIT balanced profile is still a declared input: it folds
+        # (with the empty-addendum hash), unlike an absent profile.
+        store = ScheduleStore(tmp_path)
+        schedule = store.add(cron="* * * * *", goal="Nightly triage")
+        sup = ScheduleSupervisor(store, lambda _e: None, _StubAuditLog())
+        epoch = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+
+        plain = sup._fire(schedule, epoch, counterfactual=True)
+        schedule.extra["response_profile"] = "balanced"
+        profiled = sup._fire(schedule, epoch, counterfactual=True)
+
+        assert plain.projection_hash != profiled.projection_hash

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -143,6 +143,67 @@ class TestParseSeedValid:
         with pytest.raises(SeedError, match="allowed credential variable name"):
             parse_seed(seed_file)
 
+    def test_role_model_policy_parses_response_style(self, seed_file: Path) -> None:
+        seed_file.write_text(
+            'goal: "T"\n'
+            "role_model_policy:\n"
+            "  backend:\n"
+            "    model: gpt-5\n"
+            "    response_style: terse\n"
+        )
+        cfg = parse_seed(seed_file)
+        assert cfg.role_model_policy is not None
+        assert cfg.role_model_policy["backend"]["response_style"] == "terse"
+
+    def test_role_model_policy_rejects_unknown_response_style(self, seed_file: Path) -> None:
+        seed_file.write_text(
+            'goal: "T"\n'
+            "role_model_policy:\n"
+            "  backend:\n"
+            "    model: gpt-5\n"
+            "    response_style: shouty\n"
+        )
+        with pytest.raises(SeedError, match="response_style"):
+            parse_seed(seed_file)
+
+    def test_response_style_with_missing_template_fails_validation(self, seed_file: Path) -> None:
+        # AC4 (#2243): a style whose mapped mode-profile template file is
+        # missing from the workdir override directory fails config
+        # validation with the typed template error, not at spawn time.
+        from bernstein.core.agents.response_style import ResponseStyleTemplateError
+
+        profiles = seed_file.parent / "templates" / "mode_profiles"
+        profiles.mkdir(parents=True)
+        (profiles / "deep.yaml").write_text(
+            "name: deep\nsystem_prompt_preamble: |\n  Deep preamble.\n",
+            encoding="utf-8",
+        )
+        seed_file.write_text(
+            'goal: "T"\n'
+            "role_model_policy:\n"
+            "  backend:\n"
+            "    model: gpt-5\n"
+            "    response_style: terse\n"
+        )
+        with pytest.raises(SeedError, match="fast.yaml") as excinfo:
+            parse_seed(seed_file)
+        assert isinstance(excinfo.value, ResponseStyleTemplateError) or isinstance(
+            excinfo.value.__cause__, ResponseStyleTemplateError
+        )
+
+    def test_response_style_with_bundled_templates_passes_validation(self, seed_file: Path) -> None:
+        # No workdir override dir -> bundled templates satisfy validation.
+        seed_file.write_text(
+            'goal: "T"\n'
+            "role_model_policy:\n"
+            "  default:\n"
+            "    model: gpt-5\n"
+            "    response_style: verbose\n"
+        )
+        cfg = parse_seed(seed_file)
+        assert cfg.role_model_policy is not None
+        assert cfg.role_model_policy["default"]["response_style"] == "verbose"
+
     def test_batch_config_parsed(self, seed_file: Path) -> None:
         seed_file.write_text('goal: "T"\nbatch:\n  enabled: true\n  eligible: [docs, style, tests]\n')
         cfg = parse_seed(seed_file)

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -144,24 +144,14 @@ class TestParseSeedValid:
             parse_seed(seed_file)
 
     def test_role_model_policy_parses_response_style(self, seed_file: Path) -> None:
-        seed_file.write_text(
-            'goal: "T"\n'
-            "role_model_policy:\n"
-            "  backend:\n"
-            "    model: gpt-5\n"
-            "    response_style: terse\n"
-        )
+        seed_file.write_text('goal: "T"\nrole_model_policy:\n  backend:\n    model: gpt-5\n    response_style: terse\n')
         cfg = parse_seed(seed_file)
         assert cfg.role_model_policy is not None
         assert cfg.role_model_policy["backend"]["response_style"] == "terse"
 
     def test_role_model_policy_rejects_unknown_response_style(self, seed_file: Path) -> None:
         seed_file.write_text(
-            'goal: "T"\n'
-            "role_model_policy:\n"
-            "  backend:\n"
-            "    model: gpt-5\n"
-            "    response_style: shouty\n"
+            'goal: "T"\nrole_model_policy:\n  backend:\n    model: gpt-5\n    response_style: shouty\n'
         )
         with pytest.raises(SeedError, match="response_style"):
             parse_seed(seed_file)
@@ -178,13 +168,7 @@ class TestParseSeedValid:
             "name: deep\nsystem_prompt_preamble: |\n  Deep preamble.\n",
             encoding="utf-8",
         )
-        seed_file.write_text(
-            'goal: "T"\n'
-            "role_model_policy:\n"
-            "  backend:\n"
-            "    model: gpt-5\n"
-            "    response_style: terse\n"
-        )
+        seed_file.write_text('goal: "T"\nrole_model_policy:\n  backend:\n    model: gpt-5\n    response_style: terse\n')
         with pytest.raises(SeedError, match="fast.yaml") as excinfo:
             parse_seed(seed_file)
         assert isinstance(excinfo.value, ResponseStyleTemplateError) or isinstance(
@@ -194,11 +178,7 @@ class TestParseSeedValid:
     def test_response_style_with_bundled_templates_passes_validation(self, seed_file: Path) -> None:
         # No workdir override dir -> bundled templates satisfy validation.
         seed_file.write_text(
-            'goal: "T"\n'
-            "role_model_policy:\n"
-            "  default:\n"
-            "    model: gpt-5\n"
-            "    response_style: verbose\n"
+            'goal: "T"\nrole_model_policy:\n  default:\n    model: gpt-5\n    response_style: verbose\n'
         )
         cfg = parse_seed(seed_file)
         assert cfg.role_model_policy is not None

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -1216,9 +1216,7 @@ def test_record_cost_tags_response_profile_from_session(tmp_path: Path, make_tas
     assert tags["profile_content_sha256"] == "f" * 64
 
 
-def test_record_cost_tags_response_profile_from_task_metadata_when_session_lost(
-    tmp_path: Path, make_task: Any
-) -> None:
+def test_record_cost_tags_response_profile_from_task_metadata_when_session_lost(tmp_path: Path, make_task: Any) -> None:
     """When the session is already gone (dead-exit recovery), the profile
     stamped on task metadata at spawn still reaches the ledger entry."""
     from bernstein.core.tasks.task_lifecycle import _record_cost_and_convergence

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -1189,3 +1189,66 @@ def test_claim_and_spawn_batches_spawns_claimed_subset_on_partial_claim_failure(
     assert [t.id for t in spawned_batch] == ["T-a"]
     # Task B's claim failure is recorded, but does not block A.
     assert any("T-b" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Response-profile ledger coupling
+# ---------------------------------------------------------------------------
+
+
+def test_record_cost_tags_response_profile_from_session(tmp_path: Path, make_task: Any) -> None:
+    """A task spawned with a terse response profile produces a cost ledger
+    entry carrying response_profile and the rendered-addendum hash."""
+    from bernstein.core.tasks.task_lifecycle import _record_cost_and_convergence
+
+    task = make_task(id="T-style", title="qa task", description="d", status=TaskStatus.DONE)
+    session = _session_for(task.id, exit_code=0)
+    session.response_profile = "terse"
+    session.profile_content_sha256 = "f" * 64
+    orch = _process_orch(tmp_path, session)
+    task_m = SimpleNamespace(tokens_prompt=100, tokens_completion=50)
+
+    _record_cost_and_convergence(orch, task, session, task_m, cost_usd=1.0, janitor_passed=True)
+
+    _, cumulative_kwargs = orch._cost_tracker.record_cumulative.call_args
+    tags = cumulative_kwargs["cost_tags"]
+    assert tags["response_profile"] == "terse"
+    assert tags["profile_content_sha256"] == "f" * 64
+
+
+def test_record_cost_tags_response_profile_from_task_metadata_when_session_lost(
+    tmp_path: Path, make_task: Any
+) -> None:
+    """When the session is already gone (dead-exit recovery), the profile
+    stamped on task metadata at spawn still reaches the ledger entry."""
+    from bernstein.core.tasks.task_lifecycle import _record_cost_and_convergence
+
+    task = make_task(id="T-style-meta", title="t", description="d", status=TaskStatus.DONE)
+    task.metadata["response_profile"] = "verbose"
+    task.metadata["profile_content_sha256"] = "a" * 64
+    session = _session_for("other-task", exit_code=0)
+    orch = _process_orch(tmp_path, session)
+    task_m = SimpleNamespace(tokens_prompt=1, tokens_completion=1)
+
+    _record_cost_and_convergence(orch, task, None, task_m, cost_usd=0.5, janitor_passed=True)
+
+    _, cumulative_kwargs = orch._cost_tracker.record_cumulative.call_args
+    tags = cumulative_kwargs["cost_tags"]
+    assert tags["response_profile"] == "verbose"
+    assert tags["profile_content_sha256"] == "a" * 64
+
+
+def test_record_cost_tags_absent_for_pre_change_sessions(tmp_path: Path, make_task: Any) -> None:
+    """Sessions and tasks with no profile stamped (pre-change state) keep the
+    ledger mutation byte-identical: cost_tags stays None."""
+    from bernstein.core.tasks.task_lifecycle import _record_cost_and_convergence
+
+    task = make_task(id="T-legacy", title="t", description="d", status=TaskStatus.DONE)
+    session = _session_for(task.id, exit_code=0)
+    orch = _process_orch(tmp_path, session)
+    task_m = SimpleNamespace(tokens_prompt=1, tokens_completion=1)
+
+    _record_cost_and_convergence(orch, task, session, task_m, cost_usd=0.5, janitor_passed=True)
+
+    _, cumulative_kwargs = orch._cost_tracker.record_cumulative.call_args
+    assert cumulative_kwargs["cost_tags"] is None


### PR DESCRIPTION
## Problem

Operators running many parallel workers have no way to control worker output verbosity per role or per task. The repo ships three response-style primitives (mode profiles, output styles, per-model conciseness strategy) but none is invoked from the live spawn path: `apply_mode_to_spawn` has no production callers and the spawner hardcodes `system_addendum=""`. A reviewer role and an investigator role produce the same verbose prose, inflating per-task token cost with no operator recourse short of hand-editing role templates.

## What was built

- **`core/agents/response_style.py`** (new): deterministic style resolver and addendum renderer. Resolution order, documented and snapshot-tested: `Task.metadata["mode"]` > role policy `response_style` > seed default (`role_model_policy.default`) > `"balanced"`. The vocabulary (`verbose`/`balanced`/`terse`) is the conciseness vocabulary from `claude_model_prompts.PromptStrategy`; the addendum body reuses the `templates/mode_profiles/{fast,smart,deep}.yaml` preambles (terse->fast, balanced->smart, verbose->deep) - no new prompt dialect. Carve-outs are baked into every non-empty addendum: code blocks, commit messages, error text, and completion API JSON payloads are never style-compressed.
- **Spawn path** (`spawner_core.py`): every spawn resolves a style, renders the addendum, and passes it via the previously hardcoded `system_addendum` parameter. The profile name and the addendum SHA-256 are stamped on the `AgentSession`, on `task.metadata`, and emitted as a `task_response_profile` audit event per task.
- **Ledger coupling** (`task_lifecycle.py`): the completion-time cost ledger entry carries `response_profile` and `profile_content_sha256` cost tags (session-first, task-metadata fallback for dead-exit recovery), so cost analysis can group spend per profile.
- **Config** (`config_schema.py`, `seed_parser.py`): `role_model_policy.<role>.response_style` with closed-vocabulary validation; a declared style whose mapped template file is missing from the workdir profile directory fails `parse_seed` with a typed `ResponseStyleTemplateError` (surfaced as a `SeedError` with the typed cause chained).
- **Deterministic task graph** (`schedule_projection.py`, `schedule_supervisor.py`): a schedule that declares `extra.response_profile` folds the profile name and addendum hash into the task identity seed and canonical payload, so the profile is an input to the task hash. The fold is conditional: schedules without a declared profile produce byte-identical seeds, payloads, and hashes to prior revs.
- **CLI** (`task_cmd.py`): `--mode` passthrough on task creation, accepting both style names and mode-profile names; stamped as `metadata["mode"]`.

## Acceptance criteria mapping

1. Byte-identical addendum across machines: frozen snapshot tests in `tests/unit/agents/test_response_style.py` plus a determinism test at the spawn seam.
2. Terse spawn ledger entry: `tests/unit/test_task_lifecycle.py::test_record_cost_tags_response_profile_from_session` and the spawner stamp tests.
3. No-style back-compat: golden-prompt regression in `tests/unit/agents/test_spawner_response_style.py` - a no-profile spawn passes `system_addendum=""` (byte-equal to the previous hardcoded value) and its rendered prompt is byte-identical to a profiled spawn's prompt (the addendum never enters the prompt).
4. Missing template: `tests/unit/test_seed.py::test_response_style_with_missing_template_fails_validation` (typed error at parse time) and render-time typed-error tests.

## Deviations from the issue text (existing architecture preferred)

- The issue suggests calling `apply_mode_to_spawn` during prompt assembly. That helper prepends the mode preamble into the prompt itself and always resolves a model-family profile (e.g. claude -> smart, non-empty preamble), which would mutate the rendered prompt of every existing spawn and violate AC3. Instead the same mode-profile templates are rendered into the dedicated `system_addendum` channel the adapters already accept, keeping prompt rendering untouched. `apply_mode_to_spawn` remains available for the sampling-override path that already consumes profiles.
- `balanced` renders an empty addendum by design: it declares the neutral house style, which is what makes AC3 satisfiable while still recording `response_profile: balanced` plus the empty-addendum hash in every ledger entry.
- The profile-hash fold into task identity is conditional on an explicitly declared profile, per the back-compat requirement: unconditional folding would fork the task identity of every profile-less schedule against previously recorded audit chains.
- The fold is wired at the deterministic schedule projection (the task-graph hashing surface this repo has); ad-hoc tasks record the profile in the ledger, audit chain, and task metadata rather than in a graph hash, since no deterministic graph exists for them.

## How it is tested

- New: `tests/unit/agents/test_response_style.py` (23), `tests/unit/agents/test_spawner_response_style.py` (7), `tests/unit/cli/test_task_cmd_mode.py` (8).
- Extended: `tests/unit/test_task_lifecycle.py` (+3), `tests/unit/test_seed.py` (+4), `tests/unit/test_schedule_projection.py` (+5), `tests/unit/test_schedule_supervisor.py` (+3).
- Regression sweep: spawner, orchestrator, audit, cost-tracker, seed-parser mutation-kill, mode-profile, schedule audit chain, and fresh-context-retry suites all pass (1700+ tests across the touched surfaces). `ruff check`, `ruff format --check`, `lint-imports`, and the routes broad-except check pass.

Fixes #2243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable response-style options for task creation and agent spawning.
  * Response style is now captured in task/session metadata and reflected in scheduling and cost tracking.

* **Bug Fixes**
  * Improved consistency by keeping profile-related projections and hashes stable for identical inputs.
  * Unknown style values are safely ignored or rejected with clear validation errors.

* **Tests**
  * Added coverage for response-style selection, rendering, projection hashing, CLI passthrough, seed validation, and cost-tag propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->