### PR TITLE
ci(sonar): scope SARIF export to security-relevant findings

### DIFF
--- a/.github/workflows/sonar-code-scanning.yml
+++ b/.github/workflows/sonar-code-scanning.yml
@@ -1,10 +1,15 @@
 name: Sonar findings to code scanning
 
-# Converts open SonarQube findings (issues of every type plus security
-# hotspots) into a SARIF document and uploads it to GitHub code
-# scanning. On a public repo this keeps finding detail in the Security
-# tab, which is visible to maintainers (write access and above) rather
-# than to every reader of the public issue tracker.
+# Converts open SonarQube findings into a SARIF document and uploads it
+# to GitHub code scanning. On a public repo this keeps finding detail in
+# the Security tab, which is visible to maintainers (write access and
+# above) rather than to every reader of the public issue tracker.
+#
+# The export is scoped to security- and reliability-relevant findings
+# (VULNERABILITY, SECURITY_HOTSPOT, BUG) so the Security tab is not
+# diluted by pure-maintainability CODE_SMELL findings, which stay in the
+# SonarQube dashboard. (Pass --sarif-include-code-smells to the emitter
+# to override.)
 #
 # The SARIF conversion reuses the Sonar client in
 # scripts/sweep_sonar_findings.py via its --emit-sarif mode; it never

--- a/docs/operations/sonar-sweeper.md
+++ b/docs/operations/sonar-sweeper.md
@@ -13,7 +13,8 @@ of on the public issue tracker.
 | Workflow | `.github/workflows/sonar-code-scanning.yml` (daily cron + manual dispatch) |
 | Upload | `github/codeql-action/upload-sarif` with `category: sonarqube` |
 | Output | SARIF 2.1.0 uploaded to the Security tab; no files committed |
-| Covers | issues of every type (BUG, VULNERABILITY, CODE_SMELL) and security hotspots |
+| Covers | security- and reliability-relevant findings (VULNERABILITY, SECURITY_HOTSPOT, BUG) by default; pure-maintainability CODE_SMELL findings stay in the SonarQube dashboard |
+| Opt-in | `--sarif-include-code-smells` emits every type, including CODE_SMELL |
 
 ## Env vars
 
@@ -32,17 +33,26 @@ variables and `SONAR_TOKEN` from a repository secret.
 1. The emitter reuses the same Sonar client the sweeper uses: it pages
    `/api/issues/search` for issues of every type and severity and
    `/api/hotspots/search` for security hotspots.
-2. Each finding becomes a SARIF result. The Sonar component key has its
-   project prefix stripped (`bernstein:src/...` -> `src/...`) so the
+2. The finding set is scoped to the Security tab's remit before the
+   document is built: only security- and reliability-relevant types
+   (VULNERABILITY, SECURITY_HOTSPOT, BUG) are kept. Pure-maintainability
+   CODE_SMELL findings are dropped so the Security tab is not diluted;
+   they remain visible in the SonarQube dashboard, which is their home.
+   This matters because code-scanning dismissals persist by fingerprint,
+   and a smell's fingerprint shifts when surrounding code moves, so a
+   dismissed smell would otherwise reappear as a fresh alert. Pass
+   `--sarif-include-code-smells` to export the full set.
+4. Each kept finding becomes a SARIF result. The Sonar component key has
+   its project prefix stripped (`bernstein:src/...` -> `src/...`) so the
    `artifactLocation.uri` is repo-relative and code scanning can anchor
    it to a line.
-3. Each unique rule becomes a SARIF `rules[]` entry with a `helpUri`
+5. Each unique rule becomes a SARIF `rules[]` entry with a `helpUri`
    back to the Sonar rule page. Vulnerabilities and hotspots also carry a
    `security-severity` property (a 0-10 value mapped from the Sonar
    severity or hotspot probability) so GitHub buckets them correctly.
-4. Every result carries `partialFingerprints.sonarFindingKey` (the Sonar
+6. Every result carries `partialFingerprints.sonarFindingKey` (the Sonar
    issue key) so code scanning dedup is stable across runs.
-5. The output is deterministic: rules and results are sorted on stable
+7. The output is deterministic: rules and results are sorted on stable
    keys, so an unchanged finding set produces byte-identical SARIF.
 
 The workflow uploads the SARIF via `github/codeql-action/upload-sarif`
@@ -61,6 +71,12 @@ SONAR_HOST_URL=... SONAR_TOKEN=... \
 uv run python scripts/sweep_sonar_findings.py \
   --emit-sarif sonar.sarif \
   --fixture tests/unit/sweep/fixtures/issues_search.json
+
+# Include pure-maintainability CODE_SMELL findings too (full surface).
+uv run python scripts/sweep_sonar_findings.py \
+  --emit-sarif sonar.sarif \
+  --fixture tests/unit/sweep/fixtures/issues_search.json \
+  --sarif-include-code-smells
 
 # Inspect the result.
 python -c "import json; d=json.load(open('sonar.sarif')); \
@@ -87,7 +103,9 @@ uv run pytest tests/unit/sweep/ -q
 
 The suite covers the SARIF emitter (required 2.1.0 structure, project-key
 prefix stripping, the VULNERABILITY -> error + `security-severity`
-mapping, security-hotspot handling, and byte-for-byte determinism) plus
+mapping, security-hotspot handling, the default security scope that drops
+CODE_SMELL findings while keeping VULNERABILITY/SECURITY_HOTSPOT/BUG, the
+`--sarif-include-code-smells` opt-in, and byte-for-byte determinism) plus
 the local backlog sweep (de-dup, idempotent double-run, severity filter,
 per-day cap, the rule-family blurb guard, exclusive-create emission, and
 the HTTP retry on 5xx/429).

--- a/scripts/sweep_sonar_findings.py
+++ b/scripts/sweep_sonar_findings.py
@@ -30,16 +30,20 @@ SARIF mode
 ----------
 
     python scripts/sweep_sonar_findings.py --emit-sarif sonar.sarif \\
-        [--fixture path/to/issues.json]
+        [--fixture path/to/issues.json] [--sarif-include-code-smells]
 
-``--emit-sarif PATH`` reuses the same Sonar client to fetch *all*
-findings (issues of every type plus security hotspots) and writes them
-as a SARIF 2.1.0 document at ``PATH``. This is the path that feeds
-GitHub code scanning (the Security tab), so vulnerability detail stays
-visible to maintainers rather than public issue readers. In SARIF mode
-the script never writes backlog tickets and never opens GitHub issues.
-Output is deterministic (rules and results are sorted on stable keys)
-so an unchanged finding set produces byte-identical SARIF on re-run.
+``--emit-sarif PATH`` reuses the same Sonar client to fetch findings and
+writes them as a SARIF 2.1.0 document at ``PATH``. This is the path that
+feeds GitHub code scanning (the Security tab), so vulnerability detail
+stays visible to maintainers rather than public issue readers. The
+export is scoped to security- and reliability-relevant findings
+(VULNERABILITY, SECURITY_HOTSPOT, BUG) by default so the Security tab is
+not diluted by pure-maintainability CODE_SMELL findings (those remain in
+the SonarQube dashboard); pass ``--sarif-include-code-smells`` to emit
+the full set. In SARIF mode the script never writes backlog tickets and
+never opens GitHub issues. Output is deterministic (rules and results
+are sorted on stable keys) so an unchanged finding set produces
+byte-identical SARIF on re-run.
 
 Exit codes
 ----------
@@ -1246,6 +1250,40 @@ def maybe_create_gh_issue(
 SARIF_SCHEMA_URI = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
 SARIF_VERSION = "2.1.0"
 
+# Sonar finding types that carry security or reliability signal and so
+# belong in the GitHub Security tab (which code scanning powers):
+# VULNERABILITY and SECURITY_HOTSPOT are security; BUG is reliability.
+# The remaining Sonar type, CODE_SMELL, is pure maintainability -- it
+# stays in the SonarQube dashboard rather than the Security tab. The
+# SARIF export is scoped to this set by default; ``--sarif-include-code-
+# smells`` (``filter_sarif_findings(..., include_code_smells=True)``)
+# widens it to everything when an operator wants the full surface. The
+# whitelist is deliberate: an unrecognised type is dropped rather than
+# leaked into the Security tab.
+SARIF_CODE_SCANNING_TYPES: frozenset[str] = frozenset({"VULNERABILITY", "SECURITY_HOTSPOT", "BUG"})
+
+
+def filter_sarif_findings(
+    findings: Iterable[Finding],
+    *,
+    include_code_smells: bool = False,
+) -> list[Finding]:
+    """Scope findings to the security- and reliability-relevant set.
+
+    Code scanning powers the GitHub Security tab, so by default only
+    findings whose type is in :data:`SARIF_CODE_SCANNING_TYPES`
+    (VULNERABILITY, SECURITY_HOTSPOT, BUG) are exported. Pure-
+    maintainability CODE_SMELL findings are dropped here; they remain
+    visible in the SonarQube dashboard, which is their proper home.
+    Pass ``include_code_smells=True`` to keep the full finding set.
+
+    Order is preserved so the downstream SARIF sort stays deterministic.
+    """
+    if include_code_smells:
+        return list(findings)
+    return [f for f in findings if f.type in SARIF_CODE_SCANNING_TYPES]
+
+
 # GitHub reads ``security-severity`` (a 0-10 string) to bucket a finding
 # into critical/high/medium/low in the Security tab. Map Sonar's issue
 # severities and hotspot probability bands onto that scale.
@@ -1440,13 +1478,25 @@ def run_emit_sarif(args: argparse.Namespace) -> int:
             return 1
         host = config.host
 
+    # Scope the upload to security-/reliability-relevant findings before
+    # building the document. This is an export-policy decision kept out of
+    # the pure builder (``build_sarif``), so the builder stays a faithful
+    # projection of whatever findings it is handed.
+    total_findings = len(findings)
+    include_smells = getattr(args, "sarif_include_code_smells", False)
+    findings = filter_sarif_findings(findings, include_code_smells=include_smells)
+    dropped = total_findings - len(findings)
+
     sarif = build_sarif(findings, host=host)
     if out_path.parent and not out_path.parent.exists():
         out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(sarif, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     n_rules = len(sarif["runs"][0]["tool"]["driver"]["rules"])
     n_results = len(sarif["runs"][0]["results"])
-    print(f"sonar-sarif: findings={len(findings)} rules={n_rules} results={n_results} out={out_path}")
+    print(
+        f"sonar-sarif: findings={len(findings)} (dropped {dropped} maintainability) "
+        f"rules={n_rules} results={n_results} out={out_path}"
+    )
     return 0
 
 
@@ -1638,9 +1688,21 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=None,
         metavar="PATH",
         help=(
-            "Write all findings (issues of every type plus security "
-            "hotspots) as a SARIF 2.1.0 document at PATH instead of "
-            "emitting backlog tickets. Feeds GitHub code scanning."
+            "Write findings as a SARIF 2.1.0 document at PATH instead of "
+            "emitting backlog tickets. Feeds GitHub code scanning. By "
+            "default the export is scoped to security- and reliability-"
+            "relevant findings (VULNERABILITY, SECURITY_HOTSPOT, BUG); see "
+            "--sarif-include-code-smells."
+        ),
+    )
+    p.add_argument(
+        "--sarif-include-code-smells",
+        action="store_true",
+        help=(
+            "In --emit-sarif mode, keep pure-maintainability CODE_SMELL "
+            "findings in the SARIF export. Off by default so the GitHub "
+            "Security tab is not polluted by maintainability smells; those "
+            "stay visible in the SonarQube dashboard."
         ),
     )
     return p.parse_args(argv)

--- a/tests/unit/sweep/test_sonar_sarif.py
+++ b/tests/unit/sweep/test_sonar_sarif.py
@@ -3,7 +3,9 @@
 Covers the ``--emit-sarif`` path that feeds GitHub code scanning:
 required SARIF 2.1.0 structure, project-key prefix stripping, the
 VULNERABILITY -> error + security-severity mapping, security-hotspot
-handling, and byte-for-byte determinism on re-run.
+handling, byte-for-byte determinism on re-run, and the security-scope
+filter that keeps pure-maintainability CODE_SMELL findings out of the
+Security tab.
 """
 
 from __future__ import annotations
@@ -12,11 +14,14 @@ import json
 from pathlib import Path
 
 from sweep_sonar_findings import (  # type: ignore[import-not-found]
-    _load_sarif_fixture as load_sarif_fixture,
+    SARIF_CODE_SCANNING_TYPES,
+    Finding,
+    build_sarif,
+    filter_sarif_findings,
+    main,
 )
 from sweep_sonar_findings import (  # type: ignore[import-not-found]
-    build_sarif,
-    main,
+    _load_sarif_fixture as load_sarif_fixture,
 )
 
 _FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
@@ -200,8 +205,11 @@ def test_emit_sarif_cli_writes_valid_file(tmp_path: Path, capsys) -> None:  # ty
     doc = json.loads(out.read_text(encoding="utf-8"))
     assert doc["version"] == "2.1.0"
     captured = capsys.readouterr()
-    assert "rules=6" in captured.out
-    assert "results=6" in captured.out
+    # The canonical fixture has 6 findings, but 4 are pure-maintainability
+    # CODE_SMELL findings that the default security scope drops, leaving
+    # the VULNERABILITY and BUG (2 rules, 2 results).
+    assert "rules=2" in captured.out
+    assert "results=2" in captured.out
 
 
 def test_emit_sarif_writes_no_backlog_tickets(tmp_path: Path) -> None:
@@ -210,3 +218,114 @@ def test_emit_sarif_writes_no_backlog_tickets(tmp_path: Path) -> None:
     assert rc == 0
     # SARIF mode must not emit any Markdown backlog ticket anywhere.
     assert list(tmp_path.rglob("*.md")) == []
+
+
+# ---------------------------------------------------------------------------
+# Security-scope filter (keep the Security tab focused on security)
+# ---------------------------------------------------------------------------
+
+
+def _finding(key: str, ftype: str, *, rule: str | None = None) -> Finding:
+    """Build a minimal Finding of a given Sonar type for filter tests."""
+    return Finding(
+        key=key,
+        rule=rule or f"python:{key}",
+        severity="MAJOR",
+        type=ftype,
+        component="bernstein:src/bernstein/core/x.py",
+        line=10,
+        creation_date="2026-06-01T00:00:00+0000",
+    )
+
+
+def test_code_scanning_types_constant() -> None:
+    # The exported set is exactly the security- and reliability-relevant
+    # Sonar types. CODE_SMELL (pure maintainability) is deliberately out.
+    assert frozenset({"VULNERABILITY", "SECURITY_HOTSPOT", "BUG"}) == SARIF_CODE_SCANNING_TYPES
+    assert "CODE_SMELL" not in SARIF_CODE_SCANNING_TYPES
+
+
+def test_filter_excludes_code_smells_by_default() -> None:
+    findings = [
+        _finding("V1", "VULNERABILITY"),
+        _finding("H1", "SECURITY_HOTSPOT"),
+        _finding("B1", "BUG"),
+        _finding("C1", "CODE_SMELL"),
+        _finding("C2", "CODE_SMELL"),
+    ]
+    kept = filter_sarif_findings(findings)
+    kept_types = {f.type for f in kept}
+    assert "CODE_SMELL" not in kept_types
+    assert kept_types == {"VULNERABILITY", "SECURITY_HOTSPOT", "BUG"}
+    assert {f.key for f in kept} == {"V1", "H1", "B1"}
+
+
+def test_filter_include_code_smells_keeps_everything() -> None:
+    findings = [
+        _finding("V1", "VULNERABILITY"),
+        _finding("C1", "CODE_SMELL"),
+        _finding("C2", "CODE_SMELL"),
+    ]
+    kept = filter_sarif_findings(findings, include_code_smells=True)
+    # Order preserved, nothing dropped when the operator opts into everything.
+    assert [f.key for f in kept] == ["V1", "C1", "C2"]
+
+
+def test_filter_drops_unknown_types_by_default() -> None:
+    # The whitelist is conservative: any non-security type (including a
+    # hypothetical future Sonar type) is dropped unless smells are opted in.
+    findings = [_finding("V1", "VULNERABILITY"), _finding("X1", "SOME_NEW_TYPE")]
+    assert [f.key for f in filter_sarif_findings(findings)] == ["V1"]
+
+
+def test_emit_sarif_drops_code_smell_rules_by_default(tmp_path: Path) -> None:
+    out = tmp_path / "sonar.sarif"
+    rc = main(argv=["--emit-sarif", str(out), "--fixture", str(_ISSUES_FIXTURE)])
+    assert rc == 0
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+    # The fixture's four CODE_SMELL rules must not reach code scanning.
+    for smell_rule in ("python:S3776", "python:S1192", "python:S1481", "python:S125"):
+        assert smell_rule not in rule_ids
+    # The VULNERABILITY and BUG rules must remain.
+    assert "python:S2068" in rule_ids  # VULNERABILITY
+    assert "python:S2589" in rule_ids  # BUG
+    fingerprints = {res["partialFingerprints"]["sonarFindingKey"] for res in doc["runs"][0]["results"]}
+    assert fingerprints == {"FINDING-BLOCKER-001", "FINDING-BUG-001"}
+
+
+def test_emit_sarif_keeps_hotspots_and_vulnerabilities(tmp_path: Path) -> None:
+    out = tmp_path / "sonar.sarif"
+    rc = main(argv=["--emit-sarif", str(out), "--fixture", str(_HOTSPOTS_FIXTURE)])
+    assert rc == 0
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    fingerprints = {res["partialFingerprints"]["sonarFindingKey"] for res in doc["runs"][0]["results"]}
+    # One VULNERABILITY + two SECURITY_HOTSPOT findings, all retained.
+    assert fingerprints == {"ISSUE-VULN-001", "HOTSPOT-HIGH-001", "HOTSPOT-LOW-001"}
+
+
+def test_emit_sarif_include_code_smells_flag_keeps_all(tmp_path: Path) -> None:
+    out = tmp_path / "sonar.sarif"
+    rc = main(
+        argv=[
+            "--emit-sarif",
+            str(out),
+            "--fixture",
+            str(_ISSUES_FIXTURE),
+            "--sarif-include-code-smells",
+        ]
+    )
+    assert rc == 0
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    assert len(doc["runs"][0]["results"]) == 6
+    rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+    assert "python:S3776" in rule_ids  # a CODE_SMELL rule is retained on opt-in
+
+
+def test_emit_sarif_include_code_smells_is_deterministic(tmp_path: Path) -> None:
+    out1 = tmp_path / "a.sarif"
+    out2 = tmp_path / "b.sarif"
+    common = ["--fixture", str(_ISSUES_FIXTURE), "--sarif-include-code-smells"]
+    assert main(argv=["--emit-sarif", str(out1), *common]) == 0
+    assert main(argv=["--emit-sarif", str(out2), *common]) == 0
+    assert out1.read_bytes() == out2.read_bytes()


### PR DESCRIPTION
## What

Scope the Sonar-to-code-scanning SARIF export (`scripts/sweep_sonar_findings.py --emit-sarif`) to security- and reliability-relevant findings, so pure-maintainability `CODE_SMELL` findings no longer land in the GitHub Security tab.

## Why

The `--emit-sarif` path uploaded **every** Sonar finding type into GitHub code scanning, including `CODE_SMELL` (unused params, duplicated literals, style, cognitive complexity). The Security tab is scoped to security and reliability, so these smells diluted it.

They also cannot be permanently dismissed there: code-scanning dismissals persist by **fingerprint**, and a smell's fingerprint shifts when surrounding code moves, so a dismissed smell reappears as a fresh alert. Left alone, the Security tab re-accumulates maintainability smells over time.

## Change

| | |
|---|---|
| Default export | `VULNERABILITY`, `SECURITY_HOTSPOT`, `BUG` (via `SARIF_CODE_SCANNING_TYPES` whitelist) |
| Dropped by default | `CODE_SMELL` (stays in the SonarQube dashboard at sonar.bernstein.run) |
| Opt-out | `--sarif-include-code-smells` emits the full set |
| Whitelist behaviour | conservative: an unrecognised type is dropped rather than leaked into the Security tab |

- New `filter_sarif_findings(findings, *, include_code_smells=False)` step in the emit path. `build_sarif` stays a pure projection of whatever findings it is handed; the scoping is an export-policy decision kept separate from it.
- The daily `sonar-code-scanning.yml` workflow calls `--emit-sarif` with no extra flag, so the scoped default applies automatically.

## Tests

Added to `tests/unit/sweep/test_sonar_sarif.py`:
- `CODE_SMELL` excluded by default while `VULNERABILITY`/`SECURITY_HOTSPOT`/`BUG` are kept (unit-level and end-to-end via the CLI/fixtures).
- `--sarif-include-code-smells` restores the full set.
- Unknown types dropped by default; determinism preserved on the opt-in path.
- Updated the one existing CLI count assertion (fixture: 6 findings -> 2 after the default scope).

```
uv run pytest tests/unit/sweep/ -q   # 55 passed
uv run ruff check / ruff format       # clean
```

## Docs

- `docs/operations/sonar-sweeper.md`: updated coverage table, the "How it works" scoping step, a local-invocation example, and the test-coverage note.
- `.github/workflows/sonar-code-scanning.yml`: updated the header comment.