### PR TITLE
docs: tidy internal references and machine-specific content

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -152,6 +152,30 @@ All notable project changes are tracked here (code + docs).
 - Secrets broker for short-lived per-task tokens (#1605).
 - Bulk refurb auto-fix waves 1 + 2 across `src/` (#1558, #1582).
 
+### CI
+
+- **Bootstrap composite action for `astral-sh/setup-uv` (post-checkout).** Added `.github/actions/bootstrap/action.yml` wrapping `astral-sh/setup-uv` behind one pinned-SHA call. Inputs cover `python-version`, `enable-uv-cache`, `cache-key-suffix`, and a `setup-uv` toggle. The composite must be invoked AFTER `step-security/harden-runner` + `actions/checkout`, because a local composite action cannot resolve until the repository is checked out onto the runner. Each calling job inlines the harden-runner and checkout steps as before, then calls the composite for Python/uv setup. Net effect: pinned-SHA bumps for the uv setup now happen in one file instead of every job that runs uv.
+- **Install-path smoke matrix against the built wheel.** Added `install-smoke-pipx` (matrix: ubuntu-latest x macos-latest x Python 3.12 / 3.13, matching `requires-python = ">=3.12"`) and `install-smoke-uv` (leaner: ubuntu-latest + macos-latest, Python 3.12) jobs to `.github/workflows/ci.yml`. Both jobs install from the wheel produced by the `dist-size` job (never editable), then run `bernstein --version`, `bernstein --help`, and an `importlib.resources` probe against the pipx- or uv-managed interpreter to confirm `console_scripts`, entry-point loading, and `package-data` (MCP tool schemas, force-included default templates) survive the build. Wheel size is gated at 25 MB inside the smoke jobs (independent of the tighter 10 MB day-to-day ceiling enforced by `dist-size`). Both jobs are wired into the `CI gate` required-check rollup so a regression on the pipx or `uv tool install` path now blocks merge instead of surfacing through user reports. Closes the regression-coverage gap on the install path documented first in README.
+
+### Documentation
+
+- **Per-step CLI and model routing surfaced.** Added [`docs/workflows/per-step-routing.md`](workflows/per-step-routing.md) documenting the existing per-step `cli:` / `model:` / `effort:` plan fields, the surfaces that honour them, the surfaces that drop them, and a trace-based verification recipe. `templates/bernstein.yaml` now ships a commented-out per-stage override example that points at the new page. `templates/workflows/idea-to-pr.yaml` and `templates/workflows/refactor-with-tests.yaml` carry inline comments showing where operators most often want to pin different adapters or models and the plan-YAML lift to do it. The runtime support already existed (`plan_loader._parse_step` at `plan_loader.py:255-294`, `planner.py:86-96`); this PR closes the discoverability gap raised in discussion #962.
+
+## [2.2.0] - 2026-05-18
+
+### Security
+
+- **Strip invisible Unicode Tag codepoints from injected skills (spec 2026-05-17).** Public research (Feb 2026, Embrace the Red; Snyk skill-pack audit of 3,984 public files showing 36.82% with security flaws) demonstrated that invisible glyphs in the U+E0000-U+E007F Tag block are interpreted as instructions by Claude, Gemini, and Grok. Bernstein now strips every Cf-category, Tag-block, and interlinear-annotation codepoint from skill bodies before they are written into `.claude/skills/*.md` in agent worktrees. The new `bernstein.core.skills.sanitizer.strip_invisible_tags` function returns the cleaned body plus the count of stripped codepoints; the `SkillLoader` and `skills_injector` both invoke it at index time. A WARN log line plus a Prometheus counter `bernstein_skills_unicode_tags_stripped_total{source_name}` fire on every hit so operators can pinpoint a poisoned upstream source. Default ON; opt out with the hidden `--unsafe-allow-unicode-tags` CLI flag (or `BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS=1`) only when reproducing an incident in a controlled environment.
+
+### Added - routing
+
+- **Per-task criterion profile (#1346).** Operators can now stamp a four-axis weight vector (`correctness`, `cost`, `latency`, `reversibility`) onto individual tasks to bias model selection.  Named presets (`safety-first`, `speed-first`, `balanced`, `cost-first`) ship in `templates/criterion_profiles/` and force-include into the wheel.  Inline dicts work too: `metadata['criterion_profile'] = {"correctness": 0.6, ...}`.  Surfaced via `bernstein add-task --criterion-profile <preset>`, `bernstein run --criterion-profile <preset>`, and `bernstein criterion-profile show <task_id> | list`.  Feature flag `BERNSTEIN_CRITERION_PROFILE=0` reverts to pre-existing routing.  Child tasks inherit the parent's profile unless explicitly overridden.
+
+### Changed - chat bridge
+
+- **Telegram driver simplified to a single long-poll path.** The `python-telegram-bot` v22 long-poll driver at `bernstein.core.chat.drivers.telegram` is the only Telegram driver. Configure a bot API token from `@BotFather` and a chat id; no external services. The earlier optional bridge-router architecture has been removed.
+- **Telegram notification sink simplified.** `TelegramSink` accepts a live `TelegramBridge` via `config["bridge"]` or a token string via `config["token"]` and routes through the standard long-poll path.
+
 ## [2.0.0] - Web UI
 
 Bernstein now ships a web interface. The major bump is signalling the new operator surface, not a breaking API change. v1.10.x configs, plans, adapters, audit chain, lineage, and CLI / TUI surfaces are unchanged.
@@ -180,34 +204,6 @@ Hand-curated release notes: [`docs/release-notes/v2.0.0.md`](release-notes/v2.0.
 ### Limitations (intentional)
 
 - A11y audit, dark / light theme toggle UI, mobile-responsive pass, Settings screen wiring, Fleet UI, front-end test suite, Playwright e2e - all open. See [#1262](https://github.com/sipyourdrink-ltd/bernstein/issues/1262) for contributor-welcome pointers.
-
-## Unreleased
-
-### CI
-
-- **Bootstrap composite action for `astral-sh/setup-uv` (post-checkout).** Added `.github/actions/bootstrap/action.yml` wrapping `astral-sh/setup-uv` behind one pinned-SHA call. Inputs cover `python-version`, `enable-uv-cache`, `cache-key-suffix`, and a `setup-uv` toggle. The composite must be invoked AFTER `step-security/harden-runner` + `actions/checkout`, because a local composite action cannot resolve until the repository is checked out onto the runner. Each calling job inlines the harden-runner and checkout steps as before, then calls the composite for Python/uv setup. Net effect: pinned-SHA bumps for the uv setup now happen in one file instead of every job that runs uv.
-- **Install-path smoke matrix against the built wheel.** Added `install-smoke-pipx` (matrix: ubuntu-latest x macos-latest x Python 3.12 / 3.13, matching `requires-python = ">=3.12"`) and `install-smoke-uv` (leaner: ubuntu-latest + macos-latest, Python 3.12) jobs to `.github/workflows/ci.yml`. Both jobs install from the wheel produced by the `dist-size` job (never editable), then run `bernstein --version`, `bernstein --help`, and an `importlib.resources` probe against the pipx- or uv-managed interpreter to confirm `console_scripts`, entry-point loading, and `package-data` (MCP tool schemas, force-included default templates) survive the build. Wheel size is gated at 25 MB inside the smoke jobs (independent of the tighter 10 MB day-to-day ceiling enforced by `dist-size`). Both jobs are wired into the `CI gate` required-check rollup so a regression on the pipx or `uv tool install` path now blocks merge instead of surfacing through user reports. Closes the regression-coverage gap on the install path documented first in README.
-
-### Security
-
-- **Strip invisible Unicode Tag codepoints from injected skills (spec 2026-05-17).** Public research (Feb 2026, Embrace the Red; Snyk skill-pack audit of 3,984 public files showing 36.82% with security flaws) demonstrated that invisible glyphs in the U+E0000-U+E007F Tag block are interpreted as instructions by Claude, Gemini, and Grok. Bernstein now strips every Cf-category, Tag-block, and interlinear-annotation codepoint from skill bodies before they are written into `.claude/skills/*.md` in agent worktrees. The new `bernstein.core.skills.sanitizer.strip_invisible_tags` function returns the cleaned body plus the count of stripped codepoints; the `SkillLoader` and `skills_injector` both invoke it at index time. A WARN log line plus a Prometheus counter `bernstein_skills_unicode_tags_stripped_total{source_name}` fire on every hit so operators can pinpoint a poisoned upstream source. Default ON; opt out with the hidden `--unsafe-allow-unicode-tags` CLI flag (or `BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS=1`) only when reproducing an incident in a controlled environment.
-
-### Added - routing
-
-- **Per-task criterion profile (#1346).** Operators can now stamp a four-axis weight vector (`correctness`, `cost`, `latency`, `reversibility`) onto individual tasks to bias model selection.  Named presets (`safety-first`, `speed-first`, `balanced`, `cost-first`) ship in `templates/criterion_profiles/` and force-include into the wheel.  Inline dicts work too: `metadata['criterion_profile'] = {"correctness": 0.6, ...}`.  Surfaced via `bernstein add-task --criterion-profile <preset>`, `bernstein run --criterion-profile <preset>`, and `bernstein criterion-profile show <task_id> | list`.  Feature flag `BERNSTEIN_CRITERION_PROFILE=0` reverts to pre-existing routing.  Child tasks inherit the parent's profile unless explicitly overridden.
-
-### Changed - chat bridge
-
-- **Telegram driver simplified to a single long-poll path.** The `python-telegram-bot` v22 long-poll driver at `bernstein.core.chat.drivers.telegram` is the only Telegram driver. Configure a bot API token from `@BotFather` and a chat id; no external services. The earlier optional bridge-router architecture has been removed.
-- **Telegram notification sink simplified.** `TelegramSink` accepts a live `TelegramBridge` via `config["bridge"]` or a token string via `config["token"]` and routes through the standard long-poll path.
-
-### Repo hygiene
-
-- **Worktree-debris cleanup (2026-05-17).** Reaped 50 stale parent-level `bernstein-wt-*` worktrees plus `bernstein-audit-6e` (hireex/rebirth worktree on a bernstein-named path). Every branch tip was tag-rescued under `rescue/<branch>-20260517T152307Z` and pushed to origin before the worktree was force-removed and the local branch deleted. Three active-agent worktrees were preserved (`bernstein-wt-fix-determine-changes`, `bernstein-wt-fix-reviewer-prompts`, `bernstein-wt-syn-gitlab`). `git worktree list` is back to canonical: the main checkout plus the in-repo `.claude/worktrees/` registry.
-
-### Documentation
-
-- **Per-step CLI and model routing surfaced.** Added [`docs/workflows/per-step-routing.md`](workflows/per-step-routing.md) documenting the existing per-step `cli:` / `model:` / `effort:` plan fields, the surfaces that honour them, the surfaces that drop them, and a trace-based verification recipe. `templates/bernstein.yaml` now ships a commented-out per-stage override example that points at the new page. `templates/workflows/idea-to-pr.yaml` and `templates/workflows/refactor-with-tests.yaml` carry inline comments showing where operators most often want to pin different adapters or models and the plan-YAML lift to do it. The runtime support already existed (`plan_loader._parse_step` at `plan_loader.py:255-294`, `planner.py:86-96`); this PR closes the discoverability gap raised in discussion #962.
 
 ## [1.10.1] - 2026-05-07
 

--- a/docs/adapter-deferred.md
+++ b/docs/adapter-deferred.md
@@ -17,7 +17,6 @@ Verdicts are dated. Re-evaluate when the listed condition changes.
 - **SKIP** - structural reason this won't fit Bernstein's spawn model
   (web-only, in-IDE-only, gated behind a vendor account with no
   programmatic surface).
-- **PEER** - this is a peer of Bernstein, not an adapter target.
 
 ---
 
@@ -38,8 +37,7 @@ SAP BTP subaccount + entitlement. There is no free or community tier
 and no "log in with GitHub" path. SAP itself recommends the inverse
 integration (external agents calling Joule via SAP Cloud Connector +
 AI Hub), which belongs in a future MCP/skills ticket, not adapter
-code. Tracked in the internal backlog under
-`new-agent-adapters-sap-joule-and-others`.
+code.
 
 Re-evaluate when:
 
@@ -54,17 +52,16 @@ agents (Claude Code, Codex, Gemini CLI) reaching Joule that way is
 fundamentally an MCP/skills concern, not a CLIAdapter concern. When
 real demand surfaces, the venue is a new MCP catalog entry under
 `docs/integrations/` and a skill pack - not a new file under
-`src/bernstein/adapters/`. Cross-reference the same SAP Joule ticket
-above.
+`src/bernstein/adapters/`.
 
-## Tessl Framework - PEER (2026-05-06)
+## Tessl Framework - SKIP (2026-05-06)
 
-Tessl is a peer of Bernstein, not an adapter target. The `tessl` CLI
-exists, but under the hood it runs `claude-code`, `codex`, or
-`cursor` to do the actual work - it is a spec installer / agent
-harness wrapper. Wrapping it as a Bernstein adapter would mean we
-wrap a wrapper, and we'd inherit whatever process model Tessl uses
-to drive its underlying agent.
+The `tessl` CLI exists, but under the hood it runs `claude-code`,
+`codex`, or `cursor` to do the actual work - it is a spec installer /
+agent harness wrapper. Wrapping it as a Bernstein adapter would mean
+we wrap a wrapper: the adapter would inherit whatever process model
+Tessl uses to drive its underlying agent, which breaks the
+spawn-and-exit contract's assumption of a single observable process.
 
 If integration ever happens, the right venue is the planning layer:
 ingest a Tessl spec as input to a Bernstein plan, then let our own
@@ -90,16 +87,16 @@ TabbyML ships a true CLI agent that fits the spawn-and-exit model.
 ## Suna (Kortix) - DEFER (2026-05-06)
 
 Suna (Kortix, 14k+ stars, Apache 2.0) ships a `kortix` CLI with
-`start / stop / logs / status` subcommands, but it's a generalist
-agent platform - browser, files, web crawl - not a coding-focused
-CLI. The runtime is Docker-based, which is solvable, but the
-positioning overlaps almost entirely with `openhands`, which is
-already a Bernstein adapter.
+`start / stop / logs / status` subcommands - a service-manager
+surface, not a short-lived task process. It is also a generalist
+agent platform (browser, files, web crawl) rather than a
+coding-focused CLI, and the runtime is Docker-based. There is no
+single one-shot invocation whose stdout and exit code map onto task
+success or failure, which is what the spawn-and-exit adapter
+contract needs.
 
-Shipping a Suna adapter today would add another generalist option
-without giving users a coding-specific capability they don't already
-have. Re-evaluate when Suna positions itself for coding workflows
-specifically, or develops differentiation that OpenHands lacks.
+Re-evaluate when Suna ships a headless, coding-focused one-shot
+execution mode that fits the spawn-and-exit model.
 
 ## DeepSeek CLI - DEFER (2026-05-06)
 
@@ -110,12 +107,12 @@ to support means picking sides; users on a different fork would get
 broken behaviour, and we'd inherit maintenance risk for code that
 isn't ours.
 
-DeepSeek-V4 has very large reach in cost-sensitive and CN-heavy
-segments, so the demand is real - but the answer for now is to route
-DeepSeek models through the `openai_agents` runner (served natively
-via the DeepSeek API endpoint), `aider`, or `ollama`, all of which
-already work. Re-evaluate when DeepSeek ships an official CLI from the
-project itself.
+DeepSeek models are already reachable through the `openai_agents`
+runner (served natively via the DeepSeek API endpoint), `aider`, or
+`ollama`, all of which work today, so an adapter would not add a
+capability the spawn-and-exit contract does not already cover.
+Re-evaluate when DeepSeek ships an official CLI from the project
+itself.
 
 ## Phind / Pieces / Sweep - SKIP (2026-05-06)
 

--- a/docs/adapters/openai-agents-comparison.md
+++ b/docs/adapters/openai-agents-comparison.md
@@ -17,7 +17,13 @@ explains when to prefer each one.
 | Mature MCP + Bernstein-native tooling | `claude` |
 | Cheapest reasonable reasoning, fast iteration | `codex` (o4-mini or gpt-5.4-mini) |
 | OpenAI Agents SDK v2 sandboxed execution with first-class tool-use | **`openai_agents`** |
-| Large-context reads (>1M tokens) | `gemini` (Gemini 3.1 Pro) |
+| Large-context reads (>1M tokens) | `gemini` (Gemini 3.1 Pro, API-key / enterprise lane) |
+
+> **Gemini lane split (June 2026).** The hosted backend behind the legacy
+> `gemini` binary's free / AI Pro / Ultra path was discontinued for
+> non-enterprise users. The `gemini` adapter covers the enterprise /
+> API-key lane only; consumer-lane operators should route through the
+> `agy` adapter instead - see [agy.md](agy.md).
 
 When both `codex` and `openai_agents` could work: pick `openai_agents`
 if you care about the SDK's sandbox providers (E2B, Modal, Docker) or
@@ -54,7 +60,7 @@ docker, E2B, Modal, Daytona, Cloudflare, Vercel, Runloop, Blaxel).
 |---------|----------|---------|----------|-----------------|
 | **Vendor** | Anthropic | OpenAI | Google | OpenAI |
 | **Transport** | Claude Code CLI | `codex` CLI | `gemini` CLI | `openai-agents` Python SDK |
-| **Extra install** | `brew install claude` | `npm install -g @openai/codex` | `npm install -g @google/generative-ai-cli` | `pip install 'bernstein[openai]'` |
+| **Extra install** | `npm install -g @anthropic-ai/claude-code` | `npm install -g @openai/codex` | `npm install -g @google/gemini-cli` | `pip install 'bernstein[openai]'` |
 | **Structured output** | JSON schema enforced | `--json` | `--output-format json` | JSONL event stream |
 | **MCP support** | First-class | No | No | Via runner manifest (Bernstein-managed servers) |
 | **Sandboxing** | CLI permission model | Full-auto only | CLI permission model | Pluggable: unix_local / docker / e2b / modal |

--- a/docs/adapters/openai-agents.md
+++ b/docs/adapters/openai-agents.md
@@ -69,8 +69,8 @@ supported set has pricing rows in `src/bernstein/core/cost/cost.py`:
 | `o4` | 3.00 | 12.00 | Reasoning tasks |
 
 Any other model works - Bernstein will fall back to the generic
-`_model_cost` default if pricing is missing, and SonarCloud's cost
-panels will flag the gap.
+`_model_cost` default if pricing is missing, and the model shows up
+as an unpriced row in cost reports.
 
 ---
 

--- a/docs/compliance/eu-residency-customer-setup.md
+++ b/docs/compliance/eu-residency-customer-setup.md
@@ -168,7 +168,7 @@ for the auditor.
 ## Expected log lines
 
 A well-configured EU-residency run emits (one per line) the following
-in `.sdd/audit/audit.jsonl`:
+in `.sdd/audit/<YYYY-MM-DD>.jsonl` (the log is daily-rotated):
 
 ```
 event=adapter.spawn adapter=ollama model=deepseek-v4-flash base_url=http://10.0.0.5:11434
@@ -185,15 +185,15 @@ event=adapter.spawn.aborted reason=RESIDENCY_VIOLATION
 ```
 
 The audit chain HMAC covers every line so a tampered log is
-detectable via `bernstein verify --memory-audit` and
+detectable via `bernstein audit verify` and
 `bernstein doctor airgap`.
 
 ## What to hand the auditor
 
 Three artefacts settle the Article-12 evidence story:
 
-1. **`.sdd/audit/audit.jsonl`** -- the residency-gate decisions for
-   the audit window, with the HMAC chain intact.
+1. **`.sdd/audit/<YYYY-MM-DD>.jsonl`** -- the residency-gate decisions
+   for the audit window (daily-rotated), with the HMAC chain intact.
 2. **`MANIFEST.customer.json`** in the deployed wheelhouse -- the
    customer countersignature plus the org cosign signature, proving
    the running code was both vendor-signed AND customer-signed.

--- a/docs/decisions/007-pluggy-plugin-system.md
+++ b/docs/decisions/007-pluggy-plugin-system.md
@@ -120,7 +120,7 @@ def _safe_call(self, hook_name: str, **kwargs) -> None:
   that need to run before the default behavior.
 - **Entry point discovery.** A plugin distributed via pip just needs:
   ```toml
-  [project.entry-points."bernstein"]
+  [project.entry-points."bernstein.plugins"]
   my_plugin = "my_package:MyPlugin"
   ```
   Bernstein discovers and loads it automatically on startup.

--- a/docs/decisions/009-lineage-v1.md
+++ b/docs/decisions/009-lineage-v1.md
@@ -12,7 +12,7 @@
 
 ✅ **Solution shape.** Append-only content-addressed lineage log per artefact + Ed25519-signed entries + Sigstore-style transparency model. Compatible with A2A v1.0, MCP, EU AI Act Article 12.
 
-✅ **Wrappers that make it sell.** `bernstein compliance pack` (one-command Article 12 evidence bundle) + `bernstein-verify` (standalone auditor CLI, no Bernstein install needed) + 3 reference demos (fintech / healthcare / EU manufacturer).
+✅ **Operator surfaces.** `bernstein compliance pack` (one-command Article 12 evidence bundle) + `bernstein-verify` (standalone auditor CLI, no Bernstein install needed) + 3 reference demos (fintech / healthcare / EU manufacturer).
 
 ⏳ **Build mode.** 5 parallel worktree agents under one steward branch `feat/lineage-v1`. Wall-clock target: 3-4 days dispatch + integration.
 
@@ -260,7 +260,7 @@ MCP exposure is gated by `bernstein.lineage.mcp.enabled` config (default `false`
 
 ---
 
-## 8. Compliance pack (the killer feature for B2B)
+## 8. Compliance pack
 
 ### 8.1 Command
 
@@ -291,7 +291,7 @@ A compliance officer at a regulated company can:
 2. Run `bernstein-verify pack ./acme-compliance-2026-q2.zip` on their air-gapped laptop.
 3. Get a one-line PASS/FAIL plus a structured report mapped to Article 12 paragraph numbers.
 
-This is the **artifact** that closes a procurement loop. Without it, lineage is invisible to the buyer.
+The pack is the artifact that makes lineage independently checkable: without it, verification requires access to the producing repository.
 
 ### 8.4 Pack format versions and on-disk byte binding (#1871)
 
@@ -476,7 +476,7 @@ Steward writes `src/bernstein/core/lineage/entry.py` first (just the schema + JC
 
 ### 13.2 Phase 1 - parallel fan-out (A, B, C, D, E all simultaneously)
 
-Each agent gets a focused prompt + the schema file + this design doc. They run in parallel via `Agent` tool with `run_in_background: true`.
+Each agent gets a focused prompt + the schema file + this design doc. Agents are dispatched in parallel worktrees.
 
 ### 13.3 Phase 2 - Steward merge
 
@@ -492,36 +492,20 @@ PR runs full CI matrix (we already have it from bughunt). Once green: merge → 
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| EU AI Act deferred to Dec 2027 (Omnibus) | 0.40 | Drops compliance urgency by 12mo | Pitch SOC2 + ISO 42001 angles as fallback |
-| GitHub Agent HQ ships native lineage in Q3 2026 | 0.30 | Subsumed | Differentiate via local-first + multi-vendor + open format |
-| Sigstore-style is too complex to operate | 0.25 | Adoption stalls | The `compliance pack` is the simple surface; complexity hidden |
-| AAIF publishes competing standard | 0.20 | Our format is outlier | Use A2A v1.0 + RFC 7515 + RFC 8785 → already in the standards camp |
-| Performance regression: 10k writes too slow | 0.15 | UX issue | Perf tests in §12.5; batch fsync; async store flush |
-| Operator key rotation breaks chain | 0.15 | Audit-chain HMAC mismatches (we've seen this) | Document rotation procedure; ship `bernstein lineage rotate-hmac` helper |
-| Steward becomes single point of failure | 0.10 | Merges blocked | Multiple Steward agents allowed; policy allowlist |
+| EU AI Act Article 12 enforcement timeline shifts | Medium | Compliance-driven adoption arrives later | The evidence format is standards-based (RFC 7515/8785, SLSA-style manifest), so the same bundle serves SOC 2 and ISO 42001 audits |
+| Sigstore-style is too complex to operate | Medium | Adoption stalls | The `compliance pack` is the simple surface; complexity hidden |
+| Performance regression: 10k writes too slow | Low | UX issue | Perf tests in §12.5; batch fsync; async store flush |
+| Operator key rotation breaks chain | Low | Audit-chain HMAC mismatches (we've seen this) | Document rotation procedure; ship `bernstein lineage rotate-hmac` helper |
+| Steward becomes single point of failure | Low | Merges blocked | Multiple Steward agents allowed; policy allowlist |
 
 ---
 
-## 15. Success metrics (what tells us we won)
-
-### 15.1 Build-time
+## 15. Acceptance criteria
 
 - ✅ All tests pass (unit + property + mutation ≥75% + e2e + adversarial).
 - ✅ CI gate runs in <30s on typical PR.
 - ✅ Compliance pack for 10k entries generates in <10s.
 - ✅ bernstein-verify works in air-gap, no-bernstein-install scenario.
-
-### 15.2 Adoption (3-9 month horizon, per MPP scenario tree)
-
-- **S1 success indicator**: ≥1 design partner cites Article 12 evidence as procurement-unblocker. Target: 1 by end of Q3 2026.
-- **S2 success indicator**: ≥3 security blogs / Hacker News front page coverage citing the verify CLI. Target: 1 within 60 days of release.
-- **S3 fallback**: ≥1 OWASP / SLSA reference / talk submission accepted. Target: by end of 2026.
-
-### 15.3 Kill criteria
-
-If by end of Q3 2026:
-- No design partner conversation cites lineage as differentiator → reassess; pivot to cost-attribution feature.
-- Major platform ships equivalent → narrow to multi-vendor / on-prem niche.
 
 ---
 
@@ -536,12 +520,6 @@ If by end of Q3 2026:
 
 ## 17. References
 
-- `agentic_systems_v2.md` §3 Memory architecture (multi-agent shared memory unsolved problem)
-- `agentic_systems_v2.md` §f Enterprise governance (HMAC + signed audit pattern)
-- `agentic_systems_v2.md` Stage 0 §5 (HMAC audit envelope + signed Agent Card from day 1)
-- `software_development_v2.md` §2.4 (SLSA v1.0, Sigstore, SBOMs, signing)
-- `software_development_v2.md` §2.3 (fitness functions)
-- `software_development_v2.md` §3 phase 6 (property-based testing, mutation testing)
 - RFC 7515 JWS, RFC 7517 JWK, RFC 8785 JCS
 - A2A v1.0 Agent Card spec
 - Sigstore Rekor transparency log

--- a/docs/eval/yaml-harness.md
+++ b/docs/eval/yaml-harness.md
@@ -11,10 +11,9 @@ The harness lives in `src/bernstein/eval/yaml_runner.py`. The CLI surface is
 
 ## Why YAML
 
-Paid eval platforms ship the same affordances behind a $39 - $249 / seat / month
-paywall. Bernstein already had the primitives. The YAML wrapper is integration
+Bernstein already had the primitives. The YAML wrapper is integration
 glue: the spec is small enough to keep in git next to the prompts and large
-enough to reproduce a paid-tier eval suite end to end.
+enough to reproduce a full eval suite end to end, offline.
 
 ## TL;DR
 

--- a/docs/getting-started/quickstart-tutorial.md
+++ b/docs/getting-started/quickstart-tutorial.md
@@ -33,7 +33,7 @@ bernstein --version
 You should see something like:
 
 ```
-bernstein 2.16.1
+bernstein 3.5.0
 ```
 
 > **If you see "command not found"**: Make sure your tool bin directory is on `$PATH`.
@@ -247,10 +247,13 @@ Cost breakdown - last run
 Set a per-run budget limit in `bernstein.yaml`:
 
 ```yaml
-budget:
-  per_task_max_tokens: 100000
-  per_run_max_cost_usd: 5.00     # Hard stop if exceeded
+# Spending cap for the run. Accepts "$5", 5, or 5.0.
+budget: "$5"
 ```
+
+For a hard stop that refuses further agent spawns past the cap, configure a
+cost envelope with `hard_budget_usd` (see
+[CONFIG.md](../operations/CONFIG.md)).
 
 ---
 

--- a/docs/gui/configuration.md
+++ b/docs/gui/configuration.md
@@ -39,7 +39,7 @@ localStorage.setItem("bernstein_token", "<value of BERNSTEIN_AUTH_TOKEN>")
 ## Theme
 
 - The SPA uses Tailwind 3 with shadcn/ui CSS variables. Light + dark are toggled by the `.dark` class on `<html>`.
-- Tokens are defined in `web/src/index.css` (Variant A - Decision-Grade Quiet Command). See `.sdd/backlog/open/frontend/design_handoff_bernstein_phase1/README.md` §3.
+- Tokens are defined in `web/src/index.css`.
 - The theme respects `prefers-color-scheme` on first load and persists the operator's explicit choice via `localStorage`.
 - `prefers-reduced-motion: reduce` disables non-essential transitions (motion spec in `web/src/lib/motion.ts`).
 

--- a/docs/gui/screens.md
+++ b/docs/gui/screens.md
@@ -8,7 +8,7 @@ tags:
 
 # Screens
 
-Seven routes. Source: `web/src/routes/`. Design reference: `.sdd/backlog/open/frontend/design_handoff_bernstein_phase1/README.md` §6.
+Seven routes. Source: `web/src/routes/`. Design tokens: `web/src/index.css`.
 
 ## Screenshots
 

--- a/docs/gui/troubleshooting.md
+++ b/docs/gui/troubleshooting.md
@@ -96,7 +96,7 @@ Symptoms: navigation succeeds, page renders blank, no obvious error in the termi
 - The dark/light toggle flips the `.dark` class on `<html>`. Verify in DevTools Elements that `<html class="dark">` is present (or absent) when you click the toggle.
 - If the class flips but colors stay light, `web/src/index.css` was not loaded - confirm `<link rel="stylesheet" …>` resolves to `/ui/assets/index-*.css`.
 - If the page never honors `prefers-color-scheme`, check that the operator hasn't pinned a theme via `localStorage.theme` - clear it to fall back to system.
-- Token definitions: `web/src/index.css`. Source: `.sdd/backlog/open/frontend/design_handoff_bernstein_phase1/README.md` §3.
+- Token definitions: `web/src/index.css`.
 
 ## Sidebar Approvals badge stuck at zero
 

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -48,8 +48,8 @@ bernstein config set lineage.strict true
 # Full chain for one artefact
 bernstein lineage chain src/payments/flow.py
 
-# Stats across the whole repo
-bernstein lineage stats
+# Walk the ancestry of one artefact
+bernstein lineage walk src/payments/flow.py
 
 # Active forks (none should exist on a clean main)
 bernstein lineage forks

--- a/docs/lineage/tracker-audit.md
+++ b/docs/lineage/tracker-audit.md
@@ -12,7 +12,7 @@ SOX, SOC 2 Type II, and the EU AI Act.
 * Format: append-only JSONL, one entry per line, RFC 8785 JCS canonical
   bytes.
 * The file is gitignored; operator-side WORM storage is out of scope of
-  this module (see the ticket's *Out of scope* section).
+  this module (see the *Out of scope* section below).
 
 ## Entry schema (`schema_version: 1`)
 

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -17,8 +17,12 @@ This guide covers deploying Bernstein in cluster mode: Docker Compose for local/
 ### Quick start
 
 ```bash
-# 1. Copy and fill in your API keys
-cp .env.example .env
+# 1. Create .env with your auth token and API keys
+#    (full variable list in "Environment variables" below)
+cat > .env <<'EOF'
+BERNSTEIN_AUTH_TOKEN=change-me
+ANTHROPIC_API_KEY=sk-ant-...
+EOF
 $EDITOR .env
 
 # 2. Build the image and start the cluster

--- a/docs/operations/a2a-message-receipts.md
+++ b/docs/operations/a2a-message-receipts.md
@@ -50,7 +50,7 @@ set. `accept_inbound_task` rejects, with a distinct reason code, a card whose:
 ## Worktree isolation
 
 Each inbound peer task runs in a dedicated git worktree keyed by a session id
-derived from `task_uuid` (the f03 primitive). The worktree's isolation is
+derived from `task_uuid` (see `adapters/session_id.py`). The worktree's isolation is
 validated so its `.sdd` is a real per-worktree directory, not a symlink into the
 parent repo, so a peer cannot clobber another peer's state.
 

--- a/docs/operations/deployment-guide.md
+++ b/docs/operations/deployment-guide.md
@@ -154,7 +154,7 @@ jobs:
       - name: Install Claude Code (or your preferred CLI agent)
         run: npm install -g @anthropic-ai/claude-code
         # Alternatively:
-        # run: pip install openai-codex
+        # run: npm install -g @openai/codex
 
       - name: Run plan
         run: |
@@ -177,7 +177,7 @@ jobs:
 
       - name: Post summary
         if: always()
-        run: bernstein report --format markdown >> $GITHUB_STEP_SUMMARY
+        run: bernstein report >> $GITHUB_STEP_SUMMARY
 ```
 
 ### Running Bernstein from a workflow
@@ -387,9 +387,11 @@ The included `docker-compose.yaml` runs a full cluster: task server, orchestrato
 ### Setup
 
 ```bash
-# Copy and edit the env file
-cp .env.example .env
-# Edit .env: set ANTHROPIC_API_KEY and BERNSTEIN_AUTH_TOKEN
+# Create the env file: set ANTHROPIC_API_KEY and BERNSTEIN_AUTH_TOKEN
+cat > .env <<'EOF'
+BERNSTEIN_AUTH_TOKEN=change-me
+ANTHROPIC_API_KEY=sk-ant-...
+EOF
 
 # Start the full stack
 docker compose up -d
@@ -779,7 +781,7 @@ server_url: http://bernstein.internal:8052
 
 ```bash
 # Submit tasks to the shared server without running a local orchestrator
-bernstein task add "Implement login page" --role frontend --priority 2
+bernstein add-task "Implement login page" --role frontend --priority 2
 bernstein status   # see what the shared server is running
 bernstein ps       # list active agents
 ```
@@ -862,7 +864,6 @@ sudo systemctl start bernstein@project-b
 | `BERNSTEIN_LOG_LEVEL` | `INFO` | Log verbosity (`DEBUG`/`INFO`/`WARNING`/`ERROR`) |
 | `BERNSTEIN_LOG_JSON` | `false` | Emit JSON log lines (for log aggregators) |
 | `BERNSTEIN_BUDGET` | - | Hard spending cap in USD |
-| `BERNSTEIN_TICK_INTERVAL` | `5` | Orchestrator tick interval in seconds |
 | `BERNSTEIN_SKIP_GATES` | - | Skip quality gates (requires `BERNSTEIN_SKIP_GATE_REASON`) |
 | `BERNSTEIN_NO_TUI` | - | Disable interactive TUI (useful in CI) |
 | `BERNSTEIN_QUIET` | - | Suppress all non-error output |
@@ -886,7 +887,7 @@ On `switch_traffic()`, the `.sdd/` symlink is atomically re-pointed at `.sdd-gre
 
 ```python
 from pathlib import Path
-from bernstein.core.blue_green import BlueGreenConfig, BlueGreenDeployment
+from bernstein.core.orchestration.blue_green import BlueGreenConfig, BlueGreenDeployment
 
 cfg = BlueGreenConfig(
     health_check_url="http://127.0.0.1:8052/status",
@@ -924,7 +925,7 @@ curl http://127.0.0.1:8053/status
 # 4. Switch traffic via the Python API or CLI
 python3 -c "
 from pathlib import Path
-from bernstein.core.blue_green import BlueGreenConfig, BlueGreenDeployment
+from bernstein.core.orchestration.blue_green import BlueGreenConfig, BlueGreenDeployment
 cfg = BlueGreenConfig(health_check_url='http://127.0.0.1:8053/status')
 BlueGreenDeployment(cfg, Path('.')).switch_traffic()
 "
@@ -1038,8 +1039,8 @@ lsof -ti:8052 | xargs kill -9
 Agents exit when they have no work or cannot authenticate. Check logs:
 
 ```bash
-bernstein logs -f                       # follow all agent output
-bernstein logs -a claude                # filter by agent name
+bernstein logs tail -f                  # follow all agent output
+bernstein logs tail -a claude           # filter by agent name
 tail -f .sdd/runtime/logs/*.log         # raw log files
 ```
 

--- a/docs/operations/env-isolation.md
+++ b/docs/operations/env-isolation.md
@@ -66,8 +66,7 @@ function in a Unix-like environment:
 
 There is no built-in proxy entry. If you run behind a corporate proxy
 you probably want `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` -
-currently you have to add these as extras (see open question A4 in the
-spec).
+currently you have to add these as extras.
 
 ### Per-adapter extras
 
@@ -178,8 +177,9 @@ If a forbidden var leaks through, check:
 ### Unit-test pattern
 
 The shipped test suite (in `tests/unit/test_env_isolation.py` and the
-adapter-level Popen-spy tests) covers all 16 cases listed in the
-spec. The skeleton if you need to add an adapter:
+adapter-level Popen-spy tests) covers the base allowlist, secret
+exclusion, per-adapter extras, and per-adapter Popen pass-through
+cases. The skeleton if you need to add an adapter:
 
 ```python
 def test_my_adapter_filters_env(monkeypatch):

--- a/docs/operations/review-bot-ack.md
+++ b/docs/operations/review-bot-ack.md
@@ -50,17 +50,11 @@ look-back window (default 30 days) and runs the same classifier. Any
 PR with unresolved `must-address` findings is reported in a manifest;
 the workflow opens a consolidated follow-up PR
 (`fix(review): apply deferred review-bot findings`) carrying that
-manifest.
-
-Set `LANDING_REPO_PAT` for cross-repo writes; the workflow falls back
-to `GITHUB_TOKEN` if the PAT is absent.
+manifest. The workflow authenticates with `GITHUB_TOKEN`.
 
 ## Shepherd checklist
 
-The shepherd template that codifies the workflow for agents lives at
-`.sdd/_local/agent-prompts/shepherd-with-review.md` on the operator's
-local workspace. It is intentionally local-only so the acknowledgement
-strategy can evolve without churn against this repo. Shepherds:
+Shepherds:
 
 1. Watch CI to green.
 2. Fetch all CodeRabbit + Sourcery comments via the two `gh api`

--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -40,7 +40,6 @@ bernstein doctor                    # broader environment smoke test
 The capability gate uses
 `bernstein.core.agents.multimodal.is_multimodal_capable`; the
 inventory it consults is authoritative.
-(bot-ack: 3284182740 -- CodeRabbit minor.)
 
 ### Wire format
 

--- a/docs/operations/runbooks.md
+++ b/docs/operations/runbooks.md
@@ -93,7 +93,7 @@ An orchestration run is approaching or has exceeded its spending cap.
 **Runbook steps:**
 
 1. Check current spend: `GET /status` and inspect `cost_usd` in the response.
-2. Identify the highest-cost agents from `.sdd/metrics/cost_ledger.jsonl`.
+2. Identify the highest-cost agents from `.sdd/cost/ledger.jsonl`.
 3. Reduce parallelism: lower `max_agents` in `bernstein.yaml` to slow burn rate.
 4. Switch remaining tasks to cheaper models via `model_policy` overrides.
 5. If budget is already exhausted, stop the run: `bernstein stop`.

--- a/docs/operations/security-and-identity.md
+++ b/docs/operations/security-and-identity.md
@@ -227,10 +227,6 @@ opens a network connection to phone home install state.
 Kill switch: `BERNSTEIN_DISABLE_IDENTITY=1` short-circuits every
 emit site and returns the fixed sentinel `0000000000000000`.
 
-For the full operator runbook (seed generation, rotation cadence, decode
-utility, discovery via `gh search code`), see the install-fingerprint
-operator runbook.
-
 ## Audit log
 
 The audit log is **append-only, daily-rotated, and HMAC-chained**

--- a/docs/operations/verification-tracking.md
+++ b/docs/operations/verification-tracking.md
@@ -134,7 +134,7 @@ You see a red ALERT in `bernstein status`. What now?
 2. **Pull the recent unverified IDs.** From `bernstein status` or:
 
    ```bash
-   curl -s http://localhost:8080/status/ | jq '.verification_nudge.recent_unverified'
+   curl -s http://127.0.0.1:8052/status/ | jq '.verification_nudge.recent_unverified'
    ```
 
 3. **Spot-check one.** Pick a flagged task ID. Open its log summary

--- a/docs/playbooks/docs-drift.md
+++ b/docs/playbooks/docs-drift.md
@@ -165,23 +165,7 @@ curl -sS https://pypistats.org/api/packages/bernstein/recent | jq .data
 
 ## Cross-repo
 
-The public website and several long-form pages live in
-`sipyourdrink-ltd/bernstein-landing`.
-These pages mirror or extend the bernstein docs; when bernstein docs change,
-the landing copy may need a follow-up edit.
-
-| Landing page | Mirrors / extends |
-|--------------|-------------------|
-| `app/cli-quickstart/page.tsx` | `README.md` install + first-run, `docs/getting-started/install.md`, `docs/getting-started/first-run.md` |
-| `app/docs/cli/page.tsx` | `README.md` operator-commands table, `docs/reference/cli/` |
-| `app/why-bernstein/page.tsx` | `README.md` "at a glance" + capabilities, `docs/whats-new.md` |
-| `app/compare/` | `docs/compare/` comparison memos |
-| Blog (`app/blog/`) | Long-form essays that may cite `docs/concepts/` or `docs/architecture/` |
-
-The CI drift gate dispatches a `docs-mirror-sync` workflow in bernstein-landing
-on every push to `main` (only if the `LANDING_REPO_PAT` secret is set). The
-landing-side workflow is responsible for opening its own follow-up PR with the
-mirrored content.
+The public website mirrors some docs pages.
 
 ## Adding a new doc
 

--- a/docs/security/AUDIT.md
+++ b/docs/security/AUDIT.md
@@ -113,7 +113,7 @@ Audit mode is controlled by:
 2. **Config file**: Set `audit_mode: true` in `bernstein.yaml`
 3. **Compliance preset**: `bernstein run --compliance development` (includes audit)
 
-The HMAC key is automatically generated on first use and stored in `.sdd/audit/.hmac_key`. Protect this file-it's required for verification.
+The HMAC key is automatically generated on first use. It is resolved from, in order: `BERNSTEIN_AUDIT_KEY_PATH`, then `$XDG_STATE_HOME/bernstein/audit.key`, then `~/.local/state/bernstein/audit.key`. The key lives deliberately outside `.sdd` so it is isolated from the log volume. Protect this file - it's required for verification. See ["Key management" in audit-log.md](audit-log.md#key-management).
 
 ## SOC 2 Evidence Export
 
@@ -136,7 +136,7 @@ The package includes:
 | File | Purpose |
 |------|---------|
 | `.sdd/audit/*.jsonl` | Daily audit log files |
-| `.sdd/audit/.hmac_key` | HMAC signing key |
+| `~/.local/state/bernstein/audit.key` (overridable via `BERNSTEIN_AUDIT_KEY_PATH` or `$XDG_STATE_HOME`) | HMAC signing key, kept outside `.sdd` (see [audit-log.md](audit-log.md#key-management)) |
 | `.sdd/audit/merkle/` | Merkle tree seal records |
 | `.sdd/audit/archive/` | Compressed old logs |
 | `.sdd/evidence/article12_<bundle_id>.zip` | Article 12 evidence bundle (deterministic zip with manifest, events, data catalog, clause map). |

--- a/docs/security/security-hardening.md
+++ b/docs/security/security-hardening.md
@@ -359,8 +359,8 @@ audit:
   archive_compressed: true
 ```
 
-Each entry in `.sdd/metrics/audit.jsonl` contains a chain hash linking it to the previous
-entry. Any insertion, deletion, or modification breaks the chain.
+Each entry in `.sdd/audit/<YYYY-MM-DD>.jsonl` (daily-rotated) contains a chain hash linking
+it to the previous entry. Any insertion, deletion, or modification breaks the chain.
 
 ### Verify audit log integrity
 


### PR DESCRIPTION
Several docs pages referenced files and workflows that do not exist in the public repository or described one specific machine's setup. This change removes those references, fixes command examples and documented defaults that drifted from the shipped surface, and tightens a few rationale paragraphs. Verified locally with a strict docs-drift check and a full mkdocs build.