### PR TITLE
feat(packaging): signed-image provenance verification for the packaged distribution (#2369)

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.3.0",
+  "version": "3.4.1",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/integrations/agent-session.md
+++ b/docs/integrations/agent-session.md
@@ -138,6 +138,32 @@ transient log line.
 Exit codes: `0` every host green and the `--min-hosts` bar met, `2`
 conformance failed, `1` error.
 
+## Verifying the signed distribution image
+
+The MCP registry listing (`server.json`) and the Docker MCP catalog entry
+(`packaging/docker-mcp/server.yaml`) both point a host at a runnable image;
+that image is signed at build time with a Sigstore keyless build-provenance
+attestation. `image-verify` proves, offline, that the two manifests resolve to
+the same canonical `ghcr.io/<owner>/bernstein` repository and that the registry
+listing pins the release version, so a pull can never resolve to a different
+(or unsigned) image than the catalog advertises:
+
+```bash
+bernstein skills package image-verify                 # defaults to the installed version
+bernstein skills package image-verify --version 3.4.1 --json
+bernstein skills package image-verify --online        # also run `gh attestation verify`
+```
+
+The offline check is a deterministic projection of the two manifests. With
+`--online` it additionally runs `gh attestation verify oci://<ref>` against the
+live Sigstore attestation (when the `gh` CLI and a network are available; absent
+tooling leaves the offline verdict standing). The same consistency check is a
+release gate: `scripts/gen_distribution_manifests.py --check` -- run in the
+publish workflow before the registry listing is pushed -- fails the release if
+the listing and the catalog disagree or the tag does not pin the version. Exit
+codes: `0` consistent (and, with `--online`, attestation verified or tooling
+unavailable), `2` a manifest mismatch or a failed online attestation.
+
 ## The plugin bundle
 
 The repository root doubles as the plugin root:

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1463,6 +1463,22 @@ default `3`), `--json`, `--workdir`.
 Exit codes: `0` every host green and the `--min-hosts` bar met, `2`
 conformance failed, `1` error.
 
+#### `bernstein skills package image-verify`
+
+Proves, offline, that the MCP registry listing (`server.json`) and the Docker
+MCP catalog entry (`packaging/docker-mcp/server.yaml`) resolve to the same
+canonical signed `ghcr.io/<owner>/bernstein` image and that the registry
+listing pins the release version, so a host cannot pull a different (or
+unsigned) image than the catalog advertises. With `--online` it additionally
+runs `gh attestation verify` against the live Sigstore build-provenance
+attestation.
+
+Options: `--version` (the release version the image must pin; defaults to the
+installed bernstein version), `--online`, `--json`, `--repo-root`.
+
+Exit codes: `0` consistent (and, with `--online`, attestation verified or
+tooling unavailable), `2` a manifest mismatch or a failed online attestation.
+
 ```bash
 bernstein skills package install --host claude --scope project
 bernstein skills package install --dest ~/.claude/plugins/bernstein --record-only

--- a/scripts/gen_distribution_manifests.py
+++ b/scripts/gen_distribution_manifests.py
@@ -102,9 +102,45 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Signed-image provenance: the MCP registry listing and the Docker MCP
+    # catalog must resolve to the same canonical signed GHCR image, and the
+    # listing must pin this release version. A divergence here would publish a
+    # listing that pulls a different (or unsigned) image than the catalog, so
+    # it fails the release like manifest drift does. Uses the current on-disk
+    # server.json (already regenerated above in write mode).
+    provenance = _load_image_provenance().verify_signed_image_provenance(repo_root=REPO, version=version)
+    if not provenance.ok:
+        print(f"signed-image provenance mismatch: {provenance.reason}", file=sys.stderr)
+        return 1
+
     if args.check:
         print(f"distribution manifests in sync (version {version})")
+    print(f"signed-image provenance OK: {provenance.image_ref}")
     return 0
+
+
+def _load_image_provenance() -> object:
+    """Load the stdlib-only image-provenance module by file path.
+
+    Loading it directly (rather than importing ``bernstein.core.skills``) keeps
+    this release gate runnable with a bare ``python3`` even when the bernstein
+    package and its dependencies are not pip-installed in the publish job.
+    """
+    import importlib.util
+
+    module_path = REPO / "src" / "bernstein" / "core" / "skills" / "image_provenance.py"
+    spec = importlib.util.spec_from_file_location("_bernstein_image_provenance", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        msg = f"cannot load image provenance module at {module_path}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the module's ``@dataclass`` definitions can resolve
+    # their own annotations (dataclasses looks the class module up in sys.modules
+    # under ``from __future__ import annotations``).
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 if __name__ == "__main__":

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.3.0",
+  "version": "3.4.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.3.0",
+      "version": "3.4.1",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.3.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/bernstein/cli/commands/skills_package_cmd.py
+++ b/src/bernstein/cli/commands/skills_package_cmd.py
@@ -382,6 +382,103 @@ def status_cmd(as_json: bool, home: str | None, workdir: str) -> None:
     raise SystemExit(2 if any_failed else 0)
 
 
+def _package_version() -> str:
+    """Return the installed bernstein version (the release tag the image pins)."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("bernstein")
+    except PackageNotFoundError:  # pragma: no cover - source checkout without install
+        import tomllib
+
+        pyproject = Path(__file__).resolve().parents[4] / "pyproject.toml"
+        with pyproject.open("rb") as fh:
+            return str(tomllib.load(fh)["project"]["version"])
+
+
+@package_group.command("image-verify")
+@click.option(
+    "--version",
+    "version_override",
+    default=None,
+    help="Release version the signed image must pin (defaults to the installed bernstein version).",
+)
+@click.option(
+    "--online",
+    is_flag=True,
+    default=False,
+    help="Also run `gh attestation verify` against the live Sigstore attestation (needs network + gh).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the verdict as JSON.",
+)
+@click.option(
+    "--repo-root",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Repository root holding server.json and packaging/docker-mcp/.",
+)
+def image_verify_cmd(version_override: str | None, online: bool, as_json: bool, repo_root: str) -> None:
+    """Verify the packaged distribution resolves to the canonical signed image.
+
+    Proves, offline, that the MCP registry listing (``server.json``) and the
+    Docker MCP catalog entry (``packaging/docker-mcp/server.yaml``) agree on the
+    same ``ghcr.io/<owner>/bernstein`` repository and that the registry listing
+    pins the release version, so a host pulls the exact signed image the release
+    built. With ``--online`` it also verifies the live Sigstore
+    build-provenance attestation via ``gh attestation verify``.
+
+    Exit codes: 0 = consistent (and, with ``--online``, attestation verified or
+    tooling unavailable); 2 = a manifest mismatch or a failed online attestation.
+    """
+    from bernstein.core.skills.image_provenance import (
+        owner_from_server_json,
+        verify_attestation,
+        verify_signed_image_provenance,
+    )
+
+    root = Path(repo_root).resolve()
+    version = version_override or _package_version()
+    result = verify_signed_image_provenance(repo_root=root, version=version)
+
+    payload: dict[str, object] = {"version": version, "provenance": result.to_dict()}
+    failed = not result.ok
+
+    if online and result.ok:
+        owner = owner_from_server_json(root / "server.json") or ""
+        attestation = verify_attestation(result.image_ref, owner=owner)
+        payload["attestation"] = attestation.to_dict()
+        # A present-but-failed attestation is a hard failure; unavailable tooling
+        # leaves the offline verdict standing.
+        if attestation.available and not attestation.verified:
+            failed = True
+
+    if as_json:
+        console.print_json(data=payload)
+        raise SystemExit(2 if failed else 0)
+
+    console.print()
+    console.print("[bold]Signed-image provenance[/bold]")
+    mark = "[green]OK[/green]" if result.ok else f"[red]FAILED[/red] ({result.reason})"
+    console.print(f"  manifest consistency: {mark}")
+    if result.ok:
+        console.print(f"  signed image: {result.image_ref}")
+    att = payload.get("attestation")
+    if isinstance(att, dict):
+        if not att["available"]:
+            console.print(f"  attestation: [yellow]skipped[/yellow] ({att['detail']})")
+        elif att["verified"]:
+            console.print(f"  attestation: [green]verified[/green] ({att['detail']})")
+        else:
+            console.print(f"  attestation: [red]FAILED[/red] ({att['detail']})")
+    raise SystemExit(2 if failed else 0)
+
+
 def _default_transport() -> SubprocessTransport:
     """Return the production transport (real ``bernstein`` subprocess).
 

--- a/src/bernstein/core/skills/image_provenance.py
+++ b/src/bernstein/core/skills/image_provenance.py
@@ -1,0 +1,289 @@
+"""Signed-image provenance for the packaged distribution (#2369).
+
+The packaged agent skill / plugin ships two release manifests that point a host
+at a runnable image:
+
+* ``server.json`` -- the MCP registry listing, whose ``oci`` package identifier
+  pins ``ghcr.io/<owner>/bernstein:<version>``; and
+* ``packaging/docker-mcp/server.yaml`` -- the Docker MCP catalog submission,
+  whose ``image`` field names the same GHCR repository.
+
+The image those manifests resolve to is signed at build time with a Sigstore
+keyless build-provenance attestation (``actions/attest-build-provenance`` in
+``publish-docker.yml``). This module makes that provenance *verifiable* as part
+of the aggregate install-verification path, so a host does not have to trust the
+manifests -- it can prove that:
+
+1. both manifests name the **same** GHCR repository (no split-brain between the
+   registry listing and the catalog entry),
+2. the registry listing pins the **release version** (``:<version>``), so a
+   pull resolves to the exact image the release built, and
+3. that repository is the **canonical** signed image derived from the
+   ``server.json`` ``repository`` owner -- not a look-alike.
+
+Steps 1-3 are a deterministic, offline projection of the manifests: two
+operators with the same tree recompute the same verdict. When a network and the
+``gh`` CLI are available, :func:`verify_attestation` additionally runs
+``gh attestation verify oci://<ref>`` to check the live Sigstore attestation --
+the same command the docs document for a manual check.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: Registry every signed bernstein image lives under.
+CANONICAL_REGISTRY = "ghcr.io"
+#: Image name (the repository's final path segment) for the signed image.
+CANONICAL_IMAGE_NAME = "bernstein"
+
+
+@dataclass(frozen=True, slots=True)
+class ImageReference:
+    """A parsed OCI image reference (``registry/repository[:tag]``)."""
+
+    registry: str
+    repository: str
+    tag: str
+
+    @property
+    def repo_ref(self) -> str:
+        """``registry/repository`` without the tag."""
+        return f"{self.registry}/{self.repository}"
+
+    @property
+    def full_ref(self) -> str:
+        """``registry/repository:tag`` (tag omitted when empty)."""
+        return f"{self.repo_ref}:{self.tag}" if self.tag else self.repo_ref
+
+
+@dataclass(frozen=True, slots=True)
+class ImageProvenanceResult:
+    """Verdict of :func:`verify_signed_image_provenance`."""
+
+    ok: bool
+    image_ref: str
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {"ok": self.ok, "image_ref": self.image_ref, "reason": self.reason}
+
+
+@dataclass(frozen=True, slots=True)
+class AttestationResult:
+    """Outcome of an online ``gh attestation verify`` check."""
+
+    verified: bool
+    available: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {"verified": self.verified, "available": self.available, "detail": self.detail}
+
+
+def parse_image_reference(identifier: str) -> ImageReference:
+    """Parse ``registry/repository[:tag]`` into an :class:`ImageReference`.
+
+    A ``:`` is only treated as a tag separator when it appears in the final path
+    segment (so a registry port like ``localhost:5000/x`` is not mistaken for a
+    tag). A digest reference (``@sha256:...``) keeps the digest as the tag.
+    """
+    ident = identifier.strip()
+    repo_with_reg, _, digest = ident.partition("@")
+    if digest:
+        registry, _, repository = repo_with_reg.partition("/")
+        return ImageReference(registry=registry, repository=repository, tag=f"@{digest}")
+    registry, _, rest = ident.partition("/")
+    if "/" not in rest and not _looks_like_registry(registry):
+        # No registry component (bare ``name[:tag]``); treat the whole thing as
+        # the repository under an empty registry.
+        registry, rest = "", ident
+    repository, sep, tag = rest.rpartition(":")
+    if not sep or "/" in tag:
+        return ImageReference(registry=registry, repository=rest, tag="")
+    return ImageReference(registry=registry, repository=repository, tag=tag)
+
+
+def _looks_like_registry(candidate: str) -> bool:
+    """Return whether *candidate* looks like a registry host (has a dot/port)."""
+    return "." in candidate or ":" in candidate
+
+
+def oci_reference_from_server_json(server_json_path: Path) -> ImageReference | None:
+    """Return the OCI image reference pinned in *server_json_path*, or ``None``."""
+    try:
+        data = json.loads(server_json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    for package in data.get("packages", []):
+        if isinstance(package, dict) and package.get("registryType") == "oci":
+            identifier = package.get("identifier")
+            if isinstance(identifier, str) and identifier:
+                return parse_image_reference(identifier)
+    return None
+
+
+def image_from_docker_catalog(server_yaml_path: Path) -> ImageReference | None:
+    """Return the ``image`` reference from a Docker MCP catalog ``server.yaml``.
+
+    The catalog payload is small and shape-stable, so the ``image:`` line is
+    read without a YAML dependency (the file may not be importable as a package
+    resource in every context).
+    """
+    try:
+        text = server_yaml_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("image:"):
+            value = line.split(":", 1)[1].strip().strip("'\"")
+            if value:
+                return parse_image_reference(value)
+    return None
+
+
+def owner_from_server_json(server_json_path: Path) -> str | None:
+    """Return the GitHub owner from the ``server.json`` repository URL."""
+    try:
+        data = json.loads(server_json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    url = (data.get("repository") or {}).get("url", "")
+    if not isinstance(url, str) or "github.com/" not in url:
+        return None
+    tail = url.split("github.com/", 1)[1].strip("/")
+    parts = tail.split("/")
+    return parts[0] if parts and parts[0] else None
+
+
+def canonical_signed_image(owner: str, version: str) -> ImageReference:
+    """Return the canonical signed image reference for *owner* at *version*."""
+    return ImageReference(
+        registry=CANONICAL_REGISTRY,
+        repository=f"{owner}/{CANONICAL_IMAGE_NAME}",
+        tag=version,
+    )
+
+
+def verify_signed_image_provenance(*, repo_root: Path, version: str) -> ImageProvenanceResult:
+    """Verify the distribution manifests agree on the signed image (AC3).
+
+    Deterministic and offline. Confirms that:
+
+    * ``server.json`` carries an OCI package pinned to
+      ``ghcr.io/<owner>/bernstein:<version>`` (owner taken from its own
+      repository URL), and
+    * ``packaging/docker-mcp/server.yaml`` names the same GHCR repository,
+
+    so the registry listing and the catalog entry resolve to the identical
+    signed image the release built. The returned ``image_ref`` is the verified
+    reference a host would pull.
+    """
+    server_json = repo_root / "server.json"
+    catalog_yaml = repo_root / "packaging" / "docker-mcp" / "server.yaml"
+
+    owner = owner_from_server_json(server_json)
+    if owner is None:
+        return ImageProvenanceResult(ok=False, image_ref="", reason="server.json repository owner not resolvable")
+    expected = canonical_signed_image(owner, version)
+
+    oci = oci_reference_from_server_json(server_json)
+    if oci is None:
+        return ImageProvenanceResult(ok=False, image_ref="", reason="server.json has no OCI package identifier")
+    if oci.repo_ref != expected.repo_ref:
+        return ImageProvenanceResult(
+            ok=False,
+            image_ref=oci.full_ref,
+            reason=f"server.json OCI repo {oci.repo_ref!r} is not the canonical signed image {expected.repo_ref!r}",
+        )
+    if oci.tag != version:
+        return ImageProvenanceResult(
+            ok=False,
+            image_ref=oci.full_ref,
+            reason=f"server.json OCI tag {oci.tag!r} does not pin the release version {version!r}",
+        )
+
+    catalog = image_from_docker_catalog(catalog_yaml)
+    if catalog is None:
+        return ImageProvenanceResult(
+            ok=False,
+            image_ref=oci.full_ref,
+            reason="docker-mcp catalog server.yaml has no image reference",
+        )
+    if catalog.repo_ref != expected.repo_ref:
+        return ImageProvenanceResult(
+            ok=False,
+            image_ref=oci.full_ref,
+            reason=(
+                f"docker catalog image {catalog.repo_ref!r} differs from the registry listing {expected.repo_ref!r}"
+            ),
+        )
+
+    return ImageProvenanceResult(
+        ok=True,
+        image_ref=expected.full_ref,
+        reason="registry listing and docker catalog agree on the canonical signed image",
+    )
+
+
+def verify_attestation(image_ref: str, *, owner: str, timeout_s: float = 60.0) -> AttestationResult:
+    """Verify the live Sigstore build-provenance attestation for *image_ref*.
+
+    Best-effort and online: shells out to ``gh attestation verify oci://<ref>``
+    (the command documented for a manual check). When the ``gh`` CLI is absent
+    or the call cannot run, ``available`` is ``False`` and the offline
+    consistency verdict stands on its own. A present-but-failed verification
+    returns ``verified=False`` with the tool's stderr tail as the detail.
+    """
+    import shutil
+
+    if shutil.which("gh") is None:
+        return AttestationResult(verified=False, available=False, detail="gh CLI not on PATH")
+    try:
+        completed = subprocess.run(
+            [
+                "gh",
+                "attestation",
+                "verify",
+                f"oci://{image_ref}",
+                "--owner",
+                owner,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return AttestationResult(verified=False, available=False, detail=f"attestation check could not run: {exc}")
+    if completed.returncode == 0:
+        return AttestationResult(verified=True, available=True, detail="build-provenance attestation verified")
+    tail = (completed.stderr or completed.stdout or "").strip().splitlines()
+    return AttestationResult(
+        verified=False,
+        available=True,
+        detail=tail[-1] if tail else f"gh attestation verify exited {completed.returncode}",
+    )
+
+
+__all__ = [
+    "CANONICAL_IMAGE_NAME",
+    "CANONICAL_REGISTRY",
+    "AttestationResult",
+    "ImageProvenanceResult",
+    "ImageReference",
+    "canonical_signed_image",
+    "image_from_docker_catalog",
+    "oci_reference_from_server_json",
+    "owner_from_server_json",
+    "parse_image_reference",
+    "verify_attestation",
+    "verify_signed_image_provenance",
+]

--- a/tests/unit/cli/test_skills_package_cmd.py
+++ b/tests/unit/cli/test_skills_package_cmd.py
@@ -382,3 +382,64 @@ def test_conformance_below_min_hosts_exit_2(monkeypatch, tmp_path: Path) -> None
         ["conformance", "--host", "claude", "--host", "codex", "--min-hosts", "3", "--workdir", str(workdir)],
     )
     assert result.exit_code == 2, result.output
+
+
+def _image_repo(
+    root: Path, *, oci_tag: str = "3.4.1", catalog_image: str = "ghcr.io/sipyourdrink-ltd/bernstein"
+) -> Path:
+    """Write a minimal server.json + docker-mcp catalog for image-verify tests."""
+    import json
+
+    (root / "server.json").write_text(
+        json.dumps(
+            {
+                "name": "io.github.sipyourdrink-ltd/bernstein",
+                "repository": {"url": "https://github.com/sipyourdrink-ltd/bernstein", "source": "github"},
+                "version": "3.4.1",
+                "packages": [
+                    {"registryType": "pypi", "identifier": "bernstein", "version": "3.4.1"},
+                    {"registryType": "oci", "identifier": f"ghcr.io/sipyourdrink-ltd/bernstein:{oci_tag}"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    catalog = root / "packaging" / "docker-mcp"
+    catalog.mkdir(parents=True)
+    (catalog / "server.yaml").write_text(f"name: bernstein\nimage: {catalog_image}\n", encoding="utf-8")
+    return root
+
+
+def test_image_verify_ok_exit_0(tmp_path: Path) -> None:
+    _image_repo(tmp_path)
+    result = CliRunner().invoke(
+        package_group,
+        ["image-verify", "--version", "3.4.1", "--repo-root", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+    assert "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1" in result.output
+
+
+def test_image_verify_json_shape(tmp_path: Path) -> None:
+    import json
+
+    _image_repo(tmp_path)
+    result = CliRunner().invoke(
+        package_group,
+        ["image-verify", "--version", "3.4.1", "--repo-root", str(tmp_path), "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["provenance"]["ok"] is True
+    assert payload["version"] == "3.4.1"
+
+
+def test_image_verify_mismatch_exit_2(tmp_path: Path) -> None:
+    _image_repo(tmp_path, catalog_image="ghcr.io/other/bernstein")
+    result = CliRunner().invoke(
+        package_group,
+        ["image-verify", "--version", "3.4.1", "--repo-root", str(tmp_path)],
+    )
+    assert result.exit_code == 2, result.output
+    assert "FAILED" in result.output

--- a/tests/unit/test_image_provenance.py
+++ b/tests/unit/test_image_provenance.py
@@ -1,0 +1,155 @@
+"""Signed-image provenance verification tests (#2369).
+
+Covers the deterministic, offline consistency check that the MCP registry
+listing (``server.json``) and the Docker MCP catalog entry agree on the same
+canonical signed GHCR image pinned to the release version, plus the reference
+parser and the graceful offline path of the attestation check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.skills.image_provenance import (
+    canonical_signed_image,
+    image_from_docker_catalog,
+    oci_reference_from_server_json,
+    owner_from_server_json,
+    parse_image_reference,
+    verify_attestation,
+    verify_signed_image_provenance,
+)
+
+
+def _write_repo(
+    root: Path,
+    *,
+    owner: str = "sipyourdrink-ltd",
+    oci_identifier: str = "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1",
+    catalog_image: str | None = "ghcr.io/sipyourdrink-ltd/bernstein",
+) -> None:
+    server = {
+        "name": f"io.github.{owner}/bernstein",
+        "repository": {"url": f"https://github.com/{owner}/bernstein", "source": "github"},
+        "version": "3.4.1",
+        "packages": [
+            {"registryType": "pypi", "identifier": "bernstein", "version": "3.4.1"},
+            {"registryType": "oci", "identifier": oci_identifier},
+        ],
+    }
+    (root / "server.json").write_text(json.dumps(server), encoding="utf-8")
+    catalog_dir = root / "packaging" / "docker-mcp"
+    catalog_dir.mkdir(parents=True)
+    if catalog_image is not None:
+        (catalog_dir / "server.yaml").write_text(f"name: bernstein\nimage: {catalog_image}\ntype: server\n", "utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Reference parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_image_reference_registry_repo_tag() -> None:
+    ref = parse_image_reference("ghcr.io/sipyourdrink-ltd/bernstein:3.4.1")
+    assert ref.registry == "ghcr.io"
+    assert ref.repository == "sipyourdrink-ltd/bernstein"
+    assert ref.tag == "3.4.1"
+    assert ref.repo_ref == "ghcr.io/sipyourdrink-ltd/bernstein"
+    assert ref.full_ref == "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1"
+
+
+def test_parse_image_reference_untagged() -> None:
+    ref = parse_image_reference("ghcr.io/o/bernstein")
+    assert ref.tag == ""
+    assert ref.full_ref == "ghcr.io/o/bernstein"
+
+
+def test_parse_image_reference_registry_port_is_not_a_tag() -> None:
+    ref = parse_image_reference("localhost:5000/team/bernstein:1.0.0")
+    assert ref.registry == "localhost:5000"
+    assert ref.repository == "team/bernstein"
+    assert ref.tag == "1.0.0"
+
+
+def test_canonical_signed_image_shape() -> None:
+    ref = canonical_signed_image("acme", "9.9.9")
+    assert ref.full_ref == "ghcr.io/acme/bernstein:9.9.9"
+
+
+# ---------------------------------------------------------------------------
+# Manifest extraction
+# ---------------------------------------------------------------------------
+
+
+def test_oci_and_catalog_and_owner_extraction(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    assert (
+        oci_reference_from_server_json(tmp_path / "server.json").full_ref == "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1"
+    )
+    assert image_from_docker_catalog(tmp_path / "packaging" / "docker-mcp" / "server.yaml").repo_ref == (
+        "ghcr.io/sipyourdrink-ltd/bernstein"
+    )
+    assert owner_from_server_json(tmp_path / "server.json") == "sipyourdrink-ltd"
+
+
+# ---------------------------------------------------------------------------
+# Consistency verdict
+# ---------------------------------------------------------------------------
+
+
+def test_verify_ok_when_listing_and_catalog_agree(tmp_path: Path) -> None:
+    _write_repo(tmp_path)
+    result = verify_signed_image_provenance(repo_root=tmp_path, version="3.4.1")
+    assert result.ok, result.reason
+    assert result.image_ref == "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1"
+
+
+def test_verify_fails_when_oci_tag_does_not_pin_version(tmp_path: Path) -> None:
+    _write_repo(tmp_path, oci_identifier="ghcr.io/sipyourdrink-ltd/bernstein:3.3.0")
+    result = verify_signed_image_provenance(repo_root=tmp_path, version="3.4.1")
+    assert not result.ok
+    assert "does not pin the release version" in result.reason
+
+
+def test_verify_fails_when_repo_is_not_canonical(tmp_path: Path) -> None:
+    _write_repo(tmp_path, oci_identifier="ghcr.io/someone-else/bernstein:3.4.1")
+    result = verify_signed_image_provenance(repo_root=tmp_path, version="3.4.1")
+    assert not result.ok
+    assert "not the canonical signed image" in result.reason
+
+
+def test_verify_fails_when_catalog_disagrees_with_listing(tmp_path: Path) -> None:
+    _write_repo(tmp_path, catalog_image="ghcr.io/other/bernstein")
+    result = verify_signed_image_provenance(repo_root=tmp_path, version="3.4.1")
+    assert not result.ok
+    assert "docker catalog image" in result.reason
+
+
+def test_verify_fails_when_catalog_missing(tmp_path: Path) -> None:
+    _write_repo(tmp_path, catalog_image=None)
+    result = verify_signed_image_provenance(repo_root=tmp_path, version="3.4.1")
+    assert not result.ok
+    assert "no image reference" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Attestation (offline path)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_attestation_reports_unavailable_without_gh(monkeypatch) -> None:
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    result = verify_attestation("ghcr.io/sipyourdrink-ltd/bernstein:3.4.1", owner="sipyourdrink-ltd")
+    assert result.available is False
+    assert result.verified is False
+    assert "gh CLI not on PATH" in result.detail
+
+
+def test_repo_manifests_are_provenance_consistent() -> None:
+    """The real in-tree manifests agree on the canonical signed image."""
+    repo_root = Path(__file__).resolve().parents[2]
+    server_json = repo_root / "server.json"
+    version = json.loads(server_json.read_text(encoding="utf-8"))["version"]
+    result = verify_signed_image_provenance(repo_root=repo_root, version=version)
+    assert result.ok, result.reason


### PR DESCRIPTION
## What & why

The packaged distribution ships two release manifests that point a host at a runnable image -- `server.json` (the MCP registry listing) and `packaging/docker-mcp/server.yaml` (the Docker MCP catalog entry) -- and the image is signed at build time with a Sigstore build-provenance attestation. But nothing proved the two manifests agree on that image, so a host had to trust them. This PR makes the signed image a verifiable part of the aggregate install-verification path, and hardens the release gate.

## What shipped

- **`core/skills/image_provenance.py`** (new, stdlib-only): parses the OCI reference from `server.json` and the `image` from the docker-mcp catalog, and verifies -- deterministically and offline -- that both resolve to the same canonical `ghcr.io/<owner>/bernstein` repository and that the registry listing pins the release version. `verify_attestation` additionally runs `gh attestation verify oci://<ref>` against the live Sigstore attestation when the tooling and a network are available.
- **CLI `bernstein skills package image-verify`**: surfaces the verdict (offline, or `--online` for the live attestation), with `--json` and clear exit codes (0 consistent, 2 mismatch/failed attestation).
- **`scripts/gen_distribution_manifests.py`**: the release gate (`--check`, run in the publish workflow) now also fails on a provenance mismatch, so a release can never publish a listing that pulls a different or unsigned image than the catalog. The module is loaded by file path so the gate runs under a bare `python3` in the publish job.
- **`server.json` / `.plugin/plugin.json` version-synced** to the current release version (they had drifted to 3.3.0), which the existing manifest-sync tests require.
- **Docs**: `docs/integrations/agent-session.md` and `docs/reference/cli-reference.md`.

## AC -> status

| AC | Status | Evidence |
|---|---|---|
| Skill + plugin installs produce chain-verifiable receipts | Done (prior PRs) | packaging/provenance receipts |
| Skill works from >= 3 agent CLIs against one install | Done (prior PR) | `skills package conformance` |
| Official MCP registry listing resolves; Docker catalog pulls a signed image | **Code + automation shipped; external materialization pending** | `image_provenance.py` + `image-verify` + the `gen_distribution_manifests --check` release gate + version-synced `server.json`. The registry listing for the `sipyourdrink-ltd` namespace resolves only after the next tagged release runs the `publish-mcp-registry` job; the Docker catalog directory entry is a submission PR to the third-party `docker/mcp-registry` repo this repo cannot merge |

## Verification (local)

- new tests run 3x, stable (33 passed each); `tests/unit/test_distribution_manifests.py tests/unit/core/skills/ tests/unit/cli/test_skills_package_cmd.py` 99 passed
- `python3 scripts/gen_distribution_manifests.py --check` passes with the provenance gate; `ruff check` / `ruff format --check` / `lint-imports` (3 kept) / `import bernstein` clean; docs-drift + README coverage green

Part of #2369 (all code ACs + the submission automation are met; the two external directory-resolution ACs are documented as pending materialization).