### PR TITLE
fix(server): build a fresh /api/v1 router per create_app call

### DIFF
--- a/src/bernstein/core/routes/api_v1.py
+++ b/src/bernstein/core/routes/api_v1.py
@@ -39,4 +39,22 @@ class _VersionedRoute(APIRoute):
         return handler
 
 
-router = APIRouter(prefix="/api/v1", route_class=_VersionedRoute)
+def build_router() -> APIRouter:
+    """Return a fresh ``/api/v1`` router for a single application instance.
+
+    ``create_app`` includes every route group into this router. Using a
+    module-level router for that would make the mutation global: each
+    ``create_app`` call would append another full copy of the v1 route set
+    to the shared object, so every subsequent app instance grows by ~220
+    routes. In a long-lived process that builds many apps (the test suite
+    creates one per test) the route table grows without bound, RSS climbs
+    with it, and app startup eventually fails with ``RecursionError``.
+    Each app must therefore get its own router instance.
+    """
+    return APIRouter(prefix="/api/v1", route_class=_VersionedRoute)
+
+
+# Kept for backward compatibility with external importers. Application code
+# must not mutate this shared instance; ``create_app`` builds a fresh router
+# via ``build_router()``.
+router = build_router()

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1220,7 +1220,7 @@ def create_app(
     # is matched before /tasks/{task_id}.
     from bernstein.core.routes.acp import router as acp_router
     from bernstein.core.routes.agent_comparison import router as agent_comparison_router
-    from bernstein.core.routes.api_v1 import router as api_v1_router
+    from bernstein.core.routes.api_v1 import build_router as build_api_v1_router
     from bernstein.core.routes.approvals import router as approvals_router
     from bernstein.core.routes.audit_log import router as audit_log_router
     from bernstein.core.routes.batch_ops import router as batch_ops_router
@@ -1312,6 +1312,12 @@ def create_app(
         session_peek_router,
         orchestrator_holds_router,
     ]
+
+    # Fresh per-app router: including route groups mutates the target router,
+    # so reusing the module-level instance would grow it by a full copy of
+    # the v1 route set on every create_app call (unbounded route/memory
+    # growth in app-per-test suites, ending in RecursionError at startup).
+    api_v1_router = build_api_v1_router()
 
     for r in all_routers:
         application.include_router(r)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,24 +92,43 @@ if platform.system() != "Windows":
         resource.setrlimit(resource.RLIMIT_AS, (_MAX_RSS_BYTES, _hard))
 
 
+def _current_rss_bytes() -> int:
+    """Return the process's current resident set size in bytes.
+
+    Deliberately the *current* RSS, not ``ru_maxrss``: the latter is the
+    lifetime peak and never decreases, so once any single test spiked past
+    the cap every later teardown in the run would trip the guard even
+    though the memory had long been reclaimed.
+    """
+    import psutil
+
+    return int(psutil.Process().memory_info().rss)
+
+
+def _enforce_memory_guard(rss_bytes: int) -> None:
+    """Abort the pytest session once if live RSS exceeds the cap.
+
+    Uses ``pytest.exit`` rather than ``sys.exit``: ``SystemExit`` raised in
+    a fixture teardown is recorded as a per-test ERROR and the run keeps
+    going, so a single crossing used to cascade into an error on every
+    remaining test in the session. ``pytest.exit`` stops the run exactly
+    once with a clear message.
+    """
+    if rss_bytes > _MAX_RSS_BYTES:
+        pytest.exit(
+            f"pytest RSS exceeded {_MAX_RSS_BYTES // (1024**3)} GB (actual: {rss_bytes / (1024**3):.1f} GB). Aborting.",
+            returncode=137,
+        )
+
+
 @pytest.fixture(autouse=True)
 def _memory_guard():
-    """Force GC before and after every test; abort if RSS exceeds limit."""
+    """Force GC after every test; abort the session if live RSS exceeds the cap."""
     yield
     # Aggressive garbage collection to prevent accumulation
     gc.collect()
     if platform.system() == "Darwin":
-        import resource
-
-        usage = resource.getrusage(resource.RUSAGE_SELF)
-        rss_bytes = usage.ru_maxrss  # macOS reports bytes
-        if rss_bytes > _MAX_RSS_BYTES:
-            print(
-                f"\n\nFATAL: pytest RSS exceeded {_MAX_RSS_BYTES // (1024**3)} GB "
-                f"(actual: {rss_bytes / (1024**3):.1f} GB). Aborting.\n",
-                file=sys.stderr,
-            )
-            sys.exit(137)
+        _enforce_memory_guard(_current_rss_bytes())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_app_factory_isolation.py
+++ b/tests/unit/test_app_factory_isolation.py
@@ -1,0 +1,83 @@
+"""Regression tests for app-factory isolation and the suite memory guard.
+
+Combined pytest batches that included app-creating suites (test_dashboard
+among them) used to fail late in the run: every ``create_app`` call appended
+a full copy of the /api/v1 route set to a shared module-level router, so
+each successive app instance grew by ~220 routes. Route tables and RSS grew
+without bound across the session, app startup eventually died with
+``RecursionError``, and the suite memory guard then converted the crossing
+into a teardown error on every remaining test. Each file passed in
+isolation, which made the batch failure look like cross-file pollution.
+
+These tests pin both invariants cheaply so the pollution cannot return:
+
+* building an app must not mutate shared router state, and
+* the memory guard must abort the session exactly once, based on current
+  (not lifetime-peak) RSS.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from _pytest.outcomes import Exit
+
+from bernstein.core.routes import api_v1
+from bernstein.core.server import create_app
+from tests.conftest import _MAX_RSS_BYTES, _enforce_memory_guard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_create_app_does_not_grow_route_table_across_instances(tmp_path: Path) -> None:
+    """Two consecutive apps must have identical route tables.
+
+    Before the fix the second app inherited an extra copy of the whole
+    /api/v1 route set from the shared module-level router, so its route
+    count was ~220 higher than the first app's.
+    """
+    app_one = create_app(jsonl_path=tmp_path / "one" / "tasks.jsonl")
+    app_two = create_app(jsonl_path=tmp_path / "two" / "tasks.jsonl")
+
+    assert len(app_two.routes) == len(app_one.routes)
+
+
+def test_create_app_does_not_mutate_shared_api_v1_router(tmp_path: Path) -> None:
+    """Building an app must leave the module-level v1 router untouched."""
+    routes_before = len(api_v1.router.routes)
+
+    create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    assert len(api_v1.router.routes) == routes_before
+
+
+def test_build_router_returns_fresh_instances() -> None:
+    """Each call must return a distinct, empty router."""
+    first = api_v1.build_router()
+    second = api_v1.build_router()
+
+    assert first is not second
+    assert first.routes == []
+    assert second.routes == []
+
+
+def test_memory_guard_below_cap_is_noop() -> None:
+    """RSS below the cap must not interrupt the run."""
+    _enforce_memory_guard(_MAX_RSS_BYTES - 1)
+
+
+def test_memory_guard_above_cap_aborts_session_once() -> None:
+    """RSS above the cap must stop the session via pytest.exit.
+
+    ``pytest.exit`` raises ``_pytest.outcomes.Exit``, which ends the run
+    exactly once. The old ``sys.exit(137)`` raised ``SystemExit`` from a
+    fixture teardown, which pytest records as a per-test ERROR and keeps
+    running - one crossing used to error every remaining test in the batch.
+    """
+    with pytest.raises(Exit) as excinfo:
+        _enforce_memory_guard(_MAX_RSS_BYTES + 1)
+
+    assert not isinstance(excinfo.value, SystemExit)
+    assert excinfo.value.returncode == 137


### PR DESCRIPTION
## Symptom

One specific combined pytest batch (test_dashboard and test_cli_status among the files) finished with `137 passed, 19 errors` while every file in the batch passed in isolation. The errors landed on unrelated tests at the tail of the run (pure-function helpers in test_dashboard and test_cli_status), and longer sessions died earlier with `RecursionError: maximum recursion depth exceeded` during `TestClient(app)` startup.

## Minimal repro (on main)

```
uv run pytest tests/unit/test_task_store_property.py \
  tests/unit/test_api_contracts.py \
  tests/unit/test_frontend_smoke_bug_sweep.py \
  tests/unit/test_auto_commit_on_complete.py \
  tests/unit/test_task_crud_log_sanitization.py \
  tests/unit/test_task_crud_claim_conflict_logging.py \
  tests/unit/test_interactive_tasks.py \
  tests/unit/test_dashboard.py \
  tests/unit/test_status_route_ui_payload.py \
  tests/unit/test_cli_status.py -q
```

Before: `137 passed, 19 errors in ~6 min`. After: `139 passed in ~1 min`.

## Root cause

Two stacked defects:

1. **`create_app` mutated a shared module-level router.** `bernstein/core/routes/api_v1.py` defined `router` at module level, and `create_app` ran `api_v1_router.include_router(r)` for every route group. `include_router` mutates the target, so each `create_app` call appended a full copy of the v1 route set (~220 routes) to the shared object. Every later app inherited the accumulated copies: app 1 had 463 routes, app 25 had 5791. RSS climbed monotonically across the session (2 GB after ~120 tests in the batch), and at ~20 apps in one process `TestClient` startup exceeded the recursion limit.

2. **The suite memory guard amplified the failure and misattributed it.** `_memory_guard` in `tests/conftest.py` compared `ru_maxrss` (lifetime peak RSS, which never decreases) against the 2 GB cap and raised `sys.exit(137)` from a fixture teardown. pytest records `SystemExit` in teardown as a per-test ERROR and keeps running, so a single crossing errored every remaining test in the batch - the 19 errors on innocent files.

## Fix

- `create_app` now builds a fresh `/api/v1` router per application via `api_v1.build_router()`; the module-level instance is never mutated. Route count is constant across instances and RSS stays flat (verified with 40 consecutive `create_app` + `TestClient` startups).
- The memory guard now measures current RSS via psutil (already a dependency) and aborts the session exactly once via `pytest.exit(returncode=137)` instead of erroring every remaining teardown.

## Regression guard

`tests/unit/test_app_factory_isolation.py` (runs in ~3 s):

- two consecutive `create_app` calls produce identical route tables;
- app construction leaves the shared v1 router untouched;
- `build_router()` returns fresh empty instances;
- the memory guard is a no-op below the cap and raises pytest's session-level `Exit` (not `SystemExit`) with returncode 137 above it.

## Verification

- previously failing 10-file batch: `139 passed, 0 errors` (was `137 passed, 19 errors`)
- `tests/unit/test_dashboard.py` alone: `29 passed`; `tests/unit/test_cli_status.py` alone: `4 passed`
- `uv run ruff check src/ tests/`: clean; `uv run python -c "import bernstein"`: ok
- note: `pytest tests/unit/test_api_v1_routing.py tests/unit/test_server_track_b.py` has one order-dependent failure that pre-exists on main (reproduced on the pristine base commit); unrelated to this change

Fixes #2254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app initialization so repeated starts don’t accumulate duplicate routes, helping keep behavior consistent and reliable.
  * Reduced risk of memory-related test/runtime issues on macOS by tightening how high-memory conditions are detected and handled.

* **Tests**
  * Added coverage to verify app instances stay isolated and routing remains stable across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->