### PR TITLE
chore(tests): drop duplicate _reap_leaked_timeout_watchdogs fixture

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -75,25 +75,3 @@ def _reap_leaked_timeout_watchdogs():
     for thread in threading.enumerate():
         if isinstance(thread, threading.Timer) and thread.name.startswith("timeout-watchdog"):
             thread.cancel()
-
-
-@pytest.fixture(autouse=True)
-def _reap_leaked_timeout_watchdogs():
-    """Cancel any timeout-watchdog Timer a spawn test leaves running.
-
-    ``CLIAdapter._start_timeout_watchdog`` starts a ``threading.Timer`` that
-    production code cancels when the agent is reaped. Adapter unit tests
-    routinely discard the ``SpawnResult`` (they only assert on the manifest
-    or log), so each spawn leaks a live Timer that sleeps for the full
-    timeout. Across a shard's worth of adapter tests these accumulate until
-    the process can no longer start new threads
-    (``RuntimeError: can't start new thread``), which flakes an unrelated
-    later test in the same shard. Cancel any that survive a test so worker
-    threads never pile up.
-    """
-    yield
-    import threading
-
-    for thread in threading.enumerate():
-        if isinstance(thread, threading.Timer) and thread.name.startswith("timeout-watchdog"):
-            thread.cancel()


### PR DESCRIPTION
## What

`tests/unit/conftest.py` defined the autouse fixture `_reap_leaked_timeout_watchdogs` twice with identical bodies (two consecutive blocks at the end of the file). The second definition silently shadowed the first. This removes the duplicate and keeps one copy.

## Why

Duplicate fixture definitions are a latent trap: if someone edits the first copy, the change is silently ignored because the second definition wins at module level.

## Verification

- `uv run ruff check tests/unit/conftest.py` passes; `ruff format --check` clean
- `uv run pytest tests/unit/test_adapter_timeout.py` passes (14 passed), confirming the surviving fixture still reaps leaked watchdog timers

No behaviour change: the remaining definition is byte-identical to the one pytest was already using.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the cleanup logic used after unit tests to more reliably remove leftover timeout watchdog timers.
  * No functional behavior was changed for test fixtures beyond the cleanup implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->