### PR TITLE
chore(release): 2.16.0

### DIFF
--- a/docs/release-notes/v2.16.0.md
+++ b/docs/release-notes/v2.16.0.md
@@ -1,0 +1,34 @@
+# v2.16.0
+
+Released 2026-07-05.
+
+An output-economy and worker-reliability release: response-style profiles wired end to end, ledger-attributed savings you can recompute, a three-arm cost-and-quality A/B harness, proactive context compaction with signed receipts, schema-enforced worker outcomes, and pinned team manifests. Plus a batch of contributor reliability fixes.
+
+## Output economy
+
+- Response-style profiles are now resolved deterministically per role or per task and rendered into the worker spawn prompt; the profile hash is folded into task identity and recorded in the cost ledger. (#2251)
+- Per-profile cost attribution: `bernstein cost --by profile` and a content-addressed, audit-chain-anchored `bernstein cost profile-report` whose every figure recomputes from ledger entries; mid-run profile changes are excluded rather than guessed. (#2255)
+- Three-arm profile A/B harness (`bernstein eval ab --suite ... --arms 3`): baseline, minimal-control, and candidate arms, cost and quality in one canonical-JSON comparison artifact with every cost figure referenced to a ledger line. (#2264)
+- Operator-gated role-template compression (`bernstein templates compress|restore`): mechanical invariant validators, out-of-tree hash-verified backups, byte-identical restore, and chained receipts; savings are only ever reported from real ledger deltas. (#2272)
+
+## Worker reliability and safety
+
+- Proactive context compaction: long-running workers compact at a configurable pressure threshold instead of waiting for an overflow failure; each event is validated by zero-LLM invariant checks (code blocks and error text must survive) and recorded as an HMAC-chained receipt. `bernstein compaction log --task <id>`. (#2263)
+- Credential-shaped content is refused before any compaction or summary request reaches a model API; redactions and refusals are audit-logged by span hash, never by content. Reactive-path refusals now fail fast with a typed reason instead of burning retries. (#2250, #2270)
+- Schema-enforced worker completion payloads with typed refusal outcomes; an invalid payload is a typed `contract_violation` failure, and blocked workers report a closed set of refusal kinds the orchestrator can route deterministically. (#2252)
+- Named, sha256-pinned team manifests with drift detection and lineage-recorded digests: `bernstein team list|show|drift`. (#2256)
+
+## Contributor fixes
+
+Thanks to @shanemmattner for a deep reliability batch, all merged with authorship preserved:
+
+- Tasks now transition to failed on `MaxTurnsExceeded` instead of hanging in `claimed`; the previously dead timeout / auth-error / api-error fast-fail paths are activated. (#2259)
+- Static budget-aware prompt nudge for turn-limited models, composing with the response-style addendum. (#2260)
+- A batch of ten independent bugfixes across the run-id override, seed-path resolution, model-alias matching, auto-commit deny list, merge safety, and secret-log hygiene. (#2261)
+- Instrumentation capture for content, tool results, and batched-task fan-out; JSONL parser resilience; a single documented max_turns validation story across the API, adapter, and resolution layers. (#2262)
+
+## Internal
+
+- Fixed a per-request `/api/v1` router mutation that grew route tables quadratically and could crash the test harness with recursion; app factories now build a fresh router each call. (#2266)
+- Migrated the remaining str-Enum classes to `StrEnum`. (#2267)
+- Refreshed the deferred-adapter review stamps and resolved outstanding scanner findings. (#2258)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.15.0"
+version = "2.16.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/unit/test_rate_limit_tracker.py
+++ b/tests/unit/test_rate_limit_tracker.py
@@ -482,7 +482,7 @@ class TestCompletionProgressSkipSet:
         assert self._tracker().detect_failure_type(log) == "rate_limit"
 
     def test_assistant_type_prose_with_error_context_does_not_match(self, tmp_path):
-        """"assistant" events carry free-form model narration, not
+        """ "assistant" events carry free-form model narration, not
         structured provider/HTTP data -- healthy narration that happens to
         mention "timeout" alongside an error-context word (e.g. "status")
         must not trip a false-positive throttle."""
@@ -502,6 +502,7 @@ class TestCompletionProgressSkipSet:
             '{"type": "error", "message": "Error code: 429 - rate limit exceeded"}\n'
         )
         assert self._tracker().detect_failure_type(log) == "rate_limit"
+
 
 class TestMaxTurnsDetection:
     """A MaxTurnsExceeded death was never classified by detect_failure_type,

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.15.0"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump to 2.16.0 with release notes.

The output-economy suite (response-style profiles, per-profile ledger-attributed cost reporting, three-arm cost-and-quality A/B harness, operator-gated template compression), proactive context compaction with mechanical validation and signed receipts, a credential-shaped-content gate on model-bound summaries, schema-enforced worker completion payloads with typed refusals, and sha256-pinned team manifests. Plus a contributor reliability batch and internal fixes.

Full notes in docs/release-notes/v2.16.0.md.