### PR TITLE
observability: fix backend collection and act on metric regressions

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -207,31 +207,32 @@ alwaysApply: false
 
 ### `src/bernstein/evolution/` - self-evolution engine
 
-| File                   | Purpose |
-|------------------------|---------|
-| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`        | Change applicator - execute upgrades via file modification |
-| `benchmark.py`         | Tiered benchmark runner for evolution validation |
-| `circuit.py`           | CircuitBreaker - halt evolution when safety conditions are violated |
-| `creative.py`          | Creative evolution pipeline - visionary → analyst → production gate |
-| `cycle_helpers.py`     | Evolution cycle helper logic - community, creative, and GitHub sync |
-| `cycle_runner.py`      | Evolution cycle execution engine |
-| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`          | Opportunity detection from aggregated metrics |
-| `gate.py`              | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
-| `governance.py`        | Adaptive governance for the evolution system |
-| `invariants.py`        | InvariantsGuard - hash-lock safety-critical files |
-| `loop.py`              | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
-| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
-| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
-| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
-| `proposals.py`         | Upgrade proposal generation |
-| `report.py`            | Evolution observability - history table and static report generation |
-| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`           | SandboxValidator - isolated testing of evolution proposals |
-| `types.py`             | Shared types for the evolution system |
+| File                       | Purpose |
+|----------------------------|---------|
+| `_shared.py`               | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`            | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`            | Change applicator - execute upgrades via file modification |
+| `benchmark.py`             | Tiered benchmark runner for evolution validation |
+| `circuit.py`               | CircuitBreaker - halt evolution when safety conditions are violated |
+| `creative.py`              | Creative evolution pipeline - visionary → analyst → production gate |
+| `cycle_helpers.py`         | Evolution cycle helper logic - community, creative, and GitHub sync |
+| `cycle_runner.py`          | Evolution cycle execution engine |
+| `data_collector.py`        | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`              | Opportunity detection from aggregated metrics |
+| `gate.py`                  | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
+| `governance.py`            | Adaptive governance for the evolution system |
+| `invariants.py`            | InvariantsGuard - hash-lock safety-critical files |
+| `loop.py`                  | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
+| `observability_signals.py` | Read ``bernstein doctor observe`` snapshots into evolution signals |
+| `oscillation_guard.py`     | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`       | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`       | Proposal risk scoring and routing classification |
+| `proposals.py`             | Upgrade proposal generation |
+| `report.py`                | Evolution observability - history table and static report generation |
+| `report_generator.py`      | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`                  | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`               | SandboxValidator - isolated testing of evolution proposals |
+| `types.py`                 | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` - evaluation harness
 

--- a/.github/workflows/docs-observability-snapshot.yml
+++ b/.github/workflows/docs-observability-snapshot.yml
@@ -52,11 +52,11 @@ jobs:
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
-          BERNSTEIN_GLITCHTIP_TOKEN: ${{ secrets.BERNSTEIN_GLITCHTIP_TOKEN }}
+          BERNSTEIN_GLITCHTIP_TOKEN: ${{ secrets.GLITCHTIP_API_TOKEN }}
           BERNSTEIN_GLITCHTIP_BASE_URL: ${{ vars.BERNSTEIN_GLITCHTIP_BASE_URL }}
           BERNSTEIN_GLITCHTIP_ORG: ${{ vars.BERNSTEIN_GLITCHTIP_ORG }}
-          DTRACK_URL: ${{ vars.DTRACK_URL }}
-          DTRACK_TOKEN: ${{ secrets.DTRACK_TOKEN }}
+          DTRACK_URL: ${{ secrets.DT_API_URL }}
+          DTRACK_TOKEN: ${{ secrets.DT_API_KEY }}
           DTRACK_PROJECT: ${{ vars.DTRACK_PROJECT }}
         run: |
           set -euo pipefail
@@ -72,6 +72,49 @@ jobs:
             --snapshots-dir docs/observability/snapshots \
             --out docs/observability/trends.md \
             --days 30
+
+      - name: Detect metric regressions and alert
+        # Non-blocking: the snapshot PR still opens on a regression. The gate
+        # diffs today's snapshot against yesterday's and pages Telegram only
+        # on a fail-severity regression (new critical/high vuln, a metric that
+        # crossed its fail threshold). Warn-level drift (coverage slip, a
+        # backend that lost its credentials) is recorded in the run summary.
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          set -uo pipefail
+          mkdir -p .ci/observability
+          uv run python scripts/observability/gate.py \
+            --snapshots docs/observability/snapshots \
+            --out .ci/observability/regressions.json \
+            --summary-out "${GITHUB_STEP_SUMMARY:-/dev/null}" || true
+
+          if [ ! -s .ci/observability/regressions.json ]; then
+            echo "No regressions recorded."
+            exit 0
+          fi
+          FAILS=$(jq '[.[] | select(.severity == "fail")] | length' .ci/observability/regressions.json)
+          if [ "${FAILS:-0}" -eq 0 ]; then
+            echo "No fail-severity regression; not paging."
+            exit 0
+          fi
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram not configured; skipping push."
+            exit 0
+          fi
+          DETAIL=$(jq -r '[.[] | select(.severity == "fail") | "\(.backend) \(.metric): \(.reason)"] | join("\n")' \
+            .ci/observability/regressions.json)
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}"
+          TEXT="observability regression (${FAILS} fail-severity)
+          ${DETAIL}
+          ${RUN_URL}"
+          BODY=$(jq -n --arg chat "${TELEGRAM_CHAT_ID}" --arg text "${TEXT}" '{chat_id: $chat, text: $text}')
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H "Content-Type: application/json" \
+            -d "${BODY}" \
+            || echo "Telegram notification failed"
 
       - name: Open PR with snapshot + trends
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1

--- a/.goosehints
+++ b/.goosehints
@@ -208,31 +208,32 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` - self-evolution engine
 
-| File                   | Purpose |
-|------------------------|---------|
-| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`        | Change applicator - execute upgrades via file modification |
-| `benchmark.py`         | Tiered benchmark runner for evolution validation |
-| `circuit.py`           | CircuitBreaker - halt evolution when safety conditions are violated |
-| `creative.py`          | Creative evolution pipeline - visionary → analyst → production gate |
-| `cycle_helpers.py`     | Evolution cycle helper logic - community, creative, and GitHub sync |
-| `cycle_runner.py`      | Evolution cycle execution engine |
-| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`          | Opportunity detection from aggregated metrics |
-| `gate.py`              | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
-| `governance.py`        | Adaptive governance for the evolution system |
-| `invariants.py`        | InvariantsGuard - hash-lock safety-critical files |
-| `loop.py`              | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
-| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
-| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
-| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
-| `proposals.py`         | Upgrade proposal generation |
-| `report.py`            | Evolution observability - history table and static report generation |
-| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`           | SandboxValidator - isolated testing of evolution proposals |
-| `types.py`             | Shared types for the evolution system |
+| File                       | Purpose |
+|----------------------------|---------|
+| `_shared.py`               | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`            | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`            | Change applicator - execute upgrades via file modification |
+| `benchmark.py`             | Tiered benchmark runner for evolution validation |
+| `circuit.py`               | CircuitBreaker - halt evolution when safety conditions are violated |
+| `creative.py`              | Creative evolution pipeline - visionary → analyst → production gate |
+| `cycle_helpers.py`         | Evolution cycle helper logic - community, creative, and GitHub sync |
+| `cycle_runner.py`          | Evolution cycle execution engine |
+| `data_collector.py`        | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`              | Opportunity detection from aggregated metrics |
+| `gate.py`                  | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
+| `governance.py`            | Adaptive governance for the evolution system |
+| `invariants.py`            | InvariantsGuard - hash-lock safety-critical files |
+| `loop.py`                  | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
+| `observability_signals.py` | Read ``bernstein doctor observe`` snapshots into evolution signals |
+| `oscillation_guard.py`     | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`       | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`       | Proposal risk scoring and routing classification |
+| `proposals.py`             | Upgrade proposal generation |
+| `report.py`                | Evolution observability - history table and static report generation |
+| `report_generator.py`      | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`                  | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`               | SandboxValidator - isolated testing of evolution proposals |
+| `types.py`                 | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` - evaluation harness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,31 +208,32 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` - self-evolution engine
 
-| File                   | Purpose |
-|------------------------|---------|
-| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`        | Change applicator - execute upgrades via file modification |
-| `benchmark.py`         | Tiered benchmark runner for evolution validation |
-| `circuit.py`           | CircuitBreaker - halt evolution when safety conditions are violated |
-| `creative.py`          | Creative evolution pipeline - visionary → analyst → production gate |
-| `cycle_helpers.py`     | Evolution cycle helper logic - community, creative, and GitHub sync |
-| `cycle_runner.py`      | Evolution cycle execution engine |
-| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`          | Opportunity detection from aggregated metrics |
-| `gate.py`              | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
-| `governance.py`        | Adaptive governance for the evolution system |
-| `invariants.py`        | InvariantsGuard - hash-lock safety-critical files |
-| `loop.py`              | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
-| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
-| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
-| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
-| `proposals.py`         | Upgrade proposal generation |
-| `report.py`            | Evolution observability - history table and static report generation |
-| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`           | SandboxValidator - isolated testing of evolution proposals |
-| `types.py`             | Shared types for the evolution system |
+| File                       | Purpose |
+|----------------------------|---------|
+| `_shared.py`               | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`            | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`            | Change applicator - execute upgrades via file modification |
+| `benchmark.py`             | Tiered benchmark runner for evolution validation |
+| `circuit.py`               | CircuitBreaker - halt evolution when safety conditions are violated |
+| `creative.py`              | Creative evolution pipeline - visionary → analyst → production gate |
+| `cycle_helpers.py`         | Evolution cycle helper logic - community, creative, and GitHub sync |
+| `cycle_runner.py`          | Evolution cycle execution engine |
+| `data_collector.py`        | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`              | Opportunity detection from aggregated metrics |
+| `gate.py`                  | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
+| `governance.py`            | Adaptive governance for the evolution system |
+| `invariants.py`            | InvariantsGuard - hash-lock safety-critical files |
+| `loop.py`                  | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
+| `observability_signals.py` | Read ``bernstein doctor observe`` snapshots into evolution signals |
+| `oscillation_guard.py`     | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`       | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`       | Proposal risk scoring and routing classification |
+| `proposals.py`             | Upgrade proposal generation |
+| `report.py`                | Evolution observability - history table and static report generation |
+| `report_generator.py`      | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`                  | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`               | SandboxValidator - isolated testing of evolution proposals |
+| `types.py`                 | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` - evaluation harness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,31 +208,32 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` - self-evolution engine
 
-| File                   | Purpose |
-|------------------------|---------|
-| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`        | Change applicator - execute upgrades via file modification |
-| `benchmark.py`         | Tiered benchmark runner for evolution validation |
-| `circuit.py`           | CircuitBreaker - halt evolution when safety conditions are violated |
-| `creative.py`          | Creative evolution pipeline - visionary → analyst → production gate |
-| `cycle_helpers.py`     | Evolution cycle helper logic - community, creative, and GitHub sync |
-| `cycle_runner.py`      | Evolution cycle execution engine |
-| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`          | Opportunity detection from aggregated metrics |
-| `gate.py`              | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
-| `governance.py`        | Adaptive governance for the evolution system |
-| `invariants.py`        | InvariantsGuard - hash-lock safety-critical files |
-| `loop.py`              | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
-| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
-| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
-| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
-| `proposals.py`         | Upgrade proposal generation |
-| `report.py`            | Evolution observability - history table and static report generation |
-| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`           | SandboxValidator - isolated testing of evolution proposals |
-| `types.py`             | Shared types for the evolution system |
+| File                       | Purpose |
+|----------------------------|---------|
+| `_shared.py`               | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`            | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`            | Change applicator - execute upgrades via file modification |
+| `benchmark.py`             | Tiered benchmark runner for evolution validation |
+| `circuit.py`               | CircuitBreaker - halt evolution when safety conditions are violated |
+| `creative.py`              | Creative evolution pipeline - visionary → analyst → production gate |
+| `cycle_helpers.py`         | Evolution cycle helper logic - community, creative, and GitHub sync |
+| `cycle_runner.py`          | Evolution cycle execution engine |
+| `data_collector.py`        | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`              | Opportunity detection from aggregated metrics |
+| `gate.py`                  | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
+| `governance.py`            | Adaptive governance for the evolution system |
+| `invariants.py`            | InvariantsGuard - hash-lock safety-critical files |
+| `loop.py`                  | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
+| `observability_signals.py` | Read ``bernstein doctor observe`` snapshots into evolution signals |
+| `oscillation_guard.py`     | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`       | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`       | Proposal risk scoring and routing classification |
+| `proposals.py`             | Upgrade proposal generation |
+| `report.py`                | Evolution observability - history table and static report generation |
+| `report_generator.py`      | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`                  | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`               | SandboxValidator - isolated testing of evolution proposals |
+| `types.py`                 | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` - evaluation harness
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -208,31 +208,32 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` - self-evolution engine
 
-| File                   | Purpose |
-|------------------------|---------|
-| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`        | Change applicator - execute upgrades via file modification |
-| `benchmark.py`         | Tiered benchmark runner for evolution validation |
-| `circuit.py`           | CircuitBreaker - halt evolution when safety conditions are violated |
-| `creative.py`          | Creative evolution pipeline - visionary → analyst → production gate |
-| `cycle_helpers.py`     | Evolution cycle helper logic - community, creative, and GitHub sync |
-| `cycle_runner.py`      | Evolution cycle execution engine |
-| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`          | Opportunity detection from aggregated metrics |
-| `gate.py`              | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
-| `governance.py`        | Adaptive governance for the evolution system |
-| `invariants.py`        | InvariantsGuard - hash-lock safety-critical files |
-| `loop.py`              | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
-| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
-| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
-| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
-| `proposals.py`         | Upgrade proposal generation |
-| `report.py`            | Evolution observability - history table and static report generation |
-| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`           | SandboxValidator - isolated testing of evolution proposals |
-| `types.py`             | Shared types for the evolution system |
+| File                       | Purpose |
+|----------------------------|---------|
+| `_shared.py`               | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`            | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`            | Change applicator - execute upgrades via file modification |
+| `benchmark.py`             | Tiered benchmark runner for evolution validation |
+| `circuit.py`               | CircuitBreaker - halt evolution when safety conditions are violated |
+| `creative.py`              | Creative evolution pipeline - visionary → analyst → production gate |
+| `cycle_helpers.py`         | Evolution cycle helper logic - community, creative, and GitHub sync |
+| `cycle_runner.py`          | Evolution cycle execution engine |
+| `data_collector.py`        | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`              | Opportunity detection from aggregated metrics |
+| `gate.py`                  | ApprovalGate and EvalGate - risk-stratified routing for evolution proposals |
+| `governance.py`            | Adaptive governance for the evolution system |
+| `invariants.py`            | InvariantsGuard - hash-lock safety-critical files |
+| `loop.py`                  | Autoresearch evolution loop - continuous self-improvement via experiment cycles |
+| `observability_signals.py` | Read ``bernstein doctor observe`` snapshots into evolution signals |
+| `oscillation_guard.py`     | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`       | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`       | Proposal risk scoring and routing classification |
+| `proposals.py`             | Upgrade proposal generation |
+| `report.py`                | Evolution observability - history table and static report generation |
+| `report_generator.py`      | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`                  | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`               | SandboxValidator - isolated testing of evolution proposals |
+| `types.py`                 | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` - evaluation harness
 

--- a/docs/observability/unified-doctor.md
+++ b/docs/observability/unified-doctor.md
@@ -91,7 +91,16 @@ Two workflows ship alongside the command:
   06:00 UTC that writes today's snapshot to
   `docs/observability/snapshots/<YYYY-MM-DD>.json` and re-renders
   `docs/observability/trends.md` with the last 30 days as unicode
-  sparklines.
+  sparklines. After the render it runs `scripts/observability/gate.py`,
+  which diffs today's snapshot against yesterday's and reports
+  regressions by reading each row's `threshold_status` and computing the
+  numeric delta from the two files. It flags a status flip for the worse
+  (`ok -> warn`, `* -> fail`), a coverage drop past a small tolerance, a
+  new or increased security finding, and a backend that lost its
+  credentials. On a fail-severity regression the step pushes a Telegram
+  message (`TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID`); it is non-blocking,
+  so the snapshot pull request still opens and warn-level drift is
+  recorded in the run summary.
 
 ## Local watch mode
 

--- a/scripts/observability/gate.py
+++ b/scripts/observability/gate.py
@@ -1,0 +1,324 @@
+"""Day-over-day regression gate for ``bernstein doctor observe`` snapshots.
+
+The daily workflow ``docs-observability-snapshot.yml`` appends one JSON
+snapshot per day under ``docs/observability/snapshots/<YYYY-MM-DD>.json``.
+Every metric row in a snapshot already carries a ``threshold_status``
+(``ok|warn|fail``) computed at probe time. Until now that verdict was
+written and never read. This gate diffs the two most recent snapshots and
+turns the verdict into an actionable signal:
+
+* a ``threshold_status`` flip for the worse (``ok -> warn`` / ``* -> fail``),
+* a numeric worsening of a security metric (new or increased vulns/alerts),
+* a coverage drop beyond a small tolerance (early warning, before it fails),
+* a backend that silently lost its credentials (``ok -> skipped/error``).
+
+The numeric delta is computed here from the two snapshot files rather than
+read from the row's own ``delta`` field: the daily job runs ``--no-persist``
+so that field is inert (``"new"``/``"-"``).
+
+Like its sibling ``render_trends.py`` the module is dependency-free (Python
+standard library only) so it runs in CI and locally without any Bernstein
+import::
+
+    python scripts/observability/gate.py \\
+        --snapshots docs/observability/snapshots \\
+        --out .ci/observability/regressions.json
+
+Exit code is ``1`` when at least one ``fail``-severity regression is found,
+``0`` otherwise (including when fewer than two snapshots exist).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+#: Coverage is the only metric where a higher value is better. A drop of at
+#: least this many points trips an early-warning regression even while the
+#: metric is still inside its ``ok`` band.
+COVERAGE_FLOOR = -1.0
+
+#: Metrics where a higher number is better. Everything else is "lower better".
+_UP_METRICS: frozenset[str] = frozenset({"coverage_pct"})
+
+#: ``(backend, metric)`` security signals whose increase is release-blocking.
+_FAIL_ON_INCREASE: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("dt", "critical_vulns"),
+        ("dt", "high_vulns"),
+        ("code-scanning", "critical_alerts"),
+        ("code-scanning", "high_alerts"),
+    }
+)
+
+#: ``(backend, metric)`` security signals whose increase is worth a warning.
+_WARN_ON_INCREASE: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("sonar", "vulnerabilities"),
+        ("sonar", "security_hotspots"),
+        ("dt", "medium_vulns"),
+        ("code-scanning", "open_alerts"),
+    }
+)
+
+#: Backend-level statuses that mean the probe produced real data.
+_ACTIVE_STATUSES: frozenset[str] = frozenset({"ok", "warn", "fail"})
+
+_SENTINEL_METRIC = "__backend__"
+
+
+@dataclass(frozen=True)
+class Regression:
+    """A single detected day-over-day regression."""
+
+    backend: str
+    metric: str
+    prev: float | None
+    curr: float | None
+    delta: float | None
+    status: str
+    severity: str  # "fail" | "warn"
+    reason: str
+
+
+def _num(metric: dict[str, Any] | None) -> float | None:
+    """Return the numeric value of a metric row, or ``None``."""
+
+    if not metric:
+        return None
+    value = metric.get("numeric")
+    if isinstance(value, bool):  # bool is an int subclass; never a metric value
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _fmt_delta(delta: float) -> str:
+    """Format a numeric delta compactly (``+3`` / ``-1.4``)."""
+
+    if abs(delta - round(delta)) < 1e-9:
+        return f"{delta:+.0f}"
+    return f"{delta:+.1f}"
+
+
+def _classify_metric(
+    backend: str,
+    metric: str,
+    prev: dict[str, Any] | None,
+    curr: dict[str, Any],
+) -> Regression | None:
+    """Return a :class:`Regression` for one metric, or ``None`` if clean."""
+
+    c_status = str(curr.get("threshold_status") or "")
+    p_status = str(prev.get("threshold_status") or "") if prev else None
+    c_num = _num(curr)
+    p_num = _num(prev)
+    delta = c_num - p_num if (c_num is not None and p_num is not None) else None
+
+    worse = False
+    if delta is not None:
+        worse = delta < 0 if metric in _UP_METRICS else delta > 0
+
+    key = (backend, metric)
+    candidates: list[tuple[str, str]] = []
+
+    # A metric that crosses its own fail threshold is always a fail regression.
+    if c_status == "fail" and p_status != "fail":
+        candidates.append(("fail", f"{p_status or 'new'}->fail"))
+    # Critical / high security signals that increase are release-blocking.
+    if key in _FAIL_ON_INCREASE and worse and delta is not None:
+        candidates.append(("fail", f"{metric} {_fmt_delta(delta)}"))
+    # A metric that slips from ok into warn is a warning regression.
+    if c_status == "warn" and p_status == "ok":
+        candidates.append(("warn", "ok->warn"))
+    # New or increased lower-severity security signals warn.
+    if key in _WARN_ON_INCREASE and worse and delta is not None:
+        candidates.append(("warn", f"{metric} {_fmt_delta(delta)}"))
+    # Coverage drop past the floor warns even while still inside the ok band.
+    if metric == "coverage_pct" and delta is not None and delta <= COVERAGE_FLOOR:
+        candidates.append(("warn", f"coverage {delta:+.1f}pt"))
+
+    if not candidates:
+        return None
+
+    severity = "fail" if any(sev == "fail" for sev, _ in candidates) else "warn"
+    reason = next(reason for sev, reason in candidates if sev == severity)
+    return Regression(
+        backend=backend,
+        metric=metric,
+        prev=p_num,
+        curr=c_num,
+        delta=delta,
+        status=c_status,
+        severity=severity,
+        reason=reason,
+    )
+
+
+def _backends(payload: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    """Index a snapshot's backends by name."""
+
+    if not payload:
+        return {}
+    return {b.get("backend", "?"): b for b in payload.get("backends") or []}
+
+
+def detect_regressions(
+    prev: dict[str, Any] | None,
+    curr: dict[str, Any] | None,
+) -> list[Regression]:
+    """Diff two snapshots and return the list of regressions.
+
+    ``prev`` may be ``None`` (first ever snapshot); in that case only
+    unambiguous ``fail``-status metrics are flagged and no lost-creds
+    check runs. The function never raises on malformed input.
+    """
+
+    if not curr:
+        return []
+
+    regressions: list[Regression] = []
+    curr_backends = _backends(curr)
+    prev_backends = _backends(prev)
+
+    # Metric-level regressions.
+    for name, cb in curr_backends.items():
+        pb = prev_backends.get(name)
+        prev_metrics = {m.get("name"): m for m in (pb.get("metrics") if pb else []) or []}
+        for cm in cb.get("metrics") or []:
+            metric = cm.get("name")
+            if not metric:
+                continue
+            reg = _classify_metric(name, metric, prev_metrics.get(metric), cm)
+            if reg is not None:
+                regressions.append(reg)
+
+    # Backend-level lost-credentials regressions: a backend that produced
+    # real data yesterday and is skipped / errored / gone today.
+    for name, pb in prev_backends.items():
+        if pb.get("status") not in _ACTIVE_STATUSES or not (pb.get("metrics") or []):
+            continue
+        cb = curr_backends.get(name)
+        curr_status = cb.get("status") if cb else "absent"
+        if curr_status not in _ACTIVE_STATUSES:
+            regressions.append(
+                Regression(
+                    backend=name,
+                    metric=_SENTINEL_METRIC,
+                    prev=None,
+                    curr=None,
+                    delta=None,
+                    status=str(curr_status),
+                    severity="warn",
+                    reason=f"backend lost creds ({pb.get('status')}->{curr_status})",
+                )
+            )
+
+    return regressions
+
+
+def _load(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def load_two_latest(
+    snapshots_dir: Path,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Return ``(prev, curr)`` for the two most recent dated snapshots.
+
+    Files are ordered by their ISO-date stem. When fewer than two valid
+    snapshots exist, the missing slot(s) are ``None``.
+    """
+
+    if not snapshots_dir.exists():
+        return (None, None)
+    dated: list[tuple[dt.date, Path]] = []
+    for path in snapshots_dir.glob("*.json"):
+        try:
+            day = dt.date.fromisoformat(path.stem)
+        except ValueError:
+            continue
+        dated.append((day, path))
+    dated.sort(key=lambda item: item[0])
+    if not dated:
+        return (None, None)
+    curr = _load(dated[-1][1])
+    prev = _load(dated[-2][1]) if len(dated) >= 2 else None
+    return (prev, curr)
+
+
+def _one_line(regressions: list[Regression]) -> str:
+    if not regressions:
+        return "observability gate: no regressions"
+    fails = sum(1 for r in regressions if r.severity == "fail")
+    warns = len(regressions) - fails
+    return f"observability gate: {fails} fail, {warns} warn regression(s)"
+
+
+def _render_summary(regressions: list[Regression]) -> str:
+    """Render a Markdown summary block for the CI step summary."""
+
+    lines = ["## Observability regression gate", "", _one_line(regressions), ""]
+    if regressions:
+        lines += ["| severity | backend | metric | prev | curr | reason |", "| --- | --- | --- | ---: | ---: | --- |"]
+        for r in sorted(regressions, key=lambda x: (x.severity != "fail", x.backend, x.metric)):
+            metric = "" if r.metric == _SENTINEL_METRIC else r.metric
+            prev = "-" if r.prev is None else f"{r.prev:g}"
+            curr = "-" if r.curr is None else f"{r.curr:g}"
+            lines.append(f"| {r.severity} | {r.backend} | {metric} | {prev} | {curr} | {r.reason} |")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--snapshots",
+        required=True,
+        type=Path,
+        help="Directory containing per-day observe JSON snapshots.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the regressions list as JSON to this path.",
+    )
+    parser.add_argument(
+        "--summary-out",
+        type=Path,
+        default=None,
+        help="Append a Markdown summary block to this path (e.g. $GITHUB_STEP_SUMMARY).",
+    )
+    args = parser.parse_args(argv)
+
+    prev, curr = load_two_latest(args.snapshots)
+    regressions = detect_regressions(prev, curr)
+
+    payload = [asdict(r) for r in regressions]
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if args.summary_out is not None:
+        with args.summary_out.open("a", encoding="utf-8") as handle:
+            handle.write(_render_summary(regressions))
+
+    print(_one_line(regressions))
+    for r in regressions:
+        metric = "" if r.metric == _SENTINEL_METRIC else f".{r.metric}"
+        print(f"  [{r.severity}] {r.backend}{metric}: {r.reason}")
+
+    return 1 if any(r.severity == "fail" for r in regressions) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bernstein/evolution/detector.py
+++ b/src/bernstein/evolution/detector.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from bernstein.evolution.aggregator import MetricsCollector
+    from bernstein.evolution.observability_signals import ObservabilityRegression
 
 
 class UpgradeCategory(Enum):
@@ -41,6 +42,46 @@ class ImprovementOpportunity:
     risk_level: Literal["low", "medium", "high"]
     affected_components: list[str] = field(default_factory=list[str])
     estimated_cost_impact_usd: float = 0.0
+
+
+_SEVERITY_RISK: dict[str, Literal["low", "medium", "high"]] = {
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
+}
+
+
+def _regression_to_opportunity(reg: ObservabilityRegression) -> ImprovementOpportunity:
+    """Map an observability regression to an ``ImprovementOpportunity``."""
+
+    if reg.kind == "coverage":
+        prev_txt = "n/a" if reg.prev is None else f"{reg.prev:.1f}%"
+        return ImprovementOpportunity(
+            category=UpgradeCategory.POLICY_UPDATE,
+            title="Restore test coverage",
+            description=(
+                f"Sonar coverage fell {reg.delta:+.1f} points ({prev_txt} -> {reg.curr:.1f}%) "
+                "between the two most recent observability snapshots."
+            ),
+            expected_improvement="Return coverage to its prior level and lower regression risk",
+            confidence=0.75,
+            risk_level="medium",
+            affected_components=[reg.backend],
+        )
+
+    prev_txt = "n/a" if reg.prev is None else f"{reg.prev:g}"
+    return ImprovementOpportunity(
+        category=UpgradeCategory.POLICY_UPDATE,
+        title=f"Resolve {reg.backend} {reg.metric} increase",
+        description=(
+            f"{reg.backend} {reg.metric} rose {reg.delta:+g} ({prev_txt} -> {reg.curr:g}) "
+            "between the two most recent observability snapshots."
+        ),
+        expected_improvement=f"Clear the new {reg.metric} finding(s)",
+        confidence=0.9 if reg.severity == "high" else 0.7,
+        risk_level=_SEVERITY_RISK.get(reg.severity, "medium"),
+        affected_components=[reg.backend],
+    )
 
 
 @dataclass
@@ -237,10 +278,16 @@ class OpportunityDetector:
         collector: MetricsCollector,
         failure_analyzer: FailureAnalyzer | None = None,
         analysis_dir: Path | None = None,
+        observability_snapshots_dir: Path | None = None,
     ) -> None:
         self.collector = collector
         self.failure_analyzer = failure_analyzer
         self._analysis_dir = analysis_dir
+        # When set, the detector reads the daily observe snapshot corpus and
+        # emits opportunities for external security / coverage regressions.
+        # Left None (the default) it is a no-op, so callers that only care
+        # about internal cost / task metrics are unaffected.
+        self._observability_snapshots_dir = observability_snapshots_dir
 
     def identify_opportunities(self) -> list[ImprovementOpportunity]:
         """Identify improvement opportunities from recent metrics."""
@@ -285,10 +332,38 @@ class OpportunityDetector:
         # Check for failure-driven opportunities
         opportunities.extend(self.identify_failure_opportunities())
 
+        # Check for external repo-health regressions (security / coverage).
+        opportunities.extend(self.identify_observability_opportunities())
+
         if self._analysis_dir is not None:
             self._write_opportunities(opportunities)
 
         return opportunities
+
+    def identify_observability_opportunities(self) -> list[ImprovementOpportunity]:
+        """Emit opportunities for security / coverage regressions in snapshots.
+
+        Reads the two most recent ``bernstein doctor observe`` snapshots and
+        turns each security or coverage regression into an
+        ``ImprovementOpportunity``. This feeds external repo-health signals
+        into the self-improvement loop, which otherwise sees only internal
+        cost and task metrics.
+
+        Guarded: returns an empty list when no snapshots directory is
+        configured, the directory is missing, or fewer than two snapshots
+        exist. Never raises.
+        """
+
+        if self._observability_snapshots_dir is None:
+            return []
+        try:
+            from bernstein.evolution.observability_signals import detect_regressions
+
+            regressions = detect_regressions(self._observability_snapshots_dir)
+        except Exception:
+            logger.exception("observability regression scan failed")
+            return []
+        return [_regression_to_opportunity(reg) for reg in regressions]
 
     def _write_opportunities(self, opportunities: list[ImprovementOpportunity]) -> None:
         """Write detected opportunities to .sdd/analysis/opportunities.json."""

--- a/src/bernstein/evolution/loop.py
+++ b/src/bernstein/evolution/loop.py
@@ -145,7 +145,15 @@ class EvolutionLoop:
         self._analysis_dir.mkdir(parents=True, exist_ok=True)
         self._collector = FileMetricsCollector(state_dir)
         self._aggregator = MetricsAggregator(self._collector, analysis_dir=self._analysis_dir)
-        self._detector = OpportunityDetector(self._collector, analysis_dir=self._analysis_dir)
+        self._observability_snapshots_dir = self._repo_root / "docs" / "observability" / "snapshots"
+        self._detector = OpportunityDetector(
+            self._collector,
+            analysis_dir=self._analysis_dir,
+            observability_snapshots_dir=self._observability_snapshots_dir,
+        )
+        # Cached signed Sonar coverage delta (fraction) read from the two most
+        # recent observe snapshots; populated lazily by _coverage_delta().
+        self._coverage_delta_cache: float | None = None
         self._feature_discovery = FeatureDiscovery(
             repo_root=self._repo_root,
             backlog_dir=state_dir / "backlog",
@@ -1163,8 +1171,29 @@ class EvolutionLoop:
         return self._risk_scorer.score_proposal(
             target_files=target_files,
             diff_size=diff_estimate,
-            test_coverage_delta=0.0,  # unknown pre-execution
+            test_coverage_delta=self._coverage_delta(),
         )
+
+    def _coverage_delta(self) -> float:
+        """Signed Sonar coverage delta (fraction) from the two latest snapshots.
+
+        Reads the daily observe snapshot corpus so the risk scorer weighs a
+        real coverage trend instead of a hardcoded zero. Cached per loop
+        instance. Returns ``0.0`` when the delta cannot be computed (no
+        snapshots, coverage missing, malformed JSON).
+        """
+
+        if self._coverage_delta_cache is not None:
+            return self._coverage_delta_cache
+        try:
+            from bernstein.evolution.observability_signals import coverage_delta_fraction
+
+            delta = coverage_delta_fraction(self._observability_snapshots_dir)
+        except Exception:
+            logger.exception("coverage delta read failed")
+            delta = 0.0
+        self._coverage_delta_cache = delta
+        return delta
 
     @staticmethod
     def _classify_risk_route(composite_risk: float) -> str:

--- a/src/bernstein/evolution/observability_signals.py
+++ b/src/bernstein/evolution/observability_signals.py
@@ -22,12 +22,9 @@ from __future__ import annotations
 
 import datetime as dt
 import json
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-logger = logging.getLogger(__name__)
 
 #: Default location of the daily snapshot corpus, relative to the repo root.
 DEFAULT_SNAPSHOTS_DIR = Path("docs/observability/snapshots")

--- a/src/bernstein/evolution/observability_signals.py
+++ b/src/bernstein/evolution/observability_signals.py
@@ -1,0 +1,180 @@
+"""Read ``bernstein doctor observe`` snapshots into evolution signals.
+
+The daily observability workflow appends one JSON snapshot per day under
+``docs/observability/snapshots/<YYYY-MM-DD>.json``. Every metric row carries a
+``threshold_status`` (``ok|warn|fail``) and a ``numeric`` value. This module
+turns the two most recent snapshots into signals the self-improvement loop can
+consume:
+
+* :func:`coverage_delta_fraction` - the signed Sonar coverage change as a
+  fraction, matching the ``test_coverage_delta`` domain of
+  ``RiskScorer.score_proposal``.
+* :func:`detect_regressions` - security or coverage regressions worth an
+  ``ImprovementOpportunity``.
+
+Everything is best-effort and guarded: a missing directory, fewer than two
+snapshots, or malformed JSON yields an empty / zero result rather than an
+error. The self-improvement loop otherwise sees only internal cost and task
+metrics; these functions feed it external repo-health signals.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Default location of the daily snapshot corpus, relative to the repo root.
+DEFAULT_SNAPSHOTS_DIR = Path("docs/observability/snapshots")
+
+#: ``(backend, metric)`` security signals and the severity of an increase.
+_SECURITY_METRICS: dict[tuple[str, str], str] = {
+    ("dt", "critical_vulns"): "high",
+    ("dt", "high_vulns"): "high",
+    ("code-scanning", "critical_alerts"): "high",
+    ("code-scanning", "high_alerts"): "high",
+    ("sonar", "vulnerabilities"): "medium",
+    ("sonar", "security_hotspots"): "medium",
+    ("dt", "medium_vulns"): "low",
+    ("code-scanning", "open_alerts"): "low",
+}
+
+#: Coverage drop (percentage points) that warrants an opportunity.
+_COVERAGE_DROP_PT = 1.0
+
+
+@dataclass(frozen=True)
+class ObservabilityRegression:
+    """A security or coverage regression derived from two snapshots."""
+
+    backend: str
+    metric: str
+    prev: float | None
+    curr: float
+    delta: float
+    kind: str  # "security" | "coverage"
+    severity: str  # "high" | "medium" | "low"
+
+
+def _load(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def latest_two_snapshots(
+    snapshots_dir: Path,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Return ``(prev, curr)`` for the two most recent dated snapshots."""
+
+    if not snapshots_dir.exists():
+        return (None, None)
+    dated: list[tuple[dt.date, Path]] = []
+    for path in snapshots_dir.glob("*.json"):
+        try:
+            day = dt.date.fromisoformat(path.stem)
+        except ValueError:
+            continue
+        dated.append((day, path))
+    dated.sort(key=lambda item: item[0])
+    if not dated:
+        return (None, None)
+    curr = _load(dated[-1][1])
+    prev = _load(dated[-2][1]) if len(dated) >= 2 else None
+    return (prev, curr)
+
+
+def _metric_numeric(payload: dict[str, Any] | None, backend: str, metric: str) -> float | None:
+    """Return the numeric value of ``backend.metric`` in a snapshot, or None."""
+
+    if not payload:
+        return None
+    for b in payload.get("backends") or []:
+        if b.get("backend") != backend:
+            continue
+        for m in b.get("metrics") or []:
+            if m.get("name") == metric:
+                value = m.get("numeric")
+                if isinstance(value, bool):
+                    return None
+                if isinstance(value, (int, float)):
+                    return float(value)
+        return None
+    return None
+
+
+def coverage_delta_fraction(snapshots_dir: Path = DEFAULT_SNAPSHOTS_DIR) -> float:
+    """Return the signed Sonar coverage change as a fraction in ``[-1, 1]``.
+
+    Positive means coverage improved. Sonar reports coverage in percent, so the
+    percentage-point delta is divided by 100 to match the fraction domain of
+    ``RiskScorer.score_proposal``. Returns ``0.0`` when the delta cannot be
+    computed (no directory, fewer than two snapshots, coverage missing).
+    """
+
+    prev, curr = latest_two_snapshots(snapshots_dir)
+    prev_cov = _metric_numeric(prev, "sonar", "coverage_pct")
+    curr_cov = _metric_numeric(curr, "sonar", "coverage_pct")
+    if prev_cov is None or curr_cov is None:
+        return 0.0
+    return (curr_cov - prev_cov) / 100.0
+
+
+def detect_regressions(snapshots_dir: Path = DEFAULT_SNAPSHOTS_DIR) -> list[ObservabilityRegression]:
+    """Return security or coverage regressions from the two latest snapshots.
+
+    A regression requires a real day-over-day baseline: a metric present only
+    in the newer snapshot (for example a backend that just gained credentials)
+    is a first observation, not a regression, and is skipped.
+    """
+
+    prev, curr = latest_two_snapshots(snapshots_dir)
+    if prev is None or curr is None:
+        return []
+
+    regressions: list[ObservabilityRegression] = []
+
+    prev_cov = _metric_numeric(prev, "sonar", "coverage_pct")
+    curr_cov = _metric_numeric(curr, "sonar", "coverage_pct")
+    if prev_cov is not None and curr_cov is not None:
+        delta = curr_cov - prev_cov
+        if delta <= -_COVERAGE_DROP_PT:
+            regressions.append(
+                ObservabilityRegression(
+                    backend="sonar",
+                    metric="coverage_pct",
+                    prev=prev_cov,
+                    curr=curr_cov,
+                    delta=delta,
+                    kind="coverage",
+                    severity="medium",
+                )
+            )
+
+    for (backend, metric), severity in _SECURITY_METRICS.items():
+        prev_num = _metric_numeric(prev, backend, metric)
+        curr_num = _metric_numeric(curr, backend, metric)
+        if prev_num is None or curr_num is None:
+            continue
+        delta = curr_num - prev_num
+        if delta > 0:
+            regressions.append(
+                ObservabilityRegression(
+                    backend=backend,
+                    metric=metric,
+                    prev=prev_num,
+                    curr=curr_num,
+                    delta=delta,
+                    kind="security",
+                    severity=severity,
+                )
+            )
+
+    return regressions

--- a/tests/observability/test_gate.py
+++ b/tests/observability/test_gate.py
@@ -1,0 +1,282 @@
+"""Unit tests for the observability regression gate.
+
+Covers ``scripts/observability/gate.py`` ``detect_regressions`` over two
+in-memory snapshot payloads (the same shape ``bernstein doctor observe
+--json`` writes under ``docs/observability/snapshots/``):
+
+- an ``ok -> fail`` threshold-status flip,
+- a coverage drop past the early-warning floor,
+- a new / increased security vulnerability,
+- a backend that silently lost its credentials,
+- a clean (green) diff that must stay quiet,
+- the ``load_two_latest`` file-ordering + exit-code plumbing.
+
+The script is import-only at module level so these tests drive its pure
+functions directly without spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+# ``scripts/observability/`` is not an installed package, so load by path.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "observability" / "gate.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("observability_gate", _SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["observability_gate"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module()
+
+
+def _metric(name: str, numeric: float, status: str, threshold: str = "0") -> dict[str, Any]:
+    return {
+        "name": name,
+        "value": str(numeric),
+        "numeric": numeric,
+        "threshold": threshold,
+        "threshold_status": status,
+        "delta": "-",
+    }
+
+
+def _backend(name: str, status: str, metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"backend": name, "status": status, "detail": "", "error": None, "metrics": metrics}
+
+
+def _snapshot(*backends: dict[str, Any]) -> dict[str, Any]:
+    summary = {"ok": 0, "warn": 0, "fail": 0, "skipped": 0, "error": 0}
+    for b in backends:
+        summary[b["status"]] = summary.get(b["status"], 0) + 1
+    return {"summary": summary, "backends": list(backends)}
+
+
+# --------------------------------------------------------------------------
+# ok -> fail flip
+# --------------------------------------------------------------------------
+
+
+def test_ok_to_fail_flip_is_fail_severity() -> None:
+    prev = _snapshot(_backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok")]))
+    curr = _snapshot(_backend("dt", "fail", [_metric("critical_vulns", 1.0, "fail")]))
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].backend == "dt"
+    assert regs[0].metric == "critical_vulns"
+    assert regs[0].severity == "fail"
+    assert regs[0].delta == 1.0
+
+
+def test_ok_to_warn_flip_is_warn_severity() -> None:
+    prev = _snapshot(_backend("code-scanning", "ok", [_metric("open_alerts", 0.0, "ok")]))
+    curr = _snapshot(_backend("code-scanning", "warn", [_metric("open_alerts", 2.0, "warn")]))
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].severity == "warn"
+
+
+# --------------------------------------------------------------------------
+# coverage drop
+# --------------------------------------------------------------------------
+
+
+def test_coverage_drop_past_floor_warns_even_while_ok() -> None:
+    prev = _snapshot(_backend("sonar", "ok", [_metric("coverage_pct", 82.0, "ok", "80.0%")]))
+    curr = _snapshot(_backend("sonar", "ok", [_metric("coverage_pct", 80.6, "ok", "80.0%")]))
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].metric == "coverage_pct"
+    assert regs[0].severity == "warn"
+    assert regs[0].delta is not None
+    assert regs[0].delta < 0
+
+
+def test_coverage_improvement_is_not_a_regression() -> None:
+    prev = _snapshot(_backend("sonar", "ok", [_metric("coverage_pct", 80.6, "ok", "80.0%")]))
+    curr = _snapshot(_backend("sonar", "ok", [_metric("coverage_pct", 82.0, "ok", "80.0%")]))
+
+    assert gate.detect_regressions(prev, curr) == []
+
+
+def test_small_coverage_wobble_within_tolerance_stays_quiet() -> None:
+    prev = _snapshot(_backend("sonar", "ok", [_metric("coverage_pct", 81.0, "ok", "80.0%")]))
+    curr = _snapshot(_backend("sonar", "ok", [_metric("coverage_pct", 80.5, "ok", "80.0%")]))
+
+    assert gate.detect_regressions(prev, curr) == []
+
+
+# --------------------------------------------------------------------------
+# new / increased vulnerability
+# --------------------------------------------------------------------------
+
+
+def test_new_vulnerability_is_flagged() -> None:
+    prev = _snapshot(_backend("sonar", "ok", [_metric("vulnerabilities", 0.0, "ok")]))
+    curr = _snapshot(_backend("sonar", "warn", [_metric("vulnerabilities", 3.0, "warn")]))
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].metric == "vulnerabilities"
+    assert regs[0].severity == "warn"
+    assert regs[0].delta == 3.0
+
+
+def test_increased_critical_dt_vulns_is_fail_severity() -> None:
+    prev = _snapshot(_backend("dt", "fail", [_metric("critical_vulns", 1.0, "fail")]))
+    curr = _snapshot(_backend("dt", "fail", [_metric("critical_vulns", 4.0, "fail")]))
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].severity == "fail"
+    assert regs[0].delta == 3.0
+
+
+# --------------------------------------------------------------------------
+# backend lost creds
+# --------------------------------------------------------------------------
+
+
+def test_backend_lost_creds_is_flagged() -> None:
+    prev = _snapshot(_backend("glitchtip", "ok", [_metric("issues_24h", 0.0, "ok")]))
+    curr = _snapshot(_backend("glitchtip", "skipped", []))
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].backend == "glitchtip"
+    assert regs[0].severity == "warn"
+    assert "lost creds" in regs[0].reason
+
+
+def test_backend_disappearing_entirely_is_flagged() -> None:
+    prev = _snapshot(_backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok")]))
+    curr = _snapshot()
+
+    regs = gate.detect_regressions(prev, curr)
+
+    assert len(regs) == 1
+    assert regs[0].backend == "dt"
+    assert regs[0].severity == "warn"
+
+
+# --------------------------------------------------------------------------
+# green / no-regression cases
+# --------------------------------------------------------------------------
+
+
+def test_flat_green_snapshots_produce_no_regressions() -> None:
+    prev = _snapshot(
+        _backend("sonar", "ok", [_metric("coverage_pct", 81.0, "ok", "80.0%"), _metric("bugs", 0.0, "ok")]),
+        _backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok"), _metric("high_vulns", 0.0, "ok")]),
+        _backend("code-scanning", "ok", [_metric("open_alerts", 0.0, "ok")]),
+    )
+    curr = _snapshot(
+        _backend("sonar", "ok", [_metric("coverage_pct", 81.0, "ok", "80.0%"), _metric("bugs", 0.0, "ok")]),
+        _backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok"), _metric("high_vulns", 0.0, "ok")]),
+        _backend("code-scanning", "ok", [_metric("open_alerts", 0.0, "ok")]),
+    )
+
+    assert gate.detect_regressions(prev, curr) == []
+
+
+def test_backend_gaining_creds_is_not_a_regression() -> None:
+    prev = _snapshot(_backend("dt", "skipped", []))
+    curr = _snapshot(_backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok")]))
+
+    assert gate.detect_regressions(prev, curr) == []
+
+
+def test_missing_previous_snapshot_only_flags_hard_fails() -> None:
+    curr = _snapshot(
+        _backend("dt", "fail", [_metric("critical_vulns", 2.0, "fail")]),
+        _backend("code-scanning", "warn", [_metric("open_alerts", 3.0, "warn")]),
+    )
+
+    regs = gate.detect_regressions(None, curr)
+
+    # The brand-new warn metric must not fire; only the fail-status one does.
+    assert len(regs) == 1
+    assert regs[0].severity == "fail"
+    assert regs[0].backend == "dt"
+
+
+# --------------------------------------------------------------------------
+# load_two_latest + main() plumbing
+# --------------------------------------------------------------------------
+
+
+def test_load_two_latest_orders_by_date(tmp_path: Path) -> None:
+    (tmp_path / "2026-07-10.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
+    (tmp_path / "2026-07-14.json").write_text(
+        json.dumps(_snapshot(_backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok")]))),
+        encoding="utf-8",
+    )
+    (tmp_path / "notes.json").write_text("{}", encoding="utf-8")  # non-dated ignored
+
+    prev, curr = gate.load_two_latest(tmp_path)
+
+    assert prev is not None
+    assert curr is not None
+    assert curr["backends"][0]["backend"] == "dt"
+    assert prev["backends"] == []
+
+
+def test_load_two_latest_handles_single_snapshot(tmp_path: Path) -> None:
+    (tmp_path / "2026-07-14.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    prev, curr = gate.load_two_latest(tmp_path)
+
+    assert prev is None
+    assert curr is not None
+
+
+def test_main_exit_code_and_output(tmp_path: Path) -> None:
+    (tmp_path / "2026-07-13.json").write_text(
+        json.dumps(_snapshot(_backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok")]))),
+        encoding="utf-8",
+    )
+    (tmp_path / "2026-07-14.json").write_text(
+        json.dumps(_snapshot(_backend("dt", "fail", [_metric("critical_vulns", 2.0, "fail")]))),
+        encoding="utf-8",
+    )
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
+
+    assert code == 1  # a fail-severity regression exits non-zero
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert len(payload) == 1
+    assert payload[0]["severity"] == "fail"
+
+
+def test_main_green_exits_zero_and_writes_empty(tmp_path: Path) -> None:
+    (tmp_path / "2026-07-13.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
+    (tmp_path / "2026-07-14.json").write_text(json.dumps(_snapshot()), encoding="utf-8")
+    out = tmp_path / "regressions.json"
+
+    code = gate.main(["--snapshots", str(tmp_path), "--out", str(out)])
+
+    assert code == 0
+    assert json.loads(out.read_text(encoding="utf-8")) == []

--- a/tests/unit/test_observability_signals.py
+++ b/tests/unit/test_observability_signals.py
@@ -1,0 +1,142 @@
+"""Unit tests for evolution observability signals and detector wiring.
+
+Covers ``src/bernstein/evolution/observability_signals.py`` and the
+``OpportunityDetector.identify_observability_opportunities`` wiring:
+
+- ``coverage_delta_fraction`` returns a signed fraction (pt / 100) and a
+  ``0.0`` fallback when a snapshot or coverage row is missing,
+- ``detect_regressions`` flags a coverage drop and a security increase but
+  stays quiet on a flat / improved / single-snapshot corpus,
+- ``OpportunityDetector`` only emits observability opportunities when a
+  snapshots directory is configured (opt-in; default stays a no-op).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from bernstein.evolution import observability_signals as sig
+from bernstein.evolution.detector import OpportunityDetector
+
+
+def _metric(name: str, numeric: float, status: str) -> dict[str, Any]:
+    return {"name": name, "value": str(numeric), "numeric": numeric, "threshold": "0", "threshold_status": status}
+
+
+def _backend(name: str, status: str, metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"backend": name, "status": status, "detail": "", "error": None, "metrics": metrics}
+
+
+def _write(dir_: Path, day: str, *backends: dict[str, Any]) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    (dir_ / f"{day}.json").write_text(json.dumps({"summary": {}, "backends": list(backends)}), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# coverage_delta_fraction
+# --------------------------------------------------------------------------
+
+
+def test_coverage_delta_is_signed_fraction(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-10", _backend("sonar", "ok", [_metric("coverage_pct", 82.0, "ok")]))
+    _write(tmp_path, "2026-07-11", _backend("sonar", "warn", [_metric("coverage_pct", 80.6, "ok")]))
+
+    delta = sig.coverage_delta_fraction(tmp_path)
+
+    assert abs(delta - (-0.014)) < 1e-9
+
+
+def test_coverage_delta_zero_when_missing(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-11", _backend("sonar", "ok", [_metric("coverage_pct", 80.6, "ok")]))
+
+    # Only one snapshot -> no delta.
+    assert sig.coverage_delta_fraction(tmp_path) == 0.0
+    # Absent directory -> no delta.
+    assert sig.coverage_delta_fraction(tmp_path / "nope") == 0.0
+
+
+# --------------------------------------------------------------------------
+# detect_regressions
+# --------------------------------------------------------------------------
+
+
+def test_detect_regressions_flags_coverage_drop(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-10", _backend("sonar", "ok", [_metric("coverage_pct", 82.0, "ok")]))
+    _write(tmp_path, "2026-07-11", _backend("sonar", "warn", [_metric("coverage_pct", 80.5, "ok")]))
+
+    regs = sig.detect_regressions(tmp_path)
+
+    assert len(regs) == 1
+    assert regs[0].kind == "coverage"
+    assert regs[0].delta < 0
+
+
+def test_detect_regressions_flags_security_increase(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-10", _backend("dt", "ok", [_metric("high_vulns", 0.0, "ok")]))
+    _write(tmp_path, "2026-07-11", _backend("dt", "warn", [_metric("high_vulns", 2.0, "warn")]))
+
+    regs = sig.detect_regressions(tmp_path)
+
+    assert len(regs) == 1
+    assert regs[0].kind == "security"
+    assert regs[0].backend == "dt"
+    assert regs[0].severity == "high"
+    assert regs[0].delta == 2.0
+
+
+def test_detect_regressions_quiet_on_flat_and_improved(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-10", _backend("sonar", "ok", [_metric("coverage_pct", 80.0, "ok")]))
+    _write(tmp_path, "2026-07-11", _backend("sonar", "ok", [_metric("coverage_pct", 83.0, "ok")]))
+
+    assert sig.detect_regressions(tmp_path) == []
+
+
+def test_detect_regressions_skips_first_observation(tmp_path: Path) -> None:
+    # dt only appears in the newer snapshot -> first observation, not a regression.
+    _write(tmp_path, "2026-07-10", _backend("sonar", "ok", [_metric("coverage_pct", 80.0, "ok")]))
+    _write(tmp_path, "2026-07-11", _backend("dt", "warn", [_metric("high_vulns", 3.0, "warn")]))
+
+    assert sig.detect_regressions(tmp_path) == []
+
+
+def test_detect_regressions_empty_without_two_snapshots(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-11", _backend("dt", "fail", [_metric("critical_vulns", 5.0, "fail")]))
+
+    assert sig.detect_regressions(tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# OpportunityDetector wiring (opt-in)
+# --------------------------------------------------------------------------
+
+
+def _collector_stub() -> MagicMock:
+    collector = MagicMock()
+    collector.get_recent_cost_metrics.return_value = []
+    collector.get_recent_task_metrics.return_value = []
+    return collector
+
+
+def test_detector_no_op_without_snapshots_dir() -> None:
+    detector = OpportunityDetector(_collector_stub())
+
+    assert detector.identify_observability_opportunities() == []
+
+
+def test_detector_emits_opportunity_for_regression(tmp_path: Path) -> None:
+    _write(tmp_path, "2026-07-10", _backend("dt", "ok", [_metric("critical_vulns", 0.0, "ok")]))
+    _write(tmp_path, "2026-07-11", _backend("dt", "fail", [_metric("critical_vulns", 2.0, "fail")]))
+
+    detector = OpportunityDetector(_collector_stub(), observability_snapshots_dir=tmp_path)
+    opps = detector.identify_observability_opportunities()
+
+    assert len(opps) == 1
+    assert opps[0].affected_components == ["dt"]
+    assert opps[0].risk_level == "high"
+    assert "critical_vulns" in opps[0].title
+
+    # It also flows through the umbrella identify_opportunities().
+    assert any("critical_vulns" in o.title for o in detector.identify_opportunities())


### PR DESCRIPTION
## Summary

The daily observability snapshot (`docs-observability-snapshot.yml` runs
`bernstein doctor observe --json`) writes one JSON snapshot per day under
`docs/observability/snapshots/` and re-renders `trends.md`. Two gaps: two of the
four backends collected no data, and every metric row's `threshold_status`
verdict was computed and then discarded. This closes both.

## Changes

**Fix collection.** The workflow read glitchtip and Dependency-Track credentials
under env names that no repository secret populated, so both backends soft-failed
to `skipped` on every run. Repointed them at the secrets that exist:

- `BERNSTEIN_GLITCHTIP_TOKEN` from `secrets.GLITCHTIP_API_TOKEN`
- `DTRACK_URL` from `secrets.DT_API_URL`
- `DTRACK_TOKEN` from `secrets.DT_API_KEY`
- `DTRACK_PROJECT` provisioned as a repository variable holding the
  Dependency-Track project UUID

A manual run confirms the flip: `summary.skipped` went from 2 to 0, and both
glitchtip and dt now report metrics.

**Regression gate.** New `scripts/observability/gate.py` diffs the two most
recent snapshots and reports regressions from each row's `threshold_status` plus
a numeric delta computed from the files directly (the daily job runs
`--no-persist`, so the row's own delta field is inert). It flags a status flip
for the worse (`ok -> warn`, `* -> fail`), a coverage drop past a small
tolerance, a new or increased security finding, and a backend that lost its
credentials. It is wired into the workflow after the trends render; on a
fail-severity regression the step pushes a Telegram message using the same
direct `sendMessage` call as `notify-other-failures.yml`. The step is
non-blocking, so the snapshot pull request still opens and warn-level drift is
recorded in the run summary.

**Evolution loop.** The self-improvement loop previously scored proposals with a
hardcoded `test_coverage_delta=0.0` and saw no external repo-health input. New
`src/bernstein/evolution/observability_signals.py` reads the snapshot corpus
into a signed coverage delta and a list of security or coverage regressions.
`OpportunityDetector` gains an opt-in `observability_snapshots_dir` argument and
emits an `ImprovementOpportunity` per regression (default no-op, so existing
callers are unchanged); `loop.py` feeds the real coverage delta into the risk
scorer.

## Tests

- `tests/observability/test_gate.py`: `detect_regressions` over in-memory
  snapshots (ok to fail flip, coverage drop, new vuln, lost creds, green) plus
  file ordering and exit-code plumbing.
- `tests/unit/test_observability_signals.py`: coverage delta, regression
  detection, and the opt-in detector wiring.

All green. `ruff check` and `ruff format --check` clean on the changed Python;
`actionlint` clean on the workflow.
