### PR TITLE
feat(platform): process-tree lifecycle layer and Windows worktree semantics

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -16,6 +16,25 @@ to follow the [first-run walkthrough](first-run.md).
 
 That's it. You do **not** need a CLI coding agent installed yet - that comes in the first-run page.
 
+### Supported platforms
+
+| Platform | Status | Process management |
+|----------|--------|--------------------|
+| Linux | Supported | POSIX process groups; graceful stop with force-kill escalation |
+| macOS | Supported | POSIX process groups; graceful stop with force-kill escalation |
+| Windows | Supported | Native process-tree termination (no POSIX signals required); `.cmd`/`.bat` adapter shims resolved automatically |
+
+Windows notes:
+
+- Worktree directory sharing via symlinks (`node_modules`, `.venv`) requires
+  Developer Mode or Administrator privileges; without it, agents fall back to
+  per-worktree installs.
+- Deep worktree paths are handled with extended-length path support; no
+  registry changes are needed.
+- Forced agent stops are recorded in the audit chain with the same receipt
+  format on every platform, so run histories verify identically across
+  mixed-OS teams.
+
 ---
 
 ## Recommended: `uv tool install`

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -16,8 +16,8 @@ from typing import TYPE_CHECKING, Any, Protocol
 from bernstein.core.lineage.spine import LineageSpine
 from bernstein.core.platform_compat import (
     kill_process_group,
-    kill_process_group_graceful,
     process_alive,
+    reap_process_group,
 )
 from bernstein.core.resource_limits import ResourceLimits, make_preexec_fn
 
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from bernstein.core.config.platform_compat import ProcessReapReceipt
     from bernstein.core.lineage.identity import AgentCard
     from bernstein.core.models import AbortReason, ApiTierInfo, ModelConfig
 
@@ -719,20 +720,27 @@ class CLIAdapter(ABC):
         """Check if the agent process is still running."""
         return process_alive(pid)
 
-    def kill(self, pid: int) -> None:
+    def kill(self, pid: int) -> ProcessReapReceipt:
         """Terminate the agent process and its entire process group.
 
-        Processes are spawned with ``start_new_session=True``, so the PID
-        equals the PGID.  Using the PID directly avoids ``os.getpgid()``
-        failing when the wrapper process has already exited - this prevents
-        orphan child processes from accumulating.
+        Processes are spawned with process-group isolation (POSIX
+        ``start_new_session=True``), so the PID equals the PGID.  Using the
+        PID directly avoids ``os.getpgid()`` failing when the wrapper
+        process has already exited - this prevents orphan child processes
+        from accumulating.  On Windows the same PID anchors a process-tree
+        termination instead.
 
-        Sends SIGTERM first, polls for exit for a short grace period, then
-        escalates to SIGKILL if the group is still alive.  Without this
-        escalation, agents that trap SIGTERM survive reap paths (wall-clock
-        timeout and stale heartbeat) - see prior audit.
+        Sends a graceful stop first, polls for exit for a short grace
+        period, then escalates to a force-kill if the group is still alive.
+        Without this escalation, agents that trap SIGTERM survive reap
+        paths (wall-clock timeout and stale heartbeat) - see prior audit.
+
+        Returns:
+            A :class:`~bernstein.core.config.platform_compat.ProcessReapReceipt`
+            describing how the reap was performed, so callers can mirror it
+            into the audit chain.
         """
-        kill_process_group_graceful(pid)
+        return reap_process_group(pid)
 
     @abstractmethod
     def name(self) -> str:

--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from bernstein.adapters.plugin_sdk import AdapterPluginInfo
+    from bernstein.core.config.platform_compat import ProcessReapReceipt
     from bernstein.core.models import ModelConfig
 
 logger = logging.getLogger(__name__)
@@ -223,11 +224,11 @@ class CachingAdapter(CLIAdapter):
             return False
         return self._inner.is_alive(pid)
 
-    def kill(self, pid: int) -> None:
-        """Delegate to inner adapter."""
+    def kill(self, pid: int) -> ProcessReapReceipt | None:
+        """Delegate to inner adapter (no receipt for cached PID 0)."""
         if pid == 0:
-            return
-        self._inner.kill(pid)
+            return None
+        return self._inner.kill(pid)
 
     def detect_tier(self) -> Any:
         """Delegate to inner adapter."""

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -23,7 +23,7 @@ import sys
 import time
 from collections.abc import Mapping  # noqa: TC003 - runtime use in ClassVar annotations
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.claude_agents import build_agents_json
@@ -50,7 +50,15 @@ from bernstein.adapters.env_isolation import (
 )
 from bernstein.core.defaults import COST
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
-from bernstein.core.platform_compat import kill_process_group_graceful, process_alive
+from bernstein.core.platform_compat import (
+    kill_process_group_graceful,
+    process_alive,
+    process_group_popen_kwargs,
+    reap_process_group,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.config.platform_compat import ProcessReapReceipt
 
 # task-budgets-2026-03-13 propagation. Inlined (rather than imported from
 # ``bernstein.core.cost.budget_countdown``) to keep this adapter free of
@@ -610,8 +618,8 @@ class ClaudeCodeAdapter(CLIAdapter):
                     env=env,
                     stdout=subprocess.PIPE,
                     stderr=stderr_file,
-                    start_new_session=True,
                     preexec_fn=preexec_fn,
+                    **process_group_popen_kwargs(),
                 )
             except FileNotFoundError as exc:
                 raise RuntimeError("claude not found in PATH. Install Claude Code: https://claude.ai/code") from exc
@@ -624,9 +632,9 @@ class ClaudeCodeAdapter(CLIAdapter):
                     stdin=claude_proc.stdout,
                     stdout=log_file,
                     stderr=stderr_file,
-                    start_new_session=True,
                     cwd=workdir,
                     env=env,
+                    **process_group_popen_kwargs(),
                 )
             except Exception:
                 claude_proc.kill()
@@ -898,23 +906,24 @@ class ClaudeCodeAdapter(CLIAdapter):
         # Fallback for processes we didn't spawn
         return process_alive(pid)
 
-    def kill(self, pid: int) -> None:
-        # The claude process is spawned with start_new_session=True, so
+    def kill(self, pid: int) -> ProcessReapReceipt:
+        # The claude process is spawned with process-group isolation, so
         # its PID equals its PGID.  Use the PID directly as PGID instead
         # of os.getpgid() which fails when the process is already dead -
         # this ensures we kill the entire session group including any
         # child processes (the actual claude CLI) that outlive the wrapper.
         #
-        # ``kill_process_group_graceful`` sends SIGTERM, polls briefly, and
+        # ``reap_process_group`` sends SIGTERM, polls briefly, and
         # escalates to SIGKILL if the group is still alive.  Without the
         # escalation, agents that trap SIGTERM survive reap paths - see
-        # .
-        kill_process_group_graceful(pid)
+        # .  The returned receipt describes the primary (agent) group reap.
+        receipt = reap_process_group(pid)
         # Also kill the wrapper process with the same TERM→KILL escalation
         wrapper_pid = self._wrapper_pids.pop(pid, None)
         if wrapper_pid:
             kill_process_group_graceful(wrapper_pid)
         self._procs.pop(pid, None)
+        return receipt
 
     def name(self) -> str:
         return "Claude Code"

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -18,6 +18,7 @@ from typing import Any
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
+from bernstein.core.platform_compat import process_group_popen_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class CodexAdapter(CLIAdapter):
                     env=env,
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
-                    start_new_session=True,
+                    **process_group_popen_kwargs(),
                 )
             except FileNotFoundError as exc:
                 raise RuntimeError("codex not found in PATH. Install it with: npm install -g @openai/codex") from exc

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -56,6 +56,7 @@ from bernstein.adapters.base import (
 )
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
+from bernstein.core.platform_compat import process_group_popen_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +284,7 @@ class GeminiAdapter(CLIAdapter):
                     env=env,
                     stdout=log_file,
                     stderr=subprocess.STDOUT,
-                    start_new_session=True,
+                    **process_group_popen_kwargs(),
                 )
             except FileNotFoundError as exc:
                 raise RuntimeError(

--- a/src/bernstein/core/agents/heartbeat_escalation.py
+++ b/src/bernstein/core/agents/heartbeat_escalation.py
@@ -22,8 +22,13 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 
 from bernstein.core.defaults import AGENT
+from bernstein.core.platform_compat import is_signal_supported
 
 logger = logging.getLogger(__name__)
+
+# Numeric force-kill code used when SIGKILL is not defined (Windows).
+# ``kill_process_group`` maps it to a native process-tree termination.
+_FORCE_KILL_CODE = 9
 
 
 class EscalationTier(IntEnum):
@@ -286,20 +291,33 @@ class HeartbeatEscalationLadder:
             return True
 
         if tier == EscalationTier.SIGUSR1:
+            # SIGUSR1 has no Windows equivalent; degrade to a logged no-op
+            # instead of raising AttributeError at escalation time.  The
+            # SIGTERM and SIGKILL tiers above it still fire.
+            if not is_signal_supported("SIGUSR1"):
+                logger.warning(
+                    "SIGUSR1 nudge unsupported on this platform for agent %s (heartbeat age: %.0fs)",
+                    state.session_id,
+                    heartbeat_age_s,
+                )
+                return False
             return self._send_signal(state, signal.SIGUSR1, "SIGUSR1", heartbeat_age_s)
 
         if tier == EscalationTier.SIGTERM:
             return self._send_signal(state, signal.SIGTERM, "SIGTERM", heartbeat_age_s)
 
         if tier == EscalationTier.SIGKILL:
-            return self._send_signal(state, signal.SIGKILL, "SIGKILL", heartbeat_age_s)
+            # On platforms without SIGKILL the numeric force-kill code is
+            # sent; ``kill_process_group`` maps it to a native tree kill.
+            kill_sig = signal.SIGKILL if is_signal_supported("SIGKILL") else _FORCE_KILL_CODE
+            return self._send_signal(state, kill_sig, "SIGKILL", heartbeat_age_s)
 
         return False
 
     def _send_signal(
         self,
         state: AgentEscalationState,
-        sig: signal.Signals,
+        sig: signal.Signals | int,
         sig_name: str,
         heartbeat_age_s: float,
     ) -> bool:

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -120,6 +120,7 @@ if TYPE_CHECKING:
     from bernstein.core.agency_loader import AgencyAgent
     from bernstein.core.agents.warm_pool import PoolSlot, WarmPool
     from bernstein.core.bulletin import BulletinBoard
+    from bernstein.core.config.platform_compat import ProcessReapReceipt
     from bernstein.core.git_ops import MergeResult
     from bernstein.core.knowledge.task_graph import TaskGraph
     from bernstein.core.mcp_manager import MCPManager
@@ -196,6 +197,56 @@ def _list_subdirs_cached(path: Path) -> list[str]:
 
 
 logger = logging.getLogger(__name__)
+
+
+def emit_process_reap_receipt(
+    workdir: Path,
+    session_id: str,
+    receipt: ProcessReapReceipt | None,
+    *,
+    reason: str,
+    actor: str = "spawner",
+) -> None:
+    """Mirror a process-tree reap receipt into the audit chain (#2367).
+
+    Best-effort by design: audit mirroring must never mask the kill itself
+    (mirrors ``_emit_routing_failover_receipt``).  ``None`` receipts (from
+    adapters that could not report a reap) are skipped silently.
+
+    Args:
+        workdir: Project root containing ``.sdd/audit``.
+        session_id: Agent session whose process tree was reaped.
+        receipt: The reap receipt returned by the adapter kill path.
+        reason: Why the reap ran (e.g. ``"kill_requested"``).
+        actor: Recorded actor for the audit event.
+    """
+    if receipt is None:
+        return
+    try:
+        from bernstein.core.security.audit_chain import (
+            AuditChainStore,
+            record_process_reap_receipt,
+        )
+
+        chain = AuditChainStore(workdir / ".sdd" / "audit")
+        record_process_reap_receipt(
+            chain=chain,
+            session_id=session_id,
+            pgid=receipt.pgid,
+            os_name=receipt.os_name,
+            method=receipt.method,
+            delivered=receipt.delivered,
+            escalated=receipt.escalated,
+            grace_seconds=receipt.grace_seconds,
+            reason=reason,
+            actor=actor,
+        )
+    except Exception as exc:  # audit must never block the reap path
+        logger.warning(
+            "Could not emit process.reap_receipt audit event for session %s: %s",
+            session_id,
+            type(exc).__name__,
+        )
 
 
 def _sanitise_for_log(value: str) -> str:
@@ -4809,7 +4860,13 @@ class AgentSpawner:
                 session.exit_code = exit_code_val
             self._in_process.cleanup(session.id)
         elif session.pid is not None:
-            self._adapter.kill(session.pid)
+            receipt = self._adapter.kill(session.pid)
+            emit_process_reap_receipt(
+                self._workdir,
+                session.id,
+                receipt,
+                reason="kill_requested",
+            )
         self._transition_to_dead(session, "kill requested", "local process kill requested by orchestrator")
 
     def _transition_to_dead(self, session: AgentSession, reason: str, detail: str) -> None:

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -13,19 +13,23 @@ the POSIX APIs are unavailable.
 from __future__ import annotations
 
 import logging
+import ntpath
 import os
 import platform
 import shlex
+import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     import pytest
 
@@ -322,22 +326,110 @@ def kill_process_group_graceful(
         later had to be used).  ``False`` when the group was already dead
         or the initial SIGTERM could not be sent.
     """
+    return reap_process_group(
+        pgid,
+        grace_seconds=grace_seconds,
+        poll_interval=poll_interval,
+    ).delivered
+
+
+# Reap-method identifiers recorded in :class:`ProcessReapReceipt`.
+_REAP_METHOD_POSIX = "posix_process_group"
+_REAP_METHOD_WINDOWS = "windows_process_tree"
+
+
+@dataclass(frozen=True)
+class ProcessReapReceipt:
+    """Structured outcome of a process-tree reap.
+
+    A deterministic projection of what the reap path did: which platform
+    mechanism delivered the stop, whether the graceful stop was delivered,
+    and whether escalation to a force-kill was required.  Callers mirror
+    the receipt into the audit chain so a failure window can be
+    reconstructed offline.
+
+    Attributes:
+        pgid: Process group ID (POSIX) or lead PID (Windows) targeted.
+        os_name: Normalised OS name (``"linux"``, ``"macos"``, ``"windows"``).
+        method: Delivery mechanism identifier
+            (``"posix_process_group"`` or ``"windows_process_tree"``).
+        delivered: Whether the initial graceful stop was delivered.
+        escalated: Whether a force-kill was required after the grace window.
+        grace_seconds: The grace window that applied to this reap.
+    """
+
+    pgid: int
+    os_name: str
+    method: str
+    delivered: bool
+    escalated: bool
+    grace_seconds: float
+
+    def to_details(self) -> dict[str, object]:
+        """Return the receipt as a plain dict for audit-chain payloads."""
+        return {
+            "pgid": self.pgid,
+            "os_name": self.os_name,
+            "method": self.method,
+            "delivered": self.delivered,
+            "escalated": self.escalated,
+            "grace_seconds": self.grace_seconds,
+        }
+
+
+def reap_process_group(
+    pgid: int,
+    *,
+    grace_seconds: float = 3.0,
+    poll_interval: float = 0.1,
+) -> ProcessReapReceipt:
+    """Reap a process group and return a structured receipt.
+
+    Same TERM -> poll -> force-kill escalation as
+    :func:`kill_process_group_graceful` (which delegates here), but the
+    outcome is returned as a :class:`ProcessReapReceipt` so callers can
+    record *how* the reap was performed instead of a bare bool.
+
+    Args:
+        pgid: Process group ID (on Unix) or PID (on Windows).
+        grace_seconds: Total time to wait for the graceful stop to take
+            effect before escalating to a force-kill.
+        poll_interval: How often to poll :func:`process_alive` during the
+            grace window.
+
+    Returns:
+        A frozen :class:`ProcessReapReceipt` describing the reap outcome.
+    """
+    os_name = _detect_os_name()
+    method = _REAP_METHOD_WINDOWS if IS_WINDOWS else _REAP_METHOD_POSIX
+
+    def _receipt(*, delivered: bool, escalated: bool) -> ProcessReapReceipt:
+        return ProcessReapReceipt(
+            pgid=pgid,
+            os_name=os_name,
+            method=method,
+            delivered=delivered,
+            escalated=escalated,
+            grace_seconds=grace_seconds,
+        )
+
     if pgid <= 0:
-        return False
+        return _receipt(delivered=False, escalated=False)
 
     # Best-effort TERM first; if it fails the group is already gone.
     if not kill_process_group(pgid, signal.SIGTERM):
-        return False
+        return _receipt(delivered=False, escalated=False)
 
     # Poll for graceful exit.  Using the lead PID as a liveness proxy is
     # safe because it is guaranteed to be the session leader (start_new_session=True).
     deadline = time.monotonic() + grace_seconds
     while time.monotonic() < deadline:
         if not process_alive(pgid):
-            return True
+            return _receipt(delivered=True, escalated=False)
         time.sleep(poll_interval)
 
     # Still alive after grace period - escalate.
+    escalated = False
     if process_alive(pgid):
         logger.warning(
             "Process group %d did not exit within %.1fs of SIGTERM; sending SIGKILL",
@@ -346,7 +438,8 @@ def kill_process_group_graceful(
         )
         kill_sig = signal.SIGKILL if is_signal_supported("SIGKILL") else 9
         kill_process_group(pgid, kill_sig)
-    return True
+        escalated = True
+    return _receipt(delivered=True, escalated=escalated)
 
 
 def process_alive(pid: int) -> bool:
@@ -531,3 +624,363 @@ def _win_process_alive(pid: int) -> bool:
         return False
     finally:
         kernel32.CloseHandle(handle)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Process-group spawn keywords
+# ---------------------------------------------------------------------------
+
+# CREATE_NEW_PROCESS_GROUP is only defined by the subprocess module on
+# Windows; the literal value is stable Win32 API surface.
+_WIN_CREATE_NEW_PROCESS_GROUP = 0x00000200
+
+
+def process_group_popen_kwargs() -> dict[str, Any]:
+    """Return the ``subprocess.Popen`` keywords that isolate a process tree.
+
+    Deterministic projection of the current platform onto spawn flags:
+
+    * POSIX: ``{"start_new_session": True}`` - the child becomes a session
+      leader, so its PID equals its PGID and the whole tree can be reaped
+      with ``os.killpg``.
+    * Windows: ``{"creationflags": CREATE_NEW_PROCESS_GROUP}`` - the child
+      anchors its own process group so console control events and
+      ``taskkill /T`` tree termination target the agent tree, not the
+      orchestrator.
+
+    ``start_new_session`` is silently ignored by CPython on Windows, so
+    call sites that spread these kwargs get real group semantics on both
+    platforms instead of POSIX-only behaviour.
+
+    Returns:
+        Keyword arguments to spread into ``subprocess.Popen``.
+    """
+    if IS_WINDOWS:
+        creationflags: int = getattr(
+            subprocess,
+            "CREATE_NEW_PROCESS_GROUP",
+            _WIN_CREATE_NEW_PROCESS_GROUP,
+        )
+        return {"creationflags": creationflags}
+    return {"start_new_session": True}
+
+
+# ---------------------------------------------------------------------------
+# Windows Job Objects
+# ---------------------------------------------------------------------------
+
+# Win32 constants used by the Job Object primitives.
+_WIN_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+_WIN_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+_WIN_PROCESS_SET_QUOTA = 0x0100
+_WIN_PROCESS_TERMINATE = 0x0001
+
+
+def _win_kernel32() -> Any:
+    """Return the kernel32 DLL handle (Windows only).
+
+    Isolated in a helper so tests can exercise the Job Object logic on any
+    platform by substituting a mock kernel32.
+    """
+    import ctypes
+
+    return ctypes.windll.kernel32  # type: ignore[attr-defined]
+
+
+def _win_job_limit_info() -> Any:
+    """Build a JOBOBJECT_EXTENDED_LIMIT_INFORMATION with kill-on-close set.
+
+    The ctypes structure definitions are portable; only the kernel32 calls
+    that consume the structure are Windows-specific.
+    """
+    import ctypes
+    import ctypes.wintypes
+
+    class _IoCounters(ctypes.Structure):
+        _fields_ = (
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        )
+
+    class _BasicLimitInformation(ctypes.Structure):
+        _fields_ = (
+            ("PerProcessUserTimeLimit", ctypes.wintypes.LARGE_INTEGER),
+            ("PerJobUserTimeLimit", ctypes.wintypes.LARGE_INTEGER),
+            ("LimitFlags", ctypes.wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", ctypes.wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", ctypes.wintypes.DWORD),
+            ("SchedulingClass", ctypes.wintypes.DWORD),
+        )
+
+    class _ExtendedLimitInformation(ctypes.Structure):
+        _fields_ = (
+            ("BasicLimitInformation", _BasicLimitInformation),
+            ("IoInfo", _IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        )
+
+    info = _ExtendedLimitInformation()
+    info.BasicLimitInformation.LimitFlags = _WIN_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    return info
+
+
+class WindowsJobObject:
+    """Job Object supervision for a Windows process tree.
+
+    Job Objects are the Windows-native replacement for POSIX process
+    groups: every process assigned to the job (and every descendant it
+    spawns) is a member, so :meth:`terminate` reaps the whole tree in one
+    kernel call, and the ``KILL_ON_JOB_CLOSE`` limit guarantees the tree
+    dies with the supervisor even if the orchestrator crashes.
+
+    Inert on POSIX: :meth:`available` returns ``False`` and every other
+    method raises :class:`RuntimeError` so accidental use is loud.
+
+    Usage::
+
+        with WindowsJobObject() as job:
+            if job.create():
+                job.assign(proc.pid)
+            ...
+            job.terminate()
+    """
+
+    def __init__(self) -> None:
+        self._handle: int | None = None
+
+    @staticmethod
+    def available() -> bool:
+        """Return ``True`` when Job Objects exist on this platform."""
+        return IS_WINDOWS
+
+    def _require_windows(self) -> None:
+        if not IS_WINDOWS:
+            raise RuntimeError("Job Objects are Windows-only; check WindowsJobObject.available() first")
+
+    def create(self) -> bool:
+        """Create an anonymous Job Object with kill-on-close semantics.
+
+        Returns:
+            ``True`` when the job was created and configured.
+        """
+        self._require_windows()
+        import ctypes
+
+        kernel32 = _win_kernel32()
+        handle = kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            logger.warning("CreateJobObjectW failed; falling back to taskkill tree termination")
+            return False
+        info = _win_job_limit_info()
+        ok = kernel32.SetInformationJobObject(
+            handle,
+            _WIN_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+            ctypes.byref(info),
+            ctypes.sizeof(info),
+        )
+        if not ok:
+            logger.warning("SetInformationJobObject failed; closing job handle")
+            kernel32.CloseHandle(handle)
+            return False
+        self._handle = int(handle)
+        return True
+
+    def assign(self, pid: int) -> bool:
+        """Assign *pid* (and its future descendants) to this job.
+
+        Args:
+            pid: Lead process ID to place under supervision.
+
+        Returns:
+            ``True`` when the process joined the job.
+        """
+        self._require_windows()
+        if self._handle is None or pid <= 0:
+            return False
+        kernel32 = _win_kernel32()
+        proc = kernel32.OpenProcess(
+            _WIN_PROCESS_SET_QUOTA | _WIN_PROCESS_TERMINATE,
+            False,
+            pid,
+        )
+        if not proc:
+            return False
+        try:
+            return bool(kernel32.AssignProcessToJobObject(self._handle, proc))
+        finally:
+            kernel32.CloseHandle(proc)
+
+    def terminate(self, exit_code: int = 1) -> bool:
+        """Terminate every process in the job in a single kernel call.
+
+        Args:
+            exit_code: Exit code reported for the terminated processes.
+
+        Returns:
+            ``True`` when the job tree was terminated.
+        """
+        self._require_windows()
+        if self._handle is None:
+            return False
+        kernel32 = _win_kernel32()
+        return bool(kernel32.TerminateJobObject(self._handle, exit_code))
+
+    def close(self) -> None:
+        """Release the job handle.  Idempotent.
+
+        With ``KILL_ON_JOB_CLOSE`` set, closing the last handle also
+        terminates any processes still in the job.
+        """
+        if self._handle is None:
+            return
+        if IS_WINDOWS:
+            _win_kernel32().CloseHandle(self._handle)
+        self._handle = None
+
+    def __enter__(self) -> WindowsJobObject:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem semantics (worktree handling)
+# ---------------------------------------------------------------------------
+
+# Legacy Windows path-length ceiling that still applies to many Win32 file
+# APIs unless the extended-length prefix is used.  CreateDirectoryW caps at
+# MAX_PATH - 12 (248); staying below that keeps every worktree file
+# operation safe.
+_WIN_LONG_PATH_THRESHOLD = 248
+_WIN_EXTENDED_PREFIX = "\\\\?\\"
+
+
+def to_extended_length_path(path: str | Path) -> str:
+    """Return *path* in a form safe for long Windows paths.
+
+    On Windows, absolute paths at or beyond the legacy limit are given the
+    extended-length prefix (``\\\\?\\`` or ``\\\\?\\UNC\\`` for UNC paths) so
+    deep worktree trees survive Win32 file APIs.  Short paths are returned
+    as normalised absolute paths without the prefix.  On POSIX the input is
+    returned unchanged.
+
+    Args:
+        path: Filesystem path (string or ``Path``).
+
+    Returns:
+        A string path usable with ``open``, ``shutil``, and ``os`` calls.
+    """
+    raw = os.fspath(path)
+    if not IS_WINDOWS:
+        return raw
+    if raw.startswith(_WIN_EXTENDED_PREFIX):
+        return raw
+    absolute = ntpath.abspath(raw)
+    if len(absolute) < _WIN_LONG_PATH_THRESHOLD:
+        return absolute
+    if absolute.startswith("\\\\"):
+        # UNC path: \\server\share\... -> \\?\UNC\server\share\...
+        return _WIN_EXTENDED_PREFIX + "UNC" + absolute[1:]
+    return _WIN_EXTENDED_PREFIX + absolute
+
+
+def _win_clear_readonly(func: Callable[[str], object], path: str, _exc: BaseException) -> None:
+    """``shutil.rmtree`` onexc handler: clear read-only and retry once."""
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def robust_rmtree(
+    path: str | Path,
+    *,
+    max_attempts: int = 5,
+    retry_delay_s: float = 0.1,
+) -> bool:
+    """Remove a directory tree, tolerating Windows filesystem semantics.
+
+    On POSIX this is a single ``shutil.rmtree`` attempt - behaviour is
+    unchanged from calling it directly, except failures are logged and
+    reported instead of raised.  On Windows, read-only attributes (which
+    git sets on object files) are cleared on demand, long paths get the
+    extended-length prefix, and transient sharing violations (antivirus,
+    indexers, a slow-to-exit child holding a handle) are retried with a
+    linear backoff.
+
+    Args:
+        path: Directory tree to remove.
+        max_attempts: Maximum removal attempts on Windows (must be >= 1).
+        retry_delay_s: Base delay between attempts; grows linearly.
+
+    Returns:
+        ``True`` when the tree is gone (or never existed), ``False`` when
+        removal ultimately failed.
+    """
+    raw = os.fspath(path)
+    if not os.path.lexists(raw):
+        return True
+
+    if not IS_WINDOWS:
+        try:
+            shutil.rmtree(raw)
+        except OSError as exc:
+            logger.warning("Failed to remove tree %s: %s", raw, type(exc).__name__)
+            return False
+        return True
+
+    target = to_extended_length_path(raw)
+    attempts = max(1, max_attempts)
+    for attempt in range(1, attempts + 1):
+        try:
+            shutil.rmtree(target, onexc=_win_clear_readonly)
+        except OSError as exc:
+            if attempt == attempts:
+                logger.warning(
+                    "Failed to remove tree %s after %d attempts: %s",
+                    raw,
+                    attempts,
+                    type(exc).__name__,
+                )
+                return False
+            time.sleep(retry_delay_s * attempt)
+        else:
+            return True
+    return False
+
+
+def is_filesystem_link(path: Path) -> bool:
+    """Return ``True`` when *path* is a symlink or an NTFS junction.
+
+    ``Path.is_symlink()`` is ``False`` for junctions, so Windows callers
+    that only check for symlinks can be bypassed by a junction pointing at
+    the same target.  Junction probing is a no-op on POSIX
+    (``Path.is_junction()`` always returns ``False`` there), so POSIX
+    behaviour is identical to ``is_symlink()``.
+
+    Args:
+        path: Path to probe.  Only ``is_symlink``/``is_junction`` are used,
+            so duck-typed stand-ins work in tests.
+
+    Returns:
+        ``True`` for symlinks and junctions; ``False`` otherwise (including
+        unreadable paths).
+    """
+    try:
+        if path.is_symlink():
+            return True
+        is_junction = getattr(path, "is_junction", None)
+        if is_junction is None:
+            return False
+        return bool(is_junction())
+    except OSError:
+        return False

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 from bernstein.core.git.git_ops import branch_delete, worktree_add, worktree_list, worktree_remove
 from bernstein.core.git.salvage import SalvageResult, salvage_worktree
 from bernstein.core.git.worktree_isolation import validate_worktree_isolation
-from bernstein.core.platform_compat import process_alive
+from bernstein.core.platform_compat import IS_WINDOWS, process_alive, robust_rmtree
 
 if TYPE_CHECKING:
     import threading
@@ -830,6 +830,32 @@ class WorktreeManager:
                 )
         except Exception as exc:
             logger.warning("Failed to remove worktree for %s: %s", session_id, exc)
+
+        # 1b. Windows: git can leave the directory behind when a file inside
+        # it is still locked (antivirus, indexers, a slow-to-exit child
+        # holding a handle) or read-only.  Retry the removal with the
+        # platform-layer helper (read-only clearing + backoff), then prune
+        # the now-orphaned worktree metadata.  POSIX behaviour is unchanged.
+        if IS_WINDOWS and worktree_path.exists():
+            if robust_rmtree(worktree_path):
+                try:
+                    subprocess.run(
+                        ["git", "worktree", "prune"],
+                        cwd=self.repo_root,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        timeout=10,
+                    )
+                except Exception as exc:
+                    logger.debug("git worktree prune after residual removal failed: %s", exc)
+            else:
+                logger.warning(
+                    "Residual worktree directory could not be removed for %s: %s",
+                    session_id,
+                    worktree_path,
+                )
 
         # 2. Delete the branch
         #    When salvage moved the branch to salvage/<id> the original agent

--- a/src/bernstein/core/git/worktree_isolation.py
+++ b/src/bernstein/core/git/worktree_isolation.py
@@ -16,10 +16,21 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from bernstein.core.platform_compat import is_filesystem_link
+
 if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_link_target(path: Path) -> Path:
+    """Resolve a link (symlink or junction) to its target path.
+
+    Isolated in a helper so tests can exercise the junction branches on
+    platforms where junctions cannot be created.
+    """
+    return path.resolve()
 
 
 class WorktreeIsolationError(Exception):
@@ -53,8 +64,8 @@ def check_sdd_not_shared(worktree_path: Path, repo_root: Path) -> list[str]:
 
     The .sdd/ directory inside a worktree must be either absent (fine, will
     be created fresh) or a real directory local to the worktree.  It must NOT
-    be a symlink into the parent repo's .sdd/ because that would let agents
-    clobber each other's state files.
+    be a symlink (or, on Windows, an NTFS junction) into the parent repo's
+    .sdd/ because that would let agents clobber each other's state files.
 
     Args:
         worktree_path: Path to the worktree directory.
@@ -69,8 +80,8 @@ def check_sdd_not_shared(worktree_path: Path, repo_root: Path) -> list[str]:
     if not sdd_path.exists():
         return violations
 
-    if sdd_path.is_symlink():
-        link_target = sdd_path.resolve()
+    if is_filesystem_link(sdd_path):
+        link_target = _resolve_link_target(sdd_path)
         parent_sdd = repo_root / ".sdd"
         if link_target == parent_sdd.resolve() or str(link_target).startswith(str(parent_sdd.resolve())):
             violations.append(f".sdd/ is a symlink to parent repo state: {sdd_path} -> {link_target}")
@@ -109,14 +120,14 @@ def check_symlinks_read_only(
         return violations
 
     for entry in worktree_path.iterdir():
-        if not entry.is_symlink():
+        if not is_filesystem_link(entry):
             continue
 
         rel_name = entry.name
         if rel_name in allowed_symlink_dirs:
             continue
 
-        link_target = entry.resolve()
+        link_target = _resolve_link_target(entry)
         # Symlinks pointing into the parent repo's mutable state dirs are dangerous
         mutable_dirs = (".sdd", ".git")
         for mutable in mutable_dirs:

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -343,6 +343,16 @@ EVENT_TASK_MAILBOX_MESSAGE = "task.mailbox_message"
 #: scheduler decision.
 EVENT_TASK_CLAIM_RECEIPT = "task.claim_receipt"
 
+#: Issue #2367 -- emitted when the orchestrator forcibly reaps an agent
+#: process tree.  The event records which platform mechanism delivered the
+#: stop (POSIX process-group signalling or Windows process-tree
+#: termination), whether the graceful stop was delivered, whether
+#: escalation to a force-kill was required, and the grace window that
+#: applied.  Reaps stop being an unobservable side effect of supervision:
+#: an operator reconstructing a failure window can prove offline which
+#: reap path ran and on which platform semantics it relied.
+EVENT_PROCESS_REAP_RECEIPT = "process.reap_receipt"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -2135,6 +2145,64 @@ def record_task_claim_receipt(
     )
 
 
+def record_process_reap_receipt(
+    *,
+    chain: AuditChainStore,
+    session_id: str,
+    pgid: int,
+    os_name: str,
+    method: str,
+    delivered: bool,
+    escalated: bool,
+    grace_seconds: float,
+    reason: str,
+    actor: str = "spawner",
+) -> AuditEvent:
+    """Append a ``process.reap_receipt`` event into *chain* (#2367).
+
+    Mirrors a forced agent process-tree reap into the audit chain.  The
+    receipt records which platform mechanism delivered the stop (POSIX
+    process-group signalling or Windows process-tree termination), whether
+    the graceful stop was delivered, and whether escalation to a force-kill
+    was required.  A verifier reconstructing a failure window can prove
+    offline which reap path ran instead of inferring it from log lines.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        session_id: Agent session whose process tree was reaped.
+        pgid: Process group ID (POSIX) or lead PID (Windows) targeted.
+        os_name: Normalised OS name (``"linux"``/``"macos"``/``"windows"``).
+        method: Delivery mechanism identifier
+            (``"posix_process_group"`` / ``"windows_process_tree"``).
+        delivered: Whether the initial graceful stop was delivered.
+        escalated: Whether a force-kill was required after the grace window.
+        grace_seconds: The grace window that applied to this reap.
+        reason: Why the reap ran (e.g. ``"kill_requested"``,
+            ``"heartbeat_stale"``, ``"wall_clock_timeout"``).
+        actor: Recorded actor; defaults to ``"spawner"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
+        in its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_PROCESS_REAP_RECEIPT,
+        actor=actor,
+        resource_type="process_reap",
+        resource_id=session_id,
+        details={
+            "session_id": session_id,
+            "pgid": pgid,
+            "os_name": os_name,
+            "method": method,
+            "delivered": delivered,
+            "escalated": escalated,
+            "grace_seconds": grace_seconds,
+            "reason": reason,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -2156,6 +2224,7 @@ __all__ = [
     "EVENT_MEMORY_WRITE",
     "EVENT_MULTIMODAL_ATTACH",
     "EVENT_OTEL_PROJECTION",
+    "EVENT_PROCESS_REAP_RECEIPT",
     "EVENT_REVIEW_RECEIPT",
     "EVENT_ROUTING_FAILOVER_RECEIPT",
     "EVENT_SCHEDULE_FIRE_PROJECTION",
@@ -2195,6 +2264,7 @@ __all__ = [
     "record_memory_write",
     "record_multimodal_attach",
     "record_otel_projection",
+    "record_process_reap_receipt",
     "record_review_receipt",
     "record_routing_failover_receipt",
     "record_schedule_fire_projection",

--- a/tests/unit/test_adapter_aider.py
+++ b/tests/unit/test_adapter_aider.py
@@ -381,13 +381,13 @@ class TestAiderKill:
     def test_calls_killpg_with_pid_as_pgid(self) -> None:
         """kill() uses pid directly as pgid (start_new_session=True)."""
         adapter = AiderAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_kill:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_kill:
             adapter.kill(555)
         mock_kill.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = AiderAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_amp.py
+++ b/tests/unit/test_adapter_amp.py
@@ -361,13 +361,13 @@ class TestAmpIsAlive:
 class TestAmpKill:
     def test_calls_killpg(self) -> None:
         adapter = AmpAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = AmpAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_claude.py
+++ b/tests/unit/test_adapter_claude.py
@@ -392,22 +392,28 @@ class TestIsAlive:
 class TestKill:
     """kill() terminates both the claude process and the wrapper process."""
 
-    def test_calls_kill_process_group_on_claude_process(self) -> None:
+    def test_calls_reap_on_claude_process(self) -> None:
         adapter = ClaudeCodeAdapter()
         ClaudeCodeAdapter._procs[50] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[50] = 51
 
-        with patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg:
+        with (
+            patch("bernstein.adapters.claude.reap_process_group") as mock_reap,
+            patch("bernstein.adapters.claude.kill_process_group_graceful"),
+        ):
             adapter.kill(50)
 
-        mock_kpg.assert_any_call(50)
+        mock_reap.assert_called_once_with(50)
 
     def test_kills_wrapper_process(self) -> None:
         adapter = ClaudeCodeAdapter()
         ClaudeCodeAdapter._procs[60] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[60] = 61
 
-        with patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg:
+        with (
+            patch("bernstein.adapters.claude.reap_process_group"),
+            patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg,
+        ):
             adapter.kill(60)
 
         mock_kpg.assert_any_call(61)
@@ -417,7 +423,10 @@ class TestKill:
         ClaudeCodeAdapter._procs[70] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[70] = 71
 
-        with patch("bernstein.adapters.claude.kill_process_group_graceful"):
+        with (
+            patch("bernstein.adapters.claude.reap_process_group"),
+            patch("bernstein.adapters.claude.kill_process_group_graceful"),
+        ):
             adapter.kill(70)
 
         assert 70 not in ClaudeCodeAdapter._procs
@@ -429,7 +438,10 @@ class TestKill:
         ClaudeCodeAdapter._procs[80] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[80] = 81
 
-        with patch("bernstein.adapters.claude.kill_process_group_graceful", return_value=False):
+        with (
+            patch("bernstein.adapters.claude.reap_process_group"),
+            patch("bernstein.adapters.claude.kill_process_group_graceful", return_value=False),
+        ):
             adapter.kill(80)  # must not raise
 
     def test_handles_failed_wrapper_kill(self) -> None:
@@ -438,13 +450,13 @@ class TestKill:
         ClaudeCodeAdapter._procs[90] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[90] = 91
 
-        # kill_process_group_graceful succeeds for main pid (90), fails for wrapper (91)
-        def _kpg_side_effect(pgid: int) -> bool:
-            return pgid != 91
-
-        with patch(
-            "bernstein.adapters.claude.kill_process_group_graceful",
-            side_effect=_kpg_side_effect,
+        # Wrapper kill fails for wrapper pid (91); primary reap succeeds.
+        with (
+            patch("bernstein.adapters.claude.reap_process_group"),
+            patch(
+                "bernstein.adapters.claude.kill_process_group_graceful",
+                return_value=False,
+            ),
         ):
             adapter.kill(90)  # must not raise
 
@@ -454,11 +466,15 @@ class TestKill:
         ClaudeCodeAdapter._procs[100] = MagicMock()
         # _wrapper_pids intentionally not set for pid 100
 
-        with patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg:
+        with (
+            patch("bernstein.adapters.claude.reap_process_group") as mock_reap,
+            patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg,
+        ):
             adapter.kill(100)
 
-        # Only the main process group is killed, no wrapper
-        mock_kpg.assert_called_once_with(100)
+        # Only the main process group is reaped, no wrapper kill
+        mock_reap.assert_called_once_with(100)
+        mock_kpg.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -390,13 +390,13 @@ class TestCodexIsAlive:
 class TestCodexKill:
     def test_calls_killpg(self) -> None:
         adapter = CodexAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = CodexAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -223,12 +223,12 @@ class TestAdapterContract:
 
     def test_kill_does_not_raise(self, name: str, factory: Any) -> None:
         adapter = factory()
-        with patch("bernstein.adapters.base.kill_process_group_graceful"):
+        with patch("bernstein.adapters.base.reap_process_group"):
             adapter.kill(999)  # must not raise
 
     def test_kill_suppresses_oserror(self, name: str, factory: Any) -> None:
         adapter = factory()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(99999)  # must not raise
 
     def test_detect_tier_returns_none_or_api_tier_info(self, name: str, factory: Any) -> None:

--- a/tests/unit/test_adapter_devin_terminal.py
+++ b/tests/unit/test_adapter_devin_terminal.py
@@ -450,13 +450,13 @@ class TestDevinTerminalIsAlive:
 class TestDevinTerminalKill:
     def test_calls_killpg(self) -> None:
         adapter = DevinTerminalAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = DevinTerminalAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_gemini.py
+++ b/tests/unit/test_adapter_gemini.py
@@ -493,13 +493,13 @@ class TestGeminiIsAlive:
 class TestGeminiKill:
     def test_calls_killpg(self) -> None:
         adapter = GeminiAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = GeminiAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_generic.py
+++ b/tests/unit/test_adapter_generic.py
@@ -368,13 +368,13 @@ class TestGenericIsAlive:
 class TestGenericKill:
     def test_calls_killpg(self) -> None:
         adapter = GenericAdapter(cli_command="agent")
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = GenericAdapter(cli_command="agent")
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_iac.py
+++ b/tests/unit/test_adapter_iac.py
@@ -354,7 +354,7 @@ class TestIaCIsAlive:
 class TestIaCKill:
     def test_calls_killpg_with_pid_as_pgid(self) -> None:
         adapter = IaCAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 

--- a/tests/unit/test_adapter_junie.py
+++ b/tests/unit/test_adapter_junie.py
@@ -656,7 +656,7 @@ class TestJunieIsAlive:
 class TestJunieKill:
     def test_calls_killpg(self) -> None:
         adapter = JunieAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -680,7 +680,7 @@ class TestKill:
 
     def test_calls_killpg(self, adapter_factory: Callable[[], CLIAdapter]) -> None:
         adapter = adapter_factory()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         # PID is used directly as PGID (start_new_session=True); the helper
         # performs the SIGTERM→poll→SIGKILL escalation required by audit-011.
@@ -688,7 +688,7 @@ class TestKill:
 
     def test_does_not_raise_on_oserror(self, adapter_factory: Callable[[], CLIAdapter]) -> None:
         adapter = adapter_factory()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_q_dev.py
+++ b/tests/unit/test_adapter_q_dev.py
@@ -414,11 +414,11 @@ class TestQDevIsAlive:
 class TestQDevKill:
     def test_calls_kill_process_group_graceful(self) -> None:
         adapter = QDevAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_kill:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_kill:
             adapter.kill(555)
         mock_kill.assert_called_once_with(555)
 
     def test_does_not_raise_on_dead_process(self) -> None:
         adapter = QDevAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -563,13 +563,13 @@ class TestQwenIsAlive:
 class TestQwenKill:
     def test_calls_killpg(self) -> None:
         adapter = QwenAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = QwenAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+        with patch("bernstein.adapters.base.reap_process_group", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_audit_chain_process_reap.py
+++ b/tests/unit/test_audit_chain_process_reap.py
@@ -1,0 +1,132 @@
+"""Audit-chain receipts for process-tree reaps (issue #2367).
+
+Every forced termination of an agent process tree is mirrored into the
+HMAC-chained audit log as a reap receipt: which platform mechanism delivered
+the stop, whether escalation to a force-kill was required, and the grace
+window that applied.  An operator reconstructing a failure window can prove
+offline which reap path ran and on which platform semantics it relied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import (
+    EVENT_PROCESS_REAP_RECEIPT,
+    AuditChainStore,
+    record_process_reap_receipt,
+)
+
+
+def test_record_process_reap_receipt_appends_event(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    event = record_process_reap_receipt(
+        chain=chain,
+        session_id="agent-1",
+        pgid=4321,
+        os_name="linux",
+        method="posix_process_group",
+        delivered=True,
+        escalated=False,
+        grace_seconds=3.0,
+        reason="kill_requested",
+    )
+    assert event.event_type == EVENT_PROCESS_REAP_RECEIPT
+    rows = chain.query(event_type=EVENT_PROCESS_REAP_RECEIPT)
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["session_id"] == "agent-1"
+    assert details["pgid"] == 4321
+    assert details["os_name"] == "linux"
+    assert details["method"] == "posix_process_group"
+    assert details["delivered"] is True
+    assert details["escalated"] is False
+    assert details["grace_seconds"] == 3.0
+    assert details["reason"] == "kill_requested"
+    assert "prev_chain_digest" in details
+
+
+def test_record_process_reap_receipt_windows_method(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    record_process_reap_receipt(
+        chain=chain,
+        session_id="agent-2",
+        pgid=999,
+        os_name="windows",
+        method="windows_process_tree",
+        delivered=True,
+        escalated=True,
+        grace_seconds=3.0,
+        reason="heartbeat_stale",
+        actor="orchestrator",
+    )
+    rows = chain.query(event_type=EVENT_PROCESS_REAP_RECEIPT)
+    assert rows[0].details["method"] == "windows_process_tree"
+    assert rows[0].details["escalated"] is True
+    assert rows[0].actor == "orchestrator"
+
+
+def test_audit_chain_stays_verifiable_after_reap_receipt(tmp_path: Path) -> None:
+    chain = AuditChainStore(tmp_path / "audit", key=b"0" * 32)
+    record_process_reap_receipt(
+        chain=chain,
+        session_id="agent-1",
+        pgid=4321,
+        os_name="macos",
+        method="posix_process_group",
+        delivered=False,
+        escalated=False,
+        grace_seconds=3.0,
+        reason="kill_requested",
+    )
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_spawner_emit_helper_writes_receipt(tmp_path: Path) -> None:
+    """The spawner-side emit helper mirrors a reap receipt best-effort."""
+    from bernstein.core.platform_compat import ProcessReapReceipt
+
+    from bernstein.core.agents.spawner_core import emit_process_reap_receipt
+
+    (tmp_path / ".sdd").mkdir()
+    receipt = ProcessReapReceipt(
+        pgid=777,
+        os_name="linux",
+        method="posix_process_group",
+        delivered=True,
+        escalated=True,
+        grace_seconds=3.0,
+    )
+    emit_process_reap_receipt(tmp_path, "sess-7", receipt, reason="kill_requested")
+
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit")
+    rows = chain.query(event_type=EVENT_PROCESS_REAP_RECEIPT)
+    assert len(rows) == 1
+    assert rows[0].details["session_id"] == "sess-7"
+    assert rows[0].details["pgid"] == 777
+    assert rows[0].details["escalated"] is True
+
+
+def test_spawner_emit_helper_never_raises(tmp_path: Path) -> None:
+    """Audit mirroring must never mask the kill itself."""
+    from unittest.mock import patch
+
+    from bernstein.core.platform_compat import ProcessReapReceipt
+
+    from bernstein.core.agents.spawner_core import emit_process_reap_receipt
+
+    receipt = ProcessReapReceipt(
+        pgid=1,
+        os_name="linux",
+        method="posix_process_group",
+        delivered=False,
+        escalated=False,
+        grace_seconds=3.0,
+    )
+    with patch(
+        "bernstein.core.security.audit_chain.AuditChainStore",
+        side_effect=RuntimeError("audit backend down"),
+    ):
+        # Must not raise.
+        emit_process_reap_receipt(tmp_path, "sess-8", receipt, reason="kill_requested")

--- a/tests/unit/test_cloudflare_agents_adapter.py
+++ b/tests/unit/test_cloudflare_agents_adapter.py
@@ -381,6 +381,6 @@ class TestCloudflareIsAlive:
 class TestCloudflareKill:
     def test_calls_killpg(self) -> None:
         adapter = CloudflareAgentsAdapter()
-        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
+        with patch("bernstein.adapters.base.reap_process_group") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)

--- a/tests/unit/test_heartbeat_escalation.py
+++ b/tests/unit/test_heartbeat_escalation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import signal
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -117,7 +116,6 @@ class TestBasicEscalation:
         assert result.tier == EscalationTier.SIGTERM
         mock_kill.assert_called_with(1234, signal.SIGTERM)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="SIGKILL not available on Windows")
     @patch("bernstein.core.platform_compat.kill_process_group")
     def test_sigkill_at_threshold(self, mock_kill: MagicMock) -> None:
         ladder = HeartbeatEscalationLadder()
@@ -128,7 +126,10 @@ class TestBasicEscalation:
         result = ladder.check_and_escalate("agent-1", heartbeat_age_s=150.0)
         assert result is not None
         assert result.tier == EscalationTier.SIGKILL
-        mock_kill.assert_called_with(1234, signal.SIGKILL)
+        # On hosts without SIGKILL the ladder falls back to the numeric
+        # force-kill code, which the platform layer maps to a tree kill.
+        expected_sig = getattr(signal, "SIGKILL", 9)
+        mock_kill.assert_called_with(1234, expected_sig)
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +148,6 @@ class TestIdempotency:
         assert result1.tier == EscalationTier.WARN
         assert result2 is None  # already warned
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="SIGKILL not available on Windows")
     def test_escalates_to_next_tier(self) -> None:
         ladder = HeartbeatEscalationLadder()
         ladder.register_agent("agent-1", pid=1234)
@@ -275,3 +275,71 @@ class TestUnregister:
     def test_unregister_nonexistent_is_safe(self) -> None:
         ladder = HeartbeatEscalationLadder()
         ladder.unregister_agent("nonexistent")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Platform-safe tier delivery (issue #2367)
+# ---------------------------------------------------------------------------
+
+_HB = "bernstein.core.agents.heartbeat_escalation"
+
+
+class TestPlatformSafeTiers:
+    """The escalation ladder must run on hosts without POSIX signals.
+
+    SIGUSR1 has no Windows equivalent, so that tier degrades to a logged
+    no-op instead of an ``AttributeError`` at escalation time.  SIGKILL is
+    represented by the numeric force-kill code (9), which the platform
+    layer translates to a native tree termination.
+    """
+
+    def _escalate_to(self, ladder: HeartbeatEscalationLadder, age: float) -> EscalationAction | None:
+        ladder.register_agent("agent-1", pid=1234)
+        result: EscalationAction | None = None
+        for step_age in (60.0, 90.0, 120.0, 150.0):
+            if step_age > age:
+                break
+            result = ladder.check_and_escalate("agent-1", heartbeat_age_s=step_age) or result
+        return result
+
+    @patch("bernstein.core.platform_compat.kill_process_group")
+    @patch(f"{_HB}.is_signal_supported", return_value=False)
+    def test_sigusr1_tier_is_noop_without_signal_support(
+        self,
+        _mock_supported: MagicMock,
+        mock_kill: MagicMock,
+    ) -> None:
+        ladder = HeartbeatEscalationLadder()
+        result = self._escalate_to(ladder, 90.0)
+        assert result is not None
+        assert result.tier == EscalationTier.SIGUSR1
+        assert result.action_taken is False
+        mock_kill.assert_not_called()
+
+    @patch("bernstein.core.platform_compat.kill_process_group")
+    @patch(f"{_HB}.is_signal_supported", return_value=False)
+    def test_sigkill_tier_uses_numeric_force_kill(
+        self,
+        _mock_supported: MagicMock,
+        mock_kill: MagicMock,
+    ) -> None:
+        ladder = HeartbeatEscalationLadder()
+        result = self._escalate_to(ladder, 150.0)
+        assert result is not None
+        assert result.tier == EscalationTier.SIGKILL
+        assert result.action_taken is True
+        mock_kill.assert_called_with(1234, 9)
+
+    @patch("bernstein.core.platform_compat.kill_process_group")
+    @patch(f"{_HB}.is_signal_supported", return_value=False)
+    def test_sigterm_tier_still_delivers(
+        self,
+        _mock_supported: MagicMock,
+        mock_kill: MagicMock,
+    ) -> None:
+        ladder = HeartbeatEscalationLadder()
+        result = self._escalate_to(ladder, 120.0)
+        assert result is not None
+        assert result.tier == EscalationTier.SIGTERM
+        assert result.action_taken is True
+        mock_kill.assert_called_with(1234, signal.SIGTERM)

--- a/tests/unit/test_platform_fs_compat.py
+++ b/tests/unit/test_platform_fs_compat.py
@@ -1,0 +1,188 @@
+"""Filesystem platform layer for worktree handling (issue #2367).
+
+Covers the Windows filesystem semantics that worktree management relies on:
+
+* ``to_extended_length_path`` - extended-length (``\\\\?\\``) prefixing for
+  paths that exceed the legacy Windows path limit.  Pass-through on POSIX.
+* ``robust_rmtree`` - tree removal that clears the Windows read-only
+  attribute and retries transient sharing violations.  Single attempt on
+  POSIX, byte-identical to ``shutil.rmtree``.
+* ``is_filesystem_link`` - link detection that treats NTFS junctions the
+  same as symlinks, so isolation checks cannot be bypassed by a junction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.platform_compat import (
+    IS_WINDOWS,
+    is_filesystem_link,
+    robust_rmtree,
+    to_extended_length_path,
+)
+
+_PC = "bernstein.core.config.platform_compat"
+
+
+# ---------------------------------------------------------------------------
+# to_extended_length_path
+# ---------------------------------------------------------------------------
+
+
+class TestToExtendedLengthPath:
+    def test_posix_passthrough(self) -> None:
+        if IS_WINDOWS:
+            pytest.skip("POSIX passthrough asserted under mock below")
+        assert to_extended_length_path("/usr/local/bin") == "/usr/local/bin"
+
+    @patch(f"{_PC}.IS_WINDOWS", False)
+    def test_passthrough_preserves_relative_paths(self) -> None:
+        assert to_extended_length_path("src/pkg") == "src/pkg"
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_short_windows_path_unprefixed(self) -> None:
+        result = to_extended_length_path("C:\\repo\\worktree")
+        assert not result.startswith("\\\\?\\")
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_long_windows_path_gets_prefix(self) -> None:
+        long_path = "C:\\" + "\\".join(["deep-worktree-segment"] * 16)
+        assert len(long_path) >= 248
+        result = to_extended_length_path(long_path)
+        assert result.startswith("\\\\?\\C:")
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_already_prefixed_unchanged(self) -> None:
+        prefixed = "\\\\?\\C:\\" + "x" * 300
+        assert to_extended_length_path(prefixed) == prefixed
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_long_unc_path_gets_unc_prefix(self) -> None:
+        unc = "\\\\server\\share\\" + "\\".join(["seg"] * 80)
+        assert len(unc) >= 248
+        result = to_extended_length_path(unc)
+        assert result.startswith("\\\\?\\UNC\\server\\share")
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_prefixing_is_deterministic(self) -> None:
+        long_path = "C:\\" + "y" * 300
+        assert to_extended_length_path(long_path) == to_extended_length_path(long_path)
+
+
+# ---------------------------------------------------------------------------
+# robust_rmtree
+# ---------------------------------------------------------------------------
+
+
+class TestRobustRmtree:
+    def test_removes_populated_tree(self, tmp_path: Path) -> None:
+        tree = tmp_path / "victim"
+        (tree / "nested").mkdir(parents=True)
+        (tree / "nested" / "file.txt").write_text("payload", encoding="utf-8")
+        assert robust_rmtree(tree) is True
+        assert not tree.exists()
+
+    def test_missing_path_is_success(self, tmp_path: Path) -> None:
+        assert robust_rmtree(tmp_path / "never-existed") is True
+
+    def test_posix_failure_returns_false(self, tmp_path: Path) -> None:
+        tree = tmp_path / "victim"
+        tree.mkdir()
+        with (
+            patch(f"{_PC}.IS_WINDOWS", False),
+            patch(f"{_PC}.shutil.rmtree", side_effect=OSError("boom")),
+        ):
+            assert robust_rmtree(tree) is False
+
+    def test_windows_retries_transient_lock(self, tmp_path: Path) -> None:
+        """A sharing-violation style failure is retried, then succeeds."""
+        tree = tmp_path / "victim"
+        tree.mkdir()
+        calls: list[int] = []
+
+        def _flaky(path: object, **_kwargs: object) -> None:
+            calls.append(1)
+            if len(calls) == 1:
+                raise OSError("access denied (simulated file lock)")
+
+        with (
+            patch(f"{_PC}.IS_WINDOWS", True),
+            patch(f"{_PC}.shutil.rmtree", side_effect=_flaky),
+            patch(f"{_PC}.time.sleep"),
+        ):
+            assert robust_rmtree(tree) is True
+        assert len(calls) == 2
+
+    def test_windows_gives_up_after_max_attempts(self, tmp_path: Path) -> None:
+        tree = tmp_path / "victim"
+        tree.mkdir()
+        with (
+            patch(f"{_PC}.IS_WINDOWS", True),
+            patch(f"{_PC}.shutil.rmtree", side_effect=OSError("still locked")),
+            patch(f"{_PC}.time.sleep") as mock_sleep,
+        ):
+            assert robust_rmtree(tree, max_attempts=3) is False
+        assert mock_sleep.call_count == 2  # no sleep after the final attempt
+
+    def test_readonly_file_removed(self, tmp_path: Path) -> None:
+        """Read-only entries must not survive removal (Windows attribute case)."""
+        tree = tmp_path / "victim"
+        tree.mkdir()
+        target = tree / "readonly.txt"
+        target.write_text("locked", encoding="utf-8")
+        target.chmod(0o444)
+        assert robust_rmtree(tree) is True
+        assert not tree.exists()
+
+
+# ---------------------------------------------------------------------------
+# is_filesystem_link
+# ---------------------------------------------------------------------------
+
+
+class _JunctionStub:
+    """Duck-typed Path stand-in modelling an NTFS junction."""
+
+    def is_symlink(self) -> bool:
+        return False
+
+    def is_junction(self) -> bool:
+        return True
+
+
+class _BrokenStub:
+    """Duck-typed Path stand-in whose probes raise OSError."""
+
+    def is_symlink(self) -> bool:
+        raise OSError("unreadable")
+
+    def is_junction(self) -> bool:  # pragma: no cover - never reached
+        raise OSError("unreadable")
+
+
+class TestIsFilesystemLink:
+    def test_regular_dir_is_not_link(self, tmp_path: Path) -> None:
+        target = tmp_path / "plain"
+        target.mkdir()
+        assert is_filesystem_link(target) is False
+
+    def test_symlink_detected(self, tmp_path: Path) -> None:
+        if IS_WINDOWS:
+            pytest.skip("symlink creation needs Developer Mode on Windows")
+        source = tmp_path / "src"
+        source.mkdir()
+        link = tmp_path / "lnk"
+        link.symlink_to(source)
+        assert is_filesystem_link(link) is True
+
+    def test_junction_detected(self) -> None:
+        assert is_filesystem_link(_JunctionStub()) is True  # type: ignore[arg-type]
+
+    def test_probe_error_is_not_link(self) -> None:
+        assert is_filesystem_link(_BrokenStub()) is False  # type: ignore[arg-type]
+
+    def test_missing_path_is_not_link(self, tmp_path: Path) -> None:
+        assert is_filesystem_link(tmp_path / "absent") is False

--- a/tests/unit/test_platform_process_tree.py
+++ b/tests/unit/test_platform_process_tree.py
@@ -1,0 +1,282 @@
+"""Process-tree lifecycle platform layer (issue #2367).
+
+Covers the cross-platform process supervision surface:
+
+* ``process_group_popen_kwargs`` - the deterministic projection of the
+  current platform onto ``subprocess.Popen`` spawn keywords.
+* ``reap_process_group`` - the TERM -> poll -> KILL escalation that returns
+  a structured :class:`ProcessReapReceipt` instead of a bare bool, so every
+  reap can be mirrored into the audit chain.
+* ``WindowsJobObject`` - Job Object supervision primitives that replace
+  POSIX process groups on Windows.  Inert on POSIX; exercised here through
+  a mocked kernel32 so the Windows branches are covered on every OS.
+* ``CLIAdapter.kill`` returning the reap receipt to its caller.
+"""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.platform_compat import (
+    IS_WINDOWS,
+    ProcessReapReceipt,
+    WindowsJobObject,
+    kill_process_group_graceful,
+    process_group_popen_kwargs,
+    reap_process_group,
+)
+
+_PC = "bernstein.core.config.platform_compat"
+
+
+# ---------------------------------------------------------------------------
+# process_group_popen_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestProcessGroupPopenKwargs:
+    def test_posix_uses_start_new_session(self) -> None:
+        if IS_WINDOWS:
+            pytest.skip("POSIX projection asserted under mock below")
+        assert process_group_popen_kwargs() == {"start_new_session": True}
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_windows_uses_new_process_group_flag(self) -> None:
+        kwargs = process_group_popen_kwargs()
+        assert "start_new_session" not in kwargs
+        expected = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+        assert kwargs == {"creationflags": expected}
+
+    @patch(f"{_PC}.IS_WINDOWS", False)
+    def test_projection_is_deterministic(self) -> None:
+        """Two calls on the same platform produce identical kwargs."""
+        assert process_group_popen_kwargs() == process_group_popen_kwargs()
+
+    def test_kwargs_accepted_by_popen(self) -> None:
+        """The projected kwargs must spawn a real process on this platform."""
+        import sys
+
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "pass"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            **process_group_popen_kwargs(),  # type: ignore[arg-type]
+        )
+        assert proc.wait(timeout=30) == 0
+
+
+# ---------------------------------------------------------------------------
+# reap_process_group -> ProcessReapReceipt
+# ---------------------------------------------------------------------------
+
+
+class TestReapProcessGroup:
+    def test_invalid_pgid_receipt(self) -> None:
+        receipt = reap_process_group(0)
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        assert receipt.pgid == 0
+
+    def test_undeliverable_term_receipt(self) -> None:
+        with patch(f"{_PC}.kill_process_group", return_value=False) as mock_kpg:
+            receipt = reap_process_group(12345)
+        assert receipt.delivered is False
+        assert receipt.escalated is False
+        mock_kpg.assert_called_once_with(12345, signal.SIGTERM)
+
+    def test_clean_exit_receipt(self) -> None:
+        alive = iter([True, False])
+        with (
+            patch(f"{_PC}.kill_process_group", return_value=True) as mock_kpg,
+            patch(f"{_PC}.process_alive", side_effect=lambda _pid: next(alive, False)),
+        ):
+            receipt = reap_process_group(12345, grace_seconds=1.0, poll_interval=0.01)
+        assert receipt.delivered is True
+        assert receipt.escalated is False
+        assert mock_kpg.call_count == 1
+
+    def test_escalation_receipt(self) -> None:
+        with (
+            patch(f"{_PC}.kill_process_group", return_value=True) as mock_kpg,
+            patch(f"{_PC}.process_alive", return_value=True),
+        ):
+            receipt = reap_process_group(12345, grace_seconds=0.05, poll_interval=0.01)
+        assert receipt.delivered is True
+        assert receipt.escalated is True
+        assert mock_kpg.call_count == 2
+        # First TERM, then the platform force-kill signal.
+        assert mock_kpg.call_args_list[0].args == (12345, signal.SIGTERM)
+
+    def test_receipt_details_projection(self) -> None:
+        """to_details() is a deterministic dict projection of the receipt."""
+        receipt = ProcessReapReceipt(
+            pgid=42,
+            os_name="linux",
+            method="posix_process_group",
+            delivered=True,
+            escalated=False,
+            grace_seconds=3.0,
+        )
+        details = receipt.to_details()
+        assert details == {
+            "pgid": 42,
+            "os_name": "linux",
+            "method": "posix_process_group",
+            "delivered": True,
+            "escalated": False,
+            "grace_seconds": 3.0,
+        }
+        # Frozen dataclass: two identical receipts project identically.
+        assert (
+            details
+            == ProcessReapReceipt(
+                pgid=42,
+                os_name="linux",
+                method="posix_process_group",
+                delivered=True,
+                escalated=False,
+                grace_seconds=3.0,
+            ).to_details()
+        )
+
+    def test_receipt_method_names_platform(self) -> None:
+        with patch(f"{_PC}.kill_process_group", return_value=False):
+            receipt = reap_process_group(999)
+        if IS_WINDOWS:
+            assert receipt.method == "windows_process_tree"
+        else:
+            assert receipt.method == "posix_process_group"
+
+    def test_graceful_wrapper_matches_receipt(self) -> None:
+        """kill_process_group_graceful stays a bool projection of the receipt."""
+        with patch(f"{_PC}.kill_process_group", return_value=False):
+            assert kill_process_group_graceful(12345) is False
+        alive = iter([False])
+        with (
+            patch(f"{_PC}.kill_process_group", return_value=True),
+            patch(f"{_PC}.process_alive", side_effect=lambda _pid: next(alive, False)),
+        ):
+            assert kill_process_group_graceful(12345, grace_seconds=0.1, poll_interval=0.01) is True
+
+
+# ---------------------------------------------------------------------------
+# WindowsJobObject
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsJobObject:
+    def test_unavailable_on_posix(self) -> None:
+        if IS_WINDOWS:
+            pytest.skip("availability asserted on POSIX")
+        assert WindowsJobObject.available() is False
+
+    def test_create_raises_on_posix(self) -> None:
+        if IS_WINDOWS:
+            pytest.skip("POSIX misuse guard")
+        job = WindowsJobObject()
+        with pytest.raises(RuntimeError):
+            job.create()
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_create_configures_kill_on_close(self) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateJobObjectW.return_value = 1234
+        kernel32.SetInformationJobObject.return_value = 1
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            job = WindowsJobObject()
+            assert job.create() is True
+        kernel32.CreateJobObjectW.assert_called_once()
+        kernel32.SetInformationJobObject.assert_called_once()
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_create_failure_returns_false(self) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateJobObjectW.return_value = 0
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            job = WindowsJobObject()
+            assert job.create() is False
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_assign_opens_and_assigns_process(self) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateJobObjectW.return_value = 1234
+        kernel32.SetInformationJobObject.return_value = 1
+        kernel32.OpenProcess.return_value = 555
+        kernel32.AssignProcessToJobObject.return_value = 1
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            job = WindowsJobObject()
+            assert job.create() is True
+            assert job.assign(4321) is True
+        kernel32.OpenProcess.assert_called_once()
+        kernel32.AssignProcessToJobObject.assert_called_once_with(1234, 555)
+        kernel32.CloseHandle.assert_called_with(555)
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_assign_without_create_returns_false(self) -> None:
+        kernel32 = MagicMock()
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            job = WindowsJobObject()
+            assert job.assign(4321) is False
+        kernel32.OpenProcess.assert_not_called()
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_terminate_kills_whole_tree(self) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateJobObjectW.return_value = 1234
+        kernel32.SetInformationJobObject.return_value = 1
+        kernel32.TerminateJobObject.return_value = 1
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            job = WindowsJobObject()
+            assert job.create() is True
+            assert job.terminate() is True
+        kernel32.TerminateJobObject.assert_called_once()
+        assert kernel32.TerminateJobObject.call_args.args[0] == 1234
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_close_releases_handle(self) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateJobObjectW.return_value = 1234
+        kernel32.SetInformationJobObject.return_value = 1
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            job = WindowsJobObject()
+            assert job.create() is True
+            job.close()
+            # Second close is a no-op.
+            job.close()
+        kernel32.CloseHandle.assert_called_once_with(1234)
+
+    @patch(f"{_PC}.IS_WINDOWS", True)
+    def test_context_manager_closes(self) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateJobObjectW.return_value = 1234
+        kernel32.SetInformationJobObject.return_value = 1
+        with patch(f"{_PC}._win_kernel32", return_value=kernel32):
+            with WindowsJobObject() as job:
+                assert job.create() is True
+        kernel32.CloseHandle.assert_called_once_with(1234)
+
+
+# ---------------------------------------------------------------------------
+# CLIAdapter.kill returns the reap receipt
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterKillReceipt:
+    def test_base_kill_returns_receipt(self) -> None:
+        from bernstein.adapters.base import CLIAdapter
+
+        class _Stub(CLIAdapter):
+            def spawn(self, *args: object, **kwargs: object) -> object:  # type: ignore[override]
+                raise NotImplementedError
+
+            def name(self) -> str:
+                return "stub"
+
+        with patch(f"{_PC}.kill_process_group", return_value=False):
+            receipt = _Stub().kill(31337)
+        assert isinstance(receipt, ProcessReapReceipt)
+        assert receipt.pgid == 31337
+        assert receipt.delivered is False

--- a/tests/unit/test_worktree_isolation.py
+++ b/tests/unit/test_worktree_isolation.py
@@ -135,3 +135,60 @@ class TestValidateIsolation:
     def test_skip_hardlink_check(self, worktree_path: Path, repo_root: Path) -> None:
         result = validate_worktree_isolation(worktree_path, repo_root, check_hardlinks=False)
         assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# NTFS junction handling (issue #2367)
+# ---------------------------------------------------------------------------
+
+
+class TestJunctionDetection:
+    """Junctions must be treated like symlinks by the isolation checks.
+
+    On Windows, ``Path.is_symlink()`` is False for NTFS junctions, so a
+    junction from the worktree's ``.sdd/`` into the parent repo would
+    bypass a symlink-only check.  The checks route through the platform
+    layer's ``is_filesystem_link``, which also detects junctions.
+    """
+
+    def test_junction_sdd_flagged(
+        self,
+        worktree_path: Path,
+        repo_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        sdd = worktree_path / ".sdd"
+        sdd.mkdir()
+
+        import bernstein.core.git.worktree_isolation as wi
+
+        monkeypatch.setattr(wi, "is_filesystem_link", lambda p: Path(p) == sdd)
+        violations = check_sdd_not_shared(worktree_path, repo_root)
+        assert len(violations) == 1
+
+    def test_junction_entry_into_parent_sdd_flagged(
+        self,
+        worktree_path: Path,
+        repo_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        entry = worktree_path / "state"
+        entry.mkdir()
+
+        import bernstein.core.git.worktree_isolation as wi
+
+        monkeypatch.setattr(wi, "is_filesystem_link", lambda p: Path(p) == entry)
+        monkeypatch.setattr(
+            wi,
+            "_resolve_link_target",
+            lambda p: (repo_root / ".sdd" / "state").resolve(),
+        )
+        violations = check_symlinks_read_only(worktree_path, repo_root)
+        assert len(violations) == 1
+        assert "mutable state" in violations[0]
+
+    def test_plain_dirs_still_pass(self, worktree_path: Path, repo_root: Path) -> None:
+        (worktree_path / ".sdd").mkdir()
+        (worktree_path / "src").mkdir()
+        result = validate_worktree_isolation(worktree_path, repo_root)
+        assert result.passed


### PR DESCRIPTION
## Summary

Closes the POSIX-only gaps in process management and worktree handling behind a single platform layer, per the design in the issue. POSIX behaviour is byte-identical (same signal order, same log lines, same return contracts); every Windows branch is inert on POSIX and covered on all platforms via mocked kernel32 / platform flags.

### Platform layer (`bernstein.core.platform_compat`)

- `process_group_popen_kwargs()`: deterministic projection of the platform onto `Popen` spawn flags - `start_new_session=True` on POSIX, `CREATE_NEW_PROCESS_GROUP` on Windows (where `start_new_session` is silently ignored by CPython, so agents previously never got group semantics).
- `reap_process_group()`: the existing TERM -> poll -> KILL escalation now returns a frozen `ProcessReapReceipt` (mechanism, delivered, escalated, grace window). `kill_process_group_graceful` delegates to it and keeps its bool contract unchanged.
- `WindowsJobObject`: Job Object supervision primitives (create / assign / terminate / close) with `KILL_ON_JOB_CLOSE`, the Windows-native replacement for POSIX process groups. Raises loudly if used on POSIX; `available()` gates call sites.
- `to_extended_length_path()` (long-path `\\?\` prefixing), `robust_rmtree()` (read-only clearing + retry with backoff for transient sharing violations), `is_filesystem_link()` (junction-aware link detection).

### Wiring

- `CLIAdapter.kill` (and the Claude adapter override) return the reap receipt; the spawner kill path mirrors it into the HMAC audit chain as a new additive `process.reap_receipt` event (best-effort, never masks the kill). Forced stops are now offline-verifiable on every platform instead of being an unobservable side effect of supervision.
- Heartbeat escalation ladder no longer raises `AttributeError` on hosts without `signal.SIGUSR1` / `signal.SIGKILL`: the SIGUSR1 nudge degrades to a logged no-op, the SIGKILL tier falls back to the numeric force-kill code, which the platform layer maps to a native process-tree termination.
- claude / codex / gemini spawns route through the spawn-kwargs projection.
- Worktree isolation checks (`check_sdd_not_shared`, `check_symlinks_read_only`) route through junction-aware link detection, so an NTFS junction into the parent repo's `.sdd/` can no longer bypass a symlink-only check.
- Worktree cleanup retries residual directory removal (Windows only) after a failed `git worktree remove`, then prunes the orphaned metadata.

### Docs

- Supported-platforms table plus Windows notes in `docs/getting-started/install.md`.

## AC -> test map

| Acceptance criterion | Status | Tests |
|---|---|---|
| Platform-reason skip count drops below 5, each remaining skip individually justified in-code | Partially met | Unskipped `test_heartbeat_escalation.py` SIGKILL-tier tests (now platform-neutral); Windows branches of the new layer are tested on every OS via mocks (`tests/unit/test_platform_process_tree.py`, `tests/unit/test_platform_fs_compat.py`). Remaining platform skips: 23 markers in 11 files, each carrying an in-code reason; the majority need a real POSIX kernel (signal delivery, chmod 0o000, shlex semantics). Full inventory below. |
| Conformance suite green on Windows CI for claude, codex, gemini adapters, incl. stop/restart | Groundwork | Stop paths now return receipts and use native tree termination on Windows (`tests/unit/test_platform_process_tree.py::TestReapProcessGroup`, `TestWindowsJobObject`, `TestAdapterKillReceipt`; adapter kill tests updated in `test_adapter_claude.py` and 14 sibling files). Needs a Windows runner pass to verify; deferred. |
| Windows lane is a required check for merges to main | Deferred | Lane exists in `ci.yml` with `continue-on-error: true`; promotion is a branch-protection change (procedure already documented in `docs/operations/merge-gate.md`) and should follow a green streak, not precede it. |
| Full example goal runs end to end on a Windows host with worktree isolation intact | Deferred | Worktree layer prepared (junction detection: `tests/unit/test_worktree_isolation.py::TestJunctionDetection`; lock-tolerant removal: `tests/unit/test_platform_fs_compat.py::TestRobustRmtree`); needs a Windows host run. |

New/updated tests also include `tests/unit/test_audit_chain_process_reap.py` (receipt event, chain verifiability, spawner emit helper, never-raises) and `tests/unit/test_heartbeat_escalation.py::TestPlatformSafeTiers`.

## Platform-skip inventory (remaining markers, all reason-annotated in-code)

| File | Markers | Why the skip is genuine |
|---|---|---|
| `tests/unit/test_platform_compat.py` | 7 | real SIGKILL delivery, real process groups, SIGTERM trap end-to-end |
| `tests/property/test_shell_quote_properties.py` | 4 | POSIX `shlex` round-trip semantics |
| `tests/stress/test_subprocess_hygiene.py` | 3 | real POSIX signal delivery under load |
| `tests/unit/test_canary_real_run.py` | 2 | spawns real POSIX shell wrappers |
| `tests/unit/test_resource_limits.py` | 2 | `resource.setrlimit` is POSIX-only |
| `tests/unit/test_heartbeat_escalation.py` | 0 (was 2) | unskipped in this PR |
| `tests/unit/test_adapter_timeout.py` | 1 | real SIGKILL delivery |
| `tests/unit/test_catalog_discover.py` | 1 | `chmod 0o000` has no effect on Windows |
| `tests/unit/test_ci_fix.py` | 1 | Unix mode bits |
| `tests/unit/test_plugin_installer.py` | 1 | Unix mode bits |
| `tests/unit/test_worker.py` | 1 | real POSIX process-group signal forwarding |

## Verification

- `uv run ruff check src/ tests/` clean; `ruff format --check` clean on touched files; `uv run lint-imports` clean; `uv run python -c "import bernstein"` OK.
- Touched and new test files run 3x locally, green each pass.
- POSIX byte-identity: `kill_process_group_graceful` keeps signal order, grace polling, warning text, and bool contract; spawn kwargs on POSIX are exactly `{"start_new_session": True}`; isolation checks are `is_symlink()`-equivalent on POSIX.

Part of #2367 (deferred: Windows CI lane promotion to required, Windows-runner conformance verification, end-to-end Windows host run).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved Windows support for process management, long paths, worktree cleanup, symlinks, and junctions.
  * Forced agent stops now record process termination outcomes in the audit history.
  * Process termination now reports whether graceful stopping or escalation occurred.

* **Bug Fixes**
  * Improved cleanup of stubborn or read-only worktree files on Windows.
  * Prevented unsupported signals from causing failures on certain platforms.
  * Improved worktree isolation checks for Windows junctions and shared directories.

* **Documentation**
  * Added supported-platform guidance and Windows setup notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->