### PR TITLE
fix(adapters): align aider adapter with current aider CLI

### DIFF
--- a/docs/adapters/conformance-canary.md
+++ b/docs/adapters/conformance-canary.md
@@ -41,6 +41,14 @@ reconstructable offline rather than living only in a CI log.
 * A regression must repeat: **two consecutive failures with the same
   failure fingerprint** are required before the canary proposes an
   issue, so one upstream flake never pages anyone.
+* A `--help` that advertises **none** of a contract's required tokens (or
+  prints nothing) is classified as an **inconclusive `skip`, not a
+  `fail`** -- an installed CLI cannot legitimately drop its entire
+  required surface in one release, so this signals a broken, paginated,
+  or wholesale-redesigned `--help` (or a shim binary on `PATH`) that an
+  operator must investigate, rather than genuine per-flag drift. A
+  *partial* miss (at least one required token still present) remains a
+  real drift `fail`. The `skip` is independent of the process exit code.
 * Issues are **deduped on the failure fingerprint** (adapter + version +
   failure lines): the same regression never opens two issues, while a
   new upstream version failing fresh reports again.

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -262,6 +262,49 @@ def _capability_failures(spec: ContractSpec, help_text: str) -> list[str]:
     return failures
 
 
+#: Minimum number of required tokens below which the "every required token
+#: missing" signal cannot be told apart from ordinary single-flag drift. A
+#: one-token contract that loses its one token is genuine drift, not a broken
+#: probe, so the classification below only applies at two or more tokens.
+_BROKEN_PROBE_MIN_REQUIRED = 2
+
+
+def probe_failure_reason(spec: ContractSpec, help_text: str) -> str | None:
+    """Classify ``help_text`` as a broken/degraded probe rather than drift.
+
+    Returns a short reason phrase when the captured ``--help`` output looks
+    like a probe or upstream runtime failure -- the CLI crashed before
+    emitting help, paginated it away, was redesigned/renamed wholesale, or a
+    shim binary is shadowing ``PATH`` -- and ``None`` when the output is real
+    help text that should drive normal flag matching.
+
+    Signals, in order:
+
+    * **No output.** An installed binary whose ``--help`` prints nothing is
+      broken, not drifted.
+    * **Every required token absent at once.** A working binary cannot
+      legitimately drop its *entire* declared required surface in one
+      release; when all of ``>= _BROKEN_PROBE_MIN_REQUIRED`` required tokens
+      vanish together the likelier cause is a broken or wholesale-redesigned
+      ``--help``. Reporting each token as "missing" would page an operator
+      with a misleading per-flag "every flag removed" finding (issue #2488).
+
+    A single-token contract is exempt from the second signal: losing its one
+    token is indistinguishable from ordinary drift, so it stays drift. This
+    is independent of the process exit code -- some CLIs emit a redesigned or
+    paginated help and still exit 0.
+    """
+    total_required = len(spec.required_flags) + len(spec.required_subcommands)
+    if total_required == 0:
+        return None
+    if not _strip_ansi(help_text).strip():
+        return "no output"
+    failures = _capability_failures(spec, help_text)
+    if len(failures) == total_required and total_required >= _BROKEN_PROBE_MIN_REQUIRED:
+        return "no required tokens advertised"
+    return None
+
+
 def _model_failures(spec: ContractSpec, models_text: str) -> list[str]:
     """List required models missing from the CLI's model-list output."""
     failures: list[str] = []
@@ -316,33 +359,34 @@ def check_contract(spec: ContractSpec) -> ContractResult:
         result.skipped_reason = help_text.strip()
         return result
 
-    # Guard: a non-zero help exit that fails to advertise the required
-    # contract surface is a CLI runtime failure, not contract drift.
+    # Guard: a help exit that fails to advertise the required contract
+    # surface is a CLI runtime/probe failure, not contract drift.
     # Reporting every required flag as "missing" against an empty (or
     # truncated) haystack produces misleading drift issues (one failure
     # line per required flag) when the real problem is a broken --help.
-    # Cover two patterns seen in real CI:
+    # Covers the patterns seen in real CI:
     #   * help_text empty (CLI crashed before emitting anything).
     #   * help_text non-empty but ALL required flags missing (CLI emitted
-    #     a stub or error preamble and bailed before the flag section).
-    # Surface the runtime failure on a dedicated field so the CLI can
-    # exit with a "checker error" status rather than a drift status; the
-    # workflow distinguishes the two and only treats real drift as
-    # contract regression.
+    #     a stub or error preamble, or a redesigned/paginated help, and
+    #     advertised none of the required tokens).
+    # This is independent of the exit code: some CLIs ship a redesigned or
+    # paginated --help that still exits 0, so gating on a non-zero exit
+    # would miss exactly the regression that opened issue #2488. Surface
+    # the runtime failure on a dedicated field so the CLI can exit with a
+    # "checker error" status rather than a drift status; the workflow
+    # distinguishes the two and only treats real drift as contract
+    # regression.
     stripped_help = _strip_ansi(help_text).strip()
-    raw_failures = _capability_failures(spec, help_text)
-    total_required = len(spec.required_flags) + len(spec.required_subcommands)
-    all_required_missing = total_required > 0 and len(raw_failures) == total_required
-    if rc != 0 and (not stripped_help or all_required_missing):
+    probe_reason = probe_failure_reason(spec, help_text)
+    if probe_reason is not None:
         snippet = stripped_help[:300] or "<no output>"
-        reason = "no output" if not stripped_help else "no required tokens advertised"
         result.runtime_failure = (
-            f"`{' '.join(spec.resolved_help_command())}` exited {rc} with {reason}; "
+            f"`{' '.join(spec.resolved_help_command())}` exited {rc} with {probe_reason}; "
             f"upstream CLI runtime failure, not contract drift: {snippet}"
         )
         return result
 
-    result.capability_failures = raw_failures
+    result.capability_failures = _capability_failures(spec, help_text)
 
     # 2. Optional model-presence check.
     if spec.models_required_present and spec.models_command:

--- a/src/bernstein/adapters/report.py
+++ b/src/bernstein/adapters/report.py
@@ -32,6 +32,7 @@ from bernstein.adapters._contract import (
     StrategyView,
     _capability_failures,  # pyright: ignore[reportPrivateUsage]
     _strip_ansi,  # pyright: ignore[reportPrivateUsage]
+    probe_failure_reason,
     strategy_for,
 )
 
@@ -352,6 +353,26 @@ def check_adapter_in_process(
         )
 
     help_text = (proc.stdout or "") + (proc.stderr or "")
+
+    # A binary that is installed and answers --help but advertises none of
+    # its required tokens (or nothing at all) is a broken/redesigned probe
+    # surface, not genuine per-flag drift: an installed adapter cannot
+    # legitimately drop its entire required surface in one release. Record it
+    # as an inconclusive skip so the canary flags it for investigation
+    # instead of paging with a misleading "every flag removed" regression
+    # (issue #2488). Partial misses still fall through to a fail below.
+    probe_reason = probe_failure_reason(spec, help_text)
+    if probe_reason is not None:
+        total_required = len(spec.required_flags) + len(spec.required_subcommands)
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_SKIP,
+            detail=(
+                f"probe inconclusive ({probe_reason}): `{' '.join(help_cmd)}` advertised none of "
+                f"the {total_required} required tokens; not treated as drift"
+            ),
+            capabilities=capabilities,
+        )
+
     failures = _capability_failures(spec, help_text)
     if failures:
         return ConformanceVerdictPayload(

--- a/tests/unit/adapters/test_report.py
+++ b/tests/unit/adapters/test_report.py
@@ -430,6 +430,62 @@ def test_check_adapter_subcommand_present_yields_ok(contracts_tmp: Path) -> None
     assert v.verdict == CONFORMANCE_OK
 
 
+def test_check_adapter_all_flags_missing_yields_skip_not_fail(contracts_tmp: Path) -> None:
+    """Help advertising none of the required tokens is a probe failure (skip).
+
+    Regression for issue #2488: an installed binary whose --help advertised
+    none of the six aider flags was misreported as six-flag contract drift
+    (one "missing flag" line per flag), paging an operator even though the
+    flags were all still present. An adapter cannot legitimately drop its
+    entire required surface at once, so this is a broken/redesigned probe and
+    must record ``skip`` (investigate), never ``fail`` (drift).
+    """
+    _write_contract(contracts_tmp, "stub", flags=("--model", "--message", "--yes-always"))
+    # A redesigned help banner that advertises none of the required flags.
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="Stub 3.13 - see `stub docs` for usage.\n", stderr=""
+    )
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_SKIP
+    assert "none of" in v.detail
+    assert "3 required tokens" in v.detail
+
+
+def test_check_adapter_empty_help_yields_skip(contracts_tmp: Path) -> None:
+    """An installed binary whose --help prints nothing is a probe failure."""
+    _write_contract(contracts_tmp, "stub", flags=("--model", "--message"))
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_SKIP
+    assert "no output" in v.detail
+
+
+def test_check_adapter_partial_miss_still_fails(contracts_tmp: Path) -> None:
+    """A partial miss (some tokens present) is genuine drift and stays ``fail``."""
+    _write_contract(contracts_tmp, "stub", flags=("--model", "--message", "--yes-always"))
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="usage: stub [--model M] [--message X]\n", stderr=""
+    )
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_FAIL
+    assert "--yes-always" in v.detail
+
+
+def test_check_adapter_single_flag_missing_stays_fail(contracts_tmp: Path) -> None:
+    """A one-token contract losing its token is ordinary drift, not a probe
+    failure: it cannot be told apart from a wholesale surface loss, so the
+    broken-probe classification is deliberately not applied at one token."""
+    _write_contract(contracts_tmp, "stub", flags=("--model",))
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="usage: stub [--other X]\n", stderr="")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_FAIL
+    assert "--model" in v.detail
+
+
 # ---------------------------------------------------------------------------
 # build_report
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_canary.py
+++ b/tests/unit/test_adapter_canary.py
@@ -186,6 +186,38 @@ class TestRunCanaryTarget:
         assert any("--output-format" in failure for failure in outcome.failures)
         assert outcome.transcript  # the failing transcript rides into the issue
 
+    def test_help_advertising_no_required_tokens_is_skip_not_fail(self, tmp_path: Path) -> None:
+        """Regression for issue #2488: a --help that advertises none of the
+        contract's required tokens is a broken/redesigned probe, not drift.
+
+        The reported regression saw all six aider flags marked "missing" at
+        once and a misleading per-flag issue opened, even though the flags
+        were still present. A binary that answers --help but advertises none
+        of its declared surface must probe as ``skip`` (investigate) so no
+        regression issue is opened; only a *partial* miss is genuine drift.
+        """
+        bin_dir = tmp_path / "bin"
+        # A wholesale-redesigned help banner that advertises none of the six
+        # aider flags, exactly the shape that produced #2488.
+        stub = _write_stub_cli(
+            bin_dir,
+            "aider",
+            version="3.13",
+            help_text="aider 3.13 - run 'aider docs' for the new command surface.",
+        )
+        contracts = tmp_path / "contracts"
+        _write_contract(
+            contracts,
+            "aider",
+            ["--model", "--message", "--yes-always", "--auto-commits", "--map-tokens", "--no-auto-lint"],
+            binary=stub,
+        )
+        target = CanaryTarget(adapter="aider", binary="aider", model="gpt-5-mini")
+        outcome = run_canary_target(target, which=lambda _n: str(stub), contracts_dir=contracts)
+        assert outcome.verdict == "skip"
+        assert outcome.failures == ()
+        assert any("none of" in line for line in outcome.transcript)
+
 
 # ---------------------------------------------------------------------------
 # Receipts: canonical, content-addressed, tamper-evident

--- a/tests/unit/test_adapter_contract_check.py
+++ b/tests/unit/test_adapter_contract_check.py
@@ -474,6 +474,82 @@ def test_check_contract_help_nonzero_with_output_still_checks_flags(
     assert result.capability_failures == []
 
 
+def test_check_contract_help_zero_exit_all_flags_missing_is_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A *zero* exit whose output lacks ALL required tokens is still a runtime
+    failure, not drift.
+
+    Regression for issue #2488: some CLIs ship a redesigned or paginated
+    --help that advertises none of the required flags yet still exits 0.
+    Gating the broken-probe guard on a non-zero exit misclassified that as
+    six-flag drift and paged an operator with a misleading "every flag
+    removed" finding. The guard now fires regardless of exit code once every
+    required token is absent.
+    """
+    spec = _contract.ContractSpec(
+        adapter="redesigned",
+        binary="redesigned",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=("--alpha", "--beta", "--gamma"),
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    monkeypatch.setattr(_contract.shutil, "which", lambda _name: "/fake/bin/redesigned")
+    monkeypatch.setattr(
+        _contract,
+        "_run_capture",
+        _make_run_capture({("redesigned", "--help"): (0, "redesigned 3.13 - see docs for the new surface.\n")}),
+    )
+    result = _contract.check_contract(spec)
+    assert result.passed is False
+    assert result.capability_failures == []
+    assert "runtime failure" in result.runtime_failure
+    assert "no required tokens advertised" in result.runtime_failure
+
+
+def test_check_contract_help_zero_exit_partial_miss_is_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero exit with *some* required tokens present is genuine drift.
+
+    The broken-probe guard must only swallow a wholesale surface loss; a
+    partial miss (at least one required token still advertised) is a real
+    contract regression and must keep reporting per-flag drift.
+    """
+    spec = _contract.ContractSpec(
+        adapter="partial",
+        binary="partial",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=("--alpha", "--beta", "--gamma"),
+        required_subcommands=(),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    monkeypatch.setattr(_contract.shutil, "which", lambda _name: "/fake/bin/partial")
+    monkeypatch.setattr(
+        _contract,
+        "_run_capture",
+        _make_run_capture({("partial", "--help"): (0, "usage: partial [--alpha A] [--beta B]\n")}),
+    )
+    result = _contract.check_contract(spec)
+    assert result.passed is False
+    assert result.runtime_failure == ""
+    assert len(result.capability_failures) == 1
+    assert "--gamma" in result.capability_failures[0]
+
+
 def test_check_contract_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     spec = _contract.ContractSpec(
         adapter="ghost",


### PR DESCRIPTION
## Summary

The nightly adapter conformance canary opened a regression for the `aider` adapter reporting all six required flags (`--model`, `--message`, `--yes-always`, `--auto-commits`, `--map-tokens`, `--no-auto-lint`) missing from `aider --help` on two consecutive runs.

Verified against the current released aider CLI: every one of those flags is still present and `aider --help` exits 0. The adapter and its contract already match the CLI, so the finding was a false positive. The adapter code and the contract YAML are intentionally unchanged.

## Root cause

The canary's probe path, `report.check_adapter_in_process`, runs `--help`, matches the contract's required tokens, and reports any miss as per-flag drift. Its sibling `check_contract` already treats the "every required token missing at once" shape as a broken-probe / runtime failure rather than drift, but that guard was gated on a non-zero exit code and was never present in the canary path at all.

A `--help` that is paginated, wholesale-redesigned, or shadowed by a stray binary on `PATH` can advertise none of the required tokens while still exiting 0. Both paths then misread a broken probe as a six-line "every flag removed" drift finding and page an operator. An installed CLI cannot legitimately drop its entire declared required surface in a single release, so all-tokens-missing is a probe fault, not upstream drift.

## Fix

- Add a shared classifier, `probe_failure_reason`, that flags empty help, or an all-required-tokens-missing help with two or more required tokens, as a probe failure independent of exit code. A single-token contract stays drift, because one missing token cannot be told apart from ordinary drift.
- `check_adapter_in_process` records that case as an inconclusive `skip` (investigate) instead of a `fail`, so the canary no longer opens a misleading regression issue. A partial miss (at least one required token still present) remains a genuine drift `fail`.
- `check_contract` routes the same signature to its `runtime_failure` field regardless of exit code, closing the identical blind spot in the contract-drift path.
- Document the classification in `docs/adapters/conformance-canary.md`.

## Tests

- New regression test reproducing the exact #2488 shape: an aider stub whose `--help` advertises none of the six flags probes as `skip`, not `fail`.
- Coverage for the report path (all-missing -> skip, empty help -> skip, partial miss -> fail, single-token miss stays fail) and the contract path (zero-exit all-missing -> runtime failure, zero-exit partial miss -> drift).
- Existing partial-drift detection is unchanged and still fails as before.

Ran `pytest -k "aider or conformance"` over the unit suite (513 passed, 17 pre-existing env skips) plus the adapter report, contract-check, canary, doctor adapter-check, and advisory suites. `ruff check` and `ruff format --check` are clean.

Closes #2488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adapter conformance checks now mark empty or completely missing `--help` capability output as inconclusive (`skip`) instead of a failure.
  - Partial capability omissions continue to be reported as contract drift (`fail`).
  - Behavior is now consistent regardless of the `--help` process exit code.

- **Documentation**
  - Clarified regression-handling rules for inconclusive adapter probes and partial capability mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->