### PR TITLE
fix: instrumentation capture, JSONL parser resilience, and max_turns validation

### DIFF
--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -422,9 +422,7 @@ class ClaudeCodeAdapter(CLIAdapter):
                     "rather than emitting an invalid --max-turns flag to the Claude CLI",
                     explicit_max_turns,
                 )
-                raise ValueError(
-                    f"explicit_max_turns must be a positive integer, got {explicit_max_turns}"
-                )
+                raise ValueError(f"explicit_max_turns must be a positive integer, got {explicit_max_turns}")
             max_turns = explicit_max_turns
             _logger.info(
                 "_build_command: max_turns=%d (explicit override; bypassing batch_mode/scope_multiplier computation)",

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -416,6 +416,15 @@ class ClaudeCodeAdapter(CLIAdapter):
         model_id = _MODEL_MAP.get(model_config.model, model_config.model)
         effort = getattr(model_config, "effort", "high")
         if explicit_max_turns is not None:
+            if explicit_max_turns <= 0:
+                _logger.warning(
+                    "_build_command: explicit_max_turns=%d is not a positive integer - rejecting "
+                    "rather than emitting an invalid --max-turns flag to the Claude CLI",
+                    explicit_max_turns,
+                )
+                raise ValueError(
+                    f"explicit_max_turns must be a positive integer, got {explicit_max_turns}"
+                )
             max_turns = explicit_max_turns
             _logger.info(
                 "_build_command: max_turns=%d (explicit override; bypassing batch_mode/scope_multiplier computation)",

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -293,6 +293,20 @@ class OpenAIAgentsAdapter(PluginAdapter):
             task_id = mcp_config.get("task_id")
             if isinstance(task_id, str) and task_id:
                 overrides["task_id"] = task_id
+            # Bug fix (instrumentation audit, bug 3 - "4 of 9 implement
+            # tasks have zero instrumentation"): spawner_core batches
+            # multiple tasks onto a single agent process for role-batched
+            # spawns, but only ever injected ``task_id`` (tasks[0].id) here
+            # - every other task in the batch got zero instrumentation
+            # coverage since the runner only knew about one task_id. When
+            # present, ``task_ids`` carries the full batch so the runner can
+            # fan instrumentation out to every task involved (see
+            # RunnerManifest.task_ids / RunInstrumenter.extra_dirs).
+            task_ids = mcp_config.get("task_ids")
+            if isinstance(task_ids, list) and task_ids:
+                cleaned_task_ids = [t for t in task_ids if isinstance(t, str) and t]
+                if cleaned_task_ids:
+                    overrides["task_ids"] = cleaned_task_ids
             # Wave 3 (per-agent instrumentation): orchestrator-root
             # directory injected by spawner_core (mirrors heartbeat_dir
             # above). ``workdir`` is a per-session worktree under default

--- a/src/bernstein/adapters/openai_agents_runner.py
+++ b/src/bernstein/adapters/openai_agents_runner.py
@@ -145,15 +145,22 @@ def _log_initial_conversation_messages(manifest: RunnerManifest) -> None:
     """
     instrumenter = get_instrumenter()
     if manifest.system_addendum:
+        logger.debug(
+            "_log_initial_conversation_messages: logging system_addendum, length=%d",
+            len(manifest.system_addendum),
+        )
         instrumenter.log_message(
             idx=next(_conversation_idx_counter),
             role="system",
             content_length=len(manifest.system_addendum),
+            content=manifest.system_addendum,
         )
+    logger.debug("_log_initial_conversation_messages: logging user prompt, length=%d", len(manifest.prompt))
     instrumenter.log_message(
         idx=next(_conversation_idx_counter),
         role="user",
         content_length=len(manifest.prompt),
+        content=manifest.prompt,
     )
 
 
@@ -187,11 +194,13 @@ def _log_result_conversation_messages(result: Any) -> None:
             role = str(getattr(raw_item, "role", None) or _infer_role_from_item_type(item_type))
             content = getattr(raw_item, "content", None)
             tool_name = getattr(raw_item, "name", None)
-            content_length = len(str(content)) if content is not None else len(str(raw_item))
+            content_text = str(content) if content is not None else str(raw_item)
+            content_length = len(content_text)
             instrumenter.log_message(
                 idx=next(_conversation_idx_counter),
                 role=role,
                 content_length=content_length,
+                content=content_text,
                 tool_calls=[str(tool_name)] if tool_name else None,
             )
         except Exception as exc:
@@ -200,10 +209,12 @@ def _log_result_conversation_messages(result: Any) -> None:
     try:
         final_output = getattr(result, "final_output", None)
         if final_output is not None:
+            final_output_text = str(final_output)
             instrumenter.log_message(
                 idx=next(_conversation_idx_counter),
                 role="assistant",
-                content_length=len(str(final_output)),
+                content_length=len(final_output_text),
+                content=final_output_text,
             )
     except Exception as exc:
         logger.warning("_log_result_conversation_messages: failed to log final_output: %s", exc)
@@ -249,11 +260,13 @@ def _log_hook_turn_conversation(response: Any) -> None:
             role = str(getattr(item, "role", None) or _infer_role_from_item_type(item_type))
             content = getattr(item, "content", None)
             tool_name = getattr(item, "name", None)
-            content_length = len(str(content)) if content is not None else len(str(item))
+            content_text = str(content) if content is not None else str(item)
+            content_length = len(content_text)
             instrumenter.log_message(
                 idx=next(_conversation_idx_counter),
                 role=role,
                 content_length=content_length,
+                content=content_text,
                 tool_calls=[str(tool_name)] if tool_name else None,
             )
         except Exception as exc:
@@ -489,6 +502,25 @@ def _build_instrumentation_hooks(sdk: Any, manifest: RunnerManifest) -> Any:
                 ts_start = pending["ts_start"] if pending else ts_end
                 args = pending["args"] if pending else None
                 is_error = isinstance(result, BaseException)
+                # Bug fix (instrumentation audit, bug 2): tool-calls.jsonl
+                # previously never recorded what a tool actually returned -
+                # only its name/args/success flag - making it impossible to
+                # see tool output without re-running the agent. The SDK's
+                # on_tool_end hook receives the tool's return value directly
+                # as `result` (a BaseException on failure per the is_error
+                # check above, otherwise whatever the tool function
+                # returned - str, dict, etc.); RunInstrumenter.log_tool_call
+                # stringifies + truncates it. On the error path pass None
+                # (the error string itself is already captured in the
+                # `error` field) rather than duplicating the exception text.
+                result_for_log = None if is_error else result
+                logger.debug(
+                    "on_tool_end: tool=%s call_id=%s is_error=%s result_type=%s",
+                    tool_name,
+                    call_id,
+                    is_error,
+                    type(result).__name__,
+                )
                 instrumenter.log_tool_call(
                     call_id=call_id,
                     ts_start=ts_start,
@@ -497,6 +529,7 @@ def _build_instrumentation_hooks(sdk: Any, manifest: RunnerManifest) -> Any:
                     args=args,
                     success=not is_error,
                     error=f"{type(result).__name__}: {result}" if is_error else None,
+                    result=result_for_log,
                 )
                 logger.debug(
                     "wrote tool_call entry call_id=%s tool=%s session=%s success=%s",
@@ -582,6 +615,24 @@ def _instrument_event(event: Mapping[str, Any]) -> None:
             ts_start = pending["ts_start"] if pending else now
             args = pending["args"] if pending else None
             is_error = bool(event.get("is_error")) or bool(event.get("error"))
+            # Bug fix (instrumentation audit, bug 2): mirror whatever
+            # result-shaped data the emitting event carries. Today's builtin
+            # tool emitters (openai_agents_builtins.py) only send metadata
+            # (bytes/count), never the actual content, so this is best-effort
+            # and frequently None for builtin-sourced events - the primary
+            # fix for gateway-sourced tools is the on_tool_end hook path
+            # above, which DOES see the tool's real return value.
+            result_value = event.get("result") if "result" in event else event.get("output")
+            if result_value is None and not is_error:
+                # Fall back to whatever non-standard metadata keys this event
+                # carries (e.g. bytes/count) so SOMETHING beyond
+                # success/failure survives to tool-calls.jsonl even without
+                # a first-class result payload.
+                metadata_preview = {
+                    k: v for k, v in event.items() if k not in {"type", "name", "tool_source", "status", "error"}
+                }
+                if metadata_preview:
+                    result_value = metadata_preview
             instrumenter.log_tool_call(
                 call_id=call_id,
                 ts_start=ts_start,
@@ -590,6 +641,7 @@ def _instrument_event(event: Mapping[str, Any]) -> None:
                 args=args if isinstance(args, dict) else {"args": args},
                 success=not is_error,
                 error=str(event.get("error")) if event.get("error") else None,
+                result=result_value,
             )
             return
     except Exception as exc:
@@ -834,6 +886,20 @@ class RunnerManifest:
     # hand-written manifest for a direct invocation/test) - the runner then
     # instruments under a literal "unknown" task bucket rather than failing.
     task_id: str | None = None
+    # Bug fix (instrumentation audit, bug 3 - "4 of 9 implement tasks have
+    # zero instrumentation"): when spawner_core batches multiple Bernstein
+    # tasks onto ONE agent process (``_spawn_for_tasks_internal``'s
+    # ``tasks: list[Task]``), only ``tasks[0].id`` was ever threaded through
+    # as ``task_id`` above - every OTHER task in the batch got no
+    # instrumentation directory at all, since a single RunInstrumenter only
+    # ever knew about one task_id. ``task_ids`` carries the FULL batch (all
+    # task ids this agent process is working, ``task_id`` included) so
+    # :func:`run` can fan the same instrumentation out to every task's
+    # ``.sdd/runs/<run_id>/tasks/<task_id>/agents/<agent_id>/`` directory,
+    # not just the first. ``None``/empty on hand-written manifests and on
+    # single-task spawns (the common case) - the runner then falls back to
+    # the single ``task_id`` dir exactly as before.
+    task_ids: list[str] | None = None
     # Wave 3 (per-agent instrumentation): orchestrator-root directory,
     # injected by ``spawner_core`` (mirrors ``heartbeat_dir`` above - same
     # reasoning: ``workdir`` is a per-session worktree under default
@@ -1764,13 +1830,44 @@ def run(manifest: RunnerManifest) -> int:
     # falling back to ``workdir`` there is correct.
     instrumentation_base = manifest.instrumentation_root or manifest.workdir
     agent_dir = resolve_agent_dir(Path(instrumentation_base), run_id, task_id, manifest.session_id)
-    init_instrumenter(run_id=run_id, task_id=task_id, agent_id=manifest.session_id, base_dir=agent_dir)
+
+    # Bug fix (instrumentation audit, bug 3): if this agent process is
+    # working a BATCH of tasks (manifest.task_ids has more than one entry),
+    # resolve an agent dir for every OTHER task in the batch too and pass
+    # them as extra_dirs so init_instrumenter fans every JSONL write out to
+    # all of them - see RunnerManifest.task_ids and RunInstrumenter.extra_dirs
+    # docstrings for the full root-cause writeup.
+    batch_task_ids = list(manifest.task_ids or [])
+    extra_dirs = [
+        resolve_agent_dir(Path(instrumentation_base), run_id, other_task_id, manifest.session_id)
+        for other_task_id in batch_task_ids
+        if other_task_id and other_task_id != task_id
+    ]
+    if batch_task_ids:
+        logger.info(
+            "Batched-task instrumentation check: manifest.task_ids=%s primary task_id=%s -> "
+            "%d extra instrumentation dir(s) will receive a full copy of this agent's records",
+            batch_task_ids,
+            task_id,
+            len(extra_dirs),
+        )
+    if not manifest.task_id:
+        logger.debug(
+            "run(): manifest.task_id is unset - this session's instrumentation will be bucketed "
+            "under the literal 'unknown' task_id; run_id from env BERNSTEIN_RUN_ID=%s",
+            os.environ.get("BERNSTEIN_RUN_ID"),
+        )
+    init_instrumenter(
+        run_id=run_id, task_id=task_id, agent_id=manifest.session_id, base_dir=agent_dir, extra_dirs=extra_dirs
+    )
     logger.info(
-        "Instrumentation base dir resolved: instrumentation_root=%r workdir=%r -> using %r -> agent_dir=%s",
+        "Instrumentation base dir resolved: instrumentation_root=%r workdir=%r -> using %r -> agent_dir=%s "
+        "extra_dirs=%s",
         manifest.instrumentation_root,
         manifest.workdir,
         instrumentation_base,
         agent_dir,
+        extra_dirs,
     )
 
     # Every effective sampling/endpoint param is logged here.  The key

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -840,6 +840,27 @@ def _requeue_rate_limited_task(
     return True
 
 
+def _resolve_agent_worktree_dir(workdir: Path, session: AgentSession) -> Path | None:
+    """Find the agent's worktree directory across every layout this codebase supports.
+
+    Checks the current default layout (``.sdd/runtime/worktrees/<id>``) first,
+    then the legacy layout (``.sdd/worktrees/<id>``). Returns ``None`` when
+    neither exists -- e.g. worktrees are disabled entirely and the agent runs
+    directly against ``workdir`` with no per-task worktree at all. Callers
+    must handle the ``None`` case with their own root-level fallback rather
+    than assuming a worktree always exists (see the liveness-probe FAIL-NOTE:
+    hardcoding only the legacy ``.sdd/worktrees/<id>`` layout misjudged a
+    live agent running under either alternate layout as dead).
+    """
+    for _wt_dir in (
+        workdir / ".sdd" / "runtime" / "worktrees" / session.id,
+        workdir / ".sdd" / "worktrees" / session.id,
+    ):
+        if _wt_dir.exists():
+            return _wt_dir
+    return None
+
+
 def _resolve_agent_log_path(workdir: Path, session: AgentSession) -> Path:
     """Find the agent's log file, checking session attribute then standard locations."""
     _session_lp = getattr(session, "log_path", "")
@@ -847,9 +868,11 @@ def _resolve_agent_log_path(workdir: Path, session: AgentSession) -> Path:
         return Path(_session_lp)
     log_path = workdir / ".sdd" / "runtime" / f"{session.id}.log"
     if not log_path.exists():
-        _wt_log = workdir / ".sdd" / "worktrees" / session.id / ".sdd" / "runtime" / f"{session.id}.log"
-        if _wt_log.exists():
-            return _wt_log
+        _wt_dir = _resolve_agent_worktree_dir(workdir, session)
+        if _wt_dir is not None:
+            _wt_log = _wt_dir / ".sdd" / "runtime" / f"{session.id}.log"
+            if _wt_log.exists():
+                return _wt_log
     return log_path
 
 
@@ -901,16 +924,30 @@ def _read_runner_cost_usd(
     except OSError:
         return 0.0, 0, 0
 
-    for line in raw.splitlines():
+    for line_num, line in enumerate(raw.splitlines(), 1):
         line = line.strip()
         if not line:
             continue
         try:
             rec = json.loads(line)
-        except ValueError:
+            total_in += int(rec.get("in", 0) or 0)
+            total_out += int(rec.get("out", 0) or 0)
+        except (ValueError, TypeError, AttributeError) as exc:
+            # Widened beyond just the json.loads() parse: a well-formed-but-
+            # wrong-shape record (not a dict, or "in"/"out" not coercible to
+            # int) raises on the SUBSEQUENT .get()/int() calls, not on
+            # json.loads() itself. This is read on the failure-recovery path
+            # for a dead agent, so a malformed record is realistic input --
+            # skip it and keep summing the rest rather than aborting cost
+            # recovery for the whole task.
+            logger.debug(
+                "Skipping malformed .tokens sidecar record at %s:%d: %s - line=%s",
+                sidecar_path,
+                line_num,
+                exc,
+                line[:500],
+            )
             continue
-        total_in += int(rec.get("in", 0) or 0)
-        total_out += int(rec.get("out", 0) or 0)
 
     if total_in <= 0 and total_out <= 0:
         return 0.0, 0, 0
@@ -1325,10 +1362,17 @@ def _probe_liveness_signals(orch: Any, session: AgentSession, now: float) -> dic
     heartbeat_path = orch._workdir / ".sdd" / "runtime" / "heartbeats" / f"{session.id}.json"
     heartbeat_age = _mtime_age(heartbeat_path, now)
 
-    log_path = orch._workdir / ".sdd" / "worktrees" / session.id / ".sdd" / "runtime" / f"{session.id}.log"
+    # Resolve log/git paths across every layout this codebase supports
+    # (.sdd/runtime/worktrees/<id>/..., legacy .sdd/worktrees/<id>/..., and
+    # the root .sdd/runtime/<id>.log fallback when worktrees are disabled
+    # entirely) rather than hardcoding the legacy worktree layout -- a live
+    # agent running under either alternate layout was previously misjudged
+    # dead (and then killed/reaped) by this probe.
+    log_path = _resolve_agent_log_path(orch._workdir, session)
     log_age = _mtime_age(log_path, now)
 
-    git_path = orch._workdir / ".sdd" / "worktrees" / session.id / ".git"
+    _wt_dir = _resolve_agent_worktree_dir(orch._workdir, session)
+    git_path = (_wt_dir / ".git") if _wt_dir is not None else (orch._workdir / ".git")
     git_age = _mtime_age(git_path, now)
 
     fresh_ages = [a for a in (heartbeat_age, log_age, git_age) if a is not None and a < _ORPHAN_LIVENESS_GRACE_S]

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1522,9 +1522,20 @@ def _probe_liveness_signals(orch: Any, session: AgentSession, now: float) -> dic
     log_path = _resolve_agent_log_path(orch._workdir, session)
     log_age = _mtime_age(log_path, now)
 
+    # The git signal is only meaningful when this agent has its own worktree:
+    # the worktree ``.git`` mtime reflects THIS agent's commit/branch activity.
+    # When no per-agent worktree exists there is deliberately NO git signal
+    # (git_age stays None) rather than falling back to the root ``workdir/.git``
+    # mtime -- the root repo is shared mutable state touched by the
+    # orchestrator's own git operations, sibling agents, and repo setup, so
+    # its freshness cannot be attributed to this agent. Treating it as a
+    # liveness signal made genuinely dead agents look alive on any busy (or
+    # freshly initialised) repo, deferring the fail path indefinitely. In the
+    # worktrees-disabled layout the agent-specific signals are the heartbeat
+    # file and the root ``.sdd/runtime/<id>.log`` resolved above.
     _wt_dir = _resolve_agent_worktree_dir(orch._workdir, session)
-    git_path = (_wt_dir / ".git") if _wt_dir is not None else (orch._workdir / ".git")
-    git_age = _mtime_age(git_path, now)
+    git_path = (_wt_dir / ".git") if _wt_dir is not None else None
+    git_age = _mtime_age(git_path, now) if git_path is not None else None
 
     fresh_ages = [a for a in (heartbeat_age, log_age, git_age) if a is not None and a < _ORPHAN_LIVENESS_GRACE_S]
     has_fresh_signal = bool(fresh_ages)
@@ -1546,7 +1557,7 @@ def _probe_liveness_signals(orch: Any, session: AgentSession, now: float) -> dic
         f"{heartbeat_age:.1f}" if heartbeat_age is not None else "missing",
         log_path,
         f"{log_age:.1f}" if log_age is not None else "missing",
-        git_path,
+        git_path if git_path is not None else "no-per-agent-worktree",
         f"{git_age:.1f}" if git_age is not None else "missing",
         _ORPHAN_LIVENESS_GRACE_S,
         verdict,

--- a/src/bernstein/core/agents/claude_max_turns.py
+++ b/src/bernstein/core/agents/claude_max_turns.py
@@ -111,8 +111,20 @@ def compute_max_turns(
         min_turns: Absolute minimum turns.
         max_turns_cap: Absolute maximum turns.
         explicit_max_turns: When set (e.g. from ``TaskCreate.max_turns``), bypasses
-            all complexity/model/timeout math below and is used verbatim. This lets
-            API callers take exact control over agent turn budgets.
+            all complexity/model/timeout math below but is still clamped to the
+            absolute ``[min_turns, max_turns_cap]`` bounds. This lets API callers
+            take exact control over agent turn budgets within those bounds.
+
+            Validation layering for explicit max_turns (single story):
+
+            1. API boundary: ``TaskCreate.max_turns`` (``server_models.py``)
+               rejects out-of-range values with a 422 (``ge=1, le=10_000``).
+            2. Resolution (here): callers that resolve a turn budget through
+               this function get the explicit value clamped to the same
+               absolute bounds as computed values.
+            3. Adapter (``claude.py`` ``_build_command``): last-resort
+               rejection of non-positive values arriving via paths that
+               bypass both, e.g. ``Task`` records deserialized from disk.
 
     Returns:
         MaxTurnsConfig with the computed (or explicit) value and reasoning.

--- a/src/bernstein/core/agents/claude_max_turns.py
+++ b/src/bernstein/core/agents/claude_max_turns.py
@@ -127,8 +127,7 @@ def compute_max_turns(
         clamped_max_turns = max(min_turns, min(explicit_max_turns, max_turns_cap))
         if clamped_max_turns != explicit_max_turns:
             logger.warning(
-                "max_turns=%s (explicit override clamped to %s; absolute bounds are "
-                "min_turns=%s, max_turns_cap=%s)",
+                "max_turns=%s (explicit override clamped to %s; absolute bounds are min_turns=%s, max_turns_cap=%s)",
                 explicit_max_turns,
                 clamped_max_turns,
                 min_turns,

--- a/src/bernstein/core/agents/claude_max_turns.py
+++ b/src/bernstein/core/agents/claude_max_turns.py
@@ -118,16 +118,39 @@ def compute_max_turns(
         MaxTurnsConfig with the computed (or explicit) value and reasoning.
     """
     if explicit_max_turns is not None:
-        logger.info("max_turns=%s (explicit)", explicit_max_turns)
+        # min_turns/max_turns_cap are documented as ABSOLUTE bounds (see the
+        # Args docstring above) - the explicit-override path must not be able
+        # to defeat them. Clamp the same way the computed path does below
+        # (`max(min_turns, min(turns, max_turns_cap))`) so a caller-supplied
+        # 100000 can't blow the cost ceiling and a caller-supplied 0/negative
+        # can't break the agent's first turn.
+        clamped_max_turns = max(min_turns, min(explicit_max_turns, max_turns_cap))
+        if clamped_max_turns != explicit_max_turns:
+            logger.warning(
+                "max_turns=%s (explicit override clamped to %s; absolute bounds are "
+                "min_turns=%s, max_turns_cap=%s)",
+                explicit_max_turns,
+                clamped_max_turns,
+                min_turns,
+                max_turns_cap,
+            )
+        else:
+            logger.info("max_turns=%s (explicit)", explicit_max_turns)
         return MaxTurnsConfig(
-            max_turns=explicit_max_turns,
+            max_turns=clamped_max_turns,
             complexity=complexity,
             model=model,
             timeout_s=timeout_s,
             turns_per_minute=_TURNS_PER_MINUTE.get(_classify_model_tier(model), DEFAULT_TURNS_PER_MINUTE),
             constrained_by_timeout=False,
             reasoning=(
-                f"Explicit max_turns={explicit_max_turns} supplied by caller; complexity-based computation bypassed."
+                f"Explicit max_turns={explicit_max_turns} supplied by caller; complexity-based computation "
+                f"bypassed, clamped to absolute bounds [{min_turns}, {max_turns_cap}] -> {clamped_max_turns}."
+                if clamped_max_turns != explicit_max_turns
+                else (
+                    f"Explicit max_turns={explicit_max_turns} supplied by caller; "
+                    "complexity-based computation bypassed."
+                )
             ),
         )
 

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -3194,6 +3194,28 @@ class AgentSpawner:
                     if "openai_agents" in adapter_name and tasks:
                         attempt_mcp = dict(attempt_mcp or {})
                         attempt_mcp.setdefault("task_id", tasks[0].id)
+                        # Bug fix (instrumentation audit, bug 3 - "4 of 9
+                        # implement tasks have zero instrumentation"): this
+                        # spawn can carry MULTIPLE tasks in one agent
+                        # process (role-batched spawns / spawn_for_resume
+                        # with a multi-task batch). Only tagging tasks[0].id
+                        # meant every OTHER task in the batch got no
+                        # instrumentation directory at all - the runner's
+                        # singleton RunInstrumenter only ever knew about the
+                        # first task. Pass the FULL id list so the runner
+                        # can fan its JSONL writes out to every task's own
+                        # agents/<agent_id>/ directory, not just the first.
+                        all_task_ids = [t.id for t in tasks if getattr(t, "id", None)]
+                        if len(all_task_ids) > 1:
+                            attempt_mcp.setdefault("task_ids", all_task_ids)
+                        logger.info(
+                            "instrumentation task-id injection: adapter=%s primary_task_id=%s "
+                            "batch_size=%d all_task_ids=%s",
+                            adapter_name,
+                            tasks[0].id,
+                            len(tasks),
+                            all_task_ids,
+                        )
 
                     # Inline per-role council block
                     # (``role_model_policy.<role>.council``, parsed and

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -92,16 +92,29 @@ def read_tokens_sidecar_totals(sidecar_path: Path) -> tuple[int, int]:
         return 0, 0
     total_in = 0
     total_out = 0
-    for line in raw.splitlines():
+    for line_num, line in enumerate(raw.splitlines(), 1):
         line = line.strip()
         if not line:
             continue
         try:
             rec = json.loads(line)
-        except ValueError:
+            total_in += int(rec.get("in", 0) or 0)
+            total_out += int(rec.get("out", 0) or 0)
+        except (ValueError, TypeError, AttributeError) as exc:
+            # Widened beyond json.loads(): this file is RE-READ IN FULL every
+            # orchestrator tick, so a well-formed-but-wrong-shape record (not
+            # a dict, or "in"/"out" not coercible to int) that raises on the
+            # SUBSEQUENT .get()/int() calls would otherwise poison every
+            # subsequent tick's cost read for the whole session, not just one
+            # call. Skip the bad record and keep summing the rest.
+            logger.debug(
+                "Skipping malformed .tokens sidecar record at %s:%d: %s - line=%s",
+                sidecar_path,
+                line_num,
+                exc,
+                line[:500],
+            )
             continue
-        total_in += int(rec.get("in", 0) or 0)
-        total_out += int(rec.get("out", 0) or 0)
     return total_in, total_out
 
 

--- a/src/bernstein/core/instrumentation.py
+++ b/src/bernstein/core/instrumentation.py
@@ -43,7 +43,7 @@ import json
 import logging
 import re
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -64,6 +64,15 @@ RUN_ID_ENV_VAR = "BERNSTEIN_RUN_ID"
 # wanted here, never full payloads (see module docstring + task spec).
 _ARG_VALUE_TRUNCATE_CHARS = 500
 _TRUNCATE_MARKER = "...[truncated]"
+
+# Truncation cap for captured conversation message content. Deliberately much
+# larger than _ARG_VALUE_TRUNCATE_CHARS: the whole point of recording content
+# (see RunInstrumenter.log_message) is that reviewing a run's prompts and
+# responses is possible without re-running the agent, so a 500-char preview
+# would defeat the purpose. Still bounded so a single enormous prompt cannot
+# bloat conversation.jsonl without limit. content_length always records the
+# TRUE pre-truncation length.
+_MESSAGE_CONTENT_TRUNCATE_CHARS = 20_000
 
 # Filesystem-safe shape for a single directory-name component. run_id arrives
 # via an environment variable and task_id/agent_id via the runner manifest,
@@ -148,10 +157,23 @@ class RunInstrumenter:
     task_id: str
     agent_id: str
     base_dir: Path
+    # Batched-task fan-out (instrumentation audit, bug 3): when one agent
+    # process works MULTIPLE Bernstein tasks (spawner_core role-batched
+    # spawns), only the first task's directory used to receive any
+    # instrumentation - every other task in the batch had zero coverage.
+    # ``extra_dirs`` carries the per-agent directory of every OTHER task in
+    # the batch; each JSONL append is mirrored to all of them so every task
+    # involved gets a full copy of this agent's records. Empty on
+    # single-task spawns (the common case) - behaviour is then byte-identical
+    # to the pre-fan-out implementation.
+    extra_dirs: list[Path] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self._lock = threading.Lock()
         self._dir_ready = False
+        # Extra dirs that were successfully created; a failure to create one
+        # fan-out dir only drops THAT dir (logged below), never the primary.
+        self._ready_extra_dirs: list[Path] = []
         try:
             self.base_dir.mkdir(parents=True, exist_ok=True)
             self._dir_ready = True
@@ -176,6 +198,20 @@ class RunInstrumenter:
                 sanitize_log(self.agent_id),
                 exc,
             )
+        for extra_dir in self.extra_dirs:
+            try:
+                extra_dir.mkdir(parents=True, exist_ok=True)
+                self._ready_extra_dirs.append(extra_dir)
+            except OSError as exc:
+                logger.warning(
+                    "RunInstrumenter: failed to create batched-task fan-out dir %s (run_id=%s "
+                    "agent_id=%s): %s - records will not be mirrored to this dir; the primary "
+                    "dir and other fan-out dirs are unaffected",
+                    extra_dir,
+                    sanitize_log(self.run_id),
+                    sanitize_log(self.agent_id),
+                    exc,
+                )
 
     # -- path helpers ---------------------------------------------------
 
@@ -216,6 +252,24 @@ class RunInstrumenter:
             logger.warning(
                 "RunInstrumenter: failed to write %s record %s=%s to %s: %s", kind, kind, sanitize_log(key), path, exc
             )
+        # Batched-task fan-out: mirror the same line into every other task's
+        # per-agent dir (see the ``extra_dirs`` field docstring). Per-dir
+        # failures are logged and skipped so one bad dir cannot break the
+        # primary write above (already committed) or the remaining mirrors.
+        for extra_dir in self._ready_extra_dirs:
+            mirror_path = extra_dir / path.name
+            try:
+                with self._lock, mirror_path.open("a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+            except OSError as exc:
+                logger.warning(
+                    "RunInstrumenter: failed to mirror %s record %s=%s to %s: %s",
+                    kind,
+                    kind,
+                    sanitize_log(key),
+                    mirror_path,
+                    exc,
+                )
 
     # -- public API -------------------------------------------------------
 
@@ -281,12 +335,17 @@ class RunInstrumenter:
         success: bool,
         error: str | None = None,
         wall_ms: float | None = None,
+        result: Any | None = None,
     ) -> None:
         """Append one record to ``tool-calls.jsonl`` for a single tool invocation.
 
         ``args`` is truncated (see :func:`_truncate_value`) before being
-        written - never the full tool result, only the call's own
-        arguments.
+        written. ``result`` (instrumentation audit, bug 2) carries what the
+        tool actually returned - previously only name/args/success were
+        recorded, making tool output impossible to review without re-running
+        the agent. It is stringified and truncated the same way ``args`` is,
+        so a huge return value (e.g. a full file body) is capped to a
+        preview, never stored whole.
         """
         try:
             if wall_ms is None:
@@ -300,6 +359,7 @@ class RunInstrumenter:
                 "args": _truncate_value(args or {}),
                 "success": success,
                 "error": error,
+                "result": _truncate_value(result) if result is not None else None,
             }
             self._append_line(self._tool_calls_path(), record, kind="tool_call", key=call_id)
         except Exception as exc:  # intentional-broad-except: instrumentation must never raise
@@ -313,11 +373,17 @@ class RunInstrumenter:
         content_length: int,
         tool_calls: list[str] | None = None,
         ts: str | None = None,
+        content: str | None = None,
     ) -> None:
         """Append one record to ``conversation.jsonl`` for a new message.
 
-        Only shape metadata is recorded - never message content - per the
-        task spec's privacy/size constraint.
+        ``content_length`` always records the TRUE length of the message.
+        ``content`` (instrumentation audit, bug 1) optionally carries the
+        message text itself, truncated to
+        :data:`_MESSAGE_CONTENT_TRUNCATE_CHARS` - shape-only records made it
+        impossible to review what an agent was actually told or said without
+        re-running it. ``None`` keeps the original shape-metadata-only
+        record for callers that must not persist content.
         """
         try:
             record: dict[str, Any] = {
@@ -326,6 +392,8 @@ class RunInstrumenter:
                 "content_length": content_length,
                 "ts": ts or _now_iso(),
             }
+            if content is not None:
+                record["content"] = _truncate_value(content, max_chars=_MESSAGE_CONTENT_TRUNCATE_CHARS)
             if tool_calls:
                 record["tool_calls"] = list(tool_calls)
             self._append_line(self._conversation_path(), record, kind="message", key=str(idx))
@@ -361,8 +429,10 @@ class _NullInstrumenter(RunInstrumenter):
         self.task_id = "uninitialized"
         self.agent_id = "uninitialized"
         self.base_dir = Path()
+        self.extra_dirs = []
         self._lock = threading.Lock()
         self._dir_ready = False
+        self._ready_extra_dirs = []
 
 
 _instrumenter_lock = threading.Lock()
@@ -395,16 +465,34 @@ def resolve_agent_dir(workdir: Path, run_id: str, task_id: str, agent_id: str) -
     )
 
 
-def init_instrumenter(*, run_id: str, task_id: str, agent_id: str, base_dir: Path) -> RunInstrumenter:
+def init_instrumenter(
+    *,
+    run_id: str,
+    task_id: str,
+    agent_id: str,
+    base_dir: Path,
+    extra_dirs: list[Path] | None = None,
+) -> RunInstrumenter:
     """Create and install the process-wide :class:`RunInstrumenter` singleton.
 
     Safe to call more than once (e.g. a test re-initializing between cases);
     each call replaces the previous singleton. Never raises - construction
     failures are caught inside :meth:`RunInstrumenter.__post_init__` and
     degrade to a disabled-but-non-crashing instance.
+
+    ``extra_dirs`` (batched-task fan-out - see the
+    :class:`RunInstrumenter` ``extra_dirs`` field docstring) lists the
+    per-agent directories of every OTHER task a batched agent process is
+    working; each JSONL append is mirrored to all of them.
     """
     global _instrumenter
-    instrumenter = RunInstrumenter(run_id=run_id, task_id=task_id, agent_id=agent_id, base_dir=base_dir)
+    instrumenter = RunInstrumenter(
+        run_id=run_id,
+        task_id=task_id,
+        agent_id=agent_id,
+        base_dir=base_dir,
+        extra_dirs=list(extra_dirs or []),
+    )
     with _instrumenter_lock:
         _instrumenter = instrumenter
     return instrumenter

--- a/src/bernstein/core/quality/retrospective.py
+++ b/src/bernstein/core/quality/retrospective.py
@@ -78,7 +78,21 @@ def _read_persisted_task_costs(runtime_dir: Path) -> dict[str, float]:
                     continue
                 try:
                     record = json.loads(line)
-                except json.JSONDecodeError as exc:
+                    task_id = record.get("task_id")
+                    if not task_id:
+                        continue
+                    cost_usd = record.get("cost_usd")
+                    if cost_usd is None:
+                        continue
+                    costs[task_id] = float(cost_usd)  # last write wins (final retry outcome)
+                except (json.JSONDecodeError, ValueError, TypeError, AttributeError) as exc:
+                    # Widened beyond json.JSONDecodeError: a well-formed-but-
+                    # wrong-shape record (not a dict, or cost_usd not
+                    # coercible to float) raises on the SUBSEQUENT
+                    # .get()/float() calls, not on json.loads() itself. This
+                    # feeds the final run retrospective, so skip the bad
+                    # record and log the exact exception rather than
+                    # aborting the whole durable cross-check.
                     logger.warning(
                         "cost_aggregation: skipping malformed line %d in %s: %s",
                         line_no,
@@ -86,13 +100,6 @@ def _read_persisted_task_costs(runtime_dir: Path) -> dict[str, float]:
                         exc,
                     )
                     continue
-                task_id = record.get("task_id")
-                if not task_id:
-                    continue
-                cost_usd = record.get("cost_usd")
-                if cost_usd is None:
-                    continue
-                costs[task_id] = float(cost_usd)  # last write wins (final retry outcome)
     except OSError as exc:
         logger.warning("cost_aggregation: failed to read %s: %s", metrics_path, exc)
         return {}

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -157,7 +157,9 @@ class TaskCreate(BaseModel):
     # When set, callers get exact control over how many turns a Claude agent spawn
     # gets, bypassing scope/complexity math entirely (see claude_max_turns.py).
     # Bounded because the value reaches the CLI --max-turns flag verbatim: 0 or a
-    # negative would break the spawn, and an unbounded value defeats turn budgeting.
+    # negative would break the spawn (ge=1 also gives a clean 422 instead of a
+    # confusing CLI-level failure downstream), and an unbounded value defeats
+    # turn budgeting.
     max_turns: int | None = Field(default=None, ge=1, le=10_000)
 
     @field_validator("scope", "complexity", "task_type")

--- a/tests/unit/test_adapter_claude.py
+++ b/tests/unit/test_adapter_claude.py
@@ -141,6 +141,33 @@ class TestSpawnCommandArgs:
         )
         assert cmd[cmd.index("--max-turns") + 1] == expected_turns
 
+    def test_explicit_max_turns_used_verbatim(self, tmp_path: Path) -> None:
+        """A positive explicit_max_turns bypasses scope/effort math and is used as-is."""
+        adapter = ClaudeCodeAdapter()
+        cmd = adapter._build_command(
+            ModelConfig(model="sonnet", effort="high"),
+            None,
+            "do something",
+            explicit_max_turns=7,
+        )
+        assert cmd[cmd.index("--max-turns") + 1] == "7"
+
+    @pytest.mark.parametrize("bad_value", [0, -1, -100])
+    def test_explicit_max_turns_non_positive_rejected(self, tmp_path: Path, bad_value: int) -> None:
+        """0/negative explicit_max_turns must not reach the Claude CLI as --max-turns.
+
+        Without this guard, a caller-supplied 0 or negative value sailed
+        through verbatim to the CLI flag instead of failing fast.
+        """
+        adapter = ClaudeCodeAdapter()
+        with pytest.raises(ValueError, match="positive integer"):
+            adapter._build_command(
+                ModelConfig(model="sonnet", effort="high"),
+                None,
+                "do something",
+                explicit_max_turns=bad_value,
+            )
+
     def test_fixed_flags_always_present(self, tmp_path: Path) -> None:
         cmd, _, __ = self._spawn(tmp_path)
         assert "--permission-mode" in cmd

--- a/tests/unit/test_claude_max_turns.py
+++ b/tests/unit/test_claude_max_turns.py
@@ -54,6 +54,25 @@ class TestComputeMaxTurns:
         cfg = compute_max_turns(complexity="medium", model="sonnet")
         assert len(cfg.reasoning) > 0
 
+    def test_explicit_max_turns_clamped_to_cap(self) -> None:
+        """An absurdly-large explicit override cannot defeat max_turns_cap.
+
+        min_turns/max_turns_cap are documented as "absolute" bounds; the
+        explicit-override path used to bypass them entirely.
+        """
+        cfg = compute_max_turns(explicit_max_turns=100_000, max_turns_cap=200, min_turns=5)
+        assert cfg.max_turns == 200
+
+    def test_explicit_max_turns_clamped_to_min(self) -> None:
+        """A too-small explicit override is raised up to min_turns, not left as-is."""
+        cfg = compute_max_turns(explicit_max_turns=1, max_turns_cap=200, min_turns=5)
+        assert cfg.max_turns == 5
+
+    def test_explicit_max_turns_within_bounds_passes_through(self) -> None:
+        """An explicit value already inside [min_turns, max_turns_cap] is untouched."""
+        cfg = compute_max_turns(explicit_max_turns=50, max_turns_cap=200, min_turns=5)
+        assert cfg.max_turns == 50
+
 
 class TestMaxTurnsConfig:
     def test_to_dict(self) -> None:

--- a/tests/unit/test_instrumentation_capture.py
+++ b/tests/unit/test_instrumentation_capture.py
@@ -1,0 +1,131 @@
+"""Unit tests for RunInstrumenter content/result capture and batched-task fan-out.
+
+Covers the instrumentation-module half of the batched-task instrumentation
+fix: the runner (``openai_agents_runner.run``) passes ``extra_dirs`` to
+``init_instrumenter`` and ``content``/``result`` to ``log_message``/
+``log_tool_call``; these tests pin the module-side contract those calls
+depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.instrumentation import (
+    _MESSAGE_CONTENT_TRUNCATE_CHARS,
+    RunInstrumenter,
+    init_instrumenter,
+)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class TestLogMessageContent:
+    def test_content_recorded(self, tmp_path: Path) -> None:
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        inst.log_message(idx=0, role="user", content_length=5, content="hello")
+        records = _read_jsonl(tmp_path / "agent" / "conversation.jsonl")
+        assert records[0]["content"] == "hello"
+        assert records[0]["content_length"] == 5
+
+    def test_content_none_keeps_shape_only_record(self, tmp_path: Path) -> None:
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        inst.log_message(idx=0, role="user", content_length=5)
+        records = _read_jsonl(tmp_path / "agent" / "conversation.jsonl")
+        assert "content" not in records[0]
+
+    def test_content_truncated_but_length_true(self, tmp_path: Path) -> None:
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        huge = "x" * (_MESSAGE_CONTENT_TRUNCATE_CHARS + 100)
+        inst.log_message(idx=0, role="assistant", content_length=len(huge), content=huge)
+        records = _read_jsonl(tmp_path / "agent" / "conversation.jsonl")
+        content = records[0]["content"]
+        assert isinstance(content, str)
+        assert len(content) < len(huge)
+        assert content.endswith("...[truncated]")
+        assert records[0]["content_length"] == len(huge)
+
+
+class TestLogToolCallResult:
+    def test_result_recorded(self, tmp_path: Path) -> None:
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        inst.log_tool_call(
+            call_id="c1",
+            ts_start="2026-01-01T00:00:00+00:00",
+            ts_end="2026-01-01T00:00:01+00:00",
+            tool="read_file",
+            success=True,
+            result={"bytes": 42, "body": "abc"},
+        )
+        records = _read_jsonl(tmp_path / "agent" / "tool-calls.jsonl")
+        assert records[0]["result"] == {"bytes": 42, "body": "abc"}
+
+    def test_result_none_serialized_as_null(self, tmp_path: Path) -> None:
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        inst.log_tool_call(
+            call_id="c1",
+            ts_start="2026-01-01T00:00:00+00:00",
+            ts_end="2026-01-01T00:00:01+00:00",
+            tool="read_file",
+            success=False,
+            error="Boom: failed",
+        )
+        records = _read_jsonl(tmp_path / "agent" / "tool-calls.jsonl")
+        assert records[0]["result"] is None
+
+    def test_huge_string_result_truncated(self, tmp_path: Path) -> None:
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        inst.log_tool_call(
+            call_id="c1",
+            ts_start="2026-01-01T00:00:00+00:00",
+            ts_end="2026-01-01T00:00:01+00:00",
+            tool="read_file",
+            success=True,
+            result="y" * 10_000,
+        )
+        records = _read_jsonl(tmp_path / "agent" / "tool-calls.jsonl")
+        result = records[0]["result"]
+        assert isinstance(result, str)
+        assert len(result) < 10_000
+        assert result.endswith("...[truncated]")
+
+
+class TestExtraDirsFanOut:
+    def test_writes_mirrored_to_every_extra_dir(self, tmp_path: Path) -> None:
+        base = tmp_path / "t1" / "agents" / "a1"
+        extra_a = tmp_path / "t2" / "agents" / "a1"
+        extra_b = tmp_path / "t3" / "agents" / "a1"
+        inst = init_instrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=base, extra_dirs=[extra_a, extra_b])
+        inst.log_message(idx=0, role="user", content_length=2, content="hi")
+        inst.log_tool_call(
+            call_id="c1",
+            ts_start="2026-01-01T00:00:00+00:00",
+            ts_end="2026-01-01T00:00:01+00:00",
+            tool="ls",
+            success=True,
+            result="ok",
+        )
+        for root in (base, extra_a, extra_b):
+            conv = _read_jsonl(root / "conversation.jsonl")
+            assert conv[0]["content"] == "hi"
+            tools = _read_jsonl(root / "tool-calls.jsonl")
+            assert tools[0]["result"] == "ok"
+
+    def test_no_extra_dirs_matches_prior_behaviour(self, tmp_path: Path) -> None:
+        inst = init_instrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=tmp_path / "agent")
+        inst.log_message(idx=0, role="user", content_length=2, content="hi")
+        assert (tmp_path / "agent" / "conversation.jsonl").exists()
+
+    def test_unwritable_extra_dir_does_not_break_primary(self, tmp_path: Path) -> None:
+        base = tmp_path / "t1" / "agents" / "a1"
+        # A regular FILE at the extra-dir path makes mkdir raise OSError.
+        blocked = tmp_path / "blocked"
+        blocked.write_text("not a dir", encoding="utf-8")
+        inst = RunInstrumenter(run_id="r1", task_id="t1", agent_id="a1", base_dir=base, extra_dirs=[blocked])
+        inst.log_message(idx=0, role="user", content_length=2, content="hi")
+        records = _read_jsonl(base / "conversation.jsonl")
+        assert records[0]["content"] == "hi"
+        assert blocked.read_text(encoding="utf-8") == "not a dir"

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -159,6 +159,34 @@ def test_task_create_meta_messages_list_capped() -> None:
         TaskCreate(title="ok", description="ok", meta_messages=["ok"] * 101)
 
 
+def test_task_create_max_turns_zero_rejected() -> None:
+    """max_turns=0 is rejected by pydantic Field(ge=1) with a clean 422-shaped error.
+
+    Without the ge=1 constraint, 0/negative values sailed through to a
+    confusing CLI-level failure downstream (an invalid --max-turns flag).
+    """
+    with pytest.raises(ValidationError):
+        TaskCreate(title="ok", description="ok", max_turns=0)
+
+
+def test_task_create_max_turns_negative_rejected() -> None:
+    """max_turns=-1 is rejected by pydantic Field(ge=1)."""
+    with pytest.raises(ValidationError):
+        TaskCreate(title="ok", description="ok", max_turns=-1)
+
+
+def test_task_create_max_turns_positive_accepted() -> None:
+    """A positive max_turns still round-trips normally."""
+    t = TaskCreate(title="ok", description="ok", max_turns=25)
+    assert t.max_turns == 25
+
+
+def test_task_create_max_turns_none_accepted() -> None:
+    """max_turns is optional - None (the default) is still accepted."""
+    t = TaskCreate(title="ok", description="ok")
+    assert t.max_turns is None
+
+
 def test_task_create_happy_path_still_works() -> None:
     """Normal-sized input still parses successfully."""
     t = TaskCreate(


### PR DESCRIPTION
## Summary
Three related fixes improving observability and input validation:

1. **Conversation capture** (`openai_agents.py`, `openai_agents_runner.py`, `spawner_core.py`): capture conversation content, tool results, and batch task instrumentation — fixes gap where 4 of 9 implement tasks had zero instrumentation data

2. **JSONL parser resilience** (`agent_lifecycle.py`, `cost.py`, `retrospective.py`): widen sidecar JSONL parsers to catch field-access errors alongside JSON decode errors, fix worktree-layout liveness probe path

3. **max_turns validation** (`claude.py`, `claude_max_turns.py`, `server_models.py`): validate and clamp max_turns across API, adapter, and resolution layers — prevents unchecked values from reaching the runner

## Test plan
- [ ] `test_agent_lifecycle.py` — all tests pass
- [ ] `test_claude_max_turns.py` — all tests pass
- [ ] 238 targeted tests, zero regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved batched-task instrumentation fan-out so JSONL logs are written for all tasks, with enhanced message and tool-result details.
* **Bug Fixes**
  * Added validation to reject non-positive explicit max-turn overrides and clamp explicit values within documented bounds.
  * Fixed worktree and runner log discovery across non-legacy layouts to improve liveness checks.
  * Hardened token/cost and persisted task parsing to skip malformed records instead of failing.
* **Tests**
  * Expanded unit coverage for max-turns validation/clamping and instrumentation fan-out/content/result capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->