### PR TITLE
fix(docs): restore guarded leaderboard page and skills mirror URL

### DIFF
--- a/docs/benchmarks/leaderboard.html
+++ b/docs/benchmarks/leaderboard.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Benchmarks - Bernstein</title>
+  <meta name="description" content="Bernstein benchmark results on SWE-Bench Lite: solo vs orchestrated agent comparison. Methodology, reproduction steps, and verified evaluation pipeline for multi-agent coding performance." />
+  <link rel="stylesheet" href="style.css" />
+  <link id="hljs-theme" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" />
+  <script src="https://unpkg.com/lucide@latest"></script>
+  <script src="script.js"></script>
+  <style>
+    .metric-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: var(--space-6);
+      margin-bottom: var(--space-12);
+    }
+    .metric-card {
+      padding: var(--space-6);
+      background: var(--bg-card);
+      border: 1px solid var(--bg-card-border);
+      border-radius: var(--radius);
+    }
+    .metric-label {
+      font-size: var(--text-sm);
+      color: var(--text-3);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: var(--space-2);
+    }
+    .metric-copy {
+      font-size: var(--text-lg);
+      color: var(--text-1);
+      line-height: 1.5;
+    }
+    .status-banner {
+      padding: var(--space-6);
+      background: var(--bg-card);
+      border: 1px solid var(--bg-card-border);
+      border-radius: var(--radius);
+      margin-bottom: var(--space-10);
+    }
+    .status-banner ul {
+      margin: 0;
+      padding-left: 1.25rem;
+    }
+    .comparison-table th {
+      background: var(--bg-2);
+      text-align: left;
+    }
+  </style>
+  <link rel="canonical" href="https://sipyourdrink-ltd.github.io/bernstein/leaderboard.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Benchmarks - Bernstein" />
+  <meta property="og:description" content="Bernstein benchmark results on SWE-Bench Lite: solo vs orchestrated agent comparison. Methodology, reproduction steps, and verified evaluation pipeline for multi-agent coding performance." />
+  <meta property="og:url" content="https://sipyourdrink-ltd.github.io/bernstein/leaderboard.html" />
+  <meta property="og:image" content="https://sipyourdrink-ltd.github.io/bernstein/assets/banner_one_command_1536x1024.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Benchmarks - Bernstein" />
+  <meta name="twitter:description" content="Bernstein benchmark results on SWE-Bench Lite: solo vs orchestrated agent comparison. Methodology, reproduction steps, and verified evaluation pipeline for multi-agent coding performance." />
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Bernstein","item":"https://sipyourdrink-ltd.github.io/bernstein/"},{"@type":"ListItem","position":2,"name":"Benchmarks","item":"https://sipyourdrink-ltd.github.io/bernstein/leaderboard.html"}]}
+</script>
+  <link rel="author" href="https://alexchernysh.com" />
+  <meta property="article:modified_time" content="2026-04-06T09:00:00+03:00" />
+  <script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Dataset","name":"Bernstein SWE-Bench Benchmarks","description":"Multi-agent orchestration benchmark results on SWE-Bench Lite","datePublished":"2025-03-01","dateModified":"2026-04-06","url":"https://sipyourdrink-ltd.github.io/bernstein/leaderboard.html","creator":{"@type":"Person","name":"Alex Chernysh","url":"https://alexchernysh.com"}}
+</script>
+</head>
+<body>
+<nav class="nav">
+  <div class="nav-inner">
+    <a href="../index.html" class="nav-logo">bernstein</a>
+    <div class="nav-links">
+      <a href="../index.html" class="nav-link" data-page="index.html">Overview</a>
+      <a href="../getting-started/getting-started.html" class="nav-link" data-page="getting-started.html">Getting Started</a>
+      <a href="../concepts.html" class="nav-link" data-page="concepts.html">Concepts</a>
+      <a href="../adapters/adapters.html" class="nav-link" data-page="adapters.html">Adapters</a>
+      <a href="../api-reference.html" class="nav-link" data-page="api.html">API Reference</a>
+      <a href="leaderboard.html" class="nav-link active" data-page="leaderboard.html">Benchmarks</a>
+      <a href="../compare/index.html" class="nav-link" data-page="compare/index.html">Compare</a>
+      <a href="../docs-index.html" class="nav-link" data-page="docs-index.html">All Docs</a>
+      <a href="../blog.html" class="nav-link" data-page="blog.html">Blog</a>
+      <a href="../limitations.html" class="nav-link" data-page="limitations.html">Limitations</a>
+    </div>
+    <div class="nav-actions">
+      <button class="btn-icon" id="theme-toggle" aria-label="Toggle theme">
+        <i id="theme-icon" data-lucide="moon-star" aria-hidden="true"></i>
+      </button>
+      <a href="https://github.com/sipyourdrink-ltd/bernstein" class="btn-primary" target="_blank" rel="noopener">
+        GitHub &#8599;
+      </a>
+      <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu"><i id="nav-toggle-icon" data-lucide="menu" aria-hidden="true"></i></button>
+    </div>
+  </div>
+</nav>
+
+<div class="page-hero">
+  <div class="container">
+    <div class="section-label">Benchmarks</div>
+    <h1>Benchmark Status &amp; Methodology</h1>
+    <p>Bernstein publishes benchmark claims only from verified SWE-Bench eval artifacts. Simulation and modeling harnesses remain available for previewing methodology and internal capacity planning.</p>
+  </div>
+</div>
+
+<div class="container" style="margin-top: var(--space-12); margin-bottom: var(--space-16);">
+  <div class="status-banner">
+    <h2 style="margin-top: 0;">Methodology</h2>
+    <ul><li>Public benchmark claims are sourced only from <code>benchmarks/swe_bench/run.py eval</code> with <code>verified=true</code> artifacts.</li><li>Checked-in mock or simulation outputs are preview data and are not used for public claims.</li><li>This page documents methodology, harness coverage, and reproducibility - not headline numbers.</li></ul>
+  </div>
+
+  <div class="metric-grid">
+<div class="metric-card"><div class="metric-label">Public claim source</div><div class="metric-copy">benchmarks/swe_bench/run.py eval only</div></div>
+<div class="metric-card"><div class="metric-label">Comparison scope</div><div class="metric-copy">Bernstein vs solo single-agent baselines on SWE-Bench Lite.</div></div>
+  </div>
+
+
+  <section id="artifact-state" style="padding: 0; margin-bottom: var(--space-16);">
+    <h2>Current Artifact State</h2>
+    <p>This page does not show headline benchmark numbers from the checked-in artifacts because they are mock/preview only.</p>
+    <div class="comparison-wrap">
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>Source type</th>
+            <th>Verified</th>
+            <th>Sample size</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Solo Sonnet</td><td>mock</td><td>No</td><td>300</td><td>Checked-in mock preview artifact. Do not use for public benchmark claims.</td></tr>
+<tr><td>Solo Opus</td><td>mock</td><td>No</td><td>300</td><td>Checked-in mock preview artifact. Do not use for public benchmark claims.</td></tr>
+<tr><td>Bernstein 3x Sonnet</td><td>mock</td><td>No</td><td>300</td><td>Checked-in mock preview artifact. Do not use for public benchmark claims.</td></tr>
+<tr><td>Bernstein Mixed</td><td>mock</td><td>No</td><td>300</td><td>Checked-in mock preview artifact. Do not use for public benchmark claims.</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+
+  <section id="scope" style="padding: 0; margin-bottom: var(--space-16);">
+    <h2>Comparison Scope</h2>
+    <p>Verified comparisons are narrow: Bernstein vs real single-agent baselines on SWE-Bench Lite.</p>
+    <div class="comparison-wrap">
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Solo Sonnet</td><td>Cheap single-agent baseline</td></tr><tr><td>Solo Opus</td><td>Expensive single-agent baseline</td></tr><tr><td>Bernstein 3x Sonnet</td><td>All-Sonnet Bernstein pipeline</td></tr><tr><td>Bernstein Mixed</td><td>Cost-optimized Bernstein pipeline</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section id="reproduce" style="padding: 0;">
+    <h2>Reproduce</h2>
+    <p>Simulation/modeling harnesses remain useful for workflow exploration, but only the SWE-Bench eval path is eligible for public benchmark numbers.</p>
+    <div class="code-block">
+      <pre><code class="language-bash"># Simulation/modeling harnesses (preview only)
+uv run python benchmarks/run_benchmark.py
+uv run python benchmarks/run_benchmark.py --issues-file benchmarks/issues.json
+
+# Verified evaluation harness for public benchmark numbers
+uv run python benchmarks/swe_bench/run.py eval \
+    --scenarios solo-sonnet solo-opus bernstein-sonnet bernstein-mixed \
+    --limit 50
+
+# Generate markdown report and docs page from saved artifacts
+uv run python benchmarks/swe_bench/run.py report
+uv run python scripts/generate_benchmark_docs.py</code></pre>
+    </div>
+  </section>
+</div>
+
+<footer>
+  <div class="container">
+    <p>Built by <a href="https://alexchernysh.com/bernstein" target="_blank" rel="noopener author">Alex Chernysh - Staff AI Engineer</a> &middot; <a href="../index.html">Overview</a> &middot; <a href="https://github.com/sipyourdrink-ltd/bernstein" target="_blank" rel="noopener">GitHub</a> &middot; Apache 2.0</p>
+  </div>
+</footer>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+</body>
+</html>

--- a/docs/operations/skills-catalog.md
+++ b/docs/operations/skills-catalog.md
@@ -29,7 +29,9 @@ All commands honour `--scope project` (writes into
 
 No catalog network request is made until a `bernstein skills catalog`
 command runs. The built-in source is the operator-published catalog at
-`https://bernstein.run/skills-catalog.json`.
+`https://bernstein.run/skills-catalog.json`, with a read-only mirror at
+`https://raw.githubusercontent.com/chernistry/bernstein-skills-catalog/main/skills-catalog.json`
+used as a fallback when the primary is unreachable.
 The URL is validated as HTTPS before fetch, and fetched payloads must
 match the signed catalog schema before they are cached or used.
 


### PR DESCRIPTION
The documentation hygiene pass (#2372) removed `docs/benchmarks/leaderboard.html` and dropped the skills catalog mirror URL from `docs/operations/skills-catalog.md`. Both are pinned by guard tests, so the full main suite went red:

- `test_benchmark_public_site.py::test_public_docs_guard_banned_claims_absent` reads the leaderboard page and asserts it is free of banned headline claims (FileNotFoundError after the deletion).
- `test_catalog_docs.py::test_skills_catalog_docs_state_default_urls` asserts the doc documents the mirror URL the fetcher defaults to.

Restores the leaderboard page verbatim and re-adds the mirror fallback line. Guard suite green (6 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public Benchmarks page with benchmark methodology, scope, artifact status tables, and reproduction steps.
* **Documentation**
  * Updated catalog source guidance to include a primary catalog URL with a GitHub mirror fallback when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->