### PR TITLE
release: v3.4.2

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.4.2.md
+++ b/docs/release-notes/v3.4.2.md
@@ -1,0 +1,57 @@
+# v3.4.2
+
+Released 2026-07-12.
+
+A patch release on top of v3.4.1. It wires the cost-aware batch and cache
+policies into the live run loop, runs the adapter conformance suite on a real
+Windows CI runner, and makes the packaged distribution image verifiable. There
+are no breaking changes and no configuration migration is required.
+
+## Cost-aware scheduling now live in the run loop
+
+- Batch routing is enforced during dispatch. Before a single-task batch is
+  spawned, the run resolves the adapter that would run the task and takes the
+  capability-gated routing decision: a batch-eligible task reaches a provider
+  batch endpoint only on an adapter that has one, a task that is not
+  batch-eligible never routes to batch, and a batch-eligible task on an adapter
+  with no batch surface runs interactively rather than being faked onto a batch
+  path that does not exist. Each routing decision is recorded as a verifiable
+  `cost.batch_route` audit-chain entry.
+- Cache-window fan-out is wired into the tournament fan-out. When the resolved
+  adapter supports a prompt-cache window and the operator has opted in, one
+  warm-up call primes the shared prompt prefix before the sibling attempts
+  spawn, so each attempt hits the warm cache instead of racing to write it. The
+  feature stays off by default.
+
+## Windows conformance on a real Windows runner
+
+- The adapter conformance suite for the claude, codex, and gemini adapters now
+  runs on a `windows-latest` CI runner and exercises the real spawn, stop, and
+  restart contract against a cross-platform fake-CLI harness, alongside the
+  Windows worktree-isolation contract. This replaces the previous mock-only
+  Windows coverage for those paths.
+- The fake-CLI test harness is cross-platform: it installs a batch shim on
+  Windows and a shell wrapper on Unix, and the fake reads its own configuration
+  so the same integration tests drive a real subprocess on every runner.
+- The count of platform-reason test skips is reduced, with the file-mode and
+  permission cases and the canary worktree round-trip now running on every
+  platform.
+
+## Packaging
+
+- Signed-image provenance verification. The MCP registry listing and the Docker
+  catalog entry are checked, offline, to resolve to the same signed container
+  image pinned to the release version. A new `bernstein skills package
+  image-verify` command surfaces the verdict, and the release manifest check
+  fails a release that would publish a listing pointing at a different or
+  unsigned image. The registry and plugin manifests are version-synced with the
+  release.
+
+## Upgrading
+
+```bash
+pipx upgrade bernstein     # or: uv tool upgrade bernstein
+```
+
+No configuration migration is required. Every capability available in v3.4.1
+is unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.4.1"
+version = "3.4.2"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.4.1",
+  "version": "3.4.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.1",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/bernstein/core/skills/image_provenance.py
+++ b/src/bernstein/core/skills/image_provenance.py
@@ -158,9 +158,8 @@ def owner_from_server_json(server_json_path: Path) -> str | None:
     url = (data.get("repository") or {}).get("url", "")
     if not isinstance(url, str) or "github.com/" not in url:
         return None
-    tail = url.split("github.com/", 1)[1].strip("/")
-    parts = tail.split("/")
-    return parts[0] if parts and parts[0] else None
+    owner = url.split("github.com/", 1)[1].strip("/").split("/", 1)[0]
+    return owner or None
 
 
 def canonical_signed_image(owner: str, version: str) -> ImageReference:

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Patch release folding in the three follow-up PRs since v3.4.1:

- #2354 cost-aware batch routing plus cache-window fan-out wired into the live run loop (cost.batch_route receipts; tournament cache warm-up).
- #2367 adapter conformance (real spawn/stop/restart for claude/codex/gemini) on a windows-latest CI runner via the cross-platform fake-CLI harness; platform-skip reduction.
- #2369 signed-image provenance verification (skills package image-verify plus release-gate check) and version-synced registry/plugin manifests.

Bumps pyproject.toml plus uv.lock to 3.4.2, version-syncs server.json and .plugin/plugin.json, and adds docs/release-notes/v3.4.2.md. No breaking changes, no configuration migration.