### PR TITLE
feat(security): issue scoped per-task credentials with chain-anchored delegation receipts

### DIFF
--- a/.github/workflows/spiffe-extra-e2e.yml
+++ b/.github/workflows/spiffe-extra-e2e.yml
@@ -1,0 +1,112 @@
+name: SPIFFE Extra E2E
+
+# Packages the SPIFFE credential path end to end (issue #2516). The default
+# self-contained install ships the Ed25519 identity path with the ``spiffe``
+# extra absent; operators who need workload-attested credentials install
+# ``bernstein[spiffe]``. This job builds the wheel and proves both shapes:
+#
+#   * the built wheel installs with the ``spiffe`` extra and the extra-present
+#     grant / SPIFFE suite passes (injected Workload API factory; no live SPIRE
+#     agent required);
+#   * a clean install WITHOUT the extra runs the same identity suites and the
+#     default Ed25519 paths pass unchanged.
+#
+# Kept out of the main CI matrix because it builds and installs the wheel into
+# throwaway virtualenvs, which the docs+test matrix does not need.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/bernstein/core/identity/grants.py"
+      - "src/bernstein/core/identity/spiffe/**"
+      - "src/bernstein/core/security/secrets_broker.py"
+      - "src/bernstein/cli/commands/secrets_cmd.py"
+      - "tests/unit/identity/test_grants.py"
+      - "tests/unit/identity/spiffe/**"
+      - "tests/unit/security/test_secrets_broker_grants.py"
+      - "pyproject.toml"
+      - ".github/workflows/spiffe-extra-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/bernstein/core/identity/grants.py"
+      - "src/bernstein/core/identity/spiffe/**"
+      - "src/bernstein/core/security/secrets_broker.py"
+      - ".github/workflows/spiffe-extra-e2e.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: spiffe-extra-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spiffe-extra-e2e:
+    name: SPIFFE extra E2E (built wheel, extra-present + no-extra suites)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: ./.github/actions/bootstrap
+        with:
+          python-version: "3.13"
+
+      - name: Build the wheel
+        run: |
+          uv build --wheel --out-dir dist
+          ls -1 dist/*.whl
+
+      - name: No-extra regression suite (default Ed25519 path, extra absent)
+        # The critical guarantee: with the spiffe extra ABSENT the default
+        # identity paths pass unchanged. This step is hard-required.
+        run: |
+          python -m venv .venv-noextra
+          . .venv-noextra/bin/activate
+          pip install --upgrade pip
+          pip install dist/*.whl pytest
+          # Prove the extra is genuinely absent, then run the identity suites.
+          python -c "import importlib.util as u; assert u.find_spec('spiffe') is None, 'spiffe extra unexpectedly present'; print('spiffe extra absent: OK')"
+          python -c "from bernstein.core.identity import grants; print('grants import OK without extra')"
+          python -c "from bernstein.core.identity.spiffe.workload_api import spiffe_extra_available; assert spiffe_extra_available() is False; print('spiffe_extra_available()=False OK')"
+          pytest -q \
+            tests/unit/identity/test_grants.py \
+            tests/unit/identity/spiffe/ \
+            tests/unit/security/test_secrets_broker_grants.py \
+            tests/unit/security/test_broker_grant_config.py \
+            tests/unit/cli/test_secrets_grants_cli.py \
+            tests/unit/test_doctor_spiffe.py
+
+      - name: Extra-present suite (built wheel installed with [spiffe])
+        # Best-effort: the py-spiffe SDK is a real third-party install; when it
+        # is unavailable on the runner this step degrades to a skip rather than
+        # reddening the packaging gate. The no-extra suite above is the hard
+        # guarantee; this step proves the packaged extra path when installable.
+        continue-on-error: true
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          python -m venv .venv-extra
+          . .venv-extra/bin/activate
+          pip install --upgrade pip
+          if ! pip install "${WHEEL}[spiffe]" pytest; then
+            echo "::warning::py-spiffe SDK not installable on this runner; skipping extra-present suite"
+            exit 0
+          fi
+          python -c "from bernstein.core.identity.spiffe.workload_api import spiffe_extra_available; assert spiffe_extra_available() is True; print('spiffe extra present: OK')"
+          # The grant / spiffe suites use an injected Workload API factory, so
+          # they exercise the packaged path without a live SPIRE agent.
+          pytest -q \
+            tests/unit/identity/test_grants.py \
+            tests/unit/identity/spiffe/ \
+            tests/unit/security/test_secrets_broker_grants.py \
+            tests/unit/test_doctor_spiffe.py

--- a/docs/reference/spiffe-workload-identity.md
+++ b/docs/reference/spiffe-workload-identity.md
@@ -104,6 +104,20 @@ With the socket reachable, `bernstein.core.identity.spiffe.workload_api`
 fetches the SVID, `bind_svid_to_card` binds it to the card and records the
 receipt, and `svid_tls_config` wires the SVID into the task server's mTLS.
 
+## Scoped credential grants carry the SPIFFE ID
+
+When the secrets broker runs in grant-enforcing mode with
+`grants.identity_mode: spiffe`, `bernstein.core.identity.spiffe.grant_identity`
+resolves the workload SPIFFE ID (from the fetched SVID) as the issuer identity
+on each scoped credential grant. The grant record's issuer is then the same
+`spiffe://` id checkable via `bernstein spiffe verify-binding`, so a
+per-task downstream credential is bound to the workload identity, not just to
+the install-scoped manager key. `bernstein doctor` preflights the extra and the
+Workload API socket; with the extra absent the grant issuer falls back to the
+default Ed25519 manager identity and the regression suite is unchanged. See
+[the secrets broker guide](../security/secrets-broker.md#scoped-per-task-grants)
+for the full grant lifecycle.
+
 ## Threat model notes
 
 - **Determinism is the trust root.** The SPIFFE ID is a pure function of the

--- a/docs/security/secrets-broker.md
+++ b/docs/security/secrets-broker.md
@@ -34,7 +34,14 @@ security:
         SHORT_LIVED_TOKEN: 60
     backend_settings:           # forwarded to the backend constructor
       path: /var/lib/bernstein/secrets.enc
+    grants:                     # scoped per-task credential grants (optional)
+      require_grant: false      # refuse to mint without a verifiable grant
+      identity_mode: ed25519    # ed25519 (default) | spiffe
 ```
+
+When `grants.require_grant` is `true`, the orchestrator must supply a
+verifiable, chain-anchored grant to `mint()`; the broker fails closed
+otherwise. See [Scoped per-task grants](#scoped-per-task-grants) below.
 
 ## Backend setup
 
@@ -115,3 +122,70 @@ in-process registry and scrubs every minted token value and raw backing
 value from the text it processes. The registry is updated automatically
 on mint and revoke; tests can clear it via
 `clear_redaction_registry()`.
+
+## Scoped per-task grants
+
+By default the broker hands any token holder the full backing secret. In
+grant-enforcing mode the credential becomes a projection of a
+chain-recorded grant, so a worker holds only a scoped, expiring token and
+post-incident forensics can prove the exact credential window per task
+from the chain alone.
+
+### The grant record
+
+Before a worker spawn the orchestrator issues a scoped grant with
+`bernstein.core.identity.grants.GrantLedger.issue_grant`: task id, secret
+name, audience, expiry, and capability ceiling. Each grant record carries
+two independent tamper anchors:
+
+- an **Ed25519 signature** by the manager identity over the grant body
+  (proves who authorized it), and
+- an **HMAC** over `prev_hmac` + the canonical record body, keyed by the
+  install audit key (the same construction as the delegation receipts in
+  `docs/security/manager-auth.md`), so a mutated, deleted, or reordered
+  record breaks the chain.
+
+Records land under `<audit>/grants/<run>.jsonl` and reconstruct the full
+`grant_issued -> grant_exchanged -> grant_revoked` lifecycle offline.
+
+### Broker exchange
+
+`SecretsBroker.mint(..., grant=grant)` refuses to mint unless the grant
+verifies against the chain and matches the `(task_id, secret_name)` pair;
+the refusal is itself a `grant_refused` chain record. The minted token
+inherits the grant's task id, audience, and expiry, and the token id is
+recorded via a `grant_exchanged` record so token-to-grant resolution
+works offline. `resolve(token, audience=...)` refuses a token presented
+outside its granted audience, recording the refusal as a chain event.
+`revoke()` and task-exit auto-revoke append a signed `grant_revoked`
+record referencing the grant.
+
+### Verifying offline
+
+```
+bernstein secrets grants list run-42            # reconstructed lifecycle
+bernstein secrets grants verify run-42          # HMAC + Ed25519 offline
+bernstein secrets grants verify run-42 --json   # byte-identical report
+bernstein audit verify                          # includes all grant chains
+```
+
+`grants verify` exits non-zero and names the first failing record on any
+mutation, deletion, or reordering. Two independent verifiers over the
+same chain slice produce byte-identical `--json` reports.
+
+### SPIFFE identity mode
+
+With `grants.identity_mode: spiffe` and the optional `spiffe` extra
+installed against a reachable SPIRE Workload API socket, new grants carry
+the workload's SPIFFE ID as the issuer identity, binding grants to the
+workload identity already checkable via `bernstein spiffe
+verify-binding`. `bernstein doctor` preflights the extra and socket. With
+the extra absent the default Ed25519 identity path is unchanged.
+
+### Migration
+
+Existing broker configs keep working unchanged: `grants.require_grant`
+defaults to `false` and `identity_mode` to `ed25519`, so a broker built
+without a grant ledger behaves exactly as before. To adopt scoped grants,
+add the `grants` block, construct the broker with a `GrantLedger`, and
+issue a grant per task before the spawn.

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -218,8 +218,65 @@ def verify_cmd(merkle_only: bool, hmac_only: bool) -> None:
     # must fail verify (#2556). Orthogonal to both HMAC chain and Merkle seal.
     all_passed = _verify_clearance_gates() and all_passed
 
+    # Credential grant chains are a further integrity pillar: a mutated,
+    # deleted, or reordered grant / exchange / revocation record must fail
+    # verify exactly like a tampered chain entry (#2516). Orthogonal to both
+    # HMAC chain and Merkle seal.
+    all_passed = _verify_grant_chains() and all_passed
+
     console.print()
     raise SystemExit(0 if all_passed else 1)
+
+
+def _verify_grant_chains() -> bool:
+    """Verify every per-run credential grant chain. Returns True if all valid.
+
+    Reconstructs each ``<audit>/grants/<run>.jsonl`` from genesis, recomputing
+    the HMAC linkage and the manager Ed25519 signature on every record. A
+    mutated field, a deleted record, or reordered records make ``bernstein
+    audit verify`` fail with the run and record named, exactly like a tampered
+    chain entry (#2516). When no grant chains exist the check is a silent no-op.
+    """
+    from bernstein.core.identity import grants
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    grants_dir = AUDIT_DIR / "grants"
+    if not grants_dir.is_dir():
+        return True  # no grant chains recorded; nothing to verify
+    run_files = sorted(grants_dir.glob("*.jsonl"))
+    if not run_files:
+        return True
+
+    try:
+        key = load_or_create_audit_key()
+    except OSError as exc:  # pragma: no cover - filesystem race
+        console.print(f"[red]Failed to load audit key for grant verification: {exc}[/red]")
+        return False
+
+    failures: list[tuple[str, list[str]]] = []
+    for path in run_files:
+        run_id = path.stem
+        result = grants.verify_grant_chain(root=AUDIT_DIR, run_id=run_id, key=key)
+        if not result.valid:
+            failures.append((run_id, result.errors))
+
+    console.print()
+    if not failures:
+        console.print(
+            Panel("[bold green]Grant Chain Verification Passed[/bold green]", border_style="green", expand=False)
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value")
+        table.add_row("Runs", str(len(run_files)))
+        console.print(table)
+        return True
+
+    console.print(Panel("[bold red]Grant Chain Verification FAILED[/bold red]", border_style="red", expand=False))
+    for run_id, errors in failures:
+        for err in errors:
+            console.print(f"  [red]![/red] run {run_id}: {err}")
+    return False
 
 
 def _verify_hmac_chain() -> bool:

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -495,6 +495,90 @@ def check_port_available() -> dict[str, Any]:
     }
 
 
+def _spiffe_extra_available() -> bool:
+    """Return True when the optional ``spiffe`` extra (py-spiffe SDK) is importable.
+
+    Wrapped as a module-level indirection so tests can stub the extra presence
+    without installing the SDK.
+    """
+    from bernstein.core.identity.spiffe.workload_api import spiffe_extra_available
+
+    return spiffe_extra_available()
+
+
+def _spiffe_socket_reachable(endpoint: str) -> bool:
+    """Return True when the SPIRE Workload API socket at ``endpoint`` accepts a connect.
+
+    Accepts a ``unix://`` endpoint or a bare filesystem path. A missing path or
+    a non-socket file is treated as unreachable; the probe never blocks longer
+    than half a second and never sends credential material.
+    """
+    import stat as _stat
+
+    path = endpoint[len("unix://") :] if endpoint.startswith("unix://") else endpoint
+    if not path:
+        return False
+    try:
+        mode = os.stat(path).st_mode
+    except OSError:
+        return False
+    if not _stat.S_ISSOCK(mode):
+        return False
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        probe.settimeout(0.5)
+        probe.connect(path)
+    except OSError:
+        return False
+    finally:
+        probe.close()
+    return True
+
+
+def check_spiffe_workload_api() -> dict[str, Any]:
+    """Preflight the packaged SPIFFE credential path (issue #2516, Phase 4).
+
+    The default Ed25519 identity path needs no extra. This check reports:
+
+    * PASS (informational) when the ``spiffe`` extra is absent -- the default
+      path is active and nothing is broken;
+    * WARN when the extra is present but ``SPIFFE_ENDPOINT_SOCKET`` is unset or
+      the socket is not reachable -- workload-attested grants cannot be issued
+      until a SPIRE agent is wired up;
+    * PASS when the extra is present and the Workload API socket is reachable --
+      the SVID path is ready and new grants can carry the SPIFFE ID issuer.
+    """
+    name = "SPIFFE workload API"
+    if not _spiffe_extra_available():
+        return {
+            "name": name,
+            "status": _CHECK_PASS,
+            "detail": "spiffe extra not installed; default Ed25519 identity path active",
+            "fix": "",
+        }
+    endpoint = os.environ.get("SPIFFE_ENDPOINT_SOCKET", "").strip()
+    if not endpoint:
+        return {
+            "name": name,
+            "status": _CHECK_WARN,
+            "detail": "spiffe extra present but SPIFFE_ENDPOINT_SOCKET is unset",
+            "fix": "Point SPIFFE_ENDPOINT_SOCKET at the SPIRE agent's Workload API socket",
+        }
+    if not _spiffe_socket_reachable(endpoint):
+        return {
+            "name": name,
+            "status": _CHECK_WARN,
+            "detail": f"Workload API socket not reachable at {endpoint}",
+            "fix": "Start the SPIRE agent or correct SPIFFE_ENDPOINT_SOCKET",
+        }
+    return {
+        "name": name,
+        "status": _CHECK_PASS,
+        "detail": f"SVID path ready; Workload API socket reachable at {endpoint}",
+        "fix": "",
+    }
+
+
 def check_sdd_workspace() -> dict[str, Any]:
     """Check for .sdd/ workspace structure."""
     workdir = Path.cwd()
@@ -727,6 +811,7 @@ def run_all_checks() -> list[dict[str, Any]]:
             check_port_available(),
             check_sdd_workspace(),
             check_schedule_supervisor(),
+            check_spiffe_workload_api(),
         )
     )
     return checks

--- a/src/bernstein/cli/commands/secrets_cmd.py
+++ b/src/bernstein/cli/commands/secrets_cmd.py
@@ -117,3 +117,121 @@ def secrets_mint(
         "value": token.value if reveal else mask(token.value, keep=4),
     }
     click.echo(json.dumps(payload, sort_keys=True))
+
+
+# ---------------------------------------------------------------------------
+# ``bernstein secrets grants ...`` - chain-anchored per-task credential grants
+# ---------------------------------------------------------------------------
+
+
+@secrets_group.group(name="grants")
+def grants_group() -> None:
+    """Reconstruct and verify chain-anchored credential grants (issue #2516).
+
+    \b
+    A scoped grant (task id, secret name, audience, expiry, capability ceiling)
+    is an Ed25519-signed record anchored in the HMAC audit chain. The broker
+    refuses to mint a downstream token without a grant that verifies, and a
+    run's full issue / exchange / revoke history reconstructs offline from the
+    chain alone.
+
+    \b
+    Examples:
+      bernstein secrets grants list run-42
+      bernstein secrets grants verify run-42 --json
+    """
+
+
+def _grant_root(root: Path | None) -> Path:
+    from bernstein.core.identity import grants as _grants
+
+    return root if root is not None else _grants.DEFAULT_ROOT
+
+
+@grants_group.command(name="verify")
+@click.argument("run")
+@click.option(
+    "--root",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help="Grant-record root (default: .sdd/audit).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit the byte-identical JSON report.")
+def grants_verify(run: str, root: Path | None, as_json: bool) -> None:
+    """Reconstruct and verify the grant chain for RUN offline.
+
+    Exits 0 when the chain is intact (at least one record, every record
+    verifies from genesis to tail with a valid HMAC and Ed25519 signature); 1
+    otherwise, naming the first failing record.
+    """
+    from bernstein.core.identity import grants as _grants
+
+    result = _grants.verify_grant_chain(root=_grant_root(root), run_id=run, key=_grants._audit_key())
+
+    if as_json:
+        click.echo(_grants.render_report(result, run_id=run))
+        raise SystemExit(0 if result.valid else 1)
+
+    if not result.records and not result.errors:
+        click.echo(f"no grant records for run {run}", err=True)
+        raise SystemExit(1)
+    for r in result.records:
+        click.echo(
+            f"  record {r.record_index}: {r.kind}  grant={r.grant_id[:12]}  task={r.task_id}  secret={r.secret_name}"
+        )
+    if result.valid:
+        click.echo(f"grant chain intact ({len(result.records)} record(s))")
+        raise SystemExit(0)
+    for err in result.errors:
+        click.echo(f"  {err}", err=True)
+    click.echo("grant chain verification failed", err=True)
+    raise SystemExit(1)
+
+
+@grants_group.command(name="list")
+@click.argument("run")
+@click.option(
+    "--root",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help="Grant-record root (default: .sdd/audit).",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def grants_list(run: str, root: Path | None, as_json: bool) -> None:
+    """List the grants recorded for RUN with their reconstructed lifecycle."""
+    from bernstein.core.identity import grants as _grants
+
+    result = _grants.verify_grant_chain(root=_grant_root(root), run_id=run, key=_grants._audit_key())
+    life = result.lifecycles()
+
+    if as_json:
+        payload = {
+            "run": run,
+            "valid": result.valid,
+            "grants": [
+                {
+                    "grant_id": gid,
+                    "task_id": state["task_id"],
+                    "secret_name": state["secret_name"],
+                    "audience": state["audience"],
+                    "expiry": state["expiry"],
+                    "revoked": state["revoked"],
+                    "token_ids": list(state["token_ids"]),
+                }
+                for gid, state in sorted(life.items())
+            ],
+        }
+        click.echo(json.dumps(payload, sort_keys=True))
+        raise SystemExit(0 if result.valid else 1)
+
+    if not life:
+        click.echo(f"no grants for run {run}", err=True)
+        raise SystemExit(1)
+    for gid, state in sorted(life.items()):
+        status = "revoked" if state["revoked"] else "active"
+        click.echo(
+            f"  {gid[:12]}  task={state['task_id']}  secret={state['secret_name']}  "
+            f"audience={state['audience']}  {status}  tokens={len(state['token_ids'])}"
+        )
+    if not result.valid:
+        raise SystemExit(1)

--- a/src/bernstein/core/identity/grants.py
+++ b/src/bernstein/core/identity/grants.py
@@ -1,0 +1,766 @@
+"""Chain-anchored, Ed25519-signed per-task credential grants (issue #2516).
+
+A worker fleet should never hand each task the install-wide static credential.
+Instead the orchestrator writes a *scoped grant* before a worker spawn: the
+task id, the backing secret name, the audience the token may be presented to,
+an expiry, and a capability ceiling. The grant is the authorization artifact --
+the secrets broker refuses to mint a downstream token without a grant that
+verifies -- and it is recorded as a record in the same HMAC-chained
+construction as the per-hop delegation receipts
+(:mod:`bernstein.core.identity.delegation`), anchored to the install-scoped
+audit key.
+
+Killer shape
+------------
+The grant is not "a secret plus a log line". The grant record *is* a signed
+chain event, and the broker exchange references it. Strip the audit chain and
+the grant loses its meaning, not just its observability: an ordinary token
+vault cannot prove to a third party which task held which credential power over
+which time window, and who authorized it. Here that proof is the chain itself.
+
+Two anchors per record
+----------------------
+Each record carries two independent tamper anchors:
+
+* an **Ed25519 signature** by the manager identity over the grant's canonical
+  body -- proves *who authorized* the grant; and
+* an **HMAC** over ``prev_hmac`` concatenated with the canonical record body,
+  keyed by the install audit key (``load_or_create_audit_key``) -- the same
+  construction as :mod:`delegation`, so linkage, deletion, and reordering
+  surface as a chain break.
+
+A verifier holding only the chain slice and the install audit key reconstructs
+the full ``grant_issued -> grant_exchanged -> grant_revoked`` lifecycle offline
+and rejects any mutated, deleted, or reordered record, naming the offender. The
+issuer public key travels inside each record, so the signature layer is
+self-describing; an attacker who swaps it cannot re-chain the HMAC without the
+install key.
+
+Record shape
+------------
+One JSONL line per record under ``<root>/grants/<run_id>.jsonl``::
+
+    {
+      "run_id": "...",
+      "record_index": 0,
+      "kind": "grant_issued",           # issued | exchanged | revoked | refused
+      "grant_id": "...",
+      "task_id": "t-42",
+      "secret_name": "ANTHROPIC_API_KEY",
+      "audience": "api.anthropic.com",
+      "expiry": 1730000900,             # epoch seconds; 0 == no explicit expiry
+      "capability_ceiling": ["read"],   # sorted, canonical
+      "issuer": "manager:...",          # or a spiffe:// id under SPIFFE mode
+      "issuer_pubkey": "-----BEGIN PUBLIC KEY----- ...",
+      "token_id": "",                   # set on grant_exchanged
+      "reason": "",                     # set on revoked / refused
+      "created": 1730000000,
+      "prev_hmac": "<hex>",
+      "signature": "<hex ed25519>",
+      "hmac": "<hex hmac>"
+    }
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "DEFAULT_ROOT",
+    "GENESIS_HMAC",
+    "GRANT_EXCHANGED",
+    "GRANT_ISSUED",
+    "GRANT_REFUSED",
+    "GRANT_REVOKED",
+    "GrantChainResult",
+    "GrantError",
+    "GrantLedger",
+    "GrantReceipt",
+    "GrantSigner",
+    "default_ledger",
+    "find_active_grant",
+    "install_grant_signer",
+    "render_report",
+    "verify_grant_chain",
+    "verify_grant_signature",
+]
+
+#: Genesis linkage value for the first record of a run (matches the audit-chain
+#: convention of a fixed 64-hex-zero anchor, identical to :mod:`delegation`).
+GENESIS_HMAC: Final[str] = "0" * 64
+
+_SUBDIR: Final[str] = "grants"
+
+#: Default root -- the same tree as the HMAC-chained audit log, so
+#: ``.sdd/audit/grants/`` sits beside ``.sdd/audit/delegation/``.
+DEFAULT_ROOT: Final[Path] = Path(".sdd/audit")
+
+#: Record kinds. ``grant_issued`` and ``grant_revoked`` are the audit events the
+#: issue calls out; ``grant_exchanged`` records the broker token exchange and
+#: ``grant_refused`` records a mint/resolve refusal so the refusal itself is a
+#: chain-anchored event, not only an in-process callback.
+GRANT_ISSUED: Final[str] = "grant_issued"
+GRANT_EXCHANGED: Final[str] = "grant_exchanged"
+GRANT_REVOKED: Final[str] = "grant_revoked"
+GRANT_REFUSED: Final[str] = "grant_refused"
+
+_KINDS: Final[frozenset[str]] = frozenset({GRANT_ISSUED, GRANT_EXCHANGED, GRANT_REVOKED, GRANT_REFUSED})
+
+#: Fields the manager signs (the grant's semantic identity). Excludes chain
+#: state (``prev_hmac``, ``hmac``) and the signature itself.
+_SIGNED_FIELDS: Final[tuple[str, ...]] = (
+    "run_id",
+    "record_index",
+    "kind",
+    "grant_id",
+    "task_id",
+    "secret_name",
+    "audience",
+    "expiry",
+    "capability_ceiling",
+    "issuer",
+    "issuer_pubkey",
+    "token_id",
+    "reason",
+    "created",
+)
+
+
+class GrantError(Exception):
+    """Raised when a grant cannot be signed, recorded, or verified."""
+
+
+# ---------------------------------------------------------------------------
+# Canonical encoding + HMAC (identical construction to delegation / audit)
+# ---------------------------------------------------------------------------
+
+
+def _canonical(body: dict[str, Any]) -> str:
+    """Return the canonical JSON encoding used for signing (compact, sorted)."""
+    return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
+def _compute_hmac(key: bytes, prev_hmac: str, body: dict[str, Any]) -> str:
+    """HMAC-SHA256 over ``prev_hmac`` concatenated with the canonical record body.
+
+    Identical construction to
+    :func:`bernstein.core.identity.delegation._compute_hmac` and
+    :func:`bernstein.core.security.audit._compute_hmac`, so the grant chain
+    shares tamper-evidence semantics with the delegation and audit chains.
+    """
+    payload = prev_hmac + json.dumps(body, sort_keys=True)
+    return _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Ed25519 manager signer
+# ---------------------------------------------------------------------------
+
+
+class GrantSigner:
+    """Ed25519 manager identity that signs scoped grants.
+
+    Reuses the ``cryptography`` package already pulled in by the agent-card
+    signer. The public key is embedded in every record so verification is
+    self-describing; the HMAC chain anchored on the install audit key is what
+    prevents an attacker from swapping the key and re-chaining.
+    """
+
+    def __init__(self, private_key_pem: bytes, public_key_pem: bytes, *, issuer: str) -> None:
+        self._private_pem = private_key_pem
+        self._public_pem = public_key_pem
+        self._issuer = issuer
+
+    @classmethod
+    def generate(cls, *, issuer: str) -> GrantSigner:
+        """Generate a fresh Ed25519 manager signer (test / ephemeral use)."""
+        from bernstein.core.security.agent_card_signer import generate_ed25519_keypair
+
+        private_pem, public_pem = generate_ed25519_keypair()
+        return cls(private_pem, public_pem, issuer=issuer)
+
+    @property
+    def issuer(self) -> str:
+        return self._issuer
+
+    @property
+    def public_key_pem(self) -> str:
+        return self._public_pem.decode() if isinstance(self._public_pem, bytes) else str(self._public_pem)
+
+    def with_issuer(self, issuer: str) -> GrantSigner:
+        """Return a signer with the same key but a different issuer label.
+
+        Used when a SPIFFE identity mode relabels the issuer to the workload's
+        SPIFFE ID while the manager key that proves authorship is unchanged.
+        """
+        return GrantSigner(self._private_pem, self._public_pem, issuer=issuer)
+
+    def sign(self, body: dict[str, Any]) -> str:
+        """Return the hex Ed25519 signature over the canonical ``body``."""
+        from cryptography.hazmat.primitives import serialization
+
+        key = serialization.load_pem_private_key(self._private_pem, password=None)
+        return key.sign(_canonical(body).encode()).hex()  # type: ignore[union-attr]
+
+
+def verify_grant_signature(public_key_pem: bytes | str, body: dict[str, Any], signature_hex: str) -> bool:
+    """Return True when ``signature_hex`` is a valid Ed25519 signature over ``body``.
+
+    ``body`` must be the signed body (the :data:`_SIGNED_FIELDS`), and
+    ``public_key_pem`` the SPKI PEM embedded in the record.
+    """
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import serialization
+
+    pem = public_key_pem.encode() if isinstance(public_key_pem, str) else public_key_pem
+    try:
+        key = serialization.load_pem_public_key(pem)
+        key.verify(bytes.fromhex(signature_hex), _canonical(body).encode())  # type: ignore[union-attr]
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Grant receipt
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GrantReceipt:
+    """A single chain-anchored, Ed25519-signed grant-lifecycle record."""
+
+    run_id: str
+    record_index: int
+    kind: str
+    grant_id: str
+    task_id: str
+    secret_name: str
+    audience: str
+    expiry: int
+    capability_ceiling: tuple[str, ...]
+    issuer: str
+    issuer_pubkey: str
+    created: int
+    token_id: str = ""
+    reason: str = ""
+    prev_hmac: str = GENESIS_HMAC
+    signature: str = ""
+    hmac: str = ""
+
+    def signed_body(self) -> dict[str, Any]:
+        """Return the canonical body the manager signs (chain-state-free)."""
+        return {
+            "run_id": self.run_id,
+            "record_index": self.record_index,
+            "kind": self.kind,
+            "grant_id": self.grant_id,
+            "task_id": self.task_id,
+            "secret_name": self.secret_name,
+            "audience": self.audience,
+            "expiry": self.expiry,
+            "capability_ceiling": list(self.capability_ceiling),
+            "issuer": self.issuer,
+            "issuer_pubkey": self.issuer_pubkey,
+            "token_id": self.token_id,
+            "reason": self.reason,
+            "created": self.created,
+        }
+
+    def chain_body(self) -> dict[str, Any]:
+        """Return the full record body the HMAC covers (everything but ``hmac``)."""
+        body = self.signed_body()
+        body["prev_hmac"] = self.prev_hmac
+        body["signature"] = self.signature
+        return body
+
+    def to_entry(self) -> dict[str, Any]:
+        """Return the on-disk JSONL entry (chain body plus ``hmac``)."""
+        entry = self.chain_body()
+        entry["hmac"] = self.hmac
+        return entry
+
+    @classmethod
+    def from_entry(cls, obj: dict[str, Any]) -> GrantReceipt:
+        """Rebuild a :class:`GrantReceipt` from its on-disk entry."""
+        return cls(
+            run_id=str(obj["run_id"]),
+            record_index=int(obj["record_index"]),
+            kind=str(obj["kind"]),
+            grant_id=str(obj["grant_id"]),
+            task_id=str(obj["task_id"]),
+            secret_name=str(obj["secret_name"]),
+            audience=str(obj["audience"]),
+            expiry=int(obj["expiry"]),
+            capability_ceiling=tuple(str(c) for c in obj.get("capability_ceiling", [])),
+            issuer=str(obj["issuer"]),
+            issuer_pubkey=str(obj["issuer_pubkey"]),
+            created=int(obj["created"]),
+            token_id=str(obj.get("token_id", "")),
+            reason=str(obj.get("reason", "")),
+            prev_hmac=str(obj.get("prev_hmac", GENESIS_HMAC)),
+            signature=str(obj.get("signature", "")),
+            hmac=str(obj.get("hmac", "")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Grant ledger (append-only, one JSONL file per run)
+# ---------------------------------------------------------------------------
+
+
+class GrantLedger:
+    """Append-only, HMAC-chained + Ed25519-signed grant-record store.
+
+    One JSONL file per run under ``<root>/grants/``. The running ``prev_hmac``
+    per run is read from the tail of the file, so records appended across
+    process restarts still chain continuously.
+    """
+
+    def __init__(self, root: Path, key: bytes, signer: GrantSigner) -> None:
+        """Bind the ledger to a root directory, an HMAC key, and a manager signer.
+
+        Args:
+            root: Base directory; records land under ``root/grants/``.
+            key: HMAC key -- use the install audit key so the chain is anchored
+                to the install identity.
+            signer: The Ed25519 manager identity that authorizes grants.
+        """
+        self.root = Path(root)
+        self._key = key
+        self._signer = signer
+        self._dir = self.root / _SUBDIR
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def issuer(self) -> str:
+        return self._signer.issuer
+
+    @property
+    def hmac_key(self) -> bytes:
+        """Return the install-scoped HMAC key the chain is anchored on."""
+        return self._key
+
+    def receipt_path(self, run_id: str) -> Path:
+        """Return the JSONL path backing ``run_id``'s records."""
+        safe = run_id.replace("/", "_").replace("\\", "_")
+        return self._dir / f"{safe}.jsonl"
+
+    def _tail(self, run_id: str) -> tuple[str, int]:
+        """Return ``(prev_hmac, next_record_index)`` for the run."""
+        path = self.receipt_path(run_id)
+        if not path.is_file():
+            return GENESIS_HMAC, 0
+        prev = GENESIS_HMAC
+        count = 0
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            prev = obj.get("hmac", prev)
+            count += 1
+        return prev, count
+
+    def _append(
+        self,
+        *,
+        run_id: str,
+        kind: str,
+        grant_id: str,
+        task_id: str,
+        secret_name: str,
+        audience: str,
+        expiry: int,
+        capability_ceiling: Sequence[str],
+        token_id: str,
+        reason: str,
+        created: int | None,
+    ) -> GrantReceipt:
+        if kind not in _KINDS:  # pragma: no cover - defensive
+            raise GrantError(f"unknown grant record kind {kind!r}")
+        prev_hmac, record_index = self._tail(run_id)
+        ts = int(created if created is not None else time.time())
+        signed = {
+            "run_id": run_id,
+            "record_index": record_index,
+            "kind": kind,
+            "grant_id": grant_id,
+            "task_id": task_id,
+            "secret_name": secret_name,
+            "audience": audience,
+            "expiry": int(expiry),
+            "capability_ceiling": sorted(str(c) for c in capability_ceiling),
+            "issuer": self._signer.issuer,
+            "issuer_pubkey": self._signer.public_key_pem,
+            "token_id": token_id,
+            "reason": reason,
+            "created": ts,
+        }
+        signature = self._signer.sign(signed)
+        chain_body = signed.copy()
+        chain_body["prev_hmac"] = prev_hmac
+        chain_body["signature"] = signature
+        computed = _compute_hmac(self._key, prev_hmac, chain_body)
+        entry = chain_body.copy()
+        entry["hmac"] = computed
+        path = self.receipt_path(run_id)
+        with path.open("a", encoding="utf-8", newline="") as fh:
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+        return GrantReceipt.from_entry(entry)
+
+    def issue_grant(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        secret_name: str,
+        audience: str,
+        expiry: int = 0,
+        capability_ceiling: Sequence[str] = (),
+        grant_id: str | None = None,
+        created: int | None = None,
+    ) -> GrantReceipt:
+        """Issue a scoped grant and append it as a ``grant_issued`` record.
+
+        Args:
+            run_id: Run the grant belongs to.
+            task_id: Task the grant scopes the credential to.
+            secret_name: Backing secret name in the broker backend.
+            audience: The downstream target the minted token may be presented to.
+            expiry: Epoch-second expiry; ``0`` means no explicit expiry.
+            capability_ceiling: Symbolic capability names the grant caps.
+            grant_id: Optional explicit id (defaults to a fresh uuid4 hex).
+            created: Optional unix timestamp (exposed for deterministic tests).
+
+        Returns:
+            The freshly-appended :class:`GrantReceipt`.
+        """
+        return self._append(
+            run_id=run_id,
+            kind=GRANT_ISSUED,
+            grant_id=grant_id or uuid.uuid4().hex,
+            task_id=task_id,
+            secret_name=secret_name,
+            audience=audience,
+            expiry=expiry,
+            capability_ceiling=capability_ceiling,
+            token_id="",
+            reason="",
+            created=created,
+        )
+
+    def record_exchange(
+        self,
+        *,
+        run_id: str,
+        grant_id: str,
+        token_id: str,
+        task_id: str = "",
+        secret_name: str = "",
+        audience: str = "",
+        created: int | None = None,
+    ) -> GrantReceipt:
+        """Append a ``grant_exchanged`` record binding a minted ``token_id`` to a grant."""
+        return self._append(
+            run_id=run_id,
+            kind=GRANT_EXCHANGED,
+            grant_id=grant_id,
+            task_id=task_id,
+            secret_name=secret_name,
+            audience=audience,
+            expiry=0,
+            capability_ceiling=(),
+            token_id=token_id,
+            reason="",
+            created=created,
+        )
+
+    def revoke_grant(
+        self,
+        *,
+        run_id: str,
+        grant_id: str,
+        reason: str = "revoked",
+        task_id: str = "",
+        secret_name: str = "",
+        created: int | None = None,
+    ) -> GrantReceipt:
+        """Append a signed ``grant_revoked`` record referencing ``grant_id``."""
+        return self._append(
+            run_id=run_id,
+            kind=GRANT_REVOKED,
+            grant_id=grant_id,
+            task_id=task_id,
+            secret_name=secret_name,
+            audience="",
+            expiry=0,
+            capability_ceiling=(),
+            token_id="",
+            reason=reason,
+            created=created,
+        )
+
+    def record_refusal(
+        self,
+        *,
+        run_id: str,
+        task_id: str,
+        secret_name: str,
+        reason: str,
+        grant_id: str = "",
+        audience: str = "",
+        token_id: str = "",
+        created: int | None = None,
+    ) -> GrantReceipt:
+        """Append a ``grant_refused`` record so a refusal is itself chain-anchored."""
+        return self._append(
+            run_id=run_id,
+            kind=GRANT_REFUSED,
+            grant_id=grant_id,
+            task_id=task_id,
+            secret_name=secret_name,
+            audience=audience,
+            expiry=0,
+            capability_ceiling=(),
+            token_id=token_id,
+            reason=reason,
+            created=created,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Offline verification
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GrantChainResult:
+    """Outcome of reconstructing a run's grant chain offline."""
+
+    valid: bool
+    records: list[GrantReceipt] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def lifecycles(self) -> dict[str, dict[str, Any]]:
+        """Reconstruct each grant's issue/exchange/revoke state from the records."""
+        life: dict[str, dict[str, Any]] = {}
+        for r in self.records:
+            if not r.grant_id:
+                continue
+            state = life.setdefault(
+                r.grant_id,
+                {
+                    "task_id": "",
+                    "secret_name": "",
+                    "audience": "",
+                    "expiry": 0,
+                    "issued": False,
+                    "revoked": False,
+                    "token_ids": [],
+                    "refusals": [],
+                },
+            )
+            if r.kind == GRANT_ISSUED:
+                state["issued"] = True
+                state["task_id"] = r.task_id
+                state["secret_name"] = r.secret_name
+                state["audience"] = r.audience
+                state["expiry"] = r.expiry
+            elif r.kind == GRANT_EXCHANGED and r.token_id:
+                state["token_ids"].append(r.token_id)
+            elif r.kind == GRANT_REVOKED:
+                state["revoked"] = True
+            elif r.kind == GRANT_REFUSED:
+                state["refusals"].append(r.reason)
+        return life
+
+
+def verify_grant_chain(*, root: Path, run_id: str, key: bytes) -> GrantChainResult:
+    """Reconstruct and verify a run's grant chain offline.
+
+    Walks ``<root>/grants/<run_id>.jsonl`` from genesis, recomputing each
+    record's HMAC, checking linkage, and verifying the manager Ed25519
+    signature against the embedded issuer public key. A mutated field, a
+    deleted record, or reordered records surface as an error naming the
+    offending record; verification stops at the first break.
+
+    Args:
+        root: Base directory the ledger was rooted at.
+        run_id: Run to verify.
+        key: The HMAC key (install audit key) the records were written with.
+
+    Returns:
+        A :class:`GrantChainResult`. ``valid`` is True only when at least one
+        record exists and the whole chain verifies from genesis to tail.
+    """
+    ledger_dir = Path(root) / _SUBDIR
+    safe = run_id.replace("/", "_").replace("\\", "_")
+    path = ledger_dir / f"{safe}.jsonl"
+    if not path.is_file():
+        return GrantChainResult(valid=False, records=[], errors=["no grant records for run"])
+
+    records: list[GrantReceipt] = []
+    errors: list[str] = []
+    prev_hmac = GENESIS_HMAC
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines()):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            errors.append(f"record {lineno}: malformed JSON: {exc}")
+            break
+        stored_hmac = obj.get("hmac", "")
+        idx = obj.get("record_index", lineno)
+        chain_body = {k: v for k, v in obj.items() if k != "hmac"}
+        if chain_body.get("prev_hmac") != prev_hmac:
+            errors.append(f"record {idx}: broken linkage (prev_hmac does not match preceding record)")
+            break
+        expected = _compute_hmac(key, prev_hmac, chain_body)
+        if not _hmac.compare_digest(expected, stored_hmac):
+            errors.append(f"record {idx}: HMAC mismatch (record tampered or wrong key)")
+            break
+        signed = {k: v for k, v in chain_body.items() if k not in ("prev_hmac", "signature")}
+        if not verify_grant_signature(str(obj.get("issuer_pubkey", "")), signed, str(obj.get("signature", ""))):
+            errors.append(f"record {idx}: Ed25519 signature invalid (grant not authorized by the issuer key)")
+            break
+        records.append(GrantReceipt.from_entry(obj))
+        prev_hmac = stored_hmac
+
+    valid = not errors and len(records) > 0
+    return GrantChainResult(valid=valid, records=records, errors=errors)
+
+
+def render_report(result: GrantChainResult, *, run_id: str) -> str:
+    """Render a deterministic, byte-identical verification report as canonical JSON.
+
+    Two independent verifiers given the same chain slice produce byte-identical
+    output, so the report can be diffed across environments or handed to a
+    third party.
+    """
+    payload = {
+        "run": run_id,
+        "valid": result.valid,
+        "record_count": len(result.records),
+        "errors": result.errors.copy(),
+        "records": [
+            {
+                "record_index": r.record_index,
+                "kind": r.kind,
+                "grant_id": r.grant_id,
+                "task_id": r.task_id,
+                "secret_name": r.secret_name,
+                "audience": r.audience,
+                "expiry": r.expiry,
+                "capability_ceiling": list(r.capability_ceiling),
+                "issuer": r.issuer,
+                "token_id": r.token_id,
+                "reason": r.reason,
+            }
+            for r in result.records
+        ],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def find_active_grant(
+    result: GrantChainResult,
+    *,
+    task_id: str,
+    secret_name: str,
+    now: float | None = None,
+) -> GrantReceipt | None:
+    """Return the newest verified grant for ``(task_id, secret_name)`` still active.
+
+    A grant is active when it was issued, is not revoked in the chain, and has
+    either no expiry or an expiry in the future. Returns ``None`` if the chain
+    did not verify or no matching active grant exists.
+    """
+    if not result.valid:
+        return None
+    current = now if now is not None else time.time()
+    life = result.lifecycles()
+    # Index the issued records so we can return the receipt itself.
+    issued: dict[str, GrantReceipt] = {r.grant_id: r for r in result.records if r.kind == GRANT_ISSUED}
+    best: GrantReceipt | None = None
+    for grant_id, state in life.items():
+        if not state["issued"] or state["revoked"]:
+            continue
+        if state["task_id"] != task_id or state["secret_name"] != secret_name:
+            continue
+        expiry = int(state["expiry"])
+        if expiry and current >= expiry:
+            continue
+        candidate = issued.get(grant_id)
+        if candidate is None:
+            continue
+        if best is None or candidate.record_index > best.record_index:
+            best = candidate
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Install-anchored convenience helpers
+# ---------------------------------------------------------------------------
+
+
+def _audit_key() -> bytes:
+    """Return the install-scoped audit HMAC key (the grant chain anchor)."""
+    from bernstein.core.security.audit import load_or_create_audit_key
+
+    return load_or_create_audit_key()
+
+
+def install_grant_signer(*, runtime_dir: Path | None = None, issuer: str = "manager") -> GrantSigner:
+    """Return a manager signer backed by the install agent-card keystore.
+
+    The keystore persists one Ed25519 keypair per install, so grant records
+    across runs share a stable manager identity that a verifier can pin.
+    """
+    import os
+
+    from bernstein.core.identity.http_signing import ENV_KEY_DIR
+    from bernstein.core.security.agent_card_keystore import (
+        DEFAULT_KEY_DIR,
+        AgentCardKeystore,
+    )
+
+    if runtime_dir is not None:
+        key_dir: Path = runtime_dir
+    else:
+        override = os.environ.get(ENV_KEY_DIR, "").strip()
+        key_dir = Path(override) if override else DEFAULT_KEY_DIR
+    private_pem, public_pem = AgentCardKeystore(key_dir).load_or_generate()
+    return GrantSigner(private_pem, public_pem, issuer=issuer)
+
+
+def default_ledger(
+    root: Path | None = None,
+    *,
+    signer: GrantSigner | None = None,
+    issuer: str = "manager",
+) -> GrantLedger:
+    """Return a ledger rooted at the audit tree, keyed by the install audit key.
+
+    Args:
+        root: Optional root override; defaults to :data:`DEFAULT_ROOT`.
+        signer: Optional signer override; defaults to the install manager signer.
+        issuer: Issuer label when the default signer is built.
+
+    Returns:
+        A :class:`GrantLedger` chained to the install identity's audit key.
+    """
+    active_signer = signer if signer is not None else install_grant_signer(issuer=issuer)
+    return GrantLedger(root=root or DEFAULT_ROOT, key=_audit_key(), signer=active_signer)

--- a/src/bernstein/core/identity/spiffe/grant_identity.py
+++ b/src/bernstein/core/identity/spiffe/grant_identity.py
@@ -1,0 +1,98 @@
+"""SPIFFE issuer resolution for chain-anchored grants (issue #2516, Phase 4).
+
+When the ``spiffe`` extra is installed and a SPIRE Workload API socket is
+reachable, a grant record can carry the workload's SPIFFE ID as its issuer
+identity, binding the grant to the workload identity already checkable via
+``bernstein spiffe verify-binding``. This module is the thin, extra-gated
+bridge between the Workload API fetch and the grant ledger issuer label.
+
+Nothing here is imported on any default coordination path, and the fetch is
+lazy: with the extra absent :func:`spiffe_grant_issuer` returns ``None`` and
+the default Ed25519 manager issuer stays in force. The SVID private key is
+never returned; only the SPIFFE ID (a public label) and the private-key-free
+:class:`~bernstein.core.identity.spiffe.svid.SvidReference` cross this boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.identity.spiffe.workload_api import (
+    WorkloadApiError,
+    fetch_x509_svid,
+    spiffe_extra_available,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bernstein.core.identity.spiffe.svid import SvidReference
+
+__all__ = [
+    "spiffe_extra_available",
+    "spiffe_grant_issuer",
+    "spiffe_grant_issuer_with_reference",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_svid_or_none(
+    *,
+    socket_path: str | None,
+    client_factory: Callable[[str | None], Any] | None,
+) -> Any:
+    """Fetch an SVID when the extra is present and the socket is reachable.
+
+    Returns the fetched SVID or ``None``. Never raises for the missing-extra or
+    unreachable-socket case; those degrade to the default path rather than
+    failing a mint.
+    """
+    if not spiffe_extra_available():
+        return None
+    try:
+        return fetch_x509_svid(socket_path=socket_path, client_factory=client_factory)
+    except WorkloadApiError as exc:
+        logger.debug("SPIFFE grant issuer unavailable: %s", type(exc).__name__)
+        return None
+
+
+def spiffe_grant_issuer(
+    *,
+    socket_path: str | None = None,
+    client_factory: Callable[[str | None], Any] | None = None,
+) -> str | None:
+    """Return the workload SPIFFE ID to use as a grant issuer, or ``None``.
+
+    The issuer label is the SVID's SPIFFE ID -- a public identifier, not the
+    private key. Returns ``None`` when the ``spiffe`` extra is absent or an SVID
+    cannot be fetched, so callers fall back to the default Ed25519 manager
+    issuer.
+    """
+    svid = _fetch_svid_or_none(socket_path=socket_path, client_factory=client_factory)
+    return svid.spiffe_id if svid is not None else None
+
+
+def spiffe_grant_issuer_with_reference(
+    *,
+    socket_path: str | None = None,
+    client_factory: Callable[[str | None], Any] | None = None,
+) -> tuple[str, SvidReference] | None:
+    """Return ``(spiffe_id, svid_reference)`` for grant issuer binding, or ``None``.
+
+    Like :func:`spiffe_grant_issuer` but also projects the SVID onto its
+    private-key-free :class:`SvidReference`. Returns ``None`` when the extra is
+    absent, the fetch fails, or the leaf certificate cannot be parsed.
+    """
+    svid = _fetch_svid_or_none(socket_path=socket_path, client_factory=client_factory)
+    if svid is None:
+        return None
+    try:
+        from bernstein.core.identity.spiffe.svid import svid_reference_from_x509
+
+        reference = svid_reference_from_x509(svid)
+    except ValueError as exc:
+        logger.debug("SPIFFE SVID reference projection failed: %s", type(exc).__name__)
+        return None
+    return svid.spiffe_id, reference

--- a/src/bernstein/core/security/secrets_broker.py
+++ b/src/bernstein/core/security/secrets_broker.py
@@ -189,6 +189,7 @@ class MintedToken:
     task_id: str
     expires_at: float
     ttl_seconds: int
+    audience: str = ""
 
     def is_expired(self, *, now: float | None = None) -> bool:
         """Return ``True`` when wall-clock time has passed ``expires_at``."""
@@ -471,6 +472,14 @@ class FileEncryptedBackend(SecretsBackend):
 # ---------------------------------------------------------------------------
 
 
+#: Valid identity modes for grant issuance. ``ed25519`` is the default,
+#: self-contained manager identity; ``spiffe`` relabels the grant issuer to the
+#: workload's SPIFFE ID when the ``spiffe`` extra and a Workload API socket are
+#: available (issue #2516).
+IdentityMode = Literal["ed25519", "spiffe"]
+_IDENTITY_MODES: frozenset[str] = frozenset({"ed25519", "spiffe"})
+
+
 @dataclass(frozen=True)
 class BrokerConfig:
     """Runtime configuration for the broker, mirrored from bernstein.yaml.
@@ -480,12 +489,18 @@ class BrokerConfig:
         ttl_seconds_default: Default token lifetime in seconds.
         ttl_overrides: Per-secret-name override map.
         backend_settings: Free-form options forwarded to the backend ctor.
+        require_grant: When True the broker refuses to mint without a
+            verifiable, chain-anchored grant (issue #2516).
+        identity_mode: ``ed25519`` (default) or ``spiffe``; ``spiffe`` binds
+            grant issuer identity to the workload SPIFFE ID when available.
     """
 
     backend: BackendName
     ttl_seconds_default: int = _DEFAULT_TTL_SECONDS
     ttl_overrides: dict[str, int] = field(default_factory=dict)
     backend_settings: dict[str, Any] = field(default_factory=dict)
+    require_grant: bool = False
+    identity_mode: IdentityMode = "ed25519"
 
     @classmethod
     def from_raw(cls, raw: dict[str, Any] | None) -> BrokerConfig:
@@ -514,11 +529,28 @@ class BrokerConfig:
         if not isinstance(backend_settings_raw, dict):
             raise SecretsBrokerError("backend_settings must be a mapping")
         backend_settings: dict[str, Any] = {str(k): v for k, v in backend_settings_raw.items()}
+
+        # Grant / identity block (issue #2516). Both default to the legacy,
+        # grant-free, self-contained Ed25519 behaviour when the block is absent.
+        grants_raw: object = raw.get("grants")
+        if grants_raw is None:
+            grants_raw = {}
+        if not isinstance(grants_raw, dict):
+            raise SecretsBrokerError("grants block must be a mapping")
+        require_grant = bool(grants_raw.get("require_grant", False))
+        identity_mode_raw: object = grants_raw.get("identity_mode", "ed25519")
+        if not isinstance(identity_mode_raw, str) or identity_mode_raw not in _IDENTITY_MODES:
+            valid = ", ".join(sorted(_IDENTITY_MODES))
+            raise SecretsBrokerError(f"unknown grants.identity_mode {identity_mode_raw!r}; valid: {valid}")
+        identity_mode: IdentityMode = identity_mode_raw  # type: ignore[assignment]
+
         return cls(
             backend=backend,
             ttl_seconds_default=ttl_default,
             ttl_overrides=overrides,
             backend_settings=backend_settings,
+            require_grant=require_grant,
+            identity_mode=identity_mode,
         )
 
 
@@ -534,6 +566,10 @@ class _Registration:
     token: MintedToken
     raw_value: str
     revoked: bool = False
+    # Grant lineage (issue #2516). Empty in legacy (grant-free) mode.
+    grant_id: str = ""
+    run_id: str = ""
+    audience: str = ""
 
 
 class SecretsBroker:
@@ -543,6 +579,19 @@ class SecretsBroker:
     The broker is designed to be created once at orchestrator startup and
     shared across tasks. Backends do their own connectivity per call;
     operators wanting caching should wrap the backend.
+
+    Grant-enforcing mode (issue #2516)
+    ==================================
+
+    When constructed with a ``grant_ledger`` and ``require_grant=True``, the
+    broker refuses to mint a token unless a verifiable, chain-anchored grant
+    exists for the ``(task_id, secret_name)`` pair. The refusal is itself a
+    chain event. A minted token inherits the grant's task id, audience, and
+    expiry; the token id is recorded in the grant lifecycle. ``resolve`` then
+    refuses a token presented outside its granted audience, and audience,
+    expiry, and revocation refusals are recorded as chain-anchored records
+    rather than only as in-process callbacks. Left unset, the broker keeps its
+    legacy grant-free behaviour unchanged.
     """
 
     def __init__(
@@ -552,11 +601,15 @@ class SecretsBroker:
         config: BrokerConfig,
         audit_sink: AuditSink | None = None,
         clock: Callable[[], float] = time.time,
+        grant_ledger: Any = None,
+        require_grant: bool = False,
     ) -> None:
         self._backend = backend
         self._config = config
         self._audit_sink = audit_sink
         self._clock = clock
+        self._grant_ledger = grant_ledger
+        self._require_grant = require_grant
         self._lock = threading.Lock()
         self._registry: dict[str, _Registration] = {}
         # Secondary index keyed by token value so ``resolve`` is O(1).
@@ -574,6 +627,8 @@ class SecretsBroker:
         secret_name: str,
         task_id: str,
         ttl_seconds: int | None = None,
+        grant: Any = None,
+        run_id: str | None = None,
     ) -> MintedToken:
         """Mint a short-lived token for ``secret_name`` scoped to ``task_id``.
 
@@ -584,34 +639,83 @@ class SecretsBroker:
                 keyed off this id.
             ttl_seconds: Lifetime override. ``None`` uses the per-secret
                 override, then the config default.
+            grant: A :class:`~bernstein.core.identity.grants.GrantReceipt` the
+                orchestrator issued for this task. Required in grant-enforcing
+                mode; the minted token inherits the grant's audience and expiry.
+            run_id: Run scope for chain-anchored refusal records when no grant
+                is presented. Defaults to the grant's run id, else ``task_id``.
 
         Returns:
             A :class:`MintedToken`. The ``value`` field is what the agent
             process should see in its env.
+
+        Raises:
+            SecretsBrokerError: In grant-enforcing mode, when no verifiable
+                grant exists for the ``(task_id, secret_name)`` pair. The
+                refusal is recorded as a chain event before the error is raised.
         """
         if not secret_name:
             raise SecretsBrokerError("secret_name must not be empty")
         if not task_id:
             raise SecretsBrokerError("task_id must not be empty")
+
+        audience = ""
+        grant_id = ""
+        grant_run_id = run_id or ""
+        expires_override: float | None = None
+        if self._require_grant:
+            grant_run_id, grant_id, audience, expires_override = self._authorize_mint(
+                secret_name=secret_name, task_id=task_id, grant=grant, run_id=run_id
+            )
+        elif grant is not None:
+            # Grant supplied without enforcement: still honour its scope so the
+            # token carries the audience and expiry the grant authorized.
+            grant_run_id = str(getattr(grant, "run_id", "") or run_id or "")
+            grant_id = str(getattr(grant, "grant_id", ""))
+            audience = str(getattr(grant, "audience", ""))
+            grant_expiry = int(getattr(grant, "expiry", 0) or 0)
+            if grant_expiry:
+                expires_override = float(grant_expiry)
+
         ttl = self._resolve_ttl(secret_name, ttl_seconds)
         raw_value = self._backend.read(secret_name)
         token_id = _new_token_id()
         token_value = _new_token_value()
         now = self._clock()
+        expires_at = expires_override if expires_override is not None else now + ttl
+        effective_ttl = int(expires_at - now) if expires_override is not None else ttl
         token = MintedToken(
             token_id=token_id,
             value=token_value,
             secret_name=secret_name,
             task_id=task_id,
-            expires_at=now + ttl,
-            ttl_seconds=ttl,
+            expires_at=expires_at,
+            ttl_seconds=effective_ttl,
+            audience=audience,
         )
-        registration = _Registration(token=token, raw_value=raw_value)
+        registration = _Registration(
+            token=token,
+            raw_value=raw_value,
+            grant_id=grant_id,
+            run_id=grant_run_id,
+            audience=audience,
+        )
         with self._lock:
             self._registry[token_id] = registration
             self._by_value[token_value] = registration
         register_secret_for_redaction(raw_value)
         register_secret_for_redaction(token_value)
+        # Record the broker exchange in the grant lifecycle so token-to-grant
+        # resolution works offline from the chain alone (issue #2516).
+        if grant_id and grant_run_id and self._grant_ledger is not None:
+            self._record_grant_exchange(
+                run_id=grant_run_id,
+                grant_id=grant_id,
+                token_id=token_id,
+                task_id=task_id,
+                secret_name=secret_name,
+                audience=audience,
+            )
         self._emit(
             AuditEvent(
                 kind="mint",
@@ -619,7 +723,7 @@ class SecretsBroker:
                 secret_name=secret_name,
                 task_id=task_id,
                 ts_ns=time.time_ns(),
-                ttl_seconds=ttl,
+                ttl_seconds=effective_ttl,
             )
         )
         return token
@@ -631,19 +735,34 @@ class SecretsBroker:
         secret_name: str,
         task_id: str,
         ttl_seconds: int | None = None,
+        grant: Any = None,
+        run_id: str | None = None,
     ) -> Generator[MintedToken, None, None]:
         """Mint a token; auto-revoke on context-manager exit."""
-        token = self.mint(secret_name=secret_name, task_id=task_id, ttl_seconds=ttl_seconds)
+        token = self.mint(
+            secret_name=secret_name,
+            task_id=task_id,
+            ttl_seconds=ttl_seconds,
+            grant=grant,
+            run_id=run_id,
+        )
         try:
             yield token
         finally:
             self.revoke(token.token_id, reason="scope-exit")
 
-    def resolve(self, token_value: str) -> str:
+    def resolve(self, token_value: str, *, audience: str | None = None) -> str:
         """Return the raw backing value for a minted token value.
 
+        Args:
+            token_value: The opaque token the agent process holds.
+            audience: When set, the audience the caller is presenting the token
+                to. A token minted from a grant refuses to resolve outside its
+                granted audience, and the refusal is recorded as a chain event.
+
         Raises:
-            SecretsBrokerError: If the token is unknown, revoked, or expired.
+            SecretsBrokerError: If the token is unknown, revoked, expired, or
+                presented outside its granted audience.
         """
         if not token_value:
             raise SecretsBrokerError("empty token value")
@@ -651,17 +770,25 @@ class SecretsBroker:
         # Stage the audit event inside the lock, dispatch it outside so a
         # slow audit sink cannot stall every other broker operation.
         deferred: AuditEvent | None = None
-        expired = False
         raw_value: str | None = None
+        # Chain-anchored refusal descriptor: (reason, run_id, task_id, secret,
+        # grant_id, error_message). Recorded and raised after the lock.
+        refusal: tuple[str, str, str, str, str, str] | None = None
         with self._lock:
             reg = self._by_value.get(token_value)
             if reg is None:
                 raise SecretsBrokerError("unknown token")
             if reg.revoked:
-                raise SecretsBrokerError("token has been revoked")
-            if now >= reg.token.expires_at:
+                refusal = (
+                    "revoked",
+                    reg.run_id,
+                    reg.token.task_id,
+                    reg.token.secret_name,
+                    reg.grant_id,
+                    "token has been revoked",
+                )
+            elif now >= reg.token.expires_at:
                 reg.revoked = True
-                expired = True
                 deferred = AuditEvent(
                     kind="expire",
                     token_id=reg.token.token_id,
@@ -670,6 +797,23 @@ class SecretsBroker:
                     ts_ns=time.time_ns(),
                     ttl_seconds=reg.token.ttl_seconds,
                     reason="ttl",
+                )
+                refusal = (
+                    "expired",
+                    reg.run_id,
+                    reg.token.task_id,
+                    reg.token.secret_name,
+                    reg.grant_id,
+                    "token has expired",
+                )
+            elif reg.audience and audience is not None and audience != reg.audience:
+                refusal = (
+                    f"audience_mismatch:{audience}",
+                    reg.run_id,
+                    reg.token.task_id,
+                    reg.token.secret_name,
+                    reg.grant_id,
+                    f"token presented outside its granted audience {reg.audience!r}",
                 )
             else:
                 raw_value = reg.raw_value
@@ -682,8 +826,16 @@ class SecretsBroker:
                 )
         if deferred is not None:
             self._emit(deferred)
-        if expired:
-            raise SecretsBrokerError("token has expired")
+        if refusal is not None:
+            reason, run_id, task_id, secret_name, grant_id, message = refusal
+            self._record_grant_refusal(
+                run_id=run_id,
+                task_id=task_id,
+                secret_name=secret_name,
+                grant_id=grant_id,
+                reason=f"resolve_{reason}",
+            )
+            raise SecretsBrokerError(message)
         if raw_value is None:  # pragma: no cover - defensive; branch above ensures non-None
             raise SecretsBrokerError("broker internal state corrupt")
         return raw_value
@@ -692,6 +844,7 @@ class SecretsBroker:
         """Revoke a single token by id. Returns ``True`` when it existed."""
         deferred: AuditEvent | None = None
         token_value_to_drop: str | None = None
+        grant_ref: tuple[str, str, str, str] | None = None
         with self._lock:
             reg = self._registry.get(token_id)
             if reg is None or reg.revoked:
@@ -707,8 +860,12 @@ class SecretsBroker:
                 reason=reason,
             )
             token_value_to_drop = reg.token.value
+            if reg.grant_id and reg.run_id:
+                grant_ref = (reg.run_id, reg.grant_id, reg.token.task_id, reg.token.secret_name)
         if token_value_to_drop is not None:
             unregister_secret_for_redaction(token_value_to_drop)
+        if grant_ref is not None:
+            self._record_grant_revocation(*grant_ref, reason=reason)
         if deferred is not None:
             self._emit(deferred)
         return True
@@ -717,6 +874,7 @@ class SecretsBroker:
         """Revoke every live token owned by ``task_id``. Returns count."""
         deferred: list[AuditEvent] = []
         token_values_to_drop: list[str] = []
+        grant_refs: list[tuple[str, str, str, str]] = []
         with self._lock:
             for reg in self._registry.values():
                 if reg.revoked or reg.token.task_id != task_id:
@@ -734,8 +892,12 @@ class SecretsBroker:
                     )
                 )
                 token_values_to_drop.append(reg.token.value)
+                if reg.grant_id and reg.run_id:
+                    grant_refs.append((reg.run_id, reg.grant_id, task_id, reg.token.secret_name))
         for value in token_values_to_drop:
             unregister_secret_for_redaction(value)
+        for ref in grant_refs:
+            self._record_grant_revocation(*ref, reason=reason)
         for event in deferred:
             self._emit(event)
         return len(deferred)
@@ -768,6 +930,128 @@ class SecretsBroker:
         if per_secret is not None:
             return int(per_secret)
         return self._config.ttl_seconds_default
+
+    # -- grant enforcement (issue #2516) ------------------------------------
+
+    def _authorize_mint(
+        self,
+        *,
+        secret_name: str,
+        task_id: str,
+        grant: Any,
+        run_id: str | None,
+    ) -> tuple[str, str, str, float | None]:
+        """Refuse to mint without a verifiable grant; record refusals on-chain.
+
+        Returns ``(run_id, grant_id, audience, expires_override)`` for a grant
+        that verifies against the chain and matches ``(task_id, secret_name)``.
+        Any refusal is appended to the grant ledger as a ``grant_refused``
+        record before the raising :class:`SecretsBrokerError` propagates.
+        """
+        refusal_run = run_id or (str(getattr(grant, "run_id", "")) if grant is not None else "") or task_id
+        if grant is None:
+            self._record_grant_refusal(
+                run_id=refusal_run,
+                task_id=task_id,
+                secret_name=secret_name,
+                grant_id="",
+                reason="no_grant_presented",
+            )
+            raise SecretsBrokerError(f"no verifiable grant for task {task_id!r} secret {secret_name!r}")
+
+        grant_run = str(getattr(grant, "run_id", "") or refusal_run)
+        grant_id = str(getattr(grant, "grant_id", ""))
+        ok, reason = self._verify_grant(grant, task_id=task_id, secret_name=secret_name)
+        if not ok:
+            self._record_grant_refusal(
+                run_id=grant_run,
+                task_id=task_id,
+                secret_name=secret_name,
+                grant_id=grant_id,
+                reason=f"grant_{reason}",
+            )
+            raise SecretsBrokerError(f"grant refused for task {task_id!r} secret {secret_name!r}: {reason}")
+
+        audience = str(getattr(grant, "audience", ""))
+        expiry = int(getattr(grant, "expiry", 0) or 0)
+        expires_override = float(expiry) if expiry else None
+        return grant_run, grant_id, audience, expires_override
+
+    def _verify_grant(self, grant: Any, *, task_id: str, secret_name: str) -> tuple[bool, str]:
+        """Confirm ``grant`` verifies against the chain and matches the request."""
+        if getattr(grant, "task_id", None) != task_id:
+            return False, "task_mismatch"
+        if getattr(grant, "secret_name", None) != secret_name:
+            return False, "secret_mismatch"
+        if self._grant_ledger is None:
+            return False, "no_ledger"
+        from bernstein.core.identity import grants as _grants
+
+        run_id = str(getattr(grant, "run_id", ""))
+        grant_id = str(getattr(grant, "grant_id", ""))
+        result = _grants.verify_grant_chain(
+            root=self._grant_ledger.root, run_id=run_id, key=self._grant_ledger.hmac_key
+        )
+        if not result.valid:
+            return False, "chain_unverified"
+        active = _grants.find_active_grant(result, task_id=task_id, secret_name=secret_name, now=self._clock())
+        if active is None or active.grant_id != grant_id:
+            return False, "not_active"
+        return True, "ok"
+
+    def _record_grant_exchange(
+        self,
+        *,
+        run_id: str,
+        grant_id: str,
+        token_id: str,
+        task_id: str,
+        secret_name: str,
+        audience: str,
+    ) -> None:
+        if self._grant_ledger is None:
+            return
+        try:
+            self._grant_ledger.record_exchange(
+                run_id=run_id,
+                grant_id=grant_id,
+                token_id=token_id,
+                task_id=task_id,
+                secret_name=secret_name,
+                audience=audience,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("grant exchange record failed: %s", type(exc).__name__)
+
+    def _record_grant_revocation(
+        self, run_id: str, grant_id: str, task_id: str, secret_name: str, *, reason: str
+    ) -> None:
+        if self._grant_ledger is None:
+            return
+        try:
+            self._grant_ledger.revoke_grant(
+                run_id=run_id,
+                grant_id=grant_id,
+                task_id=task_id,
+                secret_name=secret_name,
+                reason=reason,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("grant revocation record failed: %s", type(exc).__name__)
+
+    def _record_grant_refusal(self, *, run_id: str, task_id: str, secret_name: str, grant_id: str, reason: str) -> None:
+        if self._grant_ledger is None or not run_id:
+            return
+        try:
+            self._grant_ledger.record_refusal(
+                run_id=run_id,
+                task_id=task_id,
+                secret_name=secret_name,
+                grant_id=grant_id,
+                reason=reason,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("grant refusal record failed: %s", type(exc).__name__)
 
     def _emit(self, event: AuditEvent) -> None:
         """Dispatch *event* to the logger and the optional audit sink.
@@ -823,9 +1107,24 @@ def build_broker_from_config(
     raw: dict[str, Any] | None,
     *,
     audit_sink: AuditSink | None = None,
+    grant_ledger: Any = None,
 ) -> SecretsBroker:
-    """Build a broker from a raw ``security.secrets`` mapping."""
+    """Build a broker from a raw ``security.secrets`` mapping.
+
+    When ``grants.require_grant`` is set in config, pass a ``grant_ledger``
+    (a :class:`~bernstein.core.identity.grants.GrantLedger`) so the broker can
+    enforce and record chain-anchored grants (issue #2516). Grant enforcement
+    is a no-op without a ledger even when ``require_grant`` is set, so a
+    misconfigured install fails closed at mint time rather than silently
+    minting unscoped tokens.
+    """
     config = BrokerConfig.from_raw(raw)
     factory = _BACKEND_REGISTRY[config.backend]
     backend = factory(**config.backend_settings)
-    return SecretsBroker(backend, config=config, audit_sink=audit_sink)
+    return SecretsBroker(
+        backend,
+        config=config,
+        audit_sink=audit_sink,
+        grant_ledger=grant_ledger,
+        require_grant=config.require_grant,
+    )

--- a/tests/unit/cli/test_audit_verify_grants.py
+++ b/tests/unit/cli/test_audit_verify_grants.py
@@ -1,0 +1,47 @@
+"""``bernstein audit verify`` includes credential grant chains (issue #2516).
+
+A tampered grant record makes ``bernstein audit verify`` fail with the run and
+record named, exactly like a tampered chain entry. When no grant chains exist
+the check is a silent no-op that does not affect the exit code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.cli.commands import audit_cmd
+from bernstein.core.identity import grants
+
+
+@pytest.fixture(autouse=True)
+def _pin_audit_key(monkeypatch):
+    # The audit-verify path loads the install audit key directly, so pin it.
+    monkeypatch.setattr("bernstein.core.security.audit.load_or_create_audit_key", lambda *a, **k: b"k" * 32)
+
+
+def _seed_grants(audit_dir, *, tamper: bool = False) -> None:
+    signer = grants.GrantSigner.generate(issuer="manager:test")
+    ledger = grants.GrantLedger(root=audit_dir, key=b"k" * 32, signer=signer)
+    g = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=2_000_000_000)
+    ledger.record_exchange(run_id="run-1", grant_id=g.grant_id, token_id="brn-tok-1")
+    if tamper:
+        path = ledger.receipt_path("run-1")
+        raw = path.read_text(encoding="utf-8")
+        path.write_text(raw.replace("aud", "attacker", 1), encoding="utf-8")
+
+
+def test_verify_grant_chains_passes_for_intact(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    _seed_grants(tmp_path)
+    assert audit_cmd._verify_grant_chains() is True
+
+
+def test_verify_grant_chains_fails_for_tampered(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    _seed_grants(tmp_path, tamper=True)
+    assert audit_cmd._verify_grant_chains() is False
+
+
+def test_verify_grant_chains_noop_when_absent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    assert audit_cmd._verify_grant_chains() is True

--- a/tests/unit/cli/test_secrets_grants_cli.py
+++ b/tests/unit/cli/test_secrets_grants_cli.py
@@ -1,0 +1,97 @@
+"""Tests for ``bernstein secrets grants list|verify`` (issue #2516, Phase 3).
+
+The grants surface reconstructs a run's full issue / exchange / revoke history
+offline from the chain alone, following the pattern of ``bernstein delegation
+verify``. A tampered, deleted, or reordered record flips ``verify`` to a
+non-zero exit naming the failing record, and two ``--json`` runs over the same
+chain slice produce byte-identical reports.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.secrets_cmd import secrets_group
+from bernstein.core.identity import grants
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _pin_audit_key(monkeypatch):
+    # Pin the install audit key so the CLI reconstructs with a known key.
+    monkeypatch.setattr(grants, "_audit_key", lambda: b"k" * 32)
+
+
+def _seed(root, *, revoke: bool = True) -> grants.GrantReceipt:
+    signer = grants.GrantSigner.generate(issuer="manager:test")
+    ledger = grants.GrantLedger(root=root, key=b"k" * 32, signer=signer)
+    g = ledger.issue_grant(
+        run_id="run-1",
+        task_id="t-1",
+        secret_name="K",
+        audience="api.anthropic.com",
+        expiry=2_000_000_000,
+        capability_ceiling=("read",),
+    )
+    ledger.record_exchange(run_id="run-1", grant_id=g.grant_id, token_id="brn-tok-1")
+    if revoke:
+        ledger.revoke_grant(run_id="run-1", grant_id=g.grant_id, reason="task-exit")
+    return g
+
+
+class TestGrantsVerify:
+    def test_verify_ok_for_intact_chain(self, runner, tmp_path) -> None:
+        _seed(tmp_path)
+        result = runner.invoke(secrets_group, ["grants", "verify", "run-1", "--root", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "grant_issued" in result.output
+
+    def test_verify_json_is_byte_identical(self, runner, tmp_path) -> None:
+        _seed(tmp_path)
+        r1 = runner.invoke(secrets_group, ["grants", "verify", "run-1", "--root", str(tmp_path), "--json"])
+        r2 = runner.invoke(secrets_group, ["grants", "verify", "run-1", "--root", str(tmp_path), "--json"])
+        assert r1.exit_code == 0, r1.output
+        assert r1.output == r2.output
+        payload = json.loads(r1.output)
+        assert payload["run"] == "run-1"
+        assert payload["valid"] is True
+
+    def test_verify_tampered_expiry_exits_nonzero_naming_record(self, runner, tmp_path) -> None:
+        _seed(tmp_path)
+        # Tamper the persisted expiry.
+        signer = grants.GrantSigner.generate(issuer="x")
+        path = grants.GrantLedger(root=tmp_path, key=b"k" * 32, signer=signer).receipt_path("run-1")
+        raw = path.read_text(encoding="utf-8")
+        path.write_text(raw.replace("2000000000", "9999999999", 1), encoding="utf-8")
+        result = runner.invoke(secrets_group, ["grants", "verify", "run-1", "--root", str(tmp_path)])
+        assert result.exit_code == 1
+        assert "record 0" in result.output or "index 0" in result.output
+
+    def test_verify_missing_run_exits_nonzero(self, runner, tmp_path) -> None:
+        result = runner.invoke(secrets_group, ["grants", "verify", "absent", "--root", str(tmp_path)])
+        assert result.exit_code == 1
+
+
+class TestGrantsList:
+    def test_list_shows_lifecycle(self, runner, tmp_path) -> None:
+        _seed(tmp_path)
+        result = runner.invoke(secrets_group, ["grants", "list", "run-1", "--root", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "t-1" in result.output
+        assert "revoked" in result.output.lower()
+
+    def test_list_json(self, runner, tmp_path) -> None:
+        _seed(tmp_path, revoke=False)
+        result = runner.invoke(secrets_group, ["grants", "list", "run-1", "--root", str(tmp_path), "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["run"] == "run-1"
+        assert payload["grants"]
+        assert payload["grants"][0]["task_id"] == "t-1"

--- a/tests/unit/identity/spiffe/test_grant_identity.py
+++ b/tests/unit/identity/spiffe/test_grant_identity.py
@@ -1,0 +1,56 @@
+"""Tests for the SPIFFE grant-issuer path (issue #2516, Phase 4).
+
+When the ``spiffe`` extra is installed and a Workload API socket is reachable,
+newly issued grants carry the workload's SPIFFE ID as the issuer identity,
+binding grants to the workload identity already checkable via
+``bernstein spiffe verify-binding``. With the extra absent the resolver returns
+``None`` and the default Ed25519 manager issuer stays in force -- the default
+identity path is unchanged.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.identity.spiffe import grant_identity
+from bernstein.core.identity.spiffe.svid import X509Svid
+
+
+class _FakeSvid:
+    """Duck-typed stand-in for a py-spiffe X509Svid (no SDK needed)."""
+
+    spiffe_id = "spiffe://example.org/bernstein/inst/agent-1"
+    cert_chain_pem = b"-----BEGIN CERTIFICATE-----\nZmFrZQ==\n-----END CERTIFICATE-----\n"
+    private_key_pem = b"-----BEGIN PRIVATE KEY-----\nZmFrZQ==\n-----END PRIVATE KEY-----\n"
+    bundle_pem = b"-----BEGIN CERTIFICATE-----\nYnVuZGxl\n-----END CERTIFICATE-----\n"
+    expires_at = 2_000_000_000.0
+    hint = ""
+
+
+def test_issuer_is_none_when_extra_absent(monkeypatch) -> None:
+    monkeypatch.setattr(grant_identity, "spiffe_extra_available", lambda: False)
+    issuer = grant_identity.spiffe_grant_issuer()
+    assert issuer is None
+
+
+def test_issuer_is_spiffe_id_when_svid_fetchable(monkeypatch) -> None:
+    monkeypatch.setattr(grant_identity, "spiffe_extra_available", lambda: True)
+
+    def _factory(_socket):
+        return X509Svid(
+            spiffe_id="spiffe://example.org/bernstein/inst/agent-1",
+            cert_chain_pem=_FakeSvid.cert_chain_pem,
+            private_key_pem=_FakeSvid.private_key_pem,
+            bundle_pem=_FakeSvid.bundle_pem,
+            expires_at=_FakeSvid.expires_at,
+        )
+
+    issuer = grant_identity.spiffe_grant_issuer(client_factory=_factory)
+    assert issuer == "spiffe://example.org/bernstein/inst/agent-1"
+
+
+def test_issuer_none_when_fetch_fails(monkeypatch) -> None:
+    monkeypatch.setattr(grant_identity, "spiffe_extra_available", lambda: True)
+
+    def _factory(_socket):
+        raise RuntimeError("no socket")
+
+    assert grant_identity.spiffe_grant_issuer(client_factory=_factory) is None

--- a/tests/unit/identity/test_grants.py
+++ b/tests/unit/identity/test_grants.py
@@ -1,0 +1,200 @@
+"""Tests for chain-anchored, Ed25519-signed per-task credential grants.
+
+Covers issue #2516: a scoped grant (task id, secret name, audience, expiry,
+capability ceiling) is an Ed25519-signed record anchored in the same
+HMAC-chained construction as the per-hop delegation receipts. The grant is the
+authorization artifact the secrets broker exchanges for a short-lived token;
+its issue, exchange, and revocation history reconstruct offline from the chain
+alone, and mutating, deleting, or reordering any record flips verification to a
+failure naming the offending record.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.identity import grants
+
+
+@pytest.fixture
+def signer() -> grants.GrantSigner:
+    return grants.GrantSigner.generate(issuer="manager:test")
+
+
+@pytest.fixture
+def ledger(tmp_path, signer) -> grants.GrantLedger:
+    return grants.GrantLedger(root=tmp_path, key=b"k" * 32, signer=signer)
+
+
+class TestGrantIssuance:
+    def test_issue_grant_chains_to_genesis_and_is_signed(self, ledger, signer) -> None:
+        g = ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-42",
+            secret_name="ANTHROPIC_API_KEY",
+            audience="api.anthropic.com",
+            expiry=2_000_000_000,
+            capability_ceiling=("read",),
+        )
+        assert g.kind == grants.GRANT_ISSUED
+        assert g.prev_hmac == grants.GENESIS_HMAC
+        assert g.record_index == 0
+        assert g.grant_id
+        assert g.hmac
+        assert g.signature
+        assert g.issuer == "manager:test"
+        # The signature verifies against the embedded issuer public key.
+        assert grants.verify_grant_signature(g.issuer_pubkey, g.signed_body(), g.signature)
+
+    def test_grant_carries_scope_fields(self, ledger) -> None:
+        g = ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-42",
+            secret_name="K",
+            audience="vault.internal",
+            expiry=1_900_000_000,
+            capability_ceiling=("read", "list"),
+        )
+        assert g.task_id == "t-42"
+        assert g.secret_name == "K"
+        assert g.audience == "vault.internal"
+        assert g.expiry == 1_900_000_000
+        assert tuple(g.capability_ceiling) == ("list", "read")  # sorted, canonical
+
+    def test_exchange_and_revoke_chain_to_previous(self, ledger) -> None:
+        g = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=0)
+        ex = ledger.record_exchange(run_id="run-1", grant_id=g.grant_id, token_id="brn-tok-1")
+        rv = ledger.revoke_grant(run_id="run-1", grant_id=g.grant_id, reason="task-exit")
+        assert ex.kind == grants.GRANT_EXCHANGED
+        assert ex.prev_hmac == g.hmac
+        assert ex.token_id == "brn-tok-1"
+        assert rv.kind == grants.GRANT_REVOKED
+        assert rv.prev_hmac == ex.hmac
+        assert rv.grant_id == g.grant_id
+
+    def test_refusal_is_a_chain_record(self, ledger) -> None:
+        r = ledger.record_refusal(run_id="run-1", task_id="t-1", secret_name="K", reason="no_grant")
+        assert r.kind == grants.GRANT_REFUSED
+        assert r.reason == "no_grant"
+        assert r.hmac
+
+
+class TestOfflineReconstruction:
+    def _seed(self, ledger) -> grants.GrantReceipt:
+        g = ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="aud",
+            expiry=2_000_000_000,
+            capability_ceiling=("read",),
+        )
+        ledger.record_exchange(run_id="run-1", grant_id=g.grant_id, token_id="brn-tok-1")
+        ledger.revoke_grant(run_id="run-1", grant_id=g.grant_id, reason="task-exit")
+        return g
+
+    def test_full_history_reconstructs_offline(self, ledger) -> None:
+        self._seed(ledger)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert result.valid
+        assert result.errors == []
+        kinds = [r.kind for r in result.records]
+        assert kinds == [grants.GRANT_ISSUED, grants.GRANT_EXCHANGED, grants.GRANT_REVOKED]
+
+    def test_lifecycle_marks_grant_revoked(self, ledger) -> None:
+        g = self._seed(ledger)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        life = result.lifecycles()
+        assert life[g.grant_id]["issued"] is True
+        assert life[g.grant_id]["revoked"] is True
+        assert "brn-tok-1" in life[g.grant_id]["token_ids"]
+
+    def test_tampered_expiry_field_fails_naming_record(self, ledger) -> None:
+        self._seed(ledger)
+        path = ledger.receipt_path("run-1")
+        raw = path.read_text(encoding="utf-8")
+        # Flip the grant's expiry in the persisted record.
+        tampered = raw.replace("2000000000", "9999999999", 1)
+        assert tampered != raw
+        path.write_text(tampered, encoding="utf-8")
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert not result.valid
+        assert result.errors
+        # The failing record is named (record 0).
+        assert any("record 0" in e or "index 0" in e for e in result.errors)
+
+    def test_deleted_record_breaks_linkage(self, ledger) -> None:
+        self._seed(ledger)
+        path = ledger.receipt_path("run-1")
+        lines = path.read_text(encoding="utf-8").splitlines()
+        # Drop the middle (exchange) record -> revoke no longer links.
+        path.write_text(lines[0] + "\n" + lines[2] + "\n", encoding="utf-8")
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert not result.valid
+
+    def test_reordered_records_break_linkage(self, ledger) -> None:
+        self._seed(ledger)
+        path = ledger.receipt_path("run-1")
+        lines = path.read_text(encoding="utf-8").splitlines()
+        path.write_text(lines[1] + "\n" + lines[0] + "\n" + lines[2] + "\n", encoding="utf-8")
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert not result.valid
+
+    def test_forged_signature_fails(self, ledger) -> None:
+        self._seed(ledger)
+        path = ledger.receipt_path("run-1")
+        obj = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        # Swap the audience without the manager key: the HMAC will not match,
+        # but even recomputing HMAC would leave the Ed25519 signature broken.
+        obj["audience"] = "attacker.example"
+        # Re-chain the HMAC as an attacker who holds the install audit key would
+        # NOT be able to; here we only prove the signature layer also rejects.
+        body = {k: v for k, v in obj.items() if k not in ("hmac", "signature")}
+        assert not grants.verify_grant_signature(obj["issuer_pubkey"], body, obj["signature"])
+
+    def test_wrong_hmac_key_fails(self, ledger) -> None:
+        self._seed(ledger)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"x" * 32)
+        assert not result.valid
+
+    def test_missing_run_is_empty_not_valid(self, tmp_path) -> None:
+        result = grants.verify_grant_chain(root=tmp_path, run_id="absent", key=b"k" * 32)
+        assert result.records == []
+        assert not result.valid
+
+
+class TestByteIdenticalReport:
+    def test_two_verifiers_produce_identical_report(self, ledger) -> None:
+        g = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=2_000_000_000)
+        ledger.record_exchange(run_id="run-1", grant_id=g.grant_id, token_id="brn-tok-1")
+        r1 = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        r2 = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        report1 = grants.render_report(r1, run_id="run-1")
+        report2 = grants.render_report(r2, run_id="run-1")
+        assert report1 == report2
+        # Report is canonical JSON that names the run and every record.
+        parsed = json.loads(report1)
+        assert parsed["run"] == "run-1"
+        assert parsed["valid"] is True
+
+
+class TestActiveGrantLookup:
+    def test_find_active_grant_matches_task_and_secret(self, ledger) -> None:
+        ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=2_000_000_000)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        g = grants.find_active_grant(result, task_id="t-1", secret_name="K", now=1_000_000_000)
+        assert g is not None
+        assert g.audience == "aud"
+
+    def test_find_active_grant_skips_revoked(self, ledger) -> None:
+        g = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=2_000_000_000)
+        ledger.revoke_grant(run_id="run-1", grant_id=g.grant_id, reason="revoked")
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert grants.find_active_grant(result, task_id="t-1", secret_name="K", now=1_000_000_000) is None
+
+    def test_find_active_grant_skips_expired(self, ledger) -> None:
+        ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=1_000)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert grants.find_active_grant(result, task_id="t-1", secret_name="K", now=2_000) is None

--- a/tests/unit/security/test_broker_grant_config.py
+++ b/tests/unit/security/test_broker_grant_config.py
@@ -1,0 +1,30 @@
+"""Config-schema additions for grant enforcement (issue #2516, Phase 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.security.secrets_broker import BrokerConfig, SecretsBrokerError
+
+
+class TestGrantConfig:
+    def test_defaults_are_legacy_grant_free(self) -> None:
+        cfg = BrokerConfig.from_raw({"backend": "file_encrypted"})
+        assert cfg.require_grant is False
+        assert cfg.identity_mode == "ed25519"
+
+    def test_require_grant_parsed(self) -> None:
+        cfg = BrokerConfig.from_raw({"backend": "file_encrypted", "grants": {"require_grant": True}})
+        assert cfg.require_grant is True
+
+    def test_identity_mode_spiffe_parsed(self) -> None:
+        cfg = BrokerConfig.from_raw({"backend": "file_encrypted", "grants": {"identity_mode": "spiffe"}})
+        assert cfg.identity_mode == "spiffe"
+
+    def test_unknown_identity_mode_rejected(self) -> None:
+        with pytest.raises(SecretsBrokerError, match="identity_mode"):
+            BrokerConfig.from_raw({"backend": "file_encrypted", "grants": {"identity_mode": "kerberos"}})
+
+    def test_grants_block_must_be_mapping(self) -> None:
+        with pytest.raises(SecretsBrokerError, match="grants block"):
+            BrokerConfig.from_raw({"backend": "file_encrypted", "grants": []})

--- a/tests/unit/security/test_secrets_broker_grants.py
+++ b/tests/unit/security/test_secrets_broker_grants.py
@@ -1,0 +1,169 @@
+"""Broker <-> grant integration tests (issue #2516).
+
+The secrets broker in grant-enforcing mode refuses to mint a token unless a
+verifiable, chain-anchored grant exists for the (task id, secret name) pair;
+the refusal is itself a chain event. A minted token inherits the grant's task
+id, audience, and expiry, and the token id is recorded in the grant lifecycle
+so token-to-grant resolution works offline. ``resolve()`` refuses a token
+presented outside its granted audience, and audience, expiry, and revocation
+refusals are all recorded as chain-anchored records, not only in-process
+callbacks. Revocation appends a signed revocation record referencing the grant,
+and a run's full credential history reconstructs offline from the chain alone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.identity import grants
+from bernstein.core.security.secrets_broker import (
+    BrokerConfig,
+    SecretsBackend,
+    SecretsBroker,
+    SecretsBrokerError,
+    clear_redaction_registry,
+)
+
+
+class _MemoryBackend(SecretsBackend):
+    name = "memory"
+
+    def __init__(self, secrets: dict[str, str]) -> None:
+        self._secrets = dict(secrets)
+
+    def read(self, secret_name: str) -> str:
+        if secret_name not in self._secrets:
+            raise SecretsBrokerError(f"memory: no entry for {secret_name!r}")
+        return self._secrets[secret_name]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    clear_redaction_registry()
+    yield
+    clear_redaction_registry()
+
+
+def _build(tmp_path, *, require_grant: bool = True, clock_value: float = 1_000.0):
+    now = [clock_value]
+
+    def clock() -> float:
+        return now[0]
+
+    signer = grants.GrantSigner.generate(issuer="manager:test")
+    ledger = grants.GrantLedger(root=tmp_path, key=b"k" * 32, signer=signer)
+    backend = _MemoryBackend({"K": "raw-value-K", "J": "raw-value-J"})
+    cfg = BrokerConfig(backend="file_encrypted", ttl_seconds_default=900)
+    broker = SecretsBroker(
+        backend,
+        config=cfg,
+        clock=clock,
+        grant_ledger=ledger,
+        require_grant=require_grant,
+    )
+    return broker, ledger, now
+
+
+class TestMintRequiresGrant:
+    def test_mint_without_grant_refuses_and_records_chain_event(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        with pytest.raises(SecretsBrokerError, match="grant"):
+            broker.mint(secret_name="K", task_id="t-1", run_id="run-1")
+        # The refusal is itself a chain-anchored record.
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert result.valid
+        assert result.records[-1].kind == grants.GRANT_REFUSED
+        assert result.records[-1].reason
+
+    def test_mint_with_verifiable_grant_inherits_scope_and_records_exchange(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(
+            run_id="run-1",
+            task_id="t-1",
+            secret_name="K",
+            audience="api.anthropic.com",
+            expiry=5_000,
+        )
+        token = broker.mint(secret_name="K", task_id="t-1", grant=grant)
+        assert token.task_id == "t-1"
+        assert token.audience == "api.anthropic.com"
+        # Token inherits the grant expiry rather than the config TTL default.
+        assert token.expires_at == 5_000
+        # The exchange is recorded, binding token id to the grant.
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        life = result.lifecycles()
+        assert token.token_id in life[grant.grant_id]["token_ids"]
+
+    def test_mint_rejects_grant_for_wrong_secret(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=5_000)
+        with pytest.raises(SecretsBrokerError, match="grant"):
+            broker.mint(secret_name="J", task_id="t-1", grant=grant)
+
+    def test_mint_rejects_grant_for_wrong_task(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=5_000)
+        with pytest.raises(SecretsBrokerError, match="grant"):
+            broker.mint(secret_name="K", task_id="t-OTHER", grant=grant)
+
+    def test_mint_rejects_already_revoked_grant(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=5_000)
+        ledger.revoke_grant(run_id="run-1", grant_id=grant.grant_id, reason="pre-revoked")
+        with pytest.raises(SecretsBrokerError, match="grant"):
+            broker.mint(secret_name="K", task_id="t-1", grant=grant)
+
+
+class TestResolveAudienceScoping:
+    def test_resolve_refuses_wrong_audience_and_records_event(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(
+            run_id="run-1", task_id="t-1", secret_name="K", audience="api.anthropic.com", expiry=5_000
+        )
+        token = broker.mint(secret_name="K", task_id="t-1", grant=grant)
+        # Correct audience resolves.
+        assert broker.resolve(token.value, audience="api.anthropic.com") == "raw-value-K"
+        # Wrong audience is refused.
+        with pytest.raises(SecretsBrokerError, match="audience"):
+            broker.resolve(token.value, audience="evil.example")
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        refusals = [r for r in result.records if r.kind == grants.GRANT_REFUSED]
+        assert any("audience" in r.reason for r in refusals)
+
+    def test_resolve_without_audience_is_allowed(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=5_000)
+        token = broker.mint(secret_name="K", task_id="t-1", grant=grant)
+        # A caller that does not assert an audience still resolves (broker-internal path).
+        assert broker.resolve(token.value) == "raw-value-K"
+
+
+class TestRevocationChainEvent:
+    def test_revoke_writes_signed_revocation_record(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=5_000)
+        token = broker.mint(secret_name="K", task_id="t-1", grant=grant)
+        assert broker.revoke(token.token_id, reason="task-exit") is True
+        with pytest.raises(SecretsBrokerError):
+            broker.resolve(token.value)
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        assert result.lifecycles()[grant.grant_id]["revoked"] is True
+
+    def test_full_history_reconstructs_offline(self, tmp_path) -> None:
+        broker, ledger, _ = _build(tmp_path)
+        grant = ledger.issue_grant(run_id="run-1", task_id="t-1", secret_name="K", audience="aud", expiry=5_000)
+        token = broker.mint(secret_name="K", task_id="t-1", grant=grant)
+        broker.revoke(token.token_id, reason="task-exit")
+        result = grants.verify_grant_chain(root=ledger.root, run_id="run-1", key=b"k" * 32)
+        kinds = [r.kind for r in result.records]
+        assert grants.GRANT_ISSUED in kinds
+        assert grants.GRANT_EXCHANGED in kinds
+        assert grants.GRANT_REVOKED in kinds
+        assert result.valid
+
+
+class TestLegacyModeUnchanged:
+    def test_non_enforcing_broker_mints_without_grant(self, tmp_path) -> None:
+        broker, _, _ = _build(tmp_path, require_grant=False)
+        token = broker.mint(secret_name="K", task_id="t-1")
+        assert broker.resolve(token.value) == "raw-value-K"

--- a/tests/unit/test_doctor_spiffe.py
+++ b/tests/unit/test_doctor_spiffe.py
@@ -1,0 +1,60 @@
+"""Doctor preflight for the SPIFFE workload-API credential path (issue #2516).
+
+With the ``spiffe`` extra absent the check is an informational PASS: the
+default Ed25519 identity path is active and nothing is broken. With the extra
+present and a reachable Workload API socket the check reports the SVID path
+green; with the extra present but the socket unset or missing it warns.
+"""
+
+from __future__ import annotations
+
+import socket as _socket
+
+from bernstein.cli.commands import doctor_cmd
+
+
+class TestSpiffeDoctorCheck:
+    def test_extra_absent_is_informational_pass(self, monkeypatch) -> None:
+        monkeypatch.setattr(doctor_cmd, "_spiffe_extra_available", lambda: False)
+        result = doctor_cmd.check_spiffe_workload_api()
+        assert result["name"] == "SPIFFE workload API"
+        assert result["status"] == "PASS"
+        assert "extra" in result["detail"].lower()
+
+    def test_extra_present_socket_unset_warns(self, monkeypatch) -> None:
+        monkeypatch.setattr(doctor_cmd, "_spiffe_extra_available", lambda: True)
+        monkeypatch.delenv("SPIFFE_ENDPOINT_SOCKET", raising=False)
+        result = doctor_cmd.check_spiffe_workload_api()
+        assert result["status"] == "WARN"
+
+    def test_extra_present_socket_missing_warns(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr(doctor_cmd, "_spiffe_extra_available", lambda: True)
+        monkeypatch.setenv("SPIFFE_ENDPOINT_SOCKET", f"unix://{tmp_path}/nope.sock")
+        result = doctor_cmd.check_spiffe_workload_api()
+        assert result["status"] == "WARN"
+
+    def test_extra_present_socket_reachable_passes(self, monkeypatch) -> None:
+        import os
+        import tempfile
+
+        # AF_UNIX paths are capped near 104 chars; the session scratchpad
+        # tmp_path is longer, so bind under a short dedicated temp dir.
+        sock_dir = tempfile.mkdtemp(prefix="bstn-spf-", dir="/tmp")
+        sock_path = os.path.join(sock_dir, "agent.sock")
+        srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        srv.bind(sock_path)
+        srv.listen(1)
+        try:
+            monkeypatch.setattr(doctor_cmd, "_spiffe_extra_available", lambda: True)
+            monkeypatch.setenv("SPIFFE_ENDPOINT_SOCKET", f"unix://{sock_path}")
+            result = doctor_cmd.check_spiffe_workload_api()
+            assert result["status"] == "PASS"
+            assert "SVID" in result["detail"] or "reachable" in result["detail"].lower()
+        finally:
+            srv.close()
+            os.unlink(sock_path)
+            os.rmdir(sock_dir)
+
+    def test_check_is_wired_into_run_all_checks(self) -> None:
+        names = {c["name"] for c in doctor_cmd.run_all_checks()}
+        assert "SPIFFE workload API" in names


### PR DESCRIPTION
## What

Makes a downstream per-task credential a projection of a chain-recorded grant, and packages the SPIFFE credential path so workload-attested installs get the same shape.

Before a worker spawn, the orchestrator issues a scoped grant (task id, secret name, audience, expiry, capability ceiling) as an Ed25519-signed record anchored in the HMAC audit chain, reusing the delegation-receipt chaining construction and the install-scoped audit key. The secrets broker refuses to mint a downstream token without a grant that verifies, exchanges the grant for a short-lived token that inherits its task id, audience, and expiry, and records the token id in the grant lifecycle so token-to-grant resolution works offline. Strip the chain and the grant is a static secret with a log; anchored to the chain, it is a verifiable authorization receipt.

## Acceptance criteria

- The broker refuses to mint when no verifiable grant exists for the (task id, secret name) pair, and the refusal is a chain-anchored record.
- resolve() refuses a token presented outside its granted audience; audience, expiry, and revocation refusals are all chain-anchored records, not only in-process callbacks.
- A run's full credential history (grant, exchange, revocation) reconstructs offline from the chain alone; mutating any field, deleting a record, or reordering records flips verification to a non-zero exit naming the failing record.
- Two independent verifiers over the same chain slice produce byte-identical reports.
- With the spiffe extra absent, all default Ed25519 identity paths pass unchanged; with the extra installed against a reachable Workload API socket, doctor reports the SVID path green and new grants carry the SPIFFE ID issuer.

## How it works

- New `bernstein.core.identity.grants` module: `GrantLedger` writes signed, HMAC-chained `grant_issued` / `grant_exchanged` / `grant_revoked` / `grant_refused` records under `<audit>/grants/<run>.jsonl`; `verify_grant_chain` reconstructs and verifies offline (HMAC linkage plus Ed25519 signature per record); `render_report` emits a deterministic, byte-identical report.
- `SecretsBroker` gains an opt-in grant-enforcing mode (`grant_ledger` + `require_grant`); minted tokens inherit the grant audience and expiry, and mint / resolve / revoke record chain events. Legacy grant-free behaviour is unchanged when no ledger is supplied.
- `bernstein secrets grants list|verify` reconstruct a run's history offline; `bernstein audit verify` now also verifies every grant chain.
- SPIFFE packaging: a `bernstein doctor` preflight for the extra and Workload API socket, and `spiffe.grant_identity.spiffe_grant_issuer` which labels the grant issuer with the workload SPIFFE ID when the extra and socket are available.
- Config: `security.secrets.grants.require_grant` and `identity_mode` (`ed25519` default, or `spiffe`); both default to the legacy self-contained path.

## Verification

Drive of the full flow (grant issued and chain-recorded, broker exchange to a short-lived token, audience-scoped resolve, revocation as a chain event, offline reconstruction, byte-identical report, tamper detection):

```
== 1. refuse mint without a grant (refusal is a chain event) ==
   REFUSED: no verifiable grant for task 't-42' secret 'ANTHROPIC_API_KEY'
== 2. orchestrator issues a scoped grant (chain-recorded) ==
   grant_id=739c72af139847b2 kind=grant_issued audience=api.anthropic.com expiry=2000000000
   signed=True hmac=cdaa1a364ecae68f... issuer=manager:orchestrator
== 3. broker exchanges the grant for a short-lived downstream token ==
   token_id=HSdqjGDdApI audience=api.anthropic.com expires_at=2000000000.0
   token value != raw secret: True
   resolve within audience: REAL-SECRET-ANTHROPIC_API_KEY
== 4. resolve refused outside granted audience (chain event) ==
   REFUSED: token presented outside its granted audience 'api.anthropic.com'
== 5. revocation as a chain event ==
   revoke -> True
== 6. reconstruct full credential history offline (no broker running) ==
   valid=True records=['grant_refused', 'grant_issued', 'grant_exchanged', 'grant_refused', 'grant_revoked']
   grant 739c72af1398: issued=True revoked=True tokens=['HSdqjGDdApI']
== 7. offline verify report (byte-identical across verifiers) ==
   byte-identical: True
== 8. tamper detection: flip the grant expiry on disk ==
   valid_after_tamper=False
   errors=['record 1: HMAC mismatch (record tampered or wrong key)']
```

New tests: 40 across grant ledger, broker integration, SPIFFE issuer, doctor preflight, CLI, and audit-verify wiring. Relevant existing suites (secrets, keystore, spiffe, identity, doctor) green locally: 369 in `tests/unit/security`, plus the identity and delegation suites. `ruff check` and `ruff format --check` clean; refurb suggestions applied to new files. A `spiffe-extra-e2e` CI job builds the wheel and runs both the extra-present and no-extra suites.

Closes #2516
