### PR TITLE
ci(sonar): add a daily scheduled backstop so a scan lands despite cancelled main CI

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,16 +1,29 @@
 name: SonarQube scan
 
-# Runs after main CI succeeds or on manual dispatch.
+# Runs after main CI succeeds, on a daily schedule, or on manual dispatch.
 #
-# The workflow consumes the coverage-report artifact from the same CI run
-# that triggered it. It intentionally does not run directly on push:
-# push-time scans can start before CI uploads coverage.xml and then report
-# a partial fallback coverage number for main.
+# The workflow_run path consumes the coverage-report artifact from the same CI
+# run that triggered it, so it reports accurate main coverage. It intentionally
+# does not run directly on push: push-time scans can start before CI uploads
+# coverage.xml and then report a partial fallback coverage number for main.
+#
+# The daily schedule is a reliability backstop. CI on main uses
+# cancel-in-progress: true, so under a rapid-merge cadence most main CI runs are
+# cancelled by the next push and never reach success; the workflow_run gate then
+# short-circuits this scan to skipped on the majority of pushes. The scheduled
+# run has no cancellable upstream: it resolves the most recent successful main
+# CI run and pulls its coverage artifact, and if none is available it regenerates
+# coverage in-job, so a scan lands at least daily even when workflow_run scans
+# keep skipping. This also keeps the downstream tracker, which chains on a
+# successful scan, from starving.
 on:  # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["CI"]
     branches: [main]
     types: [completed]
+  schedule:
+    # Daily backstop at 04:17 UTC. Off the hour to avoid the top-of-hour rush.
+    - cron: "17 4 * * *"
   workflow_dispatch:
 
 permissions:
@@ -26,11 +39,12 @@ jobs:
     name: SonarQube scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Run after main CI succeeds or on manual dispatch.
+    # Run after main CI succeeds, on the daily schedule, or on manual dispatch.
     # SONAR_HOST_URL must be configured as a repo variable.
     if: >-
       ${{ vars.SONAR_HOST_URL != '' &&
           (github.event_name == 'workflow_dispatch' ||
+           github.event_name == 'schedule' ||
            (github.event_name == 'workflow_run' &&
             github.event.workflow_run.conclusion == 'success' &&
             github.event.workflow_run.head_branch == 'main')) }}
@@ -49,10 +63,10 @@ jobs:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           persist-credentials: false
 
-      # Manual dispatch has no upstream run id, so resolve the most recent
-      # successful main CI run and pull its coverage-report artifact.
-      - name: Resolve latest successful CI run (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
+      # Schedule and manual dispatch have no upstream run id, so resolve the
+      # most recent successful main CI run and pull its coverage-report artifact.
+      - name: Resolve latest successful CI run (schedule/dispatch)
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         id: ci_run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +83,7 @@ jobs:
             echo "Found successful CI run: $run_id"
             echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::No successful CI run found on main; scanning without coverage"
+            echo "::warning::No successful CI run found on main; will regenerate coverage in-job"
           fi
 
       - name: Download coverage artifact (workflow_run)
@@ -81,9 +95,9 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download coverage artifact (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch' && steps.ci_run.outputs.run_id != ''
-        continue-on-error: true  # manual bootstrap may not have a usable artifact
+      - name: Download coverage artifact (schedule/dispatch)
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && steps.ci_run.outputs.run_id != ''
+        continue-on-error: true  # the resolved run's artifact may be past retention
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: coverage-report
@@ -103,16 +117,19 @@ jobs:
           fi
 
       - name: Set up uv for fallback
-        if: github.event_name == 'workflow_dispatch' && steps.coverage_check.outputs.missing == 'true'
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && steps.coverage_check.outputs.missing == 'true'
         uses: ./.github/actions/bootstrap
 
-      # Thin coverage fallback is manual-dispatch only. Automatic main
-      # scans without a CI coverage artifact skip the Sonar upload instead
-      # of sending a partial fallback coverage report.
+      # Thin coverage fallback runs on the schedule/dispatch backstop only. It
+      # regenerates a coverage report in-job so the daily scan always lands a
+      # coverage number even when no CI coverage artifact is available (fresh
+      # repo, artifact past retention, or no successful CI run yet). Automatic
+      # workflow_run scans without the matching CI artifact skip the Sonar upload
+      # instead of sending a partial fallback coverage report for main.
       - name: Thin coverage fallback
-        if: github.event_name == 'workflow_dispatch' && steps.coverage_check.outputs.missing == 'true'
+        if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && steps.coverage_check.outputs.missing == 'true'
         timeout-minutes: 10
-        continue-on-error: true  # manual bootstrap should not fail before the scan step
+        continue-on-error: true  # backstop should not fail before the scan step
         run: |
           set +e
           uv sync --group dev --no-progress 2>&1 | tail -20 || true

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -72,7 +72,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/soc2-evidence-nightly.yml | soc2-evidence-nightly | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "soc2-evidence-${{ github.ref }}"} | 2 |
 | .github/workflows/sonar-hotspot-review.yml | SonarQube hotspot review | workflow_dispatch | {"cancel-in-progress": "false", "group": "sonar-hotspot-review"} | 1 |
 | .github/workflows/sonar-pr-comment.yml | SonarQube PR insights comment | pull_request | {"cancel-in-progress": "true", "group": "sonar-pr-comment-${{ github.event.pull_request.number }}"} | 1 |
-| .github/workflows/sonar-scan.yml | SonarQube scan | workflow_dispatch, workflow_run | {"cancel-in-progress": "false", "group": "sonar-scan-${{ github.ref }}"} | 1 |
+| .github/workflows/sonar-scan.yml | SonarQube scan | schedule, workflow_dispatch, workflow_run | {"cancel-in-progress": "false", "group": "sonar-scan-${{ github.ref }}"} | 1 |
 | .github/workflows/sonar-tracker.yml | SonarQube findings tracker | schedule, workflow_dispatch, workflow_run | {"cancel-in-progress": "false", "group": "sonar-tracker"} | 1 |
 | .github/workflows/stale.yml | Stale cleanup | schedule | {"cancel-in-progress": "false", "group": "stale-${{ github.ref }}"} | 1 |
 | .github/workflows/static-analysis-extended.yml | static-analysis (extended) | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "static-analysis-extended-${{ github.ref }}"} | 6 |

--- a/tests/unit/test_sonar_scan_workflow_yaml.py
+++ b/tests/unit/test_sonar_scan_workflow_yaml.py
@@ -1,17 +1,29 @@
 """Structural assertions on the SonarQube scan workflow.
 
-These tests pin the contract that the Sonar scan consumes the coverage
-artifact from a successful CI run for the same main commit. The scan
-must not start on the raw push event or on a cancelled CI run before the
-matching CI coverage artifact exists.
+These tests pin two properties of the Sonar scan design:
+
+    * Accurate coverage: the ``workflow_run`` path consumes the coverage
+      artifact from the successful CI run for the same main commit. That
+      path must not start on the raw push event or on a cancelled CI run
+      before the matching CI coverage artifact exists.
+    * Reliability: a daily ``schedule`` backstop lands a scan even when
+      main CI runs keep getting cancelled (CI on main uses
+      cancel-in-progress, so rapid merges cancel most runs before
+      success and the workflow_run gate then skips). The scheduled run
+      has no cancellable upstream and regenerates coverage in-job when no
+      CI artifact is available.
 
 The tests below assert the workflow has:
 
     * a ``workflow_run`` trigger for completed main CI runs,
-    * a job guard that accepts only successful main CI workflow runs,
+    * a ``schedule`` (cron) trigger as a reliability backstop,
+    * a job guard that accepts successful main CI runs, the schedule, and
+      manual dispatch,
     * no direct ``push`` trigger, because that races the CI artifact,
     * a workflow-run artifact download keyed to the triggering CI run,
-    * a thin fallback limited to manual dispatch only.
+    * a thin coverage fallback limited to the schedule/dispatch backstop
+      (never the workflow_run path, which skips rather than reporting a
+      partial coverage number for main).
 
 The tests are cheap; they parse YAML only and do not call the GitHub
 API.
@@ -66,8 +78,46 @@ def test_sonar_scan_keeps_workflow_dispatch(sonar_doc: dict[str, object]) -> Non
     assert "workflow_dispatch" in on_block, "Sonar scan must keep its manual dispatch trigger"
 
 
+def test_sonar_scan_has_scheduled_backstop_that_regenerates_coverage(sonar_doc: dict[str, object]) -> None:
+    """A daily ``schedule`` trigger must land a scan even when workflow_run scans skip.
+
+    CI on main uses cancel-in-progress, so rapid merges cancel most main
+    CI runs before success and the workflow_run gate then skips this scan.
+    The scheduled run has no cancellable upstream, so it must exist and it
+    must be able to produce coverage in-job (the thin fallback runs on the
+    schedule path) rather than depending on a CI artifact that may never
+    have been uploaded.
+    """
+    on_block = sonar_doc.get(True) or sonar_doc.get("on")
+    assert isinstance(on_block, dict)
+    schedule = on_block.get("schedule")
+    assert isinstance(schedule, list) and schedule, "Sonar scan must define a schedule (cron) backstop"
+    crons = [entry.get("cron") for entry in schedule if isinstance(entry, dict)]
+    assert any(isinstance(cron, str) and cron.strip() for cron in crons), "schedule must declare a cron expression"
+
+    # The cron/dispatch backstop must be able to regenerate coverage in-job
+    # so a scan lands even with no upstream CI artifact.
+    jobs = sonar_doc.get("jobs", {})
+    assert isinstance(jobs, dict)
+    scan = jobs.get("scan", {})
+    assert isinstance(scan, dict)
+    steps = scan.get("steps", [])
+    assert isinstance(steps, list) and steps
+
+    fallback_steps = [step for step in steps if isinstance(step, dict) and step.get("name") == "Thin coverage fallback"]
+    assert len(fallback_steps) == 1, "backstop must regenerate coverage via the thin coverage fallback step"
+    fallback_if = str(fallback_steps[0].get("if", ""))
+    assert "github.event_name == 'schedule'" in fallback_if, (
+        "The scheduled backstop must be able to regenerate coverage in-job"
+    )
+    fallback_run = str(fallback_steps[0].get("run", ""))
+    assert "coverage xml" in fallback_run and "coverage.xml" in fallback_run, (
+        "The fallback must produce coverage.xml so the scheduled scan lands a coverage number"
+    )
+
+
 def test_sonar_scan_job_if_accepts_successful_workflow_run_and_dispatch(sonar_doc: dict[str, object]) -> None:
-    """The job-level `if` must accept successful CI runs and manual dispatch."""
+    """The job-level `if` must accept successful CI runs, the schedule, and manual dispatch."""
     jobs = sonar_doc.get("jobs")
     assert isinstance(jobs, dict) and jobs, "Workflow must declare a `jobs:` block"
     scan_job = jobs.get("scan")
@@ -76,6 +126,8 @@ def test_sonar_scan_job_if_accepts_successful_workflow_run_and_dispatch(sonar_do
     assert isinstance(job_if, str)
     flat = " ".join(job_if.split())
     assert "workflow_dispatch" in flat, "Job `if` must accept workflow_dispatch events"
+    # The daily schedule is the reliability backstop; it must not be gated out.
+    assert "schedule" in flat, "Job `if` must accept the scheduled backstop run"
     assert "workflow_run" in flat, "Job `if` must accept workflow_run events from CI"
     assert "github.event.workflow_run.conclusion == 'success'" in flat, (
         "Workflow-run scans must ignore cancelled or failed CI runs that do not produce coverage artifacts"
@@ -107,10 +159,13 @@ def test_sonar_scan_downloads_workflow_run_coverage_artifact(sonar_doc: dict[str
 
 
 def test_sonar_scan_limits_thin_fallback_to_manual_dispatch(sonar_doc: dict[str, object]) -> None:
-    """Thin fallback must not replace missing main CI coverage.
+    """Thin fallback must not replace missing main CI coverage on the accurate path.
 
-    A push or workflow-run scan without the matching CI artifact should
-    skip the scan instead of reporting a partial coverage number.
+    A push or workflow_run scan without the matching CI artifact must
+    skip the scan instead of reporting a partial coverage number. The
+    fallback is allowed only on the schedule/dispatch backstop, where no
+    upstream CI run exists and regenerating coverage in-job is the whole
+    point of landing a daily scan.
     """
     jobs = sonar_doc.get("jobs", {})
     assert isinstance(jobs, dict)
@@ -123,7 +178,10 @@ def test_sonar_scan_limits_thin_fallback_to_manual_dispatch(sonar_doc: dict[str,
     fallback_steps = [step for step in steps if isinstance(step, dict) and step.get("name") == "Thin coverage fallback"]
     assert len(fallback_steps) == 1, f"Found steps: {step_names!r}"
     fallback_if = str(fallback_steps[0].get("if", ""))
+    # Backstop paths (manual dispatch or the daily schedule) may regenerate
+    # coverage; the accurate workflow_run path must never fall back.
     assert "github.event_name == 'workflow_dispatch'" in fallback_if
+    assert "github.event_name == 'schedule'" in fallback_if
     assert "workflow_run" not in fallback_if
 
     sonar_steps = [


### PR DESCRIPTION
## Problem

The Sonar scan triggers on `workflow_run(CI, completed)` gated on `conclusion == success`. CI on main uses `cancel-in-progress: true`, so under a rapid-merge cadence most main CI runs are cancelled by the next push and never reach `success`. The gate then short-circuits the scan to `skipped` on the majority of pushes (~73% observed), which also starves the downstream findings tracker that chains on a successful scan.

The coverage-accuracy design is correct; only the reliability is broken.

## Fix

Keep the accurate path, add a reliable backstop.

- **Keep the `workflow_run` path exactly as designed.** It consumes the `coverage-report` artifact from the triggering CI run, so it reports accurate main coverage, pins `sonar.scm.revision` to the CI run's `head_sha`, and still skips (rather than reporting a partial fallback number) when the matching artifact is missing.
- **Add a daily `schedule` (cron) backstop** alongside the existing `workflow_dispatch`. The scheduled run has no cancellable upstream: it resolves the most recent successful main CI run and pulls its coverage artifact, and if none is available it regenerates coverage in-job via the thin coverage fallback. A scan therefore lands at least daily even when `workflow_run` scans keep skipping.
- **Thin coverage fallback runs on the schedule or dispatch backstop only, never on `workflow_run`.** The accurate path never reports a partial coverage number for main.

## Trust surface

`schedule`, `workflow_dispatch`, and `workflow_run` on main are all trusted contexts (base-repo, code already merged, dispatch is maintainer-only). No `pull_request` / `pull_request_target` trigger is added, so `SONAR_TOKEN` / `GITHUB_TOKEN` exposure is unchanged and no dangerous-trigger suppression is needed.

## Tests

- Guard tests in `tests/unit/test_sonar_scan_workflow_yaml.py` broadened to accept the schedule trigger and its coverage regeneration, without weakening the `workflow_run` coverage-accuracy assertions.
- New test asserts the cron backstop exists and can regenerate `coverage.xml` in-job.
- Workflow topology report regenerated (`scripts/gen_workflow_topology.py --check` passes).

`sonar-tracker.yml` is unchanged: it chains on Sonar scan success and recovers once a daily scan lands.