### PR TITLE
style: resolve open refurb idiom alerts (FURB108/123/138/184)

### DIFF
--- a/src/bernstein/cli/commands/run_service_cmd.py
+++ b/src/bernstein/cli/commands/run_service_cmd.py
@@ -113,8 +113,7 @@ def submit_cmd(
         raise SystemExit(EXIT_NO_RUN)
 
     root = _root(workdir)
-    svc = RunService(root)
-    handle = svc.submit(goal, task_ids)
+    handle = RunService(root).submit(goal, task_ids)
     run_id = handle.run_id
 
     pid: int | None = None

--- a/src/bernstein/core/cost/scheduling/pools.py
+++ b/src/bernstein/core/cost/scheduling/pools.py
@@ -47,7 +47,7 @@ def project_pools(entries: Iterable[LedgerEntry]) -> dict[str, float]:
     for entry in entries:
         pool = entry.quota_envelope or DEFAULT_POOL
         totals[pool] += entry.cost_usd
-    return dict(totals)
+    return {**totals}
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bernstein/core/cost/scheduling/price_table.py
+++ b/src/bernstein/core/cost/scheduling/price_table.py
@@ -210,9 +210,9 @@ def load_price_table(
     base_table = base if base is not None else DEFAULT_PRICE_TABLE
     if not models:
         return base_table
-    merged: dict[str, ModelPrice] = dict(base_table.models)
+    merged: dict[str, ModelPrice] = base_table.models.copy()
     for key, raw in models.items():
-        merged[str(key)] = _coerce_rates(raw, key=str(key))
+        merged[key] = _coerce_rates(raw, key=key)
     return PriceTable(
         models=merged,
         as_of=as_of or base_table.as_of,

--- a/src/bernstein/core/identity/spiffe/spiffe_id.py
+++ b/src/bernstein/core/identity/spiffe/spiffe_id.py
@@ -119,7 +119,7 @@ def install_segment(install_public_key_pem: bytes) -> str:
     """
     if not isinstance(install_public_key_pem, (bytes, bytearray)):
         raise SpiffeIdError("install_public_key_pem must be bytes")
-    digest = hashlib.sha256(bytes(install_public_key_pem)).hexdigest()
+    digest = hashlib.sha256(install_public_key_pem).hexdigest()
     return digest[:_INSTALL_SEGMENT_LEN]
 
 

--- a/src/bernstein/core/run_service/descriptor.py
+++ b/src/bernstein/core/run_service/descriptor.py
@@ -46,7 +46,7 @@ class RunDescriptor:
             "run_id": self.run_id,
             "goal": self.goal,
             "goal_sha256": self.goal_sha256,
-            "task_ids": list(self.task_ids),
+            "task_ids": self.task_ids.copy(),
             "created_ts": self.created_ts,
         }
 

--- a/src/bernstein/core/run_service/service.py
+++ b/src/bernstein/core/run_service/service.py
@@ -122,7 +122,7 @@ class RunService:
         descriptor = RunDescriptor(
             run_id=run_id,
             goal=goal,
-            task_ids=[str(t) for t in task_ids],
+            task_ids=list(task_ids),
             created_ts=time.time(),
         )
 

--- a/src/bernstein/core/run_service/verify.py
+++ b/src/bernstein/core/run_service/verify.py
@@ -47,7 +47,7 @@ class RunVerification:
             "ledger_ok": self.ledger_ok,
             "continuity_ok": self.continuity_ok,
             "receipts_seen": self.receipts_seen,
-            "errors": list(self.errors),
+            "errors": self.errors.copy(),
         }
 
 
@@ -102,7 +102,7 @@ def verify_run(root: Path, run_id: str) -> RunVerification:
             if transition in CONTINUITY_TRANSITIONS:
                 from_idx = _hash_index(hashes, str(details.get("from_head", "")))
                 to_idx = _hash_index(hashes, str(details.get("to_head", "")))
-                if from_idx == -2 or to_idx == -2:
+                if -2 in (from_idx, to_idx):
                     continuity_ok = False
                     errors.append(f"continuity: {transition} boundary head is not an ancestor in the chain")
                 elif from_idx > to_idx:

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -2628,9 +2628,9 @@ def record_tournament_selection(
             "task_id": task_id,
             "receipt_hash": receipt_hash,
             "winner_hash": winner_hash,
-            "attempt_hashes": list(attempt_hashes),
+            "attempt_hashes": [*attempt_hashes],
             "attempt_count": len(attempt_hashes),
-            "evaluator_names": list(evaluator_names),
+            "evaluator_names": [*evaluator_names],
         },
     )
 

--- a/src/bernstein/core/security/hook_gate.py
+++ b/src/bernstein/core/security/hook_gate.py
@@ -169,7 +169,7 @@ def policy_from_task_fields(
     return HookGatePolicy(
         task_id=task_id,
         producers=parse_producers(list(evidence_producers)),
-        path_allowlist=tuple(str(p) for p in owned_files),
+        path_allowlist=tuple(owned_files),
     )
 
 

--- a/src/bernstein/core/skills/packaging.py
+++ b/src/bernstein/core/skills/packaging.py
@@ -754,8 +754,9 @@ def _verify_updated_install(
                 f"installed {installed_manifest_hash[:12]}...)"
             ),
         )
-    spine = LineageSpine(workdir / ".sdd" / "lineage", run_id=INSTALL_RUN_ID, hmac_key=hmac_key)
-    spine_result = spine.verify()
+    spine_result = LineageSpine(
+        workdir / ".sdd" / "lineage", run_id=INSTALL_RUN_ID, hmac_key=hmac_key
+    ).verify()
     if not spine_result.ok:
         return InstallVerifyResult(
             ok=False,

--- a/src/bernstein/core/skills/packaging.py
+++ b/src/bernstein/core/skills/packaging.py
@@ -754,9 +754,7 @@ def _verify_updated_install(
                 f"installed {installed_manifest_hash[:12]}...)"
             ),
         )
-    spine_result = LineageSpine(
-        workdir / ".sdd" / "lineage", run_id=INSTALL_RUN_ID, hmac_key=hmac_key
-    ).verify()
+    spine_result = LineageSpine(workdir / ".sdd" / "lineage", run_id=INSTALL_RUN_ID, hmac_key=hmac_key).verify()
     if not spine_result.ok:
         return InstallVerifyResult(
             ok=False,

--- a/src/bernstein/sdd/spec_pipeline/compiler.py
+++ b/src/bernstein/sdd/spec_pipeline/compiler.py
@@ -163,15 +163,14 @@ class TaskGraph:
         :func:`bernstein.core.planning.plan_schema.validate_plan`. Requirement
         ids are recorded per step so the plan file keeps the lineage anchor.
         """
-        steps: list[dict[str, object]] = []
-        for node in self.nodes:
-            steps.append(
-                {
-                    "title": node.title,
-                    "role": node.role,
-                    "description": "Implements " + ", ".join(node.requirement_ids),
-                }
-            )
+        steps: list[dict[str, object]] = [
+            {
+                "title": node.title,
+                "role": node.role,
+                "description": "Implements " + ", ".join(node.requirement_ids),
+            }
+            for node in self.nodes
+        ]
         return {
             "name": name,
             "description": description or f"Compiled from requirement set {self.requirement_set_hash}",


### PR DESCRIPTION
Clears the 15 open code-scanning refurb findings across the newly landed feature modules.

- FURB123 (redundant casts): drop no-op `str()`/`bytes()` and replace `dict()`/`list()` copies with `.copy()` or unpacking. `pools.project_pools` returns a plain dict via `{**totals}` because the source is a `defaultdict`, where `.copy()` would preserve the defaultdict type.
- FURB108: membership test instead of chained equality in run-service verify.
- FURB138: build the plan steps list with a comprehension in the spec-pipeline compiler.
- FURB184: chain the `LineageSpine` and `RunService` temporaries.

Behavior is unchanged. Audit-chain receipt payloads stay byte-identical (list unpacking preserves element order and content). Targeted module tests pass (tournament, spec pipeline, cost scheduling, spiffe id, hook gate, run service, price table, pools).