### PR TITLE
chore: resolve scanner findings in wave-3a projection and payment code

### DIFF
--- a/src/bernstein/core/lineage/c2pa.py
+++ b/src/bernstein/core/lineage/c2pa.py
@@ -152,7 +152,7 @@ class SoftBinding:
     blocks: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
 
     def to_assertion_data(self) -> dict[str, Any]:
-        return {"alg": self.alg, "blocks": list(self.blocks)}
+        return {"alg": self.alg, "blocks": self.blocks.copy()}
 
 
 @dataclass(slots=True)

--- a/src/bernstein/core/observability/otel_projection.py
+++ b/src/bernstein/core/observability/otel_projection.py
@@ -225,7 +225,7 @@ class ProjectedSpan:
             "operation": self.operation,
             "entry_hash": self.entry_hash,
             "index": self.index,
-            "attributes": dict(self.attributes),
+            "attributes": self.attributes.copy(),
         }
 
 
@@ -461,7 +461,7 @@ def sign_projection(
         trace_id=projection.trace_id,
         run_head=projection.run_head,
         genai_stability=projection.genai_stability,
-        spans=list(projection.spans),
+        spans=projection.spans.copy(),
         keyid=projection.keyid,
         signature_b64=base64.b64encode(sig).decode("ascii"),
     )
@@ -518,7 +518,7 @@ def verify_projection(
       install identity. Any tampering with a span changes the canonical
       bytes and fails this check.
     """
-    errors: list[str] = list(recompute_span_ids(projection, events))
+    errors: list[str] = recompute_span_ids(projection, events).copy()
 
     if not projection.signature_b64:
         errors.append("projection is unsigned")
@@ -536,7 +536,7 @@ def verify_projection(
         trace_id=projection.trace_id,
         run_head=projection.run_head,
         genai_stability=projection.genai_stability,
-        spans=list(projection.spans),
+        spans=projection.spans.copy(),
         keyid=projection.keyid,
         signature_b64="",
     )

--- a/src/bernstein/core/protocols/payments/mandates.py
+++ b/src/bernstein/core/protocols/payments/mandates.py
@@ -185,7 +185,7 @@ class IntentMandate:
         """Return a copy carrying the HMAC signature over the body."""
         return IntentMandate(
             task_id=self.task_id,
-            allowed_tool_calls=tuple(self.allowed_tool_calls),
+            allowed_tool_calls=self.allowed_tool_calls,
             spend_cap_usd=self.spend_cap_usd,
             expires_at=self.expires_at,
             signature=_sign(key, self._body()),
@@ -251,7 +251,7 @@ class CartMandate:
         """Return a copy carrying the HMAC signature over the body."""
         return CartMandate(
             intent_hash=self.intent_hash,
-            tool_calls=tuple(self.tool_calls),
+            tool_calls=self.tool_calls,
             amount_usd=self.amount_usd,
             signature=_sign(key, self._body()),
         )

--- a/src/bernstein/core/sandbox/snapshot.py
+++ b/src/bernstein/core/sandbox/snapshot.py
@@ -94,7 +94,7 @@ def commit_worktree_snapshot(
     index_fd, index_name = tempfile.mkstemp(prefix="bernstein-snapshot-index-")
     os.close(index_fd)
     scratch_index = Path(index_name)
-    env = dict(os.environ)
+    env = os.environ.copy()
     env["GIT_INDEX_FILE"] = str(scratch_index)
     # Deterministic author/committer identity keeps the commit sha a pure
     # function of the tree + parent, so a byte-identical worktree snapshots
@@ -124,7 +124,7 @@ def commit_worktree_snapshot(
         # 2. Pin the commit to a dedicated ref in the owning repo so the
         #    snapshot survives worktree teardown and git gc.
         ref = snapshot_ref_name(run_id, step_index)
-        _run(["update-ref", ref, sha], repo_root, dict(os.environ))
+        _run(["update-ref", ref, sha], repo_root, os.environ.copy())
     finally:
         try:
             scratch_index.unlink(missing_ok=True)
@@ -157,7 +157,7 @@ def resume_worktree_snapshot(
     _run(
         ["worktree", "add", "--detach", str(dest_path), snapshot_id],
         repo_root,
-        dict(os.environ),
+        os.environ.copy(),
     )
 
 


### PR DESCRIPTION
Ten mechanical refurb fixes (FURB123) across wave-3 feature modules: copy() over list()/dict() constructor calls (OTel projection, payment mandates, content credentials, and worktree snapshot env capture), and dropping a redundant tuple() over an already-tuple field. Clears all open FURB123 code-scanning alerts on main. No behavior change.