### PR TITLE
fix: batch of 10 independent bugfixes

### DIFF
--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -331,11 +331,23 @@ class OpenAIAgentsAdapter(PluginAdapter):
         if isinstance(raw_allow, bool):
             allow_run_command = raw_allow
         else:
+            if raw_allow is not None:
+                logger.warning(
+                    "mcp_config allow_run_command=%r must be a bool; falling back to env %s",
+                    raw_allow,
+                    _ALLOW_RUN_COMMAND_ENV_VAR,
+                )
             allow_run_command = os.environ.get(_ALLOW_RUN_COMMAND_ENV_VAR) == "1"
         raw_max_turns = (mcp_config or {}).get("max_turns")
         if isinstance(raw_max_turns, int) and not isinstance(raw_max_turns, bool) and raw_max_turns > 0:
             max_turns: int | None = raw_max_turns
         else:
+            if raw_max_turns is not None:
+                logger.warning(
+                    "mcp_config max_turns=%r must be a positive int; falling back to "
+                    "env/tuning.agent.max_turns/SDK default",
+                    raw_max_turns,
+                )
             # Spawn-side resolution of env > tuning.agent.max_turns > None,
             # reusing the runner's own resolver (in this process the env is
             # the parent env and defaults are the yaml-loaded tuning).

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -121,6 +121,16 @@ _entrypoints_loaded = False
 _PROVIDER_ALIAS_TABLE: dict[str, str] = {}
 _provider_aliases_built = False
 
+#: Substring-fallback exclusions, keyed by alias. If the alias matches as a
+#: substring of the combined provider/model text but the text ALSO contains
+#: one of the excluded substrings, the match is rejected -- e.g. the bare
+#: "gpt" alias (registered by the Codex adapter's ``provides``) would
+#: otherwise substring-match "gpt-oss:20b", misrouting that distinct model
+#: family to Codex even though it is not an OpenAI GPT model.
+_ALIAS_SUBSTRING_EXCLUSIONS: dict[str, tuple[str, ...]] = {
+    "gpt": ("gpt-oss",),
+}
+
 
 def _load_entrypoint_adapters() -> None:
     """Discover and register adapters from the ``bernstein.adapters`` entry-point group.
@@ -376,6 +386,17 @@ def adapter_name_for_provider(provider_name: str | None, model: str) -> str | No
     text = f"{provider_name or ''} {model}".lower()
     for alias in sorted(_PROVIDER_ALIAS_TABLE, key=len, reverse=True):
         if alias in text:
+            excluded = _ALIAS_SUBSTRING_EXCLUSIONS.get(alias, ())
+            if any(excl in text for excl in excluded):
+                logger.info(
+                    "registry.adapter_name_for_provider: SUBSTRING fallback SKIPPED "
+                    "alias=%r in text=%r -- text matches an exclusion pattern for "
+                    "this alias (e.g. 'gpt-oss' is a distinct model family, not an "
+                    "OpenAI GPT model, despite containing the substring 'gpt')",
+                    alias,
+                    text,
+                )
+                continue
             adapter_name = _PROVIDER_ALIAS_TABLE[alias]
             logger.info(
                 "registry.adapter_name_for_provider: SUBSTRING fallback matched "

--- a/src/bernstein/core/agents/agent_recycling.py
+++ b/src/bernstein/core/agents/agent_recycling.py
@@ -190,6 +190,13 @@ def _reap_completed_agent(orch: Any, session: AgentSession, completion_file: Pat
     _save_partial_work(orch._spawner, session)
     with contextlib.suppress(Exception):
         orch._spawner.kill(session)
+    # Bug fix (2026-07-04): every forced-kill path must reap the session's
+    # backgrounded heartbeat shell loop (see heartbeat.py's
+    # _reap_session_heartbeat_loop / Defect-10), not just the two stall-kill
+    # paths inside heartbeat.py itself - otherwise the loop outlives the
+    # agent it was monitoring.
+    with contextlib.suppress(Exception):
+        heartbeat_protocol._reap_session_heartbeat_loop(orch, session, reason="completed_reap")
     _propagate_abort_to_children(orch, session.id)
     orch._idle_shutdown_ts.pop(session.id, None)
     with contextlib.suppress(OSError):
@@ -257,6 +264,10 @@ def _recycle_or_kill(orch: Any, session: AgentSession, now: float, reason: str) 
         _save_partial_work(orch._spawner, session)
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
+        # Bug fix (2026-07-04): reap the heartbeat loop on every forced kill
+        # (see _reap_completed_agent above for full rationale).
+        with contextlib.suppress(Exception):
+            heartbeat_protocol._reap_session_heartbeat_loop(orch, session, reason="idle_recycle_kill")
         _propagate_abort_to_children(orch, session.id)
         orch._idle_shutdown_ts.pop(session.id, None)
         with contextlib.suppress(OSError):
@@ -306,6 +317,10 @@ def check_kill_signals(orch: Any, result: Any) -> None:
             continue
         logger.info("Kill signal received for %s, terminating", session_id)
         orch._spawner.kill(session)
+        # Bug fix (2026-07-04): reap the heartbeat loop on every forced kill
+        # (see _reap_completed_agent above for full rationale).
+        with contextlib.suppress(Exception):
+            heartbeat_protocol._reap_session_heartbeat_loop(orch, session, reason="kill_signal")
         _propagate_abort_to_children(orch, session_id)
         result.reaped.append(session_id)
 
@@ -397,6 +412,10 @@ def _recover_loops(orch: Any, detector: Any, lock_mgr: Any) -> None:
         )
         with contextlib.suppress(Exception):
             orch._spawner.kill(session)
+        # Bug fix (2026-07-04): reap the heartbeat loop on every forced kill
+        # (see _reap_completed_agent above for full rationale).
+        with contextlib.suppress(Exception):
+            heartbeat_protocol._reap_session_heartbeat_loop(orch, session, reason="edit_loop_kill")
         _propagate_abort_to_children(orch, loop.agent_id)
         detector.clear_wait(loop.agent_id)
         if lock_mgr is not None:

--- a/src/bernstein/core/config/seed.py
+++ b/src/bernstein/core/config/seed.py
@@ -438,6 +438,6 @@ def resolve_seed_path(workdir: Path, explicit: Path | None = None) -> Path:
         logger.debug("resolve_seed_path: using BERNSTEIN_SEED_PATH=%s -> %s", env_path, resolved)
         return resolved
 
-    resolved = workdir / "bernstein.yaml"
+    resolved = (workdir / "bernstein.yaml").resolve()
     logger.debug("resolve_seed_path: falling back to workdir default %s", resolved)
     return resolved

--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -25,11 +25,18 @@ _CONVENTIONAL_COMMIT_RE = re.compile(r"^(feat|fix|chore|docs|test|refactor)(\([a
 # merge-preflight safety guard in :mod:`bernstein.core.git.git_pr` blocks
 # the COMMIT, but to close the gap at the staging layer too we extend the
 # deny list with every prefix that must never reach a default branch.
+#
+# NOTE: entries here are matched as bare substrings against candidate paths
+# (see ``stage_files``/``stage_task_files`` below), so every entry MUST be
+# scoped with enough of a path prefix to avoid matching unrelated legitimate
+# paths.  A bare ``"attestations/"`` or ``"auth/"`` entry would also match
+# any legitimate path that happens to contain that substring anywhere (e.g.
+# ``src/myapp/auth/handler.py``), silently excluding real work from staging
+# -- the inverse of the leak this list exists to prevent.  Keep only the
+# ``.sdd/``-scoped forms.
 _NEVER_STAGE: frozenset[str] = frozenset(
     {
         ".sdd/",
-        "attestations/",
-        "auth/",
         ".sdd/runtime/",
         ".sdd/metrics/",
         ".sdd/attestations/",

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -219,8 +219,7 @@ def _check_python_syntax(cwd: Path) -> list[str]:
         # Fail closed: report it as a blocking error so the merge is
         # refused rather than let a mundane git hiccup pass as clean.
         logger.warning(
-            "Syntax check: STAGED-READ-FAILED cwd=%s returncode=%d stderr=%s -- "
-            "refusing merge as fail-closed",
+            "Syntax check: STAGED-READ-FAILED cwd=%s returncode=%d stderr=%s -- refusing merge as fail-closed",
             cwd,
             names_result.returncode,
             names_result.stderr.strip(),

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -154,6 +154,23 @@ def _verify_merge_staging_is_safe(
         )
         return ["<staged-read-failed>"]
 
+    if not staged_r.ok:
+        # The subprocess ran without raising, but git itself reported a
+        # non-zero exit (a binary hiccup, filesystem error, etc.).  Treating
+        # this the same as "no staged files" would silently report the
+        # merge as safe -- exactly the fail-open this guard exists to
+        # prevent.  Fail closed instead: an unverifiable staged set is
+        # never a clean bill of health.
+        logger.warning(
+            "merge_preflight: STAGED-READ-FAILED cwd=%s branch=%s returncode=%d stderr=%s "
+            "-- refusing merge as fail-closed",
+            cwd,
+            branch,
+            staged_r.returncode,
+            staged_r.stderr.strip(),
+        )
+        return ["<staged-read-failed>"]
+
     staged_paths = [p.strip() for p in staged_r.stdout.splitlines() if p.strip()]
     forbidden = [p for p in staged_paths if _is_forbidden_for_merge(p)]
 
@@ -195,6 +212,20 @@ def _check_python_syntax(cwd: Path) -> list[str]:
 
     # Get the list of files modified in the staged merge
     names_result = run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"], cwd, timeout=15)
+    if not names_result.ok:
+        # A failed git invocation (non-zero exit, no exception) must not be
+        # treated as "no staged .py files" -- that would silently skip the
+        # syntax gate and let unverified files through to the merge commit.
+        # Fail closed: report it as a blocking error so the merge is
+        # refused rather than let a mundane git hiccup pass as clean.
+        logger.warning(
+            "Syntax check: STAGED-READ-FAILED cwd=%s returncode=%d stderr=%s -- "
+            "refusing merge as fail-closed",
+            cwd,
+            names_result.returncode,
+            names_result.stderr.strip(),
+        )
+        return [f"<staged-read-failed>: git diff --cached failed (returncode={names_result.returncode})"]
     errors: list[str] = []
     for raw_name in names_result.stdout.strip().splitlines():
         name = raw_name.strip()

--- a/src/bernstein/core/observability/rate_limit_tracker.py
+++ b/src/bernstein/core/observability/rate_limit_tracker.py
@@ -203,7 +203,14 @@ _RISKY_BARE_TOKENS: frozenset[str] = frozenset(
 # having occurred. Excluding them from substring scanning closes that
 # false-positive hole; risky-bare-token matches on OTHER line types still
 # require same-line error context via ``_ERROR_CONTEXT_RE``.
-_DATA_LINE_TYPES: frozenset[str] = frozenset({"tool_call", "tool_result", "heartbeat", "completion", "progress"})
+#
+# "assistant" was added on the same rationale: assistant-type log events
+# carry free-form model narration (the agent's own commentary), not
+# structured provider/HTTP data, so they are just as prone to incidental
+# risky-token false positives as "completion"/"progress" lines.
+_DATA_LINE_TYPES: frozenset[str] = frozenset(
+    {"tool_call", "tool_result", "heartbeat", "completion", "progress", "assistant"}
+)
 
 # Words that indicate a line is plausibly describing a real provider/HTTP
 # error, rather than incidental structured data. Deliberately narrow -

--- a/src/bernstein/core/observability/watchdog.py
+++ b/src/bernstein/core/observability/watchdog.py
@@ -7,6 +7,7 @@ incident to humans via the existing notification and bulletin channels.
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 import time
@@ -332,9 +333,16 @@ class WatchdogManager:
                 incident.detail = finding.detail
 
             if incident.triage_task_id is None:
+                # Bug fix (2026-07-04): dedupe must also cover incidents
+                # created EARLIER IN THIS SAME sync() call. Those live only
+                # in ``active`` (not yet persisted to ``state`` - that
+                # happens once, after the loop, via ``self._save_state``),
+                # so scanning ``state.values()`` alone missed same-pass
+                # duplicates and could create two "Watchdog triage: ..."
+                # tasks with the same title in one sync.
                 existing_open_titles = [
                     f"Watchdog triage: {other.summary}"
-                    for other in state.values()
+                    for other in itertools.chain(state.values(), active.values())
                     if other.triage_task_id is not None and other.key != finding.key
                 ]
                 triage_task_id = self._create_triage_task(finding, existing_open_titles)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -500,7 +500,7 @@ class Orchestrator:
         # cap (set by ``bernstein run --hard-budget``). Attach a rolling
         # JSONL ledger so per-call attribution lands in
         # ``.sdd/cost/ledger.jsonl``.
-        run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+        run_id = os.environ.get("BERNSTEIN_RUN_ID") or datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
         self._run_id = run_id
         # Wave 3 (per-agent instrumentation): export the run id onto the
         # process environment so it threads through

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3046,6 +3046,7 @@ class Orchestrator:
         """Dispatch an anomaly signal: log, stop spawning, or kill agent."""
         import contextlib
 
+        from bernstein.core import heartbeat as heartbeat_protocol
         from bernstein.core.cost_anomaly import AnomalySignal
 
         assert isinstance(signal, AnomalySignal)
@@ -3056,6 +3057,12 @@ class Orchestrator:
             if session:
                 with contextlib.suppress(Exception):
                     self._spawner.kill(session)
+                # Every forced-kill path must reap the session's backgrounded
+                # heartbeat shell loop (see heartbeat.py's
+                # _reap_session_heartbeat_loop / Defect-10) so the loop does
+                # not outlive the agent it was monitoring.
+                with contextlib.suppress(Exception):
+                    heartbeat_protocol._reap_session_heartbeat_loop(self, session, reason="anomaly_kill")
         elif signal.action == "stop_spawning":
             logger.warning("Anomaly [%s]: %s - stopping new spawns", signal.rule, signal.message)
             self._stop_spawning = True
@@ -3325,6 +3332,14 @@ class Orchestrator:
 
         with contextlib.suppress(Exception):
             self._spawner.kill(session)
+        # Every forced-kill path must reap the session's backgrounded
+        # heartbeat shell loop (see heartbeat.py's
+        # _reap_session_heartbeat_loop / Defect-10) so the loop does not
+        # outlive the agent it was monitoring.
+        with contextlib.suppress(Exception):
+            from bernstein.core import heartbeat as heartbeat_protocol
+
+            heartbeat_protocol._reap_session_heartbeat_loop(self, session, reason="cost_cap_kill")
 
         from bernstein.core.lifecycle import transition_agent
 
@@ -3431,10 +3446,18 @@ class Orchestrator:
             elapsed,
             len(pending_kill),
         )
+        from bernstein.core import heartbeat as heartbeat_protocol
+
         for session in pending_kill:
             self._budget_stop_killed_agents.add(session.id)
             with contextlib.suppress(Exception):
                 self._spawner.kill(session)
+            # Every forced-kill path must reap the session's backgrounded
+            # heartbeat shell loop (see heartbeat.py's
+            # _reap_session_heartbeat_loop / Defect-10) so the loop does
+            # not outlive the agent it was monitoring.
+            with contextlib.suppress(Exception):
+                heartbeat_protocol._reap_session_heartbeat_loop(self, session, reason="budget_killswitch")
         self._post_bulletin(
             "alert",
             f"budget.exhaust: SIGKILLed {len(pending_kill)} agent(s) after "

--- a/src/bernstein/core/orchestration/orchestrator_evolve.py
+++ b/src/bernstein/core/orchestration/orchestrator_evolve.py
@@ -821,7 +821,11 @@ def _create_upgrade_tasks(orch: Any, proposals: list[Any], result: Any) -> None:
                 proposal.title,
                 risk_score.composite_risk,
             )
-        except httpx.HTTPError as exc:
+        except (httpx.HTTPError, OSError) as exc:
+            # OSError covers AutoSpawnGuard._save_count() raising on a
+            # transient .sdd/runtime write failure (guard.evaluate() above);
+            # without it here, one bad write aborted the ENTIRE upgrade-
+            # proposal batch instead of just skipping this one proposal.
             logger.warning(
                 "Failed to create upgrade task for proposal %s: %s",
                 proposal.id,

--- a/src/bernstein/core/orchestration/watchdog.py
+++ b/src/bernstein/core/orchestration/watchdog.py
@@ -357,15 +357,22 @@ def tick(
         if not session.is_paused:
             continue
         kind = classify_prompt(session.recent_output)
-        # Every paused-session probe conclusion, logged with the classifier
-        # input (last line) and verdict -- this is the decision that
-        # determines auto-answer vs. escalate vs. no-op.
+        # Bug fix (2026-07-04): the raw agent-stdout tail (`_last_line`) can
+        # contain secrets, API tokens, or file contents an operator never
+        # intended to persist to logs/log-aggregation - this fired on
+        # EVERY paused-session probe tick, not just failures. INFO now
+        # carries only the classifier's verdict (safe to persist); the raw
+        # tail is only emitted at DEBUG for deep debugging.
         logger.info(
-            "watchdog probe: session=%s is_paused=True classified=%s last_line=%r approved_classes=%s",
+            "watchdog probe: session=%s is_paused=True classified=%s approved_classes=%s",
             session.session_id,
             kind,
-            _last_line(session.recent_output),
             sorted(session.approved_prompt_classes),
+        )
+        logger.debug(
+            "watchdog probe raw tail: session=%s last_line=%r",
+            session.session_id,
+            _last_line(session.recent_output),
         )
         if kind == "model_question":
             skipped.append(session.session_id)

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -75,7 +75,13 @@ _JUDGE_TEMPLATE_PATH = _BUNDLED_TEMPLATES_DIR / "prompts" / "judge.md"
 
 # Task types that legitimately produce no diff (research/exploration output
 # lives in task notes, not the repo). Everything else must show work.
-_NOOP_TASK_TYPES = frozenset({TaskType.RESEARCH})
+#
+# TaskType.UPGRADE_PROPOSAL is included because verify_upgrade_task() (see
+# the UPGRADE_PROPOSAL branch above) is the real pass/fail authority for
+# these tasks, and UpgradeProposal.to_task() never sets owned_files -- there
+# is no attribution source for this task type, so the generic empty-diff
+# guard would hard-reject an already-verified upgrade proposal.
+_NOOP_TASK_TYPES = frozenset({TaskType.RESEARCH, TaskType.UPGRADE_PROPOSAL})
 
 _ATTRIBUTION_MAX_COMMITS = 50
 

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -259,17 +259,22 @@ def _is_auto_commit_denied(path: str) -> bool:
     for prefix in _AUTO_COMMIT_DENY_DIR_PREFIXES:
         if p.startswith(prefix):
             return True
+    base = os.path.basename(p)
     for glob in _AUTO_COMMIT_DENY_GLOBS:
         if glob.endswith(".*"):
             stem = glob[:-2]
-            if p == stem or p.startswith(stem + "."):
+            # Match against the basename as well as the full path so a
+            # nested dotenv variant (e.g. ``config/.env.local``) stays
+            # denied -- the full-path checks alone only cover repo-root
+            # ``.env.*`` files.
+            if p == stem or p.startswith(stem + ".") or base == stem or base.startswith(stem + "."):
                 return True
         # Exact basename/path match rather than substring containment --
         # substring containment (``glob in p``) would also match unrelated
         # paths that merely contain ".env" somewhere, e.g. ".envrc" or
         # "config.envelope.json", silently excluding legitimate files from
         # auto-commit.
-        elif p == glob or os.path.basename(p) == glob:
+        elif p == glob or base == glob:
             return True
     return False
 

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import subprocess
 import time
 from contextlib import suppress
@@ -263,7 +264,12 @@ def _is_auto_commit_denied(path: str) -> bool:
             stem = glob[:-2]
             if p == stem or p.startswith(stem + "."):
                 return True
-        elif glob in p:
+        # Exact basename/path match rather than substring containment --
+        # substring containment (``glob in p``) would also match unrelated
+        # paths that merely contain ".env" somewhere, e.g. ".envrc" or
+        # "config.envelope.json", silently excluding legitimate files from
+        # auto-commit.
+        elif p == glob or os.path.basename(p) == glob:
             return True
     return False
 

--- a/tests/unit/adapters/test_openai_agents.py
+++ b/tests/unit/adapters/test_openai_agents.py
@@ -2106,6 +2106,63 @@ class TestManifestControlKnobs:
         manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-mt2")
         assert manifest["max_turns"] == 77
 
+    def test_rejected_allow_run_command_override_is_logged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-bool mcp_config allow_run_command must fall back to the env
+        default AND leave a WARNING diagnostic -- a silently-dropped override
+        was previously undiagnosable from logs alone."""
+        monkeypatch.delenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", raising=False)
+        with caplog.at_level("WARNING", logger="bernstein.adapters.openai_agents"):
+            manifest = self._spawn_and_read_manifest(
+                tmp_path, session_id="oai-arc4", mcp_config={"allow_run_command": "yes"}
+            )
+        assert manifest["allow_run_command"] is False
+        assert "allow_run_command='yes' must be a bool" in caplog.text
+
+    def test_valid_allow_run_command_override_is_not_logged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.delenv("BERNSTEIN_BUILTIN_ALLOW_RUN_COMMAND", raising=False)
+        with caplog.at_level("WARNING", logger="bernstein.adapters.openai_agents"):
+            self._spawn_and_read_manifest(tmp_path, session_id="oai-arc5", mcp_config={"allow_run_command": True})
+        assert "allow_run_command" not in caplog.text
+
+    def test_rejected_max_turns_override_is_logged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-positive / wrong-type mcp_config max_turns must fall back to
+        env/tuning resolution AND leave a WARNING diagnostic, matching the
+        runner-side _resolve_max_turns rejection logging."""
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "77")
+        with caplog.at_level("WARNING", logger="bernstein.adapters.openai_agents"):
+            manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-mt3", mcp_config={"max_turns": 0})
+        assert manifest["max_turns"] == 77
+        assert "max_turns=0 must be a positive int" in caplog.text
+
+    def test_rejected_bool_max_turns_override_is_logged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """bool is an int subclass; ``True`` must be rejected (and logged),
+        not treated as max_turns=1."""
+        monkeypatch.setenv(MAX_TURNS_ENV_VAR, "77")
+        with caplog.at_level("WARNING", logger="bernstein.adapters.openai_agents"):
+            manifest = self._spawn_and_read_manifest(tmp_path, session_id="oai-mt4", mcp_config={"max_turns": True})
+        assert manifest["max_turns"] == 77
+        assert "max_turns=True must be a positive int" in caplog.text
+
     def test_runner_manifest_parses_control_knobs(self) -> None:
         manifest = RunnerManifest.from_dict(
             {

--- a/tests/unit/test_adapter_inference.py
+++ b/tests/unit/test_adapter_inference.py
@@ -58,6 +58,37 @@ def test_bare_openai_provider_routes_to_codex(tmp_path: Path) -> None:
     assert result == "codex"
 
 
+def test_gpt_oss_model_does_not_route_to_codex(tmp_path: Path) -> None:
+    """gpt-oss:20b must NOT be misrouted to Codex via the bare 'gpt' substring
+    alias -- gpt-oss is a distinct open-weights model family, not an OpenAI
+    GPT model, despite textually containing 'gpt'."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider(None, "gpt-oss:20b")
+    assert result != "codex"
+
+
+def test_gpt_oss_120b_model_does_not_route_to_codex(tmp_path: Path) -> None:
+    """Same exclusion applies to other gpt-oss size variants."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider(None, "gpt-oss:120b")
+    assert result != "codex"
+
+
+def test_legitimate_gpt_model_still_routes_to_codex(tmp_path: Path) -> None:
+    """Legitimate gpt-* models (not gpt-oss) must still route to codex after
+    the gpt-oss exclusion is applied."""
+    spawner = _make_spawner(tmp_path)
+    result = spawner._infer_adapter_name_for_provider(None, "gpt-4.1")
+    assert result == "codex"
+
+
+def test_registry_gpt_oss_excluded_from_gpt_alias() -> None:
+    """Direct registry-level coverage: the substring fallback must reject the
+    'gpt' alias match when the model text contains 'gpt-oss'."""
+    assert registry.adapter_name_for_provider(None, "gpt-oss:20b") != "codex"
+    assert registry.adapter_name_for_provider(None, "gpt-5.5") == "codex"
+
+
 def test_unrecognized_provider_falls_back_to_current_adapter(tmp_path: Path) -> None:
     """Unrecognized provider/model still falls back to self._adapter.name(),
     exactly as the old substring chain did -- Claude-only / unrecognized

--- a/tests/unit/test_auto_commit_on_complete.py
+++ b/tests/unit/test_auto_commit_on_complete.py
@@ -46,6 +46,7 @@ from bernstein.core.tasks.models import Task, TaskStatus
         ".env",
         ".env.local",
         ".env.production",
+        "config/.env",
     ],
 )
 def test_is_auto_commit_denied_true(path: str) -> None:
@@ -60,6 +61,13 @@ def test_is_auto_commit_denied_true(path: str) -> None:
         "templates/roles/backend/system_prompt.md",
         "README.md",
         "docs/operations/runbook.md",
+        # Regression: plain substring containment on ".env" previously
+        # matched any path that merely contains the substring ".env"
+        # anywhere, silently excluding unrelated legitimate files from
+        # auto-commit.
+        ".envrc",
+        "config.envelope.json",
+        "src/bernstein/core/envelope.py",
     ],
 )
 def test_is_auto_commit_denied_false(path: str) -> None:

--- a/tests/unit/test_auto_commit_on_complete.py
+++ b/tests/unit/test_auto_commit_on_complete.py
@@ -47,6 +47,13 @@ from bernstein.core.tasks.models import Task, TaskStatus
         ".env.local",
         ".env.production",
         "config/.env",
+        # Regression: switching the ".env" glob from substring containment
+        # to exact path/basename matching must not fail open for NESTED
+        # dotenv variants -- "config/.env.local" has basename ".env.local",
+        # which matches neither the exact ".env" glob nor the full-path
+        # ".env.*" check, so the ".env.*" branch must consult the basename.
+        "config/.env.local",
+        "backend/.env.production",
     ],
 )
 def test_is_auto_commit_denied_true(path: str) -> None:

--- a/tests/unit/test_budget_killswitch.py
+++ b/tests/unit/test_budget_killswitch.py
@@ -219,3 +219,35 @@ class TestBudgetKillSwitchRearm:
 
         assert stub._budget_stop_fired_at is None
         assert stub._budget_stop_killed_agents == set()
+
+
+class TestBudgetKillSwitchHeartbeatReap:
+    """Forced SIGKILL must also reap the session's heartbeat shell loop."""
+
+    def test_sigkill_reaps_heartbeat_loop_per_agent(self, tmp_path: Path) -> None:
+        """Every forced-kill path must call the Defect-10 heartbeat reaper so
+        the backgrounded heartbeat shell loop does not outlive the agent it
+        was monitoring (regression: the budget kill-switch SIGKILL path used
+        to call ``spawner.kill`` without reaping)."""
+        from unittest.mock import patch
+
+        sessions = [_session("A-1"), _session("A-2")]
+        stub = _build_orch_stub(
+            tmp_path,
+            sessions,
+            budget_usd=1.0,
+            kill_grace_period_s=30,
+        )
+        stub._cost_tracker.record("A-0", "T-0", "opus", 0, 0, cost_usd=1.5)
+
+        stub._enforce_budget_killswitch()
+        stub._budget_stop_fired_at = time.time() - 31
+
+        with patch("bernstein.core.agents.heartbeat._reap_session_heartbeat_loop") as reap:
+            stub._enforce_budget_killswitch()
+
+        assert stub._spawner.kill.call_count == 2
+        assert reap.call_count == 2
+        reaped_ids = {c.args[1].id for c in reap.call_args_list}
+        assert reaped_ids == {"A-1", "A-2"}
+        assert all(c.kwargs["reason"] == "budget_killswitch" for c in reap.call_args_list)

--- a/tests/unit/test_git_basic.py
+++ b/tests/unit/test_git_basic.py
@@ -9,7 +9,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from bernstein.core.git_basic import GitResult, run_git, safe_push, stage_all_except, stage_task_files
+from bernstein.core.git_basic import (
+    GitResult,
+    run_git,
+    safe_push,
+    stage_all_except,
+    stage_files,
+    stage_task_files,
+)
 
 
 def test_run_git_raises_called_process_error_when_check_is_true(tmp_path: Path) -> None:
@@ -49,6 +56,30 @@ def test_stage_all_except_unstages_explicit_and_never_stage_paths(tmp_path: Path
     assert "README.md" in reset_args
     assert ".sdd/runtime/" in reset_args
     assert ".sdd/metrics/" in reset_args
+
+
+def test_stage_files_does_not_exclude_legitimate_paths_that_merely_contain_auth_or_attestations(
+    tmp_path: Path,
+) -> None:
+    """``_NEVER_STAGE`` entries are matched as bare substrings, so a legitimate
+    path that happens to contain ``auth/`` or ``attestations/`` anywhere in
+    it (not under ``.sdd/``) must still be staged -- only the ``.sdd/``-scoped
+    forms are forbidden."""
+    with patch("bernstein.core.git_basic.run_git") as mock_run_git:
+        stage_files(
+            tmp_path,
+            [
+                "src/myapp/auth/handler.py",
+                "src/myapp/attestations/verifier.py",
+                ".sdd/auth/agent_identity_jwt_secret",
+                ".sdd/attestations/ed25519-signing-key.pem",
+            ],
+        )
+
+    mock_run_git.assert_called_once_with(
+        ["add", "--", "src/myapp/auth/handler.py", "src/myapp/attestations/verifier.py"],
+        tmp_path,
+    )
 
 
 def test_safe_push_corrects_master_and_rebases_when_remote_is_ahead(tmp_path: Path) -> None:

--- a/tests/unit/test_git_pr.py
+++ b/tests/unit/test_git_pr.py
@@ -197,6 +197,59 @@ def test_is_forbidden_for_merge_matches_deny_list() -> None:
         assert git_pr._is_forbidden_for_merge(path) is False, f"path {path!r} should NOT be forbidden"
 
 
+# ---------------------------------------------------------------------------
+# Fail-closed on a FAILED (non-exception) ``git diff --cached`` result.
+#
+# ``run_git`` can report failure two ways: raising (SubprocessError/OSError)
+# or returning a ``GitResult`` with a non-zero ``returncode``/``ok is
+# False``. Only the exception path used to be handled -- a mundane git
+# failure (binary hiccup, filesystem issue) that merely returns a failed
+# result fell through to "no staged files", silently clearing the way for
+# the exact decoy/forbidden-path condition these guards exist to catch.
+# ---------------------------------------------------------------------------
+
+
+def test_verify_merge_staging_is_safe_fails_closed_on_failed_gitresult(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed (non-exception) ``git diff --cached`` GitResult must be
+    treated as unsafe, not as an empty (safe) staged set."""
+
+    def _fake_run_git(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
+        if args[:3] == ["diff", "--cached", "--name-only"]:
+            # Failure WITHOUT raising: non-zero exit, empty stdout -- the
+            # exact shape that used to silently look like "no staged files".
+            return GitResult(returncode=128, stdout="", stderr="fatal: unable to read index")
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(git_pr, "run_git", _fake_run_git)
+
+    forbidden = git_pr._verify_merge_staging_is_safe(tmp_path, "agent/qa-fail-closed")
+
+    assert forbidden, "a failed staged-read must be treated as unsafe, never as an empty/safe staged set"
+
+
+def test_check_python_syntax_fails_closed_on_failed_gitresult(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed (non-exception) ``git diff --cached`` GitResult in the
+    syntax-check helper must be reported as a blocking error, not silently
+    treated as "no staged .py files"."""
+
+    def _fake_run_git(args: list[str], cwd: Path, timeout: int = 30, **kwargs: object) -> GitResult:
+        if args[:3] == ["diff", "--cached", "--name-only"]:
+            return GitResult(returncode=128, stdout="", stderr="fatal: unable to read index")
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(git_pr, "run_git", _fake_run_git)
+
+    errors = git_pr._check_python_syntax(tmp_path)
+
+    assert errors, "a failed staged-read must be reported as a blocking error, never treated as a clean pass"
+
+
 def test_create_task_branch_delegates_to_git(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     seen: list[str] = []
 

--- a/tests/unit/test_janitor.py
+++ b/tests/unit/test_janitor.py
@@ -22,7 +22,7 @@ from bernstein.core.janitor import (
     run_janitor,
     verify_task,
 )
-from bernstein.core.models import CompletionSignal, Task, TaskType
+from bernstein.core.models import CompletionSignal, Task, TaskType, UpgradeProposalDetails
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -1398,6 +1398,32 @@ class TestEmptyDiffGuardAndAttribution:
 
         assert len(results) == 1
         assert results[0].passed is True
+
+    @pytest.mark.asyncio
+    async def test_upgrade_proposal_task_exempt_from_empty_diff_guard(self, tmp_path: Path) -> None:
+        """UPGRADE_PROPOSAL tasks are verified by verify_upgrade_task(), which
+        does not require owned_files -- UpgradeProposal.to_task() never sets
+        owned_files, so the generic empty-diff attribution guard would
+        otherwise hard-reject an already-verified upgrade proposal that made
+        no repo changes of its own (e.g. an analysis-only proposal). This
+        regression covers CodeRabbit's janitor.py:72 finding."""
+        _init_git_repo(tmp_path)
+        task = Task(
+            id="UPGRADE-1",
+            title="Upgrade proposal",
+            description="Propose an upgrade; verified via verify_upgrade_task, not a diff.",
+            role="backend",
+            task_type=TaskType.UPGRADE_PROPOSAL,
+            completion_signals=[CompletionSignal(type="path_exists", value="base.txt")],
+            upgrade_details=UpgradeProposalDetails(),
+        )
+
+        results = await run_janitor([task], tmp_path)
+
+        assert len(results) == 1
+        assert results[0].passed is True, f"signal_results={results[0].signal_results}"
+        failed = [d for d, ok, _ in results[0].signal_results if not ok]
+        assert not any("empty_diff" in d for d in failed), f"failed={failed}"
 
     @pytest.mark.asyncio
     async def test_non_git_workdir_guard_skipped(self, tmp_path: Path) -> None:

--- a/tests/unit/test_orchestration_watchdog.py
+++ b/tests/unit/test_orchestration_watchdog.py
@@ -334,3 +334,30 @@ def test_tick_audit_recovery_id_is_unique_per_session(tmp_path: Path) -> None:
         by_id.setdefault(str(ev["recovery_id"]), []).append(str(ev["event"]))
     for rid, evs in by_id.items():
         assert evs == ["watchdog.recover.detected", "watchdog.recover.succeeded"], rid
+
+
+def test_tick_probe_info_log_omits_raw_output_tail(tmp_path: Path, caplog) -> None:
+    """The raw agent-stdout tail can contain secrets or file contents; the
+    per-probe INFO line must carry only the classifier verdict. The raw tail
+    is available at DEBUG only, for deep debugging."""
+    caplog.set_level("DEBUG", logger="bernstein.core.orchestration.watchdog")
+    sentinel = "sk-live-DO-NOT-PERSIST-1234"
+    captured: list[tuple[str, str]] = []
+    # The sentinel is the LAST line: exactly what ``_last_line`` extracts
+    # and what the old INFO probe line persisted on every paused tick.
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output=f"Continue? [y/N]\ntoken {sentinel}",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    tick([snapshot], _record_calls(captured), audit, env=env)
+
+    info_messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+    assert any("watchdog probe" in m and "session=s1" in m for m in info_messages), info_messages
+    assert not any(sentinel in m for m in info_messages), info_messages
+    debug_messages = [r.getMessage() for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("watchdog probe raw tail" in m and sentinel in m for m in debug_messages), debug_messages

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6113,6 +6113,76 @@ def test_record_live_costs_enforces_max_cost_per_agent(tmp_path: Path) -> None:
     mock_retry.assert_called_once()
 
 
+def test_kill_agent_for_cost_cap_reaps_heartbeat_loop(tmp_path: Path) -> None:
+    """The cost-cap forced-kill path must reap the session's backgrounded
+    heartbeat shell loop (Defect-10) so it does not outlive the agent."""
+    config = OrchestratorConfig(
+        max_agents=2,
+        poll_interval_s=1,
+        heartbeat_timeout_s=60,
+        server_url="http://testserver",
+        max_cost_per_agent=0.001,
+    )
+    transport = _mock_transport({})
+    orch = _build_orchestrator(tmp_path, transport=transport, config=config)
+    session = AgentSession(
+        id="agent-cap-reap",
+        role="backend",
+        task_ids=["task-cap"],
+        status="working",
+    )
+    session.tokens_used = 1000
+    orch._agents[session.id] = session
+    orch._spawner.kill = MagicMock()
+    orch._release_file_ownership = MagicMock()
+    orch._release_task_to_session = MagicMock()
+    orch._record_provider_health = MagicMock()
+
+    with (
+        patch("bernstein.core.orchestrator.retry_or_fail_task"),
+        patch("bernstein.core.agents.heartbeat._reap_session_heartbeat_loop") as reap,
+    ):
+        orch._record_live_costs()
+
+    orch._spawner.kill.assert_called_once()
+    reap.assert_called_once()
+    assert reap.call_args.args[1] is session
+    assert reap.call_args.kwargs["reason"] == "cost_cap_kill"
+
+
+def test_handle_anomaly_signal_kill_reaps_heartbeat_loop(tmp_path: Path) -> None:
+    """The anomaly kill_agent path must reap the session's backgrounded
+    heartbeat shell loop (Defect-10) so it does not outlive the agent."""
+    import time as _time
+
+    from bernstein.core.cost_anomaly import AnomalySignal
+
+    transport = _mock_transport({})
+    orch = _build_orchestrator(tmp_path, transport=transport)
+    session = AgentSession(id="agent-anomaly", role="backend", status="working")
+    orch._agents[session.id] = session
+    orch._spawner.kill = MagicMock()
+
+    signal = AnomalySignal(
+        rule="burn_rate",
+        severity="critical",
+        action="kill_agent",
+        agent_id=session.id,
+        task_id=None,
+        message="burn rate exceeded",
+        details={},
+        timestamp=_time.time(),
+    )
+
+    with patch("bernstein.core.agents.heartbeat._reap_session_heartbeat_loop") as reap:
+        orch._handle_anomaly_signal(signal)
+
+    orch._spawner.kill.assert_called_once_with(session)
+    reap.assert_called_once()
+    assert reap.call_args.args[1] is session
+    assert reap.call_args.kwargs["reason"] == "anomaly_kill"
+
+
 def test_record_live_costs_accumulates_from_tokens_sidecar(tmp_path: Path) -> None:
     """Ledger spent_usd must accumulate from the .tokens sidecar (bug item-7).
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -6113,6 +6113,33 @@ def test_record_live_costs_enforces_max_cost_per_agent(tmp_path: Path) -> None:
     mock_retry.assert_called_once()
 
 
+def test_orchestrator_honors_external_bernstein_run_id(tmp_path: Path) -> None:
+    """An externally-set BERNSTEIN_RUN_ID (exported by run.py before the
+    orchestrator starts) must be adopted as the orchestrator's run id, not
+    overwritten with a fresh timestamp -- otherwise phase results and
+    per-agent instrumentation land under two different run directories."""
+    import os
+
+    transport = _mock_transport({})
+    with patch.dict(os.environ, {"BERNSTEIN_RUN_ID": "external-run-42"}, clear=False):
+        orch = _build_orchestrator(tmp_path, transport=transport)
+        assert orch._run_id == "external-run-42"
+        assert os.environ["BERNSTEIN_RUN_ID"] == "external-run-42"
+
+
+def test_orchestrator_generates_run_id_when_env_unset(tmp_path: Path) -> None:
+    """Without an external BERNSTEIN_RUN_ID the orchestrator still generates
+    a timestamp id and exports it for spawned-agent instrumentation."""
+    import os
+
+    transport = _mock_transport({})
+    env = {k: v for k, v in os.environ.items() if k != "BERNSTEIN_RUN_ID"}
+    with patch.dict(os.environ, env, clear=True):
+        orch = _build_orchestrator(tmp_path, transport=transport)
+        assert orch._run_id
+        assert os.environ["BERNSTEIN_RUN_ID"] == orch._run_id
+
+
 def test_kill_agent_for_cost_cap_reaps_heartbeat_loop(tmp_path: Path) -> None:
     """The cost-cap forced-kill path must reap the session's backgrounded
     heartbeat shell loop (Defect-10) so it does not outlive the agent."""

--- a/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
+++ b/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
@@ -14,10 +14,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from bernstein.core.models import Task, TaskStatus, TaskType
-from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard
 
 from bernstein.core.orchestration.evolution import UpgradeStatus
 from bernstein.core.orchestration.orchestrator_evolve import _create_upgrade_tasks
+from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard
 
 
 def _proposal(

--- a/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
+++ b/tests/unit/test_orchestrator_evolve_upgrade_tasks.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from bernstein.core.models import Task, TaskStatus, TaskType
+from bernstein.core.tasks.auto_spawn_guard import AutoSpawnGuard
 
 from bernstein.core.orchestration.evolution import UpgradeStatus
 from bernstein.core.orchestration.orchestrator_evolve import _create_upgrade_tasks
@@ -106,3 +107,32 @@ def test_non_eligible_proposal_status_is_skipped_before_guard(tmp_path: Path) ->
     _create_upgrade_tasks(orch, [_proposal("p1", "Applied already", status=UpgradeStatus.APPLIED)], result)
 
     assert orch._client.post.call_count == 0
+
+
+def test_oserror_from_guard_save_skips_only_that_proposal(tmp_path: Path) -> None:
+    """AutoSpawnGuard._save_count() can raise OSError on a transient
+    .sdd/runtime write failure. Before this fix, the per-proposal try/except
+    only caught httpx.HTTPError, so an OSError on the first proposal's
+    guard.evaluate() escaped and aborted the ENTIRE batch -- the second,
+    unrelated proposal never got a chance to post. This asserts the OSError
+    is caught, recorded, and the batch continues to the next proposal."""
+    orch = _orch(tmp_path)
+    result = SimpleNamespace(errors=[])
+
+    with patch.object(AutoSpawnGuard, "_save_count", side_effect=OSError("disk full")):
+        _create_upgrade_tasks(
+            orch,
+            [
+                _proposal("p1", "Improve task success rate"),
+                _proposal("p2", "Reduce flaky retries"),
+            ],
+            result,
+        )
+
+    # Both proposals hit the same failing guard.evaluate() -> both are
+    # skipped, but neither raises out of _create_upgrade_tasks, and both
+    # failures are recorded rather than silently swallowed or crashing the
+    # batch.
+    assert orch._client.post.call_count == 0
+    assert len(result.errors) == 2
+    assert all("disk full" in e for e in result.errors)

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -480,3 +480,25 @@ class TestCompletionProgressSkipSet:
             '{"type": "error", "message": "Error code: 429 - rate limit exceeded"}\n'
         )
         assert self._tracker().detect_failure_type(log) == "rate_limit"
+
+    def test_assistant_type_prose_with_error_context_does_not_match(self, tmp_path):
+        """"assistant" events carry free-form model narration, not
+        structured provider/HTTP data -- healthy narration that happens to
+        mention "timeout" alongside an error-context word (e.g. "status")
+        must not trip a false-positive throttle."""
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "assistant", "text": "I checked the status of the request and '
+            'confirmed there was no timeout this run."}\n'
+        )
+        assert self._tracker().detect_failure_type(log) is None
+
+    def test_assistant_type_with_real_error_elsewhere_still_detected(self, tmp_path):
+        """Sanity check: excluding assistant lines from scanning does not
+        mask a genuine error reported on a different, non-data line type."""
+        log = tmp_path / "agent.log"
+        log.write_text(
+            '{"type": "assistant", "text": "Everything looks healthy, no rate limit issues."}\n'
+            '{"type": "error", "message": "Error code: 429 - rate limit exceeded"}\n'
+        )
+        assert self._tracker().detect_failure_type(log) == "rate_limit"

--- a/tests/unit/test_seed.py
+++ b/tests/unit/test_seed.py
@@ -725,3 +725,36 @@ class TestQualityGatesBenchmarkParsing:
         seed_file.write_text('goal: "Test"\nquality_gates:\n  benchmark: "enabled"\n')
         with pytest.raises(SeedError, match="benchmark must be a mapping"):
             parse_seed(seed_file)
+
+
+# ---------------------------------------------------------------------------
+# resolve_seed_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSeedPathWorkdirFallback:
+    """The workdir fallback must honour the documented contract of returning
+    a resolved, absolute path -- matching the explicit-path and
+    BERNSTEIN_SEED_PATH branches."""
+
+    def test_fallback_returns_absolute_resolved_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core.config.seed import resolve_seed_path
+
+        monkeypatch.delenv("BERNSTEIN_SEED_PATH", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        resolved = resolve_seed_path(Path("."))
+
+        assert resolved.is_absolute()
+        assert resolved == (tmp_path / "bernstein.yaml").resolve()
+
+    def test_fallback_normalizes_dot_segments(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core.config.seed import resolve_seed_path
+
+        monkeypatch.delenv("BERNSTEIN_SEED_PATH", raising=False)
+        (tmp_path / "sub").mkdir()
+
+        resolved = resolve_seed_path(tmp_path / "sub" / "..")
+
+        assert resolved.is_absolute()
+        assert resolved == (tmp_path / "bernstein.yaml").resolve()

--- a/tests/unit/test_watchdog.py
+++ b/tests/unit/test_watchdog.py
@@ -260,3 +260,40 @@ def test_watchdog_manager_dedupes_triage_tasks_across_incidents(tmp_path: Path) 
         manager.sync([finding_b])
 
     assert client.post.call_count == 1
+
+
+def test_watchdog_manager_dedupes_triage_tasks_within_single_sync_pass(tmp_path: Path) -> None:
+    """Same-pass dedupe: two distinct incidents arriving in ONE sync() call
+    must still only spawn one identically-worded triage task. Incidents
+    created earlier in the same pass live only in the in-memory ``active``
+    dict (state is persisted once, after the loop), so a dedupe scan of
+    ``state.values()`` alone missed them."""
+    client = MagicMock()
+    client.post.return_value = _response("triage-5")
+    manager = WatchdogManager(tmp_path, client, "http://server")
+
+    finding_a = WatchdogFinding(
+        key="heartbeat:sess-a:task-a",
+        session_id="sess-a",
+        task_id="task-a",
+        source="heartbeat",
+        severity="high",
+        summary="Heartbeat stale for task Fix API",
+        detail="detail-a",
+        task_title="Fix API",
+    )
+    finding_b = WatchdogFinding(
+        key="heartbeat:sess-b:task-b",
+        session_id="sess-b",
+        task_id="task-b",
+        source="heartbeat",
+        severity="high",
+        summary="Heartbeat stale for task Fix API",
+        detail="detail-b",
+        task_title="Fix API",
+    )
+
+    with patch("bernstein.core.observability.watchdog.time.time", return_value=300.0):
+        manager.sync([finding_a, finding_b])
+
+    assert client.post.call_count == 1


### PR DESCRIPTION
## Summary
Batch of 10 small, independent bugfixes — each touches a different subsystem with no cross-dependencies:

- **BERNSTEIN_RUN_ID**: honor externally-set value instead of overwriting
- **seed_parser**: resolve_seed_path workdir fallback returns absolute path
- **registry**: exclude gpt-oss models from bare gpt alias substring match
- **rate_limit_tracker**: exclude assistant-type log lines from risky-token scan
- **task_crud**: use exact path/basename match for .env in auto-commit deny list
- **janitor**: exempt UPGRADE_PROPOSAL tasks from empty-diff guard
- **orchestrator_evolve**: catch OSError alongside httpx.HTTPError in _create_upgrade_tasks
- **git_basic/git_pr**: close merge-safety fail-open, scope _NEVER_STAGE substring matches
- **openai_agents**: log rejected mcp_config max_turns/allow_run_command overrides
- **watchdog/recycling**: reap heartbeat loops on forced-kill paths, stop leaking secrets to INFO logs

## Test plan
- [ ] Existing unit tests pass (238 targeted tests verified green)
- [ ] Each fix is isolated — can be reviewed/reverted independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adapter/provider resolution to prevent misrouting similar model names and aliases.
  * Strengthened fail-closed Git merge preflight and staged syntax checks when staged file reads fail.
  * Ensured background heartbeat loops are always cleaned up when agents are force-killed across multiple kill scenarios.
  * Reduced watchdog/rate-limit log false positives, prevented duplicate triage tasks in a single run, and removed raw output tail content from INFO logs.
  * Refined path-matching for staging and auto-commit denial rules to avoid incorrect exclusions.

* **Tests**
  * Added regression coverage for the new validation, kill-cleanup, watchdog, and path-matching behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->