### PR TITLE
release: v3.4.1

### DIFF
--- a/docs/release-notes/v3.4.1.md
+++ b/docs/release-notes/v3.4.1.md
@@ -1,0 +1,44 @@
+# v3.4.1
+
+Released 2026-07-12.
+
+A patch release on top of v3.4.0. It completes the follow-up work that landed
+after the v3.4.0 tag: Windows parity coverage and a security hardening and
+static-analysis cleanup pass. There are no breaking changes and no
+configuration migration is required.
+
+## Security hardening
+
+- ssh secret handling for the detached run service now keeps only vault
+  provider ids in its backend descriptor. The connection sidecar that a
+  supervisor rebuilds on restart names which vault provider supplies which
+  remote environment variable and never carries a secret value. Resolved
+  credentials continue to flow through the vault path into the remote process
+  environment only, and are never written to the sidecar, the work ledger, the
+  receipts, or the logs. The failure log now records the provider id and the
+  exception type, never the credential payload.
+- Run journal path hardening. The per-run event journal derives its on-disk
+  path only from a run id that has passed an anchored allowlist, an explicit
+  rejection of the current and parent directory, and a realpath containment
+  check against the runs root. A run id can no longer steer the journal file
+  outside the runs directory.
+
+## Static-analysis cleanup
+
+- Removed redundant idioms in the skills conformance command and reworded a
+  detached-run log line, clearing the corresponding scanner findings.
+
+## Windows parity coverage
+
+- Self-promoting lane gate, mocked stop and restart with worktree isolation,
+  and a reduction in skipped Windows cases, closing gaps ahead of first-class
+  Windows support (#2448).
+
+## Upgrading
+
+```bash
+pipx upgrade bernstein     # or: uv tool upgrade bernstein
+```
+
+No configuration migration is required. Every capability available in v3.4.0
+is unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.4.0"
+version = "3.4.1"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Patch release on top of v3.4.0.

## Contents
- Bump `version` to 3.4.1 (pyproject + uv.lock).
- `docs/release-notes/v3.4.1.md`.

## What v3.4.1 folds in
- Security hardening: ssh secret handling for the detached run service keeps only vault provider ids in its backend descriptor (resolved credentials never touch the sidecar, ledger, receipts, or logs); run journal path hardening (allowlisted, containment-checked run id).
- Static-analysis cleanup: redundant idioms and a reworded log line, clearing scanner findings.
- Windows parity coverage (#2448).

No breaking changes; no configuration migration.