### PR TITLE
chore(release): 2.16.1

### DIFF
--- a/docs/release-notes/v2.16.1.md
+++ b/docs/release-notes/v2.16.1.md
@@ -1,0 +1,7 @@
+# v2.16.1
+
+Released 2026-07-06.
+
+## Fixes
+
+- Windows: adapter binaries installed as `.cmd`/`.bat` shims (for example Codex via nvm-windows) now spawn correctly. The worker resolves the adapter binary to its absolute path before spawning and routes resolved shims through the command interpreter on Windows, and `PATHEXT` is passed through the worker environment. Real executables and all POSIX spawns are unchanged. (#2287, #2290; thanks @ViteaVlaikov for the report and diagnostics)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.16.0"
+version = "2.16.1"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.16.0"
+version = "2.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Patch release: Windows adapter spawn fix for .cmd/.bat shims (nvm-windows Codex and similar). Fixes #2287 via #2290.

Full notes in docs/release-notes/v2.16.1.md.

## Summary by Sourcery

Prepare 2.16.1 patch release and document the Windows adapter spawn fix.

Bug Fixes:
- Document fix for Windows adapter binaries installed as .cmd/.bat shims spawning correctly when used via tools like nvm-windows Codex.

Build:
- Bump project version from 2.16.0 to 2.16.1 in pyproject configuration.

Documentation:
- Add v2.16.1 release notes outlining the Windows adapter spawn behavior fix and related details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Windows where adapter binaries installed as command shims now launch correctly.
  * Improved handling so shim-based adapters are resolved properly before being started, while other platforms remain unchanged.

* **Documentation**
  * Added release notes for version 2.16.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->