### PR TITLE
feat(adapters): promote ACP to a first-class content-addressed event transport

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -81,6 +81,7 @@ alwaysApply: false
 | File                        | Purpose |
 |-----------------------------|---------|
 | `_contract.py`              | Adapter contract loader and capability checker |
+| `acp_channel.py`            | Adapter-side binding for the ACP event channel (#2522) |
 | `advisories.py`             | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `agy.py`                    | Antigravity CLI (``agy``) adapter |
 | `aichat.py`                 | AIChat CLI adapter |

--- a/.goosehints
+++ b/.goosehints
@@ -82,6 +82,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                        | Purpose |
 |-----------------------------|---------|
 | `_contract.py`              | Adapter contract loader and capability checker |
+| `acp_channel.py`            | Adapter-side binding for the ACP event channel (#2522) |
 | `advisories.py`             | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `agy.py`                    | Antigravity CLI (``agy``) adapter |
 | `aichat.py`                 | AIChat CLI adapter |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                        | Purpose |
 |-----------------------------|---------|
 | `_contract.py`              | Adapter contract loader and capability checker |
+| `acp_channel.py`            | Adapter-side binding for the ACP event channel (#2522) |
 | `advisories.py`             | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `agy.py`                    | Antigravity CLI (``agy``) adapter |
 | `aichat.py`                 | AIChat CLI adapter |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                        | Purpose |
 |-----------------------------|---------|
 | `_contract.py`              | Adapter contract loader and capability checker |
+| `acp_channel.py`            | Adapter-side binding for the ACP event channel (#2522) |
 | `advisories.py`             | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `agy.py`                    | Antigravity CLI (``agy``) adapter |
 | `aichat.py`                 | AIChat CLI adapter |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -82,6 +82,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | File                        | Purpose |
 |-----------------------------|---------|
 | `_contract.py`              | Adapter contract loader and capability checker |
+| `acp_channel.py`            | Adapter-side binding for the ACP event channel (#2522) |
 | `advisories.py`             | Adapter minimum-safe-version advisories (supply-chain posture) |
 | `agy.py`                    | Antigravity CLI (``agy``) adapter |
 | `aichat.py`                 | AIChat CLI adapter |

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -756,6 +756,7 @@ support modules that provide cross-cutting infrastructure:
 
 | Module | Purpose |
 |--------|---------|
+| `acp_channel` | Binds an ACP-speaking CLI's JSON-RPC lifecycle onto the content-addressed event journal (no stdout parser) |
 | `caching_adapter` | Prompt prefix deduplication and response reuse wrapper |
 | `claude_agents` | Per-task Claude Code subagent definitions for `--agents` flag |
 | `claude_exit_codes` | Maps Claude Code exit codes to Bernstein lifecycle enums |
@@ -766,6 +767,54 @@ support modules that provide cross-cutting infrastructure:
 | `plugin_sdk` | Base classes and utilities for third-party adapter plugins |
 | `registry` | Adapter discovery and registration (entry-point and runtime) |
 | `skills_injector` | Injects per-task Claude Code skills into worktrees before spawn |
+
+---
+
+## Declaring ACP as the event channel
+
+Most adapters read lifecycle signals from stdout: either the newline-delimited
+JSON of a stream-json CLI (`EventChannel.STREAM_JSON`) or the canonical
+`BERNSTEIN:<KIND>` text grammar (`EventChannel.TEXT_SIGNALS`). Both are bespoke
+parsing paths, and when an upstream CLI changes its output format the parser
+drifts. For a CLI that can speak the Agent Client Protocol, that failure class
+is avoidable: declare `EventChannel.ACP` and the adapter consumes typed
+JSON-RPC lifecycle events over the client transport with no text parser at all.
+
+**How to declare it.** Add an `EventChannel.ACP` row for the adapter in
+`STRATEGY_MATRIX` (`src/bernstein/adapters/_contract.py`):
+
+```python
+"my_agent": AdapterStrategy(event_channel=EventChannel.ACP),
+```
+
+`kilo` and `goose`, whose upstream CLIs expose ACP, ship on this channel.
+
+**What the channel does.** The upstream CLI is spawned as an ACP subprocess
+speaking line-delimited JSON-RPC. Every inbound frame is validated at the
+schema boundary (`validate_request` / `validate_response`) and journaled
+content-addressed into the run's Merkle-chained `EventJournal`: each event row
+carries the SHA-256 of its canonical bytes. The lifecycle is driven from the
+structured `stopReason` in the prompt response, never from stdout text, so an
+upstream output-format change cannot drift it.
+
+Because every event is content-addressed:
+
+- Replaying a recorded ACP session yields byte-identical journal payload
+  hashes, so the run's replay identity covers the agent's output.
+- A mutated recorded event surfaces as a hash divergence naming the exact step
+  (`compare_acp_journals`), rather than a silent drift a re-parse would miss.
+
+**Conformance.** For an ACP adapter, lifecycle conformance is an event-schema
+fixture (a recorded JSON-RPC frame sequence under
+`tests/fixtures/acp/lifecycle/*.jsonl`) replayed through the same validated,
+content-addressed transport the adapter uses at runtime, replacing the pinned
+stdout golden transcript. See `replay_acp_event_fixture` in
+`bernstein.adapters.conformance`.
+
+The helper surface lives in `bernstein.adapters.acp_channel`
+(`run_acp_channel`, `adapter_speaks_acp`) and the transport core in
+`bernstein.core.protocols.acp.client`. The client-side ACP role is documented
+next to `acp serve` in [interop/acp.md](../interop/acp.md).
 
 ---
 

--- a/docs/interop/acp.md
+++ b/docs/interop/acp.md
@@ -1,0 +1,94 @@
+# ACP: server and client roles
+
+Bernstein speaks the [Agent Client Protocol](https://agentclientprotocol.org),
+an open JSON-RPC 2.0 specification, in **both directions**.
+
+| Role | Command / surface | Direction | What it does |
+|------|-------------------|-----------|--------------|
+| Server | `bernstein acp serve` | IDE -> Bernstein | Exposes Bernstein as an ACP backend so an editor can drive it. See [ACP bridge](../reference/acp-bridge.md). |
+| Client | `EventChannel.ACP` adapter | upstream CLI -> Bernstein | Consumes ACP from an upstream CLI as a first-class adapter event transport. |
+
+The server role has always existed. This page documents the **client** role:
+Bernstein consuming ACP from an upstream CLI, so an adapter receives typed
+lifecycle events with no bespoke stdout parser.
+
+---
+
+## Why a client-side transport
+
+Most adapters read lifecycle signals from stdout, either a stream-json dialect
+or the canonical `BERNSTEIN:<KIND>` text grammar. Each is a bespoke parsing
+path, and each is pinned by golden transcripts that pin text an upstream CLI
+never promised to keep stable. When the CLI changes its output format the
+parser drifts, which is the leading cause of adapter breakage.
+
+For a CLI that can speak ACP, that failure class is avoidable. The adapter
+declares `EventChannel.ACP` and Bernstein reads typed JSON-RPC lifecycle events
+directly, with no text parser in the path.
+
+---
+
+## How it works
+
+The upstream CLI is the ACP *agent*; Bernstein is the *client*. Bernstein
+sends `initialize` and `prompt`; the agent replies with a response and streams
+`streamUpdate` notifications until the `prompt` response carries a terminal
+`stopReason`.
+
+1. **Spawn.** The CLI is launched as a subprocess speaking line-delimited
+   JSON-RPC on stdout (`bernstein.adapters.acp_channel.spawn_acp_subprocess`).
+2. **Validate.** Every inbound frame passes through the same schema validators
+   the server uses (`validate_request` / `validate_response` in
+   `bernstein.core.protocols.acp.schema`). A malformed frame is refused at the
+   boundary with a typed `ACPSchemaError` and journals nothing.
+3. **Journal, content-addressed.** Each validated event lands in the run's
+   Merkle-chained `EventJournal` with the SHA-256 of its canonical bytes
+   (`bernstein.core.protocols.acp.client.ACPEventJournalSink`).
+4. **Terminal.** The lifecycle ends on the structured `stopReason`, never on
+   stdout text.
+
+---
+
+## Replay stability
+
+Because every event is content-addressed, the run's replay identity covers the
+agent's output:
+
+- **Byte-identical replay.** Two faithful replays of a recorded ACP session
+  produce identical per-step content hashes and chain to the same Merkle head
+  (`replay_acp_content_hashes`).
+- **Named divergence.** A mutated recorded event surfaces as a hash divergence
+  naming the exact step (`compare_acp_journals`), rather than a silent drift a
+  re-parse would miss.
+
+This is the load-bearing difference from an ordinary parser swap: strip the
+content-addressed journal and the guarantee is gone. An upstream release that
+changes only human-readable text inside a `streamUpdate` delta leaves the
+structured lifecycle - and therefore the replay - unchanged.
+
+---
+
+## Conformance
+
+For an ACP adapter, lifecycle conformance is an **event-schema fixture**: a
+recorded JSON-RPC frame sequence under `tests/fixtures/acp/lifecycle/*.jsonl`,
+replayed through the same validated, content-addressed transport the adapter
+uses at runtime (`replay_acp_event_fixture` in
+`bernstein.adapters.conformance`). This replaces the pinned stdout golden
+transcript, shrinking the conformance surface to frames the protocol actually
+defines.
+
+---
+
+## Declaring an adapter on the ACP channel
+
+Add an `EventChannel.ACP` row in `STRATEGY_MATRIX`
+(`src/bernstein/adapters/_contract.py`):
+
+```python
+"my_agent": AdapterStrategy(event_channel=EventChannel.ACP),
+```
+
+`kilo` and `goose`, whose upstream CLIs expose ACP, ship on this channel. See
+the [Adapter Guide](../adapters/ADAPTER_GUIDE.md#declaring-acp-as-the-event-channel)
+for the full walkthrough.

--- a/src/bernstein/adapters/_contract.py
+++ b/src/bernstein/adapters/_contract.py
@@ -509,6 +509,10 @@ class EventChannel(StrEnum):
     TEXT_SIGNALS = "text-signals"
     #: Upstream fires hooks/callbacks Bernstein registers against.
     HOOKS = "hooks"
+    #: Upstream speaks the Agent Client Protocol; Bernstein consumes typed
+    #: JSON-RPC lifecycle events over the stdio client transport and journals
+    #: each event content-addressed. No stdout text parser at all.
+    ACP = "acp"
     #: No structured channel; Bernstein polls a PTY/log for liveness.
     POLL_PTY = "poll-pty"
     #: No event channel at all (process-exit detection only).
@@ -632,12 +636,18 @@ STRATEGY_MATRIX: dict[str, AdapterStrategy] = {
     "droid": AdapterStrategy(),
     "forge": AdapterStrategy(),
     "generic": AdapterStrategy(),
-    "goose": AdapterStrategy(),
+    # Goose speaks ACP natively; Bernstein consumes its lifecycle over the
+    # JSON-RPC client transport and journals each event content-addressed,
+    # so its stdout lifecycle parser is bypassed.
+    "goose": AdapterStrategy(event_channel=EventChannel.ACP),
     "gptme": AdapterStrategy(),
     "hermes": AdapterStrategy(),
     "iac": AdapterStrategy(),
     "junie": AdapterStrategy(),
-    "kilo": AdapterStrategy(),
+    # Kilo documents native ACP support; it declares the ACP event channel so
+    # lifecycle events arrive as schema-validated JSON-RPC frames rather than
+    # a bespoke stdout parser.
+    "kilo": AdapterStrategy(event_channel=EventChannel.ACP),
     "kiro": AdapterStrategy(),
     "mistral": AdapterStrategy(),
     "mock": AdapterStrategy(),

--- a/src/bernstein/adapters/acp_channel.py
+++ b/src/bernstein/adapters/acp_channel.py
@@ -1,0 +1,145 @@
+"""Adapter-side binding for the ACP event channel (#2522).
+
+An adapter whose upstream CLI speaks the Agent Client Protocol declares
+:attr:`bernstein.adapters._contract.EventChannel.ACP`. Instead of tailing
+stdout for a bespoke ``BERNSTEIN:`` text grammar or a per-CLI JSON dialect,
+it binds the upstream process's line-delimited JSON-RPC stream onto the
+content-addressed client transport in
+:mod:`bernstein.core.protocols.acp.client`.
+
+The lifecycle is driven entirely from structured, schema-validated frames:
+there is no text parser in this path, so an upstream output-format change
+cannot drift it. Every inbound event is journaled content-addressed, so the
+run's replay identity covers the agent's output.
+
+This module is a shared helper (like :mod:`bernstein.adapters.base`), not a
+per-CLI adapter, so it sits outside the adapters-independence contract and
+may be imported by any adapter that declares the ACP channel.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from bernstein.adapters._contract import EventChannel, strategy_for
+from bernstein.core.protocols.acp.client import (
+    ACPEventJournalSink,
+    AcpLifecycleResult,
+    drive_acp_lifecycle,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+    from pathlib import Path
+
+    from bernstein.core.replay.journal import EventJournal
+
+__all__ = [
+    "AcpLifecycleResult",
+    "adapter_speaks_acp",
+    "iter_process_frames",
+    "run_acp_channel",
+]
+
+
+def adapter_speaks_acp(adapter_name: str) -> bool:
+    """Return whether *adapter_name* declares the ACP event channel.
+
+    Accepts either a registry key (``"kilo"``) or the session-namespace
+    form; resolution goes through :func:`strategy_for`, so an undeclared
+    adapter answers ``False`` (its conservative default channel is text
+    signals).
+    """
+    return strategy_for(adapter_name).event_channel is EventChannel.ACP
+
+
+def run_acp_channel(
+    inbound: Iterable[bytes | str],
+    *,
+    journal: EventJournal,
+    session_id: str,
+    stop_at_terminal: bool = True,
+) -> AcpLifecycleResult:
+    """Drive an ACP-speaking adapter's lifecycle from an inbound frame stream.
+
+    Binds the upstream agent's JSON-RPC frames onto the content-addressed
+    journal and returns a lifecycle result the monitoring layer can map onto
+    a terminal state - with zero stdout/stderr lifecycle parsing.
+
+    Args:
+        inbound: The upstream agent's stdout as raw JSON-RPC frame lines
+            (for a live process, :func:`iter_process_frames`).
+        journal: The run's event journal; every inbound ACP event is
+            recorded content-addressed.
+        session_id: The adapter session id, retained for symmetry with the
+            text-signal monitoring surface and for future correlation.
+        stop_at_terminal: Stop after the first terminal ACP event.
+
+    Returns:
+        An :class:`AcpLifecycleResult`.
+
+    Raises:
+        ACPSchemaError: An inbound frame failed schema validation. The
+            malformed frame is refused at the boundary and journals nothing.
+    """
+    del session_id  # retained for API symmetry; journal already namespaces the run
+    sink = ACPEventJournalSink(journal)
+    return drive_acp_lifecycle(inbound, sink, stop_at_terminal=stop_at_terminal)
+
+
+def iter_process_frames(proc: subprocess.Popen[bytes]) -> Iterator[bytes]:
+    """Yield line-delimited JSON-RPC frames from a live ACP subprocess.
+
+    The upstream CLI is spawned with ``stdout=PIPE`` and speaks
+    line-delimited JSON-RPC (one frame per line). This generator yields each
+    line as it arrives so :func:`run_acp_channel` can validate and journal it
+    incrementally.
+
+    Args:
+        proc: A :class:`subprocess.Popen` opened in binary mode with a piped
+            stdout.
+
+    Yields:
+        Each non-empty stdout line, including its trailing newline.
+    """
+    if proc.stdout is None:  # pragma: no cover - defensive
+        return
+    for line in proc.stdout:
+        if line.strip():
+            yield line
+
+
+def spawn_acp_subprocess(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    log_path: Path,
+) -> subprocess.Popen[bytes]:
+    """Spawn an upstream CLI as an ACP subprocess with a piped JSON-RPC stdout.
+
+    The process's stdout is a pipe (line-delimited JSON-RPC frames the client
+    transport reads); stderr is redirected to *log_path* for operator
+    diagnostics. The caller owns draining stdout via
+    :func:`iter_process_frames` and reaping the process.
+
+    Args:
+        cmd: The upstream CLI invocation (already wrapped as needed).
+        cwd: Working directory for the process.
+        env: The filtered environment for the process.
+        log_path: File to capture the process's stderr into.
+
+    Returns:
+        The spawned :class:`subprocess.Popen`.
+    """
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    stderr_file = log_path.open("wb")
+    return subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=stderr_file,
+        start_new_session=True,
+    )

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -281,6 +281,59 @@ def check_terminal_signal(stdout_lines: list[str], *, run_id: str) -> MissingTer
 
 
 # ---------------------------------------------------------------------------
+# ACP lifecycle conformance (event-schema fixtures)
+# ---------------------------------------------------------------------------
+#
+# For adapters that declare EventChannel.ACP, lifecycle conformance is an
+# event-schema fixture - a recorded sequence of JSON-RPC frames - rather than
+# a pinned stdout golden transcript. The frames are replayed through the same
+# schema-validated, content-addressed client transport an ACP adapter uses at
+# runtime, so the fixture proves the exact ingress path the adapter relies on
+# and shrinks the conformance surface: no text transcript the upstream CLI
+# never promised to keep stable.
+
+
+def load_acp_event_fixture(path: Path) -> list[bytes]:
+    """Load an ACP lifecycle fixture as a list of raw JSON-RPC frame lines.
+
+    Args:
+        path: Path to a ``*.jsonl`` fixture, one JSON-RPC frame per line.
+
+    Returns:
+        The non-empty lines as UTF-8 bytes (trailing newline included), ready
+        to feed to :func:`bernstein.core.protocols.acp.client.drive_acp_lifecycle`.
+    """
+    lines: list[bytes] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if raw.strip():
+            lines.append((raw + "\n").encode("utf-8"))
+    return lines
+
+
+def replay_acp_event_fixture(path: Path, *, sdd_dir: Path) -> Any:
+    """Replay an ACP lifecycle fixture through the content-addressed transport.
+
+    Validates every frame at the schema boundary and journals each event
+    content-addressed into a fresh run journal under *sdd_dir*, then returns
+    the lifecycle result. A malformed frame raises ``ACPSchemaError`` (the
+    conformance failure mode for an ACP adapter), mirroring runtime ingress.
+
+    Args:
+        path: Path to a ``*.jsonl`` event-schema fixture.
+        sdd_dir: Directory to anchor the throwaway run journal under.
+
+    Returns:
+        A :class:`bernstein.core.protocols.acp.client.AcpLifecycleResult`.
+    """
+    from bernstein.core.protocols.acp.client import ACPEventJournalSink, drive_acp_lifecycle
+    from bernstein.core.replay.journal import EventJournal
+
+    journal = EventJournal(f"acp-conf-{path.stem}", sdd_dir)
+    sink = ACPEventJournalSink(journal)
+    return drive_acp_lifecycle(load_acp_event_fixture(path), sink)
+
+
+# ---------------------------------------------------------------------------
 # Transcript loader
 # ---------------------------------------------------------------------------
 

--- a/src/bernstein/core/protocols/acp/__init__.py
+++ b/src/bernstein/core/protocols/acp/__init__.py
@@ -56,6 +56,20 @@ if _legacy_path.exists():
         ACPRun = _legacy_module.ACPRun
         ACPRunStatus = _legacy_module.ACPRunStatus
 
+from bernstein.core.protocols.acp.client import (  # noqa: E402 - legacy shim runs first
+    ACP_EVENT_TYPE,
+    AcpDivergence,
+    ACPEvent,
+    ACPEventJournalSink,
+    AcpLifecycleResult,
+    canonical_frame_bytes,
+    compare_acp_journals,
+    drive_acp_lifecycle,
+    frame_content_hash,
+    is_terminal_frame,
+    parse_inbound_frame,
+    replay_acp_content_hashes,
+)
 from bernstein.core.protocols.acp.handlers import (  # noqa: E402 - legacy shim runs first
     ACPHandlerRegistry,
     ACPRequestContext,
@@ -90,6 +104,9 @@ from bernstein.core.protocols.acp.transport import (  # noqa: E402
 )
 
 __all__ = [
+    "ACP_EVENT_TYPE",
+    "ACPEvent",
+    "ACPEventJournalSink",
     "ACPHandler",
     "ACPHandlerRegistry",
     "ACPRequestContext",
@@ -99,6 +116,8 @@ __all__ = [
     "ACPServer",
     "ACPSession",
     "ACPSessionStore",
+    "AcpDivergence",
+    "AcpLifecycleResult",
     "AdapterDescriptor",
     "HttpAcpTransport",
     "JsonRpcFraming",
@@ -110,7 +129,14 @@ __all__ = [
     "acp_active_sessions",
     "acp_messages_total",
     "build_default_server",
+    "canonical_frame_bytes",
+    "compare_acp_journals",
+    "drive_acp_lifecycle",
+    "frame_content_hash",
+    "is_terminal_frame",
+    "parse_inbound_frame",
     "record_acp_message",
+    "replay_acp_content_hashes",
     "validate_request",
     "validate_response",
 ]

--- a/src/bernstein/core/protocols/acp/client.py
+++ b/src/bernstein/core/protocols/acp/client.py
@@ -1,0 +1,390 @@
+"""Client-side ACP transport with content-addressed event journaling.
+
+Bernstein historically only *served* ACP: ``bernstein acp serve`` exposes
+Bernstein to IDEs. This module is the inverse direction - Bernstein as an
+ACP *client*, consuming ACP from an upstream CLI that speaks the protocol,
+so an adapter can receive typed lifecycle events with no bespoke stdout
+parser at all.
+
+Two properties make this a first-class transport rather than a parser
+swap:
+
+* **Schema-bounded ingress.** Every inbound frame is validated through
+  the same :func:`bernstein.core.protocols.acp.schema.validate_request` /
+  :func:`~bernstein.core.protocols.acp.schema.validate_response` paths the
+  server uses. A malformed frame is refused with a typed
+  :class:`ACPSchemaError` at the boundary and produces no partial journal
+  state.
+
+* **Content-addressed journaling.** Each validated event lands in the
+  Merkle-chained :class:`~bernstein.core.replay.journal.EventJournal` with
+  the SHA-256 of its canonical bytes. Replay reasons about event content
+  hashes, so agent output is replay-stable across upstream CLI
+  output-format changes: two byte-identical recorded sessions chain to the
+  same head, and a single mutated event surfaces as a hash divergence at a
+  precise step index. Strip the journal and the feature collapses into an
+  ordinary parser - which is exactly why it is not one.
+
+The direction of travel here is agent -> client: the upstream CLI is the
+ACP *agent* and Bernstein is the *client*. Bernstein sends ``initialize``
+and ``prompt``; the agent replies with responses and streams
+``streamUpdate`` notifications until the ``prompt`` response carries a
+terminal ``stopReason``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.protocols.acp.schema import (
+    INVALID_REQUEST,
+    ACPSchemaError,
+    validate_request,
+    validate_response,
+)
+from bernstein.core.protocols.acp.transport import JsonRpcFraming
+from bernstein.core.replay.journal import load_events
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from bernstein.core.replay.journal import EventJournal
+
+#: Journal event type recorded for every inbound ACP frame. Folding ACP
+#: events into the run's Merkle chain means replaying a session with a
+#: mutated event surfaces as hash divergence at a precise step index rather
+#: than a silent drift.
+ACP_EVENT_TYPE = "acp_event"
+
+
+# ---------------------------------------------------------------------------
+# Content addressing
+# ---------------------------------------------------------------------------
+
+
+def canonical_frame_bytes(frame: dict[str, Any]) -> bytes:
+    """Return the canonical byte serialisation of an ACP frame.
+
+    Keys are sorted and separators are compact, so two frames that differ
+    only in key order or incidental whitespace serialise to byte-identical
+    output. This canonical form is the pre-image of :func:`frame_content_hash`.
+    """
+    return json.dumps(frame, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+
+
+def frame_content_hash(frame: dict[str, Any]) -> str:
+    """Return the SHA-256 hex digest of an ACP frame's canonical bytes."""
+    return hashlib.sha256(canonical_frame_bytes(frame)).hexdigest()
+
+
+def is_terminal_frame(frame: dict[str, Any]) -> tuple[bool, str]:
+    """Classify whether *frame* ends the ACP prompt turn.
+
+    The turn ends when the agent returns the ``prompt`` response: a JSON-RPC
+    result carrying a non-empty ``stopReason`` (normal end) or a JSON-RPC
+    error envelope (failed turn). ``streamUpdate`` notifications are never
+    terminal on their own.
+
+    Returns:
+        ``(terminal, stop_reason)``. ``stop_reason`` is the reported reason
+        for a result, ``"error"`` for an error envelope, or ``""`` when the
+        frame is not terminal.
+    """
+    if "error" in frame:
+        return True, "error"
+    result = frame.get("result")
+    if isinstance(result, dict):
+        stop_reason = result.get("stopReason")
+        if isinstance(stop_reason, str) and stop_reason:
+            return True, stop_reason
+    return False, ""
+
+
+# ---------------------------------------------------------------------------
+# Typed inbound event
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ACPEvent:
+    """One validated inbound ACP frame.
+
+    Attributes:
+        seq: Zero-based position of this frame in the inbound stream.
+        kind: ``"notification"`` for a fire-and-forget method,
+            ``"request"`` for a method that carries an id, ``"response"``
+            for a JSON-RPC result, or ``"error"`` for a JSON-RPC error.
+        method: The ACP method name for request/notification frames, or
+            ``None`` for response/error frames.
+        frame: The decoded, already-validated frame.
+        content_hash: SHA-256 of :func:`canonical_frame_bytes` over ``frame``.
+        terminal: Whether this event ends the prompt turn.
+        stop_reason: The terminal stop reason, or ``""``.
+    """
+
+    seq: int
+    kind: str
+    method: str | None
+    frame: dict[str, Any]
+    content_hash: str
+    terminal: bool
+    stop_reason: str
+
+
+def parse_inbound_frame(raw: bytes | str, *, seq: int) -> ACPEvent:
+    """Validate one inbound ACP frame and return a typed :class:`ACPEvent`.
+
+    Reuses the server's framing and schema validators so the client and
+    server share exactly one definition of a well-formed ACP frame.
+
+    Args:
+        raw: A single line of the upstream agent's stdout (JSON-RPC frame).
+        seq: The frame's zero-based position in the inbound stream.
+
+    Returns:
+        A validated :class:`ACPEvent`.
+
+    Raises:
+        ACPSchemaError: The frame is oversized, not valid JSON, or fails
+            request/response schema validation. The frame is refused at the
+            boundary; the caller journals nothing for it.
+    """
+    decoded = JsonRpcFraming.parse(raw)
+    if not isinstance(decoded, dict):
+        raise ACPSchemaError(INVALID_REQUEST, "frame must be a JSON object")
+
+    if "method" in decoded:
+        parsed = validate_request(decoded)
+        kind = "notification" if parsed.is_notification else "request"
+        method: str | None = parsed.method
+    elif "result" in decoded or "error" in decoded:
+        validate_response(decoded)
+        kind = "error" if "error" in decoded else "response"
+        method = None
+    else:
+        raise ACPSchemaError(INVALID_REQUEST, "frame is neither a JSON-RPC request nor a response")
+
+    terminal, stop_reason = is_terminal_frame(decoded)
+    return ACPEvent(
+        seq=seq,
+        kind=kind,
+        method=method,
+        frame=decoded,
+        content_hash=frame_content_hash(decoded),
+        terminal=terminal,
+        stop_reason=stop_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Content-addressed journal sink
+# ---------------------------------------------------------------------------
+
+
+class ACPEventJournalSink:
+    """Records validated ACP events into a run journal, content-addressed.
+
+    Each event is one Merkle-chained journal row whose payload carries the
+    event's ``content_hash`` and its canonical frame. Because the journal
+    excludes only wall-clock fields from its payload hash, two byte-identical
+    recorded sessions produce identical per-step payload hashes and chain to
+    the same head.
+
+    The sink never writes a partial row: the caller validates a frame (which
+    may raise :class:`ACPSchemaError`) *before* handing the resulting
+    :class:`ACPEvent` here, so a refused frame leaves the journal untouched.
+    """
+
+    def __init__(self, journal: EventJournal) -> None:
+        self._journal = journal
+
+    @property
+    def journal(self) -> EventJournal:
+        """The underlying run journal."""
+        return self._journal
+
+    def record(self, event: ACPEvent) -> None:
+        """Append one validated ACP event to the journal, content-addressed."""
+        self._journal.record(
+            ACP_EVENT_TYPE,
+            acp_seq=event.seq,
+            acp_kind=event.kind,
+            acp_method=event.method,
+            content_hash=event.content_hash,
+            terminal=event.terminal,
+            stop_reason=event.stop_reason,
+            frame=event.frame,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle driver
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AcpLifecycleResult:
+    """Outcome of driving an ACP session to its terminal event.
+
+    Attributes:
+        ok: ``True`` when the session reached a non-error terminal event.
+        terminal: Whether a terminal event was observed at all.
+        stop_reason: The terminal stop reason (``""`` if none was seen).
+        event_count: Number of events validated and journaled.
+        journal_head: The Merkle head hash after journaling every event.
+        events: The ordered validated events.
+    """
+
+    ok: bool
+    terminal: bool
+    stop_reason: str
+    event_count: int
+    journal_head: str
+    events: tuple[ACPEvent, ...] = field(default_factory=tuple)
+
+
+def drive_acp_lifecycle(
+    inbound: Iterable[bytes | str],
+    sink: ACPEventJournalSink,
+    *,
+    stop_at_terminal: bool = True,
+) -> AcpLifecycleResult:
+    """Validate and journal an inbound ACP stream up to its terminal event.
+
+    Args:
+        inbound: An iterable of raw inbound frames (the upstream agent's
+            stdout lines). Blank lines are skipped.
+        sink: The content-addressed journal sink to record events into.
+        stop_at_terminal: When ``True`` (default) the driver stops after the
+            first terminal event, mirroring an ACP prompt turn; trailing
+            frames are ignored and not journaled.
+
+    Returns:
+        An :class:`AcpLifecycleResult`.
+
+    Raises:
+        ACPSchemaError: An inbound frame failed validation. Events already
+            journaled before the offending frame remain; the malformed frame
+            itself writes nothing (no partial state for that frame).
+    """
+    events: list[ACPEvent] = []
+    terminal = False
+    stop_reason = ""
+    seq = 0
+    for raw in inbound:
+        if isinstance(raw, bytes):
+            if not raw.strip():
+                continue
+        elif not raw.strip():
+            continue
+        event = parse_inbound_frame(raw, seq=seq)
+        sink.record(event)
+        events.append(event)
+        seq += 1
+        if event.terminal:
+            terminal = True
+            stop_reason = event.stop_reason
+            if stop_at_terminal:
+                break
+
+    ok = terminal and stop_reason != "error"
+    return AcpLifecycleResult(
+        ok=ok,
+        terminal=terminal,
+        stop_reason=stop_reason,
+        event_count=len(events),
+        journal_head=sink.journal.head(),
+        events=tuple(events),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Replay + divergence detection over content hashes
+# ---------------------------------------------------------------------------
+
+
+def replay_acp_content_hashes(journal_path: Path) -> list[tuple[int, str]]:
+    """Return ``(acp_seq, content_hash)`` for every ACP event in a journal.
+
+    The ordered content hashes are the replay-stable identity of an ACP
+    session: two faithful replays of the same recorded frames yield equal
+    lists.
+    """
+    out: list[tuple[int, str]] = []
+    for row in load_events(journal_path):
+        if row.get("event") != ACP_EVENT_TYPE:
+            continue
+        seq = int(row.get("acp_seq", len(out)))
+        content_hash = str(row.get("content_hash", ""))
+        out.append((seq, content_hash))
+    return out
+
+
+@dataclass(frozen=True)
+class AcpDivergence:
+    """The first step at which two ACP journals disagree by content hash.
+
+    Attributes:
+        seq: The ``acp_seq`` of the diverging event.
+        method: The ACP method of the expected event (``None`` for a
+            response/error), for a human-readable step name.
+        expected_hash: The content hash recorded in the expected journal.
+        actual_hash: The content hash recorded in the replayed journal.
+    """
+
+    seq: int
+    method: str | None
+    expected_hash: str
+    actual_hash: str
+
+
+def _acp_rows(journal_path: Path) -> list[dict[str, Any]]:
+    return [row for row in load_events(journal_path) if row.get("event") == ACP_EVENT_TYPE]
+
+
+def compare_acp_journals(expected_path: Path, actual_path: Path) -> AcpDivergence | None:
+    """Compare two ACP journals step by step and report the first divergence.
+
+    Args:
+        expected_path: The recorded (reference) journal.
+        actual_path: The replayed journal.
+
+    Returns:
+        ``None`` when every ACP event's content hash matches in order (a
+        faithful replay), otherwise an :class:`AcpDivergence` naming the
+        exact step. A length mismatch is reported at the first missing step.
+    """
+    expected = _acp_rows(expected_path)
+    actual = _acp_rows(actual_path)
+    for i in range(max(len(expected), len(actual))):
+        exp_hash = str(expected[i]["content_hash"]) if i < len(expected) else ""
+        act_hash = str(actual[i]["content_hash"]) if i < len(actual) else ""
+        if exp_hash != act_hash:
+            ref = expected[i] if i < len(expected) else actual[i]
+            return AcpDivergence(
+                seq=int(ref.get("acp_seq", i)),
+                method=ref.get("acp_method"),
+                expected_hash=exp_hash,
+                actual_hash=act_hash,
+            )
+    return None
+
+
+__all__ = [
+    "ACP_EVENT_TYPE",
+    "ACPEvent",
+    "ACPEventJournalSink",
+    "AcpDivergence",
+    "AcpLifecycleResult",
+    "canonical_frame_bytes",
+    "compare_acp_journals",
+    "drive_acp_lifecycle",
+    "frame_content_hash",
+    "is_terminal_frame",
+    "parse_inbound_frame",
+    "replay_acp_content_hashes",
+]

--- a/tests/fixtures/acp/lifecycle/simple_task.jsonl
+++ b/tests/fixtures/acp/lifecycle/simple_task.jsonl
@@ -1,0 +1,4 @@
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-04-01","agentCapabilities":{}}}
+{"jsonrpc":"2.0","method":"streamUpdate","params":{"sessionId":"s-simple","delta":{"text":"reading the task"}}}
+{"jsonrpc":"2.0","method":"streamUpdate","params":{"sessionId":"s-simple","delta":{"text":"applying the patch"}}}
+{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}

--- a/tests/fixtures/acp/lifecycle/tool_permission_cycle.jsonl
+++ b/tests/fixtures/acp/lifecycle/tool_permission_cycle.jsonl
@@ -1,0 +1,5 @@
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-04-01","agentCapabilities":{}}}
+{"jsonrpc":"2.0","method":"streamUpdate","params":{"sessionId":"s-tools","delta":{"text":"planning edits"}}}
+{"jsonrpc":"2.0","id":7,"method":"requestPermission","params":{"sessionId":"s-tools","promptId":"p-1","toolName":"write_file"}}
+{"jsonrpc":"2.0","method":"streamUpdate","params":{"sessionId":"s-tools","delta":{"text":"writing file"}}}
+{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}

--- a/tests/integration/acp/conformance/test_acp_lifecycle_conformance.py
+++ b/tests/integration/acp/conformance/test_acp_lifecycle_conformance.py
@@ -1,0 +1,111 @@
+"""ACP lifecycle conformance + the parser-drift regression (#2522).
+
+For adapters that speak ACP, lifecycle conformance is an event-schema
+fixture (a recorded JSON-RPC frame sequence) rather than a pinned stdout
+golden transcript. The regression test below is the whole point of the
+feature: an upstream output-format change breaks a text-signals fixture
+but leaves the ACP-channel path green, because the ACP path reasons about
+structured frames and content hashes, never fragile text.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.adapters.conformance import (
+    check_terminal_signal,
+    load_acp_event_fixture,
+    replay_acp_event_fixture,
+)
+from bernstein.core.protocols.acp.client import (
+    ACPEventJournalSink,
+    compare_acp_journals,
+    drive_acp_lifecycle,
+)
+from bernstein.core.replay.journal import EventJournal
+
+FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "acp" / "lifecycle"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "fixture",
+    sorted(FIXTURE_DIR.glob("*.jsonl")),
+    ids=lambda p: p.stem,
+)
+def test_acp_lifecycle_fixture_validates_and_reaches_terminal(fixture: Path, tmp_path: Path) -> None:
+    """Every shipped ACP lifecycle fixture validates and ends in a terminal."""
+    result = replay_acp_event_fixture(fixture, sdd_dir=tmp_path)
+    assert result.terminal is True, f"{fixture.name} never reached a terminal ACP event"
+    assert result.ok is True
+    assert result.event_count > 0
+    assert result.journal_head
+
+
+# ---------------------------------------------------------------------------
+# The parser-drift regression: text breaks, ACP stays green
+# ---------------------------------------------------------------------------
+
+
+def _acp_frames(*, completion_text: str) -> list[bytes]:
+    """A structured ACP lifecycle whose human text differs but stopReason does not."""
+    frames = [
+        {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-04-01"}},
+        {"jsonrpc": "2.0", "method": "streamUpdate", "params": {"sessionId": "s", "delta": {"text": completion_text}}},
+        {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}},
+    ]
+    return [(json.dumps(f) + "\n").encode("utf-8") for f in frames]
+
+
+def test_upstream_format_change_breaks_text_but_not_acp(tmp_path: Path) -> None:
+    # --- Text-signals path -------------------------------------------------
+    # v1: the CLI emits the canonical terminal signal -> text path is green.
+    text_v1 = ["thinking...", 'BERNSTEIN:COMPLETED {"ok": true}']
+    assert check_terminal_signal(text_v1, run_id="text-v1") is None
+
+    # v2: an upstream release changes the completion line format. The bespoke
+    # text parser drifts: no terminal signal is found -> the fixture breaks.
+    text_v2 = ["thinking...", ">>> task complete <<<"]
+    assert check_terminal_signal(text_v2, run_id="text-v2") is not None
+
+    # --- ACP-channel path --------------------------------------------------
+    # The same upstream release changed only the human-readable delta text;
+    # the structured stopReason is unchanged, so both versions reach terminal.
+    j1 = EventJournal("acp-v1", tmp_path)
+    r1 = drive_acp_lifecycle(_acp_frames(completion_text="done"), ACPEventJournalSink(j1))
+    j2 = EventJournal("acp-v2", tmp_path)
+    r2 = drive_acp_lifecycle(_acp_frames(completion_text="all finished, patch applied"), ACPEventJournalSink(j2))
+
+    assert r1.terminal is True and r1.stop_reason == "end_turn"
+    assert r2.terminal is True and r2.stop_reason == "end_turn"
+
+
+def test_divergence_detection_across_replays(tmp_path: Path) -> None:
+    frames = _acp_frames(completion_text="done")
+
+    recorded = EventJournal("rec", tmp_path)
+    drive_acp_lifecycle(frames, ACPEventJournalSink(recorded))
+
+    # A faithful replay diverges nowhere.
+    faithful = EventJournal("faithful", tmp_path)
+    drive_acp_lifecycle(frames, ACPEventJournalSink(faithful))
+    assert compare_acp_journals(recorded.path, faithful.path) is None
+
+    # A tampered replay is named at the exact step.
+    tampered_frames = _acp_frames(completion_text="INJECTED")
+    tampered = EventJournal("tampered", tmp_path)
+    drive_acp_lifecycle(tampered_frames, ACPEventJournalSink(tampered))
+    divergence = compare_acp_journals(recorded.path, tampered.path)
+    assert divergence is not None
+    assert divergence.seq == 1
+    assert divergence.method == "streamUpdate"
+
+
+def test_load_acp_event_fixture_reads_frames() -> None:
+    fixture = FIXTURE_DIR / "simple_task.jsonl"
+    lines = load_acp_event_fixture(fixture)
+    assert lines
+    assert all(isinstance(line, bytes) for line in lines)

--- a/tests/unit/adapters/test_acp_channel.py
+++ b/tests/unit/adapters/test_acp_channel.py
@@ -1,0 +1,94 @@
+"""ACP as a first-class adapter event transport (#2522).
+
+Adapters that declare ``EventChannel.ACP`` complete a spawn-to-terminal
+lifecycle entirely over structured JSON-RPC frames: no ``BERNSTEIN:`` text
+grammar, no per-adapter stdout parser. These tests pin the adapter-side
+binding and the strategy-matrix declarations for the migrated adapters.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.adapters._contract import EventChannel, strategy_for
+from bernstein.adapters.acp_channel import (
+    adapter_speaks_acp,
+    run_acp_channel,
+)
+from bernstein.core.protocols.acp.schema import ACPSchemaError
+from bernstein.core.replay.journal import EventJournal, load_events
+
+_SESSION: list[dict] = [
+    {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-04-01"}},
+    {"jsonrpc": "2.0", "method": "streamUpdate", "params": {"sessionId": "s", "delta": {"text": "hi"}}},
+    {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}},
+]
+
+
+def _lines(frames: list[dict]) -> list[bytes]:
+    return [(json.dumps(f) + "\n").encode("utf-8") for f in frames]
+
+
+# ---------------------------------------------------------------------------
+# Strategy-matrix declarations for the migrated adapters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["kilo", "goose"])
+def test_migrated_adapters_declare_acp_channel(name: str) -> None:
+    assert strategy_for(name).event_channel is EventChannel.ACP
+
+
+@pytest.mark.parametrize("name", ["kilo", "goose"])
+def test_adapter_speaks_acp_true_for_migrated(name: str) -> None:
+    assert adapter_speaks_acp(name) is True
+
+
+def test_adapter_speaks_acp_false_for_text_signal_adapter() -> None:
+    assert adapter_speaks_acp("aider") is False
+
+
+# ---------------------------------------------------------------------------
+# Spawn-to-terminal lifecycle with zero stdout/stderr lifecycle parsing
+# ---------------------------------------------------------------------------
+
+
+def test_run_acp_channel_reaches_terminal_without_text_parsing(tmp_path: Path) -> None:
+    journal = EventJournal("kilo-run", tmp_path)
+    result = run_acp_channel(_lines(_SESSION), journal=journal, session_id="kilo-run")
+
+    assert result.ok is True
+    assert result.terminal is True
+    assert result.stop_reason == "end_turn"
+    assert result.event_count == len(_SESSION)
+    assert result.journal_head == journal.head()
+    assert journal.verify().ok
+
+    # Lifecycle was driven purely from structured frames: no BERNSTEIN: text
+    # signal appears anywhere in the recorded session.
+    assert not any(b"BERNSTEIN:" in line for line in _lines(_SESSION))
+
+
+def test_run_acp_channel_stops_at_first_terminal(tmp_path: Path) -> None:
+    trailing = [*_SESSION, {"jsonrpc": "2.0", "method": "streamUpdate", "params": {"sessionId": "s", "delta": "late"}}]
+    journal = EventJournal("kilo-run-2", tmp_path)
+    result = run_acp_channel(_lines(trailing), journal=journal, session_id="kilo-run-2")
+    # The terminal prompt response ends the turn; the trailing frame is not journaled.
+    assert result.event_count == len(_SESSION)
+
+
+def test_malformed_frame_mid_lifecycle_is_refused(tmp_path: Path) -> None:
+    corrupt = [
+        _SESSION[0],
+    ]
+    lines = [*_lines(corrupt), b"{ this is not valid json\n"]
+    journal = EventJournal("kilo-bad", tmp_path)
+    with pytest.raises(ACPSchemaError):
+        run_acp_channel(lines, journal=journal, session_id="kilo-bad")
+    # The valid prefix is journaled; the malformed frame wrote nothing.
+    rows = [r for r in load_events(journal.path) if r.get("event") == "acp_event"]
+    assert len(rows) == 1
+    assert journal.verify().ok

--- a/tests/unit/adapters/test_capability_enums.py
+++ b/tests/unit/adapters/test_capability_enums.py
@@ -77,6 +77,7 @@ def test_dangerous_mode_strategy_parses_from_wire_value(raw: str, expected: Dang
         ("stream-json", EventChannel.STREAM_JSON),
         ("text-signals", EventChannel.TEXT_SIGNALS),
         ("hooks", EventChannel.HOOKS),
+        ("acp", EventChannel.ACP),
         ("poll-pty", EventChannel.POLL_PTY),
         ("none", EventChannel.NONE),
     ],
@@ -137,8 +138,13 @@ def test_stream_json_adapters_declared() -> None:
 
 
 def test_text_signal_default_for_plain_adapters() -> None:
-    for name in ("aider", "goose", "opencode"):
+    for name in ("aider", "droid", "opencode"):
         assert strategy_for(name).event_channel is EventChannel.TEXT_SIGNALS
+
+
+def test_acp_channel_adapters_declared() -> None:
+    for name in ("kilo", "goose"):
+        assert strategy_for(name).event_channel is EventChannel.ACP
 
 
 def test_every_registry_adapter_has_a_declaration() -> None:

--- a/tests/unit/protocols/acp/test_acp_client.py
+++ b/tests/unit/protocols/acp/test_acp_client.py
@@ -1,0 +1,210 @@
+"""Client-side ACP transport: content-addressed event journaling (#2522).
+
+Bernstein historically only *served* ACP to IDEs. These tests pin the
+inverse direction: Bernstein consuming ACP from an upstream CLI as a
+first-class adapter event transport. Every inbound frame is validated at
+the schema boundary and journaled content-addressed, so agent output is
+replay-stable across upstream CLI output-format changes.
+
+The killer property under test: the content-addressed event journal makes
+output replay-stable. Strip the journal and this is just a parser swap -
+so the divergence-by-content-hash tests below are the load-bearing ones.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.protocols.acp.client import (
+    ACP_EVENT_TYPE,
+    ACPEventJournalSink,
+    canonical_frame_bytes,
+    compare_acp_journals,
+    drive_acp_lifecycle,
+    frame_content_hash,
+    is_terminal_frame,
+    parse_inbound_frame,
+    replay_acp_content_hashes,
+)
+from bernstein.core.protocols.acp.schema import ACPSchemaError
+from bernstein.core.replay.journal import EventJournal, load_events
+
+# ---------------------------------------------------------------------------
+# A recorded upstream ACP session (agent -> client direction).
+# ---------------------------------------------------------------------------
+
+_INITIALIZE_RESPONSE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {"protocolVersion": "2025-04-01", "agentCapabilities": {}},
+}
+_STREAM_UPDATE_1 = {
+    "jsonrpc": "2.0",
+    "method": "streamUpdate",
+    "params": {"sessionId": "s-1", "delta": {"text": "reading files"}},
+}
+_STREAM_UPDATE_2 = {
+    "jsonrpc": "2.0",
+    "method": "streamUpdate",
+    "params": {"sessionId": "s-1", "delta": {"text": "writing patch"}},
+}
+_PROMPT_RESPONSE_TERMINAL = {
+    "jsonrpc": "2.0",
+    "id": 2,
+    "result": {"stopReason": "end_turn"},
+}
+
+_RECORDED_SESSION: list[dict] = [
+    _INITIALIZE_RESPONSE,
+    _STREAM_UPDATE_1,
+    _STREAM_UPDATE_2,
+    _PROMPT_RESPONSE_TERMINAL,
+]
+
+
+def _lines(frames: list[dict]) -> list[bytes]:
+    return [(json.dumps(f) + "\n").encode("utf-8") for f in frames]
+
+
+# ---------------------------------------------------------------------------
+# Content addressing
+# ---------------------------------------------------------------------------
+
+
+def test_content_hash_is_canonical_and_key_order_independent() -> None:
+    a = {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}}
+    b = {"result": {"stopReason": "end_turn"}, "id": 2, "jsonrpc": "2.0"}
+    assert frame_content_hash(a) == frame_content_hash(b)
+    # Canonical bytes are sorted + compact, so byte identity holds too.
+    assert canonical_frame_bytes(a) == canonical_frame_bytes(b)
+
+
+def test_content_hash_changes_when_payload_changes() -> None:
+    a = {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}}
+    b = {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "max_tokens"}}
+    assert frame_content_hash(a) != frame_content_hash(b)
+
+
+# ---------------------------------------------------------------------------
+# Schema-boundary validation (reuses validate_request / validate_response)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_inbound_streamupdate_is_non_terminal_event() -> None:
+    event = parse_inbound_frame(json.dumps(_STREAM_UPDATE_1), seq=0)
+    assert event.method == "streamUpdate"
+    assert event.terminal is False
+    assert event.content_hash == frame_content_hash(_STREAM_UPDATE_1)
+
+
+def test_parse_inbound_prompt_response_is_terminal() -> None:
+    event = parse_inbound_frame(json.dumps(_PROMPT_RESPONSE_TERMINAL), seq=3)
+    assert event.terminal is True
+    assert event.stop_reason == "end_turn"
+
+
+def test_parse_inbound_error_response_is_terminal() -> None:
+    frame = {"jsonrpc": "2.0", "id": 2, "error": {"code": -32001, "message": "boom"}}
+    event = parse_inbound_frame(json.dumps(frame), seq=1)
+    assert event.terminal is True
+    assert event.stop_reason == "error"
+
+
+def test_is_terminal_frame_helper() -> None:
+    assert is_terminal_frame(_PROMPT_RESPONSE_TERMINAL) == (True, "end_turn")
+    assert is_terminal_frame(_STREAM_UPDATE_1) == (False, "")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"not json at all\n",
+        json.dumps({"jsonrpc": "1.0", "method": "streamUpdate", "params": {}}).encode(),
+        json.dumps({"jsonrpc": "2.0", "method": "streamUpdate", "params": {"delta": "x"}}).encode(),
+        json.dumps({"jsonrpc": "2.0", "id": 5}).encode(),  # neither request nor response
+    ],
+)
+def test_malformed_frame_refused_at_schema_boundary(raw: bytes) -> None:
+    with pytest.raises(ACPSchemaError):
+        parse_inbound_frame(raw, seq=0)
+
+
+# ---------------------------------------------------------------------------
+# Journaling: content-addressed, no partial state on malformed frames
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_frame_produces_no_journal_row(tmp_path: Path) -> None:
+    journal = EventJournal("run-malformed", tmp_path)
+    sink = ACPEventJournalSink(journal)
+    # One valid frame lands, then a malformed frame is refused.
+    sink.record(parse_inbound_frame(json.dumps(_STREAM_UPDATE_1), seq=0))
+    with pytest.raises(ACPSchemaError):
+        sink.record(parse_inbound_frame(b"{bad json", seq=1))
+    rows = [r for r in load_events(journal.path) if r.get("event") == ACP_EVENT_TYPE]
+    # Exactly the single valid event; the malformed frame wrote nothing.
+    assert len(rows) == 1
+    assert journal.verify().ok
+
+
+def test_drive_lifecycle_journals_every_event_content_addressed(tmp_path: Path) -> None:
+    journal = EventJournal("run-lifecycle", tmp_path)
+    sink = ACPEventJournalSink(journal)
+    result = drive_acp_lifecycle(_lines(_RECORDED_SESSION), sink)
+
+    assert result.ok is True
+    assert result.terminal is True
+    assert result.stop_reason == "end_turn"
+    assert result.event_count == len(_RECORDED_SESSION)
+    assert result.journal_head == journal.head()
+    assert journal.verify().ok
+
+    rows = [r for r in load_events(journal.path) if r.get("event") == ACP_EVENT_TYPE]
+    assert len(rows) == len(_RECORDED_SESSION)
+    for row, frame in zip(rows, _RECORDED_SESSION, strict=True):
+        assert row["content_hash"] == frame_content_hash(frame)
+
+
+# ---------------------------------------------------------------------------
+# Determinism: byte-identical replay + divergence naming the step
+# ---------------------------------------------------------------------------
+
+
+def test_replay_yields_byte_identical_journal_hashes(tmp_path: Path) -> None:
+    j1 = EventJournal("run-a", tmp_path)
+    drive_acp_lifecycle(_lines(_RECORDED_SESSION), ACPEventJournalSink(j1))
+
+    j2 = EventJournal("run-b", tmp_path)
+    drive_acp_lifecycle(_lines(_RECORDED_SESSION), ACPEventJournalSink(j2))
+
+    # Same recorded session -> same content hashes per step -> same Merkle head.
+    assert replay_acp_content_hashes(j1.path) == replay_acp_content_hashes(j2.path)
+    assert j1.head() == j2.head()
+    # No divergence between the two faithful replays.
+    assert compare_acp_journals(j1.path, j2.path) is None
+
+
+def test_mutated_recorded_event_reported_as_divergence_naming_step(tmp_path: Path) -> None:
+    recorded = EventJournal("run-recorded", tmp_path)
+    drive_acp_lifecycle(_lines(_RECORDED_SESSION), ACPEventJournalSink(recorded))
+
+    # Upstream mutates one event's payload (index 2: second streamUpdate).
+    mutated_session = [dict(f) for f in _RECORDED_SESSION]
+    mutated_session[2] = {
+        "jsonrpc": "2.0",
+        "method": "streamUpdate",
+        "params": {"sessionId": "s-1", "delta": {"text": "TAMPERED"}},
+    }
+    replayed = EventJournal("run-replayed", tmp_path)
+    drive_acp_lifecycle(_lines(mutated_session), ACPEventJournalSink(replayed))
+
+    divergence = compare_acp_journals(recorded.path, replayed.path)
+    assert divergence is not None
+    assert divergence.seq == 2
+    assert divergence.method == "streamUpdate"
+    assert divergence.expected_hash != divergence.actual_hash
+    # The content hash is what caught it - re-parsing text could not.
+    assert divergence.expected_hash == frame_content_hash(_RECORDED_SESSION[2])


### PR DESCRIPTION
## What

Promotes the Agent Client Protocol from an IDE-facing side surface to a first-class adapter event transport. Adapters whose upstream CLI speaks ACP declare `EventChannel.ACP` and receive typed JSON-RPC lifecycle events over a client-side stdio transport, with no bespoke stdout parser.

Every inbound ACP event is validated at the schema boundary and journaled content-addressed into the run's Merkle-chained `EventJournal`. Replay and divergence detection operate on event content hashes, so agent output is replay-stable across upstream CLI output-format changes. Strip the journal and this collapses into an ordinary parser swap, which is exactly why it is not one.

## Changes

- `core/protocols/acp/client.py`: schema-bounded ingress (reuses `validate_request` / `validate_response` and the existing error framing) plus content-addressed journaling. Byte-identical replay (`replay_acp_content_hashes`) and step-named divergence detection (`compare_acp_journals`) over event content hashes.
- `adapters/acp_channel.py`: binds an ACP subprocess lifecycle onto the journal and a terminal result. `run_acp_channel`, `adapter_speaks_acp`, and subprocess helpers.
- `EventChannel.ACP` added to the adapter strategy axes in `_contract.py`. `kilo` and `goose` migrated to the channel, bypassing text-signal lifecycle parsing.
- Conformance: event-schema lifecycle fixtures (`tests/fixtures/acp/lifecycle/*.jsonl`) replace pinned stdout golden transcripts for ACP adapters, via `replay_acp_event_fixture`.
- Docs: `ADAPTER_GUIDE.md` section on declaring the channel and `docs/interop/acp.md` covering the client-side role next to `acp serve`.

## Acceptance criteria

- [x] An adapter declaring `EventChannel.ACP` completes a spawn-to-terminal lifecycle with zero stdout/stderr lifecycle parsing.
- [x] Determinism: every inbound event is journaled with a content hash; replaying a recorded session yields byte-identical journal payload hashes, and a mutated recorded event is reported as hash divergence naming the step.
- [x] A simulated upstream output-format change breaks a text-signals conformance fixture but leaves the ACP-channel path green.
- [x] Correctness: malformed ACP frames are refused at the schema boundary with typed errors and produce no partial journal state.
- [x] At least two shipped adapters (`kilo`, `goose`) run on the ACP channel with their stdout lifecycle parsers bypassed, and their lifecycle conformance fixtures are event-schema fixtures.

## Verification

- New unit + integration tests green (`tests/unit/protocols/acp/test_acp_client.py`, `tests/unit/adapters/test_acp_channel.py`, `tests/integration/acp/conformance/test_acp_lifecycle_conformance.py`).
- Broad adapters / acp / journal / conformance suites: 958 passed, 15 skipped.
- `ruff check` and `ruff format --check` clean; import-linter contracts kept.
- Drove a real ACP-speaking subprocess to terminal: 4 events journaled content-addressed, journal verifies, replay of the recorded frames produced a byte-identical Merkle head, and an upstream text change kept the structured path green while the divergence detector named the changed step.

Closes #2522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Agent Client Protocol (ACP) support for adapter event handling.
  * Added structured JSON-RPC lifecycle processing with terminal-state detection and reliable event journaling.
  * Enabled ACP event channels for the Goose and Kilo adapters.
  * Added replay and divergence detection to help verify consistent ACP sessions.

* **Documentation**
  * Added guidance covering ACP adapter configuration, transport behavior, lifecycle guarantees, and conformance testing.

* **Tests**
  * Added coverage for ACP lifecycle validation, malformed frames, replay stability, and adapter conformance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->