### PR TITLE
fix: correct README install command and harden parallel-verify test

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ $ bernstein -g "Add JWT auth"
 
 ### YAML workflow manifests (optional)
 
-When `bernstein run -g "<goal>"` is too coarse-grained, `bernstein workflow` runs a declarative DAG of agent / command / loop nodes. Manifests are plain YAML, validated up-front, dispatched through the same `AgentSpawner` the rest of Bernstein uses.
+When `bernstein -g "<goal>"` is too coarse-grained, `bernstein workflow` runs a declarative DAG of agent / command / loop nodes. Manifests are plain YAML, validated up-front, dispatched through the same `AgentSpawner` the rest of Bernstein uses.
 
 ```bash
 bernstein workflow list                          # bundled + user-installed

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -5053,21 +5053,48 @@ class TestProcessCompletedTasksParallel:
         )
         orch = _build_orchestrator(tmp_path, transport)
 
+        # Record the [start, end) interval of every verify call. Proving
+        # parallelism by total wall-clock is unreliable on a loaded CI runner
+        # (shard-level oversubscription can serialize threads and inflate the
+        # elapsed time past the serial baseline). Instead assert the calls
+        # OVERLAP: with a real thread pool every call starts before the first
+        # one returns, so the peak number of concurrently-open intervals must
+        # exceed one. That signal is immune to absolute scheduler slowness.
+        import threading
+
+        lock = threading.Lock()
+        intervals: list[tuple[float, float]] = []
+
         def slow_verify(task: object, workdir: object) -> tuple[bool, list[str]]:
+            begin = time.monotonic()
             time.sleep(SLEEP)
+            with lock:
+                intervals.append((begin, time.monotonic()))
             return True, []
 
         with patch("bernstein.core.tasks.task_lifecycle.verify_task", side_effect=slow_verify):
             tick_result = TickResult()
-            start = time.monotonic()
             orch._process_completed_tasks([Task.from_dict(d) for d in task_dicts], tick_result)
-            elapsed = time.monotonic() - start
 
         # All tasks verified successfully
         assert len(tick_result.verified) == N
         assert tick_result.verification_failures == []
-        # Parallel: total wall time should be much less than N * SLEEP
-        assert elapsed < SLEEP * N * 0.75, f"Expected parallel execution (<{SLEEP * N * 0.75:.2f}s), got {elapsed:.2f}s"
+        assert len(intervals) == N
+
+        # Peak concurrency: sweep the interval endpoints and count how many
+        # calls were open at once. Serial execution peaks at 1; a working
+        # thread pool peaks at >= 2 (here up to N).
+        events: list[tuple[float, int]] = []
+        for begin, end in intervals:
+            events.append((begin, 1))
+            events.append((end, -1))
+        events.sort()
+        open_now = 0
+        peak = 0
+        for _ts, delta in events:
+            open_now += delta
+            peak = max(peak, open_now)
+        assert peak >= 2, f"Expected concurrent verification (peak >= 2), got peak={peak}"
 
 
 class TestComputeTotalSpentCache:

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -372,7 +372,7 @@ def test_readme_has_three_line_install_block() -> None:
     required_lines = (
         "pipx install bernstein",
         "bernstein init",
-        'bernstein run -g "fix the failing test in tests/test_foo.py"',
+        'bernstein -g "fix the failing test in tests/test_foo.py"',
     )
     missing = [line for line in required_lines if line not in readme]
     if missing:


### PR DESCRIPTION
Two fixes for a red main after the README refresh landed.

## README install command
The top-level goal shortcut is `bernstein -g`. The `run` subcommand only accepts the long `--goal` form (no `-g` short flag), so `bernstein run -g` errors. The README install block was corrected to `bernstein -g`, but `test_readme_has_three_line_install_block` still required the old, non-working string, and one prose line still used it. This aligns both to the working command.

## Parallel-verify test hardening
`test_multiple_done_tasks_verified_concurrently` asserted parallelism by total wall-clock (elapsed < 0.6s). Under CI shard oversubscription the elapsed time can exceed even the serial baseline while the work still runs on a thread pool, so the assertion is flaky. Replaced it with a concurrency-overlap check: record each verify call interval and assert peak concurrency is at least 2. That proves the pool parallelized without depending on absolute scheduler timing.

Both failing tests pass locally; ruff and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow manifest guidance to use the streamlined `bernstein -g "<goal>"` command.
  * Updated the installation example to reflect the current command syntax.

* **Tests**
  * Improved parallel verification coverage by directly confirming that multiple tasks run concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->