### PR TITLE
fix: transition task to failed on MaxTurnsExceeded

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -931,7 +931,6 @@ def _read_runner_cost_usd(
     return price_result.cost_usd, total_in, total_out
 
 
-
 # Failure types detected via log-pattern scanning that are unambiguous,
 # fatal, and MUST fail/retry the task immediately rather than falling
 # through to the generic "died without output" path (which defers behind
@@ -1026,10 +1025,7 @@ def _handle_failure_detection(
         return True
 
     if _failure_type in _FAST_FAIL_LOG_FAILURE_TYPES:
-        reason = (
-            f"Agent {session.id} died; {_failure_type} detected in agent log "
-            f"(exit_code={session.exit_code!r})"
-        )
+        reason = f"Agent {session.id} died; {_failure_type} detected in agent log (exit_code={session.exit_code!r})"
         try:
             retry_or_fail_task(
                 task_id,

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -989,22 +989,40 @@ def _handle_failure_detection(
         )
         return False
 
-    _rl_tracker.throttle_provider(session.provider, getattr(orch, "_router", None))
-    # Triggering evidence: the specific pattern/excerpt that caused this
-    # throttle decision is logged by RateLimitTracker._scan_log_for_patterns
-    # (matched pattern=..., line_type=..., excerpt=...) immediately before
-    # this line -- log_path here is the pointer that ties the two together.
-    logger.warning(
-        "Failure detected (%s) in log for session %s (provider=%r, task=%s, log_path=%s) -> throttling provider %r",
-        _failure_type,
-        session.id,
-        session.provider,
-        task_id,
-        _log_path,
-        session.provider,
-    )
+    _fallback_model: str | None = None
+    if _failure_type == "max_turns":
+        # A max-turns cap is task-scoped: the agent exhausted its own turn
+        # budget, which says nothing about provider health. Skip the
+        # provider throttle (exponential backoff + background suppression)
+        # and the cascade model fallback that the provider-scoped failure
+        # types below get -- both would penalize a healthy provider for a
+        # per-task configuration ceiling. Fall through to the fast-fail
+        # branch, which retries the task with the same routing.
+        logger.warning(
+            "Failure detected (max_turns) in log for session %s (provider=%r, task=%s, log_path=%s)"
+            " - turn-cap exhaustion is task-scoped, provider not throttled",
+            session.id,
+            session.provider,
+            task_id,
+            _log_path,
+        )
+    else:
+        _rl_tracker.throttle_provider(session.provider, getattr(orch, "_router", None))
+        # Triggering evidence: the specific pattern/excerpt that caused this
+        # throttle decision is logged by RateLimitTracker._scan_log_for_patterns
+        # (matched pattern=..., line_type=..., excerpt=...) immediately before
+        # this line -- log_path here is the pointer that ties the two together.
+        logger.warning(
+            "Failure detected (%s) in log for session %s (provider=%r, task=%s, log_path=%s) -> throttling provider %r",
+            _failure_type,
+            session.id,
+            session.provider,
+            task_id,
+            _log_path,
+            session.provider,
+        )
 
-    _fallback_model = _run_cascade_fallback(orch, task, task_id, session, _rl_tracker, _failure_type)
+        _fallback_model = _run_cascade_fallback(orch, task, task_id, session, _rl_tracker, _failure_type)
 
     if _failure_type == "rate_limit":
         _handle_rate_limit_orphan(orch, task, task_id, session, base, start_ts, _fallback_model)

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -931,6 +931,30 @@ def _read_runner_cost_usd(
     return price_result.cost_usd, total_in, total_out
 
 
+
+# Failure types detected via log-pattern scanning that are unambiguous,
+# fatal, and MUST fail/retry the task immediately rather than falling
+# through to the generic "died without output" path (which defers behind
+# the double-fork liveness-signal grace window in
+# ``_probe_liveness_signals`` - correct for a process that genuinely might
+# still be alive under an untracked re-exec, but wrong here because the
+# runner already logged an unambiguous fatal exception before it exited).
+#
+# Root-cause fix (task-claimed-stuck bug, 2026-07-05): a MaxTurnsExceeded
+# death was not classified as ANY of these types before, so it fell all the
+# way through ``detect_failure_type`` -> ``_handle_orphan_no_signals`` ->
+# the liveness-deferral / clean-exit branches, and (depending on timing)
+# could sit "claimed" far longer than necessary before ``retry_or_fail_task``
+# ever ran - up to the orchestrator's 30-minute wall-clock reap ceiling in
+# the worst case. Generalized to the other deterministic-fatal log signals
+# (timeout, auth_error, api_error) per the same reasoning - previously only
+# "rate_limit" and "context_overflow" were actually handled here; the other
+# three were detected by ``detect_failure_type`` but silently fell through
+# to ``return False`` below, losing both the fast-fail and the diagnostic
+# reason string.
+_FAST_FAIL_LOG_FAILURE_TYPES: frozenset[str] = frozenset({"max_turns", "timeout", "auth_error", "api_error"})
+
+
 def _handle_failure_detection(
     orch: Any,
     task: Task,
@@ -940,7 +964,11 @@ def _handle_failure_detection(
     start_ts: float,
     tasks_snapshot: dict[str, list[Task]],
 ) -> bool:
-    """Detect rate-limit/context-overflow failures and handle them. Returns True if handled."""
+    """Detect fatal failure signatures in the agent log and handle them.
+
+    Returns True if handled (task already failed/retried/compacted - caller
+    must not fall through to the generic orphan-no-signals path).
+    """
     _rl_tracker = getattr(orch, "_rate_limit_tracker", None)
     if _rl_tracker is None or not session.provider:
         return False
@@ -994,6 +1022,34 @@ def _handle_failure_detection(
         )
         error_type = "context_overflow_compacted" if _compacted else "context_overflow_compact_failed"
         emit_orphan_metrics(orch._workdir, task_id, session, start_ts, success=False, error_type=error_type)
+        orch._record_provider_health(session, success=False)
+        return True
+
+    if _failure_type in _FAST_FAIL_LOG_FAILURE_TYPES:
+        reason = (
+            f"Agent {session.id} died; {_failure_type} detected in agent log "
+            f"(exit_code={session.exit_code!r})"
+        )
+        try:
+            retry_or_fail_task(
+                task_id,
+                reason,
+                client=orch._client,
+                server_url=base,
+                max_task_retries=orch._config.max_task_retries,
+                retried_task_ids=orch._retried_task_ids,
+                tasks_snapshot=tasks_snapshot,
+                workdir=getattr(orch, "_workdir", None),
+                **_retry_escalation_context(orch),
+            )
+            logger.warning(
+                "Task '%s' failed/retried fast (log-detected fatal error): %s",
+                task.title,
+                reason,
+            )
+        except httpx.HTTPError as exc:
+            logger.error("Failed to retry/fail task %s after %s detection: %s", task_id, _failure_type, exc)
+        emit_orphan_metrics(orch._workdir, task_id, session, start_ts, success=False, error_type=_failure_type)
         orch._record_provider_health(session, success=False)
         return True
 

--- a/src/bernstein/core/observability/rate_limit_tracker.py
+++ b/src/bernstein/core/observability/rate_limit_tracker.py
@@ -118,6 +118,23 @@ _AUTH_ERROR_PATTERNS: tuple[str, ...] = (
     "PermissionDeniedError",
 )
 
+# Text patterns that indicate the OpenAI Agents SDK's turn cap fired
+# (``agents.exceptions.MaxTurnsExceeded``). This is an unambiguous, fatal,
+# deterministic signal - the runner has already logged the exception and
+# exited - so it must never be treated as "died without output" (which
+# defers behind the double-fork liveness-signal grace window, see
+# ``_probe_liveness_signals`` in agent_lifecycle.py). Root-cause fix for the
+# bug where a task stayed "claimed" for the full 30-minute wall-clock
+# timeout after its agent died with MaxTurnsExceeded: the failure was never
+# classified, so it fell through to the generic no-signal path instead of
+# failing/retrying immediately.
+_MAX_TURNS_PATTERNS: tuple[str, ...] = (
+    "MaxTurnsExceeded",
+    "max turns exceeded",
+    "max_turns exceeded",
+    "Max turns (",  # runner's own log line: "Max turns (30) exceeded"
+)
+
 # Text patterns that indicate a context-overflow / prompt-too-long (413) error.
 #
 # "413" and "context window" are risky bare/generic tokens (see
@@ -488,6 +505,17 @@ class RateLimitTracker:
         """
         return self._scan_log_for_patterns(log_path, _AUTH_ERROR_PATTERNS)
 
+    def scan_log_for_max_turns(self, log_path: Path) -> bool:
+        """Scan the tail of *log_path* for an SDK ``MaxTurnsExceeded`` cap hit.
+
+        Args:
+            log_path: Path to the agent's subprocess log file.
+
+        Returns:
+            True if a max-turns-cap indicator was found, False otherwise.
+        """
+        return self._scan_log_for_patterns(log_path, _MAX_TURNS_PATTERNS)
+
     def scan_log_for_context_overflow(self, log_path: Path) -> bool:
         """Scan the tail of *log_path* for context-overflow / 413 patterns.
 
@@ -505,21 +533,30 @@ class RateLimitTracker:
     def detect_failure_type(self, log_path: Path) -> str | None:
         """Scan an agent log and return the detected failure type.
 
-        Checks for rate limits first, then context overflow, then timeouts,
-        then auth errors, then general API errors.
+        Checks for rate limits first, then context overflow, then the SDK
+        max-turns cap, then timeouts, then auth errors, then general API
+        errors.
 
         Args:
             log_path: Path to the agent's subprocess log file.
 
         Returns:
-            One of ``"rate_limit"``, ``"context_overflow"``, ``"timeout"``,
-            ``"auth_error"``, ``"api_error"``, or ``None`` if no failure
-            pattern was detected.
+            One of ``"rate_limit"``, ``"context_overflow"``, ``"max_turns"``,
+            ``"timeout"``, ``"auth_error"``, ``"api_error"``, or ``None`` if
+            no failure pattern was detected.
         """
         if self.scan_log_for_429(log_path):
             return "rate_limit"
         if self.scan_log_for_context_overflow(log_path):
             return "context_overflow"
+        # Checked before the generic timeout/api_error patterns: a
+        # MaxTurnsExceeded death is unambiguous (the SDK exception was
+        # caught and logged by the runner before it exited) and must never
+        # be reclassified as a vaguer "timeout"/"api_error" - both of those
+        # would still resolve to a fail/retry via the fallthrough below, but
+        # with a less accurate reason string.
+        if self.scan_log_for_max_turns(log_path):
+            return "max_turns"
         if self.scan_log_for_timeout(log_path):
             return "timeout"
         if self.scan_log_for_auth_error(log_path):

--- a/tests/unit/test_agent_lifecycle.py
+++ b/tests/unit/test_agent_lifecycle.py
@@ -768,3 +768,76 @@ def test_reap_heartbeat_timeout_logs_and_continues_when_evolution_raises(tmp_pat
     assert any(session.id in r.getMessage() for r in error_records), caplog.text
     assert any("record_agent_lifetime" in r.getMessage() for r in error_records), caplog.text
     assert any(r.exc_info for r in error_records), "expected logger.exception to attach a traceback"
+
+
+# ---------------------------------------------------------------------------
+# Log-detected fatal failures: fast-fail via retry_or_fail_task
+# ---------------------------------------------------------------------------
+
+
+def _make_orch_fast_fail(tmp_path, failure_type: str) -> SimpleNamespace:  # type: ignore[no-untyped-def]
+    """Orch mock whose tracker classifies the dead agent's log as *failure_type*."""
+    orch = _make_orch(
+        tmp_path,
+        CascadeExhausted(excluded_providers=frozenset({"claude"}), reason="all alternates throttled"),
+    )
+    orch._rate_limit_tracker.detect_failure_type.return_value = failure_type
+    orch._config = SimpleNamespace(
+        server_url="http://server",
+        recovery="restart",
+        max_crash_retries=3,
+        max_task_retries=3,
+    )
+    return orch
+
+
+def test_handle_orphaned_task_max_turns_fast_fails_without_provider_throttle(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """MaxTurnsExceeded (task-claimed-stuck fix): the task is failed/retried
+    immediately instead of deferring behind the liveness grace window, and
+    the provider is NOT throttled or cascade-reassigned - a turn cap is a
+    per-task ceiling, not a provider-health signal."""
+    task = _make_task()
+    task.status = TaskStatus.CLAIMED
+    session = AgentSession(
+        id="sess-1",
+        role="backend",
+        provider="claude",
+        model_config=ModelConfig("sonnet", "high"),
+        task_ids=[task.id],
+    )
+    orch = _make_orch_fast_fail(tmp_path, "max_turns")
+
+    with patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as retry_or_fail_task:
+        handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+    retry_or_fail_task.assert_called_once()
+    assert "max_turns" in retry_or_fail_task.call_args.args[1]
+    orch._rate_limit_tracker.throttle_provider.assert_not_called()
+    orch._cascade_manager.find_fallback.assert_not_called()
+    orch._record_provider_health.assert_called_once_with(session, success=False)
+
+
+def test_handle_orphaned_task_provider_fatal_types_fast_fail_and_throttle(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """timeout/auth_error/api_error used to be detected but never acted on
+    (they fell through to the generic no-signals path and its liveness
+    deferral); they now fast-fail via retry_or_fail_task while keeping the
+    provider throttle they always triggered."""
+    for failure_type in ("timeout", "auth_error", "api_error"):
+        task = _make_task(task_id=f"T-{failure_type}")
+        task.status = TaskStatus.CLAIMED
+        session = AgentSession(
+            id=f"sess-{failure_type}",
+            role="backend",
+            provider="claude",
+            model_config=ModelConfig("sonnet", "high"),
+            task_ids=[task.id],
+        )
+        orch = _make_orch_fast_fail(tmp_path, failure_type)
+
+        with patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as retry_or_fail_task:
+            handle_orphaned_task(orch, task.id, session, {"claimed": [task], "open": [], "in_progress": [], "done": []})
+
+        retry_or_fail_task.assert_called_once()
+        assert failure_type in retry_or_fail_task.call_args.args[1]
+        orch._rate_limit_tracker.throttle_provider.assert_called_once()
+        orch._record_provider_health.assert_called_once_with(session, success=False)

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -480,3 +480,74 @@ class TestCompletionProgressSkipSet:
             '{"type": "error", "message": "Error code: 429 - rate limit exceeded"}\n'
         )
         assert self._tracker().detect_failure_type(log) == "rate_limit"
+
+
+class TestMaxTurnsDetection:
+    """A MaxTurnsExceeded death was never classified by detect_failure_type,
+    so the orchestrator treated it as ambiguous and the task sat 'claimed'
+    behind the liveness grace window. The runner's cap-hit WARNING and the
+    SDK exception signature now classify as "max_turns"."""
+
+    def _tracker(self):
+        from bernstein.core.observability.rate_limit_tracker import RateLimitTracker
+
+        return RateLimitTracker()
+
+    def test_runner_cap_hit_warning_detected(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text(
+            "MaxTurnsExceeded: session hit the turn cap "
+            "(max_turns=30, turns_used=30, work_already_completed=no). "
+            "Raise tuning.agent.max_turns / BERNSTEIN_MAX_TURNS / manifest max_turns "
+            "if this workflow legitimately needs more turns.\n"
+        )
+        assert self._tracker().detect_failure_type(log) == "max_turns"
+
+    def test_sdk_exception_message_detected(self, tmp_path):
+        log = tmp_path / "agent.log"
+        log.write_text("agents.exceptions.MaxTurnsExceeded: Max turns (30) exceeded\n")
+        assert self._tracker().detect_failure_type(log) == "max_turns"
+
+    def test_quoted_in_tool_result_does_not_match(self, tmp_path):
+        """An agent reading/editing code that mentions the exception (e.g.
+        this very repo) echoes the string inside tool traffic - data-line
+        types are never substring-scanned."""
+        import json as _json
+
+        log = tmp_path / "agent.log"
+        log.write_text(
+            _json.dumps(
+                {
+                    "type": "tool_result",
+                    "name": "read_file",
+                    "result": {"preview": 'raise MaxTurnsExceeded(f"Max turns ({max_turns}) exceeded")'},
+                }
+            )
+            + "\n"
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_quoted_in_progress_prose_does_not_match(self, tmp_path):
+        import json as _json
+
+        log = tmp_path / "agent.log"
+        log.write_text(
+            _json.dumps(
+                {
+                    "type": "progress",
+                    "message": "adding MaxTurnsExceeded so max turns exceeded deaths are classified",
+                }
+            )
+            + "\n"
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_max_turns_takes_priority_over_timeout(self, tmp_path):
+        """A cap-hit run whose log also carries a transient timeout error must
+        classify as the unambiguous max_turns, not the vaguer timeout."""
+        log = tmp_path / "agent.log"
+        log.write_text(
+            "openai.APITimeoutError: HTTP request failed: read timeout\n"
+            "agents.exceptions.MaxTurnsExceeded: Max turns (30) exceeded\n"
+        )
+        assert self._tracker().detect_failure_type(log) == "max_turns"


### PR DESCRIPTION
## Summary
When an agent hits MaxTurnsExceeded, the task stays in `claimed` status indefinitely (up to the 30-minute wall-clock reap ceiling) instead of transitioning to `failed`.

**Root cause**: `MaxTurnsExceeded` didn't match any known fatal patterns in `RateLimitTracker.detect_failure_type()` (`rate_limit`, `context_overflow`, `timeout`, `auth_error`, `api_error`). The orchestrator treated the dead agent as "ambiguous" and deferred behind a 90s liveness grace window that never expired (log mtime always looked fresh). Additionally, detected patterns like `timeout`, `auth_error`, `api_error` were dead code — `_handle_failure_detection` only acted on `rate_limit` and `context_overflow`.

**Fix**:
- `rate_limit_tracker.py`: added `max_turns` as a recognized failure type with pattern matching for MaxTurnsExceeded log signatures
- `agent_lifecycle.py`: `_handle_failure_detection()` now fast-fails `max_turns`, `timeout`, `auth_error`, `api_error` through `retry_or_fail_task()` immediately, short-circuiting the liveness-deferral logic

## Test plan
- [ ] `test_rate_limit_tracker.py` — all tests pass
- [ ] `test_agent_lifecycle.py` + `test_agent_lifecycle_helpers.py` — all tests pass (238 total, zero regressions)
- [ ] Verified on Mac Studio: M2.7 agent hitting MaxTurnsExceeded now transitions task to `failed` instead of hanging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter detection for dead-agent failure cases, including turn-limit, timeout, authentication, and API errors.

* **Bug Fixes**
  * Improved orphaned task recovery to fail fast when a fatal log signal is detected, reducing unnecessary waiting.
  * Made turn-limit failures follow a task-scoped path, avoiding extra fallback handling when it isn’t needed.
  * Enhanced failure classification so similar-looking log content is less likely to be misidentified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->