### PR TITLE
Operator-gated role template compression with verified backups and chained receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Highest-value commands; full list in [docs/operations/commands.md](docs/operatio
 | `bernstein chat serve --platform=telegram\|discord\|slack` | Drive runs from chat with `/run`, `/status`, `/approve`, `/reject`. |
 | `bernstein workflow run <name>` | Run a YAML workflow manifest. |
 | `bernstein schedule add\|list\|run` | Manage operator-registered recurring schedules; `schedule audit` walks persisted fire receipts to prove the sequence is replayable. |
+| `bernstein templates compress <role>\|--all` | Operator-gated, one-time LLM compression of role prompt templates: mechanically validated (fenced blocks, headings, URLs, placeholders, completion contract stay byte-equal), originals backed up out of tree by content hash, receipt chained to the audit log. `bernstein templates restore <role>` reverses it byte-identically; savings appear in `bernstein cost --by role`. |
 
 ### retrieval & caching: what's actually under the hood
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -529,6 +529,8 @@ Lists plugins in `.bernstein/plugins/<name>/meta.json`.
 | `list` | List available templates. |
 | `show TEMPLATE [OUTPUT]` | Print template content (or write to OUTPUT). |
 | `apply TEMPLATE` | Apply a template to the current project. `--dest DIR`, `--force`. |
+| `compress ROLE\|--all` | Operator-gated LLM compression of role prompt templates (`cli/commands/templates_cmd.py`). Rewrite via the configured adapter (`--model`, `--provider`), then mechanical validators (fenced blocks, headings, URLs, inline code, placeholders, completion-contract block; at most two targeted fix retries), then apply. Originals are stored under `~/.local/share/bernstein/template-backups/` keyed by content hash with readback verification; the receipt `{role, pre_sha256, post_sha256, pre_tokens, post_tokens, validators, adapter, model}` is chained to the audit log and a `templates.lock` row lets `bernstein team drift` classify the change as intentional. Prints only the template token delta; per-spawn savings come from `bernstein cost --by role`. `--workdir DIR`, `--yes` skips the confirmation. |
+| `restore ROLE` | Reverse the most recent receipted compression byte-identically (backup hash, on-disk hash, and directory digest all verified). `--workdir DIR`. |
 
 ---
 

--- a/src/bernstein/cli/commands/team_cmd.py
+++ b/src/bernstein/cli/commands/team_cmd.py
@@ -24,7 +24,7 @@ import click
 
 from bernstein.cli.helpers import console
 from bernstein.core.teams.audit import TeamManifestAuditor
-from bernstein.core.teams.drift import detect_role_template_drift
+from bernstein.core.teams.drift import classify_role_template_drift
 from bernstein.core.teams.manifest import (
     TeamManifest,
     TeamManifestError,
@@ -118,7 +118,10 @@ def drift_cmd(name: str | None, workdir: Path) -> None:
     """Compare pinned role template digests to the on-disk templates.
 
     With NAME, checks one manifest; without, checks every visible
-    manifest. Exits 1 when any pinned role template diverged.
+    manifest. A divergence explained by a receipted template
+    compression (``bernstein templates compress``, issue #2249) is
+    reported as intentional. Exits 1 when any pinned role template
+    drifted for another reason.
     """
     if name is not None:
         manifests = [_resolve_or_fail(name, workdir)]
@@ -132,16 +135,27 @@ def drift_cmd(name: str | None, workdir: Path) -> None:
 
     any_drift = False
     for manifest in manifests:
-        drift = detect_role_template_drift(manifest, workdir=workdir)
-        if not drift:
+        findings = classify_role_template_drift(manifest, workdir=workdir)
+        if not findings:
             console.print(f"[green]{manifest.name}: no drift detected[/green]")
             continue
+        drifted = {role: finding for role, finding in findings.items() if not finding.intentional}
+        intentional = {role: finding for role, finding in findings.items() if finding.intentional}
+        for role, finding in sorted(intentional.items()):
+            console.print(
+                f"[cyan]{manifest.name}: {role}: receipted template compression "
+                f"(intentional, not drift)[/cyan] pinned {finding.pinned_digest[:12]}... -> "
+                f"on-disk {finding.actual_digest[:12]}..."
+            )
+        if not drifted:
+            continue
         any_drift = True
-        console.print(f"[yellow]{manifest.name}: drift detected[/yellow] in {len(drift)} role template(s):")
-        for role, (pinned, actual) in sorted(drift.items()):
+        console.print(f"[yellow]{manifest.name}: drift detected[/yellow] in {len(drifted)} role template(s):")
+        for role, finding in sorted(drifted.items()):
+            actual = finding.actual_digest
             actual_label = actual if actual == "<missing>" else actual[:12] + "..."
-            console.print(f"  - {role}: pinned {pinned[:12]}... vs on-disk {actual_label}")
-        _record_drift(workdir, manifest, sorted(drift))
+            console.print(f"  - {role}: pinned {finding.pinned_digest[:12]}... vs on-disk {actual_label}")
+        _record_drift(workdir, manifest, sorted(drifted))
 
     if any_drift:
         raise SystemExit(1)

--- a/src/bernstein/cli/commands/templates_cmd.py
+++ b/src/bernstein/cli/commands/templates_cmd.py
@@ -1,15 +1,32 @@
-"""Plan template library: list and scaffold reusable YAML plans."""
+"""Plan template library: list, scaffold, and compress role templates.
+
+Besides the plan/hook template browsing commands, this module carries
+the operator-gated role-template compression surface (issue #2249):
+
+  bernstein templates compress <role>|--all    LLM rewrite, validated,
+                                               backed up, receipted.
+  bernstein templates restore <role>           Byte-identical reversal.
+
+Compression is never automatic - it runs only through this explicit
+command. Savings figures come from the spend ledger on subsequent
+spawns (``bernstein cost --by role``); compression itself reports only
+the template token delta.
+"""
 
 from __future__ import annotations
 
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.table import Table
 
 from bernstein.cli.helpers import console
 from bernstein.core.hook_templates import list_hook_templates, scaffold_hook_template
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _YAML_GLOB = "*.yaml"
 
@@ -190,4 +207,160 @@ def templates_hooks_use(template_name: str, workdir: str, force: bool) -> None:
 
     console.print(f"[green]Installed hook template:[/green] [bold]{template_name}[/bold]")
     for path in created:
+        console.print(f"  [dim]-[/dim] {path}")
+
+
+# ---------------------------------------------------------------------------
+# Role template compression (issue #2249)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_COMPRESS_MODEL = "anthropic/claude-haiku-4-5"
+_DEFAULT_COMPRESS_PROVIDER = "openrouter"
+
+_ROLE_WORKDIR_OPTION = click.option(
+    "--workdir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=".",
+    help="Project root the role templates are resolved from.",
+)
+
+
+def _compress_llm_call(model: str, provider: str) -> Callable[[str], str]:
+    """Return a sync ``prompt -> response`` callable over the configured adapter.
+
+    Module-level indirection so tests can substitute a deterministic
+    rewrite function without a live provider.
+    """
+    import asyncio
+
+    from bernstein.core.llm import call_llm
+
+    def _call(prompt: str) -> str:
+        return asyncio.run(call_llm(prompt, model=model, provider=provider, max_tokens=8_000, temperature=0.0))
+
+    return _call
+
+
+def _resolve_compress_roles(workdir: Path, role: str | None, compress_all: bool) -> list[str]:
+    """Return the role names to compress, validating the role/--all choice."""
+    from bernstein.core.teams.drift import resolve_roles_dir
+
+    if compress_all == (role is not None):
+        raise click.UsageError("Provide exactly one of ROLE or --all.")
+    if role is not None:
+        return [role]
+    roles_dir = resolve_roles_dir(workdir)
+    if not roles_dir.is_dir():
+        raise click.ClickException(f"role templates directory not found: {roles_dir}")
+    return sorted(p.name for p in roles_dir.iterdir() if p.is_dir() and not p.name.startswith("_"))
+
+
+@templates_group.command("compress")
+@click.argument("role", required=False, default=None)
+@click.option("--all", "compress_all", is_flag=True, default=False, help="Compress every role template.")
+@_ROLE_WORKDIR_OPTION
+@click.option("--model", default=_DEFAULT_COMPRESS_MODEL, show_default=True, help="Model for the rewrite.")
+@click.option(
+    "--provider",
+    default=_DEFAULT_COMPRESS_PROVIDER,
+    show_default=True,
+    help="Adapter/provider for the rewrite (openrouter, openai, ...).",
+)
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+def templates_compress(
+    role: str | None,
+    compress_all: bool,
+    workdir: Path,
+    model: str,
+    provider: str,
+    yes: bool,
+) -> None:
+    """Compress role prompt templates in place (operator-gated).
+
+    The rewrite goes through the configured adapter, must pass every
+    mechanical validator (fenced blocks, headings, URLs, inline code,
+    placeholders, completion-contract block; at most two targeted fix
+    passes), and is receipted on the audit chain. Originals are backed
+    up out of tree, keyed by content hash; ``bernstein templates
+    restore ROLE`` reverses the compression byte-identically.
+    """
+    from bernstein.core.tokens.sensitive_gate import resolve_default_chain
+    from bernstein.core.tokens.template_compression import (
+        TemplateCompressionError,
+        compress_role_templates,
+        default_backup_root,
+    )
+
+    roles = _resolve_compress_roles(workdir, role, compress_all)
+    if not roles:
+        console.print("[yellow]No role templates found to compress.[/yellow]")
+        return
+
+    if not yes:
+        console.print(
+            f"About to compress {len(roles)} role template(s) in place: {', '.join(roles)}.\n"
+            f"Originals are backed up under [bold]{default_backup_root()}[/bold] "
+            "(content-hash keyed, readback-verified) and every rewrite is receipted "
+            "on the audit chain."
+        )
+        if not click.confirm("Proceed?", default=False):
+            console.print("[dim]Cancelled.[/dim]")
+            return
+
+    chain = resolve_default_chain(workdir)
+    llm_call = _compress_llm_call(model, provider)
+    failures = 0
+    for role_name in roles:
+        try:
+            outcome = compress_role_templates(
+                role_name,
+                workdir=workdir,
+                llm_call=llm_call,
+                adapter=provider,
+                model=model,
+                chain=chain,
+            )
+        except TemplateCompressionError as exc:
+            console.print(f"[red]{role_name}: {exc}[/red]")
+            failures += 1
+            continue
+        if outcome.applied:
+            console.print(
+                f"{role_name}: template reduced {outcome.pre_tokens} -> {outcome.post_tokens} tokens; "
+                "per-spawn savings will appear in the ledger",
+                soft_wrap=True,
+            )
+        else:
+            console.print(f"[yellow]{role_name}: {outcome.reason}[/yellow]")
+            failures += 1
+    if failures:
+        raise SystemExit(1)
+
+
+@templates_group.command("restore")
+@click.argument("role")
+@_ROLE_WORKDIR_OPTION
+def templates_restore(role: str, workdir: Path) -> None:
+    """Restore ROLE's templates to the byte-identical pre-compression originals.
+
+    Reads the out-of-tree backups keyed by content hash, verifies every
+    hash on the way in and the role directory digest on the way out, and
+    records the reversal on the audit chain.
+    """
+    from bernstein.core.tokens.sensitive_gate import resolve_default_chain
+    from bernstein.core.tokens.template_compression import (
+        TemplateCompressionError,
+        restore_role_templates,
+    )
+
+    try:
+        outcome = restore_role_templates(role, workdir=workdir, chain=resolve_default_chain(workdir))
+    except TemplateCompressionError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(
+        f"[green]{role}: restored {len(outcome.restored_files)} file(s) byte-identically[/green] "
+        f"(directory digest verified: {outcome.pre_digest[:12]}...)"
+    )
+    for path in outcome.restored_files:
         console.print(f"  [dim]-[/dim] {path}")

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -86,6 +86,21 @@ EVENT_COST_PROFILE_REPORT = "cost.profile_report"
 #: artifact byte-identically and check it against the chain.
 EVENT_EVAL_AB_COMPARISON = "eval.ab_comparison"
 
+#: Issue #2249 -- emitted once per applied role-template compression
+#: (``bernstein templates compress``). The event carries the full
+#: compression receipt: role, pre/post role-template directory digests,
+#: token estimates, validator verdicts, adapter and model, per-file
+#: content hashes, and the previous chain digest. See
+#: :mod:`bernstein.core.tokens.template_compression` for the payload
+#: builder and the verification helper.
+EVENT_TEMPLATE_COMPRESSION_RECEIPT = "template.compression.receipt"
+
+#: Issue #2249 -- emitted when ``bernstein templates restore`` reverses
+#: a receipted compression byte-identically. The event references the
+#: compression's correlation id and the verified pre/post role-template
+#: directory digests.
+EVENT_TEMPLATE_COMPRESSION_RESTORE = "template.compression.restore"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -472,6 +487,8 @@ __all__ = [
     "EVENT_COST_PROFILE_REPORT",
     "EVENT_EVAL_AB_COMPARISON",
     "EVENT_MULTIMODAL_ATTACH",
+    "EVENT_TEMPLATE_COMPRESSION_RECEIPT",
+    "EVENT_TEMPLATE_COMPRESSION_RESTORE",
     "AuditChainStore",
     "CostProfileReportDetails",
     "EvalAbComparisonDetails",

--- a/src/bernstein/core/teams/__init__.py
+++ b/src/bernstein/core/teams/__init__.py
@@ -14,6 +14,8 @@ from bernstein.core.teams.audit import (
 )
 from bernstein.core.teams.drift import (
     MISSING_TEMPLATE,
+    RoleDriftFinding,
+    classify_role_template_drift,
     compute_role_digests,
     detect_role_template_drift,
     resolve_roles_dir,
@@ -56,6 +58,7 @@ __all__ = [
     "TEAMS_LOCK_FILENAME",
     "TEAM_MANIFEST_DIR_NAME",
     "ExpandedTeam",
+    "RoleDriftFinding",
     "TeamCoordination",
     "TeamLockEntry",
     "TeamLockState",
@@ -68,6 +71,7 @@ __all__ = [
     "TeamManifestValidationError",
     "TeamRoleSpec",
     "canonical_toml",
+    "classify_role_template_drift",
     "compute_role_digests",
     "detect_role_template_drift",
     "discover_team_manifest_paths",

--- a/src/bernstein/core/teams/drift.py
+++ b/src/bernstein/core/teams/drift.py
@@ -23,6 +23,7 @@ Digest definition
 from __future__ import annotations
 
 import hashlib
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from bernstein import get_templates_dir
@@ -108,8 +109,70 @@ def detect_role_template_drift(manifest: TeamManifest, *, workdir: Path) -> dict
     return out
 
 
+@dataclass(frozen=True, slots=True)
+class RoleDriftFinding:
+    """One pinned role whose on-disk template digest diverged.
+
+    Attributes:
+        role: The pinned role name.
+        pinned_digest: Digest recorded in the manifest.
+        actual_digest: Digest of the on-disk template directory (or
+            :data:`MISSING_TEMPLATE`).
+        intentional: True when a chain of receipted template
+            compressions (issue #2249, ``templates.lock``) explains the
+            divergence; the change was operator-gated, not drift.
+    """
+
+    role: str
+    pinned_digest: str
+    actual_digest: str
+    intentional: bool
+
+
+def classify_role_template_drift(manifest: TeamManifest, *, workdir: Path) -> dict[str, RoleDriftFinding]:
+    """Classify every diverged pin as intentional (receipted) or drift.
+
+    Same digest comparison as :func:`detect_role_template_drift`, then
+    each divergence is checked against the receipted compression rows in
+    ``templates.lock``: when the pinned digest reaches the on-disk
+    digest through recorded ``pre_digest -> post_digest`` edges, the
+    change is a knowing, receipted compression rather than drift.
+
+    Args:
+        manifest: The manifest whose pins to check.
+        workdir: Project root the role templates and ``templates.lock``
+            are resolved from.
+
+    Returns:
+        Map of ``role -> RoleDriftFinding`` for every diverged pin.
+    """
+    from bernstein.core.tokens.template_compression import (
+        compression_explains_digest_change,
+        read_templates_lock,
+        templates_lock_path,
+    )
+
+    lock_state = read_templates_lock(templates_lock_path(workdir))
+    findings: dict[str, RoleDriftFinding] = {}
+    for role, (pinned, actual) in detect_role_template_drift(manifest, workdir=workdir).items():
+        findings[role] = RoleDriftFinding(
+            role=role,
+            pinned_digest=pinned,
+            actual_digest=actual,
+            intentional=compression_explains_digest_change(
+                lock_state,
+                role=role,
+                pinned_digest=pinned,
+                actual_digest=actual,
+            ),
+        )
+    return findings
+
+
 __all__ = [
     "MISSING_TEMPLATE",
+    "RoleDriftFinding",
+    "classify_role_template_drift",
     "compute_role_digests",
     "detect_role_template_drift",
     "resolve_roles_dir",

--- a/src/bernstein/core/tokens/template_compress_validate.py
+++ b/src/bernstein/core/tokens/template_compress_validate.py
@@ -1,0 +1,533 @@
+"""Zero-LLM mechanical validators for role-template rewrites (issue #2249).
+
+``bernstein templates compress`` sends a role prompt template to a model
+for a token-economy rewrite. A template is a load-bearing artifact: every
+worker spawn renders it, so a rewrite that drops a URL, rewords a fenced
+command block, or touches the completion-payload instructions silently
+breaks every subsequent spawn. These validators are the mechanical gate
+between the rewrite stage and the on-disk template - pure functions over
+the ``(pre, post)`` string pair, no LLM, no IO, no clock.
+
+The base compaction validators from
+:mod:`bernstein.core.tokens.compaction_validate` are reused unchanged
+(fenced blocks byte-equal, quoted errors, retained sections, path and
+pin preservation). Template-specific validators run after them, in this
+fixed order:
+
+``frontmatter``
+    A leading YAML frontmatter block (``---`` fences) must be restored
+    byte-equal. The compression engine splits it off before the rewrite
+    and re-attaches it verbatim; this validator proves the round trip.
+
+``headings``
+    The full ATX heading sequence (outside fenced blocks) must survive
+    byte-equal and in order. Compression shortens prose under headings,
+    never the structural map itself.
+
+``urls``
+    The set of URLs must be preserved exactly: a dropped URL loses an
+    instruction target, an invented URL is a hallucination.
+
+``inline_code``
+    The set of single-line inline-code spans (commands, flags, file
+    names) must be preserved exactly.
+
+``placeholders``
+    Every ``{{...}}`` template token (placeholders, ``{{#IF}}`` blocks,
+    ``{{INCLUDE}}`` directives) must be preserved as a multiset. The
+    renderer contract depends on these bytes.
+
+``completion_block``
+    The completion-payload instruction block (worker completion
+    contracts, #2244) is copied verbatim, never rewritten. Both forms
+    are protected: the ``{{INCLUDE completion_contract}}`` directive
+    line, and - for templates that inline the block - the expanded
+    section starting at the completion-contract heading.
+
+On validator failure the caller may run targeted fix passes
+(:func:`validate_template_rewrite`): the fix prompt forbids
+re-compressing and supplies the original as reference, retried at most
+:data:`TEMPLATE_MAX_FIX_RETRIES` (= 2) times before the compression is
+aborted and the original template is left untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import Counter
+from typing import TYPE_CHECKING, Final
+
+from bernstein.core.tokens.compaction_validate import (
+    _FENCE_OPEN_RE,  # pyright: ignore[reportPrivateUsage]
+    ValidationOutcome,
+    ValidatorVerdict,
+    all_passed,
+    build_fix_prompt,
+    run_validators,
+)
+from bernstein.core.tokens.compaction_validate import (
+    VALIDATOR_NAMES as BASE_VALIDATOR_NAMES,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Maximum number of targeted fix passes before a compression is aborted
+#: and the original template restored (issue #2249 spec: max 2).
+TEMPLATE_MAX_FIX_RETRIES: Final[int] = 2
+
+#: Template-specific validator names, in run order (after the base ones).
+TEMPLATE_VALIDATOR_NAMES: Final[tuple[str, ...]] = (
+    "frontmatter",
+    "headings",
+    "urls",
+    "inline_code",
+    "placeholders",
+    "completion_block",
+)
+
+#: Every validator :func:`run_template_validators` executes, in order.
+ALL_TEMPLATE_VALIDATOR_NAMES: Final[tuple[str, ...]] = BASE_VALIDATOR_NAMES + TEMPLATE_VALIDATOR_NAMES
+
+#: Heading line of the expanded completion-payload instruction block
+#: (``templates/roles/_includes/completion_contract.md``). Matches any
+#: contract version so a contract bump does not silently disarm the
+#: validator.
+_COMPLETION_HEADING_RE: Final[re.Pattern[str]] = re.compile(
+    r"^## Done signal \(completion contract [\w./-]+\)\s*$",
+)
+
+#: ``{{INCLUDE name}}`` directive (same shape the renderer expands).
+_INCLUDE_DIRECTIVE_RE: Final[re.Pattern[str]] = re.compile(r"\{\{INCLUDE\s+[\w-]+\}\}")
+
+#: Any ``{{...}}`` template token: placeholders, conditional block
+#: markers, include directives. Single line, non-greedy.
+_TEMPLATE_TOKEN_RE: Final[re.Pattern[str]] = re.compile(r"\{\{[^{}\n]+\}\}")
+
+#: URL shape: scheme plus non-space run, trailing punctuation excluded so
+#: prose like "(see https://x.test/docs)." extracts cleanly.
+_URL_RE: Final[re.Pattern[str]] = re.compile(r"https?://[^\s<>\"'`)\]]+[^\s<>\"'`)\].,;:]")
+
+#: Single-line inline-code span. One backtick on each side; double
+#: backticks and fence lines are excluded by construction (fence lines
+#: are stripped from the prose view before extraction).
+_INLINE_CODE_RE: Final[re.Pattern[str]] = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+
+#: ATX heading: up to 3 spaces of indent, 1-6 ``#``, a space, then text.
+_HEADING_RE: Final[re.Pattern[str]] = re.compile(r"^ {0,3}#{1,6} \S")
+
+_FRONTMATTER_FENCE: Final[str] = "---"
+
+
+# ---------------------------------------------------------------------------
+# Structure helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    """Split a leading YAML frontmatter block off *text*.
+
+    A frontmatter block is a first line of exactly ``---`` followed by a
+    later line of exactly ``---`` (both allowing trailing whitespace).
+
+    Args:
+        text: Full template text.
+
+    Returns:
+        ``(frontmatter, body)``. ``frontmatter`` includes both fence
+        lines and the trailing newline of the closing fence; it is the
+        empty string when *text* has no frontmatter, in which case
+        ``body`` is *text* unchanged. ``frontmatter + body == text``
+        always holds.
+    """
+    lines = text.split("\n")
+    if not lines or lines[0].rstrip() != _FRONTMATTER_FENCE:
+        return "", text
+    for index in range(1, len(lines)):
+        if lines[index].rstrip() == _FRONTMATTER_FENCE:
+            frontmatter = "\n".join(lines[: index + 1]) + "\n"
+            body = "\n".join(lines[index + 1 :])
+            return frontmatter, body
+    return "", text
+
+
+def _prose_lines(text: str) -> list[str]:
+    """Return the lines of *text* outside fenced code blocks.
+
+    Fence handling mirrors :func:`~bernstein.core.tokens.
+    compaction_validate.extract_fenced_blocks`: backtick and tilde
+    fences, closing fences of equal or greater length and the same
+    character, unclosed fences running to end of text. Fence lines
+    themselves are excluded from the prose view.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        match = _FENCE_OPEN_RE.match(lines[i])
+        if match is None:
+            out.append(lines[i])
+            i += 1
+            continue
+        fence = match.group(2)
+        close_re = re.compile(rf"^ {{0,3}}{re.escape(fence[0])}{{{len(fence)},}}[ \t]*$")
+        j = i + 1
+        while j < len(lines) and close_re.match(lines[j]) is None:
+            j += 1
+        i = j + 1
+    return out
+
+
+def extract_headings(text: str) -> list[str]:
+    """Return ATX heading lines (rstripped) outside fenced blocks, in order."""
+    return [line.rstrip() for line in _prose_lines(text) if _HEADING_RE.match(line)]
+
+
+def extract_completion_block(text: str) -> str | None:
+    """Return the expanded completion-instruction block from *text*, if any.
+
+    The block starts at the completion-contract heading and runs to the
+    next heading of the same or higher level (outside fenced blocks) or
+    to end of text. Returns ``None`` when the heading is absent.
+    """
+    lines = text.split("\n")
+    prose = set()
+    # Mark which physical line indexes are prose (outside fences) so the
+    # section scan cannot terminate on a "#" line inside a code block.
+    i = 0
+    while i < len(lines):
+        match = _FENCE_OPEN_RE.match(lines[i])
+        if match is None:
+            prose.add(i)
+            i += 1
+            continue
+        fence = match.group(2)
+        close_re = re.compile(rf"^ {{0,3}}{re.escape(fence[0])}{{{len(fence)},}}[ \t]*$")
+        j = i + 1
+        while j < len(lines) and close_re.match(lines[j]) is None:
+            j += 1
+        i = j + 1
+
+    start: int | None = None
+    for index, line in enumerate(lines):
+        if index in prose and _COMPLETION_HEADING_RE.match(line):
+            start = index
+            break
+    if start is None:
+        return None
+    level = lines[start].split(" ", 1)[0].count("#")
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if index not in prose:
+            continue
+        match = _HEADING_RE.match(lines[index])
+        if match is None:
+            continue
+        heading_level = lines[index].lstrip().split(" ", 1)[0].count("#")
+        if heading_level <= level:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+# ---------------------------------------------------------------------------
+# Template-specific validators (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def validate_frontmatter(pre: str, post: str) -> ValidatorVerdict:
+    """The leading YAML frontmatter block must be restored byte-equal.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        A ``frontmatter`` verdict; fails when the frontmatter was
+        edited, dropped, or invented.
+    """
+    pre_front, _ = split_frontmatter(pre)
+    post_front, _ = split_frontmatter(post)
+    if pre_front != post_front:
+        return ValidatorVerdict(
+            name="frontmatter",
+            passed=False,
+            detail=(f"frontmatter must be restored verbatim: expected {pre_front[:80]!r}, got {post_front[:80]!r}"),
+        )
+    return ValidatorVerdict(name="frontmatter", passed=True)
+
+
+def validate_headings(pre: str, post: str) -> ValidatorVerdict:
+    """The ATX heading sequence must survive byte-equal and in order.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        A ``headings`` verdict naming the first diverging heading.
+    """
+    pre_headings = extract_headings(pre)
+    post_headings = extract_headings(post)
+    if pre_headings == post_headings:
+        return ValidatorVerdict(name="headings", passed=True)
+    for index, heading in enumerate(pre_headings):
+        if index >= len(post_headings) or post_headings[index] != heading:
+            found = post_headings[index] if index < len(post_headings) else "<missing>"
+            return ValidatorVerdict(
+                name="headings",
+                passed=False,
+                detail=f"heading #{index + 1} diverged: expected {heading!r}, got {found!r}",
+            )
+    return ValidatorVerdict(
+        name="headings",
+        passed=False,
+        detail=f"rewrite invented heading(s): {post_headings[len(pre_headings)][:80]!r}",
+    )
+
+
+def validate_urls(pre: str, post: str) -> ValidatorVerdict:
+    """The URL set must be preserved exactly - no drops, no inventions.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        A ``urls`` verdict naming the first missing or invented URL.
+    """
+    pre_urls = set(_URL_RE.findall(pre))
+    post_urls = set(_URL_RE.findall(post))
+    missing = sorted(pre_urls - post_urls)
+    if missing:
+        return ValidatorVerdict(
+            name="urls",
+            passed=False,
+            detail=f"rewrite dropped URL: {missing[0]!r}",
+        )
+    invented = sorted(post_urls - pre_urls)
+    if invented:
+        return ValidatorVerdict(
+            name="urls",
+            passed=False,
+            detail=f"rewrite invented URL: {invented[0]!r}",
+        )
+    return ValidatorVerdict(name="urls", passed=True)
+
+
+def _inline_code_set(text: str) -> set[str]:
+    """Return the set of inline-code spans in the prose of *text*."""
+    prose = "\n".join(_prose_lines(text))
+    return set(_INLINE_CODE_RE.findall(prose))
+
+
+def validate_inline_code(pre: str, post: str) -> ValidatorVerdict:
+    """The inline-code span set must be preserved exactly.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        An ``inline_code`` verdict naming the first missing or invented
+        span.
+    """
+    pre_spans = _inline_code_set(pre)
+    post_spans = _inline_code_set(post)
+    missing = sorted(pre_spans - post_spans)
+    if missing:
+        return ValidatorVerdict(
+            name="inline_code",
+            passed=False,
+            detail=f"rewrite dropped inline code span: {missing[0][:80]!r}",
+        )
+    invented = sorted(post_spans - pre_spans)
+    if invented:
+        return ValidatorVerdict(
+            name="inline_code",
+            passed=False,
+            detail=f"rewrite invented inline code span: {invented[0][:80]!r}",
+        )
+    return ValidatorVerdict(name="inline_code", passed=True)
+
+
+def validate_placeholders(pre: str, post: str) -> ValidatorVerdict:
+    """Every ``{{...}}`` template token must be preserved as a multiset.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        A ``placeholders`` verdict naming the first missing or invented
+        token.
+    """
+    pre_tokens = Counter(_TEMPLATE_TOKEN_RE.findall(pre))
+    post_tokens = Counter(_TEMPLATE_TOKEN_RE.findall(post))
+    if pre_tokens == post_tokens:
+        return ValidatorVerdict(name="placeholders", passed=True)
+    missing = sorted((pre_tokens - post_tokens).elements())
+    if missing:
+        return ValidatorVerdict(
+            name="placeholders",
+            passed=False,
+            detail=f"rewrite dropped template token: {missing[0]!r}",
+        )
+    invented = sorted((post_tokens - pre_tokens).elements())
+    return ValidatorVerdict(
+        name="placeholders",
+        passed=False,
+        detail=f"rewrite invented template token: {invented[0]!r}",
+    )
+
+
+def validate_completion_block(pre: str, post: str) -> ValidatorVerdict:
+    """The completion-payload instruction block is copied verbatim.
+
+    Two forms are protected (worker completion contracts, #2244):
+
+    * ``{{INCLUDE ...}}`` directive lines must survive as a multiset
+      (byte-equal; the renderer expands them at spawn time).
+    * When *pre* inlines the expanded block (completion-contract
+      heading), the whole section must survive byte-equal.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        A ``completion_block`` verdict.
+    """
+    pre_includes = Counter(_INCLUDE_DIRECTIVE_RE.findall(pre))
+    post_includes = Counter(_INCLUDE_DIRECTIVE_RE.findall(post))
+    if pre_includes != post_includes:
+        changed = sorted(set((pre_includes - post_includes) + (post_includes - pre_includes)))
+        return ValidatorVerdict(
+            name="completion_block",
+            passed=False,
+            detail=f"include directive altered or dropped: {changed[0]!r}",
+        )
+
+    pre_block = extract_completion_block(pre)
+    if pre_block is not None:
+        post_block = extract_completion_block(post)
+        if post_block != pre_block:
+            return ValidatorVerdict(
+                name="completion_block",
+                passed=False,
+                detail="completion-payload instruction block was rewritten; it must be copied verbatim",
+            )
+    return ValidatorVerdict(name="completion_block", passed=True)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_VALIDATORS: Final[tuple[Callable[[str, str], ValidatorVerdict], ...]] = (
+    validate_frontmatter,
+    validate_headings,
+    validate_urls,
+    validate_inline_code,
+    validate_placeholders,
+    validate_completion_block,
+)
+
+
+def run_template_validators(pre: str, post: str) -> tuple[ValidatorVerdict, ...]:
+    """Run the base compaction validators plus the template-specific ones.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+
+    Returns:
+        One verdict per validator in
+        :data:`ALL_TEMPLATE_VALIDATOR_NAMES` order; deterministic for a
+        given pair.
+    """
+    base = run_validators(pre, post)
+    extra = tuple(validator(pre, post) for validator in _TEMPLATE_VALIDATORS)
+    return base + extra
+
+
+def validate_template_rewrite(
+    pre: str,
+    post: str,
+    *,
+    fix_call: Callable[[str], str] | None = None,
+    max_retries: int = TEMPLATE_MAX_FIX_RETRIES,
+) -> ValidationOutcome:
+    """Validate *post*; on failure run up to *max_retries* targeted fix passes.
+
+    The fix prompt (reused from the compaction validators) forbids
+    re-compressing and carries the original template as the byte
+    reference. An outcome with ``aborted=True`` means the caller must
+    leave the on-disk template untouched.
+
+    Args:
+        pre: Template text before compression.
+        post: Candidate compressed template.
+        fix_call: Optional callable receiving the fix-only prompt and
+            returning a repaired candidate. ``None`` aborts on the
+            first failure.
+        max_retries: Maximum fix passes (default
+            :data:`TEMPLATE_MAX_FIX_RETRIES`).
+
+    Returns:
+        A :class:`~bernstein.core.tokens.compaction_validate.
+        ValidationOutcome` whose ``retry_count`` is the number of fix
+        passes executed.
+    """
+    candidate = post
+    verdicts = run_template_validators(pre, candidate)
+    retries = 0
+    while not all_passed(verdicts) and fix_call is not None and retries < max_retries:
+        prompt = build_fix_prompt(pre, candidate, verdicts)
+        retries += 1
+        try:
+            candidate = fix_call(prompt)
+        except Exception as exc:
+            logger.warning("Template compression fix pass raised; aborting: %s", exc)
+            return ValidationOutcome(
+                text=candidate,
+                verdicts=verdicts,
+                retry_count=retries,
+                passed=False,
+                aborted=True,
+            )
+        verdicts = run_template_validators(pre, candidate)
+
+    passed = all_passed(verdicts)
+    return ValidationOutcome(
+        text=candidate,
+        verdicts=verdicts,
+        retry_count=retries,
+        passed=passed,
+        aborted=not passed,
+    )
+
+
+__all__ = [
+    "ALL_TEMPLATE_VALIDATOR_NAMES",
+    "TEMPLATE_MAX_FIX_RETRIES",
+    "TEMPLATE_VALIDATOR_NAMES",
+    "extract_completion_block",
+    "extract_headings",
+    "run_template_validators",
+    "split_frontmatter",
+    "validate_completion_block",
+    "validate_frontmatter",
+    "validate_headings",
+    "validate_inline_code",
+    "validate_placeholders",
+    "validate_template_rewrite",
+    "validate_urls",
+]

--- a/src/bernstein/core/tokens/template_compression.py
+++ b/src/bernstein/core/tokens/template_compression.py
@@ -1,0 +1,1052 @@
+"""Operator-gated role-template compression with chained receipts (issue #2249).
+
+Every worker spawn renders its role's ``system_prompt.md`` and
+``task_prompt.md``; that fixed input cost recurs on every spawn and
+again after every compaction reinjection. This module implements the
+one-time compression pass behind ``bernstein templates compress`` - it
+is never automatic:
+
+* **LLM rewrite, mechanically gated.** The rewrite candidate must pass
+  every validator in :mod:`bernstein.core.tokens.
+  template_compress_validate` (base compaction validators plus the
+  template-specific ones), with at most two targeted fix passes. A
+  failing candidate never reaches disk.
+* **Sensitive gate before the model.** Template text is scanned by the
+  compaction sensitive gate before anything is sent to the configured
+  adapter; any finding (redaction or refusal) refuses the compression
+  outright, because writing redaction placeholders back into a template
+  would corrupt it.
+* **Out-of-tree backups, readback-verified.** Originals are stored
+  under ``~/.local/share/bernstein/template-backups/`` keyed by content
+  hash, so template loaders never re-ingest them, and each write is
+  read back and re-hashed before the working copy is touched.
+  ``bernstein templates restore <role>`` reverses the compression
+  byte-identically, verified by hash.
+* **Chained receipt.** ``{role, pre_sha256, post_sha256, pre_tokens,
+  post_tokens, validators, adapter, model}`` is appended to the HMAC
+  audit chain as a ``template.compression.receipt`` event with the
+  previous chain digest embedded in the payload. The receipt's ``ts``
+  is the boundary for before/after ``bernstein cost --by role`` ledger
+  windows; savings figures come from the ledger, never from this
+  module.
+* **Lockfile entry for drift.** Each applied compression appends a row
+  to ``templates.lock`` mapping the role's pre and post directory
+  digests, so the team-manifest drift check (#2248) recognizes a
+  receipted compression as intentional rather than reporting spurious
+  drift.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import time
+import tomllib
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, cast
+
+from bernstein.core.skills.catalog.lockfile import (
+    _acquire_lock,  # pyright: ignore[reportPrivateUsage]
+    _release_lock,  # pyright: ignore[reportPrivateUsage]
+)
+from bernstein.core.skills.lifecycle import _toml_quote  # pyright: ignore[reportPrivateUsage]
+from bernstein.core.tokens.template_compress_validate import (
+    split_frontmatter,
+    validate_template_rewrite,
+)
+from bernstein.core.tokens.token_estimation import estimate_tokens_for_text
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bernstein.core.security.audit import AuditEvent
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Filename of the template compression lock; sibling of ``teams.lock``
+#: at the project root.
+TEMPLATES_LOCK_FILENAME: Final[str] = "templates.lock"
+
+#: Prompt files inside a role template directory that compression may
+#: rewrite. Everything else (``config.yaml``, includes) is never touched.
+TEMPLATE_PROMPT_FILENAMES: Final[tuple[str, ...]] = ("system_prompt.md", "task_prompt.md")
+
+#: Actor recorded on chain events emitted by this module.
+AUDIT_ACTOR: Final[str] = "bernstein.templates"
+
+#: Resource type recorded on chain events emitted by this module.
+AUDIT_RESOURCE_TYPE: Final[str] = "role_template"
+
+#: ``assumed_type`` used for deterministic template token estimates.
+_TOKEN_ESTIMATE_TYPE: Final[str] = "text"
+
+_HEX_DIGEST_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9a-f]{64}$")
+
+
+class TemplateCompressionError(Exception):
+    """Base error for template compression and restore operations."""
+
+
+class BackupIntegrityError(TemplateCompressionError):
+    """A backup readback or hash verification failed."""
+
+
+# ---------------------------------------------------------------------------
+# Out-of-tree backup store (content-hash keyed, readback-verified)
+# ---------------------------------------------------------------------------
+
+
+def default_backup_root() -> Path:
+    """Return the out-of-tree backup directory for template originals.
+
+    XDG-conventional: ``$XDG_DATA_HOME/bernstein/template-backups`` with
+    the documented ``~/.local/share`` fallback. Out-of-tree by design so
+    template loaders (which scan the project tree) never re-ingest the
+    uncompressed originals.
+    """
+    raw = os.environ.get("XDG_DATA_HOME", "").strip()
+    base = Path(raw) if raw else Path.home() / ".local" / "share"
+    return base / "bernstein" / "template-backups"
+
+
+def store_backup(content: bytes, *, backup_root: Path | None = None) -> str:
+    """Store *content* keyed by its SHA-256, verifying the write by readback.
+
+    Idempotent: storing the same bytes twice reuses the existing file
+    (after re-verifying it).
+
+    Args:
+        content: The exact original file bytes.
+        backup_root: Backup directory override (tests); defaults to
+            :func:`default_backup_root`.
+
+    Returns:
+        The lower-case SHA-256 hex digest keying the backup.
+
+    Raises:
+        BackupIntegrityError: When the readback bytes do not hash to the
+            expected digest.
+    """
+    root = backup_root if backup_root is not None else default_backup_root()
+    digest = hashlib.sha256(content).hexdigest()
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / digest
+    if not target.is_file():
+        tmp = target.with_suffix(".tmp")
+        tmp.write_bytes(content)
+        tmp.replace(target)
+    readback = target.read_bytes()
+    if hashlib.sha256(readback).hexdigest() != digest:
+        raise BackupIntegrityError(f"backup readback verification failed for {target}")
+    return digest
+
+
+def read_backup(digest: str, *, backup_root: Path | None = None) -> bytes:
+    """Return the backup bytes for *digest*, hash-verified.
+
+    Args:
+        digest: Lower-case SHA-256 hex digest of the original content.
+        backup_root: Backup directory override (tests).
+
+    Returns:
+        The original bytes.
+
+    Raises:
+        BackupIntegrityError: When the backup is missing or its bytes no
+            longer hash to *digest*.
+    """
+    root = backup_root if backup_root is not None else default_backup_root()
+    target = root / digest
+    if not target.is_file():
+        raise BackupIntegrityError(f"backup not found for digest {digest}")
+    content = target.read_bytes()
+    if hashlib.sha256(content).hexdigest() != digest:
+        raise BackupIntegrityError(f"backup content for digest {digest} failed hash verification")
+    return content
+
+
+# ---------------------------------------------------------------------------
+# Receipt
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CompressedFileRecord:
+    """Pre/post content hashes for one rewritten template file.
+
+    Attributes:
+        path: File path relative to the role template directory (POSIX).
+        pre_sha256: SHA-256 of the original bytes (the backup key).
+        post_sha256: SHA-256 of the compressed bytes on disk.
+    """
+
+    path: str
+    pre_sha256: str
+    post_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateCompressionReceipt:
+    """One role-template compression, in the shape the chain records it.
+
+    Attributes:
+        role: Role whose templates were compressed.
+        pre_sha256: Role template directory digest before compression
+            (:func:`bernstein.core.teams.drift.role_template_digest`).
+        post_sha256: Role template directory digest after compression.
+        pre_tokens: Deterministic token estimate before compression
+            (sum over the rewritten files).
+        post_tokens: Deterministic token estimate after compression.
+        validators: ``(name, passed)`` pairs in validator run order.
+        adapter: Configured adapter/provider used for the rewrite.
+        model: Model name used for the rewrite.
+        retry_count: Targeted fix passes executed before validation.
+        files: Per-file pre/post content hashes.
+        ts: Unix epoch seconds when the receipt was built. This is the
+            boundary for before/after ``bernstein cost --by role``
+            ledger windows; savings are claimed only from the ledger.
+        correlation_id: Id shared by the chain event and the
+            ``templates.lock`` row.
+    """
+
+    role: str
+    pre_sha256: str
+    post_sha256: str
+    pre_tokens: int
+    post_tokens: int
+    validators: tuple[tuple[str, bool], ...]
+    adapter: str
+    model: str
+    retry_count: int
+    files: tuple[CompressedFileRecord, ...]
+    ts: float
+    correlation_id: str
+
+    def to_details(self) -> dict[str, Any]:
+        """Return the JSON-safe payload recorded in the audit chain."""
+        return {
+            "role": self.role,
+            "pre_sha256": self.pre_sha256,
+            "post_sha256": self.post_sha256,
+            "pre_tokens": self.pre_tokens,
+            "post_tokens": self.post_tokens,
+            "validators": [{"name": name, "result": "pass" if passed else "fail"} for name, passed in self.validators],
+            "adapter": self.adapter,
+            "model": self.model,
+            "retry_count": self.retry_count,
+            "files": [
+                {"path": record.path, "pre_sha256": record.pre_sha256, "post_sha256": record.post_sha256}
+                for record in self.files
+            ],
+            "ts": self.ts,
+            "correlation_id": self.correlation_id,
+        }
+
+
+def receipt_from_details(details: dict[str, Any]) -> TemplateCompressionReceipt:
+    """Rebuild a receipt from a chain event's details payload."""
+    raw_validators = details.get("validators") or []
+    raw_files = details.get("files") or []
+    return TemplateCompressionReceipt(
+        role=str(details.get("role", "")),
+        pre_sha256=str(details.get("pre_sha256", "")),
+        post_sha256=str(details.get("post_sha256", "")),
+        pre_tokens=int(details.get("pre_tokens", 0)),
+        post_tokens=int(details.get("post_tokens", 0)),
+        validators=tuple((str(v.get("name", "")), v.get("result") == "pass") for v in raw_validators),
+        adapter=str(details.get("adapter", "")),
+        model=str(details.get("model", "")),
+        retry_count=int(details.get("retry_count", 0)),
+        files=tuple(
+            CompressedFileRecord(
+                path=str(f.get("path", "")),
+                pre_sha256=str(f.get("pre_sha256", "")),
+                post_sha256=str(f.get("post_sha256", "")),
+            )
+            for f in raw_files
+        ),
+        ts=float(details.get("ts", 0.0)),
+        correlation_id=str(details.get("correlation_id", "")),
+    )
+
+
+def record_compression_receipt(*, chain: AuditChainStore, receipt: TemplateCompressionReceipt) -> AuditEvent:
+    """Append a ``template.compression.receipt`` event into *chain*.
+
+    Same anchoring as compaction receipts (#2246): the previous chain
+    digest is embedded in the payload before the HMAC is computed, so
+    the receipt is position-locked in the chain.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TEMPLATE_COMPRESSION_RECEIPT
+
+    return chain.log_with_prev_digest(
+        event_type=EVENT_TEMPLATE_COMPRESSION_RECEIPT,
+        actor=AUDIT_ACTOR,
+        resource_type=AUDIT_RESOURCE_TYPE,
+        resource_id=receipt.role,
+        details=receipt.to_details(),
+    )
+
+
+def load_compression_receipts(chain: AuditChainStore, *, role: str | None = None) -> list[TemplateCompressionReceipt]:
+    """Return compression receipts recorded in *chain*, in chain order.
+
+    Malformed receipt events are skipped with a warning;
+    :func:`verify_compression_receipts` turns them into hard errors.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TEMPLATE_COMPRESSION_RECEIPT
+
+    receipts: list[TemplateCompressionReceipt] = []
+    for event in chain.query(event_type=EVENT_TEMPLATE_COMPRESSION_RECEIPT):
+        try:
+            receipt = receipt_from_details(event.details)
+        except (ValueError, TypeError) as exc:
+            logger.warning("Skipping malformed template compression receipt event: %s", exc)
+            continue
+        if role is not None and receipt.role != role:
+            continue
+        receipts.append(receipt)
+    return receipts
+
+
+def verify_compression_receipts(
+    chain: AuditChainStore,
+    *,
+    lock_state: TemplatesLockState | None = None,
+    role: str | None = None,
+) -> tuple[bool, list[str]]:
+    """Verify compression receipts against the chain and the lockfile.
+
+    Three checks, all of which must hold:
+
+    1. The audit chain's HMAC chain verifies end to end.
+    2. Every ``template.compression.receipt`` event parses.
+    3. When *lock_state* is given, every lock row has a chain receipt
+       with the same correlation id pinning the same pre/post directory
+       digests.
+
+    Returns:
+        ``(ok, errors)``.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TEMPLATE_COMPRESSION_RECEIPT
+
+    errors: list[str] = []
+    chain_ok, chain_errors = chain.verify()
+    if not chain_ok:
+        errors.extend(f"audit chain: {err}" for err in chain_errors)
+
+    receipts: dict[str, TemplateCompressionReceipt] = {}
+    for event in chain.query(event_type=EVENT_TEMPLATE_COMPRESSION_RECEIPT):
+        try:
+            receipt = receipt_from_details(event.details)
+        except (ValueError, TypeError) as exc:
+            errors.append(f"audit chain: receipt event at {event.timestamp} unparseable: {exc}")
+            continue
+        if role is not None and receipt.role != role:
+            continue
+        receipts[receipt.correlation_id] = receipt
+
+    if lock_state is not None:
+        for row in lock_state.compressions:
+            if role is not None and row.role != role:
+                continue
+            receipt = receipts.get(row.correlation_id)
+            if receipt is None:
+                errors.append(
+                    f"templates.lock row for role {row.role!r} (correlation={row.correlation_id}) "
+                    f"has no chain receipt; verification fails"
+                )
+                continue
+            if receipt.pre_sha256 != row.pre_digest or receipt.post_sha256 != row.post_digest:
+                errors.append(
+                    f"templates.lock row for role {row.role!r} pins digests that disagree with "
+                    f"chain receipt {row.correlation_id}"
+                )
+    return (not errors, errors)
+
+
+# ---------------------------------------------------------------------------
+# templates.lock (drift recognition + restore bookkeeping)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompressionLockEntry:
+    """One ``[[compressions]]`` row in ``templates.lock``.
+
+    Attributes:
+        role: Compressed role name.
+        correlation_id: Matches the chain receipt's correlation id.
+        pre_digest: Role template directory digest before compression.
+        post_digest: Role template directory digest after compression.
+        adapter: Adapter/provider used for the rewrite.
+        model: Model used for the rewrite.
+        chain_head: HMAC of the chain receipt event ("" when the chain
+            was unavailable at compression time).
+        timestamp: ISO-8601 UTC timestamp of the compression.
+        files: Per-file pre/post content hashes (restore bookkeeping;
+            ``pre_sha256`` is the backup key).
+    """
+
+    role: str
+    correlation_id: str
+    pre_digest: str
+    post_digest: str
+    adapter: str
+    model: str
+    chain_head: str
+    timestamp: str
+    files: tuple[CompressedFileRecord, ...] = ()
+
+
+@dataclass(frozen=True)
+class TemplatesLockState:
+    """Parsed view of ``templates.lock``."""
+
+    compressions: list[CompressionLockEntry] = field(default_factory=list)
+
+    def entries_for(self, role: str) -> list[CompressionLockEntry]:
+        """Return the rows for *role* in file order."""
+        return [row for row in self.compressions if row.role == role]
+
+
+def templates_lock_path(workdir: Path) -> Path:
+    """Return the ``templates.lock`` path for *workdir* (project root)."""
+    return workdir / TEMPLATES_LOCK_FILENAME
+
+
+def read_templates_lock(lock_path: Path) -> TemplatesLockState:
+    """Parse ``templates.lock``, returning an empty state on any parse error."""
+    if not lock_path.is_file():
+        return TemplatesLockState()
+    try:
+        data = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return TemplatesLockState()
+
+    rows: list[CompressionLockEntry] = []
+    for raw in cast("list[object]", data.get("compressions", [])):
+        if not isinstance(raw, dict):
+            continue
+        row = cast("dict[str, object]", raw)
+        files: list[CompressedFileRecord] = []
+        for raw_file in cast("list[object]", row.get("files", [])):
+            if not isinstance(raw_file, dict):
+                continue
+            file_row = cast("dict[str, object]", raw_file)
+            path = file_row.get("path")
+            pre = file_row.get("pre_sha256")
+            post = file_row.get("post_sha256")
+            if isinstance(path, str) and isinstance(pre, str) and isinstance(post, str):
+                files.append(CompressedFileRecord(path=path, pre_sha256=pre, post_sha256=post))
+        try:
+            rows.append(
+                CompressionLockEntry(
+                    role=_required(row, "role"),
+                    correlation_id=_required(row, "correlation_id"),
+                    pre_digest=_required(row, "pre_digest"),
+                    post_digest=_required(row, "post_digest"),
+                    adapter=_required(row, "adapter"),
+                    model=_required(row, "model"),
+                    chain_head=str(row.get("chain_head", "")),
+                    timestamp=_required(row, "timestamp"),
+                    files=tuple(files),
+                )
+            )
+        except KeyError:
+            continue
+    return TemplatesLockState(compressions=rows)
+
+
+def _required(row: dict[str, object], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value:
+        raise KeyError(key)
+    return value
+
+
+def write_templates_lock(lock_path: Path, state: TemplatesLockState) -> None:
+    """Write ``templates.lock`` atomically with deterministic formatting."""
+    lines: list[str] = [
+        "# bernstein templates lock file - regenerated by `bernstein templates` commands.",
+        "# Do not edit by hand.",
+        "",
+    ]
+    for row in state.compressions:
+        lines.extend(
+            (
+                "[[compressions]]",
+                f"role = {_toml_quote(row.role)}",
+                f"correlation_id = {_toml_quote(row.correlation_id)}",
+                f"pre_digest = {_toml_quote(row.pre_digest)}",
+                f"post_digest = {_toml_quote(row.post_digest)}",
+                f"adapter = {_toml_quote(row.adapter)}",
+                f"model = {_toml_quote(row.model)}",
+                f"chain_head = {_toml_quote(row.chain_head)}",
+                f"timestamp = {_toml_quote(row.timestamp)}",
+            )
+        )
+        for record in row.files:
+            lines.extend(
+                (
+                    "",
+                    "[[compressions.files]]",
+                    f"path = {_toml_quote(record.path)}",
+                    f"pre_sha256 = {_toml_quote(record.pre_sha256)}",
+                    f"post_sha256 = {_toml_quote(record.post_sha256)}",
+                )
+            )
+        lines.append("")
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = lock_path.with_suffix(lock_path.suffix + ".tmp")
+    tmp.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    tmp.replace(lock_path)
+
+
+def append_compression_entry(lock_path: Path, entry: CompressionLockEntry) -> TemplatesLockState:
+    """Append a compression row under the coarse cross-worktree file lock."""
+    guard = _acquire_lock(lock_path)
+    try:
+        state = read_templates_lock(lock_path)
+        new_state = TemplatesLockState(compressions=[*state.compressions, entry])
+        write_templates_lock(lock_path, new_state)
+        return new_state
+    finally:
+        _release_lock(guard)
+
+
+def remove_compression_entry(lock_path: Path, correlation_id: str) -> TemplatesLockState:
+    """Remove the row with *correlation_id* under the file lock."""
+    guard = _acquire_lock(lock_path)
+    try:
+        state = read_templates_lock(lock_path)
+        new_state = TemplatesLockState(
+            compressions=[row for row in state.compressions if row.correlation_id != correlation_id]
+        )
+        write_templates_lock(lock_path, new_state)
+        return new_state
+    finally:
+        _release_lock(guard)
+
+
+# ---------------------------------------------------------------------------
+# Compression engine
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CompressionOutcome:
+    """Result of one role compression attempt.
+
+    Attributes:
+        role: The role that was processed.
+        applied: Whether compressed templates were written to disk.
+        reason: Human-readable explanation when ``applied`` is False.
+        receipt: The chained receipt when ``applied`` is True.
+        pre_tokens: Token estimate before (rewritten files only).
+        post_tokens: Token estimate after.
+    """
+
+    role: str
+    applied: bool
+    reason: str = ""
+    receipt: TemplateCompressionReceipt | None = None
+    pre_tokens: int = 0
+    post_tokens: int = 0
+
+
+def build_compression_prompt(body: str) -> str:
+    """Build the rewrite prompt for one template body (frontmatter removed).
+
+    The prompt states every mechanical invariant the validators enforce,
+    so a competent rewrite passes on the first attempt; the validators
+    remain the gate regardless of what the model returns.
+    """
+    return (
+        "Rewrite the role prompt template below to use fewer tokens while "
+        "preserving every instruction. HARD CONSTRAINTS - the rewrite is "
+        "mechanically rejected if any is violated:\n"
+        "- Keep every heading line byte-identical and in the same order.\n"
+        "- Keep every fenced code block byte-identical (or drop one whole, never edit it).\n"
+        "- Keep every URL exactly as written; add none.\n"
+        "- Keep every inline `code` span exactly as written; add none.\n"
+        "- Keep every {{PLACEHOLDER}}, {{#IF ...}}/{{/IF}} marker, and {{INCLUDE ...}} "
+        "directive byte-identical.\n"
+        "- Copy any completion-contract instruction section verbatim; never reword it.\n"
+        "Shorten only the surrounding prose. Return ONLY the rewritten template text, "
+        "no commentary, no code fences around the whole answer.\n\n"
+        f"<<<TEMPLATE\n{body}\nTEMPLATE>>>\n"
+    )
+
+
+def _extract_rewrite(raw: str) -> str:
+    """Return the rewritten template from a raw model response.
+
+    Strips the delimiters some models echo back; otherwise returns the
+    response unchanged (the validators are the real gate).
+    """
+    text = raw.strip("\n")
+    if text.startswith("<<<TEMPLATE\n") and text.endswith("\nTEMPLATE>>>"):
+        text = text[len("<<<TEMPLATE\n") : -len("\nTEMPLATE>>>")]
+    return text
+
+
+def _gate_refuses(text: str, *, role: str, chain: AuditChainStore | None) -> bool:
+    """Run the sensitive gate over *text*; True when compression must stop.
+
+    Unlike compaction (which forwards redacted text), template
+    compression refuses on ANY finding: writing redaction placeholders
+    back into a template would corrupt every subsequent spawn. The gate
+    outcome is chained either way.
+    """
+    from bernstein.core.tokens.sensitive_gate import (
+        GateConfig,
+        emit_gate_audit,
+        scan_for_sensitive_content,
+    )
+
+    decision = scan_for_sensitive_content(text, config=GateConfig.from_defaults())
+    emit_gate_audit(decision, chain=chain, task_id=f"template-compress:{role}", session_id=AUDIT_ACTOR)
+    # ``allow`` covers clean input and operator-allowlisted suppressions;
+    # any live finding (redacted or refused) stops the compression.
+    return decision.action != "allow"
+
+
+def _atomic_write(path: Path, content: bytes, *, expected_sha256: str) -> None:
+    """Write *content* atomically and verify the on-disk bytes by readback."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(content)
+    tmp.replace(path)
+    if hashlib.sha256(path.read_bytes()).hexdigest() != expected_sha256:
+        raise BackupIntegrityError(f"readback verification failed after writing {path}")
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+def compress_role_templates(
+    role: str,
+    *,
+    workdir: Path,
+    llm_call: Callable[[str], str],
+    adapter: str,
+    model: str,
+    chain: AuditChainStore | None = None,
+    lock_path: Path | None = None,
+    backup_root: Path | None = None,
+    ts: float | None = None,
+) -> CompressionOutcome:
+    """Compress one role's prompt templates in place, gated and receipted.
+
+    Pipeline per prompt file: sensitive gate -> frontmatter split ->
+    LLM rewrite via *llm_call* -> full validator suite with up to two
+    targeted fix passes -> token-savings check. Nothing touches disk
+    until every file validated; then originals are backed up out of
+    tree (readback-verified), the compressed files are written
+    atomically (readback-verified), the receipt is chained, and the
+    ``templates.lock`` row is appended.
+
+    Args:
+        role: Role template directory name (e.g. ``backend``).
+        workdir: Project root; templates resolve like the drift check.
+        llm_call: Callable sending one prompt to the configured adapter
+            and returning the response text. Used for both the rewrite
+            and the targeted fix passes.
+        adapter: Adapter/provider name recorded in the receipt.
+        model: Model name recorded in the receipt.
+        chain: Audit chain for the receipt and gate events; resolved
+            callers may pass ``None`` to skip chain anchoring.
+        lock_path: ``templates.lock`` override (defaults to
+            ``<workdir>/templates.lock``).
+        backup_root: Backup directory override (tests).
+        ts: Explicit receipt timestamp; ``time.time()`` when omitted.
+
+    Returns:
+        A :class:`CompressionOutcome`; ``applied`` is False when the
+        compression was refused, failed validation, or saved nothing,
+        and in every such case the on-disk templates are untouched.
+
+    Raises:
+        TemplateCompressionError: When the role directory does not
+            exist, is not project-local, or has no prompt files.
+    """
+    from bernstein.core.teams.drift import resolve_roles_dir, role_template_digest
+
+    if role.startswith("_"):
+        raise TemplateCompressionError(f"role {role!r} is not a compressible role template")
+    roles_dir = resolve_roles_dir(workdir)
+    if not _is_project_local(roles_dir, workdir):
+        raise TemplateCompressionError(
+            f"role templates resolve to the bundled package copy ({roles_dir}); "
+            "compression rewrites files in place and requires project-local templates "
+            "(templates/roles/ under the project root)"
+        )
+    role_dir = roles_dir / role
+    if not role_dir.is_dir():
+        raise TemplateCompressionError(f"role template directory not found: {role_dir}")
+
+    prompt_files = [role_dir / name for name in TEMPLATE_PROMPT_FILENAMES if (role_dir / name).is_file()]
+    if not prompt_files:
+        raise TemplateCompressionError(f"role {role!r} has no prompt files to compress under {role_dir}")
+
+    pre_dir_digest = role_template_digest(role_dir)
+
+    rewritten: list[tuple[Path, bytes, bytes]] = []  # (path, original, compressed)
+    merged_verdicts: dict[str, bool] = {}
+    retry_total = 0
+    for path in prompt_files:
+        original_bytes = path.read_bytes()
+        original_text = original_bytes.decode("utf-8")
+
+        if _gate_refuses(original_text, role=role, chain=chain):
+            return CompressionOutcome(
+                role=role,
+                applied=False,
+                reason=f"sensitive gate refused compression of {path.name}; template left untouched",
+            )
+
+        frontmatter, body = split_frontmatter(original_text)
+        try:
+            candidate_body = _extract_rewrite(llm_call(build_compression_prompt(body)))
+        except Exception as exc:
+            return CompressionOutcome(
+                role=role,
+                applied=False,
+                reason=f"adapter call failed for {path.name}: {exc}",
+            )
+        candidate = frontmatter + candidate_body
+        # Adapters commonly trim trailing whitespace; keep the file
+        # POSIX-clean when the original ended with a newline.
+        if original_text.endswith("\n") and not candidate.endswith("\n"):
+            candidate += "\n"
+
+        outcome = validate_template_rewrite(original_text, candidate, fix_call=llm_call)
+        retry_total += outcome.retry_count
+        if not outcome.passed:
+            failed = ", ".join(v.name for v in outcome.verdicts if not v.passed)
+            return CompressionOutcome(
+                role=role,
+                applied=False,
+                reason=(
+                    f"validators rejected the rewrite of {path.name} after "
+                    f"{outcome.retry_count} fix pass(es): {failed}; template left untouched"
+                ),
+            )
+        for verdict in outcome.verdicts:
+            merged_verdicts[verdict.name] = merged_verdicts.get(verdict.name, True) and verdict.passed
+
+        compressed_bytes = outcome.text.encode("utf-8")
+        if len(compressed_bytes) < len(original_bytes):
+            rewritten.append((path, original_bytes, compressed_bytes))
+
+    if not rewritten:
+        return CompressionOutcome(role=role, applied=False, reason="rewrite saved no tokens; template left untouched")
+
+    pre_tokens = sum(
+        estimate_tokens_for_text(original.decode("utf-8"), _TOKEN_ESTIMATE_TYPE) for _, original, _ in rewritten
+    )
+    post_tokens = sum(
+        estimate_tokens_for_text(compressed.decode("utf-8"), _TOKEN_ESTIMATE_TYPE) for _, _, compressed in rewritten
+    )
+
+    # Backups first (out of tree, readback-verified); nothing in the
+    # role directory changes until every backup is durable.
+    file_records: list[CompressedFileRecord] = []
+    for path, original_bytes, compressed_bytes in rewritten:
+        pre_sha = store_backup(original_bytes, backup_root=backup_root)
+        file_records.append(
+            CompressedFileRecord(
+                path=path.relative_to(role_dir).as_posix(),
+                pre_sha256=pre_sha,
+                post_sha256=hashlib.sha256(compressed_bytes).hexdigest(),
+            )
+        )
+
+    written: list[tuple[Path, bytes]] = []
+    try:
+        for (path, original_bytes, compressed_bytes), record in zip(rewritten, file_records, strict=True):
+            _atomic_write(path, compressed_bytes, expected_sha256=record.post_sha256)
+            written.append((path, original_bytes))
+    except Exception:
+        # Roll back any partial write from the in-memory originals so
+        # the role directory is byte-identical to its pre-state.
+        for path, original_bytes in written:
+            path.write_bytes(original_bytes)
+        raise
+
+    post_dir_digest = role_template_digest(role_dir)
+
+    receipt = TemplateCompressionReceipt(
+        role=role,
+        pre_sha256=pre_dir_digest,
+        post_sha256=post_dir_digest,
+        pre_tokens=pre_tokens,
+        post_tokens=post_tokens,
+        validators=tuple(merged_verdicts.items()),
+        adapter=adapter,
+        model=model,
+        retry_count=retry_total,
+        files=tuple(file_records),
+        ts=ts if ts is not None else time.time(),
+        correlation_id=f"tmplc-{uuid.uuid4().hex[:8]}",
+    )
+
+    chain_head = ""
+    if chain is not None:
+        try:
+            event = record_compression_receipt(chain=chain, receipt=receipt)
+            chain_head = event.hmac or ""
+        except Exception as exc:
+            logger.warning("Template compression receipt chain write failed for role %s: %s", role, exc)
+
+    entry = CompressionLockEntry(
+        role=role,
+        correlation_id=receipt.correlation_id,
+        pre_digest=pre_dir_digest,
+        post_digest=post_dir_digest,
+        adapter=adapter,
+        model=model,
+        chain_head=chain_head,
+        timestamp=_utc_now_iso(),
+        files=tuple(file_records),
+    )
+    append_compression_entry(lock_path if lock_path is not None else templates_lock_path(workdir), entry)
+
+    return CompressionOutcome(
+        role=role,
+        applied=True,
+        receipt=receipt,
+        pre_tokens=pre_tokens,
+        post_tokens=post_tokens,
+    )
+
+
+def _is_project_local(roles_dir: Path, workdir: Path) -> bool:
+    """Whether *roles_dir* lives under *workdir* (never the bundled copy)."""
+    try:
+        roles_dir.resolve().relative_to(workdir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Restore
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreOutcome:
+    """Result of a role restore.
+
+    Attributes:
+        role: The restored role.
+        restored_files: Relative paths written back byte-identically.
+        pre_digest: Role directory digest after restore (equals the
+            digest recorded before compression; hash-verified).
+        correlation_id: The reversed compression's correlation id.
+    """
+
+    role: str
+    restored_files: tuple[str, ...]
+    pre_digest: str
+    correlation_id: str
+
+
+def restore_role_templates(
+    role: str,
+    *,
+    workdir: Path,
+    lock_path: Path | None = None,
+    backup_root: Path | None = None,
+    chain: AuditChainStore | None = None,
+) -> RestoreOutcome:
+    """Reverse the most recent receipted compression of *role* byte-identically.
+
+    Every step is hash-verified: the on-disk files must match the lock
+    row's post hashes (refusing to clobber manual edits), the backups
+    must hash to their keys, and after the write the role directory
+    digest must equal the pre-compression digest recorded in the lock.
+
+    Args:
+        role: Role to restore.
+        workdir: Project root.
+        lock_path: ``templates.lock`` override.
+        backup_root: Backup directory override (tests).
+        chain: Optional audit chain receiving a
+            ``template.compression.restore`` event.
+
+    Returns:
+        A :class:`RestoreOutcome` with the verified pre-digest.
+
+    Raises:
+        TemplateCompressionError: When no receipted compression exists
+            for *role*, the on-disk templates diverged from the lock
+            row, or a hash verification fails.
+    """
+    from bernstein.core.teams.drift import resolve_roles_dir, role_template_digest
+
+    resolved_lock = lock_path if lock_path is not None else templates_lock_path(workdir)
+    state = read_templates_lock(resolved_lock)
+    entries = state.entries_for(role)
+    if not entries:
+        raise TemplateCompressionError(f"no receipted compression found for role {role!r} in {resolved_lock}")
+    entry = entries[-1]
+
+    role_dir = resolve_roles_dir(workdir) / role
+    if not role_dir.is_dir():
+        raise TemplateCompressionError(f"role template directory not found: {role_dir}")
+
+    # Refuse when the on-disk state is not the compressed state the lock
+    # row describes - restoring over manual edits would destroy them.
+    for record in entry.files:
+        target = role_dir / record.path
+        if not target.is_file():
+            raise TemplateCompressionError(f"compressed file missing on disk: {target}")
+        current = hashlib.sha256(target.read_bytes()).hexdigest()
+        if current != record.post_sha256:
+            raise TemplateCompressionError(
+                f"{target} was modified after compression (sha256 {current[:12]}... != "
+                f"recorded {record.post_sha256[:12]}...); refusing to restore over it"
+            )
+    # The whole directory must be in the recorded post-compression state
+    # (catches edits to files the compression never touched, such as
+    # config.yaml); only then does restoring the prompt files provably
+    # reproduce the recorded pre-compression digest.
+    current_dir_digest = role_template_digest(role_dir)
+    if current_dir_digest != entry.post_digest:
+        raise TemplateCompressionError(
+            f"role template directory changed since compression (digest "
+            f"{current_dir_digest[:12]}... != recorded {entry.post_digest[:12]}...); "
+            "refusing to restore over it"
+        )
+
+    originals = {record.path: read_backup(record.pre_sha256, backup_root=backup_root) for record in entry.files}
+    for record in entry.files:
+        _atomic_write(role_dir / record.path, originals[record.path], expected_sha256=record.pre_sha256)
+
+    post_restore_digest = role_template_digest(role_dir)
+    if post_restore_digest != entry.pre_digest:
+        raise TemplateCompressionError(
+            f"restore verification failed for role {role!r}: directory digest "
+            f"{post_restore_digest[:12]}... != recorded pre-compression digest {entry.pre_digest[:12]}..."
+        )
+
+    remove_compression_entry(resolved_lock, entry.correlation_id)
+
+    if chain is not None:
+        try:
+            from bernstein.core.security.audit_chain import EVENT_TEMPLATE_COMPRESSION_RESTORE
+
+            chain.log_with_prev_digest(
+                event_type=EVENT_TEMPLATE_COMPRESSION_RESTORE,
+                actor=AUDIT_ACTOR,
+                resource_type=AUDIT_RESOURCE_TYPE,
+                resource_id=role,
+                details={
+                    "role": role,
+                    "correlation_id": entry.correlation_id,
+                    "restored_pre_sha256": entry.pre_digest,
+                    "from_post_sha256": entry.post_digest,
+                },
+            )
+        except Exception as exc:
+            logger.warning("Template restore chain write failed for role %s: %s", role, exc)
+
+    return RestoreOutcome(
+        role=role,
+        restored_files=tuple(record.path for record in entry.files),
+        pre_digest=post_restore_digest,
+        correlation_id=entry.correlation_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift recognition helper (consumed by bernstein.core.teams.drift)
+# ---------------------------------------------------------------------------
+
+
+def compression_explains_digest_change(
+    lock_state: TemplatesLockState,
+    *,
+    role: str,
+    pinned_digest: str,
+    actual_digest: str,
+) -> bool:
+    """Whether receipted compressions turn *pinned_digest* into *actual_digest*.
+
+    Walks the ``pre_digest -> post_digest`` edges recorded for *role*
+    (repeat compressions chain), so the team-manifest drift check can
+    classify the divergence as intentional rather than drift.
+
+    Args:
+        lock_state: Parsed ``templates.lock``.
+        role: The pinned role being checked.
+        pinned_digest: The manifest's pinned role template digest.
+        actual_digest: The on-disk role template digest.
+
+    Returns:
+        True when a chain of receipted compressions leads from the
+        pinned digest to the actual digest.
+    """
+    if not _HEX_DIGEST_RE.match(pinned_digest) or not _HEX_DIGEST_RE.match(actual_digest):
+        return False
+    edges: dict[str, set[str]] = {}
+    for row in lock_state.entries_for(role):
+        edges.setdefault(row.pre_digest, set()).add(row.post_digest)
+    seen: set[str] = set()
+    frontier = [pinned_digest]
+    while frontier:
+        digest = frontier.pop()
+        if digest in seen:
+            continue
+        seen.add(digest)
+        for nxt in edges.get(digest, ()):
+            if nxt == actual_digest:
+                return True
+            frontier.append(nxt)
+    return False
+
+
+__all__ = [
+    "AUDIT_ACTOR",
+    "AUDIT_RESOURCE_TYPE",
+    "TEMPLATES_LOCK_FILENAME",
+    "TEMPLATE_PROMPT_FILENAMES",
+    "BackupIntegrityError",
+    "CompressedFileRecord",
+    "CompressionLockEntry",
+    "CompressionOutcome",
+    "RestoreOutcome",
+    "TemplateCompressionError",
+    "TemplateCompressionReceipt",
+    "TemplatesLockState",
+    "append_compression_entry",
+    "build_compression_prompt",
+    "compress_role_templates",
+    "compression_explains_digest_change",
+    "default_backup_root",
+    "load_compression_receipts",
+    "read_backup",
+    "read_templates_lock",
+    "receipt_from_details",
+    "record_compression_receipt",
+    "remove_compression_entry",
+    "restore_role_templates",
+    "store_backup",
+    "templates_lock_path",
+    "verify_compression_receipts",
+    "write_templates_lock",
+]

--- a/tests/integration/test_template_compression_drift.py
+++ b/tests/integration/test_template_compression_drift.py
@@ -1,0 +1,136 @@
+"""Integration test: receipted compression is intentional, not drift (AC4, #2249).
+
+End-to-end over the real modules (no mocks except the adapter rewrite):
+a team manifest pins its role template digest, ``compress_role_templates``
+rewrites the template with a chained receipt and a ``templates.lock``
+row, and the team-manifest drift check (#2248) - both the library
+classification and the ``bernstein team drift`` CLI - reports the
+divergence as an intentional receipted compression instead of drift.
+A manual edit on top of the compression is still reported as drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.teams.drift import classify_role_template_drift, role_template_digest
+from bernstein.core.teams.manifest import load_team_manifest
+from bernstein.core.tokens.template_compression import (
+    compress_role_templates,
+    restore_role_templates,
+)
+
+pytestmark = pytest.mark.integration
+
+ORIGINAL_SYSTEM = """\
+# You are a Backend Engineer
+
+## Your specialization
+You implement server-side logic and APIs with great care and attention,
+always reading the existing code before writing anything new at all.
+
+## Rules
+- Run `uv run ruff check src/` before completing
+
+## Current task
+{{TASK_DESCRIPTION}}
+"""
+
+COMPRESSED_SYSTEM = """\
+# You are a Backend Engineer
+
+## Your specialization
+Server-side logic and APIs; read existing code first.
+
+## Rules
+- Run `uv run ruff check src/` before completing
+
+## Current task
+{{TASK_DESCRIPTION}}
+"""
+
+MANIFEST_TEMPLATE = """\
+name = "crew"
+version = "1.0.0"
+
+[[roles]]
+role = "backend"
+
+[role_template_digests]
+"backend" = "{digest}"
+"""
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    role_dir = tmp_path / "templates" / "roles" / "backend"
+    role_dir.mkdir(parents=True)
+    (role_dir / "system_prompt.md").write_text(ORIGINAL_SYSTEM, encoding="utf-8")
+
+    teams_dir = tmp_path / "templates" / "teams"
+    teams_dir.mkdir(parents=True)
+    (teams_dir / "crew.toml").write_text(
+        MANIFEST_TEMPLATE.format(digest=role_template_digest(role_dir)),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _compress(workdir: Path, tmp_path: Path) -> None:
+    outcome = compress_role_templates(
+        "backend",
+        workdir=workdir,
+        llm_call=lambda prompt: COMPRESSED_SYSTEM,
+        adapter="openrouter",
+        model="test-model",
+        chain=AuditChainStore(tmp_path / "audit", key=b"k" * 32),
+        backup_root=tmp_path / "backups",
+    )
+    assert outcome.applied, outcome.reason
+
+
+class TestDriftRecognizesReceiptedCompression:
+    def test_classification_marks_compression_intentional(self, workdir: Path, tmp_path: Path) -> None:
+        _compress(workdir, tmp_path)
+        manifest = load_team_manifest(workdir / "templates" / "teams" / "crew.toml")
+        findings = classify_role_template_drift(manifest, workdir=workdir)
+        assert set(findings) == {"backend"}
+        finding = findings["backend"]
+        assert finding.intentional
+        assert finding.pinned_digest == manifest.role_template_digests["backend"]
+        assert finding.actual_digest == role_template_digest(workdir / "templates" / "roles" / "backend")
+
+    def test_team_drift_cli_reports_intentional_and_exits_zero(self, workdir: Path, tmp_path: Path) -> None:
+        _compress(workdir, tmp_path)
+        result = CliRunner().invoke(cli, ["team", "drift", "crew", "--workdir", str(workdir)])
+        assert result.exit_code == 0, result.output
+        assert "intentional" in result.output
+        assert "receipted template compression" in result.output
+        assert "drift detected" not in result.output
+
+    def test_manual_edit_on_top_of_compression_is_still_drift(self, workdir: Path, tmp_path: Path) -> None:
+        _compress(workdir, tmp_path)
+        prompt = workdir / "templates" / "roles" / "backend" / "system_prompt.md"
+        prompt.write_text(prompt.read_text(encoding="utf-8") + "x", encoding="utf-8")
+        result = CliRunner().invoke(cli, ["team", "drift", "crew", "--workdir", str(workdir)])
+        assert result.exit_code == 1, result.output
+        assert "drift detected" in result.output
+
+    def test_uncompressed_manual_edit_is_drift(self, workdir: Path) -> None:
+        prompt = workdir / "templates" / "roles" / "backend" / "system_prompt.md"
+        prompt.write_text(prompt.read_text(encoding="utf-8") + "x", encoding="utf-8")
+        manifest = load_team_manifest(workdir / "templates" / "teams" / "crew.toml")
+        findings = classify_role_template_drift(manifest, workdir=workdir)
+        assert not findings["backend"].intentional
+
+    def test_restore_returns_to_pinned_digest_no_drift(self, workdir: Path, tmp_path: Path) -> None:
+        _compress(workdir, tmp_path)
+        restore_role_templates("backend", workdir=workdir, backup_root=tmp_path / "backups")
+        result = CliRunner().invoke(cli, ["team", "drift", "crew", "--workdir", str(workdir)])
+        assert result.exit_code == 0, result.output
+        assert "no drift detected" in result.output

--- a/tests/unit/test_template_compress_validate.py
+++ b/tests/unit/test_template_compress_validate.py
@@ -1,0 +1,316 @@
+"""Tests for role-template rewrite validators (issue #2249, AC1).
+
+Adversarial fixtures: every rewrite that alters a fenced block, drops a
+URL, or touches the completion-instruction block must be rejected by
+the mechanical validators, plus the template-specific invariants
+(frontmatter, headings, inline code, placeholders) and the two-retry
+targeted fix loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.tokens.compaction_validate import all_passed
+from bernstein.core.tokens.template_compress_validate import (
+    ALL_TEMPLATE_VALIDATOR_NAMES,
+    TEMPLATE_MAX_FIX_RETRIES,
+    extract_completion_block,
+    extract_headings,
+    run_template_validators,
+    split_frontmatter,
+    validate_completion_block,
+    validate_frontmatter,
+    validate_headings,
+    validate_inline_code,
+    validate_placeholders,
+    validate_template_rewrite,
+    validate_urls,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture template (representative of templates/roles/*/task_prompt.md)
+# ---------------------------------------------------------------------------
+
+TEMPLATE = """\
+# Task: {{TASK_TITLE}}
+
+## Description
+{{TASK_DESCRIPTION}}
+
+{{#IF FILES}}
+## Files to work with
+{{FILES}}
+{{/IF}}
+
+## Instructions
+1. Read all listed files carefully before you start writing any code at all
+2. Run `uv run ruff check src/` before marking the task as complete
+3. Consult https://docs.example.test/style for the full style guide
+
+## Verify
+```bash
+uv run python scripts/run_tests.py -x
+```
+
+{{INCLUDE completion_contract}}
+"""
+
+COMPRESSED_OK = """\
+# Task: {{TASK_TITLE}}
+
+## Description
+{{TASK_DESCRIPTION}}
+
+{{#IF FILES}}
+## Files to work with
+{{FILES}}
+{{/IF}}
+
+## Instructions
+1. Read listed files first
+2. Run `uv run ruff check src/` before completing
+3. Style guide: https://docs.example.test/style
+
+## Verify
+```bash
+uv run python scripts/run_tests.py -x
+```
+
+{{INCLUDE completion_contract}}
+"""
+
+EXPANDED_TEMPLATE = """\
+# Task: {{TASK_TITLE}}
+
+## Instructions
+Do the work described in {{TASK_DESCRIPTION}} carefully and completely.
+
+## Done signal (completion contract worker-completion/v1)
+
+Report your terminal outcome as a structured JSON payload.
+
+```bash
+curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete
+```
+
+Only retry on connection refused errors.
+
+## Bulletin board
+Post discoveries so parallel agents stay informed.
+"""
+
+
+def _failed_names(pre: str, post: str) -> set[str]:
+    return {v.name for v in run_template_validators(pre, post) if not v.passed}
+
+
+# ---------------------------------------------------------------------------
+# AC1 adversarial fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialRewrites:
+    def test_good_compression_passes_every_validator(self) -> None:
+        verdicts = run_template_validators(TEMPLATE, COMPRESSED_OK)
+        assert all_passed(verdicts), [v for v in verdicts if not v.passed]
+        assert tuple(v.name for v in verdicts) == ALL_TEMPLATE_VALIDATOR_NAMES
+
+    def test_altered_fenced_block_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace(
+            "uv run python scripts/run_tests.py -x",
+            "uv run pytest tests/",
+        )
+        assert "code_blocks" in _failed_names(TEMPLATE, tampered)
+
+    def test_dropped_url_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("3. Style guide: https://docs.example.test/style\n", "")
+        assert "urls" in _failed_names(TEMPLATE, tampered)
+
+    def test_invented_url_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK + "\nSee also https://other.example.test/notes\n"
+        assert "urls" in _failed_names(TEMPLATE, tampered)
+
+    def test_dropped_include_directive_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("{{INCLUDE completion_contract}}\n", "")
+        failed = _failed_names(TEMPLATE, tampered)
+        assert "completion_block" in failed
+
+    def test_reworded_expanded_completion_block_is_rejected(self) -> None:
+        tampered = EXPANDED_TEMPLATE.replace(
+            "Report your terminal outcome as a structured JSON payload.",
+            "Send a JSON payload when done.",
+        )
+        verdict = validate_completion_block(EXPANDED_TEMPLATE, tampered)
+        assert not verdict.passed
+        assert "verbatim" in verdict.detail
+
+    def test_expanded_completion_block_survives_verbatim(self) -> None:
+        shortened = EXPANDED_TEMPLATE.replace(
+            "Do the work described in {{TASK_DESCRIPTION}} carefully and completely.",
+            "Do {{TASK_DESCRIPTION}} carefully and completely.",
+        )
+        assert validate_completion_block(EXPANDED_TEMPLATE, shortened).passed
+
+
+# ---------------------------------------------------------------------------
+# Template-specific invariants
+# ---------------------------------------------------------------------------
+
+
+class TestFrontmatter:
+    FRONT = "---\nrole: backend\n---\n# Body\n\nProse here.\n"
+
+    def test_split_round_trips(self) -> None:
+        front, body = split_frontmatter(self.FRONT)
+        assert front == "---\nrole: backend\n---\n"
+        assert front + body == self.FRONT
+
+    def test_no_frontmatter_returns_text_unchanged(self) -> None:
+        front, body = split_frontmatter("# Heading\n")
+        assert front == ""
+        assert body == "# Heading\n"
+
+    def test_unterminated_frontmatter_is_not_split(self) -> None:
+        text = "---\nrole: backend\n# Body\n"
+        assert split_frontmatter(text) == ("", text)
+
+    def test_edited_frontmatter_is_rejected(self) -> None:
+        tampered = self.FRONT.replace("role: backend", "role: qa")
+        assert not validate_frontmatter(self.FRONT, tampered).passed
+
+    def test_verbatim_frontmatter_passes(self) -> None:
+        shorter = self.FRONT.replace("Prose here.", "Prose.")
+        assert validate_frontmatter(self.FRONT, shorter).passed
+
+
+class TestHeadings:
+    def test_reworded_heading_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("## Instructions", "## Steps")
+        verdict = validate_headings(TEMPLATE, tampered)
+        assert not verdict.passed
+        assert "Instructions" in verdict.detail
+
+    def test_dropped_heading_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("## Verify\n", "")
+        assert not validate_headings(TEMPLATE, tampered).passed
+
+    def test_invented_heading_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK + "\n## Bonus section\n"
+        assert not validate_headings(TEMPLATE, tampered).passed
+
+    def test_hash_lines_inside_fences_are_not_headings(self) -> None:
+        text = "# Real\n```bash\n# not a heading\n```\n"
+        assert extract_headings(text) == ["# Real"]
+
+
+class TestInlineCodeAndPlaceholders:
+    def test_dropped_inline_code_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("`uv run ruff check src/`", "the linter")
+        verdict = validate_inline_code(TEMPLATE, tampered)
+        assert not verdict.passed
+        assert "uv run ruff check src/" in verdict.detail
+
+    def test_invented_inline_code_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK + "\nAlso run `make lint` now.\n"
+        assert not validate_inline_code(TEMPLATE, tampered).passed
+
+    def test_dropped_placeholder_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("{{TASK_DESCRIPTION}}", "the task")
+        verdict = validate_placeholders(TEMPLATE, tampered)
+        assert not verdict.passed
+        assert "TASK_DESCRIPTION" in verdict.detail
+
+    def test_dropped_conditional_marker_is_rejected(self) -> None:
+        tampered = COMPRESSED_OK.replace("{{#IF FILES}}\n", "").replace("{{/IF}}\n", "")
+        assert not validate_placeholders(TEMPLATE, tampered).passed
+
+    def test_url_set_check_ignores_repeated_mentions(self) -> None:
+        doubled = TEMPLATE + "\nAgain: https://docs.example.test/style\n"
+        assert validate_urls(doubled, TEMPLATE).passed
+
+
+class TestCompletionBlockExtraction:
+    def test_extracts_expanded_block_to_next_same_level_heading(self) -> None:
+        block = extract_completion_block(EXPANDED_TEMPLATE)
+        assert block is not None
+        assert block.startswith("## Done signal (completion contract worker-completion/v1)")
+        assert "curl -s -X POST" in block
+        assert "## Bulletin board" not in block
+
+    def test_absent_block_returns_none(self) -> None:
+        assert extract_completion_block(TEMPLATE) is None
+
+    def test_matches_any_contract_version(self) -> None:
+        bumped = EXPANDED_TEMPLATE.replace("worker-completion/v1", "worker-completion/v2")
+        assert extract_completion_block(bumped) is not None
+
+
+# ---------------------------------------------------------------------------
+# Targeted fix retry loop (max 2)
+# ---------------------------------------------------------------------------
+
+
+class TestFixRetryLoop:
+    def test_passing_candidate_needs_no_fix(self) -> None:
+        outcome = validate_template_rewrite(TEMPLATE, COMPRESSED_OK, fix_call=None)
+        assert outcome.passed
+        assert not outcome.aborted
+        assert outcome.retry_count == 0
+        assert outcome.text == COMPRESSED_OK
+
+    def test_failure_without_fix_call_aborts(self) -> None:
+        bad = COMPRESSED_OK.replace("{{INCLUDE completion_contract}}\n", "")
+        outcome = validate_template_rewrite(TEMPLATE, bad, fix_call=None)
+        assert outcome.aborted
+        assert outcome.retry_count == 0
+
+    def test_fix_succeeds_on_second_retry(self) -> None:
+        bad = COMPRESSED_OK.replace("{{INCLUDE completion_contract}}\n", "")
+        still_bad = COMPRESSED_OK.replace("## Verify", "## Check")
+        responses = iter([still_bad, COMPRESSED_OK])
+
+        prompts: list[str] = []
+
+        def fix_call(prompt: str) -> str:
+            prompts.append(prompt)
+            return next(responses)
+
+        outcome = validate_template_rewrite(TEMPLATE, bad, fix_call=fix_call)
+        assert outcome.passed
+        assert outcome.retry_count == 2
+        assert outcome.text == COMPRESSED_OK
+        # The fix prompt carries the original as the byte reference.
+        assert TEMPLATE in prompts[0]
+
+    def test_aborts_after_two_failed_retries(self) -> None:
+        bad = COMPRESSED_OK.replace("{{INCLUDE completion_contract}}\n", "")
+        calls = 0
+
+        def fix_call(prompt: str) -> str:
+            nonlocal calls
+            calls += 1
+            return bad
+
+        outcome = validate_template_rewrite(TEMPLATE, bad, fix_call=fix_call)
+        assert outcome.aborted
+        assert not outcome.passed
+        assert calls == TEMPLATE_MAX_FIX_RETRIES == 2
+        assert outcome.retry_count == 2
+
+    def test_fix_call_exception_aborts(self) -> None:
+        bad = COMPRESSED_OK.replace("{{INCLUDE completion_contract}}\n", "")
+
+        def fix_call(prompt: str) -> str:
+            raise RuntimeError("adapter down")
+
+        outcome = validate_template_rewrite(TEMPLATE, bad, fix_call=fix_call)
+        assert outcome.aborted
+
+
+class TestDeterminism:
+    @pytest.mark.parametrize("post", [COMPRESSED_OK, TEMPLATE, EXPANDED_TEMPLATE])
+    def test_same_pair_yields_identical_verdicts(self, post: str) -> None:
+        first = run_template_validators(TEMPLATE, post)
+        second = run_template_validators(TEMPLATE, post)
+        assert first == second

--- a/tests/unit/test_template_compression.py
+++ b/tests/unit/test_template_compression.py
@@ -1,0 +1,467 @@
+"""Tests for role-template compression (issue #2249).
+
+Covers:
+- Out-of-tree backup store: content-hash keying, readback verification,
+  corruption detection.
+- Compression engine: validated rewrite applied, failing rewrite leaves
+  the template untouched, sensitive-gate refusal, no-savings skip.
+- Restore (AC2): byte-identical reversal, verified by hash; refusal to
+  clobber post-compression manual edits.
+- Receipt (AC3): verifies in the audit chain and pins pre/post hashes.
+- templates.lock round trip and drift recognition
+  (compression_explains_digest_change).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit_chain import (
+    EVENT_TEMPLATE_COMPRESSION_RECEIPT,
+    AuditChainStore,
+)
+from bernstein.core.teams.drift import role_template_digest
+from bernstein.core.tokens.template_compression import (
+    BackupIntegrityError,
+    CompressedFileRecord,
+    CompressionLockEntry,
+    TemplateCompressionError,
+    TemplatesLockState,
+    append_compression_entry,
+    compress_role_templates,
+    compression_explains_digest_change,
+    load_compression_receipts,
+    read_backup,
+    read_templates_lock,
+    receipt_from_details,
+    restore_role_templates,
+    store_backup,
+    templates_lock_path,
+    verify_compression_receipts,
+    write_templates_lock,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ORIGINAL_SYSTEM = """\
+# You are a Backend Engineer
+
+## Your specialization
+You implement server-side logic and APIs with great care and attention,
+always reading the existing code before writing anything new at all.
+
+## Rules
+- Run `uv run ruff check src/` before completing
+- Style guide: https://docs.example.test/style
+
+## Current task
+{{TASK_DESCRIPTION}}
+"""
+
+COMPRESSED_SYSTEM = """\
+# You are a Backend Engineer
+
+## Your specialization
+Server-side logic and APIs; read existing code first.
+
+## Rules
+- Run `uv run ruff check src/` before completing
+- Style guide: https://docs.example.test/style
+
+## Current task
+{{TASK_DESCRIPTION}}
+"""
+
+
+def _write_role(workdir: Path, role: str = "backend", text: str = ORIGINAL_SYSTEM) -> Path:
+    role_dir = workdir / "templates" / "roles" / role
+    role_dir.mkdir(parents=True, exist_ok=True)
+    (role_dir / "system_prompt.md").write_text(text, encoding="utf-8")
+    return role_dir
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+
+
+def _compress(
+    workdir: Path,
+    tmp_path: Path,
+    *,
+    llm_response: str = COMPRESSED_SYSTEM,
+    chain: AuditChainStore | None = None,
+):
+    return compress_role_templates(
+        "backend",
+        workdir=workdir,
+        llm_call=lambda prompt: llm_response,
+        adapter="openrouter",
+        model="test-model",
+        chain=chain,
+        backup_root=tmp_path / "backups",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backup store
+# ---------------------------------------------------------------------------
+
+
+class TestBackupStore:
+    def test_store_is_keyed_by_content_hash(self, tmp_path: Path) -> None:
+        digest = store_backup(b"original bytes", backup_root=tmp_path / "b")
+        assert digest == hashlib.sha256(b"original bytes").hexdigest()
+        assert (tmp_path / "b" / digest).read_bytes() == b"original bytes"
+
+    def test_store_is_idempotent(self, tmp_path: Path) -> None:
+        first = store_backup(b"same", backup_root=tmp_path / "b")
+        second = store_backup(b"same", backup_root=tmp_path / "b")
+        assert first == second
+
+    def test_read_back_verifies_hash(self, tmp_path: Path) -> None:
+        digest = store_backup(b"payload", backup_root=tmp_path / "b")
+        assert read_backup(digest, backup_root=tmp_path / "b") == b"payload"
+
+    def test_corrupted_backup_is_detected(self, tmp_path: Path) -> None:
+        digest = store_backup(b"payload", backup_root=tmp_path / "b")
+        (tmp_path / "b" / digest).write_bytes(b"tampered")
+        with pytest.raises(BackupIntegrityError, match="hash verification"):
+            read_backup(digest, backup_root=tmp_path / "b")
+
+    def test_missing_backup_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(BackupIntegrityError, match="not found"):
+            read_backup("0" * 64, backup_root=tmp_path / "b")
+
+
+# ---------------------------------------------------------------------------
+# Compression engine
+# ---------------------------------------------------------------------------
+
+
+class TestCompressRole:
+    def test_validated_rewrite_is_applied(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        outcome = _compress(tmp_path, tmp_path)
+        assert outcome.applied, outcome.reason
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == COMPRESSED_SYSTEM
+        assert outcome.post_tokens < outcome.pre_tokens
+
+    def test_receipt_shape(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        pre_digest = role_template_digest(role_dir)
+        outcome = _compress(tmp_path, tmp_path)
+        receipt = outcome.receipt
+        assert receipt is not None
+        assert receipt.role == "backend"
+        assert receipt.pre_sha256 == pre_digest
+        assert receipt.post_sha256 == role_template_digest(role_dir)
+        assert receipt.adapter == "openrouter"
+        assert receipt.model == "test-model"
+        assert receipt.pre_tokens > receipt.post_tokens > 0
+        assert all(passed for _, passed in receipt.validators)
+        assert receipt.files[0].path == "system_prompt.md"
+        assert receipt.files[0].pre_sha256 == hashlib.sha256(ORIGINAL_SYSTEM.encode()).hexdigest()
+        assert receipt.files[0].post_sha256 == hashlib.sha256(COMPRESSED_SYSTEM.encode()).hexdigest()
+
+    def test_invalid_rewrite_leaves_template_untouched(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        bad = COMPRESSED_SYSTEM.replace("https://docs.example.test/style", "")
+        outcome = _compress(tmp_path, tmp_path, llm_response=bad)
+        assert not outcome.applied
+        assert "urls" in outcome.reason
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == ORIGINAL_SYSTEM
+        assert not templates_lock_path(tmp_path).exists()
+
+    def test_no_savings_leaves_template_untouched(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        outcome = _compress(tmp_path, tmp_path, llm_response=ORIGINAL_SYSTEM)
+        assert not outcome.applied
+        assert "saved no tokens" in outcome.reason
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == ORIGINAL_SYSTEM
+
+    def test_sensitive_gate_refuses_credential_shaped_template(self, tmp_path: Path) -> None:
+        secret = "AKIA" + "A" * 16
+        text = ORIGINAL_SYSTEM + f"\nExample key: {secret}\n"
+        role_dir = _write_role(tmp_path, text=text)
+        calls = 0
+
+        def llm_call(prompt: str) -> str:
+            nonlocal calls
+            calls += 1
+            return COMPRESSED_SYSTEM
+
+        outcome = compress_role_templates(
+            "backend",
+            workdir=tmp_path,
+            llm_call=llm_call,
+            adapter="openrouter",
+            model="test-model",
+            backup_root=tmp_path / "backups",
+        )
+        assert not outcome.applied
+        assert "sensitive gate" in outcome.reason
+        # Nothing was sent to the model and nothing was written.
+        assert calls == 0
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == text
+
+    def test_unknown_role_raises(self, tmp_path: Path) -> None:
+        _write_role(tmp_path)
+        with pytest.raises(TemplateCompressionError, match="not found"):
+            compress_role_templates(
+                "no-such-role",
+                workdir=tmp_path,
+                llm_call=lambda prompt: "",
+                adapter="a",
+                model="m",
+                backup_root=tmp_path / "backups",
+            )
+
+    def test_bundled_templates_are_refused(self, tmp_path: Path) -> None:
+        # No project-local templates/ dir: resolution falls back to the
+        # bundled package copy, which compression must never rewrite.
+        with pytest.raises(TemplateCompressionError, match="project-local"):
+            compress_role_templates(
+                "backend",
+                workdir=tmp_path,
+                llm_call=lambda prompt: "",
+                adapter="a",
+                model="m",
+                backup_root=tmp_path / "backups",
+            )
+
+    def test_include_role_names_are_refused(self, tmp_path: Path) -> None:
+        _write_role(tmp_path)
+        with pytest.raises(TemplateCompressionError, match="not a compressible"):
+            compress_role_templates(
+                "_includes",
+                workdir=tmp_path,
+                llm_call=lambda prompt: "",
+                adapter="a",
+                model="m",
+                backup_root=tmp_path / "backups",
+            )
+
+    def test_lock_entry_written_with_digest_edge(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        pre_digest = role_template_digest(role_dir)
+        outcome = _compress(tmp_path, tmp_path)
+        state = read_templates_lock(templates_lock_path(tmp_path))
+        assert len(state.compressions) == 1
+        row = state.compressions[0]
+        assert row.role == "backend"
+        assert row.pre_digest == pre_digest
+        assert row.post_digest == role_template_digest(role_dir)
+        assert outcome.receipt is not None
+        assert row.correlation_id == outcome.receipt.correlation_id
+
+
+# ---------------------------------------------------------------------------
+# Restore (AC2)
+# ---------------------------------------------------------------------------
+
+
+class TestRestore:
+    def test_restore_is_byte_identical_and_hash_verified(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        original_bytes = (role_dir / "system_prompt.md").read_bytes()
+        pre_digest = role_template_digest(role_dir)
+
+        assert _compress(tmp_path, tmp_path).applied
+        assert (role_dir / "system_prompt.md").read_bytes() != original_bytes
+
+        outcome = restore_role_templates(
+            "backend",
+            workdir=tmp_path,
+            backup_root=tmp_path / "backups",
+        )
+        assert (role_dir / "system_prompt.md").read_bytes() == original_bytes
+        assert outcome.pre_digest == pre_digest
+        assert outcome.restored_files == ("system_prompt.md",)
+        # The reversed lock row is gone; a second restore has nothing to do.
+        with pytest.raises(TemplateCompressionError, match="no receipted compression"):
+            restore_role_templates("backend", workdir=tmp_path, backup_root=tmp_path / "backups")
+
+    def test_restore_refuses_over_manual_edits(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        assert _compress(tmp_path, tmp_path).applied
+        prompt = role_dir / "system_prompt.md"
+        prompt.write_text(prompt.read_text(encoding="utf-8") + "x", encoding="utf-8")
+        with pytest.raises(TemplateCompressionError, match="modified after compression"):
+            restore_role_templates("backend", workdir=tmp_path, backup_root=tmp_path / "backups")
+
+    def test_restore_refuses_when_untouched_files_changed(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        (role_dir / "config.yaml").write_text("default_model: sonnet\n", encoding="utf-8")
+        assert _compress(tmp_path, tmp_path).applied
+        # A file the compression never rewrote changes afterwards; the
+        # directory is no longer in the recorded post-compression state.
+        (role_dir / "config.yaml").write_text("default_model: opus\n", encoding="utf-8")
+        with pytest.raises(TemplateCompressionError, match="directory changed since compression"):
+            restore_role_templates("backend", workdir=tmp_path, backup_root=tmp_path / "backups")
+
+    def test_restore_without_compression_raises(self, tmp_path: Path) -> None:
+        _write_role(tmp_path)
+        with pytest.raises(TemplateCompressionError, match="no receipted compression"):
+            restore_role_templates("backend", workdir=tmp_path, backup_root=tmp_path / "backups")
+
+
+# ---------------------------------------------------------------------------
+# Receipt in the audit chain (AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestChainReceipt:
+    def test_receipt_verifies_in_chain_and_pins_hashes(self, tmp_path: Path) -> None:
+        role_dir = _write_role(tmp_path)
+        pre_digest = role_template_digest(role_dir)
+        chain = _chain(tmp_path)
+
+        outcome = _compress(tmp_path, tmp_path, chain=chain)
+        assert outcome.applied
+
+        ok, errors = chain.verify()
+        assert ok, errors
+
+        receipts = load_compression_receipts(chain, role="backend")
+        assert len(receipts) == 1
+        receipt = receipts[0]
+        assert receipt.pre_sha256 == pre_digest
+        assert receipt.post_sha256 == role_template_digest(role_dir)
+
+        # The previous chain digest is embedded in the payload.
+        events = chain.query(event_type=EVENT_TEMPLATE_COMPRESSION_RECEIPT)
+        assert len(events) == 1
+        assert "prev_chain_digest" in events[0].details
+
+        lock_state = read_templates_lock(templates_lock_path(tmp_path))
+        ok, errors = verify_compression_receipts(chain, lock_state=lock_state)
+        assert ok, errors
+
+    def test_lock_row_without_chain_receipt_fails_verification(self, tmp_path: Path) -> None:
+        chain = _chain(tmp_path)
+        lock_state = TemplatesLockState(
+            compressions=[
+                CompressionLockEntry(
+                    role="backend",
+                    correlation_id="tmplc-missing",
+                    pre_digest="a" * 64,
+                    post_digest="b" * 64,
+                    adapter="openrouter",
+                    model="m",
+                    chain_head="",
+                    timestamp="2026-01-01T00:00:00+00:00",
+                )
+            ]
+        )
+        ok, errors = verify_compression_receipts(chain, lock_state=lock_state)
+        assert not ok
+        assert any("no chain receipt" in err for err in errors)
+
+    def test_digest_mismatch_between_lock_and_receipt_fails(self, tmp_path: Path) -> None:
+        _write_role(tmp_path)
+        chain = _chain(tmp_path)
+        outcome = _compress(tmp_path, tmp_path, chain=chain)
+        assert outcome.receipt is not None
+        tampered = TemplatesLockState(
+            compressions=[
+                CompressionLockEntry(
+                    role="backend",
+                    correlation_id=outcome.receipt.correlation_id,
+                    pre_digest="c" * 64,
+                    post_digest="d" * 64,
+                    adapter="openrouter",
+                    model="m",
+                    chain_head="",
+                    timestamp="2026-01-01T00:00:00+00:00",
+                )
+            ]
+        )
+        ok, errors = verify_compression_receipts(chain, lock_state=tampered)
+        assert not ok
+        assert any("disagree" in err for err in errors)
+
+    def test_receipt_round_trips_through_details(self, tmp_path: Path) -> None:
+        _write_role(tmp_path)
+        chain = _chain(tmp_path)
+        outcome = _compress(tmp_path, tmp_path, chain=chain)
+        assert outcome.receipt is not None
+        rebuilt = receipt_from_details(outcome.receipt.to_details())
+        assert rebuilt == outcome.receipt
+
+
+# ---------------------------------------------------------------------------
+# templates.lock round trip + drift recognition edges
+# ---------------------------------------------------------------------------
+
+
+def _entry(role: str, pre: str, post: str, correlation: str = "tmplc-1") -> CompressionLockEntry:
+    return CompressionLockEntry(
+        role=role,
+        correlation_id=correlation,
+        pre_digest=pre,
+        post_digest=post,
+        adapter="openrouter",
+        model="m",
+        chain_head="h" * 64,
+        timestamp="2026-01-01T00:00:00+00:00",
+        files=(CompressedFileRecord(path="system_prompt.md", pre_sha256="e" * 64, post_sha256="f" * 64),),
+    )
+
+
+class TestTemplatesLock:
+    def test_write_read_round_trip(self, tmp_path: Path) -> None:
+        lock = tmp_path / "templates.lock"
+        state = TemplatesLockState(compressions=[_entry("backend", "a" * 64, "b" * 64)])
+        write_templates_lock(lock, state)
+        loaded = read_templates_lock(lock)
+        assert loaded.compressions == state.compressions
+
+    def test_append_preserves_existing_rows(self, tmp_path: Path) -> None:
+        lock = tmp_path / "templates.lock"
+        append_compression_entry(lock, _entry("backend", "a" * 64, "b" * 64, "tmplc-1"))
+        append_compression_entry(lock, _entry("qa", "c" * 64, "d" * 64, "tmplc-2"))
+        loaded = read_templates_lock(lock)
+        assert [row.role for row in loaded.compressions] == ["backend", "qa"]
+
+    def test_unparseable_lock_returns_empty_state(self, tmp_path: Path) -> None:
+        lock = tmp_path / "templates.lock"
+        lock.write_text("not [ valid toml", encoding="utf-8")
+        assert read_templates_lock(lock).compressions == []
+
+
+class TestCompressionExplainsDigestChange:
+    def test_direct_edge_is_recognized(self) -> None:
+        state = TemplatesLockState(compressions=[_entry("backend", "a" * 64, "b" * 64)])
+        assert compression_explains_digest_change(state, role="backend", pinned_digest="a" * 64, actual_digest="b" * 64)
+
+    def test_chained_recompression_is_recognized(self) -> None:
+        state = TemplatesLockState(
+            compressions=[
+                _entry("backend", "a" * 64, "b" * 64, "tmplc-1"),
+                _entry("backend", "b" * 64, "c" * 64, "tmplc-2"),
+            ]
+        )
+        assert compression_explains_digest_change(state, role="backend", pinned_digest="a" * 64, actual_digest="c" * 64)
+
+    def test_unrelated_edit_is_not_recognized(self) -> None:
+        state = TemplatesLockState(compressions=[_entry("backend", "a" * 64, "b" * 64)])
+        assert not compression_explains_digest_change(
+            state, role="backend", pinned_digest="a" * 64, actual_digest="9" * 64
+        )
+
+    def test_other_roles_edges_do_not_apply(self) -> None:
+        state = TemplatesLockState(compressions=[_entry("qa", "a" * 64, "b" * 64)])
+        assert not compression_explains_digest_change(
+            state, role="backend", pinned_digest="a" * 64, actual_digest="b" * 64
+        )
+
+    def test_missing_template_marker_is_never_intentional(self) -> None:
+        state = TemplatesLockState(compressions=[_entry("backend", "a" * 64, "b" * 64)])
+        assert not compression_explains_digest_change(
+            state, role="backend", pinned_digest="a" * 64, actual_digest="<missing>"
+        )

--- a/tests/unit/test_templates_compress_cmd.py
+++ b/tests/unit/test_templates_compress_cmd.py
@@ -1,0 +1,178 @@
+"""Tests for ``bernstein templates compress`` / ``restore`` (issue #2249).
+
+The compression is operator-gated: it runs only through this explicit
+command (confirmation required unless ``--yes``), prints only the
+template token delta with a ledger reference for savings, and exits
+non-zero when a role fails validation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+
+ORIGINAL_SYSTEM = """\
+# You are a QA Engineer
+
+## Your specialization
+You design and run test plans with great care and attention to detail,
+always reading the existing suites before writing anything new at all.
+
+## Rules
+- Run `uv run ruff check src/` before completing
+
+## Current task
+{{TASK_DESCRIPTION}}
+"""
+
+COMPRESSED_SYSTEM = """\
+# You are a QA Engineer
+
+## Your specialization
+Test plans; read existing suites first.
+
+## Rules
+- Run `uv run ruff check src/` before completing
+
+## Current task
+{{TASK_DESCRIPTION}}
+"""
+
+
+def _write_role(workdir: Path, role: str = "qa") -> Path:
+    role_dir = workdir / "templates" / "roles" / role
+    role_dir.mkdir(parents=True, exist_ok=True)
+    (role_dir / "system_prompt.md").write_text(ORIGINAL_SYSTEM, encoding="utf-8")
+    return role_dir
+
+
+@pytest.fixture
+def fake_adapter(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Route the compress command's adapter call to a canned rewrite."""
+    import bernstein.cli.commands.templates_cmd as mod
+    import bernstein.core.tokens.template_compression as engine
+
+    calls: list[str] = []
+
+    def _fake(model: str, provider: str):
+        def _call(prompt: str) -> str:
+            calls.append(prompt)
+            return COMPRESSED_SYSTEM
+
+        return _call
+
+    monkeypatch.setattr(mod, "_compress_llm_call", _fake)
+    # Keep backups inside the test tree rather than the operator's home.
+    monkeypatch.setattr(engine, "default_backup_root", lambda: tmp_path / "backups")
+    return calls
+
+
+class TestTemplatesCompressCmd:
+    def test_compress_prints_ledger_only_savings_line(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        role_dir = _write_role(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "qa", "--workdir", str(tmp_path), "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "template reduced" in result.output
+        assert "per-spawn savings will appear in the ledger" in result.output
+        # No dollar or percentage claims at compression time.
+        assert "$" not in result.output
+        assert "%" not in result.output
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == COMPRESSED_SYSTEM
+        assert (tmp_path / "templates.lock").is_file()
+
+    def test_compress_requires_confirmation(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        role_dir = _write_role(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "qa", "--workdir", str(tmp_path)],
+            input="n\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Cancelled" in result.output
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == ORIGINAL_SYSTEM
+        assert not fake_adapter
+
+    def test_role_and_all_are_mutually_exclusive(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        _write_role(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "qa", "--all", "--workdir", str(tmp_path), "--yes"],
+        )
+        assert result.exit_code != 0
+        assert "exactly one of ROLE or --all" in result.output
+
+    def test_missing_role_and_all_fails(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        _write_role(tmp_path)
+        result = CliRunner().invoke(cli, ["templates", "compress", "--workdir", str(tmp_path), "--yes"])
+        assert result.exit_code != 0
+
+    def test_all_compresses_every_role_dir(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        _write_role(tmp_path, "qa")
+        qa2 = tmp_path / "templates" / "roles" / "backend"
+        qa2.mkdir(parents=True)
+        (qa2 / "system_prompt.md").write_text(ORIGINAL_SYSTEM, encoding="utf-8")
+        result = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "--all", "--workdir", str(tmp_path), "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+        assert result.output.count("template reduced") == 2
+
+    def test_unknown_role_exits_nonzero(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        _write_role(tmp_path)
+        result = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "nope", "--workdir", str(tmp_path), "--yes"],
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_failed_validation_exits_nonzero_and_keeps_original(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import bernstein.cli.commands.templates_cmd as mod
+
+        role_dir = _write_role(tmp_path)
+        bad = COMPRESSED_SYSTEM.replace("`uv run ruff check src/`", "the linter")
+        monkeypatch.setattr(mod, "_compress_llm_call", lambda model, provider: lambda prompt: bad)
+        result = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "qa", "--workdir", str(tmp_path), "--yes"],
+        )
+        assert result.exit_code == 1
+        assert "validators rejected" in result.output
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == ORIGINAL_SYSTEM
+
+
+class TestTemplatesRestoreCmd:
+    def test_restore_round_trips_byte_identically(self, tmp_path: Path, fake_adapter: list[str]) -> None:
+        role_dir = _write_role(tmp_path)
+        compress = CliRunner().invoke(
+            cli,
+            ["templates", "compress", "qa", "--workdir", str(tmp_path), "--yes"],
+        )
+        assert compress.exit_code == 0, compress.output
+
+        restore = CliRunner().invoke(cli, ["templates", "restore", "qa", "--workdir", str(tmp_path)])
+        assert restore.exit_code == 0, restore.output
+        assert "byte-identically" in restore.output
+        assert (role_dir / "system_prompt.md").read_text(encoding="utf-8") == ORIGINAL_SYSTEM
+
+    def test_restore_without_compression_fails_cleanly(self, tmp_path: Path) -> None:
+        _write_role(tmp_path)
+        result = CliRunner().invoke(cli, ["templates", "restore", "qa", "--workdir", str(tmp_path)])
+        assert result.exit_code != 0
+        assert "no receipted compression" in result.output
+
+    def test_subcommands_registered_on_templates_group(self) -> None:
+        result = CliRunner().invoke(cli, ["templates", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "compress" in result.output
+        assert "restore" in result.output


### PR DESCRIPTION
## Problem

Every worker spawn injects its role's `system_prompt.md` and `task_prompt.md`; across a fleet of parallel workers this fixed input cost is paid on every spawn and again after every compaction reinjection. The templates were written for human maintainability, not token economy. A one-time compression pass can cut this recurring cost, but only if the rewrite is mechanically verified, reversible, and its savings claims come from real ledger deltas.

## What was built

- **`bernstein templates compress <role>|--all`** (operator-gated, never automatic): LLM rewrite via the configured adapter (`--model`, `--provider`), then the full validator suite, then up to two targeted fix passes, then apply. A failing rewrite never reaches disk.
- **Validators** (`core/tokens/template_compress_validate.py`): reuse the compaction validators from #2246 unchanged and add template-specific invariants - frontmatter split-and-restored verbatim, ATX heading sequence byte-equal, URL and inline-code sets preserved exactly, every `{{...}}` template token kept, and the completion-payload instruction block (#2244) copied verbatim in both its `{{INCLUDE completion_contract}}` and expanded forms.
- **Sensitive gate**: template text is scanned by `core/tokens/sensitive_gate.py` before anything is sent to the model (same lane as compaction); any live finding refuses the compression, because writing redaction placeholders into a template would corrupt it.
- **Out-of-tree backups**: originals go to `~/.local/share/bernstein/template-backups/` keyed by content hash with readback verification, so template loaders never re-ingest them. **`bernstein templates restore <role>`** reverses the compression byte-identically - backup hash, on-disk hash, and role directory digest all verified.
- **Chained receipt**: `{role, pre_sha256, post_sha256, pre_tokens, post_tokens, validators, adapter, model}` appended to the HMAC audit chain as `template.compression.receipt` with the previous chain digest embedded (same helpers pattern as the #2246 compaction receipts); `verify_compression_receipts` cross-checks chain rows against `templates.lock`.
- **Drift integration (#2248)**: each compression appends a `templates.lock` row recording the role's pre/post directory digest edge. `classify_role_template_drift` walks those edges so `bernstein team drift` reports a receipted compression as intentional instead of drift; a manual edit on top still fails the check.
- **Ledger-only savings claims**: at compression time the command prints only `template reduced N -> M tokens; per-spawn savings will appear in the ledger`; the receipt `ts` is the boundary for before/after `bernstein cost --by role` windows (#2245).

## How it was tested

- `tests/unit/test_template_compress_validate.py` (32 tests): adversarial fixtures for AC1 - altered fenced block, dropped/invented URL, dropped include directive, reworded expanded completion block, frontmatter/heading/inline-code/placeholder tampering; two-retry fix loop semantics; determinism.
- `tests/unit/test_template_compression.py` (30 tests): backup store keying, readback verification, corruption detection; engine success/refusal/no-savings paths leaving templates untouched; AC2 byte-identical restore verified by hash, plus refusal over manual edits; AC3 receipt verifies in the chain and pins pre/post hashes; `templates.lock` round trip and digest-edge recognition.
- `tests/unit/test_templates_compress_cmd.py` (10 tests): CLI gating (confirmation, `--yes`), exact ledger-only output line, `--all`, failure exit codes, restore round trip.
- `tests/integration/test_template_compression_drift.py` (5 tests, AC4): pinned team manifest + real compression + `bernstein team drift` reports intentional and exits 0; manual edits still drift; restore returns to the pinned digest.
- Full sweep: 441 tests across the new files and every importer of the touched modules; `uv run ruff check src/ tests/`, `ruff format --check` on touched files, `uv run lint-imports` (3 contracts kept), `uv run python -c "import bernstein"`.

Fixes #2249
