### PR TITLE
fix: regenerate distribution manifests and cover agy in adapter contract

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -38,6 +38,7 @@ ignore_imports =
 name = Adapters are independent of one another
 type = independence
 modules =
+    bernstein.adapters.agy
     bernstein.adapters.aichat
     bernstein.adapters.aider
     bernstein.adapters.amp

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.2.0",
+  "version": "3.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "transport": {
         "type": "stdio"
       }
@@ -19,7 +19,7 @@
     {
       "registryType": "oci",
       "identifier": "ghcr.io/sipyourdrink-ltd/bernstein",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Fixes the two test failures on main after the 3.3.0 bump.

- server.json and .plugin/plugin.json regenerated via scripts/gen_distribution_manifests.py so their versions match pyproject (3.3.0); test_distribution_manifests was failing on the drift.
- .importlinter adapter independence contract now lists bernstein.adapters.agy; test_importlinter_contracts was failing because the registered adapter set and the contract set diverged.

Verification: both test modules pass locally (5 passed) and lint-imports reports 3 contracts kept, 0 broken.

## Summary by Sourcery

Align distribution manifests and importlinter adapter contracts with the 3.3.0 release to resolve failing tests on main.

Bug Fixes:
- Update server.json and .plugin/plugin.json distribution manifests so their version matches the 3.3.0 pyproject configuration, eliminating manifest drift that broke tests.
- Extend the importlinter adapter independence contract to include the bernstein.adapters.agy adapter, restoring consistency between registered adapters and contract definitions.

Tests:
- Restore passing status for distribution manifest and importlinter contract test modules following the 3.3.0 version bump.

Chores:
- Regenerate distribution manifest files via the existing manifest generation script to keep metadata in sync with the project version.