### PR TITLE
feat(scheduling): pin dispatch knobs into the deterministic dispatch fingerprint

### DIFF
--- a/docs/operations/cost-aware-scheduling.md
+++ b/docs/operations/cost-aware-scheduling.md
@@ -179,6 +179,65 @@ siblings spawn, so each sibling hits the warm cache inside the TTL instead of
 racing to write it. The observed warm-up and cache-hit counts are recorded on
 the round outcome.
 
+## Dispatch knob matrix
+
+The price table is keyed by model name, but the per-call knobs that actually
+move the price of an identical task are the reasoning **effort** level, the
+processing **lane** (interactive / priority / batch, each with its own USD rate
+multiplier), and the prompt-cache **strategy** (none / reuse / warm-up). The
+**knob matrix** pins those, model by model, as a versioned, content-addressed
+map -- its `sha256` content hash pins exactly which knob economics a dispatch
+resolved against. Its defaults derive from the same sources the rest of the
+layer uses: the cache economics come from the price rows (a model that prices
+cache reads offers `reuse`; one that prices cache writes offers `warm_up`), and
+the lanes exist because the adapter contract declares a batch surface.
+
+Inspect the pinned matrix and its hash:
+
+```bash
+bernstein cost policy knobs                 # full matrix + content hash
+bernstein cost policy knobs --model opus    # one row
+```
+
+Operators override the shipped defaults without a code change, exactly like the
+price table:
+
+```yaml
+cost_policy:
+  knobs:
+    as_of: "2026-07-01"
+    revision: 2
+    models:
+      opus:
+        effort_levels: ["low", "high"]
+        default_effort: "low"
+        lanes: { interactive: 1.0, batch: 0.5 }
+```
+
+For each dispatch a **pure resolver** (no clock, filesystem, or network) turns
+the candidate plus the pinned matrix into a sealed **knob selection**: the
+resolved effort, lane, cache strategy, and rate multiplier, each carrying its
+own digest. The selection's content hash **folds into the `decision_hash`**, so
+two operators with identical state provably dispatch identically (byte-identical
+fingerprint) and a knob change surfaces as fingerprint divergence rather than an
+unexplained cost delta. The candidate projection applies the resolved lane
+multiplier, so admit and halt decisions account for the lane and effort actually
+chosen.
+
+The halt receipt seals the selection alongside `price_table_hash`,
+`ledger_state_hash`, and `policy_hash`. `bernstein cost policy verify` re-derives
+it offline: mutating any single knob field (effort, lane, cache strategy, or
+multiplier) fails verification with the mismatching field **named**, because the
+selection is falsification-evident per field, not merely logged. A model absent
+from the matrix resolves to an explicit default carrying `resolved=false` and a
+machine-readable reason with multiplier `1.0`, so the admit/halt outcome is
+unchanged for unpriced models -- never a silent fallback.
+
+The resolved selection is also recorded as a Merkle-chained event in the run
+journal, so replaying a run with a different knob assignment is reported as
+divergence at the exact step index. `bernstein doctor` carries a non-blocking
+advisory when the shipped matrix is stale.
+
 ## Determinism and verifiability
 
 The whole layer is a deterministic projection. The decision reads no clock, no

--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -1568,6 +1568,102 @@ def cost_policy_preflight_cmd(
     console.print("[green]All capped pools within budget.[/green]")
 
 
+@cost_policy_group.command("knobs")
+@click.option(
+    "--config",
+    "config_path",
+    type=str,
+    default="bernstein.yaml",
+    show_default=True,
+    help="Path to bernstein.yaml holding an optional ``cost_policy.knobs`` override.",
+)
+@click.option(
+    "--model",
+    "model_filter",
+    type=str,
+    default=None,
+    help="Show only the row whose key matches this model (longest-key match).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def cost_policy_knobs_cmd(config_path: str, model_filter: str | None, as_json: bool) -> None:
+    """Show the pinned dispatch knob matrix and its content hash (issue #2519).
+
+    The matrix declares, per model, the supported reasoning-effort levels, the
+    processing lanes (interactive / priority / batch) with their USD rate
+    multipliers, and the cache strategies (none / reuse / warm-up) with their
+    token economics. Its ``sha256`` content hash is what every sealed dispatch
+    knob selection names, so an operator can confirm which knob economics a run
+    resolved against. Reports the matrix staleness advisory alongside.
+    """
+    from datetime import UTC, datetime
+
+    from bernstein.core.cost.scheduling.knob_matrix import (
+        DEFAULT_KNOB_MATRIX,
+        knob_matrix_staleness,
+        load_knob_matrix,
+    )
+
+    policy = _read_cost_policy_from_yaml(Path(config_path))
+    knobs_cfg = policy.get("knobs") if isinstance(policy.get("knobs"), dict) else {}
+    models_cfg = knobs_cfg.get("models") if isinstance(knobs_cfg.get("models"), dict) else {}
+    if models_cfg:
+        matrix = load_knob_matrix(
+            models_cfg,
+            as_of=(knobs_cfg.get("as_of") or None),
+            revision=int(knobs_cfg.get("revision", 0) or 0),
+        )
+    else:
+        matrix = DEFAULT_KNOB_MATRIX
+    now_iso = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    staleness = knob_matrix_staleness(matrix, now_iso=now_iso)
+
+    models = matrix.models
+    if model_filter:
+        knobs = matrix.knobs_for(model_filter)
+        models = {model_filter: knobs} if knobs is not None else {}
+
+    if as_json or is_json():
+        print_json(
+            {
+                "matrix_hash": matrix.content_hash(),
+                "as_of": matrix.as_of,
+                "revision": matrix.revision,
+                "models": {name: knobs.to_dict() for name, knobs in models.items() if knobs is not None},
+                "stale": staleness.stale,
+                "message": staleness.message,
+            }
+        )
+        return
+
+    console.print(f"[bold]Dispatch knob matrix[/bold] {matrix.content_hash()}")
+    console.print(f"[dim]as_of={matrix.as_of} revision={matrix.revision}[/dim]")
+    if not models:
+        console.print(f"[yellow]No matrix row matches model {model_filter!r}.[/yellow]")
+        return
+
+    from rich.table import Table
+
+    table = Table(header_style="bold cyan")
+    table.add_column("Model", no_wrap=True)
+    table.add_column("Effort levels")
+    table.add_column("Lanes (multiplier)")
+    table.add_column("Cache strategies")
+    for name in sorted(models):
+        knobs = models[name]
+        if knobs is None:
+            continue
+        lanes = ", ".join(f"{lane}={mult:g}" for lane, mult in sorted(knobs.lanes.items()))
+        table.add_row(
+            name,
+            ", ".join(knobs.effort_levels),
+            lanes,
+            ", ".join(sorted(knobs.cache_strategies)),
+        )
+    console.print(table)
+    if staleness.stale:
+        console.print(f"[yellow]knob matrix advisory:[/yellow] {staleness.message}")
+
+
 @cost_policy_group.command("verify")
 @click.argument("decision_hash", type=str)
 @click.option(

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -491,6 +491,29 @@ def check_price_table_advisory() -> dict[str, Any]:
     }
 
 
+def check_knob_matrix_advisory() -> dict[str, Any]:
+    """Warn when the shipped dispatch knob matrix is stale (issue #2519).
+
+    The knob matrix pins the effort, lane, and cache economics every dispatch
+    fingerprint seals; its lane / cache multipliers drift with provider pricing,
+    so a matrix older than the staleness window is a signal to refresh
+    ``cost_policy.knobs`` (or the shipped defaults). Advisory only -- non-blocking.
+    """
+    from datetime import UTC, datetime
+
+    from bernstein.core.cost.scheduling.knob_matrix import DEFAULT_KNOB_MATRIX, knob_matrix_staleness
+
+    advisory = knob_matrix_staleness(DEFAULT_KNOB_MATRIX, now_iso=datetime.now(tz=UTC).strftime("%Y-%m-%d"))
+    return {
+        "name": "Cost knob matrix",
+        "status": _CHECK_WARN if advisory.stale else _CHECK_PASS,
+        "detail": advisory.message,
+        "fix": "Refresh cost_policy.knobs in bernstein.yaml or update the shipped knob matrix"
+        if advisory.stale
+        else "",
+    }
+
+
 def run_all_checks() -> list[dict[str, Any]]:
     """Run all health checks and return results."""
     checks: list[dict[str, Any]] = []
@@ -499,6 +522,7 @@ def run_all_checks() -> list[dict[str, Any]]:
     checks.extend(check_adapter_advisories())
     checks.extend(check_canary_last_green())
     checks.append(check_price_table_advisory())
+    checks.append(check_knob_matrix_advisory())
     checks.extend(check_api_keys())
     checks.extend(
         (

--- a/src/bernstein/core/cost/scheduling/__init__.py
+++ b/src/bernstein/core/cost/scheduling/__init__.py
@@ -18,6 +18,9 @@ Public surface:
 * :mod:`.batch` -- capability-gated batch routing (AC3).
 * :mod:`.cache_window` -- capability-gated, default-off cache-window fan-out
   (AC4).
+* :mod:`.knob_matrix` -- versioned, content-addressed dispatch knob matrix
+  (effort, processing lane, cache strategy) plus a pure resolver whose sealed
+  selection folds into the decision fingerprint (#2519).
 """
 
 from bernstein.core.cost.scheduling.batch import (
@@ -51,7 +54,28 @@ from bernstein.core.cost.scheduling.dispatch_gate import (
     resolve_cost_caps as resolve_cost_caps,
 )
 from bernstein.core.cost.scheduling.dispatch_gate import (
+    resolve_knob_matrix as resolve_knob_matrix,
+)
+from bernstein.core.cost.scheduling.dispatch_gate import (
     resolve_price_table as resolve_price_table,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    DEFAULT_KNOB_MATRIX as DEFAULT_KNOB_MATRIX,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    KnobMatrix as KnobMatrix,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    ModelKnobs as ModelKnobs,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    knob_matrix_staleness as knob_matrix_staleness,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    load_knob_matrix as load_knob_matrix,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    resolve_knob_selection as resolve_knob_selection,
 )
 from bernstein.core.cost.scheduling.policy import (
     CostCaps as CostCaps,
@@ -61,6 +85,9 @@ from bernstein.core.cost.scheduling.policy import (
 )
 from bernstein.core.cost.scheduling.policy import (
     DispatchDecision as DispatchDecision,
+)
+from bernstein.core.cost.scheduling.policy import (
+    KnobSelection as KnobSelection,
 )
 from bernstein.core.cost.scheduling.policy import (
     LedgerSpend as LedgerSpend,

--- a/src/bernstein/core/cost/scheduling/dispatch_gate.py
+++ b/src/bernstein/core/cost/scheduling/dispatch_gate.py
@@ -27,10 +27,16 @@ the orchestrator sealed.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.cost.scheduling.knob_matrix import (
+    DEFAULT_KNOB_MATRIX,
+    KnobMatrix,
+    load_knob_matrix,
+    resolve_knob_selection,
+)
 from bernstein.core.cost.scheduling.policy import (
     CostCaps,
     DispatchCandidate,
@@ -116,6 +122,52 @@ def resolve_price_table(cost_policy: Any | None) -> PriceTable:
     )
 
 
+def _knob_models(knobs: Any) -> dict[str, dict[str, Any]]:
+    """Flatten a config ``knobs.models`` block into plain knob rows."""
+    raw = getattr(knobs, "models", None)
+    if not raw:
+        return {}
+    rows: dict[str, dict[str, Any]] = {}
+    for key, entry in raw.items():
+        if hasattr(entry, "model_dump"):
+            row = entry.model_dump()
+        elif isinstance(entry, dict):
+            row = dict(entry)
+        else:
+            row = {
+                "effort_levels": getattr(entry, "effort_levels", None),
+                "default_effort": getattr(entry, "default_effort", None),
+                "lanes": getattr(entry, "lanes", None),
+                "cache_strategies": getattr(entry, "cache_strategies", None),
+            }
+        rows[str(key)] = row
+    return rows
+
+
+def resolve_knob_matrix(cost_policy: Any | None) -> KnobMatrix:
+    """Resolve the hash-pinned dispatch knob matrix (#2519).
+
+    Config ``cost_policy.knobs`` overrides the shipped defaults (same contract
+    as :func:`~bernstein.core.cost.scheduling.knob_matrix.load_knob_matrix`); an
+    absent knobs block yields :data:`DEFAULT_KNOB_MATRIX` unchanged. The matrix
+    is never probed -- its :meth:`KnobMatrix.content_hash` is what the sealed
+    knob selection names in every decision.
+    """
+    if cost_policy is None:
+        return DEFAULT_KNOB_MATRIX
+    knobs = getattr(cost_policy, "knobs", None)
+    if knobs is None:
+        return DEFAULT_KNOB_MATRIX
+    models = _knob_models(knobs)
+    if not models:
+        return DEFAULT_KNOB_MATRIX
+    return load_knob_matrix(
+        models,
+        as_of=(getattr(knobs, "as_of", "") or None),
+        revision=int(getattr(knobs, "revision", 0) or 0),
+    )
+
+
 def build_dispatch_candidates(
     batches: Iterable[Any],
     *,
@@ -123,6 +175,7 @@ def build_dispatch_candidates(
     run_id: str,
     day_key: str,
     pool: str = "",
+    knob_matrix: KnobMatrix | None = None,
 ) -> list[DispatchCandidate]:
     """Build one :class:`DispatchCandidate` per about-to-spawn batch.
 
@@ -131,13 +184,24 @@ def build_dispatch_candidates(
     it never manufactures spend). The candidate is attributed to the batch's
     lead task for the per-task dimension. Empty batches are skipped.
 
+    When *knob_matrix* is supplied, each candidate's per-call knobs (effort,
+    lane, cache strategy) are resolved deterministically and sealed onto the
+    candidate, and the projected cost is multiplied by the resolved lane
+    multiplier -- so admit and halt decisions account for the lane and effort
+    actually chosen (#2519). The sealed selection folds into the decision hash
+    downstream. With no matrix the behaviour is byte-identical to the pre-#2519
+    contract (multiplier ``1.0``, no knob selection).
+
     Args:
         batches: Role-grouped batches of Task-like objects (each item is
-            iterable and indexable, exposing ``id`` and optional ``model``).
+            iterable and indexable, exposing ``id`` and optional ``model`` /
+            ``adapter`` / ``effort`` / ``is_batch`` / ``cache_strategy``).
         cost_estimates: ``task_id -> estimated_cost_usd`` from the tick.
         run_id: The active run id (attributed to every candidate).
         day_key: UTC ``YYYY-MM-DD`` bucket for the day dimension.
         pool: Optional quota pool attributed to the candidates.
+        knob_matrix: The pinned knob matrix to resolve per-call knobs against,
+            or ``None`` to keep the pre-#2519 projection unchanged.
 
     Returns:
         Candidates in the batches' dispatch order.
@@ -149,16 +213,26 @@ def build_dispatch_candidates(
             continue
         lead = tasks[0]
         projected = sum(float(cost_estimates.get(getattr(task, "id", ""), 0.0)) for task in tasks)
-        candidates.append(
-            DispatchCandidate(
-                task_id=str(getattr(lead, "id", "")),
-                run_id=run_id,
-                model=str(getattr(lead, "model", "") or ""),
-                projected_cost_usd=projected,
-                day_key=day_key,
-                pool=pool,
-            )
+        candidate = DispatchCandidate(
+            task_id=str(getattr(lead, "id", "")),
+            run_id=run_id,
+            model=str(getattr(lead, "model", "") or ""),
+            projected_cost_usd=projected,
+            day_key=day_key,
+            pool=pool,
+            adapter=str(getattr(lead, "adapter", "") or ""),
+            requested_effort=str(getattr(lead, "effort", "") or ""),
+            batch_eligible=bool(getattr(lead, "is_batch", False)),
+            requested_cache=str(getattr(lead, "cache_strategy", "") or ""),
         )
+        if knob_matrix is not None:
+            selection = resolve_knob_selection(candidate=candidate, matrix=knob_matrix)
+            candidate = replace(
+                candidate,
+                projected_cost_usd=projected * selection.rate_multiplier,
+                knob_selection=selection,
+            )
+        candidates.append(candidate)
     return candidates
 
 
@@ -259,5 +333,6 @@ __all__ = [
     "build_dispatch_candidates",
     "evaluate_run_dispatch",
     "resolve_cost_caps",
+    "resolve_knob_matrix",
     "resolve_price_table",
 ]

--- a/src/bernstein/core/cost/scheduling/knob_matrix.py
+++ b/src/bernstein/core/cost/scheduling/knob_matrix.py
@@ -1,0 +1,455 @@
+"""Versioned, hash-pinned dispatch knob matrix + pure resolver (#2519).
+
+The cost-aware dispatch policy (:mod:`bernstein.core.cost.scheduling.policy`)
+admits or halts a spawn from a USD projection over a hash-pinned price table,
+but the projection was keyed by model name only. The per-call knobs that
+actually move the price of an identical task -- the reasoning ``effort`` level,
+the processing ``lane`` (interactive / priority / batch, with distinct rate
+multipliers), and the prompt-cache ``strategy`` (none / reuse / warm-up) -- were
+scattered and unpinned, so two runs of the same plan could execute with
+different effective knobs, pay different amounts, and produce receipts that
+verify equally well.
+
+This module closes that gap the same way the price table did:
+
+* :class:`KnobMatrix` is an immutable ``model -> ModelKnobs`` map plus an
+  ``as_of`` date and a monotonic ``revision``; its :meth:`~KnobMatrix.content_hash`
+  is a canonical-JSON SHA-256 pinning exactly which knob economics a decision
+  used. Its defaults derive from the existing single sources of truth: the
+  cache economics come from :data:`bernstein.core.cost.model_prices.MODEL_COSTS_PER_1M_TOKENS`
+  rows (a model with a ``cache_read`` rate offers ``reuse``; one with a
+  ``cache_write`` rate offers ``warm_up``), and the fact that batch and
+  cache-window lanes exist at all derives from
+  :data:`bernstein.adapters._contract.BATCH_DISPATCH_CAPABILITY_MATRIX` and
+  :data:`bernstein.adapters._contract.CACHE_WINDOW_CAPABILITY_MATRIX`.
+* :func:`load_knob_matrix` builds a matrix from validated config, so an operator
+  overrides the shipped defaults without a code change (same contract as
+  :func:`bernstein.core.cost.scheduling.price_table.load_price_table`).
+* :func:`resolve_knob_selection` is a *pure* resolver -- no clock, no filesystem,
+  no network -- that, given a :class:`DispatchCandidate` and the pinned matrix,
+  returns a sealed :class:`KnobSelection`. Its selection hash folds into the
+  decision hash, so the knob choice is part of the decision identity, not a
+  side effect; a model absent from the matrix resolves to an explicit default
+  carrying ``resolved=False`` and a machine-readable reason (never a silent
+  fallback), and its ``rate_multiplier`` is ``1.0`` so the admit/halt outcome is
+  unchanged from an unpriced model's current behaviour.
+* :func:`knob_matrix_staleness` mirrors ``price_table_staleness`` for a
+  non-blocking ``doctor`` advisory.
+
+Determinism and tie-breaks (AC1). Every branch below is a pure function of the
+candidate and the pinned matrix:
+
+* **effort** -- the candidate's ``requested_effort`` is honoured when it is one
+  of the model's declared levels; otherwise the resolver falls back to the
+  model's declared ``default_effort`` and records the fallback reason. An empty
+  request also uses the default.
+* **lane** -- ``batch`` is chosen only when the candidate is ``batch_eligible``,
+  the resolved ``adapter`` is batch-capable
+  (:func:`bernstein.adapters._contract.batch_dispatch_capability` is ``NATIVE``),
+  and the model declares a batch lane; otherwise the lane is ``interactive``.
+  The batch lane carries the lowest multiplier, so choosing it can only lower a
+  projection -- a lane upgrade never silently raises spend.
+* **cache strategy** -- ``warm_up`` requires the adapter to be cache-window
+  capable, the model to declare ``warm_up``, and the candidate to request it;
+  ``reuse`` requires the model to declare ``reuse`` and the candidate to request
+  ``reuse`` or ``warm_up``; otherwise ``none``.
+* **rate_multiplier** -- the resolved lane's multiplier, the single headline
+  factor applied to the candidate projection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from bernstein.adapters._contract import (
+    BatchDispatchCapability,
+    CacheWindowCapability,
+    batch_dispatch_capability,
+    cache_window_capability,
+)
+from bernstein.core.cost.model_prices import MODEL_COSTS_PER_1M_TOKENS
+from bernstein.core.cost.scheduling.policy import DispatchCandidate, KnobSelection
+
+#: ``as_of`` date shipped with :data:`DEFAULT_KNOB_MATRIX`. Mirrors the price
+#: table's ``as_of`` -- the knob economics are derived from the same rows.
+DEFAULT_KNOB_MATRIX_AS_OF = "2026-05-05"
+
+#: Default window after which a knob matrix is advised stale (mirrors the price
+#: table's staleness window; lane economics drift with provider pricing).
+DEFAULT_STALENESS_WINDOW_DAYS = 90
+
+#: The declared reasoning-effort ladder every priced model supports by default,
+#: lowest to highest. Operators re-declare per model via config.
+DEFAULT_EFFORT_LEVELS = ("low", "medium", "high", "max")
+
+#: The default effort a candidate resolves to when it requests none, or requests
+#: a level the model does not declare. A stable middle rung, never the extreme.
+DEFAULT_EFFORT = "medium"
+
+#: Processing lanes and their USD rate multipliers relative to interactive
+#: list price. ``batch`` reflects the ~50% non-interactive discount the model
+#: pricing comments document; ``priority`` a premium express lane. The *set* of
+#: lanes exists because the adapter contract declares a batch surface
+#: (:data:`bernstein.adapters._contract.BATCH_DISPATCH_CAPABILITY_MATRIX`);
+#: whether a candidate may *select* the batch lane is gated per-adapter by the
+#: resolver.
+LANE_INTERACTIVE = "interactive"
+LANE_PRIORITY = "priority"
+LANE_BATCH = "batch"
+LANE_MULTIPLIERS: dict[str, float] = {
+    LANE_INTERACTIVE: 1.0,
+    LANE_PRIORITY: 2.0,
+    LANE_BATCH: 0.5,
+}
+
+#: Cache strategies. ``none`` is always available; ``reuse`` / ``warm_up`` are
+#: declared per model only when the price row prices cache reads / writes, and
+#: the resolver additionally gates ``warm_up`` on adapter cache-window
+#: capability (:data:`bernstein.adapters._contract.CACHE_WINDOW_CAPABILITY_MATRIX`).
+CACHE_NONE = "none"
+CACHE_REUSE = "reuse"
+CACHE_WARM_UP = "warm_up"
+
+#: Machine-readable resolver reasons (AC: never a silent fallback).
+REASON_RESOLVED = "resolved"
+REASON_MODEL_NOT_IN_MATRIX = "model_not_in_matrix"
+REASON_EFFORT_FALLBACK = "effort_not_declared_default_applied"
+
+
+@dataclass(frozen=True)
+class ModelKnobs:
+    """The declared knob economics for one model.
+
+    Attributes:
+        effort_levels: Ordered, declared reasoning-effort levels (lowest first).
+        default_effort: The level a candidate resolves to when it requests an
+            undeclared or empty effort.
+        lanes: ``lane -> USD rate multiplier`` (relative to interactive list
+            price). ``interactive`` is always present with multiplier ``1.0``.
+        cache_strategies: ``strategy -> relative input-token cost fraction``.
+            ``none`` is always present at ``1.0``; ``reuse`` / ``warm_up`` are
+            present only when the price row prices cache reads / writes.
+    """
+
+    effort_levels: tuple[str, ...]
+    default_effort: str
+    lanes: dict[str, float]
+    cache_strategies: dict[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "effort_levels": list(self.effort_levels),
+            "default_effort": self.default_effort,
+            "lanes": {name: round(mult, 6) for name, mult in self.lanes.items()},
+            "cache_strategies": {name: round(frac, 6) for name, frac in self.cache_strategies.items()},
+        }
+
+
+@dataclass(frozen=True)
+class KnobMatrix:
+    """Immutable, content-addressed dispatch knob matrix.
+
+    Attributes:
+        models: Map of model key (matched case-insensitively as a substring,
+            longest key first, exactly like the price table) to its
+            :class:`ModelKnobs`.
+        as_of: ISO date (``YYYY-MM-DD``) the economics were captured.
+        revision: Monotonic revision counter, bumped on any change.
+    """
+
+    models: dict[str, ModelKnobs]
+    as_of: str = DEFAULT_KNOB_MATRIX_AS_OF
+    revision: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "as_of": self.as_of,
+            "revision": self.revision,
+            "models": {name: knobs.to_dict() for name, knobs in self.models.items()},
+        }
+
+    def _canonical_bytes(self) -> bytes:
+        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    def content_hash(self) -> str:
+        """``sha256:`` digest pinning exactly these knob economics + metadata."""
+        return "sha256:" + hashlib.sha256(self._canonical_bytes()).hexdigest()
+
+    def knobs_for(self, model: str) -> ModelKnobs | None:
+        """Return the :class:`ModelKnobs` for *model*, longest key first.
+
+        An unknown model returns ``None`` so the resolver can emit an explicit
+        default selection rather than guessing -- identical fallback semantics
+        to the price table's unknown-model path.
+        """
+        model_lower = model.lower()
+        for key in sorted(self.models, key=len, reverse=True):
+            if key.lower() in model_lower:
+                return self.models[key]
+        return None
+
+
+def _default_model_knobs(pricing: Mapping[str, Any]) -> ModelKnobs:
+    """Build one model's knobs from its leaf pricing row.
+
+    Cache strategies derive from the row: a model that prices ``cache_read``
+    offers ``reuse``; one that prices ``cache_write`` offers ``warm_up``. The
+    per-strategy fraction is the cache rate over the input rate (rounded), the
+    token economics the projection would apply.
+    """
+    input_rate = float(pricing.get("input", 0.0) or 0.0)
+    cache_read = float(pricing.get("cache_read") or 0.0)
+    cache_write = float(pricing.get("cache_write") or 0.0)
+
+    cache_strategies: dict[str, float] = {CACHE_NONE: 1.0}
+    if cache_read > 0.0:
+        cache_strategies[CACHE_REUSE] = round(cache_read / input_rate, 6) if input_rate > 0.0 else 1.0
+    if cache_write > 0.0:
+        cache_strategies[CACHE_WARM_UP] = round(cache_write / input_rate, 6) if input_rate > 0.0 else 1.0
+
+    return ModelKnobs(
+        effort_levels=DEFAULT_EFFORT_LEVELS,
+        default_effort=DEFAULT_EFFORT,
+        lanes=dict(LANE_MULTIPLIERS),
+        cache_strategies=cache_strategies,
+    )
+
+
+def _default_models() -> dict[str, ModelKnobs]:
+    """Build the shipped model knob map from the leaf pricing table."""
+    return {key: _default_model_knobs(pricing) for key, pricing in MODEL_COSTS_PER_1M_TOKENS.items()}
+
+
+#: Shipped default knob matrix, derived from the same rows the price table and
+#: the adapter capability maps are. Hash-pinned via
+#: :meth:`KnobMatrix.content_hash`.
+DEFAULT_KNOB_MATRIX = KnobMatrix(models=_default_models(), as_of=DEFAULT_KNOB_MATRIX_AS_OF, revision=1)
+
+
+def _coerce_knobs(raw: Mapping[str, Any], *, key: str) -> ModelKnobs:
+    """Validate one config knob row into a :class:`ModelKnobs`.
+
+    Raises:
+        ValueError: A declared multiplier / fraction is non-numeric or negative,
+            or the effort ladder is empty -- a misconfiguration that must fail
+            loudly rather than corrupt every downstream dispatch fingerprint.
+    """
+    levels_raw = raw.get("effort_levels") or list(DEFAULT_EFFORT_LEVELS)
+    effort_levels = tuple(str(level) for level in levels_raw)
+    if not effort_levels:
+        raise ValueError(f"knobs for model {key!r} declare an empty effort ladder")
+    default_effort = str(raw.get("default_effort") or effort_levels[len(effort_levels) // 2])
+    if default_effort not in effort_levels:
+        raise ValueError(f"knobs for model {key!r} default_effort {default_effort!r} not in declared levels")
+
+    def _numeric_map(field: str, fallback: dict[str, float], *, always: dict[str, float]) -> dict[str, float]:
+        rows = raw.get(field)
+        if not isinstance(rows, Mapping):
+            return dict(fallback)
+        out: dict[str, float] = dict(always)
+        for name, value in rows.items():
+            try:
+                num = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"knobs for model {key!r} {field}[{name!r}] is non-numeric: {value!r}") from exc
+            if num < 0:
+                raise ValueError(f"knobs for model {key!r} {field}[{name!r}] is negative: {num}")
+            out[str(name)] = num
+        return out
+
+    lanes = _numeric_map("lanes", dict(LANE_MULTIPLIERS), always={LANE_INTERACTIVE: 1.0})
+    cache_strategies = _numeric_map("cache_strategies", {CACHE_NONE: 1.0}, always={CACHE_NONE: 1.0})
+    return ModelKnobs(
+        effort_levels=effort_levels,
+        default_effort=default_effort,
+        lanes=lanes,
+        cache_strategies=cache_strategies,
+    )
+
+
+def load_knob_matrix(
+    models: Mapping[str, Mapping[str, Any]] | None = None,
+    *,
+    as_of: str | None = None,
+    revision: int = 0,
+    base: KnobMatrix | None = None,
+) -> KnobMatrix:
+    """Build a :class:`KnobMatrix` from validated config knob rows.
+
+    When *models* is ``None`` or empty the shipped :data:`DEFAULT_KNOB_MATRIX`
+    (or *base*) is returned unchanged. Otherwise the config rows override /
+    extend *base* (the shipped defaults by default), so an operator names only
+    the models they want to re-declare.
+
+    Raises:
+        ValueError: A declared multiplier / fraction is non-numeric or negative,
+            an effort ladder is empty, or a default effort is not declared.
+    """
+    base_matrix = base if base is not None else DEFAULT_KNOB_MATRIX
+    if not models:
+        return base_matrix
+    merged: dict[str, ModelKnobs] = dict(base_matrix.models)
+    for key, raw in models.items():
+        merged[key] = _coerce_knobs(raw, key=key)
+    return KnobMatrix(models=merged, as_of=as_of or base_matrix.as_of, revision=revision)
+
+
+@dataclass(frozen=True, slots=True)
+class StalenessAdvisory:
+    """Result of a knob-matrix staleness check (drives the doctor advisory)."""
+
+    stale: bool
+    age_days: int
+    as_of: str
+    message: str
+
+
+def _parse_iso_date(value: str) -> date | None:
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def knob_matrix_staleness(
+    matrix: KnobMatrix,
+    *,
+    now_iso: str,
+    max_age_days: int = DEFAULT_STALENESS_WINDOW_DAYS,
+) -> StalenessAdvisory:
+    """Return whether *matrix* is older than ``max_age_days`` as of ``now_iso``.
+
+    A malformed ``as_of`` is treated as stale (fail-visible). The advisory never
+    raises and never blocks -- it is a doctor hint, mirroring
+    :func:`bernstein.core.cost.scheduling.price_table.price_table_staleness`.
+    """
+    now = _parse_iso_date(now_iso)
+    captured = _parse_iso_date(matrix.as_of)
+    if now is None:
+        return StalenessAdvisory(
+            stale=False,
+            age_days=0,
+            as_of=matrix.as_of,
+            message=f"knob matrix as_of={matrix.as_of!r}: cannot evaluate staleness (bad now {now_iso!r})",
+        )
+    if captured is None:
+        return StalenessAdvisory(
+            stale=True,
+            age_days=max_age_days + 1,
+            as_of=matrix.as_of,
+            message=f"knob matrix as_of={matrix.as_of!r} is not a valid ISO date; treat economics as stale",
+        )
+    age_days = (now - captured).days
+    stale = age_days > max_age_days
+    if stale:
+        message = (
+            f"knob matrix as_of={matrix.as_of} is {age_days}d old (> {max_age_days}d); "
+            "lane / cache economics may have drifted -- refresh cost_policy.knobs or the shipped matrix"
+        )
+    else:
+        message = f"knob matrix as_of={matrix.as_of} is {age_days}d old (<= {max_age_days}d)"
+    return StalenessAdvisory(stale=stale, age_days=age_days, as_of=matrix.as_of, message=message)
+
+
+def _resolve_effort(knobs: ModelKnobs, requested: str) -> tuple[str, bool]:
+    """Return ``(effort, fell_back)`` for a candidate's requested effort."""
+    if requested and requested in knobs.effort_levels:
+        return requested, False
+    return knobs.default_effort, bool(requested)
+
+
+def _resolve_lane(knobs: ModelKnobs, *, batch_eligible: bool, adapter: str) -> str:
+    """Return the resolved processing lane (batch only when fully capable)."""
+    if (
+        batch_eligible
+        and LANE_BATCH in knobs.lanes
+        and batch_dispatch_capability(adapter) is BatchDispatchCapability.NATIVE
+    ):
+        return LANE_BATCH
+    return LANE_INTERACTIVE
+
+
+def _resolve_cache(knobs: ModelKnobs, *, requested: str, adapter: str) -> str:
+    """Return the resolved cache strategy (warm-up gated on adapter capability)."""
+    cache_capable = cache_window_capability(adapter) is CacheWindowCapability.SUPPORTED
+    if requested == CACHE_WARM_UP and CACHE_WARM_UP in knobs.cache_strategies and cache_capable:
+        return CACHE_WARM_UP
+    if requested in (CACHE_REUSE, CACHE_WARM_UP) and CACHE_REUSE in knobs.cache_strategies:
+        return CACHE_REUSE
+    return CACHE_NONE
+
+
+def resolve_knob_selection(*, candidate: DispatchCandidate, matrix: KnobMatrix) -> KnobSelection:
+    """Resolve the sealed :class:`KnobSelection` for *candidate* (pure, AC1).
+
+    Deterministic: no clock, no filesystem, no network -- the effort, lane, and
+    cache strategy are pure functions of the candidate and the pinned *matrix*
+    (plus the declared, never-probed adapter capability maps). Two operators
+    with the same candidate and matrix derive a byte-identical sealed selection.
+
+    A model absent from *matrix* resolves to an explicit default carrying
+    ``resolved=False`` and :data:`REASON_MODEL_NOT_IN_MATRIX`, with
+    ``rate_multiplier == 1.0`` so the admit/halt outcome is unchanged from an
+    unpriced model's current behaviour (never a silent fallback).
+    """
+    matrix_hash = matrix.content_hash()
+    knobs = matrix.knobs_for(candidate.model)
+    if knobs is None:
+        return KnobSelection(
+            model=candidate.model,
+            effort="",
+            lane=LANE_INTERACTIVE,
+            cache_strategy=CACHE_NONE,
+            rate_multiplier=1.0,
+            resolved=False,
+            reason=REASON_MODEL_NOT_IN_MATRIX,
+            matrix_hash=matrix_hash,
+        ).sealed()
+
+    effort, fell_back = _resolve_effort(knobs, candidate.requested_effort)
+    lane = _resolve_lane(knobs, batch_eligible=candidate.batch_eligible, adapter=candidate.adapter)
+    cache_strategy = _resolve_cache(knobs, requested=candidate.requested_cache, adapter=candidate.adapter)
+    rate_multiplier = knobs.lanes.get(lane, 1.0)
+    reason = REASON_EFFORT_FALLBACK if fell_back else REASON_RESOLVED
+
+    return KnobSelection(
+        model=candidate.model,
+        effort=effort,
+        lane=lane,
+        cache_strategy=cache_strategy,
+        rate_multiplier=rate_multiplier,
+        resolved=True,
+        reason=reason,
+        matrix_hash=matrix_hash,
+    ).sealed()
+
+
+__all__ = [
+    "CACHE_NONE",
+    "CACHE_REUSE",
+    "CACHE_WARM_UP",
+    "DEFAULT_EFFORT",
+    "DEFAULT_EFFORT_LEVELS",
+    "DEFAULT_KNOB_MATRIX",
+    "DEFAULT_KNOB_MATRIX_AS_OF",
+    "DEFAULT_STALENESS_WINDOW_DAYS",
+    "LANE_BATCH",
+    "LANE_INTERACTIVE",
+    "LANE_MULTIPLIERS",
+    "LANE_PRIORITY",
+    "REASON_EFFORT_FALLBACK",
+    "REASON_MODEL_NOT_IN_MATRIX",
+    "REASON_RESOLVED",
+    "KnobMatrix",
+    "KnobSelection",
+    "ModelKnobs",
+    "StalenessAdvisory",
+    "knob_matrix_staleness",
+    "load_knob_matrix",
+    "resolve_knob_selection",
+]

--- a/src/bernstein/core/cost/scheduling/policy.py
+++ b/src/bernstein/core/cost/scheduling/policy.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -67,9 +67,144 @@ class CostCaps:
         return "sha256:" + hashlib.sha256(payload).hexdigest()
 
 
+#: The per-call knob dimensions whose values enter the decision fingerprint and
+#: are independently falsification-evident. Ordering is the tie-break used when
+#: naming the first field that fails its sealed digest during verification.
+KNOB_FIELDS = ("effort", "lane", "cache_strategy", "rate_multiplier")
+
+
+def _digest_value(value: Any) -> str:
+    """Return a canonical ``sha256:`` digest of a single knob field value."""
+    payload = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class KnobSelection:
+    """The resolved per-call knob settings for one dispatch (#2519).
+
+    A ``KnobSelection`` names the effort level, processing lane, and cache
+    strategy a dispatch resolved to, plus the ``rate_multiplier`` the lane
+    contributes to the projected cost. It is content-addressed: its
+    :attr:`selection_hash` folds into the :class:`DispatchDecision` decision
+    hash, so two operators who resolve identical knobs derive a byte-identical
+    fingerprint and a knob change surfaces as fingerprint divergence.
+
+    Every knob field additionally carries its own sealed digest
+    (:attr:`field_digests`), so a receipt verifier can name *which* knob field
+    was mutated (effort, lane, cache strategy, or multiplier) rather than only
+    reporting a generic tamper -- the selection is falsification-evident per
+    field, not merely logged.
+
+    A model absent from the pinned matrix resolves to an explicit default with
+    ``resolved=False`` and a machine-readable ``reason``; its
+    ``rate_multiplier`` is ``1.0`` so the admit/halt outcome is unchanged from
+    an unpriced model's current behaviour.
+    """
+
+    model: str
+    effort: str
+    lane: str
+    cache_strategy: str
+    rate_multiplier: float
+    resolved: bool
+    reason: str
+    matrix_hash: str
+    field_digests: dict[str, str] | None = None
+    selection_hash: str = ""
+
+    def _values(self) -> dict[str, Any]:
+        """The four tamper-checkable knob values in canonical form."""
+        return {
+            "effort": self.effort,
+            "lane": self.lane,
+            "cache_strategy": self.cache_strategy,
+            "rate_multiplier": round(self.rate_multiplier, 6),
+        }
+
+    def compute_field_digests(self) -> dict[str, str]:
+        """Recompute each knob field's sealed digest from its current value."""
+        values = self._values()
+        return {field: _digest_value(values[field]) for field in KNOB_FIELDS}
+
+    def _body(self) -> dict[str, Any]:
+        """The hashed body: every field except ``selection_hash`` itself."""
+        return {
+            "model": self.model,
+            "effort": self.effort,
+            "lane": self.lane,
+            "cache_strategy": self.cache_strategy,
+            "rate_multiplier": round(self.rate_multiplier, 6),
+            "resolved": self.resolved,
+            "reason": self.reason,
+            "matrix_hash": self.matrix_hash,
+            "field_digests": self.field_digests if self.field_digests is not None else self.compute_field_digests(),
+        }
+
+    def compute_hash(self) -> str:
+        """Canonical ``sha256:`` digest over the selection body."""
+        return _hash_obj(self._body())
+
+    def sealed(self) -> KnobSelection:
+        """Return a copy with the field digests and selection hash pinned."""
+        digests = self.compute_field_digests()
+        primed = replace(self, field_digests=digests, selection_hash="")
+        return replace(primed, selection_hash=primed.compute_hash())
+
+    def to_dict(self) -> dict[str, Any]:
+        body = self._body()
+        body["selection_hash"] = self.selection_hash
+        return body
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> KnobSelection:
+        digests = raw.get("field_digests")
+        return cls(
+            model=str(raw["model"]),
+            effort=str(raw["effort"]),
+            lane=str(raw["lane"]),
+            cache_strategy=str(raw["cache_strategy"]),
+            rate_multiplier=float(raw["rate_multiplier"]),
+            resolved=bool(raw["resolved"]),
+            reason=str(raw["reason"]),
+            matrix_hash=str(raw["matrix_hash"]),
+            field_digests={str(k): str(v) for k, v in digests.items()} if isinstance(digests, dict) else None,
+            selection_hash=str(raw.get("selection_hash", "")),
+        )
+
+    def verify_self_hash(self) -> bool:
+        """True iff ``selection_hash`` recomputes from the current body."""
+        return self.compute_hash() == self.selection_hash
+
+    def first_field_digest_mismatch(self) -> str | None:
+        """Return the first knob field whose value no longer matches its digest.
+
+        A sealed selection whose stored ``field_digests`` no longer match the
+        digests recomputed from the current field values has had at least one
+        knob mutated; the first divergent field (in :data:`KNOB_FIELDS` order)
+        is named so a verifier can report exactly which knob was tampered.
+        """
+        stored = self.field_digests or {}
+        recomputed = self.compute_field_digests()
+        for field in KNOB_FIELDS:
+            if stored.get(field) != recomputed[field]:
+                return field
+        return None
+
+
 @dataclass(frozen=True, slots=True)
 class DispatchCandidate:
-    """The next unit of work the scheduler is about to dispatch."""
+    """The next unit of work the scheduler is about to dispatch.
+
+    The ``adapter`` / ``requested_effort`` / ``batch_eligible`` / ``requested_cache``
+    fields are resolver inputs (they name what the tick would like to dispatch
+    with); they are deliberately excluded from :meth:`to_dict` so the ledger
+    projection stays byte-identical to the pre-knob contract. The only economic
+    effect a resolved knob has on the projection flows through
+    ``projected_cost_usd`` (the lane multiplier is applied by
+    :func:`~bernstein.core.cost.scheduling.dispatch_gate.build_dispatch_candidates`)
+    and through the resolved :attr:`knob_selection` folded into the decision hash.
+    """
 
     task_id: str
     run_id: str
@@ -77,6 +212,11 @@ class DispatchCandidate:
     projected_cost_usd: float
     day_key: str = ""
     pool: str = ""
+    adapter: str = ""
+    requested_effort: str = ""
+    batch_eligible: bool = False
+    requested_cache: str = ""
+    knob_selection: KnobSelection | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -161,10 +301,17 @@ class DispatchDecision:
     ledger_state_hash: str
     policy_hash: str
     decision_hash: str
+    knob_selection: KnobSelection | None = None
 
     def _body(self) -> dict[str, Any]:
-        """The hashed body: every field except ``decision_hash`` itself."""
-        return {
+        """The hashed body: every field except ``decision_hash`` itself.
+
+        The resolved :attr:`knob_selection` is folded in only when present, so
+        a decision taken without a knob matrix hashes byte-identically to the
+        pre-#2519 contract (back-compat); once a selection is resolved, the
+        knob fingerprint is part of the decision identity, not a side effect.
+        """
+        body: dict[str, Any] = {
             "task_id": self.task_id,
             "run_id": self.run_id,
             "model": self.model,
@@ -182,6 +329,9 @@ class DispatchDecision:
             "ledger_state_hash": self.ledger_state_hash,
             "policy_hash": self.policy_hash,
         }
+        if self.knob_selection is not None:
+            body["knob_selection"] = self.knob_selection.to_dict()
+        return body
 
     def to_dict(self) -> dict[str, Any]:
         body = self._body()
@@ -222,6 +372,9 @@ class DispatchDecision:
             ledger_state_hash=str(raw["ledger_state_hash"]),
             policy_hash=str(raw["policy_hash"]),
             decision_hash=str(raw["decision_hash"]),
+            knob_selection=(
+                KnobSelection.from_dict(raw["knob_selection"]) if isinstance(raw.get("knob_selection"), dict) else None
+            ),
         )
 
 
@@ -237,6 +390,7 @@ def decide_dispatch(
     caps: CostCaps,
     price_table_hash: str,
     policy_hash: str | None = None,
+    knob_selection: KnobSelection | None = None,
 ) -> DispatchDecision:
     """Decide whether *candidate* is admitted under *caps*, or must halt (AC1).
 
@@ -254,10 +408,15 @@ def decide_dispatch(
             candidate cost was priced against (named in the decision).
         policy_hash: Override for the policy hash; defaults to
             ``caps.content_hash()``.
+        knob_selection: The resolved per-call knob selection (effort, lane,
+            cache strategy, multiplier) to fold into the decision fingerprint.
+            Defaults to ``candidate.knob_selection`` when the candidate carries
+            one; ``None`` on both keeps the pre-#2519 decision hash unchanged.
 
     Returns:
         A deterministic :class:`DispatchDecision`.
     """
+    selection = knob_selection if knob_selection is not None else candidate.knob_selection
     spend = project_spend(
         entries,
         task_id=candidate.task_id,
@@ -307,6 +466,8 @@ def decide_dispatch(
         "ledger_state_hash": ledger_state_hash,
         "policy_hash": resolved_policy_hash,
     }
+    if selection is not None:
+        body["knob_selection"] = selection.to_dict()
     decision_hash = _hash_obj(body)
 
     return DispatchDecision(
@@ -327,13 +488,16 @@ def decide_dispatch(
         ledger_state_hash=ledger_state_hash,
         policy_hash=resolved_policy_hash,
         decision_hash=decision_hash,
+        knob_selection=selection,
     )
 
 
 __all__ = [
+    "KNOB_FIELDS",
     "CostCaps",
     "DispatchCandidate",
     "DispatchDecision",
+    "KnobSelection",
     "LedgerSpend",
     "decide_dispatch",
     "project_spend",

--- a/src/bernstein/core/cost/scheduling/receipt.py
+++ b/src/bernstein/core/cost/scheduling/receipt.py
@@ -171,6 +171,7 @@ def build_dispatch_receipt(
             ledger_state_hash=decision.ledger_state_hash,
             policy_hash=decision.policy_hash,
             journal_entry_hash=anchor,
+            knob_selection_hash=(decision.knob_selection.selection_hash if decision.knob_selection is not None else ""),
         )
     return sealed
 
@@ -199,6 +200,26 @@ class DispatchVerifyResult:
     receipt: DispatchReceipt | None
 
 
+def _verify_knob_selection(decision: DispatchDecision) -> str | None:
+    """Return a named failure reason for a tampered knob field, else ``None``.
+
+    The sealed :class:`~bernstein.core.cost.scheduling.policy.KnobSelection`
+    carries a per-field digest, so a receipt whose stored effort / lane / cache
+    strategy / multiplier no longer matches its sealed digest fails with the
+    exact knob field named -- an ordinary scheduler logs knobs, it does not make
+    each one falsification-evident.
+    """
+    selection = decision.knob_selection
+    if selection is None:
+        return None
+    tampered_field = selection.first_field_digest_mismatch()
+    if tampered_field is not None:
+        return f"dispatch knob field {tampered_field!r} does not match its sealed digest (tampered)"
+    if not selection.verify_self_hash():
+        return "knob selection_hash does not recompute from the sealed knob fields (tampered)"
+    return None
+
+
 def verify_dispatch_receipt(
     *,
     workdir: Path,
@@ -220,6 +241,9 @@ def verify_dispatch_receipt(
     decision = receipt.decision
     if decision.decision_hash != decision_hash:
         return DispatchVerifyResult(ok=False, reason="receipt decision_hash does not match request", receipt=receipt)
+    knob_failure = _verify_knob_selection(decision)
+    if knob_failure is not None:
+        return DispatchVerifyResult(ok=False, reason=knob_failure, receipt=receipt)
     if not decision.verify_self_hash():
         return DispatchVerifyResult(
             ok=False, reason="decision_hash does not recompute from the receipt body (tampered)", receipt=receipt

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1136,6 +1136,7 @@ class Orchestrator:
             build_dispatch_candidates,
             evaluate_run_dispatch,
             resolve_cost_caps,
+            resolve_knob_matrix,
             resolve_price_table,
         )
 
@@ -1147,12 +1148,15 @@ class Orchestrator:
 
         now_ts = time.time()
         day_key = datetime.now(UTC).strftime("%Y-%m-%d")
-        price_table = resolve_price_table(getattr(self._config, "cost_policy", None))
+        cost_policy = getattr(self._config, "cost_policy", None)
+        price_table = resolve_price_table(cost_policy)
+        knob_matrix = resolve_knob_matrix(cost_policy)
         candidates = build_dispatch_candidates(
             batches,
             cost_estimates=cost_estimates,
             run_id=self._run_id,
             day_key=day_key,
+            knob_matrix=knob_matrix,
         )
         entries = SpendLedger.load_entries(self._spend_ledger.path)
         outcome = evaluate_run_dispatch(

--- a/src/bernstein/core/replay/journal.py
+++ b/src/bernstein/core/replay/journal.py
@@ -404,6 +404,52 @@ def verify_journal(path: Path) -> JournalVerifyResult:
     return JournalVerifyResult(ok=True, count=len(events))
 
 
+#: Event type recorded for a resolved dispatch knob selection (#2519). Folding
+#: the selection into the Merkle chain means replaying a run with a different
+#: knob assignment surfaces as hash divergence at a precise step index rather
+#: than an unexplained cost delta.
+DISPATCH_KNOB_SELECTION_EVENT = "dispatch_knob_selection"
+
+
+def record_dispatch_knob_selection(
+    journal: EventJournal,
+    *,
+    task_id: str,
+    run_id: str,
+    selection_hash: str,
+    effort: str,
+    lane: str,
+    cache_strategy: str,
+    rate_multiplier: float,
+    resolved: bool,
+    reason: str,
+) -> None:
+    """Append a resolved dispatch knob selection to the run journal (#2519).
+
+    Recorded as a Merkle-chained event so the journal head covers the effort,
+    lane, and cache strategy a dispatch executed with. Two operators who resolve
+    identical knobs chain to the same head; a forced knob change during replay
+    is reported by :meth:`EventJournal.verify` as divergence at the exact step
+    index, not passed off with a different cost.
+
+    The parameters are primitives (never the cost-layer ``KnobSelection`` type)
+    so this replay module keeps no dependency on the cost package -- the caller
+    projects its sealed selection onto these fields.
+    """
+    journal.record(
+        DISPATCH_KNOB_SELECTION_EVENT,
+        task_id=task_id,
+        knob_run_id=run_id,
+        selection_hash=selection_hash,
+        effort=effort,
+        lane=lane,
+        cache_strategy=cache_strategy,
+        rate_multiplier=round(rate_multiplier, 6),
+        resolved=resolved,
+        reason=reason,
+    )
+
+
 def seal_journal_into_spine(
     journal: EventJournal,
     *,
@@ -500,6 +546,7 @@ def rebuild_state(path: Path, *, from_step: int) -> dict[str, Any]:
 
 
 __all__ = [
+    "DISPATCH_KNOB_SELECTION_EVENT",
     "JOURNAL_FILENAME",
     "RETENTION_ENV_VAR",
     "EventJournal",
@@ -507,6 +554,7 @@ __all__ = [
     "compute_event_hash",
     "load_events",
     "rebuild_state",
+    "record_dispatch_knob_selection",
     "seal_journal_into_spine",
     "verify_journal",
 ]

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -2849,6 +2849,7 @@ def record_cost_dispatch_receipt(
     ledger_state_hash: str,
     policy_hash: str,
     journal_entry_hash: str,
+    knob_selection_hash: str = "",
     actor: str = "cost_policy",
 ) -> AuditEvent:
     """Append a ``cost.dispatch_receipt`` event into *chain* (#2354).
@@ -2878,29 +2879,37 @@ def record_cost_dispatch_receipt(
         policy_hash: Content hash of the caps the decision enforced.
         journal_entry_hash: Lineage-spine entry hash anchoring the sealed
             decision bytes; a verifier holding the spine can recompute it.
+        knob_selection_hash: Content hash of the sealed dispatch knob selection
+            (effort, lane, cache strategy, multiplier). Recorded only when a
+            knob matrix resolved the dispatch, so a verifier can pin the exact
+            knob configuration the decision used (#2519). Empty when no matrix
+            was consulted (back-compat).
         actor: Recorded actor; defaults to ``"cost_policy"``.
 
     Returns:
         The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
         its details payload.
     """
+    details: dict[str, Any] = {
+        "decision_hash": decision_hash,
+        "run_id": run_id,
+        "task_id": task_id,
+        "admit": admit,
+        "breached_dimension": breached_dimension,
+        "projected_overrun_usd": round(projected_overrun_usd, 6),
+        "price_table_hash": price_table_hash,
+        "ledger_state_hash": ledger_state_hash,
+        "policy_hash": policy_hash,
+        "journal_entry_hash": journal_entry_hash,
+    }
+    if knob_selection_hash:
+        details["knob_selection_hash"] = knob_selection_hash
     return chain.log_with_prev_digest(
         event_type=EVENT_COST_DISPATCH_RECEIPT,
         actor=actor,
         resource_type="cost_dispatch_receipt",
         resource_id=decision_hash,
-        details={
-            "decision_hash": decision_hash,
-            "run_id": run_id,
-            "task_id": task_id,
-            "admit": admit,
-            "breached_dimension": breached_dimension,
-            "projected_overrun_usd": round(projected_overrun_usd, 6),
-            "price_table_hash": price_table_hash,
-            "ledger_state_hash": ledger_state_hash,
-            "policy_hash": policy_hash,
-            "journal_entry_hash": journal_entry_hash,
-        },
+        details=details,
     )
 
 

--- a/tests/unit/cost/test_cost_scheduling_cli.py
+++ b/tests/unit/cost/test_cost_scheduling_cli.py
@@ -141,3 +141,40 @@ def test_verify_roundtrip_and_tamper(tmp_path: Path, monkeypatch: pytest.MonkeyP
     bad = runner.invoke(cost_cmd, ["policy", "verify", decision.decision_hash, "--workdir", str(workdir), "--json"])
     assert bad.exit_code == 1, bad.output
     assert json.loads(bad.output)["ok"] is False
+
+
+def test_knobs_shows_pinned_matrix_and_hash(tmp_path: Path) -> None:
+    # No config -> shipped default matrix; JSON carries the content hash and rows.
+    runner = CliRunner()
+    result = runner.invoke(cost_cmd, ["policy", "knobs", "--config", str(tmp_path / "absent.yaml"), "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["matrix_hash"].startswith("sha256:")
+    assert "opus" in payload["models"]
+    assert "stale" in payload
+
+
+def test_knobs_config_override_changes_hash(tmp_path: Path) -> None:
+    import yaml
+
+    config = tmp_path / "bernstein.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "goal": "x",
+                "cost_policy": {
+                    "knobs": {
+                        "revision": 2,
+                        "models": {"opus": {"effort_levels": ["low", "high"], "default_effort": "low"}},
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    default = runner.invoke(cost_cmd, ["policy", "knobs", "--config", str(tmp_path / "absent.yaml"), "--json"])
+    overridden = runner.invoke(cost_cmd, ["policy", "knobs", "--config", str(config), "--model", "opus", "--json"])
+    assert overridden.exit_code == 0, overridden.output
+    assert json.loads(overridden.output)["matrix_hash"] != json.loads(default.output)["matrix_hash"]
+    assert json.loads(overridden.output)["models"]["opus"]["effort_levels"] == ["low", "high"]

--- a/tests/unit/cost/test_dispatch_knob_matrix.py
+++ b/tests/unit/cost/test_dispatch_knob_matrix.py
@@ -1,0 +1,483 @@
+"""Dispatch knob matrix: knobs pinned into the deterministic fingerprint (#2519).
+
+The cost-aware dispatch policy priced a spawn from a USD projection keyed by
+model name only; the per-call knobs that move the price of an identical task
+(reasoning effort, processing lane, cache strategy) were scattered and unpinned,
+so two runs of the same plan could pay differently and produce receipts that
+verify equally well. These tests pin the fix:
+
+* **Determinism** -- two processes given the same candidate + matrix produce
+  byte-identical ``KnobSelection`` canonical JSON and the identical decision
+  hash; a single knob change flips the decision hash.
+* **Verifiability** -- a sealed receipt verifies offline; mutating any single
+  knob field (effort, lane, cache strategy, multiplier) fails verification with
+  the mismatching field named.
+* **Determinism (replay)** -- a run whose journal recorded knob selections
+  reproduces the same head hash; a forced knob change surfaces as divergence at
+  the exact step index.
+* **Correctness** -- a model absent from the matrix resolves to an explicit
+  default carrying ``resolved=False`` and a machine-readable reason, multiplier
+  ``1.0``, so the admit/halt outcome is unchanged for unpriced models.
+* **Observability** -- candidate costing applies the resolved lane multiplier;
+  a cap halt caused by a lane/effort choice names that knob in the receipt.
+* **Purity** -- the resolver reads no clock, filesystem, or network.
+
+Every test fails against the pre-#2519 tree (the knob matrix does not exist yet).
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import socket
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.scheduling.dispatch_gate import (
+    build_dispatch_candidates,
+    evaluate_run_dispatch,
+    resolve_knob_matrix,
+)
+from bernstein.core.cost.scheduling.knob_matrix import (
+    CACHE_NONE,
+    CACHE_WARM_UP,
+    DEFAULT_KNOB_MATRIX,
+    LANE_BATCH,
+    LANE_INTERACTIVE,
+    REASON_MODEL_NOT_IN_MATRIX,
+    KnobMatrix,
+    knob_matrix_staleness,
+    load_knob_matrix,
+    resolve_knob_selection,
+)
+from bernstein.core.cost.scheduling.policy import (
+    KNOB_FIELDS,
+    CostCaps,
+    DispatchCandidate,
+    KnobSelection,
+    decide_dispatch,
+)
+from bernstein.core.cost.scheduling.receipt import (
+    build_dispatch_receipt,
+    verify_dispatch_receipt,
+)
+from bernstein.core.cost.spend_ledger import LedgerEntry
+from bernstein.core.replay.journal import (
+    DISPATCH_KNOB_SELECTION_EVENT,
+    EventJournal,
+    record_dispatch_knob_selection,
+)
+
+_KEY = b"0" * 32
+
+
+def _day_key(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=UTC).strftime("%Y-%m-%d")
+
+
+def _entry(*, task_id: str = "t1", run_id: str = "r1", model: str = "opus", cost_usd: float = 1.0) -> LedgerEntry:
+    ts = 1_762_000_000.0
+    return LedgerEntry(
+        ts=ts,
+        ts_iso=datetime.fromtimestamp(ts, tz=UTC).isoformat(timespec="seconds"),
+        run_id=run_id,
+        task_id=task_id,
+        agent_id="a1",
+        role="dev",
+        feature_label="",
+        model=model,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        cost_usd=cost_usd,
+        quota_envelope="api",
+    )
+
+
+@dataclass
+class _Task:
+    """Minimal Task-like object for build_dispatch_candidates."""
+
+    id: str
+    model: str = "opus"
+    adapter: str = "claude"
+    effort: str = ""
+    is_batch: bool = False
+    cache_strategy: str = ""
+
+
+def _candidate(**overrides: object) -> DispatchCandidate:
+    base: dict[str, object] = {
+        "task_id": "t1",
+        "run_id": "r1",
+        "model": "opus",
+        "projected_cost_usd": 1.0,
+        "adapter": "claude",
+        "requested_effort": "high",
+        "batch_eligible": False,
+        "requested_cache": "",
+    }
+    base.update(overrides)
+    return DispatchCandidate(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# KnobMatrix: content-addressed, config-overridable, derived defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_matrix_is_content_addressed_and_stable() -> None:
+    assert DEFAULT_KNOB_MATRIX.content_hash().startswith("sha256:")
+    # Rebuilding the same matrix content hashes byte-identically.
+    rebuilt = KnobMatrix(models=dict(DEFAULT_KNOB_MATRIX.models), as_of=DEFAULT_KNOB_MATRIX.as_of, revision=1)
+    assert rebuilt.content_hash() == DEFAULT_KNOB_MATRIX.content_hash()
+
+
+def test_default_matrix_declares_known_models_and_lane_economics() -> None:
+    knobs = DEFAULT_KNOB_MATRIX.knobs_for("opus")
+    assert knobs is not None
+    # A batch lane exists and is cheaper than interactive (the ~50% discount).
+    assert knobs.lanes[LANE_BATCH] < knobs.lanes[LANE_INTERACTIVE]
+    # Cache strategies always include "none"; opus prices cache reads/writes so
+    # it also offers reuse + warm_up (derived from the price row).
+    assert CACHE_NONE in knobs.cache_strategies
+    assert CACHE_WARM_UP in knobs.cache_strategies
+
+
+def test_config_override_extends_defaults_and_changes_hash() -> None:
+    override = load_knob_matrix(
+        {"opus": {"effort_levels": ["low", "high"], "default_effort": "low"}},
+        as_of="2026-07-01",
+        revision=2,
+    )
+    assert override.content_hash() != DEFAULT_KNOB_MATRIX.content_hash()
+    knobs = override.knobs_for("opus")
+    assert knobs is not None
+    assert knobs.effort_levels == ("low", "high")
+    # Untouched models still come from the shipped defaults.
+    assert override.knobs_for("sonnet") is not None
+
+
+def test_config_override_rejects_negative_multiplier() -> None:
+    with pytest.raises(ValueError, match="negative"):
+        load_knob_matrix({"opus": {"lanes": {"batch": -0.5}}})
+
+
+# ---------------------------------------------------------------------------
+# Resolver: determinism, purity, tie-breaks, explicit unknown-model fallback
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_is_deterministic_across_processes() -> None:
+    # Two independent resolutions of the same candidate + matrix produce
+    # byte-identical canonical JSON (the "two operators" determinism AC).
+    first = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    second = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    assert json.dumps(first.to_dict(), sort_keys=True) == json.dumps(second.to_dict(), sort_keys=True)
+    assert first.selection_hash == second.selection_hash
+    assert first.verify_self_hash()
+
+
+def test_resolver_reads_no_clock_fs_or_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Enforce purity: any clock / filesystem / network access raises, and the
+    # resolver must still produce its selection.
+    def _boom(*_a: object, **_k: object) -> object:
+        raise AssertionError("resolver touched a clock / filesystem / network")
+
+    monkeypatch.setattr(time, "time", _boom)
+    monkeypatch.setattr(builtins, "open", _boom)
+    monkeypatch.setattr(socket, "socket", _boom)
+    selection = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    assert selection.resolved is True
+    assert selection.effort == "high"
+
+
+def test_batch_lane_selected_only_when_eligible_and_capable() -> None:
+    # Batch-eligible on a batch-capable adapter -> batch lane (cheaper).
+    on = resolve_knob_selection(candidate=_candidate(batch_eligible=True, adapter="claude"), matrix=DEFAULT_KNOB_MATRIX)
+    assert on.lane == LANE_BATCH
+    assert on.rate_multiplier < 1.0
+    # Batch-eligible on a non-batch adapter -> interactive (never faked).
+    off = resolve_knob_selection(candidate=_candidate(batch_eligible=True, adapter="aider"), matrix=DEFAULT_KNOB_MATRIX)
+    assert off.lane == LANE_INTERACTIVE
+    assert off.rate_multiplier == pytest.approx(1.0)
+
+
+def test_effort_fallback_is_explicit_when_undeclared() -> None:
+    selection = resolve_knob_selection(candidate=_candidate(requested_effort="ludicrous"), matrix=DEFAULT_KNOB_MATRIX)
+    knobs = DEFAULT_KNOB_MATRIX.knobs_for("opus")
+    assert knobs is not None
+    assert selection.effort == knobs.default_effort
+    assert selection.reason != "resolved"
+
+
+def test_unknown_model_resolves_explicit_default_not_silent_fallback() -> None:
+    selection = resolve_knob_selection(
+        candidate=_candidate(model="totally-unknown-sku-xyz"), matrix=DEFAULT_KNOB_MATRIX
+    )
+    assert selection.resolved is False
+    assert selection.reason == REASON_MODEL_NOT_IN_MATRIX
+    # Multiplier 1.0 so the admit/halt outcome is unchanged for unpriced models.
+    assert selection.rate_multiplier == pytest.approx(1.0)
+    assert selection.verify_self_hash()
+
+
+def test_unknown_model_leaves_admit_halt_outcome_unchanged() -> None:
+    # The decision with an unknown-model knob selection admits/halts identically
+    # to one with no selection (same projected cost, only the fingerprint gains
+    # the sealed default selection).
+    caps = CostCaps(per_run_usd=10.0)
+    entries = [_entry(cost_usd=9.5)]
+    cand = _candidate(model="totally-unknown-sku-xyz", projected_cost_usd=1.0)
+    selection = resolve_knob_selection(candidate=cand, matrix=DEFAULT_KNOB_MATRIX)
+    with_knob = decide_dispatch(
+        candidate=cand, entries=entries, caps=caps, price_table_hash="sha256:pt", knob_selection=selection
+    )
+    without = decide_dispatch(candidate=cand, entries=entries, caps=caps, price_table_hash="sha256:pt")
+    assert with_knob.admit == without.admit
+    assert with_knob.projected_cost_usd == pytest.approx(without.projected_cost_usd)
+
+
+# ---------------------------------------------------------------------------
+# Decision fingerprint: the knob choice is part of the decision identity
+# ---------------------------------------------------------------------------
+
+
+def test_knobs_enter_decision_hash_identically_for_identical_state() -> None:
+    caps = CostCaps(per_run_usd=100.0)
+    entries = [_entry(cost_usd=1.0)]
+    sel1 = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    sel2 = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    d1 = decide_dispatch(
+        candidate=_candidate(), entries=entries, caps=caps, price_table_hash="sha256:pt", knob_selection=sel1
+    )
+    d2 = decide_dispatch(
+        candidate=_candidate(), entries=list(entries), caps=caps, price_table_hash="sha256:pt", knob_selection=sel2
+    )
+    assert d1.decision_hash == d2.decision_hash
+
+
+def test_knob_change_flips_decision_hash() -> None:
+    caps = CostCaps(per_run_usd=100.0)
+    entries = [_entry(cost_usd=1.0)]
+    base_sel = resolve_knob_selection(candidate=_candidate(requested_effort="high"), matrix=DEFAULT_KNOB_MATRIX)
+    changed_sel = resolve_knob_selection(candidate=_candidate(requested_effort="low"), matrix=DEFAULT_KNOB_MATRIX)
+    assert base_sel.selection_hash != changed_sel.selection_hash
+    base = decide_dispatch(
+        candidate=_candidate(), entries=entries, caps=caps, price_table_hash="sha256:pt", knob_selection=base_sel
+    )
+    changed = decide_dispatch(
+        candidate=_candidate(), entries=entries, caps=caps, price_table_hash="sha256:pt", knob_selection=changed_sel
+    )
+    assert base.decision_hash != changed.decision_hash
+
+
+def test_decision_without_knob_selection_matches_pre_2519_hash() -> None:
+    # Back-compat: a decision taken with no knob selection hashes byte-identically
+    # to the pre-#2519 body (the "knob_selection" key is omitted entirely).
+    caps = CostCaps(per_run_usd=100.0)
+    entries = [_entry(cost_usd=1.0)]
+    decision = decide_dispatch(candidate=_candidate(), entries=entries, caps=caps, price_table_hash="sha256:pt")
+    assert "knob_selection" not in decision.to_dict()
+    assert decision.verify_self_hash()
+
+
+# ---------------------------------------------------------------------------
+# Receipt: sealed knobs verify offline; per-knob-field tamper is named
+# ---------------------------------------------------------------------------
+
+
+def _seal_receipt(tmp_path: Path, *, selection: KnobSelection) -> tuple[Path, Path, str]:
+    caps = CostCaps(per_run_usd=100.0)
+    entries = [_entry(cost_usd=1.0)]
+    decision = decide_dispatch(
+        candidate=_candidate(), entries=entries, caps=caps, price_table_hash="sha256:pt", knob_selection=selection
+    )
+    workdir = tmp_path / "proj"
+    lineage_root = workdir / ".sdd" / "lineage"
+    build_dispatch_receipt(
+        decision=decision, workdir=workdir, lineage_root=lineage_root, hmac_key=_KEY, timestamp=1_762_000_001
+    )
+    return workdir, lineage_root, decision.decision_hash
+
+
+def test_sealed_knob_receipt_verifies_offline(tmp_path: Path) -> None:
+    selection = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    workdir, lineage_root, decision_hash = _seal_receipt(tmp_path, selection=selection)
+    result = verify_dispatch_receipt(
+        workdir=workdir, lineage_root=lineage_root, hmac_key=_KEY, decision_hash=decision_hash
+    )
+    assert result.ok is True
+    # The sealed selection is on the receipt.
+    payload = json.loads((workdir / ".sdd" / "cost" / "dispatch" / f"{decision_hash}.json").read_text(encoding="utf-8"))
+    assert payload["knob_selection"]["lane"] in {LANE_INTERACTIVE, LANE_BATCH}
+    assert payload["knob_selection"]["selection_hash"] == selection.selection_hash
+
+
+@pytest.mark.parametrize(
+    ("field_name", "tampered_value"),
+    [
+        ("effort", "low"),
+        ("lane", "priority"),
+        ("cache_strategy", "warm_up"),
+        ("rate_multiplier", 0.25),
+    ],
+)
+def test_tampering_any_knob_field_fails_verification_naming_it(
+    tmp_path: Path, field_name: str, tampered_value: object
+) -> None:
+    selection = resolve_knob_selection(
+        candidate=_candidate(batch_eligible=True, adapter="claude"), matrix=DEFAULT_KNOB_MATRIX
+    )
+    workdir, lineage_root, decision_hash = _seal_receipt(tmp_path, selection=selection)
+    path = workdir / ".sdd" / "cost" / "dispatch" / f"{decision_hash}.json"
+    forged = json.loads(path.read_text(encoding="utf-8"))
+    assert forged["knob_selection"][field_name] != tampered_value
+    forged["knob_selection"][field_name] = tampered_value
+    path.write_text(json.dumps(forged), encoding="utf-8")
+
+    result = verify_dispatch_receipt(
+        workdir=workdir, lineage_root=lineage_root, hmac_key=_KEY, decision_hash=decision_hash
+    )
+    assert result.ok is False
+    assert field_name in result.reason
+
+
+def test_all_knob_fields_are_field_addressed() -> None:
+    # Every named knob field carries its own sealed digest.
+    selection = resolve_knob_selection(candidate=_candidate(), matrix=DEFAULT_KNOB_MATRIX)
+    assert selection.field_digests is not None
+    assert set(selection.field_digests) == set(KNOB_FIELDS)
+    assert selection.first_field_digest_mismatch() is None
+
+
+# ---------------------------------------------------------------------------
+# Journal: knob selections fold into the Merkle head; a flip diverges by index
+# ---------------------------------------------------------------------------
+
+
+def _record_run(sdd: Path, *, run_id: str, effort: str) -> str:
+    journal = EventJournal(run_id, sdd)
+    journal.record("task_claimed", task_id="t1")
+    selection = resolve_knob_selection(candidate=_candidate(requested_effort=effort), matrix=DEFAULT_KNOB_MATRIX)
+    record_dispatch_knob_selection(
+        journal,
+        task_id="t1",
+        run_id=run_id,
+        selection_hash=selection.selection_hash,
+        effort=selection.effort,
+        lane=selection.lane,
+        cache_strategy=selection.cache_strategy,
+        rate_multiplier=selection.rate_multiplier,
+        resolved=selection.resolved,
+        reason=selection.reason,
+    )
+    journal.record("task_done", task_id="t1")
+    return journal.head()
+
+
+def test_identical_runs_reproduce_journal_head(tmp_path: Path) -> None:
+    head_a = _record_run(tmp_path / "a", run_id="run", effort="high")
+    head_b = _record_run(tmp_path / "b", run_id="run", effort="high")
+    assert head_a == head_b
+
+
+def test_forced_knob_change_diverges_at_exact_step(tmp_path: Path) -> None:
+    sdd = tmp_path / "sdd"
+    _record_run(sdd, run_id="run", effort="high")
+    journal_path = sdd / "runs" / "run" / "journal.jsonl"
+    rows = [json.loads(line) for line in journal_path.read_text().splitlines() if line.strip()]
+    # The knob-selection event is the second row (index 1).
+    knob_idx = next(i for i, r in enumerate(rows) if r.get("event") == DISPATCH_KNOB_SELECTION_EVENT)
+    rows[knob_idx]["effort"] = "low"  # forced knob change, hash not recomputed
+    journal_path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    result = EventJournal("run", sdd).verify()
+    assert result.ok is False
+    assert result.divergent_index == knob_idx
+
+
+# ---------------------------------------------------------------------------
+# Candidate costing: the resolved lane multiplier reaches the projection
+# ---------------------------------------------------------------------------
+
+
+def test_build_candidates_applies_lane_multiplier() -> None:
+    batches = [[_Task(id="t1", model="opus", adapter="claude", is_batch=True)]]
+    candidates = build_dispatch_candidates(
+        batches,
+        cost_estimates={"t1": 2.0},
+        run_id="r1",
+        day_key=_day_key(1_762_000_000.0),
+        knob_matrix=DEFAULT_KNOB_MATRIX,
+    )
+    assert len(candidates) == 1
+    cand = candidates[0]
+    assert cand.knob_selection is not None
+    assert cand.knob_selection.lane == LANE_BATCH
+    # Base estimate 2.0 * batch multiplier (< 1) -> lower projection.
+    assert cand.projected_cost_usd < 2.0
+    assert cand.projected_cost_usd == pytest.approx(2.0 * cand.knob_selection.rate_multiplier)
+
+
+def test_build_candidates_without_matrix_is_unchanged() -> None:
+    batches = [[_Task(id="t1", model="opus")]]
+    candidates = build_dispatch_candidates(
+        batches, cost_estimates={"t1": 2.0}, run_id="r1", day_key=_day_key(1_762_000_000.0)
+    )
+    assert candidates[0].projected_cost_usd == pytest.approx(2.0)
+    assert candidates[0].knob_selection is None
+
+
+def test_lane_choice_names_the_knob_in_halt_receipt(tmp_path: Path) -> None:
+    # A candidate whose interactive projection would breach a cap but whose
+    # batch lane keeps it under: the resolved selection is sealed into the
+    # decision so a verifier can attribute the outcome to the lane knob.
+    day = _day_key(1_762_000_000.0)
+    batches = [[_Task(id="t1", model="opus", adapter="claude", is_batch=True)]]
+    candidates = build_dispatch_candidates(
+        batches, cost_estimates={"t1": 2.0}, run_id="r1", day_key=day, knob_matrix=DEFAULT_KNOB_MATRIX
+    )
+    caps = CostCaps(per_run_usd=1.5)  # 2.0 interactive would breach; batch (1.0) does not
+    outcome = evaluate_run_dispatch(
+        candidates=candidates, entries=[], caps=caps, price_table_hash="sha256:pt", now_ts=1_762_000_000.0
+    )
+    assert outcome.halt is None  # the batch lane multiplier kept it admitted
+    admitted = outcome.admitted[0]
+    assert admitted.knob_selection is not None
+    assert admitted.knob_selection.lane == LANE_BATCH
+
+
+# ---------------------------------------------------------------------------
+# Staleness advisory: non-blocking doctor hint
+# ---------------------------------------------------------------------------
+
+
+def test_staleness_advisory_is_nonblocking_and_never_raises() -> None:
+    fresh = knob_matrix_staleness(DEFAULT_KNOB_MATRIX, now_iso=DEFAULT_KNOB_MATRIX.as_of)
+    assert fresh.stale is False
+    stale = knob_matrix_staleness(DEFAULT_KNOB_MATRIX, now_iso="2099-01-01")
+    assert stale.stale is True
+    # A malformed as_of is treated as stale (fail-visible), never raises.
+    bad = knob_matrix_staleness(KnobMatrix(models={}, as_of="not-a-date"), now_iso="2026-07-16")
+    assert bad.stale is True
+
+
+def test_resolve_knob_matrix_defaults_without_config() -> None:
+    assert resolve_knob_matrix(None).content_hash() == DEFAULT_KNOB_MATRIX.content_hash()
+
+    @dataclass
+    class _Knobs:
+        models: dict[str, object] = field(default_factory=dict)
+
+    @dataclass
+    class _Policy:
+        knobs: _Knobs = field(default_factory=_Knobs)
+
+    # Empty knobs block -> shipped defaults unchanged.
+    assert resolve_knob_matrix(_Policy()).content_hash() == DEFAULT_KNOB_MATRIX.content_hash()


### PR DESCRIPTION
## Problem

The cost-aware dispatch policy priced a spawn from a USD projection keyed by model name only. The per-call knobs that actually move the price of an identical task were scattered and unpinned:

- reasoning **effort** was a free-form string with no declared valid set per model and no price consequence;
- the processing **lane** existed only as a boolean batch route, with no general notion of lanes with distinct rate multipliers;
- the **cache strategy** assumed by a dispatch was never recorded, so projected and actual cost could diverge without a named cause.

Two runs of the same plan could execute with different effective knobs, pay different amounts, and produce receipts that verified equally well. Replay could not prove which knob configuration produced a result because the knobs never entered the fingerprint.

## Change

A versioned, content-addressed dispatch knob matrix, with the resolved selection made part of the decision identity.

- `knob_matrix.py`: immutable `model -> ModelKnobs` map (effort levels, processing lanes with USD rate multipliers, cache strategies with token economics), canonical-JSON sha256 content hash, config override loader, and a non-blocking staleness advisory. Defaults derive from the existing single sources of truth: the model price rows and the adapter batch / cache-window capability maps.
- A **pure resolver** (no clock, filesystem, or network) turns a `DispatchCandidate` plus the pinned matrix into a sealed `KnobSelection`. Each knob field carries its own digest, so a tamper is named per field.
- The selection hash **folds into `decide_dispatch`'s decision hash** and is sealed into the dispatch receipt alongside `price_table_hash`, `ledger_state_hash`, and `policy_hash`. `verify_dispatch_receipt` re-derives it offline and fails with the mismatching knob field named. A model absent from the matrix resolves to an explicit default (`resolved=false`, machine-readable reason, multiplier `1.0`), so the admit/halt outcome is unchanged for unpriced models.
- The resolved selection is recorded as a Merkle-chained run-journal event, so replaying with a different knob assignment surfaces as divergence at the exact step index.
- Candidate costing applies the resolved lane multiplier; the tick-level gate and spawn path resolve knobs from the pinned matrix.
- CLI: `bernstein cost policy knobs` shows the pinned matrix and its content hash; `bernstein doctor` carries a non-blocking stale-matrix advisory; the cost-aware-scheduling docs describe the sealed knob fields.

## Killer shape

Strip the fingerprint and the feature is just config. Because the sealed selection folds into the decision hash and the run-journal Merkle head, two operators with identical state provably dispatch identically (byte-identical fingerprint), a knob change is caught as fingerprint divergence at a precise step, and a single mutated knob field fails offline receipt verification with the field named.

## Tests

- New `tests/unit/cost/test_dispatch_knob_matrix.py` (26 cases): content-addressing, config override validation, resolver determinism and purity (no clock / fs / network enforced), lane / effort / cache tie-breaks, explicit unknown-model fallback, decision-hash folding and divergence, per-knob-field receipt tamper naming, journal head reproduction and forced-knob divergence at exact index, lane-multiplier candidate costing, and the staleness advisory.
- New `bernstein cost policy knobs` CLI cases.
- Existing scheduling, dispatch-gate, journal, receipt, audit-chain, doctor, orchestrator, and CLI-snapshot suites stay green (back-compat: a decision taken with no matrix hashes byte-identically to the pre-change body).

## Verification

Two dispatches with identical state produced a byte-identical `decision_hash` including the resolved knobs (`effort=high lane=batch cache=warm_up x0.5`); flipping the effort knob diverged the hash; a clean receipt verified offline and a tampered `lane` field failed with `dispatch knob field 'lane' does not match its sealed digest (tampered)`.

`ruff check` and `ruff format --check` clean; import-linter contracts kept.

Closes #2519
