### PR TITLE
release: v3.4.3

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.4.3.md
+++ b/docs/release-notes/v3.4.3.md
@@ -1,0 +1,14 @@
+# v3.4.3
+
+Released 2026-07-12.
+
+A patch release that fixes the MCP registry listing publish.
+
+## Fixes
+
+- The published container image now carries the
+  `io.modelcontextprotocol.server.name` label that the MCP registry requires,
+  so the registry listing publish succeeds instead of failing validation on the
+  release. A distribution-manifest guard keeps the Dockerfile label in sync with
+  the `server.json` identity.
+- Version-synced `server.json` and `.plugin/plugin.json` to 3.4.3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.4.2"
+version = "3.4.3"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.4.2",
+  "version": "3.4.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.2",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.3",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.4.2"
+version = "3.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Patch release. Fixes the Publish MCP registry listing job by shipping the required io.modelcontextprotocol.server.name image label (added in the prior fix), and version-syncs pyproject, uv.lock, server.json, and .plugin/plugin.json to 3.4.3. Notes in docs/release-notes/v3.4.3.md.