### PR TITLE
feat(orchestration): route ACP-declared adapters through the ACP event channel

### DIFF
--- a/src/bernstein/core/orchestration/event_channel_router.py
+++ b/src/bernstein/core/orchestration/event_channel_router.py
@@ -1,0 +1,131 @@
+"""Route a spawned adapter's lifecycle by its declared ``EventChannel``.
+
+Follow-up to the ACP event transport (#2522). That work added a first-class,
+content-addressed ACP client transport
+(:mod:`bernstein.core.protocols.acp.client`), the adapter-side binding
+(:func:`bernstein.adapters.acp_channel.run_acp_channel`), and migrated the
+``goose`` and ``kilo`` adapters to
+:attr:`bernstein.adapters._contract.EventChannel.ACP`. What it did not add was a
+consumer: the orchestrator's monitoring loop never read the declared channel, so
+in a real run an ACP-declared adapter still fell through the text-signal
+lifecycle path and none of its structured events reached the run journal.
+
+This module is that missing dispatch seam. It reads an adapter's declared
+``EventChannel`` and, for an ACP-channel adapter, drives the upstream agent's
+JSON-RPC frame stream through ``run_acp_channel`` - every frame schema-validated
+and chained into the run's Merkle journal content-addressed, so the run's replay
+identity covers the agent's output and a mutated event surfaces as a hash
+divergence at a precise step index rather than a silent drift. Text-signal
+adapters return ``None`` and keep their existing path unchanged; the dispatch is
+strictly additive.
+
+The seam lives in ``core.orchestration`` rather than ``adapters`` on purpose:
+the ``adapters-no-scheduler`` import-linter contract forbids an adapter from
+importing the scheduler, but the scheduler may import
+:mod:`bernstein.adapters.acp_channel`, so this is the correct side of the
+boundary for wiring the declared channel into the monitoring loop.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.adapters.acp_channel import (
+    AcpLifecycleResult,
+    adapter_speaks_acp,
+    run_acp_channel,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+    from pathlib import Path
+
+    from bernstein.core.replay.journal import EventJournal
+
+__all__ = [
+    "AcpLifecycleResult",
+    "agent_uses_acp_channel",
+    "iter_journal_frames",
+    "route_agent_lifecycle",
+]
+
+
+def agent_uses_acp_channel(adapter_name: str) -> bool:
+    """Return whether *adapter_name* declares :attr:`EventChannel.ACP`.
+
+    Resolution goes through
+    :func:`bernstein.adapters.acp_channel.adapter_speaks_acp`, so the name may be
+    either a registry key (``"kilo"``) or the session-namespace form, and an
+    undeclared or empty name answers ``False`` (its conservative default channel
+    is text signals).
+    """
+    return bool(adapter_name) and adapter_speaks_acp(adapter_name)
+
+
+def iter_journal_frames(log_path: Path) -> Iterator[bytes]:
+    """Yield the JSON-RPC frame lines a finished ACP agent wrote to its log.
+
+    The detached-worker model captures an agent's stdout to a per-session log
+    file, so once the process has exited its ACP frame stream can be replayed
+    from that file byte for byte. Blank lines are skipped and a missing file
+    yields nothing, mirroring
+    :func:`bernstein.adapters.acp_channel.iter_process_frames` for the live-pipe
+    case.
+
+    Args:
+        log_path: The file capturing the upstream agent's stdout.
+
+    Yields:
+        Each non-empty line, including its trailing newline.
+    """
+    if not log_path.exists():
+        return
+    with log_path.open("rb") as fh:
+        for line in fh:
+            if line.strip():
+                yield line
+
+
+def route_agent_lifecycle(
+    adapter_name: str,
+    inbound: Iterable[bytes | str],
+    *,
+    journal: EventJournal,
+    session_id: str,
+    stop_at_terminal: bool = True,
+) -> AcpLifecycleResult | None:
+    """Dispatch a spawned adapter's lifecycle by its declared ``EventChannel``.
+
+    An ACP-channel adapter is driven through
+    :func:`bernstein.adapters.acp_channel.run_acp_channel`: the structured
+    JSON-RPC lifecycle with content-addressed journaling into *journal*. The
+    returned :class:`AcpLifecycleResult` carries the terminal outcome and the
+    Merkle journal head. Every other adapter returns ``None`` - the caller keeps
+    the existing text-signal lifecycle path, and *journal* is left untouched.
+
+    Args:
+        adapter_name: Registry key or namespace form of the session's adapter.
+        inbound: The upstream agent's JSON-RPC frames (for a finished agent,
+            :func:`iter_journal_frames` over its captured log).
+        journal: The run's event journal; every inbound ACP event is recorded
+            content-addressed.
+        session_id: The adapter session id, retained for correlation.
+        stop_at_terminal: Stop after the first terminal ACP event.
+
+    Returns:
+        An :class:`AcpLifecycleResult` for an ACP-channel adapter, otherwise
+        ``None``.
+
+    Raises:
+        ACPSchemaError: An inbound frame failed schema validation. The malformed
+            frame is refused at the boundary and journals nothing; events already
+            recorded before it remain.
+    """
+    if not agent_uses_acp_channel(adapter_name):
+        return None
+    return run_acp_channel(
+        inbound,
+        journal=journal,
+        session_id=session_id,
+        stop_at_terminal=stop_at_terminal,
+    )

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -91,6 +91,11 @@ from bernstein.core.models import (
 )
 from bernstein.core.notifications import NotificationManager, NotificationPayload, NotificationTarget
 from bernstein.core.orchestration.adaptive_parallelism import AdaptiveParallelism
+from bernstein.core.orchestration.event_channel_router import (
+    agent_uses_acp_channel,
+    iter_journal_frames,
+    route_agent_lifecycle,
+)
 from bernstein.core.orchestration.evolution import EvolutionCoordinator
 from bernstein.core.orchestration.tick_pipeline import (
     CompletionData,
@@ -602,6 +607,12 @@ class Orchestrator:
         # absence of mutation entries distinguishable from an inability to
         # observe them.
         self._mutation_capability_recorded: set[str] = set()
+
+        # Sessions whose ACP event channel has already been driven into the run
+        # journal (#2522 follow-up). The monitoring loop drives an ACP-declared
+        # adapter's structured lifecycle once, after its process exits; this set
+        # keeps that pass idempotent across ticks.
+        self._acp_driven: set[str] = set()
 
         # Replay gateway: captures LLM + tool dispatch responses into
         # .sdd/runs/{run_id}/events.jsonl so a run can be re-executed
@@ -1499,6 +1510,12 @@ class Orchestrator:
 
         # Sync failure timestamps to spawner for cooldown enforcement
         self._spawner._agent_failure_timestamps = self._agent_failure_timestamps
+
+        # Route finished ACP-declared adapters (goose/kilo) through the ACP event
+        # channel before dead-agent finalization purges them: their structured
+        # JSON-RPC lifecycle is chained into the run journal content-addressed
+        # instead of falling through the text-signal path (#2522 follow-up).
+        self._drive_finished_acp_channels()
 
         refresh_agent_states(self, tasks_by_status)
         alive_count = sum(1 for a in self._agents.values() if a.status != "dead")
@@ -4884,6 +4901,62 @@ class Orchestrator:
                 agent_id,
                 type(exc).__name__,
             )
+
+    def _resolve_acp_log_path(self, session: AgentSession) -> Path:
+        """Resolve the file capturing a session's upstream JSON-RPC frame stream.
+
+        Prefers the session's recorded ``log_path`` when it exists, else the
+        canonical per-session runtime log. Mirrors the primary branches of
+        :func:`bernstein.core.agents.agent_lifecycle._resolve_agent_log_path`
+        without importing a private symbol across modules.
+        """
+        from pathlib import Path
+
+        recorded = getattr(session, "log_path", "")
+        if recorded and Path(recorded).exists():
+            return Path(recorded)
+        return self._workdir / ".sdd" / "runtime" / f"{session.id}.log"
+
+    def _drive_finished_acp_channels(self) -> None:
+        """Route finished ACP-declared agents through the ACP event channel.
+
+        Follow-up to the ACP transport (#2522): the monitoring loop reads the run
+        adapter's declared ``EventChannel``. When it is
+        :attr:`~bernstein.adapters._contract.EventChannel.ACP` (``goose`` /
+        ``kilo``), each tracked agent whose process has exited has its captured
+        JSON-RPC frame stream validated and chained into the run journal
+        content-addressed via the structured ACP lifecycle - not the
+        ``BERNSTEIN:`` text grammar. Text-signal adapters are left entirely on
+        their existing path (the method returns immediately for a non-ACP run).
+
+        The frame stream is only complete once the process has exited, so a
+        still-alive agent is skipped and revisited on a later tick. The pass is
+        idempotent - each session is driven at most once via ``_acp_driven`` -
+        and every failure is logged and swallowed so channel routing can never
+        break a tick.
+        """
+        adapter_name = getattr(self._spawner, "default_adapter_name", "") or ""
+        if not agent_uses_acp_channel(adapter_name):
+            return
+        for session in list(self._agents.values()):
+            if session.id in self._acp_driven:
+                continue
+            if session.status != "dead" and self._spawner.check_alive(session):
+                continue
+            self._acp_driven.add(session.id)
+            try:
+                route_agent_lifecycle(
+                    adapter_name,
+                    iter_journal_frames(self._resolve_acp_log_path(session)),
+                    journal=self._recorder,
+                    session_id=session.id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "acp-channel: routing failed for agent %s: %s",
+                    session.id,
+                    type(exc).__name__,
+                )
 
     def _log_summary(self, result: TickResult) -> None:
         """Write a one-line summary and agent state snapshot each tick."""

--- a/tests/unit/orchestration/test_event_channel_router.py
+++ b/tests/unit/orchestration/test_event_channel_router.py
@@ -1,0 +1,213 @@
+"""Orchestrator routes ACP-declared adapters through the ACP event channel.
+
+Follow-up to the ACP transport (#2522): the transport, the content-addressed
+client journal, and the goose/kilo strategy-matrix migration all landed, but the
+orchestrator's monitoring loop never read the declared ``EventChannel``, so in a
+real run an ACP-declared adapter still fell through the text-signal lifecycle
+path. These tests pin the missing dispatch seam at two levels:
+
+* the pure router (:mod:`bernstein.core.orchestration.event_channel_router`),
+  which reads the declared channel and drives ACP adapters through
+  ``run_acp_channel`` while returning ``None`` for text-signal adapters, and
+* the orchestrator monitoring method that calls it for finished agents, proving
+  an ACP-declared adapter is journaled end to end (content-addressed, terminal,
+  byte-identically replayable) with no ``BERNSTEIN:`` text parsing involved.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+from typing import Any
+
+from bernstein.core.models import AgentSession
+
+from bernstein.core.orchestration.event_channel_router import (
+    agent_uses_acp_channel,
+    iter_journal_frames,
+    route_agent_lifecycle,
+)
+from bernstein.core.orchestration.orchestrator import Orchestrator
+from bernstein.core.protocols.acp.client import (
+    compare_acp_journals,
+    replay_acp_content_hashes,
+)
+from bernstein.core.replay.journal import EventJournal, load_events
+
+# A well-formed ACP prompt turn: initialize response, one stream update, and the
+# terminal prompt response carrying a non-error stopReason. No BERNSTEIN: text
+# grammar anywhere - the lifecycle is driven purely from structured frames.
+_SESSION_FRAMES: list[dict[str, Any]] = [
+    {"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-04-01"}},
+    {"jsonrpc": "2.0", "method": "streamUpdate", "params": {"sessionId": "s", "delta": {"text": "hi"}}},
+    {"jsonrpc": "2.0", "id": 2, "result": {"stopReason": "end_turn"}},
+]
+
+
+def _frame_lines(frames: list[dict[str, Any]]) -> list[bytes]:
+    return [(json.dumps(f) + "\n").encode("utf-8") for f in frames]
+
+
+def _acp_rows(journal: EventJournal) -> list[dict[str, Any]]:
+    return [row for row in load_events(journal.path) if row.get("event") == "acp_event"]
+
+
+# ---------------------------------------------------------------------------
+# Router: declared-channel dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_router_drives_acp_declared_adapter_through_acp_channel(tmp_path: Path) -> None:
+    journal = EventJournal("kilo-run", tmp_path)
+    result = route_agent_lifecycle(
+        "kilo",
+        _frame_lines(_SESSION_FRAMES),
+        journal=journal,
+        session_id="kilo-run",
+    )
+
+    assert result is not None  # kilo declares EventChannel.ACP -> routed, not None
+    assert result.terminal is True
+    assert result.ok is True
+    assert result.stop_reason == "end_turn"
+    assert result.event_count == len(_SESSION_FRAMES)
+    # Every inbound frame is chained into the run journal content-addressed.
+    assert len(_acp_rows(journal)) == len(_SESSION_FRAMES)
+    assert result.journal_head == journal.head()
+    assert journal.verify().ok
+    # The lifecycle used structured frames only: no text grammar was emitted.
+    assert not any(b"BERNSTEIN:" in line for line in _frame_lines(_SESSION_FRAMES))
+
+
+def test_router_leaves_text_signal_adapter_on_existing_path(tmp_path: Path) -> None:
+    journal = EventJournal("aider-run", tmp_path)
+    result = route_agent_lifecycle(
+        "aider",
+        _frame_lines(_SESSION_FRAMES),
+        journal=journal,
+        session_id="aider-run",
+    )
+
+    # aider is a text-signal adapter: the router does not consume its stream and
+    # records nothing, so the existing lifecycle path is left untouched.
+    assert result is None
+    assert _acp_rows(journal) == []
+
+
+def test_agent_uses_acp_channel_predicate() -> None:
+    assert agent_uses_acp_channel("kilo") is True
+    assert agent_uses_acp_channel("goose") is True
+    assert agent_uses_acp_channel("aider") is False
+    assert agent_uses_acp_channel("") is False
+
+
+def test_router_journal_replay_is_byte_identical(tmp_path: Path) -> None:
+    frames = _frame_lines(_SESSION_FRAMES)
+    first = EventJournal("kilo-a", tmp_path / "a")
+    second = EventJournal("kilo-b", tmp_path / "b")
+    route_agent_lifecycle("kilo", frames, journal=first, session_id="kilo-a")
+    route_agent_lifecycle("kilo", frames, journal=second, session_id="kilo-b")
+
+    # Byte-identical replay: the ordered content hashes are the ACP session's
+    # replay-stable identity, so two faithful drives agree at every step.
+    assert replay_acp_content_hashes(first.path) == replay_acp_content_hashes(second.path)
+    assert compare_acp_journals(first.path, second.path) is None
+
+
+# ---------------------------------------------------------------------------
+# iter_journal_frames helper
+# ---------------------------------------------------------------------------
+
+
+def test_iter_journal_frames_yields_nonblank_lines(tmp_path: Path) -> None:
+    log = tmp_path / "agent.log"
+    log.write_bytes(b"".join(_frame_lines(_SESSION_FRAMES)) + b"\n   \n")
+    assert list(iter_journal_frames(log)) == _frame_lines(_SESSION_FRAMES)
+
+
+def test_iter_journal_frames_missing_file_is_empty(tmp_path: Path) -> None:
+    assert list(iter_journal_frames(tmp_path / "absent.log")) == []
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator monitoring loop: end-to-end dispatch for a finished agent
+# ---------------------------------------------------------------------------
+
+
+def _bind(stub: SimpleNamespace, name: str) -> None:
+    setattr(stub, name, MethodType(getattr(Orchestrator, name), stub))
+
+
+def _orch_stub(tmp_path: Path, *, adapter: str) -> SimpleNamespace:
+    stub = SimpleNamespace(
+        _agents={},
+        _workdir=tmp_path,
+        _recorder=EventJournal("run-1", tmp_path / ".sdd"),
+        _acp_driven=set(),
+        _spawner=SimpleNamespace(default_adapter_name=adapter, check_alive=lambda _s: False),
+    )
+    _bind(stub, "_drive_finished_acp_channels")
+    _bind(stub, "_resolve_acp_log_path")
+    return stub
+
+
+def _finished_session(tmp_path: Path, session_id: str) -> AgentSession:
+    log = tmp_path / f"{session_id}.log"
+    log.write_bytes(b"".join(_frame_lines(_SESSION_FRAMES)))
+    return AgentSession(id=session_id, role="impl", status="dead", log_path=str(log))
+
+
+def test_monitoring_loop_drives_finished_acp_agent_end_to_end(tmp_path: Path) -> None:
+    stub = _orch_stub(tmp_path, adapter="kilo")
+    session = _finished_session(tmp_path, "agent-kilo")
+    stub._agents[session.id] = session
+
+    stub._drive_finished_acp_channels()
+
+    rows = _acp_rows(stub._recorder)
+    assert len(rows) == len(_SESSION_FRAMES)
+    assert rows[-1]["terminal"] is True
+    assert rows[-1]["stop_reason"] == "end_turn"
+    assert stub._recorder.verify().ok
+    assert session.id in stub._acp_driven
+
+
+def test_monitoring_loop_skips_text_signal_adapter(tmp_path: Path) -> None:
+    stub = _orch_stub(tmp_path, adapter="aider")
+    session = _finished_session(tmp_path, "agent-aider")
+    stub._agents[session.id] = session
+
+    stub._drive_finished_acp_channels()
+
+    # A text-signal run never routes through the ACP channel: nothing recorded.
+    assert _acp_rows(stub._recorder) == []
+
+
+def test_monitoring_loop_does_not_drive_live_agent(tmp_path: Path) -> None:
+    stub = _orch_stub(tmp_path, adapter="kilo")
+    stub._spawner.check_alive = lambda _s: True  # still running
+    session = _finished_session(tmp_path, "agent-live")
+    session.status = "working"
+    stub._agents[session.id] = session
+
+    stub._drive_finished_acp_channels()
+
+    # The frame stream is only complete after the process exits.
+    assert _acp_rows(stub._recorder) == []
+    assert session.id not in stub._acp_driven
+
+
+def test_monitoring_loop_acp_drive_is_idempotent(tmp_path: Path) -> None:
+    stub = _orch_stub(tmp_path, adapter="kilo")
+    session = _finished_session(tmp_path, "agent-kilo")
+    stub._agents[session.id] = session
+
+    stub._drive_finished_acp_channels()
+    first = len(_acp_rows(stub._recorder))
+    stub._drive_finished_acp_channels()
+    second = len(_acp_rows(stub._recorder))
+
+    # Each session is driven at most once: the second pass records nothing new.
+    assert first == len(_SESSION_FRAMES)
+    assert second == first


### PR DESCRIPTION
## What

Wire the orchestrator monitoring loop to route an adapter whose contract
declares `EventChannel.ACP` through `run_acp_channel`, so ACP-declared adapters
(`goose`, `kilo`) drive their lifecycle over structured JSON-RPC frames with
content-addressed journaling instead of falling through the text-signal path.

Follow-up to #2522, which added the first-class ACP event transport
(`core/protocols/acp/client.py`, `adapters/acp_channel.py`) and migrated the
`goose`/`kilo` adapters to `EventChannel.ACP`. That work shipped the transport
and the declaration but no consumer: nothing in `core.orchestration` read the
declared channel, so in a real run those adapters still used the text-signal
lifecycle and none of their structured events reached the run journal. This PR
completes that transport by adding the dispatch seam.

## How

- New `core/orchestration/event_channel_router.py`: reads the declared
  `EventChannel` and, for an ACP-channel adapter, drives the upstream agent's
  JSON-RPC frames through `run_acp_channel` (schema-validated, chained into the
  run journal content-addressed). Text-signal adapters return `None` and keep
  their existing path, so the change is strictly additive.
- `Orchestrator._drive_finished_acp_channels`: called from the tick before
  dead-agent finalization. For a run whose adapter declares ACP, each finished
  agent has its captured frame stream replayed into the run journal
  (`orch._recorder`) exactly once. Idempotent via `_acp_driven`; per-agent
  failures are logged and swallowed so routing can never break a tick.

The dispatch lives in `core.orchestration` (not `adapters/`) so the
`adapters-no-scheduler` import contract stays intact: an adapter must never
import the scheduler, but the scheduler may import `adapters.acp_channel`.

## Wiring point

`src/bernstein/core/orchestration/orchestrator.py` tick, immediately before
`refresh_agent_states(...)`, dispatching via the new
`core/orchestration/event_channel_router.py`.

## Tests

`tests/unit/orchestration/test_event_channel_router.py`:

- ACP-declared adapter routed through the ACP channel end to end (content-addressed
  journal rows, terminal outcome, `journal.verify().ok`), with no `BERNSTEIN:`
  text grammar involved.
- Text-signal adapter left on its existing path (`None`, journal untouched).
- Byte-identical replay: two journals over identical frames produce equal ordered
  content hashes and `compare_acp_journals(...) is None`.
- The orchestrator monitoring method drives a finished ACP agent into the run
  journal, skips still-running agents, skips text-signal runs, and is idempotent.

## Quality gates

- `ruff check` + `ruff format --check`: clean
- `lint-imports`: 3 contracts kept (no contract weakened)
- `bernstein agents-md verify`: in sync
- Golden CLI snapshots: unchanged (no serialized field changed)
- `pytest tests/unit/orchestration tests/unit/adapters/test_acp_channel.py tests/unit/adapters/test_capability_enums.py tests/unit/test_agent_lifecycle.py`: pass

Follow-up to #2522; closes nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ACP event-channel routing for adapters that declare ACP support.
  * Completed ACP lifecycle processing for finished sessions, including terminal status and stop reasons.
  * Added reliable replay of captured JSON-RPC event frames into the run journal.
  * Preserved the existing text-signal workflow for adapters that do not use ACP.

* **Bug Fixes**
  * Prevented duplicate ACP processing during monitoring cycles.
  * Ensured routing failures do not interrupt monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->