### PR TITLE
docs: standardize adapter count and consolidate duplicated pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ bernstein cloud run plan.yaml  # execute a plan on Cloudflare
 
 ## capabilities
 
-Bernstein ships parallel execution + worktree isolation + a janitor that gates merges on tests/lint/types, signed lineage records, MCP server mode, an HMAC-SHA256 audit chain, and 43 CLI adapters out of the box. Pluggable sandbox backends (worktree, Docker, [E2B](https://e2b.dev), [Modal](https://modal.com)), pluggable artifact sinks (local, S3, GCS, Azure Blob, R2), progressive-disclosure skill packs, and a [lethal-trifecta capability gate](docs/security/lethal-trifecta.md) round it out.
+Bernstein ships parallel execution + worktree isolation + a janitor that gates merges on tests/lint/types, signed lineage records, MCP server mode, an HMAC-SHA256 audit chain, and 40+ CLI adapters out of the box. Pluggable sandbox backends (worktree, Docker, [E2B](https://e2b.dev), [Modal](https://modal.com)), pluggable artifact sinks (local, S3, GCS, Azure Blob, R2), progressive-disclosure skill packs, and a [lethal-trifecta capability gate](docs/security/lethal-trifecta.md) round it out.
 
 Full feature matrix: [docs/reference/FEATURE_MATRIX.md](docs/reference/FEATURE_MATRIX.md). Recent features: [docs/whats-new.md](docs/whats-new.md).
 

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -751,7 +751,7 @@ Use these when you have an existing workflow built on Composio or ralphex and wa
 
 ## Support Modules
 
-In addition to the 44 CLI agent adapters above, the adapter package includes
+In addition to the CLI agent adapters above, the adapter package includes
 support modules that provide cross-cutting infrastructure:
 
 | Module | Purpose |

--- a/docs/adapters/compatibility.md
+++ b/docs/adapters/compatibility.md
@@ -45,18 +45,7 @@ The detailed comparison matrix with cost tier, reasoning grade, and recommended 
 
 ### Support modules
 
-| Module | Purpose |
-|--------|---------|
-| `caching_adapter` | Prompt prefix deduplication and response reuse |
-| `claude_agents` | Subagent definitions for Claude Code `--agents` flag |
-| `claude_exit_codes` | Exit code to lifecycle enum mapping |
-| `claude_stream_parser` | Stream-JSON event parsing |
-| `conformance` | Golden-transcript replay and adapter conformance testing |
-| `env_isolation` | Environment variable filtering for credential safety |
-| `manager` | Internal ManagerAgent spawner |
-| `plugin_sdk` | Third-party adapter plugin base classes |
-| `registry` | Adapter discovery and registration |
-| `skills_injector` | Per-task Claude Code skill injection |
+The adapter package also ships cross-cutting support modules (caching, conformance testing, environment isolation, plugin SDK, registry, skill injection, and more). The canonical table lives in [`ADAPTER_GUIDE.md`](ADAPTER_GUIDE.md#support-modules).
 
 Compatibility details can vary by adapter version and local toolchain.
 

--- a/docs/architecture/a2a.md
+++ b/docs/architecture/a2a.md
@@ -178,9 +178,9 @@ All three live in `AUTH_PUBLIC_PATHS` so any network caller can read
 them without provisioning a token. They expose only the public surface;
 no task data, no secrets.
 
-For the wider `.well-known` catalog (including the MCP tools manifest
-and the agents-md cross-CLI sync surface), see
-[the `.well-known` service manifest](../protocols/well-known-manifest.md).
+For the full index of `.well-known` discovery paths (agent card, JWKS,
+`llms.txt`, and the HTTP Message Signatures directory), see
+[the `.well-known` service catalog](../protocols/well-known-manifest.md).
 
 ---
 
@@ -222,7 +222,7 @@ race.
 ## Related
 
 - Persistent keystore semantics: [security/keystore.md](../security/keystore.md).
-- `.well-known` service manifest catalog:
+- `.well-known` service catalog (index of discovery paths):
   [protocols/well-known-manifest.md](../protocols/well-known-manifest.md).
 - Operator security runbook:
   [operations/security-and-identity.md](../operations/security-and-identity.md).

--- a/docs/architecture/orchestration-approaches.md
+++ b/docs/architecture/orchestration-approaches.md
@@ -37,21 +37,7 @@ graph TD
     class A1,A2,A3 agent
 ```
 
-**What goes wrong at scale:**
-
-```mermaid
-graph TD
-    PA["LLM Manager Agent\nfalls asleep →\nall queues drain"]
-    A1["Worker A\n283 bulletin messages\n0 code commits\n138 idle hunger messages"]
-    A2["Worker B\n2 real commits / 40 claimed\nconfused its own work\nwith others' after hours of drift"]
-    Phantom["5 phantom agents\n(spawned without identity)\n200+ noise messages\n0 useful output"]
-    Fail["Result: 737 tasks / 47 hours\n~3 of 12 agents did real work"]
-
-    PA --> A1 & A2 & Phantom --> Fail
-
-    classDef bad fill:#f94144,stroke:#c1121f,color:#fff
-    class PA,A1,A2,Phantom,Fail bad
-```
+**What goes wrong at scale:** the LLM manager stalls and every queue drains behind it, workers spin on idle "hunger" signals instead of committing code, and phantom agents spawned without identity flood the bus with noise. This failure mode is documented with measured numbers (agent counts, bulletin volume, useful-work ratio) in [Why Deterministic Orchestration](../architecture/WHY_DETERMINISTIC.md#why-this-matters-the-rag_challenge-evidence).
 
 ---
 
@@ -100,28 +86,7 @@ graph TD
 
 ## Task state machine (deterministic FSM)
 
-The task lifecycle is a state machine implemented in Python. Every transition has
-a defined trigger. There are no judgment calls.
-
-```mermaid
-stateDiagram-v2
-    [*] --> PLANNED: plan loaded
-    PLANNED --> OPEN: stage deps satisfied
-    OPEN --> CLAIMED: agent calls claim_next()
-    CLAIMED --> IN_PROGRESS: agent begins execution
-    IN_PROGRESS --> DONE: agent reports completion
-    DONE --> CLOSED: janitor verification passed + merged
-    IN_PROGRESS --> ORPHANED: heartbeat timeout / crash
-    ORPHANED --> OPEN: retry (max_retries default=3)
-    CLAIMED --> OPEN: claim expired (agent died before starting)
-    IN_PROGRESS --> FAILED: max retries exceeded
-    OPEN --> BLOCKED: blocking dependency added
-    BLOCKED --> OPEN: blocker resolved
-    OPEN --> CANCELLED: explicit cancellation
-    DONE --> OPEN: janitor rejected (signals failed)
-    IN_PROGRESS --> WAITING_FOR_SUBTASKS: auto-decomposed
-    WAITING_FOR_SUBTASKS --> IN_PROGRESS: subtasks CLOSED
-```
+The task lifecycle is a state machine implemented in Python: every transition has a defined trigger, and there are no judgment calls. The canonical state diagram and the exhaustive transition table live in [Lifecycle State Machines](../architecture/LIFECYCLE.md#task-state-diagram); this page links to it rather than carrying a second copy that can drift.
 
 ---
 
@@ -183,36 +148,13 @@ sequenceDiagram
 
 ## Token cost model
 
-### LLM-based orchestration
+The coordination cost is the sharpest structural difference.
 
-```
-Per scheduling tick:
-  Manager context  ≈ 5,000–20,000 tokens (grows with task count and agent count)
-  Manager response ≈ 500–2,000 tokens
+**LLM-based** - every scheduling tick pays for the manager's context and response (roughly 5,000-20,000 tokens in, 500-2,000 out, growing with task and agent count), and idle agents burn more tokens polling and signalling. The manager's reasoning is pure coordination overhead: it produces no code.
 
-Per agent per idle hour:
-  Hunger polling   ≈ 500–5,000 tokens (spinning, spam, status checks)
-  Worst-case agent observed: ~50,000 tokens on idle signaling, 0 code commits
+**Deterministic** - the orchestrator spends zero tokens on scheduling (a tick is sub-millisecond Python). The only tokens a Bernstein run spends are on task execution: a one-time system prompt per spawn (~1,500-3,000 tokens), amortised to ~500-1,000 tokens per task across a 3-task batch.
 
-For 737 tasks over 47 hours, 12 agents:
-  Coordination overhead: tens of millions of tokens
-  Useful work ratio:      ~3/12 agents = 25%
-```
-
-### Deterministic orchestration
-
-```
-Per scheduling tick:
-  Orchestrator CPU ≈ <1ms, 0 tokens
-
-Per agent spawn:
-  System prompt    ≈ 1,500–3,000 tokens (one-time per batch)
-  Amortized (3 tasks/batch) ≈ 500–1,000 tokens per task
-
-For 737 tasks over 47 hours, 12 agents:
-  Coordination overhead: 0 tokens
-  Useful work ratio:      ~100% (agents only run when they have work)
-```
+For the measured overhead of a real 12-agent LLM-orchestrated run (tens of millions of coordination tokens, roughly a 25% useful-work ratio), see [Why Deterministic Orchestration](../architecture/WHY_DETERMINISTIC.md#2-token-cost-of-coordination).
 
 ---
 

--- a/docs/cloudflare/cloudflare-mcp.md
+++ b/docs/cloudflare/cloudflare-mcp.md
@@ -3,7 +3,9 @@
 **Module:** `bernstein.mcp.remote_transport`
 **Class:** `StreamableHTTPTransport`
 
-The MCP remote transport exposes Bernstein's MCP server over HTTP using the streamable HTTP transport spec. This allows remote MCP clients (Claude Desktop, other agents, CI systems) to interact with a Bernstein instance over the network -- including deployment on Cloudflare Workers via a Python worker.
+The MCP remote transport exposes Bernstein's MCP server over HTTP using the streamable HTTP transport spec. This lets remote MCP clients (Claude Desktop, other agents, CI systems) interact with a Bernstein instance over the network -- including deployment on Cloudflare Workers via a Python worker.
+
+> This page covers configuring and deploying the streamable HTTP transport as a standalone ASGI app. For the MCP protocol surface itself -- transports, the stateless serving model, auth (bearer and OAuth-2 PKCE), JSON-RPC methods, the cost-meter envelope, cancellation, and worked `curl` examples -- see [Bernstein MCP server](../mcp/server.md). That surface is identical across every deployment and is documented once there.
 
 ---
 
@@ -20,12 +22,7 @@ The MCP remote transport exposes Bernstein's MCP server over HTTP using the stre
 | `auth_token` | `str` | `""` | Bearer token; when empty it is read from `BERNSTEIN_MCP_TOKEN` (or `BERNSTEIN_MCP_AUTH_TOKEN`) |
 | `cors_origins` | `list[str]` | `["http://localhost:*"]` | CORS allowed origins |
 
-The config is safe by default: it binds to loopback and expects a bearer
-token. Construction raises `RemoteMCPConfigError` for any combination that
-would expose the JSON-RPC surface without authentication - `auth_type="none"`
-on a non-loopback host, or `auth_type="bearer"` with no token on a
-non-loopback host. There is no session store, so there are no session
-capacity or timeout fields (see "Stateless operation" below).
+The config is safe by default: it binds to loopback and expects a bearer token. Construction raises `RemoteMCPConfigError` for any combination that would expose the JSON-RPC surface without authentication -- `auth_type="none"` on a non-loopback host, or `auth_type="bearer"` with no token on a non-loopback host. There is no session store, so there are no session capacity or timeout fields; see [Stateless serving](../mcp/server.md#stateless-serving).
 
 ---
 
@@ -90,104 +87,7 @@ import uvicorn
 uvicorn.run(app, host="0.0.0.0", port=8053)
 ```
 
----
-
-## HTTP protocol
-
-The transport implements the MCP streamable HTTP transport spec:
-
-| Method | Path | Purpose |
-|--------|------|---------|
-| POST | `/mcp` | JSON-RPC 2.0 request/notification (single or batch) |
-| GET | `/mcp` | Server-initiated SSE stream (stub, returns 501; use POST plus `notifications/cancelled`) |
-| DELETE | `/mcp` | Legacy session close; acknowledged as a no-op during the compat window, 405 afterwards |
-| OPTIONS | `/mcp` | CORS preflight |
-
-### Headers
-
-| Header | Direction | Description |
-|--------|-----------|-------------|
-| `Authorization` | Request | `Bearer <token>` when `auth_type="bearer"` |
-| `Content-Type` | Both | `application/json` |
-| `mcp-session-id` | Request (legacy) | Removed by the stateless spec revision; accepted and ignored until 2027-07-28, then refused with 400. Never returned in responses. |
-
-### Stateless operation
-
-The 2026-07-28 MCP spec revision removed protocol sessions, and the
-transport implements the stateless model (#2506):
-
-1. There is no server-side session store. Every request is served from its
-   body plus the per-request `_meta` field alone, so any transport instance
-   can serve any request with no shared memory.
-2. Cross-call continuity is anchored in the run journal and the HMAC audit
-   chain, not in a session: when a journal and audit chain are wired in,
-   every served `tools/call` is recorded as an ordered
-   `mcp.stateless_call` entry with content-derived ids.
-3. A legacy client that still sends the removed `mcp-session-id` header is
-   served normally, with the header ignored, until 2027-07-28. After that
-   date a request carrying the header is refused with HTTP 400.
-4. `DELETE /mcp` (the removed session-close lifecycle) is acknowledged as a
-   no-op (`200 {"status":"ok"}`) during the same window; there is nothing
-   to close. After the window it returns 405.
-
----
-
-## JSON-RPC methods
-
-| Method | Description |
-|--------|-------------|
-| `initialize` | Return server info and capabilities |
-| `tools/list` | List available Bernstein tools |
-| `tools/call` | Execute a tool by name |
-| `ping` | Liveness check |
-| `notifications/initialized` | Client notification (no-op) |
-
-### Example request
-
-Every request is self-contained; no session header is exchanged.
-
-```bash
-# Initialize (returns server info and capabilities)
-curl -X POST http://localhost:8053/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $BERNSTEIN_MCP_TOKEN" \
-  -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'
-
-# List tools
-curl -X POST http://localhost:8053/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $BERNSTEIN_MCP_TOKEN" \
-  -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}'
-
-# Run a task
-curl -X POST http://localhost:8053/mcp \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $BERNSTEIN_MCP_TOKEN" \
-  -d '{
-    "jsonrpc":"2.0",
-    "method":"tools/call",
-    "params":{
-      "name":"bernstein_run",
-      "arguments":{"goal":"Add input validation","role":"backend"}
-    },
-    "id":3
-  }'
-```
-
----
-
-## Authentication
-
-| Mode | Config | Behavior |
-|------|--------|----------|
-| `bearer` | `auth_type="bearer"` (default), token from `auth_token=` or `BERNSTEIN_MCP_TOKEN` | Validates the `Authorization: Bearer <token>` header |
-| `none` | `auth_type="none"` | No authentication; only accepted on a loopback host |
-
-!!! warning "Non-loopback binds require a token"
-    `RemoteMCPConfig` refuses to start (`RemoteMCPConfigError`) when the
-    host is not loopback and either `auth_type="none"` or the bearer token
-    is empty. Set `BERNSTEIN_MCP_TOKEN` (or pass `auth_token=`) before
-    binding to a public interface.
+The app serves the single `/mcp` endpoint (JSON-RPC 2.0 over POST, plus CORS preflight). Authenticate with `Authorization: Bearer <token>`; the full request/response protocol is in [Bernstein MCP server](../mcp/server.md).
 
 ---
 
@@ -203,9 +103,7 @@ config = RemoteMCPConfig(
 )
 ```
 
-The legacy `mcp-session-id` header stays preflight-allowed during the
-compat window so older browser clients can still send it (the transport
-ignores it); no response header exposes it.
+The legacy `mcp-session-id` header stays preflight-allowed during the compat window so older browser clients can still send it (the transport ignores it); no response header exposes it.
 
 ---
 
@@ -228,4 +126,4 @@ app = create_asgi_app(
 )
 ```
 
-This lets MCP clients connect to your Bernstein instance from anywhere with Cloudflare's global edge network handling TLS and routing.
+This lets MCP clients connect to your Bernstein instance from anywhere, with Cloudflare's global edge network handling TLS and routing.

--- a/docs/gui/install.md
+++ b/docs/gui/install.md
@@ -58,7 +58,7 @@ URL after launch: `http://127.0.0.1:8052/ui/`.
 
 4. **Static assets missing.** `bernstein gui serve` will exit with `GUI static assets not found at …` if the wheel was built without the `static/` bundle. Rebuild with `cd web && npm install && npm run build` (writes to `../src/bernstein/gui/static/`).
 
-5. **No extras gate.** `bernstein gui serve` runs on a plain install; the `[gui]` extra is forward-compat only and is not required at runtime. Install it (`pip install 'bernstein[gui]'`) only to pin the `qrcode` dep for `bernstein gui qr` / `--tunnel`.
+5. **No extras gate.** `bernstein gui serve` runs on a plain install. See [Install the extras](#install-the-extras) above for why the `[gui]` extra is forward-compat only and when you need it.
 
 ## Verify
 

--- a/docs/gui/troubleshooting.md
+++ b/docs/gui/troubleshooting.md
@@ -10,7 +10,7 @@ tags:
 
 ## `ModuleNotFoundError: sse_starlette` or `qrcode`
 
-There is no runtime extras gate: `bernstein gui serve` runs on a plain install because `sse-starlette` arrives transitively via core deps and `fastapi` / `uvicorn` are already required (`src/bernstein/gui/cli.py` module docstring). You only need the `[gui]` extra to pin `qrcode` for `bernstein gui qr` / `--tunnel`.
+There is no runtime extras gate - `bernstein gui serve` runs on a plain install. See [Install the extras](install.md#install-the-extras) for why. You only need the `[gui]` extra to pin `qrcode` for `bernstein gui qr` / `--tunnel`.
 
 **Fix.**
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3,7 +3,7 @@
 > Forward-deployed engineering, with a coding swarm that fits in your `.sdd/`.
 >
 > Bernstein is an open-source multi-agent orchestration platform for AI coding
-> agents. Deterministic scheduling, 41 CLI adapters, pluggable sandbox backends,
+> agents. Deterministic scheduling, 40+ CLI adapters, pluggable sandbox backends,
 > cloud artifact storage sinks, progressive-disclosure skill packs, zero vendor
 > lock-in. Apache 2.0 licensed.
 
@@ -19,7 +19,7 @@ itself is deterministic Python - zero LLM tokens on scheduling. Every run is
 reproducible. Every step is logged and replayable.
 
 - Pure Python orchestration. No LLM in the coordination loop.
-- 41 CLI agent adapters. Mix Claude Code, Codex, Gemini CLI, Aider, Cursor,
+- 40+ CLI agent adapters. Mix Claude Code, Codex, Gemini CLI, Aider, Cursor,
   and more in the same run.
 - Git worktree isolation per agent. Main branch stays clean.
 - Janitor verification: tests, lint, types, PII gating.
@@ -32,7 +32,7 @@ Bernstein is built for the forward-deployed engineering pattern:
 parachute onto a client repo and stand up an AI engineering crew in
 minutes. State lives in `.sdd/` - no server to provision. Per-agent
 credential scoping keeps your keys out of the client's environment.
-The 41-adapter spread means the swarm runs on whichever CLI agent
+The multi-adapter spread means the swarm runs on whichever CLI agent
 the client already trusts (Claude Code, Codex, Gemini CLI, Aider,
 and more). Every step is an HMAC-signed audit record, replayable
 for client compliance review.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -3,7 +3,7 @@
 > Forward-deployed engineering, with a coding swarm that fits in your `.sdd/`.
 >
 > Bernstein is an open-source multi-agent orchestration platform for AI coding agents.
-> Deterministic scheduling, 45 CLI adapters, pluggable sandbox backends, cloud artifact
+> Deterministic scheduling, 40+ CLI adapters, pluggable sandbox backends, cloud artifact
 > storage sinks, progressive-disclosure skill packs, zero vendor lock-in. Apache 2.0 licensed.
 
 ## Forward-deployed engineering use case
@@ -16,7 +16,7 @@ running on whichever CLI agents the client already trusts.
 ## Core Documentation
 - [Getting Started](https://bernstein.readthedocs.io/getting-started/install/): Install, configure, run first orchestration in 60 seconds
 - [Architecture & Concepts](https://bernstein.readthedocs.io/architecture/ARCHITECTURE/): Task server, agent spawner, janitor verification, worktree isolation
-- [Adapter Reference](https://bernstein.readthedocs.io/adapters/): 45 supported agents - Claude Code, Codex, OpenAI Agents SDK v2, Gemini CLI, Cursor, Aider, Devin Terminal, CLM gateway, and more
+- [Adapter Reference](https://bernstein.readthedocs.io/adapters/): 40+ supported agents - Claude Code, Codex, OpenAI Agents SDK v2, Gemini CLI, Cursor, Aider, Devin Terminal, CLM gateway, and more
 - [API Reference](https://bernstein.readthedocs.io/reference/openapi-reference/): 120+ REST endpoints for tasks, agents, cost tracking, quality gates
 
 ## Guides

--- a/docs/operations/glitchtip-setup.md
+++ b/docs/operations/glitchtip-setup.md
@@ -4,10 +4,11 @@ Audience: operators wiring Bernstein into a GlitchTip (or any
 Sentry-protocol-compatible) error sink and confirming events flow end to
 end.
 
-Companion to [`observability.md`](./observability.md), which documents the
-broader telemetry contract.  This doc focuses on the operator-facing
-mechanics: project provisioning, DSN distribution, runtime export, and
-event verification.
+This doc is the canonical operator guide for the error-telemetry DSN
+flow: project provisioning, DSN distribution, runtime export, and event
+verification. The env-var resolution and side-channel transport are
+documented in [`side-channel.md`](../observability/side-channel.md);
+SBOM upload is covered in [`observability.md`](./observability.md).
 
 ## TL;DR
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -6,24 +6,19 @@ SBOM tracker.
 ## Error telemetry DSN flow
 
 Bernstein ships a Sentry-protocol-compatible error sink wired through
-`sentry-sdk`.  The DSN flows as follows:
+`sentry-sdk`, with a dependency-free side-channel fallback for worker
+subprocesses. Export the project DSN as `BERNSTEIN_TELEMETRY_DSN` (the
+legacy `GLITCHTIP_DSN` name is still honoured as a deprecated fallback);
+when neither is set the sink is a no-op and `sentry-sdk` is never
+imported, so minimal installs pay zero overhead. Sample rates are zero,
+so events fire only on unhandled exceptions or explicit
+`sentry_sdk.capture_*` calls -- no performance probes, no PII.
 
-1. Operator stands up a Sentry-protocol-compatible endpoint (any backend
-   speaking the Sentry envelope protocol works).
-2. Operator exports `GLITCHTIP_DSN=<dsn>` into the Bernstein process
-   environment (systemd unit, container env, `direnv`, etc.).
-3. `src/bernstein/cli/main.py::_init_error_telemetry` reads the env var
-   at import time and calls `sentry_sdk.init(dsn=..., traces_sample_rate=0,
-   profiles_sample_rate=0, send_default_pii=False, release=__version__)`.
-4. When the env var is unset, missing, or empty, the helper is a no-op and
-   the `sentry-sdk` package is not imported -- minimal installs pay zero
-   overhead.
-5. The `observability` extra (`pip install 'bernstein[observability]'`)
-   pulls in `sentry-sdk[fastapi]>=2.20`; without it the helper short-circuits
-   on `ImportError`.
-
-Sample rates of zero mean events fire only on unhandled exceptions or
-explicit `sentry_sdk.capture_*` calls.  No performance probes, no PII.
+For the full operator flow -- project provisioning, DSN distribution,
+the CI contexts that carry the DSN, how failure signals route, and event
+verification -- see [GlitchTip setup](glitchtip-setup.md). The broader
+telemetry contract (env-var resolution and the side-channel transport)
+lives in [the telemetry side channel](../observability/side-channel.md).
 
 ## SBOM upload to operator Dependency-Track
 

--- a/docs/operations/skills-catalog.md
+++ b/docs/operations/skills-catalog.md
@@ -88,8 +88,10 @@ neither self-referential nor sensitive to operator-side flags.
 ## Audit chain integration
 
 Every install / upgrade / uninstall appends an HMAC-chained event under
-`.sdd/audit/`, reusing
-[`bernstein.core.security.audit.AuditLog`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/src/bernstein/core/security/audit.py):
+`.sdd/audit/`, reusing the same
+[`AuditLog`](https://github.com/sipyourdrink-ltd/bernstein/blob/main/src/bernstein/core/security/audit.py)
+chain documented in [audit-log.md](../security/audit-log.md) (chain
+construction, verification, recovery). The catalog-specific event types:
 
 | Event type                 | Payload fields                                                                                                |
 |----------------------------|---------------------------------------------------------------------------------------------------------------|

--- a/docs/protocols/well-known-manifest.md
+++ b/docs/protocols/well-known-manifest.md
@@ -8,7 +8,7 @@ Bernstein's task server publishes a small set of unauthenticated discovery endpo
 | `GET /.well-known/agent.json/keys` | JWKS for verifying the agent-card signatures. | [a2a.md](../architecture/a2a.md#how-a-verifier-consumes-the-card) |
 | `GET /llms.txt` | Markdown summary of the same public surface for LLM consumers. | [a2a.md](../architecture/a2a.md#endpoints-summary) |
 | `GET /.well-known/http-message-signatures-directory` | JWKS for verifying the RFC 9421 HTTP Message Signatures on Bernstein's outbound agent-facing requests (install-identity keypair). | `src/bernstein/core/routes/well_known.py` |
-| `.well-known/security.txt` | Security contact and disclosure policy (RFC 9116), served from the repo/site root. | [SECURITY.md](../../SECURITY.md) |
+| `.well-known/security.txt` | Security contact and disclosure policy (RFC 9116), served from the repo/site root. | [SECURITY.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/SECURITY.md) |
 
 All task-server endpoints above are unauthenticated and listed in the auth-middleware public-path allowlist; they expose only the public surface (no task data, no secrets).
 

--- a/docs/protocols/well-known-manifest.md
+++ b/docs/protocols/well-known-manifest.md
@@ -1,82 +1,34 @@
-# Static service manifest (`.well-known/agent.json` + `llms.txt`)
+# `.well-known` service catalog
 
-Bernstein's task server publishes two machine-readable manifests so
-external agents (Claude Code, Codex, third-party orchestrators) can
-discover its endpoints, auth scheme, and task-orchestration
-capabilities without hand configuration.
+Bernstein's task server publishes a small set of unauthenticated discovery endpoints so external agents and scanners can find the orchestrator's public surface without hand configuration. This page is the index; the agent-card contract itself is documented in [A2A v1.0 - signed agent cards](../architecture/a2a.md).
 
-| URL | Format | Purpose |
+| Path | Purpose | Reference |
 |---|---|---|
-| `GET /.well-known/agent.json` | A2A-compliant JSON | Structured agent card with auth, endpoints, version |
-| `GET /llms.txt` | markdown | Human + LLM-friendly summary of the same |
+| `GET /.well-known/agent.json` | A2A v1.0 signed agent card (JCS-canonical body, detached Ed25519 JWS). | [a2a.md](../architecture/a2a.md) |
+| `GET /.well-known/agent.json/keys` | JWKS for verifying the agent-card signatures. | [a2a.md](../architecture/a2a.md#how-a-verifier-consumes-the-card) |
+| `GET /llms.txt` | Markdown summary of the same public surface for LLM consumers. | [a2a.md](../architecture/a2a.md#endpoints-summary) |
+| `GET /.well-known/http-message-signatures-directory` | JWKS for verifying the RFC 9421 HTTP Message Signatures on Bernstein's outbound agent-facing requests (install-identity keypair). | `src/bernstein/core/routes/well_known.py` |
+| `.well-known/security.txt` | Security contact and disclosure policy (RFC 9116), served from the repo/site root. | [SECURITY.md](../../SECURITY.md) |
 
-Both endpoints are unauthenticated and listed in the auth-middleware
-whitelist; they expose the public surface only.
-
-## Why it exists
-
-Before this, an external agent talking to Bernstein had to be
-hand-configured: someone had to know "task server is on 8052,
-endpoints are POST /tasks, etc." Serving a static manifest closes the
-loop and makes Bernstein a first-class platform other agents can
-discover.
+All task-server endpoints above are unauthenticated and listed in the auth-middleware public-path allowlist; they expose only the public surface (no task data, no secrets).
 
 ## How to use it
 
-Hit either endpoint:
-
 ```bash
 curl http://127.0.0.1:8052/.well-known/agent.json
+curl http://127.0.0.1:8052/.well-known/agent.json/keys
 curl http://127.0.0.1:8052/llms.txt
 ```
 
-Sample `agent.json` (truncated):
-
-```json
-{
-  "schema_version": "0.1.0",
-  "name": "bernstein-task-server",
-  "version": "1.9.4",
-  "auth": {
-    "scheme": "bearer",
-    "token_endpoint": null
-  },
-  "endpoints": {
-    "tasks_create":   "POST /tasks",
-    "tasks_list":     "GET /tasks",
-    "tasks_complete": "POST /tasks/{id}/complete",
-    "bulletin_post":  "POST /bulletin",
-    "bulletin_read":  "GET /bulletin"
-  }
-}
-```
-
-`llms.txt` is the same information rendered as markdown for an LLM to
-parse, plus a short prose description.
-
-The contents are rendered from the templates `templates/well_known/agent.json.j2`
-and `templates/well_known/llms.txt.j2` against the running server's
-version + endpoint list at startup.
-
-## Configuration
-
-There are no user-facing knobs. The endpoints are always served and
-always public. To customise the manifest content, edit the Jinja
-templates under `templates/well_known/` and rebuild.
+The agent card is A2A v1.0: a JCS-canonical (RFC 8785) JSON body signed with a per-installation Ed25519 key (RFC 8037) as a detached JWS (RFC 7515), verifiable from the JWKS at the same prefix. For the card fields, signing flow, verifier loop, key rotation, and configuration knobs (`BERNSTEIN_PUBLIC_BASE_URL`, `BERNSTEIN_AGENT_CARD_KEY_DIR`, `BERNSTEIN_RESOURCE_INDICATOR`), see [A2A v1.0 - signed agent cards](../architecture/a2a.md).
 
 ## Limitations
 
-- One global manifest per server.
-- Plugin / adapter manifests are **not** aggregated - only the
-  task-server's own surface is published.
-- The manifest is static at boot. Endpoints added by hot-loaded
-  plugins after startup do not appear until restart.
-- The endpoints live on the local task server; there is no central
-  registry of running Bernstein instances.
+- One global manifest per server; the task server publishes only its own surface, not aggregated plugin or adapter manifests.
+- There is no central registry of running Bernstein instances; each server serves its own `.well-known` surface on its own host.
 
 ## Related
 
-- Source: `src/bernstein/core/routes/well_known.py`
-- Templates: `templates/well_known/`
-- Auth middleware: `src/bernstein/core/security/auth_middleware.py`
-- A2A schema: parsed by `claude_agent_card.py`
+- [A2A v1.0 - signed agent cards](../architecture/a2a.md) - the agent-card contract, signing, and verification.
+- [Persistent agent-card keystore](../security/keystore.md) - key storage and rotation.
+- Source: `src/bernstein/core/routes/well_known.py`.

--- a/docs/reference/mcp-catalog.md
+++ b/docs/reference/mcp-catalog.md
@@ -249,7 +249,7 @@ All five accept absolute or `~`-expanded paths (where applicable) and parse inte
 - **`signature`** - Optional cryptographic signature over the entry. The schema permits any string; verification is delegated to the catalog service implementation in `core/protocols/mcp_catalog`.
 - **`additionalProperties: false`** at top level and per-entry - the catalog is rejected wholesale on unknown fields. This blocks silent capability drift.
 - **Sandbox preview** - Every install / upgrade runs the install command in a sandbox first. The host config is touched only after you confirm the diff. Failed previews abort without modifying state.
-- **HMAC-chained audit** - Every fetch, install, upgrade, and uninstall is recorded to `.sdd/audit/` with a chained HMAC, making after-the-fact tampering detectable.
+- **HMAC-chained audit** - Every fetch, install, upgrade, and uninstall is recorded to `.sdd/audit/` with a chained HMAC, making after-the-fact tampering detectable. The chain construction, verification, and recovery are documented once in [audit-log.md](../security/audit-log.md).
 - **Bernstein-managed block** - Edits to the user MCP config are bracketed; Bernstein only owns its own block. Manually-added user entries elsewhere in the file are preserved.
 
 There is no allow-list on which catalogs can be loaded; the catalog source URL is configured by the runtime, not by the user. If you operate in a high-trust environment, point the cache at an internally-mirrored catalog and treat the public catalog as untrusted by setting `BERNSTEIN_MCP_CATALOG_CACHE_PATH` and disabling auto-refresh.

--- a/docs/security/AUDIT.md
+++ b/docs/security/AUDIT.md
@@ -2,8 +2,10 @@
 
 Bernstein includes a SOC 2-compatible audit mode that creates a tamper-evident, append-only audit trail of every orchestrator action.
 
-> Operator guide: see [`audit-log.md`](audit-log.md) for key
-> management, rotation, verify/replay procedures, and SIEM setup.
+> Operator guide: see [`audit-log.md`](audit-log.md) for the record format, key
+> management, rotation, verify/replay procedures, Merkle sealing, and SIEM setup.
+> This page covers only the SOC 2 enabling switches and the evidence-export surface;
+> all chain mechanics live in the operator guide so there is one source of truth.
 
 ## Quick Start
 
@@ -21,99 +23,17 @@ bernstein audit verify
 bernstein audit export --period Q1-2026
 ```
 
-## How It Works
-
-### HMAC-Chained Audit Log
-
-Every action in the orchestrator (task creation, state transitions, agent spawns, completions, etc.) is logged as a structured JSON event with an HMAC-SHA256 signature chained to the previous event:
-
-```json
-{
-  "timestamp": "2026-04-01T14:30:00Z",
-  "event_type": "task.transition",
-  "actor": "orchestrator",
-  "resource_type": "task",
-  "resource_id": "TASK-001",
-  "details": {
-    "from_status": "open",
-    "to_status": "claimed"
-  },
-  "prev_hmac": "a1b2c3...",
-  "hmac": "d4e5f6..."
-}
-```
-
-Each event's HMAC is computed over the canonical JSON payload concatenated with the previous event's HMAC. This creates a tamper-evident chain: modifying any event invalidates all subsequent HMACs.
-
-### Merkle Tree Sealing
-
-Periodically (or on demand), Bernstein computes a Merkle root hash across all audit log files. This seal can be:
-
-- Stored locally in `.sdd/audit/merkle/`
-- Anchored to a Git commit for external verification
-- Included in SOC 2 evidence packages
-
-```bash
-# Compute and store a Merkle seal
-bernstein audit seal
-
-# Anchor the seal to Git
-bernstein audit seal --anchor-git
-```
-
-### Daily Log Rotation
-
-Audit logs are rotated daily, producing one JSONL file per day (e.g., `2026-04-01.jsonl`). The HMAC chain carries across file boundaries.
-
-### Retention & Archiving
-
-Old audit logs are automatically compressed and archived:
-
-```python
-# Default: 90-day retention, then gzip-compress to archive/
-from bernstein.core.audit import AuditLog, RetentionPolicy
-
-log = AuditLog(audit_dir=Path(".sdd/audit"))
-log.archive(RetentionPolicy(retention_days=90))
-```
-
-## Verification
-
-### HMAC Chain Verification
-
-Walks all JSONL files and re-computes every HMAC to verify the chain is intact:
-
-```bash
-bernstein audit verify
-bernstein audit verify --hmac-only
-```
-
-### Merkle Tree Verification
-
-Recomputes the Merkle root and compares against stored seals:
-
-```bash
-bernstein audit verify --merkle-only
-```
-
-### Querying Events
-
-Filter audit events by type, actor, or time range:
-
-```bash
-bernstein audit query --event-type task.transition --since 2026-03-01
-bernstein audit query --actor orchestrator --limit 50
-```
-
-## Configuration
+## Enabling audit mode
 
 Audit mode is controlled by:
 
 1. **CLI flag**: `bernstein run --audit`
-2. **Config file**: Set `audit_mode: true` in `bernstein.yaml`
+2. **Config file**: set `audit_mode: true` in `bernstein.yaml`
 3. **Compliance preset**: `bernstein run --compliance development` (includes audit)
 
-The HMAC key is automatically generated on first use. It is resolved from, in order: `BERNSTEIN_AUDIT_KEY_PATH`, then `$XDG_STATE_HOME/bernstein/audit.key`, then `~/.local/state/bernstein/audit.key`. The key lives deliberately outside `.sdd` so it is isolated from the log volume. Protect this file - it's required for verification. See ["Key management" in audit-log.md](audit-log.md#key-management).
+Once enabled, every orchestrator action (task creation, state transitions, agent spawns, completions) is written to an HMAC-SHA256 chained, daily-rotated JSONL log under `.sdd/audit/`. The signing key is resolved from `BERNSTEIN_AUDIT_KEY_PATH`, then `$XDG_STATE_HOME/bernstein/audit.key`, then `~/.local/state/bernstein/audit.key`, and lives deliberately outside `.sdd` so it is isolated from the log volume.
+
+For the record format, the HMAC chain construction, key resolution and rotation, Merkle sealing, verification, retention, and SIEM export, see the [audit-log operator guide](audit-log.md).
 
 ## SOC 2 Evidence Export
 
@@ -124,6 +44,7 @@ bernstein audit export --period Q1-2026 --format zip
 ```
 
 The package includes:
+
 - All audit log files for the period
 - HMAC verification results
 - Merkle seal records
@@ -143,11 +64,11 @@ The package includes:
 
 ## Related
 
-- [Audit-log operator guide](audit-log.md) - key management, rotation,
-  verify, SIEM, recovery.
-- [Multi-tenant audit-chain export](audit-multitenant.md) - per-tenant
-  slice with optional RFC 3161 timestamping.
-- [DSSE / in-toto envelope](audit-dsse-envelope.md) -
-  third-party-verifiable wrapper over the bundle.
+- [Audit-log operator guide](audit-log.md) - record format, key management, rotation,
+  verify, Merkle seal, SIEM, recovery.
+- [Multi-tenant audit-chain export](audit-multitenant.md) - per-tenant slice with
+  optional RFC 3161 timestamping.
+- [DSSE / in-toto envelope](audit-dsse-envelope.md) - third-party-verifiable wrapper
+  over the bundle.
 - [EU AI Act Article 12 evidence pack](../compliance/eu-ai-act-article-12-bundle.md)
   - operator guide for the bundle this page references.

--- a/src/bernstein/__init__.py
+++ b/src/bernstein/__init__.py
@@ -7,7 +7,7 @@ scheduling decision.
 
 Highlights:
 
-* 43 CLI agent adapters in v1.10.1 (40 third-party + 2 leaf-node + 1 generic).
+* 40+ CLI agent adapters (run ``bernstein integrations list`` for the current set).
 * HMAC-SHA256 chained audit log per RFC 2104; key sits outside the audit
   volume; ``bernstein audit verify`` validates integrity.
 * Detached JWS (RFC 7515 §A.5) over JCS-canonicalized (RFC 8785) agent


### PR DESCRIPTION
## Summary

Two related documentation-hygiene changes, no file moves (page relocations and redirects are a separate follow-up).

### 1. Adapter-count standardization

The adapter count is hand-maintained in several surfaces and had drifted from the registry (46 keys). The dedicated supported-agents section in `README.md` already carries the precise breakdown, so the remaining surfaces are de-precisioned rather than re-stamped with a number, so they stop drifting:

- `docs/llms.txt`: `45` to `40+`
- `docs/llms-full.txt`: `41` to `40+` (and "the 41-adapter spread" to "the multi-adapter spread")
- `src/bernstein/__init__.py`: drop the stale `in v1.10.1 (40 + 2 + 1)` breakdown; point at `bernstein integrations list`
- `docs/adapters/ADAPTER_GUIDE.md`: "the 44 CLI agent adapters above" to "the CLI agent adapters above"
- `README.md`: `45` to `40+` in the feature-summary line, consistent with the canonical section

### 2. Consolidate duplicated pages (in place)

Several pages substantially duplicated each other and had drifted apart. Each is slimmed to point at a single canonical source; the pages stay in place so inbound links still resolve, and any facts that differed are reconciled to the current value.

| Topic | Canonical | Slimmed / pointed at canonical |
|---|---|---|
| Audit chain mechanics | `security/audit-log.md` | `security/AUDIT.md` reduced to SOC 2 enabling + evidence export |
| `.well-known` agent card | `architecture/a2a.md` | `protocols/well-known-manifest.md` rewritten as a catalog index (stale `schema_version 0.1.0` / `v1.9.4` / Jinja-at-boot claims removed) |
| MCP streamable-HTTP protocol | `mcp/server.md` | `cloudflare/cloudflare-mcp.md` trimmed to deployment (RemoteMCPConfig, ASGI, Workers) |
| Adapter support modules | `adapters/ADAPTER_GUIDE.md#support-modules` | table in `adapters/compatibility.md` replaced with a link |
| GUI extras gate | `gui/install.md` | duplicate note in install.md + `gui/troubleshooting.md` reduced to pointers |
| Error-telemetry DSN flow | `operations/glitchtip-setup.md` | `operations/observability.md` DSN section slimmed (also fixes legacy `GLITCHTIP_DSN` to `BERNSTEIN_TELEMETRY_DSN`), keeps unique SBOM content |
| Orchestration evidence + task FSM | `WHY_DETERMINISTIC.md` + `LIFECYCLE.md` | `orchestration-approaches.md` keeps its comparison, defers the incident evidence and FSM |
| Catalog audit-chain prose | `security/audit-log.md` | `reference/mcp-catalog.md` and `operations/skills-catalog.md` point at it for the shared chain mechanics |

## Verification

- `scripts/check_docs_drift.py --strict`: clean ("No drift detected").
- `mkdocs build`: exits 0 with no link or content warnings (remaining warnings are the `social` plugin's missing imaging dependency in the local environment, unrelated to this change).
- No em-dashes in added lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated capability descriptions to consistently reference 40+ CLI adapters.
  * Clarified GUI installation and troubleshooting, including plain-install support.
  * Refined MCP, telemetry, audit logging, adapter, and architecture guidance.
  * Expanded `.well-known` discovery documentation with additional endpoints and usage examples.
  * Consolidated detailed diagrams, tables, and protocol explanations into focused guides and cross-references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->