### PR TITLE
fix(mcp): make tasks/list projection deterministic and paginate

### DIFF
--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -310,6 +310,8 @@ def task_to_response(task: Task) -> TaskResponse:
         metadata=task.metadata,
         created_at=task.created_at,
         claimed_at=task.claimed_at,
+        completed_at=task.completed_at,
+        closed_at=task.closed_at,
         progress_log=cast("list[ProgressEntry]", task.progress_log).copy(),  # type: ignore[reportUnknownMemberType]
         version=task.version,
         parent_session_id=task.parent_session_id,

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -256,6 +256,8 @@ class TaskResponse(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: float
     claimed_at: float | None = None
+    completed_at: float | None = None
+    closed_at: float | None = None
     deadline: float | None = None
     progress_log: list[ProgressEntry] = Field(default_factory=lambda: list[ProgressEntry]())
     version: int = 1

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -22,6 +22,8 @@ Tools:
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import os
@@ -228,12 +230,27 @@ def _project_task_helper(data: dict[str, Any]) -> Any:
     created_at_ts = data.get("created_at")
     created_at = datetime.fromtimestamp(created_at_ts, tz=UTC) if created_at_ts else datetime.now(UTC)
 
+    # Derive lastUpdatedAt from the task's newest recorded transition
+    # (created -> claimed -> completed -> closed) so two reads of an unchanged
+    # task project the SAME timestamp. Stamping wall-clock now() here is
+    # non-idempotent: it manufactures phantom updates for change-detection
+    # clients and breaks the deterministic-projection contract. now() stays
+    # only as a last resort when the payload carries no timestamp at all.
+    transition_ts = (
+        data.get("created_at"),
+        data.get("claimed_at"),
+        data.get("completed_at"),
+        data.get("closed_at"),
+    )
+    newest_ts = max((t for t in transition_ts if t is not None), default=None)
+    last_updated = datetime.fromtimestamp(newest_ts, tz=UTC) if newest_ts is not None else datetime.now(UTC)
+
     return Task(
         taskId=mcp_task_id,
         status=mcp_status,
         statusMessage=status_message,
         createdAt=created_at,
-        lastUpdatedAt=datetime.now(UTC),
+        lastUpdatedAt=last_updated,
         ttl=None,
         pollInterval=5000,
     )
@@ -759,6 +776,37 @@ def _apply_tool_tier(mcp: FastMCP[None], active_tier: ToolTier) -> None:
         mcp._tool_manager._tools.pop(name, None)
 
 
+# MCP ``tasks/list`` is a paginated request whose only client-supplied knob is
+# an opaque cursor. We page the task server in fixed windows and encode the next
+# offset into the cursor, so a client can walk past the legacy 500-item cap the
+# server applies to unpaginated GET /tasks calls.
+_LIST_TASKS_PAGE_SIZE = 100
+
+_CURSOR_PREFIX = "offset="
+
+
+def _encode_task_cursor(offset: int) -> str:
+    """Encode a pagination offset as an opaque, deterministic cursor token."""
+    return base64.urlsafe_b64encode(f"{_CURSOR_PREFIX}{offset}".encode()).decode()
+
+
+def _decode_task_cursor(cursor: str | None) -> int:
+    """Decode a cursor produced by :func:`_encode_task_cursor` back to an offset.
+
+    A missing cursor starts at offset 0. A malformed cursor is a client error
+    (the token did not originate from this server) and raises ``ValueError``.
+    """
+    if not cursor:
+        return 0
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode()).decode()
+        if raw.startswith(_CURSOR_PREFIX):
+            return max(0, int(raw[len(_CURSOR_PREFIX) :]))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        pass
+    raise ValueError(f"Invalid pagination cursor: {cursor!r}")
+
+
 def _register_tasks_extension(mcp: FastMCP[None], server_url: str) -> None:
     """Register custom experimental handlers for the MCP Tasks extension."""
     import httpx
@@ -811,12 +859,28 @@ def _register_tasks_extension(mcp: FastMCP[None], server_url: str) -> None:
 
     @mcp._mcp_server.experimental.list_tasks()
     async def list_tasks(req: ListTasksRequest) -> ListTasksResult:
+        # Translate the opaque cursor into an offset and always send explicit
+        # limit/offset, so the server returns the paginated envelope instead of
+        # the legacy flat list hard-capped at 500 (which strands the tail for
+        # any operator with more than 500 tasks).
+        offset = _decode_task_cursor(req.params.cursor if req.params else None)
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            resp = await client.get(f"{server_url}/tasks", headers=_auth_headers())
+            resp = await client.get(
+                f"{server_url}/tasks",
+                params={"limit": _LIST_TASKS_PAGE_SIZE, "offset": offset},
+                headers=_auth_headers(),
+            )
             resp.raise_for_status()
-            tasks_data = resp.json()
+            envelope = resp.json()
+        # Envelope shape: {tasks, total, limit, offset}. Compute nextCursor from
+        # the offset/limit the server actually applied (it clamps both), so the
+        # walk terminates exactly when the last page has been served.
+        tasks_data = envelope["tasks"]
+        total = envelope["total"]
+        next_offset = envelope["offset"] + envelope["limit"]
         mcp_tasks = [_project_task_helper(t) for t in tasks_data]
-        return ListTasksResult(tasks=mcp_tasks)
+        next_cursor = _encode_task_cursor(next_offset) if next_offset < total else None
+        return ListTasksResult(tasks=mcp_tasks, nextCursor=next_cursor)
 
     @mcp._mcp_server.experimental.cancel_task()
     async def cancel_task(req: CancelTaskRequest) -> CancelTaskResult:

--- a/tests/golden/cli_snapshots/task_response.json
+++ b/tests/golden/cli_snapshots/task_response.json
@@ -5,6 +5,8 @@
   "cell_id": null,
   "claimed_at": null,
   "cli": null,
+  "closed_at": null,
+  "completed_at": null,
   "completion_signals": [],
   "complexity": "medium",
   "created_at": 1700000000.0,

--- a/tests/unit/test_mcp_tasks.py
+++ b/tests/unit/test_mcp_tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,6 +21,7 @@ from mcp.types import (
     GetTaskResult,
     ListTasksRequest,
     ListTasksResult,
+    PaginatedRequestParams,
     TextContent,
 )
 
@@ -45,16 +47,34 @@ def mock_client() -> AsyncMock:
     return client
 
 
-def _make_task_dict(task_id: str, status: str = "open", result_summary: str | None = None) -> dict[str, Any]:
-    return {
+def _make_task_dict(
+    task_id: str,
+    status: str = "open",
+    result_summary: str | None = None,
+    *,
+    created_at: float = 1711574400.0,
+    claimed_at: float | None = None,
+    completed_at: float | None = None,
+    closed_at: float | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
         "id": task_id,
         "title": "Test task",
         "description": "A test task description",
         "role": "backend",
         "status": status,
-        "created_at": 1711574400.0,
+        "created_at": created_at,
         "result_summary": result_summary,
     }
+    # Only attach transition timestamps when supplied, mirroring the server
+    # payload where an unclaimed/unclosed task omits these keys entirely.
+    if claimed_at is not None:
+        data["claimed_at"] = claimed_at
+    if completed_at is not None:
+        data["completed_at"] = completed_at
+    if closed_at is not None:
+        data["closed_at"] = closed_at
+    return data
 
 
 @pytest.mark.asyncio
@@ -120,10 +140,15 @@ async def test_list_tasks_endpoint(mock_client: AsyncMock) -> None:
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     mock_response.json = MagicMock(
-        return_value=[
-            _make_task_dict("task-1", status="done"),
-            _make_task_dict("task-2", status="failed"),
-        ]
+        return_value={
+            "tasks": [
+                _make_task_dict("task-1", status="done"),
+                _make_task_dict("task-2", status="failed"),
+            ],
+            "total": 2,
+            "limit": 100,
+            "offset": 0,
+        }
     )
     mock_client.get = AsyncMock(return_value=mock_response)
 
@@ -385,3 +410,160 @@ def test_spawn_for_tasks_trace_env_is_scoped_and_restored(monkeypatch: pytest.Mo
     spawner.spawn_for_tasks([task_b])
     assert seen["TRACEPARENT"] is None  # B must NOT inherit A's traceparent
     assert os.environ.get("TRACEPARENT") is None
+
+
+# ---------------------------------------------------------------------------
+# lastUpdatedAt determinism (a projection of an unchanged task must be idempotent)
+# ---------------------------------------------------------------------------
+
+
+def test_project_task_helper_last_updated_derived_from_last_transition() -> None:
+    """lastUpdatedAt must reflect the task's newest stored transition timestamp.
+
+    A closed task's last change is ``closed_at``; the projection must surface
+    that instant, not wall-clock ``now()``.
+    """
+    created = 1711574400.0
+    data = _make_task_dict(
+        "t-ts",
+        status="closed",
+        created_at=created,
+        claimed_at=created + 60,
+        completed_at=created + 120,
+        closed_at=created + 180,
+    )
+    task_obj = _project_task_helper(data)
+    assert task_obj.createdAt == datetime.fromtimestamp(created, tz=UTC)
+    assert task_obj.lastUpdatedAt == datetime.fromtimestamp(created + 180, tz=UTC)
+
+
+def test_project_task_helper_last_updated_is_deterministic() -> None:
+    """Two projections of the same unchanged task return identical timestamps.
+
+    Non-idempotent ``lastUpdatedAt`` produces phantom updates for
+    change-detection clients and breaks the deterministic-substrate contract.
+    """
+    data = _make_task_dict("t-idem", status="claimed", created_at=1711574400.0, claimed_at=1711574460.0)
+    first = _project_task_helper(data).lastUpdatedAt
+    second = _project_task_helper(data).lastUpdatedAt
+    assert first == second
+    # The stable value is the newest transition (claimed_at here), not now().
+    assert first == datetime.fromtimestamp(1711574460.0, tz=UTC)
+
+
+def test_project_task_helper_last_updated_falls_back_to_created_at() -> None:
+    """A freshly-opened task (no later transitions) reports lastUpdatedAt == createdAt."""
+    data = _make_task_dict("t-open", status="open", created_at=1711574400.0)
+    task_obj = _project_task_helper(data)
+    assert task_obj.lastUpdatedAt == task_obj.createdAt
+    assert task_obj.lastUpdatedAt == datetime.fromtimestamp(1711574400.0, tz=UTC)
+
+
+def test_task_response_exposes_completion_timestamps() -> None:
+    """The task API must serialise completed_at/closed_at so the MCP layer can
+    derive a deterministic lastUpdatedAt for terminal tasks."""
+    from bernstein.core.server.server_app import task_to_response
+    from bernstein.core.tasks.models import Task, TaskStatus
+
+    task = Task(
+        id="t-serialise",
+        title="t",
+        description="",
+        role="backend",
+        status=TaskStatus.CLOSED,
+        batch_eligible=False,
+        claimed_at=111.0,
+        completed_at=222.0,
+        closed_at=333.0,
+    )
+    resp = task_to_response(task)
+    assert resp.completed_at == 222.0
+    assert resp.closed_at == 333.0
+
+
+# ---------------------------------------------------------------------------
+# list_tasks pagination (cursor in -> limit/offset out -> nextCursor)
+# ---------------------------------------------------------------------------
+
+
+def _paginated_envelope(tasks: list[dict[str, Any]], *, total: int, limit: int, offset: int) -> dict[str, Any]:
+    return {"tasks": tasks, "total": total, "limit": limit, "offset": offset}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_requests_pagination_and_sets_next_cursor(mock_client: AsyncMock) -> None:
+    mcp = create_mcp_server()
+    handler = mcp._mcp_server.request_handlers[ListTasksRequest]  # pyright: ignore[reportPrivateUsage]
+
+    page = [_make_task_dict(f"task-{i}", status="open") for i in range(100)]
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(return_value=_paginated_envelope(page, total=250, limit=100, offset=0))
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("bernstein.mcp.server.httpx.AsyncClient", return_value=mock_client):
+        res = (await handler(ListTasksRequest())).root
+        assert isinstance(res, ListTasksResult)
+
+    # The handler must send explicit pagination so the server returns the
+    # envelope path instead of the legacy list hard-capped at 500.
+    sent_params = cast(dict[str, Any], mock_client.get.call_args.kwargs.get("params") or {})
+    assert sent_params.get("limit") is not None
+    assert sent_params.get("offset") == 0
+    assert len(res.tasks) == 100
+    # 250 total, only 100 returned -> the client can page further.
+    assert res.nextCursor is not None
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_no_next_cursor_at_tail(mock_client: AsyncMock) -> None:
+    mcp = create_mcp_server()
+    handler = mcp._mcp_server.request_handlers[ListTasksRequest]  # pyright: ignore[reportPrivateUsage]
+
+    page = [_make_task_dict("task-only", status="done")]
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(return_value=_paginated_envelope(page, total=1, limit=100, offset=0))
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("bernstein.mcp.server.httpx.AsyncClient", return_value=mock_client):
+        res = (await handler(ListTasksRequest())).root
+        assert isinstance(res, ListTasksResult)
+
+    assert len(res.tasks) == 1
+    assert res.nextCursor is None
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_cursor_translates_to_offset(mock_client: AsyncMock) -> None:
+    mcp = create_mcp_server()
+    handler = mcp._mcp_server.request_handlers[ListTasksRequest]  # pyright: ignore[reportPrivateUsage]
+
+    # Page 1: 100 of 150 -> yields a cursor pointing past the first page.
+    page1 = [_make_task_dict(f"task-{i}") for i in range(100)]
+    resp1 = MagicMock()
+    resp1.raise_for_status = MagicMock()
+    resp1.json = MagicMock(return_value=_paginated_envelope(page1, total=150, limit=100, offset=0))
+    mock_client.get = AsyncMock(return_value=resp1)
+
+    with patch("bernstein.mcp.server.httpx.AsyncClient", return_value=mock_client):
+        res1 = (await handler(ListTasksRequest())).root
+        assert isinstance(res1, ListTasksResult)
+        cursor = res1.nextCursor
+        assert cursor is not None
+
+        # Page 2: feed the cursor back; the handler must request offset=100.
+        page2 = [_make_task_dict(f"task-{i}") for i in range(100, 150)]
+        resp2 = MagicMock()
+        resp2.raise_for_status = MagicMock()
+        resp2.json = MagicMock(return_value=_paginated_envelope(page2, total=150, limit=100, offset=100))
+        mock_client.get = AsyncMock(return_value=resp2)
+
+        res2 = (await handler(ListTasksRequest(params=PaginatedRequestParams(cursor=cursor)))).root
+        assert isinstance(res2, ListTasksResult)
+
+    sent_params = cast(dict[str, Any], mock_client.get.call_args.kwargs.get("params") or {})
+    assert sent_params.get("offset") == 100
+    assert len(res2.tasks) == 50
+    # 100 + 100 >= 150 -> tail reached.
+    assert res2.nextCursor is None


### PR DESCRIPTION
## Summary

Two correctness fixes to the MCP Tasks extension projection (fast-follow to #2468).

### 1. `lastUpdatedAt` was non-deterministic

`_project_task_helper` stamped `lastUpdatedAt` with wall-clock `datetime.now(UTC)` on every projection, so two reads of an unchanged task returned different timestamps. That is non-idempotent: a change-detection client sees a phantom update on every poll, and it contradicts the deterministic projection the rest of the extension aims for.

Fix: derive `lastUpdatedAt` from the task's newest recorded transition (`created_at`, `claimed_at`, `completed_at`, `closed_at`). Repeated reads of an unchanged task now project the same instant. `now()` remains only as a last resort when the payload carries no timestamp at all.

`completed_at` and `closed_at` are now serialised on `TaskResponse` (they already exist on the domain `Task`) so a terminal task reports its true last-transition time rather than under-reporting from `claimed_at`.

### 2. `list_tasks` ignored pagination

The `tasks/list` handler ignored `req.params.cursor`, never set `nextCursor`, and sent no `limit`/`offset` to `GET /tasks`. It therefore hit the legacy path hard-capped at 500 items (`_LIST_TASKS_HARD_CAP`), so a client could never reach the tail once an operator had more than 500 tasks.

Fix: translate the opaque cursor to `limit`/`offset`, read the paginated envelope (`{tasks, total, limit, offset}`), and compute `nextCursor` from the offset/limit the server actually applied so the walk terminates exactly at the last page.

## Tests

`tests/unit/test_mcp_tasks.py` adds regression coverage:

- projection determinism (two reads of an unchanged task are identical)
- `lastUpdatedAt` derived from the newest transition, with the created-only fallback
- `completed_at`/`closed_at` serialisation on `TaskResponse`
- cursor to offset translation and `nextCursor` termination at the tail

All new and existing MCP-tasks tests pass; contract, pagination-route, and API-compat suites are unaffected by the two added optional fields.
