### PR TITLE
release: v3.4.4

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.4.4.md
+++ b/docs/release-notes/v3.4.4.md
@@ -30,3 +30,9 @@ the Bernstein MCP server, plus release-pipeline hardening.
 - The MCP registry listing publish is now idempotent: a version that is already
   live is treated as success instead of failing the release on a re-run or a
   tag-push/dispatch race. (#2466)
+
+## Housekeeping
+
+- Refreshed the packaged adapter last-green projection and its docs table from
+  the nightly conformance canary; every row stays anchored to its attesting
+  receipt.

--- a/docs/release-notes/v3.4.4.md
+++ b/docs/release-notes/v3.4.4.md
@@ -1,0 +1,32 @@
+# v3.4.4
+
+Released 2026-07-12.
+
+A capability release that adds the experimental MCP Tasks protocol surface to
+the Bernstein MCP server, plus release-pipeline hardening.
+
+## MCP Tasks extension
+
+- Long-running runs are now exposed through the experimental MCP Tasks protocol.
+  A task-capable MCP client (Claude Code, Cursor, Cline, and others) can start a
+  run with `bernstein_run`, receive a `CreateTaskResult`, and then poll status
+  and retrieve the result asynchronously through the `get_task`,
+  `get_task_result`, `list_tasks`, and `cancel_task` handlers without holding a
+  blocking session open. The task handle embeds the run's audit-chain head hash
+  (`{task_id}:{head_hash}`) so a stateless client can still tie a progress claim
+  back to the signed chain.
+- W3C trace-context (`traceparent`, `tracestate`, `baggage`) is ingested from
+  the incoming request and propagated to the spawned agent, scoped per task so a
+  run without trace-context never inherits another run's context.
+- Every task status projects to a terminal MCP status on completion, and
+  `get_task_result` reports an error for terminal-error and in-flight tasks
+  instead of reporting success.
+
+  Thanks to @Amanmeena0 for contributing the MCP Tasks protocol implementation
+  and the trace-context propagation.
+
+## Release pipeline
+
+- The MCP registry listing publish is now idempotent: a version that is already
+  live is treated as success instead of failing the release on a re-run or a
+  tag-push/dispatch race. (#2466)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.4.3"
+version = "3.4.4"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.4.3",
+  "version": "3.4.4",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.3",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.4",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.4.3"
+version = "3.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Bump to 3.4.4 with synced distribution manifests (server.json, .plugin/plugin.json, uv.lock) and release notes.

Included since v3.4.3:
- Experimental MCP Tasks protocol surface with scoped W3C trace-context propagation (#2468, thanks @Amanmeena0)
- Idempotent MCP registry listing publish (#2466)
- Coverage baseline ratchet to 80.58% (#2467)

Manifest guards pass (7/7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental support for asynchronous, task-based MCP operations, including task polling and trace-context propagation.
  * Documented terminal task statuses and error reporting behavior.

* **Bug Fixes**
  * Improved release publishing reliability by safely handling repeated publication of an already-live version.

* **Chores**
  * Updated the application, plugin, package, and server version to 3.4.4.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->