### PR TITLE
refactor(skills): use or for host fallback (FURB110)

### DIFF
--- a/src/bernstein/cli/commands/skills_package_cmd.py
+++ b/src/bernstein/cli/commands/skills_package_cmd.py
@@ -444,7 +444,7 @@ def conformance_cmd(
     met, 2 = conformance failed, 1 = error.
     """
     root = Path(workdir).resolve()
-    selected = hosts if hosts else supported_hosts()
+    selected = hosts or supported_hosts()
 
     try:
         outcome = run_conformance(


### PR DESCRIPTION
Follow-up to the FURB123 cleanup in #2453/#2452. Dropping the redundant `tuple()` left `hosts if hosts else supported_hosts()`, which the idiom scanner now flags as FURB110. Collapse it to `hosts or supported_hosts()` (identical behaviour: an empty host tuple is falsy). Drives the last remaining static-analysis alert on this line to zero. ruff clean; refurb reports no findings on the file.