### PR TITLE
ci(bootstrap): tolerate empty uv cache in post-run save

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -39,6 +39,12 @@ runs:
         enable-cache: ${{ inputs.enable-uv-cache }}
         python-version: ${{ inputs.python-version }}
         cache-suffix: ${{ inputs.cache-key-suffix }}
+        # Tolerate the post-run cache-save when no dependencies were
+        # installed (e.g. a job that gates all install steps behind a
+        # token check and skips them). Without this the post step exits
+        # non-zero on the empty cache dir and reddens an otherwise
+        # advisory job.
+        ignore-nothing-to-cache: "true"
     - name: Set up uv (no python-version pin)
       if: ${{ inputs.setup-uv == 'true' && inputs.python-version == '' }}
       uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -46,3 +52,6 @@ runs:
         version: "0.11.26"
         enable-cache: ${{ inputs.enable-uv-cache }}
         cache-suffix: ${{ inputs.cache-key-suffix }}
+        # See note above: keep the post cache-save step from failing a
+        # job that installed no dependencies.
+        ignore-nothing-to-cache: "true"


### PR DESCRIPTION
The Sourcery CLI advisory lane reddens on its post-run step: when the token check gates all install steps to skipped, uv never populates a cache dir and setup-uv's post cache-save exits non-zero. Adds ignore-nothing-to-cache to both setup-uv invocations in the bootstrap composite (input exists in setup-uv v8.3.0) so the advisory job no longer fails on an empty cache.

Found during a code-quality service integration audit. No behavior change to the actual review.