### PR TITLE
feat(coordination): materialize BLOCKER signals into audit-anchored clearance gates

### DIFF
--- a/docs/orchestration/worker-coordination.md
+++ b/docs/orchestration/worker-coordination.md
@@ -115,3 +115,58 @@ chain-verifiable instead of becoming an unaudited side conversation.
 address (for example an evidence-bundle hash). The consumer resolves the
 address through the store it already trusts; the mailbox never carries the
 artefact bytes themselves.
+
+## BLOCKER clearance gates
+
+The bulletin board ships a typed signal vocabulary
+(`alert | blocker | finding | status | dependency`). A posted `blocker`
+used to be inert: the multi-cell tick logged it and moved on, so dependent
+work kept getting claimed against an unresolved blocker and no attestable
+record showed which dependent tasks ran while the blocker was open.
+
+A per-signal action registry closes that gap. Its default action is
+`observe` (a no-op), so `alert` / `finding` / `status` / `dependency` are
+unchanged; only `blocker` carries the `materialize_clearance_gate` action.
+
+Posting a `blocker` deterministically projects a clearance gate into the
+task graph:
+
+```
+blocker signal -> clearance task + injected depends_on edges -> resolution
+```
+
+The projection is a pure function of `(ordered bulletin journal prefix,
+blocker content hash, scope)` onto a canonical `(clearance_task_id,
+injected_edge_set, graph_delta_hash)` (no wall-clock, no RNG), so two
+operators replaying the same journal produce byte-identical gates. The
+clearance task participates as an ordinary `depends_on` edge, so the
+dependency gate described above already withholds every open dependent task
+in the blocker's cell until the clearance reaches a terminal cleared state.
+
+Every projection and every resolution is sealed as a `signal.gate_projection`
+receipt on the HMAC audit chain, carrying `blocker_content_hash`,
+`clearance_task_id`, `injected_edges`, `graph_delta_hash`, `scope_cell_id`,
+`deadline`, `resolution` (`pending` / `cleared` / `expired`), `resolver`, and
+(for a resolution) the `blocker_entry_hash` of the materialization it clears.
+`graph_delta_hash` is a pure function of the recorded fields, so a verifier
+recomputes it byte-identically from the chain entry alone. Clearance expiry is
+a deterministic function of the recorded deadline and an explicit evaluation
+instant, never a wall-clock read at query time.
+
+The gate state is a projection of those chained rows, not mutable side-table
+state: strip the deterministic scheduler and the audit chain and the feature
+collapses back to a logged blocker.
+
+```python
+from bernstein.core.communication.signal_actions import ClearanceGateCoordinator
+
+coordinator = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+board.set_post_hook(coordinator.materialize)   # a posted blocker materializes a gate
+# ... later, when the blocker is fixed:
+coordinator.resolve(clearance_task_id, resolver="operator:alex")
+```
+
+`bernstein audit verify-gates` reconstructs, offline from the chain alone,
+that no dependent task was claimed between a blocker post and its clearance,
+and reports any violation with the offending task id and its claim position.
+The check also runs inside `bernstein audit verify`.

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -15,6 +15,7 @@ Commands:
   bernstein audit verify --hmac-only Verify HMAC chain only.
   bernstein audit verify --merkle-only  Verify Merkle tree only.
   bernstein audit verify-hmac        Verify HMAC chain across all audit files.
+  bernstein audit verify-gates       Verify clearance-gate integrity offline.
   bernstein audit export             Export a signed Article 12 evidence pack.
   bernstein audit pack               Build a SOC 2 evidence checklist.
   bernstein audit capabilities       Print lethal-trifecta capability matrix.
@@ -212,6 +213,11 @@ def verify_cmd(merkle_only: bool, hmac_only: bool) -> None:
     # chain entry (#2353). Orthogonal to both HMAC chain and Merkle seal.
     all_passed = _verify_tournament_receipts() and all_passed
 
+    # Clearance gates are a further integrity pillar: a dependent task claimed
+    # while its blocker gate was still open, or a tampered graph_delta_hash,
+    # must fail verify (#2556). Orthogonal to both HMAC chain and Merkle seal.
+    all_passed = _verify_clearance_gates() and all_passed
+
     console.print()
     raise SystemExit(0 if all_passed else 1)
 
@@ -345,6 +351,65 @@ def _verify_tournament_receipts() -> bool:
         task = result.receipt.task_id if result.receipt is not None else "?"
         console.print(f"  [red]![/red] task {task}: {result.reason}")
     return False
+
+
+def _verify_clearance_gates() -> bool:
+    """Verify clearance-gate integrity from the audit chain. Returns True if valid.
+
+    Reconstructs, from the ``signal.gate_projection`` chain entries alone, that
+    (a) every recorded ``graph_delta_hash`` recomputes byte-identically from the
+    projection's recorded inputs, and (b) no ``task.claim_receipt`` granted a
+    scoped dependent while its clearance gate was still open (#2556, AC4). When
+    no gates were recorded the check is a silent no-op.
+    """
+    from bernstein.core.communication.signal_actions import verify_clearance_gates
+    from bernstein.core.security.audit import AuditLog
+
+    events = AuditLog(AUDIT_DIR).query()
+    result = verify_clearance_gates(events)
+    if result.gate_count == 0:
+        return True  # no clearance gates recorded; nothing to verify
+
+    console.print()
+    if result.ok:
+        console.print(
+            Panel("[bold green]Clearance Gate Verification Passed[/bold green]", border_style="green", expand=False)
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value")
+        table.add_row("Gates", str(result.gate_count))
+        console.print(table)
+        return True
+
+    console.print(Panel("[bold red]Clearance Gate Verification FAILED[/bold red]", border_style="red", expand=False))
+    for task_id, claim_index in result.violations:
+        console.print(f"  [red]![/red] dependent {task_id} claimed at chain index {claim_index} during an open gate")
+    for err in result.errors:
+        console.print(f"  [red]![/red] {err}")
+    return False
+
+
+@audit_group.command("verify-gates")
+def verify_gates_cmd() -> None:
+    """Verify clearance-gate integrity offline from the audit chain (#2556).
+
+    \b
+    Replays every ``signal.gate_projection`` entry and proves, from the chain
+    alone, that:
+      * each recorded graph_delta_hash recomputes byte-identically, and
+      * no dependent task was claimed between a blocker post and its clearance.
+
+    Reports any violation with the offending task id and its claim chain
+    position. Exits non-zero on any violation or hash mismatch.
+    """
+    if not AUDIT_DIR.is_dir():
+        console.print(f"[red]Audit directory not found:[/red] {AUDIT_DIR}")
+        raise SystemExit(1)
+
+    passed = _verify_clearance_gates()
+    console.print()
+    raise SystemExit(0 if passed else 1)
 
 
 @audit_group.command("verify-hmac")

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -483,6 +483,7 @@ _REDIRECT_MAP: dict[str, str] = {
     # checkpoint.PartialState) is the operator-visible progress slice.
     "session_continuity": "bernstein.core.persistence.session_continuity",
     "shutdown_sequence": "bernstein.core.orchestration.shutdown_sequence",
+    "signal_actions": "bernstein.core.communication.signal_actions",
     "signals": "bernstein.core.communication.signals",
     "sigstore_attestation": "bernstein.core.security.sigstore_attestation",
     "skill_badges": "bernstein.core.plugins_core.skill_badges",

--- a/src/bernstein/core/communication/bulletin.py
+++ b/src/bernstein/core/communication/bulletin.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import itertools
 import json
+import logging
 import threading
 import time
 import uuid
@@ -21,7 +22,10 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 MessageType = Literal["alert", "blocker", "finding", "status", "dependency"]
 
@@ -439,6 +443,24 @@ class BulletinBoard:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _status_notifications: list[AgentStatusNotification] = field(default_factory=list)
     _activity_summaries: dict[str, AgentActivitySummary] = field(default_factory=dict)
+    # Optional per-type action hook (#2556). When set via ``set_post_hook``, it
+    # is invoked with each stored message after the append + lock release, so a
+    # typed signal (e.g. ``blocker``) can drive deterministic scheduler state.
+    # Default ``None`` keeps existing observe-only behaviour unchanged.
+    _post_hook: Callable[[BulletinMessage], None] | None = field(default=None, repr=False)
+
+    def set_post_hook(self, hook: Callable[[BulletinMessage], None] | None) -> None:
+        """Register (or clear) a per-message action hook invoked after ``post``.
+
+        The hook receives every stored message (timestamp filled in) and may
+        dispatch a typed-signal action such as materializing a clearance gate.
+        A hook exception is swallowed so a faulty action layer never breaks the
+        append-only board.
+
+        Args:
+            hook: Callable invoked with each stored message, or ``None`` to clear.
+        """
+        self._post_hook = hook
 
     def post(self, msg: BulletinMessage) -> BulletinMessage:
         """Append a message to the board.
@@ -461,7 +483,22 @@ class BulletinBoard:
             )
         with self._lock:
             self._messages.append(msg)
+        hook = self._post_hook
+        if hook is not None:
+            try:
+                hook(msg)
+            except Exception:
+                logger.exception("bulletin post hook failed for %s signal from %s", msg.type, msg.agent_id)
         return msg
+
+    def snapshot(self) -> list[BulletinMessage]:
+        """Return an ordered copy of every message currently on the board.
+
+        Used by the clearance-gate coordinator to derive the ordered journal
+        prefix a blocker projection is computed against (#2556).
+        """
+        with self._lock:
+            return list(self._messages)
 
     def read_since(self, ts: float) -> list[BulletinMessage]:
         """Return all messages with timestamp strictly greater than *ts*.

--- a/src/bernstein/core/communication/signal_actions.py
+++ b/src/bernstein/core/communication/signal_actions.py
@@ -1,0 +1,642 @@
+"""Typed-signal action layer: BLOCKER -> audit-anchored clearance gate (#2556).
+
+The bulletin board already ships a typed signal vocabulary
+(``MessageType = alert | blocker | finding | status | dependency``), but a
+posted ``blocker`` is inert: the multi-cell tick only logs it, so dependent
+work keeps getting claimed against an unresolved blocker and there is no
+attestable record of which dependent tasks ran while a blocker was open.
+
+This module adds the missing auto-action layer. A per-``MessageType`` action
+registry (default ``observe`` no-op) turns a ``blocker`` into a deterministic
+projection into the task graph:
+
+    blocker signal -> clearance task + injected ``depends_on`` edges -> resolution
+
+The projection is a **pure function** of ``(ordered bulletin journal prefix,
+blocker content hash, scope)`` onto a canonical ``(clearance_task_id,
+injected_edge_set, graph_delta_hash)`` -- no wall-clock, no RNG -- so two
+operators replaying the same journal produce byte-identical gates. The clearance
+task participates as an ordinary ``depends_on`` edge, so the existing dependency
+gate (``store.claim_next`` / ``store.list_tasks`` withhold tasks whose
+dependencies are not terminal) already halts dependent work until the clearance
+reaches a terminal cleared state.
+
+Every projection and every resolution is sealed as a ``signal.gate_projection``
+receipt on the HMAC-chained audit log
+(:func:`bernstein.core.security.audit_chain.record_signal_gate_projection`).
+The gate state is a projection of those chained rows -- strip the deterministic
+scheduler and the audit chain and the feature collapses to today's logged
+blocker. An offline verifier reconstructs, from the chain alone, that no
+dependent task was claimed while a gate was open.
+
+Non-blocker signal types (``alert`` / ``finding`` / ``status`` / ``dependency``)
+stay observe-only through the registry default, leaving the action layer
+extensible (``INFO`` / ``REQUEST`` can follow the same shape).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Protocol
+
+from bernstein.core.security.audit_chain import (
+    EVENT_SIGNAL_GATE_PROJECTION,
+    EVENT_TASK_CLAIM_RECEIPT,
+    record_signal_gate_projection,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from bernstein.core.communication.bulletin import BulletinBoard, BulletinMessage
+    from bernstein.core.security.audit import AuditEvent
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+
+# ---------------------------------------------------------------------------
+# Per-MessageType action registry (Phase 1)
+# ---------------------------------------------------------------------------
+
+#: No-op action: the signal is observed but never mutates the scheduler.
+ACTION_OBSERVE = "observe"
+#: Blocker action: the signal materializes a deterministic clearance gate.
+ACTION_MATERIALIZE_CLEARANCE_GATE = "materialize_clearance_gate"
+
+#: Registry mapping each ``MessageType`` to its action. The default (used for
+#: any unregistered type) is :data:`ACTION_OBSERVE`, so a new signal type never
+#: mutates the scheduler until it is explicitly wired. ``INFO`` / ``REQUEST``
+#: can follow ``blocker`` by adding an entry here plus a projection.
+SIGNAL_ACTIONS: dict[str, str] = {
+    "alert": ACTION_OBSERVE,
+    "blocker": ACTION_MATERIALIZE_CLEARANCE_GATE,
+    "finding": ACTION_OBSERVE,
+    "status": ACTION_OBSERVE,
+    "dependency": ACTION_OBSERVE,
+}
+
+
+def action_for(msg_type: str) -> str:
+    """Return the registered action for *msg_type* (default ``observe``)."""
+    return SIGNAL_ACTIONS.get(msg_type, ACTION_OBSERVE)
+
+
+class ClearanceStatus(Enum):
+    """Lifecycle states for a clearance gate, mirroring ``DelegationStatus``."""
+
+    PENDING = "pending"  # Gate is open; dependent work is withheld
+    CLEARED = "cleared"  # Blocker resolved; dependents released
+    EXPIRED = "expired"  # Deadline passed (deterministic timeout terminal)
+
+
+# ---------------------------------------------------------------------------
+# Pure projection core (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def _canonical(obj: object) -> bytes:
+    """Serialise *obj* to canonical (sorted-key, compact) JSON bytes."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def blocker_content_hash(*, agent_id: str, content: str, cell_id: str | None) -> str:
+    """Return a ``sha256:`` digest over a blocker's stable content fields.
+
+    The hash omits the wall-clock timestamp so it is a stable identity for the
+    blocker's *content*; journal position is folded into the clearance-task id
+    separately (see :func:`project_clearance_gate`).
+    """
+    payload = _canonical({"agent_id": agent_id, "cell_id": cell_id or "", "content": content, "type": "blocker"})
+    return "sha256:" + _sha256_hex(payload)
+
+
+def journal_prefix_hash(messages: Sequence[BulletinMessage]) -> str:
+    """Return a ``sha256:`` digest over an ordered bulletin journal prefix.
+
+    Two operators replaying the same ordered messages compute the same prefix
+    hash; a different prefix (extra prior message, different order) yields a
+    different hash, which disambiguates otherwise-identical blockers.
+    """
+    items = [
+        {
+            "agent_id": m.agent_id,
+            "cell_id": m.cell_id or "",
+            "content": m.content,
+            "timestamp": m.timestamp,
+            "type": m.type,
+        }
+        for m in messages
+    ]
+    return "sha256:" + _sha256_hex(_canonical(items))
+
+
+def compute_graph_delta_hash(
+    *,
+    clearance_task_id: str,
+    injected_edges: Sequence[str],
+    blocker_content_hash: str,
+    scope_cell_id: str,
+    deadline: int,
+) -> str:
+    """Return the canonical task-graph delta hash (64 hex chars).
+
+    Computed over exactly the fields recorded in the ``signal.gate_projection``
+    audit entry, so an offline verifier holding only the chain entry recomputes
+    it byte-identically. Flipping any recorded input (e.g. the blocker content
+    hash) diverges the result.
+    """
+    payload = _canonical(
+        {
+            "clearance_task_id": clearance_task_id,
+            "injected_edges": sorted(injected_edges),
+            "blocker_content_hash": blocker_content_hash,
+            "scope_cell_id": scope_cell_id,
+            "deadline": int(deadline),
+        }
+    )
+    return _sha256_hex(payload)
+
+
+@dataclass(frozen=True)
+class ClearanceGateSpec:
+    """The canonical projection of a blocker signal onto the task graph.
+
+    Attributes:
+        blocker_content_hash: ``sha256:`` digest of the blocker's content.
+        clearance_task_id: Deterministic clearance-task id (``clearance-<hex>``).
+        injected_edges: Sorted, de-duplicated dependent task ids receiving a
+            ``depends_on`` edge onto the clearance task.
+        scope_cell_id: The blocker's cell scope.
+        journal_prefix_hash: Digest of the ordered journal prefix the projection
+            was computed against.
+        graph_delta_hash: Canonical task-graph delta hash (64 hex chars).
+        deadline: Deterministic expiry deadline (Unix seconds; 0 = no expiry).
+    """
+
+    blocker_content_hash: str
+    clearance_task_id: str
+    injected_edges: tuple[str, ...]
+    scope_cell_id: str
+    journal_prefix_hash: str
+    graph_delta_hash: str
+    deadline: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable representation of the spec."""
+        return {
+            "blocker_content_hash": self.blocker_content_hash,
+            "clearance_task_id": self.clearance_task_id,
+            "injected_edges": list(self.injected_edges),
+            "scope_cell_id": self.scope_cell_id,
+            "journal_prefix_hash": self.journal_prefix_hash,
+            "graph_delta_hash": self.graph_delta_hash,
+            "deadline": self.deadline,
+        }
+
+
+def project_clearance_gate(
+    *,
+    blocker: BulletinMessage,
+    scope_task_ids: Sequence[str],
+    journal_prefix_hash: str,
+    ttl_seconds: int = 0,
+) -> ClearanceGateSpec:
+    """Deterministically project a blocker signal onto a clearance gate.
+
+    Pure function: no wall-clock read, no RNG. Given the same ``blocker``,
+    ``scope_task_ids`` (order-independent), and ``journal_prefix_hash``, the
+    returned spec is byte-identical across runs and across operators.
+
+    Args:
+        blocker: The posted blocker message.
+        scope_task_ids: Open dependent task ids in the blocker's scope; the set
+            is sorted and de-duplicated to form the injected edge set.
+        journal_prefix_hash: Digest of the ordered journal prefix up to and
+            including the blocker (see :func:`journal_prefix_hash`).
+        ttl_seconds: Optional deterministic expiry horizon; the deadline is a
+            pure function of the recorded blocker timestamp plus this value.
+
+    Returns:
+        The canonical :class:`ClearanceGateSpec`.
+    """
+    scope = blocker.cell_id or ""
+    content_hash = blocker_content_hash(agent_id=blocker.agent_id, content=blocker.content, cell_id=blocker.cell_id)
+    seed = _canonical({"content_hash": content_hash, "journal_prefix_hash": journal_prefix_hash, "scope": scope})
+    clearance_task_id = "clearance-" + _sha256_hex(seed)[:16]
+    injected = tuple(sorted({str(t) for t in scope_task_ids}))
+    deadline = int(blocker.timestamp) + int(ttl_seconds) if ttl_seconds and ttl_seconds > 0 else 0
+    graph_delta_hash = compute_graph_delta_hash(
+        clearance_task_id=clearance_task_id,
+        injected_edges=injected,
+        blocker_content_hash=content_hash,
+        scope_cell_id=scope,
+        deadline=deadline,
+    )
+    return ClearanceGateSpec(
+        blocker_content_hash=content_hash,
+        clearance_task_id=clearance_task_id,
+        injected_edges=injected,
+        scope_cell_id=scope,
+        journal_prefix_hash=journal_prefix_hash,
+        graph_delta_hash=graph_delta_hash,
+        deadline=deadline,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task-graph injector (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class ClearanceGateInjector(Protocol):
+    """Applies a projected clearance gate to a task graph.
+
+    Implementations enqueue the clearance task and inject the dependency edges
+    into whichever task store backs the deployment. The coordinator owns the
+    projection, receipt, and idempotency; the injector owns the graph mutation.
+    """
+
+    def open_dependent_task_ids(self, scope_cell_id: str) -> list[str]:
+        """Return the open dependent task ids in *scope_cell_id*."""
+        ...
+
+    def create_clearance_task(self, spec: ClearanceGateSpec, blocker: BulletinMessage) -> None:
+        """Create the clearance task with ``spec.clearance_task_id``."""
+        ...
+
+    def add_dependency_edge(self, dependent_task_id: str, clearance_task_id: str) -> None:
+        """Inject a ``depends_on`` edge from *dependent_task_id* -> clearance."""
+        ...
+
+    def release_clearance_task(self, clearance_task_id: str) -> None:
+        """Mark the clearance task terminal so its dependents are released."""
+        ...
+
+
+@dataclass
+class InMemoryClearanceInjector:
+    """In-memory :class:`ClearanceGateInjector` for tests and dry runs.
+
+    Records every mutation so a caller can assert on the projected graph
+    without a live task store.
+    """
+
+    open_by_cell: dict[str, list[str]] = field(default_factory=dict)
+    created: list[ClearanceGateSpec] = field(default_factory=list)
+    edges: list[tuple[str, str]] = field(default_factory=list)
+    released: list[str] = field(default_factory=list)
+
+    def open_dependent_task_ids(self, scope_cell_id: str) -> list[str]:
+        return list(self.open_by_cell.get(scope_cell_id, []))
+
+    def create_clearance_task(self, spec: ClearanceGateSpec, blocker: BulletinMessage) -> None:
+        self.created.append(spec)
+
+    def add_dependency_edge(self, dependent_task_id: str, clearance_task_id: str) -> None:
+        self.edges.append((dependent_task_id, clearance_task_id))
+
+    def release_clearance_task(self, clearance_task_id: str) -> None:
+        self.released.append(clearance_task_id)
+
+
+# ---------------------------------------------------------------------------
+# Coordinator (Phase 2 + 3)
+# ---------------------------------------------------------------------------
+
+
+class ClearanceGateCoordinator:
+    """Materializes blocker signals into audit-anchored clearance gates.
+
+    The coordinator reads new blocker signals from a bulletin board, projects
+    each deterministically, applies the projection through an injector, and
+    seals a ``signal.gate_projection`` receipt on the HMAC chain. Resolving a
+    clearance emits a signed release entry that references the materialization
+    entry hash. Materialization is idempotent per clearance-task id, so
+    reprocessing the same journal never double-injects.
+    """
+
+    def __init__(
+        self,
+        *,
+        bulletin: BulletinBoard,
+        injector: ClearanceGateInjector,
+        chain: AuditChainStore,
+        actor: str = "clearance_gate",
+        ttl_seconds: int = 0,
+        lineage_seal: Callable[[ClearanceGateSpec, str], str] | None = None,
+    ) -> None:
+        self._bulletin = bulletin
+        self._injector = injector
+        self._chain = chain
+        self._actor = actor
+        self._ttl_seconds = ttl_seconds
+        self._lineage_seal = lineage_seal
+        self._materialized: dict[str, ClearanceGateSpec] = {}
+        self._entry_hmac: dict[str, str] = {}
+        self._last_bulletin_ts: float = 0.0
+
+    # -- read side ----------------------------------------------------------
+
+    def _prefix_for(self, blocker: BulletinMessage) -> list[BulletinMessage]:
+        """Return the ordered journal prefix up to and including *blocker*."""
+        msgs = self._bulletin.snapshot()
+        for i, m in enumerate(msgs):
+            if m is blocker:
+                return msgs[: i + 1]
+        if blocker in msgs:
+            return msgs[: msgs.index(blocker) + 1]
+        return [*msgs, blocker]
+
+    # -- materialization ----------------------------------------------------
+
+    def materialize(self, blocker: BulletinMessage) -> ClearanceGateSpec | None:
+        """Project *blocker* into a clearance gate and seal the receipt.
+
+        Returns the :class:`ClearanceGateSpec`, or ``None`` when the signal type
+        is observe-only. Idempotent: a blocker already materialized returns its
+        existing spec without re-injecting or re-recording.
+        """
+        if action_for(blocker.type) != ACTION_MATERIALIZE_CLEARANCE_GATE:
+            return None
+
+        scope = blocker.cell_id or ""
+        jph = journal_prefix_hash(self._prefix_for(blocker))
+        # A prior gate's clearance task is itself an open task in the cell; never
+        # gate a gate on another gate.
+        open_deps = [
+            dep for dep in self._injector.open_dependent_task_ids(scope) if not str(dep).startswith("clearance-")
+        ]
+        spec = project_clearance_gate(
+            blocker=blocker,
+            scope_task_ids=open_deps,
+            journal_prefix_hash=jph,
+            ttl_seconds=self._ttl_seconds,
+        )
+        if spec.clearance_task_id in self._materialized:
+            return spec
+
+        self._injector.create_clearance_task(spec, blocker)
+        for dependent_id in spec.injected_edges:
+            self._injector.add_dependency_edge(dependent_id, spec.clearance_task_id)
+
+        journal_entry_hash = self._lineage_seal(spec, "pending") if self._lineage_seal is not None else ""
+        event = record_signal_gate_projection(
+            chain=self._chain,
+            blocker_content_hash=spec.blocker_content_hash,
+            clearance_task_id=spec.clearance_task_id,
+            injected_edges=list(spec.injected_edges),
+            graph_delta_hash=spec.graph_delta_hash,
+            scope_cell_id=spec.scope_cell_id,
+            deadline=spec.deadline,
+            resolution="pending",
+            resolver="",
+            last_state_hash="genesis",
+            journal_entry_hash=journal_entry_hash,
+            blocker_entry_hash="",
+            actor=self._actor,
+        )
+        self._materialized[spec.clearance_task_id] = spec
+        self._entry_hmac[spec.clearance_task_id] = event.hmac
+        return spec
+
+    def process_new_blockers(self) -> list[ClearanceGateSpec]:
+        """Materialize gates for every blocker posted since the last call."""
+        new_messages = self._bulletin.read_since(self._last_bulletin_ts)
+        if new_messages:
+            self._last_bulletin_ts = max(m.timestamp for m in new_messages)
+        specs: list[ClearanceGateSpec] = []
+        seen: set[str] = set()
+        for message in new_messages:
+            if action_for(message.type) != ACTION_MATERIALIZE_CLEARANCE_GATE:
+                continue
+            spec = self.materialize(message)
+            if spec is not None and spec.clearance_task_id not in seen:
+                seen.add(spec.clearance_task_id)
+                specs.append(spec)
+        return specs
+
+    # -- resolution ---------------------------------------------------------
+
+    def resolve(
+        self,
+        clearance_task_id: str,
+        resolver: str,
+        resolution: str = "cleared",
+    ) -> AuditEvent:
+        """Resolve a clearance gate and emit a signed release entry.
+
+        Args:
+            clearance_task_id: The gate to resolve.
+            resolver: Identity clearing the gate (recorded as the actor).
+            resolution: ``cleared`` (blocker fixed) or ``expired`` (timeout).
+
+        Returns:
+            The recorded release :class:`AuditEvent`; its ``blocker_entry_hash``
+            references the materialization entry.
+        """
+        if resolution not in ("cleared", "expired"):
+            raise ValueError(f"resolution must be 'cleared' or 'expired', got {resolution!r}")
+        spec = self._materialized.get(clearance_task_id)
+        if spec is None:
+            raise KeyError(clearance_task_id)
+
+        blocker_entry_hash = self._entry_hmac.get(clearance_task_id, "")
+        self._injector.release_clearance_task(clearance_task_id)
+
+        journal_entry_hash = self._lineage_seal(spec, resolution) if self._lineage_seal is not None else ""
+        return record_signal_gate_projection(
+            chain=self._chain,
+            blocker_content_hash=spec.blocker_content_hash,
+            clearance_task_id=spec.clearance_task_id,
+            injected_edges=list(spec.injected_edges),
+            graph_delta_hash=spec.graph_delta_hash,
+            scope_cell_id=spec.scope_cell_id,
+            deadline=spec.deadline,
+            resolution=resolution,
+            resolver=resolver,
+            last_state_hash=blocker_entry_hash or "genesis",
+            journal_entry_hash=journal_entry_hash,
+            blocker_entry_hash=blocker_entry_hash,
+            actor=resolver or self._actor,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gate-state projection + offline verification (Phase 3 + 4)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClearanceGateState:
+    """A clearance gate's state, projected from chained ``signal.gate_projection`` rows."""
+
+    clearance_task_id: str
+    blocker_content_hash: str
+    injected_edges: tuple[str, ...]
+    graph_delta_hash: str
+    scope_cell_id: str
+    deadline: int
+    status: ClearanceStatus
+    resolver: str
+    projection_index: int
+    resolution_index: int | None
+
+
+def project_gate_states(
+    events: Sequence[AuditEvent],
+    *,
+    as_of: int | None = None,
+) -> dict[str, ClearanceGateState]:
+    """Project clearance-gate states from ``signal.gate_projection`` events.
+
+    The gate state is a pure projection of the chained rows, not mutable
+    side-table state. When *as_of* is supplied, a still-pending gate whose
+    recorded deadline has passed is reported ``EXPIRED`` -- expiry is a
+    deterministic function of the recorded inputs and the explicit *as_of*, not
+    a wall-clock read at query time.
+    """
+    states: dict[str, ClearanceGateState] = {}
+    for idx, event in enumerate(events):
+        if event.event_type != EVENT_SIGNAL_GATE_PROJECTION:
+            continue
+        details = event.details
+        clearance_task_id = str(details.get("clearance_task_id", ""))
+        resolution = str(details.get("resolution", "pending"))
+        if resolution == "pending":
+            states[clearance_task_id] = ClearanceGateState(
+                clearance_task_id=clearance_task_id,
+                blocker_content_hash=str(details.get("blocker_content_hash", "")),
+                injected_edges=tuple(details.get("injected_edges", [])),
+                graph_delta_hash=str(details.get("graph_delta_hash", "")),
+                scope_cell_id=str(details.get("scope_cell_id", "")),
+                deadline=int(details.get("deadline", 0) or 0),
+                status=ClearanceStatus.PENDING,
+                resolver="",
+                projection_index=idx,
+                resolution_index=None,
+            )
+            continue
+        state = states.get(clearance_task_id)
+        if state is None:
+            continue
+        state.status = ClearanceStatus.CLEARED if resolution == "cleared" else ClearanceStatus.EXPIRED
+        state.resolver = str(details.get("resolver", ""))
+        state.resolution_index = idx
+
+    if as_of is not None:
+        for state in states.values():
+            if state.status is ClearanceStatus.PENDING and state.deadline > 0 and as_of >= state.deadline:
+                state.status = ClearanceStatus.EXPIRED
+    return states
+
+
+@dataclass
+class GateVerifyResult:
+    """Outcome of an offline clearance-gate verification pass."""
+
+    ok: bool
+    gate_count: int
+    errors: list[str] = field(default_factory=list)
+    violations: list[tuple[str, int]] = field(default_factory=list)
+
+
+def verify_clearance_gates(
+    events: Sequence[AuditEvent],
+    *,
+    as_of: int | None = None,
+) -> GateVerifyResult:
+    """Reconstruct clearance-gate integrity from the audit chain alone.
+
+    Walks the ordered chain and, for every ``signal.gate_projection`` entry,
+    recomputes ``graph_delta_hash`` from the recorded fields (a mismatch is an
+    error). It then confirms no ``task.claim_receipt`` granted a scoped
+    dependent while its clearance gate was still open, reporting each violation
+    as ``(task_id, claim chain index)``.
+
+    Args:
+        events: The full ordered audit chain (materializations, resolutions, and
+            claim receipts interleaved).
+        as_of: Unused today; reserved so callers can pin a deterministic
+            evaluation instant without changing the signature.
+
+    Returns:
+        A :class:`GateVerifyResult`. ``ok`` is ``True`` only when there are no
+        hash mismatches and no claims during an open gate.
+    """
+    del as_of  # reserved for a future deterministic-expiry policy hook
+    errors: list[str] = []
+    violations: list[tuple[str, int]] = []
+    open_gates: dict[str, dict[str, object]] = {}
+    seen: set[str] = set()
+
+    for idx, event in enumerate(events):
+        if event.event_type == EVENT_SIGNAL_GATE_PROJECTION:
+            details = event.details
+            clearance_task_id = str(details.get("clearance_task_id", ""))
+            resolution = str(details.get("resolution", "pending"))
+            recomputed = compute_graph_delta_hash(
+                clearance_task_id=clearance_task_id,
+                injected_edges=[str(e) for e in details.get("injected_edges", [])],
+                blocker_content_hash=str(details.get("blocker_content_hash", "")),
+                scope_cell_id=str(details.get("scope_cell_id", "")),
+                deadline=int(details.get("deadline", 0) or 0),
+            )
+            stored = str(details.get("graph_delta_hash", ""))
+            if recomputed != stored:
+                errors.append(
+                    f"gate {clearance_task_id}: graph_delta_hash mismatch at chain index {idx} "
+                    f"(recomputed {recomputed[:12]}.. != stored {stored[:12]}..)"
+                )
+            if resolution == "pending":
+                seen.add(clearance_task_id)
+                open_gates[clearance_task_id] = {
+                    "edges": {str(e) for e in details.get("injected_edges", [])},
+                    "index": idx,
+                }
+            else:
+                if clearance_task_id not in seen:
+                    errors.append(
+                        f"gate {clearance_task_id}: resolution '{resolution}' at chain index {idx} "
+                        "has no prior projection"
+                    )
+                open_gates.pop(clearance_task_id, None)
+        elif event.event_type == EVENT_TASK_CLAIM_RECEIPT:
+            claimed = str(event.details.get("task_id", "") or event.resource_id)
+            for clearance_task_id, gate in open_gates.items():
+                edges = gate["edges"]
+                if isinstance(edges, set) and claimed in edges:
+                    violations.append((claimed, idx))
+                    errors.append(
+                        f"dependent {claimed} claimed at chain index {idx} while clearance gate "
+                        f"{clearance_task_id} (opened at index {gate['index']}) was still open"
+                    )
+
+    ok = not errors and not violations
+    return GateVerifyResult(ok=ok, gate_count=len(seen), errors=errors, violations=violations)
+
+
+__all__ = [
+    "ACTION_MATERIALIZE_CLEARANCE_GATE",
+    "ACTION_OBSERVE",
+    "SIGNAL_ACTIONS",
+    "ClearanceGateCoordinator",
+    "ClearanceGateInjector",
+    "ClearanceGateSpec",
+    "ClearanceGateState",
+    "ClearanceStatus",
+    "GateVerifyResult",
+    "InMemoryClearanceInjector",
+    "action_for",
+    "blocker_content_hash",
+    "compute_graph_delta_hash",
+    "journal_prefix_hash",
+    "project_clearance_gate",
+    "project_gate_states",
+    "verify_clearance_gates",
+]

--- a/src/bernstein/core/compat_redirect_ledger.py
+++ b/src/bernstein/core/compat_redirect_ledger.py
@@ -39,7 +39,7 @@ REDIRECT_LEDGER_POLICY: Final[RedirectLedgerPolicy] = RedirectLedgerPolicy(
     ),
 )
 
-REVIEWED_REDIRECT_MAP_DIGEST: Final[str] = "7739633119917414455f337b5550be737e9aed29c19f7a441e8bbf6dd0b74c57"
+REVIEWED_REDIRECT_MAP_DIGEST: Final[str] = "819ef90b237c891eba14562979c78e6377e571cbf826b228a7f7115b1ec449de"
 
 
 def redirect_map_digest(redirects: Mapping[str, str]) -> str:

--- a/src/bernstein/core/orchestration/multi_cell.py
+++ b/src/bernstein/core/orchestration/multi_cell.py
@@ -30,6 +30,7 @@ from bernstein.core.orchestration.orchestrator import TickResult, group_by_role
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.core.communication.signal_actions import ClearanceGateCoordinator
     from bernstein.core.spawner import AgentSpawner
 
 logger = logging.getLogger(__name__)
@@ -170,6 +171,7 @@ class MultiCellOrchestrator:
         workdir: Path,
         bulletin: BulletinBoard | None = None,
         client: httpx.Client | None = None,
+        clearance_coordinator: ClearanceGateCoordinator | None = None,
     ) -> None:
         self._config = config
         self._spawner = spawner
@@ -179,6 +181,12 @@ class MultiCellOrchestrator:
         self._cells: dict[str, Cell] = {}
         self._running = False
         self._last_bulletin_ts: float = 0.0
+        # Optional clearance-gate coordinator (#2556). When wired, a posted
+        # ``blocker`` is not merely logged: it is deterministically projected
+        # into a clearance task plus injected ``depends_on`` edges, sealed as a
+        # ``signal.gate_projection`` receipt on the audit chain. When ``None``,
+        # blockers stay observe-only (logged), preserving legacy behaviour.
+        self._clearance_coordinator = clearance_coordinator
 
     @property
     def cells(self) -> dict[str, Cell]:
@@ -239,6 +247,21 @@ class MultiCellOrchestrator:
                 blocker.cell_id or "global",
                 blocker.content,
             )
+            # Materialize the blocker into an audit-anchored clearance gate when
+            # a coordinator is wired: the projection creates a clearance task
+            # plus injected ``depends_on`` edges so dependent work is withheld
+            # until the clearance is terminal, instead of merely being logged.
+            if self._clearance_coordinator is not None:
+                try:
+                    spec = self._clearance_coordinator.materialize(blocker)
+                    if spec is not None:
+                        result.vp_actions.append(
+                            f"clearance gate {spec.clearance_task_id} materialized "
+                            f"({len(spec.injected_edges)} edge(s), cell={blocker.cell_id or 'global'})"
+                        )
+                except Exception as exc:
+                    logger.error("clearance gate materialization failed: %s", exc)
+                    result.errors.append(f"clearance_gate: {exc}")
 
         # 2. For each cell: run cell-level tick
         for cell_id, cell in self._cells.items():

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -491,6 +491,24 @@ EVENT_TOURNAMENT_SELECTION = "tournament.selection"
 #: worktree across the ssh boundary (distinct worktree per task, none lost).
 EVENT_RUN_SSH_TASK = "run.ssh_task"
 
+#: Issue #2556 -- emitted whenever a typed ``blocker`` bulletin signal is
+#: materialized into a clearance gate, and again at each clearance / expiry
+#: transition. Posting a ``blocker`` deterministically projects a clearance
+#: task plus injected ``depends_on`` edges onto the open dependent tasks in the
+#: blocker's scope; the whole chain (blocker signal -> clearance task + injected
+#: edges -> resolution) is sealed as a receipt on the HMAC chain. The event
+#: records ``{blocker_content_hash, clearance_task_id, injected_edges,
+#: graph_delta_hash, scope_cell_id, deadline, last_state_hash,
+#: journal_entry_hash, blocker_entry_hash, resolution (pending/cleared/expired),
+#: resolver}``. ``graph_delta_hash`` is a pure function of the recorded detail
+#: fields, so a verifier recomputes it byte-identically from the chain entry
+#: alone; a resolution entry references the materialization entry hash via
+#: ``blocker_entry_hash``. The signal-to-gate map is a pure projection, so two
+#: operators replaying the same bulletin journal produce byte-identical gates --
+#: strip the deterministic scheduler and this chain and the gate collapses to a
+#: logged blocker. See :mod:`bernstein.core.communication.signal_actions`.
+EVENT_SIGNAL_GATE_PROJECTION = "signal.gate_projection"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -1631,6 +1649,116 @@ def record_schedule_fire_projection(
             "trigger_input_hash": trigger_input_hash,
             "recurrence": recurrence,
         },
+    )
+
+
+@dataclass(frozen=True)
+class SignalGateProjectionDetails:
+    """Structured payload for the ``signal.gate_projection`` event (#2556)."""
+
+    blocker_content_hash: str
+    clearance_task_id: str
+    injected_edges: tuple[str, ...]
+    graph_delta_hash: str
+    scope_cell_id: str
+    deadline: int
+    resolution: str
+    resolver: str
+    last_state_hash: str
+    journal_entry_hash: str
+    blocker_entry_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "blocker_content_hash": self.blocker_content_hash,
+            "clearance_task_id": self.clearance_task_id,
+            "injected_edges": list(self.injected_edges),
+            "graph_delta_hash": self.graph_delta_hash,
+            "scope_cell_id": self.scope_cell_id,
+            "deadline": self.deadline,
+            "resolution": self.resolution,
+            "resolver": self.resolver,
+            "last_state_hash": self.last_state_hash,
+            "journal_entry_hash": self.journal_entry_hash,
+            "blocker_entry_hash": self.blocker_entry_hash,
+        }
+
+
+def record_signal_gate_projection(
+    *,
+    chain: AuditChainStore,
+    blocker_content_hash: str,
+    clearance_task_id: str,
+    injected_edges: list[str],
+    graph_delta_hash: str,
+    scope_cell_id: str,
+    deadline: int = 0,
+    resolution: str = "pending",
+    resolver: str = "",
+    last_state_hash: str = "genesis",
+    journal_entry_hash: str = "",
+    blocker_entry_hash: str = "",
+    actor: str = "clearance_gate",
+) -> AuditEvent:
+    """Append a ``signal.gate_projection`` event into *chain* (#2556).
+
+    A typed ``blocker`` bulletin signal is not a chat line but a deterministic
+    projection into the task graph: it materializes a clearance task plus
+    injected ``depends_on`` edges onto the open dependent tasks in the blocker's
+    scope, and the whole chain (blocker signal -> clearance task + injected edges
+    -> resolution) is sealed as a receipt here. ``resolution`` is ``pending`` for
+    the materialization entry and ``cleared`` / ``expired`` for a resolution
+    entry; a resolution entry references the materialization entry hash via
+    ``blocker_entry_hash``. ``graph_delta_hash`` is a pure function of the
+    recorded detail fields, so a verifier recomputes it byte-identically from the
+    chain entry alone -- strip the deterministic scheduler and this chain and the
+    gate collapses to a logged blocker.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        blocker_content_hash: ``sha256:`` digest over the blocker's stable
+            content fields (agent, content, scope).
+        clearance_task_id: The deterministic clearance-task id derived from the
+            blocker content hash and the ordered journal prefix.
+        injected_edges: The dependent task ids that received a ``depends_on``
+            edge onto the clearance task (canonical sorted order).
+        graph_delta_hash: The canonical task-graph delta hash the projection
+            produced (64 hex chars); recomputable from the recorded fields.
+        scope_cell_id: The blocker's cell scope the edges were injected into.
+        deadline: Deterministic expiry deadline (Unix seconds; 0 = no expiry).
+        resolution: ``pending`` (materialization) / ``cleared`` / ``expired``.
+        resolver: Identity that resolved the clearance (empty for pending).
+        last_state_hash: Prior gate-state anchor folded into this entry
+            (``genesis`` for the first projection of a clearance task).
+        journal_entry_hash: Lineage-spine entry hash the projection was sealed
+            into; empty when no lineage sealer is wired.
+        blocker_entry_hash: For a resolution entry, the HMAC of the
+            materialization entry it clears; empty for the materialization entry.
+        actor: Recorded actor; defaults to ``"clearance_gate"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    payload = SignalGateProjectionDetails(
+        blocker_content_hash=blocker_content_hash,
+        clearance_task_id=clearance_task_id,
+        injected_edges=tuple(injected_edges),
+        graph_delta_hash=graph_delta_hash,
+        scope_cell_id=scope_cell_id,
+        deadline=deadline,
+        resolution=resolution,
+        resolver=resolver,
+        last_state_hash=last_state_hash,
+        journal_entry_hash=journal_entry_hash,
+        blocker_entry_hash=blocker_entry_hash,
+    ).to_dict()
+    return chain.log_with_prev_digest(
+        event_type=EVENT_SIGNAL_GATE_PROJECTION,
+        actor=actor or "clearance_gate",
+        resource_type="signal_gate_projection",
+        resource_id=clearance_task_id,
+        details=payload,
     )
 
 
@@ -3260,6 +3388,7 @@ __all__ = [
     "EVENT_RUN_LIFECYCLE",
     "EVENT_RUN_SSH_TASK",
     "EVENT_SCHEDULE_FIRE_PROJECTION",
+    "EVENT_SIGNAL_GATE_PROJECTION",
     "EVENT_SKILL_INSTALL_RECEIPT",
     "EVENT_SKILL_USAGE",
     "EVENT_SPEC_REQUIREMENT_SET",
@@ -3317,6 +3446,7 @@ __all__ = [
     "record_run_ssh_task",
     "record_schedule_fire_projection",
     "record_sensitive_gate",
+    "record_signal_gate_projection",
     "record_skill_install_receipt",
     "record_skill_usage",
     "record_spec_requirement_set",

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1031,6 +1031,125 @@ class TaskStore:
 
         return task
 
+    # -- clearance-gate wiring (#2556) --------------------------------------
+    # A ``blocker`` bulletin signal materializes a clearance task with a
+    # deterministic id (derived from the blocker content hash) plus injected
+    # ``depends_on`` edges onto the open dependent tasks in scope. The clearance
+    # task participates as an ordinary dependency edge, so ``claim_next`` and the
+    # ``list_tasks(status="open")`` exclusion already withhold dependent work
+    # until the gate is terminal. These additive helpers let the deterministic
+    # projection create a task at a chosen id and inject the edges without going
+    # through the id-generating ``create`` path.
+
+    async def create_gate_task(
+        self,
+        *,
+        clearance_task_id: str,
+        title: str,
+        role: str,
+        cell_id: str | None = None,
+        priority: int = 1,
+        tenant_id: str = "default",
+    ) -> Task:
+        """Create a clearance task with a caller-supplied deterministic id.
+
+        Args:
+            clearance_task_id: The projected clearance-task id (``clearance-…``).
+            title: Human-readable gate title.
+            role: Role lane the clearance task belongs to (kept distinct from
+                worker roles so workers never claim the gate itself).
+            cell_id: Cell scope the gate belongs to.
+            priority: Task priority (defaults to 1 so the gate surfaces first).
+            tenant_id: Tenant scope.
+
+        Returns:
+            The created clearance :class:`Task`.
+
+        Raises:
+            ValueError: If a task with ``clearance_task_id`` already exists.
+        """
+        task = Task(
+            id=clearance_task_id,
+            title=title,
+            description=f"Clearance gate for a bulletin blocker in cell {cell_id or 'global'}.",
+            role=role,
+            priority=priority,
+            status=TaskStatus.OPEN,
+            cell_id=cell_id,
+            tenant_id=normalize_tenant_id(tenant_id),
+        )
+        async with self._lock:
+            if clearance_task_id in self._tasks:
+                raise ValueError(f"clearance task already exists: {clearance_task_id}")
+            self._tasks[task.id] = task
+            self._index_add(task)
+            self._parent_index_add(task)
+            await self._append_jsonl(self._task_to_record(task))
+        return task
+
+    async def inject_dependency(self, task_id: str, depends_on_id: str) -> Task:
+        """Inject a ``depends_on`` edge onto an existing non-terminal task.
+
+        The edge is idempotent (a repeated injection is a no-op) and the target
+        dependency must already exist so the dependency gate can resolve it. The
+        task's version is bumped and the change is persisted.
+
+        Args:
+            task_id: The dependent task receiving the edge.
+            depends_on_id: The clearance (or other) task it must now wait on.
+
+        Returns:
+            The updated dependent :class:`Task`.
+
+        Raises:
+            KeyError: If either task id is unknown.
+        """
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise KeyError(task_id)
+            if depends_on_id not in self._tasks:
+                raise KeyError(depends_on_id)
+            if depends_on_id not in task.depends_on:
+                task.depends_on = [*task.depends_on, depends_on_id]
+                task.version += 1
+                await self._append_jsonl(self._task_to_record(task))
+        return task
+
+    async def resolve_gate_task(self, clearance_task_id: str, *, resolution: str = "cleared") -> Task:
+        """Mark a clearance task terminal so its dependents are released.
+
+        Transitions the gate ``OPEN -> CLAIMED -> DONE`` (both legal steps) so
+        the terminal ``DONE`` status satisfies the dependency gate and dependent
+        work becomes claimable again. ``resolution`` is recorded in the result
+        summary for the archive trail.
+
+        Args:
+            clearance_task_id: The clearance task to resolve.
+            resolution: ``cleared`` or ``expired`` (recorded in the summary).
+
+        Returns:
+            The resolved clearance :class:`Task`.
+
+        Raises:
+            KeyError: If ``clearance_task_id`` is unknown.
+        """
+        async with self._lock:
+            task = self._tasks.get(clearance_task_id)
+            if task is None:
+                raise KeyError(clearance_task_id)
+            if task.status not in (TaskStatus.DONE, TaskStatus.CLOSED):
+                self._index_remove(task)
+                if task.status == TaskStatus.OPEN:
+                    transition_task(task, TaskStatus.CLAIMED, actor="clearance_gate", reason="gate resolve")
+                transition_task(task, TaskStatus.DONE, actor="clearance_gate", reason=f"gate {resolution}")
+                task.result_summary = f"clearance {resolution}"
+                task.completed_at = time.time()
+                task.version += 1
+                self._index_add(task)
+                await self._append_jsonl(self._task_to_record(task))
+        return task
+
     async def create_batch(
         self,
         requests: list[TaskCreateRequest],

--- a/tests/unit/cli/test_audit_verify_gates_cmd.py
+++ b/tests/unit/cli/test_audit_verify_gates_cmd.py
@@ -1,0 +1,85 @@
+"""Tests for ``bernstein audit verify-gates`` (#2556).
+
+The forensic verifier reconstructs, from the audit chain alone, that no
+dependent task was claimed while its clearance gate was open, and that every
+recorded ``graph_delta_hash`` recomputes byte-identically.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.communication.bulletin import BulletinBoard, BulletinMessage
+from bernstein.core.communication.signal_actions import (
+    ClearanceGateCoordinator,
+    InMemoryClearanceInjector,
+)
+from bernstein.core.security.audit import AUDIT_KEY_ENV
+from bernstein.core.security.audit_chain import AuditChainStore, record_task_claim_receipt
+
+AUDIT_DIR = Path(".sdd/audit")
+
+
+@pytest.fixture
+def isolated_audit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"a" * 64)
+    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _materialize() -> str:
+    """Materialize one clearance gate onto the isolated audit chain."""
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = AuditChainStore(AUDIT_DIR)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+    blocker = board.post(
+        BulletinMessage(agent_id="w", type="blocker", content="dep broke", timestamp=1.0, cell_id="cell-a")
+    )
+    spec = coord.materialize(blocker)
+    assert spec is not None
+    return spec.clearance_task_id
+
+
+def test_verify_gates_passes_on_clean_chain(isolated_audit: Path) -> None:
+    _materialize()  # a pending gate with no rogue claims verifies clean
+    result = CliRunner().invoke(audit_group, ["verify-gates"])
+    assert result.exit_code == 0, result.output
+    assert "Clearance Gate Verification Passed" in result.output
+
+
+def test_verify_gates_fails_on_claim_during_open_gate(isolated_audit: Path) -> None:
+    clearance_id = _materialize()
+    # A rogue claim of the scoped dependent while the gate is still open.
+    chain = AuditChainStore(AUDIT_DIR)
+    record_task_claim_receipt(
+        chain=chain,
+        task_id="task-x",
+        role="backend",
+        claimed_by="sess-rogue",
+        depends_on=[clearance_id],
+        task_version=2,
+        claim_path="by_id",
+    )
+
+    result = CliRunner().invoke(audit_group, ["verify-gates"])
+    assert result.exit_code == 1, result.output
+    assert "Clearance Gate Verification FAILED" in result.output
+    assert "task-x" in result.output
+
+
+def test_verify_gates_noop_when_no_gates(isolated_audit: Path) -> None:
+    # A directory with a chain but no gate projections passes silently.
+    AuditChainStore(AUDIT_DIR).log(
+        event_type="task.transition", actor="x", resource_type="task", resource_id="t1", details={}
+    )
+    result = CliRunner().invoke(audit_group, ["verify-gates"])
+    assert result.exit_code == 0, result.output

--- a/tests/unit/test_audit_chain_signal_gate.py
+++ b/tests/unit/test_audit_chain_signal_gate.py
@@ -1,0 +1,137 @@
+"""Tests for the additive ``signal.gate_projection`` chain helper (#2556).
+
+Each blocker projection and each clearance / expiry transition is mirrored
+into the HMAC-chained audit log so the gate is independently attestable and
+tamper-evident. Flipping the blocker content hash or the resolver identity in
+a stored entry must break verification at that entry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import (
+    EVENT_SIGNAL_GATE_PROJECTION,
+    AuditChainStore,
+    record_signal_gate_projection,
+)
+
+
+def _store(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+
+
+def test_record_projection_appends_chained_event(tmp_path: Path) -> None:
+    chain = _store(tmp_path)
+    event = record_signal_gate_projection(
+        chain=chain,
+        blocker_content_hash="sha256:" + "a" * 64,
+        clearance_task_id="clearance-deadbeef00000000",
+        injected_edges=["task-a", "task-b"],
+        graph_delta_hash="c" * 64,
+        scope_cell_id="cell-a",
+        deadline=0,
+        resolution="pending",
+        resolver="",
+        journal_entry_hash="sha256:" + "d" * 64,
+    )
+    assert event.event_type == EVENT_SIGNAL_GATE_PROJECTION
+    assert event.resource_id == "clearance-deadbeef00000000"
+    assert event.details["resolution"] == "pending"
+    assert event.details["injected_edges"] == ["task-a", "task-b"]
+    assert event.details["blocker_content_hash"] == "sha256:" + "a" * 64
+    assert "prev_chain_digest" in event.details
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_resolution_references_blocker_entry_hash(tmp_path: Path) -> None:
+    chain = _store(tmp_path)
+    projection = record_signal_gate_projection(
+        chain=chain,
+        blocker_content_hash="sha256:" + "a" * 64,
+        clearance_task_id="clearance-1111",
+        injected_edges=["t1"],
+        graph_delta_hash="c" * 64,
+        scope_cell_id="cell-a",
+        deadline=0,
+        resolution="pending",
+        resolver="",
+    )
+    release = record_signal_gate_projection(
+        chain=chain,
+        blocker_content_hash="sha256:" + "a" * 64,
+        clearance_task_id="clearance-1111",
+        injected_edges=["t1"],
+        graph_delta_hash="c" * 64,
+        scope_cell_id="cell-a",
+        deadline=0,
+        resolution="cleared",
+        resolver="operator:alex",
+        last_state_hash=projection.hmac,
+        blocker_entry_hash=projection.hmac,
+    )
+    # The release entry references the projection (blocker) entry hash.
+    assert release.details["blocker_entry_hash"] == projection.hmac
+    assert release.details["resolver"] == "operator:alex"
+    assert release.details["resolution"] == "cleared"
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_tamper_blocker_content_hash_breaks_chain(tmp_path: Path) -> None:
+    chain = _store(tmp_path)
+    record_signal_gate_projection(
+        chain=chain,
+        blocker_content_hash="sha256:" + "a" * 64,
+        clearance_task_id="clearance-2222",
+        injected_edges=["t1"],
+        graph_delta_hash="c" * 64,
+        scope_cell_id="cell-a",
+        deadline=0,
+        resolution="pending",
+        resolver="",
+    )
+    ok, _ = chain.verify()
+    assert ok
+
+    # Flip the recorded blocker content hash in the stored JSONL.
+    log_files = sorted((tmp_path / "audit").glob("*.jsonl"))
+    assert log_files
+    log_path = log_files[0]
+    lines = log_path.read_text().splitlines()
+    entry = json.loads(lines[-1])
+    entry["details"]["blocker_content_hash"] = "sha256:" + "f" * 64
+    lines[-1] = json.dumps(entry, sort_keys=True)
+    log_path.write_text("\n".join(lines) + "\n")
+
+    ok_after, errors = chain.verify()
+    assert not ok_after
+    assert any("HMAC mismatch" in e for e in errors)
+
+
+def test_tamper_resolver_identity_breaks_chain(tmp_path: Path) -> None:
+    chain = _store(tmp_path)
+    record_signal_gate_projection(
+        chain=chain,
+        blocker_content_hash="sha256:" + "a" * 64,
+        clearance_task_id="clearance-3333",
+        injected_edges=["t1"],
+        graph_delta_hash="c" * 64,
+        scope_cell_id="cell-a",
+        deadline=0,
+        resolution="cleared",
+        resolver="operator:honest",
+    )
+    log_files = sorted((tmp_path / "audit").glob("*.jsonl"))
+    log_path = log_files[0]
+    lines = log_path.read_text().splitlines()
+    entry = json.loads(lines[-1])
+    entry["details"]["resolver"] = "operator:attacker"
+    lines[-1] = json.dumps(entry, sort_keys=True)
+    log_path.write_text("\n".join(lines) + "\n")
+
+    ok_after, errors = chain.verify()
+    assert not ok_after
+    assert any("HMAC mismatch" in e for e in errors)

--- a/tests/unit/test_clearance_gate.py
+++ b/tests/unit/test_clearance_gate.py
@@ -1,0 +1,306 @@
+"""End-to-end tests for the BLOCKER clearance-gate coordinator (#2556).
+
+Posting a ``blocker`` deterministically projects a clearance task plus injected
+``depends_on`` edges, sealed as ``signal.gate_projection`` receipts on the HMAC
+audit chain. The gate state is a projection of chained rows; resolving the
+clearance emits a signed release entry referencing the blocker entry hash; and
+an offline verifier reconstructs, from the chain alone, that no dependent task
+was claimed while a gate was open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.communication.bulletin import BulletinBoard, BulletinMessage
+from bernstein.core.communication.signal_actions import (
+    ClearanceGateCoordinator,
+    ClearanceStatus,
+    InMemoryClearanceInjector,
+    journal_prefix_hash,
+    project_clearance_gate,
+    project_gate_states,
+    verify_clearance_gates,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_SIGNAL_GATE_PROJECTION,
+    AuditChainStore,
+    record_task_claim_receipt,
+)
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+
+
+def _post_blocker(board: BulletinBoard, content: str = "shared dep broke", cell_id: str = "cell-a") -> BulletinMessage:
+    return board.post(
+        BulletinMessage(
+            agent_id="worker-3", type="blocker", content=content, timestamp=1_700_000_000.0, cell_id=cell_id
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Materialization + idempotency (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_materializes_one_clearance_task_and_edges(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x", "task-y"]})
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=_chain(tmp_path))
+
+    _post_blocker(board)
+    specs = coord.process_new_blockers()
+
+    assert len(specs) == 1
+    spec = specs[0]
+    assert len(injector.created) == 1
+    assert injector.created[0].clearance_task_id == spec.clearance_task_id
+    # Every open dependent task in scope receives an edge onto the clearance task.
+    assert set(injector.edges) == {("task-x", spec.clearance_task_id), ("task-y", spec.clearance_task_id)}
+
+
+def test_reprocessing_same_blocker_is_idempotent(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    blocker = _post_blocker(board)
+    coord.materialize(blocker)
+    coord.materialize(blocker)  # replay same blocker
+
+    # One clearance task, one edge, one projection receipt: no double injection.
+    assert len(injector.created) == 1
+    assert len(injector.edges) == 1
+    projections = chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION)
+    assert len(projections) == 1
+
+
+def test_non_blocker_signals_are_observe_only(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    for observe_type in ("alert", "finding", "status", "dependency"):
+        board.post(BulletinMessage(agent_id="w", type=observe_type, content="hi", timestamp=1.0, cell_id="cell-a"))
+    specs = coord.process_new_blockers()
+
+    assert specs == []
+    assert injector.created == []
+    assert chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION) == []
+
+
+# ---------------------------------------------------------------------------
+# Determinism (AC2): replay yields byte-identical gate state
+# ---------------------------------------------------------------------------
+
+
+def test_replaying_journal_yields_identical_gate_state(tmp_path: Path) -> None:
+    def run(sub: str) -> tuple[str, tuple[str, ...], str]:
+        board = BulletinBoard()
+        injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-y", "task-x"]})
+        coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=_chain(tmp_path / sub))
+        board.post(BulletinMessage(agent_id="w1", type="status", content="up", timestamp=1.0, cell_id="cell-a"))
+        blocker = board.post(
+            BulletinMessage(agent_id="worker-3", type="blocker", content="x", timestamp=2.0, cell_id="cell-a")
+        )
+        spec = coord.materialize(blocker)
+        assert spec is not None
+        return spec.clearance_task_id, spec.injected_edges, spec.graph_delta_hash
+
+    assert run("a") == run("b")
+
+
+# ---------------------------------------------------------------------------
+# Gate state is a projection of chained rows (AC2 / AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_gate_state_projects_from_chain_rows(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    blocker = _post_blocker(board)
+    spec = coord.materialize(blocker)
+    assert spec is not None
+
+    states = project_gate_states(chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION))
+    assert states[spec.clearance_task_id].status is ClearanceStatus.PENDING
+
+    coord.resolve(spec.clearance_task_id, resolver="operator:alex")
+    assert injector.released == [spec.clearance_task_id]
+
+    states_after = project_gate_states(chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION))
+    resolved = states_after[spec.clearance_task_id]
+    assert resolved.status is ClearanceStatus.CLEARED
+    assert resolved.resolver == "operator:alex"
+
+
+def test_expiry_is_deterministic_function_of_recorded_inputs(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain, ttl_seconds=3600)
+
+    blocker = _post_blocker(board)  # timestamp 1_700_000_000
+    spec = coord.materialize(blocker)
+    assert spec is not None
+
+    events = chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION)
+    # Before deadline: still pending. After deadline: deterministically expired.
+    before = project_gate_states(events, as_of=1_700_000_000 + 10)
+    after = project_gate_states(events, as_of=1_700_000_000 + 3601)
+    assert before[spec.clearance_task_id].status is ClearanceStatus.PENDING
+    assert after[spec.clearance_task_id].status is ClearanceStatus.EXPIRED
+
+
+# ---------------------------------------------------------------------------
+# Forensic replay (AC4)
+# ---------------------------------------------------------------------------
+
+
+def test_forensic_verify_passes_on_clean_chain(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    blocker = _post_blocker(board)
+    spec = coord.materialize(blocker)
+    assert spec is not None
+    coord.resolve(spec.clearance_task_id, resolver="operator:alex")
+
+    result = verify_clearance_gates(chain.query())
+    assert result.ok, result.errors
+    assert result.gate_count == 1
+    assert result.violations == []
+
+
+def test_forensic_verify_flags_claim_during_open_gate(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    blocker = _post_blocker(board)
+    spec = coord.materialize(blocker)
+    assert spec is not None
+
+    # Simulate a rogue claim of a scoped dependent while the gate is still open.
+    record_task_claim_receipt(
+        chain=chain,
+        task_id="task-x",
+        role="backend",
+        claimed_by="sess-rogue",
+        depends_on=[spec.clearance_task_id],
+        task_version=2,
+        claim_path="by_id",
+    )
+
+    result = verify_clearance_gates(chain.query())
+    assert not result.ok
+    assert ("task-x" in v[0] for v in result.violations)
+    assert result.violations
+    offending_task, _claim_index = result.violations[0]
+    assert offending_task == "task-x"
+
+
+# ---------------------------------------------------------------------------
+# AC1 with the real task store: claim_next withholds dependents until cleared
+# ---------------------------------------------------------------------------
+
+
+def test_real_store_withholds_dependent_until_clearance_cleared(tmp_path: Path) -> None:
+    from bernstein.core.communication.bulletin import BulletinMessage as _BM
+    from bernstein.core.server import TaskCreate
+    from bernstein.core.tasks.task_store_core import TaskStore
+
+    async def scenario() -> tuple[bool, bool]:
+        store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+        dep = await store.create(TaskCreate(title="dependent work", description="d", role="backend", cell_id="cell-a"))
+
+        # Deterministic projection over the real open-task scope in the cell.
+        blocker = _BM(agent_id="worker-3", type="blocker", content="shared dep broke", timestamp=1.0, cell_id="cell-a")
+        open_ids = [t.id for t in store.list_tasks(status="open", cell_id="cell-a")]
+        spec = project_clearance_gate(
+            blocker=blocker, scope_task_ids=open_ids, journal_prefix_hash=journal_prefix_hash([blocker])
+        )
+
+        # Materialize: create the clearance task with the projected id and inject
+        # the edge onto every open dependent. The clearance task participates as
+        # an ordinary depends_on edge, so the existing dependency gate applies.
+        await store.create_gate_task(
+            clearance_task_id=spec.clearance_task_id,
+            title="clearance gate",
+            role="clearance",
+            cell_id="cell-a",
+        )
+        for dependent_id in spec.injected_edges:
+            await store.inject_dependency(dependent_id, spec.clearance_task_id)
+
+        # Dependent now depends on the still-open clearance task -> not claimable.
+        blocked = await store.claim_next("backend") is None
+
+        # Clear the gate -> the clearance task becomes terminal, releasing deps.
+        await store.resolve_gate_task(spec.clearance_task_id, resolution="cleared")
+        claimed = await store.claim_next("backend")
+        released = claimed is not None and claimed.id == dep.id
+        return blocked, released
+
+    blocked, released = asyncio.run(scenario())
+    assert blocked, "dependent must be withheld while the clearance gate is open"
+    assert released, "dependent must be claimable once the clearance is cleared"
+
+
+# ---------------------------------------------------------------------------
+# Bulletin post hook (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def test_bulletin_post_hook_materializes_on_blocker(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    board.set_post_hook(coord.materialize)
+    _post_blocker(board)  # hook fires on post
+
+    assert len(injector.created) == 1
+    assert len(chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION)) == 1
+
+
+def test_bulletin_default_has_no_hook(tmp_path: Path) -> None:
+    # Regression (AC5): a board with no hook behaves exactly as before.
+    board = BulletinBoard()
+    stored = _post_blocker(board)
+    assert board.count == 1
+    assert stored.type == "blocker"
+
+
+@pytest.mark.parametrize("resolution", ["cleared", "expired"])
+def test_resolution_release_entry_references_projection(tmp_path: Path, resolution: str) -> None:
+    board = BulletinBoard()
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    chain = _chain(tmp_path)
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+
+    blocker = _post_blocker(board)
+    spec = coord.materialize(blocker)
+    assert spec is not None
+    projection = chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION)[0]
+
+    release = coord.resolve(spec.clearance_task_id, resolver="operator:alex", resolution=resolution)
+    assert release.details["blocker_entry_hash"] == projection.hmac
+    assert release.details["resolution"] == resolution
+    ok, errors = chain.verify()
+    assert ok, errors

--- a/tests/unit/test_multi_cell_clearance.py
+++ b/tests/unit/test_multi_cell_clearance.py
@@ -1,0 +1,65 @@
+"""Multi-cell tick wiring for BLOCKER clearance gates (#2556).
+
+When a clearance coordinator is wired, a posted ``blocker`` is materialized into
+an audit-anchored clearance gate during the tick instead of being merely logged.
+Without a coordinator, the tick stays observe-only (regression, AC5).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from bernstein.core.models import OrchestratorConfig
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.core.communication.bulletin import BulletinBoard, BulletinMessage
+from bernstein.core.communication.signal_actions import (
+    ClearanceGateCoordinator,
+    InMemoryClearanceInjector,
+)
+from bernstein.core.orchestration.multi_cell import MultiCellOrchestrator
+from bernstein.core.security.audit_chain import EVENT_SIGNAL_GATE_PROJECTION, AuditChainStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _orchestrator(
+    tmp_path: Path, board: BulletinBoard, coord: ClearanceGateCoordinator | None
+) -> MultiCellOrchestrator:
+    return MultiCellOrchestrator(
+        config=OrchestratorConfig(server_url="http://localhost:9999"),
+        spawner=MagicMock(spec=AgentSpawner),
+        workdir=tmp_path,
+        bulletin=board,
+        clearance_coordinator=coord,
+    )
+
+
+def test_tick_materializes_blocker_when_coordinator_wired(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    chain = AuditChainStore(tmp_path / "audit", key=b"k" * 32)
+    injector = InMemoryClearanceInjector(open_by_cell={"cell-a": ["task-x"]})
+    coord = ClearanceGateCoordinator(bulletin=board, injector=injector, chain=chain)
+    orch = _orchestrator(tmp_path, board, coord)
+
+    board.post(BulletinMessage(agent_id="w", type="blocker", content="dep broke", timestamp=1.0, cell_id="cell-a"))
+    result = orch.tick()
+
+    assert result.blockers_found == 1
+    assert len(injector.created) == 1
+    assert chain.query(event_type=EVENT_SIGNAL_GATE_PROJECTION)
+    assert any("clearance gate" in action for action in result.vp_actions)
+
+
+def test_tick_observe_only_without_coordinator(tmp_path: Path) -> None:
+    board = BulletinBoard()
+    orch = _orchestrator(tmp_path, board, None)
+
+    board.post(BulletinMessage(agent_id="w", type="blocker", content="dep broke", timestamp=1.0, cell_id="cell-a"))
+    result = orch.tick()
+
+    # Blocker is counted and logged, but nothing is materialized (legacy path).
+    assert result.blockers_found == 1
+    assert not any("clearance gate" in action for action in result.vp_actions)

--- a/tests/unit/test_signal_actions.py
+++ b/tests/unit/test_signal_actions.py
@@ -1,0 +1,135 @@
+"""Tests for the deterministic BLOCKER -> clearance-gate projection (#2556).
+
+The projection is a pure function of ``(ordered bulletin journal prefix,
+blocker content hash, scope)`` onto a canonical ``(clearance_task_id,
+injected_edge_set, graph_delta_hash)``. No wall-clock, no RNG: two operators
+replaying the same journal must produce byte-identical gates.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.communication.bulletin import BulletinMessage
+from bernstein.core.communication.signal_actions import (
+    ACTION_MATERIALIZE_CLEARANCE_GATE,
+    ACTION_OBSERVE,
+    ClearanceStatus,
+    action_for,
+    blocker_content_hash,
+    compute_graph_delta_hash,
+    journal_prefix_hash,
+    project_clearance_gate,
+)
+
+
+def _blocker(content: str = "shared db migration broke", cell_id: str | None = "cell-a") -> BulletinMessage:
+    return BulletinMessage(
+        agent_id="worker-3",
+        type="blocker",
+        content=content,
+        timestamp=1_700_000_000.0,
+        cell_id=cell_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signal action registry (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_blocker_materializes_and_others_observe() -> None:
+    assert action_for("blocker") == ACTION_MATERIALIZE_CLEARANCE_GATE
+    for observe_type in ("alert", "finding", "status", "dependency"):
+        assert action_for(observe_type) == ACTION_OBSERVE
+
+
+def test_registry_unknown_type_defaults_to_observe() -> None:
+    # Default is observe so an unrecognised signal never mutates the scheduler.
+    assert action_for("totally-new-type") == ACTION_OBSERVE
+
+
+def test_clearance_status_mirrors_delegation_lifecycle() -> None:
+    assert {s.value for s in ClearanceStatus} == {"pending", "cleared", "expired"}
+
+
+# ---------------------------------------------------------------------------
+# Pure projection (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def test_projection_is_deterministic_across_runs() -> None:
+    blocker = _blocker()
+    prefix = [BulletinMessage(agent_id="w1", type="status", content="up", timestamp=1.0, cell_id="cell-a"), blocker]
+    jph = journal_prefix_hash(prefix)
+    scope = ["task-b", "task-a", "task-c"]
+
+    spec1 = project_clearance_gate(blocker=blocker, scope_task_ids=scope, journal_prefix_hash=jph)
+    spec2 = project_clearance_gate(blocker=blocker, scope_task_ids=list(reversed(scope)), journal_prefix_hash=jph)
+
+    assert spec1.clearance_task_id == spec2.clearance_task_id
+    assert spec1.injected_edges == spec2.injected_edges
+    assert spec1.graph_delta_hash == spec2.graph_delta_hash
+    # Injected edges are sorted + de-duplicated (canonical set).
+    assert spec1.injected_edges == ("task-a", "task-b", "task-c")
+
+
+def test_clearance_task_id_disambiguated_by_journal_prefix() -> None:
+    # Two identical blockers at different journal positions get distinct gates.
+    blocker = _blocker()
+    jph_a = journal_prefix_hash([blocker])
+    jph_b = journal_prefix_hash(
+        [BulletinMessage(agent_id="x", type="status", content="noise", timestamp=0.5, cell_id="cell-a"), blocker]
+    )
+    spec_a = project_clearance_gate(blocker=blocker, scope_task_ids=["t1"], journal_prefix_hash=jph_a)
+    spec_b = project_clearance_gate(blocker=blocker, scope_task_ids=["t1"], journal_prefix_hash=jph_b)
+    assert spec_a.clearance_task_id != spec_b.clearance_task_id
+
+
+def test_content_hash_stable_and_prefixed() -> None:
+    h = blocker_content_hash(agent_id="worker-3", content="x", cell_id="cell-a")
+    assert h.startswith("sha256:")
+    assert h == blocker_content_hash(agent_id="worker-3", content="x", cell_id="cell-a")
+    assert h != blocker_content_hash(agent_id="worker-3", content="y", cell_id="cell-a")
+
+
+def test_graph_delta_hash_recomputes_from_recorded_fields() -> None:
+    blocker = _blocker()
+    jph = journal_prefix_hash([blocker])
+    spec = project_clearance_gate(blocker=blocker, scope_task_ids=["t2", "t1"], journal_prefix_hash=jph)
+    # A verifier holding only the recorded detail fields recomputes the hash.
+    recomputed = compute_graph_delta_hash(
+        clearance_task_id=spec.clearance_task_id,
+        injected_edges=spec.injected_edges,
+        blocker_content_hash=spec.blocker_content_hash,
+        scope_cell_id=spec.scope_cell_id,
+        deadline=spec.deadline,
+    )
+    assert recomputed == spec.graph_delta_hash
+    # Flipping the blocker content hash diverges the recomputation (tamper).
+    tampered = compute_graph_delta_hash(
+        clearance_task_id=spec.clearance_task_id,
+        injected_edges=spec.injected_edges,
+        blocker_content_hash="sha256:" + "0" * 64,
+        scope_cell_id=spec.scope_cell_id,
+        deadline=spec.deadline,
+    )
+    assert tampered != spec.graph_delta_hash
+
+
+def test_deadline_is_deterministic_function_of_inputs_not_wallclock() -> None:
+    blocker = _blocker()
+    jph = journal_prefix_hash([blocker])
+    spec = project_clearance_gate(blocker=blocker, scope_task_ids=["t1"], journal_prefix_hash=jph, ttl_seconds=3600)
+    # Deadline is a pure function of the recorded blocker timestamp + ttl.
+    assert spec.deadline == int(blocker.timestamp) + 3600
+    # No ttl => no expiry deadline.
+    spec_no_ttl = project_clearance_gate(blocker=blocker, scope_task_ids=["t1"], journal_prefix_hash=jph)
+    assert spec_no_ttl.deadline == 0
+
+
+def test_empty_scope_yields_no_injected_edges() -> None:
+    blocker = _blocker()
+    jph = journal_prefix_hash([blocker])
+    spec = project_clearance_gate(blocker=blocker, scope_task_ids=[], journal_prefix_hash=jph)
+    assert spec.injected_edges == ()
+    # A clearance task is still projected so the blocker has an owning artifact.
+    assert spec.clearance_task_id.startswith("clearance-")


### PR DESCRIPTION
## What

The bulletin board ships a typed signal vocabulary (`alert | blocker | finding | status | dependency`), but a posted `blocker` was inert: the multi-cell tick logged it and moved on, so dependent work kept getting claimed against an unresolved blocker and no attestable record showed which dependent tasks ran while a blocker was open.

This adds the missing auto-action layer.

## How

- **Per-`MessageType` action registry** (`signal_actions.py`), default `observe` no-op; only `blocker` carries `materialize_clearance_gate`. `INFO` / `REQUEST` can follow the same shape.
- **Deterministic projection**: posting a `blocker` projects a clearance task plus injected `depends_on` edges onto the open dependent tasks in the blocker's cell. The projection is a pure function of `(ordered bulletin journal prefix, blocker content hash, scope)` onto a canonical `(clearance_task_id, injected_edge_set, graph_delta_hash)` (no wall-clock, no RNG), so replaying the same journal yields byte-identical gates.
- **Gate enforcement via the existing dependency edge**: the clearance task participates as an ordinary `depends_on` edge, so `store.claim_next` and the `list_tasks(status="open")` dependency exclusion already withhold dependent work until the clearance is terminal. New additive store helpers (`create_gate_task`, `inject_dependency`, `resolve_gate_task`) wire the deterministic id and edges.
- **Audit-anchored receipts**: every projection and every resolution is sealed as a `signal.gate_projection` entry on the HMAC audit chain. `graph_delta_hash` recomputes byte-identically from the recorded fields; a resolution entry references the materialization entry hash; gate state is a projection of the chained rows, not mutable side-table state.
- **Offline verification**: `bernstein audit verify-gates` (also folded into `bernstein audit verify`) reconstructs from the chain alone that no dependent task was claimed between a blocker post and its clearance, reporting any violation with the offending task id and claim position.
- **Multi-cell wiring**: an optional coordinator on `MultiCellOrchestrator` materializes gates during the tick; without it, blockers stay observe-only (unchanged).

## Acceptance criteria

- [x] Posting a `blocker` creates exactly one clearance task and injects a `depends_on` edge onto every open dependent task in scope; `claim_next` withholds them until the clearance is terminal.
- [x] Determinism: replaying the same journal yields byte-identical `clearance_task_id`, injected edge set, and `graph_delta_hash`; expiry is a deterministic function of recorded inputs, not a query-time wall-clock read.
- [x] Verifiability: each projection and resolution is a `signal.gate_projection` chain entry; `bernstein audit verify` passes on a clean chain, and flipping the blocker content hash or resolver identity in a stored entry fails verification.
- [x] Forensic replay: the verify subcommand reconstructs offline that no dependent task was claimed between blocker post and clearance, reporting the offending task id and claim position.
- [x] Regression: `alert` / `finding` / `status` / `dependency` stay observe-only; existing bulletin and delegation behaviour unchanged.

## Tests

New: `test_signal_actions.py`, `test_audit_chain_signal_gate.py`, `test_clearance_gate.py`, `test_multi_cell_clearance.py`, `cli/test_audit_verify_gates_cmd.py` (projection determinism, tamper, real-store gating, forensic verify, CLI, multi-cell wiring). Existing bulletin / multi-cell / task-store / audit-chain / redirect-ledger suites stay green. Lint and format checks are clean.

Closes #2556
