### PR TITLE
chore: drop redundant tuple() in review receipt

### DIFF
--- a/src/bernstein/core/review/receipt.py
+++ b/src/bernstein/core/review/receipt.py
@@ -374,7 +374,7 @@ def emit_review_receipt(
         plan_hash=compute_plan_hash(plan),
         journal_head=journal_head,
         diff_hash=compute_diff_hash(diff),
-        findings=tuple(findings),
+        findings=findings,
         verdict=verdict,
         task_id=task_id,
         timestamp=timestamp,


### PR DESCRIPTION
One FURB123 fix: the findings parameter is already tuple-typed, so tuple(findings) is redundant. The two FURB184 chained-assignment suggestions were dismissed as won't-fix (the named intermediates read clearer). Clears the remaining wave-3b scanner findings. No behavior change.

## Summary by Sourcery

Enhancements:
- Remove redundant tuple() wrapping of an already tuple-typed findings parameter in review receipt generation.