### PR TITLE
Three-arm profile A/B harness: cost plus quality in one chain-anchored comparison artifact

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -230,6 +230,7 @@ alwaysApply: false
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_comparison.py`        | Three-arm profile A/B comparison artifact (issue #2247) |
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |

--- a/.goosehints
+++ b/.goosehints
@@ -231,6 +231,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_comparison.py`        | Three-arm profile A/B comparison artifact (issue #2247) |
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_comparison.py`        | Three-arm profile A/B comparison artifact (issue #2247) |
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_comparison.py`        | Three-arm profile A/B comparison artifact (issue #2247) |
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -231,6 +231,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_comparison.py`        | Three-arm profile A/B comparison artifact (issue #2247) |
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |

--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -1026,7 +1026,41 @@ def cost_cmd(
 # ---------------------------------------------------------------------------
 
 
-def _render_profile_report_human(cons: Console, content: dict[str, Any], sha256: str, artifact: Path) -> None:
+def _profile_comparison_evidence(
+    eval_ab_dir: Path,
+    comparisons: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Link each cross-profile claim to the latest comparison artifact.
+
+    For every (profile_a, profile_b) pair in the report's comparisons,
+    look up the newest ``eval ab`` comparison artifact for that pair in
+    the pair index. Pairs without recorded evidence are omitted; the
+    link is presentation metadata and never enters the report's hashed
+    payload.
+    """
+    from bernstein.eval.ab_comparison import latest_comparison_for_pair
+
+    evidence: dict[str, dict[str, Any]] = {}
+    for comp in comparisons:
+        pair_key = f"{comp['profile_a']} vs {comp['profile_b']}"
+        if pair_key in evidence:
+            continue
+        found = latest_comparison_for_pair(eval_ab_dir, str(comp["profile_a"]), str(comp["profile_b"]))
+        if found is not None:
+            evidence[pair_key] = {
+                "artifact_name": str(found.get("artifact_name", "")),
+                "artifact_sha256": str(found.get("artifact_sha256", "")),
+            }
+    return evidence
+
+
+def _render_profile_report_human(
+    cons: Console,
+    content: dict[str, Any],
+    sha256: str,
+    artifact: Path,
+    evidence: dict[str, dict[str, Any]] | None = None,
+) -> None:
     """Render the profile report as a table plus its verification anchors."""
     from rich.table import Table
 
@@ -1068,6 +1102,9 @@ def _render_profile_report_human(cons: Console, content: dict[str, Any], sha256:
                 f"  {comp['profile_a']} vs {comp['profile_b']} ({comp['role']}/{comp['model']}): "
                 f"${comp['mean_cost_usd_per_task_a']:.4f} vs ${comp['mean_cost_usd_per_task_b']:.4f} per task"
             )
+            linked = (evidence or {}).get(f"{comp['profile_a']} vs {comp['profile_b']}")
+            if linked:
+                cons.print(f"    [dim]eval evidence: {linked['artifact_name']}[/dim]")
     else:
         cons.print(
             f"\n  [dim]insufficient comparable runs (need >= {content['min_comparable_tasks']} "
@@ -1121,6 +1158,14 @@ def _render_profile_report_human(cons: Console, content: dict[str, Any], sha256:
     show_default=True,
     help="Directory the content-addressed report artifact is written to.",
 )
+@click.option(
+    "--eval-ab-dir",
+    "eval_ab_dir",
+    type=str,
+    default=".sdd/reports/eval_ab",
+    show_default=True,
+    help="Directory holding eval ab comparison artifacts; cross-profile claims link the latest one per pair.",
+)
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 def cost_profile_report_cmd(
     last: str | None,
@@ -1129,6 +1174,7 @@ def cost_profile_report_cmd(
     transitions_path: str,
     audit_dir: str,
     reports_dir: str,
+    eval_ab_dir: str,
     as_json: bool,
 ) -> None:
     """Emit a content-addressed per-profile cost report (issue #2245).
@@ -1184,17 +1230,23 @@ def cost_profile_report_cmd(
             console.print(f"[red]Audit chain append failed:[/red] {exc}")
         raise SystemExit(1) from exc
 
+    # Evidence links live outside ``content`` so the report's hashed
+    # payload (and its byte-identical recomputability) is untouched.
+    comparisons = cast("list[dict[str, Any]]", report.content["comparisons"])
+    evidence = _profile_comparison_evidence(Path(eval_ab_dir), comparisons)
+
     if as_json or is_json():
         print_json(
             {
                 "artifact": str(artifact),
                 "sha256": report.sha256,
                 "content": report.content,
+                "comparison_evidence": evidence,
             }
         )
         return
 
-    _render_profile_report_human(console, report.content, report.sha256, artifact)
+    _render_profile_report_human(console, report.content, report.sha256, artifact, evidence)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -1168,24 +1168,104 @@ def eval_generate_scenarios(from_traces: int, out_dir: str | None, seed: int) ->
 @click.option(
     "--variant-a",
     "variant_a_path",
-    required=True,
     type=click.Path(exists=True, dir_okay=False),
+    default=None,
     help="YAML file with the A variant (keys: name, prompt, [model], [metadata]).",
 )
 @click.option(
     "--variant-b",
     "variant_b_path",
-    required=True,
     type=click.Path(exists=True, dir_okay=False),
+    default=None,
     help="YAML file with the B variant.",
 )
 @click.option(
     "--tasks",
     "tasks_path",
-    required=True,
     type=click.Path(exists=True, dir_okay=False),
+    default=None,
     help="YAML file with a top-level 'tasks: [...]' list.",
 )
+@click.option(
+    "--suite",
+    "suite_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Suite YAML ('tasks: [...]') for the profile-arm mode.",
+)
+@click.option(
+    "--arm-a",
+    "arm_a",
+    default=None,
+    help="Response profile for arm A (three-arm mode: 'baseline' or 'balanced').",
+)
+@click.option(
+    "--arm-b",
+    "arm_b",
+    default=None,
+    help="Response profile for arm B (the candidate in three-arm mode).",
+)
+@click.option(
+    "--arms",
+    "arm_count",
+    type=click.IntRange(2, 3),
+    default=2,
+    show_default=True,
+    help="2 compares the named profiles; 3 adds the unset baseline and the built-in minimal-control arm.",
+)
+@click.option(
+    "--trials",
+    "trials",
+    type=click.IntRange(min=1),
+    default=1,
+    show_default=True,
+    help="Trials per (arm, task) pair.",
+)
+@click.option(
+    "--executor",
+    "executor_name",
+    type=click.Choice(["synthetic", "spawn"]),
+    default="synthetic",
+    show_default=True,
+    help="'synthetic' is deterministic and offline; 'spawn' runs each arm as a real task in an isolated worktree.",
+)
+@click.option("--model", "model", default=None, help="Model pin for spawned arms and model label in the artifact.")
+@click.option("--role", "role", default="backend", show_default=True, help="Agent role for spawned arms.")
+@click.option(
+    "--timeout",
+    "timeout_seconds",
+    type=int,
+    default=1800,
+    show_default=True,
+    help="Max seconds to wait per spawned task.",
+)
+@click.option(
+    "--ledger",
+    "ledger_path",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help=(
+        "Spend ledger the runs are joined against "
+        "(defaults: synthetic -> .sdd/eval/ab/ledger.jsonl, spawn -> .sdd/cost/ledger.jsonl)."
+    ),
+)
+@click.option(
+    "--reports-dir",
+    "reports_dir",
+    type=click.Path(file_okay=False),
+    default=".sdd/reports/eval_ab",
+    show_default=True,
+    help="Directory the content-addressed comparison artifact is written to.",
+)
+@click.option(
+    "--audit-dir",
+    "audit_dir",
+    type=click.Path(file_okay=False),
+    default=".sdd/audit",
+    show_default=True,
+    help="Audit chain directory the comparison event is appended to.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON (suite mode).")
 @click.option(
     "--output",
     "output_path",
@@ -1198,25 +1278,76 @@ def eval_generate_scenarios(from_traces: int, out_dir: str | None, seed: int) ->
     type=click.Choice(["exact", "none"]),
     default="exact",
     show_default=True,
-    help="Built-in scorer to apply (synthetic-friendly).",
+    help="Built-in scorer for the variant mode (synthetic-friendly).",
 )
 def eval_ab(
-    variant_a_path: str,
-    variant_b_path: str,
-    tasks_path: str,
+    variant_a_path: str | None,
+    variant_b_path: str | None,
+    tasks_path: str | None,
+    suite_path: str | None,
+    arm_a: str | None,
+    arm_b: str | None,
+    arm_count: int,
+    trials: int,
+    executor_name: str,
+    model: str | None,
+    role: str,
+    timeout_seconds: int,
+    ledger_path: str | None,
+    reports_dir: str,
+    audit_dir: str,
+    as_json: bool,
     output_path: str | None,
     scorer: str,
 ) -> None:
-    """Run two prompt variants over a task set; emit a comparison JSON.
+    """Run an A/B comparison; emit a deterministic comparison JSON.
 
-    Synthetic-only slice: uses the deterministic ``echo_executor``
-    so this command runs offline with zero LLM cost. Real executors plug
-    in via the Python API (``bernstein.eval.ab_runner.run_ab``).
+    Two modes:
+
+    Variant mode (--variant-a/--variant-b/--tasks) compares two prompt
+    variants with the deterministic ``echo_executor`` - offline, zero
+    LLM cost.
+
+    Suite mode (--suite/--arm-a/--arm-b) runs the suite under two
+    response profiles and emits one chain-anchored artifact carrying
+    both the cost delta (ledger-referenced) and the quality delta.
+    With ``--arms 3`` the candidate is measured against a minimal
+    built-in control arm (the honest delta) as well as the unset
+    baseline (shown, labelled conflated).
 
     \b
       bernstein eval ab --variant-a a.yaml --variant-b b.yaml --tasks tasks.yaml
-      bernstein eval ab --variant-a a.yaml --variant-b b.yaml --tasks t.yaml --output report.json
+      bernstein eval ab --suite suite.yaml --arm-a balanced --arm-b terse --json
+      bernstein eval ab --suite suite.yaml --arm-a baseline --arm-b terse --arms 3 --trials 3
+      bernstein eval ab --suite suite.yaml --arm-a balanced --arm-b terse --executor spawn
     """
+    suite_mode = suite_path is not None or arm_a is not None or arm_b is not None
+    if suite_mode:
+        if not (suite_path and arm_a and arm_b):
+            raise click.UsageError("suite mode requires --suite, --arm-a, and --arm-b together")
+        _run_profile_ab_command(
+            suite_path=suite_path,
+            arm_a=arm_a,
+            arm_b=arm_b,
+            arm_count=arm_count,
+            trials=trials,
+            executor_name=executor_name,
+            model=model,
+            role=role,
+            timeout_seconds=timeout_seconds,
+            ledger_path=ledger_path,
+            reports_dir=reports_dir,
+            audit_dir=audit_dir,
+            as_json=as_json,
+            output_path=output_path,
+        )
+        return
+
+    if not (variant_a_path and variant_b_path and tasks_path):
+        raise click.UsageError(
+            "provide --variant-a/--variant-b/--tasks (variant mode) or --suite/--arm-a/--arm-b (suite mode)"
+        )
+
     from bernstein.eval.ab_runner import (
         echo_executor,
         exact_match_scorer,
@@ -1245,6 +1376,172 @@ def eval_ab(
         console.print(f"[green]wrote[/green] {output_path}  winner={comparison.winner}")
     else:
         click.echo(payload)
+
+
+def _run_profile_ab_command(
+    *,
+    suite_path: str,
+    arm_a: str,
+    arm_b: str,
+    arm_count: int,
+    trials: int,
+    executor_name: str,
+    model: str | None,
+    role: str,
+    timeout_seconds: int,
+    ledger_path: str | None,
+    reports_dir: str,
+    audit_dir: str,
+    as_json: bool,
+    output_path: str | None,
+) -> None:
+    """Run the suite under the arm plan and emit the comparison artifact.
+
+    The artifact is content-addressed canonical JSON, written under
+    *reports_dir*, appended to the audit chain, and registered in the
+    pair index that ``bernstein cost profile-report`` links from.
+    """
+    import json as _json
+
+    from bernstein import __version__
+    from bernstein.core.security.audit_chain import AuditChainStore, record_eval_ab_comparison
+    from bernstein.eval.ab_comparison import (
+        append_comparison_index,
+        build_arms,
+        build_comparison_artifact,
+        run_arms,
+        spawn_arm_executor,
+        suite_file_sha256,
+        synthetic_arm_executor,
+        write_comparison_artifact,
+    )
+    from bernstein.eval.ab_runner import load_tasks_yaml
+
+    suite = Path(suite_path)
+    tasks = load_tasks_yaml(suite)
+    if not tasks:
+        console.print("[yellow]Suite has no tasks.[/yellow]")
+        raise SystemExit(1)
+
+    try:
+        plan = build_arms(arm_a, arm_b, arms=arm_count, workdir=Path())
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    if executor_name == "spawn":
+        from bernstein.cli.helpers import SERVER_URL
+
+        lpath = Path(ledger_path) if ledger_path else Path(".sdd/cost/ledger.jsonl")
+        executor = spawn_arm_executor(
+            SERVER_URL,
+            role=role,
+            model=model,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        from bernstein.core.cost.spend_ledger import SpendLedger
+
+        # Synthetic figures never land in the production spend ledger.
+        lpath = Path(ledger_path) if ledger_path else Path(".sdd/eval/ab/ledger.jsonl")
+        executor = synthetic_arm_executor(SpendLedger(path=lpath, run_id="eval-ab"))
+
+    rows = run_arms(plan, tasks, executor=executor, trials=trials)
+    artifact = build_comparison_artifact(
+        plan=plan,
+        rows=rows,
+        ledger_path=lpath,
+        suite_sha256=suite_file_sha256(suite),
+        suite_name=suite.name,
+        adapter_versions={"bernstein": __version__},
+        trials=trials,
+        model=model,
+    )
+    artifact_path = write_comparison_artifact(artifact, Path(reports_dir))
+
+    winner = artifact.content["winner"]
+    try:
+        chain = AuditChainStore(Path(audit_dir))
+        record_eval_ab_comparison(
+            chain=chain,
+            artifact_sha256=artifact.sha256,
+            suite_sha256=str(artifact.content["suite_sha256"]),
+            profile_a_sha256=str(artifact.content["profile_a_sha256"]),
+            profile_b_sha256=str(artifact.content["profile_b_sha256"]),
+            arm_count=len(artifact.content["arms"]),
+            row_count=len(artifact.content["per_task"]),
+            winner_arm=str(winner["arm"]),
+            artifact_name=artifact.artifact_name,
+        )
+    except Exception as exc:
+        # The artifact is only trustworthy once anchored; refuse to
+        # pretend otherwise.
+        if as_json:
+            click.echo(_json.dumps({"error": f"Audit chain append failed: {exc}", "artifact": str(artifact_path)}))
+        else:
+            console.print(f"[red]Audit chain append failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    append_comparison_index(Path(reports_dir), profile_pair=plan.profile_pair, artifact=artifact)
+
+    payload = _json.dumps(
+        {"artifact": str(artifact_path), "sha256": artifact.sha256, "content": artifact.content},
+        indent=2,
+        sort_keys=True,
+    )
+    if output_path:
+        Path(output_path).write_text(payload + "\n", encoding="utf-8")
+    if as_json:
+        click.echo(payload)
+        return
+
+    _render_profile_ab_human(artifact.content, artifact.sha256, artifact_path)
+
+
+def _render_profile_ab_human(content: dict[str, object], sha256: str, artifact_path: Path) -> None:
+    """Rich rendering of the suite-mode comparison artifact."""
+    from typing import cast
+
+    from rich.table import Table
+
+    aggregates = cast("dict[str, dict[str, object]]", content["aggregates"])
+    table = Table(title="Profile A/B comparison", header_style=_STYLE_BOLD_CYAN, show_lines=False)
+    table.add_column("Arm", min_width=12)
+    table.add_column("Profile", min_width=10)
+    table.add_column("Runs", justify="right")
+    table.add_column("Pass rate", justify="right")
+    table.add_column("Median tokens", justify="right")
+    table.add_column("Median USD", justify="right")
+
+    arms = cast("dict[str, dict[str, object]]", content["arms"])
+    for arm_name, agg in aggregates.items():
+        pass_rate = agg["pass_rate"]
+        median_tokens = agg["median_tokens"]
+        median_usd = agg["median_usd"]
+        table.add_row(
+            arm_name,
+            str(arms[arm_name]["profile"] or "(unset)"),
+            str(agg["runs"]),
+            f"{pass_rate:.1%}" if isinstance(pass_rate, (int, float)) else "not measured",
+            f"{median_tokens:.0f}" if isinstance(median_tokens, (int, float)) else "not measured",
+            f"${median_usd:.6f}" if isinstance(median_usd, (int, float)) else "not measured",
+        )
+    console.print(table)
+
+    deltas = cast("dict[str, dict[str, object]]", content["deltas"])
+    for name, delta in deltas.items():
+        label = "conflated" if delta["conflated"] else "honest"
+        console.print(
+            f"  {name} [{label}]: pass_rate {delta['pass_rate_delta']}  "
+            f"median_usd {delta['median_usd_delta']}  median_tokens {delta['median_tokens_delta']}"
+        )
+
+    winner = cast("dict[str, object]", content["winner"])
+    console.print(f"\n[bold]Winner:[/bold] {winner['arm']}  [dim]{winner['reason']}[/dim]")
+    if winner["missing"]:
+        console.print(f"  [yellow]missing:[/yellow] {', '.join(cast('list[str]', winner['missing']))}")
+    console.print(f"\n  Artifact sha256: {sha256}")
+    console.print(f"  Artifact:        {artifact_path}")
+    console.print("  [dim]Appended to the audit chain as eval.ab_comparison[/dim]")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -69,6 +69,14 @@ EVENT_COMPACTION_SENSITIVE_GATE = "compaction.sensitive_gate"
 #: check it against the chain.
 EVENT_COST_PROFILE_REPORT = "cost.profile_report"
 
+#: Issue #2247 -- emitted whenever ``bernstein eval ab`` writes a
+#: content-addressed profile comparison artifact. The event records the
+#: artifact's SHA-256 plus the suite and profile-addendum hashes that
+#: pin exactly what was compared, and the previous chain digest, so a
+#: verifier holding the suite and the spend ledger can recompute the
+#: artifact byte-identically and check it against the chain.
+EVENT_EVAL_AB_COMPARISON = "eval.ab_comparison"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -370,15 +378,96 @@ def record_cost_profile_report(
     )
 
 
+@dataclass(frozen=True)
+class EvalAbComparisonDetails:
+    """Structured payload for the ``eval.ab_comparison`` event."""
+
+    artifact_sha256: str
+    suite_sha256: str
+    profile_a_sha256: str
+    profile_b_sha256: str
+    arm_count: int
+    row_count: int
+    winner_arm: str
+    artifact_name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_sha256": self.artifact_sha256,
+            "suite_sha256": self.suite_sha256,
+            "profile_a_sha256": self.profile_a_sha256,
+            "profile_b_sha256": self.profile_b_sha256,
+            "arm_count": self.arm_count,
+            "row_count": self.row_count,
+            "winner_arm": self.winner_arm,
+            "artifact_name": self.artifact_name,
+        }
+
+
+def record_eval_ab_comparison(
+    *,
+    chain: AuditChainStore,
+    artifact_sha256: str,
+    suite_sha256: str,
+    profile_a_sha256: str,
+    profile_b_sha256: str,
+    arm_count: int,
+    row_count: int,
+    winner_arm: str,
+    artifact_name: str,
+    actor: str = "eval",
+) -> AuditEvent:
+    """Append an ``eval.ab_comparison`` event into *chain*.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        artifact_sha256: Hex digest of the artifact's canonical content.
+        suite_sha256: Hex digest of the eval suite file bytes.
+        profile_a_sha256: Addendum hash of the honest pair's A arm.
+        profile_b_sha256: Addendum hash of the honest pair's B arm.
+        arm_count: Number of arms in the comparison (2 or 3).
+        row_count: Number of per-task run rows in the artifact.
+        winner_arm: Declared winner arm name, ``tie``, or
+            ``incomparable``.
+        artifact_name: Content-addressed artifact filename.
+        actor: Recorded actor; defaults to ``"eval"`` (the CLI surface).
+
+    Returns:
+        The recorded :class:`AuditEvent`. The event details payload
+        carries every input plus ``prev_chain_digest`` (set to the
+        chain head at write time).
+    """
+    payload = EvalAbComparisonDetails(
+        artifact_sha256=artifact_sha256,
+        suite_sha256=suite_sha256,
+        profile_a_sha256=profile_a_sha256,
+        profile_b_sha256=profile_b_sha256,
+        arm_count=arm_count,
+        row_count=row_count,
+        winner_arm=winner_arm,
+        artifact_name=artifact_name,
+    ).to_dict()
+    return chain.log_with_prev_digest(
+        event_type=EVENT_EVAL_AB_COMPARISON,
+        actor=actor,
+        resource_type="eval_ab_comparison",
+        resource_id=artifact_sha256,
+        details=payload,
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_COMPACTION_SENSITIVE_GATE",
     "EVENT_COST_PROFILE_REPORT",
+    "EVENT_EVAL_AB_COMPARISON",
     "EVENT_MULTIMODAL_ATTACH",
     "AuditChainStore",
     "CostProfileReportDetails",
+    "EvalAbComparisonDetails",
     "MultimodalAttachDetails",
     "record_cost_profile_report",
+    "record_eval_ab_comparison",
     "record_multimodal_attach",
     "record_sensitive_gate",
 ]

--- a/src/bernstein/eval/ab_comparison.py
+++ b/src/bernstein/eval/ab_comparison.py
@@ -1,0 +1,754 @@
+"""Three-arm profile A/B comparison artifact (issue #2247).
+
+``bernstein eval ab --suite`` runs one eval suite under two response
+profiles and emits a single deterministic artifact carrying both the
+cost delta and the quality delta. Two disciplines keep the artifact
+honest:
+
+* **Minimal-control arm.** Comparing a profile against an unconstrained
+  baseline conflates the profile's content with the generic instruction
+  to be brief. The three-arm plan runs ``baseline`` (profile unset),
+  ``control`` (a minimal built-in terse addendum), and ``candidate``
+  (the named profile). The honest delta is candidate vs control;
+  candidate vs baseline is reported but labelled ``conflated``.
+* **Ledger-anchored cost.** Every cost figure is a sum over concrete
+  spend-ledger rows, referenced by the SHA-256 of their raw JSONL line
+  bytes. A verifier holding the ledger resolves each reference and
+  recomputes every aggregate; nothing is estimated.
+
+The artifact invariants mirror ``cost/profile_report.py``: canonical
+JSON (sorted keys, compact separators, ASCII escapes), no timestamps in
+the hashed payload, content-addressed on-disk envelope, and one audit
+chain event per emission (``eval.ab_comparison``). Aggregation uses
+medians. A winner is declared only when both cost and quality are
+measured for both honest arms; a run missing either emits
+``incomparable``, never a partial winner. What the harness does not
+measure is declared as structured fields (:data:`NOT_MEASURED`), not
+prose.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from statistics import median
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.agents.response_style import addendum_sha256, render_style_addendum
+from bernstein.core.cost.profile_report import canonical_json_bytes, read_ledger_window
+from bernstein.core.cost.spend_ledger import CallTags
+from bernstein.eval.ab_runner import (
+    VARIANT_ADDENDUM_KEY,
+    VARIANT_PROFILE_KEY,
+    Task,
+    Variant,
+    spawn_executor,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
+    from pathlib import Path
+
+    from bernstein.core.cost.spend_ledger import SpendLedger
+
+logger = logging.getLogger(__name__)
+
+#: Discriminator embedded in every artifact payload.
+ARTIFACT_KIND = "eval_ab_comparison"
+
+#: Payload schema version. Bump when the content shape changes; the hash
+#: covers the version so v1 and v2 artifacts never collide.
+ARTIFACT_VERSION = 1
+
+#: Reserved arm names in the three-arm plan.
+ARM_BASELINE = "baseline"
+ARM_CONTROL = "control"
+ARM_CANDIDATE = "candidate"
+
+#: Winner value emitted when cost or quality is missing on either honest
+#: arm. Never accompanied by a partial per-axis winner.
+INCOMPARABLE = "incomparable"
+
+#: The minimal-control addendum: the generic brevity instruction with
+#: none of a named profile's content. Constant by design - its SHA-256
+#: is pinned into every three-arm artifact, so two operators running the
+#: same bernstein version compare against the byte-identical control.
+CONTROL_ADDENDUM = "## Response style: control\n\nKeep responses brief. Prefer short answers over long explanations."
+
+#: Axes this harness deliberately does not measure, declared as stable
+#: identifiers inside the artifact (sorted; structured, not prose).
+NOT_MEASURED: tuple[str, ...] = (
+    "cross_model_generalization",
+    "fidelity_beyond_suite_verdicts",
+    "latency",
+)
+
+#: Verdict vocabulary for one run.
+VERDICT_PASS = "pass"
+VERDICT_FAIL = "fail"
+VERDICT_NOT_MEASURED = "not_measured"
+
+#: Pass-rate / median-score tolerance band for tie-calling (mirrors
+#: ``ab_runner.run_ab``).
+DEFAULT_TOLERANCE = 0.05
+
+#: Append-only pair index next to the artifacts, consumed by
+#: ``bernstein cost profile-report`` to link cross-profile claims to the
+#: latest comparison evidence.
+INDEX_FILENAME = "index.jsonl"
+
+#: USD figures are rounded to this many decimals everywhere in the
+#: artifact; a verifier recomputing from the ledger applies the same
+#: rounding.
+_USD_DECIMALS = 6
+
+#: Ratio figures (pass rates, scores) are rounded to this many decimals.
+_RATE_DECIMALS = 4
+
+
+# ---------------------------------------------------------------------------
+# Arms
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Arm:
+    """One comparison arm.
+
+    Attributes:
+        name: Arm label used in rows, aggregates, and winner fields.
+        profile: Named response profile the arm runs under; empty for
+            the ``baseline`` (profile unset) and ``control`` (built-in
+            addendum) arms.
+        addendum_sha256: SHA-256 of the exact addendum text the arm's
+            runs carry - this hash pins what was compared.
+    """
+
+    name: str
+    profile: str
+    addendum_sha256: str
+
+
+@dataclass(frozen=True)
+class ArmPlan:
+    """The resolved set of arms plus the pairs the artifact reports on.
+
+    Attributes:
+        arms: Arms in execution order.
+        honest_pair: ``(a, b)`` arm names of the like-for-like
+            comparison the winner is declared over.
+        conflated_pair: ``(a, b)`` arm names of the shown-but-conflated
+            comparison (three-arm plans only), else ``None``.
+        profile_pair: Sorted named-profile pair used by the pair index
+            (``baseline`` normalises to the unset-profile name).
+    """
+
+    arms: tuple[Arm, ...]
+    honest_pair: tuple[str, str]
+    conflated_pair: tuple[str, str] | None
+    profile_pair: tuple[str, str]
+
+
+#: Aliases accepted for the unset-profile baseline arm in three-arm mode.
+_BASELINE_ALIASES = frozenset({ARM_BASELINE, "balanced"})
+
+
+def build_arms(arm_a: str, arm_b: str, *, arms: int = 2, workdir: Path | None = None) -> ArmPlan:
+    """Resolve CLI arm profiles into an executable :class:`ArmPlan`.
+
+    Two-arm plans compare the named profiles directly; arm names are the
+    profile names. Three-arm plans pin arm A to the unset-profile
+    baseline (``baseline`` or ``balanced``), inject the built-in
+    minimal-control arm, and treat arm B as the candidate.
+
+    Args:
+        arm_a: Profile for arm A. In three-arm mode this must be
+            ``baseline`` or ``balanced`` (both mean "profile unset").
+        arm_b: Profile for arm B (the candidate in three-arm mode).
+        arms: 2 or 3.
+        workdir: Project root used to resolve profile templates.
+
+    Returns:
+        The resolved :class:`ArmPlan`.
+
+    Raises:
+        ValueError: On an unknown profile, an invalid arm count, two
+            identical two-arm profiles, a three-arm plan whose arm A is
+            not the unset baseline, or a three-arm candidate that
+            renders an empty addendum.
+    """
+    if arms == 2:
+        if arm_a == arm_b:
+            msg = f"arm profiles must differ; got {arm_a!r} twice"
+            raise ValueError(msg)
+        arm_objs = tuple(
+            Arm(
+                name=profile,
+                profile=profile,
+                addendum_sha256=addendum_sha256(render_style_addendum(profile, workdir=workdir)),
+            )
+            for profile in (arm_a, arm_b)
+        )
+        return ArmPlan(
+            arms=arm_objs,
+            honest_pair=(arm_a, arm_b),
+            conflated_pair=None,
+            profile_pair=_sorted_pair(arm_a, arm_b),
+        )
+
+    if arms == 3:
+        if arm_a not in _BASELINE_ALIASES:
+            msg = (
+                f"three-arm plans pin arm A to the unset-profile baseline; "
+                f"pass --arm-a baseline (or balanced), got {arm_a!r}"
+            )
+            raise ValueError(msg)
+        candidate_addendum = render_style_addendum(arm_b, workdir=workdir)
+        if not candidate_addendum:
+            msg = (
+                f"three-arm candidate profile {arm_b!r} renders an empty addendum "
+                "and would be indistinguishable from the baseline arm"
+            )
+            raise ValueError(msg)
+        arm_objs = (
+            Arm(name=ARM_BASELINE, profile="", addendum_sha256=addendum_sha256("")),
+            Arm(name=ARM_CONTROL, profile="", addendum_sha256=addendum_sha256(CONTROL_ADDENDUM)),
+            Arm(name=ARM_CANDIDATE, profile=arm_b, addendum_sha256=addendum_sha256(candidate_addendum)),
+        )
+        return ArmPlan(
+            arms=arm_objs,
+            honest_pair=(ARM_CONTROL, ARM_CANDIDATE),
+            conflated_pair=(ARM_BASELINE, ARM_CANDIDATE),
+            profile_pair=_sorted_pair("balanced", arm_b),
+        )
+
+    msg = f"arms must be 2 or 3, got {arms}"
+    raise ValueError(msg)
+
+
+def _sorted_pair(a: str, b: str) -> tuple[str, str]:
+    first, second = sorted((a, b))
+    return (first, second)
+
+
+# ---------------------------------------------------------------------------
+# Run rows and executors
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArmRunRow:
+    """One executed (arm, task, trial) run.
+
+    Attributes:
+        task_id: Suite task id.
+        arm: Arm name the run was executed under.
+        trial: Zero-based trial index.
+        verdict: ``pass`` / ``fail`` / ``not_measured``.
+        score: Normalised score in ``[0.0, 1.0]``.
+        ledger_task_id: Join key into the spend ledger (the ``task_id``
+            the run's LLM calls were recorded under).
+    """
+
+    task_id: str
+    arm: str
+    trial: int
+    verdict: str
+    score: float
+    ledger_task_id: str
+
+
+if TYPE_CHECKING:
+    ArmExecutor = Callable[[Arm, Task, int], ArmRunRow]
+    """Executes one (arm, task, trial) run and returns its row."""
+
+
+def run_arms(
+    plan: ArmPlan,
+    tasks: Iterable[Task],
+    *,
+    executor: ArmExecutor,
+    trials: int = 1,
+) -> tuple[ArmRunRow, ...]:
+    """Execute every (task, arm, trial) combination in deterministic order.
+
+    Args:
+        plan: The resolved arm plan.
+        tasks: Suite tasks, consumed once; execution follows input order.
+        executor: Callable producing one :class:`ArmRunRow` per run.
+        trials: Number of trials per (arm, task) pair.
+
+    Returns:
+        Rows in execution order: task-major, then arm, then trial.
+    """
+    rows: list[ArmRunRow] = []
+    for task in tasks:
+        for arm in plan.arms:
+            rows.extend(executor(arm, task, trial) for trial in range(trials))
+    return tuple(rows)
+
+
+def synthetic_arm_executor(ledger: SpendLedger, *, run_token: str | None = None) -> ArmExecutor:
+    """Return the zero-network executor backed by a real spend ledger.
+
+    Each run deterministically derives its output, token counts, and
+    cost from the SHA-256 of ``(arm addendum hash, task id, trial)`` and
+    records one genuine ledger row, so the full artifact flow - ledger
+    references included - runs in CI without a network or an adapter.
+    The output is ``"<arm name>::<task input>"``; the verdict is an
+    exact match against ``task.expected`` (``not_measured`` when the
+    suite provides no expectation).
+
+    Args:
+        ledger: Spend ledger the synthetic rows are recorded into. Point
+            this at a dedicated file (never the production ledger) - the
+            figures are synthetic.
+        run_token: Uniqueness token folded into every ledger task id so
+            repeated runs against the same ledger never alias. Defaults
+            to a fresh token per executor.
+
+    Returns:
+        An executor producing one :class:`ArmRunRow` per run.
+    """
+    token = run_token if run_token is not None else f"{time.time_ns():x}"
+
+    def _run(arm: Arm, task: Task, trial: int) -> ArmRunRow:
+        digest = hashlib.sha256(f"{arm.addendum_sha256}:{task.task_id}:{trial}".encode()).digest()
+        input_tokens = 200 + digest[0]
+        output_tokens = 100 + digest[1]
+        cost_usd = round((input_tokens * 3 + output_tokens * 15) / 1_000_000, 8)
+
+        ledger_task_id = f"eval-ab:{token}:{arm.name}:{task.task_id}:{trial}"
+        extra: dict[str, str] = {}
+        if arm.profile:
+            extra = {"response_profile": arm.profile, "profile_content_sha256": arm.addendum_sha256}
+        ledger.record(
+            tags=CallTags(
+                task_id=ledger_task_id,
+                agent_id=f"eval-ab-{arm.name}",
+                role="eval",
+                feature_label="eval_ab",
+                extra=extra,
+            ),
+            model="synthetic",
+            cost_usd=cost_usd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+
+        output = f"{arm.name}::{task.input}"
+        if task.expected is None:
+            verdict, score = VERDICT_NOT_MEASURED, 0.0
+        elif str(output) == str(task.expected):
+            verdict, score = VERDICT_PASS, 1.0
+        else:
+            verdict, score = VERDICT_FAIL, 0.0
+        return ArmRunRow(
+            task_id=task.task_id,
+            arm=arm.name,
+            trial=trial,
+            verdict=verdict,
+            score=score,
+            ledger_task_id=ledger_task_id,
+        )
+
+    return _run
+
+
+def spawn_arm_executor(
+    server_url: str,
+    *,
+    role: str = "backend",
+    scope: str = "small",
+    model: str | None = None,
+    timeout_seconds: int = 1800,
+    poll_interval_seconds: float = 5.0,
+    transport: Any = None,
+) -> ArmExecutor:
+    """Return the real executor: every run is a normally spawned task.
+
+    Wraps :func:`bernstein.eval.ab_runner.spawn_executor`, so each run
+    goes through the task server's spawn path in its own isolated
+    worktree. Named-profile arms are spawned with ``metadata['mode']``
+    set to the profile (the spawn path stamps ``response_profile`` into
+    the run's ledger rows); the control arm carries
+    :data:`CONTROL_ADDENDUM` appended to the task description; the
+    baseline arm is spawned untouched.
+
+    Args:
+        server_url: Base URL of the running task server.
+        role: Agent role assigned to every spawned task.
+        scope: Task scope for every spawned task.
+        model: Optional model pin applied to every arm.
+        timeout_seconds: Max seconds to wait for one task.
+        poll_interval_seconds: Seconds between status polls.
+        transport: Optional httpx transport override (tests only).
+
+    Returns:
+        An executor producing one :class:`ArmRunRow` per run; the row's
+        ``ledger_task_id`` is the server-assigned task id.
+    """
+    executor = spawn_executor(
+        server_url,
+        role=role,
+        scope=scope,
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        transport=transport,
+    )
+
+    def _run(arm: Arm, task: Task, trial: int) -> ArmRunRow:
+        metadata: dict[str, Any] = {}
+        if arm.profile:
+            metadata[VARIANT_PROFILE_KEY] = arm.profile
+        if arm.name == ARM_CONTROL:
+            metadata[VARIANT_ADDENDUM_KEY] = CONTROL_ADDENDUM
+        variant = Variant(name=arm.name, prompt="", model=model, metadata=metadata)
+        result = executor(variant, Task(task_id=f"{task.task_id}:{trial}", input=task.input, expected=task.expected))
+
+        status = str(result.output.get("status", "")) if isinstance(result.output, dict) else ""
+        measured_verdict = VERDICT_PASS if result.passed else VERDICT_FAIL
+        verdict = VERDICT_NOT_MEASURED if status == "timeout" else measured_verdict
+        return ArmRunRow(
+            task_id=task.task_id,
+            arm=arm.name,
+            trial=trial,
+            verdict=verdict,
+            score=result.score,
+            ledger_task_id=result.ledger_task_id,
+        )
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Artifact
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AbComparisonArtifact:
+    """A built comparison artifact: hashed content plus its address."""
+
+    content: dict[str, Any]
+    sha256: str
+
+    def artifact_bytes(self) -> bytes:
+        """Canonical bytes of the on-disk artifact envelope."""
+        return canonical_json_bytes({"artifact_sha256": self.sha256, "content": self.content})
+
+    @property
+    def artifact_name(self) -> str:
+        """Content-addressed filename of the artifact."""
+        return f"{self.sha256}.json"
+
+
+def suite_file_sha256(path: Path) -> str:
+    """SHA-256 hex digest of the suite file's raw bytes."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def build_comparison_artifact(
+    *,
+    plan: ArmPlan,
+    rows: Sequence[ArmRunRow],
+    ledger_path: Path,
+    suite_sha256: str,
+    suite_name: str,
+    adapter_versions: Mapping[str, str],
+    trials: int,
+    model: str | None = None,
+    tolerance: float = DEFAULT_TOLERANCE,
+) -> AbComparisonArtifact:
+    """Build the deterministic comparison artifact over recorded runs.
+
+    The content is a pure function of the recorded run set: the rows,
+    the ledger lines they reference, and the pinned suite / profile
+    hashes. Rebuilding over the same inputs re-serialises
+    byte-identically; no wall-clock context enters the hashed payload.
+
+    Args:
+        plan: The arm plan the rows were executed under.
+        rows: Recorded run rows, in execution order.
+        ledger_path: Spend ledger the runs recorded their calls into.
+        suite_sha256: SHA-256 of the suite file bytes.
+        suite_name: Suite file basename (informational).
+        adapter_versions: Adapter / harness versions recorded verbatim.
+        trials: Trials per (arm, task) pair.
+        model: Model label. ``None`` derives the label from the models
+            seen on the referenced ledger rows (sorted, comma-joined).
+        tolerance: Pass-rate / median-score tolerance band for the
+            winner decision.
+
+    Returns:
+        The built :class:`AbComparisonArtifact`.
+    """
+    entries, raw_lines = read_ledger_window(ledger_path)
+    by_ledger_task: dict[str, list[tuple[Any, str]]] = {}
+    for entry, line in zip(entries, raw_lines, strict=True):
+        line_sha = hashlib.sha256(line.encode("utf-8")).hexdigest()
+        by_ledger_task.setdefault(entry.task_id, []).append((entry, line_sha))
+
+    per_task: list[dict[str, Any]] = []
+    referenced_models: set[str] = set()
+    for row in rows:
+        matched = by_ledger_task.get(row.ledger_task_id, []) if row.ledger_task_id else []
+        refs = [sha for _entry, sha in matched]
+        tokens: int | None = None
+        usd: float | None = None
+        if matched:
+            tokens = sum(e.input_tokens + e.output_tokens for e, _sha in matched)
+            usd = round(sum(e.cost_usd for e, _sha in matched), _USD_DECIMALS)
+            referenced_models.update(e.model for e, _sha in matched if e.model)
+        per_task.append(
+            {
+                "task_id": row.task_id,
+                "arm": row.arm,
+                "trial": row.trial,
+                "tokens": tokens,
+                "usd": usd,
+                "verdict": row.verdict,
+                "ledger_ref": refs,
+            }
+        )
+
+    aggregates = {arm.name: _aggregate_arm(arm.name, per_task) for arm in plan.arms}
+    winner = _decide_winner(plan.honest_pair, aggregates, tolerance=tolerance)
+    deltas = _build_deltas(plan, aggregates)
+
+    model_label = model if model else ",".join(sorted(referenced_models)) or "unknown"
+    content: dict[str, Any] = {
+        "kind": ARTIFACT_KIND,
+        "version": ARTIFACT_VERSION,
+        "suite_sha256": suite_sha256,
+        "suite_name": suite_name,
+        "trials": trials,
+        "model": model_label,
+        "adapter_versions": dict(sorted(adapter_versions.items())),
+        "arms": {arm.name: {"profile": arm.profile, "addendum_sha256": arm.addendum_sha256} for arm in plan.arms},
+        "profile_a_sha256": _arm_sha(plan, plan.honest_pair[0]),
+        "profile_b_sha256": _arm_sha(plan, plan.honest_pair[1]),
+        "per_task": per_task,
+        "aggregates": aggregates,
+        "deltas": deltas,
+        "winner": winner,
+        "not_measured": list(NOT_MEASURED),
+    }
+    return AbComparisonArtifact(content=content, sha256=hashlib.sha256(canonical_json_bytes(content)).hexdigest())
+
+
+def _arm_sha(plan: ArmPlan, arm_name: str) -> str:
+    for arm in plan.arms:
+        if arm.name == arm_name:
+            return arm.addendum_sha256
+    return ""
+
+
+def _aggregate_arm(arm_name: str, per_task: list[dict[str, Any]]) -> dict[str, Any]:
+    """Median-based aggregates for one arm's rows.
+
+    ``cost_measured`` / ``quality_measured`` are strict: every row of
+    the arm must carry a ledger reference (cost) and a pass/fail verdict
+    (quality). Partial figures are still reported over the rows that
+    have data, but the strict flags are what gate the winner.
+    """
+    arm_rows = [r for r in per_task if r["arm"] == arm_name]
+    costed = [r for r in arm_rows if r["ledger_ref"]]
+    judged = [r for r in arm_rows if r["verdict"] in (VERDICT_PASS, VERDICT_FAIL)]
+
+    usd_values = [float(r["usd"]) for r in costed]
+    token_values = [int(r["tokens"]) for r in costed]
+    verdict_scores = [1.0 if r["verdict"] == VERDICT_PASS else 0.0 for r in judged]
+    return {
+        "runs": len(arm_rows),
+        "tasks": len({r["task_id"] for r in arm_rows}),
+        "cost_measured": bool(arm_rows) and len(costed) == len(arm_rows),
+        "quality_measured": bool(arm_rows) and len(judged) == len(arm_rows),
+        "pass_rate": round(sum(verdict_scores) / len(judged), _RATE_DECIMALS) if judged else None,
+        "median_score": round(median(verdict_scores), _RATE_DECIMALS) if judged else None,
+        "median_tokens": median(token_values) if token_values else None,
+        "median_usd": round(median(usd_values), _USD_DECIMALS) if usd_values else None,
+        "total_tokens": sum(token_values) if token_values else None,
+        "total_usd": round(sum(usd_values), _USD_DECIMALS) if usd_values else None,
+    }
+
+
+def _decide_winner(
+    honest_pair: tuple[str, str],
+    aggregates: Mapping[str, Mapping[str, Any]],
+    *,
+    tolerance: float,
+) -> dict[str, Any]:
+    """Winner over the honest pair; incomparable unless fully measured."""
+    arm_a, arm_b = honest_pair
+    agg_a, agg_b = aggregates[arm_a], aggregates[arm_b]
+
+    missing: list[str] = []
+    for name, agg in ((arm_a, agg_a), (arm_b, agg_b)):
+        if not agg["cost_measured"]:
+            missing.append(f"cost:{name}")
+        if not agg["quality_measured"]:
+            missing.append(f"quality:{name}")
+    if missing:
+        return {
+            "arm": INCOMPARABLE,
+            "pair": [arm_a, arm_b],
+            "missing": sorted(missing),
+            "reason": "winner requires cost and quality measured for both arms",
+        }
+
+    base = {"pair": [arm_a, arm_b], "missing": []}
+    pass_a, pass_b = float(agg_a["pass_rate"]), float(agg_b["pass_rate"])
+    if abs(pass_b - pass_a) > tolerance:
+        arm, hi, lo = (arm_b, pass_b, pass_a) if pass_b > pass_a else (arm_a, pass_a, pass_b)
+        return base | {"arm": arm, "reason": f"pass_rate {hi:.4f} beat {lo:.4f}"}
+
+    score_a, score_b = float(agg_a["median_score"]), float(agg_b["median_score"])
+    if abs(score_b - score_a) > tolerance:
+        arm, hi, lo = (arm_b, score_b, score_a) if score_b > score_a else (arm_a, score_a, score_b)
+        return base | {"arm": arm, "reason": f"median_score {hi:.4f} beat {lo:.4f}"}
+
+    usd_a, usd_b = float(agg_a["median_usd"]), float(agg_b["median_usd"])
+    if usd_a != usd_b:
+        arm, lo, hi = (arm_b, usd_b, usd_a) if usd_b < usd_a else (arm_a, usd_a, usd_b)
+        return base | {"arm": arm, "reason": f"quality within tolerance; median_usd {lo:.6f} beat {hi:.6f}"}
+
+    return base | {"arm": "tie", "reason": f"arms within {tolerance:.0%} tolerance and equal median_usd"}
+
+
+def _build_deltas(plan: ArmPlan, aggregates: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    """Per-pair deltas (b minus a); the conflated pair is labelled."""
+    pairs: list[tuple[tuple[str, str], bool]] = [(plan.honest_pair, False)]
+    if plan.conflated_pair is not None:
+        pairs.append((plan.conflated_pair, True))
+
+    deltas: dict[str, Any] = {}
+    for (arm_a, arm_b), conflated in pairs:
+        agg_a, agg_b = aggregates[arm_a], aggregates[arm_b]
+        deltas[f"{arm_b}_vs_{arm_a}"] = {
+            "pair": [arm_a, arm_b],
+            "conflated": conflated,
+            "pass_rate_delta": _delta(agg_a["pass_rate"], agg_b["pass_rate"], _RATE_DECIMALS),
+            "median_score_delta": _delta(agg_a["median_score"], agg_b["median_score"], _RATE_DECIMALS),
+            "median_tokens_delta": _delta(agg_a["median_tokens"], agg_b["median_tokens"], _RATE_DECIMALS),
+            "median_usd_delta": _delta(agg_a["median_usd"], agg_b["median_usd"], _USD_DECIMALS),
+        }
+    return deltas
+
+
+def _delta(a: Any, b: Any, decimals: int) -> float | None:
+    if a is None or b is None:
+        return None
+    return round(float(b) - float(a), decimals)
+
+
+# ---------------------------------------------------------------------------
+# Artifact IO and the pair index
+# ---------------------------------------------------------------------------
+
+
+def write_comparison_artifact(artifact: AbComparisonArtifact, reports_dir: Path) -> Path:
+    """Write the content-addressed artifact and return its path.
+
+    The filename is the content hash, so re-emitting the same recorded
+    run set overwrites the identical file - idempotent by construction.
+    """
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    out = reports_dir / artifact.artifact_name
+    out.write_bytes(artifact.artifact_bytes())
+    return out
+
+
+def append_comparison_index(
+    reports_dir: Path,
+    *,
+    profile_pair: tuple[str, str],
+    artifact: AbComparisonArtifact,
+    ts: float | None = None,
+) -> None:
+    """Append one pair-index row next to the artifacts.
+
+    The index is presentation metadata (it lets ``cost profile-report``
+    find the latest evidence for a profile pair); it lives outside the
+    hashed artifact payload, so it may carry a timestamp. Best-effort
+    append-only JSONL: a failed write is logged, never raised.
+    """
+    now = ts if ts is not None else time.time()
+    first, second = _sorted_pair(*profile_pair)
+    row = {
+        "ts": now,
+        "ts_iso": datetime.fromtimestamp(now, tz=UTC).isoformat(timespec="seconds"),
+        "profile_a": first,
+        "profile_b": second,
+        "artifact_name": artifact.artifact_name,
+        "artifact_sha256": artifact.sha256,
+    }
+    try:
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        with (reports_dir / INDEX_FILENAME).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, sort_keys=False, separators=(",", ":")))
+            fh.write("\n")
+    except OSError as exc:  # pragma: no cover - IO failure path
+        logger.warning("ab_comparison: failed to append pair index: %s", exc)
+
+
+def latest_comparison_for_pair(reports_dir: Path, profile_a: str, profile_b: str) -> dict[str, Any] | None:
+    """Return the newest index row for a profile pair, or ``None``.
+
+    Lookup is order-insensitive; "newest" is the last matching row in
+    file order (the index is append-only). Malformed lines are skipped.
+    """
+    index_path = reports_dir / INDEX_FILENAME
+    if not index_path.exists():
+        return None
+    first, second = _sorted_pair(profile_a, profile_b)
+    found: dict[str, Any] | None = None
+    try:
+        with index_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(parsed, dict) and parsed.get("profile_a") == first and parsed.get("profile_b") == second:
+                    found = parsed
+    except OSError as exc:  # pragma: no cover - IO failure path
+        logger.warning("ab_comparison: failed to read pair index: %s", exc)
+    return found
+
+
+__all__ = [
+    "ARM_BASELINE",
+    "ARM_CANDIDATE",
+    "ARM_CONTROL",
+    "ARTIFACT_KIND",
+    "ARTIFACT_VERSION",
+    "CONTROL_ADDENDUM",
+    "DEFAULT_TOLERANCE",
+    "INCOMPARABLE",
+    "INDEX_FILENAME",
+    "NOT_MEASURED",
+    "VERDICT_FAIL",
+    "VERDICT_NOT_MEASURED",
+    "VERDICT_PASS",
+    "AbComparisonArtifact",
+    "Arm",
+    "ArmPlan",
+    "ArmRunRow",
+    "append_comparison_index",
+    "build_arms",
+    "build_comparison_artifact",
+    "latest_comparison_for_pair",
+    "run_arms",
+    "spawn_arm_executor",
+    "suite_file_sha256",
+    "synthetic_arm_executor",
+    "write_comparison_artifact",
+]

--- a/src/bernstein/eval/ab_runner.py
+++ b/src/bernstein/eval/ab_runner.py
@@ -13,6 +13,11 @@ Design notes:
     * Companion to ``bernstein.core.quality.ab_test`` (model-vs-model on a
       single live task via httpx). This module covers prompt-vs-prompt
       offline / synthetic eval.
+    * Real runs dispatch through the normal spawn path: the task server
+      creates each run as an ordinary task executed in its own isolated
+      worktree (:func:`spawn_executor`). The spend ledger rows those runs
+      produce are the only source of cost figures - :class:`ArmCost`
+      references them by ledger line hash, never by re-estimation.
     * Benchmark loaders (SWE-bench Pro, Terminal-Bench) are intentionally
       out of scope - see ``feat-swe-bench-pro-terminal-bench-nightly``.
 """
@@ -20,13 +25,19 @@ Design notes:
 from __future__ import annotations
 
 import json
+import logging
 import statistics
+import time
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.sanitize import sanitize_log
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -79,6 +90,9 @@ class RunResult:
         duration_ms: Wall-clock duration in milliseconds.
         passed: Whether the task is considered successful (score >= 0.5
             by default; can be overridden by the scorer).
+        ledger_task_id: Join key into the spend ledger - the ``task_id``
+            the run's LLM calls were recorded under. Empty for executors
+            that produce no ledger rows (e.g. :func:`echo_executor`).
     """
 
     variant: str
@@ -87,6 +101,46 @@ class RunResult:
     score: float
     duration_ms: float = 0.0
     passed: bool = False
+    ledger_task_id: str = ""
+
+
+@dataclass(frozen=True)
+class ArmCost:
+    """Ledger-sourced cost figures for one comparison arm.
+
+    Every figure is a sum over concrete spend-ledger rows; the rows are
+    referenced by the SHA-256 of their raw JSONL line bytes so a
+    verifier holding the ledger can resolve each reference and recompute
+    the sums. Nothing here is estimated.
+
+    Attributes:
+        arm: Arm (variant) name the figures belong to.
+        entries: Number of ledger rows referenced.
+        input_tokens: Sum of ``input_tokens`` over the referenced rows.
+        output_tokens: Sum of ``output_tokens`` over the referenced rows.
+        cost_usd: Sum of ``cost_usd`` over the referenced rows, rounded
+            to 6 decimals.
+        ledger_refs: SHA-256 hex digests of the referenced raw ledger
+            lines, in ledger file order.
+    """
+
+    arm: str
+    entries: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    ledger_refs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic dict suitable for JSON serialisation."""
+        return {
+            "arm": self.arm,
+            "entries": self.entries,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cost_usd": self.cost_usd,
+            "ledger_refs": list(self.ledger_refs),
+        }
 
 
 @dataclass(frozen=True)
@@ -138,6 +192,9 @@ class Comparison:
         winner: ``"a"``, ``"b"``, or ``"tie"`` based on pass-rate then
             mean-score (5% tolerance band).
         reason: Human-readable explanation.
+        cost_a: Ledger-sourced cost figures for the A side, or ``None``
+            when the runs produced no ledger rows (synthetic executors).
+        cost_b: Ledger-sourced cost figures for the B side.
     """
 
     variant_a: VariantStats
@@ -145,16 +202,28 @@ class Comparison:
     per_task: tuple[TaskDelta, ...]
     winner: str
     reason: str
+    cost_a: ArmCost | None = None
+    cost_b: ArmCost | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Return a deterministic dict suitable for JSON serialisation."""
-        return {
+        """Return a deterministic dict suitable for JSON serialisation.
+
+        The ``cost_a`` / ``cost_b`` keys appear only when cost figures
+        were attached, so pre-cost consumers keep seeing the original
+        shape byte-for-byte.
+        """
+        out: dict[str, Any] = {
             "variant_a": _stats_to_dict(self.variant_a),
             "variant_b": _stats_to_dict(self.variant_b),
             "per_task": [_delta_to_dict(d) for d in self.per_task],
             "winner": self.winner,
             "reason": self.reason,
         }
+        if self.cost_a is not None:
+            out["cost_a"] = self.cost_a.to_dict()
+        if self.cost_b is not None:
+            out["cost_b"] = self.cost_b.to_dict()
+        return out
 
     def to_json(self, *, indent: int = 2) -> str:
         """Render as a deterministic JSON string."""
@@ -230,6 +299,156 @@ def echo_executor(variant: Variant, task: Task) -> RunResult:
         duration_ms=0.0,
         passed=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# Real executor - dispatch through the normal spawn path
+# ---------------------------------------------------------------------------
+
+#: Variant.metadata key naming the response-style profile a run is spawned
+#: under. The spawn path resolves it via ``Task.metadata['mode']`` and
+#: stamps ``response_profile`` into every ledger row the run produces.
+VARIANT_PROFILE_KEY = "response_profile"
+
+#: Variant.metadata key carrying a plain-text addendum appended to the
+#: task description (used by the minimal-control arm, which is not a
+#: named profile).
+VARIANT_ADDENDUM_KEY = "prompt_addendum"
+
+_SPAWN_TERMINAL_STATUSES = frozenset({"done", "failed", "cancelled", "closed"})
+_SPAWN_PASS_STATUSES = frozenset({"done", "closed"})
+
+
+def spawn_executor(
+    server_url: str,
+    *,
+    role: str = "backend",
+    scope: str = "small",
+    timeout_seconds: int = 1800,
+    poll_interval_seconds: float = 5.0,
+    transport: Any = None,
+) -> Executor:
+    """Return an executor that runs each (variant, task) as a real task.
+
+    Each invocation POSTs one task to the task server, so the run goes
+    through the normal spawn path: role resolution, model policy, and an
+    isolated per-task worktree. A variant whose metadata carries
+    :data:`VARIANT_PROFILE_KEY` is spawned with ``metadata['mode']`` set
+    to that profile, so the spawn path renders the profile addendum and
+    stamps ``response_profile`` / ``profile_content_sha256`` into the
+    ledger rows the run produces. A variant carrying
+    :data:`VARIANT_ADDENDUM_KEY` gets that text appended to the task
+    description instead (the minimal-control arm).
+
+    Args:
+        server_url: Base URL of the running task server.
+        role: Agent role assigned to every spawned task.
+        scope: Task scope (``small`` / ``medium`` / ``large``).
+        timeout_seconds: Max seconds to wait for one task to finish.
+        poll_interval_seconds: Seconds between status polls.
+        transport: Optional httpx transport override (tests inject an
+            ``httpx.MockTransport`` here for a zero-network path).
+
+    Returns:
+        An :data:`Executor` whose :class:`RunResult.ledger_task_id` is
+        the server-assigned task id - the join key into the spend
+        ledger.
+    """
+    import httpx  # local import: only the real path needs it
+
+    def _run(variant: Variant, task: Task) -> RunResult:
+        description = str(task.input)
+        addendum = str(variant.metadata.get(VARIANT_ADDENDUM_KEY, "") or "")
+        if addendum:
+            description = f"{description}\n\n{addendum}"
+
+        metadata: dict[str, Any] = {
+            "eval_ab": True,
+            "eval_arm": variant.name,
+            "eval_task_id": task.task_id,
+        }
+        profile = str(variant.metadata.get(VARIANT_PROFILE_KEY, "") or "")
+        if profile:
+            metadata["mode"] = profile
+        payload: dict[str, Any] = {
+            "title": f"[eval-ab:{variant.name}] {description[:80]}",
+            "description": description,
+            "role": role,
+            "scope": scope,
+            "metadata": metadata,
+        }
+        if variant.model:
+            payload["model"] = variant.model
+            metadata["pinned_model"] = True
+
+        start = time.monotonic()
+        with httpx.Client(transport=transport) as client:
+            resp = client.post(f"{server_url}/tasks", json=payload, timeout=10.0)
+            resp.raise_for_status()
+            created: dict[str, Any] = resp.json()
+            server_task_id = str(created.get("id") or "")
+            if not server_task_id:
+                msg = f"task server did not return a task id: {created}"
+                raise RuntimeError(msg)
+            logger.info(
+                "eval ab: spawned arm=%s task=%s as server task %s",
+                sanitize_log(variant.name),
+                sanitize_log(task.task_id),
+                sanitize_log(server_task_id),
+            )
+            task_data = _poll_spawned_task(
+                client,
+                server_url,
+                server_task_id,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+            )
+        duration_ms = (time.monotonic() - start) * 1000.0
+
+        status = str(task_data.get("status", "unknown"))
+        passed = status in _SPAWN_PASS_STATUSES
+        meta: dict[str, Any] = task_data.get("metadata", {}) or {}
+        quality_passed = bool(meta.get("quality_passed", task_data.get("quality_passed", passed)))
+        score = 1.0 if (passed and quality_passed) else 0.0
+        return RunResult(
+            variant=variant.name,
+            task_id=task.task_id,
+            output=task_data,
+            score=score,
+            duration_ms=duration_ms,
+            passed=passed and quality_passed,
+            ledger_task_id=server_task_id,
+        )
+
+    return _run
+
+
+def _poll_spawned_task(
+    client: Any,
+    server_url: str,
+    server_task_id: str,
+    *,
+    timeout_seconds: int,
+    poll_interval_seconds: float,
+) -> dict[str, Any]:
+    """Poll one spawned task until it is terminal or the timeout passes.
+
+    Returns:
+        The final task dict, or ``{"status": "timeout"}`` when the task
+        did not reach a terminal status in time (the caller records the
+        run as not-passed rather than raising, so one stuck arm cannot
+        abort the whole comparison).
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        resp = client.get(f"{server_url}/tasks/{server_task_id}", timeout=10.0)
+        resp.raise_for_status()
+        task_data: dict[str, Any] = resp.json()
+        if str(task_data.get("status", "")) in _SPAWN_TERMINAL_STATUSES:
+            return task_data
+        time.sleep(poll_interval_seconds)
+    logger.warning("eval ab: server task %s timed out after %ss", sanitize_log(server_task_id), timeout_seconds)
+    return {"status": "timeout"}
 
 
 # ---------------------------------------------------------------------------
@@ -458,6 +677,9 @@ def _delta_to_dict(d: TaskDelta) -> dict[str, Any]:
 
 
 __all__ = [
+    "VARIANT_ADDENDUM_KEY",
+    "VARIANT_PROFILE_KEY",
+    "ArmCost",
     "Comparison",
     "Executor",
     "RunResult",
@@ -471,4 +693,5 @@ __all__ = [
     "load_tasks_yaml",
     "load_variant_yaml",
     "run_ab",
+    "spawn_executor",
 ]

--- a/tests/unit/cli/test_eval_ab_suite_cmd.py
+++ b/tests/unit/cli/test_eval_ab_suite_cmd.py
@@ -1,0 +1,202 @@
+"""CLI tests for ``bernstein eval ab`` suite mode (issue #2247).
+
+Acceptance criterion 3 at the CLI seam: the full three-arm flow runs
+with the synthetic executor - zero network, deterministic verdicts, a
+real (synthetic) spend ledger, a content-addressed artifact, and a
+verified audit chain event.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.eval_benchmark_cmd import eval_group
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_chain import EVENT_EVAL_AB_COMPARISON
+from bernstein.eval.ab_comparison import ARM_CANDIDATE, INCOMPARABLE
+
+_SUITE_YAML = (
+    "tasks:\n"
+    "  - id: t1\n    input: hello\n    expected: candidate::hello\n"
+    "  - id: t2\n    input: world\n    expected: candidate::world\n"
+)
+
+_TWO_ARM_SUITE_YAML = (
+    "tasks:\n"
+    "  - id: t1\n    input: hello\n    expected: terse::hello\n"
+    "  - id: t2\n    input: world\n    expected: terse::world\n"
+)
+
+
+def _invoke_suite(runner: CliRunner, *extra: str, suite_yaml: str = _SUITE_YAML) -> object:
+    Path("suite.yaml").write_text(suite_yaml, encoding="utf-8")
+    return runner.invoke(
+        eval_group,
+        ["ab", "--suite", "suite.yaml", *extra],
+        env={"BERNSTEIN_AUDIT_KEY_PATH": str(Path("keys") / "audit.key")},
+    )
+
+
+class TestSuiteModeThreeArm:
+    def test_full_three_arm_flow_offline(self) -> None:
+        """AC3: three arms, two trials, synthetic executor, zero network."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(
+                runner,
+                "--arm-a",
+                "baseline",
+                "--arm-b",
+                "terse",
+                "--arms",
+                "3",
+                "--trials",
+                "2",
+                "--json",
+            )
+            assert result.exit_code == 0, result.output
+            payload = json.loads(result.output)
+            content = payload["content"]
+
+            # 3 arms x 2 tasks x 2 trials.
+            assert len(content["per_task"]) == 12
+            # Candidate passes every run (expected matches its output);
+            # control and baseline fail; costs are ledger-resolved.
+            assert content["winner"]["arm"] == ARM_CANDIDATE
+            assert all(row["ledger_ref"] for row in content["per_task"])
+
+            # The artifact is on disk, content-addressed.
+            artifact = Path(payload["artifact"])
+            assert artifact.exists()
+            assert artifact.name == f"{payload['sha256']}.json"
+
+            # The synthetic ledger exists at its dedicated default path.
+            assert Path(".sdd/eval/ab/ledger.jsonl").exists()
+
+            # The chain event landed and the chain verifies.
+            log = AuditLog(audit_dir=Path(".sdd/audit"), key_path=Path("keys") / "audit.key")
+            events = log.query(event_type=EVENT_EVAL_AB_COMPARISON)
+            assert len(events) == 1
+            assert events[0].details["artifact_sha256"] == payload["sha256"]
+            ok, errors = log.verify()
+            assert ok, errors
+
+            # The pair index links the honest named-profile pair.
+            index = Path(".sdd/reports/eval_ab") / "index.jsonl"
+            row = json.loads(index.read_text(encoding="utf-8").splitlines()[-1])
+            assert (row["profile_a"], row["profile_b"]) == ("balanced", "terse")
+            assert row["artifact_sha256"] == payload["sha256"]
+
+    def test_incomparable_when_suite_has_no_expectations(self) -> None:
+        """AC4 at the CLI seam: no verdicts -> incomparable, exit 0."""
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(
+                runner,
+                "--arm-a",
+                "baseline",
+                "--arm-b",
+                "terse",
+                "--arms",
+                "3",
+                "--json",
+                suite_yaml="tasks:\n  - id: t1\n    input: hello\n",
+            )
+            assert result.exit_code == 0, result.output
+            content = json.loads(result.output)["content"]
+            assert content["winner"]["arm"] == INCOMPARABLE
+            assert content["winner"]["missing"]
+
+    def test_three_arm_rejects_named_profile_baseline(self) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(runner, "--arm-a", "terse", "--arm-b", "verbose", "--arms", "3")
+            assert result.exit_code == 2, result.output
+            assert "baseline" in result.output
+
+
+class TestSuiteModeTwoArm:
+    def test_two_arm_default(self) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(
+                runner,
+                "--arm-a",
+                "balanced",
+                "--arm-b",
+                "terse",
+                "--json",
+                suite_yaml=_TWO_ARM_SUITE_YAML,
+            )
+            assert result.exit_code == 0, result.output
+            content = json.loads(result.output)["content"]
+            assert set(content["arms"]) == {"balanced", "terse"}
+            assert content["winner"]["arm"] == "terse"
+            assert list(content["deltas"]) == ["terse_vs_balanced"]
+
+    def test_human_output_mentions_winner_and_chain(self) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(
+                runner,
+                "--arm-a",
+                "balanced",
+                "--arm-b",
+                "terse",
+                suite_yaml=_TWO_ARM_SUITE_YAML,
+            )
+            assert result.exit_code == 0, result.output
+            assert "Winner:" in result.output
+            assert "eval.ab_comparison" in result.output
+
+    def test_output_file_written(self) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(
+                runner,
+                "--arm-a",
+                "balanced",
+                "--arm-b",
+                "terse",
+                "--output",
+                "out.json",
+                suite_yaml=_TWO_ARM_SUITE_YAML,
+            )
+            assert result.exit_code == 0, result.output
+            written = json.loads(Path("out.json").read_text(encoding="utf-8"))
+            assert written["content"]["winner"]["arm"] == "terse"
+
+
+class TestSuiteModeValidation:
+    def test_suite_requires_both_arms(self) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            Path("suite.yaml").write_text(_SUITE_YAML, encoding="utf-8")
+            result = runner.invoke(eval_group, ["ab", "--suite", "suite.yaml"])
+        assert result.exit_code == 2, result.output
+        assert "--arm-a" in result.output
+
+    def test_bare_invocation_mentions_both_modes(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(eval_group, ["ab"])
+        assert result.exit_code == 2, result.output
+        assert "--variant-a" in result.output
+        assert "--suite" in result.output
+
+    @pytest.mark.parametrize("arms", ["1", "4"])
+    def test_arm_count_out_of_range(self, arms: str) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(runner, "--arm-a", "balanced", "--arm-b", "terse", "--arms", arms)
+        assert result.exit_code == 2, result.output
+
+    def test_unknown_profile_is_usage_error(self) -> None:
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = _invoke_suite(runner, "--arm-a", "balanced", "--arm-b", "bogus")
+        assert result.exit_code == 2, result.output
+        assert "unknown response style" in result.output

--- a/tests/unit/cost/test_cost_cmd_profile.py
+++ b/tests/unit/cost/test_cost_cmd_profile.py
@@ -263,3 +263,102 @@ class TestProfileReportCmd:
         result = runner.invoke(cost_cmd, ["profile-report", "--help"])
         assert result.exit_code == 0, result.output
         assert "profile-report" in result.output or "profile" in result.output
+
+
+class TestProfileReportEvalEvidence:
+    """Cross-profile claims link the latest eval ab comparison (issue #2247)."""
+
+    def _comparable_ledger(self, sdd: Path) -> None:
+        led = SpendLedger(path=sdd / "cost" / "ledger.jsonl", run_id="r-2")
+        for i in range(MIN_COMPARABLE_TASKS):
+            _record(led, f"c-terse-{i}", "terse", cost=0.10)
+            _record(led, f"c-verbose-{i}", "verbose", cost=0.30)
+
+    def _write_evidence(self, sdd: Path) -> str:
+        """Record a comparison artifact for the terse/verbose pair."""
+        from bernstein.eval.ab_comparison import (
+            append_comparison_index,
+            build_arms,
+            build_comparison_artifact,
+            run_arms,
+            synthetic_arm_executor,
+        )
+        from bernstein.eval.ab_runner import Task
+
+        eval_ledger = sdd / "eval" / "ab" / "ledger.jsonl"
+        plan = build_arms("terse", "verbose")
+        rows = run_arms(
+            plan,
+            [Task(task_id="t1", input="x", expected="terse::x")],
+            executor=synthetic_arm_executor(SpendLedger(path=eval_ledger, run_id="e-1"), run_token="tok"),
+        )
+        artifact = build_comparison_artifact(
+            plan=plan,
+            rows=rows,
+            ledger_path=eval_ledger,
+            suite_sha256="ab" * 32,
+            suite_name="suite.yaml",
+            adapter_versions={"bernstein": "0.0.0"},
+            trials=1,
+        )
+        append_comparison_index(sdd / "reports" / "eval_ab", profile_pair=plan.profile_pair, artifact=artifact)
+        return artifact.sha256
+
+    def _invoke(self, sdd: Path, key_path: Path, *extra: str) -> tuple[int, str]:
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_profile_report_cmd,
+            [
+                "--metrics-dir",
+                str(sdd / "metrics"),
+                "--ledger",
+                str(sdd / "cost" / "ledger.jsonl"),
+                "--transitions",
+                str(sdd / "cost" / "profile_transitions.jsonl"),
+                "--audit-dir",
+                str(sdd / "audit"),
+                "--reports-dir",
+                str(sdd / "reports" / "cost_profiles"),
+                "--eval-ab-dir",
+                str(sdd / "reports" / "eval_ab"),
+                *extra,
+            ],
+            env={"BERNSTEIN_AUDIT_KEY_PATH": str(key_path)},
+        )
+        return result.exit_code, result.output
+
+    def test_json_links_latest_comparison_for_pair(
+        self, sdd: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._comparable_ledger(sdd)
+        sha = self._write_evidence(sdd)
+        key_path = tmp_path / "keys" / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        code, output = self._invoke(sdd, key_path, "--json")
+        assert code == 0, output
+        data = json.loads(output)
+        evidence = data["comparison_evidence"]["terse vs verbose"]
+        assert evidence["artifact_sha256"] == sha
+        assert evidence["artifact_name"] == f"{sha}.json"
+        # The link never enters the hashed report payload.
+        assert "comparison_evidence" not in json.dumps(data["content"])
+
+    def test_human_output_prints_evidence_line(
+        self, sdd: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._comparable_ledger(sdd)
+        sha = self._write_evidence(sdd)
+        key_path = tmp_path / "keys" / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        code, output = self._invoke(sdd, key_path)
+        assert code == 0, output
+        assert "eval evidence" in output
+        assert sha[:16] in output
+
+    def test_no_evidence_when_index_missing(self, sdd: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._comparable_ledger(sdd)
+        key_path = tmp_path / "keys" / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        code, output = self._invoke(sdd, key_path, "--json")
+        assert code == 0, output
+        assert json.loads(output)["comparison_evidence"] == {}

--- a/tests/unit/eval/test_ab_comparison.py
+++ b/tests/unit/eval/test_ab_comparison.py
@@ -1,0 +1,551 @@
+"""Three-arm profile A/B comparison artifact (issue #2247).
+
+Acceptance criteria under test:
+
+1. The comparison artifact over the same recorded run set re-serialises
+   byte-identically; suite and profile hashes pin exactly what was
+   compared.
+2. Every per-arm cost figure resolves to concrete ledger entries by
+   reference; a verifier can recompute the aggregates from the ledger
+   alone.
+3. The full three-arm flow runs with the synthetic executor: zero
+   network, deterministic verdicts, real ledger rows.
+4. A winner declaration requires both cost and quality measured on both
+   arms; a run missing either emits ``incomparable``, never a partial
+   winner.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import statistics
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.agents.response_style import addendum_sha256, render_style_addendum
+from bernstein.core.cost.spend_ledger import SpendLedger
+from bernstein.core.security.audit_chain import (
+    EVENT_EVAL_AB_COMPARISON,
+    AuditChainStore,
+    record_eval_ab_comparison,
+)
+from bernstein.eval.ab_comparison import (
+    ARM_BASELINE,
+    ARM_CANDIDATE,
+    ARM_CONTROL,
+    ARTIFACT_KIND,
+    ARTIFACT_VERSION,
+    CONTROL_ADDENDUM,
+    INCOMPARABLE,
+    NOT_MEASURED,
+    ArmRunRow,
+    append_comparison_index,
+    build_arms,
+    build_comparison_artifact,
+    latest_comparison_for_pair,
+    run_arms,
+    suite_file_sha256,
+    synthetic_arm_executor,
+    write_comparison_artifact,
+)
+from bernstein.eval.ab_runner import Task
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _tasks() -> list[Task]:
+    """Tasks whose expected outputs make the candidate arm pass 2/2."""
+    return [
+        Task(task_id="t1", input="hello", expected="candidate::hello"),
+        Task(task_id="t2", input="world", expected="candidate::world"),
+    ]
+
+
+@pytest.fixture()
+def ledger_path(tmp_path: Path) -> Path:
+    return tmp_path / "cost" / "ledger.jsonl"
+
+
+def _run_three_arm(ledger_path: Path, tasks: list[Task] | None = None, *, trials: int = 2):
+    """Run the canonical three-arm synthetic flow and build the artifact."""
+    plan = build_arms("balanced", "terse", arms=3)
+    ledger = SpendLedger(path=ledger_path, run_id="eval-ab-test")
+    executor = synthetic_arm_executor(ledger, run_token="tok")
+    rows = run_arms(plan, tasks if tasks is not None else _tasks(), executor=executor, trials=trials)
+    artifact = build_comparison_artifact(
+        plan=plan,
+        rows=rows,
+        ledger_path=ledger_path,
+        suite_sha256="ab" * 32,
+        suite_name="suite.yaml",
+        adapter_versions={"bernstein": "0.0.0"},
+        trials=trials,
+    )
+    return plan, rows, artifact
+
+
+# ---------------------------------------------------------------------------
+# Arm plans
+# ---------------------------------------------------------------------------
+
+
+class TestBuildArms:
+    def test_two_arm_plan_uses_profile_names(self) -> None:
+        plan = build_arms("balanced", "terse")
+        assert [a.name for a in plan.arms] == ["balanced", "terse"]
+        assert plan.honest_pair == ("balanced", "terse")
+        assert plan.conflated_pair is None
+        assert plan.profile_pair == ("balanced", "terse")
+
+    def test_two_arm_addendum_hashes_pin_rendered_content(self) -> None:
+        plan = build_arms("balanced", "terse")
+        assert plan.arms[0].addendum_sha256 == addendum_sha256("")
+        assert plan.arms[1].addendum_sha256 == addendum_sha256(render_style_addendum("terse"))
+
+    def test_two_arm_rejects_same_profile(self) -> None:
+        with pytest.raises(ValueError, match="differ"):
+            build_arms("terse", "terse")
+
+    def test_two_arm_rejects_unknown_profile(self) -> None:
+        with pytest.raises(ValueError, match="unknown response style"):
+            build_arms("balanced", "bogus")
+
+    def test_three_arm_plan_has_baseline_control_candidate(self) -> None:
+        plan = build_arms("balanced", "terse", arms=3)
+        assert [a.name for a in plan.arms] == [ARM_BASELINE, ARM_CONTROL, ARM_CANDIDATE]
+        baseline, control, candidate = plan.arms
+        assert baseline.profile == ""
+        assert baseline.addendum_sha256 == addendum_sha256("")
+        assert control.profile == ""
+        assert control.addendum_sha256 == addendum_sha256(CONTROL_ADDENDUM)
+        assert candidate.profile == "terse"
+        assert candidate.addendum_sha256 == addendum_sha256(render_style_addendum("terse"))
+
+    def test_three_arm_honest_pair_is_control_vs_candidate(self) -> None:
+        plan = build_arms("baseline", "verbose", arms=3)
+        assert plan.honest_pair == (ARM_CONTROL, ARM_CANDIDATE)
+        assert plan.conflated_pair == (ARM_BASELINE, ARM_CANDIDATE)
+
+    def test_three_arm_requires_unset_baseline_arm_a(self) -> None:
+        with pytest.raises(ValueError, match="baseline"):
+            build_arms("terse", "verbose", arms=3)
+
+    def test_three_arm_rejects_balanced_candidate(self) -> None:
+        # ``balanced`` renders an empty addendum; as a candidate it would
+        # be indistinguishable from the baseline arm.
+        with pytest.raises(ValueError, match="candidate"):
+            build_arms("balanced", "balanced", arms=3)
+
+    def test_invalid_arm_count_rejected(self) -> None:
+        with pytest.raises(ValueError, match="arms"):
+            build_arms("balanced", "terse", arms=4)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic executor
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticExecutor:
+    def test_deterministic_rows_and_ledger_entries(self, ledger_path: Path) -> None:
+        plan = build_arms("balanced", "terse", arms=3)
+        ledger = SpendLedger(path=ledger_path, run_id="r-1")
+        executor = synthetic_arm_executor(ledger, run_token="tok")
+        rows = run_arms(plan, _tasks(), executor=executor, trials=1)
+
+        # 3 arms x 2 tasks x 1 trial.
+        assert len(rows) == 6
+        entries = SpendLedger.load_entries(ledger_path)
+        assert len(entries) == 6
+        # One ledger entry per run, joined by ledger_task_id.
+        assert {r.ledger_task_id for r in rows} == {e.task_id for e in entries}
+
+    def test_candidate_entries_tagged_with_profile(self, ledger_path: Path) -> None:
+        plan = build_arms("balanced", "terse", arms=3)
+        ledger = SpendLedger(path=ledger_path, run_id="r-1")
+        run_arms(plan, _tasks(), executor=synthetic_arm_executor(ledger, run_token="tok"), trials=1)
+
+        entries = SpendLedger.load_entries(ledger_path)
+        candidate = [e for e in entries if f":{ARM_CANDIDATE}:" in e.task_id]
+        baseline = [e for e in entries if f":{ARM_BASELINE}:" in e.task_id]
+        assert candidate and baseline
+        assert all(e.tags.get("response_profile") == "terse" for e in candidate)
+        assert all("response_profile" not in e.tags for e in baseline)
+
+    def test_verdict_from_expected_output(self, ledger_path: Path) -> None:
+        plan = build_arms("balanced", "terse", arms=3)
+        ledger = SpendLedger(path=ledger_path, run_id="r-1")
+        rows = run_arms(plan, _tasks(), executor=synthetic_arm_executor(ledger, run_token="tok"), trials=1)
+
+        by_arm: dict[str, list[ArmRunRow]] = {}
+        for row in rows:
+            by_arm.setdefault(row.arm, []).append(row)
+        assert all(r.verdict == "pass" for r in by_arm[ARM_CANDIDATE])
+        assert all(r.verdict == "fail" for r in by_arm[ARM_BASELINE])
+        assert all(r.verdict == "fail" for r in by_arm[ARM_CONTROL])
+
+    def test_missing_expected_is_not_measured(self, ledger_path: Path) -> None:
+        plan = build_arms("balanced", "terse", arms=3)
+        ledger = SpendLedger(path=ledger_path, run_id="r-1")
+        tasks = [Task(task_id="t1", input="hello")]
+        rows = run_arms(plan, tasks, executor=synthetic_arm_executor(ledger, run_token="tok"), trials=1)
+        assert all(r.verdict == "not_measured" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# AC1 - byte-identical artifact over the same recorded run set
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactDeterminism:
+    def test_rebuild_from_same_run_set_is_byte_identical(self, ledger_path: Path) -> None:
+        plan, rows, artifact_1 = _run_three_arm(ledger_path)
+        artifact_2 = build_comparison_artifact(
+            plan=plan,
+            rows=rows,
+            ledger_path=ledger_path,
+            suite_sha256="ab" * 32,
+            suite_name="suite.yaml",
+            adapter_versions={"bernstein": "0.0.0"},
+            trials=2,
+        )
+        assert artifact_1.artifact_bytes() == artifact_2.artifact_bytes()
+        assert artifact_1.sha256 == artifact_2.sha256
+
+    def test_suite_and_profile_hashes_pin_the_comparison(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        content = artifact.content
+        assert content["kind"] == ARTIFACT_KIND
+        assert content["version"] == ARTIFACT_VERSION
+        assert content["suite_sha256"] == "ab" * 32
+        # Honest pair hashes: control vs candidate.
+        assert content["profile_a_sha256"] == addendum_sha256(CONTROL_ADDENDUM)
+        assert content["profile_b_sha256"] == addendum_sha256(render_style_addendum("terse"))
+        # Every arm's addendum hash is pinned in the arms block.
+        assert set(content["arms"]) == {ARM_BASELINE, ARM_CONTROL, ARM_CANDIDATE}
+        assert content["arms"][ARM_CANDIDATE]["profile"] == "terse"
+
+    def test_no_timestamps_in_hashed_payload(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        flat = json.dumps(artifact.content)
+        for needle in ('"ts"', "ts_iso", "timestamp", "generated_at"):
+            assert needle not in flat
+
+    def test_sha256_matches_canonical_content(self, ledger_path: Path) -> None:
+        from bernstein.core.cost.profile_report import canonical_json_bytes
+
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        assert artifact.sha256 == hashlib.sha256(canonical_json_bytes(artifact.content)).hexdigest()
+
+    def test_changed_suite_hash_changes_artifact_hash(self, ledger_path: Path) -> None:
+        plan, rows, artifact = _run_three_arm(ledger_path)
+        other = build_comparison_artifact(
+            plan=plan,
+            rows=rows,
+            ledger_path=ledger_path,
+            suite_sha256="cd" * 32,
+            suite_name="suite.yaml",
+            adapter_versions={"bernstein": "0.0.0"},
+            trials=2,
+        )
+        assert other.sha256 != artifact.sha256
+
+
+# ---------------------------------------------------------------------------
+# AC2 - cost figures resolve to ledger entries; aggregates recomputable
+# ---------------------------------------------------------------------------
+
+
+def _lines_by_hash(ledger_path: Path) -> dict[str, dict[str, object]]:
+    out: dict[str, dict[str, object]] = {}
+    for line in ledger_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            out[hashlib.sha256(line.encode("utf-8")).hexdigest()] = json.loads(line)
+    return out
+
+
+class TestLedgerResolution:
+    def test_every_row_cost_resolves_by_reference(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        resolvable = _lines_by_hash(ledger_path)
+        for row in artifact.content["per_task"]:
+            assert row["ledger_ref"], f"row {row['task_id']}/{row['arm']} has no ledger reference"
+            entries = [resolvable[ref] for ref in row["ledger_ref"]]
+            tokens = sum(int(e["input_tokens"]) + int(e["output_tokens"]) for e in entries)
+            usd = round(sum(float(e["cost_usd"]) for e in entries), 6)
+            assert row["tokens"] == tokens
+            assert row["usd"] == usd
+
+    def test_aggregates_recomputable_from_ledger_alone(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        resolvable = _lines_by_hash(ledger_path)
+        per_arm_usd: dict[str, list[float]] = {}
+        per_arm_tokens: dict[str, list[int]] = {}
+        for row in artifact.content["per_task"]:
+            entries = [resolvable[ref] for ref in row["ledger_ref"]]
+            per_arm_usd.setdefault(row["arm"], []).append(round(sum(float(e["cost_usd"]) for e in entries), 6))
+            per_arm_tokens.setdefault(row["arm"], []).append(
+                sum(int(e["input_tokens"]) + int(e["output_tokens"]) for e in entries)
+            )
+        for arm, agg in artifact.content["aggregates"].items():
+            assert agg["median_usd"] == round(statistics.median(per_arm_usd[arm]), 6)
+            assert agg["median_tokens"] == statistics.median(per_arm_tokens[arm])
+            assert agg["total_usd"] == round(sum(per_arm_usd[arm]), 6)
+            assert agg["total_tokens"] == sum(per_arm_tokens[arm])
+
+    def test_rows_without_ledger_entries_have_null_cost(self, ledger_path: Path) -> None:
+        plan, rows, _artifact = _run_three_arm(ledger_path)
+        empty_ledger = ledger_path.parent / "empty.jsonl"
+        artifact = build_comparison_artifact(
+            plan=plan,
+            rows=rows,
+            ledger_path=empty_ledger,
+            suite_sha256="ab" * 32,
+            suite_name="suite.yaml",
+            adapter_versions={"bernstein": "0.0.0"},
+            trials=2,
+        )
+        for row in artifact.content["per_task"]:
+            assert row["ledger_ref"] == []
+            assert row["tokens"] is None
+            assert row["usd"] is None
+
+
+# ---------------------------------------------------------------------------
+# Winner logic (AC4) - explicit rows against a forged ledger
+# ---------------------------------------------------------------------------
+
+
+def _forged_ledger(path: Path, costs: dict[str, float]) -> None:
+    """Write one deterministic ledger row per ledger_task_id."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for task_id, cost in costs.items():
+            row = {
+                "ts": 1000.0,
+                "ts_iso": "2026-01-01T00:00:00+00:00",
+                "run_id": "r-1",
+                "task_id": task_id,
+                "agent_id": "a-1",
+                "role": "eval",
+                "feature_label": "eval_ab",
+                "model": "sonnet",
+                "input_tokens": 50,
+                "output_tokens": 100,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "cost_usd": cost,
+                "quota_envelope": "subscription",
+                "tags": {},
+            }
+            fh.write(json.dumps(row, sort_keys=False, separators=(",", ":")) + "\n")
+
+
+def _row(task_id: str, arm: str, verdict: str, ledger_task_id: str, *, score: float | None = None) -> ArmRunRow:
+    if score is None:
+        score = 1.0 if verdict == "pass" else 0.0
+    return ArmRunRow(
+        task_id=task_id,
+        arm=arm,
+        trial=0,
+        verdict=verdict,
+        score=score,
+        ledger_task_id=ledger_task_id,
+    )
+
+
+def _pair_artifact(tmp_path: Path, rows: list[ArmRunRow], costs: dict[str, float]):
+    ledger = tmp_path / "ledger.jsonl"
+    _forged_ledger(ledger, costs)
+    plan = build_arms("balanced", "terse")
+    return build_comparison_artifact(
+        plan=plan,
+        rows=tuple(rows),
+        ledger_path=ledger,
+        suite_sha256="ab" * 32,
+        suite_name="suite.yaml",
+        adapter_versions={"bernstein": "0.0.0"},
+        trials=1,
+    )
+
+
+class TestWinner:
+    def test_quality_winner_when_both_measured(self, tmp_path: Path) -> None:
+        rows = [
+            _row("t1", "balanced", "fail", "l-a1"),
+            _row("t1", "terse", "pass", "l-b1"),
+            _row("t2", "balanced", "fail", "l-a2"),
+            _row("t2", "terse", "pass", "l-b2"),
+        ]
+        costs = {"l-a1": 0.10, "l-a2": 0.10, "l-b1": 0.10, "l-b2": 0.10}
+        artifact = _pair_artifact(tmp_path, rows, costs)
+        winner = artifact.content["winner"]
+        assert winner["arm"] == "terse"
+        assert winner["missing"] == []
+        assert "pass_rate" in winner["reason"]
+
+    def test_cost_breaks_quality_tie(self, tmp_path: Path) -> None:
+        rows = [
+            _row("t1", "balanced", "pass", "l-a1"),
+            _row("t1", "terse", "pass", "l-b1"),
+        ]
+        costs = {"l-a1": 0.30, "l-b1": 0.10}
+        artifact = _pair_artifact(tmp_path, rows, costs)
+        winner = artifact.content["winner"]
+        assert winner["arm"] == "terse"
+        assert "median_usd" in winner["reason"]
+
+    def test_tie_when_quality_and_cost_equal(self, tmp_path: Path) -> None:
+        rows = [
+            _row("t1", "balanced", "pass", "l-a1"),
+            _row("t1", "terse", "pass", "l-b1"),
+        ]
+        costs = {"l-a1": 0.10, "l-b1": 0.10}
+        artifact = _pair_artifact(tmp_path, rows, costs)
+        assert artifact.content["winner"]["arm"] == "tie"
+
+    def test_missing_quality_emits_incomparable(self, tmp_path: Path) -> None:
+        rows = [
+            _row("t1", "balanced", "not_measured", "l-a1"),
+            _row("t1", "terse", "pass", "l-b1"),
+        ]
+        costs = {"l-a1": 0.10, "l-b1": 0.10}
+        artifact = _pair_artifact(tmp_path, rows, costs)
+        winner = artifact.content["winner"]
+        assert winner["arm"] == INCOMPARABLE
+        assert "quality:balanced" in winner["missing"]
+
+    def test_missing_cost_emits_incomparable_never_partial(self, tmp_path: Path) -> None:
+        rows = [
+            _row("t1", "balanced", "fail", "l-a1"),
+            _row("t1", "terse", "pass", "l-b-unrecorded"),
+        ]
+        # Arm B's run produced no ledger entry: quality alone must not
+        # declare a winner.
+        costs = {"l-a1": 0.10}
+        artifact = _pair_artifact(tmp_path, rows, costs)
+        winner = artifact.content["winner"]
+        assert winner["arm"] == INCOMPARABLE
+        assert "cost:terse" in winner["missing"]
+
+    def test_empty_run_set_is_incomparable(self, tmp_path: Path) -> None:
+        artifact = _pair_artifact(tmp_path, [], {})
+        assert artifact.content["winner"]["arm"] == INCOMPARABLE
+
+
+# ---------------------------------------------------------------------------
+# Deltas: honest vs conflated labelling
+# ---------------------------------------------------------------------------
+
+
+class TestDeltas:
+    def test_three_arm_deltas_labelled(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        deltas = artifact.content["deltas"]
+        honest = deltas["candidate_vs_control"]
+        conflated = deltas["candidate_vs_baseline"]
+        assert honest["conflated"] is False
+        assert honest["pair"] == [ARM_CONTROL, ARM_CANDIDATE]
+        assert conflated["conflated"] is True
+        assert conflated["pair"] == [ARM_BASELINE, ARM_CANDIDATE]
+
+    def test_delta_values_derive_from_aggregates(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        agg = artifact.content["aggregates"]
+        honest = artifact.content["deltas"]["candidate_vs_control"]
+        assert honest["pass_rate_delta"] == round(agg[ARM_CANDIDATE]["pass_rate"] - agg[ARM_CONTROL]["pass_rate"], 4)
+        assert honest["median_usd_delta"] == round(agg[ARM_CANDIDATE]["median_usd"] - agg[ARM_CONTROL]["median_usd"], 6)
+
+    def test_two_arm_has_single_honest_delta(self, tmp_path: Path) -> None:
+        rows = [
+            _row("t1", "balanced", "pass", "l-a1"),
+            _row("t1", "terse", "pass", "l-b1"),
+        ]
+        artifact = _pair_artifact(tmp_path, rows, {"l-a1": 0.10, "l-b1": 0.10})
+        deltas = artifact.content["deltas"]
+        assert list(deltas) == ["terse_vs_balanced"]
+        assert deltas["terse_vs_balanced"]["conflated"] is False
+
+
+# ---------------------------------------------------------------------------
+# Structured "not measured" block
+# ---------------------------------------------------------------------------
+
+
+class TestNotMeasured:
+    def test_block_lists_stable_identifiers(self, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        assert artifact.content["not_measured"] == list(NOT_MEASURED)
+        assert artifact.content["not_measured"] == sorted(artifact.content["not_measured"])
+        assert "latency" in artifact.content["not_measured"]
+        assert "fidelity_beyond_suite_verdicts" in artifact.content["not_measured"]
+        assert "cross_model_generalization" in artifact.content["not_measured"]
+
+
+# ---------------------------------------------------------------------------
+# Artifact IO, chain anchoring, and pair index
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactAndChain:
+    def test_artifact_is_content_addressed(self, tmp_path: Path, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        out = write_comparison_artifact(artifact, tmp_path / "reports")
+        assert out.name == f"{artifact.sha256}.json"
+        envelope = json.loads(out.read_text(encoding="utf-8"))
+        assert envelope["artifact_sha256"] == artifact.sha256
+        assert envelope["content"] == artifact.content
+        assert out.read_bytes() == artifact.artifact_bytes()
+
+    def test_chain_event_carries_hashes_and_verifies(self, tmp_path: Path, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        event = record_eval_ab_comparison(
+            chain=chain,
+            artifact_sha256=artifact.sha256,
+            suite_sha256=str(artifact.content["suite_sha256"]),
+            profile_a_sha256=str(artifact.content["profile_a_sha256"]),
+            profile_b_sha256=str(artifact.content["profile_b_sha256"]),
+            arm_count=len(artifact.content["arms"]),
+            row_count=len(artifact.content["per_task"]),
+            winner_arm=str(artifact.content["winner"]["arm"]),
+            artifact_name=artifact.artifact_name,
+        )
+        assert event.event_type == EVENT_EVAL_AB_COMPARISON
+        assert event.details["artifact_sha256"] == artifact.sha256
+        assert event.details["prev_chain_digest"] is not None
+        ok, errors = chain.verify()
+        assert ok, errors
+
+    def test_index_returns_latest_for_pair(self, tmp_path: Path, ledger_path: Path) -> None:
+        _plan, _rows, artifact = _run_three_arm(ledger_path)
+        reports = tmp_path / "reports"
+        append_comparison_index(reports, profile_pair=("balanced", "terse"), artifact=artifact, ts=100.0)
+        _plan2, _rows2, artifact_2 = _run_three_arm(ledger_path, trials=1)
+        append_comparison_index(reports, profile_pair=("terse", "balanced"), artifact=artifact_2, ts=200.0)
+
+        found = latest_comparison_for_pair(reports, "balanced", "terse")
+        assert found is not None
+        assert found["artifact_sha256"] == artifact_2.sha256
+        # Order-insensitive lookup.
+        assert latest_comparison_for_pair(reports, "terse", "balanced") == found
+
+    def test_index_missing_pair_returns_none(self, tmp_path: Path) -> None:
+        assert latest_comparison_for_pair(tmp_path / "reports", "terse", "verbose") is None
+
+
+# ---------------------------------------------------------------------------
+# Suite hashing
+# ---------------------------------------------------------------------------
+
+
+class TestSuiteHash:
+    def test_suite_file_sha256_is_file_content_hash(self, tmp_path: Path) -> None:
+        suite = tmp_path / "suite.yaml"
+        suite.write_text("tasks:\n  - id: t1\n    input: hello\n", encoding="utf-8")
+        assert suite_file_sha256(suite) == hashlib.sha256(suite.read_bytes()).hexdigest()

--- a/tests/unit/test_ab_runner.py
+++ b/tests/unit/test_ab_runner.py
@@ -17,6 +17,9 @@ from pathlib import Path
 import pytest
 
 from bernstein.eval.ab_runner import (
+    VARIANT_ADDENDUM_KEY,
+    VARIANT_PROFILE_KEY,
+    ArmCost,
     Comparison,
     RunResult,
     Task,
@@ -27,6 +30,7 @@ from bernstein.eval.ab_runner import (
     load_tasks_yaml,
     load_variant_yaml,
     run_ab,
+    spawn_executor,
 )
 
 # ---------------------------------------------------------------------------
@@ -223,6 +227,110 @@ def test_comparison_dict_shape() -> None:
     )
     expected_keys = {"variant_a", "variant_b", "per_task", "winner", "reason"}
     assert set(cmp.to_dict().keys()) == expected_keys
+
+
+def test_comparison_with_costs_serialises_ledger_refs() -> None:
+    """Cost fields appear in the dict only when attached, with refs intact."""
+    cost_a = ArmCost(arm="A", entries=2, input_tokens=100, output_tokens=50, cost_usd=0.12, ledger_refs=("x1", "x2"))
+    cost_b = ArmCost(arm="B", entries=1, input_tokens=40, output_tokens=20, cost_usd=0.05, ledger_refs=("y1",))
+    cmp = Comparison(
+        variant_a=VariantStats(name="A", n=1, pass_count=1, pass_rate=1.0, mean_score=1.0, mean_duration_ms=0.0),
+        variant_b=VariantStats(name="B", n=1, pass_count=0, pass_rate=0.0, mean_score=0.0, mean_duration_ms=0.0),
+        per_task=(),
+        winner="a",
+        reason="quality",
+        cost_a=cost_a,
+        cost_b=cost_b,
+    )
+    payload = cmp.to_dict()
+    assert payload["cost_a"]["ledger_refs"] == ["x1", "x2"]
+    assert payload["cost_b"]["cost_usd"] == 0.05
+    # JSON round-trip stays byte-stable.
+    assert cmp.to_json() == cmp.to_json()
+
+
+# ---------------------------------------------------------------------------
+# spawn_executor - real path through the task server, mocked transport
+# ---------------------------------------------------------------------------
+
+
+def _mock_server(created: list[dict], status: str = "done", quality_passed: bool = True):
+    """Return an httpx.MockTransport simulating the task server."""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/tasks":
+            payload = json.loads(request.content.decode("utf-8"))
+            created.append(payload)
+            return httpx.Response(200, json={"id": f"srv-{len(created)}"})
+        if request.method == "GET" and request.url.path.startswith("/tasks/"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": request.url.path.rsplit("/", 1)[-1],
+                    "status": status,
+                    "metadata": {"quality_passed": quality_passed},
+                },
+            )
+        return httpx.Response(404, json={})
+
+    return httpx.MockTransport(handler)
+
+
+def test_spawn_executor_dispatches_through_task_server() -> None:
+    """The real executor creates one server task per run and joins the
+    ledger via the server-assigned task id."""
+    created: list[dict] = []
+    executor = spawn_executor(
+        "http://server",
+        role="qa",
+        scope="small",
+        timeout_seconds=5,
+        poll_interval_seconds=0.0,
+        transport=_mock_server(created),
+    )
+    variant = Variant(name="candidate", prompt="", metadata={VARIANT_PROFILE_KEY: "terse"})
+    result = executor(variant, Task(task_id="t1", input="fix the bug"))
+
+    assert result.passed is True
+    assert result.score == 1.0
+    assert result.ledger_task_id == "srv-1"
+    payload = created[0]
+    assert payload["role"] == "qa"
+    assert payload["metadata"]["mode"] == "terse"
+    assert payload["metadata"]["eval_arm"] == "candidate"
+    assert payload["description"] == "fix the bug"
+
+
+def test_spawn_executor_appends_control_addendum_to_description() -> None:
+    """The control arm's addendum rides the description, not the profile."""
+    created: list[dict] = []
+    executor = spawn_executor(
+        "http://server",
+        timeout_seconds=5,
+        poll_interval_seconds=0.0,
+        transport=_mock_server(created),
+    )
+    variant = Variant(name="control", prompt="", metadata={VARIANT_ADDENDUM_KEY: "Keep it brief."})
+    executor(variant, Task(task_id="t1", input="fix the bug"))
+
+    payload = created[0]
+    assert payload["description"] == "fix the bug\n\nKeep it brief."
+    assert "mode" not in payload["metadata"]
+
+
+def test_spawn_executor_failed_task_scores_zero() -> None:
+    created: list[dict] = []
+    executor = spawn_executor(
+        "http://server",
+        timeout_seconds=5,
+        poll_interval_seconds=0.0,
+        transport=_mock_server(created, status="failed", quality_passed=False),
+    )
+    result = executor(Variant(name="baseline", prompt=""), Task(task_id="t1", input="x"))
+    assert result.passed is False
+    assert result.score == 0.0
+    assert result.ledger_task_id == "srv-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The repo has two disjoint comparison tools: `bernstein ab-test` compares two models on one live task, and `bernstein eval ab` compares two prompts over a task set but is synthetic-only in the CLI and its `Comparison` record carries no cost fields. Neither answers the question operators have before changing a fleet-wide setting: run the same suite under configuration A and configuration B and show the cost delta and the quality delta in one artifact. Comparing a profile against an unconstrained baseline also conflates the profile's content with the generic instruction to be brief.

## What was built

- **Real-executor path in `eval/ab_runner.py`**: `spawn_executor` dispatches each run through the normal spawn path (one server task per run, isolated worktree). `Comparison` gains optional per-arm cost fields (`ArmCost`) sourced from spend-ledger rows referenced by ledger line hash; `RunResult` gains the ledger join key.
- **Three-arm plan in new `eval/ab_comparison.py`**: `baseline` (profile unset), `control` (built-in minimal terse addendum, constant and hash-pinned), `candidate` (named profile). The honest delta is candidate vs control; candidate vs baseline is reported but labelled `conflated`.
- **Comparison artifact**: `{suite_sha256, profile hashes, model, adapter_versions, per-task rows with ledger_ref, median aggregates, winner, not_measured, artifact_sha256}` in canonical JSON, content-addressed on disk, appended to the audit chain as a new `eval.ab_comparison` event (reusing the existing canonical-JSON and chain-append helpers). The `not_measured` block declares latency, fidelity beyond suite verdicts, and cross-model generalization as structured fields.
- **CLI**: `bernstein eval ab --suite <path> --arm-a <profile> --arm-b <profile> [--arms 3] [--trials N] [--executor synthetic|spawn] --json`. The existing variant mode is unchanged.
- **`cost profile-report` linking**: cross-profile claims now print the latest comparison artifact for the pair (new `--eval-ab-dir`, append-only pair index). The link lives outside the hashed report payload, so report recomputability is untouched.

## Acceptance criteria, test-proven

1. **Byte-identical re-serialization**: rebuilding the artifact over the same recorded run set produces identical bytes; suite and profile-addendum hashes pin what was compared (`tests/unit/eval/test_ab_comparison.py::TestArtifactDeterminism`).
2. **Ledger-resolvable cost**: every per-arm figure resolves to concrete ledger lines by hash reference, and medians/totals are recomputed from the ledger alone in the tests (`TestLedgerResolution`).
3. **Zero-network three-arm flow**: the synthetic executor records real ledger rows with deterministic figures, and the full three-arm CLI flow (artifact, chain event, pair index) runs offline (`tests/unit/cli/test_eval_ab_suite_cmd.py`).
4. **No partial winners**: a winner requires cost and quality measured on both honest arms; any missing run emits `incomparable` with a structured `missing` list (`TestWinner`).

## How tested

- `uv run pytest tests/unit/eval/test_ab_comparison.py tests/unit/test_ab_runner.py tests/unit/cli/test_eval_ab_suite_cmd.py tests/unit/cli/test_benchmark_cmd_paths.py tests/unit/cost/test_cost_cmd_profile.py tests/unit/cost/test_profile_report.py` (113 passed)
- Full `tests/unit/eval`, `tests/unit/cost`, `tests/unit/cli` sweep: 806 passed, 1 skipped
- Guard suites: api compat, core redirect ledger, CLI snapshots, audit chain byteflip regression (43 passed, none tripped)
- `uv run ruff check src/ tests/`, `ruff format --check` on touched files, `uv run lint-imports` (3 contracts kept), `bernstein agents-md verify` (13 files in sync)

Fixes #2247