### PR TITLE
refactor(skills): drop redundant tuple() around already-tuple hosts

### DIFF
--- a/src/bernstein/cli/commands/skills_package_cmd.py
+++ b/src/bernstein/cli/commands/skills_package_cmd.py
@@ -444,7 +444,7 @@ def conformance_cmd(
     met, 2 = conformance failed, 1 = error.
     """
     root = Path(workdir).resolve()
-    selected = tuple(hosts) if hosts else supported_hosts()
+    selected = hosts if hosts else supported_hosts()
 
     try:
         outcome = run_conformance(


### PR DESCRIPTION
The `hosts` parameter of the skills-package conformance command is already typed `tuple[str, ...]`, so wrapping it in `tuple(...)` is a no-op. Simplify to the bare value, matching the refurb FURB123 idiom check. Behaviour is byte-identical: `selected` remains the same tuple when hosts are supplied and falls back to `supported_hosts()` otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of explicitly selected hosts during conformance checks.
  * Preserved automatic selection of supported hosts when no host is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->