### PR TITLE
fix(worker): resolve Windows .cmd shim adapters so codex spawns via nvm-windows

### DIFF
--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -66,6 +66,14 @@ claude --version  # should print version info
 - If installed but not on PATH, add its directory: `export PATH="$HOME/.npm-global/bin:$PATH"`.
 - If running inside a virtualenv or container, ensure the binary is available in that environment.
 
+### 2a. Windows: `.cmd`/`.bat` shim not found (nvm-windows)
+
+**Symptom:** `bernstein-worker: command not found: codex` (exit 127) on Windows, even though `where.exe codex` and `python -c "import shutil; print(shutil.which('codex'))"` both resolve `C:\...\codex.cmd`.
+
+**Cause:** Node version managers such as nvm-windows install the Codex/Claude/Gemini CLIs as batch shims (`codex.cmd`), not real `.exe` files. `CreateProcess` (what `subprocess.Popen` calls without a shell) does not consult `PATHEXT` for `argv[0]`, so a bare `codex` never resolves the `.cmd`, and even a full path to a `.cmd` cannot be launched directly.
+
+**Resolution:** Bernstein now resolves the bare name via `shutil.which` and, on Windows, routes a resolved `.cmd`/`.bat` shim through `cmd.exe /c` automatically. Ensure `PATHEXT` is present in your environment (it is passed through to spawned agents). No manual action is needed on current versions; if you see this on an older build, upgrade Bernstein.
+
 ---
 
 ## 3. API Key Not Set

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -42,6 +42,12 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         # and exit with code -1 (0xFFFFFFFF) before even starting
         "SYSTEMROOT",
         "WINDIR",
+        # PATHEXT lists the extensions Windows treats as executable
+        # (.EXE;.CMD;.BAT;...). Without it in the spawned env, shutil.which
+        # inside bernstein-worker cannot recognise a batch shim such as
+        # codex.cmd (nvm-windows installs the Codex/Claude/Gemini CLIs as
+        # .cmd), so the worker fails to resolve the binary and exits 127.
+        "PATHEXT",
         "COMSPEC",  # Path to cmd.exe, needed for shell operations
         "APPDATA",
         "LOCALAPPDATA",

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
@@ -47,6 +48,71 @@ _TOOL_ABORT_POLICIES = ("contain", "sibling", "session")
 # alone and forwarding is the only delivery path.
 _FORWARD_GRACE_S = 0.2
 _FORWARD_POLL_INTERVAL_S = 0.01
+
+
+# Windows batch-shim extensions. A ``.cmd``/``.bat`` file is not a PE
+# executable, so ``CreateProcess`` (what ``subprocess.Popen`` calls with a
+# non-shell argv) cannot launch it even with the full path -- it must be
+# routed through ``cmd.exe /c``. Real ``.exe`` targets are launched directly.
+_WINDOWS_SHIM_SUFFIXES = (".cmd", ".bat")
+
+
+def _resolve_launch_cmd(cmd: list[str]) -> list[str]:
+    """Resolve ``cmd[0]`` to a launchable form, cross-platform.
+
+    Two problems this solves, both Windows-only in effect:
+
+    1. ``CreateProcess`` (used by ``subprocess.Popen`` without ``shell=True``)
+       does not consult ``PATHEXT`` for ``argv[0]``. A bare ``"codex"`` never
+       resolves to ``codex.cmd`` and raises ``FileNotFoundError`` even though
+       ``shutil.which("codex")`` finds it. We resolve the bare name to its
+       absolute path via ``shutil.which`` so ``CreateProcess`` gets a concrete
+       target.
+    2. Even with the full path, ``CreateProcess`` cannot execute a
+       ``.cmd``/``.bat`` batch shim (they are not PE binaries). On Windows we
+       wrap those as ``["cmd.exe", "/c", resolved, *rest]``; ``cmd.exe``
+       propagates the child's exit code, so the worker's ``128 + N`` exit
+       translation and signal forwarding keep working on ``child.wait()``.
+
+    Behaviour is a no-op on POSIX for anything that already worked: a bare
+    name that ``shutil.which`` resolves becomes its absolute path (which spawns
+    identically to the bare name once found on ``PATH``), and a name that does
+    not resolve is returned unchanged so the existing ``FileNotFoundError`` ->
+    "command not found" path in :func:`main` still fires. Absolute or
+    path-qualified ``cmd[0]`` values are left untouched.
+
+    Args:
+        cmd: The command argv. Must be non-empty.
+
+    Returns:
+        A new argv list ready to hand to ``subprocess.Popen`` with no shell.
+    """
+    if not cmd:
+        return cmd
+
+    first = cmd[0]
+    rest = cmd[1:]
+
+    # Only resolve a bare program name (no path separator). An operator or
+    # adapter that already passed an absolute/relative path knows what it
+    # wants; do not second-guess it.
+    if os.sep in first or (os.altsep and os.altsep in first):
+        return cmd
+
+    resolved = shutil.which(first)
+    if resolved is None:
+        # Leave the bare name so the caller's FileNotFoundError handler still
+        # produces the "command not found" diagnostic and the 127 exit code.
+        return cmd
+
+    # On Windows, batch shims (.cmd/.bat) cannot be launched by CreateProcess
+    # directly; route them through cmd.exe. Real .exe (and every POSIX target)
+    # spawns fine from its absolute path.
+    if os.name == "nt" and resolved.lower().endswith(_WINDOWS_SHIM_SUFFIXES):
+        comspec = os.environ.get("COMSPEC", "cmd.exe")
+        return [comspec, "/c", resolved, *rest]
+
+    return [resolved, *rest]
 
 
 def _set_proctitle(title: str) -> None:
@@ -270,9 +336,16 @@ def main() -> None:
         hb_dir.mkdir(parents=True, exist_ok=True)
         (hb_dir / args.session).touch()
 
-    # 3. Spawn child process (inherits our stdout/stderr/stdin)
+    # 3. Spawn child process (inherits our stdout/stderr/stdin).
+    #
+    # Resolve argv[0] first so a bare program name that only exists as a
+    # Windows batch shim (e.g. nvm4w installs codex as codex.cmd) is launched
+    # via its absolute path -- and, for .cmd/.bat, through cmd.exe -- rather
+    # than failing in CreateProcess. ``cmd[0]`` is preserved for the
+    # command-not-found diagnostic below.
+    launch_cmd = _resolve_launch_cmd(cmd)
     try:
-        child = subprocess.Popen(cmd)
+        child = subprocess.Popen(launch_cmd)
     except FileNotFoundError as exc:
         # Typed first-run error: the adapter binary is missing from PATH.
         # Callers running this worker as a subprocess can categorise via

--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -29,6 +29,29 @@ class TestBuildFilteredEnv:
         assert result["HOME"] == "/root"
         assert result["LANG"] == "en_US.UTF-8"
 
+    def test_pathext_in_allowlist(self) -> None:
+        """PATHEXT must be allowlisted so bernstein-worker's shutil.which can
+        recognise .cmd/.bat/.exe shims on Windows (issue #2287).
+
+        nvm-windows installs the Codex/Claude/Gemini CLIs as batch shims
+        (codex.cmd). Without PATHEXT in the spawned env, shutil.which cannot
+        resolve them and the worker exits 127.
+        """
+        assert "PATHEXT" in _BASE_ALLOWLIST
+
+    def test_pathext_passes_through_build_filtered_env(self) -> None:
+        """PATHEXT set in os.environ reaches the filtered agent env."""
+        fake_env = {
+            "PATH": r"C:\nvm4w\nodejs",
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+            "DATABASE_URL": "postgres://user:pass@host/db",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", fake_env):
+            result = build_filtered_env()
+        assert result["PATHEXT"] == ".COM;.EXE;.BAT;.CMD"
+        # unrelated secret still stripped
+        assert "DATABASE_URL" not in result
+
     def test_secrets_excluded(self) -> None:
         """Database credentials, CI tokens and unrelated keys are stripped."""
         sensitive = {

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -10,7 +10,10 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
+import pytest
+
 from bernstein.adapters.base import build_worker_cmd
+from bernstein.core.orchestration.worker import _resolve_launch_cmd
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -53,6 +56,121 @@ class TestBuildWorkerCmd:
         )
         assert "--model" in result
         assert result[result.index("--model") + 1] == "gpt-5.4"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_launch_cmd -- cross-platform argv[0] resolution (issue #2287)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLaunchCmd:
+    """argv[0] resolution: bare name -> absolute path, Windows .cmd -> cmd.exe.
+
+    On Windows, ``CreateProcess`` (what ``subprocess.Popen`` calls without a
+    shell) ignores ``PATHEXT`` for ``argv[0]`` and cannot run a ``.cmd``/``.bat``
+    batch shim even by full path. nvm-windows installs the Codex/Claude/Gemini
+    CLIs as ``codex.cmd`` etc., so a bare ``"codex"`` failed with ``exit 127``.
+    These tests simulate Windows via monkeypatch; CI runs on Linux.
+    """
+
+    def test_bare_name_resolves_to_absolute_path_posix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bare name that shutil.which finds becomes its absolute path."""
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "posix")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda name: "/usr/local/bin/codex" if name == "codex" else None,
+        )
+        result = _resolve_launch_cmd(["codex", "exec", "-m", "gpt-5.5"])
+        assert result == ["/usr/local/bin/codex", "exec", "-m", "gpt-5.5"]
+
+    def test_windows_cmd_shim_wrapped_in_cmd_exe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On nt, a resolved .cmd shim is routed through cmd.exe /c."""
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "nt")
+        # Windows uses ``\\`` as sep and ``/`` as altsep.
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.sep", "\\")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.altsep", "/")
+        monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda name: r"C:\nvm4w\nodejs\codex.CMD" if name == "codex" else None,
+        )
+        result = _resolve_launch_cmd(["codex", "exec", "-m", "gpt-5.5"])
+        assert result == [
+            r"C:\Windows\System32\cmd.exe",
+            "/c",
+            r"C:\nvm4w\nodejs\codex.CMD",
+            "exec",
+            "-m",
+            "gpt-5.5",
+        ]
+
+    def test_windows_bat_shim_wrapped_in_cmd_exe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A .bat shim is treated like .cmd -- routed through cmd.exe."""
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "nt")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.sep", "\\")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.altsep", "/")
+        monkeypatch.setenv("COMSPEC", r"C:\Windows\System32\cmd.exe")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda name: r"C:\tools\agent.bat" if name == "agent" else None,
+        )
+        result = _resolve_launch_cmd(["agent", "--go"])
+        assert result[0] == r"C:\Windows\System32\cmd.exe"
+        assert result[1] == "/c"
+        assert result[2] == r"C:\tools\agent.bat"
+        assert result[3:] == ["--go"]
+
+    def test_windows_real_exe_launched_directly(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A resolved .exe is a PE binary: launch it directly, no cmd.exe."""
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "nt")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.sep", "\\")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.altsep", "/")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda name: r"C:\Python\python.exe" if name == "python" else None,
+        )
+        result = _resolve_launch_cmd(["python", "-c", "pass"])
+        assert result == [r"C:\Python\python.exe", "-c", "pass"]
+
+    def test_already_absolute_path_left_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A path-qualified argv[0] is not re-resolved through shutil.which."""
+
+        def _boom(_name: str) -> str:
+            raise AssertionError("shutil.which must not be called for a path-qualified argv[0]")
+
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "posix")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.shutil.which", _boom)
+        cmd = ["/usr/local/bin/codex", "exec"]
+        assert _resolve_launch_cmd(cmd) == cmd
+
+    def test_unresolved_bare_name_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """shutil.which returning None keeps the original so the caller's
+        FileNotFoundError -> 'command not found' (exit 127) path still fires."""
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "posix")
+        monkeypatch.setattr(
+            "bernstein.core.orchestration.worker.shutil.which",
+            lambda _name: None,
+        )
+        cmd = ["nonexistent_command_xyz", "--flag"]
+        assert _resolve_launch_cmd(cmd) == cmd
+
+    def test_windows_altsep_qualified_path_left_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On Windows a forward-slash path (altsep) is also treated as
+        qualified and not re-resolved."""
+
+        def _boom(_name: str) -> str:
+            raise AssertionError("shutil.which must not be called for a path-qualified argv[0]")
+
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.name", "nt")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.sep", "\\")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.os.altsep", "/")
+        monkeypatch.setattr("bernstein.core.orchestration.worker.shutil.which", _boom)
+        cmd = ["C:/nvm4w/nodejs/codex.cmd", "exec"]
+        assert _resolve_launch_cmd(cmd) == cmd
+
+    def test_empty_cmd_returned_as_is(self) -> None:
+        """Guard: an empty argv is returned unchanged (main() handles it)."""
+        assert _resolve_launch_cmd([]) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

On Windows with nvm-windows (nvm4w), `bernstein test-adapter --adapter codex` fails with:

```
Error during adapter test: codex exited early with code 127: bernstein-worker: command not found: codex
```

...even though both `where.exe codex` and `python -c "import shutil; print(shutil.which('codex'))"` resolve `C:\nvm4w\nodejs\codex.cmd`. The Codex CLI is installed by nvm-windows as a `.cmd` batch shim, not a real `.exe`.

## Verified root cause

Two compounding defects:

1. **`worker.py`** spawns the inner command with a bare `argv[0]` (`"codex"`) via `subprocess.Popen(cmd)`. On Windows, `CreateProcess` (what `Popen` calls without a shell) does **not** consult `PATHEXT` for `argv[0]`, so it never resolves `codex.cmd` and raises `FileNotFoundError` -- which the worker reports as `command not found` with exit 127.
2. **`env_isolation.py`** `_BASE_ALLOWLIST` passed `PATH`, `SYSTEMROOT`, `WINDIR` but **not** `PATHEXT`. Without `PATHEXT` in the spawned worker's environment, `shutil.which` cannot recognise `.cmd`/`.bat`/`.exe` as executable extensions.

The issue reporter's own diagnostics confirm both: bare `subprocess.run(["codex", "--version"])` raises `FileNotFoundError [WinError 2]`, while `subprocess.run([cmd.exe, "/c", "codex --version"])` works.

## The fix

**Part A -- `worker.py`:** new `_resolve_launch_cmd` resolves a bare `argv[0]` to its absolute path via `shutil.which` before spawning.
- A bare name that resolves is replaced with its absolute path.
- An unresolved name is left unchanged, so the existing `FileNotFoundError` -> `command not found` (exit 127) path still fires.
- A path-qualified `argv[0]` (contains `os.sep`/`os.altsep`) is left untouched.

**Part B -- `env_isolation.py`:** `PATHEXT` added to the Windows portion of `_BASE_ALLOWLIST`, next to `SYSTEMROOT`/`WINDIR`, so `shutil.which` in the spawned worker recognises batch shims. `NVM_HOME`/`NVM_SYMLINK` were considered and deliberately **not** added: `PATH` already contains the resolved `nodejs` dir.

## Windows execution mechanism decision (and why)

A resolved `.cmd`/`.bat` is **not** a PE binary, so `CreateProcess` cannot launch it even with the full path -- it must go through `cmd.exe`. So resolving to the absolute path alone is insufficient for shims.

- On Windows (`os.name == "nt"`), when the resolved target ends in `.cmd`/`.bat`, wrap as `["cmd.exe", "/c", resolved, *rest]` (using `COMSPEC`).
- For a real `.exe` on Windows, and for **every** POSIX target, spawn the resolved absolute path directly with no shell.

Why cmd.exe wrapping is safe for the worker's child management: `cmd.exe /c` propagates the child's exit code, so the worker's `128 + N` signal-exit translation and the SIGTERM/SIGINT grace-window forwarding -- both keyed on `child.wait()` -- keep working. On Linux/macOS the change is a no-op in effect: a resolved absolute path spawns byte-identically to the bare name once it was found on `PATH`, so nothing changes for existing POSIX runs (confirmed: the full `test_worker_subprocess_signals` integration suite still passes).

## Tests

Worker-level (`tests/unit/test_worker.py::TestResolveLaunchCmd`, monkeypatching `os.name`/`shutil.which` to simulate Windows -- no real Windows needed):
- bare name -> absolute path (posix)
- Windows `.cmd` shim wrapped in `cmd.exe /c` (and `.bat`)
- Windows real `.exe` launched directly (no cmd.exe)
- path-qualified `argv[0]` left untouched (posix and Windows altsep)
- `shutil.which` returns `None` -> original preserved (command-not-found path still reached)
- empty argv guard

`env_isolation` (`tests/unit/test_env_isolation.py`):
- `PATHEXT` is in `_BASE_ALLOWLIST`
- `PATHEXT` passes through `build_filtered_env` while an unrelated secret is stripped

Existing worker/env_isolation tests unchanged and passing.

Gates run locally: `ruff check src/ tests/`, `ruff format --check` (touched files), `lint-imports`, `import bernstein`, and the worker + env_isolation + codex adapter + worker-signals suites (all green).

Fixes #2287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command launching so batch-based tools installed through nvm-windows can be found and run correctly.
  * Kept executable extension handling intact in spawned processes, reducing “command not found” issues on Windows.

* **Documentation**
  * Added troubleshooting guidance for Windows PATH resolution problems and when an upgrade may be needed.

* **Tests**
  * Expanded coverage for environment filtering and command resolution across Windows and non-Windows cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->