### PR TITLE
chore: resolve scanner findings in new feature modules

### DIFF
--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -274,7 +274,7 @@ def _is_auto_commit_denied(path: str) -> bool:
         # paths that merely contain ".env" somewhere, e.g. ".envrc" or
         # "config.envelope.json", silently excluding legitimate files from
         # auto-commit.
-        elif p == glob or base == glob:
+        elif glob in (p, base):
             return True
     return False
 

--- a/src/bernstein/core/teams/manifest.py
+++ b/src/bernstein/core/teams/manifest.py
@@ -298,7 +298,7 @@ def _verify_load_signature(data: dict[str, object], manifest: TeamManifest, *, c
     """Verify an embedded ``signature`` / ``signer_pubkey`` pair, if any."""
     signature = data.get("signature")
     signer_pubkey = data.get("signer_pubkey")
-    if signature is None and signer_pubkey is None:
+    if signature is signer_pubkey is None:
         return
     if signature is not None and not isinstance(signature, str):
         raise TeamManifestValidationError(f"{context}: signature must be a string")
@@ -450,7 +450,7 @@ def expand_manifest(manifest: TeamManifest) -> ExpandedTeam:
     team = [role.role for role in manifest.roles]
     policy: dict[str, dict[str, str | int]] = {}
     for role in manifest.roles:
-        entry: dict[str, str | int] = dict(role.model_policy)
+        entry: dict[str, str | int] = role.model_policy.copy()
         if role.response_profile is not None:
             entry["response_style"] = role.response_profile
         if entry:

--- a/src/bernstein/eval/ab_comparison.py
+++ b/src/bernstein/eval/ab_comparison.py
@@ -343,7 +343,7 @@ def synthetic_arm_executor(ledger: SpendLedger, *, run_token: str | None = None)
         output = f"{arm.name}::{task.input}"
         if task.expected is None:
             verdict, score = VERDICT_NOT_MEASURED, 0.0
-        elif str(output) == str(task.expected):
+        elif output == str(task.expected):
             verdict, score = VERDICT_PASS, 1.0
         else:
             verdict, score = VERDICT_FAIL, 0.0
@@ -520,7 +520,7 @@ def build_comparison_artifact(
     winner = _decide_winner(plan.honest_pair, aggregates, tolerance=tolerance)
     deltas = _build_deltas(plan, aggregates)
 
-    model_label = model if model else ",".join(sorted(referenced_models)) or "unknown"
+    model_label = model or ",".join(sorted(referenced_models)) or "unknown"
     content: dict[str, Any] = {
         "kind": ARTIFACT_KIND,
         "version": ARTIFACT_VERSION,


### PR DESCRIPTION
Mechanical refurb fixes clearing the open code-scanning findings introduced by the recent feature modules:

- task_crud auto-commit glob: membership test instead of two equality checks (FURB108)
- team manifest: chained None comparison (FURB124) and dict copy (FURB123)
- A/B comparison: redundant str cast dropped (FURB123), or-default simplification (FURB110)

The remaining credential-heuristic and single-use-local findings were triaged and dismissed (env var names and token-count sidecar records are logged, never secret values; the named intermediates read clearer than the inlined form). No behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal checks for auto-commit and manifest verification to keep behavior consistent and more reliable.
  * Made policy handling when expanding manifests more robust by preserving existing settings more safely.

* **Refactor**
  * Simplified a few comparison and fallback expressions for clearer, easier-to-maintain logic with no expected change in user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->