### PR TITLE
Per-profile cost attribution and savings report derived from the cost ledger

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -726,6 +726,7 @@ bernstein reject-tool  <request_id>
 | Command | Purpose | Source |
 |---|---|---|
 | `bernstein cost` | Spend breakdown by model / task. | `cli/commands/cost.py:540` |
+| `bernstein cost profile-report` | Content-addressed per-profile cost report, appended to the audit chain. | `cli/commands/cost.py` |
 | `bernstein estimate` | Estimate cost before running. | `cli/commands/cost.py:388` |
 | `bernstein token-report` | Token usage breakdown. | `cli/token_cmd.py` |
 
@@ -734,8 +735,24 @@ bernstein reject-tool  <request_id>
 | Flag | Default | Meaning |
 |---|---|---|
 | `--period {today\|week\|month\|all}` | week | Time window. |
-| `--by {model\|role\|task}` | model | Group-by dimension. |
+| `--by {model\|role\|task\|profile\|...}` | model | Group-by dimension. `profile` groups by response-style profile; tasks whose profile changed mid-run appear as an explicit excluded bucket. |
 | `--json` | off | Emit JSON. |
+
+#### `bernstein cost profile-report`
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--last {1h\|24h\|7d\|30d}` | whole ledger | Ledger window. |
+| `--ledger PATH` | `.sdd/cost/ledger.jsonl` | Spend ledger to compute from. |
+| `--json` | off | Emit JSON. |
+
+Emits per-profile tasks / output tokens / USD / mean tokens per task plus
+joined verification pass rates. The artifact is canonical JSON named by its
+own SHA-256, embeds the ledger line-hash range it was computed from, and is
+appended to the audit chain, so anyone holding the ledger can recompute it
+byte-identically. Cross-profile savings are only claimed when both profiles
+have at least 5 tasks with the same role and model; otherwise the report
+states "insufficient comparable runs".
 
 #### `bernstein estimate`
 

--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -91,31 +91,75 @@ def _count_task_status(task_records: list[dict[str, Any]]) -> tuple[int, int]:
     return done, failed
 
 
+def _profile_comparison_line(comp: Any) -> str:
+    """One human-readable line for a cross-profile comparison."""
+    return (
+        f"{comp.profile_a} vs {comp.profile_b} ({comp.role}/{comp.model}): "
+        f"${comp.mean_cost_usd_per_task_a:.4f} vs ${comp.mean_cost_usd_per_task_b:.4f} per task, "
+        f"{comp.mean_output_tokens_per_task_a:.0f} vs {comp.mean_output_tokens_per_task_b:.0f} out-tokens/task "
+        f"({comp.tasks_a}+{comp.tasks_b} tasks)"
+    )
+
+
+def _render_profile_savings_section(
+    cons: Console,
+    profile_comparisons: list[Any] | None,
+    profiles_seen: int,
+) -> None:
+    """Print the per-profile savings section, honouring the honesty rule.
+
+    Nothing is printed when fewer than two profiles appear in the
+    ledger window. With two or more profiles but no cohort where both
+    sides reach the comparable-task bar, the section prints
+    "insufficient comparable runs" instead of a savings claim.
+    """
+    from bernstein.core.cost.profile_attribution import MIN_COMPARABLE_TASKS
+
+    if profiles_seen < 2:
+        return
+    cons.print()
+    cons.print("[bold]Per-profile comparison[/bold]  (same role+model cohorts only)")
+    if not profile_comparisons:
+        cons.print(
+            f"  [dim]insufficient comparable runs (need >= {MIN_COMPARABLE_TASKS} "
+            f"tasks per profile with matching role and model)[/dim]"
+        )
+        return
+    for comp in profile_comparisons:
+        cons.print(f"  {_profile_comparison_line(comp)}")
+
+
 def _render_savings_comparison(
     cons: Console,
     actual_cost: float,
     savings_vs_opus: float,
+    profile_comparisons: list[Any] | None = None,
+    profiles_seen: int = 0,
 ) -> None:
-    """Print an ASCII bar chart comparing Bernstein vs all-Opus baseline."""
+    """Print an ASCII bar chart comparing Bernstein vs all-Opus baseline.
+
+    When the ledger window covers two or more response-style profiles a
+    per-profile section follows the chart (issue #2245); the section
+    obeys the honesty rule via :func:`_render_profile_savings_section`.
+    """
     single_agent_cost = actual_cost + savings_vs_opus
-    if single_agent_cost <= 0:
-        return
+    if single_agent_cost > 0:
+        savings_pct = (savings_vs_opus / single_agent_cost) * 100
 
-    savings_pct = (savings_vs_opus / single_agent_cost) * 100
+        bar_width = 34
+        single_bar = _ascii_bar(single_agent_cost, single_agent_cost, bar_width)
+        bernstein_bar = _ascii_bar(actual_cost, single_agent_cost, bar_width)
 
-    bar_width = 34
-    single_bar = _ascii_bar(single_agent_cost, single_agent_cost, bar_width)
-    bernstein_bar = _ascii_bar(actual_cost, single_agent_cost, bar_width)
-
-    cons.print()
-    cons.print("[bold]Cost Comparison[/bold]  (Bernstein vs all-Opus baseline)")
-    cons.print(f"  Single agent  [red]{single_bar}[/red]  [dim]${single_agent_cost:.4f}[/dim]")
-    cons.print(f"  Bernstein     [green]{bernstein_bar}[/green]  [bold green]${actual_cost:.4f}[/bold green]")
-    if savings_pct > 0:
-        cons.print(
-            f"\n  [bold green]You saved ${savings_vs_opus:.4f} "
-            f"({savings_pct:.0f}%) by using Bernstein's model cascade[/bold green]"
-        )
+        cons.print()
+        cons.print("[bold]Cost Comparison[/bold]  (Bernstein vs all-Opus baseline)")
+        cons.print(f"  Single agent  [red]{single_bar}[/red]  [dim]${single_agent_cost:.4f}[/dim]")
+        cons.print(f"  Bernstein     [green]{bernstein_bar}[/green]  [bold green]${actual_cost:.4f}[/bold green]")
+        if savings_pct > 0:
+            cons.print(
+                f"\n  [bold green]You saved ${savings_vs_opus:.4f} "
+                f"({savings_pct:.0f}%) by using Bernstein's model cascade[/bold green]"
+            )
+    _render_profile_savings_section(cons, profile_comparisons, profiles_seen)
 
 
 def _render_shareable_summary(
@@ -125,6 +169,8 @@ def _render_shareable_summary(
     tasks_done: int,
     tasks_failed: int,
     total_duration_s: float,
+    profile_comparisons: list[Any] | None = None,
+    profiles_seen: int = 0,
 ) -> None:
     """Print a copy-pasteable markdown run summary."""
     single_agent_cost = actual_cost + savings_vs_opus
@@ -149,6 +195,11 @@ def _render_shareable_summary(
         )
     else:
         lines.append(f"   Cost:  ${actual_cost:.2f}")
+    if profiles_seen >= 2:
+        if profile_comparisons:
+            lines.extend(f"   Profiles: {_profile_comparison_line(comp)}" for comp in profile_comparisons)
+        else:
+            lines.append("   Profiles: insufficient comparable runs")
 
     cons.print()
     cons.print(
@@ -278,6 +329,82 @@ def _aggregate_from_ledger_or_tasks(
             label = str(tags.get("feature_label", "") or "unknown") if isinstance(tags, dict) else "unknown"
         rows[label]["tasks"] += 1
         rows[label]["cost_usd"] += float(rec.get("cost_usd", 0.0) or 0.0)
+    return rows.copy()
+
+
+def _load_profile_ledger_view(ledger_path: Path, cutoff: float) -> tuple[list[Any], list[Any]]:
+    """Load (entries, transitions) for per-profile views from the ledger.
+
+    The transitions file lives next to the ledger
+    (``profile_transitions.jsonl``). A missing ledger yields empty
+    lists so callers degrade to "no profile data".
+    """
+    from bernstein.core.cost.profile_attribution import TRANSITIONS_FILENAME, load_transitions
+    from bernstein.core.cost.spend_ledger import SpendLedger
+
+    if not ledger_path.exists():
+        return [], []
+    entries = SpendLedger.load_entries(ledger_path)
+    if cutoff > 0:
+        entries = [e for e in entries if e.ts >= cutoff]
+    transitions = load_transitions(ledger_path.parent / TRANSITIONS_FILENAME)
+    return entries, transitions
+
+
+def _profile_comparisons_from_ledger(ledger_path: Path, cutoff: float) -> tuple[list[Any], int]:
+    """Return (comparisons, profiles_seen) for the savings sections.
+
+    ``profiles_seen`` counts distinct profile tags among non-excluded
+    entries; the honesty-rule renderers stay silent below two.
+    """
+    from bernstein.core.cost.profile_attribution import (
+        compute_profile_comparisons,
+        entry_profile,
+        transitioned_task_ids,
+    )
+
+    entries, transitions = _load_profile_ledger_view(ledger_path, cutoff)
+    if not entries:
+        return [], 0
+    excluded_ids = transitioned_task_ids(transitions)
+    profiles = {
+        entry_profile(e) for e in entries if entry_profile(e) and (not e.task_id or e.task_id not in excluded_ids)
+    }
+    comparisons = compute_profile_comparisons(entries, transitions)
+    return list(comparisons), len(profiles)
+
+
+def _aggregate_profile_grouping(
+    ledger_path: Path,
+    task_records: list[dict[str, Any]],
+    cutoff: float,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate spend by response-style profile (issue #2245).
+
+    Ledger-backed when the ledger exists (per-entry attribution with
+    transition exclusion); otherwise degrades to the
+    ``cost_tags.response_profile`` stamped on task records so older
+    runs still show a breakdown.
+    """
+    from bernstein.core.cost.profile_attribution import (
+        UNATTRIBUTED_LABEL,
+        aggregate_ledger_by_profile,
+    )
+
+    if ledger_path.exists():
+        entries, transitions = _load_profile_ledger_view(ledger_path, cutoff)
+        grouped = aggregate_ledger_by_profile(entries, transitions)
+        return {k: {"tasks": v["tasks"], "cost_usd": v["cost_usd"]} for k, v in grouped.items()}
+
+    rows: dict[str, dict[str, Any]] = defaultdict(lambda: {"tasks": 0, "cost_usd": 0.0})
+    for rec in task_records:
+        raw_tags: object = rec.get("cost_tags") or {}
+        label = ""
+        if isinstance(raw_tags, dict):
+            tags = cast("dict[str, Any]", raw_tags)
+            label = str(tags.get("response_profile", "") or "")
+        rows[label or UNATTRIBUTED_LABEL]["tasks"] += 1
+        rows[label or UNATTRIBUTED_LABEL]["cost_usd"] += float(rec.get("cost_usd", 0.0) or 0.0)
     return rows.copy()
 
 
@@ -511,6 +638,8 @@ def _cost_render_json(
     grouped_data: dict[str, dict[str, Any]] | None,
     group_by: str | None,
     downgrade: tuple[str, float] | None,
+    profile_comparisons: list[Any] | None = None,
+    profiles_seen: int = 0,
 ) -> None:
     """Render cost report as JSON."""
     output: dict[str, Any] = {
@@ -548,6 +677,9 @@ def _cost_render_json(
     if downgrade is not None:
         output["tip"] = downgrade[0]
         output["potential_savings_usd"] = downgrade[1]
+    if profiles_seen >= 2:
+        output["profile_comparisons"] = [c.to_dict() for c in (profile_comparisons or [])]
+        output["insufficient_comparable_runs"] = not profile_comparisons
     print_json(output)
 
 
@@ -582,7 +714,7 @@ def _cost_render_grouped(
     console.print()
 
 
-@click.command("cost")
+@click.group("cost", invoke_without_command=True)
 @click.option(
     "--metrics-dir",
     default=".sdd/metrics",
@@ -600,9 +732,12 @@ def _cost_render_grouped(
 @click.option(
     "--by",
     "group_by",
-    type=click.Choice(["agent", "model", "task", "day", "role", "feature_label", "envelope"]),
+    type=click.Choice(["agent", "model", "task", "day", "role", "feature_label", "envelope", "profile"]),
     default=None,
-    help="Group breakdown by agent, model, task, day, role, feature_label, or envelope (issue #1405).",
+    help=(
+        "Group breakdown by agent, model, task, day, role, feature_label, "
+        "envelope (issue #1405), or profile (issue #2245)."
+    ),
 )
 @click.option(
     "--ledger",
@@ -610,11 +745,13 @@ def _cost_render_grouped(
     type=str,
     default=".sdd/cost/ledger.jsonl",
     show_default=True,
-    help="Path to the rolling spend ledger (issue #1320). Used when --by is role|feature_label.",
+    help="Path to the rolling spend ledger (issue #1320). Used when --by is role|feature_label|profile.",
 )
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 @click.option("--share", is_flag=True, default=False, help="Print only the shareable summary snippet.")
+@click.pass_context
 def cost_cmd(
+    ctx: click.Context,
     metrics_dir: str,
     last: str | None,
     since: str | None,
@@ -624,6 +761,8 @@ def cost_cmd(
     share: bool,
 ) -> None:
     """Show cost breakdown for recent runs."""
+    if ctx.invoked_subcommand is not None:
+        return
     # --since is a convenience: ``today`` ≈ ``--last 24h``,
     # ``yesterday`` ≈ ``--last 48h``. When both are provided ``--last`` wins.
     if last is None and since is not None:
@@ -731,7 +870,17 @@ def cost_cmd(
             group_by,
             cutoff,
         )
+    elif group_by == "profile":
+        # Issue #2245: per-entry attribution from the ledger with
+        # transition exclusion; tasks that changed profile mid-flight
+        # appear as an explicit excluded bucket, never split.
+        grouped_data = _aggregate_profile_grouping(Path(ledger_path), task_records, cutoff)
     # group_by == "model" or None => use the default rows (by model)
+
+    # Per-profile savings inputs (issue #2245). Honesty rule: the
+    # renderers only speak when >= 2 profiles are present, and only
+    # claim savings for cohorts that clear MIN_COMPARABLE_TASKS.
+    profile_comparisons, profiles_seen = _profile_comparisons_from_ledger(Path(ledger_path), cutoff)
 
     if as_json or is_json():
         _cost_render_json(
@@ -749,6 +898,8 @@ def cost_cmd(
             grouped_data,
             group_by,
             downgrade,
+            profile_comparisons,
+            profiles_seen,
         )
         return
 
@@ -761,6 +912,8 @@ def cost_cmd(
             tasks_done=tasks_done,
             tasks_failed=tasks_failed,
             total_duration_s=total_dur,
+            profile_comparisons=profile_comparisons,
+            profiles_seen=profiles_seen,
         )
         return
 
@@ -836,8 +989,15 @@ def cost_cmd(
             f"({savings_vs_manual['manual_hours']} hrs @ $100/hr)"
         )
 
-    # ASCII bar chart: Bernstein vs single-agent baseline
-    _render_savings_comparison(console, totals["cost_usd"], savings_vs_opus)
+    # ASCII bar chart: Bernstein vs single-agent baseline, followed by
+    # the per-profile comparison section when profiles are present.
+    _render_savings_comparison(
+        console,
+        totals["cost_usd"],
+        savings_vs_opus,
+        profile_comparisons=profile_comparisons,
+        profiles_seen=profiles_seen,
+    )
 
     # Projected monthly cost
     if projected_monthly > 0:
@@ -856,7 +1016,185 @@ def cost_cmd(
         tasks_done=tasks_done,
         tasks_failed=tasks_failed,
         total_duration_s=total_dur,
+        profile_comparisons=profile_comparisons,
+        profiles_seen=profiles_seen,
     )
+
+
+# ---------------------------------------------------------------------------
+# `bernstein cost profile-report` (issue #2245)
+# ---------------------------------------------------------------------------
+
+
+def _render_profile_report_human(cons: Console, content: dict[str, Any], sha256: str, artifact: Path) -> None:
+    """Render the profile report as a table plus its verification anchors."""
+    from rich.table import Table
+
+    table = Table(title=f"Per-profile cost report ({content['window']})", header_style="bold cyan", show_lines=False)
+    table.add_column("Profile", min_width=14, no_wrap=True)
+    table.add_column("Tasks", justify="right", min_width=6)
+    table.add_column("Out tokens", justify="right", min_width=10)
+    table.add_column("Cost USD", justify="right", min_width=10)
+    table.add_column("Tokens/task", justify="right", min_width=11)
+    table.add_column("Pass rate", justify="right", min_width=9)
+
+    profiles = cast("dict[str, Any]", content["profiles"])
+    for label in sorted(profiles):
+        row = cast("dict[str, Any]", profiles[label])
+        quality = cast("dict[str, Any] | None", row.get("quality"))
+        pass_rate = f"{float(quality['verdict_pass_rate']) * 100:.0f}%" if quality else "-"
+        table.add_row(
+            label,
+            str(row["tasks"]),
+            f"{row['output_tokens']:,}",
+            f"${row['cost_usd']:.4f}",
+            f"{row['mean_output_tokens_per_task']:.0f}",
+            pass_rate,
+        )
+    cons.print(table)
+
+    excluded = cast("dict[str, Any]", content["excluded"])
+    if excluded["calls"]:
+        cons.print(
+            f"  [dim]Excluded (profile transition): {excluded['tasks']} task(s), "
+            f"${excluded['cost_usd']:.4f} - attribution is per profile or not at all[/dim]"
+        )
+
+    comparisons = cast("list[dict[str, Any]]", content["comparisons"])
+    if comparisons:
+        cons.print("\n[bold]Comparable cohorts[/bold] (same role+model, both sides >= N tasks)")
+        for comp in comparisons:
+            cons.print(
+                f"  {comp['profile_a']} vs {comp['profile_b']} ({comp['role']}/{comp['model']}): "
+                f"${comp['mean_cost_usd_per_task_a']:.4f} vs ${comp['mean_cost_usd_per_task_b']:.4f} per task"
+            )
+    else:
+        cons.print(
+            f"\n  [dim]insufficient comparable runs (need >= {content['min_comparable_tasks']} "
+            f"tasks per profile with matching role and model)[/dim]"
+        )
+
+    ledger_block = cast("dict[str, Any]", content["ledger"])
+    cons.print(f"\n  Report sha256:  {sha256}")
+    cons.print(f"  Ledger lines:   {ledger_block['line_count']} (digest {ledger_block['lines_sha256'][:16]}...)")
+    cons.print(f"  Artifact:       {artifact}")
+    cons.print("  [dim]Appended to the audit chain as cost.profile_report[/dim]")
+
+
+@cost_cmd.command("profile-report")
+@click.option("--last", "last", type=str, default=None, help="Time range: 1h, 24h, 7d, 30d. Default: whole ledger.")
+@click.option(
+    "--metrics-dir",
+    default=".sdd/metrics",
+    show_default=True,
+    help="Directory containing metrics JSONL files (quality-outcome join).",
+)
+@click.option(
+    "--ledger",
+    "ledger_path",
+    type=str,
+    default=".sdd/cost/ledger.jsonl",
+    show_default=True,
+    help="Path to the rolling spend ledger JSONL.",
+)
+@click.option(
+    "--transitions",
+    "transitions_path",
+    type=str,
+    default=".sdd/cost/profile_transitions.jsonl",
+    show_default=True,
+    help="Path to the profile_transition event records.",
+)
+@click.option(
+    "--audit-dir",
+    "audit_dir",
+    type=str,
+    default=".sdd/audit",
+    show_default=True,
+    help="Audit chain directory the report event is appended to.",
+)
+@click.option(
+    "--reports-dir",
+    "reports_dir",
+    type=str,
+    default=".sdd/reports/cost_profiles",
+    show_default=True,
+    help="Directory the content-addressed report artifact is written to.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def cost_profile_report_cmd(
+    last: str | None,
+    metrics_dir: str,
+    ledger_path: str,
+    transitions_path: str,
+    audit_dir: str,
+    reports_dir: str,
+    as_json: bool,
+) -> None:
+    """Emit a content-addressed per-profile cost report (issue #2245).
+
+    The report is computed from recorded ledger entries only, hashed
+    over canonical JSON with no timestamps in the payload, written as
+    ``<sha256>.json``, and appended to the audit chain - a third party
+    holding the ledger can recompute it byte-identically.
+
+    \b
+      bernstein cost profile-report --last 7d
+      bernstein cost profile-report --json
+    """
+    from bernstein.core.cost.profile_attribution import load_transitions
+    from bernstein.core.cost.profile_report import build_profile_report, write_report_artifact
+    from bernstein.core.security.audit_chain import AuditChainStore, record_cost_profile_report
+
+    cutoff = _parse_time_range(last) if last else 0.0
+    window_label = last if last else "all"
+
+    mdir = Path(metrics_dir)
+    task_records = _load_tasks_jsonl(mdir) if mdir.exists() else []
+    task_records = _load_archive_tasks(mdir.parent) + task_records if mdir.exists() else task_records
+
+    report = build_profile_report(
+        ledger_path=Path(ledger_path),
+        task_records=task_records,
+        transitions=load_transitions(Path(transitions_path)),
+        window_label=window_label,
+        cutoff=cutoff,
+    )
+    artifact = write_report_artifact(report, Path(reports_dir))
+
+    ledger_block = cast("dict[str, Any]", report.content["ledger"])
+    try:
+        chain = AuditChainStore(Path(audit_dir))
+        record_cost_profile_report(
+            chain=chain,
+            report_sha256=report.sha256,
+            ledger_lines_sha256=str(ledger_block["lines_sha256"]),
+            ledger_first_line_sha256=str(ledger_block["first_line_sha256"]),
+            ledger_last_line_sha256=str(ledger_block["last_line_sha256"]),
+            ledger_line_count=int(ledger_block["line_count"]),
+            window=window_label,
+            artifact_name=report.artifact_name,
+        )
+    except Exception as exc:
+        # The report is only trustworthy once anchored; refuse to
+        # pretend otherwise.
+        if as_json or is_json():
+            print_json({"error": f"Audit chain append failed: {exc}", "artifact": str(artifact)})
+        else:
+            console.print(f"[red]Audit chain append failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if as_json or is_json():
+        print_json(
+            {
+                "artifact": str(artifact),
+                "sha256": report.sha256,
+                "content": report.content,
+            }
+        )
+        return
+
+    _render_profile_report_human(console, report.content, report.sha256, artifact)
 
 
 # ---------------------------------------------------------------------------
@@ -1027,4 +1365,4 @@ def cost_envelopes_show_cmd(
     console.print(table)
 
 
-__all__ = ["cost_cmd", "cost_envelopes_group", "estimate_cmd"]
+__all__ = ["cost_cmd", "cost_envelopes_group", "cost_profile_report_cmd", "estimate_cmd"]

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1800,6 +1800,67 @@ class AgentSpawner:
                 exc,
             )
 
+    def _maybe_record_profile_transition(
+        self,
+        *,
+        task_id: str,
+        session_id: str,
+        prev_profile: str,
+        prev_sha: str,
+        new_profile: str,
+        new_sha: str,
+    ) -> None:
+        """Record a ``profile_transition`` event when a re-spawn changes profile.
+
+        A task re-spawned under a different response-style profile (for
+        example after a role-policy edit between attempts) accumulates
+        ledger entries under two profiles. Per-profile cost attribution
+        must exclude such tasks rather than split their tokens, so the
+        change is recorded to ``.sdd/cost/profile_transitions.jsonl``
+        before the new profile overwrites the stamp on task metadata.
+        First spawns (no previous stamp) and same-profile re-spawns
+        record nothing. Failures are logged and swallowed - attribution
+        metadata must never block the spawn.
+
+        Args:
+            task_id: The task being re-spawned.
+            session_id: The new session's id (recorded as the agent).
+            prev_profile: Profile previously stamped on task metadata
+                (empty on first spawn).
+            prev_sha: Previously stamped addendum hash.
+            new_profile: Profile resolved for this spawn.
+            new_sha: Rendered-addendum hash for this spawn.
+        """
+        if not prev_profile or prev_profile == new_profile:
+            return
+        try:
+            from bernstein.core.cost.profile_attribution import (
+                default_transitions_path,
+                record_profile_transition,
+            )
+
+            record_profile_transition(
+                default_transitions_path(self._workdir / ".sdd"),
+                task_id=task_id,
+                agent_id=session_id,
+                from_profile=prev_profile,
+                to_profile=new_profile,
+                from_sha256=prev_sha,
+                to_sha256=new_sha,
+            )
+            logger.info(
+                "Profile transition recorded for task %s: %s -> %s",
+                task_id,
+                prev_profile,
+                new_profile,
+            )
+        except Exception as exc:  # attribution must never block the spawn
+            logger.warning(
+                "Could not record profile_transition for task %s: %s",
+                task_id,
+                exc,
+            )
+
     def _reap_openclaw(self, session: AgentSession) -> None:
         """Sync logs from the remote bridge for an OpenClaw session."""
         reap_openclaw(session, self._runtime_bridge, self._run_bridge_call)
@@ -2811,6 +2872,14 @@ class AgentSpawner:
         profile_content_sha = addendum_sha256(style_addendum)
         for _t in tasks:
             if isinstance(_t.metadata, dict):
+                self._maybe_record_profile_transition(
+                    task_id=_t.id,
+                    session_id=session_id,
+                    prev_profile=str(_t.metadata.get("response_profile") or ""),
+                    prev_sha=str(_t.metadata.get("profile_content_sha256") or ""),
+                    new_profile=style_resolution.style,
+                    new_sha=profile_content_sha,
+                )
                 _t.metadata["response_profile"] = style_resolution.style
                 _t.metadata["profile_content_sha256"] = profile_content_sha
         logger.info(

--- a/src/bernstein/core/cost/profile_attribution.py
+++ b/src/bernstein/core/cost/profile_attribution.py
@@ -1,0 +1,410 @@
+"""Per-profile cost attribution derived from the spend ledger.
+
+``bernstein cost`` rolls up spend by agent, model, task, role, and
+envelope; response-style profiles add one more dimension. The spawn
+path stamps ``response_profile`` (and ``profile_content_sha256``) into
+each ledger entry's tag block, so attribution here is strictly
+per-entry: every figure is recomputable from recorded ledger rows and
+figures that cannot be computed from the ledger are omitted.
+
+Two rules keep the numbers trustworthy:
+
+* **Transition exclusion.** A task started under profile A and
+  re-spawned under profile B must not be credited to either profile.
+  The spawn path records a :class:`ProfileTransition` event when it
+  overwrites a previously stamped profile; every ledger entry of a
+  transitioned task lands in the excluded bucket. Attribution is
+  all-or-nothing per task - never split heuristically.
+* **Honesty rule.** No cross-profile savings claim is produced unless
+  both profiles have at least :data:`MIN_COMPARABLE_TASKS` tasks with
+  the same role and model. Below that bar the comparison list is
+  empty and renderers print "insufficient comparable runs".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from bernstein.core.cost.spend_ledger import LedgerEntry
+
+logger = logging.getLogger(__name__)
+
+#: Honesty-rule threshold: a cross-profile savings claim requires both
+#: profiles to have at least this many tasks sharing the same role and
+#: model. Five is the smallest cohort where a per-task mean is not
+#: dominated by a single outlier run; operators who want stricter or
+#: looser comparisons pass ``min_tasks`` explicitly.
+MIN_COMPARABLE_TASKS: int = 5
+
+#: Ledger tag key carrying the response-style profile name (stamped by
+#: the spawn path at completion time; see task_lifecycle).
+RESPONSE_PROFILE_TAG = "response_profile"
+
+#: Ledger tag key carrying the SHA-256 of the rendered style addendum.
+PROFILE_CONTENT_SHA_TAG = "profile_content_sha256"
+
+#: Bucket label for ledger entries that carry no profile tag (runs that
+#: predate response-style profiles).
+UNATTRIBUTED_LABEL = "unattributed"
+
+#: Bucket label for entries of tasks with a recorded profile transition.
+EXCLUDED_LABEL = "excluded (profile transition)"
+
+#: Filename of the transition event record, next to the spend ledger.
+TRANSITIONS_FILENAME = "profile_transitions.jsonl"
+
+
+def default_transitions_path(sdd_dir: Path) -> Path:
+    """Return the canonical transitions path under an ``.sdd`` directory."""
+    return sdd_dir / "cost" / TRANSITIONS_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Transition events
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProfileTransition:
+    """One ``profile_transition`` event row.
+
+    Written when a task that already carries a stamped
+    ``response_profile`` is re-spawned under a different profile, so
+    per-profile attribution can exclude the task instead of guessing
+    which tokens belong to which profile.
+    """
+
+    ts: float
+    ts_iso: str
+    task_id: str
+    agent_id: str
+    from_profile: str
+    to_profile: str
+    from_sha256: str
+    to_sha256: str
+
+    def to_json(self) -> str:
+        """Return a stable single-line JSON encoding."""
+        return json.dumps(asdict(self), sort_keys=False, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ProfileTransition:
+        """Deserialise from a parsed JSON dict; missing fields default."""
+        return cls(
+            ts=float(d.get("ts", 0.0) or 0.0),
+            ts_iso=str(d.get("ts_iso", "")),
+            task_id=str(d.get("task_id", "")),
+            agent_id=str(d.get("agent_id", "")),
+            from_profile=str(d.get("from_profile", "")),
+            to_profile=str(d.get("to_profile", "")),
+            from_sha256=str(d.get("from_sha256", "")),
+            to_sha256=str(d.get("to_sha256", "")),
+        )
+
+
+def record_profile_transition(
+    path: Path,
+    *,
+    task_id: str,
+    agent_id: str,
+    from_profile: str,
+    to_profile: str,
+    from_sha256: str = "",
+    to_sha256: str = "",
+    ts: float | None = None,
+) -> ProfileTransition:
+    """Append one transition event to *path* and return it.
+
+    Best-effort append-only JSONL, mirroring the spend ledger's IO
+    contract: a failed write is logged, never raised, because the
+    transition record is attribution metadata and must not block a
+    spawn.
+    """
+    now = ts if ts is not None else time.time()
+    rec = ProfileTransition(
+        ts=now,
+        ts_iso=datetime.fromtimestamp(now, tz=UTC).isoformat(timespec="seconds"),
+        task_id=task_id,
+        agent_id=agent_id,
+        from_profile=from_profile,
+        to_profile=to_profile,
+        from_sha256=from_sha256,
+        to_sha256=to_sha256,
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(rec.to_json())
+            fh.write("\n")
+            fh.flush()
+    except OSError as exc:  # pragma: no cover - IO failure path
+        logger.warning("profile_attribution: failed to append transition: %s", exc)
+    return rec
+
+
+def load_transitions(path: Path) -> list[ProfileTransition]:
+    """Read every transition row; missing file yields an empty list.
+
+    Malformed lines are skipped - partial recovery over a crash,
+    consistent with :meth:`SpendLedger.load_entries`.
+    """
+    if not path.exists():
+        return []
+    out: list[ProfileTransition] = []
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(parsed, dict):
+                    out.append(ProfileTransition.from_dict(parsed))
+    except OSError as exc:  # pragma: no cover
+        logger.warning("profile_attribution: failed to read %s: %s", path, exc)
+    return out
+
+
+def transitioned_task_ids(transitions: Iterable[ProfileTransition]) -> frozenset[str]:
+    """Return the set of task ids that changed profile mid-flight."""
+    return frozenset(t.task_id for t in transitions if t.task_id)
+
+
+# ---------------------------------------------------------------------------
+# Attribution
+# ---------------------------------------------------------------------------
+
+
+def entry_profile(entry: LedgerEntry) -> str:
+    """Return the response-style profile a ledger entry was recorded under.
+
+    Empty string means the entry predates profiles (or the tag was
+    dropped); such entries are grouped under
+    :data:`UNATTRIBUTED_LABEL` rather than guessed.
+    """
+    return str(entry.tags.get(RESPONSE_PROFILE_TAG, "") or "")
+
+
+@dataclass
+class ProfileBucket:
+    """Aggregated ledger figures for one profile (or the excluded set)."""
+
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+    task_ids: set[str] = field(default_factory=set)
+
+    @property
+    def tasks(self) -> int:
+        """Distinct task count in this bucket."""
+        return len(self.task_ids)
+
+    def add(self, entry: LedgerEntry) -> None:
+        """Accumulate one ledger entry."""
+        self.calls += 1
+        self.input_tokens += entry.input_tokens
+        self.output_tokens += entry.output_tokens
+        self.cost_usd += entry.cost_usd
+        if entry.task_id:
+            self.task_ids.add(entry.task_id)
+
+
+@dataclass
+class ProfileAttribution:
+    """Result of :func:`attribute_by_profile`."""
+
+    profiles: dict[str, ProfileBucket]
+    excluded: ProfileBucket
+
+
+def attribute_by_profile(
+    entries: Iterable[LedgerEntry],
+    transitions: Iterable[ProfileTransition],
+) -> ProfileAttribution:
+    """Group ledger entries per profile, excluding transitioned tasks.
+
+    Every entry lands in exactly one bucket: its profile tag, the
+    :data:`UNATTRIBUTED_LABEL` bucket when untagged, or the excluded
+    bucket when its task has a recorded transition. Bucket sums
+    therefore always equal the per-entry ledger sum.
+    """
+    excluded_ids = transitioned_task_ids(transitions)
+    profiles: dict[str, ProfileBucket] = defaultdict(ProfileBucket)
+    excluded = ProfileBucket()
+    for entry in entries:
+        if entry.task_id and entry.task_id in excluded_ids:
+            excluded.add(entry)
+            continue
+        profiles[entry_profile(entry) or UNATTRIBUTED_LABEL].add(entry)
+    return ProfileAttribution(profiles=dict(profiles), excluded=excluded)
+
+
+def aggregate_ledger_by_profile(
+    entries: Iterable[LedgerEntry],
+    transitions: Iterable[ProfileTransition],
+) -> dict[str, dict[str, Any]]:
+    """Return ``cost --by profile`` rows: label -> {tasks, calls, cost_usd, output_tokens}.
+
+    The excluded bucket appears under :data:`EXCLUDED_LABEL` (only when
+    non-empty) so the grouped total still equals the per-entry ledger
+    sum to the cent.
+    """
+    result = attribute_by_profile(entries, transitions)
+    rows: dict[str, dict[str, Any]] = {
+        label: {
+            "tasks": bucket.tasks,
+            "calls": bucket.calls,
+            "cost_usd": bucket.cost_usd,
+            "output_tokens": bucket.output_tokens,
+        }
+        for label, bucket in result.profiles.items()
+    }
+    if result.excluded.calls > 0:
+        rows[EXCLUDED_LABEL] = {
+            "tasks": result.excluded.tasks,
+            "calls": result.excluded.calls,
+            "cost_usd": result.excluded.cost_usd,
+            "output_tokens": result.excluded.output_tokens,
+        }
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Honesty rule: comparable cross-profile cohorts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProfileComparison:
+    """A cross-profile comparison over one (role, model) cohort.
+
+    Only produced when both profiles clear the honesty-rule bar; the
+    means are computed over the cohort's tasks only, so the two sides
+    are like-for-like.
+    """
+
+    profile_a: str
+    profile_b: str
+    role: str
+    model: str
+    tasks_a: int
+    tasks_b: int
+    mean_output_tokens_per_task_a: float
+    mean_output_tokens_per_task_b: float
+    mean_cost_usd_per_task_a: float
+    mean_cost_usd_per_task_b: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Deterministic dict form for reports and JSON output."""
+        return {
+            "profile_a": self.profile_a,
+            "profile_b": self.profile_b,
+            "role": self.role,
+            "model": self.model,
+            "tasks_a": self.tasks_a,
+            "tasks_b": self.tasks_b,
+            "mean_output_tokens_per_task_a": round(self.mean_output_tokens_per_task_a, 2),
+            "mean_output_tokens_per_task_b": round(self.mean_output_tokens_per_task_b, 2),
+            "mean_cost_usd_per_task_a": round(self.mean_cost_usd_per_task_a, 6),
+            "mean_cost_usd_per_task_b": round(self.mean_cost_usd_per_task_b, 6),
+        }
+
+
+def compute_profile_comparisons(
+    entries: Iterable[LedgerEntry],
+    transitions: Iterable[ProfileTransition],
+    *,
+    min_tasks: int = MIN_COMPARABLE_TASKS,
+) -> list[ProfileComparison]:
+    """Return every honest cross-profile comparison in the ledger window.
+
+    A comparison exists for a profile pair and a (role, model) cohort
+    only when both profiles have at least *min_tasks* distinct tasks in
+    that cohort (transitioned tasks never count). Output order is
+    deterministic: sorted by (profile_a, profile_b, role, model).
+    """
+    excluded_ids = transitioned_task_ids(transitions)
+    # (profile, role, model) -> per-task accumulators
+    cohort_tasks: dict[tuple[str, str, str], dict[str, dict[str, float]]] = defaultdict(dict)
+    for entry in entries:
+        profile = entry_profile(entry)
+        if not profile or not entry.task_id or entry.task_id in excluded_ids:
+            continue
+        key = (profile, entry.role or "unknown", entry.model or "unknown")
+        acc = cohort_tasks[key].setdefault(entry.task_id, {"output_tokens": 0.0, "cost_usd": 0.0})
+        acc["output_tokens"] += entry.output_tokens
+        acc["cost_usd"] += entry.cost_usd
+
+    # (role, model) -> profile -> task map
+    by_cohort: dict[tuple[str, str], dict[str, dict[str, dict[str, float]]]] = defaultdict(dict)
+    for (profile, role, model), tasks in cohort_tasks.items():
+        by_cohort[(role, model)][profile] = tasks
+
+    comparisons: list[ProfileComparison] = []
+    for (role, model), per_profile in sorted(by_cohort.items()):
+        eligible = sorted(p for p, tasks in per_profile.items() if len(tasks) >= min_tasks)
+        for i, profile_a in enumerate(eligible):
+            for profile_b in eligible[i + 1 :]:
+                tasks_a = per_profile[profile_a]
+                tasks_b = per_profile[profile_b]
+                comparisons.append(
+                    ProfileComparison(
+                        profile_a=profile_a,
+                        profile_b=profile_b,
+                        role=role,
+                        model=model,
+                        tasks_a=len(tasks_a),
+                        tasks_b=len(tasks_b),
+                        mean_output_tokens_per_task_a=_mean(tasks_a, "output_tokens"),
+                        mean_output_tokens_per_task_b=_mean(tasks_b, "output_tokens"),
+                        mean_cost_usd_per_task_a=_mean(tasks_a, "cost_usd"),
+                        mean_cost_usd_per_task_b=_mean(tasks_b, "cost_usd"),
+                    )
+                )
+    comparisons.sort(key=lambda c: (c.profile_a, c.profile_b, c.role, c.model))
+    return comparisons
+
+
+def _mean(tasks: dict[str, dict[str, float]], key: str) -> float:
+    """Mean of one accumulator key across a per-task map (0.0 when empty)."""
+    if not tasks:
+        return 0.0
+    # Sum in sorted task-id order so the float total (and thus every
+    # downstream report byte) is independent of dict insertion order.
+    return sum(tasks[tid][key] for tid in sorted(tasks)) / len(tasks)
+
+
+__all__ = [
+    "EXCLUDED_LABEL",
+    "MIN_COMPARABLE_TASKS",
+    "PROFILE_CONTENT_SHA_TAG",
+    "RESPONSE_PROFILE_TAG",
+    "TRANSITIONS_FILENAME",
+    "UNATTRIBUTED_LABEL",
+    "ProfileAttribution",
+    "ProfileBucket",
+    "ProfileComparison",
+    "ProfileTransition",
+    "aggregate_ledger_by_profile",
+    "attribute_by_profile",
+    "compute_profile_comparisons",
+    "default_transitions_path",
+    "entry_profile",
+    "load_transitions",
+    "record_profile_transition",
+    "transitioned_task_ids",
+]

--- a/src/bernstein/core/cost/profile_report.py
+++ b/src/bernstein/core/cost/profile_report.py
@@ -1,0 +1,247 @@
+"""Content-addressed per-profile cost report over the spend ledger.
+
+``bernstein cost profile-report`` needs a report a third party can
+recompute byte-identically from the ledger alone, so this module keeps
+three invariants:
+
+* **Canonical JSON.** The hashed payload is serialised with sorted
+  keys, compact separators, and ASCII escapes; the same content always
+  produces the same bytes on every machine.
+* **No timestamps inside the hashed payload.** Report identity derives
+  from ledger content only. Wall-clock context (when the report was
+  produced) lives in the audit chain event, outside the hash.
+* **Ledger anchoring.** The payload embeds the line-hash range of the
+  ledger window it was computed from (first/last line SHA-256, line
+  count, and a digest over all included lines), so tampering with any
+  ledger line changes the report hash.
+
+The artifact written to disk is ``{"content": ..., "sha256": ...}``
+named ``<sha256>.json`` - the report is content-addressed by the hash
+of its canonical content.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.cost.profile_attribution import (
+    MIN_COMPARABLE_TASKS,
+    attribute_by_profile,
+    compute_profile_comparisons,
+)
+from bernstein.core.cost.spend_ledger import LedgerEntry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.cost.profile_attribution import ProfileTransition
+
+logger = logging.getLogger(__name__)
+
+#: Discriminator embedded in every report payload.
+REPORT_KIND = "cost_profile_report"
+
+#: Payload schema version. Bump when the content shape changes; the
+#: hash covers the version so v1 and v2 reports never collide.
+REPORT_VERSION = 1
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    """Serialise *payload* to canonical JSON bytes.
+
+    Sorted keys, compact separators, ASCII-escaped: the encoding is a
+    pure function of the value, independent of platform and locale.
+    """
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_ledger_window(ledger_path: Path, cutoff: float = 0.0) -> tuple[list[LedgerEntry], list[str]]:
+    """Read the ledger rows in the window, keeping their raw line bytes.
+
+    Returns ``(entries, raw_lines)`` where ``raw_lines[i]`` is the exact
+    stripped JSONL line ``entries[i]`` was parsed from - the anchoring
+    hashes are computed over these lines so a verifier holding the same
+    ledger recomputes the same digests. Malformed lines are skipped,
+    matching :meth:`SpendLedger.load_entries`.
+    """
+    if not ledger_path.exists():
+        return [], []
+    entries: list[LedgerEntry] = []
+    raw_lines: list[str] = []
+    try:
+        with ledger_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = LedgerEntry.from_dict(json.loads(line))
+                except (ValueError, KeyError, TypeError):
+                    continue
+                if cutoff > 0 and entry.ts < cutoff:
+                    continue
+                entries.append(entry)
+                raw_lines.append(line)
+    except OSError as exc:  # pragma: no cover - IO failure path
+        logger.warning("profile_report: failed to read %s: %s", ledger_path, exc)
+    return entries, raw_lines
+
+
+@dataclass(frozen=True)
+class ProfileReport:
+    """A built report: hashed content plus its content address."""
+
+    content: dict[str, Any]
+    sha256: str
+
+    def artifact_bytes(self) -> bytes:
+        """Canonical bytes of the on-disk artifact envelope."""
+        return canonical_json_bytes({"content": self.content, "sha256": self.sha256})
+
+    @property
+    def artifact_name(self) -> str:
+        """Content-addressed filename of the artifact."""
+        return f"{self.sha256}.json"
+
+
+def _ledger_block(raw_lines: list[str]) -> dict[str, Any]:
+    """Anchor block: line-hash range of the ledger window."""
+    encoded = [line.encode("utf-8") for line in raw_lines]
+    return {
+        "line_count": len(raw_lines),
+        "first_line_sha256": _sha256_hex(encoded[0]) if encoded else "",
+        "last_line_sha256": _sha256_hex(encoded[-1]) if encoded else "",
+        "lines_sha256": _sha256_hex(b"\n".join(encoded)),
+    }
+
+
+def _quality_block(task_ids: set[str], outcomes: dict[str, bool]) -> dict[str, Any] | None:
+    """Join quality outcomes for a profile's tasks; ``None`` when none join."""
+    joined = [outcomes[tid] for tid in sorted(task_ids) if tid in outcomes]
+    if not joined:
+        return None
+    return {
+        "tasks_with_outcome": len(joined),
+        "verdict_pass_rate": round(sum(joined) / len(joined), 4),
+    }
+
+
+def _task_outcomes(task_records: list[dict[str, Any]]) -> dict[str, bool]:
+    """Extract per-task manager verdicts from metrics task records.
+
+    Records are deduplicated by task id keeping the last occurrence
+    (matching the ``bernstein cost`` dedup rule). A record contributes
+    an outcome only when it carries the ``janitor_passed`` verdict
+    field; tasks without a recorded verdict are omitted rather than
+    guessed.
+    """
+    outcomes: dict[str, bool] = {}
+    for rec in task_records:
+        tid = str(rec.get("task_id", "") or "")
+        if not tid or "janitor_passed" not in rec:
+            continue
+        outcomes[tid] = bool(rec.get("janitor_passed"))
+    return outcomes
+
+
+def build_profile_report(
+    *,
+    ledger_path: Path,
+    task_records: list[dict[str, Any]],
+    transitions: list[ProfileTransition],
+    window_label: str = "all",
+    cutoff: float = 0.0,
+    min_comparable_tasks: int = MIN_COMPARABLE_TASKS,
+) -> ProfileReport:
+    """Build the per-profile report over one ledger window.
+
+    Args:
+        ledger_path: The spend ledger JSONL to compute from.
+        task_records: Metrics task records (``.sdd/metrics/tasks.jsonl``
+            shape) used only for the quality-outcome join.
+        transitions: Profile transition events; their task ids are
+            excluded from attribution.
+        window_label: Human window spec (``"7d"``) recorded in the
+            payload. Not a timestamp - the same ledger and label always
+            hash identically.
+        cutoff: Unix-timestamp lower bound applied to ledger rows
+            (0 means the whole ledger).
+        min_comparable_tasks: Honesty-rule threshold for cross-profile
+            comparisons.
+
+    Returns:
+        The built :class:`ProfileReport`.
+    """
+    entries, raw_lines = read_ledger_window(ledger_path, cutoff)
+    attribution = attribute_by_profile(entries, transitions)
+    outcomes = _task_outcomes(task_records)
+
+    profiles: dict[str, Any] = {}
+    for label in sorted(attribution.profiles):
+        bucket = attribution.profiles[label]
+        row: dict[str, Any] = {
+            "tasks": bucket.tasks,
+            "calls": bucket.calls,
+            "output_tokens": bucket.output_tokens,
+            "cost_usd": round(bucket.cost_usd, 6),
+            "mean_output_tokens_per_task": round(bucket.output_tokens / bucket.tasks, 2) if bucket.tasks else 0.0,
+            "mean_cost_usd_per_task": round(bucket.cost_usd / bucket.tasks, 6) if bucket.tasks else 0.0,
+        }
+        quality = _quality_block(bucket.task_ids, outcomes)
+        if quality is not None:
+            row["quality"] = quality
+        profiles[label] = row
+
+    comparisons = compute_profile_comparisons(entries, transitions, min_tasks=min_comparable_tasks)
+
+    content: dict[str, Any] = {
+        "kind": REPORT_KIND,
+        "version": REPORT_VERSION,
+        "window": window_label,
+        "min_comparable_tasks": min_comparable_tasks,
+        "ledger": _ledger_block(raw_lines),
+        "profiles": profiles,
+        "excluded": {
+            "tasks": attribution.excluded.tasks,
+            "calls": attribution.excluded.calls,
+            "output_tokens": attribution.excluded.output_tokens,
+            "cost_usd": round(attribution.excluded.cost_usd, 6),
+            "task_ids": sorted(attribution.excluded.task_ids),
+            "reason": "profile_transition",
+        },
+        "comparisons": [c.to_dict() for c in comparisons],
+        "insufficient_comparable_runs": not comparisons,
+    }
+    return ProfileReport(content=content, sha256=_sha256_hex(canonical_json_bytes(content)))
+
+
+def write_report_artifact(report: ProfileReport, reports_dir: Path) -> Path:
+    """Write the content-addressed artifact and return its path.
+
+    The filename is the content hash, so re-running over the same
+    ledger overwrites the identical file - the operation is idempotent
+    by construction.
+    """
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    out = reports_dir / report.artifact_name
+    out.write_bytes(report.artifact_bytes())
+    return out
+
+
+__all__ = [
+    "REPORT_KIND",
+    "REPORT_VERSION",
+    "ProfileReport",
+    "build_profile_report",
+    "canonical_json_bytes",
+    "read_ledger_window",
+    "write_report_artifact",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -61,6 +61,14 @@ EVENT_MULTIMODAL_ATTACH = "multimodal.attach"
 #: offending span -- never the span content itself.
 EVENT_COMPACTION_SENSITIVE_GATE = "compaction.sensitive_gate"
 
+#: Issue #2245 -- emitted whenever ``bernstein cost profile-report``
+#: writes a content-addressed per-profile cost report. The event
+#: records the report's SHA-256, the ledger line-hash range the report
+#: was computed from, and the previous chain digest, so a third party
+#: holding the ledger can recompute the report byte-identically and
+#: check it against the chain.
+EVENT_COST_PROFILE_REPORT = "cost.profile_report"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -286,12 +294,91 @@ def record_sensitive_gate(
     )
 
 
+@dataclass(frozen=True)
+class CostProfileReportDetails:
+    """Structured payload for the ``cost.profile_report`` event."""
+
+    report_sha256: str
+    ledger_lines_sha256: str
+    ledger_first_line_sha256: str
+    ledger_last_line_sha256: str
+    ledger_line_count: int
+    window: str
+    artifact_name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "report_sha256": self.report_sha256,
+            "ledger_lines_sha256": self.ledger_lines_sha256,
+            "ledger_first_line_sha256": self.ledger_first_line_sha256,
+            "ledger_last_line_sha256": self.ledger_last_line_sha256,
+            "ledger_line_count": self.ledger_line_count,
+            "window": self.window,
+            "artifact_name": self.artifact_name,
+        }
+
+
+def record_cost_profile_report(
+    *,
+    chain: AuditChainStore,
+    report_sha256: str,
+    ledger_lines_sha256: str,
+    ledger_first_line_sha256: str,
+    ledger_last_line_sha256: str,
+    ledger_line_count: int,
+    window: str,
+    artifact_name: str,
+    actor: str = "cost",
+) -> AuditEvent:
+    """Append a ``cost.profile_report`` event into *chain*.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        report_sha256: Hex digest of the report's canonical content.
+        ledger_lines_sha256: Digest over every ledger line in the
+            report's window (newline-joined raw line bytes).
+        ledger_first_line_sha256: Digest of the first included ledger
+            line (empty when the window is empty).
+        ledger_last_line_sha256: Digest of the last included ledger
+            line (empty when the window is empty).
+        ledger_line_count: Number of ledger lines in the window.
+        window: Human window spec the report was computed over
+            (for example ``"7d"`` or ``"all"``).
+        artifact_name: Content-addressed artifact filename.
+        actor: Recorded actor; defaults to ``"cost"`` (the CLI surface).
+
+    Returns:
+        The recorded :class:`AuditEvent`. The event details payload
+        carries every input plus ``prev_chain_digest`` (set to the
+        chain head at write time).
+    """
+    payload = CostProfileReportDetails(
+        report_sha256=report_sha256,
+        ledger_lines_sha256=ledger_lines_sha256,
+        ledger_first_line_sha256=ledger_first_line_sha256,
+        ledger_last_line_sha256=ledger_last_line_sha256,
+        ledger_line_count=ledger_line_count,
+        window=window,
+        artifact_name=artifact_name,
+    ).to_dict()
+    return chain.log_with_prev_digest(
+        event_type=EVENT_COST_PROFILE_REPORT,
+        actor=actor,
+        resource_type="cost_profile_report",
+        resource_id=report_sha256,
+        details=payload,
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_COMPACTION_SENSITIVE_GATE",
+    "EVENT_COST_PROFILE_REPORT",
     "EVENT_MULTIMODAL_ATTACH",
     "AuditChainStore",
+    "CostProfileReportDetails",
     "MultimodalAttachDetails",
+    "record_cost_profile_report",
     "record_multimodal_attach",
     "record_sensitive_gate",
 ]

--- a/tests/unit/agents/test_spawner_profile_transition.py
+++ b/tests/unit/agents/test_spawner_profile_transition.py
@@ -1,0 +1,87 @@
+"""Spawn-path profile_transition events (issue #2245).
+
+A task re-spawned under a different response-style profile (for
+example after a role-policy change between attempts) must leave a
+``profile_transition`` record so per-profile cost attribution can
+exclude the task instead of guessing which tokens belong to which
+profile.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.agents.spawner_core import AgentSpawner
+from bernstein.core.cost.profile_attribution import (
+    default_transitions_path,
+    load_transitions,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+
+def _build_spawner(
+    workdir: Path,
+    adapter: MagicMock,
+    *,
+    role_model_policy: dict[str, dict[str, Any]] | None = None,
+) -> AgentSpawner:
+    templates_dir = workdir / "templates" / "roles"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(
+        adapter,
+        templates_dir,
+        workdir,
+        use_worktrees=False,
+        default_model="mock-model",
+        role_model_policy=role_model_policy,
+    )
+
+
+class TestProfileTransitionOnRespawn:
+    def test_respawn_under_different_profile_records_transition(
+        self, tmp_path, make_task, mock_adapter_factory
+    ) -> None:
+        task = make_task()
+        spawner_terse = _build_spawner(
+            tmp_path,
+            mock_adapter_factory(),
+            role_model_policy={"backend": {"model": "mock-model", "response_style": "terse"}},
+        )
+        spawner_terse.spawn_for_tasks([task])
+        assert task.metadata["response_profile"] == "terse"
+
+        spawner_verbose = _build_spawner(
+            tmp_path,
+            mock_adapter_factory(),
+            role_model_policy={"backend": {"model": "mock-model", "response_style": "verbose"}},
+        )
+        spawner_verbose.spawn_for_tasks([task])
+        assert task.metadata["response_profile"] == "verbose"
+
+        transitions = load_transitions(default_transitions_path(tmp_path / ".sdd"))
+        assert len(transitions) == 1
+        rec = transitions[0]
+        assert rec.task_id == task.id
+        assert rec.from_profile == "terse"
+        assert rec.to_profile == "verbose"
+        assert rec.from_sha256 != rec.to_sha256
+
+    def test_respawn_under_same_profile_records_nothing(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        task = make_task()
+        policy = {"backend": {"model": "mock-model", "response_style": "terse"}}
+        for _ in range(2):
+            spawner = _build_spawner(tmp_path, mock_adapter_factory(), role_model_policy=policy)
+            spawner.spawn_for_tasks([task])
+        assert load_transitions(default_transitions_path(tmp_path / ".sdd")) == []
+
+    def test_first_spawn_records_nothing(self, tmp_path, make_task, mock_adapter_factory) -> None:
+        spawner = _build_spawner(
+            tmp_path,
+            mock_adapter_factory(),
+            role_model_policy={"backend": {"model": "mock-model", "response_style": "terse"}},
+        )
+        spawner.spawn_for_tasks([make_task()])
+        assert load_transitions(default_transitions_path(tmp_path / ".sdd")) == []

--- a/tests/unit/cost/test_cost_cmd_profile.py
+++ b/tests/unit/cost/test_cost_cmd_profile.py
@@ -1,0 +1,265 @@
+"""CLI tests for per-profile cost attribution (issue #2245).
+
+Covers ``bernstein cost --by profile``, the per-profile savings
+section honesty rule, and ``bernstein cost profile-report``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.cost import cost_cmd, cost_profile_report_cmd
+from bernstein.core.cost.profile_attribution import (
+    EXCLUDED_LABEL,
+    MIN_COMPARABLE_TASKS,
+    UNATTRIBUTED_LABEL,
+    record_profile_transition,
+)
+from bernstein.core.cost.spend_ledger import CallTags, SpendLedger
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_chain import EVENT_COST_PROFILE_REPORT
+
+
+def _record(led: SpendLedger, task_id: str, profile: str, *, role: str = "backend", cost: float = 0.10) -> None:
+    extra = {"response_profile": profile, "profile_content_sha256": "a" * 64} if profile else {}
+    led.record(
+        tags=CallTags(task_id=task_id, agent_id="a-1", role=role, extra=extra),
+        model="sonnet",
+        cost_usd=cost,
+        output_tokens=100,
+    )
+
+
+@pytest.fixture()
+def sdd(tmp_path: Path) -> Path:
+    """A minimal ``.sdd`` tree with metrics and a profiled ledger."""
+    sdd = tmp_path / ".sdd"
+    metrics = sdd / "metrics"
+    metrics.mkdir(parents=True)
+    now = time.time()
+    rows = [
+        {
+            "task_id": tid,
+            "role": "backend",
+            "model": "sonnet",
+            "timestamp": now,
+            "cost_usd": 0.10,
+            "agent_id": "a-1",
+            "janitor_passed": True,
+        }
+        for tid in ("t-terse-1", "t-verbose-1")
+    ]
+    (metrics / "tasks.jsonl").write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    led = SpendLedger(path=sdd / "cost" / "ledger.jsonl", run_id="r-1")
+    _record(led, "t-terse-1", "terse", cost=0.10)
+    _record(led, "t-terse-2", "terse", cost=0.12)
+    _record(led, "t-verbose-1", "verbose", cost=0.30)
+    _record(led, "t-none", "", cost=0.05)
+    return sdd
+
+
+def _invoke_by_profile(sdd: Path) -> dict[str, object]:
+    runner = CliRunner()
+    result = runner.invoke(
+        cost_cmd,
+        [
+            "--metrics-dir",
+            str(sdd / "metrics"),
+            "--ledger",
+            str(sdd / "cost" / "ledger.jsonl"),
+            "--by",
+            "profile",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+class TestCostByProfile:
+    def test_grouped_by_profile_from_ledger(self, sdd: Path) -> None:
+        data = _invoke_by_profile(sdd)
+        assert data["grouped_by"] == "profile"
+        grouped = data["grouped"]
+        assert grouped["terse"]["cost_usd"] == pytest.approx(0.22)
+        assert grouped["terse"]["tasks"] == 2
+        assert grouped["verbose"]["cost_usd"] == pytest.approx(0.30)
+        assert grouped[UNATTRIBUTED_LABEL]["cost_usd"] == pytest.approx(0.05)
+
+    def test_totals_equal_ledger_sum_to_the_cent(self, sdd: Path) -> None:
+        """Acceptance 4: grouped totals == per-task ledger entry sum."""
+        data = _invoke_by_profile(sdd)
+        grouped = data["grouped"]
+        assert isinstance(grouped, dict)
+        entries = SpendLedger.load_entries(sdd / "cost" / "ledger.jsonl")
+        grouped_total = round(sum(float(v["cost_usd"]) for v in grouped.values()), 2)
+        assert grouped_total == round(sum(e.cost_usd for e in entries), 2)
+
+    def test_transitioned_task_shown_excluded(self, sdd: Path) -> None:
+        record_profile_transition(
+            sdd / "cost" / "profile_transitions.jsonl",
+            task_id="t-verbose-1",
+            agent_id="a-1",
+            from_profile="verbose",
+            to_profile="terse",
+        )
+        grouped = _invoke_by_profile(sdd)["grouped"]
+        assert isinstance(grouped, dict)
+        assert "verbose" not in grouped
+        assert grouped[EXCLUDED_LABEL]["cost_usd"] == pytest.approx(0.30)
+
+    def test_table_output_renders(self, sdd: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            [
+                "--metrics-dir",
+                str(sdd / "metrics"),
+                "--ledger",
+                str(sdd / "cost" / "ledger.jsonl"),
+                "--by",
+                "profile",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "terse" in result.output
+        assert "By Profile" in result.output
+
+
+class TestHonestyRuleInCli:
+    def test_insufficient_comparable_runs_printed(self, sdd: Path) -> None:
+        """Two profiles below the N-task bar: no savings claim, the
+        insufficiency line is printed instead."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            ["--metrics-dir", str(sdd / "metrics"), "--ledger", str(sdd / "cost" / "ledger.jsonl")],
+        )
+        assert result.exit_code == 0, result.output
+        assert "insufficient comparable runs" in result.output
+
+    def _comparable_sdd(self, sdd: Path) -> None:
+        led = SpendLedger(path=sdd / "cost" / "ledger.jsonl", run_id="r-2")
+        for i in range(MIN_COMPARABLE_TASKS):
+            _record(led, f"c-terse-{i}", "terse", cost=0.10)
+            _record(led, f"c-verbose-{i}", "verbose", cost=0.30)
+
+    def test_savings_claim_printed_when_comparable(self, sdd: Path) -> None:
+        self._comparable_sdd(sdd)
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            ["--metrics-dir", str(sdd / "metrics"), "--ledger", str(sdd / "cost" / "ledger.jsonl")],
+        )
+        assert result.exit_code == 0, result.output
+        assert "terse vs verbose" in result.output
+        assert "insufficient comparable runs" not in result.output
+
+    def test_json_carries_comparisons(self, sdd: Path) -> None:
+        self._comparable_sdd(sdd)
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            ["--metrics-dir", str(sdd / "metrics"), "--ledger", str(sdd / "cost" / "ledger.jsonl"), "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["insufficient_comparable_runs"] is False
+        comps = data["profile_comparisons"]
+        assert len(comps) == 1
+        assert comps[0]["profile_a"] == "terse"
+        assert comps[0]["profile_b"] == "verbose"
+
+    def test_share_includes_profile_line(self, sdd: Path) -> None:
+        self._comparable_sdd(sdd)
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            ["--metrics-dir", str(sdd / "metrics"), "--ledger", str(sdd / "cost" / "ledger.jsonl"), "--share"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "terse vs verbose" in result.output
+
+
+class TestProfileReportCmd:
+    def _invoke(self, sdd: Path, key_path: Path, *extra: str) -> tuple[int, str]:
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_profile_report_cmd,
+            [
+                "--metrics-dir",
+                str(sdd / "metrics"),
+                "--ledger",
+                str(sdd / "cost" / "ledger.jsonl"),
+                "--transitions",
+                str(sdd / "cost" / "profile_transitions.jsonl"),
+                "--audit-dir",
+                str(sdd / "audit"),
+                "--reports-dir",
+                str(sdd / "reports" / "cost_profiles"),
+                *extra,
+            ],
+            env={"BERNSTEIN_AUDIT_KEY_PATH": str(key_path)},
+        )
+        return result.exit_code, result.output
+
+    def test_json_report_written_and_chained(self, sdd: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        key_path = tmp_path / "keys" / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        code, output = self._invoke(sdd, key_path, "--json")
+        assert code == 0, output
+        data = json.loads(output)
+        sha = data["sha256"]
+        artifact = Path(str(data["artifact"]))
+        assert artifact.exists()
+        assert artifact.name == f"{sha}.json"
+        envelope = json.loads(artifact.read_text(encoding="utf-8"))
+        assert envelope["sha256"] == sha
+        assert envelope["content"]["profiles"]["terse"]["tasks"] == 2
+        # Quality joined from metrics task records.
+        assert envelope["content"]["profiles"]["terse"]["quality"]["verdict_pass_rate"] == pytest.approx(1.0)
+
+        # The audit chain carries the event and verifies.
+        log = AuditLog(audit_dir=sdd / "audit", key_path=key_path)
+        events = log.query(event_type=EVENT_COST_PROFILE_REPORT)
+        assert len(events) == 1
+        assert events[0].details["report_sha256"] == sha
+        ok, errors = log.verify()
+        assert ok, errors
+
+    def test_rerun_is_byte_identical(self, sdd: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Acceptance 1 at the CLI seam: two runs over the same ledger
+        produce the same content-addressed artifact."""
+        key_path = tmp_path / "keys" / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        code_1, out_1 = self._invoke(sdd, key_path, "--json")
+        assert code_1 == 0, out_1
+        first = Path(str(json.loads(out_1)["artifact"]))
+        first_bytes = first.read_bytes()
+        code_2, out_2 = self._invoke(sdd, key_path, "--json")
+        assert code_2 == 0, out_2
+        second = Path(str(json.loads(out_2)["artifact"]))
+        assert second == first
+        assert second.read_bytes() == first_bytes
+
+    def test_human_output_mentions_sha_and_honesty(
+        self, sdd: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        key_path = tmp_path / "keys" / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        code, output = self._invoke(sdd, key_path)
+        assert code == 0, output
+        assert "insufficient comparable runs" in output
+        assert "sha256" in output.lower()
+
+    def test_subcommand_reachable_via_cost_group(self, sdd: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cost_cmd, ["profile-report", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "profile-report" in result.output or "profile" in result.output

--- a/tests/unit/cost/test_profile_attribution.py
+++ b/tests/unit/cost/test_profile_attribution.py
@@ -1,0 +1,284 @@
+"""Per-profile cost attribution from the spend ledger (issue #2245).
+
+Covers:
+
+* Per-entry attribution keyed on the ``response_profile`` cost tag.
+* Transition exclusion: a task with a recorded ``profile_transition``
+  event is attributed to no profile - excluded, never split.
+* The honesty rule: cross-profile comparisons only exist when both
+  profiles have at least ``MIN_COMPARABLE_TASKS`` tasks sharing the
+  same role and model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.profile_attribution import (
+    EXCLUDED_LABEL,
+    MIN_COMPARABLE_TASKS,
+    UNATTRIBUTED_LABEL,
+    ProfileTransition,
+    aggregate_ledger_by_profile,
+    attribute_by_profile,
+    compute_profile_comparisons,
+    entry_profile,
+    load_transitions,
+    record_profile_transition,
+    transitioned_task_ids,
+)
+from bernstein.core.cost.spend_ledger import CallTags, LedgerEntry, SpendLedger
+
+
+def _entry(
+    task_id: str,
+    profile: str = "",
+    *,
+    role: str = "backend",
+    model: str = "sonnet",
+    cost_usd: float = 0.10,
+    output_tokens: int = 100,
+    ts: float = 1000.0,
+) -> LedgerEntry:
+    tags = {"response_profile": profile, "profile_content_sha256": "a" * 64} if profile else {}
+    return LedgerEntry(
+        ts=ts,
+        ts_iso="2026-01-01T00:00:00+00:00",
+        run_id="r-1",
+        task_id=task_id,
+        agent_id="agent-1",
+        role=role,
+        feature_label="",
+        model=model,
+        input_tokens=50,
+        output_tokens=output_tokens,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        cost_usd=cost_usd,
+        tags=tags,
+    )
+
+
+class TestEntryProfile:
+    def test_reads_response_profile_tag(self) -> None:
+        assert entry_profile(_entry("t-1", "terse")) == "terse"
+
+    def test_missing_tag_is_empty(self) -> None:
+        assert entry_profile(_entry("t-1")) == ""
+
+
+class TestTransitionRecords:
+    def test_record_and_load_roundtrip(self, tmp_path: Path) -> None:
+        path = tmp_path / "profile_transitions.jsonl"
+        rec = record_profile_transition(
+            path,
+            task_id="t-1",
+            agent_id="a-1",
+            from_profile="verbose",
+            to_profile="terse",
+            from_sha256="b" * 64,
+            to_sha256="c" * 64,
+            ts=1234.5,
+        )
+        assert isinstance(rec, ProfileTransition)
+        loaded = load_transitions(path)
+        assert len(loaded) == 1
+        assert loaded[0].task_id == "t-1"
+        assert loaded[0].from_profile == "verbose"
+        assert loaded[0].to_profile == "terse"
+        assert loaded[0].ts == pytest.approx(1234.5)
+
+    def test_load_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_transitions(tmp_path / "absent.jsonl") == []
+
+    def test_malformed_lines_are_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "profile_transitions.jsonl"
+        record_profile_transition(path, task_id="t-1", agent_id="a", from_profile="verbose", to_profile="terse")
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("not json\n")
+        assert len(load_transitions(path)) == 1
+
+    def test_transitioned_task_ids(self, tmp_path: Path) -> None:
+        path = tmp_path / "profile_transitions.jsonl"
+        record_profile_transition(path, task_id="t-1", agent_id="a", from_profile="verbose", to_profile="terse")
+        record_profile_transition(path, task_id="t-2", agent_id="a", from_profile="terse", to_profile="balanced")
+        assert transitioned_task_ids(load_transitions(path)) == frozenset({"t-1", "t-2"})
+
+
+class TestAttributeByProfile:
+    def test_entries_grouped_by_profile_tag(self) -> None:
+        entries = [
+            _entry("t-1", "terse", cost_usd=0.10),
+            _entry("t-2", "terse", cost_usd=0.20),
+            _entry("t-3", "verbose", cost_usd=0.30),
+        ]
+        result = attribute_by_profile(entries, [])
+        assert result.profiles["terse"].cost_usd == pytest.approx(0.30)
+        assert result.profiles["terse"].tasks == 2
+        assert result.profiles["verbose"].tasks == 1
+        assert result.excluded.calls == 0
+
+    def test_untagged_entries_are_unattributed(self) -> None:
+        result = attribute_by_profile([_entry("t-1")], [])
+        assert result.profiles[UNATTRIBUTED_LABEL].tasks == 1
+
+    def test_transitioned_task_excluded_never_split(self) -> None:
+        """Acceptance 3: a task that changed profile mid-flight is
+        attributed to exactly zero profiles - all its entries land in the
+        excluded bucket, none in either profile bucket."""
+        entries = [
+            # Task t-x started under verbose (first session entry), was
+            # overridden to terse (second session entry).
+            _entry("t-x", "verbose", cost_usd=0.40, output_tokens=400),
+            _entry("t-x", "terse", cost_usd=0.10, output_tokens=50),
+            _entry("t-ok", "terse", cost_usd=0.20),
+        ]
+        transitions = [
+            ProfileTransition(
+                ts=1000.0,
+                ts_iso="",
+                task_id="t-x",
+                agent_id="a-1",
+                from_profile="verbose",
+                to_profile="terse",
+                from_sha256="",
+                to_sha256="",
+            )
+        ]
+        result = attribute_by_profile(entries, transitions)
+        assert result.excluded.calls == 2
+        assert result.excluded.cost_usd == pytest.approx(0.50)
+        assert result.excluded.task_ids == {"t-x"}
+        assert "verbose" not in result.profiles
+        assert result.profiles["terse"].task_ids == {"t-ok"}
+        assert result.profiles["terse"].cost_usd == pytest.approx(0.20)
+
+    def test_every_entry_lands_in_exactly_one_bucket(self) -> None:
+        entries = [
+            _entry("t-1", "terse", cost_usd=0.11),
+            _entry("t-2", "verbose", cost_usd=0.22),
+            _entry("t-3", cost_usd=0.33),
+            _entry("t-4", "terse", cost_usd=0.44),
+        ]
+        transitions = [
+            ProfileTransition(
+                ts=0.0,
+                ts_iso="",
+                task_id="t-4",
+                agent_id="a",
+                from_profile="verbose",
+                to_profile="terse",
+                from_sha256="",
+                to_sha256="",
+            )
+        ]
+        result = attribute_by_profile(entries, transitions)
+        bucket_total = sum(b.cost_usd for b in result.profiles.values()) + result.excluded.cost_usd
+        assert bucket_total == pytest.approx(sum(e.cost_usd for e in entries))
+
+
+class TestAggregateLedgerByProfile:
+    def test_totals_match_entry_sum_to_the_cent(self, tmp_path: Path) -> None:
+        """Acceptance 4: grouped totals equal the per-entry ledger sum."""
+        ledger_path = tmp_path / "ledger.jsonl"
+        led = SpendLedger(path=ledger_path, run_id="r-1")
+        led.record(
+            tags=CallTags(task_id="t-1", agent_id="a", role="backend", extra={"response_profile": "terse"}),
+            model="sonnet",
+            cost_usd=0.101,
+        )
+        led.record(
+            tags=CallTags(task_id="t-2", agent_id="a", role="backend", extra={"response_profile": "verbose"}),
+            model="sonnet",
+            cost_usd=0.202,
+        )
+        led.record(tags=CallTags(task_id="t-3", agent_id="a", role="qa"), model="haiku", cost_usd=0.05)
+
+        entries = SpendLedger.load_entries(ledger_path)
+        grouped = aggregate_ledger_by_profile(entries, [])
+        grouped_total = round(sum(v["cost_usd"] for v in grouped.values()), 2)
+        entry_total = round(sum(e.cost_usd for e in entries), 2)
+        assert grouped_total == entry_total
+        assert grouped["terse"]["cost_usd"] == pytest.approx(0.101)
+        assert grouped["verbose"]["cost_usd"] == pytest.approx(0.202)
+        assert grouped[UNATTRIBUTED_LABEL]["cost_usd"] == pytest.approx(0.05)
+
+    def test_excluded_bucket_labelled(self) -> None:
+        entries = [_entry("t-x", "terse", cost_usd=0.10)]
+        transitions = [
+            ProfileTransition(
+                ts=0.0,
+                ts_iso="",
+                task_id="t-x",
+                agent_id="a",
+                from_profile="verbose",
+                to_profile="terse",
+                from_sha256="",
+                to_sha256="",
+            )
+        ]
+        grouped = aggregate_ledger_by_profile(entries, transitions)
+        assert grouped[EXCLUDED_LABEL]["cost_usd"] == pytest.approx(0.10)
+
+
+class TestHonestyRule:
+    def test_constant_default(self) -> None:
+        assert MIN_COMPARABLE_TASKS == 5
+
+    def _cohort(self, profile: str, n: int, *, role: str = "backend", model: str = "sonnet") -> list[LedgerEntry]:
+        cost = 0.10 if profile == "terse" else 0.30
+        toks = 100 if profile == "terse" else 300
+        return [
+            _entry(f"{profile}-{role}-{model}-{i}", profile, role=role, model=model, cost_usd=cost, output_tokens=toks)
+            for i in range(n)
+        ]
+
+    def test_insufficient_comparable_runs_when_below_n(self) -> None:
+        entries = self._cohort("terse", MIN_COMPARABLE_TASKS) + self._cohort("verbose", MIN_COMPARABLE_TASKS - 1)
+        comparisons = compute_profile_comparisons(entries, [])
+        assert comparisons == []
+
+    def test_role_model_mismatch_is_not_comparable(self) -> None:
+        entries = self._cohort("terse", MIN_COMPARABLE_TASKS) + self._cohort(
+            "verbose", MIN_COMPARABLE_TASKS, model="haiku"
+        )
+        assert compute_profile_comparisons(entries, []) == []
+
+    def test_comparison_emitted_when_both_reach_n(self) -> None:
+        entries = self._cohort("terse", MIN_COMPARABLE_TASKS) + self._cohort("verbose", MIN_COMPARABLE_TASKS)
+        comparisons = compute_profile_comparisons(entries, [])
+        assert len(comparisons) == 1
+        comp = comparisons[0]
+        assert comp.profile_a == "terse"
+        assert comp.profile_b == "verbose"
+        assert comp.role == "backend"
+        assert comp.model == "sonnet"
+        assert comp.tasks_a == MIN_COMPARABLE_TASKS
+        assert comp.tasks_b == MIN_COMPARABLE_TASKS
+        assert comp.mean_cost_usd_per_task_a == pytest.approx(0.10)
+        assert comp.mean_cost_usd_per_task_b == pytest.approx(0.30)
+        assert comp.mean_output_tokens_per_task_a == pytest.approx(100.0)
+        assert comp.mean_output_tokens_per_task_b == pytest.approx(300.0)
+
+    def test_transitioned_tasks_do_not_count_toward_n(self) -> None:
+        entries = self._cohort("terse", MIN_COMPARABLE_TASKS) + self._cohort("verbose", MIN_COMPARABLE_TASKS)
+        transitions = [
+            ProfileTransition(
+                ts=0.0,
+                ts_iso="",
+                task_id="verbose-backend-sonnet-0",
+                agent_id="a",
+                from_profile="verbose",
+                to_profile="terse",
+                from_sha256="",
+                to_sha256="",
+            )
+        ]
+        assert compute_profile_comparisons(entries, transitions) == []
+
+    def test_min_tasks_override(self) -> None:
+        entries = self._cohort("terse", 2) + self._cohort("verbose", 2)
+        comparisons = compute_profile_comparisons(entries, [], min_tasks=2)
+        assert len(comparisons) == 1

--- a/tests/unit/cost/test_profile_report.py
+++ b/tests/unit/cost/test_profile_report.py
@@ -1,0 +1,255 @@
+"""Content-addressed per-profile cost report (issue #2245).
+
+Acceptance criteria under test:
+
+1. The report over a fixed ledger fixture is byte-identical across
+   runs (no timestamps inside the hashed payload).
+2. The report hash verifies against its audit chain entry; tampering
+   with one ledger line changes the report hash.
+3. Tasks with a recorded profile transition are excluded, never split.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.profile_attribution import (
+    record_profile_transition,
+)
+from bernstein.core.cost.profile_report import (
+    REPORT_KIND,
+    REPORT_VERSION,
+    build_profile_report,
+    canonical_json_bytes,
+    read_ledger_window,
+    write_report_artifact,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_COST_PROFILE_REPORT,
+    AuditChainStore,
+    record_cost_profile_report,
+)
+
+
+def _write_ledger(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, sort_keys=False, separators=(",", ":")))
+            fh.write("\n")
+
+
+def _ledger_row(
+    task_id: str,
+    profile: str,
+    *,
+    ts: float = 1000.0,
+    role: str = "backend",
+    model: str = "sonnet",
+    cost_usd: float = 0.10,
+    output_tokens: int = 100,
+) -> dict[str, object]:
+    tags: dict[str, str] = {}
+    if profile:
+        tags = {"response_profile": profile, "profile_content_sha256": "a" * 64}
+    return {
+        "ts": ts,
+        "ts_iso": "2026-01-01T00:00:00+00:00",
+        "run_id": "r-1",
+        "task_id": task_id,
+        "agent_id": "agent-1",
+        "role": role,
+        "feature_label": "",
+        "model": model,
+        "input_tokens": 50,
+        "output_tokens": output_tokens,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "cost_usd": cost_usd,
+        "quota_envelope": "subscription",
+        "tags": tags,
+    }
+
+
+@pytest.fixture()
+def fixed_ledger(tmp_path: Path) -> Path:
+    path = tmp_path / "cost" / "ledger.jsonl"
+    _write_ledger(
+        path,
+        [
+            _ledger_row("t-1", "terse", ts=100.0, cost_usd=0.10, output_tokens=100),
+            _ledger_row("t-2", "terse", ts=200.0, cost_usd=0.12, output_tokens=120),
+            _ledger_row("t-3", "verbose", ts=300.0, cost_usd=0.30, output_tokens=300),
+            _ledger_row("t-4", "", ts=400.0, cost_usd=0.05, output_tokens=50),
+        ],
+    )
+    return path
+
+
+class TestCanonicalJson:
+    def test_stable_key_order_and_compact(self) -> None:
+        assert canonical_json_bytes({"b": 1, "a": 2}) == b'{"a":2,"b":1}'
+
+    def test_non_ascii_escaped(self) -> None:
+        # ensure_ascii keeps the bytes identical regardless of locale.
+        assert canonical_json_bytes({"k": "é"}) == b'{"k":"\\u00e9"}'
+
+
+class TestReadLedgerWindow:
+    def test_reads_entries_and_raw_lines(self, fixed_ledger: Path) -> None:
+        entries, lines = read_ledger_window(fixed_ledger)
+        assert len(entries) == 4
+        assert len(lines) == 4
+
+    def test_cutoff_filters_by_ts(self, fixed_ledger: Path) -> None:
+        entries, lines = read_ledger_window(fixed_ledger, cutoff=250.0)
+        assert [e.task_id for e in entries] == ["t-3", "t-4"]
+        assert len(lines) == 2
+
+    def test_missing_file_is_empty(self, tmp_path: Path) -> None:
+        entries, lines = read_ledger_window(tmp_path / "absent.jsonl")
+        assert entries == []
+        assert lines == []
+
+
+class TestReportDeterminism:
+    def test_byte_identical_across_builds(self, fixed_ledger: Path) -> None:
+        """Acceptance 1: same ledger fixture -> same artifact bytes."""
+        report_1 = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        report_2 = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        assert report_1.artifact_bytes() == report_2.artifact_bytes()
+        assert report_1.sha256 == report_2.sha256
+
+    def test_no_timestamps_in_hashed_payload(self, fixed_ledger: Path) -> None:
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        flat = json.dumps(report.content)
+        for needle in ("timestamp", '"ts"', "ts_iso", "generated_at"):
+            assert needle not in flat
+
+    def test_sha256_matches_canonical_content(self, fixed_ledger: Path) -> None:
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        assert report.sha256 == hashlib.sha256(canonical_json_bytes(report.content)).hexdigest()
+
+    def test_tampered_ledger_line_changes_hash(self, fixed_ledger: Path) -> None:
+        """Acceptance 2 (second half): one flipped ledger line -> new hash."""
+        before = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        raw = fixed_ledger.read_text(encoding="utf-8")
+        # Tamper one value without breaking JSON: 0.12 -> 0.13.
+        fixed_ledger.write_text(raw.replace('"cost_usd":0.12', '"cost_usd":0.13'), encoding="utf-8")
+        after = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        assert before.sha256 != after.sha256
+        assert before.content["ledger"]["lines_sha256"] != after.content["ledger"]["lines_sha256"]
+
+
+class TestReportContent:
+    def test_kind_version_and_ledger_range(self, fixed_ledger: Path) -> None:
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        content = report.content
+        assert content["kind"] == REPORT_KIND
+        assert content["version"] == REPORT_VERSION
+        ledger_block = content["ledger"]
+        assert ledger_block["line_count"] == 4
+        _, lines = read_ledger_window(fixed_ledger)
+        assert ledger_block["first_line_sha256"] == hashlib.sha256(lines[0].encode("utf-8")).hexdigest()
+        assert ledger_block["last_line_sha256"] == hashlib.sha256(lines[-1].encode("utf-8")).hexdigest()
+
+    def test_per_profile_figures(self, fixed_ledger: Path) -> None:
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        terse = report.content["profiles"]["terse"]
+        assert terse["tasks"] == 2
+        assert terse["output_tokens"] == 220
+        assert terse["cost_usd"] == pytest.approx(0.22)
+        assert terse["mean_output_tokens_per_task"] == pytest.approx(110.0)
+
+    def test_quality_join_from_task_records(self, fixed_ledger: Path) -> None:
+        task_records = [
+            {"task_id": "t-1", "janitor_passed": True},
+            {"task_id": "t-2", "janitor_passed": False},
+            {"task_id": "t-3", "janitor_passed": True},
+        ]
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=task_records, transitions=[])
+        terse_q = report.content["profiles"]["terse"]["quality"]
+        assert terse_q["tasks_with_outcome"] == 2
+        assert terse_q["verdict_pass_rate"] == pytest.approx(0.5)
+        verbose_q = report.content["profiles"]["verbose"]["quality"]
+        assert verbose_q["verdict_pass_rate"] == pytest.approx(1.0)
+
+    def test_quality_omitted_when_not_computable(self, fixed_ledger: Path) -> None:
+        """Figures that cannot be computed from records are omitted."""
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        assert "quality" not in report.content["profiles"]["terse"]
+
+    def test_transitioned_task_excluded(self, tmp_path: Path, fixed_ledger: Path) -> None:
+        """Acceptance 3: transitioned task appears only in the excluded block."""
+        transitions_path = tmp_path / "cost" / "profile_transitions.jsonl"
+        record_profile_transition(
+            transitions_path,
+            task_id="t-3",
+            agent_id="agent-1",
+            from_profile="verbose",
+            to_profile="terse",
+        )
+        from bernstein.core.cost.profile_attribution import load_transitions
+
+        report = build_profile_report(
+            ledger_path=fixed_ledger,
+            task_records=[],
+            transitions=load_transitions(transitions_path),
+        )
+        assert "verbose" not in report.content["profiles"]
+        excluded = report.content["excluded"]
+        assert excluded["task_ids"] == ["t-3"]
+        assert excluded["reason"] == "profile_transition"
+        assert excluded["cost_usd"] == pytest.approx(0.30)
+
+    def test_insufficient_comparable_runs_flag(self, fixed_ledger: Path) -> None:
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        assert report.content["comparisons"] == []
+        assert report.content["insufficient_comparable_runs"] is True
+
+    def test_window_label_recorded(self, fixed_ledger: Path) -> None:
+        report = build_profile_report(
+            ledger_path=fixed_ledger, task_records=[], transitions=[], window_label="7d", cutoff=50.0
+        )
+        assert report.content["window"] == "7d"
+
+
+class TestArtifactAndChain:
+    def test_artifact_is_content_addressed(self, tmp_path: Path, fixed_ledger: Path) -> None:
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        out = write_report_artifact(report, tmp_path / "reports")
+        assert out.name == f"{report.sha256}.json"
+        envelope = json.loads(out.read_text(encoding="utf-8"))
+        assert envelope["sha256"] == report.sha256
+        assert envelope["content"] == report.content
+        # The artifact bytes are exactly the canonical envelope encoding.
+        assert out.read_bytes() == report.artifact_bytes()
+
+    def test_chain_entry_verifies_against_artifact(self, tmp_path: Path, fixed_ledger: Path) -> None:
+        """Acceptance 2 (first half): the chain entry carries the report
+        sha and the chain verifies end to end."""
+        report = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        event = record_cost_profile_report(
+            chain=chain,
+            report_sha256=report.sha256,
+            ledger_lines_sha256=str(report.content["ledger"]["lines_sha256"]),
+            ledger_first_line_sha256=str(report.content["ledger"]["first_line_sha256"]),
+            ledger_last_line_sha256=str(report.content["ledger"]["last_line_sha256"]),
+            ledger_line_count=int(report.content["ledger"]["line_count"]),
+            window=str(report.content["window"]),
+            artifact_name=f"{report.sha256}.json",
+        )
+        assert event.event_type == EVENT_COST_PROFILE_REPORT
+        assert event.details["report_sha256"] == report.sha256
+        assert event.details["prev_chain_digest"] is not None
+        ok, errors = chain.verify()
+        assert ok, errors
+        # Recompute the report from the same ledger: hash must match the
+        # recorded chain entry (third-party recomputability).
+        recomputed = build_profile_report(ledger_path=fixed_ledger, task_records=[], transitions=[])
+        assert recomputed.sha256 == event.details["report_sha256"]


### PR DESCRIPTION
## Problem

`bernstein cost` rolls up spend by agent, model, task, role, and envelope, but with response-style profiles (#2243) an operator cannot answer what a profile actually cost or saved, or whether quality held. Naive whole-run attribution credits a profile with tokens produced under a previous profile, producing inflated figures operators then distrust.

## What was built

**Attribution primitives** (`core/cost/profile_attribution.py`)
- Per-entry attribution keyed on the `response_profile` cost tag the spawn path already stamps into ledger entries.
- `profile_transition` event records (`.sdd/cost/profile_transitions.jsonl`): when a task is re-spawned under a different profile, the spawner records the change and attribution excludes the whole task - attributed to exactly one profile or excluded, never split heuristically.
- Honesty rule enforced in code: `MIN_COMPARABLE_TASKS = 5` (documented constant); a cross-profile comparison exists only when both profiles have at least N tasks with the same role and model, otherwise renderers print "insufficient comparable runs".

**Content-addressed report** (`core/cost/profile_report.py`)
- Canonical JSON payload (sorted keys, compact separators, ASCII escapes) with no timestamps inside the hashed content; artifact written as `<sha256>.json` under `.sdd/reports/cost_profiles/`.
- Payload embeds the ledger line-hash range it was computed from (first/last line SHA-256, line count, digest over all included lines), so tampering with one ledger line changes the report hash.
- `cost.profile_report` audit chain event (via `log_with_prev_digest`, same pattern as `multimodal.attach`) carries the report hash and ledger anchors; a third party holding the ledger recomputes the report byte-identically and checks it against the chain.

**CLI** (`cli/commands/cost.py`)
- `bernstein cost --by profile`: ledger-backed grouping with an explicit excluded bucket; grouped totals equal the per-entry ledger sum to the cent.
- Per-profile section in the savings comparison and `--share` output, gated by the honesty rule.
- `bernstein cost profile-report --last 7d [--json]`: per profile tasks, output tokens, USD, mean tokens per task, and verification pass rate joined from task records (figures that cannot be computed are omitted). The `cost` command becomes a group with `invoke_without_command=True`; the existing surface is unchanged.

## How tested

- TDD: failing tests first per acceptance criterion, then implementation.
- New tests: `tests/unit/cost/test_profile_attribution.py` (18), `tests/unit/cost/test_profile_report.py` (18, incl. byte-identical rebuild, tamper detection, chain verification), `tests/unit/cost/test_cost_cmd_profile.py` (12, incl. totals-to-the-cent and honesty rule at the CLI seam), `tests/unit/agents/test_spawner_profile_transition.py` (3).
- Targeted sweep over touched areas (cost CLI/tracker/ledger, agents, audit chain, task lifecycle, schedule projection, CLI snapshots): 715 passed.
- `ruff check src/ tests/`, `ruff format --check` on touched files, `uv run lint-imports` (3 contracts kept), `python -c 'import bernstein'` all clean.
- Manual end-to-end smoke: seeded ledger, ran `cost profile-report`, `cost --by profile`, `cost --share`; verified the audit chain and the recorded event hash match the artifact.

Fixes #2245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-based cost reporting in the CLI, including a new per-profile report command and profile grouping in cost summaries.
  * Introduced shareable report output with per-profile comparisons, comparable-run indicators, and JSON support.
  * Added an auditable, content-addressed report artifact with verification details.

* **Bug Fixes**
  * Improved handling of tasks that change profiles mid-run by separating them into an excluded bucket.
  * Added clearer messaging when there aren’t enough comparable runs to show savings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->