### PR TITLE
Fail fast when the sensitive gate refuses a reactive compaction

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -17,6 +17,7 @@ import signal
 import subprocess
 import time
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -516,6 +517,31 @@ _COMPACT_RETRY_META = (
 #: After this many compaction-retries the task is failed permanently.
 _COMPACT_MAX_RETRIES: int = 1
 
+#: Typed terminal failure reason recorded when the sensitive gate refuses
+#: a reactive compaction. Deliberately free of the transient-failure
+#: keywords ``task_lifecycle._dynamic_retry_limit`` matches on, so the
+#: reason never earns a retry budget: combined with ``max_task_retries=0``
+#: at the call site, the failure is terminal by construction.
+_GATE_REFUSAL_FAILURE_REASON: str = "Context overflow: compaction refused by sensitive gate"
+
+
+class CompactRetryOutcome(StrEnum):
+    """Typed outcome of the reactive 413 compact-and-retry handler.
+
+    Each value doubles as the ``error_type`` tag on the orphan metric the
+    caller emits, so a gate-refusal fast-fail stays distinguishable from
+    a pipeline failure in post-run analysis.
+    """
+
+    #: Compaction succeeded and a compacted retry task was queued.
+    RETRIED = "context_overflow_compacted"
+    #: Compaction failed or the compact-retry budget was exhausted.
+    FAILED = "context_overflow_compact_failed"
+    #: The sensitive gate refused the compaction; the task was failed
+    #: fast with :data:`_GATE_REFUSAL_FAILURE_REASON` instead of burning
+    #: the remaining compact retries on an unchanged oversized prompt.
+    GATE_REFUSED = "context_overflow_gate_refused"
+
 
 def _try_compact_and_retry(
     *,
@@ -525,7 +551,7 @@ def _try_compact_and_retry(
     session: AgentSession,
     tasks_snapshot: dict[str, list[Task]],
     fallback_model: str | None,
-) -> bool:
+) -> CompactRetryOutcome:
     """Run the compaction pipeline on the task's prompt and retry once.
 
     When an agent crashes with a 413 / context-overflow error, this function:
@@ -535,10 +561,14 @@ def _try_compact_and_retry(
        on the task description (the only mutable part of the prompt).
     3. Creates a retry task with a ``meta_message`` instructing the agent
        to work with reduced context.
-    4. Returns ``True`` if the retry was queued, ``False`` if compaction
-       failed or the retry limit was reached.
 
     Bounded to ``_COMPACT_MAX_RETRIES`` retries to prevent infinite loops.
+
+    When the pipeline's sensitive gate refuses the compaction
+    (``gate_action="refused"``), the description is unchanged and a retry
+    would 413 again with the same oversized prompt - the task is failed
+    fast with a typed terminal reason instead (issue #2253); see
+    :func:`_fail_fast_on_gate_refusal`.
 
     Args:
         orch: Orchestrator instance.
@@ -549,7 +579,10 @@ def _try_compact_and_retry(
         fallback_model: Optional cascade fallback model.
 
     Returns:
-        True if a compacted retry was successfully queued.
+        ``CompactRetryOutcome.RETRIED`` when a compacted retry was queued,
+        ``CompactRetryOutcome.GATE_REFUSED`` when the sensitive gate
+        refused and the task was failed fast, ``CompactRetryOutcome.FAILED``
+        when compaction failed or the compact-retry budget was exhausted.
     """
     from bernstein.core.compaction_pipeline import CompactionPipeline
 
@@ -573,7 +606,7 @@ def _try_compact_and_retry(
             workdir=getattr(orch, "_workdir", None),
             **_retry_escalation_context(orch),
         )
-        return False
+        return CompactRetryOutcome.FAILED
 
     # Run the compaction pipeline on the task description.
     pipeline = CompactionPipeline(plugin_manager=getattr(orch, "_plugin_manager", None))
@@ -621,17 +654,22 @@ def _try_compact_and_retry(
             workdir=getattr(orch, "_workdir", None),
             **_retry_escalation_context(orch),
         )
-        return False
+        return CompactRetryOutcome.FAILED
 
     if result.gate_action == "refused":
         # The sensitive gate found credential-shaped content it could not
         # safely delimit: nothing was sent to the model and the description
-        # is unchanged. The refusal is already in the audit chain; surface
-        # it to the operator log too.
-        logger.warning(
-            "Compaction for task %s skipped by sensitive gate (rules: %s)",
-            task_id,
-            ", ".join(result.gate_rule_ids),
+        # is unchanged, so a retry would 413 again with the same oversized
+        # prompt. Fail fast instead of burning the remaining compact
+        # retries (issue #2253).
+        return _fail_fast_on_gate_refusal(
+            orch=orch,
+            task_id=task_id,
+            session=session,
+            description_text=description_text,
+            result=result,
+            chain=_gate_chain,
+            tasks_snapshot=tasks_snapshot,
         )
 
     # Reconcile post-compaction budget now that we know how many tokens were saved.
@@ -657,19 +695,19 @@ def _try_compact_and_retry(
     # Receipt the compaction (issue #2246): chain event, replay-journal
     # step, ledger row, and metric point. Recording is best-effort and
     # never alters the retry behaviour below; a missing receipt is caught
-    # by the run's audit verification instead.
-    if result.gate_action != "refused":
-        try:
-            _record_reactive_compaction_receipt(
-                orch=orch,
-                session=session,
-                task_id=task_id,
-                pre_text=description_text,
-                result=result,
-                chain=_gate_chain,
-            )
-        except Exception as _receipt_exc:
-            logger.warning("Reactive compaction receipt failed for %s: %s", task_id, _receipt_exc)
+    # by the run's audit verification instead. (The gate-refusal branch
+    # above returned already, anchoring its own refusal receipt.)
+    try:
+        _record_reactive_compaction_receipt(
+            orch=orch,
+            session=session,
+            task_id=task_id,
+            pre_text=description_text,
+            result=result,
+            chain=_gate_chain,
+        )
+    except Exception as _receipt_exc:
+        logger.warning("Reactive compaction receipt failed for %s: %s", task_id, _receipt_exc)
 
     # Retry the task with compacted description and a nudge meta-message.
     retry_or_fail_task(
@@ -718,7 +756,104 @@ def _try_compact_and_retry(
         except OSError:
             logger.debug("WAL write failed for context_overflow_compacted %s", task_id)
 
-    return True
+    return CompactRetryOutcome.RETRIED
+
+
+def _fail_fast_on_gate_refusal(
+    *,
+    orch: Any,
+    task_id: str,
+    session: AgentSession,
+    description_text: str,
+    result: Any,
+    chain: Any,
+    tasks_snapshot: dict[str, list[Task]],
+) -> CompactRetryOutcome:
+    """Terminally fail a task whose reactive compaction the gate refused.
+
+    The refusal is deterministic: the same description scanned again
+    produces the same refusal, so re-queueing the retry can only 413
+    again until ``_COMPACT_MAX_RETRIES`` burns down. Instead the task is
+    failed with :data:`_GATE_REFUSAL_FAILURE_REASON` naming the gate and
+    the deny rules that fired, routing it to the dead-letter queue (and
+    the operator error sink) on the first refusal.
+
+    Visibility contract (issue #2253): the pipeline already chained the
+    gate's own ``compaction.sensitive_gate`` events exactly once; this
+    helper anchors the refusal receipt (``gate_action="refused"``,
+    pre == post hashes) exactly once and never re-emits the gate events.
+    No compaction metric point is written - nothing was compacted.
+
+    Args:
+        orch: Orchestrator instance.
+        task_id: Task being failed.
+        session: Dead agent session that overflowed.
+        description_text: Task description the gate refused (unchanged).
+        result: The refusing ``CompactionResult`` from the pipeline.
+        chain: Audit chain store resolved for this run (may be None).
+        tasks_snapshot: Pre-fetched tasks for dedup checks.
+
+    Returns:
+        Always ``CompactRetryOutcome.GATE_REFUSED``.
+    """
+    logger.warning(
+        "Compaction for task %s refused by sensitive gate (rules: %s) - failing fast instead of retrying",
+        task_id,
+        ", ".join(result.gate_rule_ids),
+    )
+
+    # Anchor the refusal receipt before failing the task so the refusal
+    # stays auditable even if the failure PATCH fails midway.
+    try:
+        _record_reactive_compaction_receipt(
+            orch=orch,
+            session=session,
+            task_id=task_id,
+            pre_text=description_text,
+            result=result,
+            chain=chain,
+            record_metric=False,
+        )
+    except Exception as _receipt_exc:
+        logger.warning("Gate-refusal receipt failed for %s: %s", task_id, _receipt_exc)
+
+    reason = (
+        f"{_GATE_REFUSAL_FAILURE_REASON} "
+        f"(rules: {', '.join(result.gate_rule_ids)}; correlation={result.correlation_id})"
+    )
+    retry_or_fail_task(
+        task_id,
+        reason,
+        client=orch._client,
+        server_url=orch._config.server_url,
+        max_task_retries=0,  # deterministic refusal: force permanent fail
+        retried_task_ids=orch._retried_task_ids,
+        tasks_snapshot=tasks_snapshot,
+        workdir=getattr(orch, "_workdir", None),
+        **_retry_escalation_context(orch),
+    )
+
+    _wal: Any = getattr(orch, "_wal_writer", None)
+    if _wal is not None:
+        try:
+            _wal.write_entry(
+                decision_type="context_overflow_gate_refused",
+                inputs={
+                    "task_id": task_id,
+                    "agent_id": session.id,
+                    "gate_rule_ids": list(result.gate_rule_ids),
+                },
+                output={
+                    "correlation_id": result.correlation_id,
+                    "compacted": False,
+                    "failed_fast": True,
+                },
+                actor="agent_lifecycle",
+            )
+        except OSError:
+            logger.debug("WAL write failed for context_overflow_gate_refused %s", task_id)
+
+    return CompactRetryOutcome.GATE_REFUSED
 
 
 def _record_reactive_compaction_receipt(
@@ -729,6 +864,7 @@ def _record_reactive_compaction_receipt(
     pre_text: str,
     result: Any,
     chain: Any,
+    record_metric: bool = True,
 ) -> None:
     """Anchor the reactive compaction in chain, journal, ledger, metrics.
 
@@ -744,6 +880,9 @@ def _record_reactive_compaction_receipt(
         pre_text: Task description before compaction.
         result: The ``CompactionResult`` from the pipeline.
         chain: Audit chain store resolved for this run (may be None).
+        record_metric: When ``False``, skip the compaction metric point.
+            Used by the gate-refusal fast-fail, which anchors a receipt
+            for auditability but did not compact anything.
     """
     from bernstein.core.tokens.compaction_receipt import (
         build_receipt,
@@ -772,6 +911,8 @@ def _record_reactive_compaction_receipt(
         workdir=Path(_workdir) if _workdir is not None else None,
         spend_ledger=getattr(orch, "_spend_ledger", None),
     )
+    if not record_metric:
+        return
     try:
         get_collector().record_compaction(
             session.id,
@@ -1110,7 +1251,7 @@ def _handle_failure_detection(
         return True
 
     if _failure_type == "context_overflow":
-        _compacted = _try_compact_and_retry(
+        _outcome = _try_compact_and_retry(
             orch=orch,
             task=task,
             task_id=task_id,
@@ -1118,8 +1259,7 @@ def _handle_failure_detection(
             tasks_snapshot=tasks_snapshot,
             fallback_model=_fallback_model,
         )
-        error_type = "context_overflow_compacted" if _compacted else "context_overflow_compact_failed"
-        emit_orphan_metrics(orch._workdir, task_id, session, start_ts, success=False, error_type=error_type)
+        emit_orphan_metrics(orch._workdir, task_id, session, start_ts, success=False, error_type=_outcome.value)
         orch._record_provider_health(session, success=False)
         return True
 

--- a/tests/unit/test_proactive_compaction.py
+++ b/tests/unit/test_proactive_compaction.py
@@ -329,7 +329,7 @@ class TestTickWiring:
 
 class TestReactiveReceipt:
     def test_reactive_compaction_records_receipt(self, tmp_path: Path) -> None:
-        from bernstein.core.agent_lifecycle import _try_compact_and_retry
+        from bernstein.core.agent_lifecycle import CompactRetryOutcome, _try_compact_and_retry
         from bernstein.core.models import (
             AgentSession,
             Complexity,
@@ -380,13 +380,16 @@ class TestReactiveReceipt:
         orch._plugin_manager = None
 
         snapshot = {"open": [task], "claimed": [], "in_progress": [], "done": []}
-        assert _try_compact_and_retry(
-            orch=orch,
-            task=task,
-            task_id="T-413",
-            session=session,
-            tasks_snapshot=snapshot,
-            fallback_model=None,
+        assert (
+            _try_compact_and_retry(
+                orch=orch,
+                task=task,
+                task_id="T-413",
+                session=session,
+                tasks_snapshot=snapshot,
+                fallback_model=None,
+            )
+            is CompactRetryOutcome.RETRIED
         )
 
         chain = AuditChainStore(tmp_path / ".sdd" / "audit")

--- a/tests/unit/test_reactive_compact_413.py
+++ b/tests/unit/test_reactive_compact_413.py
@@ -5,6 +5,8 @@ Covers:
 - detect_failure_type returning "context_overflow"
 - _try_compact_and_retry executing the compaction pipeline and retrying
 - Retry limit enforcement (max 1 compaction retry)
+- Sensitive-gate refusal fast-fail (issue #2253): no wasted compact
+  retries, typed terminal reason, refusal receipt + audit events
 - handle_orphaned_task integration with context_overflow path
 """
 
@@ -18,6 +20,8 @@ import pytest
 from bernstein.core.agent_lifecycle import (
     _COMPACT_MAX_RETRIES,
     _COMPACT_RETRY_META,
+    _GATE_REFUSAL_FAILURE_REASON,
+    CompactRetryOutcome,
     _try_compact_and_retry,
     handle_orphaned_task,
 )
@@ -35,16 +39,44 @@ from bernstein.core.rate_limit_tracker import (
     RateLimitTracker,
 )
 
+from bernstein.core.persistence.journal import JournalReader, agent_journal_dir
+from bernstein.core.security.audit_chain import (
+    EVENT_COMPACTION_SENSITIVE_GATE,
+    AuditChainStore,
+)
+from bernstein.core.tokens.compaction_receipt import (
+    load_receipts,
+    verify_compaction_receipts,
+)
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _make_task(task_id: str = "T-413", meta_messages: list[str] | None = None) -> Task:
+#: Description with an unterminated PEM header: the sensitive gate cannot
+#: delimit the key material, so it refuses the whole compaction.
+_REFUSING_DESCRIPTION = (
+    "Investigate deploy failure.\n-----BEGIN RSA PRIVATE KEY-----\ntruncated key material with no footer\n"
+    + "filler narrative line\n" * 30
+)
+
+#: Description with a delimitable credential span: the gate redacts the
+#: span and lets the compaction proceed.
+_REDACTING_DESCRIPTION = (
+    "Rotate the leaked key AKIAABCDEFGHIJKLMNOP in the deploy scripts.\n" + "filler narrative line\n" * 30
+)
+
+
+def _make_task(
+    task_id: str = "T-413",
+    meta_messages: list[str] | None = None,
+    description: str | None = None,
+) -> Task:
     return Task(
         id=task_id,
         title="Implement feature",
-        description="Write the code for the new feature module.\n" * 20,
+        description=description or "Write the code for the new feature module.\n" * 20,
         role="backend",
         status=TaskStatus.OPEN,
         scope=Scope.MEDIUM,
@@ -224,7 +256,7 @@ class TestTryCompactAndRetry:
                 fallback_model=None,
             )
 
-        assert result is True
+        assert result is CompactRetryOutcome.RETRIED
         mock_retry.assert_called_once()
         # Verify retry was called with a 413-specific reason
         call_kwargs = mock_retry.call_args
@@ -245,7 +277,7 @@ class TestTryCompactAndRetry:
                 fallback_model=None,
             )
 
-        assert result is False
+        assert result is CompactRetryOutcome.FAILED
         # retry_or_fail_task should be called with max_task_retries=0 to force fail
         mock_retry.assert_called_once()
         assert mock_retry.call_args[1]["max_task_retries"] == 0
@@ -271,7 +303,7 @@ class TestTryCompactAndRetry:
                 fallback_model=None,
             )
 
-        assert result is False
+        assert result is CompactRetryOutcome.FAILED
         mock_retry.assert_called_once()
         assert "compaction failed" in mock_retry.call_args[0][1].lower()
 
@@ -334,6 +366,118 @@ class TestTryCompactAndRetry:
 
 
 # ---------------------------------------------------------------------------
+# Sensitive-gate refusal fast-fail (issue #2253)
+# ---------------------------------------------------------------------------
+
+
+class TestGateRefusalFastFail:
+    """gate_action=refused fails the task fast instead of burning retries."""
+
+    def _run(self, tmp_path: Path, *, with_audit_dir: bool = False) -> tuple[SimpleNamespace, MagicMock, object]:
+        task = _make_task(description=_REFUSING_DESCRIPTION)
+        session = _make_session()
+        orch = _make_orch(tmp_path)
+        orch._wal_writer = MagicMock()
+        if with_audit_dir:
+            (tmp_path / ".sdd" / "audit").mkdir(parents=True)
+
+        with patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry:
+            result = _try_compact_and_retry(
+                orch=orch,
+                task=task,
+                task_id=task.id,
+                session=session,
+                tasks_snapshot=_snapshot(task),
+                fallback_model=None,
+            )
+        return orch, mock_retry, result
+
+    def test_refusal_returns_gate_refused_outcome(self, tmp_path: Path) -> None:
+        _orch, _mock_retry, result = self._run(tmp_path)
+        assert result is CompactRetryOutcome.GATE_REFUSED
+
+    def test_refusal_fails_task_terminally_with_gate_reason(self, tmp_path: Path) -> None:
+        _orch, mock_retry, _result = self._run(tmp_path)
+        mock_retry.assert_called_once()
+        reason = mock_retry.call_args[0][1]
+        assert reason.startswith(_GATE_REFUSAL_FAILURE_REASON)
+        assert "sensitive gate" in reason
+        assert "content.pem-unterminated" in reason
+        # max_task_retries=0 forces the permanent-fail branch: no further
+        # compact retries are queued for the unchanged oversized prompt.
+        assert mock_retry.call_args[1]["max_task_retries"] == 0
+
+    def test_refusal_does_not_queue_compacted_retry(self, tmp_path: Path) -> None:
+        orch, _mock_retry, _result = self._run(tmp_path)
+        # No retry-task PATCH: the description is unchanged and no
+        # compacted retry exists to patch.
+        orch._client.patch.assert_not_called()
+
+    def test_refusal_reason_grants_no_dynamic_retry_budget(self, tmp_path: Path) -> None:
+        """Guard: the terminal reason must never match a transient marker."""
+        from bernstein.core.tasks.task_lifecycle import _dynamic_retry_limit
+
+        _orch, mock_retry, _result = self._run(tmp_path)
+        reason = mock_retry.call_args[0][1]
+        assert _dynamic_retry_limit(reason, 0) == 0
+
+    def test_refusal_receipt_and_audit_events_recorded_once(self, tmp_path: Path) -> None:
+        orch, _mock_retry, _result = self._run(tmp_path, with_audit_dir=True)
+
+        chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+        receipts = load_receipts(chain, task_id="T-413")
+        assert len(receipts) == 1
+        assert receipts[0].trigger == "reactive"
+        assert receipts[0].gate_action == "refused"
+        assert "content.pem-unterminated" in receipts[0].gate_rule_ids
+        # Refused compaction leaves the description unchanged.
+        assert receipts[0].pre_sha256 == receipts[0].post_sha256
+        assert receipts[0].tokens_before == receipts[0].tokens_after
+
+        gate_events = chain.query(event_type=EVENT_COMPACTION_SENSITIVE_GATE)
+        assert len(gate_events) == 1
+        assert gate_events[0].details["action"] == "refused"
+
+        reader = JournalReader(agent_journal_dir(tmp_path / ".sdd", "sess-413"))
+        ok, errors = verify_compaction_receipts(chain, journal_reader=reader)
+        assert ok, errors
+
+        orch._wal_writer.write_entry.assert_called_once()
+        wal_call = orch._wal_writer.write_entry.call_args
+        assert wal_call[1]["decision_type"] == "context_overflow_gate_refused"
+        assert wal_call[1]["output"]["compacted"] is False
+
+    def test_redaction_path_still_compacts_and_retries(self, tmp_path: Path) -> None:
+        """Regression: a redacted (non-refused) gate outcome keeps the
+        historical compact-and-retry behavior."""
+        task = _make_task(description=_REDACTING_DESCRIPTION)
+        session = _make_session()
+        orch = _make_orch(tmp_path)
+        (tmp_path / ".sdd" / "audit").mkdir(parents=True)
+
+        with patch("bernstein.core.agents.agent_lifecycle.retry_or_fail_task") as mock_retry:
+            result = _try_compact_and_retry(
+                orch=orch,
+                task=task,
+                task_id=task.id,
+                session=session,
+                tasks_snapshot=_snapshot(task),
+                fallback_model=None,
+            )
+
+        assert result is CompactRetryOutcome.RETRIED
+        mock_retry.assert_called_once()
+        assert "Context overflow (413)" in mock_retry.call_args[0][1]
+        # The retry keeps its normal retry budget.
+        assert mock_retry.call_args[1]["max_task_retries"] == orch._config.max_task_retries
+
+        chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+        receipts = load_receipts(chain, task_id="T-413")
+        assert len(receipts) == 1
+        assert receipts[0].gate_action == "redacted"
+
+
+# ---------------------------------------------------------------------------
 # handle_orphaned_task integration: context_overflow branch
 # ---------------------------------------------------------------------------
 
@@ -353,7 +497,10 @@ class TestHandleOrphanedTaskContextOverflow:
         log_file.write_text("ERROR: 413 prompt is too long\n")
 
         with (
-            patch("bernstein.core.agents.agent_lifecycle._try_compact_and_retry", return_value=True) as mock_compact,
+            patch(
+                "bernstein.core.agents.agent_lifecycle._try_compact_and_retry",
+                return_value=CompactRetryOutcome.RETRIED,
+            ) as mock_compact,
             patch("bernstein.core.agents.agent_lifecycle.emit_orphan_metrics"),
         ):
             handle_orphaned_task(orch, task.id, session, _snapshot(task))
@@ -371,7 +518,10 @@ class TestHandleOrphanedTaskContextOverflow:
         (sdd_runtime / f"{session.id}.log").write_text("ERROR: 413\n")
 
         with (
-            patch("bernstein.core.agents.agent_lifecycle._try_compact_and_retry", return_value=False),
+            patch(
+                "bernstein.core.agents.agent_lifecycle._try_compact_and_retry",
+                return_value=CompactRetryOutcome.FAILED,
+            ),
             patch("bernstein.core.agents.agent_lifecycle.emit_orphan_metrics") as mock_metrics,
         ):
             handle_orphaned_task(orch, task.id, session, _snapshot(task))
@@ -379,6 +529,28 @@ class TestHandleOrphanedTaskContextOverflow:
         mock_metrics.assert_called_once()
         metrics_kwargs = mock_metrics.call_args[1]
         assert metrics_kwargs["error_type"] == "context_overflow_compact_failed"
+
+    def test_context_overflow_gate_refusal_emits_typed_metric(self, tmp_path: Path) -> None:
+        task = _make_task()
+        session = _make_session()
+        orch = _make_orch(tmp_path, failure_type="context_overflow")
+
+        sdd_runtime = tmp_path / ".sdd" / "runtime"
+        sdd_runtime.mkdir(parents=True)
+        (sdd_runtime / f"{session.id}.log").write_text("ERROR: 413\n")
+
+        with (
+            patch(
+                "bernstein.core.agents.agent_lifecycle._try_compact_and_retry",
+                return_value=CompactRetryOutcome.GATE_REFUSED,
+            ),
+            patch("bernstein.core.agents.agent_lifecycle.emit_orphan_metrics") as mock_metrics,
+        ):
+            handle_orphaned_task(orch, task.id, session, _snapshot(task))
+
+        mock_metrics.assert_called_once()
+        metrics_kwargs = mock_metrics.call_args[1]
+        assert metrics_kwargs["error_type"] == "context_overflow_gate_refused"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When the sensitive gate refuses a compaction on the reactive 413 path (gate_action=refused), _try_compact_and_retry logs a warning but still queues a retry with the unchanged oversized description. The retry hits 413 again and burns the remaining compact-retry budget. Nothing gated ever reaches the model and the loop is bounded, but the retries are wasted.

## Fix

- On gate refusal the task now fails fast with a typed terminal reason naming the sensitive gate and the deny rules that fired; retry_or_fail_task runs with max_task_retries=0, so the task routes to the dead-letter queue (and the operator error sink) on the first refusal instead of re-queueing the same prompt.
- The refusal receipt (gate_action=refused, pre == post hashes) is anchored in the audit chain, replay journal, and spend ledger exactly once; the pipeline's compaction.sensitive_gate events are emitted once as before. No compaction metric point is written because nothing was compacted.
- A context_overflow_gate_refused WAL entry records the decision.
- _try_compact_and_retry now returns a typed CompactRetryOutcome (RETRIED / FAILED / GATE_REFUSED); the value doubles as the orphan-metric error_type, so a refusal stays distinguishable from a pipeline failure in post-run analysis.
- The redaction (non-refusal) path behavior is unchanged.

## Tests

- New TestGateRefusalFastFail in tests/unit/test_reactive_compact_413.py: refusal returns the typed outcome, the terminal reason names the gate and rules, no compacted retry is queued, the reason earns no dynamic retry budget, and the refusal receipt plus sensitive-gate audit event are recorded exactly once (verify_compaction_receipts passes with the journal reader).
- Regression: a redacted description still compacts and retries with its normal retry budget, receipted as gate_action=redacted.
- handle_orphaned_task emits error_type context_overflow_gate_refused for the refusal outcome.
- Ran the touched files plus the lifecycle, orchestrator, compaction, and integration importer suites: 1148 passed, 7 skipped. ruff check, ruff format --check, and lint-imports are clean.

Fixes #2253