### PR TITLE
docs: fix dead links and stale adapter counts in user-facing docs

### DIFF
--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -332,7 +332,7 @@ pip install 'bernstein[openai]'
 
 **Env vars:** `OPENAI_API_KEY` (required), plus optional `OPENAI_BASE_URL`, `OPENAI_ORGANIZATION`, `OPENAI_PROJECT`.
 
-**Best for:** OpenAI plans that benefit from SDK-native tool-use, sandboxed execution (E2B / Modal), or where the Agents SDK event protocol is a better fit than the `codex` CLI. See the [dedicated `openai_agents` doc](openai-agents.md) and the [decision guide](../compare/openai-agents.md) for when to pick `openai_agents` vs `codex` vs `claude`.
+**Best for:** OpenAI plans that benefit from SDK-native tool-use, sandboxed execution (E2B / Modal), or where the Agents SDK event protocol is a better fit than the `codex` CLI. See the [dedicated `openai_agents` doc](openai-agents.md) and the [decision guide](openai-agents-comparison.md) for when to pick `openai_agents` vs `codex` vs `claude`.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: Bernstein - Open-Source Multi-Agent Orchestration Platform
 description: >-
   Bernstein is the open-source multi-agent orchestrator for AI coding agents.
   Run Claude Code, Codex, Gemini CLI, and the OpenAI Agents SDK in parallel.
-  Deterministic scheduling, 44 adapters, pluggable sandbox backends,
+  Deterministic scheduling, 40+ adapters, pluggable sandbox backends,
   cloud artifact storage, progressive skills, zero vendor lock-in.
 tags:
   - orchestration
@@ -74,7 +74,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    44 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
+    40+ CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**

--- a/docs/operations/adapters.md
+++ b/docs/operations/adapters.md
@@ -2,7 +2,7 @@
 
 `bernstein adapters check` answers one question:
 
-> Of the 44 adapters this install declares, which ones are reachable on
+> Of the adapters this install declares, which ones are reachable on
 > this machine, which ones conform to the contract, and which ones are
 > missing binaries or have drifted?
 

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -76,7 +76,7 @@ docstrings only (`Brief`).
 
 | Capability | Docs status | Notes |
 |---|---|---|
-| Agent catalog/discovery | Full | `bernstein agents sync/list/discover/match/showcase` (43 CLI agent adapters) |
+| Agent catalog/discovery | Full | `bernstein agents sync/list/discover/match/showcase` (40+ CLI agent adapters) |
 | GitHub App and CI fix flows | Full | `bernstein ci fix <url>`, `github setup` |
 | Trigger sources (`github`, `slack`, `file_watch`, `webhook`) | Brief | Source adapters available |
 | Plugin hooks (pluggy) | Full | SDK docs in CONTRIBUTING.md |

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -6,7 +6,7 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ## 1) Adapter parity is not perfect
 
-**What:** Bernstein ships 43 CLI adapters, but different CLI agents expose different capabilities and process semantics.
+**What:** Bernstein ships 40+ CLI adapters, but different CLI agents expose different capabilities and process semantics.
 
 **Impact:** Stop/restart behavior, output shape, structured output support, and error handling can vary by adapter. The conformance harness (`adapters/conformance.py`) helps catch regressions across adapters.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -4,13 +4,13 @@ description: >-
   User-facing summary of the major features that landed in Bernstein 1.9.x -
   OpenAI Agents SDK v2 adapter, pluggable sandbox backends, cloud artifact
   storage sinks, and progressive-disclosure skill packs.
-  Current release is 1.10.x - see CHANGELOG for 1.10 features.
+  For the current release and every version since, see the CHANGELOG.
 ---
 
 # What's New in 1.9.x
 
-> **Note:** This page covers the 1.9.x feature wave. For 1.10.x (current),
-> see the [CHANGELOG](CHANGELOG.md).
+> **Note:** This page covers the historical 1.9.x feature wave. For the
+> current release and all later versions, see the [CHANGELOG](CHANGELOG.md).
 
 Bernstein 1.9 collects four feature tracks. This page summarises them in
 terms of what changes for someone upgrading from 1.8.x. Full detail lives


### PR DESCRIPTION
Docs-only freshness fixes from an audit: one dead relative link and several stale precise adapter counts replaced with a stable lower bound. 6 files, +9/-9, ASCII only. (Clean re-file of the earlier contaminated branch.)