### PR TITLE
fix(docker): add MCP registry server-name label to the published image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493
 
 LABEL org.opencontainers.image.title="bernstein" \
       org.opencontainers.image.description="Declarative agent orchestration for engineering teams" \
-      org.opencontainers.image.source="https://github.com/bernstein-ai/bernstein"
+      org.opencontainers.image.source="https://github.com/bernstein-ai/bernstein" \
+      io.modelcontextprotocol.server.name="io.github.sipyourdrink-ltd/bernstein"
 
 # Install git (required for git_ops) and curl (healthcheck)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -105,3 +105,18 @@ def test_gen_script_check_mode_passes_and_is_idempotent(tmp_path: Path) -> None:
     assert regen.returncode == 0, regen.stdout + regen.stderr
     assert (_REPO / "server.json").read_bytes() == before["server.json"]
     assert (_REPO / ".plugin" / "plugin.json").read_bytes() == before["plugin.json"]
+
+
+def test_dockerfile_has_mcp_registry_server_name_label() -> None:
+    """The published image must carry the MCP registry server-name annotation.
+
+    The MCP registry rejects a server.json whose OCI package image lacks the
+    ``io.modelcontextprotocol.server.name`` label, so the Dockerfile must set it
+    to the same identity the manifest declares.
+    """
+    import json as _json
+
+    dockerfile = (_REPO / "Dockerfile").read_text(encoding="utf-8")
+    server_name = _json.loads((_REPO / "server.json").read_text(encoding="utf-8"))["name"]
+    assert "io.modelcontextprotocol.server.name" in dockerfile
+    assert server_name in dockerfile


### PR DESCRIPTION
The `Publish MCP registry listing` job failed on the v3.4.2 release: the MCP registry rejects the submission because the GHCR image lacks the required `io.modelcontextprotocol.server.name` annotation (`registry validation failed ... missing required annotation`). Add the label to the Dockerfile matching the `server.json` identity (`io.github.sipyourdrink-ltd/bernstein`) and add a guard test so the Dockerfile and manifest stay in sync. The listing publishes correctly on the next tagged image build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP registry server-name metadata to Docker image releases.
* **Tests**
  * Added validation to ensure Docker image metadata matches the repository’s server manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->