### PR TITLE
fix(release): move OCI package version into the identifier tag

### DIFF
--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -42,8 +42,23 @@ def render_server_json(version: str) -> str:
     data = json.loads(SERVER_JSON.read_text(encoding="utf-8"))
     data["version"] = version
     for package in data.get("packages", []):
-        package["version"] = version
+        if package.get("registryType") == "oci":
+            # The registry schema forbids a top-level version on OCI
+            # packages; the version rides in the identifier tag instead
+            # (e.g. ghcr.io/owner/image:1.0.0).
+            package["identifier"] = f"{_oci_image_ref(package['identifier'])}:{version}"
+            package.pop("version", None)
+        else:
+            package["version"] = version
     return json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+
+
+def _oci_image_ref(identifier: str) -> str:
+    """Return *identifier* without its tag, keeping any registry port."""
+    ref, sep, tag = identifier.rpartition(":")
+    if sep and "/" not in tag:
+        return ref
+    return identifier
 
 
 def render_plugin_json(version: str) -> str:

--- a/server.json
+++ b/server.json
@@ -18,8 +18,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein",
-      "version": "3.3.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.3.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -15,6 +15,7 @@ These tests pin:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -36,7 +37,10 @@ def test_server_json_version_matches_pyproject() -> None:
     packages = {p["registryType"]: p for p in data["packages"]}
     assert packages["pypi"]["identifier"] == "bernstein"
     assert packages["pypi"]["version"] == version
-    assert packages["oci"]["version"] == version
+    # The registry schema forbids a top-level version on OCI packages;
+    # the version rides in the identifier tag instead.
+    assert "version" not in packages["oci"]
+    assert packages["oci"]["identifier"] == f"ghcr.io/sipyourdrink-ltd/bernstein:{version}"
 
 
 def test_plugin_manifest_version_and_paths() -> None:
@@ -59,6 +63,22 @@ def test_bundled_skill_has_frontmatter_and_stays_ascii() -> None:
     assert "description:" in body
     assert "—" not in body, "em-dash characters are not allowed in shipped skill text"
     assert body.isascii(), "shipped skill text must stay ASCII"
+
+
+def test_render_server_json_retags_oci_identifier_on_version_bump() -> None:
+    spec = importlib.util.spec_from_file_location(
+        "gen_distribution_manifests",
+        _REPO / "scripts" / "gen_distribution_manifests.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    rendered = json.loads(module.render_server_json("9.9.9"))
+    packages = {p["registryType"]: p for p in rendered["packages"]}
+    assert packages["oci"]["identifier"] == "ghcr.io/sipyourdrink-ltd/bernstein:9.9.9"
+    assert "version" not in packages["oci"]
+    assert packages["pypi"]["version"] == "9.9.9"
 
 
 def test_gen_script_check_mode_passes_and_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

The `publish-mcp-registry` job fails on every release with:

> registry validation failed for package (ghcr.io/sipyourdrink-ltd/bernstein): OCI packages must not have 'version' field - include version in 'identifier' instead (e.g., 'docker.io/owner/image:1.0.0')

The job is `continue-on-error`, so releases ship but the registry listing never lands. Example failing run: https://github.com/sipyourdrink-ltd/bernstein/actions/runs/29148327500/job/86533714285

## What

- `scripts/gen_distribution_manifests.py`: OCI package entries now carry the version in the identifier tag (`ghcr.io/sipyourdrink-ltd/bernstein:X.Y.Z`) and drop the top-level `version` field. Existing tags are stripped before re-tagging, so version bumps stay idempotent; registry ports in identifiers are preserved. The pypi entry is unchanged.
- `server.json`: regenerated with the new shape.
- `tests/unit/test_distribution_manifests.py`: pins the new OCI shape and adds a re-tag-on-version-bump test that proves no double-tagging.

## Verification

- `pytest tests/unit/test_distribution_manifests.py`: 5 passed
- `scripts/gen_distribution_manifests.py --check`: in sync, idempotent
- `server.json` validates against the declared 2025-12-11 registry schema
- ruff check + format: clean

## Summary by Sourcery

Update distribution manifest generation so OCI package versions are embedded in the identifier tag instead of a top-level version field, aligning server.json with the registry schema and keeping version bumps idempotent.

Bug Fixes:
- Ensure generated OCI package entries comply with the registry schema by removing the top-level version field and encoding the version in the identifier tag.

Enhancements:
- Add helper logic to strip existing OCI image tags while preserving registry ports before re-tagging with the new version.

Tests:
- Extend distribution manifest tests to validate the new OCI package shape and verify that re-rendering on version bumps correctly re-tags identifiers without duplicate tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OCI package references in generated server manifests now include the correct version tag.
  * Version information is represented consistently for OCI and PyPI packages.

* **Tests**
  * Added coverage to verify OCI image retagging during version updates and ensure manifest output remains valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->