### PR TITLE
chore: apply refurb idioms in task mailbox and claim receipt

### DIFF
--- a/src/bernstein/core/communication/task_mailbox.py
+++ b/src/bernstein/core/communication/task_mailbox.py
@@ -289,7 +289,7 @@ class TaskMailbox:
 
     def all_messages(self) -> list[MailboxMessage]:
         """Return every journal entry in chain append order."""
-        return list(self._messages)
+        return self._messages.copy()
 
     def pending(self, task_id: str, since_seq: int = -1) -> list[MailboxMessage]:
         """Return messages addressed to ``task_id`` in chain append order.
@@ -367,20 +367,24 @@ class TaskMailbox:
 
             private_pem, public_pem = _load_or_create_identity(self._identity_dir)
             signed = MailboxMessage(
-                **{
-                    **unsigned.binding(),
-                    "entry_hash": entry_hash,
-                    "signer_public_key_pem": public_pem,
-                },
+                **(
+                    unsigned.binding()
+                    | {
+                        "entry_hash": entry_hash,
+                        "signer_public_key_pem": public_pem,
+                    }
+                ),
             )
             signature = sign_payload(signed.signed_bytes(), private_pem)
             message = MailboxMessage(
-                **{
-                    **unsigned.binding(),
-                    "entry_hash": entry_hash,
-                    "signer_public_key_pem": public_pem,
-                    "signature": signature,
-                },
+                **(
+                    unsigned.binding()
+                    | {
+                        "entry_hash": entry_hash,
+                        "signer_public_key_pem": public_pem,
+                        "signature": signature,
+                    }
+                ),
             )
             self._append(message)
             self._messages.append(message)
@@ -412,7 +416,7 @@ class TaskMailbox:
             raise ValueError("hmac_key required to verify the mailbox chain")
         from bernstein.core.skills.catalog.signature import verify_payload
 
-        problems = list(self._load_problems)
+        problems = self._load_problems.copy()
         prev = MAILBOX_GENESIS
         for index, message in enumerate(self._messages):
             label = f"entry {index}"

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -2128,7 +2128,7 @@ def record_task_claim_receipt(
             "task_id": task_id,
             "role": role,
             "claimed_by": claimed_by,
-            "depends_on": list(depends_on),
+            "depends_on": depends_on.copy(),
             "task_version": task_version,
             "claim_path": claim_path,
         },


### PR DESCRIPTION
Closes the 5 refurb alerts raised by the latest main analysis against the mailbox and claim-receipt code.

- FURB173: build signed mailbox messages with dict union merges instead of nested unpacking (two sites)
- FURB123: replace list() copies of lists with .copy() (three sites)

Verification: refurb clean on both files, ruff clean on src/, mailbox and claim-receipt test selections pass (35 tests).

## Summary by Sourcery

Modernize mailbox and audit-chain data handling to align with current Python idioms and static analysis recommendations.

Enhancements:
- Replace list() copying of internal lists with .copy() to clarify intent and avoid unnecessary casting.
- Simplify MailboxMessage construction using dictionary union merges for signed message payloads in the task mailbox.