### PR TITLE
chore: resolve open scanner findings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -301,7 +301,9 @@ jobs:
           # compatibility with actions/setup-node's default config.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
+        # Trusted publishing for the npm wrapper needs a registry-side
+        # publisher configuration; token auth stays until that exists.
+        run: | # zizmor: ignore[use-trusted-publishing]
           if [ -z "${NPM_TOKEN:-}" ]; then
             echo "::warning::NPM_TOKEN is not configured; skipping npm wrapper publish"
             exit 0

--- a/docs/operations/ci-topology.md
+++ b/docs/operations/ci-topology.md
@@ -9,6 +9,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | Workflow | Name | Triggers | Concurrency | Jobs |
 | --- | --- | --- | --- | --- |
 | .github/workflows/a2a-federation-e2e.yml | a2a-federation-e2e | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "a2a-federation-e2e-${{ github.ref }}"} | 1 |
+| .github/workflows/adapter-conformance-canary.yml | Adapter conformance canary | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "adapter-conformance-canary"} | 1 |
 | .github/workflows/adapter-contract-drift.yml | Adapter contract drift | pull_request, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "adapter-contract-drift-${{ github.ref }}"} | 2 |
 | .github/workflows/airgap-e2e.yml | Airgap E2E | pull_request, push, schedule, workflow_dispatch | {"cancel-in-progress": "true", "group": "airgap-e2e-${{ github.ref }}"} | 1 |
 | .github/workflows/auto-heal.yml | Auto-heal v2 | workflow_call | - | 2 |
@@ -58,7 +59,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/publish-docker.yml | Publish Docker Image | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-docker-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-extension.yml | Publish VS Code Extension | push, release | {"cancel-in-progress": "false", "group": "publish-extension-${{ github.ref }}"} | 1 |
 | .github/workflows/publish-homebrew.yml | Publish Homebrew Formula | release, workflow_dispatch | {"cancel-in-progress": "false", "group": "publish-homebrew-${{ github.ref }}"} | 1 |
-| .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 7 |
+| .github/workflows/publish.yml | Publish | push, workflow_dispatch | - | 8 |
 | .github/workflows/reconcile-release.yml | Reconcile release drift | schedule, workflow_dispatch | {"cancel-in-progress": "false", "group": "reconcile-release"} | 1 |
 | .github/workflows/release-major-minor.yml | Major/Minor Release | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-major-minor-${{ github.ref }}"} | 1 |
 | .github/workflows/release-please.yml | Release Please | workflow_dispatch | {"cancel-in-progress": "false", "group": "release-please-${{ github.ref }}"} | 1 |
@@ -89,6 +90,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | Workflow | Checks |
 | --- | --- |
 | .github/workflows/a2a-federation-e2e.yml | a2a-federation-e2e: a2a-federation-e2e (${{ matrix.os }}) |
+| .github/workflows/adapter-conformance-canary.yml | canary: Canary matrix |
 | .github/workflows/adapter-contract-drift.yml | aggregate: Aggregate drift report<br>check: ${{ matrix.adapter }} |
 | .github/workflows/airgap-e2e.yml | airgap-e2e: Airgap E2E (Linux, real cosign + gpg + unshare) |
 | .github/workflows/auto-heal.yml | heal: Apply chosen strategy<br>triage: Triage and classify |
@@ -138,7 +140,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/publish-docker.yml | publish: Build and push image to GHCR |
 | .github/workflows/publish-extension.yml | publish |
 | .github/workflows/publish-homebrew.yml | update-formula: Update Homebrew formula |
-| .github/workflows/publish.yml | build: Build<br>github-release: Create GitHub Release<br>protocol-gate: Protocol Compatibility Gate<br>publish: Publish to PyPI<br>publish-npm: Publish npm wrapper<br>test: Verify tests pass<br>version-check: Verify tag matches pyproject.toml |
+| .github/workflows/publish.yml | build: Build<br>github-release: Create GitHub Release<br>protocol-gate: Protocol Compatibility Gate<br>publish: Publish to PyPI<br>publish-mcp-registry: Publish MCP registry listing<br>publish-npm: Publish npm wrapper<br>test: Verify tests pass<br>version-check: Verify tag matches pyproject.toml |
 | .github/workflows/reconcile-release.yml | reconcile: Compare pyproject.toml vs PyPI |
 | .github/workflows/release-major-minor.yml | release: ${{ inputs.bump }} release |
 | .github/workflows/release-please.yml | release-please |
@@ -169,6 +171,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | Workflow | Permissions | Secrets |
 | --- | --- | --- |
 | .github/workflows/a2a-federation-e2e.yml | workflow: {"contents": "read"} | - |
+| .github/workflows/adapter-conformance-canary.yml | workflow: {"contents": "read"}<br>canary: {"contents": "write", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN |
 | .github/workflows/adapter-contract-drift.yml | workflow: {"contents": "read"}<br>aggregate: {"contents": "read", "issues": "write"}<br>check: {"contents": "read"} | ADAPTER_CONTRACT_ANTHROPIC_API_KEY, ADAPTER_CONTRACT_GEMINI_API_KEY, ADAPTER_CONTRACT_OPENAI_API_KEY, GITHUB_TOKEN |
 | .github/workflows/airgap-e2e.yml | workflow: {"contents": "read"} | - |
 | .github/workflows/auto-heal.yml | heal: {"attestations": "write", "contents": "write", "id-token": "write", "pull-requests": "write"}<br>triage: {"actions": "read", "contents": "read", "pull-requests": "read"} | GITHUB_TOKEN, GLITCHTIP_DSN, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID |
@@ -218,7 +221,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 | .github/workflows/publish-docker.yml | publish: {"attestations": "write", "contents": "read", "id-token": "write", "packages": "write"} | GITHUB_TOKEN |
 | .github/workflows/publish-extension.yml | workflow: {"contents": "read"}<br>publish: {"contents": "write"} | OPEN_VSX_TOKEN, VS_MARKETPLACE_TOKEN |
 | .github/workflows/publish-homebrew.yml | workflow: {"contents": "read"}<br>update-formula: {"contents": "read"} | HOMEBREW_TAP_TOKEN |
-| .github/workflows/publish.yml | build: {"contents": "read"}<br>github-release: {"contents": "write"}<br>protocol-gate: {"contents": "read"}<br>publish: {"attestations": "write", "contents": "read", "id-token": "write"}<br>publish-npm: {"contents": "read"}<br>test: {"contents": "read"}<br>version-check: {"contents": "read"} | GITHUB_TOKEN, NPM_TOKEN |
+| .github/workflows/publish.yml | build: {"contents": "read"}<br>github-release: {"contents": "write"}<br>protocol-gate: {"contents": "read"}<br>publish: {"attestations": "write", "contents": "read", "id-token": "write"}<br>publish-mcp-registry: {"contents": "read", "id-token": "write"}<br>publish-npm: {"contents": "read"}<br>test: {"contents": "read"}<br>version-check: {"contents": "read"} | GITHUB_TOKEN, NPM_TOKEN |
 | .github/workflows/reconcile-release.yml | reconcile: {"contents": "read", "issues": "write"} | TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID |
 | .github/workflows/release-major-minor.yml | workflow: {"contents": "read"}<br>release: {"attestations": "write", "contents": "write", "id-token": "write"} | GITHUB_TOKEN |
 | .github/workflows/release-please.yml | workflow: {"contents": "read"}<br>release-please: {"contents": "write", "issues": "write", "pull-requests": "write"} | GITHUB_TOKEN, RELEASE_PLEASE_PAT |
@@ -254,6 +257,7 @@ This report lists the workflow graph surfaces reviewers need to inspect when CI 
 
 | Workflow | Artifact steps |
 | --- | --- |
+| .github/workflows/adapter-conformance-canary.yml | canary: upload adapter-canary-receipts |
 | .github/workflows/adapter-contract-drift.yml | aggregate: download -<br>check: upload drift-${{ matrix.adapter }} |
 | .github/workflows/bernstein-ci-fix.yml | tier3-shadow: upload tier3-shadow-${{ needs.triage.outputs.short_sha }} |
 | .github/workflows/bernstein-issues-decompose.yml | decompose: download issue-decompose-plan-${{ github.event.issue.number }}<br>plan: upload issue-decompose-plan-${{ github.event.issue.number }} |

--- a/src/bernstein/adapters/canary.py
+++ b/src/bernstein/adapters/canary.py
@@ -458,7 +458,7 @@ def apply_canary_outcome(
         ``(new_state, should_open_issue)``. The input mapping is not
         mutated.
     """
-    new_state = {name: dict(entry) for name, entry in state.items()}
+    new_state = {name: entry.copy() for name, entry in state.items()}
     if outcome.verdict == "skip":
         return new_state, False
 
@@ -592,7 +592,7 @@ def update_last_green(
     Returns:
         A new mapping; the input is not mutated.
     """
-    new_entries = dict(entries)
+    new_entries = entries.copy()
     if outcome.verdict != "pass" or not outcome.installed_version:
         return new_entries
     new_entries[outcome.adapter] = LastGreenEntry(
@@ -658,7 +658,7 @@ def write_last_green_doc(doc_path: Path, entries: dict[str, LastGreenEntry]) -> 
     text = doc_path.read_text(encoding="utf-8")
     begin = text.find(LAST_GREEN_BEGIN)
     end = text.find(LAST_GREEN_END)
-    if begin == -1 or end == -1 or end < begin:
+    if -1 in (begin, end) or end < begin:
         raise ValueError(f"{doc_path} is missing the last-green table markers")
     head = text[: begin + len(LAST_GREEN_BEGIN)]
     tail = text[end:]

--- a/src/bernstein/core/server/dashboard_auth.py
+++ b/src/bernstein/core/server/dashboard_auth.py
@@ -207,14 +207,29 @@ def _get_dashboard_password() -> str:
     return os.environ.get("BERNSTEIN_DASHBOARD_PASSWORD", "")
 
 
+# Both digests below are recomputed per comparison and never stored, so a
+# per-value random salt would serve no purpose; the fixed salt is domain
+# separation only. The KDF gives compare_digest fixed-length inputs and
+# makes each online guess computationally expensive.
+_PASSWORD_KDF_SALT = b"bernstein-dashboard-password-v1"
+_PASSWORD_KDF_ITERATIONS = 210_000
+
+
+def _password_digest(value: str) -> bytes:
+    """Fixed-length PBKDF2 digest used for constant-time comparison."""
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        value.encode("utf-8"),
+        _PASSWORD_KDF_SALT,
+        _PASSWORD_KDF_ITERATIONS,
+    )
+
+
 def verify_password(provided: str, expected: str) -> bool:
     """Constant-time password comparison."""
     if not expected:
         return False
-    return hmac.compare_digest(
-        hashlib.sha256(provided.encode("utf-8")).digest(),
-        hashlib.sha256(expected.encode("utf-8")).digest(),
-    )
+    return hmac.compare_digest(_password_digest(provided), _password_digest(expected))
 
 
 @dataclass

--- a/src/bernstein/core/server/dashboard_tokens.py
+++ b/src/bernstein/core/server/dashboard_tokens.py
@@ -328,7 +328,12 @@ class DashboardTokenRegistry:
             text = self._path.read_text(encoding="utf-8")
         except OSError as exc:
             # Key/credential-adjacent path: log the exception type only.
-            logger.warning("dashboard tokens: journal unreadable (%s)", type(exc).__name__)
+            # Semgrep FP (logger-credential-disclosure): the format string
+            # names the token journal; no token material is ever logged.
+            logger.warning(  # nosemgrep
+                "dashboard tokens: journal unreadable (%s)",
+                type(exc).__name__,
+            )
             return []
         for line in text.splitlines():
             line = line.strip()
@@ -337,7 +342,12 @@ class DashboardTokenRegistry:
             try:
                 rows.append(DashboardTokenRecord.from_dict(json.loads(line)))
             except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
-                logger.warning("dashboard tokens: skipping malformed journal row (%s)", type(exc).__name__)
+                # Semgrep FP (logger-credential-disclosure): the format string
+                # names the token journal; no token material is ever logged.
+                logger.warning(  # nosemgrep
+                    "dashboard tokens: skipping malformed journal row (%s)",
+                    type(exc).__name__,
+                )
                 continue
         return rows
 


### PR DESCRIPTION
Closes out the eight open code-scanning findings on main.

- adapters/canary.py: refurb idiom fixes (FURB108 membership test, FURB123 dict.copy x2); behaviour identical.
- core/server/dashboard_auth.py: password comparison digests are now derived with PBKDF2-HMAC-SHA256 instead of bare SHA-256, keeping the constant-time comparison while using a computationally expensive derivation (CodeQL py/weak-sensitive-data-hashing x2). Same boolean semantics; login-path only.
- core/server/dashboard_tokens.py: the two journal warning lines already log only the exception class name; the finding keys on the word tokens in the format string. Marked as scanner false positives with a justifying comment (semgrep logger-credential-disclosure x2).
- workflows/publish.yml: the npm wrapper publish keeps token auth because trusted publishing requires a registry-side publisher configuration; annotated with the audit ignore and a comment (zizmor use-trusted-publishing).

Verification: refurb clean on touched files, ruff check and format clean, semgrep rule 0 findings after (2 before), zizmor 0 findings, unit tests for the touched modules pass (151 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened dashboard password verification with modern, computationally expensive hashing and constant-time comparison.

- **Documentation**
  - Updated CI topology documentation to reflect current validation, publishing, permissions, and artifact workflows.

- **Reliability**
  - Improved handling and reporting of malformed or unreadable dashboard token records.
  - Refined canary state handling and validation while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->