### PR TITLE
fix(evidence): clear scanner findings in the evidence bundle module

### DIFF
--- a/src/bernstein/core/evidence/bundle.py
+++ b/src/bernstein/core/evidence/bundle.py
@@ -61,6 +61,7 @@ from bernstein.core.lineage.spine import (
     compute_entry_hash,
     content_hash_of,
 )
+from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -281,7 +282,7 @@ def run_producers(
     outcomes: list[ProducerOutcome] = []
     for producer in producers:
         exit_code, output = runner(producer)
-        outcomes.append(ProducerOutcome(producer=producer, exit_code=int(exit_code), output=bytes(output)))
+        outcomes.append(ProducerOutcome(producer=producer, exit_code=exit_code, output=output))
     return tuple(outcomes)
 
 
@@ -319,7 +320,7 @@ class EvidenceStore:
     def __init__(self, root: Path, *, max_blob_bytes: int = DEFAULT_MAX_BLOB_BYTES) -> None:
         # ``root`` is the ``.sdd/evidence`` directory.
         self._root = Path(root)
-        self._max_blob_bytes = max(1, int(max_blob_bytes))
+        self._max_blob_bytes = max(1, max_blob_bytes)
 
     @property
     def blobs_dir(self) -> Path:
@@ -623,7 +624,7 @@ def _seal_media_credential(
         signed = sign_manifest(manifest, signing_key=priv)
         credential = store.put(_canonical_bytes(manifest_to_dict(signed)))
     except (ValueError, TypeError, KeyError, OSError) as exc:  # pragma: no cover - defensive
-        logger.debug("evidence: media credential projection skipped: %s", exc)
+        logger.debug("evidence: media credential projection skipped: %s", sanitize_log(str(exc)))
         return ""
     else:
         return credential.content_hash


### PR DESCRIPTION
Triages the four code-scanning alerts introduced with the evidence-bundle feature (#2362):

- `bundle.py:626` semgrep logger-credential-disclosure: the media-credential-projection debug log now routes the caught exception through `sanitize_log` so it cannot echo credential-shaped content. The exception type is already narrow (ValueError/TypeError/KeyError/OSError from key load/sign/store), so this is defense in depth on a key-handling path.
- `bundle.py:284` (x2) and `bundle.py:322` refurb FURB123: dropped redundant `int()`/`bytes()` casts that the `runner -> tuple[int, bytes]` and `max_blob_bytes: int` type contracts already guarantee.

Behaviour unchanged; refurb reports zero findings on the module and the evidence suite passes (29).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log safety by masking sensitive details in error messages when media credential projection is skipped.
  * Preserved runner results more directly during producer execution, reducing unexpected changes to exit codes or output data.
  * Made blob size limits handle non-integer values more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->