### PR TITLE
release: v3.5.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.4.4"
+version = "3.5.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.4.4",
+  "version": "3.5.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.4.4",
+      "version": "3.5.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.4.4",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.4.4"
+version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Version bump to 3.5.0 with regenerated lock and distribution manifests.

Highlights since v3.4.4:

- MCP core migrated to the stateless chain-anchored design on the live client, remote transport, and gateway paths (#2506)
- Provider-side context mutations recorded as content-addressed replay journal entries with divergence detection (#2507)
- Dependency updates (pillow 12.3.0), CI reliability fixes (weekly digest accuracy, workflow topology self-heal, SARIF scoping), security triage (salt derivation, cookie flags, workflow hardening)
- Web UI contributor roadmap refresh and docs corrections

Only version, lock, and manifest files change in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and distributed package version to **3.5.0**.
  * Updated the associated container image to use the **3.5.0** release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->