### PR TITLE
fix(evidence): log only the exception type in the media credential path

### DIFF
--- a/src/bernstein/core/evidence/bundle.py
+++ b/src/bernstein/core/evidence/bundle.py
@@ -61,7 +61,6 @@ from bernstein.core.lineage.spine import (
     compute_entry_hash,
     content_hash_of,
 )
-from bernstein.core.security.sanitize import sanitize_log
 from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
@@ -624,7 +623,9 @@ def _seal_media_credential(
         signed = sign_manifest(manifest, signing_key=priv)
         credential = store.put(_canonical_bytes(manifest_to_dict(signed)))
     except (ValueError, TypeError, KeyError, OSError) as exc:  # pragma: no cover - defensive
-        logger.debug("evidence: media credential projection skipped: %s", sanitize_log(str(exc)))
+        # Log only the exception type: this path handles a private key, so
+        # even sanitized exception text stays out of the log stream.
+        logger.debug("evidence: media credential projection skipped: %s", type(exc).__name__)
         return ""
     else:
         return credential.content_hash


### PR DESCRIPTION
Resolves the remaining code-scanning alert on the media-credential projection: the debug log on the key-handling except path now records only the exception class name, never exception text. Diagnostic value is unchanged (the type identifies the failure mode); evidence suite green.

## Summary by Sourcery

Bug Fixes:
- Limit media credential projection debug logging to record only the exception type instead of full exception text to prevent sensitive key-related information from entering logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy and security of diagnostic logging by recording credential projection failure types without exposing exception details.
  * Credential sealing behavior remains unchanged when projection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->