### PR TITLE
docs: fix runnable examples and configuration references

### DIFF
--- a/docs/architecture/DEPENDENCY_RESOLVER.md
+++ b/docs/architecture/DEPENDENCY_RESOLVER.md
@@ -2,29 +2,29 @@
 
 ## Overview
 
-The dependency conflict resolver is an automated system for detecting, resolving, and testing dependency updates. It integrates with GitHub Actions to run daily security scans and automatically propose tested fixes via pull requests.
+`scripts/check_dependencies.py` detects dependency problems and suggests
+tested upgrade resolutions. It is an operator-run script; run it locally
+or wire it into your own automation.
 
-## Components
+## What it does
 
-### 1. Dependency Scanner (`scripts/check_dependencies.py`)
+- **CVE detection**: runs `pip-audit` and parses the findings
+- **Conflict detection**: runs `uv pip compile pyproject.toml --resolution highest` and captures resolver conflicts
+- **Resolution suggestions**: for each CVE with a fix version, proposes the upgrade and dry-run-tests it (`uv pip install <pkg>==<version> --dry-run`)
+- **Output**: a JSON report plus a Rich console summary
 
-Detects dependency issues using industry-standard tools:
-- **CVE Detection**: `pip-audit` (MITRE CVE database)
-- **Conflict Detection**: `uv` dependency resolver
-- **Output**: JSON report with structured vulnerability data
+## Usage
 
-**Features:**
-- Parses pip-audit output to extract CVE details
-- Extracts fix versions and suggests upgrades
-- Tests compatibility of proposed upgrades
-- Generates JSON reports for CI/CD integration
-
-**Usage:**
 ```bash
-python scripts/check_dependencies.py --output .sdd/dependency-report.json
+uv run python scripts/check_dependencies.py --output .sdd/dependency-report.json
 ```
 
-**Report Structure:**
+`--output` defaults to `.sdd/dependency-report.json`. The script exits 1
+when any CVE or conflict is found, 0 otherwise, so it can gate a shell
+pipeline.
+
+## Report structure
+
 ```json
 {
   "timestamp": "ISO-8601",
@@ -35,145 +35,56 @@ python scripts/check_dependencies.py --output .sdd/dependency-report.json
   },
   "cves": [
     {
-      "package": "pip",
-      "current_version": "25.3",
-      "cve_id": "CVE-2026-1703",
-      "fix_versions": ["26.0"]
-    },
-    {
-      "package": "pygments",
-      "current_version": "2.19.2",
-      "cve_id": "CVE-2026-4539",
-      "fix_versions": []
+      "package": "example-package",
+      "current_version": "1.2.3",
+      "cve_id": "CVE-XXXX-YYYY",
+      "fix_versions": ["1.2.4"]
     }
   ],
+  "conflicts": [],
   "suggested_resolutions": [
     {
-      "package": "pip",
-      "current": "25.3",
-      "suggested": "26.0",
-      "reason": "CVE CVE-2026-1703: upgrade to 26.0+"
+      "package": "example-package",
+      "current": "1.2.3",
+      "suggested": "1.2.4",
+      "reason": "CVE CVE-XXXX-YYYY: upgrade to 1.2.4+"
     }
   ]
 }
 ```
 
-### 2. Fix Applier (`scripts/apply_dependency_fixes.py`)
+Point-in-time scan results live in the generated report, not in this
+page.
 
-Applies suggested upgrades, validates them, and optionally creates a PR:
-
-**Features:**
-- Updates `pyproject.toml` with new version constraints
-- Regenerates lockfile with `uv sync`
-- Runs full test suite to validate changes
-- Creates GitHub PR if all tests pass
-- Provides detailed commit message with fix rationale
-
-**Usage:**
-```bash
-# Apply fixes without PR
-python scripts/apply_dependency_fixes.py --report .sdd/dependency-report.json
-
-# Apply fixes and create PR (requires gh CLI and proper permissions)
-python scripts/apply_dependency_fixes.py --report .sdd/dependency-report.json --create-pr
-```
-
-**Workflow:**
-1. Parse dependency report
-2. Upgrade packages in `pyproject.toml`
-3. Update `uv.lock` via `uv sync`
-4. Run full test suite (`scripts/run_tests.py`)
-5. Create PR if tests pass
-6. Otherwise, keep changes for manual review
-
-### 3. GitHub Actions Workflow (`.github/workflows/dependency-security.yml`)
-
-Automates dependency scanning and remediation:
-
-**Schedule:**
-- Runs **daily at 2 AM UTC** (cron: `0 2 * * *`)
-- Can be triggered manually via workflow_dispatch
-
-**Steps:**
-1. Check out latest code
-2. Install audit tools (`pip-audit`, `safety`)
-3. Run dependency scanner
-4. Upload report as artifact
-5. Parse results and comment on issues
-6. Apply fixes and create PR (if scheduled run)
-7. Create GitHub issue if vulnerabilities are unresolvable
-
-**Manual Trigger:**
-```bash
-gh workflow run dependency-security.yml \
-  --ref main \
-  --field create_pr=true
-```
-
-## Current Status
-
-**Last Scan:** 2026-03-30
-
-### CVEs Detected
-| Package | Version | CVE ID | Fix Available | Status |
-|---------|---------|--------|---------------|--------|
-| pip | 25.3 | CVE-2026-1703 | 26.0 | ✓ Resolvable |
-| pygments | 2.19.2 | CVE-2026-4539 | None | ⏳ Awaiting fix |
-
-### Resolutions Applied
-- **pip**: 25.3 → 26.0 (Path Traversal vulnerability)
-
-### Notes
-- **pygments**: Vulnerable version has no fix available yet. Transitive dependency via `rich` and `textual`. Will auto-upgrade when fix is released.
-- **pip**: Not a project dependency (environmental tool), but flagged by scanner for visibility.
-
-## Integration
-
-The system is fully integrated into the project's CI/CD pipeline:
-
-1. **Automated Scans**: Run via scheduled GitHub Actions
-2. **Issue Creation**: Automatically filed when unresolvable CVEs are found
-3. **PR Creation**: Tested fixes automatically proposed to main
-4. **Test Gating**: Full test suite must pass before PR creation
-5. **Audit Trail**: All changes logged with CVE references
-
-## How It Works
-
-### Detection Flow
+## Detection flow
 
 ```mermaid
 graph TD
-    A["pip-audit / safety"] --> B["CVE list\n(package, version, CVE-ID, fix-versions)"]
+    A["pip-audit / uv resolver"] --> B["CVE list + conflicts\n(package, version, CVE-ID, fix-versions)"]
     B --> C["check_dependencies.py"]
     C --> D["JSON report\n(.sdd/dependency-report.json)"]
-    D --> E["GitHub Actions\nCreates issue or triggers fix"]
+    D --> E["Operator reviews report,\napplies upgrades, opens PR"]
 ```
 
-### Fix Flow
+## Applying a resolution
 
-```mermaid
-graph TD
-    A["dependency-report.json"] --> B["apply_dependency_fixes.py"]
-    B --> C["Update pyproject.toml"]
-    C --> D["uv sync → update uv.lock"]
-    D --> E["Test suite → validate changes"]
-    E --> F["git push → create PR"]
-```
+The script suggests and dry-run-tests upgrades; applying them is a
+manual step:
 
-## Testing
+1. Update the constraint in `pyproject.toml`.
+2. Regenerate the lockfile with `uv sync`.
+3. Validate with the full test suite: `uv run python scripts/run_tests.py -x`.
+4. Open a PR referencing the CVE ids from the report.
 
-All dependency updates are validated with the full test suite:
-```bash
-uv run python scripts/run_tests.py -x
-```
+## Related CI coverage
 
-This ensures:
-- No breaking changes in updated dependencies
-- All unit/integration tests still pass
-- Protocol compatibility maintained
+Dependency security is continuously covered by separate mechanisms:
+
+- the `pip-audit (deps)` job in [`.github/workflows/ci.yml`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/.github/workflows/ci.yml)
+- `.github/workflows/dependency-review.yml` on pull requests
+- Dependabot version and security updates
 
 ## See Also
 
 - [DESIGN.md](./DESIGN.md) - Architecture overview
-- [.github/workflows/ci.yml](https://github.com/sipyourdrink-ltd/bernstein/blob/main/.github/workflows/ci.yml) - Main CI pipeline
 - [pyproject.toml](https://github.com/sipyourdrink-ltd/bernstein/blob/main/pyproject.toml) - Project dependencies

--- a/docs/architecture/permission-modes.md
+++ b/docs/architecture/permission-modes.md
@@ -174,24 +174,32 @@ falls back to `default` with a warning.
 
 ## Worked example
 
-You run an agent in `auto` mode. Your `rules.yaml` says:
+You run an agent in `auto` mode. Your `.bernstein/rules.yaml` says
+(rules live in a flat list under the `permission_rules:` key; `id` and
+`action` are required, and a rule without them is skipped):
 
 ```yaml
-- match:
+# .bernstein/rules.yaml
+permission_rules:
+  - id: deny-rm-root
+    action: deny
+    severity: critical
     tool: Bash
-    command: "rm -rf /"
-  action: deny
-  severity: critical
-- match:
+    command: "rm -rf /*"
+  - id: ask-rm-recursive
+    action: ask
+    severity: high
     tool: Bash
     command: "rm -rf *"
-  action: ask
-  severity: high
-- match:
+  - id: ask-write
+    action: ask
+    severity: low
     tool: Write
-  action: ask
-  severity: low
 ```
+
+See [security-hardening.md](../security/security-hardening.md) for the
+full field reference (`id`, `action`, `severity`, `tool`, `command`,
+`path`, `description`).
 
 The agent calls:
 

--- a/docs/architecture/state-persistence.md
+++ b/docs/architecture/state-persistence.md
@@ -38,8 +38,9 @@ each run) is intentional:
 | `.sdd/config/mcp_servers.yaml` | MCP server auto-discovery catalog | durable - config |
 
 Rule of thumb: anything under `.sdd/runtime/` other than `wal/` is
-disposable. Anything under `.sdd/backlog/`, `.sdd/wal/`, `.sdd/metrics/`,
-`.sdd/cas/` or `.sdd/audit/` is needed to reconstruct state.
+disposable. Anything under `.sdd/backlog/`, `.sdd/runtime/wal/`,
+`.sdd/metrics/`, `.sdd/cas/` or `.sdd/audit/` is needed to reconstruct
+state.
 
 The repo's `.gitignore` excludes the volatile pieces; the durable pieces
 can be checked in or shipped to remote storage.

--- a/docs/cloudflare/cloudflare-adapters.md
+++ b/docs/cloudflare/cloudflare-adapters.md
@@ -39,8 +39,10 @@ Spawns agents via a Cloudflare Workers backend using `npx wrangler dev` locally.
 ### Configuration in bernstein.yaml
 
 ```yaml
-cli: cloudflare_agents
+cli: cloudflare
 ```
+
+The registry key is `cloudflare` (see `bernstein.adapters.registry`); the module name `cloudflare_agents` is not a registered key.
 
 ### Spawn parameters
 

--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -13,20 +13,25 @@ The MCP remote transport exposes Bernstein's MCP server over HTTP using the stre
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `host` | `str` | `"0.0.0.0"` | Bind host |
+| `host` | `str` | `"127.0.0.1"` | Bind host (loopback by default) |
 | `port` | `int` | `8053` | Bind port |
 | `path` | `str` | `"/mcp"` | URL path for MCP endpoint |
-| `auth_type` | `str` | `"none"` | Authentication: `"none"`, `"bearer"`, or `"oauth"` |
-| `auth_token` | `str` | `""` | Bearer token (when `auth_type="bearer"`) |
-| `cors_origins` | `list[str]` | `["*"]` | CORS allowed origins |
-| `max_sessions` | `int` | `100` | Maximum concurrent MCP sessions |
-| `session_timeout_seconds` | `int` | `3600` | Session expiry (1 hour) |
+| `auth_type` | `str` | `"bearer"` | Authentication: `"none"`, `"bearer"`, or `"oauth"` |
+| `auth_token` | `str` | `""` | Bearer token; when empty it is read from `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) |
+| `cors_origins` | `list[str]` | `["http://localhost:*"]` | CORS allowed origins |
+
+The config is safe by default: it binds to loopback and expects a bearer
+token. Construction raises `RemoteMCPConfigError` for any combination that
+would expose the JSON-RPC surface without authentication - `auth_type="none"`
+on a non-loopback host, or `auth_type="bearer"` with no token on a
+non-loopback host. There is no session store, so there are no session
+capacity or timeout fields (see "Stateless operation" below).
 
 ---
 
 ## Available tools
 
-The remote transport exposes these MCP tools (same as the local MCP server):
+The remote transport exposes exactly these MCP tools:
 
 | Tool | Description | Required args |
 |------|-------------|---------------|
@@ -48,10 +53,11 @@ The remote transport exposes these MCP tools (same as the local MCP server):
 ```python
 from bernstein.mcp.remote_transport import RemoteMCPConfig, run_remote
 
-# Start with defaults (binds to 0.0.0.0:8053)
+# Start with defaults (binds to 127.0.0.1:8053; token from BERNSTEIN_MCP_TOKEN)
 run_remote()
 
-# Custom configuration
+# Custom configuration. A non-loopback bind requires a bearer token,
+# either passed explicitly or via BERNSTEIN_MCP_TOKEN.
 run_remote(
     server_url="http://127.0.0.1:8052",  # Bernstein task server
     host="0.0.0.0",
@@ -67,11 +73,11 @@ For deployment with any ASGI server (uvicorn, hypercorn, Cloudflare Python worke
 from bernstein.mcp.remote_transport import RemoteMCPConfig, create_asgi_app
 
 config = RemoteMCPConfig(
+    host="0.0.0.0",
     port=8053,
     auth_type="bearer",
     auth_token="my-secret-token",
     cors_origins=["https://myapp.example.com"],
-    max_sessions=50,
 )
 
 app = create_asgi_app(
@@ -93,25 +99,36 @@ The transport implements the MCP streamable HTTP transport spec:
 | Method | Path | Purpose |
 |--------|------|---------|
 | POST | `/mcp` | JSON-RPC 2.0 request/notification (single or batch) |
-| GET | `/mcp` | SSE stream endpoint (stub, returns 501) |
-| DELETE | `/mcp` | Close an MCP session |
+| GET | `/mcp` | Server-initiated SSE stream (stub, returns 501; use POST plus `notifications/cancelled`) |
+| DELETE | `/mcp` | Legacy session close; acknowledged as a no-op during the compat window, 405 afterwards |
 | OPTIONS | `/mcp` | CORS preflight |
 
 ### Headers
 
 | Header | Direction | Description |
 |--------|-----------|-------------|
-| `mcp-session-id` | Both | Session identifier (returned on first POST, send on subsequent requests) |
 | `Authorization` | Request | `Bearer <token>` when `auth_type="bearer"` |
 | `Content-Type` | Both | `application/json` |
+| `mcp-session-id` | Request (legacy) | Removed by the stateless spec revision; accepted and ignored until 2027-07-28, then refused with 400. Never returned in responses. |
 
-### Session lifecycle
+### Stateless operation
 
-1. First POST creates a new session and returns `mcp-session-id` in the response headers.
-2. Subsequent requests include the session ID header to maintain state.
-3. DELETE with the session ID closes the session.
-4. Sessions expire after `session_timeout_seconds` (default 1 hour) of inactivity.
-5. Expired sessions are pruned automatically on each request.
+The 2026-07-28 MCP spec revision removed protocol sessions, and the
+transport implements the stateless model (#2506):
+
+1. There is no server-side session store. Every request is served from its
+   body plus the per-request `_meta` field alone, so any transport instance
+   can serve any request with no shared memory.
+2. Cross-call continuity is anchored in the run journal and the HMAC audit
+   chain, not in a session: when a journal and audit chain are wired in,
+   every served `tools/call` is recorded as an ordered
+   `mcp.stateless_call` entry with content-derived ids.
+3. A legacy client that still sends the removed `mcp-session-id` header is
+   served normally, with the header ignored, until 2027-07-28. After that
+   date a request carrying the header is refused with HTTP 400.
+4. `DELETE /mcp` (the removed session-close lifecycle) is acknowledged as a
+   no-op (`200 {"status":"ok"}`) during the same window; there is nothing
+   to close. After the window it returns 405.
 
 ---
 
@@ -127,22 +144,25 @@ The transport implements the MCP streamable HTTP transport spec:
 
 ### Example request
 
+Every request is self-contained; no session header is exchanged.
+
 ```bash
-# Initialize session
+# Initialize (returns server info and capabilities)
 curl -X POST http://localhost:8053/mcp \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $BERNSTEIN_MCP_TOKEN" \
   -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'
 
-# List tools (include session ID from previous response)
+# List tools
 curl -X POST http://localhost:8053/mcp \
   -H "Content-Type: application/json" \
-  -H "mcp-session-id: SESSION_ID" \
+  -H "Authorization: Bearer $BERNSTEIN_MCP_TOKEN" \
   -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}'
 
 # Run a task
 curl -X POST http://localhost:8053/mcp \
   -H "Content-Type: application/json" \
-  -H "mcp-session-id: SESSION_ID" \
+  -H "Authorization: Bearer $BERNSTEIN_MCP_TOKEN" \
   -d '{
     "jsonrpc":"2.0",
     "method":"tools/call",
@@ -160,17 +180,20 @@ curl -X POST http://localhost:8053/mcp \
 
 | Mode | Config | Behavior |
 |------|--------|----------|
-| `none` | `auth_type="none"` | No authentication (default, for local development) |
-| `bearer` | `auth_type="bearer"`, `auth_token="secret"` | Validates `Authorization: Bearer secret` header |
+| `bearer` | `auth_type="bearer"` (default), token from `auth_token=` or `BERNSTEIN_MCP_TOKEN` | Validates the `Authorization: Bearer <token>` header |
+| `none` | `auth_type="none"` | No authentication; only accepted on a loopback host |
 
-!!! warning "Production deployment"
-    Always use `auth_type="bearer"` with a strong token when exposing the MCP server over the network. The `"none"` mode is only safe for local development.
+!!! warning "Non-loopback binds require a token"
+    `RemoteMCPConfig` refuses to start (`RemoteMCPConfigError`) when the
+    host is not loopback and either `auth_type="none"` or the bearer token
+    is empty. Set `BERNSTEIN_MCP_TOKEN` (or pass `auth_token=`) before
+    binding to a public interface.
 
 ---
 
 ## CORS configuration
 
-By default, all origins are allowed (`["*"]`). For production, restrict to your application domains:
+By default only localhost origins are allowed (`["http://localhost:*"]`). For production, set your application domains:
 
 ```python
 config = RemoteMCPConfig(
@@ -180,7 +203,9 @@ config = RemoteMCPConfig(
 )
 ```
 
-CORS headers exposed: `mcp-session-id`.
+The legacy `mcp-session-id` header stays preflight-allowed during the
+compat window so older browser clients can still send it (the transport
+ignores it); no response header exposes it.
 
 ---
 
@@ -195,7 +220,6 @@ from bernstein.mcp.remote_transport import RemoteMCPConfig, create_asgi_app
 config = RemoteMCPConfig(
     auth_type="bearer",
     auth_token="YOUR_SECRET",
-    max_sessions=100,
 )
 
 app = create_asgi_app(

--- a/docs/operations/CONFIG.md
+++ b/docs/operations/CONFIG.md
@@ -160,7 +160,7 @@ All magic numbers live in `src/bernstein/core/defaults.py` as typed dataclasses.
 ```yaml
 tuning:
   orchestrator:
-    tick_interval_s: 5.0
+    tick_interval_s: 5.0    # default 3.0 (ORCHESTRATOR.tick_interval_s in core/defaults.py)
     drain_timeout_s: 120.0
     stale_claim_timeout_s: 1800.0
     stalled_manager_threshold_s: 300.0

--- a/docs/operations/TROUBLESHOOTING.md
+++ b/docs/operations/TROUBLESHOOTING.md
@@ -425,15 +425,15 @@ The `bernstein stop` command cleans these up, but hard kills (SIGKILL, power los
 
 ## 17. JSONL State File Corruption
 
-**Symptom:** Task server fails to start with a JSON parse error. `backlog.jsonl` or `tasks.jsonl` contains incomplete lines.
+**Symptom:** Task server fails to start with a JSON parse error. A JSONL state file (for example `.sdd/metrics/tasks.jsonl`) contains incomplete lines, or the shared JSON backlog `.sdd/runtime/task-backlog.json` fails to parse.
 
-**Cause:** The in-memory task store persists to JSONL via append writes. If the process is killed mid-write, the last line may be truncated.
+**Cause:** JSONL state files are persisted via append writes. If the process is killed mid-write, the last line may be truncated.
 
 **Diagnosis:**
 ```bash
 python3 -c "
 import json
-for i, line in enumerate(open('.sdd/backlog.jsonl'), 1):
+for i, line in enumerate(open('.sdd/metrics/tasks.jsonl'), 1):
     try: json.loads(line)
     except: print(f'Bad line {i}: {line[:80]!r}')
 "
@@ -582,7 +582,8 @@ find . -name "*<basename-without-extension>*"
 |------|---------|
 | `.sdd/runtime/<session>.log` | Per-agent stdout/stderr |
 | `.sdd/runtime/pids/<session>.json` | PID metadata for `bernstein ps` |
-| `.sdd/backlog.jsonl` | Persistent task backlog |
+| `.sdd/backlog/{open,claimed,closed}/` | YAML task specs (persistent backlog tree) |
+| `.sdd/runtime/task-backlog.json` | Shared JSON backlog for external workers (`bernstein backlog claim`) |
 | `.sdd/runtime/cost_report.json` | Run cost tracking |
 | `.sdd/runtime/access.jsonl` | HTTP request log (rotated at 10 MiB, 1 backup retained) |
 | `.sdd/runtime/server.log` | Task server logs |

--- a/docs/operations/glitchtip-setup.md
+++ b/docs/operations/glitchtip-setup.md
@@ -55,8 +55,8 @@ do.
 
    * GitHub Actions: `Settings -> Secrets and variables -> Actions ->
      New repository secret`, name `BERNSTEIN_TELEMETRY_DSN`. The
-     `bernstein-deploy.yml` workflow passes it through to the deploy
-     target.
+     consuming workflows are `bernstein-ci-fix.yml`, `eval-nightly.yml`,
+     and `auto-heal.yml` (see the table below).
    * systemd: drop into the unit's `EnvironmentFile=` or via
      `Environment=BERNSTEIN_TELEMETRY_DSN=...`.
    * Container: pass via `--env BERNSTEIN_TELEMETRY_DSN=...` or compose

--- a/docs/operations/merge-gate.md
+++ b/docs/operations/merge-gate.md
@@ -73,9 +73,9 @@ gh api -X PUT "repos/sipyourdrink-ltd/bernstein/branches/main/merge_queue" \
 
 After enabling, `gh pr merge --auto` will route the PR into the merge queue instead of merging immediately. CI then runs against the combined branch GitHub computes for the queued merge group, and the `merge_group:` trigger added to `.github/workflows/ci.yml` makes the existing CI suite respond to that event.
 
-### 3. Expand the required-check list
+### 3. Require the `CI gate` aggregator
 
-Set every layer of the gate stack plus the existing CI jobs as required checks. The set below covers the four holes documented in the TL;DR.
+Do not enumerate individual CI job names in `required_status_checks.contexts`. The literal job names drift (the type-check context is `Type check report`, and the test matrix reports sharded contexts such as `Test (ubuntu-latest, Python 3.13, shard 1)`), and a context that never reports wedges every merge on `main`. The `ci-gate` job in `ci.yml` (context `CI gate`) already rolls up every upstream job result with conditional allowed-skips, so it is the single context to require - the same recommendation as [merge-queue.md](merge-queue.md).
 
 ```bash
 gh api -X PATCH "repos/sipyourdrink-ltd/bernstein/branches/main/protection" \
@@ -83,22 +83,15 @@ gh api -X PATCH "repos/sipyourdrink-ltd/bernstein/branches/main/protection" \
   -f required_status_checks.strict=true \
   -F required_status_checks.contexts[]='CI gate' \
   -F required_status_checks.contexts[]='review-bot-ack' \
-  -F required_status_checks.contexts[]='Repo hygiene' \
-  -F required_status_checks.contexts[]='docs-drift / Run drift check' \
-  -F required_status_checks.contexts[]='Lint' \
-  -F required_status_checks.contexts[]='Type check' \
-  -F required_status_checks.contexts[]='Workflow lint' \
-  -F required_status_checks.contexts[]='Lineage Gate' \
-  -F required_status_checks.contexts[]='Test (ubuntu-latest, Python 3.12)' \
-  -F required_status_checks.contexts[]='Test (ubuntu-latest, Python 3.13)' \
-  -F required_status_checks.contexts[]='Test (windows-latest, Python 3.13)' \
-  -F required_status_checks.contexts[]='Test (macos-latest, Python 3.13)' \
-  -F required_status_checks.contexts[]='Bandit (security)' \
-  -F required_status_checks.contexts[]='pip-audit (deps)' \
   -F required_status_checks.contexts[]='main-red-guard'
 ```
 
-Note that `pre-merge-autosync` is intentionally NOT in the required-check list. The job runs to amend the PR; if the amend fails (e.g. branch-protection rejects the push) we want the next push to retry rather than blocking the merge.
+Notes:
+
+- `CI gate` covers `Repo hygiene`, `Lint`, `Type check report`, `Workflow lint`, `Lineage Gate`, `Bandit (security)`, `pip-audit (deps)`, the full sharded test matrix, and the rest of the `ci.yml` jobs it declares in `needs:`.
+- `review-bot-ack` and `main-red-guard` run on `pull_request` only. They belong in the legacy branch-protection list above (queue entry), never in the merge-queue ruleset, which must require `CI gate` only; a PR-only check on the ruleset makes the queue wait forever.
+- `docs-drift / Run drift check` is path-filtered (it does not report on PRs that touch no docs-relevant paths), so it must not be a blanket required check; its main-branch failure mode is the post-merge gate described in the TL;DR.
+- `pre-merge-autosync` is intentionally NOT required. The job runs to amend the PR; if the amend fails (e.g. branch-protection rejects the push) we want the next push to retry rather than blocking the merge.
 
 ### 4. Verify the layers work end to end
 
@@ -150,12 +143,12 @@ still FOLLOW a green streak on a real Windows runner, not precede it.
 1. Edit `.github/windows-lane-baseline.json` and set `"established": true`.
    No workflow edit is required - the gate reads this file at run time.
 
-2. Confirm the Windows contexts are already in the required-check list
-   (they are listed in section 3 above:
-   `Test (windows-latest, Python 3.13)`). If the shard fan-out changed the
-   context name, update section 3 to match the literal job name GitHub
-   reports, or branch protection will wait forever on a context that never
-   arrives.
+2. Confirm the Windows test result reaches branch protection. The Windows
+   matrix cells are `needs:` inputs of the `ci-gate` roll-up, so with the
+   `CI gate` context required (section 3 above) a blocked Windows lane
+   fails the gate; no literal `Test (windows-latest, ...)` context needs
+   to be (or should be) in the required-check list, since shard fan-out
+   changes would silently rename it.
 
 3. Land the baseline flip on main via the normal PR flow and watch one full
    Windows lane run go green as a *blocking* check.

--- a/docs/operations/performance-tuning.md
+++ b/docs/operations/performance-tuning.md
@@ -22,15 +22,9 @@ The right `max_agents` value depends on your provider's rate limits, not just yo
 
 ### Claude (Anthropic)
 
-| Subscription tier | Rate limit (approx.) | Recommended `max_agents` | Notes |
-|---|---|---|---|
-| **Free** | 50 req/day, ~5 req/min | 1 | Serial only; limited to experimentation |
-| **Plus** | 1,000 req/day, ~50 req/min | 2–3 | Light workloads; expect throttling on bursts |
-| **Pro** | 5,000 req/day, ~100 req/min | 4–6 | Default sweet spot; handles medium projects |
-| **Enterprise / Tier 2+** | Custom SLA | 8–16 | Negotiate limits with your Anthropic account team |
-| **Unlimited / Bedrock** | No hard cap | 16–32 | Limit by hardware and cost budget only |
+Rate limits vary by plan and change over time; consult your provider console (for Anthropic, the usage and limits pages) for your actual quota rather than any published table. As a rule of thumb: start at `max_agents: 1` on trial or entry-level tiers, 4-6 on a standard paid API tier, and 8+ only on enterprise or Bedrock-style deployments where the cap is hardware and cost budget.
 
-> **Tip:** Check your actual quota with `bernstein status --provider` or via the Anthropic console. Bernstein reads `X-RateLimit-*` headers and backs off automatically, but it cannot predict limits - set `max_agents` below your burst ceiling.
+> **Tip:** `bernstein status` shows a provider/quota table once the orchestrator has recorded provider snapshots. Bernstein reads `X-RateLimit-*` headers and backs off automatically, but it cannot predict limits - set `max_agents` below your burst ceiling.
 
 ### OpenAI / Gemini / Others
 
@@ -407,13 +401,17 @@ curl http://127.0.0.1:8052/status | jq '.metrics'
 
 ### Prometheus
 
+The task server exposes `GET /metrics` in Prometheus exposition format on its own port (default 8052); there is no separate metrics config block. Point your Prometheus scraper (which itself typically listens on 9090) at the task server:
+
 ```yaml
-prometheus:
-  enabled: true
-  port: 9090
+# prometheus.yml (scraper config, not bernstein.yaml)
+scrape_configs:
+  - job_name: bernstein
+    static_configs:
+      - targets: ["localhost:8052"]
 ```
 
-Metrics at `http://localhost:9090/metrics` in Prometheus exposition format. Grafana dashboards are included in `deploy/grafana/`.
+Metrics at `http://localhost:8052/metrics`. A ready-made scrape config lives in `deploy/prometheus/`, and Grafana dashboards are included in `deploy/grafana/`.
 
 ### CPU profiling
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -29,9 +29,8 @@ operator with a verifiable email address must register the project.
    answers are mechanical.
 4. Copy the assigned project ID (a numeric string) from the project
    page URL.
-5. Replace `<PROJECT_ID>` in `README.md` (look for the
-   `TODO(operator): register at bestpractices.dev` marker).
-6. Tick the CII checkbox in #1482 and link the README change.
+5. Add the bestpractices.dev badge with the assigned project ID to
+   `README.md` (alongside the existing badges at the top of the file).
 
 ### Self-assessment cross-walk
 
@@ -50,16 +49,15 @@ existing artefacts in this repository.
 | Documented secure development knowledge for at least one committer | `docs/operations/security-and-identity.md`; CONTRIBUTING checklist. |
 | Public bug tracker | GitHub Issues. |
 | Test suite invocable with a documented command | `pytest`; `README.md` "Build & test" block. |
-| Static analysis (SAST) in CI | CodeQL (`.github/workflows/codeql.yml`), Bandit (`.github/workflows/bandit-scan.yml`), Semgrep (`.github/workflows/semgrep.yml`). |
+| Static analysis (SAST) in CI | CodeQL (`.github/workflows/codeql.yml`); Bandit and Semgrep jobs in `.github/workflows/ci.yml`; `.github/workflows/static-analysis-extended.yml`. |
 | Dynamic analysis / fuzzing | Hypothesis property tests in `tests/`; ClusterFuzzLite at `.clusterfuzzlite/` + `.github/workflows/cifuzz-pr.yml`. |
 | Dependency vulnerability scanning | Dependabot, OSV via Scorecard, `.github/workflows/dependency-review.yml`. |
 | Cryptographic primitives are well-known | HMAC-SHA256, Ed25519/EdDSA, JWS detached. See module map in `CLAUDE.md` under `src/bernstein/core/security/`. |
 
 ### Re-evaluation cadence
 
-Re-run Scorecard after replacing `<PROJECT_ID>` to confirm the
-CIIBestPracticesID signal flips from 0 to a positive score. Update
-#1482 with the new score.
+Re-run Scorecard after the badge lands in `README.md` to confirm the
+CIIBestPracticesID signal flips from 0 to a positive score.
 
 ## Fuzzing harness (OSSF-recognized)
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1221,9 +1221,9 @@ See [`reference/mcp-catalog.md`](mcp-catalog.md) for the full reference.
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--transport {stdio\|http}` | stdio | ACP transport. |
-| `--port N` | 8054 | HTTP port. |
-| `--host HOST` | 127.0.0.1 | Bind host. |
+| `--stdio/--no-stdio` | `--stdio` | Serve over POSIX stdio (line-delimited JSON-RPC), the IDE embedding transport. |
+| `--http HOST:PORT` | off | Serve over HTTP on HOST:PORT (e.g. `:8062` or `127.0.0.1:8062`). Overrides `--stdio` when both are supplied. |
+| `--server-url URL` | `http://localhost:8052` | URL of the running Bernstein task server. |
 
 #### `bernstein fingerprint`
 

--- a/docs/security/capability-matrix.md
+++ b/docs/security/capability-matrix.md
@@ -88,7 +88,7 @@ print(decision.reason)
 
 | Knob | Default | Controls |
 |---|--:|---|
-| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` (deny + audit), `warn` (audit only), `off`. |
+| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` (refuse spawn + signed refusal audit event), `warn` (allow, warning recorded), `off` (allow). Every mode still records the evaluated chain in the per-spawn manifest under `.sdd/runtime/spawn_capabilities/`. |
 | `templates/capabilities/*.yaml` | three files: `adapters.yaml` (19 adapters), `mcp_tools.yaml`, `surfaces.yaml` | Capability declarations. |
 | Default for unknown tools | `frozenset(Capability)` (all three) | Fail-closed. |
 

--- a/docs/security/lethal-trifecta.md
+++ b/docs/security/lethal-trifecta.md
@@ -222,7 +222,7 @@ Failures we do not claim to handle:
 
 | Knob | Default | Effect |
 |---|---|---|
-| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` denies and audits; `warn` audits only; `off` audits only and allows. |
+| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` refuses the spawn and emits a signed refusal audit event; `warn` allows and records the warning; `off` allows. In every mode the capability evaluation still runs and its triggered set lands in the per-spawn manifest under `.sdd/runtime/spawn_capabilities/`. |
 | `templates/capabilities/*.yaml` | bundled for stock adapters, MCP tools, surfaces | Capability declarations. |
 | Default for unknown tools | all three (`PRIVATE_DATA`, `UNTRUSTED_INPUT`, `EXTERNAL_COMM`) | Fail-closed. |
 


### PR DESCRIPTION
## Summary

Fixes documentation snippets that fail when copied as written, each verified against the current source on main.

**CLI flags**
- `docs/reference/cli-reference.md`: replace the `bernstein acp serve` flag table with the real surface (`--stdio/--no-stdio`, `--http HOST:PORT`, `--server-url`), matching `cli/commands/acp_cmd.py`.

**Config keys and defaults**
- `docs/cloudflare/cloudflare-adapters.md`: `cli: cloudflare` (the registered adapter key; `cloudflare_agents` is not registered).
- `docs/cloudflare/cloudflare-mcp.md`: remove `max_sessions` / `session_timeout_seconds` from the config table and samples (the fields no longer exist, so the samples raise `TypeError`); document the shipped defaults (loopback bind, bearer auth via `BERNSTEIN_MCP_TOKEN`, localhost CORS) and the stateless request model per #2506, including the legacy session-header compat window.
- `docs/operations/CONFIG.md`: note the real `tick_interval_s` default (3.0) next to the override example.
- `docs/security/lethal-trifecta.md`, `docs/security/capability-matrix.md`: align the `lethal_trifecta_enforcement` mode descriptions with the policy code (both pages previously disagreed about `off`).

**Permission rules**
- `docs/architecture/permission-modes.md`: rewrite the `rules.yaml` worked example in the flat `permission_rules:` schema. The previous nested `match:` form (with no `id`) parses to zero rules, so a copied config silently left the example deny/ask rules inactive.

**CI context names**
- `docs/operations/merge-gate.md`: the copy-pasteable required-status-checks command listed contexts that no longer match any job name (`Type check`, unsharded `Test (...)` names), which would wedge every merge. It now requires the `CI gate` aggregator, consistent with merge-queue.md.

**References to files that do not exist**
- `docs/architecture/DEPENDENCY_RESOLVER.md`: scope the page to `scripts/check_dependencies.py`; the fix-applier script and scheduled workflow it documented are not in the repo, so every runnable command in those sections failed. Drop the baked-in point-in-time scan snapshot.
- `docs/operations/security.md`: SAST citations point at the existing workflows (ci.yml jobs, static-analysis-extended.yml, codeql.yml); registration checklist steps updated to the current README state.
- `docs/operations/glitchtip-setup.md`: name the actual `BERNSTEIN_TELEMETRY_DSN` consumers instead of a workflow that does not exist.
- `docs/operations/TROUBLESHOOTING.md`, `docs/architecture/state-persistence.md`: real backlog and WAL paths.
- `docs/operations/performance-tuning.md`: metrics are served by the task server (`:8052/metrics`); 9090 is the Prometheus scraper's own port. Drop a status flag that does not exist and unverifiable provider quota figures.

## Verification

- `mkdocs build` passes with the repo configuration.
- `bernstein acp serve --help` output matches the new flag table.
- The `RemoteMCPConfig` samples and the `rules.yaml` worked example were executed against the current modules (config construction, refusal path, and rule matching all behave as documented).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated dependency-checker guidance, report examples, and manual resolution steps.
  - Clarified permission-rule configuration examples and state persistence paths.
  - Documented Cloudflare adapter keys, stateless MCP transport, authentication, and endpoint behavior.
  - Updated CLI options, troubleshooting paths, metrics setup, performance guidance, and merge-gate procedures.
  - Clarified security enforcement modes, audit records, and CII Best Practices setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->