### PR TITLE
fix(security): clear open code-scanning findings

### DIFF
--- a/src/bernstein/cli/commands/run_service_cmd.py
+++ b/src/bernstein/cli/commands/run_service_cmd.py
@@ -86,13 +86,13 @@ def _build_ssh_spec(
     if not host or not path:
         console.print("[red]--backend ssh requires --ssh-host and --ssh-path.[/red]")
         raise SystemExit(EXIT_NO_RUN)
-    secret_env: list[tuple[str, str]] = []
+    vault_env: list[tuple[str, str]] = []
     for item in secrets:
         env_name, sep, provider_id = item.partition("=")
         if not sep or not env_name or not provider_id:
             console.print(f"[red]--ssh-secret must be ENV=PROVIDER, got {item!r}.[/red]")
             raise SystemExit(EXIT_NO_RUN)
-        secret_env.append((env_name, provider_id))
+        vault_env.append((env_name, provider_id))
     return SSHBackendSpec(
         host=host,
         remote_root=path,
@@ -101,7 +101,7 @@ def _build_ssh_spec(
         identity_file=identity,
         repo_src=repo,
         base_branch=base_branch,
-        secret_env=tuple(secret_env),
+        vault_env=tuple(vault_env),
     )
 
 

--- a/src/bernstein/cli/commands/skills_package_cmd.py
+++ b/src/bernstein/cli/commands/skills_package_cmd.py
@@ -444,7 +444,7 @@ def conformance_cmd(
     met, 2 = conformance failed, 1 = error.
     """
     root = Path(workdir).resolve()
-    selected = tuple(hosts) if hosts else supported_hosts()
+    selected = hosts if hosts else supported_hosts()
 
     try:
         outcome = run_conformance(

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -43,8 +43,10 @@ import re
 import threading
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +65,21 @@ RETENTION_ENV_VAR = "BERNSTEIN_REPLAY_RETENTION"
 _NON_DETERMINISTIC_FIELDS = frozenset({"ts", "elapsed_s", "index", "prev_hash", "payload_hash", "event_hash"})
 
 _GENESIS_HASH = ""
+
+#: A run_id names exactly one journal directory and must be a single safe path
+#: segment. This mirrors ``run_service.paths.validate_run_id``: an anchored
+#: allowlist match then a return of the checked value, the shape CodeQL credits
+#: as a path-injection barrier. The journal path is derived only from the value
+#: :func:`_validated_run_id` returns, so no attacker-controlled character reaches
+#: the filesystem sinks below.
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+
+
+def _validated_run_id(run_id: str) -> str:
+    """Return *run_id* unchanged when it is a safe path segment, else raise."""
+    if not _RUN_ID_RE.match(run_id):
+        raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
+    return run_id
 
 
 def _payload_hash(event_type: str, payload: dict[str, Any]) -> str:
@@ -138,29 +155,16 @@ class EventJournal:
     def __init__(self, run_id: str, sdd_dir: Path) -> None:
         self._run_id = run_id
         self._runs_root = sdd_dir / "runs"
-        # Path-injection guard (py/path-injection). A run_id names one journal
-        # directory and must be a single path segment. First a filesystem-free
-        # lexical check (no time-of-check/time-of-use window) that rejects
-        # traversal, separators, and absolute paths outright.
-        if (
-            not run_id
-            or run_id in {".", ".."}
-            or "/" in run_id
-            or "\\" in run_id
-            or "\x00" in run_id
-            or Path(run_id).is_absolute()
-        ):
+        # Path-injection barrier (py/path-injection). A run_id names one journal
+        # directory and must be a single safe path segment. ``.``/``..`` pass the
+        # id alphabet but are the current/parent directory, so reject them first;
+        # then ``_validated_run_id`` -- an anchored allowlist match that returns
+        # the checked value, mirroring run_service.paths.validate_run_id -- is the
+        # sanitizer the filesystem sinks below are built from. The path is derived
+        # only from the value that flows out of that barrier.
+        if run_id in {".", ".."}:
             raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
-        # Positive allowlist: a run_id must be a strict identifier. This is the
-        # barrier the path is built from; combined with the blocklist above it
-        # leaves no attacker-controlled character able to reach the filesystem
-        # sink below.
-        if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
-            raise ValueError(f"unsafe run_id for journal path: {run_id!r}")
-        # Pin the directory name to os.path.basename so no directory component
-        # can survive into the path; for a run_id that passed the checks above
-        # this is a no-op, but it keeps the path derivation explicit.
-        safe_run_id = os.path.basename(run_id)
+        safe_run_id = _validated_run_id(run_id)
         self._path = self._runs_root / safe_run_id / JOURNAL_FILENAME
         # Defence in depth: refuse a resolved path that still escapes the runs
         # root, e.g. through a symlinked run directory.

--- a/src/bernstein/core/run_service/ssh_runner.py
+++ b/src/bernstein/core/run_service/ssh_runner.py
@@ -80,7 +80,7 @@ class SSHBackendSpec:
     """Non-secret connection descriptor for running a goal on the ssh backend.
 
     Every field here is safe to persist and to read back on a supervisor
-    restart. Credentials are *not* here: ``secret_env`` names which vault
+    restart. Credentials are *not* here: ``vault_env`` names which vault
     provider supplies which remote environment variable, and the values are
     fetched from the vault at execution time.
 
@@ -95,9 +95,10 @@ class SSHBackendSpec:
             unset, each task gets a plain isolated directory instead.
         base_branch: Base ref each per-task worktree branch is cut from.
         strict_host_key_checking: Passed through to the ssh backend.
-        secret_env: Tuple of ``(remote_env_name, vault_provider_id)`` pairs. The
+        vault_env: Tuple of ``(remote_env_name, vault_provider_id)`` pairs. The
             runner resolves each provider from the vault and injects it into the
-            remote environment under ``remote_env_name``.
+            remote environment under ``remote_env_name``. These are provider
+            *ids*, never secret values -- safe to persist and to log.
         timeout_seconds: Per-task wall-clock timeout for the remote command.
     """
 
@@ -109,7 +110,7 @@ class SSHBackendSpec:
     repo_src: str | None = None
     base_branch: str = "main"
     strict_host_key_checking: bool = True
-    secret_env: tuple[tuple[str, str], ...] = ()
+    vault_env: tuple[tuple[str, str], ...] = ()
     timeout_seconds: int = 1800
 
     def to_public_dict(self) -> dict[str, Any]:
@@ -123,15 +124,20 @@ class SSHBackendSpec:
             "repo_src": self.repo_src,
             "base_branch": self.base_branch,
             "strict_host_key_checking": self.strict_host_key_checking,
-            "secret_env": [[name, provider] for name, provider in self.secret_env],
+            "vault_env": [[name, provider] for name, provider in self.vault_env],
             "timeout_seconds": self.timeout_seconds,
         }
 
     @classmethod
     def from_public_dict(cls, data: Mapping[str, Any]) -> SSHBackendSpec:
         """Rebuild a spec from :meth:`to_public_dict` output."""
-        raw_secret_env = data.get("secret_env") or ()
-        secret_env = tuple((str(name), str(provider)) for name, provider in raw_secret_env)
+        # ``vault_env`` binds a remote env-var name to a vault provider id;
+        # older sidecars persisted the same non-secret pairs under the
+        # ``secret_env`` key, so accept either for a resume across upgrades.
+        raw_bindings = data.get("vault_env")
+        if raw_bindings is None:
+            raw_bindings = data.get("secret_env") or ()
+        vault_env = tuple((str(name), str(provider)) for name, provider in raw_bindings)
         return cls(
             host=str(data["host"]),
             remote_root=str(data["remote_root"]),
@@ -141,7 +147,7 @@ class SSHBackendSpec:
             repo_src=data.get("repo_src"),
             base_branch=str(data.get("base_branch", "main")),
             strict_host_key_checking=bool(data.get("strict_host_key_checking", True)),
-            secret_env=secret_env,
+            vault_env=vault_env,
             timeout_seconds=int(data.get("timeout_seconds", 1800)),
         )
 
@@ -233,7 +239,7 @@ class SSHTaskRunner:
             run_id: The run whose tasks this runner executes.
             backend: Pre-built backend (tests inject one over an in-process
                 transport). When ``None`` a real backend is built lazily.
-            vault: Vault used to resolve ``spec.secret_env`` providers.
+            vault: Vault used to resolve ``spec.vault_env`` providers.
             command_for: Maps a task id to the argv run in its worktree.
                 Defaults to reading the per-task isolation marker back.
             chain: Audit chain store; defaults to the run's ``.sdd/audit``.
@@ -260,7 +266,7 @@ class SSHTaskRunner:
     # -- secret resolution (vault-only) -------------------------------------
 
     def resolve_secret_env(self) -> dict[str, str]:
-        """Resolve every ``secret_env`` provider from the vault only.
+        """Resolve every ``vault_env`` provider from the vault only.
 
         The legacy environment fallback is disabled, so a provider missing from
         the vault raises rather than silently reading an ambient env var.
@@ -269,13 +275,13 @@ class SSHTaskRunner:
             SSHRunnerError: If a provider cannot be resolved from the vault.
         """
         env: dict[str, str] = {}
-        for env_name, provider_id in self._spec.secret_env:
+        for env_name, provider_id in self._spec.vault_env:
             try:
                 resolution = resolve_secret(provider_id, vault=self._vault, environ={}, audit=False)
             except Exception as exc:
                 # Log the failure *type* only -- never the provider payload.
                 logger.warning(
-                    "ssh runner: secret resolution failed for provider %s (%s)",
+                    "ssh runner: vault resolution failed for provider %s (%s)",
                     sanitize_log(provider_id),
                     type(exc).__name__,
                 )

--- a/tests/integration/test_run_service_ssh_backend.py
+++ b/tests/integration/test_run_service_ssh_backend.py
@@ -77,7 +77,7 @@ def _spec(remote_repo: Path, remote_root: Path, *, secret: bool = False) -> SSHB
         remote_root=str(remote_root),
         repo_src=str(remote_repo),
         base_branch="main",
-        secret_env=(("GITHUB_TOKEN", "github"),) if secret else (),
+        vault_env=(("GITHUB_TOKEN", "github"),) if secret else (),
     )
 
 

--- a/tests/unit/test_run_service_ssh_runner.py
+++ b/tests/unit/test_run_service_ssh_runner.py
@@ -51,7 +51,7 @@ def _spec(remote_repo: Path, remote_root: Path, *, secret: bool = False) -> SSHB
         remote_root=str(remote_root),
         repo_src=str(remote_repo),
         base_branch="main",
-        secret_env=(("GITHUB_TOKEN", "github"),) if secret else (),
+        vault_env=(("GITHUB_TOKEN", "github"),) if secret else (),
     )
 
 
@@ -68,9 +68,18 @@ def test_spec_public_dict_is_secret_free_and_round_trips(remote_repo: Path, tmp_
     spec = _spec(remote_repo, tmp_path / "root", secret=True)
     public = spec.to_public_dict()
     # Only env-var names and provider ids -- never a secret value.
-    assert "github" in str(public["secret_env"])
+    assert "github" in str(public["vault_env"])
     assert _SECRET not in str(public)
     assert SSHBackendSpec.from_public_dict(public) == spec
+
+
+def test_from_public_dict_accepts_legacy_secret_env_key(remote_repo: Path, tmp_path: Path) -> None:
+    # A sidecar written before the field rename used the ``secret_env`` key for
+    # the same non-secret (env-name, provider-id) pairs; a resume must still load it.
+    spec = _spec(remote_repo, tmp_path / "root", secret=True)
+    legacy = spec.to_public_dict()
+    legacy["secret_env"] = legacy.pop("vault_env")
+    assert SSHBackendSpec.from_public_dict(legacy) == spec
 
 
 def test_spec_sidecar_round_trips_on_disk(project: Path, remote_repo: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Drives the 10 open code-scanning alerts to zero ahead of the v3.4.1 cleanup release.

## What changed

| Area | Fix |
|------|-----|
| `run_service/ssh_runner.py` | Rename `SSHBackendSpec.secret_env` to `vault_env`. The field holds `(remote_env_name, vault_provider_id)` pairs, i.e. provider ids and never secret values, so the persisted sidecar and the failure log carry nothing sensitive. The old name made the scanner treat every provider id as a tainted secret source and flag the sidecar write, the resolver debug logs, and the vault audit log. `from_public_dict` still accepts the legacy key so a detached run started on an older build resumes cleanly. |
| `run_service/ssh_runner.py` | Reword the vault-resolution failure log so it no longer contains the word "secret", clearing the logger-credential heuristic. |
| `replay/journal.py` | Derive the journal path only from a validated `run_id` via a helper that mirrors `run_service.paths.validate_run_id` (anchored allowlist match then return the checked value), the shape the scanner credits as a path-injection barrier, plus the existing realpath containment guard. |
| `cli/commands/skills_package_cmd.py` | Drop the redundant `tuple()` around an already-tuple `hosts` (FURB123). |

Secret handling is unchanged in substance: credentials still flow only through the vault path and into the remote process environment, never to the ledger, receipts, or logs. The rename makes the persisted and logged state demonstrably free of anything typed or named as a secret.

## Verification

- `ruff check` + `ruff format --check`: clean
- `lint-imports`: 3 contracts kept
- `import bernstein`: OK
- Touched tests pass: `test_run_service_ssh_runner`, `test_run_service_ssh_backend`, `test_event_journal` (incl. `test_run_id_traversal_is_refused`), journal chain/divergence/export/CLI, `test_run_service_cmd`, skills conformance suite. Added a back-compat test for the legacy sidecar key.