### PR TITLE
chore: resolve scanner findings in wave-1 lineage and identity code

### DIFF
--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -1027,8 +1027,7 @@ def record_artifact_write(
     if not _lineage_enabled():
         return None
     ts = timestamp if timestamp is not None else time.time_ns()
-    spine = LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key)
-    return spine.record(
+    return LineageSpine(lineage_root, run_id=run_id, hmac_key=hmac_key).record(
         artifact_path=artifact_path,
         content=content,
         actor=actor,

--- a/src/bernstein/core/identity/delegation.py
+++ b/src/bernstein/core/identity/delegation.py
@@ -192,7 +192,7 @@ class DelegationLedger:
             "prev_hmac": prev_hmac,
         }
         computed = _compute_hmac(self._key, prev_hmac, body)
-        entry = dict(body)
+        entry = body.copy()
         entry["hmac"] = computed
         path = self.receipt_path(run_id)
         with path.open("a", encoding="utf-8", newline="") as fh:

--- a/src/bernstein/core/identity/http_signing.py
+++ b/src/bernstein/core/identity/http_signing.py
@@ -295,7 +295,7 @@ def sign_request(
     signature = private_key.sign(base)
     sig_b64 = base64.b64encode(signature).decode("ascii")
 
-    out = dict(headers)
+    out = headers.copy()
     out["Signature-Input"] = f"{SIGNATURE_LABEL}={params}"
     out["Signature"] = f"{SIGNATURE_LABEL}=:{sig_b64}:"
     return out

--- a/src/bernstein/core/lineage/spine.py
+++ b/src/bernstein/core/lineage/spine.py
@@ -334,7 +334,7 @@ class LineageSpine:
     def _write_head(self, head_hash: str, count: int) -> None:
         body = {"head_hash": head_hash, "count": count}
         head_hmac = _compute_hmac(self._hmac_key, body)
-        payload = {**body, "hmac": head_hmac}
+        payload = body | {"hmac": head_hmac}
         tmp = self.head_path.with_suffix(".head.tmp")
         tmp.write_text(
             json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True),

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -345,7 +345,11 @@ def main() -> None:
     # command-not-found diagnostic below.
     launch_cmd = _resolve_launch_cmd(cmd)
     try:
-        child = subprocess.Popen(launch_cmd)
+        # launch_cmd is an argv list (never a shell string) built from the
+        # trusted adapter command; shell=False, so there is no shell to inject
+        # into. The Windows cmd.exe /c wrapper also passes each arg as a
+        # separate list element, not a concatenated command line.
+        child = subprocess.Popen(launch_cmd)  # nosemgrep
     except FileNotFoundError as exc:
         # Typed first-run error: the adapter binary is missing from PATH.
         # Callers running this worker as a subprocess can categorise via


### PR DESCRIPTION
Clears the 5 code-scanning alerts introduced by the lineage-spine and outbound-signing work: four mechanical refurb fixes (FURB123/173/184) in spine.py, base.py, delegation.py, http_signing.py, and a documented nosemgrep on the worker spawn (launch_cmd is an argv list built from the trusted adapter command with shell=False, so the tainted-subprocess heuristic is a false positive). No behavior change.