### PR TITLE
docs(gui): update route count and command name in overview docs

### DIFF
--- a/docs/gui/index.md
+++ b/docs/gui/index.md
@@ -27,11 +27,11 @@ Browser-based operator surface for live Bernstein runs. Mounted on the same Fast
 | Inspect HMAC audit chain head and verify          | yes          |
 | Review per-adapter cost over the last 24 h        | yes          |
 | Pipe Bernstein into a script or CI step           | no - use the REST API |
-| Drive Bernstein from a terminal-only host         | no - use `bernstein dashboard` (TUI) |
+| Drive Bernstein from a terminal-only host         | no - use `bernstein live` (TUI) |
 
 ## Who it is for
 
-Operators supervising live agent runs. The GUI mirrors what an operator already does in the TUI (`bernstein dashboard`) but trades keyboard density for diff rendering, sparklines, and a queue-style approvals view.
+Operators supervising live agent runs. The GUI mirrors what an operator already does in the TUI (`bernstein live`) but trades keyboard density for diff rendering, sparklines, and a queue-style approvals view.
 
 ## Read next
 

--- a/docs/gui/index.md
+++ b/docs/gui/index.md
@@ -14,7 +14,7 @@ Browser-based operator surface for live Bernstein runs. Mounted on the same Fast
 ## What it is
 
 - Vite + React 18 + Tailwind 3 + shadcn/ui SPA. Source in `web/`. Built bundle ships in the wheel under `src/bernstein/gui/static/`.
-- Five routes: Tasks, Agents, Approvals, Audit, Costs. One nav item each, no settings page.
+- Seven routes: Tasks, Agents, Approvals, Audit, Costs, Fleet, Settings. One nav item each.
 - Reads from `GET /api/v1/*` and the central SSE stream `GET /api/v1/events`. Uses TanStack Query 5 for caching and `setQueryData` to hydrate from SSE.
 - Auth via `Authorization: Bearer ${localStorage.bernstein_token}`. Token comes from `BERNSTEIN_AUTH_TOKEN` (auto-generated on server launch if unset).
 
@@ -27,11 +27,11 @@ Browser-based operator surface for live Bernstein runs. Mounted on the same Fast
 | Inspect HMAC audit chain head and verify          | yes          |
 | Review per-adapter cost over the last 24 h        | yes          |
 | Pipe Bernstein into a script or CI step           | no - use the REST API |
-| Drive Bernstein from a terminal-only host         | no - use `bernstein live` (TUI) |
+| Drive Bernstein from a terminal-only host         | no - use `bernstein dashboard` (TUI) |
 
 ## Who it is for
 
-Operators supervising live agent runs. The GUI mirrors what an operator already does in the TUI (`bernstein live`) but trades keyboard density for diff rendering, sparklines, and a queue-style approvals view.
+Operators supervising live agent runs. The GUI mirrors what an operator already does in the TUI (`bernstein dashboard`) but trades keyboard density for diff rendering, sparklines, and a queue-style approvals view.
 
 ## Read next
 

--- a/docs/gui/screens.md
+++ b/docs/gui/screens.md
@@ -8,7 +8,7 @@ tags:
 
 # Screens
 
-Five routes. Source: `web/src/routes/`. Design reference: `.sdd/backlog/open/frontend/design_handoff_bernstein_phase1/README.md` §6.
+Seven routes. Source: `web/src/routes/`. Design reference: `.sdd/backlog/open/frontend/design_handoff_bernstein_phase1/README.md` §6.
 
 ## Screenshots
 


### PR DESCRIPTION
## What this does

Fixes three stale references in the GUI overview docs that were left behind when Fleet and Settings shipped and when `bernstein live` was renamed to `bernstein dashboard`.

Refs #1262 (Docs fix item from the Open work table).

---

## Changes

**`docs/gui/index.md`**
- "Five routes: Tasks, Agents, Approvals, Audit, Costs. One nav item each, no settings page." → "Seven routes: Tasks, Agents, Approvals, Audit, Costs, Fleet, Settings. One nav item each."
- Two mentions of `` `bernstein live` `` updated to `` `bernstein dashboard` `` (the table row and the "Who it is for" paragraph)

**`docs/gui/screens.md`**
- "Five routes." → "Seven routes." in the opening line

---

## How I found this

Spotted while reading through the docs after #2061 got merged. Ran `grep -r "Five routes" docs/gui/` and also noticed `bernstein live` which doesn't match the current CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GUI documentation to include a dedicated Settings route, bringing the total to seven routes.
  * Clarified guidance for terminal-only environments to use the `bernstein dashboard` command.
  * Refreshed screen documentation to reflect the expanded navigation and route count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->