### PR TITLE
fix: restore green main by routing phase-gate lineage through the spine

### DIFF
--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -465,7 +465,7 @@ def print_rich_help() -> None:
     opts.add_row("", "--fresh", "ignore saved session, start clean")
     opts.add_row("", "--version", "show version")
     c.print(opts)
-    c.print("\n  [dim]docs:[/dim] https://chernistry.github.io/bernstein/")
+    c.print("\n  [dim]docs:[/dim] https://bernstein.readthedocs.io/en/latest/")
     c.print("  [dim]repo:[/dim] https://github.com/sipyourdrink-ltd/bernstein")
     c.print("  [dim]audit chain:[/dim] docs/security/audit-log.md  (RFC 2104 HMAC-SHA256)\n")
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -722,7 +722,7 @@ def _init_impl(
     console.print("  2. Run [bold]bernstein[/bold] to start the orchestra")
     console.print("")
     console.print(
-        "  See [link=https://chernistry.github.io/bernstein/]docs[/link] "
+        "  See [link=https://bernstein.readthedocs.io/en/latest/]docs[/link] "
         "or [bold]examples/quickstart/[/bold] for a working example."
     )
 

--- a/src/bernstein/core/orchestration/phase_gate_lineage.py
+++ b/src/bernstein/core/orchestration/phase_gate_lineage.py
@@ -1,25 +1,26 @@
 """Per-artifact lineage hook for phase-gate boundary events.
 
 Each phase boundary writes a lineage record so the audit trail becomes
-per-phase, per-rule.  We reuse the existing
-:class:`bernstein.core.persistence.lineage.LineageWriter` rather than
-creating a parallel store - verifying the WAL hash chain
-(``WALReader.verify_chain``) and the audit-log HMAC chain remains a
-single operation.
+per-phase, per-rule. The live wiring
+(:func:`build_phased_runner_with_gate_lineage`) routes that write through
+the canonical always-on :class:`bernstein.core.lineage.spine.LineageSpine`
+boundary - the same single write path every other subsystem uses - so no
+deprecated v1 writer is constructed under ``src/`` (issue #2292 AC4).
 
-Record shape (mapped onto :class:`LineageRecord`)::
+Boundary entry mapped onto :meth:`LineageSpine.record`::
 
-    output_artifact -> .sdd/runtime/phase_artifacts/<task_id>/<phase>.json
-                       (the just-written artefact)
-    inputs          -> empty list; the prior phase's artefact is already
-                       on the lineage chain via its own write event
-    producer        -> AgentRef(agent_id="phase_gate", run_id=task.id)
-    prompt_sha      -> stable hash of "<rule_id>:<outcome>" entries so
-                       two replays of the same evaluation are bit-identical
-    model           -> phase id (used as a free-form tag)
+    artifact_path -> .sdd/runtime/phase_artifacts/<task_id>/<phase>.json
+                     (repo-relative POSIX string)
+    content       -> canonical JSON of the boundary + per-rule outcomes,
+                     so two replays of the same evaluation are bit-identical
+    actor         -> "phase_gate:<phase>"
+    step_id       -> "<from>-><to>" (the boundary tick)
+    model         -> phase id
+    timestamp     -> caller-supplied stable int (default 0)
 
-The ``regulatory_class`` field is set to ``"phase_gate"`` so compliance
-filters can pull every gate event in one query.
+The legacy :func:`make_lineage_hook` (v1 ``LineageWriter``) is retained for
+tests and out-of-tree callers that already hold a writer; it is never
+constructed inside ``src/``.
 """
 
 from __future__ import annotations
@@ -29,11 +30,11 @@ import json
 import time
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.lineage.spine import LineageSpine
 from bernstein.core.persistence.lineage import (
     AgentRef,
     ArtifactRef,
     LineageRecord,
-    LineageWriter,
     hash_file,
 )
 
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
 
     from bernstein.core.orchestration.phase_gates import GateResult
     from bernstein.core.orchestration.phase_pipeline import Phase
+    from bernstein.core.persistence.lineage import LineageWriter
     from bernstein.core.tasks.models import Task
 
 
@@ -73,6 +75,48 @@ def _prompt_sha(results: list[GateResult]) -> str:
         separators=(",", ":"),
     )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+#: Default phase-artifact runtime root (repo-relative POSIX). Mirrors
+#: ``phase_pipeline._DEFAULT_RUNTIME_ROOT`` without importing the runner.
+_PHASE_ARTIFACT_ROOT = ".sdd/runtime/phase_artifacts"
+
+#: Model tag recorded on the boundary spine entry uses the phase value; the
+#: actor uses this ``phase_gate:`` prefix (unchanged from the v1 hook).
+_PHASE_GATE_ACTOR_PREFIX = "phase_gate"
+
+
+def _boundary_artifact_path(task: Task, phase: Phase) -> str:
+    """Return the repo-relative POSIX phase-artifact path for the boundary.
+
+    ``LineageSpine.record`` rejects absolute paths and traversal, so the
+    path is always relative and already anchored under ``.sdd/``.
+    """
+    return f"{_PHASE_ARTIFACT_ROOT}/{task.id}/{phase.value}.json"
+
+
+def _boundary_content(
+    *,
+    phase: Phase,
+    boundary: tuple[Phase, Phase],
+    results: list[GateResult],
+) -> bytes:
+    """Return deterministic canonical bytes for this boundary evaluation.
+
+    The content is the boundary + the per-rule outcome projection - the
+    same rule/outcome structure ``_prompt_sha`` hashes and
+    :func:`gate_results_summary` renders. We hash the *evaluation* rather
+    than the on-disk artefact file: the artefact bytes are executor-driven
+    and need not be stable, whereas the boundary decision is a pure
+    function of ``(boundary, phase, [(rule_id, outcome)...])`` and reads no
+    wall-clock or randomness, so two identical runs replay byte-identically.
+    """
+    payload = {
+        "boundary": [boundary[0].value, boundary[1].value],
+        "phase": phase.value,
+        "rules": [{"rule_id": r.rule_id, "outcome": r.outcome.value} for r in results],
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
 def build_phase_gate_record(
@@ -145,6 +189,55 @@ def make_lineage_hook(
     return _hook
 
 
+def make_spine_lineage_hook(
+    spine: LineageSpine,
+    *,
+    timestamp: int = 0,
+    artifact_path_resolver: Callable[[Task, Phase], str] | None = None,
+) -> Any:
+    """Return a boundary lineage hook that writes through *spine*.
+
+    This is the canonical, always-on replacement for the v1
+    :func:`make_lineage_hook`: every boundary routes through the single
+    :meth:`LineageSpine.record` write boundary, so no deprecated v1 writer
+    is constructed under ``src/`` (issue #2292 AC4). The entry mirrors the
+    v1 record's actor (``phase_gate:<phase>``), tick (``<from>-><to>``) and
+    model (phase id).
+
+    Args:
+        spine: The run's lineage spine (the single write boundary).
+        timestamp: Stable integer timestamp recorded on every boundary
+            entry. Defaults to ``0`` so identical fixtures replay
+            byte-identically; a caller may pin a different value.
+        artifact_path_resolver: Optional callable mapping
+            ``(task, phase) -> repo-relative POSIX str`` to override the
+            default ``.sdd/runtime/phase_artifacts/<task_id>/<phase>.json``
+            path. The returned path must be relative (no leading ``/`` or
+            ``..`` segment) or :meth:`LineageSpine.record` rejects it.
+    """
+
+    def _hook(
+        task: Task,
+        phase: Phase,
+        boundary: tuple[Phase, Phase],
+        results: list[GateResult],
+    ) -> None:
+        if artifact_path_resolver is not None:
+            artifact_path = artifact_path_resolver(task, phase)
+        else:
+            artifact_path = _boundary_artifact_path(task, phase)
+        spine.record(
+            artifact_path=artifact_path,
+            content=_boundary_content(phase=phase, boundary=boundary, results=results),
+            actor=f"{_PHASE_GATE_ACTOR_PREFIX}:{phase.value}",
+            step_id=f"{boundary[0].value}->{boundary[1].value}",
+            model=phase.value,
+            timestamp=timestamp,
+        )
+
+    return _hook
+
+
 # ---------------------------------------------------------------------------
 # Signed adjudication wiring (issue #2294)
 # ---------------------------------------------------------------------------
@@ -197,11 +290,11 @@ def make_adjudication_hook(
 ) -> Any:
     """Wrap *lineage_hook* so each boundary also writes a signed adjudication record.
 
-    The returned closure first delegates to *lineage_hook* (the WAL lineage
-    emission from :func:`make_lineage_hook`) and then anchors a signed
-    adjudication record -- ``{inputs_hash, rubric_hash, panel_config,
-    per_judge_verdict, final_verdict}`` -- to the run's lineage spine, mirroring
-    it into the HMAC audit chain when *audit_dir* is supplied.
+    The returned closure first delegates to *lineage_hook* (the per-boundary
+    lineage emission - :func:`make_spine_lineage_hook` in the live wiring) and
+    then anchors a signed adjudication record -- ``{inputs_hash, rubric_hash,
+    panel_config, per_judge_verdict, final_verdict}`` -- to the run's lineage
+    spine, mirroring it into the HMAC audit chain when *audit_dir* is supplied.
 
     The gate's inputs are the per-rule ``(rule_id, outcome)`` projection; the
     rubric is the boundary. Two byte-identical gate runs produce byte-identical
@@ -254,34 +347,41 @@ def build_phased_runner_with_gate_lineage(
     hmac_key: bytes,
     run_id: str | None = None,
     emit_audit_chain: bool = False,
+    boundary_timestamp: int = 0,
     store: Any | None = None,
 ) -> Any:
     """Return a :class:`PhasedRunner` with the gate lineage hook wired live.
 
-    This is the production wiring AC1 requires: it constructs a
-    :class:`bernstein.core.persistence.lineage.LineageWriter`, calls
-    :func:`make_lineage_hook` on it (the live caller that fixes the 0-caller
-    hook), wraps it so each boundary also writes a signed adjudication record,
-    and binds the composite hook to a fresh runner.
+    This is the production wiring AC1 requires. The per-boundary lineage
+    write routes through the canonical always-on
+    :class:`bernstein.core.lineage.spine.LineageSpine` boundary - the same
+    single write path every other subsystem uses - so no deprecated v1
+    writer is constructed (issue #2292 AC4). The spine hook is wrapped by
+    :func:`make_adjudication_hook` exactly as before (issue #2294), so each
+    boundary still emits a signed adjudication record; only the underlying
+    lineage write target changed from the v1 writer to the spine.
 
     Args:
         executor: The phase executor callable passed to :class:`PhasedRunner`.
         sdd_dir: The ``.sdd`` directory root.
         hmac_key: Audit-chain HMAC key that tags spine and audit entries.
-        run_id: Run identifier for the lineage writer + spine; defaults to a
-            stable ``"phased-<>"``-free value derived from the runner.
+        run_id: Run identifier for the lineage spine; defaults to a stable
+            ``"phase-gates"``.
         emit_audit_chain: When True, also mirror each adjudication record into
             the HMAC audit log under ``sdd_dir/audit``.
+        boundary_timestamp: Stable integer timestamp recorded on every
+            boundary spine entry. Defaults to ``0`` so identical fixtures
+            replay byte-identically; pin a different value to override.
     """
     from bernstein.core.orchestration.phase_pipeline import PhasedRunner
-    from bernstein.core.persistence.lineage import LineageWriter
 
     resolved_run_id = run_id or "phase-gates"
-    writer = LineageWriter.for_run(resolved_run_id, sdd_dir)
-    lineage_hook = make_lineage_hook(writer)
+    lineage_root = sdd_dir / "lineage"
+    spine = LineageSpine(lineage_root, run_id=resolved_run_id, hmac_key=hmac_key)
+    lineage_hook = make_spine_lineage_hook(spine, timestamp=boundary_timestamp)
     hook = make_adjudication_hook(
         lineage_hook=lineage_hook,
-        lineage_root=sdd_dir / "lineage",
+        lineage_root=lineage_root,
         hmac_key=hmac_key,
         audit_dir=(sdd_dir / "audit") if emit_audit_chain else None,
         run_id=resolved_run_id,
@@ -298,4 +398,5 @@ __all__ = [
     "gate_results_summary",
     "make_adjudication_hook",
     "make_lineage_hook",
+    "make_spine_lineage_hook",
 ]

--- a/tests/unit/test_docs_url_hygiene.py
+++ b/tests/unit/test_docs_url_hygiene.py
@@ -1,0 +1,39 @@
+"""Guard: shipped source points at the canonical docs host only.
+
+The documentation site moved to ``bernstein.readthedocs.io``. The old
+GitHub Pages host (``chernistry.github.io/bernstein``) no longer serves
+docs, so any user-facing link that still points there is a dead link in
+the wheel. This test scans the shipped source tree so a regression that
+reintroduces the stale host fails CI, the same way the lineage-spine
+deprecation guard pins v1 writer construction sites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "bernstein"
+
+_DEAD_DOCS_HOST = "chernistry.github.io"
+
+
+def _dead_link_sites() -> list[str]:
+    hits: list[str] = []
+    for py in _SRC.rglob("*.py"):
+        try:
+            text = py.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _DEAD_DOCS_HOST in line:
+                hits.append(f"{py}:{lineno}")
+    return hits
+
+
+def test_no_dead_docs_host_in_src() -> None:
+    sites = _dead_link_sites()
+    assert sites == [], (
+        f"shipped source must not link to the retired docs host "
+        f"'{_DEAD_DOCS_HOST}'; use https://bernstein.readthedocs.io/ instead:\n"
+        + "\n".join(sites)
+    )

--- a/tests/unit/test_docs_url_hygiene.py
+++ b/tests/unit/test_docs_url_hygiene.py
@@ -34,6 +34,5 @@ def test_no_dead_docs_host_in_src() -> None:
     sites = _dead_link_sites()
     assert sites == [], (
         f"shipped source must not link to the retired docs host "
-        f"'{_DEAD_DOCS_HOST}'; use https://bernstein.readthedocs.io/ instead:\n"
-        + "\n".join(sites)
+        f"'{_DEAD_DOCS_HOST}'; use https://bernstein.readthedocs.io/ instead:\n" + "\n".join(sites)
     )

--- a/tests/unit/test_phase_gate_adjudication_wiring.py
+++ b/tests/unit/test_phase_gate_adjudication_wiring.py
@@ -88,7 +88,6 @@ def test_factory_returns_runner_with_live_hook(tmp_path: Path) -> None:
 
 def test_wired_runner_writes_lineage_and_adjudication_records(tmp_path: Path) -> None:
     from bernstein.core.orchestration.phase_pipeline import ArtifactStore
-    from bernstein.core.persistence.lineage import LineageReader
 
     sdd = tmp_path / ".sdd"
     runner = build_phased_runner_with_gate_lineage(
@@ -101,15 +100,18 @@ def test_wired_runner_writes_lineage_and_adjudication_records(tmp_path: Path) ->
     results = runner.run(_task())
     assert len(results) == 3
 
-    # A lineage record per boundary (research entry + plan + implement).
-    reader = LineageReader(sdd)
-    records = list(reader.iter_records())
-    assert records, "expected phase-gate lineage records"
-    assert all(r.regulatory_class == "phase_gate" for r in records)
-
-    # The adjudication spine has at least one signed record anchored.
+    # Boundary lineage now routes through the canonical spine (not the v1 WAL):
+    # one phase-gate-tagged entry per fired boundary, on a spine that verifies.
     from bernstein.core.lineage.spine import LineageSpine
 
     spine = LineageSpine(sdd / "lineage", run_id="run-wire", hmac_key=_KEY)
     result = spine.verify()
     assert result.ok, result.errors
+
+    entries = list(spine.iter_entries())
+    gate_entries = [e for e in entries if e.actor.startswith("phase_gate:")]
+    assert gate_entries, "expected phase-gate boundary lineage entries on the spine"
+
+    # The adjudication records are anchored on the same spine.
+    adjudication_entries = [e for e in entries if e.actor == "adjudication"]
+    assert adjudication_entries, "expected signed adjudication records anchored to the spine"

--- a/tests/unit/test_phase_gate_spine_lineage.py
+++ b/tests/unit/test_phase_gate_spine_lineage.py
@@ -1,0 +1,296 @@
+"""Spine-backed phase-gate boundary lineage (main-red regression guard).
+
+``build_phased_runner_with_gate_lineage`` must route the per-boundary
+lineage write through the canonical :class:`LineageSpine` write boundary
+instead of the deprecated v1 ``LineageWriter`` (issue #2292 AC4). These
+tests drive a real gate boundary through the returned runner and assert:
+
+* the boundary produces a spine entry that ``LineageSpine.verify()``
+  reports ``ok``, tagged with actor ``phase_gate:<phase>`` and the
+  repo-relative phase-artifact path;
+* two runs with a pinned timestamp produce a byte-identical spine entry
+  for the same boundary + results, independent of ``PYTHONHASHSEED``.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.orchestration.phase_gate_lineage import (
+    build_phased_runner_with_gate_lineage,
+)
+from bernstein.core.orchestration.phase_pipeline import (
+    ArtifactStore,
+    Phase,
+    PhaseArtifact,
+    PhasedRunner,
+    PhaseSpec,
+)
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+_KEY = b"k" * 32
+_RUN_ID = "run-spine"
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "bernstein"
+
+
+def _task() -> Task:
+    return Task(
+        id="t-spine-1",
+        title="title",
+        description="desc",
+        role="backend",
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        metadata={"phases": ["research", "plan", "implement"]},
+    )
+
+
+def _research() -> PhaseArtifact:
+    return PhaseArtifact(
+        summary="research summary long enough to satisfy the strict schema",
+        decisions=["use existing TaskStore <id:taskstore>"],
+        constraints=["python 3.12", "pyright strict"],
+        open_questions=[],
+    )
+
+
+def _plan() -> PhaseArtifact:
+    return PhaseArtifact(
+        summary="plan derived from research summary cleanly",
+        decisions=["adopt <id:taskstore>"],
+        constraints=["python 3.12", "pyright strict"],
+        open_questions=[],
+        extras={"dependencies": ["step1->step2"]},
+    )
+
+
+def _implement() -> PhaseArtifact:
+    return PhaseArtifact(
+        summary="implement follows the plan without dropping constraints",
+        decisions=["adopt <id:taskstore>"],
+        constraints=["python 3.12", "pyright strict"],
+        open_questions=[],
+        extras={
+            "files_changed": ["src/foo.py"],
+            "tests_added": ["tests/unit/test_foo.py"],
+            "tests_passing": ["tests/unit/test_foo.py::test_smoke"],
+        },
+    )
+
+
+def _executor(task: Task, spec: PhaseSpec, prior: PhaseArtifact | None) -> PhaseArtifact:
+    return {
+        Phase.RESEARCH: _research(),
+        Phase.PLAN: _plan(),
+        Phase.IMPLEMENT: _implement(),
+    }[spec.phase]
+
+
+def _run(sdd: Path, tmp_path: Path) -> list[object]:
+    runner = build_phased_runner_with_gate_lineage(
+        executor=_executor,
+        sdd_dir=sdd,
+        hmac_key=_KEY,
+        run_id=_RUN_ID,
+        store=ArtifactStore(root=tmp_path / "artifacts"),
+    )
+    assert isinstance(runner, PhasedRunner)
+    return runner.run(_task())
+
+
+def test_no_v1_writer_construction_in_builder_module() -> None:
+    """The builder module constructs no deprecated v1 writer (guard mirror)."""
+    module = _SRC / "core" / "orchestration" / "phase_gate_lineage.py"
+    tree = ast.parse(module.read_text(encoding="utf-8"))
+    forbidden = {"LineageRecorder", "LineageWriter"}
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in forbidden:
+            hits.append(f"{func.id}(...) @ line {node.lineno}")
+        if (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id in forbidden
+            and func.attr in {"for_run", "create"}
+        ):
+            hits.append(f"{func.value.id}.{func.attr}(...) @ line {node.lineno}")
+    assert hits == [], f"v1 writer construction leaked back into the builder: {hits}"
+
+
+def test_boundary_write_lands_on_spine_and_verifies(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    results = _run(sdd, tmp_path)
+    assert len(results) == 3
+
+    spine = LineageSpine(sdd / "lineage", run_id=_RUN_ID, hmac_key=_KEY)
+    verify = spine.verify()
+    assert verify.ok, verify.errors
+
+    entries = list(spine.iter_entries())
+    # A phase-gate lineage entry per fired boundary (plus adjudication anchors).
+    gate_entries = [e for e in entries if e.actor.startswith("phase_gate:")]
+    assert gate_entries, "expected phase-gate boundary entries on the spine"
+
+    for entry in gate_entries:
+        # actor is phase_gate:<phase>, matching the v1 hook contract.
+        assert entry.actor.startswith("phase_gate:")
+        phase_value = entry.actor.split(":", 1)[1]
+        # artifact_path is the repo-relative POSIX phase-artifact path.
+        assert entry.artifact_path == f".sdd/runtime/phase_artifacts/{_task().id}/{phase_value}.json"
+        assert not entry.artifact_path.startswith("/")
+        assert ".." not in entry.artifact_path.split("/")
+        # step_id is the boundary tick (from->to), model is the phase.
+        assert "->" in entry.step_id
+        assert entry.model == phase_value
+
+
+def test_boundary_actor_and_step_id_match_v1_record(tmp_path: Path) -> None:
+    """The plan boundary keeps actor=phase_gate:plan, step_id=research->plan."""
+    sdd = tmp_path / ".sdd"
+    _run(sdd, tmp_path)
+    spine = LineageSpine(sdd / "lineage", run_id=_RUN_ID, hmac_key=_KEY)
+    plan_entries = [e for e in spine.iter_entries() if e.actor == "phase_gate:plan"]
+    assert plan_entries, "expected a phase_gate:plan boundary entry"
+    assert plan_entries[0].step_id == "research->plan"
+    assert plan_entries[0].model == "plan"
+
+
+def _plan_entry_row(sdd: Path) -> bytes:
+    spine = LineageSpine(sdd / "lineage", run_id=_RUN_ID, hmac_key=_KEY)
+    for entry in spine.iter_entries():
+        if entry.actor == "phase_gate:plan":
+            return entry.to_row()
+    raise AssertionError("no phase_gate:plan entry found")
+
+
+def test_boundary_content_hash_is_deterministic(tmp_path: Path) -> None:
+    """Same boundary + results => identical content_hash (no wall-clock in content)."""
+    sdd_a = tmp_path / "a" / ".sdd"
+    sdd_b = tmp_path / "b" / ".sdd"
+    _run(sdd_a, tmp_path / "a")
+    _run(sdd_b, tmp_path / "b")
+
+    spine_a = LineageSpine(sdd_a / "lineage", run_id=_RUN_ID, hmac_key=_KEY)
+    spine_b = LineageSpine(sdd_b / "lineage", run_id=_RUN_ID, hmac_key=_KEY)
+    plan_a = next(e for e in spine_a.iter_entries() if e.actor == "phase_gate:plan")
+    plan_b = next(e for e in spine_b.iter_entries() if e.actor == "phase_gate:plan")
+    assert plan_a.content_hash == plan_b.content_hash
+    # The full derived entry (hash + hmac) is byte-identical too.
+    assert plan_a.to_row() == plan_b.to_row()
+
+
+_BYTE_IDENTITY_SNIPPET = """
+import sys
+from pathlib import Path
+
+sdd = Path(sys.argv[1]) / ".sdd"
+
+from bernstein.core.lineage.spine import LineageSpine
+from bernstein.core.orchestration.phase_gate_lineage import (
+    build_phased_runner_with_gate_lineage,
+)
+from bernstein.core.orchestration.phase_pipeline import (
+    ArtifactStore,
+    Phase,
+    PhaseArtifact,
+    PhaseSpec,
+)
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+KEY = b"k" * 32
+RUN_ID = "run-spine"
+
+
+def task():
+    return Task(
+        id="t-spine-1",
+        title="title",
+        description="desc",
+        role="backend",
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        metadata={"phases": ["research", "plan", "implement"]},
+    )
+
+
+def executor(t, spec, prior):
+    arts = {
+        Phase.RESEARCH: PhaseArtifact(
+            summary="research summary long enough to satisfy the strict schema",
+            decisions=["use existing TaskStore <id:taskstore>"],
+            constraints=["python 3.12", "pyright strict"],
+            open_questions=[],
+        ),
+        Phase.PLAN: PhaseArtifact(
+            summary="plan derived from research summary cleanly",
+            decisions=["adopt <id:taskstore>"],
+            constraints=["python 3.12", "pyright strict"],
+            open_questions=[],
+            extras={"dependencies": ["step1->step2"]},
+        ),
+        Phase.IMPLEMENT: PhaseArtifact(
+            summary="implement follows the plan without dropping constraints",
+            decisions=["adopt <id:taskstore>"],
+            constraints=["python 3.12", "pyright strict"],
+            open_questions=[],
+            extras={
+                "files_changed": ["src/foo.py"],
+                "tests_added": ["tests/unit/test_foo.py"],
+                "tests_passing": ["tests/unit/test_foo.py::test_smoke"],
+            },
+        ),
+    }
+    return arts[spec.phase]
+
+
+runner = build_phased_runner_with_gate_lineage(
+    executor=executor,
+    sdd_dir=sdd,
+    hmac_key=KEY,
+    run_id=RUN_ID,
+    store=ArtifactStore(root=Path(sys.argv[1]) / "artifacts"),
+)
+runner.run(task())
+spine = LineageSpine(sdd / "lineage", run_id=RUN_ID, hmac_key=KEY)
+row = next(e for e in spine.iter_entries() if e.actor == "phase_gate:plan").to_row()
+sys.stdout.buffer.write(row)
+"""
+
+
+def _run_in_subprocess(work: Path, hashseed: str) -> bytes:
+    work.mkdir(parents=True, exist_ok=True)
+    script = work / "driver.py"
+    script.write_text(_BYTE_IDENTITY_SNIPPET, encoding="utf-8")
+    env = {"PYTHONHASHSEED": hashseed}
+    import os
+
+    full_env = {**os.environ, **env}
+    proc = subprocess.run(
+        [sys.executable, str(script), str(work)],
+        capture_output=True,
+        check=True,
+        env=full_env,
+    )
+    return proc.stdout
+
+
+def test_byte_identical_across_pythonhashseed(tmp_path: Path) -> None:
+    """PYTHONHASHSEED=0 and =999 produce the byte-identical spine row."""
+    row_0 = _run_in_subprocess(tmp_path / "seed0", "0")
+    row_999 = _run_in_subprocess(tmp_path / "seed999", "999")
+    assert row_0 == row_999
+    assert row_0, "expected a non-empty phase_gate:plan spine row"


### PR DESCRIPTION
## Problem

The full main-push test suite failed on shard 4 (Python 3.12 and 3.13): `tests/unit/lineage/test_spine_deprecations.py::test_no_v1_writer_construction_in_src`. `build_phased_runner_with_gate_lineage` in `phase_gate_lineage.py` constructed the deprecated v1 `LineageWriter.for_run(...)`, the last v1 writer construction site under `src/`. The guard runs a full-tree scan that the affected-tests filter on pull requests did not select, so it only surfaced on the full main run.

## Fix

- Route the per-boundary phase-gate lineage write through the canonical `LineageSpine.record` boundary, the same path escalation, governance, review-receipt, and adjudication already use. New additive helper `make_spine_lineage_hook(spine, ...)`; `make_lineage_hook(writer: LineageWriter)` is unchanged and retained for the test path.
- The signed-adjudication composition is preserved: `make_adjudication_hook` still wraps the lineage hook; only the underlying write target moved.
- Boundary spine content is canonical JSON of the boundary and per-rule outcomes: a pure function of the evaluation, no wall-clock or randomness, so replays are byte-identical (verified across PYTHONHASHSEED 0 and 999).

## Also in this PR

- Point the `--help` epilog and post-init bootstrap hint at `https://bernstein.readthedocs.io/en/latest/`; the retired GitHub Pages host no longer serves docs. Adds a guard that fails CI if the retired host reappears in `src/`.

## Tests

- New `tests/unit/test_phase_gate_spine_lineage.py` (TDD, 5 cases incl. byte-identity + determinism).
- Green: guard, `test_phase_gate_lineage`, `test_phase_gate_adjudication_wiring`, new file; 0 v1 writer sites in `src/`; ruff, lint-imports, import all clean.

Closes #2351