### PR TITLE
release: v3.3.0

### DIFF
--- a/docs/release-notes/v3.3.0.md
+++ b/docs/release-notes/v3.3.0.md
@@ -1,0 +1,91 @@
+# v3.3.0
+
+Released 2026-07-11.
+
+An operator-capability release. The dashboard gains authentication with
+scoped tokens whose every decision lands a governance receipt, a new agy
+adapter joins the matrix with a nightly conformance canary sealing its
+probe results, and the run review board projects the run journal into a
+web view backed by sealed evidence bundles. Groundwork lands for Windows
+parity and for installing bernstein as an agent skill or plugin.
+
+## Dashboard authentication and scoped tokens (#2366)
+
+The dashboard is no longer an all-or-nothing surface. Operators issue
+scoped credentials, and every authentication decision is a receipt:
+
+- Password login and scoped bearer tokens coexist; tokens carry either a
+  read-only or an operator scope, and route access is enforced per scope.
+- Token grants and revocations are signed journal rows; a tampered grant
+  fails signature verification and is treated as no grant at all.
+- Every allow or deny decision is recorded as a governance journal
+  receipt, so an access review can reconstruct exactly who reached which
+  surface and under which credential.
+- `bernstein dashboard-token` issues, lists, and revokes tokens from the
+  CLI; revocation is itself a signed journal row, never a silent delete.
+
+## agy adapter and adapter conformance canary (#2368)
+
+agy joins the adapter matrix, and adapter contracts are now exercised
+nightly instead of waiting for a user's broken run:
+
+- The agy adapter maps goals onto the agy CLI with the same contract
+  surface as every other adapter, including golden transcripts and a
+  contract fixture.
+- A nightly canary probes every primary adapter against whatever upstream
+  version is installed; each probe result is a sealed, content-addressed
+  receipt mirrored into the audit chain.
+- A last-green table names the newest upstream version each adapter
+  passed with, and every row carries the hash of the receipt that
+  attested it. `bernstein doctor` reads the same projection and advises
+  when the installed version is newer than the last attested one.
+- Issue automation is threshold-gated and deduplicated: one upstream
+  flake never opens an issue, and the same failure fingerprint never
+  opens two.
+
+## Run review board core (#2365)
+
+Finished runs can now be reviewed on a board instead of by reading raw
+journals:
+
+- The board is a deterministic projection of the run journal: the same
+  journal always produces the same board state, byte for byte, with no
+  hand-maintained status anywhere.
+- A web view lists runs with their outcomes, decisions, and artefacts,
+  consuming sealed evidence bundles so what the reviewer sees is what the
+  journal attests.
+- Further review-board phases (annotations, sign-off flows) are tracked
+  separately.
+
+## Windows parity groundwork (#2367)
+
+The platform layer gains the pieces Windows needs, validated so far on
+the existing test matrix:
+
+- Process cleanup emits reap receipts into the audit chain, so a killed
+  worker tree is reconstructable after the fact on every platform.
+- Job Object process management groups worker processes on Windows the
+  way process groups do on POSIX, closing the orphaned-child gap.
+- Worktree isolation is junction-aware, so per-task isolation survives
+  filesystems where symlinks require elevation.
+- Full validation on Windows runners is tracked separately.
+
+## Agent skill and plugin packaging groundwork (#2369)
+
+Installing bernstein as an agent skill or plugin gets its packaging
+foundation:
+
+- `bernstein skills package` builds a skill/plugin bundle from the
+  packaged templates, with a manifest generated from the package version
+  so the bundle can never drift from the release.
+- Each install produces a lineage receipt, so an installed bundle can be
+  traced back to the exact release artefact it came from.
+- Remaining distribution surfaces are tracked separately.
+
+## Housekeeping
+
+- Resolved all open scanner alerts: applied suggested idiom cleanups,
+  moved dashboard password comparison onto a computationally expensive
+  key derivation, and annotated two exception-name-only log lines as
+  scanner false positives.
+- Dependency updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.2.0"
+version = "3.3.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump to 3.3.0 with release notes.

- pyproject.toml and uv.lock bumped to 3.3.0
- docs/release-notes/v3.3.0.md covering dashboard authentication with scoped tokens (#2366), the agy adapter and adapter conformance canary (#2368), run review board core (#2365), Windows parity groundwork (#2367), agent skill/plugin packaging groundwork (#2369), and housekeeping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped dashboard tokens with auditable access decisions and a CLI workflow for issuing and revoking tokens.
  * Added adapter compatibility monitoring with nightly conformance checks.
  * Introduced a run review board for reviewing sealed execution evidence.
  * Added groundwork for Windows support and agent skill/plugin installation.
* **Security**
  * Strengthened password protection and addressed scanner findings.
* **Chores**
  * Updated dependencies and released version 3.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->