### PR TITLE
feat(eval): add statistical gating with verdict receipts and deterministic promotion

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -245,6 +245,7 @@ alwaysApply: false
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |
+| `gate_receipt.py`         | Signed verdict receipts for statistical eval gating (#2520) |
 | `golden.py`               | Golden benchmark suite - curated tasks for eval |
 | `harness.py`              | Eval harness - multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
@@ -253,8 +254,10 @@ alwaysApply: false
 | `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
+| `promotion.py`            | Deterministic stage promotion and revocation for eval gating (#2520) |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |
 | `scenario_runner.py`      | Scenario runner - execute YAML-defined eval scenarios against the live codebase |
+| `significance.py`         | Exact statistics for eval gate verdicts (#2520) |
 | `taxonomy.py`             | Failure taxonomy - classify every eval failure into a closed set |
 | `telemetry.py`            | Telemetry contract - strict schema for agent output metadata |
 | `vcr_fixture.py`          | VCR fixture pattern - dehydrate/hydrate deterministic test fixtures (T805) |

--- a/.goosehints
+++ b/.goosehints
@@ -246,6 +246,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |
+| `gate_receipt.py`         | Signed verdict receipts for statistical eval gating (#2520) |
 | `golden.py`               | Golden benchmark suite - curated tasks for eval |
 | `harness.py`              | Eval harness - multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
@@ -254,8 +255,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
+| `promotion.py`            | Deterministic stage promotion and revocation for eval gating (#2520) |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |
 | `scenario_runner.py`      | Scenario runner - execute YAML-defined eval scenarios against the live codebase |
+| `significance.py`         | Exact statistics for eval gate verdicts (#2520) |
 | `taxonomy.py`             | Failure taxonomy - classify every eval failure into a closed set |
 | `telemetry.py`            | Telemetry contract - strict schema for agent output metadata |
 | `vcr_fixture.py`          | VCR fixture pattern - dehydrate/hydrate deterministic test fixtures (T805) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |
+| `gate_receipt.py`         | Signed verdict receipts for statistical eval gating (#2520) |
 | `golden.py`               | Golden benchmark suite - curated tasks for eval |
 | `harness.py`              | Eval harness - multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
@@ -254,8 +255,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
+| `promotion.py`            | Deterministic stage promotion and revocation for eval gating (#2520) |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |
 | `scenario_runner.py`      | Scenario runner - execute YAML-defined eval scenarios against the live codebase |
+| `significance.py`         | Exact statistics for eval gate verdicts (#2520) |
 | `taxonomy.py`             | Failure taxonomy - classify every eval failure into a closed set |
 | `telemetry.py`            | Telemetry contract - strict schema for agent output metadata |
 | `vcr_fixture.py`          | VCR fixture pattern - dehydrate/hydrate deterministic test fixtures (T805) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |
+| `gate_receipt.py`         | Signed verdict receipts for statistical eval gating (#2520) |
 | `golden.py`               | Golden benchmark suite - curated tasks for eval |
 | `harness.py`              | Eval harness - multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
@@ -254,8 +255,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
+| `promotion.py`            | Deterministic stage promotion and revocation for eval gating (#2520) |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |
 | `scenario_runner.py`      | Scenario runner - execute YAML-defined eval scenarios against the live codebase |
+| `significance.py`         | Exact statistics for eval gate verdicts (#2520) |
 | `taxonomy.py`             | Failure taxonomy - classify every eval failure into a closed set |
 | `telemetry.py`            | Telemetry contract - strict schema for agent output metadata |
 | `vcr_fixture.py`          | VCR fixture pattern - dehydrate/hydrate deterministic test fixtures (T805) |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -246,6 +246,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `ab_runner.py`            | A/B runner primitive - deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `calibration.py`          | Calibration log + Brier score for router and judge decisions |
+| `gate_receipt.py`         | Signed verdict receipts for statistical eval gating (#2520) |
 | `golden.py`               | Golden benchmark suite - curated tasks for eval |
 | `harness.py`              | Eval harness - multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |
@@ -254,8 +255,10 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `pentest_consensus.py`    | Consensus aggregation for the multi-adapter pentest fan-out |
 | `pentest_runner.py`       | Driver that runs the ``security-pentest`` scenario end-to-end |
 | `pentest_scorer.py`       | Precision and recall scorer for security pentest eval scenario |
+| `promotion.py`            | Deterministic stage promotion and revocation for eval gating (#2520) |
 | `scenario_generator.py`   | Forward-looking synthetic scenario generator |
 | `scenario_runner.py`      | Scenario runner - execute YAML-defined eval scenarios against the live codebase |
+| `significance.py`         | Exact statistics for eval gate verdicts (#2520) |
 | `taxonomy.py`             | Failure taxonomy - classify every eval failure into a closed set |
 | `telemetry.py`            | Telemetry contract - strict schema for agent output metadata |
 | `vcr_fixture.py`          | VCR fixture pattern - dehydrate/hydrate deterministic test fixtures (T805) |

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -623,6 +623,46 @@ def check_knob_matrix_advisory() -> dict[str, Any]:
     }
 
 
+def check_eval_gate_min_n_advisory(workdir: Path | None = None) -> dict[str, Any]:
+    """Warn when a stored eval gate decision was taken below the minimum n (#2520).
+
+    A verdict receipt records whether the minimum n per arm was met. A gate
+    decision taken below that floor is statistically underpowered, so any such
+    receipt in ``.sdd/eval/gate`` is surfaced here as an advisory (never
+    blocking): it flags promotions that may have stood on too few tasks to
+    survive a re-run.
+    """
+    import json as _json
+
+    root = workdir if workdir is not None else Path()
+    gate_dir = root / ".sdd" / "eval" / "gate"
+    underpowered = 0
+    scanned = 0
+    if gate_dir.is_dir():
+        for path in gate_dir.glob("sha256:*.json"):
+            try:
+                raw = _json.loads(path.read_text(encoding="utf-8"))
+                evidence = raw["evidence"]
+            except (OSError, ValueError, KeyError, TypeError):
+                continue
+            scanned += 1
+            if evidence.get("min_n_satisfied") is False:
+                underpowered += 1
+    if underpowered:
+        return {
+            "name": "Eval gate power",
+            "status": _CHECK_WARN,
+            "detail": f"{underpowered}/{scanned} verdict receipt(s) decided below the minimum n per arm",
+            "fix": "Re-run the gate with a larger suite (raise n per arm) before promoting on those verdicts",
+        }
+    return {
+        "name": "Eval gate power",
+        "status": _CHECK_PASS,
+        "detail": f"{scanned} verdict receipt(s) met the minimum n per arm" if scanned else "no verdict receipts",
+        "fix": "",
+    }
+
+
 def run_all_checks() -> list[dict[str, Any]]:
     """Run all health checks and return results."""
     checks: list[dict[str, Any]] = []
@@ -632,6 +672,7 @@ def run_all_checks() -> list[dict[str, Any]]:
     checks.extend(check_canary_last_green())
     checks.append(check_price_table_advisory())
     checks.append(check_knob_matrix_advisory())
+    checks.append(check_eval_gate_min_n_advisory())
     checks.extend(check_api_keys())
     checks.extend(
         (

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -1771,4 +1771,264 @@ def calibration_report(
 
 
 # ---------------------------------------------------------------------------
+# eval gate - statistical eval gating: signed verdict receipts, deterministic
+# stage promotion, offline verification (#2520)
+# ---------------------------------------------------------------------------
+
+
+def _load_result_set(path: str) -> dict[str, bool]:
+    """Load a per-task pass/fail JSON object from ``path``."""
+    import json as _json
+
+    raw = _json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"result set {path} must be a JSON object mapping task id -> bool"
+        raise click.UsageError(msg)
+    outcomes: dict[str, bool] = {}
+    for task_id, passed in raw.items():
+        if not isinstance(passed, bool):
+            msg = f"result set {path}: task {task_id!r} must map to a JSON boolean"
+            raise click.UsageError(msg)
+        outcomes[str(task_id)] = passed
+    return outcomes
+
+
+@eval_group.command("gate")
+@click.option(
+    "--baseline",
+    "baseline_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSON object mapping task id -> bool for the baseline arm.",
+)
+@click.option(
+    "--candidate",
+    "candidate_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="JSON object mapping task id -> bool for the candidate arm.",
+)
+@click.option("--candidate-id", "candidate_id", default="candidate", show_default=True, help="Candidate config id.")
+@click.option("--baseline-id", "baseline_id", default="baseline", show_default=True, help="Baseline config id.")
+@click.option(
+    "--workdir",
+    "workdir",
+    type=click.Path(file_okay=False),
+    default=".",
+    show_default=True,
+    help="Project root holding .sdd/eval/gate receipts and .sdd/lineage.",
+)
+@click.option(
+    "--audit-dir",
+    "audit_dir",
+    type=click.Path(file_okay=False),
+    default=".sdd/audit",
+    show_default=True,
+    help="Audit chain directory the verdict is mirrored into.",
+)
+@click.option("--alpha", "alpha", type=float, default=None, help="Significance level (default 0.05).")
+@click.option("--margin", "margin", type=float, default=None, help="Non-inferiority margin (default 0.05).")
+@click.option("--min-n", "min_n", type=int, default=None, help="Minimum n per arm (default 12).")
+@click.option("--timestamp", "timestamp", type=int, default=0, show_default=True, help="Stable receipt timestamp.")
+@click.option("--no-audit", "no_audit", is_flag=True, default=False, help="Do not mirror into the audit chain.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def eval_gate_cmd(
+    baseline_path: str,
+    candidate_path: str,
+    candidate_id: str,
+    baseline_id: str,
+    workdir: str,
+    audit_dir: str,
+    alpha: float | None,
+    margin: float | None,
+    min_n: int | None,
+    timestamp: int,
+    no_audit: bool,
+    as_json: bool,
+) -> None:
+    """Emit a signed verdict receipt for two paired result sets (#2520).
+
+    The verdict is a pure function of the paired 2x2 discordance table, so the
+    same two result sets in any ingestion order produce a byte-identical
+    receipt. A gate invoked below the minimum n per arm refuses a promoting
+    verdict with an explicit machine-readable reason.
+
+    \b
+      bernstein eval gate --baseline base.json --candidate cand.json
+      bernstein eval gate --baseline base.json --candidate cand.json --min-n 20
+    """
+    import json as _json
+
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.eval.gate_receipt import build_verdict_receipt
+    from bernstein.eval.significance import (
+        DEFAULT_ALPHA,
+        DEFAULT_MIN_N,
+        DEFAULT_NON_INFERIORITY_MARGIN,
+    )
+
+    baseline_outcomes = _load_result_set(baseline_path)
+    candidate_outcomes = _load_result_set(candidate_path)
+
+    root = Path(workdir)
+    chain = None if no_audit else AuditChainStore(Path(audit_dir))
+    try:
+        receipt = build_verdict_receipt(
+            baseline_outcomes=baseline_outcomes,
+            candidate_outcomes=candidate_outcomes,
+            candidate_config_id=candidate_id,
+            baseline_config_id=baseline_id,
+            workdir=root,
+            lineage_root=root / ".sdd" / "lineage",
+            hmac_key=load_or_create_audit_key(),
+            timestamp=timestamp,
+            alpha=DEFAULT_ALPHA if alpha is None else alpha,
+            non_inferiority_margin=DEFAULT_NON_INFERIORITY_MARGIN if margin is None else margin,
+            min_n=DEFAULT_MIN_N if min_n is None else min_n,
+            chain=chain,
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    evidence = receipt.evidence
+    if as_json:
+        click.echo(_json.dumps(receipt.to_dict(), indent=2, sort_keys=True))
+        return
+
+    console.print(f"[bold]Verdict:[/bold] {receipt.verdict.value}  [dim]({evidence.reason})[/dim]")
+    console.print(f"  receipt_hash: {receipt.receipt_hash}")
+    console.print(
+        f"  n/arm: {evidence.n_candidate}  effect: {evidence.effect:+.4f}  "
+        f"interval: [{evidence.interval_low:+.4f}, {evidence.interval_high:+.4f}]"
+    )
+    console.print(
+        f"  base_rate: {evidence.base_rate:.4f}  cand_rate: {evidence.cand_rate:.4f}  "
+        f"alpha: {evidence.alpha}  min_n_satisfied: {evidence.min_n_satisfied}"
+    )
+    if not evidence.min_n_satisfied:
+        console.print(
+            f"  [yellow]below minimum n[/yellow] ({evidence.n_candidate} < {evidence.min_n}): "
+            "a promoting verdict is refused."
+        )
+
+
+@eval_group.command("promotions")
+@click.option(
+    "--workdir",
+    "workdir",
+    type=click.Path(file_okay=False),
+    default=".",
+    show_default=True,
+    help="Project root holding .sdd/eval/gate receipts.",
+)
+@click.option("--candidate-id", "candidate_id", default=None, help="Filter to one candidate config id.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def eval_promotions_cmd(workdir: str, candidate_id: str | None, as_json: bool) -> None:
+    """Project the promotion stage history from the verdict receipt chain (#2520).
+
+    The stage assignment at every prefix of the chain is recomputed from the
+    receipts alone, with no auxiliary state file: the receipt chain IS the
+    assignment.
+
+    \b
+      bernstein eval promotions
+      bernstein eval promotions --candidate-id my-template --json
+    """
+    import json as _json
+
+    from bernstein.eval.gate_receipt import read_verdict_receipt
+    from bernstein.eval.promotion import project, steps_from_receipts
+
+    gate_dir = Path(workdir) / ".sdd" / "eval" / "gate"
+    receipts = []
+    if gate_dir.is_dir():
+        for path in gate_dir.glob("sha256:*.json"):
+            receipt = read_verdict_receipt(Path(workdir), path.stem)
+            if receipt is None:
+                continue
+            if candidate_id is not None and receipt.candidate_config_id != candidate_id:
+                continue
+            receipts.append(receipt)
+
+    receipts.sort(key=lambda r: (r.timestamp, r.receipt_hash))
+    projection = project(steps_from_receipts(receipts))
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "final_stage": projection.final_stage.value,
+                    "default_config_id": projection.default_config_id,
+                    "stage_at_prefix": [s.value for s in projection.stage_at_prefix],
+                    "revocations": [r.to_dict() for r in projection.revocations],
+                    "receipts": [r.receipt_hash for r in receipts],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    if not receipts:
+        console.print("[yellow]No verdict receipts found under .sdd/eval/gate.[/yellow]")
+        return
+
+    console.print(f"[bold]Promotion projection[/bold]: {len(receipts)} verdict receipt(s)")
+    for index, (receipt, stage) in enumerate(zip(receipts, projection.stage_at_prefix, strict=True)):
+        console.print(f"  {index}: {receipt.verdict.value:24s} -> {stage.value}  [dim]{receipt.receipt_hash}[/dim]")
+    console.print(f"\n[bold]Final stage:[/bold] {projection.final_stage.value}")
+    console.print(f"[bold]Default config:[/bold] {projection.default_config_id}")
+    for revocation in projection.revocations:
+        console.print(
+            f"  [red]rollback[/red] at step {revocation.step_index}: "
+            f"revoked {len(revocation.revoked_receipt_hashes)} receipt(s), "
+            f"reverts to {revocation.reverts_to_stage}"
+        )
+
+
+@eval_group.command("gate-verify")
+@click.argument("receipt_hash")
+@click.option(
+    "--workdir",
+    "workdir",
+    type=click.Path(file_okay=False),
+    default=".",
+    show_default=True,
+    help="Project root holding .sdd/eval/gate receipts and .sdd/lineage.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def eval_gate_verify_cmd(receipt_hash: str, workdir: str, as_json: bool) -> None:
+    """Verify a verdict receipt offline against the lineage spine (#2520).
+
+    Re-derives the receipt hash from the stored body and re-derives the verdict
+    from the embedded evidence, so a receipt whose evidence does not entail its
+    verdict fails even when its hashes are internally consistent.
+
+    \b
+      bernstein eval gate-verify sha256:<hash>
+    """
+    import json as _json
+
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.eval.gate_receipt import verify_verdict_receipt
+
+    root = Path(workdir)
+    result = verify_verdict_receipt(
+        workdir=root,
+        lineage_root=root / ".sdd" / "lineage",
+        hmac_key=load_or_create_audit_key(),
+        receipt_hash=receipt_hash,
+    )
+    if as_json:
+        click.echo(_json.dumps({"ok": result.ok, "reason": result.reason, "receipt_hash": receipt_hash}))
+        raise SystemExit(0 if result.ok else 1)
+    if result.ok:
+        console.print(f"[green]Verdict receipt verified:[/green] {receipt_hash}")
+        return
+    console.print(f"[red]Verdict receipt verification failed:[/red] {result.reason}")
+    raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
 # workspace - multi-repo workspace management

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -588,6 +588,22 @@ def _add_check(checks: list[dict[str, Any]], name: str, ok: bool, detail: str, f
     checks.append({"name": name, "ok": ok, "detail": detail, "fix": fix, "fix_id": fix_id})
 
 
+def _doctor_check_eval_gate_power(checks: list[dict[str, Any]], workdir: Path) -> None:
+    """Advisory: flag statistical eval gate decisions taken below the minimum n (#2520).
+
+    Non-blocking. A verdict receipt records whether the minimum n per arm was
+    met; any stored receipt decided below that floor is surfaced so an operator
+    knows a promotion may have stood on too few tasks to survive a re-run.
+    """
+    from bernstein.cli.commands.doctor_cmd import check_eval_gate_min_n_advisory
+
+    advisory = check_eval_gate_min_n_advisory(workdir)
+    detail = advisory["detail"]
+    fix = advisory.get("fix", "")
+    # Advisory only: never fail the run, but keep the underpowered note visible.
+    _add_check(checks, advisory["name"], True, detail, fix)
+
+
 def _doctor_check_python(checks: list[dict[str, Any]]) -> bool:
     """Check Python version. Returns True if version is adequate."""
     major, minor = sys.version_info.major, sys.version_info.minor
@@ -1067,6 +1083,7 @@ def doctor(as_json: bool, auto_fix: bool) -> None:
     _doctor_check_commit_attribution(checks, workdir)
     _doctor_check_compliance(checks, workdir)
     _doctor_check_schedule_supervisor(checks, workdir)
+    _doctor_check_eval_gate_power(checks, workdir)
 
     if auto_fix:
         _doctor_auto_fix(checks, stale_pid_paths, workdir, fixed, manual_needed)

--- a/src/bernstein/core/quality/benchmark_gate.py
+++ b/src/bernstein/core/quality/benchmark_gate.py
@@ -155,6 +155,54 @@ class BenchmarkGate:
             current_metrics=current,
         )
 
+    def evaluate_significance(
+        self,
+        *,
+        baseline_outcomes: dict[str, bool],
+        current_outcomes: dict[str, bool],
+        alpha: float | None = None,
+        non_inferiority_margin: float | None = None,
+        min_n: int | None = None,
+    ) -> object:
+        """Optional significance mode: gate on a statistical verdict (#2520).
+
+        The default :meth:`evaluate` compares point estimates against a single
+        baseline with a percentage threshold, so a re-run can flip a pass/fail.
+        This optional mode instead classifies paired per-benchmark pass/fail
+        outcomes (for example "within the regression threshold") with the exact
+        paired test in :mod:`bernstein.eval.significance`, so a merge cannot pass
+        on statistical noise: an effect below the minimum n per arm refuses a
+        promoting verdict with an explicit machine-readable reason.
+
+        Args:
+            baseline_outcomes: Per-benchmark pass/fail under the base ref.
+            current_outcomes: Per-benchmark pass/fail under the current run; must
+                cover the identical benchmark set.
+            alpha: Significance level (defaults to the module default).
+            non_inferiority_margin: Non-inferiority margin (defaults applied).
+            min_n: Minimum n per arm (defaults applied).
+
+        Returns:
+            A :class:`bernstein.eval.significance.SignificanceResult`.
+        """
+        from bernstein.eval.significance import (
+            DEFAULT_ALPHA,
+            DEFAULT_MIN_N,
+            DEFAULT_NON_INFERIORITY_MARGIN,
+            PairedTable,
+            classify,
+        )
+
+        table = PairedTable.from_outcomes(baseline_outcomes, current_outcomes)
+        return classify(
+            table,
+            alpha=DEFAULT_ALPHA if alpha is None else alpha,
+            non_inferiority_margin=(
+                DEFAULT_NON_INFERIORITY_MARGIN if non_inferiority_margin is None else non_inferiority_margin
+            ),
+            min_n=DEFAULT_MIN_N if min_n is None else min_n,
+        )
+
     def promote_candidate(self) -> bool:
         """Promote the current successful benchmark candidate into the baseline cache."""
         candidate_path = self._candidate_path()

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -559,6 +559,32 @@ EVENT_INTENT_CAPSULE = "intent.capsule"
 #: their identity.
 EVENT_INTENT_DRIFT = "intent.drift"
 
+#: Issue #2520 -- emitted once per statistical eval gate verdict. The verdict
+#: (significant_improvement / non_inferior / insufficient_evidence /
+#: significant_regression) is a pure function of the paired 2x2 discordance
+#: table, alpha, the non-inferiority margin, and the minimum n; this event
+#: mirrors the sealed verdict receipt's identity into the HMAC chain by
+#: recording ``{receipt_hash, verdict, suite_content_hash,
+#: baseline_result_set_hash, candidate_result_set_hash, n_per_arm, effect,
+#: interval_low, interval_high, alpha, min_n_satisfied, journal_entry_hash}``.
+#: A verifier holding the same result sets recomputes the verdict and the
+#: receipt hash byte-identically, so a promotion decision names exactly the
+#: evidence it stood on. Only hashes, the verdict, and the rounded statistics
+#: are recorded -- never task prompts or agent output.
+EVENT_EVAL_GATE_VERDICT = "eval.gate_verdict"
+
+#: Issue #2520 -- emitted when a significant_regression verdict at canary or
+#: default rolls a candidate configuration back. The revocation receipt names
+#: the content hashes of the verdict receipts it revokes and the stage the
+#: deterministic promotion projection reverts to; this event mirrors that
+#: linkage into the HMAC chain by recording ``{receipt_hash,
+#: candidate_config_id, revoked_receipt_hashes, reverts_to_stage,
+#: reverts_to_config_id, trigger_receipt_hash, journal_entry_hash}``. A
+#: verifier folding the receipt chain offline reproduces the identical
+#: rollback, so a regression postmortem links the exact receipt that admitted
+#: the change to the receipt that revoked it.
+EVENT_EVAL_GATE_REVOCATION = "eval.gate_revocation"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -3663,6 +3689,143 @@ def record_cost_batch_route(
     )
 
 
+def record_eval_gate_verdict(
+    *,
+    chain: AuditChainStore,
+    receipt_hash: str,
+    verdict: str,
+    suite_content_hash: str,
+    baseline_result_set_hash: str,
+    candidate_result_set_hash: str,
+    candidate_config_id: str,
+    n_per_arm: int,
+    effect: float,
+    interval_low: float,
+    interval_high: float,
+    alpha: float,
+    min_n_satisfied: bool,
+    journal_entry_hash: str = "",
+    actor: str = "eval_gate",
+) -> AuditEvent:
+    """Append an ``eval.gate_verdict`` event into *chain* (#2520).
+
+    Mirrors one sealed statistical eval verdict receipt into the HMAC chain so
+    an operator can prove, from the chain alone, that a promotion decision stood
+    on a named body of statistical evidence: the paired suite it ran over, the
+    two result sets it compared, the effect and its interval, and whether the
+    minimum n per arm was met. The verdict is a pure function of that evidence,
+    so a verifier holding the same result sets recomputes both the verdict and
+    the ``receipt_hash`` byte-identically. Only hashes, the verdict, and the
+    rounded statistics are recorded -- never task prompts or agent output.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        receipt_hash: Content hash pinning the whole verdict receipt (its
+            identity).
+        verdict: One of ``significant_improvement`` / ``non_inferior`` /
+            ``insufficient_evidence`` / ``significant_regression``.
+        suite_content_hash: Order-invariant hash over the suite's task ids.
+        baseline_result_set_hash: Order-invariant hash over the baseline arm's
+            per-task pass/fail outcomes.
+        candidate_result_set_hash: Order-invariant hash over the candidate arm's
+            per-task pass/fail outcomes.
+        candidate_config_id: Identifier of the candidate configuration under
+            evaluation.
+        n_per_arm: Paired sample size (equal per arm).
+        effect: Candidate pass rate minus baseline pass rate (rounded).
+        interval_low: Lower bound of the interval on the paired difference.
+        interval_high: Upper bound of the interval on the paired difference.
+        alpha: Significance level the verdict was decided at.
+        min_n_satisfied: Whether the minimum n per arm was met.
+        journal_entry_hash: Lineage-spine entry hash anchoring the sealed
+            receipt bytes; a verifier holding the spine can recompute it.
+        actor: Recorded actor; defaults to ``"eval_gate"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_EVAL_GATE_VERDICT,
+        actor=actor,
+        resource_type="eval_gate_verdict",
+        resource_id=receipt_hash,
+        details={
+            "receipt_hash": receipt_hash,
+            "verdict": verdict,
+            "suite_content_hash": suite_content_hash,
+            "baseline_result_set_hash": baseline_result_set_hash,
+            "candidate_result_set_hash": candidate_result_set_hash,
+            "candidate_config_id": candidate_config_id,
+            "n_per_arm": n_per_arm,
+            "effect": effect,
+            "interval_low": interval_low,
+            "interval_high": interval_high,
+            "alpha": alpha,
+            "min_n_satisfied": min_n_satisfied,
+            "journal_entry_hash": journal_entry_hash,
+        },
+    )
+
+
+def record_eval_gate_revocation(
+    *,
+    chain: AuditChainStore,
+    receipt_hash: str,
+    candidate_config_id: str,
+    revoked_receipt_hashes: list[str],
+    reverts_to_stage: str,
+    reverts_to_config_id: str,
+    trigger_receipt_hash: str,
+    journal_entry_hash: str = "",
+    actor: str = "eval_gate",
+) -> AuditEvent:
+    """Append an ``eval.gate_revocation`` event into *chain* (#2520).
+
+    Mirrors a sealed revocation receipt into the HMAC chain when a
+    significant_regression verdict rolls a candidate configuration back. The
+    event names the verdict receipts the rollback revokes, the verdict receipt
+    that triggered it, and the stage the deterministic promotion projection
+    reverts to. A verifier folding the receipt chain offline reproduces the
+    identical rollback, so a regression postmortem links the exact receipt that
+    admitted the change to the receipt that revoked it.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        receipt_hash: Content hash pinning the revocation receipt.
+        candidate_config_id: The configuration being rolled back.
+        revoked_receipt_hashes: Content hashes of the verdict receipts this
+            revocation invalidates (the promoting receipts).
+        reverts_to_stage: The stage the projection reverts to.
+        reverts_to_config_id: The configuration that serves the reverted stage
+            (the prior default).
+        trigger_receipt_hash: The verdict receipt hash whose
+            significant_regression verdict triggered the rollback.
+        journal_entry_hash: Lineage-spine entry hash anchoring the sealed
+            receipt bytes.
+        actor: Recorded actor; defaults to ``"eval_gate"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_EVAL_GATE_REVOCATION,
+        actor=actor,
+        resource_type="eval_gate_revocation",
+        resource_id=receipt_hash,
+        details={
+            "receipt_hash": receipt_hash,
+            "candidate_config_id": candidate_config_id,
+            "revoked_receipt_hashes": list(revoked_receipt_hashes),
+            "reverts_to_stage": reverts_to_stage,
+            "reverts_to_config_id": reverts_to_config_id,
+            "trigger_receipt_hash": trigger_receipt_hash,
+            "journal_entry_hash": journal_entry_hash,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -3681,6 +3844,8 @@ __all__ = [
     "EVENT_ENDPOINT_CERTIFICATION",
     "EVENT_ESCALATION_RECEIPT",
     "EVENT_EVAL_AB_COMPARISON",
+    "EVENT_EVAL_GATE_REVOCATION",
+    "EVENT_EVAL_GATE_VERDICT",
     "EVENT_EVIDENCE_BUNDLE",
     "EVENT_FORK_SNAPSHOT",
     "EVENT_GATE_ADJUDICATION",
@@ -3743,6 +3908,8 @@ __all__ = [
     "record_endpoint_certification",
     "record_escalation_receipt",
     "record_eval_ab_comparison",
+    "record_eval_gate_revocation",
+    "record_eval_gate_verdict",
     "record_evidence_bundle",
     "record_fork_snapshot",
     "record_gate_adjudication",

--- a/src/bernstein/eval/baseline.py
+++ b/src/bernstein/eval/baseline.py
@@ -14,7 +14,10 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
+
+    from bernstein.eval.gate_receipt import VerdictReceipt
 
 logger = logging.getLogger(__name__)
 
@@ -119,3 +122,54 @@ def compute_config_hash(state_dir: Path) -> str:
             except OSError:
                 continue
     return hasher.hexdigest()[:12]
+
+
+def promote_baseline_from_receipt(
+    state_dir: Path,
+    receipt: VerdictReceipt,
+    *,
+    score: float | None = None,
+    components: Mapping[str, float] | None = None,
+    config_hash: str | None = None,
+) -> bool:
+    """Advance the eval baseline only on a ``significant_improvement`` receipt (#2520).
+
+    The legacy ratchet advanced whenever a point estimate cleared a threshold,
+    so the baseline ratcheted on the same noise the gate did. Here the ratchet
+    is gated on the statistical verdict: it advances iff the verdict receipt's
+    verdict is ``significant_improvement`` -- a candidate that is merely
+    non-inferior or indistinguishable never moves the baseline.
+
+    Args:
+        state_dir: Path to the ``.sdd`` directory.
+        receipt: The sealed verdict receipt authorising (or refusing) the ratchet.
+        score: New baseline score; defaults to the candidate pass rate the
+            receipt measured.
+        components: Optional per-dimension scores to persist.
+        config_hash: Optional config fingerprint; defaults to the current config.
+
+    Returns:
+        ``True`` when the baseline was advanced, ``False`` when the verdict did
+        not authorise it.
+    """
+    from bernstein.eval.significance import Verdict
+
+    if receipt.verdict is not Verdict.SIGNIFICANT_IMPROVEMENT:
+        logger.info(
+            "Eval baseline ratchet held: verdict %r does not authorise promotion (receipt %s)",
+            receipt.verdict.value,
+            receipt.receipt_hash,
+        )
+        return False
+
+    new_baseline = EvalBaseline(
+        score=receipt.evidence.cand_rate if score is None else score,
+        components=dict(components or {}),
+        config_hash=config_hash if config_hash is not None else compute_config_hash(state_dir),
+    )
+    save_baseline(state_dir, new_baseline)
+    logger.info(
+        "Eval baseline promoted from significant_improvement receipt %s",
+        receipt.receipt_hash,
+    )
+    return True

--- a/src/bernstein/eval/gate_receipt.py
+++ b/src/bernstein/eval/gate_receipt.py
@@ -1,0 +1,439 @@
+"""Signed verdict receipts for statistical eval gating (#2520).
+
+A gate verdict is not a log line; it is a receipt that carries the exact
+statistical evidence it was decided on. :func:`build_verdict_receipt` seals a
+:class:`~bernstein.eval.significance.SignificanceResult` two ways, following the
+dispatch-receipt pattern (:mod:`bernstein.core.cost.scheduling.receipt`):
+
+* the receipt's canonical bytes are appended to the ``eval-gate`` run of the
+  Merkle+HMAC lineage spine, and the spine entry hash becomes the receipt's
+  ``journal_entry_hash``; and
+* the receipt identity is mirrored into the HMAC audit chain via
+  :func:`~bernstein.core.security.audit_chain.record_eval_gate_verdict`.
+
+The receipt IS the proof, not a decoration on a log line. Verification
+(:func:`verify_verdict_receipt`) re-derives the receipt hash from the stored
+body and, crucially, *re-derives the verdict from the embedded evidence*: it
+recomputes :func:`~bernstein.eval.significance.classify` over the stored 2x2
+table and parameters and rejects any receipt whose stored evidence does not
+entail its stored verdict -- even when the receipt's own hashes are internally
+consistent. Strip the evidence and the verdict collapses to a threshold compare
+over noise.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.eval.significance import (
+    DEFAULT_ALPHA,
+    DEFAULT_MIN_N,
+    DEFAULT_NON_INFERIORITY_MARGIN,
+    PairedTable,
+    SignificanceResult,
+    Verdict,
+    classify,
+    result_set_hash,
+    suite_content_hash,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+#: Version stamped into every verdict receipt. Bump only on a wire-format
+#: change.
+VERDICT_RECEIPT_SCHEMA_VERSION = 1
+
+#: Lineage run id under which every verdict receipt is anchored, kept separate
+#: so gate receipts never interleave with per-task journals.
+EVAL_GATE_RUN_ID = "eval-gate"
+
+_GATE_ACTOR = "bernstein.eval_gate"
+_GATE_SUBPATH = (".sdd", "eval", "gate")
+_RECEIPT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def verdict_receipt_path(workdir: Path, receipt_hash: str) -> Path:
+    """Return the on-disk receipt path for *receipt_hash* under *workdir*.
+
+    The hash is validated against ``sha256:<64 hex>`` and the resolved path is
+    asserted to stay under the gate directory, so a caller-influenced hash can
+    never escape the receipt store (path-injection defense in depth).
+
+    Raises:
+        ValueError: The hash is not a canonical ``sha256:`` digest, or the
+            resolved path escapes the gate directory.
+    """
+    if not _RECEIPT_HASH_RE.match(receipt_hash):
+        msg = f"receipt_hash is not a canonical sha256 digest: {receipt_hash!r}"
+        raise ValueError(msg)
+    base = workdir.joinpath(*_GATE_SUBPATH)
+    candidate = base / f"{receipt_hash}.json"
+    base_real = os.path.realpath(base)
+    cand_real = os.path.realpath(candidate)
+    if os.path.commonpath([base_real, cand_real]) != base_real:
+        msg = f"receipt path escapes gate directory: {receipt_hash!r}"
+        raise ValueError(msg)
+    return candidate
+
+
+def _hash_obj(obj: Any) -> str:
+    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class VerdictReceipt:
+    """A sealed statistical verdict receipt.
+
+    The body (everything the ``receipt_hash`` covers) binds the suite and both
+    result-set hashes, the candidate and baseline configuration ids, the full
+    :class:`SignificanceResult` evidence, the schema version, and the
+    timestamp. The ``journal_entry_hash`` is assigned post-seal and is not part
+    of the hashed body.
+    """
+
+    schema_version: int
+    suite_content_hash: str
+    baseline_result_set_hash: str
+    candidate_result_set_hash: str
+    candidate_config_id: str
+    baseline_config_id: str
+    evidence: SignificanceResult
+    timestamp: int
+    receipt_hash: str
+    journal_entry_hash: str = ""
+
+    @property
+    def verdict(self) -> Verdict:
+        return self.evidence.verdict
+
+    def body(self) -> dict[str, Any]:
+        """The hashed body: every field except the receipt hash and anchor."""
+        return {
+            "schema_version": self.schema_version,
+            "suite_content_hash": self.suite_content_hash,
+            "baseline_result_set_hash": self.baseline_result_set_hash,
+            "candidate_result_set_hash": self.candidate_result_set_hash,
+            "candidate_config_id": self.candidate_config_id,
+            "baseline_config_id": self.baseline_config_id,
+            "evidence": self.evidence.to_dict(),
+            "timestamp": self.timestamp,
+        }
+
+    def canonical_payload_without_anchor(self) -> str:
+        """Canonical JSON of the body plus receipt hash (excludes the anchor).
+
+        Two machines seal byte-identical bytes here; the lineage anchor is the
+        only field that could differ (it never does for identical inputs), so it
+        is excluded from the cross-machine equality contract.
+        """
+        payload = self.body()
+        payload["receipt_hash"] = self.receipt_hash
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.body()
+        payload["receipt_hash"] = self.receipt_hash
+        payload["journal_entry_hash"] = self.journal_entry_hash
+        return payload
+
+    def canonical_bytes(self) -> bytes:
+        """Canonical bytes sealed into the lineage spine (body + hash)."""
+        return self.canonical_payload_without_anchor().encode("utf-8")
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> VerdictReceipt:
+        return cls(
+            schema_version=int(raw["schema_version"]),
+            suite_content_hash=str(raw["suite_content_hash"]),
+            baseline_result_set_hash=str(raw["baseline_result_set_hash"]),
+            candidate_result_set_hash=str(raw["candidate_result_set_hash"]),
+            candidate_config_id=str(raw["candidate_config_id"]),
+            baseline_config_id=str(raw["baseline_config_id"]),
+            evidence=_significance_from_dict(raw["evidence"]),
+            timestamp=int(raw["timestamp"]),
+            receipt_hash=str(raw["receipt_hash"]),
+            journal_entry_hash=str(raw.get("journal_entry_hash", "")),
+        )
+
+
+def _significance_from_dict(raw: Mapping[str, Any]) -> SignificanceResult:
+    return SignificanceResult(
+        verdict=Verdict(str(raw["verdict"])),
+        reason=str(raw["reason"]),
+        test=str(raw["test"]),
+        alpha=float(raw["alpha"]),
+        n_baseline=int(raw["n_baseline"]),
+        n_candidate=int(raw["n_candidate"]),
+        base_pass=int(raw["base_pass"]),
+        cand_pass=int(raw["cand_pass"]),
+        base_rate=float(raw["base_rate"]),
+        cand_rate=float(raw["cand_rate"]),
+        effect=float(raw["effect"]),
+        interval_low=float(raw["interval_low"]),
+        interval_high=float(raw["interval_high"]),
+        p_improvement=float(raw["p_improvement"]),
+        p_regression=float(raw["p_regression"]),
+        min_n=int(raw["min_n"]),
+        min_n_satisfied=bool(raw["min_n_satisfied"]),
+        non_inferiority_margin=float(raw["non_inferiority_margin"]),
+        table=PairedTable.from_dict(raw["table"]),
+    )
+
+
+def recompute_receipt_hash(payload: Mapping[str, Any]) -> str:
+    """Recompute the ``receipt_hash`` from a receipt dict's body fields.
+
+    Exposed so a verifier (or a test) can confirm that a receipt whose hashes
+    are internally consistent is still rejected when its evidence does not
+    entail its verdict.
+    """
+    body = {
+        "schema_version": int(payload["schema_version"]),
+        "suite_content_hash": str(payload["suite_content_hash"]),
+        "baseline_result_set_hash": str(payload["baseline_result_set_hash"]),
+        "candidate_result_set_hash": str(payload["candidate_result_set_hash"]),
+        "candidate_config_id": str(payload["candidate_config_id"]),
+        "baseline_config_id": str(payload["baseline_config_id"]),
+        "evidence": payload["evidence"],
+        "timestamp": int(payload["timestamp"]),
+    }
+    return _hash_obj(body)
+
+
+def build_verdict_receipt(
+    *,
+    baseline_outcomes: Mapping[str, bool],
+    candidate_outcomes: Mapping[str, bool],
+    candidate_config_id: str,
+    baseline_config_id: str,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    timestamp: int,
+    alpha: float = DEFAULT_ALPHA,
+    non_inferiority_margin: float = DEFAULT_NON_INFERIORITY_MARGIN,
+    min_n: int = DEFAULT_MIN_N,
+    chain: AuditChainStore | None = None,
+) -> VerdictReceipt:
+    """Classify a paired suite and seal the verdict into a receipt.
+
+    The paired 2x2 table is built from the per-task outcomes (order-invariant),
+    the verdict is derived by :func:`classify`, the receipt is anchored in the
+    ``eval-gate`` lineage spine, written under ``.sdd/eval/gate``, and (when a
+    *chain* is supplied) mirrored into the HMAC audit chain.
+
+    Args:
+        baseline_outcomes: Per-task pass/fail under the baseline arm.
+        candidate_outcomes: Per-task pass/fail under the candidate arm; must
+            cover the identical task set.
+        candidate_config_id: Identifier of the candidate configuration.
+        baseline_config_id: Identifier of the incumbent baseline configuration.
+        workdir: Project root (receipt written under ``.sdd/eval/gate``).
+        lineage_root: ``.sdd/lineage`` root for the spine.
+        hmac_key: Audit-chain HMAC key for the spine seal.
+        timestamp: Integer timestamp anchored into the spine entry (stable, so
+            identical inputs seal byte-identically).
+        alpha: Significance level.
+        non_inferiority_margin: Non-inferiority margin on the paired difference.
+        min_n: Minimum n per arm before a promoting verdict is allowed.
+        chain: Optional :class:`AuditChainStore` accepting the mirror.
+
+    Returns:
+        The sealed :class:`VerdictReceipt`.
+    """
+    table = PairedTable.from_outcomes(baseline_outcomes, candidate_outcomes)
+    result = classify(table, alpha=alpha, non_inferiority_margin=non_inferiority_margin, min_n=min_n)
+
+    unsealed = VerdictReceipt(
+        schema_version=VERDICT_RECEIPT_SCHEMA_VERSION,
+        suite_content_hash=suite_content_hash(list(baseline_outcomes)),
+        baseline_result_set_hash=result_set_hash(baseline_outcomes),
+        candidate_result_set_hash=result_set_hash(candidate_outcomes),
+        candidate_config_id=candidate_config_id,
+        baseline_config_id=baseline_config_id,
+        evidence=result,
+        timestamp=timestamp,
+        receipt_hash="",
+    )
+    receipt_hash = _hash_obj(unsealed.body())
+    sealed_no_anchor = VerdictReceipt(
+        schema_version=unsealed.schema_version,
+        suite_content_hash=unsealed.suite_content_hash,
+        baseline_result_set_hash=unsealed.baseline_result_set_hash,
+        candidate_result_set_hash=unsealed.candidate_result_set_hash,
+        candidate_config_id=unsealed.candidate_config_id,
+        baseline_config_id=unsealed.baseline_config_id,
+        evidence=unsealed.evidence,
+        timestamp=unsealed.timestamp,
+        receipt_hash=receipt_hash,
+    )
+
+    spine = LineageSpine(lineage_root, run_id=EVAL_GATE_RUN_ID, hmac_key=hmac_key)
+    artifact_path = "/".join((*_GATE_SUBPATH, f"{receipt_hash}.json"))
+    anchor = spine.record(
+        artifact_path=artifact_path,
+        content=sealed_no_anchor.canonical_bytes(),
+        actor=_GATE_ACTOR,
+        step_id=receipt_hash,
+        model=result.test,
+        timestamp=timestamp,
+    )
+
+    sealed = VerdictReceipt(
+        schema_version=sealed_no_anchor.schema_version,
+        suite_content_hash=sealed_no_anchor.suite_content_hash,
+        baseline_result_set_hash=sealed_no_anchor.baseline_result_set_hash,
+        candidate_result_set_hash=sealed_no_anchor.candidate_result_set_hash,
+        candidate_config_id=sealed_no_anchor.candidate_config_id,
+        baseline_config_id=sealed_no_anchor.baseline_config_id,
+        evidence=sealed_no_anchor.evidence,
+        timestamp=sealed_no_anchor.timestamp,
+        receipt_hash=receipt_hash,
+        journal_entry_hash=anchor,
+    )
+
+    path = verdict_receipt_path(workdir, receipt_hash)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(sealed.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+        encoding="utf-8",
+    )
+
+    if chain is not None:
+        from bernstein.core.security.audit_chain import record_eval_gate_verdict
+
+        record_eval_gate_verdict(
+            chain=chain,
+            receipt_hash=receipt_hash,
+            verdict=result.verdict.value,
+            suite_content_hash=sealed.suite_content_hash,
+            baseline_result_set_hash=sealed.baseline_result_set_hash,
+            candidate_result_set_hash=sealed.candidate_result_set_hash,
+            candidate_config_id=candidate_config_id,
+            n_per_arm=result.n_candidate,
+            effect=result.effect,
+            interval_low=result.interval_low,
+            interval_high=result.interval_high,
+            alpha=result.alpha,
+            min_n_satisfied=result.min_n_satisfied,
+            journal_entry_hash=anchor,
+        )
+    return sealed
+
+
+def read_verdict_receipt(workdir: Path, receipt_hash: str) -> VerdictReceipt | None:
+    """Return the sealed receipt for *receipt_hash* or ``None`` if absent/bad."""
+    try:
+        path = verdict_receipt_path(workdir, receipt_hash)
+    except ValueError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        return VerdictReceipt.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.warning("eval: malformed verdict receipt at %s", path)
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class VerdictVerifyResult:
+    """Outcome of an offline verdict-receipt verification."""
+
+    ok: bool
+    reason: str
+    receipt: VerdictReceipt | None
+
+
+def verify_verdict_receipt(
+    *,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    receipt_hash: str,
+) -> VerdictVerifyResult:
+    """Re-verify the receipt for *receipt_hash* offline.
+
+    Checks, from the stored receipt alone:
+
+    * the receipt hash recomputes from the stored body (catches any mutated
+      field when the hash was not recomputed);
+    * the stored evidence *entails* the stored verdict: :func:`classify` is
+      re-run over the stored 2x2 table and parameters and every derived field
+      (verdict, effect, interval, p-values, rates, n) must match byte-for-byte,
+      so a forged verdict is rejected even when the receipt hashes are
+      internally consistent; and
+    * the lineage spine verifies and contains an entry whose content hash
+      matches the receipt's canonical bytes and whose entry hash matches the
+      receipt's ``journal_entry_hash``.
+    """
+    receipt = read_verdict_receipt(workdir, receipt_hash)
+    if receipt is None:
+        return VerdictVerifyResult(ok=False, reason=f"no verdict receipt for {receipt_hash!r}", receipt=None)
+    if receipt.receipt_hash != receipt_hash:
+        return VerdictVerifyResult(ok=False, reason="receipt hash does not match request", receipt=receipt)
+
+    recomputed = _hash_obj(receipt.body())
+    if recomputed != receipt.receipt_hash:
+        return VerdictVerifyResult(
+            ok=False,
+            reason="receipt_hash does not recompute from the receipt body (tampered)",
+            receipt=receipt,
+        )
+
+    # The verdict is re-derived, not trusted: recompute the entire evidence
+    # projection from the stored table and parameters.
+    rederived = classify(
+        receipt.evidence.table,
+        alpha=receipt.evidence.alpha,
+        non_inferiority_margin=receipt.evidence.non_inferiority_margin,
+        min_n=receipt.evidence.min_n,
+    )
+    if rederived.to_dict() != receipt.evidence.to_dict():
+        return VerdictVerifyResult(
+            ok=False,
+            reason="stored evidence does not entail its verdict (re-derivation mismatch)",
+            receipt=receipt,
+        )
+
+    spine = LineageSpine(lineage_root, run_id=EVAL_GATE_RUN_ID, hmac_key=hmac_key)
+    report = spine.verify()
+    if not report.ok:
+        detail = "; ".join(report.errors) if report.errors else report.status.value
+        return VerdictVerifyResult(ok=False, reason=f"eval-gate spine failed verification: {detail}", receipt=receipt)
+
+    expected_content = content_hash_of(receipt.canonical_bytes())
+    anchored = any(
+        entry.entry_hash == receipt.journal_entry_hash and entry.content_hash == expected_content
+        for entry in spine.iter_entries()
+    )
+    if not anchored:
+        return VerdictVerifyResult(ok=False, reason="receipt is not anchored in the eval-gate spine", receipt=receipt)
+    return VerdictVerifyResult(ok=True, reason="", receipt=receipt)
+
+
+__all__ = [
+    "EVAL_GATE_RUN_ID",
+    "VERDICT_RECEIPT_SCHEMA_VERSION",
+    "VerdictReceipt",
+    "VerdictVerifyResult",
+    "build_verdict_receipt",
+    "read_verdict_receipt",
+    "recompute_receipt_hash",
+    "verdict_receipt_path",
+    "verify_verdict_receipt",
+]

--- a/src/bernstein/eval/promotion.py
+++ b/src/bernstein/eval/promotion.py
@@ -1,0 +1,487 @@
+"""Deterministic stage promotion and revocation for eval gating (#2520).
+
+A candidate configuration moves ``shadow`` -> ``canary`` -> ``default``. The
+stage assignment at any moment is a pure fold over the ordered chain of verdict
+receipts: k consecutive non-inferior-or-better verdicts promote shadow to
+canary, m consecutive at canary promote to default, and any
+significant_regression verdict at canary or default triggers a rollback that
+reverts the projection to the prior default. No state file holds the
+assignment; the receipt chain IS the assignment, so a verifier holding only the
+chain recomputes the full promotion and rollback history, including the stage at
+every prefix, offline.
+
+A rollback emits a :class:`Revocation`, which :func:`build_revocation_receipt`
+seals into a content-addressed receipt anchored to the lineage spine and
+mirrored into the HMAC audit chain -- the same shape as the verdict receipt, so
+a regression postmortem links the exact receipts that admitted a change to the
+receipt that revoked it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.lineage.spine import LineageSpine, content_hash_of
+from bernstein.eval.significance import PROMOTING_VERDICTS, Verdict
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.eval.gate_receipt import VerdictReceipt
+
+logger = logging.getLogger(__name__)
+
+#: Consecutive non-inferior-or-better verdicts to promote shadow -> canary.
+DEFAULT_SHADOW_TO_CANARY_K = 2
+
+#: Consecutive non-inferior-or-better verdicts at canary to promote -> default.
+DEFAULT_CANARY_TO_DEFAULT_M = 2
+
+#: Version stamped into every revocation receipt.
+REVOCATION_RECEIPT_SCHEMA_VERSION = 1
+
+_REVOCATION_RUN_ID = "eval-gate"
+_REVOCATION_ACTOR = "bernstein.eval_gate"
+_REVOCATION_SUBPATH = (".sdd", "eval", "gate", "revocations")
+_RECEIPT_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class Stage(StrEnum):
+    """A candidate configuration's position on the promotion ladder."""
+
+    SHADOW = "shadow"
+    CANARY = "canary"
+    DEFAULT = "default"
+    ROLLED_BACK = "rolled_back"
+
+
+@dataclass(frozen=True, slots=True)
+class VerdictStep:
+    """One ordered entry in the receipt chain the projection folds over.
+
+    Attributes:
+        receipt_hash: Content hash of the verdict receipt.
+        verdict: The receipt's verdict.
+        candidate_config_id: The candidate configuration the receipt evaluated.
+        baseline_config_id: The incumbent baseline (the prior default).
+    """
+
+    receipt_hash: str
+    verdict: Verdict
+    candidate_config_id: str
+    baseline_config_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class Revocation:
+    """A rollback implied by a significant_regression at canary or default.
+
+    Attributes:
+        step_index: Position in the chain of the triggering verdict.
+        trigger_receipt_hash: The significant_regression receipt hash.
+        revoked_receipt_hashes: The promoting receipt hashes this rollback
+            invalidates (everything that lifted the candidate off shadow).
+        reverts_to_stage: The stage the projection reverts to.
+        reverts_to_config_id: The configuration serving the reverted stage (the
+            prior default).
+        candidate_config_id: The configuration being rolled back.
+    """
+
+    step_index: int
+    trigger_receipt_hash: str
+    revoked_receipt_hashes: tuple[str, ...]
+    reverts_to_stage: str
+    reverts_to_config_id: str
+    candidate_config_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "step_index": self.step_index,
+            "trigger_receipt_hash": self.trigger_receipt_hash,
+            "revoked_receipt_hashes": list(self.revoked_receipt_hashes),
+            "reverts_to_stage": self.reverts_to_stage,
+            "reverts_to_config_id": self.reverts_to_config_id,
+            "candidate_config_id": self.candidate_config_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionProjection:
+    """The stage assignment projected from a receipt chain.
+
+    Attributes:
+        final_stage: The candidate's stage after the whole chain.
+        default_config_id: The configuration currently serving ``default``
+            (the prior default after any rollback).
+        stage_at_prefix: The candidate's stage after each prefix of the chain.
+        revocations: The rollbacks the projection implies, in chain order.
+    """
+
+    final_stage: Stage
+    default_config_id: str
+    stage_at_prefix: tuple[Stage, ...] = field(default_factory=tuple)
+    revocations: tuple[Revocation, ...] = field(default_factory=tuple)
+
+
+def steps_from_receipts(receipts: Iterable[VerdictReceipt]) -> list[VerdictStep]:
+    """Project sealed verdict receipts onto the ordered chain the fold consumes."""
+    return [
+        VerdictStep(
+            receipt_hash=r.receipt_hash,
+            verdict=r.verdict,
+            candidate_config_id=r.candidate_config_id,
+            baseline_config_id=r.baseline_config_id,
+        )
+        for r in receipts
+    ]
+
+
+def project(
+    steps: Sequence[VerdictStep],
+    *,
+    k: int = DEFAULT_SHADOW_TO_CANARY_K,
+    m: int = DEFAULT_CANARY_TO_DEFAULT_M,
+) -> PromotionProjection:
+    """Fold the ordered verdict chain into a stage assignment.
+
+    Args:
+        steps: The ordered verdict-receipt chain.
+        k: Consecutive promoting verdicts to lift shadow -> canary.
+        m: Consecutive promoting verdicts at canary to lift -> default.
+
+    Returns:
+        A :class:`PromotionProjection`. The fold is a pure function of the
+        chain: no external state is read.
+    """
+    if k < 1 or m < 1:
+        msg = f"k and m must be >= 1, got k={k}, m={m}"
+        raise ValueError(msg)
+
+    stage = Stage.SHADOW
+    streak = 0
+    default_config_id = ""
+    promoting_hashes: list[str] = []
+    stage_prefix: list[Stage] = []
+    revocations: list[Revocation] = []
+
+    for index, step in enumerate(steps):
+        if not default_config_id:
+            default_config_id = step.baseline_config_id
+        # Coerce defensively: callers deserialising a chain may pass the raw
+        # verdict string rather than the enum member.
+        verdict = Verdict(step.verdict)
+
+        if verdict in PROMOTING_VERDICTS:
+            streak += 1
+            promoting_hashes.append(step.receipt_hash)
+            if stage is Stage.SHADOW and streak >= k:
+                stage = Stage.CANARY
+                streak = 0
+            elif stage is Stage.CANARY and streak >= m:
+                stage = Stage.DEFAULT
+                streak = 0
+                default_config_id = step.candidate_config_id
+        elif verdict is Verdict.SIGNIFICANT_REGRESSION:
+            if stage in (Stage.CANARY, Stage.DEFAULT):
+                reverts_to = step.baseline_config_id
+                revocations.append(
+                    Revocation(
+                        step_index=index,
+                        trigger_receipt_hash=step.receipt_hash,
+                        revoked_receipt_hashes=tuple(promoting_hashes),
+                        reverts_to_stage=Stage.SHADOW.value,
+                        reverts_to_config_id=reverts_to,
+                        candidate_config_id=step.candidate_config_id,
+                    )
+                )
+                stage = Stage.ROLLED_BACK
+                default_config_id = reverts_to
+                streak = 0
+                promoting_hashes = []
+            else:
+                streak = 0
+        else:  # insufficient_evidence breaks the consecutive run
+            streak = 0
+        stage_prefix.append(stage)
+
+    return PromotionProjection(
+        final_stage=stage,
+        default_config_id=default_config_id,
+        stage_at_prefix=tuple(stage_prefix),
+        revocations=tuple(revocations),
+    )
+
+
+def replay_history(
+    steps: Sequence[VerdictStep],
+    *,
+    k: int = DEFAULT_SHADOW_TO_CANARY_K,
+    m: int = DEFAULT_CANARY_TO_DEFAULT_M,
+) -> tuple[Stage, ...]:
+    """Return the candidate's stage after each prefix of the chain."""
+    return project(steps, k=k, m=m).stage_at_prefix
+
+
+# ---------------------------------------------------------------------------
+# Signed revocation receipt
+# ---------------------------------------------------------------------------
+
+
+def revocation_receipt_path(workdir: Path, receipt_hash: str) -> Path:
+    """Return the on-disk revocation-receipt path for *receipt_hash*.
+
+    Validated and containment-checked exactly like the verdict receipt path.
+
+    Raises:
+        ValueError: The hash is not canonical or the path escapes the store.
+    """
+    if not _RECEIPT_HASH_RE.match(receipt_hash):
+        msg = f"receipt_hash is not a canonical sha256 digest: {receipt_hash!r}"
+        raise ValueError(msg)
+    base = workdir.joinpath(*_REVOCATION_SUBPATH)
+    candidate = base / f"{receipt_hash}.json"
+    base_real = os.path.realpath(base)
+    cand_real = os.path.realpath(candidate)
+    if os.path.commonpath([base_real, cand_real]) != base_real:
+        msg = f"receipt path escapes revocation directory: {receipt_hash!r}"
+        raise ValueError(msg)
+    return candidate
+
+
+def _hash_obj(obj: Any) -> str:
+    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class RevocationReceipt:
+    """A sealed revocation receipt naming the receipts a rollback revokes."""
+
+    schema_version: int
+    candidate_config_id: str
+    revoked_receipt_hashes: tuple[str, ...]
+    reverts_to_stage: str
+    reverts_to_config_id: str
+    trigger_receipt_hash: str
+    timestamp: int
+    receipt_hash: str
+    journal_entry_hash: str = ""
+
+    def body(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "candidate_config_id": self.candidate_config_id,
+            "revoked_receipt_hashes": list(self.revoked_receipt_hashes),
+            "reverts_to_stage": self.reverts_to_stage,
+            "reverts_to_config_id": self.reverts_to_config_id,
+            "trigger_receipt_hash": self.trigger_receipt_hash,
+            "timestamp": self.timestamp,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        payload = self.body()
+        payload["receipt_hash"] = self.receipt_hash
+        return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.body()
+        payload["receipt_hash"] = self.receipt_hash
+        payload["journal_entry_hash"] = self.journal_entry_hash
+        return payload
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> RevocationReceipt:
+        return cls(
+            schema_version=int(raw["schema_version"]),
+            candidate_config_id=str(raw["candidate_config_id"]),
+            revoked_receipt_hashes=tuple(str(h) for h in raw["revoked_receipt_hashes"]),
+            reverts_to_stage=str(raw["reverts_to_stage"]),
+            reverts_to_config_id=str(raw["reverts_to_config_id"]),
+            trigger_receipt_hash=str(raw["trigger_receipt_hash"]),
+            timestamp=int(raw["timestamp"]),
+            receipt_hash=str(raw["receipt_hash"]),
+            journal_entry_hash=str(raw.get("journal_entry_hash", "")),
+        )
+
+
+def build_revocation_receipt(
+    *,
+    revocation: Revocation,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    timestamp: int,
+    chain: AuditChainStore | None = None,
+) -> RevocationReceipt:
+    """Seal a :class:`Revocation` into a signed, anchored receipt.
+
+    The receipt is anchored in the ``eval-gate`` lineage spine, written under
+    ``.sdd/eval/gate/revocations``, and (when *chain* is supplied) mirrored into
+    the HMAC audit chain via
+    :func:`~bernstein.core.security.audit_chain.record_eval_gate_revocation`.
+    """
+    unsealed = RevocationReceipt(
+        schema_version=REVOCATION_RECEIPT_SCHEMA_VERSION,
+        candidate_config_id=revocation.candidate_config_id,
+        revoked_receipt_hashes=revocation.revoked_receipt_hashes,
+        reverts_to_stage=revocation.reverts_to_stage,
+        reverts_to_config_id=revocation.reverts_to_config_id,
+        trigger_receipt_hash=revocation.trigger_receipt_hash,
+        timestamp=timestamp,
+        receipt_hash="",
+    )
+    receipt_hash = _hash_obj(unsealed.body())
+    sealed_no_anchor = RevocationReceipt(
+        schema_version=unsealed.schema_version,
+        candidate_config_id=unsealed.candidate_config_id,
+        revoked_receipt_hashes=unsealed.revoked_receipt_hashes,
+        reverts_to_stage=unsealed.reverts_to_stage,
+        reverts_to_config_id=unsealed.reverts_to_config_id,
+        trigger_receipt_hash=unsealed.trigger_receipt_hash,
+        timestamp=unsealed.timestamp,
+        receipt_hash=receipt_hash,
+    )
+
+    spine = LineageSpine(lineage_root, run_id=_REVOCATION_RUN_ID, hmac_key=hmac_key)
+    artifact_path = "/".join((*_REVOCATION_SUBPATH, f"{receipt_hash}.json"))
+    anchor = spine.record(
+        artifact_path=artifact_path,
+        content=sealed_no_anchor.canonical_bytes(),
+        actor=_REVOCATION_ACTOR,
+        step_id=receipt_hash,
+        model="revocation",
+        timestamp=timestamp,
+    )
+
+    sealed = RevocationReceipt(
+        schema_version=sealed_no_anchor.schema_version,
+        candidate_config_id=sealed_no_anchor.candidate_config_id,
+        revoked_receipt_hashes=sealed_no_anchor.revoked_receipt_hashes,
+        reverts_to_stage=sealed_no_anchor.reverts_to_stage,
+        reverts_to_config_id=sealed_no_anchor.reverts_to_config_id,
+        trigger_receipt_hash=sealed_no_anchor.trigger_receipt_hash,
+        timestamp=sealed_no_anchor.timestamp,
+        receipt_hash=receipt_hash,
+        journal_entry_hash=anchor,
+    )
+
+    path = revocation_receipt_path(workdir, receipt_hash)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(sealed.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+        encoding="utf-8",
+    )
+
+    if chain is not None:
+        from bernstein.core.security.audit_chain import record_eval_gate_revocation
+
+        record_eval_gate_revocation(
+            chain=chain,
+            receipt_hash=receipt_hash,
+            candidate_config_id=revocation.candidate_config_id,
+            revoked_receipt_hashes=list(revocation.revoked_receipt_hashes),
+            reverts_to_stage=revocation.reverts_to_stage,
+            reverts_to_config_id=revocation.reverts_to_config_id,
+            trigger_receipt_hash=revocation.trigger_receipt_hash,
+            journal_entry_hash=anchor,
+        )
+    return sealed
+
+
+def read_revocation_receipt(workdir: Path, receipt_hash: str) -> RevocationReceipt | None:
+    """Return the sealed revocation receipt for *receipt_hash* or ``None``."""
+    try:
+        path = revocation_receipt_path(workdir, receipt_hash)
+    except ValueError:
+        return None
+    if not path.is_file():
+        return None
+    try:
+        return RevocationReceipt.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.warning("eval: malformed revocation receipt at %s", path)
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class RevocationVerifyResult:
+    """Outcome of an offline revocation-receipt verification."""
+
+    ok: bool
+    reason: str
+    receipt: RevocationReceipt | None
+
+
+def verify_revocation_receipt(
+    *,
+    workdir: Path,
+    lineage_root: Path,
+    hmac_key: bytes,
+    receipt_hash: str,
+) -> RevocationVerifyResult:
+    """Re-verify the revocation receipt for *receipt_hash* offline.
+
+    Recomputes the receipt hash from the stored body (catches any mutated
+    field), then verifies the lineage spine and the receipt's anchor.
+    """
+    receipt = read_revocation_receipt(workdir, receipt_hash)
+    if receipt is None:
+        return RevocationVerifyResult(ok=False, reason=f"no revocation receipt for {receipt_hash!r}", receipt=None)
+    if receipt.receipt_hash != receipt_hash:
+        return RevocationVerifyResult(ok=False, reason="receipt hash does not match request", receipt=receipt)
+
+    recomputed = _hash_obj(receipt.body())
+    if recomputed != receipt.receipt_hash:
+        return RevocationVerifyResult(
+            ok=False,
+            reason="receipt_hash does not recompute from the receipt body (tampered)",
+            receipt=receipt,
+        )
+
+    spine = LineageSpine(lineage_root, run_id=_REVOCATION_RUN_ID, hmac_key=hmac_key)
+    report = spine.verify()
+    if not report.ok:
+        detail = "; ".join(report.errors) if report.errors else report.status.value
+        return RevocationVerifyResult(
+            ok=False, reason=f"eval-gate spine failed verification: {detail}", receipt=receipt
+        )
+
+    expected_content = content_hash_of(receipt.canonical_bytes())
+    anchored = any(
+        entry.entry_hash == receipt.journal_entry_hash and entry.content_hash == expected_content
+        for entry in spine.iter_entries()
+    )
+    if not anchored:
+        return RevocationVerifyResult(
+            ok=False, reason="receipt is not anchored in the eval-gate spine", receipt=receipt
+        )
+    return RevocationVerifyResult(ok=True, reason="", receipt=receipt)
+
+
+__all__ = [
+    "DEFAULT_CANARY_TO_DEFAULT_M",
+    "DEFAULT_SHADOW_TO_CANARY_K",
+    "REVOCATION_RECEIPT_SCHEMA_VERSION",
+    "PromotionProjection",
+    "Revocation",
+    "RevocationReceipt",
+    "RevocationVerifyResult",
+    "Stage",
+    "VerdictStep",
+    "build_revocation_receipt",
+    "project",
+    "read_revocation_receipt",
+    "replay_history",
+    "revocation_receipt_path",
+    "steps_from_receipts",
+    "verify_revocation_receipt",
+]

--- a/src/bernstein/eval/significance.py
+++ b/src/bernstein/eval/significance.py
@@ -1,0 +1,517 @@
+"""Exact statistics for eval gate verdicts (#2520).
+
+Every eval gate in the codebase compares point estimates over suites of a
+handful of tasks, where a pass or fail verdict is frequently noise: a re-run
+can flip it. This module makes the verdict a pure, dependency-free function of
+the evidence, so the same two result sets always produce the same verdict on
+any machine.
+
+It provides:
+
+* :func:`binom_tail_ge` - the exact upper tail of a fair-coin binomial, in
+  exact rational arithmetic (:class:`fractions.Fraction`), so the McNemar
+  paired test is bit-stable and never touches a float until the canonically
+  rounded receipt value is produced.
+* :func:`wilson_interval` - the Wilson score interval for a pass rate, using
+  a fixed z-table (no SciPy) and only the correctly-rounded ``math.sqrt``.
+* :class:`PairedTable` - the 2x2 discordance table over a paired suite; the
+  sufficient statistic the verdict is re-derived from.
+* :func:`classify` - the pure verdict function. One of
+  :class:`Verdict`. A promoting verdict is refused below the minimum n per arm
+  with an explicit machine-readable reason.
+
+The design goal is that the verdict is *entailed* by the evidence: a verifier
+holding only the 2x2 table, alpha, the non-inferiority margin, and the minimum
+n recomputes the identical verdict, effect, interval, and p-values. Strip the
+statistics and a gate degrades to a threshold compare over noise.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from decimal import ROUND_HALF_EVEN, Decimal
+from enum import StrEnum
+from fractions import Fraction
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+__all__ = [
+    "CANON_PLACES",
+    "DEFAULT_ALPHA",
+    "DEFAULT_MIN_N",
+    "DEFAULT_NON_INFERIORITY_MARGIN",
+    "SUPPORTED_ALPHAS",
+    "PairedTable",
+    "SignificanceResult",
+    "Verdict",
+    "binom_tail_ge",
+    "canonical_round",
+    "classify",
+    "result_set_hash",
+    "suite_content_hash",
+    "wilson_interval",
+]
+
+
+#: Number of decimal places every stored float is canonically rounded to.
+#: Ten places is far below float64's ~15-17 significant digits, so the
+#: round-half-even result is the nearest float to a clean decimal and its
+#: shortest repr is stable across platforms.
+CANON_PLACES: Final[int] = 10
+
+#: Default two-sided significance level.
+DEFAULT_ALPHA: Final[float] = 0.05
+
+#: Default minimum n per arm before a *promoting* verdict may be returned.
+#: Below this a strong-looking effect is treated as insufficient evidence.
+DEFAULT_MIN_N: Final[int] = 12
+
+#: Default non-inferiority margin on the paired difference of pass rates.
+DEFAULT_NON_INFERIORITY_MARGIN: Final[float] = 0.05
+
+#: Fixed two-sided z critical values keyed by alpha. Hard-coded so the module
+#: needs no SciPy and stays deterministic; only these alphas are supported.
+SUPPORTED_ALPHAS: Final[dict[float, float]] = {
+    0.10: 1.6448536269514722,
+    0.05: 1.959963984540054,
+    0.01: 2.5758293035489004,
+}
+
+_CANON_QUANTUM: Final[Decimal] = Decimal(1).scaleb(-CANON_PLACES)
+
+
+class Verdict(StrEnum):
+    """The four verdict strengths a gate decision can carry."""
+
+    SIGNIFICANT_IMPROVEMENT = "significant_improvement"
+    NON_INFERIOR = "non_inferior"
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+    SIGNIFICANT_REGRESSION = "significant_regression"
+
+
+#: Verdicts that promote a candidate up the ladder.
+PROMOTING_VERDICTS: Final[frozenset[Verdict]] = frozenset({Verdict.SIGNIFICANT_IMPROVEMENT, Verdict.NON_INFERIOR})
+
+
+# ---------------------------------------------------------------------------
+# Canonical rounding
+# ---------------------------------------------------------------------------
+
+
+def canonical_round(value: float, places: int = CANON_PLACES) -> float:
+    """Round ``value`` to ``places`` decimals with round-half-to-even.
+
+    The input float is deterministic (exact rationals plus the
+    correctly-rounded :func:`math.sqrt`), so quantising its exact decimal
+    value with a fixed rounding mode yields a bit-stable result across
+    platforms.
+    """
+    if math.isnan(value) or math.isinf(value):
+        msg = f"cannot canonically round non-finite value {value!r}"
+        raise ValueError(msg)
+    quantum = _CANON_QUANTUM if places == CANON_PLACES else Decimal(1).scaleb(-places)
+    quantised = Decimal(value).quantize(quantum, rounding=ROUND_HALF_EVEN)
+    # Normalise negative zero so ``-0.0`` never reaches a receipt.
+    result = float(quantised)
+    return 0.0 if result == 0.0 else result
+
+
+# ---------------------------------------------------------------------------
+# Exact binomial tail
+# ---------------------------------------------------------------------------
+
+
+def binom_tail_ge(k: int, n: int) -> Fraction:
+    """Return ``P(X >= k)`` for ``X ~ Binomial(n, 1/2)`` as an exact rational.
+
+    This is the exact one-sided p-value used by the McNemar paired test over
+    ``b + c`` discordant pairs. The sum of binomial coefficients is exact
+    integer arithmetic, so the value is identical on any platform.
+
+    Args:
+        k: Lower inclusive count. Values ``<= 0`` return the full mass.
+        n: Number of trials.
+
+    Raises:
+        ValueError: If ``k`` or ``n`` is negative.
+    """
+    if k < 0:
+        msg = f"k must be non-negative, got {k}"
+        raise ValueError(msg)
+    if n < 0:
+        msg = f"n must be non-negative, got {n}"
+        raise ValueError(msg)
+    if k <= 0:
+        return Fraction(1, 1)
+    if k > n:
+        return Fraction(0, 1)
+    numerator = sum(math.comb(n, i) for i in range(k, n + 1))
+    return Fraction(numerator, 1 << n)
+
+
+# ---------------------------------------------------------------------------
+# Wilson score interval
+# ---------------------------------------------------------------------------
+
+
+def wilson_interval(k: int, n: int, z: float) -> tuple[float, float]:
+    """Return the Wilson score interval for ``k`` successes in ``n`` trials.
+
+    Args:
+        k: Number of successes.
+        n: Number of trials.
+        z: The two-sided z critical value (see :data:`SUPPORTED_ALPHAS`).
+
+    Returns:
+        ``(low, high)`` clamped to ``[0, 1]``. ``n == 0`` returns
+        ``(0.0, 1.0)`` (no information).
+    """
+    if n <= 0:
+        return (0.0, 1.0)
+    p_hat = k / n
+    z2 = z * z
+    denom = 1.0 + z2 / n
+    centre = (p_hat + z2 / (2.0 * n)) / denom
+    margin = (z * math.sqrt((p_hat * (1.0 - p_hat) + z2 / (4.0 * n)) / n)) / denom
+    low = max(0.0, centre - margin)
+    high = min(1.0, centre + margin)
+    return (low, high)
+
+
+def _paired_difference_interval(both_pass: int, b: int, c: int, both_fail: int, z: float) -> tuple[float, float]:
+    """Return the confidence interval on the paired difference ``(c - b)/n``.
+
+    Uses the standard McNemar normal-approximation interval on the difference
+    of correlated proportions. All arithmetic is deterministic (the only
+    transcendental is the correctly-rounded ``math.sqrt``).
+    """
+    n = both_pass + b + c + both_fail
+    if n <= 0:
+        return (0.0, 0.0)
+    diff = (c - b) / n
+    variance = (b + c - ((c - b) ** 2) / n) / (n * n)
+    variance = max(variance, 0.0)
+    margin = z * math.sqrt(variance)
+    low = max(-1.0, diff - margin)
+    high = min(1.0, diff + margin)
+    return (low, high)
+
+
+# ---------------------------------------------------------------------------
+# Paired 2x2 discordance table
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class PairedTable:
+    """The 2x2 paired discordance table over a suite run under two arms.
+
+    Attributes:
+        both_pass: Tasks that pass under both baseline and candidate (n11).
+        base_only_pass: Tasks that pass under baseline but fail under candidate
+            (n10, the McNemar ``b``).
+        cand_only_pass: Tasks that fail under baseline but pass under candidate
+            (n01, the McNemar ``c``).
+        both_fail: Tasks that fail under both (n00).
+    """
+
+    both_pass: int
+    base_only_pass: int
+    cand_only_pass: int
+    both_fail: int
+
+    def __post_init__(self) -> None:
+        for name in ("both_pass", "base_only_pass", "cand_only_pass", "both_fail"):
+            value = getattr(self, name)
+            if type(value) is not int or value < 0:
+                msg = f"{name} must be a non-negative int, got {value!r}"
+                raise ValueError(msg)
+
+    @property
+    def n(self) -> int:
+        """Total paired sample size (equal per arm)."""
+        return self.both_pass + self.base_only_pass + self.cand_only_pass + self.both_fail
+
+    @property
+    def base_pass(self) -> int:
+        """Number of tasks the baseline passed."""
+        return self.both_pass + self.base_only_pass
+
+    @property
+    def cand_pass(self) -> int:
+        """Number of tasks the candidate passed."""
+        return self.both_pass + self.cand_only_pass
+
+    @property
+    def base_rate(self) -> float:
+        return self.base_pass / self.n if self.n else 0.0
+
+    @property
+    def cand_rate(self) -> float:
+        return self.cand_pass / self.n if self.n else 0.0
+
+    @property
+    def discordant(self) -> int:
+        """Number of discordant pairs (``b + c``); the McNemar evidence."""
+        return self.base_only_pass + self.cand_only_pass
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "both_pass": self.both_pass,
+            "base_only_pass": self.base_only_pass,
+            "cand_only_pass": self.cand_only_pass,
+            "both_fail": self.both_fail,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> PairedTable:
+        return cls(
+            both_pass=int(raw["both_pass"]),
+            base_only_pass=int(raw["base_only_pass"]),
+            cand_only_pass=int(raw["cand_only_pass"]),
+            both_fail=int(raw["both_fail"]),
+        )
+
+    @classmethod
+    def from_outcomes(cls, baseline: Mapping[str, bool], candidate: Mapping[str, bool]) -> PairedTable:
+        """Build the table from paired per-task pass/fail outcomes.
+
+        Both mappings must cover the identical task-id set (a paired suite).
+        Iteration is over the sorted task ids, so the table is invariant to the
+        ingestion order of either mapping.
+
+        Raises:
+            ValueError: If the two task-id sets differ.
+        """
+        base_keys = set(baseline)
+        cand_keys = set(candidate)
+        if base_keys != cand_keys:
+            missing = sorted(base_keys ^ cand_keys)
+            msg = f"baseline and candidate must cover the same task set; differing task ids: {missing}"
+            raise ValueError(msg)
+        both_pass = base_only = cand_only = both_fail = 0
+        for task_id in sorted(base_keys):
+            bp = bool(baseline[task_id])
+            cp = bool(candidate[task_id])
+            if bp and cp:
+                both_pass += 1
+            elif bp and not cp:
+                base_only += 1
+            elif (not bp) and cp:
+                cand_only += 1
+            else:
+                both_fail += 1
+        return cls(both_pass=both_pass, base_only_pass=base_only, cand_only_pass=cand_only, both_fail=both_fail)
+
+
+# ---------------------------------------------------------------------------
+# Significance result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SignificanceResult:
+    """The re-derivable verdict plus every quantity it was decided on.
+
+    Every float field is canonically rounded so the result is byte-stable.
+    ``verdict`` is entailed by ``table`` together with ``alpha``,
+    ``non_inferiority_margin``, and ``min_n``: :func:`classify` recomputes an
+    identical result from those alone.
+    """
+
+    verdict: Verdict
+    reason: str
+    test: str
+    alpha: float
+    n_baseline: int
+    n_candidate: int
+    base_pass: int
+    cand_pass: int
+    base_rate: float
+    cand_rate: float
+    effect: float
+    interval_low: float
+    interval_high: float
+    p_improvement: float
+    p_regression: float
+    min_n: int
+    min_n_satisfied: bool
+    non_inferiority_margin: float
+    table: PairedTable
+
+    @property
+    def never_promotes(self) -> bool:
+        """True when this verdict cannot lift a candidate up the ladder."""
+        return self.verdict not in PROMOTING_VERDICTS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict.value,
+            "reason": self.reason,
+            "test": self.test,
+            "alpha": self.alpha,
+            "n_baseline": self.n_baseline,
+            "n_candidate": self.n_candidate,
+            "base_pass": self.base_pass,
+            "cand_pass": self.cand_pass,
+            "base_rate": self.base_rate,
+            "cand_rate": self.cand_rate,
+            "effect": self.effect,
+            "interval_low": self.interval_low,
+            "interval_high": self.interval_high,
+            "p_improvement": self.p_improvement,
+            "p_regression": self.p_regression,
+            "min_n": self.min_n,
+            "min_n_satisfied": self.min_n_satisfied,
+            "non_inferiority_margin": self.non_inferiority_margin,
+            "table": self.table.to_dict(),
+        }
+
+
+def _alpha_fraction(alpha: float) -> Fraction:
+    """Return ``alpha`` as an exact rational (e.g. 0.05 -> 1/20)."""
+    return Fraction(str(alpha))
+
+
+def _decide(
+    *,
+    table: PairedTable,
+    p_improve: Fraction,
+    p_regress: Fraction,
+    interval_low: float,
+    alpha: float,
+    margin: float,
+    min_n: int,
+) -> tuple[Verdict, str, bool]:
+    """Return ``(verdict, reason, min_n_satisfied)`` from the evidence.
+
+    The order matters: a significant regression is reported even below the
+    minimum n (it never promotes), while an improvement or non-inferiority is
+    downgraded to insufficient evidence when the sample is too small.
+    """
+    b = table.base_only_pass
+    c = table.cand_only_pass
+    n = table.n
+    min_n_satisfied = n >= min_n
+    alpha_q = _alpha_fraction(alpha)
+
+    if n == 0:
+        return (Verdict.INSUFFICIENT_EVIDENCE, "empty_suite", False)
+
+    # A significant regression is admissible at any n: it only blocks.
+    if b > c and p_regress <= alpha_q:
+        return (Verdict.SIGNIFICANT_REGRESSION, "significant_regression", min_n_satisfied)
+
+    if not min_n_satisfied:
+        return (Verdict.INSUFFICIENT_EVIDENCE, "below_minimum_n", False)
+
+    if c > b and p_improve <= alpha_q:
+        return (Verdict.SIGNIFICANT_IMPROVEMENT, "significant_improvement", True)
+
+    # Non-inferiority requires actual discordant evidence and an interval that
+    # rules out a regression worse than the margin. Identical result sets carry
+    # no discordant evidence and therefore stay insufficient.
+    if table.discordant > 0 and interval_low >= -margin:
+        return (Verdict.NON_INFERIOR, "non_inferior", True)
+
+    return (Verdict.INSUFFICIENT_EVIDENCE, "no_significant_effect", True)
+
+
+def classify(
+    table: PairedTable,
+    *,
+    alpha: float = DEFAULT_ALPHA,
+    non_inferiority_margin: float = DEFAULT_NON_INFERIORITY_MARGIN,
+    min_n: int = DEFAULT_MIN_N,
+) -> SignificanceResult:
+    """Return the verdict entailed by ``table`` under the given parameters.
+
+    Args:
+        table: The paired 2x2 discordance table.
+        alpha: Significance level; must be one of :data:`SUPPORTED_ALPHAS`.
+        non_inferiority_margin: Largest tolerated regression on the paired
+            difference before non-inferiority is refused.
+        min_n: Minimum n per arm before a promoting verdict is allowed.
+
+    Returns:
+        A :class:`SignificanceResult` whose every derived field is a pure,
+        canonically rounded function of the inputs.
+
+    Raises:
+        ValueError: If ``alpha`` is not supported or ``min_n`` is negative.
+    """
+    if alpha not in SUPPORTED_ALPHAS:
+        supported = ", ".join(str(a) for a in sorted(SUPPORTED_ALPHAS))
+        msg = f"unsupported alpha {alpha!r}; supported: {supported}"
+        raise ValueError(msg)
+    if min_n < 0:
+        msg = f"min_n must be non-negative, got {min_n}"
+        raise ValueError(msg)
+
+    z = SUPPORTED_ALPHAS[alpha]
+    b = table.base_only_pass
+    c = table.cand_only_pass
+    discordant = b + c
+
+    p_improve = binom_tail_ge(c, discordant)
+    p_regress = binom_tail_ge(b, discordant)
+    interval_low, interval_high = _paired_difference_interval(table.both_pass, b, c, table.both_fail, z)
+    effect = table.cand_rate - table.base_rate
+
+    verdict, reason, min_n_satisfied = _decide(
+        table=table,
+        p_improve=p_improve,
+        p_regress=p_regress,
+        interval_low=interval_low,
+        alpha=alpha,
+        margin=non_inferiority_margin,
+        min_n=min_n,
+    )
+
+    return SignificanceResult(
+        verdict=verdict,
+        reason=reason,
+        test="mcnemar_exact",
+        alpha=alpha,
+        n_baseline=table.n,
+        n_candidate=table.n,
+        base_pass=table.base_pass,
+        cand_pass=table.cand_pass,
+        base_rate=canonical_round(table.base_rate),
+        cand_rate=canonical_round(table.cand_rate),
+        effect=canonical_round(effect),
+        interval_low=canonical_round(interval_low),
+        interval_high=canonical_round(interval_high),
+        p_improvement=canonical_round(float(p_improve)),
+        p_regression=canonical_round(float(p_regress)),
+        min_n=min_n,
+        min_n_satisfied=min_n_satisfied,
+        non_inferiority_margin=non_inferiority_margin,
+        table=table,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Content-addressed hashing of result sets and suites
+# ---------------------------------------------------------------------------
+
+
+def _hash_obj(obj: Any) -> str:
+    payload = json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def result_set_hash(outcomes: Mapping[str, bool]) -> str:
+    """Return an order-invariant content hash over per-task pass/fail outcomes."""
+    canonical = {str(task_id): bool(passed) for task_id, passed in outcomes.items()}
+    return _hash_obj(canonical)
+
+
+def suite_content_hash(task_ids: Sequence[str]) -> str:
+    """Return an order-invariant content hash over a suite's task ids."""
+    return _hash_obj(sorted(str(t) for t in task_ids))

--- a/src/bernstein/evolution/gate.py
+++ b/src/bernstein/evolution/gate.py
@@ -26,10 +26,17 @@ from __future__ import annotations
 import json
 import logging
 import time
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.eval.gate_receipt import VerdictReceipt
 
 from bernstein.evolution.oscillation_guard import (
     OscillationGuard,
@@ -511,13 +518,65 @@ class EvalGateResult:
         }
 
 
+@dataclass
+class EvalGateReceiptResult:
+    """Result of the receipt-consuming (statistical) eval gate path (#2520).
+
+    Unlike :class:`EvalGateResult` this decision is not a point-threshold
+    compare: it carries the sealed verdict receipt and the deterministic
+    promotion projection over the receipt chain. ``accepted`` is ``True`` only
+    for a promoting verdict; ``promoted`` reflects whether the baseline ratchet
+    advanced, which happens only on a ``significant_improvement`` receipt.
+
+    Attributes:
+        verdict: The statistical verdict string.
+        accepted: Whether the verdict promotes (improvement or non-inferior).
+        promoted: Whether the baseline ratchet advanced on this verdict.
+        stage: The candidate's projected promotion stage after this verdict.
+        receipt_hash: Content hash of the sealed verdict receipt.
+        revocation_receipt_hash: Content hash of the revocation receipt when a
+            rollback fired, else ``None``.
+        reason: The receipt's machine-readable reason code.
+    """
+
+    verdict: str
+    accepted: bool
+    promoted: bool
+    stage: str
+    receipt_hash: str
+    revocation_receipt_hash: str | None
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSONL logging."""
+        return {
+            "verdict": self.verdict,
+            "accepted": self.accepted,
+            "promoted": self.promoted,
+            "stage": self.stage,
+            "receipt_hash": self.receipt_hash,
+            "revocation_receipt_hash": self.revocation_receipt_hash,
+            "reason": self.reason,
+        }
+
+
 class EvalGate:
     """Gates evolution proposals on eval harness scores.
 
-    After a proposal passes sandbox testing, the eval gate runs the eval
-    harness at an appropriate tier and compares against the stored baseline.
+    Two decision paths are available:
 
-    Decision logic:
+    * The receipt-consuming statistical path (:meth:`evaluate_paired`, #2520) is
+      the recommended path: it compares two paired result sets, seals a signed
+      verdict receipt carrying the significance evidence, and promotes a
+      candidate as a deterministic projection of the receipt chain.
+    * The legacy point-threshold path (:meth:`evaluate`) compares a single
+      candidate score against the baseline with a fixed tolerance. It is kept
+      behind the ``legacy_point_threshold`` compatibility flag and is
+      **deprecated**: at suite sizes of a handful of tasks its accept/reject is
+      frequently noise a re-run can flip, and it records no evidence a later
+      regression can be traced to.
+
+    Legacy decision logic:
     - L0 proposals: skip eval entirely (tests-only validation is sufficient)
     - L1 proposals: run smoke eval (~5 tasks, ~$0.50)
     - L2 proposals: run standard eval (~15 tasks, ~$2.00)
@@ -531,6 +590,9 @@ class EvalGate:
         state_dir: Path to the .sdd directory for baseline persistence.
         regression_tolerance: Override the default regression tolerance.
         promotion_threshold: Override the default promotion threshold.
+        legacy_point_threshold: When ``True`` (the default, for backward
+            compatibility) :meth:`evaluate` uses the deprecated point-threshold
+            path. New callers should prefer :meth:`evaluate_paired`.
     """
 
     def __init__(
@@ -539,13 +601,109 @@ class EvalGate:
         state_dir: Path,
         regression_tolerance: float = EVAL_REGRESSION_TOLERANCE,
         promotion_threshold: float = EVAL_PROMOTION_THRESHOLD,
+        *,
+        legacy_point_threshold: bool = True,
     ) -> None:
         self._harness = eval_harness
         self._state_dir = state_dir
         self._regression_tolerance = regression_tolerance
         self._promotion_threshold = promotion_threshold
+        self._legacy_point_threshold = legacy_point_threshold
         self._trajectory_path = state_dir / "metrics" / "eval_trajectory.jsonl"
         self._trajectory_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def evaluate_paired(
+        self,
+        *,
+        baseline_outcomes: Mapping[str, bool],
+        candidate_outcomes: Mapping[str, bool],
+        hmac_key: bytes,
+        timestamp: int,
+        candidate_config_id: str = "candidate",
+        baseline_config_id: str = "baseline",
+        prior_receipts: Sequence[VerdictReceipt] = (),
+        audit_chain: AuditChainStore | None = None,
+        ratchet_baseline: bool = True,
+    ) -> EvalGateReceiptResult:
+        """Gate on a signed verdict receipt over two paired result sets (#2520).
+
+        Seals a verdict receipt carrying the significance evidence, projects the
+        candidate's promotion stage as a deterministic fold over
+        ``prior_receipts`` plus this verdict, ratchets the baseline only on a
+        ``significant_improvement`` verdict, and (on a rollback) seals a
+        revocation receipt. Strip the receipts and this degrades to the legacy
+        threshold compare.
+
+        Args:
+            baseline_outcomes: Per-task pass/fail under the incumbent baseline.
+            candidate_outcomes: Per-task pass/fail under the candidate; must
+                cover the identical task set.
+            hmac_key: HMAC key sealing the lineage spine and receipts.
+            timestamp: Stable integer timestamp anchored into the receipts.
+            candidate_config_id: Identifier of the candidate configuration.
+            baseline_config_id: Identifier of the incumbent baseline.
+            prior_receipts: The candidate's prior verdict receipts, in order.
+            audit_chain: Optional audit chain the receipts are mirrored into.
+            ratchet_baseline: Whether to advance the baseline on a
+                ``significant_improvement`` verdict.
+
+        Returns:
+            An :class:`EvalGateReceiptResult` naming the sealed receipt, the
+            projected stage, and any revocation receipt.
+        """
+        from bernstein.eval.baseline import promote_baseline_from_receipt
+        from bernstein.eval.gate_receipt import build_verdict_receipt
+        from bernstein.eval.promotion import (
+            build_revocation_receipt,
+            project,
+            steps_from_receipts,
+        )
+        from bernstein.eval.significance import PROMOTING_VERDICTS
+
+        lineage_root = self._state_dir / "lineage"
+        receipt = build_verdict_receipt(
+            baseline_outcomes=baseline_outcomes,
+            candidate_outcomes=candidate_outcomes,
+            candidate_config_id=candidate_config_id,
+            baseline_config_id=baseline_config_id,
+            workdir=self._state_dir.parent,
+            lineage_root=lineage_root,
+            hmac_key=hmac_key,
+            timestamp=timestamp,
+            chain=audit_chain,
+        )
+
+        steps = steps_from_receipts([*prior_receipts, receipt])
+        projection = project(steps)
+
+        revocation_receipt_hash: str | None = None
+        for revocation in projection.revocations:
+            if revocation.trigger_receipt_hash != receipt.receipt_hash:
+                continue
+            revocation_receipt = build_revocation_receipt(
+                revocation=revocation,
+                workdir=self._state_dir.parent,
+                lineage_root=lineage_root,
+                hmac_key=hmac_key,
+                timestamp=timestamp,
+                chain=audit_chain,
+            )
+            revocation_receipt_hash = revocation_receipt.receipt_hash
+
+        promoted = False
+        if ratchet_baseline:
+            promoted = promote_baseline_from_receipt(self._state_dir, receipt)
+
+        accepted = receipt.verdict in PROMOTING_VERDICTS
+        return EvalGateReceiptResult(
+            verdict=receipt.verdict.value,
+            accepted=accepted,
+            promoted=promoted,
+            stage=projection.final_stage.value,
+            receipt_hash=receipt.receipt_hash,
+            revocation_receipt_hash=revocation_receipt_hash,
+            reason=receipt.evidence.reason,
+        )
 
     def evaluate(
         self,
@@ -553,7 +711,14 @@ class EvalGate:
         risk_level: RiskLevel,
         sandbox_dir: Path | None = None,
     ) -> EvalGateResult:
-        """Evaluate a proposal against the eval baseline.
+        """Evaluate a proposal against the eval baseline (legacy, deprecated).
+
+        This is the point-threshold path (#2520 deprecates it): a single
+        candidate score is compared against the baseline with a fixed
+        tolerance. At small suite sizes the verdict is frequently noise and
+        records no evidence a later regression can be traced to. Prefer
+        :meth:`evaluate_paired`, which seals a signed verdict receipt carrying
+        the significance evidence.
 
         Args:
             proposal: The upgrade proposal being evaluated.
@@ -563,6 +728,13 @@ class EvalGate:
         Returns:
             EvalGateResult with accept/reject decision.
         """
+        if self._legacy_point_threshold:
+            warnings.warn(
+                "EvalGate.evaluate uses the deprecated point-threshold path; "
+                "prefer EvalGate.evaluate_paired for statistically gated promotion (#2520).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         eval_tier = _EVAL_TIER_FOR_RISK.get(risk_level)
 
         # L0 and L3 skip eval.

--- a/tests/unit/test_eval_gate_cli.py
+++ b/tests/unit/test_eval_gate_cli.py
@@ -1,0 +1,124 @@
+"""CLI tests for the statistical eval gate surface (#2520).
+
+Covers ``bernstein eval gate`` (emit a verdict receipt), ``bernstein eval
+promotions`` (project the stage history from the chain), and ``bernstein eval
+gate-verify`` (offline verification passthrough).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.eval_benchmark_cmd import eval_group
+
+
+def _write_result_set(path: Path, base_passes: int, n: int) -> None:
+    path.write_text(
+        json.dumps({f"t{i:03d}": (i < base_passes) for i in range(n)}),
+        encoding="utf-8",
+    )
+
+
+def test_eval_gate_emits_verdict_receipt(tmp_path: Path) -> None:
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    _write_result_set(base, base_passes=4, n=16)
+    _write_result_set(cand, base_passes=12, n=16)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        [
+            "gate",
+            "--baseline",
+            str(base),
+            "--candidate",
+            str(cand),
+            "--workdir",
+            str(tmp_path),
+            "--audit-dir",
+            str(tmp_path / ".sdd" / "audit"),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["evidence"]["verdict"] == "significant_improvement"
+    receipt_hash = payload["receipt_hash"]
+
+    # gate-verify passes on the freshly sealed receipt.
+    verify = runner.invoke(
+        eval_group,
+        ["gate-verify", receipt_hash, "--workdir", str(tmp_path), "--json"],
+    )
+    assert verify.exit_code == 0, verify.output
+    assert json.loads(verify.output)["ok"] is True
+
+
+def test_eval_gate_below_min_n_refuses_promotion(tmp_path: Path) -> None:
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    _write_result_set(base, base_passes=0, n=4)
+    _write_result_set(cand, base_passes=4, n=4)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        [
+            "gate",
+            "--baseline",
+            str(base),
+            "--candidate",
+            str(cand),
+            "--workdir",
+            str(tmp_path),
+            "--no-audit",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["evidence"]["verdict"] == "insufficient_evidence"
+    assert payload["evidence"]["reason"] == "below_minimum_n"
+
+
+def test_eval_promotions_projects_stage_history(tmp_path: Path) -> None:
+    runner = CliRunner()
+    base = tmp_path / "base.json"
+    cand = tmp_path / "cand.json"
+    _write_result_set(base, base_passes=4, n=16)
+    _write_result_set(cand, base_passes=12, n=16)
+
+    # Seal two significant improvements at distinct timestamps.
+    for ts in ("1", "2"):
+        res = runner.invoke(
+            eval_group,
+            [
+                "gate",
+                "--baseline",
+                str(base),
+                "--candidate",
+                str(cand),
+                "--candidate-id",
+                "cfg",
+                "--workdir",
+                str(tmp_path),
+                "--no-audit",
+                "--timestamp",
+                ts,
+                "--json",
+            ],
+        )
+        assert res.exit_code == 0, res.output
+
+    proj = runner.invoke(
+        eval_group,
+        ["promotions", "--workdir", str(tmp_path), "--candidate-id", "cfg", "--json"],
+    )
+    assert proj.exit_code == 0, proj.output
+    payload = json.loads(proj.output)
+    assert payload["final_stage"] == "canary"
+    assert payload["stage_at_prefix"] == ["shadow", "canary"]

--- a/tests/unit/test_eval_gate_receipt.py
+++ b/tests/unit/test_eval_gate_receipt.py
@@ -1,0 +1,184 @@
+"""Tests for the signed verdict receipt behind statistical eval gating (#2520).
+
+A gate verdict is a receipt that carries its statistical evidence and is
+anchored to the lineage spine and mirrored into the HMAC audit chain. Offline
+verification re-derives the verdict from the stored evidence, so a receipt
+whose evidence does not entail its verdict is rejected even when its hashes are
+internally consistent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit_chain import (
+    EVENT_EVAL_GATE_VERDICT,
+    AuditChainStore,
+)
+from bernstein.eval.gate_receipt import (
+    build_verdict_receipt,
+    read_verdict_receipt,
+    recompute_receipt_hash,
+    verdict_receipt_path,
+    verify_verdict_receipt,
+)
+from bernstein.eval.significance import Verdict
+
+_KEY = b"k" * 32
+
+
+def _outcomes(base_passes: int, cand_passes: int, n: int) -> tuple[dict[str, bool], dict[str, bool]]:
+    base = {f"t{i:03d}": (i < base_passes) for i in range(n)}
+    cand = {f"t{i:03d}": (i < cand_passes) for i in range(n)}
+    return base, cand
+
+
+def _build(
+    tmp_path: Path,
+    base: dict[str, bool],
+    cand: dict[str, bool],
+    *,
+    chain: AuditChainStore | None = None,
+    candidate_config_id: str = "cfg-candidate",
+):
+    return build_verdict_receipt(
+        baseline_outcomes=base,
+        candidate_outcomes=cand,
+        candidate_config_id=candidate_config_id,
+        baseline_config_id="cfg-baseline",
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        timestamp=1_700_000_000,
+        chain=chain,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Determinism (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_same_result_sets_any_order_produce_identical_receipt(tmp_path: Path) -> None:
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    machine_a = _build(tmp_path / "a", base, cand)
+    # Reverse ingestion order on a second, independent workdir.
+    base_rev = dict(reversed(list(base.items())))
+    cand_rev = dict(reversed(list(cand.items())))
+    machine_b = _build(tmp_path / "b", base_rev, cand_rev)
+    assert machine_a.receipt_hash == machine_b.receipt_hash
+    assert machine_a.canonical_payload_without_anchor() == machine_b.canonical_payload_without_anchor()
+    assert machine_a.verdict == Verdict.SIGNIFICANT_IMPROVEMENT
+
+
+# ---------------------------------------------------------------------------
+# Offline verification + tamper matrix (AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_verifies_offline(tmp_path: Path) -> None:
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    receipt = _build(tmp_path, base, cand)
+    result = verify_verdict_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=receipt.receipt_hash,
+    )
+    assert result.ok, result.reason
+
+
+@pytest.mark.parametrize(
+    ("mutate_path", "new_value"),
+    [
+        (("evidence", "n_candidate"), 99),
+        (("evidence", "interval_low"), -0.9),
+        (("evidence", "effect"), 0.99),
+        (("evidence", "verdict"), "significant_regression"),
+        (("baseline_result_set_hash",), "sha256:" + "0" * 64),
+        (("candidate_result_set_hash",), "sha256:" + "0" * 64),
+    ],
+)
+def test_tampering_any_field_breaks_verification(
+    tmp_path: Path, mutate_path: tuple[str, ...], new_value: object
+) -> None:
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    receipt = _build(tmp_path, base, cand)
+    path = verdict_receipt_path(tmp_path, receipt.receipt_hash)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    target = payload
+    for key in mutate_path[:-1]:
+        target = target[key]
+    target[mutate_path[-1]] = new_value
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    result = verify_verdict_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=receipt.receipt_hash,
+    )
+    assert not result.ok
+
+
+def test_internally_consistent_forged_verdict_is_rejected(tmp_path: Path) -> None:
+    # Flip the verdict AND recompute the receipt hash so the receipt is
+    # internally consistent; re-derivation from the evidence must still reject.
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    receipt = _build(tmp_path, base, cand)
+    path = verdict_receipt_path(tmp_path, receipt.receipt_hash)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["evidence"]["verdict"] = "significant_regression"
+    payload["receipt_hash"] = recompute_receipt_hash(payload)
+    # Re-key the on-disk file to the forged hash so the reader finds it.
+    forged_path = verdict_receipt_path(tmp_path, payload["receipt_hash"])
+    forged_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = verify_verdict_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=payload["receipt_hash"],
+    )
+    assert not result.ok
+    assert "entail" in result.reason or "verdict" in result.reason
+
+
+def test_internally_consistent_forged_effect_is_rejected(tmp_path: Path) -> None:
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    receipt = _build(tmp_path, base, cand)
+    path = verdict_receipt_path(tmp_path, receipt.receipt_hash)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["evidence"]["effect"] = 0.99
+    payload["receipt_hash"] = recompute_receipt_hash(payload)
+    forged_path = verdict_receipt_path(tmp_path, payload["receipt_hash"])
+    forged_path.write_text(json.dumps(payload), encoding="utf-8")
+    result = verify_verdict_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=payload["receipt_hash"],
+    )
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# Audit chain mirroring
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_mirrors_into_audit_chain(tmp_path: Path) -> None:
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    receipt = _build(tmp_path, base, cand, chain=chain)
+    events = chain.query(event_type=EVENT_EVAL_GATE_VERDICT)
+    assert len(events) == 1
+    assert events[0].resource_id == receipt.receipt_hash
+    assert events[0].details["verdict"] == Verdict.SIGNIFICANT_IMPROVEMENT.value
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_read_missing_receipt_returns_none(tmp_path: Path) -> None:
+    assert read_verdict_receipt(tmp_path, "sha256:" + "a" * 64) is None

--- a/tests/unit/test_eval_gating_e2e.py
+++ b/tests/unit/test_eval_gating_e2e.py
@@ -1,0 +1,244 @@
+"""End-to-end statistical eval gating through EvalGate.evaluate_paired (#2520).
+
+Drives the whole path: a noisy result does not promote, a significant result
+promotes deterministically, and a regression triggers a signed revocation whose
+linkage the audit chain confirms. Also exercises the baseline ratchet gate and
+the benchmark gate's optional significance mode.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.quality.benchmark_gate import BenchmarkGate
+from bernstein.core.security.audit_chain import (
+    EVENT_EVAL_GATE_REVOCATION,
+    EVENT_EVAL_GATE_VERDICT,
+    AuditChainStore,
+)
+from bernstein.eval.baseline import load_baseline, promote_baseline_from_receipt
+from bernstein.eval.gate_receipt import build_verdict_receipt, verify_verdict_receipt
+from bernstein.eval.promotion import Stage, project, steps_from_receipts, verify_revocation_receipt
+from bernstein.eval.significance import Verdict
+from bernstein.evolution.gate import EvalGate
+
+_KEY = b"k" * 32
+
+
+def _outcomes(base_passes: int, cand_passes: int, n: int) -> tuple[dict[str, bool], dict[str, bool]]:
+    base = {f"t{i:03d}": (i < base_passes) for i in range(n)}
+    cand = {f"t{i:03d}": (i < cand_passes) for i in range(n)}
+    return base, cand
+
+
+def _gate(tmp_path: Path) -> EvalGate:
+    state_dir = tmp_path / ".sdd"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return EvalGate(eval_harness=None, state_dir=state_dir)
+
+
+def test_noisy_result_does_not_promote(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit", key=_KEY)
+    # One extra pass out of 16 tasks: noise.
+    base, cand = _outcomes(base_passes=8, cand_passes=9, n=16)
+    result = gate.evaluate_paired(
+        baseline_outcomes=base,
+        candidate_outcomes=cand,
+        hmac_key=_KEY,
+        timestamp=1_700_000_000,
+        audit_chain=chain,
+    )
+    assert result.accepted is False
+    assert result.promoted is False
+    assert result.stage == Stage.SHADOW.value
+    assert result.verdict == Verdict.INSUFFICIENT_EVIDENCE.value
+
+
+def test_significant_result_promotes_deterministically(tmp_path: Path) -> None:
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    receipts = []
+    # Two independent significant verdicts climb shadow -> canary.
+    for ts in (1_700_000_000, 1_700_000_100):
+        r = build_verdict_receipt(
+            baseline_outcomes=base,
+            candidate_outcomes=cand,
+            candidate_config_id="cfg-candidate",
+            baseline_config_id="cfg-baseline",
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            timestamp=ts,
+        )
+        assert r.verdict == Verdict.SIGNIFICANT_IMPROVEMENT
+        receipts.append(r)
+    projection = project(steps_from_receipts(receipts))
+    assert projection.final_stage is Stage.CANARY
+    # Determinism: rebuilding from the same inputs yields the same receipt hash.
+    again = build_verdict_receipt(
+        baseline_outcomes=base,
+        candidate_outcomes=cand,
+        candidate_config_id="cfg-candidate",
+        baseline_config_id="cfg-baseline",
+        workdir=tmp_path / "other",
+        lineage_root=tmp_path / "other" / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        timestamp=1_700_000_000,
+    )
+    assert again.receipt_hash == receipts[0].receipt_hash
+
+
+def test_baseline_ratchet_only_on_significant_improvement(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".sdd"
+    state_dir.mkdir(parents=True)
+    # Non-inferior verdict must NOT advance the baseline.
+    base_ni, cand_ni = _outcomes(base_passes=10, cand_passes=11, n=16)
+    ni_receipt = build_verdict_receipt(
+        baseline_outcomes={**base_ni, "t015": False},
+        candidate_outcomes={**cand_ni, "t015": True},
+        candidate_config_id="c",
+        baseline_config_id="b",
+        workdir=tmp_path,
+        lineage_root=state_dir / "lineage",
+        hmac_key=_KEY,
+        timestamp=1,
+    )
+    # Force a non-promoting or non-improvement receipt path.
+    if ni_receipt.verdict is Verdict.SIGNIFICANT_IMPROVEMENT:
+        # Fall back to an explicitly non-inferior fixture.
+        base2, cand2 = _outcomes(base_passes=12, cand_passes=12, n=16)
+        cand2["t000"] = False
+        cand2["t013"] = True
+        ni_receipt = build_verdict_receipt(
+            baseline_outcomes=base2,
+            candidate_outcomes=cand2,
+            candidate_config_id="c",
+            baseline_config_id="b",
+            workdir=tmp_path,
+            lineage_root=state_dir / "lineage",
+            hmac_key=_KEY,
+            timestamp=2,
+        )
+    assert ni_receipt.verdict is not Verdict.SIGNIFICANT_IMPROVEMENT
+    assert promote_baseline_from_receipt(state_dir, ni_receipt) is False
+    assert load_baseline(state_dir) is None
+
+    # A significant improvement advances it.
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    imp = build_verdict_receipt(
+        baseline_outcomes=base,
+        candidate_outcomes=cand,
+        candidate_config_id="c",
+        baseline_config_id="b",
+        workdir=tmp_path,
+        lineage_root=state_dir / "lineage",
+        hmac_key=_KEY,
+        timestamp=3,
+    )
+    assert imp.verdict is Verdict.SIGNIFICANT_IMPROVEMENT
+    assert promote_baseline_from_receipt(state_dir, imp) is True
+    baseline = load_baseline(state_dir)
+    assert baseline is not None
+    assert baseline.score == imp.evidence.cand_rate
+
+
+def test_regression_triggers_signed_revocation(tmp_path: Path) -> None:
+    gate = _gate(tmp_path)
+    chain = AuditChainStore(tmp_path / ".sdd" / "audit", key=_KEY)
+    base, cand = _outcomes(base_passes=4, cand_passes=12, n=16)
+    reg_base, reg_cand = _outcomes(base_passes=14, cand_passes=4, n=16)
+
+    prior = []
+    # Two improvements climb to canary.
+    for ts in (1, 2):
+        r = build_verdict_receipt(
+            baseline_outcomes=base,
+            candidate_outcomes=cand,
+            candidate_config_id="cfg-candidate",
+            baseline_config_id="cfg-baseline",
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            timestamp=ts,
+            chain=chain,
+        )
+        prior.append(r)
+    assert project(steps_from_receipts(prior)).final_stage is Stage.CANARY
+
+    # A regression at canary rolls back and emits a signed revocation receipt.
+    result = gate.evaluate_paired(
+        baseline_outcomes=reg_base,
+        candidate_outcomes=reg_cand,
+        hmac_key=_KEY,
+        timestamp=3,
+        candidate_config_id="cfg-candidate",
+        baseline_config_id="cfg-baseline",
+        prior_receipts=prior,
+        audit_chain=chain,
+    )
+    assert result.verdict == Verdict.SIGNIFICANT_REGRESSION.value
+    assert result.stage == Stage.ROLLED_BACK.value
+    assert result.revocation_receipt_hash is not None
+
+    # The revocation receipt verifies offline and the chain confirms the linkage.
+    rev = verify_revocation_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=result.revocation_receipt_hash,
+    )
+    assert rev.ok, rev.reason
+    assert rev.receipt is not None
+    assert set(rev.receipt.revoked_receipt_hashes) == {r.receipt_hash for r in prior}
+
+    verdict_events = chain.query(event_type=EVENT_EVAL_GATE_VERDICT)
+    revocation_events = chain.query(event_type=EVENT_EVAL_GATE_REVOCATION)
+    assert len(verdict_events) == 3
+    assert len(revocation_events) == 1
+    assert revocation_events[0].details["trigger_receipt_hash"] == result.receipt_hash
+    ok, errors = chain.verify()
+    assert ok, errors
+
+    # Every sealed verdict receipt still verifies offline.
+    for r in prior:
+        v = verify_verdict_receipt(
+            workdir=tmp_path,
+            lineage_root=tmp_path / ".sdd" / "lineage",
+            hmac_key=_KEY,
+            receipt_hash=r.receipt_hash,
+        )
+        assert v.ok, v.reason
+
+
+def test_benchmark_gate_significance_mode(tmp_path: Path) -> None:
+    gate = BenchmarkGate(workdir=tmp_path, run_dir=tmp_path)
+    base = {f"b{i:02d}": True for i in range(16)}
+    # Candidate regresses on many benchmarks.
+    current = {f"b{i:02d}": (i >= 10) for i in range(16)}
+    result = gate.evaluate_significance(baseline_outcomes=base, current_outcomes=current)
+    assert result.verdict is Verdict.SIGNIFICANT_REGRESSION  # type: ignore[attr-defined]
+
+
+def test_doctor_advisory_flags_below_min_n_receipts(tmp_path: Path) -> None:
+    from bernstein.cli.commands.doctor_cmd import check_eval_gate_min_n_advisory
+
+    # No receipts yet: advisory passes.
+    clean = check_eval_gate_min_n_advisory(tmp_path)
+    assert clean["status"] == "PASS"
+
+    # Seal an underpowered (n=4) verdict receipt.
+    base, cand = _outcomes(base_passes=0, cand_passes=4, n=4)
+    receipt = build_verdict_receipt(
+        baseline_outcomes=base,
+        candidate_outcomes=cand,
+        candidate_config_id="c",
+        baseline_config_id="b",
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        timestamp=1,
+    )
+    assert receipt.evidence.min_n_satisfied is False
+    flagged = check_eval_gate_min_n_advisory(tmp_path)
+    assert flagged["status"] == "WARN"
+    assert "below the minimum n" in flagged["detail"]

--- a/tests/unit/test_eval_promotion.py
+++ b/tests/unit/test_eval_promotion.py
@@ -1,0 +1,195 @@
+"""Tests for deterministic stage promotion and revocation (#2520).
+
+The stage assignment at any moment is a pure fold over the ordered chain of
+verdict receipts: no state file holds the assignment, the receipt chain IS the
+assignment. A significant_regression at canary or default emits a revocation
+receipt that reverts the projection to the prior default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.audit_chain import (
+    EVENT_EVAL_GATE_REVOCATION,
+    AuditChainStore,
+)
+from bernstein.eval.promotion import (
+    DEFAULT_CANARY_TO_DEFAULT_M,
+    DEFAULT_SHADOW_TO_CANARY_K,
+    Stage,
+    VerdictStep,
+    build_revocation_receipt,
+    project,
+    replay_history,
+    verify_revocation_receipt,
+)
+from bernstein.eval.significance import Verdict
+
+_KEY = b"k" * 32
+
+
+def _step(idx: int, verdict: Verdict) -> VerdictStep:
+    return VerdictStep(
+        receipt_hash="sha256:" + f"{idx:064d}",
+        verdict=verdict,
+        candidate_config_id="cfg-candidate",
+        baseline_config_id="cfg-baseline",
+    )
+
+
+def _chain(verdicts: list[Verdict]) -> list[VerdictStep]:
+    return [_step(i, v) for i, v in enumerate(verdicts)]
+
+
+# ---------------------------------------------------------------------------
+# Promotion ladder
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_promotes_to_canary_after_k_promoting_verdicts() -> None:
+    steps = _chain([Verdict.NON_INFERIOR] * DEFAULT_SHADOW_TO_CANARY_K)
+    proj = project(steps)
+    assert proj.final_stage is Stage.CANARY
+
+
+def test_full_ladder_shadow_canary_default() -> None:
+    n = DEFAULT_SHADOW_TO_CANARY_K + DEFAULT_CANARY_TO_DEFAULT_M
+    steps = _chain([Verdict.SIGNIFICANT_IMPROVEMENT] * n)
+    proj = project(steps)
+    assert proj.final_stage is Stage.DEFAULT
+    assert proj.default_config_id == "cfg-candidate"
+
+
+def test_insufficient_evidence_breaks_the_streak() -> None:
+    # A non-promoting verdict interrupts the consecutive run, so the candidate
+    # never reaches canary.
+    steps = _chain([Verdict.NON_INFERIOR, Verdict.INSUFFICIENT_EVIDENCE, Verdict.NON_INFERIOR])
+    proj = project(steps, k=3)
+    assert proj.final_stage is Stage.SHADOW
+
+
+def test_noise_never_promotes() -> None:
+    steps = _chain([Verdict.INSUFFICIENT_EVIDENCE] * 10)
+    proj = project(steps)
+    assert proj.final_stage is Stage.SHADOW
+    assert proj.revocations == ()
+
+
+# ---------------------------------------------------------------------------
+# Prefix recomputability (AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_stage_at_every_prefix_is_recomputable() -> None:
+    verdicts = [
+        Verdict.SIGNIFICANT_IMPROVEMENT,
+        Verdict.SIGNIFICANT_IMPROVEMENT,
+        Verdict.NON_INFERIOR,
+        Verdict.SIGNIFICANT_IMPROVEMENT,
+        Verdict.SIGNIFICANT_REGRESSION,
+        Verdict.SIGNIFICANT_IMPROVEMENT,
+    ]
+    steps = _chain(verdicts)
+    full = project(steps)
+    history = replay_history(steps)
+    assert len(history) == len(steps)
+    # Each prefix folded independently reproduces the same stage at that point.
+    for j in range(1, len(steps) + 1):
+        prefix = project(steps[:j])
+        assert prefix.final_stage is history[j - 1]
+        assert prefix.final_stage is full.stage_at_prefix[j - 1]
+
+
+# ---------------------------------------------------------------------------
+# Rollback / revocation (AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_regression_at_canary_rolls_back_to_prior_default() -> None:
+    k = DEFAULT_SHADOW_TO_CANARY_K
+    steps = _chain([Verdict.SIGNIFICANT_IMPROVEMENT] * k + [Verdict.SIGNIFICANT_REGRESSION])
+    proj = project(steps)
+    assert proj.final_stage is Stage.ROLLED_BACK
+    # The projection reverts to the prior default (the incumbent baseline).
+    assert proj.default_config_id == "cfg-baseline"
+    assert len(proj.revocations) == 1
+    revocation = proj.revocations[0]
+    # It names the promoting receipts that lifted the candidate off shadow.
+    assert set(revocation.revoked_receipt_hashes) == {s.receipt_hash for s in steps[:k]}
+    assert revocation.reverts_to_config_id == "cfg-baseline"
+    assert revocation.trigger_receipt_hash == steps[-1].receipt_hash
+
+
+def test_regression_at_shadow_is_a_noop() -> None:
+    steps = _chain([Verdict.SIGNIFICANT_REGRESSION])
+    proj = project(steps)
+    assert proj.final_stage is Stage.SHADOW
+    assert proj.revocations == ()
+
+
+def test_projection_is_pure() -> None:
+    steps = _chain([Verdict.SIGNIFICANT_IMPROVEMENT] * 4 + [Verdict.SIGNIFICANT_REGRESSION])
+    assert project(steps) == project(steps)
+
+
+# ---------------------------------------------------------------------------
+# Signed revocation receipt (AC5 linkage)
+# ---------------------------------------------------------------------------
+
+
+def test_revocation_receipt_seals_and_verifies(tmp_path: Path) -> None:
+    k = DEFAULT_SHADOW_TO_CANARY_K
+    steps = _chain([Verdict.SIGNIFICANT_IMPROVEMENT] * k + [Verdict.SIGNIFICANT_REGRESSION])
+    proj = project(steps)
+    revocation = proj.revocations[0]
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    receipt = build_revocation_receipt(
+        revocation=revocation,
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        timestamp=1_700_000_000,
+        chain=chain,
+    )
+    result = verify_revocation_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=receipt.receipt_hash,
+    )
+    assert result.ok, result.reason
+    events = chain.query(event_type=EVENT_EVAL_GATE_REVOCATION)
+    assert len(events) == 1
+    assert set(events[0].details["revoked_receipt_hashes"]) == set(revocation.revoked_receipt_hashes)
+    assert events[0].details["trigger_receipt_hash"] == revocation.trigger_receipt_hash
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+def test_tampered_revocation_receipt_fails(tmp_path: Path) -> None:
+    import json
+
+    from bernstein.eval.promotion import revocation_receipt_path
+
+    k = DEFAULT_SHADOW_TO_CANARY_K
+    steps = _chain([Verdict.SIGNIFICANT_IMPROVEMENT] * k + [Verdict.SIGNIFICANT_REGRESSION])
+    revocation = project(steps).revocations[0]
+    receipt = build_revocation_receipt(
+        revocation=revocation,
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        timestamp=1_700_000_000,
+    )
+    path = revocation_receipt_path(tmp_path, receipt.receipt_hash)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["reverts_to_stage"] = "default"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    result = verify_revocation_receipt(
+        workdir=tmp_path,
+        lineage_root=tmp_path / ".sdd" / "lineage",
+        hmac_key=_KEY,
+        receipt_hash=receipt.receipt_hash,
+    )
+    assert not result.ok

--- a/tests/unit/test_eval_significance.py
+++ b/tests/unit/test_eval_significance.py
@@ -1,0 +1,195 @@
+"""Tests for the pure statistics layer behind statistical eval gating (#2520).
+
+The module provides exact paired tests for pass/fail outcomes, Wilson score
+intervals, a fixed minimum-n rule per verdict strength, and canonical rounding
+so verdicts are a pure, bit-stable function of the evidence.
+"""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+import pytest
+
+from bernstein.eval.significance import (
+    DEFAULT_ALPHA,
+    DEFAULT_MIN_N,
+    SUPPORTED_ALPHAS,
+    PairedTable,
+    Verdict,
+    binom_tail_ge,
+    canonical_round,
+    classify,
+    result_set_hash,
+    suite_content_hash,
+    wilson_interval,
+)
+
+# ---------------------------------------------------------------------------
+# Exact binomial tail
+# ---------------------------------------------------------------------------
+
+
+def test_binom_tail_ge_is_exact_fraction() -> None:
+    # P(X >= 5) for Binom(5, 1/2) == 1/32.
+    assert binom_tail_ge(5, 5) == Fraction(1, 32)
+    # P(X >= 0) is the whole mass.
+    assert binom_tail_ge(0, 5) == Fraction(1, 1)
+    # P(X >= 3) for Binom(4, 1/2) == (4 + 1)/16 == 5/16.
+    assert binom_tail_ge(3, 4) == Fraction(5, 16)
+
+
+def test_binom_tail_ge_zero_trials() -> None:
+    assert binom_tail_ge(0, 0) == Fraction(1, 1)
+
+
+def test_binom_tail_ge_rejects_bad_args() -> None:
+    with pytest.raises(ValueError, match="k"):
+        binom_tail_ge(-1, 5)
+    with pytest.raises(ValueError, match="n"):
+        binom_tail_ge(2, -1)
+
+
+# ---------------------------------------------------------------------------
+# Wilson interval
+# ---------------------------------------------------------------------------
+
+
+def test_wilson_interval_bounds_are_ordered_and_in_unit() -> None:
+    z = SUPPORTED_ALPHAS[DEFAULT_ALPHA]
+    low, high = wilson_interval(8, 10, z)
+    assert 0.0 <= low <= high <= 1.0
+
+
+def test_wilson_interval_zero_n_is_full_unit() -> None:
+    z = SUPPORTED_ALPHAS[DEFAULT_ALPHA]
+    low, high = wilson_interval(0, 0, z)
+    assert (low, high) == (0.0, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Canonical rounding (bit stability)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_round_is_half_even_and_stable() -> None:
+    # round-half-to-even at 10 places.
+    assert canonical_round(0.12345678905) == canonical_round(0.12345678905)
+    assert canonical_round(1 / 3) == canonical_round(1 / 3)
+    # A value already at fewer places is unchanged.
+    assert canonical_round(0.5) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# PairedTable construction and order invariance
+# ---------------------------------------------------------------------------
+
+
+def test_paired_table_from_outcomes_is_order_invariant() -> None:
+    base = {"t1": True, "t2": False, "t3": True, "t4": False}
+    cand = {"t1": True, "t2": True, "t3": True, "t4": True}
+    forward = PairedTable.from_outcomes(base, cand)
+    # Reversed insertion order must produce the identical table.
+    base_rev = dict(reversed(list(base.items())))
+    cand_rev = dict(reversed(list(cand.items())))
+    reverse = PairedTable.from_outcomes(base_rev, cand_rev)
+    assert forward == reverse
+    # base fails t2,t4 that candidate passes -> cand_only_pass == 2.
+    assert forward.cand_only_pass == 2
+    assert forward.base_only_pass == 0
+    assert forward.both_pass == 2
+    assert forward.both_fail == 0
+    assert forward.n == 4
+
+
+def test_paired_table_rejects_mismatched_task_sets() -> None:
+    with pytest.raises(ValueError, match="task"):
+        PairedTable.from_outcomes({"t1": True}, {"t2": True})
+
+
+# ---------------------------------------------------------------------------
+# classify: the pure verdict function
+# ---------------------------------------------------------------------------
+
+
+def _uniform_outcomes(base_passes: int, cand_passes: int, n: int) -> PairedTable:
+    """Build a table that is a pure function of arm pass counts.
+
+    The first ``base_passes`` tasks pass under baseline; the first
+    ``cand_passes`` tasks pass under candidate. This makes the discordant
+    structure deterministic for fixtures.
+    """
+    base = {f"t{i:03d}": (i < base_passes) for i in range(n)}
+    cand = {f"t{i:03d}": (i < cand_passes) for i in range(n)}
+    return PairedTable.from_outcomes(base, cand)
+
+
+def test_classify_significant_improvement_promotes() -> None:
+    # Baseline passes 4/16, candidate passes 12/16, all baseline passes kept.
+    table = _uniform_outcomes(base_passes=4, cand_passes=12, n=16)
+    res = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    assert res.verdict == Verdict.SIGNIFICANT_IMPROVEMENT
+    assert res.min_n_satisfied is True
+
+
+def test_classify_significant_regression() -> None:
+    table = _uniform_outcomes(base_passes=14, cand_passes=4, n=16)
+    res = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    assert res.verdict == Verdict.SIGNIFICANT_REGRESSION
+
+
+def test_classify_candidate_equals_baseline_is_insufficient() -> None:
+    # Identical result sets: no discordant evidence -> insufficient_evidence.
+    table = _uniform_outcomes(base_passes=10, cand_passes=10, n=16)
+    res = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    assert res.verdict == Verdict.INSUFFICIENT_EVIDENCE
+    assert res.never_promotes is True
+
+
+def test_classify_below_min_n_refuses_promotion_with_reason() -> None:
+    # A strong effect but only n=4 tasks: an ordinary threshold gate would pass.
+    table = _uniform_outcomes(base_passes=0, cand_passes=4, n=4)
+    res = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    assert res.verdict == Verdict.INSUFFICIENT_EVIDENCE
+    assert res.reason == "below_minimum_n"
+    assert res.min_n_satisfied is False
+    assert res.never_promotes is True
+
+
+def test_classify_noise_does_not_promote() -> None:
+    # One extra pass out of 16 tasks: not significant, interval too wide.
+    table = _uniform_outcomes(base_passes=8, cand_passes=9, n=16)
+    res = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    assert res.verdict != Verdict.SIGNIFICANT_IMPROVEMENT
+    assert res.never_promotes is True
+
+
+def test_classify_is_pure_and_reproducible() -> None:
+    table = _uniform_outcomes(base_passes=4, cand_passes=12, n=16)
+    a = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    b = classify(table, alpha=DEFAULT_ALPHA, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+    assert a.to_dict() == b.to_dict()
+
+
+def test_classify_rejects_unsupported_alpha() -> None:
+    table = _uniform_outcomes(base_passes=4, cand_passes=12, n=16)
+    with pytest.raises(ValueError, match="alpha"):
+        classify(table, alpha=0.123, non_inferiority_margin=0.05, min_n=DEFAULT_MIN_N)
+
+
+# ---------------------------------------------------------------------------
+# Hash helpers
+# ---------------------------------------------------------------------------
+
+
+def test_result_set_hash_is_order_invariant() -> None:
+    a = result_set_hash({"t1": True, "t2": False})
+    b = result_set_hash({"t2": False, "t1": True})
+    assert a == b
+    assert a.startswith("sha256:")
+
+
+def test_suite_content_hash_is_order_invariant() -> None:
+    a = suite_content_hash(["t2", "t1", "t3"])
+    b = suite_content_hash(["t1", "t2", "t3"])
+    assert a == b


### PR DESCRIPTION
## Summary

Every eval gate in the codebase compared point estimates over suites of a handful of tasks, where a pass or fail verdict is frequently noise a re-run can flip, with no evidence a later regression could be traced back to. This makes the gate verdict a receipt that carries its statistical evidence, and makes stage promotion a deterministic projection of the receipt chain.

## What landed

- **`eval/significance.py`** (pure, no new deps): exact paired test for pass/fail outcomes (McNemar over discordant pairs using exact rational binomial tails), Wilson score intervals, a fixed minimum-n rule per verdict strength, and canonical round-half-even so results are bit-stable across platforms. Verdicts are one of `significant_improvement`, `non_inferior`, `insufficient_evidence`, `significant_regression`.
- **`eval/gate_receipt.py`**: canonical-JSON verdict receipt carrying the suite content hash, both result-set hashes, the 2x2 evidence, per-arm n, effect, interval bounds, alpha, minimum-n check, and the verdict. Anchored to the lineage spine and mirrored into the HMAC audit chain (dispatch-receipt pattern). Offline verify re-derives the verdict from the embedded evidence, so a receipt whose evidence does not entail its verdict is rejected even when its hashes are internally consistent.
- **`eval/promotion.py`**: stage assignment (`shadow` -> `canary` -> `default`) as a pure fold over the ordered receipt chain; `k` consecutive non-inferior-or-better verdicts promote shadow to canary, `m` at canary promote to default, and a `significant_regression` at canary or default triggers a rollback that reverts to the prior default. Rollbacks emit signed revocation receipts naming the revoked receipt hashes. No state file holds the assignment: the receipt chain is the assignment, recomputable at every prefix.
- **Consumers**: `EvalGate.evaluate_paired` consumes verdict receipts and projects promotion; the baseline ratchet advances only on a `significant_improvement` receipt; the benchmark gate gains an optional significance mode. The legacy point-threshold path stays behind an explicit compatibility flag and is marked deprecated.
- **CLI**: `bernstein eval gate` (emit a verdict receipt for two result sets), `bernstein eval promotions` (project the stage history from the chain), `bernstein eval gate-verify` (offline verification passthrough), plus a `bernstein doctor` advisory when a gate decision was taken below the minimum n.
- **audit_chain**: additive `eval.gate_verdict` and `eval.gate_revocation` events (no existing constants touched).

## Killer shape

The verdict receipt IS the significance evidence, and the promotion stage is a deterministic projection of the receipt chain. Strip the receipts and it degrades to a threshold compare with a log.

## Acceptance criteria

- [x] Same two result sets, any ingestion order, on independent machines produce byte-identical receipt payloads and identical receipt hashes.
- [x] A stored receipt verifies offline; mutating any evidence field or the verdict fails verification, and a receipt whose evidence does not entail its verdict is rejected even when its hashes are internally consistent.
- [x] The stage assignment at every prefix of the chain is recomputable from the chain alone, reproducing promotion and rollback history with no auxiliary state file.
- [x] A candidate indistinguishable from baseline yields `insufficient_evidence` and never promotes; a gate below the minimum n per arm refuses a promoting verdict with a machine-readable reason.
- [x] A `significant_regression` at canary emits a revocation receipt naming the revoked hashes and reverts to the prior default; audit verify confirms the linkage.
- [x] The EvalGate path and baseline ratchet consume verdict receipts, with the legacy point-threshold path behind an explicit compatibility flag and marked deprecated.

## Tests

47 new tests across statistics, receipts, promotion/revocation, the end-to-end gate path, and the CLI. Existing eval-gate, benchmark-gate, calibration, evolution, audit-chain, doctor, and golden-snapshot suites stay green. `ruff check` and `ruff format --check` clean; new modules are pyright-clean.

## Verification (driven end to end)

```
NOISY (8/16 vs 9/16):      insufficient_evidence  -> stage shadow (no promotion)
SIGNIFICANT x2 (4/16 vs 12/16): significant_improvement -> shadow then canary
REGRESSION (14/16 vs 4/16): significant_regression -> rolled_back, revoked 2 receipts, reverts to shadow, default reverts to baseline
gate-verify: {"ok": true}
below-min-n (n=4): insufficient_evidence, reason below_minimum_n
```

Closes #2520