### PR TITLE
ci(coverage-ratchet): reuse one stable branch so it updates a single PR

### DIFF
--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -131,7 +131,9 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: coverage-ratchet/baseline-${{ github.run_id }}
+          # Stable branch so create-pull-request UPDATES the single open
+          # ratchet PR in place instead of opening a fresh PR every push.
+          branch: coverage-ratchet/baseline
           delete-branch: true
           add-paths: |
             .coverage-baseline.json


### PR DESCRIPTION
The coverage-ratchet workflow used a per-run-id branch name, so every push to main opened a brand-new baseline PR; under heavy merge activity these accumulated (5+ identical open PRs). Switching to a stable branch name makes peter-evans/create-pull-request update the single open ratchet PR in place instead of opening a new one. No change to the ratchet logic itself.

## Summary by Sourcery

CI:
- Adjust coverage-ratchet workflow branch configuration to reuse a single baseline branch and avoid accumulating duplicate coverage ratchet PRs.