### PR TITLE
fix(replay): refuse run_id that escapes the journal runs root

### DIFF
--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -140,6 +140,12 @@ class EventJournal:
         self._run_id = run_id
         self._runs_root = sdd_dir / "runs"
         self._path = self._runs_root / run_id / JOURNAL_FILENAME
+        # Realpath-containment guard: a run_id carrying ".." traversal or an
+        # absolute component must never redirect the journal outside the runs
+        # root. Resolve symlinks and refuse an escaping path before any file
+        # I/O touches it (py/path-injection).
+        if not self._path.resolve().is_relative_to(self._runs_root.resolve()):
+            raise ValueError(f"run_id escapes the journal runs root: {run_id!r}")
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
         self._index = 0

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -139,11 +139,22 @@ class EventJournal:
     def __init__(self, run_id: str, sdd_dir: Path) -> None:
         self._run_id = run_id
         self._runs_root = sdd_dir / "runs"
+        # Path-injection guard (py/path-injection). Validate run_id lexically
+        # first: a run_id must be a single, non-traversing path segment. This
+        # check never touches the filesystem, so it has no time-of-check /
+        # time-of-use window -- it rejects every "..", separator, or absolute
+        # run_id before a path is ever built. The realpath-containment check
+        # below is defence in depth for the resolved directory.
+        if (
+            not run_id
+            or run_id in {".", ".."}
+            or "/" in run_id
+            or "\\" in run_id
+            or "\x00" in run_id
+            or os.path.isabs(run_id)
+        ):
+            raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
         self._path = self._runs_root / run_id / JOURNAL_FILENAME
-        # Realpath-containment guard: a run_id carrying ".." traversal or an
-        # absolute component must never redirect the journal outside the runs
-        # root. Resolve symlinks and refuse an escaping path before any file
-        # I/O touches it (py/path-injection).
         if not self._path.resolve().is_relative_to(self._runs_root.resolve()):
             raise ValueError(f"run_id escapes the journal runs root: {run_id!r}")
         self._path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_event_journal.py
+++ b/tests/unit/test_event_journal.py
@@ -151,9 +151,9 @@ def test_retention_prunes_oldest_run_journals(tmp_path: Path) -> None:
 
 
 def test_run_id_traversal_is_refused(tmp_path: Path) -> None:
-    """A run_id that escapes the runs root is refused before any file I/O."""
-    for bad in ("../../etc", "..", "a/../../b"):
-        with pytest.raises(ValueError, match="escapes the journal runs root"):
+    """A run_id that traverses or escapes the runs root is refused before I/O."""
+    for bad in ("../../etc", "..", "a/../../b", "/abs/path", "", ".", "a\\b"):
+        with pytest.raises(ValueError, match="run_id"):
             EventJournal(run_id=bad, sdd_dir=tmp_path)
 
 

--- a/tests/unit/test_event_journal.py
+++ b/tests/unit/test_event_journal.py
@@ -12,6 +12,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from bernstein.core.replay.journal import (
     EventJournal,
     JournalVerifyResult,
@@ -146,3 +148,16 @@ def test_retention_prunes_oldest_run_journals(tmp_path: Path) -> None:
             j.record("only")
         surviving = sorted(p.name for p in (runs_root / "runs").iterdir() if p.is_dir())
     assert surviving == ["run-02", "run-03"]
+
+
+def test_run_id_traversal_is_refused(tmp_path: Path) -> None:
+    """A run_id that escapes the runs root is refused before any file I/O."""
+    for bad in ("../../etc", "..", "a/../../b"):
+        with pytest.raises(ValueError, match="escapes the journal runs root"):
+            EventJournal(run_id=bad, sdd_dir=tmp_path)
+
+
+def test_ordinary_run_id_is_contained(tmp_path: Path) -> None:
+    """A normal run_id builds a journal path inside the runs root."""
+    journal = EventJournal(run_id="run-ok-123", sdd_dir=tmp_path)
+    assert journal.path.resolve().is_relative_to((tmp_path / "runs").resolve())


### PR DESCRIPTION
Resolves the two open CodeQL `py/path-injection` alerts in `core/replay/journal.py`.

The `EventJournal` `run_id` is used to build the journal file path (`.sdd/runs/<run_id>/journal.jsonl`). A `run_id` carrying `..` traversal or an absolute component could redirect `mkdir` and file writes outside the runs root.

Fix: a realpath-containment guard in the constructor resolves the constructed path and refuses it when it is not relative to the resolved runs root, before any `mkdir` or file open. Same pattern already used in `core/security/always_allow.py`.

Adds regression tests: traversal run_ids are refused with a clear error; an ordinary run_id stays contained. Full journal/replay suite passes.

## Summary by Sourcery

Guard event journal paths against path traversal so run_ids cannot escape the runs root.

Bug Fixes:
- Prevent EventJournal from writing journals outside the runs root when given run_ids with path traversal or absolute components.

Tests:
- Add regression tests ensuring traversal run_ids are rejected with a clear error and valid run_ids remain contained within the runs root.