### PR TITLE
Dashboard authentication and role-based access

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ bernstein gui serve --minimal     # skip the full /api/v1/* surface
 
 The Vite bundle is committed under `src/bernstein/gui/static/`, so wheel installs work without a Node toolchain. Surface tour + per-task drawer: [docs/web-ui.md](docs/web-ui.md).
 
+The dashboard requires a credential: on a loopback bind an operator token is issued and printed at startup; a non-loopback bind refuses to start until one is configured. Issue read-only (`viewer`) or read-write (`operator`) tokens with `bernstein auth dashboard-token issue --principal <name> --scope viewer`; every grant and write authorization is a signed governance record (`bernstein governance verify dashboard-auth`).
+
 ## how it works
 
 Bernstein runs a four-stage pipeline per goal:

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -699,6 +699,7 @@ error. `BERNSTEIN_AGENT_CARD_KEY_DIR` overrides the key directory location.
 | `login` | Same as `bernstein login`. |
 | `logout` | Revoke the current session and clear the cached token. |
 | `status` | Show current authentication status. |
+| `dashboard-token` | Scoped dashboard credentials (group): `issue` / `list` / `revoke`. See [Dashboard authentication](#dashboard-authentication-bernstein-auth-dashboard-token). |
 
 #### `bernstein creds`
 
@@ -1320,3 +1321,44 @@ healthy. Each drill row carries the deterministic routing-decision hash its
 simulated outage prefix would produce; drill outcomes are mirrored into the
 audit chain when a `.sdd` workspace is present. See
 [Provider availability & failover](../operations/provider-availability.md).
+
+## Dashboard authentication: `bernstein auth dashboard-token`
+
+The dashboard (`bernstein gui serve`, `/dashboard` on the task server)
+accepts two credential kinds: a password (`BERNSTEIN_DASHBOARD_PASSWORD` or
+the `dashboard_auth` block in `bernstein.yaml`) and scoped tokens issued
+here. Tokens carry a principal and a scope: `viewer` reads every surface and
+can change nothing; `operator` can also trigger state-changing actions.
+
+Grants live in an append-only journal of HMAC-signed rows
+(`.sdd/auth/dashboard_tokens.jsonl`) that stores only the token's SHA-256
+digest - the raw token is printed once at issue time. Editing a row (for
+example widening `viewer` to `operator`) breaks its signature and the token
+stops validating. Every issue and revoke is mirrored onto the audit chain
+(`dashboard.token_grant`), and every login and write authorization is a
+signed governance decision in the `dashboard-auth` lineage run - recompute
+them offline with `bernstein governance verify dashboard-auth`.
+
+| Subcommand | Purpose |
+|---|---|
+| `issue --principal NAME [--scope viewer\|operator]` | Issue a token (printed once, digest journaled). |
+| `list` | Show journal rows: id, kind, principal, scope. Never prints tokens. |
+| `revoke TOKEN_ID` | Append a signed revocation; the token stops validating immediately. |
+
+All subcommands accept `--workdir` (default `.`) pointing at the project
+root containing `.sdd/`.
+
+```bash
+bernstein auth dashboard-token issue --principal alice --scope viewer
+bernstein auth dashboard-token list
+bernstein auth dashboard-token revoke 3f1a9c2d5e7b0a41
+bernstein governance verify dashboard-auth
+```
+
+Startup posture: `bernstein gui serve` on a loopback host without any
+credential configured issues an operator token and prints it once; on a
+non-loopback host it refuses to start until a token or password is
+configured. There is no silent open mode on a routable interface. Use the
+token as `Authorization: Bearer <token>` or in the dashboard login form
+(`POST /dashboard/auth/login`); the session cookie inherits exactly the
+token's principal and scope.

--- a/src/bernstein/cli/commands/dashboard_token_cmd.py
+++ b/src/bernstein/cli/commands/dashboard_token_cmd.py
@@ -1,0 +1,136 @@
+"""``bernstein auth dashboard-token``: scoped dashboard credential grants.
+
+Issue #2366. The dashboard accepts two credential scopes: ``viewer`` (read
+every surface, change nothing) and ``operator`` (read and trigger
+state-changing actions). Tokens are issued here, printed exactly once, and
+recorded in an append-only journal of HMAC-signed rows -- only the token's
+SHA-256 digest is stored, so the journal never holds a usable credential.
+Each grant and revocation is also mirrored onto the audit chain, and every
+write the token later authorizes lands in the ``dashboard-auth`` governance
+run (``bernstein governance verify dashboard-auth``).
+
+    bernstein auth dashboard-token issue --principal alice --scope viewer
+    bernstein auth dashboard-token list
+    bernstein auth dashboard-token revoke <token-id>
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.server.dashboard_tokens import DashboardTokenRegistry
+
+
+def _registry_for(workdir: str) -> tuple[DashboardTokenRegistry, AuditChainStore]:
+    """Build the (registry, chain) pair rooted at *workdir*'s .sdd."""
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.server.dashboard_tokens import (
+        DashboardTokenRegistry,
+        resolve_dashboard_hmac_key,
+    )
+
+    sdd_dir = Path(workdir).resolve() / ".sdd"
+    key = resolve_dashboard_hmac_key(sdd_dir)
+    registry = DashboardTokenRegistry(sdd_dir / "auth" / "dashboard_tokens.jsonl", hmac_key=key)
+    chain = AuditChainStore(sdd_dir / "audit", key=key)
+    return registry, chain
+
+
+_WORKDIR_OPTION = click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+
+
+@click.group("dashboard-token")
+def dashboard_token_group() -> None:
+    """Issue, list, and revoke scoped dashboard tokens.
+
+    \b
+      bernstein auth dashboard-token issue --principal alice --scope viewer
+      bernstein auth dashboard-token list
+      bernstein auth dashboard-token revoke <token-id>
+    """
+
+
+@dashboard_token_group.command("issue")
+@click.option("--principal", required=True, help="The person / seat the token attributes actions to.")
+@click.option(
+    "--scope",
+    type=click.Choice(["viewer", "operator"]),
+    default="viewer",
+    show_default=True,
+    help="viewer = read-only; operator = may trigger state-changing actions.",
+)
+@_WORKDIR_OPTION
+def issue_cmd(principal: str, scope: str, workdir: str) -> None:
+    """Issue a scoped dashboard token (printed once, never stored)."""
+    from bernstein.core.security.audit_chain import record_dashboard_token_grant
+
+    registry, chain = _registry_for(workdir)
+    raw, record = registry.issue(principal=principal, scope=scope, now=int(time.time()))
+    record_dashboard_token_grant(
+        chain=chain,
+        grant="issue",
+        token_id=record.token_id,
+        token_sha256=record.token_sha256,
+        principal=record.principal,
+        scope=record.scope,
+    )
+    console.print(f"Issued dashboard token for [bold]{principal}[/bold] (scope: {scope})")
+    console.print(f"  Token: {raw}")
+    console.print(f"  Id:    {record.token_id}")
+    console.print(
+        "The token is shown once and only its digest is journaled. "
+        "Pass it as `Authorization: Bearer <token>` or in the dashboard login form."
+    )
+
+
+@dashboard_token_group.command("list")
+@_WORKDIR_OPTION
+def list_cmd(workdir: str) -> None:
+    """List journal rows (grants and revocations); never prints tokens."""
+    registry, _chain = _registry_for(workdir)
+    records = registry.records()
+    if not records:
+        console.print("No dashboard tokens issued.")
+        return
+    console.print(f"{'ID':<18} {'KIND':<8} {'PRINCIPAL':<24} {'SCOPE':<10} ISSUED_AT")
+    for r in records:
+        console.print(f"{r.token_id:<18} {r.kind:<8} {r.principal:<24} {r.scope or '-':<10} {r.issued_at}")
+
+
+@dashboard_token_group.command("revoke")
+@click.argument("token_id", required=True)
+@_WORKDIR_OPTION
+def revoke_cmd(token_id: str, workdir: str) -> None:
+    """Revoke a token by its id (see `list`); appends a signed revocation."""
+    from bernstein.core.security.audit_chain import record_dashboard_token_grant
+
+    registry, chain = _registry_for(workdir)
+    live = {r.token_id: r for r in registry.records() if r.kind == "issue"}
+    if not registry.revoke(token_id, now=int(time.time())):
+        console.print(f"[yellow]No live token with id {token_id}[/yellow]")
+        raise SystemExit(1)
+    target = live[token_id]
+    record_dashboard_token_grant(
+        chain=chain,
+        grant="revoke",
+        token_id=target.token_id,
+        token_sha256=target.token_sha256,
+        principal=target.principal,
+        scope="",
+    )
+    console.print(f"Revoked dashboard token {token_id} (principal: {target.principal})")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -982,6 +982,10 @@ from bernstein.cli.commands.team_cmd import team_group as _team_group  # noqa: E
 
 cli.add_command(_team_group, "team")
 cli.add_command(test_cmd, "test")
+# Scoped dashboard tokens (issue #2366): issue/list/revoke under `auth`.
+from bernstein.cli.commands.dashboard_token_cmd import dashboard_token_group as _dashboard_token_group  # noqa: E402
+
+auth_group.add_command(_dashboard_token_group, "dashboard-token")
 cli.add_command(auth_group, "auth")
 cli.add_command(auth_login, "login")
 cli.add_command(evolve)

--- a/src/bernstein/core/routes/dashboard.py
+++ b/src/bernstein/core/routes/dashboard.py
@@ -1,4 +1,4 @@
-"""Dashboard-specific routes - file lock inspection endpoint."""
+"""Dashboard-specific routes - file locks and the auth endpoints (#2366)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,15 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from bernstein.core.server.dashboard_auth import (
+    ANONYMOUS_PRINCIPAL,
+    PASSWORD_PRINCIPAL,
+    SESSION_COOKIE,
+    DashboardAuthState,
+    verify_password,
+)
+from bernstein.core.server.dashboard_tokens import ACTION_LOGIN, SCOPE_OPERATOR
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -18,6 +27,109 @@ router = APIRouter()
 
 def _runtime_dir(request: Request) -> Path:
     return request.app.state.runtime_dir  # type: ignore[no-any-return]
+
+
+def _auth_state(request: Request) -> DashboardAuthState:
+    """Fetch the shared dashboard auth state (created in ``create_app``)."""
+    state = getattr(request.app.state, "dashboard_auth_state", None)
+    if isinstance(state, DashboardAuthState):
+        return state
+    # Minimal embeddings without create_app wiring: an empty state means
+    # auth is not configured and the endpoints degrade gracefully.
+    return DashboardAuthState()
+
+
+async def _request_json(request: Request) -> dict[str, Any]:
+    """Parse the request body as a JSON object, tolerating garbage."""
+    try:
+        parsed: object = await request.json()
+    except ValueError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+@router.get("/dashboard/auth/status")
+async def dashboard_auth_status(request: Request) -> JSONResponse:
+    """Report whether dashboard auth is required and who is logged in."""
+    state = _auth_state(request)
+    required = state.auth_required()
+    credential = state.resolve_credential(request) if required else None
+    return JSONResponse(
+        {
+            "auth_required": required,
+            "authenticated": (credential is not None) or not required,
+            "principal": credential[0] if credential else None,
+            "scope": credential[1] if credential else None,
+        }
+    )
+
+
+@router.post("/dashboard/auth/login")
+async def dashboard_auth_login(request: Request) -> JSONResponse:
+    """Open a dashboard session from a password or a scoped token.
+
+    The session cookie wraps exactly the principal and scope the credential
+    carried; a viewer token can never log into an operator session. Every
+    attempt -- success or failure -- is journaled as a signed governance
+    decision (``dashboard.login``).
+    """
+    state = _auth_state(request)
+    if not state.auth_required():
+        return JSONResponse({"authenticated": True, "token": None, "principal": None, "scope": None})
+
+    body = await _request_json(request)
+    principal = ""
+    scope = ""
+
+    raw_token = body.get("token")
+    if isinstance(raw_token, str) and raw_token and state.token_registry is not None:
+        record = state.token_registry.validate(raw_token)
+        if record is not None:
+            principal, scope = record.principal, record.scope
+
+    provided_password = body.get("password")
+    if (
+        not scope
+        and isinstance(provided_password, str)
+        and provided_password
+        and verify_password(provided_password, state.effective_password())
+    ):
+        principal, scope = PASSWORD_PRINCIPAL, SCOPE_OPERATOR
+
+    verdict = state.record_decision(
+        subject=principal or ANONYMOUS_PRINCIPAL,
+        scope=scope,
+        action=ACTION_LOGIN,
+    )
+    if verdict != "allow":
+        return JSONResponse(status_code=401, content={"detail": "Invalid dashboard credentials"})
+
+    session_token = state.session_store.create_session(principal=principal, scope=scope)
+    response = JSONResponse(
+        {
+            "authenticated": True,
+            "token": session_token,
+            "principal": principal,
+            "scope": scope,
+        }
+    )
+    response.set_cookie(SESSION_COOKIE, session_token, httponly=True, samesite="lax")
+    return response
+
+
+@router.post("/dashboard/auth/logout")
+async def dashboard_auth_logout(request: Request) -> JSONResponse:
+    """Close the current dashboard session (idempotent)."""
+    state = _auth_state(request)
+    cookie_token = request.cookies.get(SESSION_COOKIE, "")
+    if cookie_token:
+        state.session_store.revoke_session(cookie_token)
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        state.session_store.revoke_session(auth_header[7:])
+    response = JSONResponse({"message": "Logged out"})
+    response.delete_cookie(SESSION_COOKIE)
+    return response
 
 
 @router.get("/dashboard/file_locks")

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -343,6 +343,15 @@ EVENT_TASK_MAILBOX_MESSAGE = "task.mailbox_message"
 #: scheduler decision.
 EVENT_TASK_CLAIM_RECEIPT = "task.claim_receipt"
 
+#: Issue #2366 -- emitted whenever a scoped dashboard token is issued or
+#: revoked. The event mirrors the signed registry row: the short token id,
+#: the token digest, the principal, the scope, and the grant kind -- never
+#: the raw token (the registry itself only ever stores the digest). Together
+#: with the ``governance.decision`` events the dashboard authz layer
+#: records, the chain carries the full life of a dashboard credential:
+#: grant, every write it authorized, and revocation.
+EVENT_DASHBOARD_TOKEN_GRANT = "dashboard.token_grant"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -2135,6 +2144,52 @@ def record_task_claim_receipt(
     )
 
 
+def record_dashboard_token_grant(
+    *,
+    chain: AuditChainStore,
+    grant: str,
+    token_id: str,
+    token_sha256: str,
+    principal: str,
+    scope: str,
+    actor: str = "dashboard",
+) -> AuditEvent:
+    """Append a ``dashboard.token_grant`` event into *chain* (#2366).
+
+    Mirrors one signed row of the dashboard token registry so credential
+    grants and revocations are chain-attested alongside the authz decisions
+    they later authorize. Only the digest and metadata are recorded -- the
+    raw token exists solely in the issuing terminal.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        grant: ``issue`` or ``revoke``.
+        token_id: Short hex id of the token (digest prefix).
+        token_sha256: Hex SHA-256 of the raw token.
+        principal: The seat / person the token attributes actions to.
+        scope: The granted scope (``viewer`` / ``operator``; empty on
+            revocations).
+        actor: Recorded actor; defaults to ``"dashboard"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
+        in its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_DASHBOARD_TOKEN_GRANT,
+        actor=actor,
+        resource_type="dashboard_token",
+        resource_id=token_id,
+        details={
+            "grant": grant,
+            "token_id": token_id,
+            "token_sha256": token_sha256,
+            "principal": principal,
+            "scope": scope,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -2143,6 +2198,7 @@ __all__ = [
     "EVENT_COMPACTION_RECEIPT",
     "EVENT_COMPACTION_SENSITIVE_GATE",
     "EVENT_COST_PROFILE_REPORT",
+    "EVENT_DASHBOARD_TOKEN_GRANT",
     "EVENT_ENDPOINT_CERTIFICATION",
     "EVENT_ESCALATION_RECEIPT",
     "EVENT_EVAL_AB_COMPARISON",
@@ -2182,6 +2238,7 @@ __all__ = [
     "record_activity_result",
     "record_checkpoint_retry",
     "record_cost_profile_report",
+    "record_dashboard_token_grant",
     "record_endpoint_certification",
     "record_escalation_receipt",
     "record_eval_ab_comparison",

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -108,6 +108,17 @@ AUTH_PUBLIC_PATHS = frozenset(
         "/auth/cli/device",
         "/auth/cli/token",
         "/auth/providers",
+        # Dashboard auth flow (#2366). Login requires a credential in the
+        # body, status only reports whether auth is required, and logout is
+        # an idempotent session drop - none of them expose run data. The
+        # /api/v1 mirrors are listed too because this set matches exact
+        # paths.
+        "/dashboard/auth/login",
+        "/dashboard/auth/logout",
+        "/dashboard/auth/status",
+        "/api/v1/dashboard/auth/login",
+        "/api/v1/dashboard/auth/logout",
+        "/api/v1/dashboard/auth/status",
     }
 )
 
@@ -445,6 +456,16 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         # HMAC-authenticated paths: the route handler verifies a shared
         # secret; the bearer middleware lets them through.
         if path in AUTH_HMAC_PATHS or path.startswith(AUTH_HMAC_PATH_PREFIXES):
+            response = await call_next(request)
+            return response
+
+        # Dashboard requests already authenticated by the dashboard auth
+        # layer (#2366). ``dashboard_principal`` is stamped only after the
+        # outer DashboardAuthMiddleware validated a session or a signed
+        # scoped token and journaled the authz decision, so honouring it
+        # here does not widen the surface - unauthenticated dashboard
+        # requests never carry it and fall through to the bearer checks.
+        if path.startswith(("/dashboard", "/api/v1/dashboard")) and getattr(request.state, "dashboard_principal", ""):
             response = await call_next(request)
             return response
 

--- a/src/bernstein/core/server/dashboard_auth.py
+++ b/src/bernstein/core/server/dashboard_auth.py
@@ -1,10 +1,38 @@
-"""Dashboard session-based authentication.
+"""Dashboard authentication: sessions, scoped tokens, and authz enforcement.
 
-Provides a lightweight session-based auth layer for /dashboard routes.
-The password/token is configured in bernstein.yaml under ``dashboard_auth``
-or via the ``BERNSTEIN_DASHBOARD_PASSWORD`` environment variable.
+Credentials (issue #2366)
+-------------------------
+Two credential kinds open the dashboard:
 
-Sessions are stored in-memory with configurable timeout.
+* A password (``bernstein.yaml`` ``dashboard_auth`` block or the
+  ``BERNSTEIN_DASHBOARD_PASSWORD`` env var). A password login grants the
+  ``operator`` scope under the ``dashboard-operator`` principal.
+* A scoped token from the signed token journal
+  (:class:`~bernstein.core.server.dashboard_tokens.DashboardTokenRegistry`),
+  issued by ``bernstein auth dashboard-token issue``. The token carries its
+  own principal and scope (``viewer`` or ``operator``).
+
+Sessions wrap a successful login in a cookie with the same principal and
+scope -- a session can never widen what the credential granted. Sessions are
+in-memory with a timeout; the *grant* itself is not: every login and every
+write-authorization is a signed governance decision anchored in the
+``dashboard-auth`` lineage-spine run (see
+:class:`~bernstein.core.server.dashboard_tokens.DashboardGovernance`), so
+the authz history recomputes offline via ``bernstein governance verify``.
+
+Enforcement
+-----------
+When any credential is configured, every ``/dashboard`` route requires one.
+Safe methods (GET / HEAD / OPTIONS) need the ``dashboard.read`` permission;
+everything else needs ``dashboard.write``. ``viewer`` never has
+``dashboard.write``, so a read-only token cannot trigger a state-changing
+action on any route -- current or future -- under the dashboard prefix. The
+same enforcement applies to the ``/api/v1/dashboard`` mirror of the routes.
+
+When no credential is configured the middleware passes dashboard requests
+through unchanged. The serve entry points close that hole for network
+binds: see
+:func:`~bernstein.core.server.dashboard_tokens.resolve_dashboard_posture`.
 """
 
 from __future__ import annotations
@@ -15,11 +43,17 @@ import logging
 import os
 import secrets
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from bernstein.core.server.dashboard_tokens import (
+    ACTION_READ,
+    ACTION_WRITE,
+    SCOPE_OPERATOR,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -27,6 +61,12 @@ if TYPE_CHECKING:
     from fastapi import Request
     from starlette.responses import Response as StarletteResponse
     from starlette.types import ASGIApp
+
+    from bernstein.core.server.dashboard_tokens import (
+        DashboardGovernance,
+        DashboardTokenRecord,
+        DashboardTokenRegistry,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +82,9 @@ _DASHBOARD_PATHS = frozenset(
 # Prefix match for dashboard sub-routes
 _DASHBOARD_PREFIX = "/dashboard/"
 
+# The versioned mirror of the dashboard routes (AUDIT-126 parity mount).
+_API_V1_PREFIX = "/api/v1"
+
 # The login/logout endpoints themselves must be public
 _DASHBOARD_AUTH_PUBLIC = frozenset(
     {
@@ -51,21 +94,43 @@ _DASHBOARD_AUTH_PUBLIC = frozenset(
     }
 )
 
+# HTTP methods that only read state.
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
 # Cookie name for dashboard sessions
 SESSION_COOKIE = "bernstein_dashboard_session"
+
+#: Principal recorded for password logins (passwords carry no identity of
+#: their own; scoped tokens carry a real per-seat principal).
+PASSWORD_PRINCIPAL = "dashboard-operator"
+
+#: Subject recorded on decisions for requests without a valid credential.
+ANONYMOUS_PRINCIPAL = "anonymous"
+
+
+def _normalize_dashboard_path(path: str) -> str:
+    """Map the ``/api/v1`` mirror of a dashboard path onto its root form."""
+    if path.startswith(_API_V1_PREFIX + "/"):
+        return path[len(_API_V1_PREFIX) :]
+    return path
 
 
 @dataclass
 class DashboardSession:
-    """A single dashboard session."""
+    """A single dashboard session bound to the credential that opened it."""
 
     token: str
     created_at: float
     last_accessed: float
+    principal: str = PASSWORD_PRINCIPAL
+    scope: str = SCOPE_OPERATOR
 
 
 class DashboardSessionStore:
     """In-memory session store with expiration.
+
+    Sessions are ephemeral projections of a journaled login decision; the
+    durable record of the grant lives in the governance spine, not here.
 
     Args:
         timeout_seconds: Session lifetime in seconds.
@@ -77,8 +142,14 @@ class DashboardSessionStore:
         self._timeout_seconds = timeout_seconds
         self._max_sessions = max_sessions
 
-    def create_session(self) -> str:
-        """Create a new session and return the session token."""
+    def create_session(self, principal: str = PASSWORD_PRINCIPAL, scope: str = SCOPE_OPERATOR) -> str:
+        """Create a new session and return the session token.
+
+        Args:
+            principal: The acting principal the session attributes actions to.
+            scope: The credential scope the session inherits (never wider
+                than what the login credential granted).
+        """
         self._cleanup_expired()
         # Evict oldest if at capacity
         if len(self._sessions) >= self._max_sessions:
@@ -91,20 +162,26 @@ class DashboardSessionStore:
             token=token,
             created_at=now,
             last_accessed=now,
+            principal=principal,
+            scope=scope,
         )
         return token
 
-    def validate_session(self, token: str) -> bool:
-        """Check whether a session token is valid and not expired."""
+    def resolve_session(self, token: str) -> DashboardSession | None:
+        """Return the live session for *token*, or ``None``."""
         session = self._sessions.get(token)
         if session is None:
-            return False
+            return None
         now = time.time()
         if (now - session.created_at) > self._timeout_seconds:
             del self._sessions[token]
-            return False
+            return None
         session.last_accessed = now
-        return True
+        return session
+
+    def validate_session(self, token: str) -> bool:
+        """Check whether a session token is valid and not expired."""
+        return self.resolve_session(token) is not None
 
     def revoke_session(self, token: str) -> None:
         """Revoke (delete) a session."""
@@ -140,41 +217,126 @@ def verify_password(provided: str, expected: str) -> bool:
     )
 
 
-class DashboardAuthMiddleware(BaseHTTPMiddleware):
-    """Session-based authentication for /dashboard routes.
+@dataclass
+class DashboardAuthState:
+    """Shared auth state the middleware and the auth routes both use.
 
-    When a dashboard password is configured, all /dashboard requests
-    must carry a valid session cookie.  Sessions are created via
-    POST /dashboard/auth/login.
+    Attributes:
+        session_store: Live sessions.
+        token_registry: The signed scoped-token journal (may be ``None`` in
+            minimal embeddings; token login is then unavailable).
+        governance: The decision journal projection (may be ``None`` in
+            minimal embeddings; decisions are then not recorded).
+        password: Explicitly configured password. When empty the
+            ``BERNSTEIN_DASHBOARD_PASSWORD`` env var is consulted at request
+            time so operators can configure auth without a restart.
+    """
+
+    session_store: DashboardSessionStore = field(default_factory=DashboardSessionStore)
+    token_registry: DashboardTokenRegistry | None = None
+    governance: DashboardGovernance | None = None
+    password: str = ""
+
+    def effective_password(self) -> str:
+        """The password in force for this request (config over env)."""
+        return self.password or _get_dashboard_password()
+
+    def auth_required(self) -> bool:
+        """True when any dashboard credential is configured."""
+        if self.effective_password():
+            return True
+        return self.token_registry is not None and self.token_registry.has_tokens()
+
+    def resolve_credential(self, request: Request) -> tuple[str, str] | None:
+        """Resolve the request's credential to ``(principal, scope)``.
+
+        Tried in order: session cookie, session token as Bearer, scoped
+        dashboard token as Bearer. Tokens are matched verbatim.
+        """
+        cookie_token = request.cookies.get(SESSION_COOKIE, "")
+        if cookie_token:
+            session = self.session_store.resolve_session(cookie_token)
+            if session is not None:
+                return (session.principal, session.scope)
+
+        auth_header = request.headers.get("authorization", "")
+        if auth_header.startswith("Bearer "):
+            bearer = auth_header[7:]
+            session = self.session_store.resolve_session(bearer)
+            if session is not None:
+                return (session.principal, session.scope)
+            if self.token_registry is not None:
+                record: DashboardTokenRecord | None = self.token_registry.validate(bearer)
+                if record is not None:
+                    return (record.principal, record.scope)
+        return None
+
+    def record_decision(self, *, subject: str, scope: str, action: str) -> str:
+        """Journal one authz decision; returns the verdict.
+
+        Falls back to a pure (unjournaled) projection when no governance
+        sink is attached, so minimal embeddings still enforce scopes.
+        """
+        if self.governance is None:
+            allowed = scope == SCOPE_OPERATOR or (scope and action != ACTION_WRITE)
+            return "allow" if allowed else "deny"
+        decision = self.governance.decide(
+            subject=subject,
+            scope=scope,
+            action=action,
+            now=int(time.time()),
+        )
+        return decision.verdict
+
+
+class DashboardAuthMiddleware(BaseHTTPMiddleware):
+    """Scope-enforcing authentication for /dashboard routes.
+
+    When a dashboard credential is configured (password or at least one
+    scoped token), all /dashboard requests must carry a valid session
+    cookie or Bearer credential. Write methods additionally require the
+    ``operator`` scope, and every write authorization -- allowed or denied --
+    is journaled as a signed governance decision with the acting principal.
     """
 
     def __init__(
         self,
         app: ASGIApp,
+        state: DashboardAuthState | None = None,
         session_store: DashboardSessionStore | None = None,
         password: str = "",
     ) -> None:
         super().__init__(app)
-        self._session_store = session_store or DashboardSessionStore()
-        self._password = password
+        if state is None:
+            state = DashboardAuthState(
+                session_store=session_store or DashboardSessionStore(),
+                password=password,
+            )
+        self._state = state
+
+    @property
+    def state(self) -> DashboardAuthState:
+        """Access the shared auth state (for route handlers and tests)."""
+        return self._state
 
     @property
     def session_store(self) -> DashboardSessionStore:
         """Access the session store (for route handlers)."""
-        return self._session_store
+        return self._state.session_store
 
     @property
     def password(self) -> str:
         """Access the configured password."""
-        return self._password
+        return self._state.password
 
     def _is_dashboard_path(self, path: str) -> bool:
         """Check if a path requires dashboard authentication."""
+        path = _normalize_dashboard_path(path)
         return path in _DASHBOARD_PATHS or path.startswith(_DASHBOARD_PREFIX)
 
     def _is_auth_exempt(self, path: str) -> bool:
         """Check if a path is exempt from dashboard auth."""
-        return path in _DASHBOARD_AUTH_PUBLIC
+        return _normalize_dashboard_path(path) in _DASHBOARD_AUTH_PUBLIC
 
     async def dispatch(
         self,
@@ -191,32 +353,42 @@ class DashboardAuthMiddleware(BaseHTTPMiddleware):
         if self._is_auth_exempt(path):
             return await call_next(request)
 
-        # If no password is configured, pass through
-        effective_password = self._password or _get_dashboard_password()
-        if not effective_password:
+        # If no credential backend is configured, pass through. The serve
+        # entry points refuse non-loopback binds in this state, so pass-
+        # through only ever happens on loopback or in embedded test apps.
+        if not self._state.auth_required():
             return await call_next(request)
 
-        # Check session cookie
-        session_token = request.cookies.get(SESSION_COOKIE, "")
-        if session_token and self._session_store.validate_session(session_token):
-            return await call_next(request)
-
-        # Also check Authorization header (for API access to dashboard data)
-        auth_header = request.headers.get("authorization", "")
-        if auth_header.startswith("Bearer "):
-            token = auth_header[7:]
-            if self._session_store.validate_session(token):
-                return await call_next(request)
-
-        # For HTML dashboard page requests, redirect to login
-        accept = request.headers.get("accept", "")
-        if "text/html" in accept and path == "/dashboard":
+        credential = self._state.resolve_credential(request)
+        if credential is None:
+            # No valid credential: reject without journaling. Unauthenticated
+            # probes carry no subject worth anchoring and must not be able to
+            # grow the decision journal.
             return JSONResponse(
                 status_code=401,
-                content={"detail": "Dashboard authentication required", "login_url": "/dashboard/auth/login"},
+                content={"detail": "Dashboard authentication required"},
             )
 
-        return JSONResponse(
-            status_code=401,
-            content={"detail": "Dashboard authentication required"},
-        )
+        principal, scope = credential
+        action = ACTION_READ if request.method in _SAFE_METHODS else ACTION_WRITE
+
+        if action == ACTION_WRITE:
+            # Every write authorization is a journaled decision (allow or
+            # deny), so operator actions carry the acting principal into the
+            # audit receipts.
+            verdict = self._state.record_decision(subject=principal, scope=scope, action=action)
+            if verdict != "allow":
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "Dashboard scope does not permit state-changing actions"},
+                )
+            request.state.dashboard_principal = principal
+            request.state.dashboard_scope = scope
+            return await call_next(request)
+
+        # Reads: a valid credential of any scope grants dashboard.read; the
+        # grant was journaled at login / issuance, so passing reads are not
+        # re-journaled on every poll.
+        request.state.dashboard_principal = principal
+        request.state.dashboard_scope = scope
+        return await call_next(request)

--- a/src/bernstein/core/server/dashboard_tokens.py
+++ b/src/bernstein/core/server/dashboard_tokens.py
@@ -1,0 +1,502 @@
+"""Scoped dashboard tokens and startup posture (issue #2366).
+
+The dashboard's auth surface has three parts, all projections over signed
+records rather than mutable in-memory grants:
+
+Scoped token registry
+---------------------
+:class:`DashboardTokenRegistry` is an append-only JSONL journal of
+HMAC-signed issuance and revocation records. The raw token is printed once
+at issue time and never stored -- only its SHA-256 digest lands in the
+journal, so the journal can be read (and shipped in a support bundle)
+without leaking a credential. Validation is a pure projection over the
+journal rows: find the signed issue row whose digest matches, confirm its
+HMAC under the audit-chain key, and confirm no signed revocation row
+follows. Editing a row (for example widening ``viewer`` to ``operator``)
+breaks the row signature and the token stops validating -- the journal is
+the grant, and the grant is tamper-evident.
+
+Role bindings
+-------------
+:func:`dashboard_role_bindings` maps the two token scopes onto the RBAC
+roles shipped in :mod:`bernstein.core.security.governance` (#2309):
+``viewer`` reads, ``operator`` reads and writes. The bindings are signed
+with the same audit-chain key, so ``bernstein governance verify`` can
+recompute every dashboard authz verdict offline.
+
+Governance decisions
+--------------------
+:class:`DashboardGovernance` projects each authz decision through
+:func:`~bernstein.core.security.governance.decide_access` into the
+``dashboard-auth`` lineage-spine run and mirrors it onto the audit chain.
+A denied write is a signed record, not a log line.
+
+Startup posture
+---------------
+:func:`resolve_dashboard_posture` decides what a dashboard entry point must
+do for a given bind host: loopback binds without auth get a generated
+operator token printed at startup; non-loopback binds refuse to start until
+auth is configured. There is no silent open mode on a routable interface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import ipaddress
+import json
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein.core.security.governance import RoleBindings, decide_access
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.security.governance import GovernanceDecision
+
+logger = logging.getLogger(__name__)
+
+#: Read-only scope: may look at every dashboard surface, may change nothing.
+SCOPE_VIEWER = "viewer"
+
+#: Read-write scope: may trigger state-changing dashboard actions.
+SCOPE_OPERATOR = "operator"
+
+#: All scopes a dashboard token can carry.
+DASHBOARD_SCOPES: tuple[str, ...] = (SCOPE_VIEWER, SCOPE_OPERATOR)
+
+#: The lineage-spine run every dashboard authz decision anchors to.
+DASHBOARD_AUTH_RUN_ID = "dashboard-auth"
+
+#: Permission string for read access to dashboard routes.
+ACTION_READ = "dashboard.read"
+
+#: Permission string for state-changing dashboard actions.
+ACTION_WRITE = "dashboard.write"
+
+#: Permission string recorded on login decisions.
+ACTION_LOGIN = "dashboard.login"
+
+#: IDP-group prefix the token scope is projected through. A validated token
+#: with scope ``viewer`` authenticates the subject into the single group
+#: ``dashboard-scope:viewer``; the role bindings map that group to a role.
+SCOPE_GROUP_PREFIX = "dashboard-scope:"
+
+#: Journal record schema version. Bump only on a wire-format change.
+TOKEN_RECORD_VERSION = 1
+
+#: Length of the short token id (hex chars of the digest) used for listing
+#: and revocation. 16 hex chars = 64 bits: ample for a per-install registry.
+_TOKEN_ID_LEN = 16
+
+
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8)."""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def resolve_dashboard_hmac_key(sdd_dir: Path) -> bytes:
+    """Resolve the HMAC key the dashboard auth surface signs with.
+
+    Mirrors the task server's key resolution exactly (env override first,
+    then the workspace key file), so the CLI, the serve entry points, and
+    the server middleware all sign and verify against the same key.
+
+    Args:
+        sdd_dir: The workspace ``.sdd`` directory.
+
+    Returns:
+        The raw key bytes.
+    """
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    override = os.environ.get("BERNSTEIN_AUDIT_KEY_PATH", "")
+    return load_or_create_audit_key(Path(override) if override else sdd_dir / "keys" / "audit.key")
+
+
+def dashboard_role_bindings(hmac_key: bytes) -> RoleBindings:
+    """Return the signed role bindings the dashboard projects scopes through.
+
+    Deterministic: the same key always produces byte-identical signed
+    bindings, so the policy identity (``bindings_hash``) is stable across
+    restarts and across operators, and ``bernstein governance verify`` can
+    be pointed at a freshly recomputed copy.
+
+    Args:
+        hmac_key: The audit-chain HMAC key that signs the bindings.
+
+    Returns:
+        A signed :class:`RoleBindings` mapping ``dashboard-scope:*`` groups
+        onto the ``viewer`` / ``operator`` roles.
+    """
+    return RoleBindings(
+        group_to_role={
+            f"{SCOPE_GROUP_PREFIX}{SCOPE_VIEWER}": SCOPE_VIEWER,
+            f"{SCOPE_GROUP_PREFIX}{SCOPE_OPERATOR}": SCOPE_OPERATOR,
+        },
+        role_permissions={
+            SCOPE_VIEWER: (ACTION_LOGIN, ACTION_READ),
+            SCOPE_OPERATOR: (ACTION_LOGIN, ACTION_READ, ACTION_WRITE),
+        },
+    ).sign(hmac_key)
+
+
+# ---------------------------------------------------------------------------
+# Token journal records
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DashboardTokenRecord:
+    """One signed row of the dashboard token journal.
+
+    Attributes:
+        kind: ``issue`` or ``revoke``.
+        token_id: Short hex id (digest prefix) used for listing / revocation.
+        token_sha256: Hex SHA-256 of the raw token. The raw token itself is
+            never stored.
+        principal: The human / seat the token attributes actions to.
+        scope: One of :data:`DASHBOARD_SCOPES` (empty on ``revoke`` rows).
+        issued_at: Integer timestamp the row was appended at.
+        signature: HMAC-SHA256 over the row body under the audit-chain key.
+    """
+
+    kind: str
+    token_id: str
+    token_sha256: str
+    principal: str
+    scope: str
+    issued_at: int
+    signature: str = ""
+
+    def _body(self) -> dict[str, Any]:
+        return {
+            "v": TOKEN_RECORD_VERSION,
+            "kind": self.kind,
+            "token_id": self.token_id,
+            "token_sha256": self.token_sha256,
+            "principal": self.principal,
+            "scope": self.scope,
+            "issued_at": self.issued_at,
+        }
+
+    def sign(self, key: bytes) -> DashboardTokenRecord:
+        """Return a copy carrying the HMAC signature over the row body."""
+        sig = _hmac.new(key, _canonical_bytes(self._body()), hashlib.sha256).hexdigest()
+        return DashboardTokenRecord(
+            kind=self.kind,
+            token_id=self.token_id,
+            token_sha256=self.token_sha256,
+            principal=self.principal,
+            scope=self.scope,
+            issued_at=self.issued_at,
+            signature=sig,
+        )
+
+    def verify_signature(self, key: bytes) -> bool:
+        """Return True when ``signature`` matches the row body under ``key``."""
+        if not self.signature:
+            return False
+        want = _hmac.new(key, _canonical_bytes(self._body()), hashlib.sha256).hexdigest()
+        return _hmac.compare_digest(self.signature, want)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._body() | {"signature": self.signature}
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> DashboardTokenRecord:
+        return cls(
+            kind=str(row["kind"]),
+            token_id=str(row["token_id"]),
+            token_sha256=str(row["token_sha256"]),
+            principal=str(row.get("principal", "")),
+            scope=str(row.get("scope", "")),
+            issued_at=int(row["issued_at"]),
+            signature=str(row.get("signature", "")),
+        )
+
+
+class DashboardTokenRegistry:
+    """Append-only journal of signed dashboard token grants.
+
+    Args:
+        path: The journal JSONL path (created on first issue).
+        hmac_key: The audit-chain HMAC key signing every row.
+    """
+
+    def __init__(self, path: Path, hmac_key: bytes) -> None:
+        self._path = path
+        self._key = hmac_key
+
+    @property
+    def path(self) -> Path:
+        """The journal path."""
+        return self._path
+
+    @staticmethod
+    def _digest(raw_token: str) -> str:
+        """Hex SHA-256 of the raw token, taken verbatim (never stripped)."""
+        return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+    def issue(self, *, principal: str, scope: str, now: int) -> tuple[str, DashboardTokenRecord]:
+        """Generate a token, append its signed issue row, return both.
+
+        Args:
+            principal: The seat / person the token attributes actions to.
+            scope: One of :data:`DASHBOARD_SCOPES`.
+            now: Integer timestamp recorded on the row.
+
+        Returns:
+            ``(raw_token, signed_record)``. The raw token exists only in the
+            return value -- persist it nowhere.
+
+        Raises:
+            ValueError: On an unknown scope or empty principal.
+        """
+        if scope not in DASHBOARD_SCOPES:
+            raise ValueError(f"unknown dashboard token scope {scope!r}; expected one of {DASHBOARD_SCOPES}")
+        if not principal:
+            raise ValueError("dashboard token principal must be non-empty")
+        raw = secrets.token_urlsafe(32)
+        digest = self._digest(raw)
+        record = DashboardTokenRecord(
+            kind="issue",
+            token_id=digest[:_TOKEN_ID_LEN],
+            token_sha256=digest,
+            principal=principal,
+            scope=scope,
+            issued_at=now,
+        ).sign(self._key)
+        self._append(record)
+        return raw, record
+
+    def revoke(self, token_id: str, *, now: int) -> bool:
+        """Append a signed revocation row for *token_id*.
+
+        Returns:
+            True when a matching live issue row existed, False otherwise
+            (nothing is appended in that case).
+        """
+        live = {r.token_id: r for r in self._live_issue_records()}
+        target = live.get(token_id)
+        if target is None:
+            return False
+        record = DashboardTokenRecord(
+            kind="revoke",
+            token_id=target.token_id,
+            token_sha256=target.token_sha256,
+            principal=target.principal,
+            scope="",
+            issued_at=now,
+        ).sign(self._key)
+        self._append(record)
+        return True
+
+    def validate(self, raw_token: str) -> DashboardTokenRecord | None:
+        """Project *raw_token* onto its signed grant, or ``None``.
+
+        The token is hashed verbatim -- no stripping, no normalisation -- and
+        matched against signed issue rows. A row whose signature does not
+        verify is ignored (a tampered grant is no grant), and a signed
+        revocation row extinguishes the grant.
+        """
+        if not raw_token:
+            return None
+        digest = self._digest(raw_token)
+        matched: DashboardTokenRecord | None = None
+        for record in self.records():
+            if not _hmac.compare_digest(record.token_sha256, digest):
+                continue
+            if not record.verify_signature(self._key):
+                continue
+            if record.kind == "issue":
+                matched = record
+            elif record.kind == "revoke":
+                matched = None
+        return matched
+
+    def records(self) -> list[DashboardTokenRecord]:
+        """Load every journal row in append order (malformed rows skipped)."""
+        if not self._path.exists():
+            return []
+        rows: list[DashboardTokenRecord] = []
+        try:
+            text = self._path.read_text(encoding="utf-8")
+        except OSError as exc:
+            # Key/credential-adjacent path: log the exception type only.
+            logger.warning("dashboard tokens: journal unreadable (%s)", type(exc).__name__)
+            return []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(DashboardTokenRecord.from_dict(json.loads(line)))
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                logger.warning("dashboard tokens: skipping malformed journal row (%s)", type(exc).__name__)
+                continue
+        return rows
+
+    def has_tokens(self) -> bool:
+        """Return True when at least one signed, unrevoked grant exists."""
+        return bool(self._live_issue_records())
+
+    def _live_issue_records(self) -> list[DashboardTokenRecord]:
+        """Signed issue rows that no signed revocation row extinguishes."""
+        live: dict[str, DashboardTokenRecord] = {}
+        for record in self.records():
+            if not record.verify_signature(self._key):
+                continue
+            if record.kind == "issue":
+                live[record.token_sha256] = record
+            elif record.kind == "revoke":
+                live.pop(record.token_sha256, None)
+        return list(live.values())
+
+    def _append(self, record: DashboardTokenRecord) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Governance projection: every authz decision is an anchored record
+# ---------------------------------------------------------------------------
+
+
+class DashboardGovernance:
+    """Projects dashboard authz decisions into the governance spine.
+
+    Every decision goes through :func:`decide_access` (#2309): the subject's
+    scope becomes an IDP group, the signed bindings resolve it to a role,
+    and the verdict is anchored in the ``dashboard-auth`` spine run. When an
+    audit chain is attached, the decision is also mirrored as a
+    ``governance.decision`` event, so the acting principal reaches the
+    chain through the same seat-attribution path budget and RBAC decisions
+    already use.
+
+    Args:
+        lineage_root: The spine root (``.sdd/lineage``).
+        hmac_key: The audit-chain HMAC key.
+        audit_chain: Optional chain store the decisions mirror into.
+    """
+
+    def __init__(
+        self,
+        lineage_root: Path,
+        hmac_key: bytes,
+        audit_chain: AuditChainStore | None = None,
+    ) -> None:
+        self._lineage_root = lineage_root
+        self._key = hmac_key
+        self._chain = audit_chain
+        self._bindings = dashboard_role_bindings(hmac_key)
+
+    @property
+    def bindings(self) -> RoleBindings:
+        """The signed role bindings decisions project over."""
+        return self._bindings
+
+    def decide(self, *, subject: str, scope: str, action: str, now: int) -> GovernanceDecision:
+        """Record one authz decision and return the anchored record.
+
+        Args:
+            subject: The acting principal (or ``anonymous``).
+            scope: The validated credential scope; empty when the request
+                carried no valid credential (projects to a denial).
+            action: One of the ``dashboard.*`` permission strings.
+            now: Integer timestamp recorded on the decision.
+
+        Returns:
+            The anchored :class:`GovernanceDecision`; ``verdict`` is
+            ``allow`` or ``deny``.
+        """
+        groups: tuple[str, ...] = (f"{SCOPE_GROUP_PREFIX}{scope}",) if scope in DASHBOARD_SCOPES else ()
+        decision = decide_access(
+            run_id=DASHBOARD_AUTH_RUN_ID,
+            lineage_root=self._lineage_root,
+            hmac_key=self._key,
+            subject=subject,
+            idp_groups=groups,
+            action=action,
+            bindings=self._bindings,
+            now=now,
+        )
+        if self._chain is not None:
+            from bernstein.core.security.audit_chain import record_governance_decision
+
+            record_governance_decision(
+                chain=self._chain,
+                subject=decision.subject,
+                action=decision.action,
+                verdict=decision.verdict,
+                inputs_hash=decision.inputs_hash,
+                journal_entry_hash=decision.journal_entry_hash,
+                run_id=decision.run_id,
+                actor="dashboard",
+            )
+        return decision
+
+
+# ---------------------------------------------------------------------------
+# Startup posture
+# ---------------------------------------------------------------------------
+
+DashboardPosture = Literal["configured", "generate", "refuse"]
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return True when *host* can only be reached from this machine.
+
+    Recognises ``localhost``, the ``127.0.0.0/8`` block, and ``::1``. A
+    hostname other than ``localhost`` is treated as routable -- posture
+    fails closed on names it cannot prove local.
+    """
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def resolve_dashboard_posture(host: str, *, auth_configured: bool) -> DashboardPosture:
+    """Decide the startup posture for a dashboard bind on *host*.
+
+    Returns:
+        ``configured`` when auth is already configured (any host);
+        ``generate`` for an unconfigured loopback bind (the entry point must
+        issue and print an operator token); ``refuse`` for an unconfigured
+        non-loopback bind (the entry point must not start).
+    """
+    if auth_configured:
+        return "configured"
+    if is_loopback_host(host):
+        return "generate"
+    return "refuse"
+
+
+__all__ = [
+    "ACTION_LOGIN",
+    "ACTION_READ",
+    "ACTION_WRITE",
+    "DASHBOARD_AUTH_RUN_ID",
+    "DASHBOARD_SCOPES",
+    "SCOPE_GROUP_PREFIX",
+    "SCOPE_OPERATOR",
+    "SCOPE_VIEWER",
+    "TOKEN_RECORD_VERSION",
+    "DashboardGovernance",
+    "DashboardPosture",
+    "DashboardTokenRecord",
+    "DashboardTokenRegistry",
+    "dashboard_role_bindings",
+    "is_loopback_host",
+    "resolve_dashboard_hmac_key",
+    "resolve_dashboard_posture",
+]

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1106,6 +1106,36 @@ def create_app(
         expected_resource=expected_resource,
     )
 
+    # Dashboard auth (#2366) - scoped sessions / tokens for the /dashboard
+    # surface. Added AFTER the SSO middleware so it sees the request first:
+    # a validated dashboard credential stamps
+    # ``request.state.dashboard_principal``, which the SSO layer honours for
+    # dashboard paths. The audit-chain key and store are constructed here
+    # (shared with the mailbox block below) because every dashboard authz
+    # decision is anchored in the ``dashboard-auth`` lineage run and mirrored
+    # onto the chain with the acting principal attached.
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.server.dashboard_auth import DashboardAuthMiddleware, DashboardAuthState
+    from bernstein.core.server.dashboard_tokens import (
+        DashboardGovernance,
+        DashboardTokenRegistry,
+        resolve_dashboard_hmac_key,
+    )
+
+    _chain_key = resolve_dashboard_hmac_key(sdd_dir)
+    _audit_chain = AuditChainStore(sdd_dir / "audit", key=_chain_key)
+
+    dashboard_auth_state = DashboardAuthState(
+        token_registry=DashboardTokenRegistry(sdd_dir / "auth" / "dashboard_tokens.jsonl", hmac_key=_chain_key),
+        governance=DashboardGovernance(
+            sdd_dir / "lineage",
+            hmac_key=_chain_key,
+            audit_chain=_audit_chain,
+        ),
+    )
+    application.add_middleware(DashboardAuthMiddleware, state=dashboard_auth_state)
+    application.state.dashboard_auth_state = dashboard_auth_state  # type: ignore[attr-defined]
+
     # Per-endpoint request rate limiting - reads buckets from app.state.seed_config.
     application.add_middleware(RequestRateLimitMiddleware)
 
@@ -1183,12 +1213,8 @@ def create_app(
     # documents; an explicit BERNSTEIN_AUDIT_KEY_PATH override still wins
     # so operators can point every verifier at one key.
     from bernstein.core.communication.task_mailbox import TaskMailbox
-    from bernstein.core.security.audit import load_or_create_audit_key
-    from bernstein.core.security.audit_chain import AuditChainStore
 
-    _key_override = os.environ.get("BERNSTEIN_AUDIT_KEY_PATH", "")
-    _chain_key = load_or_create_audit_key(Path(_key_override) if _key_override else sdd_dir / "keys" / "audit.key")
-    application.state.audit_chain = AuditChainStore(sdd_dir / "audit", key=_chain_key)  # type: ignore[attr-defined]
+    application.state.audit_chain = _audit_chain  # type: ignore[attr-defined]
     application.state.task_mailbox = TaskMailbox(  # type: ignore[attr-defined]
         jsonl_path.parent / "mailbox.jsonl",
         hmac_key=_chain_key,

--- a/src/bernstein/gui/cli.py
+++ b/src/bernstein/gui/cli.py
@@ -154,6 +154,59 @@ def _stop_tunnel(name: str) -> None:
     reg.destroy(name)
 
 
+def _enforce_dashboard_posture(host: str, workdir: Path) -> None:
+    """Apply the dashboard startup posture for a bind on *host* (#2366).
+
+    Non-loopback binds refuse to start until dashboard auth is configured
+    (a scoped token or a password) - there is no silent open mode on a
+    routable interface. Unconfigured loopback binds get an operator token
+    issued into the signed token journal and printed once.
+
+    Raises:
+        SystemExit: On an unconfigured non-loopback bind.
+    """
+    import time
+
+    from bernstein.core.security.audit_chain import AuditChainStore, record_dashboard_token_grant
+    from bernstein.core.server.dashboard_tokens import (
+        SCOPE_OPERATOR,
+        DashboardTokenRegistry,
+        resolve_dashboard_hmac_key,
+        resolve_dashboard_posture,
+    )
+
+    sdd_dir = workdir / ".sdd"
+    key = resolve_dashboard_hmac_key(sdd_dir)
+    registry = DashboardTokenRegistry(sdd_dir / "auth" / "dashboard_tokens.jsonl", hmac_key=key)
+    configured = bool(os.environ.get("BERNSTEIN_DASHBOARD_PASSWORD", "")) or registry.has_tokens()
+
+    posture = resolve_dashboard_posture(host, auth_configured=configured)
+    if posture == "refuse":
+        raise SystemExit(
+            f"Refusing to bind the dashboard on non-loopback host {host!r} without auth configured.\n"
+            "Issue a scoped credential first:\n"
+            "  bernstein auth dashboard-token issue --principal <you> --scope operator\n"
+            "or set BERNSTEIN_DASHBOARD_PASSWORD, then re-run."
+        )
+    if posture == "generate":
+        raw, record = registry.issue(principal="local-operator", scope=SCOPE_OPERATOR, now=int(time.time()))
+        record_dashboard_token_grant(
+            chain=AuditChainStore(sdd_dir / "audit", key=key),
+            grant="issue",
+            token_id=record.token_id,
+            token_sha256=record.token_sha256,
+            principal=record.principal,
+            scope=record.scope,
+        )
+        click.echo("Dashboard token (operator scope, printed once - the journal keeps only its digest):")
+        click.echo(f"  Token: {raw}")
+        click.echo("  Use it as `Authorization: Bearer <token>` or in the dashboard login form.")
+        return
+    click.echo(
+        "Dashboard auth: configured (scoped token or password). Manage tokens with `bernstein auth dashboard-token`."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Click surface
 # ---------------------------------------------------------------------------
@@ -231,6 +284,11 @@ def serve(
     from fastapi import FastAPI
 
     from bernstein.gui import mount, pwa
+
+    # Startup posture (#2366): non-loopback binds refuse to start without
+    # dashboard auth configured; unconfigured loopback binds get a scoped
+    # operator token issued and printed once.
+    _enforce_dashboard_posture(host, Path.cwd())
 
     if minimal:
         app = FastAPI(title="Bernstein", description="Operator GUI (minimal)")

--- a/tests/unit/test_dashboard_auth_scopes.py
+++ b/tests/unit/test_dashboard_auth_scopes.py
@@ -1,0 +1,488 @@
+"""Tests for issue #2366: dashboard authentication and role-based access.
+
+Covers the four acceptance criteria:
+
+* AC1 -- a non-loopback bind refuses unauthenticated requests and refuses to
+  start without auth configured (posture projection + ``gui serve`` gate).
+* AC2 -- a read-only (viewer) token cannot trigger any state-changing action,
+  enforced per route and per credential kind (bearer token and session).
+* AC3 -- operator actions land in the governance decision journal and the
+  audit chain with the acting principal attached, and the whole run
+  recomputes via ``verify_governance``.
+* AC4 -- covered by unskipping ``TestDashboardAuth`` in
+  ``test_web_api_enhancements.py`` (same PR).
+
+Plus the substrate properties the feature leans on: scoped token issuance is
+an append-only journal of HMAC-signed records (tamper-evident, never storing
+the raw token), and every projection is deterministic.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.security.audit import load_or_create_audit_key
+from bernstein.core.security.audit_chain import EVENT_GOVERNANCE_DECISION, AuditChainStore
+from bernstein.core.security.governance import read_decisions, verify_governance
+from bernstein.core.server.dashboard_tokens import (
+    ACTION_LOGIN,
+    ACTION_WRITE,
+    DASHBOARD_AUTH_RUN_ID,
+    SCOPE_OPERATOR,
+    SCOPE_VIEWER,
+    DashboardTokenRegistry,
+    dashboard_role_bindings,
+    is_loopback_host,
+    resolve_dashboard_posture,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class SddEnv(NamedTuple):
+    """Per-test .sdd workspace paths."""
+
+    sdd: Path
+    jsonl: Path
+    key: bytes
+
+
+@pytest.fixture()
+def sdd_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SddEnv:
+    """Isolated .sdd workspace with a pinned audit key and no password env."""
+    sdd = tmp_path / ".sdd"
+    (sdd / "runtime").mkdir(parents=True)
+    key_path = tmp_path / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+    monkeypatch.delenv("BERNSTEIN_DASHBOARD_PASSWORD", raising=False)
+    key = load_or_create_audit_key(key_path)
+    return SddEnv(sdd=sdd, jsonl=sdd / "runtime" / "tasks.jsonl", key=key)
+
+
+def _registry(env: SddEnv) -> DashboardTokenRegistry:
+    return DashboardTokenRegistry(env.sdd / "auth" / "dashboard_tokens.jsonl", hmac_key=env.key)
+
+
+def _client_for(env: SddEnv) -> AsyncClient:
+    from bernstein.core.server import create_app
+
+    app = create_app(jsonl_path=env.jsonl)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# ============================================================================
+# Scoped token registry: signed, append-only, tamper-evident
+# ============================================================================
+
+
+class TestScopedTokenRegistry:
+    """The token journal is the receipt: signed rows, no raw token at rest."""
+
+    def test_issue_and_validate_roundtrip(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        raw, record = registry.issue(principal="alice", scope=SCOPE_OPERATOR, now=1000)
+        assert record.principal == "alice"
+        assert record.scope == SCOPE_OPERATOR
+        assert record.token_id
+        resolved = registry.validate(raw)
+        assert resolved is not None
+        assert resolved.principal == "alice"
+        assert resolved.scope == SCOPE_OPERATOR
+
+    def test_raw_token_never_stored(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        raw, _ = registry.issue(principal="alice", scope=SCOPE_VIEWER, now=1000)
+        journal_text = (sdd_env.sdd / "auth" / "dashboard_tokens.jsonl").read_text(encoding="utf-8")
+        assert raw not in journal_text
+
+    def test_validate_rejects_unknown_token(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        registry.issue(principal="alice", scope=SCOPE_VIEWER, now=1000)
+        assert registry.validate("not-a-real-token") is None
+
+    def test_validate_is_verbatim_no_stripping(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        raw, _ = registry.issue(principal="alice", scope=SCOPE_VIEWER, now=1000)
+        assert registry.validate(raw + "\n") is None
+        assert registry.validate(" " + raw) is None
+
+    def test_revoked_token_stops_validating(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        raw, record = registry.issue(principal="alice", scope=SCOPE_OPERATOR, now=1000)
+        assert registry.revoke(record.token_id, now=1001) is True
+        assert registry.validate(raw) is None
+
+    def test_revoke_unknown_id_returns_false(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        assert registry.revoke("deadbeefdead", now=1001) is False
+
+    def test_tampered_scope_fails_validation(self, sdd_env: SddEnv) -> None:
+        """Widening viewer -> operator by editing the journal is detected."""
+        registry = _registry(sdd_env)
+        raw, _ = registry.issue(principal="mallory", scope=SCOPE_VIEWER, now=1000)
+        journal = sdd_env.sdd / "auth" / "dashboard_tokens.jsonl"
+        text = journal.read_text(encoding="utf-8")
+        assert '"viewer"' in text
+        journal.write_text(text.replace('"viewer"', '"operator"'), encoding="utf-8")
+        assert registry.validate(raw) is None
+
+    def test_has_tokens_reflects_journal(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        assert registry.has_tokens() is False
+        registry.issue(principal="alice", scope=SCOPE_VIEWER, now=1000)
+        assert registry.has_tokens() is True
+
+    def test_records_are_signed(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        registry.issue(principal="alice", scope=SCOPE_VIEWER, now=1000)
+        registry.issue(principal="bob", scope=SCOPE_OPERATOR, now=1001)
+        records = registry.records()
+        assert len(records) == 2
+        assert all(r.verify_signature(sdd_env.key) for r in records)
+
+    def test_rejects_unknown_scope(self, sdd_env: SddEnv) -> None:
+        registry = _registry(sdd_env)
+        with pytest.raises(ValueError, match="scope"):
+            registry.issue(principal="alice", scope="root", now=1000)
+
+
+# ============================================================================
+# AC1: startup posture -- loopback vs non-loopback
+# ============================================================================
+
+
+class TestStartupPosture:
+    """Non-loopback binds refuse to start without auth; loopback gets a token."""
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "127.1.2.3"])
+    def test_loopback_hosts_detected(self, host: str) -> None:
+        assert is_loopback_host(host) is True
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.4", "10.0.0.7", "fleet.example.com", "::"])
+    def test_non_loopback_hosts_detected(self, host: str) -> None:
+        assert is_loopback_host(host) is False
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+    def test_loopback_unconfigured_generates_token(self, host: str) -> None:
+        assert resolve_dashboard_posture(host, auth_configured=False) == "generate"
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.4", "::"])
+    def test_non_loopback_unconfigured_refuses(self, host: str) -> None:
+        assert resolve_dashboard_posture(host, auth_configured=False) == "refuse"
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0"])
+    def test_configured_binds_start(self, host: str) -> None:
+        assert resolve_dashboard_posture(host, auth_configured=True) == "configured"
+
+    def test_gui_serve_refuses_non_loopback_without_auth(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import uvicorn
+        from click.testing import CliRunner
+
+        from bernstein.gui.cli import serve
+
+        called: list[object] = []
+        monkeypatch.setattr(uvicorn, "run", lambda *a, **k: called.append(a))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("BERNSTEIN_DASHBOARD_PASSWORD", raising=False)
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(tmp_path / "audit.key"))
+
+        result = CliRunner().invoke(serve, ["--host", "0.0.0.0", "--minimal", "--no-open"])
+        assert result.exit_code != 0
+        assert called == []
+        assert "dashboard-token issue" in result.output
+
+    def test_gui_serve_loopback_prints_generated_token(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import uvicorn
+        from click.testing import CliRunner
+
+        from bernstein.gui.cli import serve
+
+        monkeypatch.setattr(uvicorn, "run", lambda *a, **k: None)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("BERNSTEIN_DASHBOARD_PASSWORD", raising=False)
+        key_path = tmp_path / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+
+        result = CliRunner().invoke(serve, ["--host", "127.0.0.1", "--minimal", "--no-open"])
+        assert result.exit_code == 0
+        assert "Dashboard token" in result.output
+        registry = DashboardTokenRegistry(
+            tmp_path / ".sdd" / "auth" / "dashboard_tokens.jsonl",
+            hmac_key=load_or_create_audit_key(key_path),
+        )
+        assert registry.has_tokens() is True
+
+    def test_gui_serve_loopback_configured_does_not_reissue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import uvicorn
+        from click.testing import CliRunner
+
+        from bernstein.gui.cli import serve
+
+        monkeypatch.setattr(uvicorn, "run", lambda *a, **k: None)
+        monkeypatch.chdir(tmp_path)
+        key_path = tmp_path / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        key = load_or_create_audit_key(key_path)
+        registry = DashboardTokenRegistry(tmp_path / ".sdd" / "auth" / "dashboard_tokens.jsonl", hmac_key=key)
+        registry.issue(principal="alice", scope=SCOPE_OPERATOR, now=1000)
+
+        result = CliRunner().invoke(serve, ["--host", "127.0.0.1", "--minimal", "--no-open"])
+        assert result.exit_code == 0
+        assert len(registry.records()) == 1
+
+
+# ============================================================================
+# AC2: scope enforcement per route
+# ============================================================================
+
+
+class TestScopeEnforcement:
+    """A viewer token reads but never writes; an operator token does both."""
+
+    @pytest.fixture()
+    def tokens(self, sdd_env: SddEnv) -> dict[str, str]:
+        registry = _registry(sdd_env)
+        viewer_raw, _ = registry.issue(principal="viewer-vera", scope=SCOPE_VIEWER, now=1000)
+        operator_raw, _ = registry.issue(principal="operator-olga", scope=SCOPE_OPERATOR, now=1001)
+        return {"viewer": viewer_raw, "operator": operator_raw}
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("route", ["/dashboard/data", "/dashboard/file_locks"])
+    async def test_viewer_token_reads_route(self, sdd_env: SddEnv, tokens: dict[str, str], route: str) -> None:
+        async with _client_for(sdd_env) as client:
+            resp = await client.get(route, headers={"Authorization": f"Bearer {tokens['viewer']}"})
+            assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("route", ["/dashboard/data", "/dashboard/file_locks", "/dashboard/actions/retry"])
+    async def test_viewer_token_cannot_write_route(self, sdd_env: SddEnv, tokens: dict[str, str], route: str) -> None:
+        async with _client_for(sdd_env) as client:
+            resp = await client.post(route, headers={"Authorization": f"Bearer {tokens['viewer']}"})
+            assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("route", ["/dashboard/data", "/dashboard/file_locks"])
+    async def test_operator_token_write_passes_authz(self, sdd_env: SddEnv, tokens: dict[str, str], route: str) -> None:
+        """Operator scope clears the authz gate (route itself may 405)."""
+        async with _client_for(sdd_env) as client:
+            resp = await client.post(route, headers={"Authorization": f"Bearer {tokens['operator']}"})
+            assert resp.status_code not in (401, 403)
+
+    @pytest.mark.anyio
+    async def test_unauthenticated_request_rejected_when_tokens_exist(
+        self, sdd_env: SddEnv, tokens: dict[str, str]
+    ) -> None:
+        async with _client_for(sdd_env) as client:
+            resp = await client.get("/dashboard/data")
+            assert resp.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_viewer_session_cannot_write(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        """The session cookie wraps the token's scope: no privilege widening."""
+        async with _client_for(sdd_env) as client:
+            login = await client.post("/dashboard/auth/login", json={"token": tokens["viewer"]})
+            assert login.status_code == 200
+            resp = await client.post("/dashboard/data")
+            assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_token_login_reports_scope_and_principal(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            login = await client.post("/dashboard/auth/login", json={"token": tokens["viewer"]})
+            assert login.status_code == 200
+            data = login.json()
+            assert data["authenticated"] is True
+            assert data["scope"] == SCOPE_VIEWER
+            assert data["principal"] == "viewer-vera"
+
+    @pytest.mark.anyio
+    async def test_invalid_token_login_rejected(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            login = await client.post("/dashboard/auth/login", json={"token": "bogus"})
+            assert login.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_versioned_dashboard_surface_enforced_too(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            ok = await client.get("/api/v1/dashboard/data", headers={"Authorization": f"Bearer {tokens['viewer']}"})
+            assert ok.status_code == 200
+            denied = await client.post(
+                "/api/v1/dashboard/data", headers={"Authorization": f"Bearer {tokens['viewer']}"}
+            )
+            assert denied.status_code == 403
+            anon = await client.get("/api/v1/dashboard/data")
+            assert anon.status_code == 401
+
+
+# ============================================================================
+# AC3: principal lands in the governance journal + audit chain
+# ============================================================================
+
+
+class TestPrincipalReceipts:
+    """Every authz decision is an anchored governance record, not a log line."""
+
+    @pytest.fixture()
+    def tokens(self, sdd_env: SddEnv) -> dict[str, str]:
+        registry = _registry(sdd_env)
+        viewer_raw, _ = registry.issue(principal="viewer-vera", scope=SCOPE_VIEWER, now=1000)
+        operator_raw, _ = registry.issue(principal="operator-olga", scope=SCOPE_OPERATOR, now=1001)
+        return {"viewer": viewer_raw, "operator": operator_raw}
+
+    @pytest.mark.anyio
+    async def test_operator_write_is_journaled_with_principal(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            await client.post("/dashboard/data", headers={"Authorization": f"Bearer {tokens['operator']}"})
+        rows = read_decisions(sdd_env.sdd / "lineage", DASHBOARD_AUTH_RUN_ID)
+        writes = [r for r in rows if r.action == ACTION_WRITE and r.subject == "operator-olga"]
+        assert writes, "operator write must be journaled with the acting principal"
+        assert writes[0].verdict == "allow"
+        assert writes[0].journal_entry_hash
+
+    @pytest.mark.anyio
+    async def test_denied_viewer_write_is_journaled(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            await client.post("/dashboard/data", headers={"Authorization": f"Bearer {tokens['viewer']}"})
+        rows = read_decisions(sdd_env.sdd / "lineage", DASHBOARD_AUTH_RUN_ID)
+        denies = [r for r in rows if r.action == ACTION_WRITE and r.subject == "viewer-vera"]
+        assert denies
+        assert denies[0].verdict == "deny"
+
+    @pytest.mark.anyio
+    async def test_failed_login_is_journaled_as_deny(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            await client.post("/dashboard/auth/login", json={"token": "bogus"})
+        rows = read_decisions(sdd_env.sdd / "lineage", DASHBOARD_AUTH_RUN_ID)
+        logins = [r for r in rows if r.action == ACTION_LOGIN]
+        assert logins
+        assert logins[0].verdict == "deny"
+
+    @pytest.mark.anyio
+    async def test_governance_run_recomputes(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        """The dashboard-auth run verifies end to end from the spine."""
+        async with _client_for(sdd_env) as client:
+            await client.post("/dashboard/data", headers={"Authorization": f"Bearer {tokens['operator']}"})
+            await client.post("/dashboard/data", headers={"Authorization": f"Bearer {tokens['viewer']}"})
+        result = verify_governance(
+            run_id=DASHBOARD_AUTH_RUN_ID,
+            lineage_root=sdd_env.sdd / "lineage",
+            hmac_key=sdd_env.key,
+            bindings=dashboard_role_bindings(sdd_env.key),
+        )
+        assert result.ok, result.reason
+
+    @pytest.mark.anyio
+    async def test_decision_mirrored_into_audit_chain(self, sdd_env: SddEnv, tokens: dict[str, str]) -> None:
+        async with _client_for(sdd_env) as client:
+            await client.post("/dashboard/data", headers={"Authorization": f"Bearer {tokens['operator']}"})
+        chain = AuditChainStore(sdd_env.sdd / "audit", key=sdd_env.key)
+        events = chain.query(event_type=EVENT_GOVERNANCE_DECISION)
+        subjects = {e.details.get("subject") for e in events}
+        assert "operator-olga" in subjects
+
+
+# ============================================================================
+# Determinism of the role projection
+# ============================================================================
+
+
+class TestDeterministicProjection:
+    """Same key, same bindings: the policy identity is stable bytes."""
+
+    def test_bindings_hash_is_stable(self, sdd_env: SddEnv) -> None:
+        first = dashboard_role_bindings(sdd_env.key)
+        second = dashboard_role_bindings(sdd_env.key)
+        assert first.bindings_hash() == second.bindings_hash()
+        assert first.verify_signature(sdd_env.key)
+
+    def test_viewer_role_has_no_write_permission(self, sdd_env: SddEnv) -> None:
+        bindings = dashboard_role_bindings(sdd_env.key)
+        assert ACTION_WRITE not in bindings.role_permissions[SCOPE_VIEWER]
+        assert ACTION_WRITE in bindings.role_permissions[SCOPE_OPERATOR]
+
+    def test_identical_inputs_project_identical_decisions(self, tmp_path: Path) -> None:
+        from bernstein.core.server.dashboard_tokens import DashboardGovernance
+
+        key = b"0" * 32
+        dicts: list[dict[str, object]] = []
+        for sub in ("a", "b"):
+            root = tmp_path / sub / "lineage"
+            gov = DashboardGovernance(lineage_root=root, hmac_key=key)
+            decision = gov.decide(subject="alice", scope=SCOPE_OPERATOR, action=ACTION_WRITE, now=1234)
+            dicts.append(decision.to_dict())
+        assert dicts[0] == dicts[1]
+
+
+# ============================================================================
+# CLI: bernstein auth dashboard-token
+# ============================================================================
+
+
+class TestDashboardTokenCli:
+    """Issue / list / revoke scoped dashboard tokens from the CLI."""
+
+    def test_issue_prints_token_once_and_journals(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from click.testing import CliRunner
+
+        from bernstein.cli.commands.dashboard_token_cmd import dashboard_token_group
+
+        key_path = tmp_path / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        result = CliRunner().invoke(
+            dashboard_token_group,
+            ["issue", "--principal", "alice", "--scope", "operator", "--workdir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        registry = DashboardTokenRegistry(
+            tmp_path / ".sdd" / "auth" / "dashboard_tokens.jsonl",
+            hmac_key=load_or_create_audit_key(key_path),
+        )
+        records = registry.records()
+        assert len(records) == 1
+        assert records[0].principal == "alice"
+        # The raw token is printed exactly once and never journaled.
+        journal_text = (tmp_path / ".sdd" / "auth" / "dashboard_tokens.jsonl").read_text(encoding="utf-8")
+        token_lines = [ln for ln in result.output.splitlines() if ln.strip().startswith("Token:")]
+        assert len(token_lines) == 1
+        raw = token_lines[0].split("Token:", 1)[1].strip()
+        assert raw
+        assert raw not in journal_text
+        assert registry.validate(raw) is not None
+
+    def test_list_shows_metadata_not_tokens(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from click.testing import CliRunner
+
+        from bernstein.cli.commands.dashboard_token_cmd import dashboard_token_group
+
+        key_path = tmp_path / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        key = load_or_create_audit_key(key_path)
+        registry = DashboardTokenRegistry(tmp_path / ".sdd" / "auth" / "dashboard_tokens.jsonl", hmac_key=key)
+        raw, record = registry.issue(principal="bob", scope=SCOPE_VIEWER, now=1000)
+
+        result = CliRunner().invoke(dashboard_token_group, ["list", "--workdir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "bob" in result.output
+        assert record.token_id in result.output
+        assert raw not in result.output
+
+    def test_revoke_blocks_future_validation(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from click.testing import CliRunner
+
+        from bernstein.cli.commands.dashboard_token_cmd import dashboard_token_group
+
+        key_path = tmp_path / "audit.key"
+        monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+        key = load_or_create_audit_key(key_path)
+        registry = DashboardTokenRegistry(tmp_path / ".sdd" / "auth" / "dashboard_tokens.jsonl", hmac_key=key)
+        raw, record = registry.issue(principal="bob", scope=SCOPE_VIEWER, now=1000)
+
+        result = CliRunner().invoke(dashboard_token_group, ["revoke", record.token_id, "--workdir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert registry.validate(raw) is None

--- a/tests/unit/test_web_api_enhancements.py
+++ b/tests/unit/test_web_api_enhancements.py
@@ -468,7 +468,6 @@ class TestOpenAPISpec:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="/dashboard/auth/* routes not yet implemented")
 class TestDashboardAuth:
     """Test dashboard session-based authentication."""
 
@@ -689,6 +688,5 @@ class TestIntegration:
         assert "/tasks" in paths
         assert "/health" in paths
         assert "/tasks/counts" in paths
-        # /dashboard/auth/* routes not yet implemented
-        # assert "/dashboard/auth/login" in paths
-        # assert "/dashboard/auth/status" in paths
+        assert "/dashboard/auth/login" in paths
+        assert "/dashboard/auth/status" in paths


### PR DESCRIPTION
## Summary

The dashboard's `/dashboard/auth/*` routes were unimplemented stubs (their tests skipped), so anyone who could reach the port saw run data - acceptable on localhost and nowhere else. This PR wires the auth surface end to end, on the bearer-token and RBAC substrate already on main (#2309), and keeps it reusable for upcoming write actions from the web surface.

## What ships

**Scoped tokens.** `bernstein auth dashboard-token issue|list|revoke` issues per-principal credentials with a `viewer` (read-only) or `operator` (read-write) scope. Grants live in an append-only journal of HMAC-signed rows (`.sdd/auth/dashboard_tokens.jsonl`) that stores only the token's SHA-256 digest - the raw token is printed once. Validation is a pure projection over the journal: a row whose signature does not verify is no grant, so editing `viewer` into `operator` on disk kills the token instead of widening it. Issues and revocations are mirrored onto the audit chain (`dashboard.token_grant`).

**Auth routes + enforcement.** `POST /dashboard/auth/login` (password or token), `POST /dashboard/auth/logout`, `GET /dashboard/auth/status`. Once any credential is configured, every `/dashboard` route (and its `/api/v1` mirror) requires one; safe methods need `dashboard.read`, everything else needs `dashboard.write`. Session cookies wrap exactly the principal and scope the credential carried.

**Decisions as records, not log lines.** Every login attempt and every write authorization - allowed or denied - is projected through the shipped RBAC (`decide_access`, #2309) into the `dashboard-auth` lineage run and mirrored onto the audit chain with the acting principal, via the same seat-attribution path budget decisions use. `bernstein governance verify dashboard-auth` recomputes every verdict offline; a tampered verdict or widened binding fails the check.

**Startup posture.** `gui serve` on an unconfigured loopback bind issues an operator token and prints it once (keeps localhost friction minimal); an unconfigured non-loopback bind refuses to start with instructions. No silent open mode on a routable interface.

Browser SSO remains the existing OIDC/SAML surface on the task server (`SSOAuthMiddleware`); this PR leaves it untouched and adds the exemptions needed so dashboard logins work alongside it.

## Acceptance criteria -> tests

| AC | Tests |
|---|---|
| Non-loopback bind refuses unauthenticated requests and refuses to start without auth | `TestStartupPosture` (posture projection + `gui serve` refusal/token-generation), `TestScopeEnforcement::test_unauthenticated_request_rejected_when_tokens_exist`, `TestDashboardAuth::test_dashboard_with_password_blocks_access` |
| Read-only token cannot trigger any state-changing action (per route) | `TestScopeEnforcement` - parametrized per route, per credential kind (bearer + session), and on the `/api/v1` mirror |
| Operator actions appear in audit receipts with the acting principal | `TestPrincipalReceipts` - journaled allow/deny with principal, `verify_governance` green, audit-chain mirror carries subject |
| Previously skipped dashboard auth tests enabled and green | `TestDashboardAuth` in `tests/unit/test_web_api_enhancements.py` unskipped (18 tests), OpenAPI assertions for `/dashboard/auth/*` re-enabled |

Plus substrate coverage: token journal tamper detection, verbatim (no-strip) token matching, raw-token-never-stored, deterministic bindings hash, and byte-identical decision projection across roots.

## Verification

- `tests/unit/test_dashboard_auth_scopes.py` (53 tests) + `tests/unit/test_web_api_enhancements.py` (57 tests) ran 3x: 110 passed each run
- Dashboard/auth-middleware/governance/gui suites: 146 + 172 passed, no regressions
- `ruff check`, `ruff format --check`, `lint-imports`, `python -c "import bernstein"` all clean

Closes #2366
