### PR TITLE
feat(activity): data and ops modalities on the typed activity boundary

### DIFF
--- a/docs/operations/activity-boundary.md
+++ b/docs/operations/activity-boundary.md
@@ -81,15 +81,25 @@ A tampered journal entry or a divergent stored blob makes the reconstruction
 diverge, and `verify` exits 2. Exit 0 is a clean verify; exit 1 means the run or
 its activity entries were not found.
 
-## Modalities shipped and deferred
+## Modalities
 
-- **Research** and **browser/computer-use** ship end to end: research
-  content-addresses every fetched page at fetch time; browser records one
-  observation hash per decision step. Both anchor identically to a coding spawn.
-- **Data** and **ops** (deterministic-plan vs side-effecting split, signed
-  input/output artifacts) build on the same substrate -- their side-effecting
-  steps are observations over signed input/output artifacts dispatched through
-  the identical boundary -- and are documented follow-ups.
+- **Research** and **browser/computer-use**: research content-addresses every
+  fetched page at fetch time; browser records one observation hash per decision
+  step. Both anchor identically to a coding spawn.
+- **Data** and **ops**: a world-changing modality adds two guarantees on top of
+  the same substrate.
+  - **Deterministic-plan vs side-effecting split.** The activity records signed
+    inputs, then derives a plan whose `plan_hash` is a byte-identical projection
+    of those inputs and the declared steps, then records signed outputs. A side
+    effect before a plan (or a new input after one) is refused, so the plan is
+    provably the projection the effects were computed from.
+  - **Signed input/output artifacts.** Every input and output is content-addressed
+    and Ed25519-signed with the install key, bound into a `DataOpsReceipt` that is
+    the activity's `artifact`. The receipt's canonical bytes hash to the anchored
+    `artifact_hash` and are stored content-addressed, so `bernstein activity verify`
+    reattaches the receipt offline and re-verifies the plan projection and every
+    signature -- not just the evidence bytes. Strip the store or the journal and
+    the receipt stops verifying, not merely stops logging.
 
 ## See also
 

--- a/src/bernstein/cli/commands/activity_cmd.py
+++ b/src/bernstein/cli/commands/activity_cmd.py
@@ -80,6 +80,7 @@ def activity_verify_cmd(run: str, workdir: str, as_json: bool) -> None:
                     "kind": s.kind,
                     "ok": s.ok,
                     "evidence_reattached": s.evidence_reattached,
+                    "signed_receipt_verified": s.signed_receipt_verified,
                     "reason": s.reason,
                 }
                 for s in result.stages
@@ -95,7 +96,12 @@ def activity_verify_cmd(run: str, workdir: str, as_json: bool) -> None:
             for stage in result.stages:
                 if stage.ok:
                     tag = "[green]OK[/green]"
-                    extra = " (evidence reattached)" if stage.evidence_reattached else ""
+                    notes = []
+                    if stage.evidence_reattached:
+                        notes.append("evidence reattached")
+                    if stage.signed_receipt_verified:
+                        notes.append("signed receipt verified")
+                    extra = f" ({', '.join(notes)})" if notes else ""
                     console.print(f"  {tag} {stage.stage_id} [{stage.kind}]{extra}")
                 else:
                     console.print(f"  [red]MISMATCH[/red] {stage.stage_id} [{stage.kind}] -- {stage.reason}")

--- a/src/bernstein/core/orchestration/activity_modalities.py
+++ b/src/bernstein/core/orchestration/activity_modalities.py
@@ -22,21 +22,40 @@ The store is the shared substrate that makes the replay guarantee hold -- the
 journal pins the content hashes, the store holds the bytes, and
 :func:`replay_reattach` rejoins the two and re-verifies every hash.
 
-Deferred modalities
--------------------
-The **data** and **ops** modalities described in the epic (split
-deterministic-plan vs side-effecting activity, signed input/output artifacts)
-build on this same substrate: their side-effecting steps are
-:class:`~bernstein.core.orchestration.activity.Observation` s over signed input
-and output artifacts, dispatched through the identical boundary. They are
-documented follow-ups so the core substrate plus a research and browser proof
-land wired and tested first, rather than shipping four half-wired modalities.
+Data and ops modalities
+------------------------
+Unlike a read-only research fetch or a browser observation, a **data** or **ops**
+activity changes the world, so it carries two extra guarantees the epic calls
+for (:class:`DataActivity` / :class:`OpsActivity`):
+
+* a **deterministic-plan vs side-effecting split** -- the plan
+  (:class:`DataOpsPlan`) is a byte-identical projection of the signed inputs,
+  derived *before* any output is recorded, so a replay recomputes the same plan
+  hash from the same inputs. The runner refuses a side effect before a plan and
+  refuses a new input after one, so the plan is provably the projection the
+  effects were computed from; and
+* **signed input/output artifacts** (:class:`SignedArtifact`) -- every input and
+  output is content-addressed *and* Ed25519-signed with the install key, so a
+  verifier confirms offline both which exact bytes crossed the boundary and that
+  this install produced them.
+
+Both modalities still return an
+:class:`~bernstein.core.orchestration.activity.ActivityResult` the deterministic
+scheduler dispatches and journals identically to research/browser: the signed
+:class:`DataOpsReceipt` is the ``artifact`` (its hash anchored as
+``artifact_hash`` and its canonical bytes stored content-addressed so an offline
+verifier reattaches it), and the signed input/output bytes are the
+content-addressed observations anchored via ``evidence_set_hash``. The receipt is
+the primary artifact: strip the store and the journal and it stops verifying, not
+merely stops logging.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -49,9 +68,10 @@ from bernstein.core.orchestration.activity import (
     evidence_set_hash,
 )
 from bernstein.core.replay.journal import load_events, verify_journal
+from bernstein.core.skills.catalog.signature import sign_payload, verify_payload
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -60,15 +80,38 @@ __all__ = [
     "ActivityVerifyResult",
     "BrowserActivity",
     "ContentStore",
+    "DataActivity",
+    "DataOpsPhaseError",
+    "DataOpsPlan",
+    "DataOpsReceipt",
+    "DataOpsVerdict",
+    "OpsActivity",
     "ResearchActivity",
+    "SignedArtifact",
     "StageVerdict",
     "replay_reattach",
+    "verify_data_ops_receipt",
     "verify_run_activities",
 ]
+
+#: A bare sha256 hex digest (the addressable component of a content hash). Used
+#: to realpath-contain a content-store lookup keyed on a hash read from the
+#: journal, so a tampered hash can never escape the store root.
+_SHA256_HEX = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    """Return canonical JSON bytes (sorted keys, minimal separators, UTF-8).
+
+    Matches the canonicalisation the activity boundary hashes with, so the
+    content hash of a receipt's canonical bytes equals its anchored
+    ``artifact_hash``.
+    """
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str).encode("utf-8")
 
 
 class ContentStore:
@@ -228,6 +271,386 @@ class BrowserActivity(_ObservationCollector):
         return self._capture(obs_kind="snapshot", ref=step, content=snapshot)
 
 
+# ---------------------------------------------------------------------------
+# data / ops modalities: deterministic-plan split + signed input/output artifacts
+# ---------------------------------------------------------------------------
+
+
+class DataOpsPhaseError(RuntimeError):
+    """A data/ops activity violated the deterministic-plan vs side-effect split.
+
+    Raised when a caller records a side-effecting output before a deterministic
+    plan is derived, adds an input after the plan is fixed, or finishes before a
+    plan exists. The split is what makes the plan a provable projection of the
+    inputs it was computed from.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class SignedArtifact:
+    """A content-addressed, Ed25519-signed input or output artifact.
+
+    The signature covers the canonical ``{role, ref, content_hash}`` binding, so
+    a verifier confirms offline both which exact bytes crossed the boundary and
+    that the install key produced them. The bytes themselves live in the shared
+    :class:`ContentStore`, keyed by ``content_hash``.
+
+    Attributes:
+        role: ``input`` or ``output``.
+        ref: Provenance reference (dataset path, target, result label).
+        content_hash: The ``sha256:`` hash of the artifact bytes.
+        signature: Base64url detached Ed25519 signature over the binding.
+    """
+
+    role: str
+    ref: str
+    content_hash: str
+    signature: str
+
+    def signing_payload(self) -> bytes:
+        """Return the canonical bytes the signature covers."""
+        return _canonical_bytes({"role": self.role, "ref": self.ref, "content_hash": self.content_hash})
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the JSON projection stored on the receipt."""
+        return {"role": self.role, "ref": self.ref, "content_hash": self.content_hash, "signature": self.signature}
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> SignedArtifact:
+        """Rebuild a signed artifact from its receipt projection."""
+        return cls(
+            role=str(row.get("role", "")),
+            ref=str(row.get("ref", "")),
+            content_hash=str(row.get("content_hash", "")),
+            signature=str(row.get("signature", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DataOpsPlan:
+    """The deterministic plan a data/ops activity derives before any side effect.
+
+    The plan is a pure projection of the signed inputs and the declared steps:
+    ``plan_hash`` is a function of the sorted, de-duplicated input content hashes
+    and the ordered steps only. Two operators with the same inputs and steps
+    derive the byte-identical ``plan_hash``, whatever order the inputs arrived
+    in, so a replay recomputes and re-verifies it.
+
+    Attributes:
+        input_hashes: Sorted, de-duplicated input content hashes.
+        steps: The ordered intended side effects (declarative, not executed).
+        plan_hash: The ``sha256:`` hash over ``{input_hashes, steps}``.
+    """
+
+    input_hashes: tuple[str, ...]
+    steps: tuple[str, ...]
+    plan_hash: str
+
+    @classmethod
+    def derive_from_hashes(cls, *, input_hashes: Sequence[str], steps: Sequence[str]) -> DataOpsPlan:
+        """Derive a plan from input content hashes and declared steps."""
+        canonical_inputs = tuple(sorted(set(input_hashes)))
+        canonical_steps = tuple(steps)
+        plan_hash = "sha256:" + _sha256_hex(
+            _canonical_bytes({"input_hashes": list(canonical_inputs), "steps": list(canonical_steps)})
+        )
+        return cls(input_hashes=canonical_inputs, steps=canonical_steps, plan_hash=plan_hash)
+
+    @classmethod
+    def derive(cls, *, inputs: Sequence[SignedArtifact], steps: Sequence[str]) -> DataOpsPlan:
+        """Derive a plan from the signed input artifacts and declared steps."""
+        return cls.derive_from_hashes(input_hashes=[a.content_hash for a in inputs], steps=steps)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON projection stored on the receipt."""
+        return {
+            "input_hashes": list(self.input_hashes),
+            "steps": list(self.steps),
+            "plan_hash": self.plan_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> DataOpsPlan:
+        """Rebuild a plan from its receipt projection (input hashes re-canonicalised)."""
+        raw_inputs = row.get("input_hashes", [])
+        raw_steps = row.get("steps", [])
+        input_hashes = tuple(sorted({str(h) for h in raw_inputs})) if isinstance(raw_inputs, list) else ()
+        steps = tuple(str(s) for s in raw_steps) if isinstance(raw_steps, list) else ()
+        return cls(input_hashes=input_hashes, steps=steps, plan_hash=str(row.get("plan_hash", "")))
+
+
+@dataclass(frozen=True, slots=True)
+class DataOpsReceipt:
+    """The signed result record a data/ops activity produces (the artifact).
+
+    The receipt is the primary artifact of a data/ops boundary crossing: it binds
+    the deterministic :class:`DataOpsPlan`, the signed input and output artifacts,
+    and the install public key that signed them into one record. Its canonical
+    bytes hash to the activity's ``artifact_hash`` (anchored in the journal) and
+    are stored content-addressed so :func:`verify_run_activities` reattaches and
+    re-verifies it offline.
+
+    Attributes:
+        kind: The modality string (``data`` or ``ops``).
+        plan: The deterministic plan the side effects were computed from.
+        inputs: The signed input artifacts.
+        outputs: The signed output artifacts.
+        signer_public_key_pem: The install public key the artifacts verify under.
+    """
+
+    kind: str
+    plan: DataOpsPlan
+    inputs: tuple[SignedArtifact, ...]
+    outputs: tuple[SignedArtifact, ...]
+    signer_public_key_pem: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON artifact projection (hashed as ``artifact_hash``)."""
+        return {
+            "kind": self.kind,
+            "plan": self.plan.to_dict(),
+            "inputs": [a.to_dict() for a in self.inputs],
+            "outputs": [a.to_dict() for a in self.outputs],
+            "signer_public_key_pem": self.signer_public_key_pem,
+        }
+
+    @classmethod
+    def from_dict(cls, row: dict[str, Any]) -> DataOpsReceipt:
+        """Rebuild a receipt from its artifact projection."""
+        raw_inputs = row.get("inputs", [])
+        raw_outputs = row.get("outputs", [])
+        return cls(
+            kind=str(row.get("kind", "")),
+            plan=DataOpsPlan.from_dict(row.get("plan", {}) if isinstance(row.get("plan"), dict) else {}),
+            inputs=tuple(SignedArtifact.from_dict(a) for a in raw_inputs) if isinstance(raw_inputs, list) else (),
+            outputs=tuple(SignedArtifact.from_dict(a) for a in raw_outputs) if isinstance(raw_outputs, list) else (),
+            signer_public_key_pem=str(row.get("signer_public_key_pem", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DataOpsVerdict:
+    """Outcome of :func:`verify_data_ops_receipt`.
+
+    Attributes:
+        ok: True only when the plan recomputes, every signature verifies, and
+            (when a store is supplied) every artifact's bytes reattach.
+        plan_ok: Whether ``plan_hash`` recomputes from the signed inputs + steps.
+        signatures_ok: Whether every input/output signature verifies.
+        evidence_reattached: Whether the artifact bytes reattached from the store
+            and re-hashed to their pinned content hashes.
+        reason: A short explanation on failure, else empty.
+    """
+
+    ok: bool
+    plan_ok: bool
+    signatures_ok: bool
+    evidence_reattached: bool
+    reason: str = ""
+
+
+def verify_data_ops_receipt(receipt: DataOpsReceipt, *, store: ContentStore | None = None) -> DataOpsVerdict:
+    """Verify a data/ops signed receipt offline (determinism + signatures).
+
+    Recomputes the deterministic plan from the signed inputs and declared steps
+    and compares it to the anchored ``plan_hash`` (a tampered step list or a
+    swapped input diverges); verifies every input and output Ed25519 signature
+    against the receipt's signer public key; and, when a content store is
+    supplied, reattaches each artifact's bytes and re-hashes them to their pinned
+    content hash.
+
+    Args:
+        receipt: The receipt to verify.
+        store: Optional content store to reattach artifact bytes from.
+
+    Returns:
+        A :class:`DataOpsVerdict`. ``ok`` requires plan, signatures, and (when a
+        store is supplied) reattachment to all hold.
+    """
+    recomputed = DataOpsPlan.derive_from_hashes(
+        input_hashes=[a.content_hash for a in receipt.inputs], steps=receipt.plan.steps
+    )
+    plan_ok = recomputed.plan_hash == receipt.plan.plan_hash and recomputed.input_hashes == receipt.plan.input_hashes
+    if not plan_ok:
+        return DataOpsVerdict(
+            ok=False,
+            plan_ok=False,
+            signatures_ok=False,
+            evidence_reattached=False,
+            reason=f"plan_hash mismatch: anchored {receipt.plan.plan_hash!r}, recomputed {recomputed.plan_hash!r}",
+        )
+
+    for artifact in (*receipt.inputs, *receipt.outputs):
+        outcome = verify_payload(
+            artifact.signing_payload(),
+            artifact.signature,
+            receipt.signer_public_key_pem or None,
+            allow_unverified=True,
+        )
+        if not outcome.verified:
+            return DataOpsVerdict(
+                ok=False,
+                plan_ok=True,
+                signatures_ok=False,
+                evidence_reattached=False,
+                reason=f"signature does not verify for {artifact.role} {artifact.ref!r}: {outcome.reason}",
+            )
+
+    reattached = False
+    if store is not None:
+        for artifact in (*receipt.inputs, *receipt.outputs):
+            try:
+                content = store.get(artifact.content_hash)
+            except KeyError:
+                return DataOpsVerdict(
+                    ok=False,
+                    plan_ok=True,
+                    signatures_ok=True,
+                    evidence_reattached=False,
+                    reason=f"artifact bytes missing from store for {artifact.ref!r}",
+                )
+            if "sha256:" + _sha256_hex(content) != artifact.content_hash:
+                return DataOpsVerdict(
+                    ok=False,
+                    plan_ok=True,
+                    signatures_ok=True,
+                    evidence_reattached=False,
+                    reason=f"content hash mismatch reattaching {artifact.ref!r}",
+                )
+        reattached = True
+
+    return DataOpsVerdict(ok=True, plan_ok=True, signatures_ok=True, evidence_reattached=reattached)
+
+
+class _SignedArtifactActivity(_ObservationCollector):
+    """Shared base for the data/ops modalities: signed I/O + plan/effect split.
+
+    A subclass only declares its :class:`ActivityKind`. The base enforces the
+    deterministic-plan vs side-effecting split (inputs, then one plan, then
+    outputs), signs every artifact with the install key, content-addresses each
+    as an observation so it journals identically to research/browser, and builds
+    a :class:`DataOpsReceipt` as the result artifact.
+    """
+
+    def __init__(self, *, store: ContentStore, private_key_pem: str, public_key_pem: str) -> None:
+        super().__init__(store=store)
+        # Keys are held verbatim: they must be byte-identical to what signs /
+        # verifies, so they are never stripped or reformatted.
+        self._private_key_pem = private_key_pem
+        self._public_key_pem = public_key_pem
+        self._inputs: list[SignedArtifact] = []
+        self._outputs: list[SignedArtifact] = []
+        self._plan: DataOpsPlan | None = None
+
+    def _signed(self, *, role: str, obs: Observation) -> SignedArtifact:
+        payload = _canonical_bytes({"role": role, "ref": obs.ref, "content_hash": obs.content_hash})
+        signature = sign_payload(payload, self._private_key_pem)
+        return SignedArtifact(role=role, ref=obs.ref, content_hash=obs.content_hash, signature=signature)
+
+    def add_input(self, *, ref: str, content: bytes) -> SignedArtifact:
+        """Record a signed input artifact (the plan-phase, before any effect).
+
+        Raises:
+            DataOpsPhaseError: If called after the plan is derived.
+        """
+        if self._plan is not None:
+            raise DataOpsPhaseError("inputs are frozen once the deterministic plan is derived")
+        obs = self._capture(obs_kind="input", ref=ref, content=content)
+        artifact = self._signed(role="input", obs=obs)
+        self._inputs.append(artifact)
+        return artifact
+
+    def plan(self, steps: Sequence[str]) -> DataOpsPlan:
+        """Derive the deterministic plan from the signed inputs and *steps*.
+
+        Raises:
+            DataOpsPhaseError: If a plan was already derived.
+        """
+        if self._plan is not None:
+            raise DataOpsPhaseError("a deterministic plan was already derived")
+        self._plan = DataOpsPlan.derive(inputs=self._inputs, steps=steps)
+        return self._plan
+
+    def add_output(self, *, ref: str, content: bytes) -> SignedArtifact:
+        """Record a signed output artifact (the side-effecting phase).
+
+        Raises:
+            DataOpsPhaseError: If called before the deterministic plan exists.
+        """
+        if self._plan is None:
+            raise DataOpsPhaseError("cannot record a side effect before a deterministic plan")
+        obs = self._capture(obs_kind="output", ref=ref, content=content)
+        artifact = self._signed(role="output", obs=obs)
+        self._outputs.append(artifact)
+        return artifact
+
+    def receipt(self) -> DataOpsReceipt:
+        """Build the signed receipt for this activity.
+
+        Raises:
+            DataOpsPhaseError: If no plan has been derived.
+        """
+        if self._plan is None:
+            raise DataOpsPhaseError("no deterministic plan derived")
+        return DataOpsReceipt(
+            kind=self.kind.value,
+            plan=self._plan,
+            inputs=tuple(self._inputs),
+            outputs=tuple(self._outputs),
+            signer_public_key_pem=self._public_key_pem,
+        )
+
+    def finish(
+        self,
+        *,
+        terminal_state: TerminalState = TerminalState.COMPLETED,
+        reason_code: str = "ok",
+    ) -> ActivityResult:
+        """Build the typed :class:`ActivityResult` carrying the signed receipt.
+
+        The receipt's canonical bytes are stored content-addressed under the
+        activity's ``artifact_hash`` so an offline verifier reattaches and
+        re-verifies the receipt from the run's content store alone.
+
+        Raises:
+            DataOpsPhaseError: If no plan has been derived.
+        """
+        artifact = self.receipt().to_dict()
+        self._store.put(_canonical_bytes(artifact))
+        return ActivityResult.build(
+            kind=self.kind,
+            artifact=artifact,
+            observations=self.observations(),
+            terminal_state=terminal_state,
+            reason_code=reason_code,
+        )
+
+
+class DataActivity(_SignedArtifactActivity):
+    """A data agent: deterministic transform plan over signed input/output data.
+
+    The signed inputs are the source datasets, the plan is the deterministic
+    transform derived from them, and the signed outputs are the produced
+    datasets. The plan is a byte-identical projection of the inputs, so a replay
+    recomputes it and a verifier confirms the transform acted on the plan the
+    inputs imply.
+    """
+
+    kind = ActivityKind.DATA
+
+
+class OpsActivity(_SignedArtifactActivity):
+    """An ops agent: deterministic change plan over signed input/output targets.
+
+    The signed inputs are the target descriptors, the plan is the deterministic
+    set of intended changes, and the signed outputs are the applied results. The
+    plan/effect split guarantees no change is recorded before the plan the change
+    was derived from, so a postmortem can prove which plan a side effect executed.
+    """
+
+    kind = ActivityKind.OPS
+
+
 def replay_reattach(journal_path: Path, *, store: ContentStore, stage_id: str) -> list[bytes]:
     """Reattach the evidence bytes for an anchored activity from the store.
 
@@ -290,6 +713,8 @@ class StageVerdict:
             store is available) its evidence bytes reattach and re-verify.
         evidence_reattached: Whether the evidence bytes were reattached from the
             content store and re-verified against their pinned hashes.
+        signed_receipt_verified: Whether a data/ops signed receipt was reattached
+            from the store and its plan + input/output signatures re-verified.
         reason: A short human-readable explanation on failure, else empty.
     """
 
@@ -297,6 +722,7 @@ class StageVerdict:
     kind: str
     ok: bool
     evidence_reattached: bool
+    signed_receipt_verified: bool = False
     reason: str = ""
 
 
@@ -439,4 +865,71 @@ def _verify_stage(row: dict[str, Any], *, store: ContentStore | None, chain_ok: 
                 )
         reattached = bool(rebuilt)
 
-    return StageVerdict(stage_id=stage_id, kind=kind, ok=True, evidence_reattached=reattached)
+    receipt_verified = False
+    if store is not None and kind in {ActivityKind.DATA.value, ActivityKind.OPS.value}:
+        verdict = _verify_data_ops_stage(row, store=store)
+        if verdict is not None:
+            if not verdict.ok:
+                return StageVerdict(
+                    stage_id=stage_id,
+                    kind=kind,
+                    ok=False,
+                    evidence_reattached=reattached,
+                    reason=verdict.reason,
+                )
+            receipt_verified = True
+
+    return StageVerdict(
+        stage_id=stage_id,
+        kind=kind,
+        ok=True,
+        evidence_reattached=reattached,
+        signed_receipt_verified=receipt_verified,
+    )
+
+
+def _verify_data_ops_stage(row: dict[str, Any], *, store: ContentStore) -> DataOpsVerdict | None:
+    """Reattach and re-verify a data/ops signed receipt for one anchored row.
+
+    The receipt's canonical bytes were stored content-addressed under the
+    stage's ``artifact_hash``. This reattaches them by that hash, confirms the
+    reattached bytes still hash to the anchored ``artifact_hash`` (tamper), and
+    re-verifies the plan projection and every input/output signature. Returns
+    ``None`` when no receipt is stored (a legacy or non-receipt data/ops row),
+    so the generic evidence check stands alone.
+    """
+    artifact_hash = str(row.get("artifact_hash", ""))
+    digest = artifact_hash.split(":", 1)[-1]
+    # Realpath-contain the store lookup: the hash comes from the journal, so
+    # only a bare sha256 hex digest may address a blob (no path separators).
+    if not _SHA256_HEX.match(digest):
+        return DataOpsVerdict(
+            ok=False,
+            plan_ok=False,
+            signatures_ok=False,
+            evidence_reattached=False,
+            reason=f"malformed artifact_hash for data/ops stage: {artifact_hash!r}",
+        )
+    try:
+        receipt_bytes = store.get(artifact_hash)
+    except KeyError:
+        return None
+    if "sha256:" + _sha256_hex(receipt_bytes) != artifact_hash:
+        return DataOpsVerdict(
+            ok=False,
+            plan_ok=False,
+            signatures_ok=False,
+            evidence_reattached=False,
+            reason=f"receipt bytes do not match anchored artifact_hash {artifact_hash!r}",
+        )
+    try:
+        receipt = DataOpsReceipt.from_dict(json.loads(receipt_bytes))
+    except (ValueError, TypeError) as exc:
+        return DataOpsVerdict(
+            ok=False,
+            plan_ok=False,
+            signatures_ok=False,
+            evidence_reattached=False,
+            reason=f"stored receipt is not valid JSON: {type(exc).__name__}",
+        )
+    return verify_data_ops_receipt(receipt, store=store)

--- a/tests/unit/test_activity_data_ops.py
+++ b/tests/unit/test_activity_data_ops.py
@@ -1,0 +1,281 @@
+"""Data and ops modality activities on the typed boundary (issue #2311).
+
+The typed activity boundary generalizes past research and browser to the *data*
+and *ops* modalities. Unlike a read-only research fetch, a data/ops activity
+changes the world, so it carries two extra guarantees the epic calls for:
+
+* a deterministic-plan vs side-effecting split -- the plan is a byte-identical
+  projection of the signed inputs, derived *before* any side effect, so a replay
+  recomputes the same plan hash from the same inputs; and
+* signed input/output artifacts -- every input and output is content-addressed
+  *and* Ed25519-signed, so a verifier confirms offline both which exact bytes
+  crossed the boundary and that the install produced them.
+
+Both modalities still produce an ``ActivityResult`` the deterministic scheduler
+dispatches and journals identically to research/browser: the signed receipt is
+the ``artifact`` (its hash anchored as ``artifact_hash``) and the signed
+input/output bytes are the content-addressed observations (anchored via
+``evidence_set_hash``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.activity import (
+    ActivityKind,
+    TerminalState,
+    dispatch_activity,
+)
+from bernstein.core.orchestration.activity_modalities import (
+    ContentStore,
+    DataActivity,
+    DataOpsPhaseError,
+    DataOpsPlan,
+    DataOpsReceipt,
+    OpsActivity,
+    replay_reattach,
+    verify_data_ops_receipt,
+    verify_run_activities,
+)
+from bernstein.core.replay.journal import EventJournal, load_events
+from bernstein.core.skills.catalog.signature import generate_signer_keypair
+
+
+def _keypair() -> tuple[str, str]:
+    return generate_signer_keypair()
+
+
+def _journal(tmp_path: Path, run_id: str = "run-1") -> EventJournal:
+    return EventJournal(run_id=run_id, sdd_dir=tmp_path / ".sdd")
+
+
+# ---------------------------------------------------------------------------
+# deterministic-plan vs side-effecting split
+# ---------------------------------------------------------------------------
+
+
+def test_plan_is_deterministic_projection_of_inputs(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    # Two runs with the same signed inputs and the same steps derive the
+    # byte-identical plan hash, whatever order the inputs were added in.
+    a = DataActivity(store=ContentStore(tmp_path / "cas1"), private_key_pem=priv, public_key_pem=pub)
+    a.add_input(ref="rows.csv", content=b"id,name\n1,a\n")
+    a.add_input(ref="schema.json", content=b'{"cols":2}')
+    plan_a = a.plan(["normalize", "dedupe"])
+
+    b = OpsActivity(store=ContentStore(tmp_path / "cas2"), private_key_pem=priv, public_key_pem=pub)
+    b.add_input(ref="schema.json", content=b'{"cols":2}')  # reverse order
+    b.add_input(ref="rows.csv", content=b"id,name\n1,a\n")
+    plan_b = b.plan(["normalize", "dedupe"])
+
+    assert plan_a.plan_hash == plan_b.plan_hash
+    assert plan_a.plan_hash.startswith("sha256:")
+
+
+def test_plan_hash_changes_when_inputs_change(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    a = DataActivity(store=ContentStore(tmp_path / "cas1"), private_key_pem=priv, public_key_pem=pub)
+    a.add_input(ref="rows.csv", content=b"alpha")
+    plan_a = a.plan(["load"])
+
+    b = DataActivity(store=ContentStore(tmp_path / "cas2"), private_key_pem=priv, public_key_pem=pub)
+    b.add_input(ref="rows.csv", content=b"beta")
+    plan_b = b.plan(["load"])
+
+    assert plan_a.plan_hash != plan_b.plan_hash
+
+
+def test_side_effect_before_plan_is_refused(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    act = OpsActivity(store=ContentStore(tmp_path / "cas"), private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="target", content=b"host=db")
+    # A side-effecting output cannot be recorded before a deterministic plan.
+    with pytest.raises(DataOpsPhaseError):
+        act.add_output(ref="applied", content=b"done")
+
+
+def test_input_after_plan_is_refused(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    act = DataActivity(store=ContentStore(tmp_path / "cas"), private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="a", content=b"a")
+    act.plan(["go"])
+    # Inputs are frozen once the plan is derived: no input may change the plan
+    # the side effects were computed from.
+    with pytest.raises(DataOpsPhaseError):
+        act.add_input(ref="b", content=b"b")
+
+
+def test_finish_before_plan_is_refused(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    act = DataActivity(store=ContentStore(tmp_path / "cas"), private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="a", content=b"a")
+    with pytest.raises(DataOpsPhaseError):
+        act.finish()
+
+
+# ---------------------------------------------------------------------------
+# signed input/output artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_inputs_and_outputs_are_signed(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    act = OpsActivity(store=ContentStore(tmp_path / "cas"), private_key_pem=priv, public_key_pem=pub)
+    inp = act.add_input(ref="target", content=b"host=db")
+    act.plan(["apply-migration"])
+    out = act.add_output(ref="result", content=b"rows=3")
+
+    assert inp.role == "input"
+    assert out.role == "output"
+    assert inp.signature and out.signature
+    assert inp.content_hash.startswith("sha256:")
+
+
+def test_receipt_verifies_signatures_and_plan(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    store = ContentStore(tmp_path / "cas")
+    act = DataActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="rows.csv", content=b"raw")
+    act.plan(["normalize"])
+    act.add_output(ref="clean.csv", content=b"clean")
+    result = act.finish()
+
+    receipt = DataOpsReceipt.from_dict(result.artifact)
+    verdict = verify_data_ops_receipt(receipt, store=store)
+    assert verdict.ok
+    assert verdict.plan_ok
+    assert verdict.signatures_ok
+    assert verdict.evidence_reattached
+
+
+def test_receipt_rejects_forged_signature(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    _other_priv, other_pub = _keypair()
+    store = ContentStore(tmp_path / "cas")
+    act = DataActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="rows.csv", content=b"raw")
+    act.plan(["normalize"])
+    result = act.finish()
+
+    # Verifying against a different install's public key must fail the signatures.
+    tampered = DataOpsReceipt.from_dict({**result.artifact, "signer_public_key_pem": other_pub})
+    verdict = verify_data_ops_receipt(tampered, store=store)
+    assert not verdict.ok
+    assert not verdict.signatures_ok
+
+
+def test_receipt_rejects_tampered_plan(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    store = ContentStore(tmp_path / "cas")
+    act = OpsActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="target", content=b"host=db")
+    act.plan(["apply"])
+    result = act.finish()
+
+    forged = dict(result.artifact)
+    forged_plan = dict(forged["plan"])
+    forged_plan["steps"] = ["apply", "drop-table"]  # steps not what plan_hash covers
+    forged["plan"] = forged_plan
+    receipt = DataOpsReceipt.from_dict(forged)
+    verdict = verify_data_ops_receipt(receipt, store=store)
+    assert not verdict.ok
+    assert not verdict.plan_ok
+
+
+# ---------------------------------------------------------------------------
+# journaled identically to research/browser
+# ---------------------------------------------------------------------------
+
+
+def test_data_activity_journals_like_other_modalities(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    store = ContentStore(tmp_path / "cas")
+    act = DataActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="rows.csv", content=b"raw")
+    act.plan(["normalize"])
+    act.add_output(ref="clean.csv", content=b"clean")
+    result = act.finish()
+
+    assert result.kind is ActivityKind.DATA
+    assert result.terminal_state is TerminalState.COMPLETED
+
+    journal = _journal(tmp_path)
+    dispatch_activity(result, stage_id="data-0", journal=journal)
+    rows = load_events(journal.path)
+    assert rows[0]["event"] == "activity.result"
+    assert rows[0]["kind"] == "data"
+    # The signed input/output bytes are content-addressed observations, so a
+    # replay reattaches them byte-identically like any other modality.
+    reattached = replay_reattach(journal.path, store=store, stage_id="data-0")
+    assert b"raw" in reattached
+    assert b"clean" in reattached
+
+
+def test_ops_activity_journals_kind(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    store = ContentStore(tmp_path / "cas")
+    act = OpsActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="target", content=b"host=db")
+    act.plan(["apply"])
+    act.add_output(ref="result", content=b"ok")
+    result = act.finish()
+    journal = _journal(tmp_path)
+    dispatch_activity(result, stage_id="ops-0", journal=journal)
+    rows = load_events(journal.path)
+    assert rows[0]["kind"] == "ops"
+
+
+# ---------------------------------------------------------------------------
+# verify_run_activities re-verifies the signed receipt offline
+# ---------------------------------------------------------------------------
+
+
+def test_verify_run_reverifies_signed_receipt(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    act = DataActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="rows.csv", content=b"raw")
+    act.plan(["normalize"])
+    act.add_output(ref="clean.csv", content=b"clean")
+    result = act.finish()
+
+    journal = EventJournal(run_id="run-9", sdd_dir=sdd)
+    dispatch_activity(result, stage_id="data-0", journal=journal)
+
+    verified = verify_run_activities(sdd, run_id="run-9", store=store)
+    assert verified.ok
+    stage = verified.stages[0]
+    assert stage.ok
+    assert stage.signed_receipt_verified
+
+
+def test_verify_run_detects_tampered_receipt(tmp_path: Path) -> None:
+    priv, pub = _keypair()
+    sdd = tmp_path / ".sdd"
+    store = ContentStore(sdd / "cas")
+    act = OpsActivity(store=store, private_key_pem=priv, public_key_pem=pub)
+    act.add_input(ref="target", content=b"host=db")
+    act.plan(["apply"])
+    result = act.finish()
+
+    journal = EventJournal(run_id="run-9", sdd_dir=sdd)
+    dispatch_activity(result, stage_id="ops-0", journal=journal)
+
+    # Overwrite the stored receipt blob with bytes that no longer match the
+    # anchored artifact_hash: verification must refuse the stage.
+    store.force_put(result.artifact_hash, b'{"kind":"ops","tampered":true}')
+    verified = verify_run_activities(sdd, run_id="run-9", store=store)
+    assert not verified.ok
+    assert not verified.stages[0].ok
+
+
+def test_plan_roundtrips_through_dict() -> None:
+    plan = DataOpsPlan.derive_from_hashes(input_hashes=["sha256:bb", "sha256:aa"], steps=["s1"])
+    restored = DataOpsPlan.from_dict(plan.to_dict())
+    assert restored.plan_hash == plan.plan_hash
+    # input_hashes are stored sorted+deduplicated for a stable projection.
+    assert restored.input_hashes == ("sha256:aa", "sha256:bb")


### PR DESCRIPTION
## What

Extends the typed activity boundary (#2311) past research and browser to the world-changing **data** and **ops** modalities, the documented follow-up tracked on the epic after the core boundary shipped in #2350.

A data/ops activity changes the world, so it carries two guarantees a read-only fetch does not:

- **Deterministic-plan vs side-effecting split.** The activity records signed inputs, then derives a `DataOpsPlan` whose `plan_hash` is a byte-identical projection of those inputs and the declared steps, then records signed outputs. A side effect before a plan, or a new input after one, is refused, so the plan is provably the projection the effects were computed from.
- **Signed input/output artifacts.** Every input and output is content-addressed and Ed25519-signed with the install key (reusing the existing signature primitive), bound into a `DataOpsReceipt` that is the activity `artifact`. The receipt's canonical bytes hash to the anchored `artifact_hash` and are stored content-addressed, so `bernstein activity verify` reattaches the receipt offline and re-verifies the plan projection and every signature, not just the evidence bytes.

Both modalities return an `ActivityResult` dispatched and journalled identically to research/browser. `verify_run_activities` and the `activity verify` CLI surface `signed_receipt_verified` per stage and refuse a tampered receipt.

## AC to test map

The five epic ACs were satisfied when the core boundary shipped in #2350; this PR completes the sole remaining tracked scope (data/ops). New coverage in `tests/unit/test_activity_data_ops.py`:

| Guarantee | Test |
|---|---|
| Plan is deterministic projection of inputs (order-independent) | `test_plan_is_deterministic_projection_of_inputs` |
| Plan hash tracks input changes | `test_plan_hash_changes_when_inputs_change` |
| Side effect before plan refused | `test_side_effect_before_plan_is_refused` |
| Input after plan refused | `test_input_after_plan_is_refused` |
| Signed input/output artifacts | `test_inputs_and_outputs_are_signed` |
| Receipt verifies plan + signatures + bytes | `test_receipt_verifies_signatures_and_plan` |
| Forged signature rejected | `test_receipt_rejects_forged_signature` |
| Tampered plan rejected | `test_receipt_rejects_tampered_plan` |
| Journalled identically, replay reattaches bytes | `test_data_activity_journals_like_other_modalities`, `test_ops_activity_journals_kind` |
| CLI/verify re-verifies signed receipt offline | `test_verify_run_reverifies_signed_receipt` |
| Tampered stored receipt refused | `test_verify_run_detects_tampered_receipt` |
| Plan dict round-trip | `test_plan_roundtrips_through_dict` |

## Verification

- `uv run pytest tests/unit/test_activity_*.py` -> 55 passed; new file run 3x clean
- `uv run ruff check src/ tests/` -> clean; `ruff format --check` on touched files clean
- `uv run lint-imports` -> 3 contracts kept
- `uv run python -c "import bernstein"` -> ok
- `bernstein activity verify` smoke run on a data activity: `signed_receipt_verified: true`

Closes #2311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Data and Operations activity modalities with deterministic planning and enforced phase ordering.
  * Added signed, content-addressed input/output receipts for offline verification.
  * Activity verification now reports whether signed receipts were successfully verified.
  * CLI verification output includes evidence reattachment and receipt verification status.

* **Documentation**
  * Expanded activity boundary documentation to explain Data and Operations guarantees, artifact signing, and verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->