### PR TITLE
chore(renovate): migrate deprecated matchPackagePatterns to matchPackageNames

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,10 +12,10 @@
         "dockerfile",
         "regex"
       ],
-      "matchPackagePatterns": [
-        "^python$",
-        "actions/python-versions",
-        "actions/setup-python"
+      "matchPackageNames": [
+        "python",
+        "/actions/python-versions/",
+        "/actions/setup-python/"
       ],
       "allowedVersions": "<=3.13"
     }


### PR DESCRIPTION
Renovate deprecated `matchPackagePatterns`. Migrate the python-pin rule to `matchPackageNames` (exact name plus regex form). Clears the standing Config Migration flag on the dependency dashboard (#1511) and keeps the python 3.13 pin working on future Renovate majors.

No behavior change to which packages are matched.

## Summary by Sourcery

Migrate Renovate configuration to use matchPackageNames instead of the deprecated matchPackagePatterns for Python pinning.

Build:
- Update Renovate configuration in renovate.json to replace matchPackagePatterns with matchPackageNames for Python 3.13 pin rules.

Chores:
- Clear the Renovate config migration flag on the dependency dashboard by adopting the new matching syntax without changing package matching behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved maintenance automation for more precise Python version update targeting.
  * Reduced the risk of unrelated files or configurations being included in automated update operations.
  * No user-facing functionality or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->