### PR TITLE
release: v3.1.0

### DIFF
--- a/docs/release-notes/v3.1.0.md
+++ b/docs/release-notes/v3.1.0.md
@@ -1,0 +1,50 @@
+# v3.1.0
+
+Released 2026-07-07.
+
+A verifiability feature release. Task completion now produces a sealed,
+content-addressed proof of what passed, not just a status line, and that proof
+verifies with the same audit chain that seals everything else.
+
+## Verification evidence bundles (#2362)
+
+"Done" used to be a status plus scattered logs that died with the worktree. Now
+every completed task that declares evidence producers emits a verification
+evidence bundle:
+
+- Evidence producers (test command, coverage, lint, an optional screenshot or
+  recording command for web-facing work) are declared in the task spec and run
+  at gate time. Required producers gate completion; advisory producers attach a
+  failure record without blocking.
+- Bundle outputs are content-addressed, stored under a size-capped store with
+  garbage collection, referenced from the task lineage record, and sealed by a
+  new audit-chain event. Media evidence flows through the existing content
+  credentials support.
+- Sealing runs at task completion and is fail-open: a task that declares no
+  producers is untouched, and any error while sealing is logged and swallowed so
+  it can never block or fail a completion.
+- `bernstein evidence show <task>` renders a bundle. `bernstein audit verify`
+  now covers bundle integrity, so a tampered evidence file is detected exactly
+  like a tampered chain entry, naming the file that broke.
+- Deterministic producers replay to byte-identical bundle hashes, signatures,
+  and journal anchors.
+- Generated pull-request bodies link the sealed bundle: the `bernstein pr` path,
+  the orchestrator auto-PR path, and the issue-to-PR path each emit an evidence
+  summary when a bundle is present and are unchanged when it is absent.
+
+## Reliability
+
+- Eliminated the order-dependent shard flakiness in the unit suite: the worker
+  installs its terminating-signal handler before the PID file exists (so a
+  signal in that window cannot leave a stale file for a later test), and
+  retry-budget marker matching is anchored on token boundaries to remove a
+  cross-test leak. (#2341)
+
+## Housekeeping
+
+- Resolved the open refurb idiom warnings across the recently shipped
+  interop, orchestration, and security modules; behavior unchanged.
+- Removed the expired one-shot Scorecard 90-day self-resolve workflow now that
+  the repository has passed the threshold and its tracking checkpoint is closed.
+- Routine toolchain and action updates (uv, setup-uv, harden-runner, and
+  frontend dependency digests).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.0.0"
+version = "3.1.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Feature release. Headline: verification evidence bundles (#2362) - every completed task that declares evidence producers emits a content-addressed proof of done, sealed by the audit chain and auto-sealed at completion (fail-open), shown via `bernstein evidence show`, integrity-checked by `bernstein audit verify` (a tampered evidence file is caught like a tampered chain entry), and linked from generated pull-request bodies. Also includes the order-dependent shard flakiness fix and routine housekeeping (refurb idioms, expired workflow removal, toolchain updates).

Release notes: docs/release-notes/v3.1.0.md.

## Summary by Sourcery

Release version 3.1.0 with verification evidence bundles for task completion, reliability fixes, and routine maintenance updates.

New Features:
- Add verification evidence bundles for completed tasks, including content-addressed storage, audit-chain sealing, and deterministic replay.
- Expose evidence bundles via the `bernstein evidence show` command and integrate their integrity checks into `bernstein audit verify`.
- Link sealed evidence bundles from generated pull request bodies when available without changing behavior when absent.

Bug Fixes:
- Fix order-dependent shard flakiness in the unit test suite by hardening worker shutdown and retry-budget marker handling.

Enhancements:
- Clean up refurb idiom warnings across interop, orchestration, and security modules without changing behavior.

Build:
- Update toolchain dependencies such as uv, setup-uv, harden-runner, and frontend dependency digests.

CI:
- Remove an expired one-shot Scorecard 90-day self-resolve workflow whose tracking checkpoint is complete.

Documentation:
- Add release notes for v3.1.0 describing verification evidence bundles, reliability improvements, and housekeeping changes.