### PR TITLE
feat(cost): route batch dispatch and cache-window fan-out in the live path (#2354)

### DIFF
--- a/docs/operations/cost-aware-scheduling.md
+++ b/docs/operations/cost-aware-scheduling.md
@@ -130,6 +130,26 @@ when the adapter actually has one. An eligible task on a non-batch adapter is
 batch path that does not exist. A task that is not batch-eligible never routes
 to batch.
 
+### Live routing in the run loop
+
+The routing decision is consulted inside the live spawn loop, not only in
+preflight. Before a single-task batch is dispatched, the run resolves the
+adapter that would run the task (a per-role adapter pin wins, else the active
+default adapter), derives batch eligibility from the same classifier the
+provider-batch path uses, and takes the capability-gated route:
+
+- a batch-eligible task on a batch-capable adapter is submitted to the batch
+  surface (no local agent is spawned);
+- a batch-eligible task on an adapter with no batch surface is refused and
+  dispatched interactively;
+- a task that is not batch-eligible bypasses the batch surface entirely.
+
+Each routing decision is sealed as a `cost.batch_route` audit-chain event, so
+the routing of a task -- to the batch endpoint or to interactive dispatch -- is
+an independently verifiable receipt rather than a log line. A verifier holding
+the chain, the adapter capability map, and the task's eligibility recomputes the
+same verdict.
+
 ## Cache-window fan-out (capability-gated, default off)
 
 When M workers share a prompt prefix, dispatching them concurrently makes them
@@ -150,6 +170,14 @@ cost_policy:
 With the opt-in on a capable adapter, a fan-out of M workers issues one warm-up
 call plus M cache-hitting calls. With the default off, the workers race without
 a warm-up and no hits are assumed.
+
+The fan-out is wired into the tournament runner, whose sibling attempts of one
+task share the same prompt prefix -- the exact shape a prompt cache rewards.
+When the resolved adapter is cache-window capable and the opt-in is set, the
+runner issues one warm-up call to prime the shared prefix strictly before the
+siblings spawn, so each sibling hits the warm cache inside the TTL instead of
+racing to write it. The observed warm-up and cache-hit counts are recorded on
+the round outcome.
 
 ## Determinism and verifiability
 

--- a/src/bernstein/core/cost/scheduling/live_dispatch.py
+++ b/src/bernstein/core/cost/scheduling/live_dispatch.py
@@ -1,0 +1,181 @@
+"""Live wiring for batch routing and cache-window fan-out (#2354).
+
+The deterministic decision functions
+(:func:`~bernstein.core.cost.scheduling.batch.route_batch` and
+:func:`~bernstein.core.cost.scheduling.cache_window.plan_cache_fanout` /
+:func:`~bernstein.core.cost.scheduling.cache_window.execute_cache_fanout`)
+shipped in the cost policy layer, but nothing consulted them from a live run's
+dispatch and fan-out paths. This module is that bridge:
+
+* :func:`decide_batch_route` resolves the adapter a task would run on, derives
+  batch eligibility from the same signal the provider-batch path already uses,
+  and defers to ``route_batch`` so a batch-eligible task reaches the batch
+  surface *only* on a batch-capable adapter. A non-eligible task never routes to
+  batch; a batch-eligible task on an adapter with no batch surface is *refused*
+  (routed interactively with a recorded reason), never faked.
+* :func:`seal_batch_route` anchors that decision as a ``cost.batch_route`` audit
+  event so the routing of a task is a verifiable receipt, not a log line.
+* :func:`run_cache_window_fanout` drives ``plan_cache_fanout`` +
+  ``execute_cache_fanout`` for a shared-prefix worker fan-out, issuing one
+  warm-up call strictly before the M worker calls so a capable + enabled adapter
+  primes the shared prompt cache once and every worker hits it.
+
+Everything here is a pure function of its inputs plus the adapter capability map
+(the single source of truth, never probed), so the routing verdict a live run
+takes is the same verdict a verifier recomputes from the chain.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.cost.scheduling.batch import BatchRouteDecision, route_batch
+from bernstein.core.cost.scheduling.cache_window import (
+    CacheFanoutResult,
+    execute_cache_fanout,
+    plan_cache_fanout,
+)
+from bernstein.core.tasks.batch_router import BatchMode, classify_batch_mode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+#: Conservative fallback when no adapter can be resolved for a task. ``generic``
+#: is not in the batch-capable set, so an unresolvable adapter never routes work
+#: to a batch surface it may not have.
+_DEFAULT_ADAPTER = "generic"
+
+
+def resolve_task_adapter(orch: Any, task: Task) -> str:
+    """Return the adapter registry name that would run *task*.
+
+    Resolution mirrors the spawner: a per-role ``role_model_policy`` adapter pin
+    wins, else the spawner's ``default_adapter_name`` (the active adapter), else
+    a conservative :data:`_DEFAULT_ADAPTER` fallback that is never batch-capable.
+    """
+    spawner = getattr(orch, "_spawner", None)
+    role_policy = getattr(spawner, "role_model_policy", None)
+    if isinstance(role_policy, dict):
+        entry = role_policy.get(task.role)
+        if isinstance(entry, dict):
+            adapter = entry.get("adapter")
+            if isinstance(adapter, str) and adapter:
+                return adapter
+    default = getattr(spawner, "default_adapter_name", None)
+    if isinstance(default, str) and default:
+        return default
+    return _DEFAULT_ADAPTER
+
+
+def is_batch_eligible(task: Task) -> bool:
+    """Return whether *task* is a batch candidate.
+
+    Uses the same classifier the provider-batch path consults
+    (:func:`~bernstein.core.tasks.batch_router.classify_batch_mode`) so the
+    route gate admits exactly the tasks the batch surface would accept and
+    refuses none it would.
+    """
+    return classify_batch_mode(task).mode is BatchMode.BATCH
+
+
+def decide_batch_route(orch: Any, task: Task) -> BatchRouteDecision:
+    """Return the live batch-route decision for *task* (#2354, AC3).
+
+    Resolves the adapter, derives batch eligibility, and defers to the
+    capability-gated :func:`route_batch`: a batch-eligible task routes ``batch``
+    only on a batch-capable adapter; a non-eligible task always routes
+    ``interactive``; a batch-eligible task on an incapable adapter is refused.
+    """
+    adapter = resolve_task_adapter(orch, task)
+    eligible = is_batch_eligible(task)
+    return route_batch(task_id=task.id, adapter=adapter, batch_eligible=eligible)
+
+
+def seal_batch_route(orch: Any, decision: BatchRouteDecision) -> None:
+    """Anchor a batch-route decision as a ``cost.batch_route`` audit event.
+
+    Best-effort: the receipt is a provenance aid, so a missing workdir, missing
+    HMAC key, or IO error is logged (exception type only, since this path
+    touches the audit key) and never crashes the dispatch. The spawn proceeds on
+    the route the decision already fixed.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if workdir is None:
+        return
+    try:
+        from bernstein.core.security.audit import load_or_create_audit_key
+        from bernstein.core.security.audit_chain import (
+            AuditChainStore,
+            record_cost_batch_route,
+        )
+
+        hmac_key = load_or_create_audit_key()
+        chain = AuditChainStore(workdir / ".sdd" / "audit", key=hmac_key)
+        record_cost_batch_route(
+            chain=chain,
+            run_id=str(getattr(orch, "_run_id", "")),
+            task_id=decision.task_id,
+            adapter=decision.adapter,
+            batch_eligible=decision.batch_eligible,
+            adapter_capable=decision.adapter_capable,
+            capability=decision.capability,
+            route=decision.route,
+            refused_reason=decision.refused_reason,
+        )
+    except Exception as exc:  # sealing must never crash a dispatch
+        logger.warning("cost: failed to seal batch-route receipt: %s", type(exc).__name__)
+
+
+def run_cache_window_fanout(
+    *,
+    adapter: str,
+    prefix: str,
+    worker_count: int,
+    warmup_call: Callable[[], None],
+    worker_call: Callable[[int], bool],
+    enabled: bool,
+) -> CacheFanoutResult:
+    """Drive a shared-prefix fan-out through the cache window (#2354, AC4).
+
+    Plans the fan-out from the adapter cache-window capability and the *enabled*
+    opt-in, then executes it: a capable + enabled adapter issues exactly one
+    warm-up call (priming the shared prefix) strictly before the ``worker_count``
+    worker calls, so every worker hits the warm cache inside the TTL. An
+    incapable adapter, a disabled window, or a zero-worker fan-out issues no
+    warm-up and drives the workers directly, so turning the feature on is always
+    a deliberate operator choice.
+
+    Args:
+        adapter: Registry name of the adapter the workers run on.
+        prefix: The shared prompt prefix (hashed into the plan, never stored).
+        worker_count: Number of workers sharing *prefix*.
+        warmup_call: Invoked once (0 or 1 times) before any worker.
+        worker_call: ``worker_call(i)`` dispatches worker ``i`` and returns
+            whether it hit the warm cache.
+        enabled: Operator opt-in; the conservative default upstream is off.
+
+    Returns:
+        The :class:`~bernstein.core.cost.scheduling.cache_window.CacheFanoutResult`
+        with the observed warm-up / worker call counts and cache hits.
+    """
+    plan = plan_cache_fanout(
+        adapter=adapter,
+        worker_count=worker_count,
+        prefix=prefix,
+        enabled=enabled,
+    )
+    return execute_cache_fanout(plan, warmup_call=warmup_call, worker_call=worker_call)
+
+
+__all__ = [
+    "decide_batch_route",
+    "is_batch_eligible",
+    "resolve_task_adapter",
+    "run_cache_window_fanout",
+    "seal_batch_route",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -3044,6 +3044,75 @@ def record_run_ssh_task(
     )
 
 
+#: Issue #2354 -- emitted whenever the live dispatch loop routes a task with
+#: respect to the provider batch surface. The event mirrors the deterministic
+#: :func:`~bernstein.core.cost.scheduling.batch.route_batch` decision so an
+#: operator can prove, from the chain alone, that a batch-eligible task reached
+#: the batch endpoint only on a batch-capable adapter -- and that an eligible
+#: task on an adapter with no batch surface was refused (routed interactively),
+#: never faked. Only the routing verdict and capability facts are recorded.
+EVENT_COST_BATCH_ROUTE = "cost.batch_route"
+
+
+def record_cost_batch_route(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    task_id: str,
+    adapter: str,
+    batch_eligible: bool,
+    adapter_capable: bool,
+    capability: str,
+    route: str,
+    refused_reason: str,
+    actor: str = "cost_policy",
+) -> AuditEvent:
+    """Append a ``cost.batch_route`` event into *chain* (#2354).
+
+    Mirrors one live batch-routing decision into the HMAC chain so the routing
+    of a task -- to the batch surface or to interactive dispatch -- is a
+    verifiable receipt, not a log line. A batch-eligible task routes to
+    ``batch`` only when the resolved adapter declares a batch surface; an
+    eligible task on an incapable adapter routes ``interactive`` with
+    *refused_reason* recorded, and a non-eligible task routes ``interactive``
+    with no reason. A verifier reading the chain, the adapter capability map,
+    and the task's eligibility recomputes the same verdict.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: The run the task belonged to.
+        task_id: The task being routed.
+        adapter: Registry name of the resolved adapter.
+        batch_eligible: Whether policy marked the task batch-eligible.
+        adapter_capable: Whether the resolved adapter declares a batch surface.
+        capability: The declared batch-dispatch capability string.
+        route: ``batch`` or ``interactive``.
+        refused_reason: Why an eligible task was refused the batch surface
+            (empty unless a batch-eligible task hit an incapable adapter).
+        actor: Recorded actor; defaults to ``"cost_policy"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_COST_BATCH_ROUTE,
+        actor=actor,
+        resource_type="cost_batch_route",
+        resource_id=task_id,
+        details={
+            "run_id": run_id,
+            "task_id": task_id,
+            "adapter": adapter,
+            "batch_eligible": batch_eligible,
+            "adapter_capable": adapter_capable,
+            "capability": capability,
+            "route": route,
+            "refused_reason": refused_reason,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -3052,6 +3121,7 @@ __all__ = [
     "EVENT_CHECKPOINT_RETRY",
     "EVENT_COMPACTION_RECEIPT",
     "EVENT_COMPACTION_SENSITIVE_GATE",
+    "EVENT_COST_BATCH_ROUTE",
     "EVENT_COST_DISPATCH_RECEIPT",
     "EVENT_COST_PROFILE_REPORT",
     "EVENT_DASHBOARD_TOKEN_GRANT",
@@ -3105,6 +3175,7 @@ __all__ = [
     "record_activity_result",
     "record_adapter_canary_receipt",
     "record_checkpoint_retry",
+    "record_cost_batch_route",
     "record_cost_dispatch_receipt",
     "record_cost_profile_report",
     "record_dashboard_token_grant",

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2247,18 +2247,40 @@ def claim_and_spawn_batches(
 
         # Provider batch: submit eligible low-risk single-task work to
         # OpenAI/Anthropic batch APIs instead of spawning a local CLI agent.
+        # The capability-gated route_batch decision (#2354, AC3) is the gate:
+        # a batch-eligible task reaches the batch surface only on a
+        # batch-capable adapter, a non-eligible task never does, and a
+        # batch-eligible task on an adapter with no batch surface is refused
+        # (dispatched interactively) rather than faked. The routing decision is
+        # sealed as a cost.batch_route receipt.
         if len(batch) == 1:
             _batch_api = getattr(orch, "_batch_api", None)
             if _batch_api is not None:
-                _batch_result = _batch_api.try_submit(orch, batch[0])
-                if _batch_result.handled:
-                    if _batch_result.submitted:
-                        assigned_task_ids.add(batch[0].id)
-                        _claimed_titles.add(_base_title(batch[0].title))
-                        result.spawned.append(_batch_result.session_id or f"provider-batch:{batch[0].id}")
-                    elif _batch_result.reason:
-                        result.errors.append(f"batch:{batch[0].id}: {_batch_result.reason}")
-                    continue
+                from bernstein.core.cost.scheduling.live_dispatch import (
+                    decide_batch_route,
+                    seal_batch_route,
+                )
+
+                _route = decide_batch_route(orch, batch[0])
+                seal_batch_route(orch, _route)
+                if _route.route == "batch":
+                    _batch_result = _batch_api.try_submit(orch, batch[0])
+                    if _batch_result.handled:
+                        if _batch_result.submitted:
+                            assigned_task_ids.add(batch[0].id)
+                            _claimed_titles.add(_base_title(batch[0].title))
+                            result.spawned.append(_batch_result.session_id or f"provider-batch:{batch[0].id}")
+                        elif _batch_result.reason:
+                            result.errors.append(f"batch:{batch[0].id}: {_batch_result.reason}")
+                        continue
+                elif _route.refused_reason:
+                    logger.debug(
+                        "cost: task %s batch-eligible but adapter %s has no batch surface (%s); "
+                        "dispatching interactively",
+                        batch[0].id,
+                        _route.adapter,
+                        _route.refused_reason,
+                    )
 
         batch_timeout_s = _batch_timeout_seconds(batch)
         _shadow_bandit_decision: Any | None = None

--- a/src/bernstein/core/tournament/runner.py
+++ b/src/bernstein/core/tournament/runner.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from bernstein.core.cost.scheduling.live_dispatch import run_cache_window_fanout
 from bernstein.core.cost.ticket_cap import resolve_ticket_cap_usd
 from bernstein.core.tournament.evaluators import AttemptOutcome
 from bernstein.core.tournament.receipt import TournamentReceipt, emit_tournament_receipt
@@ -26,6 +27,7 @@ from bernstein.core.tournament.receipt import TournamentReceipt, emit_tournament
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.core.cost.scheduling.cache_window import CacheFanoutResult
     from bernstein.core.tournament.spec import TournamentSpec
 
 logger = logging.getLogger(__name__)
@@ -121,12 +123,38 @@ AttemptReclaimer = Callable[[AttemptOutcome], None]
 
 
 @dataclass(frozen=True, slots=True)
+class CacheWindowFanout:
+    """Cache-window configuration for a tournament fan-out (#2354, AC4).
+
+    A tournament fans out ``attempts`` sibling attempts of one task, so every
+    sibling shares the same prompt prefix -- the exact shape a prompt cache
+    rewards. When the resolved adapter is cache-window capable and *enabled* is
+    set, the runner issues one warm-up call to prime the shared prefix strictly
+    before the siblings spawn, so each sibling hits the warm cache inside the
+    TTL instead of racing to write it. Conservative default off: an absent
+    config or ``enabled=False`` leaves the fan-out unchanged.
+
+    Attributes:
+        adapter: Registry name of the adapter the attempts run on.
+        prefix: The shared prompt prefix (hashed into the plan, never stored).
+        warmup: Invoked at most once to prime the shared prefix.
+        enabled: Operator opt-in; the conservative default is ``False``.
+    """
+
+    adapter: str
+    prefix: str
+    warmup: Callable[[], None]
+    enabled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class TournamentOutcome:
     """Aggregated result of one tournament round."""
 
     receipt: TournamentReceipt
     winner_hash: str
     projected_usd: float
+    cache_fanout: CacheFanoutResult | None = None
 
 
 @dataclass
@@ -137,11 +165,53 @@ class TournamentRunner:
         spawner: Spawn ``n`` sibling attempts; returns their ids.
         evaluator: Block until attempts finish; returns their outcomes.
         reclaimer: Optional teardown callback for losing attempts.
+        cache_window: Optional cache-window fan-out config; when set and
+            enabled on a capable adapter, one warm-up call primes the shared
+            prompt prefix before the siblings spawn (default off / unset).
     """
 
     spawner: AttemptSpawner
     evaluator: AttemptEvaluator
     reclaimer: AttemptReclaimer | None = field(default=None)
+    cache_window: CacheWindowFanout | None = field(default=None)
+
+    def _fanout(self, task_id: str, attempts: int) -> tuple[list[str], CacheFanoutResult | None]:
+        """Spawn *attempts* siblings, optionally through the cache window.
+
+        Without a cache-window config the siblings spawn in one call, exactly
+        as before. With one, the fan-out is driven through
+        :func:`~bernstein.core.cost.scheduling.live_dispatch.run_cache_window_fanout`:
+        a capable + enabled adapter issues one warm-up call before spawning the
+        siblings one at a time, so each sibling hits the primed cache; the
+        observed call counts are returned for the receipt.
+        """
+        cache_window = self.cache_window
+        if cache_window is None:
+            return list(self.spawner(task_id, attempts)), None
+
+        collected: list[str] = []
+        primed = {"warm": False}
+
+        def _warmup_call() -> None:
+            # Only invoked by the plan on a capable + enabled adapter. Mark the
+            # cache primed so the siblings that follow report a hit.
+            primed["warm"] = True
+            cache_window.warmup()
+
+        def _worker_call(_index: int) -> bool:
+            collected.extend(self.spawner(task_id, 1))
+            # A sibling hits the cache exactly when the warm-up ran first.
+            return primed["warm"]
+
+        result = run_cache_window_fanout(
+            adapter=cache_window.adapter,
+            prefix=cache_window.prefix,
+            worker_count=attempts,
+            warmup_call=_warmup_call,
+            worker_call=_worker_call,
+            enabled=cache_window.enabled,
+        )
+        return collected, result
 
     def run(
         self,
@@ -169,7 +239,7 @@ class TournamentRunner:
             per_attempt_cost_usd=per_attempt_cost_usd,
             cap_usd=cap_usd,
         )
-        ids = list(self.spawner(task_id, spec.attempts))
+        ids, cache_fanout = self._fanout(task_id, spec.attempts)
         outcomes = list(self.evaluator(ids))
         if not outcomes:
             raise RuntimeError(f"tournament for task {task_id!r} produced zero attempt outcomes")
@@ -199,13 +269,19 @@ class TournamentRunner:
             receipt.winner_hash,
             len(outcomes),
         )
-        return TournamentOutcome(receipt=receipt, winner_hash=receipt.winner_hash, projected_usd=projected)
+        return TournamentOutcome(
+            receipt=receipt,
+            winner_hash=receipt.winner_hash,
+            projected_usd=projected,
+            cache_fanout=cache_fanout,
+        )
 
 
 __all__ = [
     "AttemptEvaluator",
     "AttemptReclaimer",
     "AttemptSpawner",
+    "CacheWindowFanout",
     "TournamentBudgetExceeded",
     "TournamentOutcome",
     "TournamentRunner",

--- a/tests/unit/cost/test_live_dispatch.py
+++ b/tests/unit/cost/test_live_dispatch.py
@@ -1,0 +1,179 @@
+"""Live batch-route + cache-window fan-out wiring tests (#2354).
+
+Covers the bridge between the run spawn loop and the deterministic cost policy
+decisions: adapter resolution, the capability-gated batch route, the sealed
+``cost.batch_route`` receipt, and the cache-window fan-out helper (one warm-up
+strictly before the M cache-hitting worker calls).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from bernstein.core.cost.scheduling.live_dispatch import (
+    decide_batch_route,
+    is_batch_eligible,
+    resolve_task_adapter,
+    run_cache_window_fanout,
+    seal_batch_route,
+)
+
+
+def _task(make_task: Any, *, batch_eligible: bool | None = None, **overrides: Any) -> Any:
+    """Build a real Task via the factory, applying the batch-eligibility flag."""
+    task = make_task(**overrides)
+    task.batch_eligible = batch_eligible
+    return task
+
+
+def _orch(
+    *, default_adapter: str | None = None, role_policy: Any = None, workdir: Path | None = None
+) -> SimpleNamespace:
+    spawner = SimpleNamespace(default_adapter_name=default_adapter, role_model_policy=role_policy)
+    return SimpleNamespace(_spawner=spawner, _workdir=workdir, _run_id="run-live")
+
+
+# ---------------------------------------------------------------------------
+# Adapter resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_task_adapter_prefers_role_policy_pin(make_task: Any) -> None:
+    orch = _orch(default_adapter="claude", role_policy={"backend": {"adapter": "openai_agents"}})
+    assert resolve_task_adapter(orch, _task(make_task, role="backend")) == "openai_agents"
+
+
+def test_resolve_task_adapter_falls_back_to_default_adapter(make_task: Any) -> None:
+    orch = _orch(default_adapter="claude", role_policy={})
+    assert resolve_task_adapter(orch, _task(make_task)) == "claude"
+
+
+def test_resolve_task_adapter_conservative_fallback_is_not_batch_capable(make_task: Any) -> None:
+    orch = _orch(default_adapter=None, role_policy=None)
+    # An unresolvable adapter falls back to a non-batch-capable name so work is
+    # never routed to a batch surface that may not exist.
+    adapter = resolve_task_adapter(orch, _task(make_task))
+    decision = decide_batch_route(orch, _task(make_task, batch_eligible=True))
+    assert adapter == "generic"
+    assert decision.route == "interactive"
+
+
+# ---------------------------------------------------------------------------
+# Eligibility + capability-gated route
+# ---------------------------------------------------------------------------
+
+
+def test_is_batch_eligible_reads_explicit_flag(make_task: Any) -> None:
+    assert is_batch_eligible(_task(make_task, batch_eligible=True)) is True
+    assert is_batch_eligible(_task(make_task, batch_eligible=False)) is False
+
+
+def test_is_batch_eligible_realtime_role_is_not_eligible(make_task: Any) -> None:
+    assert is_batch_eligible(_task(make_task, role="manager", batch_eligible=None)) is False
+
+
+def test_decide_batch_route_eligible_on_capable_adapter_routes_to_batch(make_task: Any) -> None:
+    orch = _orch(default_adapter="claude")
+    decision = decide_batch_route(orch, _task(make_task, batch_eligible=True))
+    assert decision.route == "batch"
+    assert decision.adapter_capable is True
+    assert decision.refused_reason == ""
+
+
+def test_decide_batch_route_eligible_on_incapable_adapter_is_refused(make_task: Any) -> None:
+    orch = _orch(default_adapter="mock")
+    decision = decide_batch_route(orch, _task(make_task, batch_eligible=True))
+    assert decision.route == "interactive"
+    assert decision.adapter_capable is False
+    assert decision.refused_reason  # a reason is recorded, not faked onto a missing surface
+
+
+def test_decide_batch_route_non_eligible_never_routes_to_batch(make_task: Any) -> None:
+    orch = _orch(default_adapter="claude")
+    decision = decide_batch_route(orch, _task(make_task, batch_eligible=False))
+    assert decision.route == "interactive"
+    assert decision.refused_reason == ""  # simply never a batch candidate
+
+
+# ---------------------------------------------------------------------------
+# Sealed receipt
+# ---------------------------------------------------------------------------
+
+
+def test_seal_batch_route_records_verifiable_audit_event(tmp_path: Path, make_task: Any) -> None:
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.core.security.audit_chain import EVENT_COST_BATCH_ROUTE, AuditChainStore
+
+    orch = _orch(default_adapter="claude", workdir=tmp_path)
+    decision = decide_batch_route(orch, _task(make_task, id="T-seal", batch_eligible=True))
+
+    seal_batch_route(orch, decision)
+
+    hmac_key = load_or_create_audit_key()
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit", key=hmac_key)
+    routes = chain.query(event_type=EVENT_COST_BATCH_ROUTE)
+    assert len(routes) == 1
+    assert routes[0].details["route"] == "batch"
+    assert routes[0].details["task_id"] == "T-seal"
+    assert routes[0].details["adapter"] == "claude"
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_seal_batch_route_without_workdir_is_a_noop(make_task: Any) -> None:
+    orch = _orch(default_adapter="claude", workdir=None)
+    decision = decide_batch_route(orch, _task(make_task, batch_eligible=True))
+    # No workdir -> nothing to anchor; must not raise.
+    seal_batch_route(orch, decision)
+
+
+# ---------------------------------------------------------------------------
+# Cache-window fan-out helper
+# ---------------------------------------------------------------------------
+
+
+def test_run_cache_window_fanout_capable_enabled_warms_once_then_m_hits() -> None:
+    order: list[str] = []
+    result = run_cache_window_fanout(
+        adapter="claude",
+        prefix="shared-prefix",
+        worker_count=4,
+        warmup_call=lambda: order.append("warmup"),
+        worker_call=lambda i: (order.append(f"w{i}"), True)[1],
+        enabled=True,
+    )
+    assert order == ["warmup", "w0", "w1", "w2", "w3"]  # warm-up strictly first
+    assert result.warmup_calls_made == 1
+    assert result.worker_calls_made == 4
+    assert result.cache_hits == 4
+
+
+def test_run_cache_window_fanout_disabled_issues_no_warmup() -> None:
+    warmups: list[int] = []
+    result = run_cache_window_fanout(
+        adapter="claude",
+        prefix="shared",
+        worker_count=3,
+        warmup_call=lambda: warmups.append(1),
+        worker_call=lambda i: False,
+        enabled=False,
+    )
+    assert warmups == []
+    assert result.warmup_calls_made == 0
+    assert result.worker_calls_made == 3
+
+
+def test_run_cache_window_fanout_incapable_adapter_issues_no_warmup() -> None:
+    warmups: list[int] = []
+    result = run_cache_window_fanout(
+        adapter="mock",
+        prefix="shared",
+        worker_count=2,
+        warmup_call=lambda: warmups.append(1),
+        worker_call=lambda i: False,
+        enabled=True,
+    )
+    assert warmups == []
+    assert result.warmup_calls_made == 0

--- a/tests/unit/test_task_lifecycle.py
+++ b/tests/unit/test_task_lifecycle.py
@@ -230,8 +230,14 @@ def test_claim_and_spawn_batches_auto_decomposes_large_task_before_claim(tmp_pat
 
 
 def test_claim_and_spawn_batches_submits_provider_batch_without_spawning(tmp_path: Path, make_task: Any) -> None:
-    """Eligible provider-batch work is submitted and skips the local spawn path."""
+    """Eligible provider-batch work is submitted and skips the local spawn path.
+
+    The capability-gated route_batch decision (#2354) only reaches the batch
+    surface on a batch-capable adapter, so the orchestrator resolves ``claude``
+    (a declared batch adapter).
+    """
     orch = _claim_orch(tmp_path)
+    orch._spawner.default_adapter_name = "claude"
     task = make_task(id="T-batch", title="Update docs", description="Refresh the API docs.")
     task.batch_eligible = True
     orch._batch_api = MagicMock()
@@ -247,6 +253,83 @@ def test_claim_and_spawn_batches_submits_provider_batch_without_spawning(tmp_pat
     orch._batch_api.try_submit.assert_called_once()
     orch._spawner.spawn_for_tasks.assert_not_called()
     assert result.spawned == ["batch-T-batch"]
+
+
+class _FakeBatchSurface:
+    """A faithful mock batch-capable adapter surface (#2354).
+
+    Mirrors the ``ProviderBatchManager.try_submit`` contract: it records the
+    task ids it was asked to dispatch and reports them as handled + submitted,
+    so a test can prove which tasks the live path actually routed to the batch
+    endpoint versus which bypassed it to interactive dispatch.
+    """
+
+    def __init__(self) -> None:
+        self.submitted_task_ids: list[str] = []
+
+    def try_submit(self, orch: Any, task: Any) -> SimpleNamespace:
+        self.submitted_task_ids.append(task.id)
+        return SimpleNamespace(handled=True, submitted=True, session_id=f"batch-{task.id}")
+
+    def poll(self, orch: Any) -> None:  # pragma: no cover - parity with the real surface
+        del orch
+
+
+def test_live_path_routes_batch_eligible_task_through_batch_surface(tmp_path: Path, make_task: Any) -> None:
+    """A batch-eligible task on a batch-capable adapter routes to the batch surface (AC3)."""
+    orch = _claim_orch(tmp_path)
+    orch._spawner.default_adapter_name = "claude"  # declared batch-capable
+    surface = _FakeBatchSurface()
+    orch._batch_api = surface
+    task = make_task(id="T-eligible", title="Update docs", description="Refresh the docs.")
+    task.batch_eligible = True
+    result = TickResult()
+
+    claim_and_spawn_batches(orch, [[task]], alive_count=0, assigned_task_ids=set(), done_ids=set(), result=result)
+
+    assert surface.submitted_task_ids == ["T-eligible"]
+    orch._spawner.spawn_for_tasks.assert_not_called()
+    assert result.spawned == ["batch-T-eligible"]
+
+
+def test_live_path_non_eligible_task_bypasses_batch_surface(tmp_path: Path, make_task: Any) -> None:
+    """A non-eligible task never routes to batch, even on a batch-capable adapter (AC3)."""
+    orch = _claim_orch(tmp_path)
+    orch._spawner.default_adapter_name = "claude"  # capable, but the task is not eligible
+    surface = _FakeBatchSurface()
+    orch._batch_api = surface
+    task = make_task(id="T-realtime", title="Design the API", description="Interactive work.")
+    task.batch_eligible = False  # explicit realtime -> never a batch candidate
+    session = AgentSession(
+        id="A-realtime", role="backend", task_ids=[task.id], model_config=ModelConfig("sonnet", "high")
+    )
+    orch._spawner.spawn_for_tasks.return_value = session
+    result = TickResult()
+
+    claim_and_spawn_batches(orch, [[task]], alive_count=0, assigned_task_ids=set(), done_ids=set(), result=result)
+
+    assert surface.submitted_task_ids == []  # batch surface was bypassed
+    orch._spawner.spawn_for_tasks.assert_called_once()
+
+
+def test_live_path_eligible_on_incapable_adapter_is_refused_not_faked(tmp_path: Path, make_task: Any) -> None:
+    """A batch-eligible task on an adapter with no batch surface runs interactively (AC3)."""
+    orch = _claim_orch(tmp_path)
+    orch._spawner.default_adapter_name = "mock"  # not a batch-capable adapter
+    surface = _FakeBatchSurface()
+    orch._batch_api = surface
+    task = make_task(id="T-refused", title="Update docs", description="Refresh the docs.")
+    task.batch_eligible = True
+    session = AgentSession(
+        id="A-refused", role="backend", task_ids=[task.id], model_config=ModelConfig("sonnet", "high")
+    )
+    orch._spawner.spawn_for_tasks.return_value = session
+    result = TickResult()
+
+    claim_and_spawn_batches(orch, [[task]], alive_count=0, assigned_task_ids=set(), done_ids=set(), result=result)
+
+    assert surface.submitted_task_ids == []  # refused, not faked onto a missing surface
+    orch._spawner.spawn_for_tasks.assert_called_once()
 
 
 def test_claim_and_spawn_batches_sets_small_timeout_bucket(tmp_path: Path, make_task: Any) -> None:

--- a/tests/unit/test_tournament.py
+++ b/tests/unit/test_tournament.py
@@ -394,3 +394,140 @@ def test_audit_event_records_selection(tmp_path: Path) -> None:
     assert event.event_type == EVENT_TOURNAMENT_SELECTION
     assert event.details["winner_hash"] == outcomes[0].attempt_hash
     assert event.details["attempt_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Cache-window fan-out (#2354, AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_window_fanout_warms_once_before_siblings_on_capable_adapter(tmp_path: Path) -> None:
+    """A capable + enabled adapter primes the shared prefix once, then M siblings hit it."""
+    from bernstein.core.tournament.runner import CacheWindowFanout, TournamentRunner
+
+    priv, pub = load_or_create_tournament_identity(tmp_path / ".sdd" / "tournaments")
+    hmac_key = load_or_create_audit_key(tmp_path / ".sdd" / "audit.key")
+    order: list[str] = []
+
+    def spawner(task_id: str, n: int) -> list[str]:
+        order.append(f"spawn:{n}")
+        return [f"{task_id}-{i}" for i in range(n)]
+
+    def warmup() -> None:
+        order.append("warmup")
+
+    runner = TournamentRunner(
+        spawner=spawner,
+        evaluator=lambda ids: _outcomes(),
+        cache_window=CacheWindowFanout(adapter="claude", prefix="shared-system-prompt", warmup=warmup, enabled=True),
+    )
+    outcome = runner.run(
+        task_id="T-cache",
+        spec=_spec(),  # attempts=3
+        per_attempt_cost_usd=0.5,
+        cap_usd=100.0,
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=hmac_key,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        timestamp=7,
+    )
+    # One warm-up strictly precedes the three sibling spawns.
+    assert order == ["warmup", "spawn:1", "spawn:1", "spawn:1"]
+    assert outcome.cache_fanout is not None
+    assert outcome.cache_fanout.warmup_calls_made == 1
+    assert outcome.cache_fanout.worker_calls_made == 3
+    assert outcome.cache_fanout.cache_hits == 3
+
+
+def test_cache_window_disabled_issues_no_warmup(tmp_path: Path) -> None:
+    """With the window disabled, the fan-out issues no warm-up and expects no hits."""
+    from bernstein.core.tournament.runner import CacheWindowFanout, TournamentRunner
+
+    priv, pub = load_or_create_tournament_identity(tmp_path / ".sdd" / "tournaments")
+    hmac_key = load_or_create_audit_key(tmp_path / ".sdd" / "audit.key")
+    warmups: list[int] = []
+
+    runner = TournamentRunner(
+        spawner=lambda task_id, n: [f"{task_id}-{i}" for i in range(n)],
+        evaluator=lambda ids: _outcomes(),
+        cache_window=CacheWindowFanout(
+            adapter="claude", prefix="shared", warmup=lambda: warmups.append(1), enabled=False
+        ),
+    )
+    outcome = runner.run(
+        task_id="T-off",
+        spec=_spec(),
+        per_attempt_cost_usd=0.5,
+        cap_usd=100.0,
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=hmac_key,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        timestamp=8,
+    )
+    assert warmups == []
+    assert outcome.cache_fanout is not None
+    assert outcome.cache_fanout.warmup_calls_made == 0
+    assert outcome.cache_fanout.cache_hits == 0
+
+
+def test_cache_window_incapable_adapter_issues_no_warmup(tmp_path: Path) -> None:
+    """An adapter with no cache window issues no warm-up even when enabled."""
+    from bernstein.core.tournament.runner import CacheWindowFanout, TournamentRunner
+
+    priv, pub = load_or_create_tournament_identity(tmp_path / ".sdd" / "tournaments")
+    hmac_key = load_or_create_audit_key(tmp_path / ".sdd" / "audit.key")
+    warmups: list[int] = []
+
+    runner = TournamentRunner(
+        spawner=lambda task_id, n: [f"{task_id}-{i}" for i in range(n)],
+        evaluator=lambda ids: _outcomes(),
+        cache_window=CacheWindowFanout(adapter="mock", prefix="shared", warmup=lambda: warmups.append(1), enabled=True),
+    )
+    outcome = runner.run(
+        task_id="T-incap",
+        spec=_spec(),
+        per_attempt_cost_usd=0.5,
+        cap_usd=100.0,
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=hmac_key,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        timestamp=9,
+    )
+    assert warmups == []  # mock is not a cache-window adapter
+    assert outcome.cache_fanout is not None
+    assert outcome.cache_fanout.warmup_calls_made == 0
+    assert outcome.cache_fanout.cache_hits == 0
+
+
+def test_runner_without_cache_window_spawns_in_one_call(tmp_path: Path) -> None:
+    """The default (no cache window) fans out siblings in one spawner call, unchanged."""
+    from bernstein.core.tournament.runner import TournamentRunner
+
+    priv, pub = load_or_create_tournament_identity(tmp_path / ".sdd" / "tournaments")
+    hmac_key = load_or_create_audit_key(tmp_path / ".sdd" / "audit.key")
+    calls: list[int] = []
+
+    runner = TournamentRunner(
+        spawner=lambda task_id, n: (calls.append(n), [f"{task_id}-{i}" for i in range(n)])[1],
+        evaluator=lambda ids: _outcomes(),
+    )
+    outcome = runner.run(
+        task_id="T-plain",
+        spec=_spec(),
+        per_attempt_cost_usd=0.5,
+        cap_usd=100.0,
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=hmac_key,
+        private_key_pem=priv,
+        public_key_pem=pub,
+        timestamp=10,
+    )
+    assert calls == [3]  # one call, n=attempts
+    assert outcome.cache_fanout is None


### PR DESCRIPTION
## What & why

The deterministic `route_batch` and cache-window fan-out decisions shipped in
the cost policy layer (#2435), and the live USD-cap gate landed in #2449, but
nothing consulted the routing decisions from a live run's dispatch and fan-out
paths. So batch-eligible work was never routed against the adapter capability
map, and a shared-prefix fan-out never primed the prompt cache. This PR wires
both into the live paths and seals the routing decision as a verifiable receipt.

## What shipped

- **`core/cost/scheduling/live_dispatch.py`** (new, pure/deterministic):
  - `decide_batch_route` resolves the adapter a task would run on (per-role pin
    then default adapter), derives batch eligibility from the same classifier
    the provider-batch path uses, and defers to the capability-gated
    `route_batch`.
  - `seal_batch_route` anchors the decision as a `cost.batch_route` audit event
    (best-effort, never crashes a dispatch).
  - `run_cache_window_fanout` drives `plan_cache_fanout` + `execute_cache_fanout`
    for a shared-prefix fan-out: one warm-up strictly before the M worker calls.
- **`task_lifecycle.claim_and_spawn_batches`**: the provider-batch surface is
  now consulted **only** when `route_batch` routes to `batch`. A batch-eligible
  task reaches the batch endpoint only on a batch-capable adapter; a
  non-eligible task never does; a batch-eligible task on an adapter with no
  batch surface is refused (dispatched interactively), never faked. Each
  decision is sealed as a `cost.batch_route` receipt.
- **`tournament/runner.py`**: an optional `CacheWindowFanout` config issues one
  warm-up call to prime the shared prefix strictly before the sibling attempts
  spawn, when the resolved adapter is cache-window capable and the opt-in is
  set. Default off leaves the fan-out unchanged.
- **`audit_chain.py`**: additive `EVENT_COST_BATCH_ROUTE` +
  `record_cost_batch_route`, `__all__` sorted.
- **Docs**: `docs/operations/cost-aware-scheduling.md` gains "Live routing in
  the run loop" and the tournament fan-out note.

## Acceptance criteria -> tests

| AC | Status | Test |
|---|---|---|
| AC3: batch-eligible tasks route to batch endpoints; non-eligible never do | Met (now live) | `test_task_lifecycle.py::test_live_path_routes_batch_eligible_task_through_batch_surface`, `::test_live_path_non_eligible_task_bypasses_batch_surface`, `::test_live_path_eligible_on_incapable_adapter_is_refused_not_faked` (drive the real `claim_and_spawn_batches` through a faithful mock batch surface); `test_live_dispatch.py::test_decide_batch_route_*` |
| AC4: fan-out of M workers with a shared prefix issues one warm-up + M cache-hitting calls | Met (now live) | `test_tournament.py::test_cache_window_fanout_warms_once_before_siblings_on_capable_adapter`, `::test_cache_window_disabled_issues_no_warmup`, `::test_cache_window_incapable_adapter_issues_no_warmup`; `test_live_dispatch.py::test_run_cache_window_fanout_*` |
| Routing decision is an independently verifiable receipt | Met | `test_live_dispatch.py::test_seal_batch_route_records_verifiable_audit_event` (chain query + `verify()`) |

The faithful mock batch-capable adapter is `_FakeBatchSurface` in
`test_task_lifecycle.py` (records submitted task ids, mirrors the
`ProviderBatchManager.try_submit` contract); the integration tests prove the
live path routes an eligible task through it and that non-eligible / incapable
cases bypass it.

## Verification

- `uv run ruff check src/ tests/` clean; `ruff format --check` clean; `uv run
  lint-imports` 3 contracts kept; `uv run python -c "import bernstein"` OK
- new test files run 3x, stable (37 passed each pass)
- `tests/unit/cost/ tests/unit/test_task_lifecycle.py tests/unit/test_batch_api.py` 317 passed
- audit-chain byteflip/golden regression + AGENTS.md guards green; docs drift clean

Closes #2354