### PR TITLE
style(refurb): resolve open refurb idiom warnings

### DIFF
--- a/src/bernstein/cli/commands/interop_cmd.py
+++ b/src/bernstein/cli/commands/interop_cmd.py
@@ -250,7 +250,7 @@ def verify(
     "--workdir",
     "-w",
     type=click.Path(file_okay=False, path_type=Path),
-    default=Path("."),
+    default=Path(),
     show_default=True,
     help="Project root containing .sdd/.",
 )

--- a/src/bernstein/core/interop/a2a_lineage.py
+++ b/src/bernstein/core/interop/a2a_lineage.py
@@ -656,7 +656,7 @@ def record_a2a_message(
     journal_events = (message_hash,)
 
     private_pem, public_pem = _load_or_create_message_identity(identity_dir)
-    unsigned = A2AMessageReceipt(
+    payload = A2AMessageReceipt(
         task_uuid=task_uuid,
         direction=direction,
         state=state,
@@ -669,8 +669,7 @@ def record_a2a_message(
         journal_root=journal_root,
         journal_events=journal_events,
         timestamp=timestamp,
-    )
-    payload = unsigned.to_canonical_bytes()
+    ).to_canonical_bytes()
     signature = sign_payload(payload, private_pem)
 
     spine = LineageSpine(lineage_root, run_id=A2A_MESSAGE_RECEIPT_RUN_ID, hmac_key=hmac_key)
@@ -972,8 +971,7 @@ def isolate_inbound_task(*, repo_root: Path, task_uuid: str) -> InboundTaskIsola
     from bernstein.core.git.worktree_isolation import validate_worktree_isolation
 
     session_id = inbound_task_session_id(task_uuid)
-    manager = WorktreeManager(repo_root=repo_root)
-    worktree_path = manager.create(session_id)
+    worktree_path = WorktreeManager(repo_root=repo_root).create(session_id)
     result = validate_worktree_isolation(worktree_path, repo_root)
     return InboundTaskIsolation(
         task_uuid=task_uuid,

--- a/src/bernstein/core/orchestration/activity.py
+++ b/src/bernstein/core/orchestration/activity.py
@@ -256,7 +256,7 @@ class ActivityResult:
             evidence_set_hash=evidence_set_hash(observations),
             terminal_state=terminal_state,
             reason_code=reason_code,
-            observations=tuple(observations),
+            observations=observations,
         )
 
 

--- a/src/bernstein/core/orchestration/activity_modalities.py
+++ b/src/bernstein/core/orchestration/activity_modalities.py
@@ -368,9 +368,7 @@ def verify_run_activities(
             reason="run journal holds no activity.result entries",
         )
 
-    verdicts: list[StageVerdict] = []
-    for row in rows:
-        verdicts.append(_verify_stage(row, store=store, chain_ok=chain.ok))
+    verdicts: list[StageVerdict] = [_verify_stage(row, store=store, chain_ok=chain.ok) for row in rows]
 
     ok = chain.ok and all(v.ok for v in verdicts)
     return ActivityVerifyResult(

--- a/src/bernstein/core/orchestration/recurrence.py
+++ b/src/bernstein/core/orchestration/recurrence.py
@@ -210,7 +210,7 @@ def canonicalise_recurrence(recurrence: str) -> str:
         return ""
 
     upper = text.upper()
-    if upper.startswith("RRULE:") or (upper.startswith("FREQ=")):
+    if upper.startswith(("RRULE:", "FREQ=")):
         return _canonicalise_rrule(text)
 
     expr = text[len("cron:") :].strip() if text.lower().startswith("cron:") else text

--- a/src/bernstein/core/orchestration/schedule_fire_record.py
+++ b/src/bernstein/core/orchestration/schedule_fire_record.py
@@ -339,21 +339,19 @@ def verify_all_fires(sdd_dir: Path) -> list[FireVerification]:
     inputs. The list is ordered by ``(fire_time, schedule_id)`` so two
     operators walk their fires in the same order.
     """
-    out: list[FireVerification] = []
-    for row in load_fire_records(sdd_dir):
-        out.append(
-            verify_fire(
-                schedule_id=str(row.get("schedule_id", "")),
-                fire_time=int(row.get("fire_time", 0)),
-                recorded_graph_hash=str(row.get("graph_hash", "")),
-                last_state=None,
-                goal=str(row.get("goal", "")),
-                scenario_id=str(row.get("scenario_id", "")),
-                recurrence=str(row.get("recurrence", "")),
-                trigger_input_hash=str(row.get("trigger_input_hash", "")),
-            )
+    return [
+        verify_fire(
+            schedule_id=str(row.get("schedule_id", "")),
+            fire_time=int(row.get("fire_time", 0)),
+            recorded_graph_hash=str(row.get("graph_hash", "")),
+            last_state=None,
+            goal=str(row.get("goal", "")),
+            scenario_id=str(row.get("scenario_id", "")),
+            recurrence=str(row.get("recurrence", "")),
+            trigger_input_hash=str(row.get("trigger_input_hash", "")),
         )
-    return out
+        for row in load_fire_records(sdd_dir)
+    ]
 
 
 __all__ = [

--- a/src/bernstein/core/security/governance.py
+++ b/src/bernstein/core/security/governance.py
@@ -198,7 +198,7 @@ def resolve_role(idp_groups: tuple[str, ...], bindings: RoleBindings) -> str:
             return role
     # A mapped-but-unranked role (operator-defined) still counts; pick the
     # lexicographically-first for determinism.
-    return sorted(roles)[0] if roles else ""
+    return min(roles) if roles else ""
 
 
 def _role_grants(role: str, action: str, bindings: RoleBindings) -> bool:
@@ -349,8 +349,7 @@ def _anchor_decision(
     filename = _record_filename(decision, seq)
     artifact_path = "/".join((*_DECISION_SUBPATH, filename))
 
-    spine = LineageSpine(lineage_root, run_id=decision.run_id, hmac_key=hmac_key)
-    anchor = spine.record(
+    anchor = LineageSpine(lineage_root, run_id=decision.run_id, hmac_key=hmac_key).record(
         artifact_path=artifact_path,
         content=decision.to_canonical_bytes(),
         actor=GOVERNANCE_ACTOR,

--- a/src/bernstein/core/trigger_sources/webhook_node.py
+++ b/src/bernstein/core/trigger_sources/webhook_node.py
@@ -451,7 +451,7 @@ def receive_inbound_webhook(
     journal_events = (event_hash,)
 
     private_pem, public_pem = load_or_create_node_identity(identity_dir)
-    unsigned = InboundReceipt(
+    payload = InboundReceipt(
         event_id=event_id,
         source=source,
         event_hash=event_hash,
@@ -459,8 +459,7 @@ def receive_inbound_webhook(
         journal_root=journal_root,
         journal_events=journal_events,
         timestamp=timestamp,
-    )
-    payload = unsigned.to_canonical_bytes()
+    ).to_canonical_bytes()
     signature = sign_payload(payload, private_pem)
 
     spine = LineageSpine(lineage_root, run_id=WEBHOOK_NODE_RUN_ID, hmac_key=hmac_key)


### PR DESCRIPTION
Resolves all 10 open refurb idiom code-scanning alerts. Each change is a style-only rewrite applying the refurb-suggested idiom; behaviour is preserved.

## Alerts fixed

| Alert | Location | Change |
|---|---|---|
| FURB138 | `core/orchestration/activity_modalities.py:371` | list comprehension over append-loop for stage verdicts |
| FURB123 | `core/orchestration/activity.py:259` | drop redundant `tuple()` over a tuple-typed argument |
| FURB184 | `core/interop/a2a_lineage.py:673` | chain receipt build into `.to_canonical_bytes()` |
| FURB184 | `core/interop/a2a_lineage.py:976` | chain `WorktreeManager(...).create(...)` |
| FURB153 | `cli/commands/interop_cmd.py:253` | `Path()` instead of `Path(".")` |
| FURB138 | `core/orchestration/schedule_fire_record.py:342` | list comprehension over append-loop for verifications |
| FURB102 | `core/orchestration/recurrence.py:213` | `startswith((...))` tuple over or-chained prefixes |
| FURB184 | `core/security/governance.py:353` | chain `LineageSpine(...).record(...)` |
| FURB192 | `core/security/governance.py:201` | `min(roles)` instead of `sorted(roles)[0]` |
| FURB184 | `core/trigger_sources/webhook_node.py:463` | chain inbound receipt build |

## Verification

- `uv run refurb src/` — 0 of these alerts remain
- `uv run ruff check src/ tests/` — passed
- `ruff format --check` on touched files — passed
- `uv run lint-imports` — 3 kept, 0 broken
- `uv run python -c "import bernstein"` — OK
- touched-module tests: 141 passed; `tests/unit/interop/` 68 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default working directory used by the thread verification command when no path is provided.

- **Refactor**
  - Streamlined several internal processing and verification steps for simpler, more consistent behavior.
  - No other user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->