### PR TITLE
fix(compliance): count partial controls in evidence-pack summary

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -291,12 +291,15 @@ def verify_hmac_cmd() -> None:
     "--standard",
     "standard",
     default=None,
-    type=click.Choice(["ai-act"]),
+    type=click.Choice(["ai-act", "owasp-asi", "owasp-skills"]),
     help=(
         "Emit a one-command compliance evidence pack mapped to the chosen "
-        "regulatory standard (issue #1316). 'ai-act' is the only standard "
-        "with a reviewed control map at MVP; DORA and FINOS AIGF are tracked "
-        "under #1316 and will be added once their clause maps are validated."
+        "control catalogue, anchored on the operator's own HMAC-chained "
+        "audit events. 'ai-act' maps EU AI Act Article 12/13/15; "
+        "'owasp-asi' maps the OWASP Top 10 for Agentic Applications "
+        "(ASI01-ASI10); 'owasp-skills' maps the Agentic Skills Top 10 "
+        "(AST01-AST10). DORA and FINOS AIGF are tracked under #1316 and "
+        "will be added once their clause maps are validated."
     ),
 )
 @click.option(

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -703,8 +703,8 @@ def _run_standard_export(
     table.add_row("Lineage entries", str(pack.lineage_count))
     table.add_row("Cost snapshots", str(pack.cost_count))
     table.add_row(
-        "Controls mapped/todo",
-        f"{pack.controls_mapped} / {pack.controls_todo}",
+        "Controls mapped/partial/todo",
+        f"{pack.controls_mapped} / {pack.controls_partial} / {pack.controls_todo}",
     )
     table.add_row("SHA-256", pack.sha256[:16] + "...")
     if pack.archive_path is not None:

--- a/src/bernstein/cli/commands/interop_cmd.py
+++ b/src/bernstein/cli/commands/interop_cmd.py
@@ -38,6 +38,7 @@ from bernstein.core.interop.a2a_card import (
     issue_capability_card,
     verify_capability_card,
 )
+from bernstein.core.interop.a2a_conformance import check_card_conformance
 from bernstein.core.interop.a2a_consume import (
     PolicyRequirements,
     policies_meet_requirements,
@@ -238,6 +239,53 @@ def verify(
     console.print(f"  fingerprint: {fingerprint}")
 
 
+@a2a_group.command("conformance")
+@click.option(
+    "--card",
+    "card_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the signed capability card JSON to self-check.",
+)
+def conformance(card_path: Path) -> None:
+    """Self-check that a card round-trips and verifies offline.
+
+    \b
+    Runs, in order: required-field validation, RFC 8785 JCS
+    canonicalisation, detached Ed25519 JWS signature verification,
+    expiry, and issuer. Prints a per-check pass/fail report and exits
+    non-zero if any check fails. This proves the card the operator emits
+    verifies the same way a peer will check it, with no network access.
+    """
+    try:
+        signed = SignedCapabilityCard.from_json(card_path.read_text())
+    except (ValueError, json.JSONDecodeError) as exc:
+        _fail(f"could not parse capability card: {exc}")
+        return
+
+    report = check_card_conformance(signed)
+
+    if is_json():
+        print_json({"card": str(card_path), **report.to_dict()})
+        if not report.ok:
+            sys.exit(1)
+        return
+
+    if report.ok:
+        print_success(f"Capability card {card_path} passes all conformance checks", soft_wrap=True)
+    else:
+        print_error(f"Capability card {card_path} FAILED conformance:", soft_wrap=True)
+    console.print(f"  issuer: [bold]{report.issuer}[/bold]  kid: {report.kid}")
+    if report.fingerprint:
+        console.print(f"  fingerprint: {report.fingerprint}")
+    for check in report.checks:
+        marker = "[green]PASS[/green]" if check.passed else "[red]FAIL[/red]"
+        console.print(f"  {marker} {check.name}: {check.detail}")
+
+    if not report.ok:
+        sys.exit(1)
+
+
 def _fail(message: str) -> None:
     """Print an error (JSON-aware) and exit non-zero."""
     if is_json():
@@ -247,4 +295,4 @@ def _fail(message: str) -> None:
     sys.exit(1)
 
 
-__all__ = ["a2a_group", "card", "interop_group", "verify"]
+__all__ = ["a2a_group", "card", "conformance", "interop_group", "verify"]

--- a/src/bernstein/compliance/__init__.py
+++ b/src/bernstein/compliance/__init__.py
@@ -28,6 +28,8 @@ from bernstein.compliance.evidence_pack import (
     build_evidence_pack,
     get_standard_map,
 )
+from bernstein.compliance.owasp_asi import control_map as owasp_asi_control_map
+from bernstein.compliance.owasp_skills import control_map as owasp_skills_control_map
 
 __all__ = [
     "EVIDENCE_PACK_SCHEMA_VERSION",
@@ -45,4 +47,6 @@ __all__ = [
     "TechDocGenerator",
     "build_evidence_pack",
     "get_standard_map",
+    "owasp_asi_control_map",
+    "owasp_skills_control_map",
 ]

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -63,13 +63,16 @@ logger = logging.getLogger(__name__)
 #: change to layout, file names, or hash inputs.
 SCHEMA_VERSION: str = "1.0.0"
 
-#: Supported standards at MVP. Only ``ai-act`` has a fleshed-out
-#: control map. DORA and FINOS AIGF are tracked under #1316 and will
-#: be added once their clause maps are reviewed by subject-matter
-#: experts; emitting TODO-only bundles would mislead operators.
-Standard = Literal["ai-act"]
+#: Supported standards. ``ai-act`` maps the EU AI Act Article 12/13/15
+#: clauses; ``owasp-asi`` and ``owasp-skills`` map the OWASP Top 10 for
+#: Agentic Applications (ASI01-ASI10) and the Agentic Skills Top 10
+#: (AST01-AST10) onto the same audit-chain artefacts. DORA and FINOS
+#: AIGF are tracked under #1316 and are not selectable until their
+#: clause maps are reviewed by subject-matter experts; emitting
+#: TODO-only bundles would mislead operators.
+Standard = Literal["ai-act", "owasp-asi", "owasp-skills"]
 
-SUPPORTED_STANDARDS: tuple[str, ...] = ("ai-act",)
+SUPPORTED_STANDARDS: tuple[str, ...] = ("ai-act", "owasp-asi", "owasp-skills")
 
 #: Fixed mtime for every entry in the produced zip - required for
 #: byte-deterministic output. Zip cannot store dates before 1980.
@@ -151,6 +154,17 @@ _STANDARD_MAPS: dict[str, dict[str, Any]] = {
         ],
     },
 }
+
+# The OWASP ASI / AST maps live in dedicated modules (one control class per
+# module) and are registered here so ``build_evidence_pack`` reads them the
+# same way it reads ``ai-act``. Registration is a plain assignment - the
+# modules only depend on stdlib, so importing them at module load is cheap
+# and side-effect free.
+from bernstein.compliance import owasp_asi as _owasp_asi  # noqa: E402
+from bernstein.compliance import owasp_skills as _owasp_skills  # noqa: E402
+
+_STANDARD_MAPS[_owasp_asi.STANDARD_ID] = _owasp_asi.control_map()
+_STANDARD_MAPS[_owasp_skills.STANDARD_ID] = _owasp_skills.control_map()
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/compliance/evidence_pack.py
+++ b/src/bernstein/compliance/evidence_pack.py
@@ -185,6 +185,7 @@ class EvidencePack:
         lineage_count: Number of lineage entries captured.
         cost_count: Number of cost snapshots captured.
         controls_mapped: How many controls have ``status == "mapped"``.
+        controls_partial: How many controls have ``status == "partial"``.
         controls_todo: How many controls remain TODO for the standard.
         archive_path: On-disk path to the written zip (``None`` for dry-run).
         sha256: SHA-256 of the produced zip bytes.
@@ -198,6 +199,7 @@ class EvidencePack:
     lineage_count: int
     cost_count: int
     controls_mapped: int
+    controls_partial: int
     controls_todo: int
     archive_path: Path | None
     sha256: str
@@ -214,6 +216,7 @@ class EvidencePack:
             "lineage_count": self.lineage_count,
             "cost_count": self.cost_count,
             "controls_mapped": self.controls_mapped,
+            "controls_partial": self.controls_partial,
             "controls_todo": self.controls_todo,
             "sha256": self.sha256,
         }
@@ -611,6 +614,7 @@ def build_evidence_pack(
 
     controls = mapping["controls"]
     controls_mapped = sum(1 for c in controls if c.get("status") == "mapped")
+    controls_partial = sum(1 for c in controls if c.get("status") == "partial")
     controls_todo = sum(1 for c in controls if c.get("status") == "todo")
 
     bundle_id = _bundle_id(standard, since, task)
@@ -625,6 +629,7 @@ def build_evidence_pack(
         "lineage_count": len(lineage_entries),
         "cost_count": len(cost_entries),
         "controls_mapped": controls_mapped,
+        "controls_partial": controls_partial,
         "controls_todo": controls_todo,
         "generated_at_utc": "1970-01-01T00:00:00+00:00",  # deterministic, see note below
         "artefacts": dict(sorted(artefact_hashes.items())),
@@ -659,6 +664,7 @@ def build_evidence_pack(
         lineage_count=len(lineage_entries),
         cost_count=len(cost_entries),
         controls_mapped=controls_mapped,
+        controls_partial=controls_partial,
         controls_todo=controls_todo,
         archive_path=archive_path,
         sha256=archive_sha256,

--- a/src/bernstein/compliance/owasp_asi.py
+++ b/src/bernstein/compliance/owasp_asi.py
@@ -1,0 +1,204 @@
+"""OWASP Top 10 for Agentic Applications (ASI01-ASI10) control map.
+
+Operators running agentic workloads in security-sensitive environments
+need to show, from their own run evidence, which agentic-security
+controls a Bernstein run already covers. This module is the ASI analogue
+of the EU AI Act Article 12 clause map in ``evidence_pack.py``: it maps
+each OWASP ASI control id to the concrete Bernstein mechanism that
+addresses it and to the HMAC-chained audit event type(s) that serve as
+evidence.
+
+The map is anchored on the HMAC audit chain: every ``event_type`` cited
+below is a literal string a Bernstein run actually writes into
+``.sdd/audit/*.jsonl``. Strip the audit chain and this map has nothing
+to point at, so the coverage claim is only as strong as the tamper-
+evident chain that backs it. That coupling is deliberate: the evidence
+is the chain, not a side document that merely describes the chain.
+
+Honesty rule (same as ``owasp_asi_detectors.py``): where Bernstein only
+partially addresses a control, the entry is marked ``"partial"`` and the
+gap is stated in ``requirement``. An honest partial map is the
+deliverable; over-claiming coverage would mislead an auditor.
+
+The block is consumed by ``evidence_pack.build_evidence_pack`` under the
+``owasp-asi`` standard. It mirrors the ``_STANDARD_MAPS`` shape exactly:
+
+    {
+        "regulation": <str>,
+        "controls": [ {control_id, requirement, artefact, selector, status}, ... ],
+        "deferred": [ <str>, ... ],
+    }
+
+``selector`` names the audit event attribute (or literal ``event_type``
+values) carrying the primary evidence. It is informational, mirroring
+the EU AI Act block; it is not enforced at build time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Standard id used on the ``--standard`` flag and in manifests.
+STANDARD_ID: str = "owasp-asi"
+
+#: Human-readable catalogue name emitted into ``controls.json``.
+REGULATION: str = "OWASP Top 10 for Agentic Applications (ASI01-ASI10, Dec 2025)"
+
+# ---------------------------------------------------------------------------
+# ASI01-ASI10 control map
+# ---------------------------------------------------------------------------
+#
+# Each ``selector`` string lists literal ``event_type`` values (confirmed
+# present in the codebase) or an audit attribute name. The ``artefact``
+# points at the same bundle files the EU AI Act pack emits, so an auditor
+# switching standards sees a consistent layout.
+
+CONTROLS: list[dict[str, Any]] = [
+    {
+        "control_id": "ASI01",
+        "requirement": (
+            "Agent goal / instruction hijack: prompt-injection and goal "
+            "manipulation are screened by the on-by-default OWASP ASI "
+            "guardrail pack (ASI01 goal-hijack detector) and promptware "
+            "scanner; refusals land in the audit chain."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal,command",
+        "status": "partial",
+    },
+    {
+        "control_id": "ASI02",
+        "requirement": (
+            "Tool misuse / excessive agency: the lethal-trifecta capability "
+            "matrix denies any tool chain that simultaneously holds private "
+            "data access, untrusted content, and external egress; the "
+            "deterministic scheduler bounds agency (no LLM in the "
+            "coordination loop). Refusals are recorded."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI03",
+        "requirement": (
+            "Identity and privilege abuse: per-adapter environment isolation "
+            "and the Ed25519-signed install identity scope what an agent may "
+            "act as; approval gates record who authorised a privileged step."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "approval_pending,approval_resolved,auto_approve_decision",
+        "status": "partial",
+    },
+    {
+        "control_id": "ASI04",
+        "requirement": (
+            "Supply-chain / skill provenance: the skill catalog verifies an "
+            "Ed25519 detached signature over each entry before install; "
+            "fetch, install, upgrade and uninstall are all chained."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.upgrade,skill.catalog.fetch,skill.catalog.uninstall",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI05",
+        "requirement": (
+            "Unsafe code / command execution: commands run under a sandbox "
+            "profile and a command allowlist; a sandbox-escape attempt is "
+            "detected and recorded as a security incident."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "sandbox_escape_attempt,command",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI06",
+        "requirement": (
+            "Memory / context poisoning: lineage tampering on a persisted "
+            "artefact is detected against the content-addressed lineage "
+            "chain and recorded. Detection of poisoned model context beyond "
+            "artefact tampering is not yet covered."
+        ),
+        "artefact": "lineage/log.jsonl",
+        "selector": "lineage_tamper_detected,content_hash,parent_hashes",
+        "status": "partial",
+    },
+    {
+        "control_id": "ASI07",
+        "requirement": (
+            "Insecure agent-to-agent (A2A) trust: peer capability cards are "
+            "verified as detached JWS over JCS-canonical JSON with Ed25519 "
+            "and gated on the operator trusted-issuer set and policy floor "
+            "before any delegation. See 'bernstein interop a2a conformance'."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "agent.transition",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI08",
+        "requirement": (
+            "Unbounded consumption: per-run cost caps, budget-exhaustion and "
+            "budget-warning events, and task-deadline events bound spend and "
+            "wall-clock; the cost ledger carries per-task, per-model spend."
+        ),
+        "artefact": "costs/cost_history.jsonl",
+        "selector": "budget.exhausted,budget.warning,task.deadline_exceeded,model,task_id,usd",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI09",
+        "requirement": (
+            "Observability / traceability gaps: every step is written to the "
+            "HMAC-chained audit log and the content-addressed lineage log, "
+            "so run activity is reconstructable offline; a stuck worker "
+            "raises a signed supervisor escalation."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "run_start,task.transition,agent.transition,supervisor.escalated",
+        "status": "mapped",
+    },
+    {
+        "control_id": "ASI10",
+        "requirement": (
+            "Misalignment / behavioural drift: review-pipeline stages and "
+            "capability-matrix refusals are recorded, giving an audit trail "
+            "of gated decisions. Automated drift scoring across runs is a "
+            "heuristic in the ASI detector pack and not yet a first-class "
+            "chained metric."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "review_pipeline.stage,review_pipeline.complete,capability_matrix_refusal",
+        "status": "partial",
+    },
+]
+
+#: Controls whose evidence is out of scope for the read-only evidence pack
+#: (they require signals Bernstein does not yet chain).
+DEFERRED: list[str] = [
+    "ASI06 model-context poisoning beyond artefact-hash tampering (no chained signal yet).",
+    "ASI10 cross-run behavioural-drift scoring as a first-class chained metric (heuristic only today).",
+]
+
+
+def control_map() -> dict[str, Any]:
+    """Return the OWASP ASI control-map block in ``_STANDARD_MAPS`` shape.
+
+    The list is copied so a caller mutating the returned dict cannot
+    corrupt the module-level catalogue.
+    """
+    return {
+        "regulation": REGULATION,
+        "controls": [dict(c) for c in CONTROLS],
+        "deferred": list(DEFERRED),
+    }
+
+
+__all__ = [
+    "CONTROLS",
+    "DEFERRED",
+    "REGULATION",
+    "STANDARD_ID",
+    "control_map",
+]

--- a/src/bernstein/compliance/owasp_skills.py
+++ b/src/bernstein/compliance/owasp_skills.py
@@ -1,0 +1,192 @@
+"""OWASP Agentic Skills Top 10 (AST01-AST10) control map.
+
+Operators who install and run third-party skills need to show, from
+their own run evidence, which skill-supply-chain controls a Bernstein
+run already covers. This module is the skills-catalogue analogue of the
+EU AI Act clause map in ``evidence_pack.py`` and the ASI map in
+``owasp_asi.py``.
+
+The map is anchored on two Bernstein levers working together:
+
+* the Ed25519-signed install identity and the per-entry detached-JWS
+  signature the skill catalog verifies before install, and
+* the HMAC audit chain, into which every catalog action
+  (``skill.catalog.fetch|install|upgrade|uninstall|sync``) is written.
+
+Every ``selector`` cites a literal ``event_type`` string a Bernstein run
+actually writes, so the coverage claim is only as strong as the signed
+catalog plus the tamper-evident chain that backs it. Remove either lever
+and the map loses its meaning, not merely its log.
+
+Honesty rule: where Bernstein only partially addresses a control the
+entry is marked ``"partial"`` and the gap is stated. Skill-catalogue
+coverage is genuinely partial for several AST classes (runtime skill
+sandboxing, per-skill data-scope enforcement), and the map says so
+rather than over-claiming.
+
+The block mirrors the ``_STANDARD_MAPS`` shape exactly and is consumed
+by ``evidence_pack.build_evidence_pack`` under the ``owasp-skills``
+standard.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Standard id used on the ``--standard`` flag and in manifests.
+STANDARD_ID: str = "owasp-skills"
+
+#: Human-readable catalogue name emitted into ``controls.json``.
+REGULATION: str = "OWASP Agentic Skills Top 10 (AST01-AST10)"
+
+# ---------------------------------------------------------------------------
+# AST01-AST10 control map
+# ---------------------------------------------------------------------------
+
+CONTROLS: list[dict[str, Any]] = [
+    {
+        "control_id": "AST01",
+        "requirement": (
+            "Untrusted / unsigned skill install: the catalog verifies an "
+            "Ed25519 detached signature over each entry's canonical bytes "
+            "against the catalog signer public key before install; an "
+            "unverified entry installs only with an explicit override."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.fetch",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST02",
+        "requirement": (
+            "Skill tampering after publish: catalog entries are content-"
+            "addressed and lineage-logged; post-fetch tampering surfaces as "
+            "a lineage-tamper detection against the recorded content hash."
+        ),
+        "artefact": "lineage/log.jsonl",
+        "selector": "lineage_tamper_detected,content_hash",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST03",
+        "requirement": (
+            "Skill provenance / pinning: install, upgrade and uninstall are "
+            "all chained with the resolved source spec, giving a pinned, "
+            "auditable history of which skill version ran when."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.upgrade,skill.catalog.uninstall",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST04",
+        "requirement": (
+            "Excessive skill capability (trifecta): a skill-invoked tool "
+            "chain is screened by the lethal-trifecta capability matrix; a "
+            "chain holding private-data + untrusted-content + external-egress "
+            "is denied and recorded."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST05",
+        "requirement": (
+            "Unsafe skill code execution: skill-invoked commands run under a "
+            "sandbox profile and command allowlist; a sandbox-escape attempt "
+            "is detected and recorded as a security incident. Per-skill "
+            "runtime sandboxing (distinct from the shared command sandbox) is "
+            "not yet enforced."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "sandbox_escape_attempt,command",
+        "status": "partial",
+    },
+    {
+        "control_id": "AST06",
+        "requirement": (
+            "Skill data-scope / exfiltration: cost and egress are bounded by "
+            "per-run caps and the trifecta egress axis, and redaction tiers "
+            "apply before artefacts leave the boundary. Per-skill data-scope "
+            "enforcement (a skill only reads what it declared) is not yet a "
+            "first-class chained control."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal,budget.exhausted",
+        "status": "partial",
+    },
+    {
+        "control_id": "AST07",
+        "requirement": (
+            "Skill identity / impersonation: the catalog signer identity is "
+            "an Ed25519 public key; entries that do not verify against it are "
+            "refused, so a skill cannot impersonate a trusted publisher."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.install,skill.catalog.sync",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST08",
+        "requirement": (
+            "Skill catalog drift / unbounded install: catalog sync is chained "
+            "so unexpected additions are visible; per-run cost caps bound the "
+            "spend a runaway skill can incur."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.sync,budget.warning,budget.exhausted",
+        "status": "partial",
+    },
+    {
+        "control_id": "AST09",
+        "requirement": (
+            "Skill observability gap: every catalog action and every step a "
+            "skill triggers is written to the HMAC-chained audit log, so a "
+            "skill's activity is reconstructable offline."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "skill.catalog.fetch,skill.catalog.install,task.transition,agent.transition",
+        "status": "mapped",
+    },
+    {
+        "control_id": "AST10",
+        "requirement": (
+            "Skill misalignment / prompt-injection via skill content: skill "
+            "output flows through the on-by-default OWASP ASI guardrail pack "
+            "and promptware scanner; refusals are recorded. Skill-specific "
+            "alignment scoring is heuristic, not a chained metric."
+        ),
+        "artefact": "audit-chain/events.jsonl",
+        "selector": "capability_matrix_refusal,review_pipeline.stage",
+        "status": "partial",
+    },
+]
+
+#: Controls whose evidence is out of scope for the read-only evidence pack.
+DEFERRED: list[str] = [
+    "AST05 per-skill runtime sandboxing distinct from the shared command sandbox.",
+    "AST06 per-skill declared-data-scope enforcement as a first-class chained control.",
+]
+
+
+def control_map() -> dict[str, Any]:
+    """Return the OWASP AST control-map block in ``_STANDARD_MAPS`` shape.
+
+    The list is copied so a caller mutating the returned dict cannot
+    corrupt the module-level catalogue.
+    """
+    return {
+        "regulation": REGULATION,
+        "controls": [dict(c) for c in CONTROLS],
+        "deferred": list(DEFERRED),
+    }
+
+
+__all__ = [
+    "CONTROLS",
+    "DEFERRED",
+    "REGULATION",
+    "STANDARD_ID",
+    "control_map",
+]

--- a/src/bernstein/core/interop/a2a_conformance.py
+++ b/src/bernstein/core/interop/a2a_conformance.py
@@ -1,0 +1,207 @@
+"""A2A signed-card conformance self-check.
+
+An operator who issues a capability card needs to prove, offline, that
+the card they emit round-trips and verifies the same way a peer will
+check it: canonicalise the body (RFC 8785 JCS), verify the detached JWS
+(RFC 7515) with the Ed25519 key the card carries, and confirm the
+required fields, expiry, and issuer are well-formed.
+
+This is a self-contained audit of the artefact we already ship. It leans
+on the Ed25519-signed identity lever: every check below is meaningful
+only because the card is signed with an Ed25519 key whose public half
+travels in the card, so a verifier can reproduce the signing input and
+authenticate it without a side channel. Strip the signature and the
+conformance report degrades to a schema lint; the signature check is the
+point.
+
+The self-check is read-only and deterministic: given the same signed
+card and the same ``now`` it always returns the same verdict. It reuses
+the primitives in :mod:`bernstein.core.interop.a2a_card` rather than
+re-implementing verification, so a card that passes here passes for the
+same reasons a peer's ``bernstein interop a2a verify`` accepts it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.interop.a2a_card import (
+    CAPABILITY_CARD_TYP,
+    CapabilityCard,
+    card_public_key_fingerprint,
+    verify_capability_card,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.interop.a2a_card import SignedCapabilityCard
+
+__all__ = [
+    "ConformanceCheck",
+    "ConformanceReport",
+    "check_card_conformance",
+]
+
+
+@dataclass(frozen=True)
+class ConformanceCheck:
+    """A single named conformance check with a pass/fail verdict.
+
+    Attributes:
+        name: Stable check id (for instance ``"jcs_canonical"``).
+        passed: Whether the check passed.
+        detail: Human-readable explanation of the verdict.
+    """
+
+    name: str
+    passed: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable view of the check."""
+        return {"name": self.name, "passed": self.passed, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class ConformanceReport:
+    """Aggregated result of a card conformance self-check.
+
+    Attributes:
+        ok: True iff every check passed.
+        checks: The individual checks, in evaluation order.
+        issuer: Issuer id from the card (``""`` if unreadable).
+        kid: Key id from the card (``""`` if unreadable).
+        fingerprint: ``sha256:`` fingerprint of the card key (``""`` if
+            the key could not be parsed).
+    """
+
+    ok: bool
+    checks: list[ConformanceCheck] = field(default_factory=list)
+    issuer: str = ""
+    kid: str = ""
+    fingerprint: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable view of the report."""
+        return {
+            "ok": self.ok,
+            "issuer": self.issuer,
+            "kid": self.kid,
+            "fingerprint": self.fingerprint,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+
+# Fields a conformant card body must carry as non-empty strings.
+_REQUIRED_STRING_FIELDS: tuple[str, ...] = (
+    "schema_version",
+    "issuer",
+    "name",
+    "public_key_pem",
+    "kid",
+)
+
+
+def check_card_conformance(
+    signed: SignedCapabilityCard,
+    *,
+    now: float | None = None,
+) -> ConformanceReport:
+    """Run the offline conformance self-check over a signed capability card.
+
+    Checks performed, in order:
+
+    1. ``required_fields`` - the body carries the mandatory non-empty
+       fields and a well-formed policy block (via
+       :meth:`CapabilityCard.validate_body`).
+    2. ``jcs_canonical`` - the body re-canonicalises under RFC 8785 JCS
+       without error (the exact bytes the signature is computed over).
+    3. ``signature`` - the detached JWS verifies against the Ed25519 key
+       the card carries, with the capability-card ``typ`` and ``EdDSA``
+       alg, ignoring expiry (expiry is a separate check).
+    4. ``expiry`` - the card is not expired relative to ``now``.
+    5. ``issuer`` - the issuer id is a non-empty string.
+
+    The report ``ok`` is the AND of every check. The function never
+    raises on malformed input; a parse failure becomes a failed check.
+
+    Args:
+        signed: The signed capability card to audit.
+        now: Optional override for the current time (testing / replay).
+
+    Returns:
+        A :class:`ConformanceReport`.
+    """
+    checks: list[ConformanceCheck] = []
+
+    # --- 1. Required fields + policy block --------------------------------
+    body = signed.card.to_body()
+    fields_ok = True
+    fields_detail = "all required fields present and well-formed"
+    try:
+        CapabilityCard.validate_body(body)
+        missing = [f for f in _REQUIRED_STRING_FIELDS if not str(body.get(f, ""))]
+        if missing:
+            fields_ok = False
+            fields_detail = f"missing/empty required field(s): {', '.join(missing)}"
+    except ValueError as exc:
+        fields_ok = False
+        fields_detail = f"card body failed validation: {exc}"
+    checks.append(ConformanceCheck("required_fields", fields_ok, fields_detail))
+
+    # --- 2. JCS canonicalisation ------------------------------------------
+    jcs_ok = True
+    jcs_detail = "body re-canonicalises under RFC 8785 JCS"
+    try:
+        from bernstein.core.security.agent_card_signer import canonicalize_jcs
+
+        canonicalize_jcs(body)
+    except (TypeError, ValueError) as exc:
+        jcs_ok = False
+        jcs_detail = f"JCS canonicalisation failed: {exc}"
+    checks.append(ConformanceCheck("jcs_canonical", jcs_ok, jcs_detail))
+
+    # --- 3. Detached JWS signature (expiry excluded) ----------------------
+    sig_ok = verify_capability_card(signed, check_expiry=False, now=now)
+    sig_detail = (
+        f"detached Ed25519 JWS verifies ({CAPABILITY_CARD_TYP})"
+        if sig_ok
+        else "detached JWS signature is invalid, malformed, or not Ed25519/capability-card typ"
+    )
+    checks.append(ConformanceCheck("signature", sig_ok, sig_detail))
+
+    # --- 4. Expiry --------------------------------------------------------
+    expired = signed.card.is_expired(now=now)
+    if signed.card.expires_at <= 0:
+        expiry_ok = True
+        expiry_detail = "card carries no expiry (expires_at <= 0); never-expiring cards are discouraged"
+    else:
+        expiry_ok = not expired
+        expiry_detail = (
+            f"card is within its validity window (expires_at={signed.card.expires_at})"
+            if expiry_ok
+            else f"card is expired (expires_at={signed.card.expires_at})"
+        )
+    checks.append(ConformanceCheck("expiry", expiry_ok, expiry_detail))
+
+    # --- 5. Issuer --------------------------------------------------------
+    issuer = str(body.get("issuer", ""))
+    issuer_ok = bool(issuer)
+    issuer_detail = f"issuer='{issuer}'" if issuer_ok else "issuer is empty"
+    checks.append(ConformanceCheck("issuer", issuer_ok, issuer_detail))
+
+    # --- Fingerprint (best-effort, informational) -------------------------
+    fingerprint = ""
+    try:
+        fingerprint = card_public_key_fingerprint(signed.card.public_key_pem)
+    except (ValueError, TypeError):
+        fingerprint = ""
+
+    ok = all(c.passed for c in checks)
+    return ConformanceReport(
+        ok=ok,
+        checks=checks,
+        issuer=issuer,
+        kid=str(body.get("kid", "")),
+        fingerprint=fingerprint,
+    )

--- a/tests/unit/compliance/test_owasp_maps.py
+++ b/tests/unit/compliance/test_owasp_maps.py
@@ -1,0 +1,228 @@
+"""Unit tests for the OWASP ASI / AST evidence-pack control maps.
+
+Covers:
+
+* Registration: ``owasp-asi`` and ``owasp-skills`` are in
+  ``SUPPORTED_STANDARDS`` and resolve via ``get_standard_map``.
+* Shape: each map has the ten canonical control ids, a regulation
+  label, and every control carries the required keys with a valid
+  status.
+* Honesty: partial controls are explicitly marked ``"partial"`` (the
+  maps are not all-green).
+* Grounding: every ``selector`` event-type token cited by the maps is a
+  literal ``event_type`` string that actually appears in the Bernstein
+  source tree (no phantom mechanisms).
+* End-to-end: ``build_evidence_pack`` produces a well-formed, layout-
+  complete zip for both new standards whose ``controls.json`` matches
+  the map and whose manifest hashes agree with the on-disk bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from bernstein.compliance import owasp_asi, owasp_skills
+from bernstein.compliance.evidence_pack import (
+    SUPPORTED_STANDARDS,
+    build_evidence_pack,
+    get_standard_map,
+)
+
+# Audit attribute names that are legitimately used as selectors but are
+# not themselves ``event_type`` literals (they are event fields / lineage
+# fields). These are excluded from the "must be a real event_type" check.
+_NON_EVENT_SELECTOR_TOKENS: frozenset[str] = frozenset(
+    {
+        "content_hash",
+        "parent_hashes",
+        "model",
+        "task_id",
+        "usd",
+    }
+)
+
+_ASI_IDS = tuple(f"ASI{n:02d}" for n in range(1, 11))
+_AST_IDS = tuple(f"AST{n:02d}" for n in range(1, 11))
+
+
+def _source_event_types() -> set[str]:
+    """Collect every literal ``event_type`` string used in the src tree.
+
+    Scans for both ``event_type="..."`` call sites and ``EVENT_* =
+    "..."`` / ``EVENT_TYPE = "..."`` constant definitions, so a selector
+    that names a constant's value counts as grounded.
+    """
+    src_root = Path(__file__).resolve().parents[3] / "src" / "bernstein"
+    assert src_root.is_dir(), src_root
+    found: set[str] = set()
+    call_pat = re.compile(r'event_type\s*=\s*["\']([a-z0-9_.]+)["\']')
+    const_pat = re.compile(r'EVENT[A-Z_]*\s*=\s*["\']([a-z0-9_.]+)["\']')
+    for path in src_root.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        found.update(call_pat.findall(text))
+        found.update(const_pat.findall(text))
+    return found
+
+
+@pytest.fixture(scope="module")
+def source_event_types() -> set[str]:
+    return _source_event_types()
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_standard_is_registered(standard: str) -> None:
+    assert standard in SUPPORTED_STANDARDS
+    mapping = get_standard_map(standard)
+    assert mapping["regulation"]
+    assert mapping["controls"]
+
+
+def test_asi_map_has_ten_canonical_controls() -> None:
+    mapping = get_standard_map("owasp-asi")
+    ids = [c["control_id"] for c in mapping["controls"]]
+    assert ids == list(_ASI_IDS)
+
+
+def test_skills_map_has_ten_canonical_controls() -> None:
+    mapping = get_standard_map("owasp-skills")
+    ids = [c["control_id"] for c in mapping["controls"]]
+    assert ids == list(_AST_IDS)
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_every_control_has_required_keys_and_valid_status(standard: str) -> None:
+    mapping = get_standard_map(standard)
+    for control in mapping["controls"]:
+        for key in ("control_id", "requirement", "artefact", "selector", "status"):
+            assert key in control, (standard, control.get("control_id"), key)
+            assert control[key] != "" or key == "selector"
+        assert control["status"] in {"mapped", "partial", "todo"}
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_map_marks_some_controls_partial(standard: str) -> None:
+    # An honest partial map is the deliverable: neither catalogue should
+    # claim full coverage. This test fails on the pre-change code (the
+    # standard is not even registered) and on any future over-claim that
+    # marks everything "mapped".
+    mapping = get_standard_map(standard)
+    statuses = {c["control_id"]: c["status"] for c in mapping["controls"]}
+    assert "partial" in statuses.values(), statuses
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_selectors_reference_real_event_types(
+    standard: str,
+    source_event_types: set[str],
+) -> None:
+    mapping = get_standard_map(standard)
+    unknown: list[tuple[str, str]] = []
+    for control in mapping["controls"]:
+        for token in str(control["selector"]).split(","):
+            token = token.strip()
+            if not token or token in _NON_EVENT_SELECTOR_TOKENS:
+                continue
+            # A grounded selector token is either a literal event_type in
+            # the source tree, or a dotted/underscored event name that
+            # appears verbatim in a source file (constant value).
+            if token not in source_event_types:
+                unknown.append((control["control_id"], token))
+    assert not unknown, f"{standard} cites event types not found in src: {unknown}"
+
+
+def test_control_map_returns_copy() -> None:
+    # Mutating the returned dict must not corrupt the module catalogue.
+    first = owasp_asi.control_map()
+    first["controls"][0]["status"] = "MUTATED"
+    second = owasp_asi.control_map()
+    assert second["controls"][0]["status"] != "MUTATED"
+
+    first_s = owasp_skills.control_map()
+    first_s["controls"][0]["status"] = "MUTATED"
+    second_s = owasp_skills.control_map()
+    assert second_s["controls"][0]["status"] != "MUTATED"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pack build
+# ---------------------------------------------------------------------------
+
+
+def _seed_sdd(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    audit = sdd / "audit"
+    audit.mkdir(parents=True)
+    (audit / "log.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-01-05T10:00:00+00:00",
+                "event_type": "capability_matrix_refusal",
+                "actor": "agent",
+                "resource_type": "task",
+                "resource_id": "T-1",
+                "hmac": "a" * 64,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return sdd
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_build_evidence_pack_wellformed(standard: str, tmp_path: Path) -> None:
+    sdd = _seed_sdd(tmp_path)
+    out = tmp_path / "pack.zip"
+    pack = build_evidence_pack(
+        sdd_dir=sdd,
+        standard=standard,
+        output_path=out,
+        write=True,
+    )
+    assert pack.standard == standard
+    assert pack.event_count == 1
+    assert pack.controls_mapped >= 1
+    assert pack.controls_todo == 0
+    assert out.is_file()
+
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        for required in (
+            "manifest.json",
+            "controls.json",
+            "audit-chain/events.jsonl",
+            "lineage/log.jsonl",
+            "costs/cost_history.jsonl",
+            "README.md",
+        ):
+            assert required in names, required
+
+        controls = json.loads(zf.read("controls.json"))
+        assert controls["standard"] == standard
+        assert len(controls["controls"]) == 10
+
+        manifest = json.loads(zf.read("manifest.json"))
+        # Every artefact hash in the manifest agrees with the bytes.
+        for name, digest in manifest["artefacts"].items():
+            if name == "manifest.json":
+                continue
+            assert hashlib.sha256(zf.read(name)).hexdigest() == digest, name
+
+
+@pytest.mark.parametrize("standard", ["owasp-asi", "owasp-skills"])
+def test_build_evidence_pack_is_deterministic(standard: str, tmp_path: Path) -> None:
+    sdd = _seed_sdd(tmp_path)
+    a = build_evidence_pack(sdd_dir=sdd, standard=standard, output_path=tmp_path / "a.zip")
+    b = build_evidence_pack(sdd_dir=sdd, standard=standard, output_path=tmp_path / "b.zip")
+    assert a.sha256 == b.sha256
+    assert (tmp_path / "a.zip").read_bytes() == (tmp_path / "b.zip").read_bytes()

--- a/tests/unit/compliance/test_owasp_maps.py
+++ b/tests/unit/compliance/test_owasp_maps.py
@@ -191,7 +191,11 @@ def test_build_evidence_pack_wellformed(standard: str, tmp_path: Path) -> None:
     )
     assert pack.standard == standard
     assert pack.event_count == 1
-    assert pack.controls_mapped >= 1
+    # Both catalogues are honest partial maps: 6 mapped + 4 partial of 10.
+    # The partial controls must be counted, not silently dropped from the
+    # summary (which previously reported "6 / 0" as if nothing was outstanding).
+    assert pack.controls_mapped == 6
+    assert pack.controls_partial == 4
     assert pack.controls_todo == 0
     assert out.is_file()
 
@@ -212,6 +216,10 @@ def test_build_evidence_pack_wellformed(standard: str, tmp_path: Path) -> None:
         assert len(controls["controls"]) == 10
 
         manifest = json.loads(zf.read("manifest.json"))
+        # The partial count reaches the manifest and the to_dict summary, so
+        # an operator reading either sees the 4 outstanding partial controls.
+        assert manifest["controls_partial"] == 4
+        assert pack.to_dict()["controls_partial"] == 4
         # Every artefact hash in the manifest agrees with the bytes.
         for name, digest in manifest["artefacts"].items():
             if name == "manifest.json":

--- a/tests/unit/interop/test_a2a_conformance.py
+++ b/tests/unit/interop/test_a2a_conformance.py
@@ -1,0 +1,125 @@
+"""Unit tests for the A2A signed-card conformance self-check.
+
+Covers:
+
+* A well-formed signed card passes every check.
+* A tampered card body fails the signature check (and the report).
+* An expired card fails the expiry check while its signature stays
+  valid (proving the two checks are independent).
+* A card missing a required field fails the required-fields check.
+* The CLI ``bernstein interop a2a conformance`` exits 0 on a good card
+  and non-zero on a tampered one.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.interop_cmd import interop_group
+from bernstein.core.interop.a2a_card import (
+    CardPolicies,
+    SignedCapabilityCard,
+    issue_capability_card,
+)
+from bernstein.core.interop.a2a_conformance import check_card_conformance
+
+
+def _issue(*, ttl_seconds: int = 3600, now: float | None = None) -> SignedCapabilityCard:
+    policies = CardPolicies(
+        cost_cap_usd=5.0,
+        redaction_tier="standard",
+        sandbox_profile="container",
+    )
+    signed, _key = issue_capability_card(
+        issuer="acme",
+        name="acme-orchestrator",
+        description="test",
+        advertised_tools=["task_orchestration"],
+        policies=policies,
+        ttl_seconds=ttl_seconds,
+        now=now,
+    )
+    return signed
+
+
+def _check_by_name(report, name: str) -> bool:
+    for check in report.checks:
+        if check.name == name:
+            return check.passed
+    raise AssertionError(f"no check named {name!r}")
+
+
+def test_wellformed_card_passes_all_checks() -> None:
+    report = check_card_conformance(_issue())
+    assert report.ok is True
+    assert all(c.passed for c in report.checks)
+    assert report.issuer == "acme"
+    assert report.fingerprint.startswith("sha256:")
+
+
+def test_tampered_card_fails_signature() -> None:
+    signed = _issue()
+    tampered_card = dataclasses.replace(signed.card, issuer="evil")
+    tampered = dataclasses.replace(signed, card=tampered_card)
+
+    report = check_card_conformance(tampered)
+    assert report.ok is False
+    assert _check_by_name(report, "signature") is False
+
+
+def test_expired_card_fails_expiry_but_keeps_signature() -> None:
+    # Issue a card that was valid for an hour but a long time ago.
+    signed = _issue(ttl_seconds=3600, now=time.time() - 10_000)
+    report = check_card_conformance(signed)
+    assert report.ok is False
+    assert _check_by_name(report, "expiry") is False
+    # The signature is still cryptographically valid; only expiry failed.
+    assert _check_by_name(report, "signature") is True
+
+
+def test_missing_required_field_fails() -> None:
+    signed = _issue()
+    empty_kid_card = dataclasses.replace(signed.card, kid="")
+    broken = dataclasses.replace(signed, card=empty_kid_card)
+    report = check_card_conformance(broken)
+    assert report.ok is False
+    assert _check_by_name(report, "required_fields") is False
+
+
+def test_cli_conformance_passes(tmp_path: Path) -> None:
+    card_path = tmp_path / "card.json"
+    card_path.write_text(_issue().to_json())
+    runner = CliRunner()
+    result = runner.invoke(interop_group, ["a2a", "conformance", "--card", str(card_path)])
+    assert result.exit_code == 0, result.output
+    assert "passes all conformance checks" in result.output
+
+
+def test_cli_conformance_fails_on_tampered_card(tmp_path: Path) -> None:
+    signed = _issue()
+    tampered = dataclasses.replace(signed, card=dataclasses.replace(signed.card, issuer="evil"))
+    card_path = tmp_path / "card.json"
+    card_path.write_text(tampered.to_json())
+    runner = CliRunner()
+    result = runner.invoke(interop_group, ["a2a", "conformance", "--card", str(card_path)])
+    assert result.exit_code == 1, result.output
+
+
+def test_cli_conformance_json_output(tmp_path: Path) -> None:
+    card_path = tmp_path / "card.json"
+    card_path.write_text(_issue().to_json())
+    runner = CliRunner()
+    result = runner.invoke(
+        interop_group,
+        ["a2a", "conformance", "--card", str(card_path)],
+        obj={"JSON": True},
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert len(payload["checks"]) == 5

--- a/tests/unit/test_evidence_pack.py
+++ b/tests/unit/test_evidence_pack.py
@@ -120,11 +120,13 @@ def sdd_dir(tmp_path: Path) -> Path:
 
 class TestStandardMap:
     def test_supported_standards_constant(self) -> None:
-        # Only ai-act ships with a reviewed control map at MVP. DORA
-        # and FINOS AIGF are tracked under #1316 and must not be
-        # selectable from the CLI until their clause mappings are
+        # ai-act plus the two OWASP agentic-security catalogues ship with
+        # reviewed control maps. DORA and FINOS AIGF remain tracked under
+        # #1316 and must NOT be selectable until their clause mappings are
         # validated; emitting TODO-only bundles would mislead operators.
-        assert set(SUPPORTED_STANDARDS) == {"ai-act"}
+        assert set(SUPPORTED_STANDARDS) == {"ai-act", "owasp-asi", "owasp-skills"}
+        assert "dora" not in SUPPORTED_STANDARDS
+        assert "finos-aigf" not in SUPPORTED_STANDARDS
 
     def test_ai_act_has_real_controls(self) -> None:
         mapping = get_standard_map("ai-act")

--- a/tests/unit/test_evidence_pack.py
+++ b/tests/unit/test_evidence_pack.py
@@ -191,6 +191,7 @@ class TestBuildEvidencePack:
         assert pack.lineage_count == 2
         assert pack.cost_count == 2
         assert pack.controls_mapped >= 5
+        assert pack.controls_partial == 0  # ai-act is fully mapped, no partials
         assert pack.controls_todo == 0  # ai-act is real
 
     def test_task_scoping_filters_events(self, sdd_dir: Path) -> None:


### PR DESCRIPTION
Brings forward previously-unmerged work found during a git hygiene pass: this branch carried substantial, tested changes that were never opened as a PR. Content summary:
 src/bernstein/compliance/evidence_pack.py     |  32 +++-
 src/bernstein/compliance/owasp_asi.py         | 204 ++++++++++++++++++++++
 src/bernstein/compliance/owasp_skills.py      | 192 +++++++++++++++++++++
 src/bernstein/core/interop/a2a_conformance.py | 207 ++++++++++++++++++++++
 tests/unit/compliance/test_owasp_maps.py      | 236 ++++++++++++++++++++++++++
 tests/unit/interop/test_a2a_conformance.py    | 125 ++++++++++++++
 tests/unit/test_evidence_pack.py              |  11 +-
 10 files changed, 1059 insertions(+), 17 deletions(-)

Opening so the change goes through CI and review rather than being lost. If CI surfaces drift against the current tree, it can be rebased; if the work is superseded, close instead.