### PR TITLE
ci(publish): idempotent MCP registry publish on duplicate version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -362,6 +362,22 @@ jobs:
           ./mcp-publisher --version
       - name: Publish server.json
         run: |
-          set -euo pipefail
+          set -uo pipefail
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+          # Idempotent publish: the registry rejects re-submitting a version that
+          # is already live with an HTTP 400 "cannot publish duplicate version".
+          # That happens whenever this job runs more than once for the same
+          # release (a workflow re-run, or the tag-push and workflow_dispatch
+          # triggers racing to publish the same server.json). The listing is
+          # already correct in that case, so a duplicate is a success, not a
+          # failure — swallow it and let any other error still fail the step.
+          out=$(./mcp-publisher publish 2>&1)
+          code=$?
+          printf '%s\n' "$out"
+          if [ "$code" -ne 0 ]; then
+            if printf '%s' "$out" | grep -qi "duplicate version"; then
+              echo "::notice::version already present in the MCP registry; treating duplicate as success (idempotent)"
+              exit 0
+            fi
+            exit "$code"
+          fi

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -131,9 +131,7 @@ def test_publish_workflow_mcp_registry_is_idempotent() -> None:
     The listing is already correct in that case, so the step must swallow the
     duplicate rather than fail the release with a red check.
     """
-    workflow = (
-        _REPO / ".github" / "workflows" / "publish.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (_REPO / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
     # The publish step guards on the duplicate-version marker and exits 0 for it.
     assert "duplicate version" in workflow
     assert "idempotent" in workflow.lower()

--- a/tests/unit/test_distribution_manifests.py
+++ b/tests/unit/test_distribution_manifests.py
@@ -120,3 +120,20 @@ def test_dockerfile_has_mcp_registry_server_name_label() -> None:
     server_name = _json.loads((_REPO / "server.json").read_text(encoding="utf-8"))["name"]
     assert "io.modelcontextprotocol.server.name" in dockerfile
     assert server_name in dockerfile
+
+
+def test_publish_workflow_mcp_registry_is_idempotent() -> None:
+    """The registry publish step must treat an already-published version as success.
+
+    The MCP registry rejects re-submitting a live version with an HTTP 400
+    ``cannot publish duplicate version``. This happens on any re-run or when the
+    tag-push and workflow_dispatch triggers race to publish the same server.json.
+    The listing is already correct in that case, so the step must swallow the
+    duplicate rather than fail the release with a red check.
+    """
+    workflow = (
+        _REPO / ".github" / "workflows" / "publish.yml"
+    ).read_text(encoding="utf-8")
+    # The publish step guards on the duplicate-version marker and exits 0 for it.
+    assert "duplicate version" in workflow
+    assert "idempotent" in workflow.lower()


### PR DESCRIPTION
## What

The `Publish MCP registry listing` job now treats an already-published version as success.

## Why

The registry returns HTTP 400 `cannot publish duplicate version` when a live version is re-submitted. This fires on any workflow re-run, or when the tag-push and `workflow_dispatch` triggers race to publish the same `server.json`. The listing is already correct in that case, but the check showed red on the release commit anyway.

## Change

- Capture the publisher output; a duplicate-version response exits 0. Any other non-zero exit still fails the step.
- Add a distribution-manifest guard (`test_publish_workflow_mcp_registry_is_idempotent`) so the handling cannot regress.

Verified locally: `actionlint` clean, 7/7 manifest guards pass.