### PR TITLE
fix(replay): commonpath containment for journal run_id path

### DIFF
--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -149,18 +149,16 @@ class EventJournal:
             or Path(run_id).is_absolute()
         ):
             raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
-        # Then realpath-containment (the same pattern as core.security
-        # .permissions): resolve symlinks/".." with os.path.realpath and keep
-        # the result only when it stays under the runs root. self._path is the
-        # resolved, contained path, so every downstream file operation uses a
-        # value that has passed the containment check.
-        runs_root = Path(os.path.realpath(self._runs_root))
-        resolved = Path(os.path.realpath(self._runs_root / run_id / JOURNAL_FILENAME))
-        try:
-            resolved.relative_to(runs_root)
-        except ValueError:
-            raise ValueError(f"run_id escapes the journal runs root: {run_id!r}") from None
-        self._path = resolved
+        # Then realpath-containment: normalise symlinks/".." with
+        # os.path.realpath and keep the result only when os.path.commonpath
+        # confirms it stays under the runs root. self._path is the resolved,
+        # contained path, so every downstream file operation uses a value that
+        # has passed the containment check.
+        runs_root = os.path.realpath(self._runs_root)
+        resolved = os.path.realpath(self._runs_root / run_id / JOURNAL_FILENAME)
+        if os.path.commonpath((runs_root, resolved)) != runs_root:
+            raise ValueError(f"run_id escapes the journal runs root: {run_id!r}")
+        self._path = Path(resolved)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
         self._index = 0


### PR DESCRIPTION
Second follow-up on the journal path-injection guard. The pathlib `relative_to` containment was not recognised as a sanitizing barrier, so CodeQL still tracked `run_id` into the `mkdir` and `open` sinks.

This uses the canonical path-injection containment that CodeQL recognises: `os.path.realpath` to normalise, then `os.path.commonpath((runs_root, resolved)) == runs_root`, assigning the contained realpath to `self._path`. The lexical pre-check (no separators, no `.`/`..`, not absolute, no NUL) stays as the filesystem-free first line of defence.

Journal and replay suites pass; traversal-refusal and containment regression tests retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of journal file paths to prevent access outside the configured runs directory.
  * Added handling for resolved paths, including symbolic links and relative path variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->