### PR TITLE
test: isolate status-dashboard runtime cache between unit tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,7 +55,6 @@ def _block_real_network(request: pytest.FixtureRequest) -> Iterator[None]:
         yield
 
 
-
 @pytest.fixture(autouse=True)
 def _reap_leaked_timeout_watchdogs():
     """Cancel any timeout-watchdog Timer a spawn test leaves running.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,3 +97,22 @@ def _reap_leaked_timeout_watchdogs():
     for thread in threading.enumerate():
         if isinstance(thread, threading.Timer) and thread.name.startswith("timeout-watchdog"):
             thread.cancel()
+
+
+@pytest.fixture(autouse=True)
+def _reset_status_runtime_cache() -> None:
+    """Clear the status-dashboard runtime cache before every test.
+
+    ``bernstein.core.routes.status_dashboard`` memoises ``_runtime_summary``
+    results in module globals (``_runtime_cache`` / ``_runtime_cache_ts``)
+    with a 10s TTL. The cache is keyed on nothing, so every ``create_app``
+    instance in the process shares it: a test that hits ``/status`` or
+    ``/health`` serves its ``restart_count`` / ``memory_mb`` snapshot to any
+    test that runs within the TTL window, hiding that test's own app state.
+    Clearing the globals at setup makes each test read its own state
+    regardless of what ran before it.
+    """
+    status_dashboard = sys.modules.get("bernstein.core.routes.status_dashboard")
+    if status_dashboard is not None:
+        status_dashboard._runtime_cache = {}
+        status_dashboard._runtime_cache_ts = 0.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,27 +55,6 @@ def _block_real_network(request: pytest.FixtureRequest) -> Iterator[None]:
         yield
 
 
-@pytest.fixture(autouse=True)
-def _reap_leaked_timeout_watchdogs():
-    """Cancel any timeout-watchdog Timer a spawn test leaves running.
-
-    ``CLIAdapter._start_timeout_watchdog`` starts a ``threading.Timer`` that
-    production code cancels when the agent is reaped. Adapter unit tests
-    routinely discard the ``SpawnResult`` (they only assert on the manifest
-    or log), so each spawn leaks a live Timer that sleeps for the full
-    timeout. Across a shard's worth of adapter tests these accumulate until
-    the process can no longer start new threads
-    (``RuntimeError: can't start new thread``), which flakes an unrelated
-    later test in the same shard. Cancel any that survive a test so worker
-    threads never pile up.
-    """
-    yield
-    import threading
-
-    for thread in threading.enumerate():
-        if isinstance(thread, threading.Timer) and thread.name.startswith("timeout-watchdog"):
-            thread.cancel()
-
 
 @pytest.fixture(autouse=True)
 def _reap_leaked_timeout_watchdogs():

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -482,7 +482,7 @@ class TestCompletionProgressSkipSet:
         assert self._tracker().detect_failure_type(log) == "rate_limit"
 
     def test_assistant_type_prose_with_error_context_does_not_match(self, tmp_path):
-        """"assistant" events carry free-form model narration, not
+        """ "assistant" events carry free-form model narration, not
         structured provider/HTTP data -- healthy narration that happens to
         mention "timeout" alongside an error-context word (e.g. "status")
         must not trip a false-positive throttle."""
@@ -502,6 +502,7 @@ class TestCompletionProgressSkipSet:
             '{"type": "error", "message": "Error code: 429 - rate limit exceeded"}\n'
         )
         assert self._tracker().detect_failure_type(log) == "rate_limit"
+
 
 class TestMaxTurnsDetection:
     """A MaxTurnsExceeded death was never classified by detect_failure_type,


### PR DESCRIPTION
## Problem

`tests/unit/test_server_track_b.py::test_health_reports_restart_count_and_memory` fails when it runs after `tests/unit/test_api_v1_routing.py`, while each file passes in isolation:

```
uv run pytest tests/unit/test_api_v1_routing.py tests/unit/test_server_track_b.py -q
# FAILED test_health_reports_restart_count_and_memory: assert 0 == 3
```

Minimal reproduction is a single pair of tests:

```
uv run pytest \
  tests/unit/test_api_v1_routing.py::TestAPIVersioning::test_v1_status_endpoint \
  tests/unit/test_server_track_b.py::test_health_reports_restart_count_and_memory -q
```

## Root cause

`bernstein.core.routes.status_dashboard` memoises `_runtime_summary()` results in module globals (`_runtime_cache` / `_runtime_cache_ts`) with a 10s TTL. The cache is keyed on nothing, so every `create_app` instance in the process shares it. When an earlier test hits `/status` (or `/health`), the cache is populated from that test's app (no `supervisor_state.json`, so `restart_count=0`). Any test that requests `/health` within the TTL window gets the stale snapshot instead of reading its own `supervisor_state.json`.

One test in `test_server_track_b.py` already resets these globals manually via monkeypatch; the leak just was not covered suite-wide.

## Fix

Harness-level only: an autouse fixture in `tests/unit/conftest.py` clears the two cache globals at test setup (skipped when the module was never imported). No production code changed, no test assertions weakened.

## Verification

- `tests/unit/test_api_v1_routing.py tests/unit/test_server_track_b.py`: 16 passed (previously 1 failed)
- Reverse order: 16 passed
- Each file alone: 9 passed / 7 passed
- Status-adjacent unit tests (`test_dashboard`, `test_run_summary_issue_953`, `test_health_deps_route`, `test_health_components`, `test_api_backward_compat`, `test_cli_status`, `test_server_track_b`): 88 passed
- `ruff check` and `ruff format --check` clean on the changed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved unit test isolation by clearing cached status data before each test, preventing `/status` and `/health` checks from reusing stale values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->