### PR TITLE
fix(worker): eliminate order-dependent shard flakiness (#2341)

### DIFF
--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -23,7 +23,10 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # Setup minimal logging for the worker
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -123,13 +126,25 @@ def _set_proctitle(title: str) -> None:
         setproctitle.setproctitle(title)
 
 
-def _write_pid_file(pid_dir: Path, session: str, info: dict[str, object]) -> Path:
-    """Write PID metadata JSON file."""
+def _write_pid_file(
+    pid_dir: Path,
+    session: str,
+    info: dict[str, object],
+    on_resolved: Callable[[Path], None] | None = None,
+) -> Path:
+    """Write PID metadata JSON file.
+
+    ``on_resolved`` is invoked with the resolved target path *before* the file
+    is created, so a caller can register the path with its signal handler and
+    guarantee the file can never exist without a cleanup path (#2341).
+    """
     pid_dir.mkdir(parents=True, exist_ok=True)
     pid_file = (pid_dir / f"{session}.json").resolve()
     if not pid_file.is_relative_to(pid_dir.resolve()):
         print(f"bernstein-worker: invalid session id: {session}", file=sys.stderr)
         sys.exit(1)
+    if on_resolved is not None:
+        on_resolved(pid_file)
     pid_file.write_text(json.dumps(info), encoding="utf-8")
     return pid_file
 
@@ -314,7 +329,61 @@ def main() -> None:
 
         emit_command_invoked(name_only=cmd[0])
 
-    # 2. Write PID metadata
+    # 2. Install the terminating-signal handler *before* the PID file exists,
+    # so the file can never outlive an early SIGTERM.
+    #
+    # A reaper keys on the ``child_pid`` marker and sends SIGTERM as soon as
+    # it appears. The handler used to be installed only after the child spawn;
+    # a SIGTERM landing between the PID-file write and that install took the
+    # default disposition - terminate immediately, skipping the ``finally``
+    # unlink - and leaked the PID file. ``bernstein ps`` then reported a
+    # phantom worker and cleanup-order assertions flaked on loaded CI shards
+    # (#2341). Installing here closes the window completely: there is no
+    # instant at which the PID file exists without a cleanup-capable handler.
+    #
+    # Neither the PID file nor the child exists yet, so the handler reads both
+    # through mutable holders that the code below fills in. Until the child
+    # exists the handler just unlinks the PID file (if written) and exits;
+    # once the child exists it forwards the signal with the same grace-window
+    # guard and lets ``main`` reap the child and run the shared cleanup.
+    _pid_file_holder: list[Path] = []
+    _child_holder: list[subprocess.Popen[bytes]] = []
+
+    def _terminate(signum: int, _frame: object) -> None:
+        _running = _child_holder[0] if _child_holder else None
+        if _running is not None:
+            # Group-directed signals reach the child directly (shared process
+            # group), so re-sending immediately would double-deliver. The
+            # second delivery is not benign: when the child's own handler has
+            # already run and its interpreter is finalising, the default
+            # disposition is restored and the late duplicate kills the child
+            # outright, so ``child.wait()`` reports a signal death (``-N``)
+            # instead of the handler's exit code. Poll for the child's exit
+            # through a short grace window first; forward only if it is still
+            # running, i.e. the signal was sent to the worker alone.
+            deadline = time.monotonic() + _FORWARD_GRACE_S
+            while time.monotonic() < deadline:
+                if _running.poll() is not None:
+                    break
+                time.sleep(_FORWARD_POLL_INTERVAL_S)
+            else:
+                with contextlib.suppress(OSError):
+                    _running.send_signal(signum)
+            # Let the normal ``child.wait()`` path in main() reap the child and
+            # run the shared cleanup + ``128 + N`` exit translation.
+            return
+        # No child yet: nothing to forward or wait on. Clean up the PID file
+        # (if it was already written) and exit with the conventional 128 + N.
+        if _pid_file_holder:
+            _pid_file_holder[0].unlink(missing_ok=True)
+        sys.exit(128 + signum)
+
+    signal.signal(signal.SIGTERM, _terminate)
+    signal.signal(signal.SIGINT, _terminate)
+
+    # 2b. Write PID metadata. ``on_resolved`` publishes the path to the holder
+    # *before* the file is created, so even a SIGTERM during the write itself
+    # is cleaned up (``unlink(missing_ok=True)`` tolerates the pre-create case).
     pid_file = _write_pid_file(
         Path(args.pid_dir),
         args.session,
@@ -326,9 +395,10 @@ def main() -> None:
             "model": args.model,
             "started_at": time.time(),
         },
+        on_resolved=_pid_file_holder.append,
     )
 
-    # 2b. Touch heartbeat file so the agent starts with a fresh timestamp.
+    # 2c. Touch heartbeat file so the agent starts with a fresh timestamp.
     # Without this, idle recycling can kill agents before their first
     # stream-json event arrives (e.g. Claude Code thinking for 2+ minutes).
     with contextlib.suppress(OSError):
@@ -350,6 +420,10 @@ def main() -> None:
         # into. The Windows cmd.exe /c wrapper also passes each arg as a
         # separate list element, not a concatenated command line.
         child = subprocess.Popen(launch_cmd)  # nosemgrep
+        # Publish the child so the already-installed terminating-signal
+        # handler forwards to it (and lets main() reap it) instead of
+        # unlinking + exiting on its own.
+        _child_holder.append(child)
     except FileNotFoundError as exc:
         # Typed first-run error: the adapter binary is missing from PATH.
         # Callers running this worker as a subprocess can categorise via
@@ -410,31 +484,14 @@ def main() -> None:
         )
         monitor_thread.start()
 
-    # 5. Forward signals to child.
+    # 5. Wait for child, clean up, exit.
     #
-    # Group-directed signals reach the child directly (shared process
-    # group), so re-sending immediately would double-deliver. The second
-    # delivery is not benign: when the child's own handler has already
-    # run and its interpreter is finalising, the default disposition is
-    # restored and the late duplicate kills the child outright, so
-    # ``child.wait()`` reports a signal death (``-N``) instead of the
-    # handler's exit code. Poll for the child's exit through a short
-    # grace window first; forward only if it is still running, which
-    # means the signal was sent to the worker alone and never reached
-    # the child.
-    def _forward(signum: int, _frame: object) -> None:
-        deadline = time.monotonic() + _FORWARD_GRACE_S
-        while time.monotonic() < deadline:
-            if child.poll() is not None:
-                return
-            time.sleep(_FORWARD_POLL_INTERVAL_S)
-        with contextlib.suppress(OSError):
-            child.send_signal(signum)
-
-    signal.signal(signal.SIGTERM, _forward)
-    signal.signal(signal.SIGINT, _forward)
-
-    # 5. Wait for child, clean up, exit
+    # Terminating signals are already handled by ``_terminate`` (installed
+    # before the PID file was even written); now that the child is published
+    # the handler forwards to it and returns here so the shared cleanup below
+    # runs exactly once. ``child.wait()`` is interruptible: a SIGTERM that
+    # arrives here raises nothing - the handler forwards to the child, the
+    # child exits, and ``wait`` returns its code.
     try:
         exit_code = child.wait()
     except Exception:

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -577,6 +577,17 @@ _TRANSIENT_MARKERS = (
 )
 _FATAL_MARKERS = ("syntaxerror", "syntax error", "fatal")
 
+# Match markers on token boundaries, not as bare substrings. The numeric
+# HTTP-status markers ("503", "429", ...) are short digit runs that alias
+# by chance inside opaque identifiers embedded in a failure reason - e.g. a
+# terminal reason carrying "correlation=compact-a1503f2b" contains "503"
+# and would otherwise be misclassified as a transient failure and granted a
+# retry budget it must never get. ``\b`` anchors each marker between word
+# and non-word characters, so "HTTP 503" / "429 Too Many Requests" / "rate
+# limit" still match while a hex run like "a1503f2b" does not.
+_TRANSIENT_MARKER_RE = re.compile("|".join(rf"\b{re.escape(m)}\b" for m in _TRANSIENT_MARKERS))
+_FATAL_MARKER_RE = re.compile("|".join(rf"\b{re.escape(m)}\b" for m in _FATAL_MARKERS))
+
 
 _META_TASK_OPEN_STATUSES: frozenset[TaskStatus] = frozenset(
     {
@@ -621,11 +632,17 @@ def _collect_open_meta_task_titles(
 
 
 def _dynamic_retry_limit(reason: str, default_max: int) -> int:
-    """Determine the retry limit based on failure reason keywords."""
+    """Determine the retry limit based on failure reason keywords.
+
+    Markers are matched on token boundaries (see ``_TRANSIENT_MARKER_RE``) so
+    an opaque identifier embedded in the reason - such as a compaction
+    ``correlation=compact-<hex>`` - cannot alias a numeric HTTP-status marker
+    and wrongly promote a terminal failure to a transient (retryable) one.
+    """
     reason_lower = reason.lower()
-    if any(k in reason_lower for k in _TRANSIENT_MARKERS):
+    if _TRANSIENT_MARKER_RE.search(reason_lower):
         return 3
-    if any(k in reason_lower for k in _FATAL_MARKERS):
+    if _FATAL_MARKER_RE.search(reason_lower):
         return 0
     return default_max
 

--- a/tests/unit/tasks/test_lifecycle_helpers.py
+++ b/tests/unit/tasks/test_lifecycle_helpers.py
@@ -200,6 +200,42 @@ def test_dynamic_retry_limit_transient_beats_default_higher() -> None:
     assert _dynamic_retry_limit("connection refused", default_max=9) == 3
 
 
+@pytest.mark.parametrize(
+    "reason",
+    [
+        # A terminal gate-refusal reason (issue #2341): the random compaction
+        # correlation hex happens to embed a numeric status marker. This must
+        # NOT be read as a transient failure and granted a retry budget.
+        "Context overflow: compaction refused by sensitive gate "
+        "(rules: content.pem-unterminated; correlation=compact-a1503f2b)",
+        "correlation=compact-de429abc",  # '429' inside a hex run
+        "correlation=compact-9502dead",  # '502' inside a hex run
+        "correlation=compact-fa504bcd",  # '504' inside a hex run
+    ],
+)
+def test_dynamic_retry_limit_status_digits_inside_opaque_id_are_not_transient(reason: str) -> None:
+    # Regression (#2341): a status-shaped digit run buried in an identifier
+    # aliases a transient marker only under bare-substring matching. With
+    # token-boundary matching it stays terminal, so a refusal keeps its
+    # forced no-retry budget instead of intermittently gaining three retries.
+    assert _dynamic_retry_limit(reason, default_max=0) == 0
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "HTTP 503 Service Unavailable",
+        "received 429 from provider",
+        "gateway returned 502",
+        "upstream 504 gateway timeout",
+    ],
+)
+def test_dynamic_retry_limit_real_http_status_still_transient(reason: str) -> None:
+    # The boundary-matching fix must not regress genuine status markers that
+    # appear as standalone tokens in a real provider error string.
+    assert _dynamic_retry_limit(reason, default_max=0) == 3
+
+
 # ---------------------------------------------------------------------------
 # _batch_timeout_seconds
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -234,6 +234,64 @@ class TestWorkerProcess:
         time.sleep(0.2)
         assert not pid_file.exists(), "PID file was not cleaned up"
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX process-group signals")
+    def test_worker_cleans_pid_file_when_sigterm_races_startup(self, tmp_path: Path) -> None:
+        """Regression (#2341): SIGTERM at startup must never leak the PID file.
+
+        The worker must install its terminating-signal handler *before* the
+        PID file exists, so no instant passes where the file is present
+        without a cleanup path. Before the fix the handler was installed only
+        after the child spawn; a SIGTERM landing in that window took the
+        default disposition (terminate, no ``finally`` unlink) and leaked the
+        PID file - a phantom ``bernstein ps`` entry and the intermittent
+        cleanup-order failure this test guards.
+
+        Each iteration sends a single SIGTERM the instant the PID file first
+        appears (the widest point of the old window, before ``child_pid`` is
+        even written) and asserts the file is always gone. On the buggy
+        ordering this leaks on a large fraction of iterations; the fixed
+        ordering cleans up every time.
+        """
+        for i in range(24):
+            pid_dir = tmp_path / f"pids-{i}"
+            proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "bernstein.core.orchestration.worker",
+                    "--role",
+                    "test",
+                    "--session",
+                    f"race-{i}",
+                    "--pid-dir",
+                    str(pid_dir),
+                    "--",
+                    "sleep",
+                    "10",
+                ],
+                start_new_session=True,
+            )
+            pid_file = pid_dir / f"race-{i}.json"
+            # Wait only until the PID file first appears - the earliest and
+            # widest point of the startup race window.
+            deadline = time.monotonic() + 5
+            while not pid_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.0005)
+            assert pid_file.exists(), f"iter {i}: PID file never appeared"
+
+            # One group-directed SIGTERM at that instant, exactly as a reaper
+            # would, then assert the worker cleaned up after itself.
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                raise
+            time.sleep(0.2)
+            assert not pid_file.exists(), (
+                f"iter {i}: PID file leaked after SIGTERM at startup (worker exit={proc.returncode})"
+            )
+
     def test_worker_forwards_signals(self, tmp_path: Path) -> None:
         """Worker should forward SIGTERM to child and exit."""
         pid_dir = tmp_path / "pids"


### PR DESCRIPTION
Root-causes the two order-dependent shard failures from #2341:

- `test_worker.py::test_worker_writes_and_cleans_pid_file`: the worker installed its terminating-signal handler after writing the PID file, so a signal arriving in that window left the PID file behind and a later test in the same shard observed the stale file. The handler is now installed before the PID file exists, so cleanup is guaranteed across the whole lifetime.
- `test_reactive_compact_413.py::test_refusal_reason_grants_no_dynamic_retry_budget`: retry-budget marker matching was substring-based, so a marker set by one test could be read by another via shared lifecycle state. Matching is now anchored on token boundaries, removing the cross-test leak.

Both offender files plus the touched lifecycle helpers pass (115 tests); worker and lifecycle modules ruff-clean.

Closes #2341