### PR TITLE
feat(mcp): add native claim and update tools returning verifiable receipts

### DIFF
--- a/docs/mcp/server.md
+++ b/docs/mcp/server.md
@@ -218,6 +218,69 @@ The ingested `traceparent` is carried as the lineage entry's `step_id`
 cross-link; a verifier holding the lineage spine reads the host trace off the
 artefact's provenance row.
 
+## Running the pull-worker loop over MCP
+
+An MCP-native worker drives its own claim, update, complete loop over MCP
+alone, with no second integration path (no CLI, no raw HTTP). Every step
+returns an object that verifies offline against the same audit chain
+`bernstein audit verify` walks: strip the chain and the signatures and the
+loop loses its meaning, not merely its log.
+
+1. **Claim** with `bernstein_claim`. The tool drives the dependency-gated
+   claim path: a task is offered only when every id in its `depends_on` is
+   present in `completed_ids`. Instead of a mutable task projection it returns
+   a signed **claim receipt** the worker holds:
+
+   ```json
+   {
+     "taskId": "t-42",
+     "granted": true,
+     "claimerCardFingerprint": "sha256:<claimer card>",
+     "backlogHead": "sha256:<digest of the backlog snapshot>",
+     "filterDigest": "sha256:<digest of the claim filter>",
+     "chainHead": "<audit-chain head the claim event recorded>",
+     "specRevision": "2026-07-28",
+     "receiptHash": "<content-addressed digest of this receipt>",
+     "signature": "<Ed25519 signature over the receipt hash>",
+     "signerPublicKeyPem": "<PEM public half>",
+     "pollToken": "<opaque base64; carries only the receipt identity>"
+   }
+   ```
+
+   A filter that matches no eligible task returns a signed **refusal receipt**
+   (`"granted": false`, empty `taskId`) - a claim attempt is never a silent
+   skip. Wall-clock is excluded from the pre-image, so replaying the same
+   backlog snapshot, claimer, and filter produces a byte-identical
+   `receiptHash`.
+
+2. **Report progress** with `bernstein_update`, as many times as needed. Each
+   update is DLP-redacted, HMAC-chained onto the worker mailbox journal,
+   Ed25519-signed, and mirrored to the audit chain (`task.mailbox_message`)
+   before returning. The result IS the signed journal entry (`seq`,
+   `prev_entry_hash`, `entry_hash`, `signature`, `body_hash`), not a bare
+   status string.
+
+3. **Complete** with `bernstein_approve` (the existing completion verb).
+
+Every claim and every update appears as an audit-chain entry
+(`task.claim_receipt` and `task.mailbox_message`), and no new audit event type
+is introduced. The claim receipt verifies offline - no network, no running
+server - by reprojecting the backlog head from the on-disk backlog and
+checking the embedded chain head:
+
+```bash
+bernstein backlog verify-claim --receipt receipt.json \
+  --backlog .sdd/runtime/task-backlog.json --audit-dir .sdd/audit
+```
+
+The offline verifier
+`bernstein.core.protocols.mcp.claim_receipt.verify_claim_receipt` performs the
+same check in-process. Because ownership disputes and progress questions are
+settled by replay against the chain rather than by trust, the task lifecycle
+surface over MCP is complete and uniformly provable: create, query, claim,
+update, complete, cancel, each returning an artifact that verifies against the
+chain.
+
 ## Worked example: pointing a host at the server
 
 1. Start the server over the streamable HTTP transport on loopback:

--- a/docs/mcp/tool_tiers.md
+++ b/docs/mcp/tool_tiers.md
@@ -16,7 +16,7 @@ callable.
 | Tier | Budget | Tools advertised | Use when |
 |------|--------|------------------|----------|
 | `core` | smallest | `bernstein_health`, `bernstein_run`, `bernstein_status`, `bernstein_tasks`, `bernstein_task_handle` | Cost-sensitive runs or small-context adapters; you only need to start and observe a run. |
-| `standard` (default) | medium | core plus `bernstein_cost`, `bernstein_stop`, `bernstein_approve`, `bernstein_create_subtask`, `load_skill` | The typical run: mutation, approval, and skill loading. |
+| `standard` (default) | medium | core plus `bernstein_cost`, `bernstein_stop`, `bernstein_approve`, `bernstein_create_subtask`, `bernstein_claim`, `bernstein_update`, `load_skill` | The typical run: mutation, approval, the pull-worker claim/update verbs, and skill loading. |
 | `all` | largest | standard plus the scenario bridge (`bernstein_scenarios`, `bernstein_scenario`, `bernstein_scenario_status`) and `verify_chain` | Power-user setups that drive scenario libraries or audit lineage. |
 
 The exact membership is declared once in

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -96,6 +96,62 @@ def claim_backlog(
     console.print(claimed.id)
 
 
+@backlog_group.command("verify-claim")
+@click.option(
+    "--receipt",
+    "receipt_path",
+    default="-",
+    metavar="PATH",
+    help="Claim receipt JSON to verify ('-' reads stdin).",
+)
+@click.option(
+    "--backlog",
+    "backlog_path",
+    default=Path(".sdd/runtime/task-backlog.json"),
+    show_default=True,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Path to the shared JSON backlog to reproject from.",
+)
+@click.option(
+    "--audit-dir",
+    "audit_dir",
+    default=Path(".sdd/audit"),
+    show_default=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Audit chain directory the claim event was mirrored into.",
+)
+def verify_claim(receipt_path: str, backlog_path: Path, audit_dir: Path) -> None:
+    """Verify a claim receipt offline against the backlog and audit chain.
+
+    Reprojects the backlog head from the on-disk backlog, checks the receipt
+    signature, verifies the audit chain, and confirms a matching
+    ``task.claim_receipt`` event sits at the receipt's embedded chain head -
+    the same chain ``bernstein audit verify`` walks. Exits non-zero when the
+    receipt does not verify.
+    """
+    import sys
+
+    from bernstein.core.protocols.mcp.claim_receipt import ClaimReceipt, verify_claim_receipt
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.server.dashboard_tokens import resolve_dashboard_hmac_key
+    from bernstein.core.tasks.claim import Backlog
+
+    raw = sys.stdin.read() if receipt_path == "-" else Path(receipt_path).read_text(encoding="utf-8")
+    receipt = ClaimReceipt.from_wire(json.loads(raw))
+    rows = [entry.to_dict() for entry in Backlog.load(backlog_path).entries]
+    chain = AuditChainStore(audit_dir, key=resolve_dashboard_hmac_key(audit_dir.parent))
+
+    ok, reason = verify_claim_receipt(receipt, rows, chain)
+    if is_json():
+        print_json({"verified": ok, "reason": reason, "task_id": receipt.task_id, "granted": receipt.granted})
+    elif ok:
+        console.print(f"[green]OK[/green] claim receipt verifies (task_id={receipt.task_id or '<refused>'})")
+    else:
+        console.print(f"[red]FAIL[/red] {reason}")
+    if not ok:
+        raise SystemExit(1)
+
+
 @click.command("compose", hidden=True)
 @click.argument("title")
 @click.option("--role", default="backend", show_default=True, help="Agent role for this task.")

--- a/src/bernstein/core/lineage/identity.py
+++ b/src/bernstein/core/lineage/identity.py
@@ -17,6 +17,7 @@ import base64
 import binascii
 import json
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import serialization
@@ -24,6 +25,9 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
     Ed25519PublicKey,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _b64url(data: bytes) -> str:
@@ -62,6 +66,44 @@ def generate_keypair() -> tuple[str, str]:
         .decode("ascii")
     )
     return priv_pem, pub_pem
+
+
+def load_or_create_signing_identity(
+    identity_dir: Path,
+    *,
+    private_name: str,
+    public_name: str,
+) -> tuple[str, str]:
+    """Load, or on first use create, a persisted Ed25519 signing identity.
+
+    The keypair is stored under ``identity_dir`` in two PEM files. The
+    private key is written atomically with ``0o600`` before it is exposed, so
+    a concurrent reader never sees a partially written key. Key files are
+    read verbatim, so a PEM without a trailing newline round-trips unchanged.
+
+    Args:
+        identity_dir: Directory holding the install's signing keys.
+        private_name: File name for the private PEM (e.g. ``claim_signing.pem``).
+        public_name: File name for the public PEM (e.g. ``claim_signing.pub``).
+
+    Returns:
+        ``(private_key_pem, public_key_pem)``.
+    """
+    private_path = identity_dir / private_name
+    public_path = identity_dir / public_name
+    if private_path.is_file() and public_path.is_file():
+        return (
+            private_path.read_text(encoding="ascii"),
+            public_path.read_text(encoding="ascii"),
+        )
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    private_pem, public_pem = generate_keypair()
+    tmp_priv = private_path.with_suffix(private_path.suffix + ".tmp")
+    tmp_priv.write_text(private_pem, encoding="ascii")
+    tmp_priv.chmod(0o600)
+    tmp_priv.replace(private_path)
+    public_path.write_text(public_pem, encoding="ascii")
+    return private_pem, public_pem
 
 
 def sign_detached(payload: bytes, private_key_pem: str, *, kid: str) -> str:

--- a/src/bernstein/core/protocols/mcp/claim_receipt.py
+++ b/src/bernstein/core/protocols/mcp/claim_receipt.py
@@ -1,0 +1,407 @@
+"""Verifiable claim receipts for the MCP pull-worker loop (issue #2555).
+
+The task server exposes claim over HTTP and the CLI, but a granted claim
+returns a *mutable* task projection: the worker cannot carry the claim it
+acted on and re-verify it offline when ownership is later disputed. The
+dependency snapshot the claim was granted under already lands on the audit
+chain as a ``task.claim_receipt`` event (#2357), yet the client never
+receives it as an object it holds.
+
+This module supplies the returned, client-verifiable object, modelled on
+the ``RunHandle`` receipt (:mod:`bernstein.core.protocols.mcp.tasks_extension`):
+
+* :class:`ClaimReceipt` - the receipt a worker receives from a claim. Its
+  :attr:`~ClaimReceipt.receipt_hash` is a content-addressed digest over a
+  canonical tuple ``(task_id, claimer_card_fingerprint, backlog_head,
+  filter_digest, chain_head, spec_revision)``. Wall-clock is deliberately
+  excluded, so two replays of the same backlog snapshot, claimer, and filter
+  hash identically: the receipt is a deterministic projection, not a
+  timestamped record. The receipt embeds the audit-chain head the granting
+  ``task.claim_receipt`` event recorded, so a client can later prove the
+  claim it made against the audited run.
+
+* :func:`backlog_head` / :func:`filter_digest` - the content-addressed
+  projections that anchor a receipt to a backlog snapshot and a claim
+  filter. Both are wall-clock free so the receipt reprojects byte-identically
+  from the on-disk backlog after the claim has landed.
+
+* :func:`sign_claim_receipt` - Ed25519-signs a receipt with the install's
+  signing identity, binding every field via the receipt hash. Tampering any
+  field invalidates the signature.
+
+* :func:`verify_claim_receipt` - the offline verifier (no network, no running
+  server): reprojects :func:`backlog_head` from the on-disk backlog, checks
+  the Ed25519 signature, verifies the audit chain, and confirms a matching
+  ``task.claim_receipt`` event sits at the receipt's embedded chain head.
+  ``bernstein audit verify`` walks the same chain.
+
+A refusal is also a receipt: when a filter matches no eligible row (for
+example a dependency-gated task whose ``depends_on`` are not all complete),
+:meth:`ClaimReceipt.refusal` returns a signed receipt with an empty
+``task_id`` - a claim attempt is never a silent skip.
+
+Determinism
+-----------
+Every hash here is canonical (sorted-key, compact-separator JSON) and free
+of clocks and sockets, so any server instance reprojects byte-identical wire
+values from the same on-disk state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.protocols.mcp.stateless_core import encode_request_state
+from bernstein.core.protocols.mcp.tasks_extension import SPEC_REVISION
+from bernstein.core.security.audit_chain import EVENT_TASK_CLAIM_RECEIPT
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.tasks.claim import ClaimFilter
+
+__all__ = [
+    "REFUSED_TASK_ID",
+    "ClaimReceipt",
+    "backlog_head",
+    "filter_digest",
+    "sign_claim_receipt",
+    "verify_claim_receipt",
+]
+
+#: The ``task_id`` a refusal receipt carries. An empty id means the filter
+#: matched no eligible row against the backlog snapshot; the receipt still
+#: proves that outcome (no silent skip).
+REFUSED_TASK_ID = ""
+
+#: Backlog row fields excluded from :func:`backlog_head`. ``claimed_at`` is a
+#: wall-clock stamp: including it would make the digest non-deterministic and
+#: break the byte-identical-replay contract, and would prevent the receipt
+#: from reprojecting from the post-claim on-disk backlog.
+_WALLCLOCK_FIELDS: frozenset[str] = frozenset({"claimed_at"})
+
+
+def _canonical(payload: Any) -> bytes:
+    """Return canonical (sorted-key, compact) JSON bytes for hashing."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def backlog_head(rows: Iterable[Mapping[str, Any]]) -> str:
+    """Return the content-addressed digest of an ordered backlog snapshot.
+
+    The digest covers every row in order, with wall-clock fields
+    (:data:`_WALLCLOCK_FIELDS`) stripped, so the head is a deterministic
+    projection: the same logical backlog hashes identically regardless of
+    when a claim stamped ``claimed_at``. This is what lets
+    :func:`verify_claim_receipt` reproject the head from the post-claim
+    on-disk backlog and match the receipt.
+
+    Args:
+        rows: Ordered backlog rows (each a mapping, as produced by
+            ``BacklogEntry.to_dict``).
+
+    Returns:
+        A ``sha256:`` prefixed hex digest of the normalised rows.
+    """
+    normalized = [{k: v for k, v in dict(row).items() if k not in _WALLCLOCK_FIELDS} for row in rows]
+    return "sha256:" + hashlib.sha256(_canonical(normalized)).hexdigest()
+
+
+def filter_digest(claim_filter: ClaimFilter) -> str:
+    """Return the content-addressed digest of a claim filter's predicates.
+
+    The digest covers exactly the eligibility inputs (project, role,
+    capability, the sorted completed dependency set, and the attempt
+    ceiling), so two receipts granted under the same filter carry the same
+    ``filter_digest`` and a client can prove which eligibility policy a claim
+    was granted under.
+
+    Args:
+        claim_filter: The :class:`~bernstein.core.tasks.claim.ClaimFilter`
+            the claim was evaluated against.
+
+    Returns:
+        A ``sha256:`` prefixed hex digest of the filter predicates.
+    """
+    preimage = {
+        "project": claim_filter.project,
+        "role": claim_filter.role,
+        "capability": claim_filter.capability,
+        "completed_ids": sorted(claim_filter.completed_ids),
+        "max_attempts": claim_filter.max_attempts,
+    }
+    return "sha256:" + hashlib.sha256(_canonical(preimage)).hexdigest()
+
+
+def _claim_receipt_hash(
+    *,
+    task_id: str,
+    claimer_card_fingerprint: str,
+    backlog_head: str,
+    filter_digest: str,
+    chain_head: str,
+    spec_revision: str,
+) -> str:
+    """Return the content-addressed digest that identifies a claim receipt.
+
+    The pre-image is a canonical field tuple, so two receipts projecting the
+    same claim hash identically and any tampered field surfaces as a
+    different receipt hash. Wall-clock is deliberately excluded: the receipt
+    is a deterministic projection, not a timestamped record.
+    """
+    preimage = _canonical(
+        {
+            "task_id": task_id,
+            "claimer_card_fingerprint": claimer_card_fingerprint,
+            "backlog_head": backlog_head,
+            "filter_digest": filter_digest,
+            "chain_head": chain_head,
+            "spec_revision": spec_revision,
+        }
+    )
+    return hashlib.sha256(preimage).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimReceipt:
+    """The verifiable receipt a worker receives from a claim.
+
+    The receipt is a projection of the claim decision, not standalone state:
+    :attr:`backlog_head` and :attr:`filter_digest` anchor it to the backlog
+    snapshot and eligibility filter, and :attr:`chain_head` embeds the
+    audit-chain head the granting ``task.claim_receipt`` event recorded, so a
+    client can later verify the claim it made against the audited run. Strip
+    the chain and the signature and the receipt loses its meaning (an
+    unprovable queue mutation), not merely its log.
+
+    A refusal carries an empty :attr:`task_id`: a filter that matched no
+    eligible row still produces a signed receipt, so a claim attempt is never
+    a silent skip.
+
+    Attributes:
+        task_id: The claimed task id, or :data:`REFUSED_TASK_ID` on refusal.
+        claimer_card_fingerprint: ``sha256:`` fingerprint of the claimer's
+            agent card key, or ``"unregistered"``.
+        backlog_head: Content-addressed digest of the backlog snapshot.
+        filter_digest: Content-addressed digest of the claim filter.
+        chain_head: The audit-chain head the granting event recorded (the
+            ``prev_chain_digest`` embedded by ``record_task_claim_receipt``).
+        spec_revision: The pinned Tasks-extension revision.
+        signature: Base64url Ed25519 signature over the receipt hash.
+        signer_public_key_pem: PEM public half of the signing identity.
+    """
+
+    task_id: str
+    claimer_card_fingerprint: str
+    backlog_head: str
+    filter_digest: str
+    chain_head: str
+    spec_revision: str = SPEC_REVISION
+    signature: str = ""
+    signer_public_key_pem: str = ""
+
+    @property
+    def granted(self) -> bool:
+        """Whether the claim was granted (a non-empty task id was claimed)."""
+        return self.task_id != REFUSED_TASK_ID
+
+    @property
+    def receipt_hash(self) -> str:
+        """The content-addressed digest of this receipt (the proof anchor)."""
+        return _claim_receipt_hash(
+            task_id=self.task_id,
+            claimer_card_fingerprint=self.claimer_card_fingerprint,
+            backlog_head=self.backlog_head,
+            filter_digest=self.filter_digest,
+            chain_head=self.chain_head,
+            spec_revision=self.spec_revision,
+        )
+
+    @property
+    def signed_bytes(self) -> bytes:
+        """Return the canonical bytes the Ed25519 signature covers.
+
+        The receipt hash already binds every canonical field, so signing it
+        binds the whole receipt: tampering any field changes the hash and
+        invalidates the signature.
+        """
+        return _canonical({"receipt_hash": self.receipt_hash})
+
+    @property
+    def poll_token(self) -> str:
+        """An opaque, stateless token any server instance decodes to re-verify.
+
+        The token carries only the receipt identity and the pinned revision -
+        no session id and no server-side state - so a different instance
+        answers a verify by reprojecting from the on-disk backlog and chain
+        alone (stateless-core contract, #2506).
+        """
+        return encode_request_state(
+            {
+                "task_id": self.task_id,
+                "backlog_head": self.backlog_head,
+                "filter_digest": self.filter_digest,
+                "chain_head": self.chain_head,
+                "spec_revision": self.spec_revision,
+            }
+        )
+
+    def to_wire(self) -> dict[str, Any]:
+        """Return the claim-receipt body for a client."""
+        return {
+            "taskId": self.task_id,
+            "granted": self.granted,
+            "claimerCardFingerprint": self.claimer_card_fingerprint,
+            "backlogHead": self.backlog_head,
+            "filterDigest": self.filter_digest,
+            "chainHead": self.chain_head,
+            "specRevision": self.spec_revision,
+            "receiptHash": self.receipt_hash,
+            "signature": self.signature,
+            "signerPublicKeyPem": self.signer_public_key_pem,
+            "pollToken": self.poll_token,
+        }
+
+    @staticmethod
+    def from_wire(wire: Mapping[str, Any]) -> ClaimReceipt:
+        """Reconstruct a receipt from its :meth:`to_wire` body.
+
+        The derived fields (``receiptHash``, ``pollToken``, ``granted``) are
+        ignored: they are recomputed from the canonical fields, so a client
+        cannot smuggle a mismatched hash past reconstruction.
+        """
+        return ClaimReceipt(
+            task_id=str(wire["taskId"]),
+            claimer_card_fingerprint=str(wire["claimerCardFingerprint"]),
+            backlog_head=str(wire["backlogHead"]),
+            filter_digest=str(wire["filterDigest"]),
+            chain_head=str(wire["chainHead"]),
+            spec_revision=str(wire.get("specRevision", SPEC_REVISION)),
+            signature=str(wire.get("signature", "")),
+            signer_public_key_pem=str(wire.get("signerPublicKeyPem", "")),
+        )
+
+    @staticmethod
+    def granted_receipt(
+        *,
+        task_id: str,
+        claimer_card_fingerprint: str,
+        backlog_head: str,
+        filter_digest: str,
+        chain_head: str,
+    ) -> ClaimReceipt:
+        """Build an unsigned granted receipt for ``task_id``."""
+        return ClaimReceipt(
+            task_id=task_id,
+            claimer_card_fingerprint=claimer_card_fingerprint,
+            backlog_head=backlog_head,
+            filter_digest=filter_digest,
+            chain_head=chain_head,
+        )
+
+    @staticmethod
+    def refusal(
+        *,
+        claimer_card_fingerprint: str,
+        backlog_head: str,
+        filter_digest: str,
+        chain_head: str,
+    ) -> ClaimReceipt:
+        """Build an unsigned refusal receipt (no eligible row matched)."""
+        return ClaimReceipt(
+            task_id=REFUSED_TASK_ID,
+            claimer_card_fingerprint=claimer_card_fingerprint,
+            backlog_head=backlog_head,
+            filter_digest=filter_digest,
+            chain_head=chain_head,
+        )
+
+
+def sign_claim_receipt(receipt: ClaimReceipt, *, private_key_pem: str, public_key_pem: str) -> ClaimReceipt:
+    """Return a copy of ``receipt`` Ed25519-signed with the install identity.
+
+    The signature covers :attr:`ClaimReceipt.signed_bytes` (the receipt hash),
+    so it binds every canonical field. The public half is embedded so a
+    verifier checks the signature offline without any key lookup.
+
+    Args:
+        receipt: The unsigned receipt to sign.
+        private_key_pem: PEM-encoded Ed25519 private key.
+        public_key_pem: PEM-encoded Ed25519 public key to embed.
+
+    Returns:
+        A new signed :class:`ClaimReceipt`.
+    """
+    from bernstein.core.skills.catalog.signature import sign_payload
+
+    signed = replace(receipt, signer_public_key_pem=public_key_pem)
+    signature = sign_payload(signed.signed_bytes, private_key_pem)
+    return replace(signed, signature=signature)
+
+
+def verify_claim_receipt(
+    receipt: ClaimReceipt,
+    backlog_events: Iterable[Mapping[str, Any]],
+    chain: AuditChainStore,
+) -> tuple[bool, str | None]:
+    """Confirm a claim receipt is a faithful, chain-anchored projection.
+
+    The check is fully offline: it reads only the supplied backlog rows and
+    the audit chain, no network and no running server. In order:
+
+    1. Reproject :func:`backlog_head` from ``backlog_events`` and confirm it
+       equals the receipt's ``backlog_head`` (the backlog reprojection).
+    2. Verify the Ed25519 signature over the receipt hash, which binds every
+       canonical field - a tampered ``claimer_card_fingerprint``,
+       ``backlog_head``, or ``chain_head`` invalidates it.
+    3. Verify the audit chain end to end.
+    4. For a granted receipt, confirm a ``task.claim_receipt`` event for this
+       task sits at the receipt's embedded chain head (its recorded
+       ``prev_chain_digest``), tying the receipt to the audited claim.
+
+    Args:
+        receipt: The receipt presented by a client.
+        backlog_events: The authoritative on-disk backlog rows.
+        chain: The audit chain store the claim event was mirrored into.
+
+    Returns:
+        ``(True, None)`` when the receipt verifies, or ``(False, reason)``
+        naming the first mismatch.
+    """
+    from bernstein.core.skills.catalog.signature import verify_payload
+
+    expected_backlog_head = backlog_head(backlog_events)
+    if receipt.backlog_head != expected_backlog_head:
+        return False, "backlog_head does not match the on-disk backlog"
+
+    if receipt.signature or receipt.signer_public_key_pem:
+        outcome = verify_payload(
+            receipt.signed_bytes,
+            receipt.signature or None,
+            receipt.signer_public_key_pem or None,
+            allow_unverified=True,
+        )
+        if not outcome.verified:
+            return False, f"receipt signature does not verify: {outcome.reason}"
+    elif receipt.granted:
+        return False, "granted receipt is not signed"
+
+    ok, errors = chain.verify()
+    if not ok:
+        return False, f"audit chain does not verify: {'; '.join(errors) or 'unknown'}"
+
+    if receipt.granted:
+        for event in chain.query(event_type=EVENT_TASK_CLAIM_RECEIPT):
+            details = event.details
+            if (
+                str(details.get("task_id", "")) == receipt.task_id
+                and str(details.get("prev_chain_digest", "")) == receipt.chain_head
+            ):
+                return True, None
+        return False, "no task.claim_receipt event at the embedded chain head"
+
+    return True, None

--- a/src/bernstein/core/protocols/mcp/tool_tiers.py
+++ b/src/bernstein/core/protocols/mcp/tool_tiers.py
@@ -62,6 +62,8 @@ TOOL_TIERS: Final[dict[str, ToolTier]] = {
     "bernstein_stop": "standard",
     "bernstein_approve": "standard",
     "bernstein_create_subtask": "standard",
+    "bernstein_claim": "standard",
+    "bernstein_update": "standard",
     "load_skill": "standard",
     # all - power-user surface: the scenario bridge and lineage verifier.
     "bernstein_scenarios": "all",

--- a/src/bernstein/core/routes/task_claim_receipt.py
+++ b/src/bernstein/core/routes/task_claim_receipt.py
@@ -1,0 +1,173 @@
+"""Verifiable claim-receipt route for the task server (#2555).
+
+``POST /tasks/claim-receipt`` drives the dependency-gated claim path
+(:func:`bernstein.core.tasks.claim.claim_next_entry` plus
+:class:`~bernstein.core.tasks.claim.ClaimFilter`) and returns a signed,
+content-addressed :class:`~bernstein.core.protocols.mcp.claim_receipt.ClaimReceipt`
+instead of the mutable task projection the older claim routes return.
+
+The receipt is the returned projection of the same dependency snapshot the
+existing ``task.claim_receipt`` audit event already records
+(:func:`record_task_claim_receipt`), so this route reuses that event rather
+than adding a new one. It embeds the audit-chain head the event recorded, so
+a worker holds an object it can re-verify offline against the audited run. A
+filter that matches no eligible row returns a signed *refusal* receipt: a
+claim attempt is never a silent skip.
+
+The atomic backlog-lock semantics are unchanged - ``claim_next_entry`` holds
+the cross-thread and cross-process backlog lock for the flip - and the
+operator force-claim recovery route is left untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request
+
+from bernstein.core.protocols.mcp.claim_receipt import (
+    ClaimReceipt,
+    backlog_head,
+    filter_digest,
+    sign_claim_receipt,
+)
+from bernstein.core.routes.task_crud import _get_sse_bus
+from bernstein.core.security.audit_chain import AuditChainStore, record_task_claim_receipt
+from bernstein.core.security.sanitize import sanitize_log
+from bernstein.core.server import ClaimReceiptRequest  # noqa: TC001  (FastAPI resolves the body model at runtime)
+from bernstein.core.tasks.claim import Backlog, ClaimFilter, claim_next_entry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+#: Claim receipts are signed with a dedicated install identity persisted
+#: alongside the mailbox identity. The receipt embeds its own public half, so
+#: an offline verifier checks the signature without any key lookup.
+_CLAIM_IDENTITY_PRIVATE = "claim_signing.pem"
+_CLAIM_IDENTITY_PUBLIC = "claim_signing.pub"
+
+#: The claim path used for the reused ``task.claim_receipt`` audit event.
+_MCP_CLAIM_PATH = "mcp_claim"
+
+
+def _get_claim_backlog_path(request: Request) -> Path:
+    """Return the shared JSON backlog the claim path atomically claims from."""
+    configured = getattr(request.app.state, "claim_backlog_path", None)
+    if configured is not None:
+        return configured  # type: ignore[no-any-return]
+    runtime_dir: Path = request.app.state.runtime_dir  # type: ignore[attr-defined]
+    return runtime_dir / "task-backlog.json"
+
+
+def _get_claim_identity_dir(request: Request) -> Path:
+    """Return the directory holding the install's claim-signing identity."""
+    configured = getattr(request.app.state, "claim_identity_dir", None)
+    if configured is not None:
+        return configured  # type: ignore[no-any-return]
+    sdd_dir: Path = request.app.state.sdd_dir  # type: ignore[attr-defined]
+    return sdd_dir / "identity"
+
+
+def _get_audit_chain(request: Request) -> AuditChainStore | None:
+    return getattr(request.app.state, "audit_chain", None)
+
+
+@router.post(
+    "/tasks/claim-receipt",
+    responses={
+        503: {"description": "Server is draining -- no new claims accepted"},
+    },
+)
+async def claim_receipt(body: ClaimReceiptRequest, request: Request) -> dict[str, object]:
+    """Claim the next eligible backlog row and return a signed claim receipt.
+
+    The dependency gate is enforced by :class:`ClaimFilter`: a row is offered
+    only when its ``depends_on`` are all in ``completed_ids``. The granted
+    claim is mirrored into the audit chain via the existing
+    ``record_task_claim_receipt`` (no new event type), and the returned
+    receipt embeds that event's chain head so the claim verifies offline. A
+    filter matching no eligible row returns a signed refusal receipt.
+    """
+    if request.app.state.draining:  # type: ignore[attr-defined]
+        raise HTTPException(status_code=503, detail="Server is draining -- no new claims accepted")
+
+    backlog_path = _get_claim_backlog_path(request)
+    claim_filter = ClaimFilter(
+        project=body.project,
+        role=body.role,
+        capability=body.capability,
+        completed_ids=frozenset(body.completed_ids),
+        max_attempts=body.max_attempts,
+    )
+    fingerprint = body.claimer_card_fingerprint or "unregistered"
+
+    entry = claim_next_entry(backlog_path, claimer_id=body.claimer_id, filter=claim_filter)
+
+    # Reproject the post-claim backlog head from disk: wall-clock is stripped
+    # inside backlog_head, so the head matches on a later offline reprojection.
+    rows = [e.to_dict() for e in Backlog.load(backlog_path).entries]
+    fd = filter_digest(claim_filter)
+    bh = backlog_head(rows)
+
+    chain = _get_audit_chain(request)
+    if entry is None:
+        chain_head = chain.prev_chain_digest if chain is not None else ""
+        receipt = ClaimReceipt.refusal(
+            claimer_card_fingerprint=fingerprint,
+            backlog_head=bh,
+            filter_digest=fd,
+            chain_head=chain_head,
+        )
+        logger.info(
+            "task.claim_receipt refused: claimer=%s role=%s (no eligible row)",
+            sanitize_log(body.claimer_id),
+            sanitize_log(str(body.role)),
+        )
+    else:
+        chain_head = ""
+        if chain is not None:
+            try:
+                event = record_task_claim_receipt(
+                    chain=chain,
+                    task_id=entry.id,
+                    role=entry.role or "",
+                    claimed_by=body.claimer_id,
+                    depends_on=list(entry.depends_on),
+                    task_version=entry.attempts,
+                    claim_path=_MCP_CLAIM_PATH,
+                )
+                chain_head = str(event.details.get("prev_chain_digest", ""))
+            except Exception as exc:  # intentional-broad-except: audit mirror is best-effort, never blocks the claim
+                logger.warning("task.claim_receipt audit mirror failed: %s", type(exc).__name__)
+        receipt = ClaimReceipt.granted_receipt(
+            task_id=entry.id,
+            claimer_card_fingerprint=fingerprint,
+            backlog_head=bh,
+            filter_digest=fd,
+            chain_head=chain_head,
+        )
+        _get_sse_bus(request).publish(
+            "task_claimed",
+            json.dumps({"task_id": entry.id, "claimer": body.claimer_id, "receipt_hash": receipt.receipt_hash}),
+        )
+        logger.info(
+            "task.claim_receipt granted: task_id=%s claimer=%s",
+            sanitize_log(entry.id),
+            sanitize_log(body.claimer_id),
+        )
+
+    from bernstein.core.lineage.identity import load_or_create_signing_identity
+
+    private_pem, public_pem = load_or_create_signing_identity(
+        _get_claim_identity_dir(request),
+        private_name=_CLAIM_IDENTITY_PRIVATE,
+        public_name=_CLAIM_IDENTITY_PUBLIC,
+    )
+    signed = sign_claim_receipt(receipt, private_key_pem=private_pem, public_key_pem=public_pem)
+    return signed.to_wire()

--- a/src/bernstein/core/routes/tasks.py
+++ b/src/bernstein/core/routes/tasks.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from bernstein.core.routes.task_a2a import router as _a2a_router
+from bernstein.core.routes.task_claim_receipt import router as _claim_receipt_router
 from bernstein.core.routes.task_cluster import router as _cluster_router
 from bernstein.core.routes.task_crud import router as _crud_router
 from bernstein.core.routes.task_mailbox import router as _mailbox_router
 
 router = APIRouter()
 router.include_router(_crud_router)
+router.include_router(_claim_receipt_router)
 router.include_router(_mailbox_router)
 router.include_router(_cluster_router)
 router.include_router(_a2a_router)

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1223,6 +1223,14 @@ def create_app(
         identity_dir=sdd_dir / "identity",
     )
 
+    # Verifiable claim-receipt loop (#2555). The MCP claim path atomically
+    # claims from a shared JSON backlog and signs the returned receipt with a
+    # dedicated install identity alongside the mailbox identity. The backlog
+    # path aligns with the ``bernstein backlog`` CLI default so both surfaces
+    # claim from one file.
+    application.state.claim_backlog_path = jsonl_path.parent / "task-backlog.json"  # type: ignore[attr-defined]
+    application.state.claim_identity_dir = sdd_dir / "identity"  # type: ignore[attr-defined]
+
     # Real-time behavior anomaly monitor - checks file access and output-size on
     # every progress update and writes kill signals for compromised sessions.
     from bernstein.core.behavior_anomaly import RealtimeBehaviorMonitor

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -423,6 +423,27 @@ class BatchClaimResponse(BaseModel):
     failed: list[str]
 
 
+class ClaimReceiptRequest(BaseModel):
+    """Body for POST /tasks/claim-receipt (#2555).
+
+    Drives the dependency-gated claim path over MCP and returns a signed,
+    content-addressed :class:`ClaimReceipt` instead of a mutable task
+    projection. The eligibility predicates mirror
+    :class:`bernstein.core.tasks.claim.ClaimFilter`: a task is offered only
+    when its ``depends_on`` are all present in ``completed_ids`` (the
+    dependency gate), and a filter that matches no eligible row still returns
+    a signed refusal receipt (never a silent skip).
+    """
+
+    claimer_id: str = Field(min_length=1, max_length=_MAX_SHORT_STR_LEN)
+    claimer_card_fingerprint: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)
+    role: str | None = Field(default=None, max_length=64)
+    project: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)
+    capability: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)
+    completed_ids: list[str] = Field(default_factory=list)
+    max_attempts: int | None = Field(default=None, ge=0)
+
+
 class TaskMessagePost(BaseModel):
     """Body for POST /tasks/{task_id}/messages (#2357).
 

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -504,7 +504,141 @@ def _register_task_handle_tool(mcp: FastMCP[None]) -> None:
 
 
 def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
-    """Register mutation tools: stop, approve, create_subtask."""
+    """Register mutation tools: stop, approve, create_subtask, claim, update."""
+
+    @mcp.tool()
+    async def bernstein_claim(  # pyright: ignore[reportUnusedFunction]
+        claimer_id: str,
+        role: str | None = None,
+        project: str | None = None,
+        capability: str | None = None,
+        completed_ids: list[str] | None = None,
+        max_attempts: int | None = None,
+        claimer_card_fingerprint: str | None = None,
+    ) -> str:
+        """Claim the next eligible task and return a verifiable claim receipt.
+
+        Drives the dependency-gated claim path: a task is offered only when
+        every id in its ``depends_on`` is present in ``completed_ids``. Unlike
+        a raw claim, the result is a signed, content-addressed **claim
+        receipt** the worker holds and can re-verify offline against the audit
+        chain (``bernstein audit verify``), not a mutable task projection. A
+        filter that matches no eligible task returns a signed *refusal*
+        receipt - a claim attempt is never a silent skip.
+
+        Args:
+            claimer_id: The claiming worker's identity.
+            role: Only claim tasks for this role (e.g. ``backend``).
+            project: Only claim tasks in this project namespace.
+            capability: Only claim tasks requiring this capability.
+            completed_ids: Task ids whose dependencies are satisfied; a task
+                is eligible only when all of its ``depends_on`` are listed.
+            max_attempts: Skip tasks at or above this attempt count.
+            claimer_card_fingerprint: ``sha256:`` fingerprint of the claimer's
+                agent card key, bound into the receipt.
+
+        Returns:
+            JSON of the signed claim receipt (``taskId``, ``granted``,
+            ``backlogHead``, ``filterDigest``, ``chainHead``, ``receiptHash``,
+            ``signature``, ``pollToken``, ...).
+        """
+        completed = completed_ids or []
+        err = _validate_or_error(
+            "bernstein_claim",
+            {
+                "claimer_id": claimer_id,
+                "role": role,
+                "project": project,
+                "capability": capability,
+                "completed_ids": completed,
+                "max_attempts": max_attempts,
+                "claimer_card_fingerprint": claimer_card_fingerprint,
+            },
+        )
+        if err is not None:
+            return _validation_error_response(err)
+        try:
+            payload: dict[str, Any] = {"claimer_id": claimer_id, "completed_ids": completed}
+            if role is not None:
+                payload["role"] = role
+            if project is not None:
+                payload["project"] = project
+            if capability is not None:
+                payload["capability"] = capability
+            if max_attempts is not None:
+                payload["max_attempts"] = max_attempts
+            if claimer_card_fingerprint is not None:
+                payload["claimer_card_fingerprint"] = claimer_card_fingerprint
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                resp = await client.post(
+                    f"{server_url}/tasks/claim-receipt",
+                    json=payload,
+                    headers=_auth_headers(),
+                )
+                resp.raise_for_status()
+                data: dict[str, Any] = resp.json()
+            return json.dumps(data, indent=2)
+        except Exception as exc:
+            return _error_response(exc)
+
+    @mcp.tool()
+    async def bernstein_update(  # pyright: ignore[reportUnusedFunction]
+        task_id: str,
+        body: str,
+        sender: str,
+        kind: str = "finding",
+        sender_card_fingerprint: str | None = None,
+    ) -> str:
+        """Post an incremental progress update as a signed journal entry.
+
+        Wraps the worker mailbox: the update is DLP-redacted, HMAC-chained
+        onto the mailbox journal, Ed25519-signed, and mirrored to the audit
+        chain (``task.mailbox_message``) before returning. The result IS the
+        signed journal entry - a worker holds a progress record it can verify
+        offline against the same chain ``bernstein audit verify`` walks, not a
+        bare status string.
+
+        Args:
+            task_id: The task the update is addressed to.
+            body: The progress message body (<= 4096 bytes).
+            sender: The posting worker's identity.
+            kind: Typed message kind - one of ``finding`` / ``artefact_ref``
+                / ``question``.
+            sender_card_fingerprint: ``sha256:`` fingerprint of the sender's
+                agent card key.
+
+        Returns:
+            JSON of the signed mailbox journal entry (``seq``,
+            ``prev_entry_hash``, ``entry_hash``, ``signature``,
+            ``signer_public_key_pem``, ``body_hash``, ...).
+        """
+        err = _validate_or_error(
+            "bernstein_update",
+            {
+                "task_id": task_id,
+                "body": body,
+                "sender": sender,
+                "kind": kind,
+                "sender_card_fingerprint": sender_card_fingerprint,
+            },
+        )
+        if err is not None:
+            return _validation_error_response(err)
+        try:
+            payload: dict[str, Any] = {"sender": sender, "kind": kind, "body": body}
+            if sender_card_fingerprint is not None:
+                payload["sender_card_fingerprint"] = sender_card_fingerprint
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+                resp = await client.post(
+                    f"{server_url}/tasks/{task_id}/messages",
+                    json=payload,
+                    headers=_auth_headers(),
+                )
+                resp.raise_for_status()
+                data: dict[str, Any] = resp.json()
+            return json.dumps(data, indent=2)
+        except Exception as exc:
+            return _error_response(exc)
 
     @mcp.tool()
     async def bernstein_stop(  # pyright: ignore[reportUnusedFunction]

--- a/src/bernstein/mcp/tool_schemas/bernstein_claim.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_claim.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "bernstein_claim",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["claimer_id"],
+  "properties": {
+    "claimer_id": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[A-Za-z0-9_.:-]+$"},
+    "role": {"type": ["string", "null"], "maxLength": 64},
+    "project": {"type": ["string", "null"], "maxLength": 256},
+    "capability": {"type": ["string", "null"], "maxLength": 256},
+    "completed_ids": {
+      "type": "array",
+      "maxItems": 4096,
+      "items": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[A-Za-z0-9_.:-]+$"}
+    },
+    "max_attempts": {"type": ["integer", "null"], "minimum": 0, "maximum": 100000},
+    "claimer_card_fingerprint": {"type": ["string", "null"], "maxLength": 256}
+  }
+}

--- a/src/bernstein/mcp/tool_schemas/bernstein_update.json
+++ b/src/bernstein/mcp/tool_schemas/bernstein_update.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "bernstein_update",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["task_id", "body", "sender"],
+  "properties": {
+    "task_id": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[A-Za-z0-9_.:-]+$"},
+    "body": {"type": "string", "minLength": 1, "maxLength": 4096},
+    "sender": {"type": "string", "minLength": 1, "maxLength": 256},
+    "kind": {"type": "string", "enum": ["finding", "artefact_ref", "question"]},
+    "sender_card_fingerprint": {"type": ["string", "null"], "maxLength": 256}
+  }
+}

--- a/tests/unit/mcp/test_claim_update_tools.py
+++ b/tests/unit/mcp/test_claim_update_tools.py
@@ -1,0 +1,144 @@
+"""Native MCP claim/update tools (#2555).
+
+``bernstein_claim`` and ``bernstein_update`` put the worker-inbound verbs on
+the native MCP surface: a claim returns a verifiable claim receipt and a
+progress update returns a signed journal entry. Both call the task server
+over HTTP via the existing stateless action-handler pattern. These tests
+mock the HTTP client so they assert the tool wiring, not the server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bernstein.core.protocols.mcp.tool_tiers import tool_in_tier
+
+
+def _mock_client(payload: dict[str, object]) -> AsyncMock:
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(return_value=payload)
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=mock_response)
+    return client
+
+
+def _tool_names(tier: str) -> set[str]:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(server_url="http://localhost:8052", tier=tier)
+    return {tool.name for tool in asyncio.run(mcp.list_tools())}
+
+
+# ---------------------------------------------------------------------------
+# Tier registration
+# ---------------------------------------------------------------------------
+
+
+def test_claim_and_update_are_standard_tier() -> None:
+    assert tool_in_tier("bernstein_claim", "standard")
+    assert tool_in_tier("bernstein_update", "standard")
+    # Not advertised in the core budget.
+    assert not tool_in_tier("bernstein_claim", "core")
+    assert not tool_in_tier("bernstein_update", "core")
+
+
+def test_tools_registered_in_standard_not_core() -> None:
+    standard = _tool_names("standard")
+    assert {"bernstein_claim", "bernstein_update"} <= standard
+    core = _tool_names("core")
+    assert "bernstein_claim" not in core
+    assert "bernstein_update" not in core
+
+
+# ---------------------------------------------------------------------------
+# bernstein_claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bernstein_claim_posts_to_claim_receipt_route() -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    receipt = {"taskId": "t1", "granted": True, "receiptHash": "abc", "signature": "sig"}
+    client = _mock_client(receipt)
+    mcp = create_mcp_server(server_url="http://localhost:8052")
+
+    with patch("bernstein.mcp.server.httpx.AsyncClient", return_value=client):
+        result = await mcp.call_tool(
+            "bernstein_claim",
+            {"claimer_id": "worker-1", "role": "backend", "completed_ids": ["t0"]},
+        )
+
+    call_url = client.post.call_args[0][0]
+    assert call_url.endswith("/tasks/claim-receipt")
+    body = client.post.call_args.kwargs["json"]
+    assert body["claimer_id"] == "worker-1"
+    assert body["role"] == "backend"
+    assert body["completed_ids"] == ["t0"]
+    text = result[0][0].text  # type: ignore[index]
+    assert "t1" in text
+
+
+@pytest.mark.asyncio
+async def test_bernstein_claim_rejects_bad_task_id_pattern() -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(server_url="http://localhost:8052")
+    result = await mcp.call_tool("bernstein_claim", {"claimer_id": "bad id with spaces/../"})
+    text = result[0][0].text  # type: ignore[index]
+    parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
+    assert "error" in parsed
+
+
+# ---------------------------------------------------------------------------
+# bernstein_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bernstein_update_posts_to_mailbox_route() -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    entry = {"seq": 0, "task_id": "t1", "entry_hash": "hmac-sha256:x", "signature": "sig"}
+    client = _mock_client(entry)
+    mcp = create_mcp_server(server_url="http://localhost:8052")
+
+    with patch("bernstein.mcp.server.httpx.AsyncClient", return_value=client):
+        result = await mcp.call_tool(
+            "bernstein_update",
+            {"task_id": "t1", "body": "halfway done", "sender": "worker-1"},
+        )
+
+    call_url = client.post.call_args[0][0]
+    assert call_url.endswith("/tasks/t1/messages")
+    body = client.post.call_args.kwargs["json"]
+    assert body["sender"] == "worker-1"
+    assert body["kind"] == "finding"
+    assert body["body"] == "halfway done"
+    text = result[0][0].text  # type: ignore[index]
+    assert "hmac-sha256" in text
+
+
+@pytest.mark.asyncio
+async def test_bernstein_update_rejects_unknown_kind() -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server(server_url="http://localhost:8052")
+    result = await mcp.call_tool(
+        "bernstein_update",
+        {"task_id": "t1", "body": "x", "sender": "w", "kind": "chit_chat"},
+    )
+    text = result[0][0].text  # type: ignore[index]
+    parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
+    assert "error" in parsed

--- a/tests/unit/protocols/mcp/test_claim_receipt.py
+++ b/tests/unit/protocols/mcp/test_claim_receipt.py
@@ -1,0 +1,280 @@
+"""Verifiable claim receipts for the MCP pull-worker loop (issue #2555).
+
+A claim receipt is the returned, client-verifiable object a worker receives
+from a claim: a content-addressed digest over the claim decision, embedding
+the audit-chain head so the worker can prove the claim it made offline. These
+tests isolate state with ``tmp_path`` and never depend on wall-clock ordering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from bernstein.core.protocols.mcp.claim_receipt import (
+    REFUSED_TASK_ID,
+    ClaimReceipt,
+    backlog_head,
+    filter_digest,
+    sign_claim_receipt,
+    verify_claim_receipt,
+)
+from bernstein.core.protocols.mcp.tasks_extension import SPEC_REVISION
+from bernstein.core.security.audit_chain import AuditChainStore, record_task_claim_receipt
+from bernstein.core.tasks.claim import Backlog, BacklogEntry, ClaimFilter, claim_next_entry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"claim-receipt-test-key"
+
+
+def _identity() -> tuple[str, str]:
+    from bernstein.core.lineage.identity import generate_keypair
+
+    return generate_keypair()
+
+
+def _rows(*entries: BacklogEntry) -> list[dict[str, object]]:
+    return [entry.to_dict() for entry in entries]
+
+
+class TestBacklogHead:
+    def test_head_is_content_addressed(self) -> None:
+        rows = _rows(BacklogEntry(id="t1"), BacklogEntry(id="t2"))
+        assert backlog_head(rows).startswith("sha256:")
+
+    def test_head_excludes_wall_clock(self) -> None:
+        # Two backlogs identical apart from the claim wall-clock stamp must
+        # hash the same, so the receipt reprojects from the post-claim
+        # on-disk backlog regardless of when the claim landed.
+        early = BacklogEntry(id="t1", status="in_progress", claimer="w", claimed_at=1.0)
+        late = BacklogEntry(id="t1", status="in_progress", claimer="w", claimed_at=999.0)
+        assert backlog_head(_rows(early)) == backlog_head(_rows(late))
+
+    def test_head_changes_with_row_content(self) -> None:
+        assert backlog_head(_rows(BacklogEntry(id="t1"))) != backlog_head(_rows(BacklogEntry(id="t2")))
+
+    def test_head_is_order_sensitive(self) -> None:
+        a = _rows(BacklogEntry(id="t1"), BacklogEntry(id="t2"))
+        b = _rows(BacklogEntry(id="t2"), BacklogEntry(id="t1"))
+        assert backlog_head(a) != backlog_head(b)
+
+
+class TestFilterDigest:
+    def test_digest_is_content_addressed(self) -> None:
+        assert filter_digest(ClaimFilter(role="backend")).startswith("sha256:")
+
+    def test_completed_ids_order_does_not_matter(self) -> None:
+        a = ClaimFilter(completed_ids={"a", "b", "c"})
+        b = ClaimFilter(completed_ids={"c", "b", "a"})
+        assert filter_digest(a) == filter_digest(b)
+
+    def test_digest_changes_with_role(self) -> None:
+        assert filter_digest(ClaimFilter(role="backend")) != filter_digest(ClaimFilter(role="frontend"))
+
+
+class TestReceiptHash:
+    def _receipt(self, **over: object) -> ClaimReceipt:
+        base = {
+            "task_id": "t1",
+            "claimer_card_fingerprint": "sha256:abc",
+            "backlog_head": "sha256:" + "a" * 64,
+            "filter_digest": "sha256:" + "b" * 64,
+            "chain_head": "c" * 64,
+        }
+        base.update(over)
+        return ClaimReceipt(**base)  # type: ignore[arg-type]
+
+    def test_receipt_hash_is_deterministic(self) -> None:
+        assert self._receipt().receipt_hash == self._receipt().receipt_hash
+
+    def test_receipt_hash_default_spec_revision(self) -> None:
+        assert self._receipt().spec_revision == SPEC_REVISION
+
+    def test_receipt_hash_changes_with_each_field(self) -> None:
+        base = self._receipt()
+        assert base.receipt_hash != self._receipt(task_id="t2").receipt_hash
+        assert base.receipt_hash != self._receipt(claimer_card_fingerprint="sha256:xyz").receipt_hash
+        assert base.receipt_hash != self._receipt(backlog_head="sha256:" + "z" * 64).receipt_hash
+        assert base.receipt_hash != self._receipt(filter_digest="sha256:" + "z" * 64).receipt_hash
+        assert base.receipt_hash != self._receipt(chain_head="d" * 64).receipt_hash
+
+    def test_signature_is_not_in_pre_image(self) -> None:
+        # Signing must not change the content-addressed identity.
+        priv, pub = _identity()
+        unsigned = self._receipt()
+        signed = sign_claim_receipt(unsigned, private_key_pem=priv, public_key_pem=pub)
+        assert signed.receipt_hash == unsigned.receipt_hash
+
+    def test_granted_flag_tracks_task_id(self) -> None:
+        assert self._receipt().granted is True
+        assert self._receipt(task_id=REFUSED_TASK_ID).granted is False
+
+    def test_wire_roundtrip_preserves_canonical_fields(self) -> None:
+        priv, pub = _identity()
+        signed = sign_claim_receipt(self._receipt(), private_key_pem=priv, public_key_pem=pub)
+        restored = ClaimReceipt.from_wire(signed.to_wire())
+        assert restored == signed
+        assert signed.to_wire()["receiptHash"] == signed.receipt_hash
+
+
+def _seed_backlog(path: Path, entries: list[BacklogEntry]) -> None:
+    Backlog.write(path, entries)
+
+
+def _claim_and_receipt(
+    tmp_path: Path,
+    *,
+    entries: list[BacklogEntry],
+    claim_filter: ClaimFilter,
+    claimer_id: str = "worker-1",
+    fingerprint: str = "sha256:cardfp",
+) -> tuple[ClaimReceipt, AuditChainStore, Path]:
+    """Drive the substrate claim path and build a signed receipt.
+
+    Mirrors what the claim route does: claim under the filter, record the
+    existing ``task.claim_receipt`` audit event, embed the head that event
+    recorded, and sign.
+    """
+    backlog_path = tmp_path / "task-backlog.json"
+    _seed_backlog(backlog_path, entries)
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    priv, pub = _identity()
+
+    entry = claim_next_entry(backlog_path, claimer_id=claimer_id, filter=claim_filter)
+    rows_after = _rows(*Backlog.load(backlog_path).entries)
+    fd = filter_digest(claim_filter)
+    bh = backlog_head(rows_after)
+    if entry is None:
+        chain_head = chain.prev_chain_digest
+        receipt = ClaimReceipt.refusal(
+            claimer_card_fingerprint=fingerprint,
+            backlog_head=bh,
+            filter_digest=fd,
+            chain_head=chain_head,
+        )
+    else:
+        event = record_task_claim_receipt(
+            chain=chain,
+            task_id=entry.id,
+            role=entry.role or "",
+            claimed_by=claimer_id,
+            depends_on=list(entry.depends_on),
+            task_version=entry.attempts,
+            claim_path="mcp_claim",
+        )
+        chain_head = str(event.details.get("prev_chain_digest", ""))
+        receipt = ClaimReceipt.granted_receipt(
+            task_id=entry.id,
+            claimer_card_fingerprint=fingerprint,
+            backlog_head=bh,
+            filter_digest=fd,
+            chain_head=chain_head,
+        )
+    return sign_claim_receipt(receipt, private_key_pem=priv, public_key_pem=pub), chain, backlog_path
+
+
+class TestDependencyGate:
+    def test_gated_task_is_refused_as_a_receipt(self, tmp_path: Path) -> None:
+        # A task whose depends_on is not complete must not be granted, and the
+        # refusal is itself a signed receipt (no silent skip).
+        entries = [BacklogEntry(id="t2", depends_on=["t1"])]
+        receipt, chain, backlog_path = _claim_and_receipt(
+            tmp_path,
+            entries=entries,
+            claim_filter=ClaimFilter(completed_ids=frozenset()),
+        )
+        assert receipt.granted is False
+        assert receipt.task_id == REFUSED_TASK_ID
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        ok, reason = verify_claim_receipt(receipt, rows, chain)
+        assert ok, reason
+
+    def test_task_granted_once_dependency_completes(self, tmp_path: Path) -> None:
+        entries = [BacklogEntry(id="t2", depends_on=["t1"])]
+        receipt, chain, backlog_path = _claim_and_receipt(
+            tmp_path,
+            entries=entries,
+            claim_filter=ClaimFilter(completed_ids=frozenset({"t1"})),
+        )
+        assert receipt.granted is True
+        assert receipt.task_id == "t2"
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        ok, reason = verify_claim_receipt(receipt, rows, chain)
+        assert ok, reason
+
+
+class TestDeterminism:
+    def test_replay_at_different_wall_clock_is_byte_identical(self, tmp_path: Path, monkeypatch) -> None:
+        import bernstein.core.tasks.claim as claim_mod
+
+        entries = [BacklogEntry(id="t1")]
+        claim_filter = ClaimFilter()
+
+        monkeypatch.setattr(claim_mod.time, "time", lambda: 1000.0)
+        first, _, _ = _claim_and_receipt(tmp_path / "run-a", entries=list(entries), claim_filter=claim_filter)
+
+        monkeypatch.setattr(claim_mod.time, "time", lambda: 5000.0)
+        second, _, _ = _claim_and_receipt(tmp_path / "run-b", entries=list(entries), claim_filter=claim_filter)
+
+        assert first.receipt_hash == second.receipt_hash
+
+
+class TestTamperDetection:
+    def test_tampered_fingerprint_fails(self, tmp_path: Path) -> None:
+        receipt, chain, backlog_path = _claim_and_receipt(
+            tmp_path, entries=[BacklogEntry(id="t1")], claim_filter=ClaimFilter()
+        )
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        forged = replace(receipt, claimer_card_fingerprint="sha256:evil")
+        ok, reason = verify_claim_receipt(forged, rows, chain)
+        assert not ok
+        assert reason is not None and "signature" in reason
+
+    def test_tampered_backlog_head_fails(self, tmp_path: Path) -> None:
+        receipt, chain, backlog_path = _claim_and_receipt(
+            tmp_path, entries=[BacklogEntry(id="t1")], claim_filter=ClaimFilter()
+        )
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        forged = replace(receipt, backlog_head="sha256:" + "0" * 64)
+        ok, reason = verify_claim_receipt(forged, rows, chain)
+        assert not ok
+        assert reason is not None and "backlog_head" in reason
+
+    def test_tampered_chain_head_fails(self, tmp_path: Path) -> None:
+        receipt, chain, backlog_path = _claim_and_receipt(
+            tmp_path, entries=[BacklogEntry(id="t1")], claim_filter=ClaimFilter()
+        )
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        forged = replace(receipt, chain_head="f" * 64)
+        ok, _reason = verify_claim_receipt(forged, rows, chain)
+        assert not ok
+
+    def test_tampered_audit_chain_fails_end_to_end(self, tmp_path: Path) -> None:
+        receipt, _chain, backlog_path = _claim_and_receipt(
+            tmp_path, entries=[BacklogEntry(id="t1")], claim_filter=ClaimFilter()
+        )
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        # Corrupt the on-disk audit chain, then verify from a fresh store.
+        audit_files = sorted((tmp_path / "audit").glob("*.jsonl"))
+        assert audit_files
+        content = audit_files[0].read_text(encoding="utf-8")
+        audit_files[0].write_text(content.replace("mcp_claim", "tampered"), encoding="utf-8")
+        reloaded = AuditChainStore(tmp_path / "audit", key=_KEY)
+        ok, reason = verify_claim_receipt(receipt, rows, reloaded)
+        assert not ok
+        assert reason is not None and "chain" in reason
+
+
+class TestOfflineStatelessVerify:
+    def test_second_store_verifies_from_disk_only(self, tmp_path: Path) -> None:
+        # A fresh AuditChainStore over the same on-disk state (a second server
+        # process) answers the verify with no in-memory session (#2506).
+        receipt, _, backlog_path = _claim_and_receipt(
+            tmp_path, entries=[BacklogEntry(id="t1")], claim_filter=ClaimFilter()
+        )
+        rows = _rows(*Backlog.load(backlog_path).entries)
+        second = AuditChainStore(tmp_path / "audit", key=_KEY)
+        ok, reason = verify_claim_receipt(receipt, rows, second)
+        assert ok, reason

--- a/tests/unit/test_backlog_verify_claim_cli.py
+++ b/tests/unit/test_backlog_verify_claim_cli.py
@@ -1,0 +1,111 @@
+"""CLI verify path for claim receipts (#2555, Phase 4).
+
+``bernstein backlog verify-claim`` walks a claim receipt against the on-disk
+backlog and audit chain, offline. These tests build a real receipt through
+the substrate claim path, then verify (and tamper-check) it through the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.task_cmd import backlog_group
+from bernstein.core.protocols.mcp.claim_receipt import (
+    ClaimReceipt,
+    backlog_head,
+    filter_digest,
+    sign_claim_receipt,
+)
+from bernstein.core.security.audit_chain import AuditChainStore, record_task_claim_receipt
+from bernstein.core.server.dashboard_tokens import resolve_dashboard_hmac_key
+from bernstein.core.tasks.claim import Backlog, BacklogEntry, ClaimFilter, claim_next_entry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _build_receipt(sdd_dir: Path, backlog_path: Path) -> ClaimReceipt:
+    Backlog.write(backlog_path, [BacklogEntry(id="t1", role="backend")])
+    key = resolve_dashboard_hmac_key(sdd_dir)
+    chain = AuditChainStore(sdd_dir / "audit", key=key)
+    claim_filter = ClaimFilter(role="backend")
+    entry = claim_next_entry(backlog_path, claimer_id="worker-1", filter=claim_filter)
+    assert entry is not None
+    event = record_task_claim_receipt(
+        chain=chain,
+        task_id=entry.id,
+        role=entry.role or "",
+        claimed_by="worker-1",
+        depends_on=list(entry.depends_on),
+        task_version=entry.attempts,
+        claim_path="mcp_claim",
+    )
+    rows = [e.to_dict() for e in Backlog.load(backlog_path).entries]
+    receipt = ClaimReceipt.granted_receipt(
+        task_id=entry.id,
+        claimer_card_fingerprint="sha256:fp",
+        backlog_head=backlog_head(rows),
+        filter_digest=filter_digest(claim_filter),
+        chain_head=str(event.details.get("prev_chain_digest", "")),
+    )
+    from bernstein.core.lineage.identity import load_or_create_signing_identity
+
+    priv, pub = load_or_create_signing_identity(
+        sdd_dir / "identity", private_name="claim_signing.pem", public_name="claim_signing.pub"
+    )
+    return sign_claim_receipt(receipt, private_key_pem=priv, public_key_pem=pub)
+
+
+def test_verify_claim_ok(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    backlog_path = sdd / "runtime" / "task-backlog.json"
+    receipt = _build_receipt(sdd, backlog_path)
+    receipt_file = tmp_path / "receipt.json"
+    receipt_file.write_text(json.dumps(receipt.to_wire()), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        backlog_group,
+        [
+            "verify-claim",
+            "--receipt",
+            str(receipt_file),
+            "--backlog",
+            str(backlog_path),
+            "--audit-dir",
+            str(sdd / "audit"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_verify_claim_detects_tamper(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    backlog_path = sdd / "runtime" / "task-backlog.json"
+    receipt = _build_receipt(sdd, backlog_path)
+    wire = receipt.to_wire()
+    wire["claimerCardFingerprint"] = "sha256:evil"  # tamper without re-signing
+    receipt_file = tmp_path / "receipt.json"
+    receipt_file.write_text(json.dumps(wire), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        backlog_group,
+        [
+            "verify-claim",
+            "--receipt",
+            str(receipt_file),
+            "--backlog",
+            str(backlog_path),
+            "--audit-dir",
+            str(sdd / "audit"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "FAIL" in result.output

--- a/tests/unit/test_mcp_input_validation.py
+++ b/tests/unit/test_mcp_input_validation.py
@@ -435,6 +435,8 @@ def test_registry_loads_every_shipped_schema() -> None:
         "bernstein_stop",
         "bernstein_approve",
         "bernstein_create_subtask",
+        "bernstein_claim",
+        "bernstein_update",
         "load_skill",
         "bernstein_scenarios",
         "bernstein_scenario",

--- a/tests/unit/test_mcp_pull_worker_loop.py
+++ b/tests/unit/test_mcp_pull_worker_loop.py
@@ -1,0 +1,105 @@
+"""End-to-end MCP pull-worker loop (#2555, AC1 + AC6).
+
+An MCP-only agent runs the whole worker loop over MCP alone:
+``bernstein_claim`` (signed claim receipt) -> N x ``bernstein_update``
+(signed journal entries) -> ``bernstein_approve`` (completion). Every step
+returns an object that verifies offline against the audit chain the
+``audit verify`` path walks. This test drives the real MCP tool handlers with
+their HTTP client bridged to the in-process ASGI app, so it exercises the
+tool code path, not a re-implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.communication.task_mailbox import TaskMailbox, verify_against_chain
+from bernstein.core.protocols.mcp.claim_receipt import ClaimReceipt, verify_claim_receipt
+from bernstein.core.server import create_app
+from bernstein.core.tasks.claim import Backlog, BacklogEntry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.asyncio
+
+_SERVER_URL = "http://localhost:8052"
+
+
+def _unwrap(text: str) -> dict:
+    parsed = json.loads(text)
+    if isinstance(parsed, dict) and "_meter" in parsed:
+        parsed = parsed["result"]
+    return parsed
+
+
+async def test_full_claim_update_approve_loop_verifies_offline(tmp_path: Path) -> None:
+    from bernstein.mcp.server import create_mcp_server
+
+    app = create_app(jsonl_path=tmp_path / "runtime" / "tasks.jsonl")
+
+    # An MCP agent bridges its HTTP client to the running task server; here we
+    # bind it to the in-process ASGI app so the loop runs over the real routes.
+    def _bridged_client(**_kwargs: object) -> AsyncClient:
+        return AsyncClient(transport=ASGITransport(app=app), base_url=_SERVER_URL)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=_SERVER_URL) as http:
+        create = await http.post(
+            "/tasks",
+            json={"title": "ship it", "description": "do the thing", "role": "backend"},
+        )
+        assert create.status_code == 201, create.text
+        task_id = str(create.json()["id"])
+
+    # The claim path claims from the shared JSON backlog wired by create_app.
+    Backlog.write(app.state.claim_backlog_path, [BacklogEntry(id=task_id, role="backend")])
+
+    mcp = create_mcp_server(server_url=_SERVER_URL)
+
+    from unittest.mock import patch
+
+    with patch("bernstein.mcp.server.httpx.AsyncClient", side_effect=_bridged_client):
+        # 1. CLAIM -> signed claim receipt.
+        claim_result = await mcp.call_tool("bernstein_claim", {"claimer_id": "worker-1", "role": "backend"})
+        claim_wire = _unwrap(claim_result[0][0].text)  # type: ignore[index]
+        assert claim_wire["granted"] is True
+        assert claim_wire["taskId"] == task_id
+
+        # 2. N x UPDATE -> signed journal entries.
+        for note in ("25% done", "50% done", "90% done"):
+            upd = await mcp.call_tool(
+                "bernstein_update",
+                {"task_id": task_id, "body": note, "sender": "worker-1"},
+            )
+            upd_wire = _unwrap(upd[0][0].text)  # type: ignore[index]
+            assert upd_wire["entry_hash"].startswith("hmac-sha256:")
+
+        # 3. APPROVE -> existing completion.
+        appr = await mcp.call_tool("bernstein_approve", {"task_id": task_id, "note": "looks good"})
+        appr_wire = _unwrap(appr[0][0].text)  # type: ignore[index]
+        assert appr_wire["task_id"] == task_id
+
+    # Every step verifies offline against the audit chain (AC5, AC6).
+    receipt = ClaimReceipt.from_wire(claim_wire)
+    rows = [e.to_dict() for e in Backlog.load(app.state.claim_backlog_path).entries]
+    ok, reason = verify_claim_receipt(receipt, rows, app.state.audit_chain)
+    assert ok, reason
+
+    # The mailbox journal cross-verifies against the audit chain end to end,
+    # reopened from disk with no in-memory session (offline, stateless).
+    from bernstein.core.server.dashboard_tokens import resolve_dashboard_hmac_key
+
+    reopened = TaskMailbox(
+        app.state.task_mailbox.path,
+        hmac_key=resolve_dashboard_hmac_key(app.state.sdd_dir),
+    )
+    mb_ok, problems = verify_against_chain(reopened, app.state.audit_chain)
+    assert mb_ok, problems
+
+    # The whole audit chain verifies (what ``bernstein audit verify`` walks).
+    chain_ok, errors = app.state.audit_chain.verify()
+    assert chain_ok, errors

--- a/tests/unit/test_task_claim_receipt_route.py
+++ b/tests/unit/test_task_claim_receipt_route.py
@@ -1,0 +1,145 @@
+"""Claim-receipt route tests (#2555).
+
+``POST /tasks/claim-receipt`` drives the dependency-gated claim path and
+returns a signed, content-addressed claim receipt instead of a mutable task
+projection. These tests exercise the route end to end and verify the returned
+receipt offline against the on-disk backlog and audit chain.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.protocols.mcp.claim_receipt import ClaimReceipt, verify_claim_receipt
+from bernstein.core.security.audit_chain import EVENT_TASK_CLAIM_RECEIPT, AuditChainStore
+from bernstein.core.server import SSEBus, TaskStore, create_app
+from bernstein.core.tasks.claim import Backlog, BacklogEntry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.anyio
+
+_KEY = b"claim-receipt-route-test-key"
+
+
+@pytest.fixture(scope="module")
+def _module_app(tmp_path_factory: pytest.TempPathFactory):
+    root = tmp_path_factory.mktemp("claim-receipt-server")
+    return create_app(jsonl_path=root / "runtime" / "tasks.jsonl")
+
+
+@pytest.fixture()
+def app(_module_app, tmp_path: Path):  # type: ignore[no-untyped-def]
+    _module_app.state.store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+    _module_app.state.sse_bus = SSEBus()
+    _module_app.state.draining = False
+    _module_app.state.sdd_dir = tmp_path
+    _module_app.state.runtime_dir = tmp_path / "runtime"
+    _module_app.state.audit_chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    _module_app.state.claim_backlog_path = tmp_path / "runtime" / "task-backlog.json"
+    _module_app.state.claim_identity_dir = tmp_path / "identity"
+    return _module_app
+
+
+@pytest.fixture()
+async def client(app) -> AsyncClient:  # type: ignore[no-untyped-def]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _seed(app, entries: list[BacklogEntry]) -> None:  # type: ignore[no-untyped-def]
+    Backlog.write(app.state.claim_backlog_path, entries)
+
+
+def _on_disk_rows(app) -> list[dict[str, object]]:  # type: ignore[no-untyped-def]
+    return [e.to_dict() for e in Backlog.load(app.state.claim_backlog_path).entries]
+
+
+async def test_granted_claim_returns_verifiable_receipt(app, client: AsyncClient) -> None:
+    _seed(app, [BacklogEntry(id="t1", role="backend")])
+    resp = await client.post("/tasks/claim-receipt", json={"claimer_id": "worker-1"})
+    assert resp.status_code == 200, resp.text
+    wire = resp.json()
+    assert wire["granted"] is True
+    assert wire["taskId"] == "t1"
+    assert wire["signature"]
+    assert wire["receiptHash"]
+
+    receipt = ClaimReceipt.from_wire(wire)
+    ok, reason = verify_claim_receipt(receipt, _on_disk_rows(app), app.state.audit_chain)
+    assert ok, reason
+
+
+async def test_gated_task_returns_refusal_receipt(app, client: AsyncClient) -> None:
+    # t2 depends on t1, which is not complete: the claim must be refused, and
+    # the refusal is itself a signed, verifiable receipt (no silent skip).
+    _seed(app, [BacklogEntry(id="t2", role="backend", depends_on=["t1"])])
+    resp = await client.post("/tasks/claim-receipt", json={"claimer_id": "worker-1"})
+    assert resp.status_code == 200, resp.text
+    wire = resp.json()
+    assert wire["granted"] is False
+    assert wire["taskId"] == ""
+
+    receipt = ClaimReceipt.from_wire(wire)
+    ok, reason = verify_claim_receipt(receipt, _on_disk_rows(app), app.state.audit_chain)
+    assert ok, reason
+
+
+async def test_gated_task_granted_when_dependency_completed(app, client: AsyncClient) -> None:
+    _seed(app, [BacklogEntry(id="t2", role="backend", depends_on=["t1"])])
+    resp = await client.post(
+        "/tasks/claim-receipt",
+        json={"claimer_id": "worker-1", "completed_ids": ["t1"]},
+    )
+    assert resp.status_code == 200, resp.text
+    wire = resp.json()
+    assert wire["granted"] is True
+    assert wire["taskId"] == "t2"
+
+
+async def test_granted_claim_reuses_existing_audit_event(app, client: AsyncClient) -> None:
+    # The claim must land as the existing ``task.claim_receipt`` event - no
+    # new audit event type is introduced.
+    _seed(app, [BacklogEntry(id="t1", role="backend")])
+    before = len(app.state.audit_chain.query(event_type=EVENT_TASK_CLAIM_RECEIPT))
+    await client.post("/tasks/claim-receipt", json={"claimer_id": "worker-1"})
+    events = app.state.audit_chain.query(event_type=EVENT_TASK_CLAIM_RECEIPT)
+    assert len(events) == before + 1
+    assert events[-1].details["claim_path"] == "mcp_claim"
+    assert events[-1].details["task_id"] == "t1"
+
+
+async def test_second_store_verifies_receipt_offline(app, client: AsyncClient, tmp_path: Path) -> None:
+    # A fresh chain store over the same on-disk state (a second server
+    # process) verifies the receipt with no in-memory session (#2506).
+    _seed(app, [BacklogEntry(id="t1", role="backend")])
+    resp = await client.post("/tasks/claim-receipt", json={"claimer_id": "worker-1"})
+    receipt = ClaimReceipt.from_wire(resp.json())
+    reloaded = AuditChainStore(tmp_path / "audit", key=_KEY)
+    ok, reason = verify_claim_receipt(receipt, _on_disk_rows(app), reloaded)
+    assert ok, reason
+
+
+async def test_granted_claim_publishes_task_claimed_event(app, client: AsyncClient) -> None:
+    from unittest.mock import MagicMock
+
+    _seed(app, [BacklogEntry(id="t1", role="backend")])
+    app.state.sse_bus = MagicMock()
+    await client.post("/tasks/claim-receipt", json={"claimer_id": "worker-1"})
+    published = [call.args[0] for call in app.state.sse_bus.publish.call_args_list]
+    assert "task_claimed" in published
+
+
+async def test_draining_server_refuses_new_claims(app, client: AsyncClient) -> None:
+    _seed(app, [BacklogEntry(id="t1", role="backend")])
+    app.state.draining = True
+    try:
+        resp = await client.post("/tasks/claim-receipt", json={"claimer_id": "worker-1"})
+        assert resp.status_code == 503
+    finally:
+        app.state.draining = False


### PR DESCRIPTION
## Summary

Puts the two worker-inbound verbs a pull worker needs onto the native MCP tool surface, so a heterogeneous MCP-native fleet runs the whole worker loop over MCP alone with no second integration path. Both tools return an object that verifies offline against the audit chain, not mutable queue state.

- `bernstein_claim` drives the dependency-gated claim path and returns a signed, content-addressed **ClaimReceipt**: a digest over `(task_id, claimer_card_fingerprint, backlog_head, filter_digest, chain_head, spec_revision)`, Ed25519-signed, embedding the audit-chain head the existing `task.claim_receipt` event recorded. Wall-clock is excluded from the pre-image, so the receipt is a deterministic projection. A filter matching no eligible row returns a signed **refusal** receipt (no silent skip).
- `bernstein_update` wraps the worker mailbox, surfacing the existing signed, HMAC-chained, audit-mirrored journal entry on the MCP surface.

The loop is `bernstein_claim` -> N x `bernstein_update` -> `bernstein_approve`. No new audit event type is introduced: the receipt reuses `task.claim_receipt`, updates reuse `task.mailbox_message`, and `audit verify` walks both.

## What landed

| Phase | Change |
|---|---|
| 1 | `core/protocols/mcp/claim_receipt.py`: `ClaimReceipt`, `backlog_head`, `filter_digest`, `sign_claim_receipt`, offline `verify_claim_receipt`. |
| 2 | `core/routes/task_claim_receipt.py`: `POST /tasks/claim-receipt`, atomic backlog-lock claim semantics kept, force-claim left unchanged. |
| 3 | `mcp/server.py` + `tool_schemas/{bernstein_claim,bernstein_update}.json` + `tool_tiers`: both tools registered in the `standard` tier. |
| 4 | `bernstein backlog verify-claim` walks a receipt offline; route publishes an SSE `task_claimed` event. |
| 5 | Docs (worker loop over MCP); reusable persisted signing-identity loader in `lineage/identity`. |

## Verification

- New tests: substrate (21), route (7), MCP tools (5), full loop (1), CLI verify (2). All green, plus the existing mcp/claim/tasks/audit/mailbox suites.
- `ruff check` and `ruff format --check` clean; no em-dashes.
- End-to-end loop driven through the real MCP tool handlers: claim receipt, three signed updates, approve, then `verify_claim_receipt`, mailbox `verify_against_chain`, and `audit_chain.verify()` all pass; a tampered receipt fails signature verification.

Closes #2555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP-native tools for claiming tasks and reporting progress.
  * Added signed, verifiable claim receipts, including refusal receipts when no eligible task is available.
  * Added an API endpoint for claiming eligible tasks and publishing claim events.
  * Added offline claim-receipt verification through the CLI.
  * Documented the complete MCP pull-worker workflow through task approval.

* **Documentation**
  * Updated MCP tool-tier documentation to include the new claim and update tools.

* **Tests**
  * Added coverage for claim receipts, tamper detection, offline verification, validation, and the full claim-update-approve workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
