### PR TITLE
feat(replay): record provider-side context mutations as journal chain entries

### DIFF
--- a/docs/operations/deterministic-replay.md
+++ b/docs/operations/deterministic-replay.md
@@ -126,6 +126,42 @@ one root.
 > entry timestamp. This section covers the `journal.jsonl` chain, the one
 > surfaced in run metadata and the `bernstein replay` header.
 
+## Provider-side context mutations
+
+Deterministic replay assumes context-as-sent equals context-as-consumed. The
+client half is defended by the compaction policy recorded in the step
+fingerprint (`apply_compaction_policy` in `src/bernstein/adapters/claude.py`),
+but providers also mutate model context server-side: compaction and similar
+opaque state carried between calls. Every observable mutation signal is
+therefore chained into `journal.jsonl` as a first-class entry
+(`src/bernstein/core/replay/provider_state.py`).
+
+| Item | Behaviour |
+|---|---|
+| Journal entry | `provider_state_mutation`, content-addressed over `(kind, before_digest, after_digest, step_index)` |
+| Load-bearing | The entry participates in the Merkle chain: removing or editing it breaks `--verify` at exactly its index |
+| Deterministic modes | Suppression is requested at spawn (`DISABLE_AUTO_COMPACT`); a mutation that still arrives is recorded **flagged** and `bernstein replay <run-id> --verify` exits non-zero (fail-closed) |
+| Live runs | Mutations are permitted but pinned: each is recorded before execution continues, so the journal head commits to it |
+| Divergence attribution | `bernstein replay diff A B` reports reason code `provider_state_mutation` with the mutation kind and the exact step index when the first mismatching event is a mutation entry |
+| Capability record | One `provider_state_capability` entry per provider per run: `observed` or `declared-blind` |
+| Audit mirror | Each chained mutation is mirrored into the HMAC audit chain as a `provider.state_mutation` event anchored to the journal head |
+
+The capability record is what keeps an empty run interpretable: an adapter
+that cannot observe mutations (`declared-blind`) produces no mutation entries,
+and the journal says so explicitly, so an absence of entries is
+distinguishable from an inability to see them. The claude adapter observes
+mutation signals (`compact_boundary` and related stream-json `system`
+subtypes) through its wrapper, which appends each one to
+`.sdd/runtime/provider_state/<session_id>.jsonl` in observation order; the
+orchestrator chains them into the run journal when the agent is reaped.
+
+The digests are content addresses of the provider-reported metadata, which is
+the only observable surface for a server-side rewrite: `before_digest` covers
+the fields the provider labelled as pre-mutation state (`pre_*` / `before_*`),
+`after_digest` covers the full reported payload. A journal head therefore
+certifies either what the model consumed or the precise point where
+visibility ends.
+
 ## Live thread stream
 
 The TUI and web UI render the run as a live SSE stream that is a hash-anchored

--- a/docs/operations/replay.md
+++ b/docs/operations/replay.md
@@ -148,6 +148,22 @@ These add to the existing event-type registry without modifying any
 prior entries. The audit-slice extractor picks them up via the standard
 `event_type=` filter.
 
+## Provider-side context mutations
+
+Provider-side context rewrites (compaction boundaries and similar opaque
+state markers surfaced in provider responses) are chained into the run
+journal as content-addressed `provider_state_mutation` entries, so the
+journal head commits to every observed rewrite before anything builds on
+it. In deterministic modes an arriving mutation is recorded flagged and
+`bernstein replay <run-id> --verify` fails closed; `bernstein replay diff`
+attributes a mutation-driven divergence with the `provider_state_mutation`
+reason code, the mutation kind, and the exact step index. Each adapter's
+ability to observe mutations at all is recorded per run as a
+`provider_state_capability` entry (`observed` or `declared-blind`), and
+each chained mutation is mirrored into the HMAC audit chain as a
+`provider.state_mutation` event. Full behaviour table:
+[deterministic-replay.md](deterministic-replay.md#provider-side-context-mutations).
+
 ## Backward compatibility
 
 - `bernstein git undo <snapshot_id>` works unchanged.

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -37,6 +37,22 @@ DEFAULT_TIMEOUT_SECONDS: int = 1800
 # Grace period between SIGTERM and SIGKILL (seconds).
 _SIGTERM_GRACE_SECONDS: int = 30
 
+# ---------------------------------------------------------------------------
+# Mutation-observability capability (issue #2507)
+# ---------------------------------------------------------------------------
+# Values mirror bernstein.core.replay.provider_state.CAPABILITY_* and are
+# duplicated here (rather than imported) so the adapter layer stays free of
+# replay-journal imports at module load time.
+
+#: The adapter surfaces provider-side context-mutation signals (compaction
+#: boundaries and similar opaque state markers) from its stream output.
+MUTATION_OBSERVABILITY_OBSERVED = "observed"
+
+#: The adapter has no observation surface for provider-side context
+#: mutations. Recorded per run in the replay journal so an absence of
+#: mutation entries stays distinguishable from an inability to see them.
+MUTATION_OBSERVABILITY_DECLARED_BLIND = "declared-blind"
+
 
 class SpawnError(RuntimeError):
     """Raised when an adapter process exits too early to be treated as spawned."""
@@ -826,6 +842,41 @@ class CLIAdapter(ABC):
             back to a fresh spawn.
         """
         return None
+
+    #: Mutation-observability capability of this adapter (issue #2507).
+    #: Declared-blind by default; adapters whose stream output surfaces
+    #: provider-side context-mutation signals set
+    #: :data:`MUTATION_OBSERVABILITY_OBSERVED` and override
+    #: :meth:`observed_provider_mutations`. The declaration is recorded
+    #: per run in the replay journal, so an absence of mutation entries
+    #: is distinguishable from an inability to see them.
+    provider_mutation_observability: str = MUTATION_OBSERVABILITY_DECLARED_BLIND
+
+    def observed_provider_mutations(self, workdir: Path, session_id: str) -> list[dict[str, Any]]:
+        """Return provider-side context-mutation signals observed for a session.
+
+        Optional capability declared by
+        :attr:`provider_mutation_observability`. Adapters that can parse
+        mutation signals (compaction boundaries, context edits, stored-state
+        references) out of their stream output override this method and
+        return the signals in observation order, each as
+        ``{"kind": str, "detail": dict}``. The orchestrator chains every
+        returned signal into the run's replay journal as a content-addressed
+        ``provider_state_mutation`` entry.
+
+        The default returns an empty list: a declared-blind adapter has no
+        observation surface, and that inability is itself recorded per run.
+
+        Args:
+            workdir: Agent working directory (root of ``.sdd``).
+            session_id: The Bernstein session id the agent ran under.
+
+        Returns:
+            Observed mutation signals in stream order (empty when none were
+            observed or the adapter cannot observe them).
+        """
+        del workdir, session_id
+        return []
 
     def stream_signal_parser(self, line: str) -> object | None:
         """Map one line of adapter stdout to a canonical stream signal.

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -25,7 +25,13 @@ from collections.abc import Mapping  # noqa: TC003 - runtime use in ClassVar ann
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.base import (
+    DEFAULT_TIMEOUT_SECONDS,
+    MUTATION_OBSERVABILITY_OBSERVED,
+    CLIAdapter,
+    SpawnResult,
+    build_worker_cmd,
+)
 from bernstein.adapters.claude_agents import build_agents_json
 
 # Re-export helpers that were inlined here before split them
@@ -288,6 +294,13 @@ class ClaudeCodeAdapter(CLIAdapter):
     # :mod:`bernstein.core.orchestration.commit_completion`.
     supports_session_continuation = True
 
+    # Provider-side context mutations (compaction boundaries and similar
+    # opaque state markers) surface as stream-json ``system`` events; the
+    # wrapper persists each one to a per-session sidecar (issue #2507).
+    # The declaration is recorded per run in the replay journal, so an
+    # absence of mutation entries is distinguishable from blindness.
+    provider_mutation_observability = MUTATION_OBSERVABILITY_OBSERVED
+
     # Track Popen objects for reliable is_alive() via poll()
     _procs: ClassVar[dict[int, subprocess.Popen[bytes]]] = {}
     _wrapper_pids: ClassVar[dict[int, int]] = {}  # claude_pid → wrapper_pid
@@ -525,6 +538,7 @@ class ClaudeCodeAdapter(CLIAdapter):
         tokens_path: str = "",
         heartbeat_path: str = "",
         completion_path: str = "",
+        mutation_path: str = "",
     ) -> str:
         """Return the stream-json → human-readable log converter script.
 
@@ -539,13 +553,63 @@ class ClaudeCodeAdapter(CLIAdapter):
             tokens_path: Absolute path to the ``.tokens`` sidecar file.
             heartbeat_path: Absolute path to the heartbeat file (touched on each event).
             completion_path: Absolute path to the completion marker file.
+            mutation_path: Absolute path to the provider-state mutation
+                sidecar (issue #2507); empty disables it.
         """
         return build_wrapper_script(
             session_id=session_id,
             tokens_path=tokens_path,
             heartbeat_path=heartbeat_path,
             completion_path=completion_path,
+            mutation_path=mutation_path,
         )
+
+    @staticmethod
+    def _mutation_sidecar_path(workdir: Path, session_id: str) -> Path:
+        """Return the per-session provider-state mutation sidecar path."""
+        return workdir / ".sdd" / "runtime" / "provider_state" / f"{session_id}.jsonl"
+
+    def observed_provider_mutations(self, workdir: Path, session_id: str) -> list[dict[str, Any]]:
+        """Return the provider-side mutation signals persisted for a session.
+
+        Reads the per-session sidecar the wrapper script appends to
+        (issue #2507). Each row is ``{"kind": str, "detail": dict}`` in
+        stream observation order; malformed rows are skipped so a partial
+        trailing write cannot wedge the reader.
+
+        Args:
+            workdir: Agent working directory (root of ``.sdd``).
+            session_id: The Bernstein session id the agent ran under.
+
+        Returns:
+            Observed mutation signals in stream order.
+        """
+        path = self._mutation_sidecar_path(workdir, session_id)
+        signals: list[dict[str, Any]] = []
+        if not path.exists():
+            return signals
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            return signals
+        for raw in text.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict) or not row.get("kind"):
+                continue
+            detail = row.get("detail")
+            signals.append(
+                {
+                    "kind": str(row["kind"]),
+                    "detail": detail if isinstance(detail, dict) else {},
+                }
+            )
+        return signals
 
     @staticmethod
     def _record_compaction_state(workdir: Path, session_id: str, *, compaction_disabled: bool) -> None:
@@ -579,6 +643,13 @@ class ClaudeCodeAdapter(CLIAdapter):
                 # this deterministic/replay run. It records the policy we
                 # applied, not a proof the provider honoured it.
                 "compaction_enabled": not compaction_disabled,
+                # Provider-side coverage (issue #2507): this adapter observes
+                # provider-side mutation signals and persists each one to the
+                # per-session sidecar, from which the orchestrator chains
+                # content-addressed ``provider_state_mutation`` entries into
+                # the replay journal. Folded into the same fingerprint path
+                # so the observation policy is part of the run identity.
+                "mutation_observability": MUTATION_OBSERVABILITY_OBSERVED,
             }
             state_path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
         except OSError as exc:  # pragma: no cover - best-effort, never blocks spawn
@@ -851,11 +922,18 @@ class ClaudeCodeAdapter(CLIAdapter):
         completed_dir = workdir / ".sdd" / "runtime" / "completed"
         completed_dir.mkdir(parents=True, exist_ok=True)
         completion_path = completed_dir / session_id
+        # Provider-state mutation sidecar (issue #2507): the wrapper appends
+        # every provider-side context-mutation signal here in observation
+        # order so the orchestrator can chain each one into the replay
+        # journal as a content-addressed entry.
+        mutation_path = self._mutation_sidecar_path(workdir, session_id)
+        mutation_path.parent.mkdir(parents=True, exist_ok=True)
         wrapper = self._wrapper_script(
             session_id=session_id,
             tokens_path=str(tokens_path),
             heartbeat_path=str(heartbeat_path),
             completion_path=str(completion_path),
+            mutation_path=str(mutation_path),
         )
         # Allow operator-set ANTHROPIC_BETA through so we can extend it
         # rather than overwrite. Filter is empty-safe when the env var

--- a/src/bernstein/adapters/claude_stream_parser.py
+++ b/src/bernstein/adapters/claude_stream_parser.py
@@ -37,6 +37,20 @@ _EVENT_ASSISTANT = "assistant"
 _EVENT_RESULT = "result"
 _EVENT_SYSTEM = "system"
 
+#: ``system`` subtypes that signal a provider-side context mutation: the
+#: context the model works from was rewritten between calls (compaction
+#: boundaries, context edits, and similar opaque state markers). Issue
+#: #2507: each such signal must be surfaced so the replay journal can
+#: chain it as a content-addressed ``provider_state_mutation`` entry.
+PROVIDER_MUTATION_SUBTYPES: frozenset[str] = frozenset(
+    {
+        "compact_boundary",
+        "microcompact_boundary",
+        "context_compaction",
+        "context_edit",
+    }
+)
+
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
 _CAST_DICT_STR_ANY = "dict[str, Any]"
@@ -56,6 +70,7 @@ class StreamEventType(StrEnum):
     RESULT = "result"
     ERROR = "error"
     SYSTEM = "system"
+    PROVIDER_STATE_MUTATION = "provider_state_mutation"
 
 
 @dataclass(frozen=True)
@@ -88,12 +103,15 @@ class StreamParserState:
         duration_ms: Duration from the result event.
         subtype: Result subtype (success, error_max_turns, etc.).
         errors: Any error messages encountered.
+        provider_mutations: Provider-side context mutation signals in
+            stream order, each ``{"kind": str, "detail": dict}``.
     """
 
     text_blocks: list[str] = field(default_factory=list[str])
     tool_uses: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     tool_results: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     thinking_blocks: list[str] = field(default_factory=list[str])
+    provider_mutations: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
     result: dict[str, Any] | None = None
     total_cost_usd: float = 0.0
     num_turns: int = 0
@@ -356,10 +374,20 @@ class ClaudeStreamParser:
             msg: Parsed JSON dict with type="system".
 
         Returns:
-            A system event.
+            A system event, or a provider-state-mutation event when the
+            subtype signals a provider-side context rewrite (issue #2507).
         """
         message = str(msg.get("message", ""))
         subtype = str(msg.get("subtype", ""))
+
+        if subtype in PROVIDER_MUTATION_SUBTYPES:
+            signal: dict[str, Any] = {"kind": subtype, "detail": dict(msg)}
+            self.state.provider_mutations.append(signal)
+            return StreamEvent(
+                event_type=StreamEventType.PROVIDER_STATE_MUTATION,
+                data=signal,
+                raw=msg,
+            )
 
         if subtype == "error" or "error" in message.lower():
             self.state.errors.append(message)

--- a/src/bernstein/adapters/claude_wrapper_script.py
+++ b/src/bernstein/adapters/claude_wrapper_script.py
@@ -15,6 +15,8 @@ so golden-replay tests from pass unchanged.
 
 from __future__ import annotations
 
+from bernstein.adapters.claude_stream_parser import PROVIDER_MUTATION_SUBTYPES
+
 # Prelude: shared across every wrapper invocation regardless of which
 # sidecar/heartbeat/completion features are enabled.  The wrapper reads
 # NDJSON one line at a time, extracts printable text for the adapter log,
@@ -104,6 +106,32 @@ def _build_heartbeat_touch(heartbeat_path: str) -> str:
     )
 
 
+def _build_mutation_sidecar(mutation_path: str) -> str:
+    """Return the provider-state mutation sidecar block for *mutation_path*.
+
+    Issue #2507: provider-side context mutations (compaction boundaries and
+    similar opaque state markers) arrive as stream-json ``system`` events
+    that the human-readable log conversion would otherwise drop. Each such
+    signal is appended to a per-session JSONL sidecar in observation order
+    so the orchestrator can chain it into the run's replay journal as a
+    content-addressed ``provider_state_mutation`` entry. Writing is
+    best-effort: a sidecar failure must never break the stream conversion.
+    """
+    if not mutation_path:
+        return ""
+    subtypes = tuple(sorted(PROVIDER_MUTATION_SUBTYPES))
+    return (
+        "    # Provider-side context mutation signal -> per-session sidecar\n"
+        f"    if msg.get('type', '') == 'system' and msg.get('subtype', '') in {subtypes!r}:\n"
+        "        try:\n"
+        "            _mrec = json.dumps({'kind': msg.get('subtype', ''), 'detail': msg})\n"
+        f"            with open({mutation_path!r}, 'a') as _mf:\n"
+        "                _mf.write(_mrec + '\\n')\n"
+        "        except OSError:\n"
+        "            pass\n"
+    )
+
+
 def _build_completion_write(completion_path: str) -> str:
     """Return the completion-marker writer block for *completion_path*.
 
@@ -130,6 +158,7 @@ def build_wrapper_script(
     tokens_path: str = "",
     heartbeat_path: str = "",
     completion_path: str = "",
+    mutation_path: str = "",
 ) -> str:
     """Return the stream-json → human-readable log converter script.
 
@@ -149,6 +178,10 @@ def build_wrapper_script(
         completion_path: Absolute path to the completion marker file.  Written
             when a ``result`` event is parsed, signalling the orchestrator that
             the agent finished its work and can be reaped immediately.
+        mutation_path: Absolute path to the provider-state mutation sidecar
+            (issue #2507).  Every stream-json ``system`` event whose subtype
+            signals a provider-side context mutation is appended here in
+            observation order; empty disables the sidecar.
     """
     # ``session_id`` is accepted but not referenced in the emitted source
     # today.  Kept in the signature so the adapter call-site and tests
@@ -158,8 +191,9 @@ def build_wrapper_script(
     token_writer = _build_token_writer(tokens_path)
     heartbeat_touch = _build_heartbeat_touch(heartbeat_path)
     completion_write = _build_completion_write(completion_path)
+    mutation_sidecar = _build_mutation_sidecar(mutation_path)
 
-    return _WRAPPER_PRELUDE + heartbeat_touch + _WRAPPER_DISPATCH + completion_write + token_writer
+    return _WRAPPER_PRELUDE + heartbeat_touch + mutation_sidecar + _WRAPPER_DISPATCH + completion_write + token_writer
 
 
 __all__ = ["build_wrapper_script"]

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1933,6 +1933,11 @@ def _replay_verify_journal(*, run_id: str, sdd_dir: str, as_json: bool) -> None:
     On an intact journal, reports byte-identity. When a step diverges,
     writes a ``divergence_report.json`` artifact listing ``(step_index,
     expected_hash, actual_hash)`` and exits non-zero (issue #2293, AC2).
+
+    Flagged provider-side mutation entries (a mutation that arrived in
+    deterministic mode despite suppression being requested) fail
+    verification closed even when the chain itself is intact
+    (issue #2507).
     """
     from bernstein.core.replay.journal import verify_journal
 
@@ -1944,6 +1949,7 @@ def _replay_verify_journal(*, run_id: str, sdd_dir: str, as_json: bool) -> None:
 
     result = verify_journal(journal_path)
     if result.ok:
+        _fail_on_flagged_provider_mutations(run_id=run_id, journal_path=journal_path, as_json=as_json)
         if as_json:
             console.print_json(json.dumps({"run_id": run_id, "verified": True, "count": result.count}))
         else:
@@ -1961,6 +1967,53 @@ def _replay_verify_journal(*, run_id: str, sdd_dir: str, as_json: bool) -> None:
     report_path = journal_path.parent / "divergence_report.json"
     with contextlib.suppress(OSError):
         report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    _print_verify_divergence(run_id=run_id, result=result, report=report, report_path=report_path, as_json=as_json)
+
+
+def _fail_on_flagged_provider_mutations(*, run_id: str, journal_path: Path, as_json: bool) -> None:
+    """Exit non-zero when the journal holds flagged mutation entries (#2507).
+
+    A flagged ``provider_state_mutation`` entry records a provider-side
+    context rewrite that arrived in deterministic mode after suppression
+    was requested. The chain is intact (the mutation was pinned before
+    anything built on it), but the run is not the deterministic run the
+    operator asked for, so verification fails closed instead of silently
+    accepting it.
+    """
+    from bernstein.core.replay.provider_state import verify_provider_state
+
+    state = verify_provider_state(journal_path)
+    if state.ok:
+        return
+    payload = {
+        "run_id": run_id,
+        "verified": False,
+        "reason_code": "provider_state_mutation",
+        "flagged_steps": state.flagged_indices,
+        "errors": state.errors,
+    }
+    if as_json:
+        console.print_json(json.dumps(payload))
+    else:
+        console.print(
+            f"[red]PROVIDER STATE[/red] run [bold]{run_id}[/bold] recorded "
+            f"{len(state.flagged_indices)} flagged provider-side mutation(s) in deterministic mode"
+        )
+        for err in state.errors:
+            console.print(f"[dim]{err}[/dim]")
+    raise SystemExit(1)
+
+
+def _print_verify_divergence(
+    *,
+    run_id: str,
+    result: Any,
+    report: dict[str, Any],
+    report_path: Path,
+    as_json: bool,
+) -> None:
+    """Render the chain-divergence outcome and exit non-zero."""
 
     if as_json:
         console.print_json(json.dumps(report))
@@ -2271,6 +2324,8 @@ def _replay_diff_dispatch(
             "diverged": result.diverged,
             "index": result.index,
             "reason": result.reason,
+            "reason_code": result.reason_code,
+            "mutation_kind": result.mutation_kind,
             "a_event": result.a_event,
             "b_event": result.b_event,
         }

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -596,6 +596,13 @@ class Orchestrator:
         # gate.
         self._recorder = EventJournal(run_id=run_id, sdd_dir=workdir / ".sdd")
 
+        # Providers whose mutation-observability capability has been
+        # recorded into the journal this run (issue #2507). One
+        # ``provider_state_capability`` entry per provider per run keeps an
+        # absence of mutation entries distinguishable from an inability to
+        # observe them.
+        self._mutation_capability_recorded: set[str] = set()
+
         # Replay gateway: captures LLM + tool dispatch responses into
         # .sdd/runs/{run_id}/events.jsonl so a run can be re-executed
         # against recorded fixtures. This is the fixture-replay engine, a
@@ -4774,6 +4781,7 @@ class Orchestrator:
             session = self._agents.get(session_id)
             if session is None:
                 continue
+            self._record_mutation_capability_once(session)
             self._recorder.record(
                 "agent_spawned",
                 agent_id=session.id,
@@ -4809,10 +4817,69 @@ class Orchestrator:
             self._recorder.record("task_verification_failed", task_id=task_id, failed_signals=failed_signals)
 
         for agent_id in result.reaped:
+            self._record_provider_mutations_for(agent_id)
             self._recorder.record("agent_reaped", agent_id=agent_id)
 
         for task_id in result.retried:
             self._recorder.record("task_retried", task_id=task_id)
+
+    def _record_mutation_capability_once(self, session: AgentSession) -> None:
+        """Record a provider's mutation-observability capability once per run.
+
+        Issue #2507: the adapter contract declares whether provider-side
+        context mutations are observable at all. Recording the declaration
+        into the journal keeps an absence of mutation entries
+        distinguishable from an inability to see them. Failures are logged
+        and swallowed: capability recording must never break a spawn tick.
+        """
+        key = (session.provider or "").strip() or "default"
+        if key in self._mutation_capability_recorded:
+            return
+        self._mutation_capability_recorded.add(key)
+        try:
+            from bernstein.core.replay.provider_state import (
+                capability_for_provider,
+                record_mutation_capability,
+            )
+
+            model = session.model_config.model if session.model_config else ""
+            adapter_name, capability = capability_for_provider(session.provider, model)
+            record_mutation_capability(self._recorder, adapter=adapter_name, capability=capability)
+        except Exception as exc:
+            logger.warning("provider-state: capability recording failed: %s", type(exc).__name__)
+
+    def _record_provider_mutations_for(self, agent_id: str) -> None:
+        """Chain a reaped agent's observed provider-side mutations (issue #2507).
+
+        Reads the mutation signals the adapter observed for the session and
+        chains each one into the run journal as a content-addressed
+        ``provider_state_mutation`` entry, before the ``agent_reaped`` event,
+        so nothing downstream builds on unrecorded state. In deterministic
+        modes the entries are flagged and replay verification fails closed.
+        Failures are logged and swallowed: recording must never break a tick.
+        """
+        session = self._agents.get(agent_id)
+        if session is None:
+            return
+        try:
+            from bernstein.adapters.registry import adapter_name_for_provider, get_adapter
+            from bernstein.core.replay.provider_state import record_agent_mutations
+
+            model = session.model_config.model if session.model_config else ""
+            adapter_name = adapter_name_for_provider(session.provider, model)
+            if not adapter_name:
+                return
+            adapter = get_adapter(adapter_name)
+            signals = adapter.observed_provider_mutations(self._workdir, session.id)
+            if not signals:
+                return
+            record_agent_mutations(self._recorder, signals, agent_id=agent_id)
+        except Exception as exc:
+            logger.warning(
+                "provider-state: mutation recording failed for agent %s: %s",
+                agent_id,
+                type(exc).__name__,
+            )
 
     def _log_summary(self, result: TickResult) -> None:
         """Write a one-line summary and agent state snapshot each tick."""

--- a/src/bernstein/core/replay/__init__.py
+++ b/src/bernstein/core/replay/__init__.py
@@ -53,6 +53,18 @@ from bernstein.core.replay.journal import (
     seal_journal_into_spine,
     verify_journal,
 )
+from bernstein.core.replay.provider_state import (
+    CAPABILITY_DECLARED_BLIND,
+    CAPABILITY_OBSERVED,
+    MUTATION_CAPABILITY_EVENT,
+    PROVIDER_STATE_MUTATION_EVENT,
+    ProviderStateMutation,
+    ProviderStateVerifyResult,
+    record_agent_mutations,
+    record_mutation_capability,
+    record_provider_state_mutation,
+    verify_provider_state,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -86,8 +98,12 @@ def record_run(sdd_dir: Path, conversation_id: str, adapter_name: str, run_id: s
 
 
 __all__ = [
+    "CAPABILITY_DECLARED_BLIND",
+    "CAPABILITY_OBSERVED",
     "EVENTS_FILENAME",
     "JOURNAL_FILENAME",
+    "MUTATION_CAPABILITY_EVENT",
+    "PROVIDER_STATE_MUTATION_EVENT",
     "RECORD_ENV_VAR",
     "RETENTION_ENV_VAR",
     "DivergenceResult",
@@ -96,6 +112,8 @@ __all__ = [
     "ForkResult",
     "GatewayMode",
     "JournalVerifyResult",
+    "ProviderStateMutation",
+    "ProviderStateVerifyResult",
     "ReplayGateway",
     "ReplayMissError",
     "diff_event_logs",
@@ -104,8 +122,12 @@ __all__ = [
     "load_events",
     "locate_run",
     "rebuild_state",
+    "record_agent_mutations",
+    "record_mutation_capability",
+    "record_provider_state_mutation",
     "record_run",
     "record_snapshot_event",
     "seal_journal_into_spine",
     "verify_journal",
+    "verify_provider_state",
 ]

--- a/src/bernstein/core/replay/diff.py
+++ b/src/bernstein/core/replay/diff.py
@@ -6,9 +6,16 @@ at which the recorded responses diverge. Used by
 behaved differently.
 
 Comparison is intentionally simple - equality on the ``(kind, key,
-response)`` triple. Timestamps and metadata are ignored because they
-vary by wall-clock even on identical runs. Callers who want stricter
-matching can compose the dataclass with their own comparator.
+response)`` triple for gateway logs, extended with the ``(event,
+payload_hash)`` pair so canonical journal rows compare on their hashed
+payload. Timestamps and metadata are ignored because they vary by
+wall-clock even on identical runs. Callers who want stricter matching
+can compose the dataclass with their own comparator.
+
+A divergence whose first mismatching event is a provider-side context
+mutation entry (issue #2507) is attributed with the named
+:data:`REASON_CODE_PROVIDER_STATE_MUTATION` reason code, the mutation
+kind, and the exact step index instead of a generic response mismatch.
 """
 
 from __future__ import annotations
@@ -17,8 +24,22 @@ import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.replay.provider_state import PROVIDER_STATE_MUTATION_EVENT
+
 if TYPE_CHECKING:
     from pathlib import Path
+
+#: No divergence found.
+REASON_CODE_NONE = ""
+
+#: The compared events differ in their recorded payload.
+REASON_CODE_RESPONSE_MISMATCH = "response_mismatch"
+
+#: One log has extra events after the common prefix.
+REASON_CODE_LENGTH_MISMATCH = "length_mismatch"
+
+#: The first mismatching event is a provider-side context mutation entry.
+REASON_CODE_PROVIDER_STATE_MUTATION = "provider_state_mutation"
 
 
 @dataclass(frozen=True)
@@ -35,6 +56,10 @@ class DivergenceResult:
             if ``run_a`` ran out first).
         b_event: The event from ``run_b`` at :attr:`index` (or ``None``
             if ``run_b`` ran out first).
+        reason_code: Machine-readable divergence class (one of the
+            ``REASON_CODE_*`` constants).
+        mutation_kind: Mutation kind when :attr:`reason_code` is
+            :data:`REASON_CODE_PROVIDER_STATE_MUTATION`, else empty.
     """
 
     diverged: bool
@@ -42,6 +67,8 @@ class DivergenceResult:
     reason: str
     a_event: dict[str, Any] | None = None
     b_event: dict[str, Any] | None = None
+    reason_code: str = REASON_CODE_NONE
+    mutation_kind: str = ""
 
 
 def load_events(path: Path) -> list[dict[str, Any]]:
@@ -68,12 +95,74 @@ def load_events(path: Path) -> list[dict[str, Any]]:
     return events
 
 
-def _comparable(event: dict[str, Any]) -> tuple[Any, Any, Any]:
-    """Project an event onto the fields used for divergence comparison."""
+def _comparable(event: dict[str, Any]) -> tuple[Any, ...]:
+    """Project an event onto the fields used for divergence comparison.
+
+    Gateway rows compare on ``(kind, key, response)``; canonical journal
+    rows carry ``(event, payload_hash)`` instead, so those are folded in
+    additively (both are ``None`` for gateway rows on both sides).
+    """
     return (
         event.get("kind"),
         event.get("key"),
         event.get("response"),
+        event.get("event"),
+        event.get("payload_hash"),
+    )
+
+
+def _mutation_kind_of(event: dict[str, Any] | None) -> str | None:
+    """Return the mutation kind when *event* is a mutation entry, else ``None``.
+
+    Recognises both canonical journal rows (``event`` field) and
+    gateway-style rows (``kind`` field).
+    """
+    if event is None:
+        return None
+    if PROVIDER_STATE_MUTATION_EVENT not in (event.get("event"), event.get("kind")):
+        return None
+    return str(event.get("mutation_kind", "")) or "unknown"
+
+
+def _attribute(
+    index: int,
+    a_event: dict[str, Any] | None,
+    b_event: dict[str, Any] | None,
+    *,
+    fallback_reason: str,
+    fallback_code: str,
+) -> DivergenceResult:
+    """Build the result for a divergence at *index*, naming mutations.
+
+    When either side's event at the divergence point is a provider-side
+    context mutation entry, the divergence is attributed with the named
+    reason code, the mutation kind, and the step index (issue #2507)
+    rather than the generic mismatch reason.
+    """
+    a_kind = _mutation_kind_of(a_event)
+    b_kind = _mutation_kind_of(b_event)
+    mutation_kind = a_kind or b_kind
+    if mutation_kind is not None:
+        present_in = "run_a" if a_kind is not None else "run_b"
+        return DivergenceResult(
+            diverged=True,
+            index=index,
+            reason=(
+                f"event #{index}: provider-side context mutation ({mutation_kind}) recorded in "
+                f"{present_in} has no counterpart at this step"
+            ),
+            a_event=a_event,
+            b_event=b_event,
+            reason_code=REASON_CODE_PROVIDER_STATE_MUTATION,
+            mutation_kind=mutation_kind,
+        )
+    return DivergenceResult(
+        diverged=True,
+        index=index,
+        reason=fallback_reason,
+        a_event=a_event,
+        b_event=b_event,
+        reason_code=fallback_code,
     )
 
 
@@ -100,12 +189,12 @@ def diff_event_logs(path_a: Path, path_b: Path) -> DivergenceResult:
     limit = min(len(a), len(b))
     for i in range(limit):
         if _comparable(a[i]) != _comparable(b[i]):
-            return DivergenceResult(
-                diverged=True,
-                index=i,
-                reason=(f"event #{i} differs: kind/key/response triple does not match"),
-                a_event=a[i],
-                b_event=b[i],
+            return _attribute(
+                i,
+                a[i],
+                b[i],
+                fallback_reason=f"event #{i} differs: kind/key/response triple does not match",
+                fallback_code=REASON_CODE_RESPONSE_MISMATCH,
             )
 
     if len(a) == len(b):
@@ -116,10 +205,12 @@ def diff_event_logs(path_a: Path, path_b: Path) -> DivergenceResult:
         )
 
     longer = "a" if len(a) > len(b) else "b"
-    return DivergenceResult(
-        diverged=True,
-        index=limit,
-        reason=(f"run_{longer} has {abs(len(a) - len(b))} extra event(s) after index {limit - 1 if limit else 0}"),
-        a_event=a[limit] if limit < len(a) else None,
-        b_event=b[limit] if limit < len(b) else None,
+    return _attribute(
+        limit,
+        a[limit] if limit < len(a) else None,
+        b[limit] if limit < len(b) else None,
+        fallback_reason=(
+            f"run_{longer} has {abs(len(a) - len(b))} extra event(s) after index {limit - 1 if limit else 0}"
+        ),
+        fallback_code=REASON_CODE_LENGTH_MISMATCH,
     )

--- a/src/bernstein/core/replay/provider_state.py
+++ b/src/bernstein/core/replay/provider_state.py
@@ -1,0 +1,426 @@
+"""Provider-side context mutation records for the replay journal.
+
+Issue #2507. Deterministic replay assumes context-as-sent equals
+context-as-consumed. The client side of that assumption is defended by
+the compaction policy recorded in the step fingerprint (see
+``bernstein.adapters.claude.apply_compaction_policy``), but providers
+also mutate model context server-side: compaction and similar opaque
+state carried between calls. The :class:`~bernstein.core.replay.journal.EventJournal`
+chains what was sent and what came back; a server-side rewrite between
+those two points was previously invisible, so replay either diverged
+with no attributable cause or matched byte-for-byte while the recorded
+run was not what the model actually consumed.
+
+This module treats provider-side state mutations as first-class chain
+entries:
+
+* Every observed mutation signal is recorded as a content-addressed
+  :data:`PROVIDER_STATE_MUTATION_EVENT` journal entry hashed over
+  ``(kind, before_digest, after_digest, step_index)``. Because the
+  journal chains every entry, removing or editing a mutation record
+  breaks chain verification at exactly that index: the record is
+  load-bearing, not a side log.
+* In deterministic-record and hermetic-replay modes
+  (:data:`DETERMINISTIC_SEED_ENV` / :data:`REPLAY_RUN_ID_ENV`) mutation
+  features are requested off at spawn time; a mutation that still
+  arrives is recorded **flagged** and :func:`verify_provider_state`
+  fails closed instead of silently accepting it. Outside deterministic
+  mode mutations are permitted but pinned: each is recorded before
+  execution continues.
+* An adapter's ability to observe mutations at all is itself recorded
+  per run as a :data:`MUTATION_CAPABILITY_EVENT` entry, so an absence
+  of mutation entries is distinguishable from an inability to see them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from pathlib import Path
+
+    from bernstein.core.replay.journal import EventJournal
+
+logger = logging.getLogger(__name__)
+
+#: Journal event type for one observed provider-side context mutation.
+PROVIDER_STATE_MUTATION_EVENT = "provider_state_mutation"
+
+#: Journal event type recording an adapter's mutation-observability
+#: capability for the run ("observed" or "declared-blind").
+MUTATION_CAPABILITY_EVENT = "provider_state_capability"
+
+#: The adapter surfaces provider-side mutation signals from its stream.
+CAPABILITY_OBSERVED = "observed"
+
+#: The adapter has no observation surface for provider-side mutations.
+#: Recorded per run so missing mutation entries stay interpretable.
+CAPABILITY_DECLARED_BLIND = "declared-blind"
+
+#: Env var naming deterministic-record mode. Mirrors the flag read by the
+#: orchestrator and the claude adapter; duplicated here so the replay
+#: layer does not import scheduler internals.
+DETERMINISTIC_SEED_ENV = "BERNSTEIN_DETERMINISTIC_SEED"
+
+#: Env var naming hermetic-replay mode (see :data:`DETERMINISTIC_SEED_ENV`).
+REPLAY_RUN_ID_ENV = "BERNSTEIN_REPLAY_RUN_ID"
+
+#: Prefixes that mark provider-reported *pre-mutation* state fields inside
+#: a mutation signal's detail payload (for example ``pre_tokens``).
+_BEFORE_FIELD_PREFIXES = ("pre_", "before_")
+
+
+def deterministic_mode_active(env: Mapping[str, str] | None = None) -> bool:
+    """Return whether this process runs in deterministic-record or replay mode.
+
+    Args:
+        env: Optional environment mapping (defaults to ``os.environ``).
+
+    Returns:
+        ``True`` when a deterministic seed or a replay run id is present.
+    """
+    src = os.environ if env is None else env
+    seed = src.get(DETERMINISTIC_SEED_ENV, "").strip()
+    replay = src.get(REPLAY_RUN_ID_ENV, "").strip()
+    return bool(seed) or bool(replay)
+
+
+def _canonical_sha256(payload: Any) -> str:
+    """Return the SHA-256 hex digest of the canonical JSON of *payload*."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderStateMutation:
+    """One provider-side context mutation observed during a run.
+
+    Attributes:
+        kind: Mutation kind as reported by the provider stream (for
+            example ``compact_boundary``).
+        before_digest: Content digest of the provider-reported
+            pre-mutation state metadata (empty-object digest when the
+            provider reported none).
+        after_digest: Content digest of the full provider-reported
+            mutation payload.
+        step_index: 0-based position of the mutation within the
+            session's observed signal order.
+        flagged: ``True`` when the mutation arrived in deterministic
+            mode despite suppression being requested. Policy state, not
+            mutation identity: excluded from :meth:`content_address`.
+    """
+
+    kind: str
+    before_digest: str
+    after_digest: str
+    step_index: int
+    flagged: bool = False
+
+    def content_address(self) -> str:
+        """Return the content address hashed over the identity fields.
+
+        The address is ``SHA-256`` of the canonical JSON of
+        ``(kind, before_digest, after_digest, step_index)``, so two
+        independent recorders derive the same address for the same
+        reported mutation.
+        """
+        return _canonical_sha256(
+            {
+                "kind": self.kind,
+                "before_digest": self.before_digest,
+                "after_digest": self.after_digest,
+                "step_index": self.step_index,
+            }
+        )
+
+
+def mutation_from_signal(
+    kind: str,
+    detail: Mapping[str, Any] | None,
+    *,
+    step_index: int,
+    flagged: bool = False,
+) -> ProviderStateMutation:
+    """Build a :class:`ProviderStateMutation` from a raw stream signal.
+
+    The provider-reported metadata is the only observable surface for a
+    server-side rewrite, so the digests are content addresses of that
+    report: ``before_digest`` covers the fields the provider labelled as
+    pre-mutation state (``pre_*`` / ``before_*``), ``after_digest``
+    covers the full reported payload.
+
+    Args:
+        kind: Mutation kind from the signal (for example
+            ``compact_boundary``).
+        detail: Raw provider-reported payload for the signal.
+        step_index: 0-based position within the session's signal order.
+        flagged: Whether the mutation arrived in deterministic mode.
+
+    Returns:
+        The content-addressable mutation record.
+    """
+    payload: dict[str, Any] = dict(detail or {})
+    before_fields = {k: v for k, v in payload.items() if k.startswith(_BEFORE_FIELD_PREFIXES)}
+    return ProviderStateMutation(
+        kind=str(kind),
+        before_digest=_canonical_sha256(before_fields),
+        after_digest=_canonical_sha256(payload),
+        step_index=step_index,
+        flagged=flagged,
+    )
+
+
+def record_provider_state_mutation(
+    journal: EventJournal,
+    mutation: ProviderStateMutation,
+    **extra: Any,
+) -> None:
+    """Chain one provider-side mutation into the run journal.
+
+    The entry participates in the journal's Merkle chain like any other
+    event: the head after this call commits to the mutation, so a later
+    removal or edit of the entry breaks verification at exactly its
+    index.
+
+    Args:
+        journal: The run's event journal.
+        mutation: The mutation record to chain.
+        **extra: Additional attribution fields (for example
+            ``agent_id``) folded into the hashed payload.
+    """
+    journal.record(
+        PROVIDER_STATE_MUTATION_EVENT,
+        mutation_kind=mutation.kind,
+        before_digest=mutation.before_digest,
+        after_digest=mutation.after_digest,
+        step_index=mutation.step_index,
+        content_address=mutation.content_address(),
+        flagged=mutation.flagged,
+        **extra,
+    )
+
+
+def record_mutation_capability(journal: EventJournal, *, adapter: str, capability: str) -> None:
+    """Record an adapter's mutation-observability capability for the run.
+
+    Args:
+        journal: The run's event journal.
+        adapter: Adapter registry name (or provider label when the
+            adapter could not be resolved).
+        capability: :data:`CAPABILITY_OBSERVED` or
+            :data:`CAPABILITY_DECLARED_BLIND`.
+    """
+    journal.record(MUTATION_CAPABILITY_EVENT, adapter=adapter, capability=capability)
+
+
+def capability_for_provider(provider: str | None, model: str = "") -> tuple[str, str]:
+    """Resolve the mutation-observability capability for a provider.
+
+    Falls back to :data:`CAPABILITY_DECLARED_BLIND` whenever the adapter
+    cannot be resolved: an unresolvable observation surface must read as
+    an inability to see mutations, never as their absence.
+
+    Args:
+        provider: Provider label from the agent session (may be ``None``).
+        model: Model string used for provider-name inference.
+
+    Returns:
+        ``(adapter_name, capability)``.
+    """
+    label = (provider or "").strip()
+    try:
+        from bernstein.adapters.registry import adapter_name_for_provider, get_adapter
+
+        name = adapter_name_for_provider(provider, model) or label
+        if not name:
+            return "unknown", CAPABILITY_DECLARED_BLIND
+        adapter = get_adapter(name)
+        capability = str(
+            getattr(adapter, "provider_mutation_observability", CAPABILITY_DECLARED_BLIND),
+        )
+        return name, capability
+    except Exception:
+        return label or "unknown", CAPABILITY_DECLARED_BLIND
+
+
+def record_agent_mutations(
+    journal: EventJournal,
+    signals: Iterable[Mapping[str, Any]],
+    *,
+    agent_id: str,
+    deterministic: bool | None = None,
+    audit_chain: Any | None = None,
+) -> int:
+    """Chain every observed mutation signal for one agent session.
+
+    In deterministic mode each entry is flagged (suppression was
+    requested, the mutation arrived anyway) so
+    :func:`verify_provider_state` fails closed; otherwise the entries
+    pin the mutations as part of the run identity. When *audit_chain*
+    is supplied, each chained entry is additionally mirrored into the
+    HMAC audit chain as a ``provider.state_mutation`` event anchored to
+    the journal head after the entry was chained.
+
+    Args:
+        journal: The run's event journal.
+        signals: Observed signals, each ``{"kind": str, "detail": dict}``,
+            in session observation order.
+        agent_id: The agent session the signals were observed for.
+        deterministic: Override for the run mode; defaults to
+            :func:`deterministic_mode_active`.
+        audit_chain: Optional
+            :class:`~bernstein.core.security.audit_chain.AuditChainStore`
+            accepting the mirrored events. Mirroring is best-effort: a
+            chain failure never blocks the journal entry.
+
+    Returns:
+        The number of mutation entries chained.
+    """
+    flagged = deterministic_mode_active() if deterministic is None else deterministic
+    recorded = 0
+    for step_index, signal in enumerate(signals):
+        kind = str(signal.get("kind", "")) or "unknown"
+        detail = signal.get("detail")
+        mutation = mutation_from_signal(
+            kind,
+            detail if isinstance(detail, dict) else {},
+            step_index=step_index,
+            flagged=flagged,
+        )
+        record_provider_state_mutation(journal, mutation, agent_id=agent_id)
+        recorded += 1
+        if audit_chain is not None:
+            _mirror_to_audit_chain(audit_chain, journal, mutation, agent_id=agent_id)
+    if recorded and flagged:
+        logger.warning(
+            "provider-state: %d mutation(s) arrived for agent %s in deterministic mode; recorded flagged (fail-closed)",
+            recorded,
+            agent_id,
+        )
+    return recorded
+
+
+def _mirror_to_audit_chain(
+    audit_chain: Any,
+    journal: EventJournal,
+    mutation: ProviderStateMutation,
+    *,
+    agent_id: str,
+) -> None:
+    """Mirror one chained mutation into the HMAC audit chain (best-effort)."""
+    try:
+        from bernstein.core.security.audit_chain import record_provider_state_mutation as _record_audit
+
+        _record_audit(
+            chain=audit_chain,
+            run_id=journal.run_id,
+            agent_id=agent_id,
+            mutation_kind=mutation.kind,
+            content_address=mutation.content_address(),
+            step_index=mutation.step_index,
+            flagged=mutation.flagged,
+            journal_head=journal.head(),
+        )
+    except Exception as exc:
+        # The journal entry is the load-bearing record; the audit mirror is
+        # provenance decoration and must never block it. Only the exception
+        # type is logged: this path touches the audit HMAC key.
+        logger.warning("provider-state: audit mirror failed: %s", type(exc).__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderStateVerifyResult:
+    """Outcome of :func:`verify_provider_state`.
+
+    Attributes:
+        ok: ``True`` only when the chain recomputes cleanly, every
+            mutation entry's content address matches its fields, and no
+            entry is flagged.
+        chain_ok: Whether the underlying Merkle chain verified.
+        mutation_count: Number of mutation entries walked.
+        flagged_indices: Journal indices of flagged mutation entries
+            (mutations that arrived in deterministic mode).
+        errors: Human-readable explanations for every failure.
+    """
+
+    ok: bool
+    chain_ok: bool
+    mutation_count: int
+    flagged_indices: list[int] = field(default_factory=list[int])
+    errors: list[str] = field(default_factory=list[str])
+
+
+def verify_provider_state(path: Path) -> ProviderStateVerifyResult:
+    """Verify a journal's provider-state mutation entries.
+
+    Extends plain chain verification with the fail-closed mutation
+    policy: a flagged entry (a mutation that arrived in deterministic
+    mode) or a mutation entry whose stored content address does not
+    match its recorded fields makes the result not ``ok`` even when the
+    chain itself is intact. Journals without mutation entries verify
+    exactly as before.
+
+    Args:
+        path: Path to a ``journal.jsonl`` file.
+
+    Returns:
+        A :class:`ProviderStateVerifyResult`.
+    """
+    from bernstein.core.replay.journal import load_events, verify_journal
+
+    chain = verify_journal(path)
+    errors = list(chain.errors)
+    flagged: list[int] = []
+    mutation_count = 0
+
+    for index, row in enumerate(load_events(path)):
+        if str(row.get("event", "")) != PROVIDER_STATE_MUTATION_EVENT:
+            continue
+        mutation_count += 1
+        kind = str(row.get("mutation_kind", ""))
+        expected_address = ProviderStateMutation(
+            kind=kind,
+            before_digest=str(row.get("before_digest", "")),
+            after_digest=str(row.get("after_digest", "")),
+            step_index=int(row.get("step_index", 0)),
+        ).content_address()
+        if str(row.get("content_address", "")) != expected_address:
+            errors.append(f"step {index}: provider_state_mutation content address mismatch")
+        if bool(row.get("flagged", False)):
+            flagged.append(index)
+            errors.append(
+                f"step {index}: flagged provider-side mutation ({kind}) arrived in deterministic mode",
+            )
+
+    return ProviderStateVerifyResult(
+        ok=chain.ok and not errors,
+        chain_ok=chain.ok,
+        mutation_count=mutation_count,
+        flagged_indices=flagged,
+        errors=errors,
+    )
+
+
+__all__ = [
+    "CAPABILITY_DECLARED_BLIND",
+    "CAPABILITY_OBSERVED",
+    "DETERMINISTIC_SEED_ENV",
+    "MUTATION_CAPABILITY_EVENT",
+    "PROVIDER_STATE_MUTATION_EVENT",
+    "REPLAY_RUN_ID_ENV",
+    "ProviderStateMutation",
+    "ProviderStateVerifyResult",
+    "capability_for_provider",
+    "deterministic_mode_active",
+    "mutation_from_signal",
+    "record_agent_mutations",
+    "record_mutation_capability",
+    "record_provider_state_mutation",
+    "verify_provider_state",
+]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -278,6 +278,19 @@ EVENT_ACTIVITY_RESULT = "activity.result"
 #: bytes themselves.
 EVENT_EVIDENCE_BUNDLE = "evidence.bundle"
 
+#: Issue #2507 -- emitted whenever an observed provider-side context mutation
+#: (compaction boundary or similar opaque state marker surfaced in provider
+#: responses) is chained into the run's replay journal. The event mirrors the
+#: mutation's content address ``H(kind, before_digest, after_digest,
+#: step_index)`` plus the journal head after the entry was chained, so an
+#: operator can prove, from the chain alone, that a server-side context
+#: rewrite was pinned into the run identity before anything built on the
+#: mutated state -- or that a flagged mutation arrived in deterministic mode
+#: and the run fails verification closed. Only the kind, the content address,
+#: the step index, the flag, and the journal anchor are recorded -- never the
+#: mutated context itself.
+EVENT_PROVIDER_STATE_MUTATION = "provider.state_mutation"
+
 #: Issue #2358 -- emitted whenever a run's durable work ledger is anchored
 #: to its dedicated git ref (``refs/bernstein/work-ledger/<run-id>``). The
 #: hash-chained ledger is the resumable task-graph state; this event mirrors
@@ -1920,6 +1933,62 @@ def record_evidence_bundle(
     )
 
 
+def record_provider_state_mutation(
+    *,
+    chain: AuditChainStore,
+    run_id: str,
+    agent_id: str,
+    mutation_kind: str,
+    content_address: str,
+    step_index: int,
+    flagged: bool,
+    journal_head: str,
+    actor: str = "provider_state",
+) -> AuditEvent:
+    """Append a ``provider.state_mutation`` event into *chain* (#2507).
+
+    Mirrors an observed provider-side context mutation's identity into the
+    HMAC-chained audit log after the mutation was chained into the run's
+    replay journal. Only the mutation kind, its content address, the step
+    index, the deterministic-mode flag, and the journal head anchor are
+    recorded -- never the mutated context. A verifier holding the run journal
+    can confirm the mutation entry is chain-attested and that a flagged
+    mutation fails replay verification closed.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        run_id: The run whose journal recorded the mutation.
+        agent_id: The agent session the mutation was observed for.
+        mutation_kind: Provider-reported mutation kind (for example
+            ``compact_boundary``).
+        content_address: ``H(kind, before_digest, after_digest, step_index)``
+            of the chained journal entry.
+        step_index: 0-based position within the session's signal order.
+        flagged: Whether the mutation arrived in deterministic mode.
+        journal_head: The run journal head after the entry was chained.
+        actor: Recorded actor; defaults to ``"provider_state"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded
+        in its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_PROVIDER_STATE_MUTATION,
+        actor=actor,
+        resource_type="provider_state_mutation",
+        resource_id=content_address,
+        details={
+            "run_id": run_id,
+            "agent_id": agent_id,
+            "mutation_kind": mutation_kind,
+            "content_address": content_address,
+            "step_index": step_index,
+            "flagged": flagged,
+            "journal_head": journal_head,
+        },
+    )
+
+
 def record_work_ledger_anchor(
     *,
     chain: AuditChainStore,
@@ -3143,6 +3212,7 @@ __all__ = [
     "EVENT_PLUGIN_INSTALL_RECEIPT",
     "EVENT_PLUGIN_UPDATE_RECEIPT",
     "EVENT_PROCESS_REAP_RECEIPT",
+    "EVENT_PROVIDER_STATE_MUTATION",
     "EVENT_REVIEW_BOARD_ACTION",
     "EVENT_REVIEW_RECEIPT",
     "EVENT_ROUTING_FAILOVER_RECEIPT",
@@ -3197,6 +3267,7 @@ __all__ = [
     "record_plugin_install_receipt",
     "record_plugin_update_receipt",
     "record_process_reap_receipt",
+    "record_provider_state_mutation",
     "record_review_board_action",
     "record_review_receipt",
     "record_routing_failover_receipt",

--- a/tests/unit/test_provider_state_capture.py
+++ b/tests/unit/test_provider_state_capture.py
@@ -1,0 +1,168 @@
+"""Tests for adapter-side capture of provider context mutations (issue #2507).
+
+The claude adapter's wrapper script and stream parser are the observation
+surface: provider-side context rewrites arrive as stream-json ``system``
+events. These tests pin that the signals are surfaced, persisted to the
+per-session sidecar, and exposed through the adapter contract, and that
+adapters without an observation surface declare themselves blind.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from bernstein.adapters.base import (
+    MUTATION_OBSERVABILITY_DECLARED_BLIND,
+    MUTATION_OBSERVABILITY_OBSERVED,
+    CLIAdapter,
+)
+from bernstein.adapters.claude import ClaudeCodeAdapter
+from bernstein.adapters.claude_stream_parser import (
+    PROVIDER_MUTATION_SUBTYPES,
+    ClaudeStreamParser,
+    StreamEventType,
+)
+from bernstein.adapters.claude_wrapper_script import build_wrapper_script
+from bernstein.adapters.registry import iter_adapter_specs
+
+
+class TestStreamParserMutationSignals:
+    def test_compact_boundary_system_event_is_a_mutation_signal(self) -> None:
+        parser = ClaudeStreamParser()
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "compact_boundary",
+                "compact_metadata": {"trigger": "auto", "pre_tokens": 90000},
+            }
+        )
+        events = parser.feed_line(line + "\n")
+
+        assert len(events) == 1
+        assert events[0].event_type == StreamEventType.PROVIDER_STATE_MUTATION
+        assert events[0].data["kind"] == "compact_boundary"
+        assert events[0].data["detail"]["compact_metadata"]["trigger"] == "auto"
+        assert parser.state.provider_mutations == [events[0].data]
+
+    def test_plain_system_events_are_not_mutation_signals(self) -> None:
+        parser = ClaudeStreamParser()
+        line = json.dumps({"type": "system", "subtype": "init", "message": "ready"})
+        events = parser.feed_line(line + "\n")
+
+        assert len(events) == 1
+        assert events[0].event_type == StreamEventType.SYSTEM
+        assert parser.state.provider_mutations == []
+
+    def test_all_declared_subtypes_recognised(self) -> None:
+        parser = ClaudeStreamParser()
+        for subtype in sorted(PROVIDER_MUTATION_SUBTYPES):
+            events = parser.feed_line(json.dumps({"type": "system", "subtype": subtype}) + "\n")
+            assert events[0].event_type == StreamEventType.PROVIDER_STATE_MUTATION
+        assert len(parser.state.provider_mutations) == len(PROVIDER_MUTATION_SUBTYPES)
+
+
+class TestWrapperMutationSidecar:
+    def _run_wrapper(self, script: str, ndjson: str) -> None:
+        subprocess.run(
+            [sys.executable, "-c", script],
+            input=ndjson.encode("utf-8"),
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+
+    def test_wrapper_writes_mutation_sidecar(self, tmp_path: Path) -> None:
+        sidecar = tmp_path / "session.jsonl"
+        script = build_wrapper_script(mutation_path=str(sidecar))
+        ndjson = (
+            json.dumps({"type": "system", "subtype": "init"})
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "system",
+                    "subtype": "compact_boundary",
+                    "compact_metadata": {"trigger": "auto", "pre_tokens": 12345},
+                }
+            )
+            + "\n"
+            + json.dumps({"type": "result", "result": "done"})
+            + "\n"
+        )
+        self._run_wrapper(script, ndjson)
+
+        rows = [json.loads(line) for line in sidecar.read_text(encoding="utf-8").splitlines()]
+        assert len(rows) == 1
+        assert rows[0]["kind"] == "compact_boundary"
+        assert rows[0]["detail"]["compact_metadata"]["pre_tokens"] == 12345
+
+    def test_wrapper_without_mutation_path_writes_nothing(self, tmp_path: Path) -> None:
+        script = build_wrapper_script()
+        assert "provider_state" not in script
+        ndjson = json.dumps({"type": "system", "subtype": "compact_boundary"}) + "\n"
+        self._run_wrapper(script, ndjson)
+        assert list(tmp_path.iterdir()) == []
+
+
+class TestAdapterContract:
+    def test_base_adapter_is_declared_blind(self) -> None:
+        assert CLIAdapter.provider_mutation_observability == MUTATION_OBSERVABILITY_DECLARED_BLIND
+
+    def test_base_adapter_observes_nothing(self, tmp_path: Path) -> None:
+        class _Blind(CLIAdapter):
+            def spawn(self, **kwargs: object) -> object:  # type: ignore[override]
+                raise NotImplementedError
+
+            def is_alive(self, pid: int) -> bool:
+                return False
+
+            def kill(self, pid: int) -> object:
+                raise NotImplementedError
+
+            def name(self) -> str:
+                return "blind"
+
+        assert _Blind().observed_provider_mutations(tmp_path, "s-1") == []
+
+    def test_claude_adapter_declares_observed(self) -> None:
+        assert ClaudeCodeAdapter.provider_mutation_observability == MUTATION_OBSERVABILITY_OBSERVED
+
+    def test_claude_reads_mutation_sidecar(self, tmp_path: Path) -> None:
+        sidecar_dir = tmp_path / ".sdd" / "runtime" / "provider_state"
+        sidecar_dir.mkdir(parents=True)
+        rows = [
+            {"kind": "compact_boundary", "detail": {"trigger": "auto"}},
+            {"kind": "context_edit", "detail": {}},
+            {"not-a-signal": True},
+        ]
+        (sidecar_dir / "s-9.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n",
+            encoding="utf-8",
+        )
+
+        signals = ClaudeCodeAdapter().observed_provider_mutations(tmp_path, "s-9")
+        assert signals == [
+            {"kind": "compact_boundary", "detail": {"trigger": "auto"}},
+            {"kind": "context_edit", "detail": {}},
+        ]
+
+    def test_claude_missing_sidecar_returns_empty(self, tmp_path: Path) -> None:
+        assert ClaudeCodeAdapter().observed_provider_mutations(tmp_path, "missing") == []
+
+    def test_registry_conformance_observed_adapters_override_capture(self) -> None:
+        """Adapters declaring observed capability must implement the capture hook.
+
+        Declared-blind adapters must NOT ship a partial capture surface: the
+        capability record in the journal is only trustworthy when the two
+        declarations agree.
+        """
+        for name, spec in iter_adapter_specs():
+            cls = spec if isinstance(spec, type) else type(spec)
+            capability = getattr(cls, "provider_mutation_observability", MUTATION_OBSERVABILITY_DECLARED_BLIND)
+            overrides = "observed_provider_mutations" in vars(cls)
+            if capability == MUTATION_OBSERVABILITY_OBSERVED:
+                assert overrides, f"adapter {name!r} declares observed but does not override capture"
+            else:
+                assert not overrides, f"adapter {name!r} overrides capture but declares {capability!r}"

--- a/tests/unit/test_provider_state_journal.py
+++ b/tests/unit/test_provider_state_journal.py
@@ -1,0 +1,464 @@
+"""Tests for provider-side context mutation journal entries (issue #2507).
+
+Deterministic replay assumes context-as-sent equals context-as-consumed.
+Provider-side context rewrites (compaction and similar opaque state) break
+that assumption invisibly unless every observed mutation is chained into
+the run journal before anything builds on it. These tests pin the issue's
+acceptance criteria:
+
+* AC1: a recorded mutation is load-bearing in the chain, not a side log.
+* AC2: replay diff attributes a missing mutation entry with the
+  ``provider_state_mutation`` reason code, the mutation kind, and the
+  exact step index.
+* AC3: in deterministic mode an arriving mutation is recorded flagged and
+  verification fails closed.
+* AC4: an adapter that cannot observe mutations produces a declared-blind
+  capability record.
+* AC5: journals without mutation entries verify unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from bernstein.core.replay.diff import (
+    REASON_CODE_PROVIDER_STATE_MUTATION,
+    REASON_CODE_RESPONSE_MISMATCH,
+    diff_event_logs,
+)
+from bernstein.core.replay.journal import EventJournal, verify_journal
+from bernstein.core.replay.provider_state import (
+    CAPABILITY_DECLARED_BLIND,
+    CAPABILITY_OBSERVED,
+    MUTATION_CAPABILITY_EVENT,
+    PROVIDER_STATE_MUTATION_EVENT,
+    ProviderStateMutation,
+    deterministic_mode_active,
+    mutation_from_signal,
+    record_agent_mutations,
+    record_mutation_capability,
+    record_provider_state_mutation,
+    verify_provider_state,
+)
+
+
+def _journal_with_mutation(sdd_dir: Path, run_id: str, *, flagged: bool = False) -> EventJournal:
+    """Build a journal whose third entry is a provider-side mutation."""
+    journal = EventJournal(run_id=run_id, sdd_dir=sdd_dir)
+    # Payloads are identical across fixtures so byte-identical executions
+    # chain to the same head regardless of the journal's directory name.
+    journal.record("run_started", plan="plan.yaml")
+    journal.record("task_claimed", task_id="T-1")
+    mutation = ProviderStateMutation(
+        kind="compact_boundary",
+        before_digest="a" * 64,
+        after_digest="b" * 64,
+        step_index=0,
+        flagged=flagged,
+    )
+    record_provider_state_mutation(journal, mutation)
+    journal.record("task_completed", task_id="T-1")
+    return journal
+
+
+class TestContentAddressing:
+    def test_content_address_is_stable_over_identity_fields(self) -> None:
+        m1 = ProviderStateMutation(kind="compact_boundary", before_digest="a", after_digest="b", step_index=3)
+        m2 = ProviderStateMutation(kind="compact_boundary", before_digest="a", after_digest="b", step_index=3)
+        assert m1.content_address() == m2.content_address()
+
+    def test_content_address_changes_with_any_identity_field(self) -> None:
+        base = ProviderStateMutation(kind="compact_boundary", before_digest="a", after_digest="b", step_index=3)
+        variants = [
+            ProviderStateMutation(kind="context_edit", before_digest="a", after_digest="b", step_index=3),
+            ProviderStateMutation(kind="compact_boundary", before_digest="x", after_digest="b", step_index=3),
+            ProviderStateMutation(kind="compact_boundary", before_digest="a", after_digest="y", step_index=3),
+            ProviderStateMutation(kind="compact_boundary", before_digest="a", after_digest="b", step_index=4),
+        ]
+        for variant in variants:
+            assert variant.content_address() != base.content_address()
+
+    def test_flag_does_not_change_content_address(self) -> None:
+        """The flag is policy state, not mutation identity."""
+        plain = ProviderStateMutation(kind="k", before_digest="a", after_digest="b", step_index=0)
+        flagged = ProviderStateMutation(kind="k", before_digest="a", after_digest="b", step_index=0, flagged=True)
+        assert plain.content_address() == flagged.content_address()
+
+    def test_mutation_from_signal_digests_reported_metadata(self) -> None:
+        detail = {"trigger": "auto", "pre_tokens": 90000, "post_tokens": 20000}
+        m = mutation_from_signal("compact_boundary", detail, step_index=2)
+        n = mutation_from_signal("compact_boundary", dict(detail), step_index=2)
+        assert m == n
+        assert m.before_digest
+        assert m.after_digest
+        assert m.before_digest != m.after_digest
+
+
+class TestChainLoadBearing:
+    """AC1: the mutation record is load-bearing in the chain."""
+
+    def test_two_recordings_with_mutation_produce_identical_heads(self, tmp_path: Path) -> None:
+        a = _journal_with_mutation(tmp_path / "a", "run-a")
+        b = _journal_with_mutation(tmp_path / "b", "run-b")
+        assert a.head() == b.head()
+        assert verify_journal(a.path).ok
+        assert verify_journal(b.path).ok
+
+    def test_editing_the_mutation_entry_breaks_chain_at_its_index(self, tmp_path: Path) -> None:
+        journal = _journal_with_mutation(tmp_path, "run-edit")
+        rows = journal.path.read_text(encoding="utf-8").splitlines()
+        tampered = json.loads(rows[2])
+        assert tampered["event"] == PROVIDER_STATE_MUTATION_EVENT
+        tampered["after_digest"] = "c" * 64
+        rows[2] = json.dumps(tampered)
+        journal.path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        result = verify_journal(journal.path)
+        assert not result.ok
+        assert result.divergent_index == 2
+
+    def test_removing_the_mutation_entry_breaks_chain_at_its_index(self, tmp_path: Path) -> None:
+        journal = _journal_with_mutation(tmp_path, "run-drop")
+        rows = journal.path.read_text(encoding="utf-8").splitlines()
+        del rows[2]
+        journal.path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        result = verify_journal(journal.path)
+        assert not result.ok
+        assert result.divergent_index == 2
+
+    def test_journal_without_mutations_verifies_unchanged(self, tmp_path: Path) -> None:
+        """AC5: pre-existing journals are unaffected by the new event type."""
+        journal = EventJournal(run_id="run-legacy", sdd_dir=tmp_path)
+        journal.record("run_started", run_id="run-legacy")
+        journal.record("task_completed", task_id="T-1")
+
+        assert verify_journal(journal.path).ok
+        state = verify_provider_state(journal.path)
+        assert state.ok
+        assert state.mutation_count == 0
+        assert state.flagged_indices == []
+
+
+class TestDeterministicPolicy:
+    """AC3: deterministic mode fails closed on arriving mutations."""
+
+    def test_deterministic_mode_reads_seed_and_replay_envs(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            assert not deterministic_mode_active()
+        with patch.dict("os.environ", {"BERNSTEIN_DETERMINISTIC_SEED": "42"}, clear=True):
+            assert deterministic_mode_active()
+        with patch.dict("os.environ", {"BERNSTEIN_REPLAY_RUN_ID": "run-1"}, clear=True):
+            assert deterministic_mode_active()
+
+    def test_flagged_mutation_fails_verification_closed(self, tmp_path: Path) -> None:
+        journal = _journal_with_mutation(tmp_path, "run-flagged", flagged=True)
+
+        assert verify_journal(journal.path).ok  # the chain itself is intact
+        state = verify_provider_state(journal.path)
+        assert not state.ok
+        assert state.flagged_indices == [2]
+        assert any("compact_boundary" in err for err in state.errors)
+
+    def test_unflagged_mutation_is_pinned_and_accepted(self, tmp_path: Path) -> None:
+        journal = _journal_with_mutation(tmp_path, "run-pinned", flagged=False)
+        state = verify_provider_state(journal.path)
+        assert state.ok
+        assert state.mutation_count == 1
+
+    def test_tampered_content_address_fails_verification(self, tmp_path: Path) -> None:
+        journal = _journal_with_mutation(tmp_path, "run-addr")
+        rows = journal.path.read_text(encoding="utf-8").splitlines()
+        tampered = json.loads(rows[2])
+        tampered["content_address"] = "0" * 64
+        rows[2] = json.dumps(tampered)
+        journal.path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        state = verify_provider_state(journal.path)
+        assert not state.ok
+
+    def test_record_agent_mutations_flags_in_deterministic_mode(self, tmp_path: Path) -> None:
+        journal = EventJournal(run_id="run-det", sdd_dir=tmp_path)
+        signals = [{"kind": "compact_boundary", "detail": {"trigger": "auto", "pre_tokens": 1}}]
+        with patch.dict("os.environ", {"BERNSTEIN_DETERMINISTIC_SEED": "7"}, clear=False):
+            recorded = record_agent_mutations(journal, signals, agent_id="agent-1")
+
+        assert recorded == 1
+        rows = [json.loads(line) for line in journal.path.read_text(encoding="utf-8").splitlines()]
+        assert rows[0]["event"] == PROVIDER_STATE_MUTATION_EVENT
+        assert rows[0]["flagged"] is True
+        assert rows[0]["agent_id"] == "agent-1"
+        assert not verify_provider_state(journal.path).ok
+
+    def test_record_agent_mutations_pins_outside_deterministic_mode(self, tmp_path: Path) -> None:
+        journal = EventJournal(run_id="run-live", sdd_dir=tmp_path)
+        signals = [
+            {"kind": "compact_boundary", "detail": {"trigger": "auto"}},
+            {"kind": "context_edit", "detail": {"edited": True}},
+        ]
+        with patch.dict("os.environ", {}, clear=True):
+            recorded = record_agent_mutations(journal, signals, agent_id="agent-2")
+
+        assert recorded == 2
+        rows = [json.loads(line) for line in journal.path.read_text(encoding="utf-8").splitlines()]
+        assert [r["flagged"] for r in rows] == [False, False]
+        assert [r["step_index"] for r in rows] == [0, 1]
+        assert verify_provider_state(journal.path).ok
+
+
+class TestDivergenceAttribution:
+    """AC2: replay diff names the mutation, its kind, and the step index."""
+
+    def _write_log(self, path: Path, rows: list[dict[str, object]]) -> None:
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    def test_missing_mutation_entry_attributed_with_reason_code(self, tmp_path: Path) -> None:
+        common = [
+            {"event": "run_started", "payload_hash": "p0"},
+            {"event": "task_claimed", "payload_hash": "p1"},
+        ]
+        mutation_row = {
+            "event": PROVIDER_STATE_MUTATION_EVENT,
+            "mutation_kind": "compact_boundary",
+            "payload_hash": "p2",
+        }
+        tail = [{"event": "task_completed", "payload_hash": "p3"}]
+
+        path_a = tmp_path / "a.jsonl"
+        path_b = tmp_path / "b.jsonl"
+        self._write_log(path_a, [*common, mutation_row, *tail])
+        self._write_log(path_b, [*common, *tail])
+
+        result = diff_event_logs(path_a, path_b)
+        assert result.diverged
+        assert result.index == 2
+        assert result.reason_code == REASON_CODE_PROVIDER_STATE_MUTATION
+        assert result.mutation_kind == "compact_boundary"
+        assert "compact_boundary" in result.reason
+        assert "2" in result.reason
+
+    def test_trailing_mutation_entry_attributed(self, tmp_path: Path) -> None:
+        common = [{"event": "run_started", "payload_hash": "p0"}]
+        mutation_row = {
+            "event": PROVIDER_STATE_MUTATION_EVENT,
+            "mutation_kind": "context_edit",
+            "payload_hash": "p1",
+        }
+        path_a = tmp_path / "a.jsonl"
+        path_b = tmp_path / "b.jsonl"
+        self._write_log(path_a, [*common, mutation_row])
+        self._write_log(path_b, common)
+
+        result = diff_event_logs(path_a, path_b)
+        assert result.diverged
+        assert result.index == 1
+        assert result.reason_code == REASON_CODE_PROVIDER_STATE_MUTATION
+        assert result.mutation_kind == "context_edit"
+
+    def test_plain_response_mismatch_keeps_generic_reason(self, tmp_path: Path) -> None:
+        path_a = tmp_path / "a.jsonl"
+        path_b = tmp_path / "b.jsonl"
+        self._write_log(path_a, [{"kind": "llm", "key": "k", "response": "one"}])
+        self._write_log(path_b, [{"kind": "llm", "key": "k", "response": "two"}])
+
+        result = diff_event_logs(path_a, path_b)
+        assert result.diverged
+        assert result.reason_code == REASON_CODE_RESPONSE_MISMATCH
+        assert result.mutation_kind == ""
+
+    def test_gateway_style_mutation_row_also_attributed(self, tmp_path: Path) -> None:
+        path_a = tmp_path / "a.jsonl"
+        path_b = tmp_path / "b.jsonl"
+        self._write_log(
+            path_a,
+            [
+                {"kind": "llm", "key": "k", "response": "r"},
+                {"kind": PROVIDER_STATE_MUTATION_EVENT, "mutation_kind": "compact_boundary"},
+            ],
+        )
+        self._write_log(path_b, [{"kind": "llm", "key": "k", "response": "r"}])
+
+        result = diff_event_logs(path_a, path_b)
+        assert result.diverged
+        assert result.index == 1
+        assert result.reason_code == REASON_CODE_PROVIDER_STATE_MUTATION
+
+
+class TestCapabilityRecord:
+    """AC4: observability capability is recorded per run."""
+
+    def test_record_mutation_capability_writes_journal_row(self, tmp_path: Path) -> None:
+        journal = EventJournal(run_id="run-cap", sdd_dir=tmp_path)
+        record_mutation_capability(journal, adapter="claude", capability=CAPABILITY_OBSERVED)
+
+        rows = [json.loads(line) for line in journal.path.read_text(encoding="utf-8").splitlines()]
+        assert rows[0]["event"] == MUTATION_CAPABILITY_EVENT
+        assert rows[0]["adapter"] == "claude"
+        assert rows[0]["capability"] == CAPABILITY_OBSERVED
+        assert verify_journal(journal.path).ok
+
+    def test_declared_blind_record_is_distinguishable(self, tmp_path: Path) -> None:
+        journal = EventJournal(run_id="run-blind", sdd_dir=tmp_path)
+        record_mutation_capability(journal, adapter="generic", capability=CAPABILITY_DECLARED_BLIND)
+
+        rows = [json.loads(line) for line in journal.path.read_text(encoding="utf-8").splitlines()]
+        assert rows[0]["capability"] == CAPABILITY_DECLARED_BLIND
+
+    def test_capability_for_provider_resolves_claude_as_observed(self) -> None:
+        from bernstein.core.replay.provider_state import capability_for_provider
+
+        name, capability = capability_for_provider("claude", "sonnet")
+        assert name == "claude"
+        assert capability == CAPABILITY_OBSERVED
+
+    def test_capability_for_unresolvable_provider_is_declared_blind(self) -> None:
+        from bernstein.core.replay.provider_state import capability_for_provider
+
+        name, capability = capability_for_provider("no-such-provider-2507", "")
+        assert capability == CAPABILITY_DECLARED_BLIND
+        assert name == "no-such-provider-2507"
+
+
+class TestVerifyCliFailClosed:
+    """AC3 surface: ``bernstein replay --verify`` exits non-zero on a flag."""
+
+    def test_verify_exits_nonzero_on_flagged_mutation(self, tmp_path: Path) -> None:
+        from bernstein.cli.advanced_cmd import replay_cmd
+        from click.testing import CliRunner
+
+        sdd_dir = tmp_path / ".sdd"
+        _journal_with_mutation(sdd_dir, "run-cli-flag", flagged=True)
+
+        result = CliRunner().invoke(replay_cmd, ["run-cli-flag", "--sdd-dir", str(sdd_dir), "--verify"])
+        assert result.exit_code == 1
+        assert "provider" in result.output.lower()
+
+    def test_verify_accepts_pinned_mutation(self, tmp_path: Path) -> None:
+        from bernstein.cli.advanced_cmd import replay_cmd
+        from click.testing import CliRunner
+
+        sdd_dir = tmp_path / ".sdd"
+        _journal_with_mutation(sdd_dir, "run-cli-pin", flagged=False)
+
+        result = CliRunner().invoke(replay_cmd, ["run-cli-pin", "--sdd-dir", str(sdd_dir), "--verify"])
+        assert result.exit_code == 0
+
+
+class TestOrchestratorWiring:
+    """The tick path records capability at spawn and chains mutations at reap.
+
+    Binds the real orchestrator methods onto a minimal stub (the pattern
+    used in ``tests/unit/orchestration/test_orchestrator_tick_methods.py``)
+    so the genuine implementation runs against a real journal.
+    """
+
+    @staticmethod
+    def _stub(tmp_path: Path) -> object:
+        from types import MethodType, SimpleNamespace
+
+        from bernstein.core.orchestration.orchestrator import Orchestrator
+
+        stub = SimpleNamespace(
+            _recorder=EventJournal(run_id="run-wire", sdd_dir=tmp_path / ".sdd"),
+            _mutation_capability_recorded=set(),
+            _agents={},
+            _workdir=tmp_path,
+        )
+        stub._record_mutation_capability_once = MethodType(
+            Orchestrator._record_mutation_capability_once,  # type: ignore[arg-type]
+            stub,
+        )
+        stub._record_provider_mutations_for = MethodType(
+            Orchestrator._record_provider_mutations_for,  # type: ignore[arg-type]
+            stub,
+        )
+        return stub
+
+    @staticmethod
+    def _session(session_id: str, provider: str) -> object:
+        from bernstein.core.tasks.models import AgentSession
+
+        return AgentSession(id=session_id, role="worker", provider=provider)
+
+    def _rows(self, stub: object) -> list[dict[str, object]]:
+        path = stub._recorder.path  # type: ignore[attr-defined]
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    def test_capability_recorded_once_per_provider_at_spawn(self, tmp_path: Path) -> None:
+        stub = self._stub(tmp_path)
+        session = self._session("agent-1", "claude")
+
+        stub._record_mutation_capability_once(session)
+        stub._record_mutation_capability_once(session)  # dedup within the run
+
+        rows = [r for r in self._rows(stub) if r["event"] == MUTATION_CAPABILITY_EVENT]
+        assert len(rows) == 1
+        assert rows[0]["adapter"] == "claude"
+        assert rows[0]["capability"] == CAPABILITY_OBSERVED
+
+    def test_unresolvable_provider_recorded_declared_blind(self, tmp_path: Path) -> None:
+        """AC4: inability to observe is recorded, never inferred from silence."""
+        stub = self._stub(tmp_path)
+        stub._record_mutation_capability_once(self._session("agent-2", "no-such-provider-2507"))
+
+        rows = [r for r in self._rows(stub) if r["event"] == MUTATION_CAPABILITY_EVENT]
+        assert len(rows) == 1
+        assert rows[0]["capability"] == CAPABILITY_DECLARED_BLIND
+
+    def test_reaped_agent_sidecar_signals_are_chained(self, tmp_path: Path) -> None:
+        """Sidecar -> adapter -> journal, end to end through the real reap path."""
+        stub = self._stub(tmp_path)
+        stub._agents["agent-3"] = self._session("agent-3", "claude")  # type: ignore[attr-defined]
+        sidecar_dir = tmp_path / ".sdd" / "runtime" / "provider_state"
+        sidecar_dir.mkdir(parents=True)
+        (sidecar_dir / "agent-3.jsonl").write_text(
+            json.dumps({"kind": "compact_boundary", "detail": {"trigger": "auto"}}) + "\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            stub._record_provider_mutations_for("agent-3")
+
+        rows = [r for r in self._rows(stub) if r["event"] == PROVIDER_STATE_MUTATION_EVENT]
+        assert len(rows) == 1
+        assert rows[0]["mutation_kind"] == "compact_boundary"
+        assert rows[0]["agent_id"] == "agent-3"
+        assert rows[0]["flagged"] is False
+        assert verify_provider_state(stub._recorder.path).ok  # type: ignore[attr-defined]
+
+    def test_reaped_agent_without_sidecar_records_nothing(self, tmp_path: Path) -> None:
+        stub = self._stub(tmp_path)
+        stub._agents["agent-4"] = self._session("agent-4", "claude")  # type: ignore[attr-defined]
+
+        stub._record_provider_mutations_for("agent-4")
+
+        assert [r for r in self._rows(stub) if r["event"] == PROVIDER_STATE_MUTATION_EVENT] == []
+
+
+class TestAuditMirror:
+    def test_recorded_mutation_is_mirrored_into_audit_chain(self, tmp_path: Path) -> None:
+        from bernstein.core.security.audit_chain import (
+            EVENT_PROVIDER_STATE_MUTATION,
+            AuditChainStore,
+        )
+
+        journal = EventJournal(run_id="run-audit", sdd_dir=tmp_path / "sdd")
+        chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+        signals = [{"kind": "compact_boundary", "detail": {"trigger": "auto"}}]
+
+        recorded = record_agent_mutations(
+            journal,
+            signals,
+            agent_id="agent-3",
+            deterministic=False,
+            audit_chain=chain,
+        )
+
+        assert recorded == 1
+        chain_text = "".join(p.read_text(encoding="utf-8") for p in (tmp_path / "audit").glob("*.jsonl"))
+        assert EVENT_PROVIDER_STATE_MUTATION in chain_text
+        assert journal.head() in chain_text


### PR DESCRIPTION
## Summary

Deterministic replay assumes context-as-sent equals context-as-consumed. The client half of that assumption is defended by the compaction policy recorded in the step fingerprint; provider-side context rewrites (compaction boundaries and similar opaque state carried between calls) were invisible to the journal, so replay either diverged with no attributable cause or matched while the recorded run was not what the model consumed. This change treats provider-side state mutations as first-class chain entries.

## Changes

- New `src/bernstein/core/replay/provider_state.py`: content-addressed `provider_state_mutation` journal entries hashed over `(kind, before_digest, after_digest, step_index)`, the per-run `provider_state_capability` record (`observed` / `declared-blind`), deterministic-mode policy, and `verify_provider_state` fail-closed verification.
- Claude adapter: the wrapper script appends every mutation signal (stream-json `system` subtypes such as `compact_boundary`) to a per-session sidecar; the adapter exposes them through the new `observed_provider_mutations` contract hook and declares `observed` capability. Observation policy is folded into the existing compaction fingerprint path.
- Adapter contract (`adapters/base.py`): `provider_mutation_observability` declaration, declared-blind by default, with a registry conformance test that the declaration and the capture hook agree for every adapter.
- Orchestrator: records the capability once per provider per run at spawn and chains each reaped agent's observed mutations before the `agent_reaped` event.
- Replay verification: `bernstein replay <run-id> --verify` exits non-zero when a flagged mutation (one that arrived in deterministic mode despite suppression) is present, even when the chain itself is intact.
- Divergence attribution: `bernstein replay diff` reports the `provider_state_mutation` reason code with the mutation kind and the exact step index instead of a generic response mismatch.
- Audit chain: each chained mutation is mirrored as a `provider.state_mutation` event anchored to the journal head (kind, content address, step index, flag only; never the mutated context).
- Docs: `docs/operations/deterministic-replay.md` and `docs/operations/replay.md`.

## Acceptance criteria coverage

- Recorded mutation replays to a byte-identical journal head; removing or editing the entry breaks chain verification at exactly that index: `TestChainLoadBearing` in `tests/unit/test_provider_state_journal.py`.
- Missing mutation entry attributed with reason `provider_state_mutation`, kind, and exact step index: `TestDivergenceAttribution`.
- Deterministic mode fails closed on an arriving mutation (flagged entry, non-zero verify): `TestDeterministicPolicy`, `TestVerifyCliFailClosed`.
- Declared-blind capability record for adapters that cannot observe: `TestCapabilityRecord`, `TestOrchestratorWiring`, and the registry conformance test in `tests/unit/test_provider_state_capture.py`.
- Existing journals without mutation entries verify unchanged; golden CLI snapshots pass unmodified.

Closes #2507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking of provider-side context changes during runs.
  * Deterministic replay now records and verifies these changes, including provider observability status.
  * Replay verification fails when unexpected provider mutations are detected.
  * Replay diffs identify mutation-related divergences and their affected step.
  * Provider mutations are included in the audit history.

* **Documentation**
  * Added guidance covering provider context mutations, replay behavior, verification, and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->