### PR TITLE
feat(compliance): assemble regulator-mapped export packs from the audit chain

### DIFF
--- a/docs/compliance/regulator-mapped-packs.md
+++ b/docs/compliance/regulator-mapped-packs.md
@@ -1,0 +1,94 @@
+# Regulator-mapped compliance packs
+
+The EU AI Act Article 12 bundle (`bernstein compliance pack article-12`) covers
+record-keeping. Operators with obligations beyond record-keeping needed three
+more evidence shapes, and used to assemble them by hand from raw exports. The
+`bernstein compliance pack` group now ships them as one-command packs, each a
+deterministic projection of the audit chain and each offline-verifiable with the
+standalone verifier.
+
+| Pack | Command | Maps to | Proves |
+|------|---------|---------|--------|
+| Retention | `pack retention --since --until` | Article 12(3) | logs existed over the window and were not truncated or rewritten |
+| Incident | `pack incident --run <id>` | Article 73 | the incident timeline joined with its audit slice, evidence bundles, and receipts |
+| Oversight | `pack oversight --since --until` | Article 14 | who approved what, and that the displayed action equalled the executed action |
+
+Every pack is sealed with the same operator-key signing, signed SLSA-style
+provenance manifest, and canonical-bytes rule (`PACK_FORMAT_VERSION` 2) as the
+Article 12 bundle. Two builds over the same chain window yield byte-identical
+member content hashes; build timestamps live only in the manifest, isolated from
+the member hashes so the comparison is mechanical.
+
+## Retention pack
+
+```
+bernstein compliance pack retention \
+  --since 2026-01-01 --until 2026-12-31 \
+  --org "Acme GmbH" --output acme-retention-2026.zip
+```
+
+Contents:
+
+- `retention-evidence.json` records the boundary head hashes at the window
+  edges, the entry count, detected coverage gaps, and the retention parameters
+  in force.
+- `lineage-log.jsonl` embeds the signed entries in canonical bytes, with their
+  per-entry Ed25519 signatures under `signatures/` and Agent Cards under
+  `agent-cards/`.
+- `retention-evidence.pdf` and `.csv` are the human- and machine-readable views.
+
+The verifier recomputes the boundary head hashes and entry count from the actual
+signed entries, so the continuity claim is checked against the chain, not
+trusted from the report.
+
+## Incident pack
+
+```
+bernstein compliance pack incident --run run-42 \
+  --org "Acme GmbH" --output acme-incident-run-42.zip
+```
+
+Reads `.sdd/incidents/<run>/timeline.json` (with optional `evidence_bundle_refs`
+and `receipt_refs`) and `.sdd/incidents/<run>/audit-slice.jsonl`, then joins:
+
+- `incident-timeline.json` and a fixed regulator-readable `incident-report.pdf` /
+  `.csv`.
+- `audit-slice.jsonl`, the prev_hmac-chained audit events in canonical bytes.
+- `evidence-bundles/` and `receipts/`, the referenced artefacts present in the
+  store.
+- `gaps.json`, an explicit entry for every referenced artefact missing from the
+  store.
+
+The pack never fabricates completeness: a missing bundle or receipt is recorded
+as a gap, and verification reports the gap list rather than passing silently.
+
+## Oversight pack
+
+```
+bernstein compliance pack oversight \
+  --since 2026-01-01 --until 2026-12-31 \
+  --org "Acme GmbH" --output acme-oversight-2026.zip
+```
+
+Reads resolved approvals from `.sdd/approvals/resolved.jsonl` (or `--approvals`).
+Each in-window approval becomes a canonical receipt under `receipts/` carrying
+the attested displayed-versus-executed binding (`displayed_hash`,
+`executed_hash`), the approving principal, and the decision outcome, summarised
+in `oversight-evidence.json` and rendered in `oversight-report.pdf` / `.csv`.
+The verifier recomputes each binding from the receipt payloads, so an auditor
+confirms displayed equalled executed decision by decision.
+
+## Verifying a pack offline
+
+All three kinds verify on a machine with no Bernstein install:
+
+```
+pip install bernstein-verify
+python -m bernstein_verify pack ./acme-retention-2026.zip
+```
+
+Exit 0 with a one-line `PASS` summary means every member's sha256 matches the
+signed manifest `input_hashes`, the manifest self-anchors (`output_hash`), and
+the chained substrate re-verifies for the pack kind. Flipping a single byte in
+any member, including a rendered PDF, fails verification and names the member.
+Existing Article 12 packs (format v1 and v2) verify unchanged.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,7 @@ nav:
       - Env isolation: operations/env-isolation.md
       - Compliance: operations/compliance.md
       - EU AI Act Article 12 evidence pack: compliance/eu-ai-act-article-12-bundle.md
+      - Regulator-mapped compliance packs: compliance/regulator-mapped-packs.md
       - FINOS AIGF mapping: compliance/finos-aigf-mapping.md
       - Regulator-class lineage: compliance/regulatory-lineage.md
       - Regulatory lineage export (operator guide): compliance/lineage-export.md

--- a/src/bernstein/cli/commands/compliance_cmd.py
+++ b/src/bernstein/cli/commands/compliance_cmd.py
@@ -14,13 +14,18 @@ from __future__ import annotations
 
 import json
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import click
 
 from bernstein.compliance.eu_ai_act import ComplianceEngine, bernstein_descriptor
-from bernstein.core.compliance.pack import build_pack
+from bernstein.core.compliance.pack import (
+    build_incident_pack,
+    build_oversight_pack,
+    build_pack,
+    build_retention_pack,
+)
 from bernstein.core.compliance_policies import (
     ALL_POLICIES,
     ComplianceFramework,
@@ -451,7 +456,14 @@ def export_rego(framework: str, output_dir: Path | None, workdir: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# `bernstein compliance pack` - EU AI Act Article 12 evidence bundle
+# `bernstein compliance pack` - regulator-mapped evidence packs
+#
+# ``pack`` is a group. With no subcommand (or a leading option) it defaults to
+# ``article-12`` so the legacy ``bernstein compliance pack --since ...`` call
+# keeps working; ``retention`` / ``incident`` / ``oversight`` add the packs
+# mapped to Article 12(3), Article 73, and Article 14 respectively. Each pack
+# is a deterministic projection of the chain, sealed with the operator key and
+# offline-verifiable with ``python -m bernstein_verify pack``.
 # ---------------------------------------------------------------------------
 
 
@@ -462,16 +474,75 @@ def _parse_iso_date(value: str) -> datetime:
         raise click.BadParameter(f"expected YYYY-MM-DD, got {value!r}") from exc
 
 
-@compliance_group.command("pack")
+def _window_dates(since: str, until: str) -> tuple[date, date]:
+    since_date = _parse_iso_date(since).date()
+    until_date = _parse_iso_date(until).date()
+    if since_date > until_date:
+        raise click.BadParameter("--since must be <= --until")
+    return since_date, until_date
+
+
+def _require_operator_key(operator_key: Path | None, workdir: Path) -> Path:
+    resolved_key = operator_key or (workdir / ".sdd" / "keys" / "operator.key")
+    if not resolved_key.exists():
+        raise click.ClickException(
+            f"Operator signing key not found at {resolved_key}.\n"
+            "Generate one with `openssl genpkey -algorithm Ed25519 -out "
+            f"{resolved_key}` or pass --operator-key <path>.",
+        )
+    return resolved_key
+
+
+def _load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_jsonl(path: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+    return records
+
+
+class _DefaultSubcommandGroup(click.Group):
+    """A group that routes to a default subcommand when the first token is not
+    a known subcommand, so ``pack --since ...`` still reaches ``article-12``."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self._default_cmd = kwargs.pop("default_cmd", None)
+        super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        default = self._default_cmd
+        if isinstance(default, str):
+            if not args:
+                args = [default]
+            elif args[0] not in self.commands and args[0] not in ("--help", "-h"):
+                args = [default, *args]
+        return super().parse_args(ctx, args)
+
+
+@compliance_group.group("pack", cls=_DefaultSubcommandGroup, default_cmd="article-12")
+def pack_group() -> None:
+    """Assemble regulator-mapped evidence packs from the audit chain.
+
+    Subcommands (each offline-verifiable with `python -m bernstein_verify pack`):
+
+    \b
+      article-12  record-keeping bundle (default; Article 12).
+      retention   chain-continuity evidence for a window (Article 12(3)).
+      incident    serious-incident report from a run (Article 73).
+      oversight   human-oversight evidence from receipts (Article 14).
+    """
+
+
+@pack_group.command("article-12")
 @click.option("--since", required=True, help="Window start date (YYYY-MM-DD, inclusive).")
 @click.option("--until", required=True, help="Window end date (YYYY-MM-DD, inclusive).")
 @click.option("--org", required=True, help="Organisation name (printed on the cover page).")
-@click.option(
-    "--output",
-    required=True,
-    type=click.Path(path_type=Path),
-    help="Destination .zip path.",
-)
+@click.option("--output", required=True, type=click.Path(path_type=Path), help="Destination .zip path.")
 @click.option(
     "--workdir",
     default=".",
@@ -497,7 +568,7 @@ def _parse_iso_date(value: str) -> datetime:
     type=click.Path(path_type=Path),
     help=("Path to PEM PKCS#8 Ed25519 operator key for manifest signing (default: <workdir>/.sdd/keys/operator.key)."),
 )
-def pack(
+def pack_article12(
     since: str,
     until: str,
     org: str,
@@ -513,21 +584,10 @@ def pack(
     readable PDF + machine-readable CSV + raw JSONL + per-entry signatures
     + Agent Cards, and emits an operator-signed SLSA-style manifest.
     """
-    since_date = _parse_iso_date(since).date()
-    until_date = _parse_iso_date(until).date()
-    if since_date > until_date:
-        raise click.BadParameter("--since must be <= --until")
-
+    since_date, until_date = _window_dates(since, until)
     resolved_lineage = lineage_dir or (workdir / ".sdd" / "lineage")
     resolved_cards = agent_cards_dir or (workdir / ".sdd" / "agents")
-    resolved_key = operator_key or (workdir / ".sdd" / "keys" / "operator.key")
-
-    if not resolved_key.exists():
-        raise click.ClickException(
-            f"Operator signing key not found at {resolved_key}.\n"
-            "Generate one with `openssl genpkey -algorithm Ed25519 -out "
-            f"{resolved_key}` or pass --operator-key <path>.",
-        )
+    resolved_key = _require_operator_key(operator_key, workdir)
 
     out_path = build_pack(
         since=since_date,
@@ -539,3 +599,190 @@ def pack(
         operator_key_path=resolved_key,
     )
     click.echo(f"Compliance pack written to: {out_path}")
+
+
+@pack_group.command("retention")
+@click.option("--since", required=True, help="Window start date (YYYY-MM-DD, inclusive).")
+@click.option("--until", required=True, help="Window end date (YYYY-MM-DD, inclusive).")
+@click.option("--org", required=True, help="Organisation name (printed on the cover page).")
+@click.option("--output", required=True, type=click.Path(path_type=Path), help="Destination .zip path.")
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Project root (used to locate .sdd/lineage and .sdd/agents).",
+)
+@click.option("--lineage-dir", default=None, type=click.Path(path_type=Path), help="Override lineage directory.")
+@click.option(
+    "--agent-cards-dir", default=None, type=click.Path(path_type=Path), help="Override Agent Cards directory."
+)
+@click.option("--operator-key", default=None, type=click.Path(path_type=Path), help="Override operator signing key.")
+def pack_retention(
+    since: str,
+    until: str,
+    org: str,
+    output: Path,
+    workdir: Path,
+    lineage_dir: Path | None,
+    agent_cards_dir: Path | None,
+    operator_key: Path | None,
+) -> None:
+    """Build a chain-continuity (retention) evidence pack for the window.
+
+    Records the boundary head hashes, entry count, detected coverage gaps,
+    and retention parameters, embedding the signed lineage log so an auditor
+    recomputes the boundary head hashes from the actual signed entries.
+    """
+    since_date, until_date = _window_dates(since, until)
+    resolved_lineage = lineage_dir or (workdir / ".sdd" / "lineage")
+    resolved_cards = agent_cards_dir or (workdir / ".sdd" / "agents")
+    resolved_key = _require_operator_key(operator_key, workdir)
+
+    out_path = build_retention_pack(
+        since=since_date,
+        until=until_date,
+        org=org,
+        lineage_dir=resolved_lineage,
+        agent_cards_dir=resolved_cards,
+        output_path=output,
+        operator_key_path=resolved_key,
+    )
+    click.echo(f"Retention pack written to: {out_path}")
+
+
+@pack_group.command("oversight")
+@click.option("--since", required=True, help="Window start date (YYYY-MM-DD, inclusive).")
+@click.option("--until", required=True, help="Window end date (YYYY-MM-DD, inclusive).")
+@click.option("--org", required=True, help="Organisation name (printed on the cover page).")
+@click.option("--output", required=True, type=click.Path(path_type=Path), help="Destination .zip path.")
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Project root (used to locate resolved approvals).",
+)
+@click.option(
+    "--approvals",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="JSONL/JSON of resolved approvals (default: <workdir>/.sdd/approvals/resolved.jsonl).",
+)
+@click.option("--operator-key", default=None, type=click.Path(path_type=Path), help="Override operator signing key.")
+def pack_oversight(
+    since: str,
+    until: str,
+    org: str,
+    output: Path,
+    workdir: Path,
+    approvals: Path | None,
+    operator_key: Path | None,
+) -> None:
+    """Build a human-oversight (Article 14) evidence pack from approval receipts.
+
+    Every in-window approval becomes a receipt carrying the attested
+    displayed-versus-executed binding, so an auditor recomputes the binding
+    offline decision by decision.
+    """
+    since_date, until_date = _window_dates(since, until)
+    resolved_key = _require_operator_key(operator_key, workdir)
+    approvals_path = approvals or (workdir / ".sdd" / "approvals" / "resolved.jsonl")
+
+    records: list[dict[str, object]] = []
+    if approvals_path.exists():
+        if approvals_path.suffix == ".jsonl":
+            records = _load_jsonl(approvals_path)
+        else:
+            data = _load_json(approvals_path)
+            if isinstance(data, list):
+                records = data
+            elif isinstance(data, dict):
+                records = list(data.get("approvals", []))
+
+    out_path = build_oversight_pack(
+        since=since_date,
+        until=until_date,
+        org=org,
+        approvals=records,
+        output_path=output,
+        operator_key_path=resolved_key,
+    )
+    click.echo(f"Oversight pack written to: {out_path} ({len(records)} candidate approvals)")
+
+
+@pack_group.command("incident")
+@click.option("--run", required=True, help="Run identifier of the incident.")
+@click.option("--org", required=True, help="Organisation name (printed on the cover page).")
+@click.option("--output", required=True, type=click.Path(path_type=Path), help="Destination .zip path.")
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Project root (used to locate the incident, evidence, and approval stores).",
+)
+@click.option(
+    "--incident-dir",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Override incident directory (default: <workdir>/.sdd/incidents/<run>).",
+)
+@click.option("--operator-key", default=None, type=click.Path(path_type=Path), help="Override operator signing key.")
+def pack_incident(
+    run: str,
+    org: str,
+    output: Path,
+    workdir: Path,
+    incident_dir: Path | None,
+    operator_key: Path | None,
+) -> None:
+    """Build a serious-incident (Article 73) report pack for a run.
+
+    Joins the incident timeline with the prev_hmac-chained audit slice and the
+    referenced evidence bundles and approval receipts. A referenced artefact
+    missing from the store is recorded as an explicit gap - the pack never
+    fabricates completeness.
+    """
+    resolved_key = _require_operator_key(operator_key, workdir)
+    idir = incident_dir or (workdir / ".sdd" / "incidents" / run)
+
+    timeline_path = idir / "timeline.json"
+    if timeline_path.exists():
+        timeline = _load_json(timeline_path)
+        if not isinstance(timeline, dict):
+            raise click.ClickException(f"{timeline_path}: expected a JSON object")
+    else:
+        timeline = {"run_id": run, "events": [], "involved_agents": [], "artifacts": []}
+
+    slice_path = idir / "audit-slice.jsonl"
+    audit_events = _load_jsonl(slice_path) if slice_path.exists() else []
+
+    evidence_bundles: dict[str, bytes] = {}
+    receipts: dict[str, bytes] = {}
+    gaps: list[dict[str, str]] = []
+    for ref in timeline.get("evidence_bundle_refs", []):
+        candidate = workdir / ".sdd" / "evidence" / f"{ref}.json"
+        if candidate.exists():
+            evidence_bundles[f"{ref}.json"] = candidate.read_bytes()
+        else:
+            gaps.append({"kind": "evidence_bundle", "ref": str(ref), "reason": "missing_from_store"})
+    for ref in timeline.get("receipt_refs", []):
+        candidate = workdir / ".sdd" / "approvals" / f"{ref}.json"
+        if candidate.exists():
+            receipts[f"{ref}.json"] = candidate.read_bytes()
+        else:
+            gaps.append({"kind": "receipt", "ref": str(ref), "reason": "missing_from_store"})
+
+    out_path = build_incident_pack(
+        run_id=run,
+        org=org,
+        timeline=timeline,
+        audit_events=audit_events,
+        evidence_bundles=evidence_bundles,
+        receipts=receipts,
+        gaps=gaps,
+        output_path=output,
+        operator_key_path=resolved_key,
+    )
+    click.echo(f"Incident pack written to: {out_path} ({len(gaps)} evidence gap(s))")

--- a/src/bernstein/core/compliance/pack.py
+++ b/src/bernstein/core/compliance/pack.py
@@ -23,21 +23,53 @@ from importlib import metadata
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.compliance.article12 import (
+    _MIN_RETENTION_DAYS,
     ARTICLE12_PARAGRAPH_MAP,
     render_csv,
     render_pdf,
+)
+from bernstein.core.compliance.regulator_renderers import (
+    render_incident_csv,
+    render_incident_pdf,
+    render_oversight_csv,
+    render_oversight_pdf,
+    render_retention_csv,
+    render_retention_pdf,
 )
 from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
 from bernstein.core.lineage.identity import sign_detached
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
     from datetime import date
     from pathlib import Path
 
-__all__ = ["PACK_FORMAT_VERSION", "build_pack"]
+__all__ = [
+    "PACK_FORMAT_VERSION",
+    "PACK_KIND_ARTICLE12",
+    "PACK_KIND_INCIDENT",
+    "PACK_KIND_OVERSIGHT",
+    "PACK_KIND_RETENTION",
+    "build_incident_pack",
+    "build_oversight_pack",
+    "build_pack",
+    "build_retention_pack",
+]
 
 
 _OPERATOR_KID = "operator-pack-signer"
+
+#: Pack-kind discriminator recorded in ``pack-manifest.json:kind``. The
+#: Article 12 bundle predates the field, so an absent ``kind`` is treated as
+#: Article 12 by the offline verifier (mirroring the ``pack_format_version``
+#: legacy default). The three regulator-mapped kinds below each project a
+#: different obligation out of the same chain.
+PACK_KIND_ARTICLE12 = "article-12"
+PACK_KIND_RETENTION = "retention"
+PACK_KIND_INCIDENT = "incident"
+PACK_KIND_OVERSIGHT = "oversight"
+
+_PACK_SCHEMA = "https://bernstein.run/compliance/pack-manifest/v1"
 
 #: Compliance-pack format version recorded in ``pack-manifest.json``.
 #:
@@ -322,3 +354,495 @@ def build_pack(
         zf.writestr("pack-manifest.json.sig", sig)
 
     return output_path
+
+
+# ===========================================================================
+# Regulator-mapped pack family (kind = retention / incident / oversight)
+#
+# Each builder below is a deterministic projection of the chain sealed with
+# the same operator-key signing, signed provenance manifest, and canonical-
+# bytes rule as the Article 12 pack. Members carry no wall-clock state, so
+# two builds over the same window yield byte-identical member hashes; build
+# timestamps live only in the manifest. Strip the chain (the signed lineage
+# log, the prev_hmac-chained audit slice, the receipt bindings) and each pack
+# degrades to a report generator with a log - the substrate recomputation is
+# what the offline verifier binds to.
+# ===========================================================================
+
+
+def _canonical_json(payload: Any) -> bytes:
+    """RFC 8785-style canonical JSON bytes (matches the offline verifier)."""
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _safe_member_name(value: str) -> str:
+    """Sanitise a caller-supplied id into a flat, path-safe member stem."""
+    return "".join(c if (c.isalnum() or c in "-_.") else "_" for c in value) or "unnamed"
+
+
+def _seal_pack(
+    *,
+    kind: str,
+    members: dict[str, bytes],
+    manifest_core: dict[str, Any],
+    operator_key_path: Path,
+    output_path: Path,
+    member_order: list[str] | None = None,
+) -> Path:
+    """Seal ``members`` into a signed pack ZIP with a ``kind``-tagged manifest.
+
+    ``input_hashes`` binds every member by sha256 (so a one-byte tamper in any
+    member, including a rendered PDF, is caught offline by hash mismatch).
+    ``output_hash`` self-anchors the manifest body, and ``pack-manifest.json``
+    is Ed25519-signed by the operator key. Build timestamps sit in
+    ``manifest_core`` and are excluded from ``input_hashes``.
+    """
+    input_hashes = {name: _sha256(content) for name, content in sorted(members.items())}
+    manifest: dict[str, Any] = {
+        "schema": _PACK_SCHEMA,
+        "pack_format_version": PACK_FORMAT_VERSION,
+        "kind": kind,
+        "builder": _builder_label(),
+        **manifest_core,
+        "input_hashes": input_hashes,
+        "operator_kid": _OPERATOR_KID,
+    }
+    manifest_bytes_no_output = _canonical_json(manifest)
+    manifest["output_hash"] = _sha256(manifest_bytes_no_output)
+    manifest_bytes = _canonical_json(manifest)
+
+    operator_pem = _load_operator_signer(operator_key_path)
+    sig = sign_detached(manifest_bytes, operator_pem, kid=_OPERATOR_KID)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    order = member_order or []
+    written: set[str] = set()
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name in order:
+            if name in members and name not in written:
+                zf.writestr(name, members[name])
+                written.add(name)
+        for name in sorted(members):
+            if name not in written:
+                zf.writestr(name, members[name])
+                written.add(name)
+        zf.writestr("pack-manifest.json", manifest_bytes)
+        zf.writestr("pack-manifest.json.sig", sig)
+    return output_path
+
+
+def _collect_sig_card_members(
+    filtered: list[LineageEntry],
+    signatures_src: Path,
+    agent_cards_dir: Path,
+) -> tuple[dict[str, bytes], dict[str, bytes]]:
+    """Gather the per-entry JWS sidecars and Agent Cards for ``filtered``.
+
+    Ships exactly the signatures and cards needed to re-verify every entry
+    offline, and nothing else. Each JWS is re-keyed to
+    ``signatures/<entry_hash>.jws`` (the full ``sha256:`` form the offline
+    verifier looks up), so the pack is verifiable regardless of whether the
+    source ``.sdd/lineage/signatures`` layout named files by hex stem or by
+    the prefixed entry hash.
+    """
+    hex_to_full = {entry_hash(e).split(":", 1)[1]: entry_hash(e) for e in filtered}
+    sig_payload: dict[str, bytes] = {}
+    if signatures_src.exists():
+        for sig_file in signatures_src.iterdir():
+            if not sig_file.is_file() or not sig_file.name.endswith(".jws"):
+                continue
+            stem = sig_file.stem
+            full_hash: str | None = None
+            if stem in hex_to_full:
+                full_hash = hex_to_full[stem]
+            elif stem.startswith("sha256:") and stem.split(":", 1)[1] in hex_to_full:
+                full_hash = stem
+            if full_hash is not None:
+                sig_payload[f"signatures/{full_hash}.jws"] = sig_file.read_bytes()
+
+    used_agent_ids = {e.agent_id for e in filtered}
+    card_payload: dict[str, bytes] = {}
+    if agent_cards_dir.exists():
+        for card_file in agent_cards_dir.iterdir():
+            if not card_file.is_file() or not card_file.name.endswith(".json"):
+                continue
+            try:
+                card_data = json.loads(card_file.read_text(encoding="utf-8"))
+            except (ValueError, OSError):
+                continue
+            if card_data.get("agent_id") in used_agent_ids or not used_agent_ids:
+                card_payload[f"agent-cards/{card_file.name}"] = card_file.read_bytes()
+    return sig_payload, card_payload
+
+
+def _regulator_verify_instructions(kind: str) -> str:
+    return (
+        f"# Verifying this {kind} compliance pack\n\n"
+        "## Quick path (no Bernstein install)\n\n"
+        "```\n"
+        "pip install bernstein-verify\n"
+        "python -m bernstein_verify pack ./pack.zip\n"
+        "```\n\n"
+        "Exit 0 + a one-line PASS summary indicates every member's sha256\n"
+        "matches `pack-manifest.json:input_hashes`, the manifest self-anchors\n"
+        "(`output_hash`), and the chained substrate this pack projects re-\n"
+        "verifies: for a retention pack the embedded signed lineage log and\n"
+        "its boundary head hashes; for an incident pack the prev_hmac linkage\n"
+        "of `audit-slice.jsonl` plus the declared evidence-gap list; for an\n"
+        "oversight pack the recomputed displayed-versus-executed binding of\n"
+        "every approval receipt.\n\n"
+        "Flipping a single byte in any member (including a rendered PDF) is\n"
+        "rejected by hash mismatch, naming the member. The pack is a\n"
+        "projection of the chain, not a new log: verification recomputes the\n"
+        "facts from the substrate rather than trusting the rendered surface.\n"
+    )
+
+
+def _retention_readme(*, org: str, since: date, until: date, entry_count: int) -> str:
+    return (
+        f"# Retention evidence pack - {org}\n\n"
+        f"**Period:** {since.isoformat()} -> {until.isoformat()}\n"
+        f"**Entries in period:** {entry_count}\n\n"
+        "Chain-continuity evidence for the record-keeping obligation of\n"
+        "Article 12(3) of Regulation (EU) 2024/1689 (EU AI Act): the logs\n"
+        "existed over the window and were not truncated or rewritten.\n\n"
+        "## Contents\n\n"
+        "- `retention-evidence.json` - boundary head hashes, entry count,\n"
+        "  detected coverage gaps, and the retention parameters in force.\n"
+        "- `retention-evidence.pdf` / `.csv` - human- and machine-readable views.\n"
+        "- `lineage-log.jsonl` - the signed entries in the window (canonical bytes).\n"
+        "- `signatures/`, `agent-cards/` - per-entry Ed25519 JWS + cards.\n"
+        "- `pack-manifest.json(.sig)` - signed SLSA-style provenance.\n"
+    )
+
+
+def _incident_readme(*, org: str, run_id: str, gap_count: int) -> str:
+    return (
+        f"# Serious-incident report pack - {org}\n\n"
+        f"**Run:** {run_id}\n"
+        f"**Evidence gaps:** {gap_count}\n\n"
+        "A serious-incident report in the shape Article 73 of Regulation (EU)\n"
+        "2024/1689 expects: the incident timeline joined with the referenced\n"
+        "audit slice, evidence bundles, and approval/delegation receipts.\n\n"
+        "## Contents\n\n"
+        "- `incident-timeline.json` - the correlated timeline.\n"
+        "- `audit-slice.jsonl` - the prev_hmac-chained audit events (canonical).\n"
+        "- `evidence-bundles/`, `receipts/` - referenced artefacts present in the store.\n"
+        "- `gaps.json` - explicit entries for referenced artefacts missing from the store.\n"
+        "- `incident-report.pdf` / `.csv` - human- and machine-readable views.\n"
+        "- `pack-manifest.json(.sig)` - signed SLSA-style provenance.\n"
+    )
+
+
+def _oversight_readme(*, org: str, since: date, until: date, receipt_count: int) -> str:
+    return (
+        f"# Human-oversight evidence pack - {org}\n\n"
+        f"**Period:** {since.isoformat()} -> {until.isoformat()}\n"
+        f"**Approval receipts:** {receipt_count}\n\n"
+        "Human-oversight evidence in the shape Article 14 of Regulation (EU)\n"
+        "2024/1689 expects: who approved what, and that the displayed action\n"
+        "equalled the executed action, decision by decision.\n\n"
+        "## Contents\n\n"
+        "- `oversight-evidence.json` - one row per receipt with the attested\n"
+        "  displayed-versus-executed binding, principal, and decision outcome.\n"
+        "- `receipts/` - the raw approval receipts (canonical bytes).\n"
+        "- `oversight-report.pdf` / `.csv` - human- and machine-readable views.\n"
+        "- `pack-manifest.json(.sig)` - signed SLSA-style provenance.\n"
+    )
+
+
+def _detect_coverage_gaps(
+    all_entries: list[LineageEntry],
+    filtered: list[LineageEntry],
+) -> list[dict[str, str]]:
+    """Report in-window entries whose parent is absent from the whole log.
+
+    A missing parent is the signature of truncation or rewrite: the child was
+    kept but the record it descends from is gone. Boundary crossings are not
+    gaps here - only parents absent from the *entire* log are flagged.
+    """
+    present = {entry_hash(e) for e in all_entries}
+    gaps: list[dict[str, str]] = []
+    for e in sorted(filtered, key=lambda x: (x.ts_ns, entry_hash(x))):
+        for parent in e.parent_hashes:
+            if parent not in present:
+                gaps.append({"entry_hash": entry_hash(e), "missing_parent": parent})
+    return gaps
+
+
+def build_retention_pack(
+    *,
+    since: date,
+    until: date,
+    org: str,
+    lineage_dir: Path,
+    agent_cards_dir: Path,
+    output_path: Path,
+    operator_key_path: Path,
+) -> Path:
+    """Assemble a chain-continuity (retention) evidence pack.
+
+    Projects the signed lineage log onto the Article 12(3) retention
+    obligation: boundary head hashes at the window edges, entry count,
+    detected coverage gaps, and the retention parameters in force. The
+    embedded log ships its per-entry signatures so an auditor recomputes the
+    boundary head hashes from the actual signed entries offline.
+    """
+    build_started_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    log_path = lineage_dir / "log.jsonl"
+    signatures_src = lineage_dir / "signatures"
+    all_entries = _read_entries(log_path)
+    filtered = _filter_entries(all_entries, since, until)
+
+    log_lines = [canonicalise(e) for e in filtered]
+    log_bytes = b"\n".join(log_lines) + (b"\n" if log_lines else b"")
+
+    ordered = sorted(filtered, key=lambda e: (e.ts_ns, entry_hash(e)))
+    if ordered:
+        boundary: dict[str, Any] = {
+            "first_entry_hash": entry_hash(ordered[0]),
+            "last_entry_hash": entry_hash(ordered[-1]),
+            "first_ts_ns": ordered[0].ts_ns,
+            "last_ts_ns": ordered[-1].ts_ns,
+        }
+    else:
+        boundary = {"first_entry_hash": None, "last_entry_hash": None, "first_ts_ns": None, "last_ts_ns": None}
+
+    coverage_gaps = _detect_coverage_gaps(all_entries, filtered)
+    span_days = (until - since).days
+    retention_params = {
+        "period_days": span_days,
+        "minimum_required_days": _MIN_RETENTION_DAYS,
+        "meets_minimum": span_days >= _MIN_RETENTION_DAYS,
+    }
+
+    evidence = {
+        "kind": PACK_KIND_RETENTION,
+        "org": org,
+        "period": {"since": since.isoformat(), "until": until.isoformat()},
+        "entry_count": len(filtered),
+        "boundary": boundary,
+        "coverage_gaps": coverage_gaps,
+        "retention_params": retention_params,
+    }
+    evidence_bytes = _canonical_json(evidence)
+
+    sig_payload, card_payload = _collect_sig_card_members(filtered, signatures_src, agent_cards_dir)
+    members: dict[str, bytes] = (
+        {
+            "README.md": _retention_readme(org=org, since=since, until=until, entry_count=len(filtered)).encode(
+                "utf-8"
+            ),
+            "verify-instructions.md": _regulator_verify_instructions(PACK_KIND_RETENTION).encode("utf-8"),
+            "retention-evidence.json": evidence_bytes,
+            "retention-evidence.csv": render_retention_csv(evidence).encode("utf-8"),
+            "retention-evidence.pdf": render_retention_pdf(
+                org=org, period=(since.isoformat(), until.isoformat()), evidence=evidence
+            ),
+            "lineage-log.jsonl": log_bytes,
+        }
+        | sig_payload
+        | card_payload
+    )
+
+    build_finished_at = datetime.now(UTC).isoformat(timespec="seconds")
+    manifest_core = {
+        "org": org,
+        "period": {"since": since.isoformat(), "until": until.isoformat()},
+        "build_started_at": build_started_at,
+        "build_finished_at": build_finished_at,
+        "entry_count": len(filtered),
+        "boundary": boundary,
+        "coverage_gaps": coverage_gaps,
+        "retention_params": retention_params,
+    }
+    return _seal_pack(
+        kind=PACK_KIND_RETENTION,
+        members=members,
+        manifest_core=manifest_core,
+        operator_key_path=operator_key_path,
+        output_path=output_path,
+        member_order=[
+            "README.md",
+            "verify-instructions.md",
+            "retention-evidence.pdf",
+            "retention-evidence.csv",
+            "retention-evidence.json",
+            "lineage-log.jsonl",
+        ],
+    )
+
+
+def build_oversight_pack(
+    *,
+    since: date,
+    until: date,
+    org: str,
+    approvals: Sequence[Mapping[str, Any]],
+    output_path: Path,
+    operator_key_path: Path,
+) -> Path:
+    """Assemble a human-oversight (Article 14) evidence pack from receipts.
+
+    Each approval in the window becomes a canonical receipt carrying the
+    attested displayed-versus-executed binding: ``displayed_hash`` and
+    ``executed_hash`` are content-addressed over the two payloads, so an
+    auditor recomputes the binding offline and cannot be told "displayed
+    equalled executed" without the bytes to prove it.
+    """
+    build_started_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    lo = _date_to_ns_inclusive(since, end_of_day=False)
+    hi = _date_to_ns_inclusive(until, end_of_day=True)
+    in_window = [a for a in approvals if lo <= int(a["ts_ns"]) <= hi]
+    in_window.sort(key=lambda a: (int(a["ts_ns"]), str(a["receipt_id"])))
+
+    receipt_members: dict[str, bytes] = {}
+    evidence_rows: list[dict[str, Any]] = []
+    decision_counts: dict[str, int] = {}
+    for a in in_window:
+        displayed = a["displayed"]
+        executed = a["executed"]
+        displayed_hash = _sha256(_canonical_json(displayed))
+        executed_hash = _sha256(_canonical_json(executed))
+        binding_ok = displayed_hash == executed_hash
+        receipt = {
+            "v": 1,
+            "receipt_id": str(a["receipt_id"]),
+            "principal": str(a["principal"]),
+            "decision": str(a["decision"]),
+            "ts_ns": int(a["ts_ns"]),
+            "displayed": displayed,
+            "executed": executed,
+            "displayed_hash": displayed_hash,
+            "executed_hash": executed_hash,
+        }
+        receipt_members[f"receipts/{_safe_member_name(receipt['receipt_id'])}.json"] = _canonical_json(receipt)
+        evidence_rows.append(
+            {
+                "receipt_id": receipt["receipt_id"],
+                "principal": receipt["principal"],
+                "decision": receipt["decision"],
+                "ts_ns": receipt["ts_ns"],
+                "displayed_hash": displayed_hash,
+                "executed_hash": executed_hash,
+                "binding_ok": binding_ok,
+            }
+        )
+        decision_counts[receipt["decision"]] = decision_counts.get(receipt["decision"], 0) + 1
+
+    evidence = {
+        "kind": PACK_KIND_OVERSIGHT,
+        "org": org,
+        "period": {"since": since.isoformat(), "until": until.isoformat()},
+        "receipt_count": len(evidence_rows),
+        "decision_counts": decision_counts,
+        "receipts": evidence_rows,
+    }
+    members = {
+        "README.md": _oversight_readme(org=org, since=since, until=until, receipt_count=len(evidence_rows)).encode(
+            "utf-8"
+        ),
+        "verify-instructions.md": _regulator_verify_instructions(PACK_KIND_OVERSIGHT).encode("utf-8"),
+        "oversight-evidence.json": _canonical_json(evidence),
+        "oversight-report.csv": render_oversight_csv(evidence).encode("utf-8"),
+        "oversight-report.pdf": render_oversight_pdf(
+            org=org, period=(since.isoformat(), until.isoformat()), evidence=evidence
+        ),
+    } | receipt_members
+
+    build_finished_at = datetime.now(UTC).isoformat(timespec="seconds")
+    manifest_core = {
+        "org": org,
+        "period": {"since": since.isoformat(), "until": until.isoformat()},
+        "build_started_at": build_started_at,
+        "build_finished_at": build_finished_at,
+        "receipt_count": len(evidence_rows),
+        "decision_counts": decision_counts,
+    }
+    return _seal_pack(
+        kind=PACK_KIND_OVERSIGHT,
+        members=members,
+        manifest_core=manifest_core,
+        operator_key_path=operator_key_path,
+        output_path=output_path,
+        member_order=[
+            "README.md",
+            "verify-instructions.md",
+            "oversight-report.pdf",
+            "oversight-report.csv",
+            "oversight-evidence.json",
+        ],
+    )
+
+
+def build_incident_pack(
+    *,
+    run_id: str,
+    org: str,
+    timeline: Mapping[str, Any],
+    audit_events: Sequence[Mapping[str, Any]],
+    evidence_bundles: Mapping[str, bytes],
+    receipts: Mapping[str, bytes],
+    gaps: Sequence[Mapping[str, Any]],
+    output_path: Path,
+    operator_key_path: Path,
+) -> Path:
+    """Assemble a serious-incident (Article 73) report pack.
+
+    Joins the incident timeline with the prev_hmac-chained audit slice, the
+    referenced evidence bundles, and the approval/delegation receipts for the
+    affected window. A referenced bundle or receipt missing from the store is
+    recorded as an explicit ``gaps.json`` entry (and counted in the manifest)
+    so the pack never fabricates completeness - the offline verifier surfaces
+    the gap list rather than passing silently.
+    """
+    build_started_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    timeline_bytes = _canonical_json(timeline)
+    slice_bytes = b"".join(_canonical_json(ev) + b"\n" for ev in audit_events)
+    gap_list = [dict(g) for g in gaps]
+    gaps_doc = {"kind": PACK_KIND_INCIDENT, "run_id": run_id, "gaps": gap_list}
+
+    members: dict[str, bytes] = {
+        "README.md": _incident_readme(org=org, run_id=run_id, gap_count=len(gap_list)).encode("utf-8"),
+        "verify-instructions.md": _regulator_verify_instructions(PACK_KIND_INCIDENT).encode("utf-8"),
+        "incident-timeline.json": timeline_bytes,
+        "audit-slice.jsonl": slice_bytes,
+        "gaps.json": _canonical_json(gaps_doc),
+        "incident-report.csv": render_incident_csv(dict(timeline)).encode("utf-8"),
+        "incident-report.pdf": render_incident_pdf(org=org, timeline=dict(timeline), gaps=gap_list),
+    }
+    for name, data in evidence_bundles.items():
+        members[f"evidence-bundles/{_safe_member_name(name)}"] = data
+    for name, data in receipts.items():
+        members[f"receipts/{_safe_member_name(name)}"] = data
+
+    build_finished_at = datetime.now(UTC).isoformat(timespec="seconds")
+    manifest_core = {
+        "org": org,
+        "run_id": run_id,
+        "build_started_at": build_started_at,
+        "build_finished_at": build_finished_at,
+        "event_count": len(list(timeline.get("events", []))),
+        "audit_event_count": len(audit_events),
+        "gap_count": len(gap_list),
+        "gaps": gap_list,
+    }
+    return _seal_pack(
+        kind=PACK_KIND_INCIDENT,
+        members=members,
+        manifest_core=manifest_core,
+        operator_key_path=operator_key_path,
+        output_path=output_path,
+        member_order=[
+            "README.md",
+            "verify-instructions.md",
+            "incident-report.pdf",
+            "incident-report.csv",
+            "incident-timeline.json",
+            "audit-slice.jsonl",
+            "gaps.json",
+        ],
+    )

--- a/src/bernstein/core/compliance/regulator_renderers.py
+++ b/src/bernstein/core/compliance/regulator_renderers.py
@@ -1,0 +1,215 @@
+"""Deterministic renderers for the regulator-mapped compliance packs.
+
+Every renderer here is a pure projection of already-derived facts: it
+takes no wall-clock reading and embeds none, so two builds over the same
+chain window produce byte-identical members. PDFs are rendered with
+reportlab's ``invariant`` mode so the ``/CreationDate`` / document-id
+metadata that would otherwise vary run-to-run is fixed.
+
+The rendered members carry no verification authority of their own: the
+offline verifier binds a pack by member sha256 (recorded in the signed
+manifest ``input_hashes``) plus recomputation of the chained substrate
+(the lineage log, audit slice, and receipt bindings). These renderers only
+make that substrate human-readable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import csv
+import io
+from typing import TYPE_CHECKING, Any
+
+import reportlab.rl_config
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import cm
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+__all__ = [
+    "render_incident_csv",
+    "render_incident_pdf",
+    "render_oversight_csv",
+    "render_oversight_pdf",
+    "render_retention_csv",
+    "render_retention_pdf",
+]
+
+
+@contextlib.contextmanager
+def _invariant_pdf() -> Iterator[None]:
+    """Force reportlab into deterministic (invariant) output for one build."""
+    prior = reportlab.rl_config.invariant
+    reportlab.rl_config.invariant = 1
+    try:
+        yield
+    finally:
+        reportlab.rl_config.invariant = prior
+
+
+def _pdf(title: str, story_rows: Sequence[Any]) -> bytes:
+    with _invariant_pdf():
+        buf = io.BytesIO()
+        doc = SimpleDocTemplate(
+            buf,
+            pagesize=A4,
+            leftMargin=2 * cm,
+            rightMargin=2 * cm,
+            topMargin=2 * cm,
+            bottomMargin=2 * cm,
+            title=title,
+            invariant=1,
+        )
+        doc.build(list(story_rows))
+        return buf.getvalue()
+
+
+def _fact_table(rows: list[list[str]], col_widths: list[float]) -> Table:
+    tbl = Table(rows, colWidths=col_widths)
+    tbl.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 8.5),
+            ]
+        )
+    )
+    return tbl
+
+
+def _csv(fieldnames: Sequence[str], rows: Sequence[dict[str, Any]]) -> str:
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=list(fieldnames), lineterminator="\n")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({k: row.get(k, "") for k in fieldnames})
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+def render_retention_pdf(*, org: str, period: tuple[str, str], evidence: dict[str, Any]) -> bytes:
+    """Human-readable chain-continuity summary (Article 12(3) retention)."""
+    styles = getSampleStyleSheet()
+    boundary = evidence["boundary"]
+    params = evidence["retention_params"]
+    story: list[Any] = [
+        Paragraph("<b>EU AI Act Article 12(3) - Retention Evidence</b>", styles["Title"]),
+        Spacer(1, 0.4 * cm),
+        Paragraph(f"<b>Organisation:</b> {org}", styles["Normal"]),
+        Paragraph(f"<b>Period:</b> {period[0]} &#8594; {period[1]}", styles["Normal"]),
+        Paragraph(f"<b>Entries in period:</b> {evidence['entry_count']}", styles["Normal"]),
+        Spacer(1, 0.4 * cm),
+    ]
+    rows = [
+        ["Fact", "Value"],
+        ["First entry hash", str(boundary["first_entry_hash"])],
+        ["Last entry hash", str(boundary["last_entry_hash"])],
+        ["Entry count", str(evidence["entry_count"])],
+        ["Coverage gaps", str(len(evidence["coverage_gaps"]))],
+        ["Period days", str(params["period_days"])],
+        ["Minimum required days", str(params["minimum_required_days"])],
+        ["Meets minimum", str(params["meets_minimum"])],
+    ]
+    story.append(_fact_table(rows, [5 * cm, 11 * cm]))
+    return _pdf(f"Article 12(3) Retention - {org}", story)
+
+
+def render_retention_csv(evidence: dict[str, Any]) -> str:
+    boundary = evidence["boundary"]
+    params = evidence["retention_params"]
+    row = {
+        "period_since": evidence["period"]["since"],
+        "period_until": evidence["period"]["until"],
+        "entry_count": evidence["entry_count"],
+        "first_entry_hash": boundary["first_entry_hash"],
+        "last_entry_hash": boundary["last_entry_hash"],
+        "coverage_gaps": len(evidence["coverage_gaps"]),
+        "period_days": params["period_days"],
+        "minimum_required_days": params["minimum_required_days"],
+        "meets_minimum": params["meets_minimum"],
+    }
+    return _csv(list(row.keys()), [row])
+
+
+# ---------------------------------------------------------------------------
+# Oversight
+# ---------------------------------------------------------------------------
+
+
+def render_oversight_pdf(*, org: str, period: tuple[str, str], evidence: dict[str, Any]) -> bytes:
+    """Human-readable human-oversight summary (Article 14)."""
+    styles = getSampleStyleSheet()
+    receipts = evidence["receipts"]
+    story: list[Any] = [
+        Paragraph("<b>EU AI Act Article 14 - Human Oversight Evidence</b>", styles["Title"]),
+        Spacer(1, 0.4 * cm),
+        Paragraph(f"<b>Organisation:</b> {org}", styles["Normal"]),
+        Paragraph(f"<b>Period:</b> {period[0]} &#8594; {period[1]}", styles["Normal"]),
+        Paragraph(f"<b>Approval receipts:</b> {len(receipts)}", styles["Normal"]),
+        Spacer(1, 0.4 * cm),
+    ]
+    rows = [["Receipt", "Principal", "Decision", "Displayed=Executed"]]
+    for r in receipts:
+        rows.append([r["receipt_id"], r["principal"], r["decision"], "yes" if r["binding_ok"] else "NO"])
+    story.append(_fact_table(rows, [3.5 * cm, 5.5 * cm, 3 * cm, 4 * cm]))
+    return _pdf(f"Article 14 Oversight - {org}", story)
+
+
+def render_oversight_csv(evidence: dict[str, Any]) -> str:
+    fields = ("receipt_id", "principal", "decision", "ts_ns", "displayed_hash", "executed_hash", "binding_ok")
+    return _csv(fields, evidence["receipts"])
+
+
+# ---------------------------------------------------------------------------
+# Incident
+# ---------------------------------------------------------------------------
+
+
+def render_incident_pdf(*, org: str, timeline: dict[str, Any], gaps: list[dict[str, Any]]) -> bytes:
+    """Human-readable serious-incident report (Article 73 shape)."""
+    styles = getSampleStyleSheet()
+    events = timeline.get("events", [])
+    agents = ", ".join(timeline.get("involved_agents", [])) or "n/a"
+    artifacts = ", ".join(timeline.get("artifacts", [])) or "n/a"
+    story: list[Any] = [
+        Paragraph("<b>EU AI Act Article 73 - Serious Incident Report</b>", styles["Title"]),
+        Spacer(1, 0.4 * cm),
+        Paragraph(f"<b>Organisation:</b> {org}", styles["Normal"]),
+        Paragraph(f"<b>Run:</b> {timeline.get('run_id', 'n/a')}", styles["Normal"]),
+        Paragraph(f"<b>Involved agents:</b> {agents}", styles["Normal"]),
+        Paragraph(f"<b>Affected artifacts:</b> {artifacts}", styles["Normal"]),
+        Spacer(1, 0.4 * cm),
+        Paragraph("<b>Timeline</b>", styles["Heading3"]),
+    ]
+    tl_rows = [["ts_ns", "kind", "detail"]]
+    for e in events:
+        tl_rows.append([str(e.get("ts_ns", "")), str(e.get("kind", "")), str(e.get("detail", ""))])
+    story.extend(
+        (
+            _fact_table(tl_rows, [4 * cm, 3 * cm, 9 * cm]),
+            Spacer(1, 0.4 * cm),
+            Paragraph(f"<b>Evidence gaps: {len(gaps)}</b>", styles["Heading3"]),
+        )
+    )
+    if gaps:
+        gap_rows = [["kind", "ref", "reason"]]
+        for g in gaps:
+            gap_rows.append([str(g.get("kind", "")), str(g.get("ref", "")), str(g.get("reason", ""))])
+        story.append(_fact_table(gap_rows, [4 * cm, 6 * cm, 6 * cm]))
+    return _pdf(f"Article 73 Incident - {org}", story)
+
+
+def render_incident_csv(timeline: dict[str, Any]) -> str:
+    fields = ("ts_ns", "kind", "detail")
+    return _csv(fields, timeline.get("events", []))

--- a/tests/unit/compliance/test_regulator_packs.py
+++ b/tests/unit/compliance/test_regulator_packs.py
@@ -1,0 +1,426 @@
+"""Tests for the regulator-mapped compliance pack family.
+
+Covers the three pack kinds added on top of the Article 12 bundle:
+
+* retention  - chain-continuity evidence for a window.
+* incident   - incident timeline joined with audit slice, evidence
+               bundles, and receipts, with explicit gap entries.
+* oversight  - approval receipts with attested displayed-vs-executed
+               bindings.
+
+Each pack is a deterministic projection of the chain sealed with the same
+operator-key signing and signed provenance manifest as the Article 12 pack
+(PACK_FORMAT_VERSION 2 canonical-bytes rule).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from dataclasses import asdict
+from datetime import date
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.compliance.pack import (
+    PACK_KIND_INCIDENT,
+    PACK_KIND_OVERSIGHT,
+    PACK_KIND_RETENTION,
+    build_incident_pack,
+    build_oversight_pack,
+    build_retention_pack,
+)
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.identity import (
+    AgentCard,
+    generate_keypair,
+    sign_detached,
+    verify_detached,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _date_to_ns(d: str) -> int:
+    from datetime import UTC, datetime
+
+    dt = datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _canon(payload: dict) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _operator_key(tmp_path: Path) -> tuple[Path, str]:
+    priv = Ed25519PrivateKey.generate()
+    pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path = tmp_path / "operator.key"
+    key_path.write_bytes(pem)
+    pub_pem = (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return key_path, pub_pem
+
+
+def _make_entry(*, path: str, content: str, agent_id: str, kid: str, ts_ns: int) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=path,
+        artefact_kind="file",
+        content_hash="sha256:" + hashlib.sha256(content.encode()).hexdigest(),
+        parent_hashes=[],
+        agent_id=agent_id,
+        agent_card_kid=kid,
+        tool_call_id=f"tc-{ts_ns}",
+        span_id=f"{ts_ns:016x}"[:16],
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef",
+    )
+
+
+@pytest.fixture
+def lineage_layout(tmp_path: Path) -> dict[str, Path]:
+    """A .sdd/lineage/ dir with two in-window and one out-of-window signed entry."""
+    lineage_dir = tmp_path / "lineage"
+    signatures_dir = lineage_dir / "signatures"
+    agent_cards_dir = tmp_path / "agents"
+    lineage_dir.mkdir()
+    signatures_dir.mkdir()
+    agent_cards_dir.mkdir()
+
+    priv_pem, pub_pem = generate_keypair()
+    agent_id = "agent:worker-1"
+    kid = f"{agent_id}-kid"
+    card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=pub_pem)
+    (agent_cards_dir / f"{agent_id.replace(':', '_')}.json").write_text(
+        json.dumps(asdict(card), sort_keys=True),
+        encoding="utf-8",
+    )
+
+    entries = [
+        _make_entry(path="src/a.py", content="a", agent_id=agent_id, kid=kid, ts_ns=_date_to_ns("2026-03-01")),
+        _make_entry(path="src/b.py", content="b", agent_id=agent_id, kid=kid, ts_ns=_date_to_ns("2026-03-20")),
+        _make_entry(path="src/old.py", content="old", agent_id=agent_id, kid=kid, ts_ns=_date_to_ns("2025-12-31")),
+    ]
+    log_path = lineage_dir / "log.jsonl"
+    with log_path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+
+    for entry in entries:
+        canonical = canonicalise(entry)
+        h = entry_hash(entry)
+        jws = sign_detached(canonical, priv_pem, kid=kid)
+        (signatures_dir / f"{h.split(':', 1)[1]}.jws").write_text(jws, encoding="utf-8")
+
+    return {"lineage_dir": lineage_dir, "agent_cards_dir": agent_cards_dir, "log_path": log_path}
+
+
+def _read_manifest(zip_path: Path) -> dict:
+    with zipfile.ZipFile(zip_path) as zf:
+        return json.loads(zf.read("pack-manifest.json"))
+
+
+def _assert_manifest_sealed(zip_path: Path, pub_pem: str, *, kind: str) -> dict:
+    """Every pack manifest: kind field, v2, self-anchored output_hash, signed."""
+    with zipfile.ZipFile(zip_path) as zf:
+        manifest_bytes = zf.read("pack-manifest.json")
+        sig = zf.read("pack-manifest.json.sig").decode("ascii")
+    manifest = json.loads(manifest_bytes)
+    assert manifest["kind"] == kind
+    assert manifest["pack_format_version"] == 2
+    assert manifest["output_hash"].startswith("sha256:")
+    # output_hash self-anchors the manifest body.
+    body = {k: v for k, v in manifest.items() if k != "output_hash"}
+    assert manifest["output_hash"] == _sha256(_canon(body))
+    # operator signature over the full manifest verifies.
+    card = AgentCard(agent_id="operator", kid=manifest["operator_kid"], public_key_pem=pub_pem)
+    assert verify_detached(manifest_bytes, sig, card)
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Retention pack
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionPack:
+    def test_builds_and_seals(self, tmp_path: Path, lineage_layout: dict[str, Path]) -> None:
+        key_path, pub_pem = _operator_key(tmp_path)
+        out = tmp_path / "retention.zip"
+        result = build_retention_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 6, 30),
+            org="Acme",
+            lineage_dir=lineage_layout["lineage_dir"],
+            agent_cards_dir=lineage_layout["agent_cards_dir"],
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        assert result == out
+        manifest = _assert_manifest_sealed(out, pub_pem, kind=PACK_KIND_RETENTION)
+        with zipfile.ZipFile(out) as zf:
+            names = set(zf.namelist())
+        assert {
+            "retention-evidence.json",
+            "retention-evidence.pdf",
+            "retention-evidence.csv",
+            "lineage-log.jsonl",
+        } <= names
+        assert manifest["entry_count"] == 2  # two in-window entries
+
+    def test_boundary_head_hashes_recomputable(self, tmp_path: Path, lineage_layout: dict[str, Path]) -> None:
+        """Boundary head hashes in the evidence == entry_hash of the actual signed entries."""
+        key_path, _ = _operator_key(tmp_path)
+        out = tmp_path / "retention.zip"
+        build_retention_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 6, 30),
+            org="Acme",
+            lineage_dir=lineage_layout["lineage_dir"],
+            agent_cards_dir=lineage_layout["agent_cards_dir"],
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        with zipfile.ZipFile(out) as zf:
+            evidence = json.loads(zf.read("retention-evidence.json"))
+            log_lines = [json.loads(ln) for ln in zf.read("lineage-log.jsonl").decode().split("\n") if ln]
+        entries = [LineageEntry(**rec) for rec in log_lines]
+        ordered = sorted(entries, key=lambda e: (e.ts_ns, entry_hash(e)))
+        assert evidence["boundary"]["first_entry_hash"] == entry_hash(ordered[0])
+        assert evidence["boundary"]["last_entry_hash"] == entry_hash(ordered[-1])
+        assert evidence["entry_count"] == len(entries)
+
+    def test_deterministic_member_hashes(self, tmp_path: Path, lineage_layout: dict[str, Path]) -> None:
+        """Two builds over the same window -> byte-identical member hashes."""
+        key_path, _ = _operator_key(tmp_path)
+        h1 = _build_and_input_hashes(build_retention_pack, tmp_path / "r1.zip", key_path, lineage_layout)
+        h2 = _build_and_input_hashes(build_retention_pack, tmp_path / "r2.zip", key_path, lineage_layout)
+        assert h1 == h2, "member content hashes must be byte-identical across builds"
+
+
+def _build_and_input_hashes(fn, out: Path, key_path: Path, layout: dict[str, Path]) -> dict[str, str]:
+    fn(
+        since=date(2026, 1, 1),
+        until=date(2026, 6, 30),
+        org="Acme",
+        lineage_dir=layout["lineage_dir"],
+        agent_cards_dir=layout["agent_cards_dir"],
+        output_path=out,
+        operator_key_path=key_path,
+    )
+    return _read_manifest(out)["input_hashes"]
+
+
+# ---------------------------------------------------------------------------
+# Oversight pack
+# ---------------------------------------------------------------------------
+
+
+def _approval_records() -> list[dict]:
+    return [
+        {
+            "receipt_id": "ap-1111",
+            "principal": "alice@acme.example",
+            "decision": "allow",
+            "ts_ns": _date_to_ns("2026-03-05"),
+            "displayed": {"tool": "shell", "args": {"command": "ls -la"}},
+            "executed": {"tool": "shell", "args": {"command": "ls -la"}},
+        },
+        {
+            "receipt_id": "ap-2222",
+            "principal": "bob@acme.example",
+            "decision": "reject",
+            "ts_ns": _date_to_ns("2026-03-06"),
+            "displayed": {"tool": "http", "args": {"url": "https://x.example/y"}},
+            "executed": {"tool": "http", "args": {"url": "https://x.example/y"}},
+        },
+    ]
+
+
+class TestOversightPack:
+    def test_builds_and_seals(self, tmp_path: Path) -> None:
+        key_path, pub_pem = _operator_key(tmp_path)
+        out = tmp_path / "oversight.zip"
+        result = build_oversight_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 6, 30),
+            org="Acme",
+            approvals=_approval_records(),
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        assert result == out
+        manifest = _assert_manifest_sealed(out, pub_pem, kind=PACK_KIND_OVERSIGHT)
+        assert manifest["receipt_count"] == 2
+        with zipfile.ZipFile(out) as zf:
+            names = set(zf.namelist())
+            evidence = json.loads(zf.read("oversight-evidence.json"))
+        assert any(n.startswith("receipts/") and n.endswith(".json") for n in names)
+        assert {"oversight-evidence.json", "oversight-report.pdf", "oversight-report.csv"} <= names
+        # every row carries the displayed-vs-executed binding.
+        for row in evidence["receipts"]:
+            assert "displayed_hash" in row and "executed_hash" in row
+            assert row["binding_ok"] == (row["displayed_hash"] == row["executed_hash"])
+
+    def test_displayed_executed_binding_recomputable(self, tmp_path: Path) -> None:
+        key_path, _ = _operator_key(tmp_path)
+        out = tmp_path / "oversight.zip"
+        build_oversight_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 6, 30),
+            org="Acme",
+            approvals=_approval_records(),
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        with zipfile.ZipFile(out) as zf:
+            names = [n for n in zf.namelist() if n.startswith("receipts/") and n.endswith(".json")]
+            for name in names:
+                receipt = json.loads(zf.read(name))
+                assert receipt["displayed_hash"] == _sha256(_canon(receipt["displayed"]))
+                assert receipt["executed_hash"] == _sha256(_canon(receipt["executed"]))
+
+    def test_window_filters_receipts(self, tmp_path: Path) -> None:
+        key_path, _ = _operator_key(tmp_path)
+        out = tmp_path / "oversight.zip"
+        records = _approval_records()
+        records.append(
+            {
+                "receipt_id": "ap-old",
+                "principal": "carol@acme.example",
+                "decision": "allow",
+                "ts_ns": _date_to_ns("2020-01-01"),
+                "displayed": {"tool": "noop", "args": {}},
+                "executed": {"tool": "noop", "args": {}},
+            }
+        )
+        build_oversight_pack(
+            since=date(2026, 1, 1),
+            until=date(2026, 6, 30),
+            org="Acme",
+            approvals=records,
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        assert _read_manifest(out)["receipt_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Incident pack
+# ---------------------------------------------------------------------------
+
+
+def _incident_inputs() -> dict:
+    timeline = {
+        "run_id": "run-42",
+        "opened_ts_ns": _date_to_ns("2026-03-10"),
+        "events": [
+            {"ts_ns": _date_to_ns("2026-03-10"), "kind": "detected", "detail": "error rate spike"},
+            {"ts_ns": _date_to_ns("2026-03-11"), "kind": "mitigated", "detail": "rollback"},
+        ],
+        "involved_agents": ["agent:worker-1"],
+        "artifacts": ["src/a.py"],
+    }
+    audit_events = [
+        {"seq": 0, "prev_hmac": "", "hmac": "aaaa", "event": "task_start"},
+        {"seq": 1, "prev_hmac": "aaaa", "hmac": "bbbb", "event": "tool_call"},
+        {"seq": 2, "prev_hmac": "bbbb", "hmac": "cccc", "event": "task_end"},
+    ]
+    return {"timeline": timeline, "audit_events": audit_events}
+
+
+class TestIncidentPack:
+    def test_builds_and_seals(self, tmp_path: Path) -> None:
+        key_path, pub_pem = _operator_key(tmp_path)
+        out = tmp_path / "incident.zip"
+        inp = _incident_inputs()
+        result = build_incident_pack(
+            run_id="run-42",
+            org="Acme",
+            timeline=inp["timeline"],
+            audit_events=inp["audit_events"],
+            evidence_bundles={"task-1.json": b'{"bundle":"task-1"}'},
+            receipts={"ap-9.json": b'{"receipt":"ap-9"}'},
+            gaps=[],
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        assert result == out
+        manifest = _assert_manifest_sealed(out, pub_pem, kind=PACK_KIND_INCIDENT)
+        assert manifest["run_id"] == "run-42"
+        with zipfile.ZipFile(out) as zf:
+            names = set(zf.namelist())
+        assert {"incident-timeline.json", "audit-slice.jsonl", "gaps.json", "incident-report.pdf"} <= names
+        assert any(n.startswith("evidence-bundles/") for n in names)
+        assert any(n.startswith("receipts/") for n in names)
+
+    def test_missing_reference_recorded_as_gap(self, tmp_path: Path) -> None:
+        """A referenced bundle/receipt missing from the store becomes an explicit gap."""
+        key_path, _ = _operator_key(tmp_path)
+        out = tmp_path / "incident.zip"
+        inp = _incident_inputs()
+        gaps = [
+            {"kind": "evidence_bundle", "ref": "task-77", "reason": "missing_from_store"},
+            {"kind": "receipt", "ref": "ap-55", "reason": "missing_from_store"},
+        ]
+        build_incident_pack(
+            run_id="run-42",
+            org="Acme",
+            timeline=inp["timeline"],
+            audit_events=inp["audit_events"],
+            evidence_bundles={},
+            receipts={},
+            gaps=gaps,
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        with zipfile.ZipFile(out) as zf:
+            gaps_doc = json.loads(zf.read("gaps.json"))
+        manifest = _read_manifest(out)
+        assert manifest["gap_count"] == 2
+        assert len(gaps_doc["gaps"]) == 2
+        refs = {g["ref"] for g in gaps_doc["gaps"]}
+        assert refs == {"task-77", "ap-55"}
+
+    def test_audit_slice_is_canonical_jsonl(self, tmp_path: Path) -> None:
+        key_path, _ = _operator_key(tmp_path)
+        out = tmp_path / "incident.zip"
+        inp = _incident_inputs()
+        build_incident_pack(
+            run_id="run-42",
+            org="Acme",
+            timeline=inp["timeline"],
+            audit_events=inp["audit_events"],
+            evidence_bundles={},
+            receipts={},
+            gaps=[],
+            output_path=out,
+            operator_key_path=key_path,
+        )
+        with zipfile.ZipFile(out) as zf:
+            slice_bytes = zf.read("audit-slice.jsonl")
+        assert slice_bytes.endswith(b"\n")
+        for raw in [ln for ln in slice_bytes.split(b"\n") if ln]:
+            obj = json.loads(raw)
+            assert _canon(obj) == raw, "audit-slice lines must be byte-canonical"

--- a/tests/unit/compliance/test_regulator_packs_cli.py
+++ b/tests/unit/compliance/test_regulator_packs_cli.py
@@ -1,0 +1,201 @@
+"""CLI wiring tests for `bernstein compliance pack <kind>`.
+
+Covers the default-subcommand fallback (legacy ``pack --since ...`` still
+reaches ``article-12``) and the three regulator-mapped subcommands, each
+driven from a seeded workspace with no manual file selection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.cli.commands.compliance_cmd import compliance_group
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
+
+
+def _date_to_ns(d: str) -> int:
+    return int(datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=UTC).timestamp() * 1_000_000_000)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    lineage = sdd / "lineage"
+    signatures = lineage / "signatures"
+    agents = sdd / "agents"
+    keys = sdd / "keys"
+    for d in (lineage, signatures, agents, keys):
+        d.mkdir(parents=True)
+
+    priv = Ed25519PrivateKey.generate()
+    (keys / "operator.key").write_bytes(
+        priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+
+    a_priv, a_pub = generate_keypair()
+    agent_id = "agent:worker-1"
+    kid = f"{agent_id}-kid"
+    (agents / f"{agent_id.replace(':', '_')}.json").write_text(
+        json.dumps(asdict(AgentCard(agent_id=agent_id, kid=kid, public_key_pem=a_pub)), sort_keys=True)
+    )
+    entry = LineageEntry(
+        v=1,
+        artefact_path="src/a.py",
+        artefact_kind="file",
+        content_hash="sha256:" + hashlib.sha256(b"a").hexdigest(),
+        parent_hashes=[],
+        agent_id=agent_id,
+        agent_card_kid=kid,
+        tool_call_id="tc-1",
+        span_id="0" * 16,
+        ts_ns=_date_to_ns("2026-03-01"),
+        operator_hmac="deadbeef",
+    )
+    (lineage / "log.jsonl").write_text(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    h = entry_hash(entry)
+    (signatures / f"{h.split(':', 1)[1]}.jws").write_text(sign_detached(canonicalise(entry), a_priv, kid=kid))
+
+    # Resolved approvals for the oversight pack.
+    (sdd / "approvals").mkdir()
+    (sdd / "approvals" / "resolved.jsonl").write_text(
+        json.dumps(
+            {
+                "receipt_id": "ap-1",
+                "principal": "alice@acme.example",
+                "decision": "allow",
+                "ts_ns": _date_to_ns("2026-03-05"),
+                "displayed": {"tool": "shell", "args": {"command": "ls"}},
+                "executed": {"tool": "shell", "args": {"command": "ls"}},
+            }
+        )
+        + "\n"
+    )
+
+    # Incident directory with a timeline referencing one present + one missing ref.
+    idir = sdd / "incidents" / "run-42"
+    idir.mkdir(parents=True)
+    (idir / "timeline.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-42",
+                "opened_ts_ns": _date_to_ns("2026-03-10"),
+                "events": [{"ts_ns": _date_to_ns("2026-03-10"), "kind": "detected", "detail": "spike"}],
+                "involved_agents": [agent_id],
+                "artifacts": ["src/a.py"],
+                "evidence_bundle_refs": ["task-present", "task-missing"],
+                "receipt_refs": ["ap-1"],
+            }
+        )
+    )
+    (idir / "audit-slice.jsonl").write_text(
+        json.dumps({"seq": 0, "prev_hmac": "", "hmac": "aaaa", "event": "start"}, sort_keys=True) + "\n"
+    )
+    (sdd / "evidence").mkdir()
+    (sdd / "evidence" / "task-present.json").write_text('{"bundle":"present"}')
+    (sdd / "approvals" / "ap-1.json").write_text('{"receipt":"ap-1"}')
+    return tmp_path
+
+
+def _run(args: list[str]) -> object:
+    return CliRunner().invoke(compliance_group, args)
+
+
+def test_legacy_pack_defaults_to_article12(workspace: Path) -> None:
+    out = workspace / "a12.zip"
+    result = _run(
+        [
+            "pack",
+            "--since",
+            "2026-01-01",
+            "--until",
+            "2026-06-30",
+            "--org",
+            "Acme",
+            "--output",
+            str(out),
+            "--workdir",
+            str(workspace),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    with zipfile.ZipFile(out) as zf:
+        assert "article12-evidence.pdf" in zf.namelist()
+
+
+def test_pack_retention_subcommand(workspace: Path) -> None:
+    out = workspace / "retention.zip"
+    result = _run(
+        [
+            "pack",
+            "retention",
+            "--since",
+            "2026-01-01",
+            "--until",
+            "2026-06-30",
+            "--org",
+            "Acme",
+            "--output",
+            str(out),
+            "--workdir",
+            str(workspace),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    with zipfile.ZipFile(out) as zf:
+        assert json.loads(zf.read("pack-manifest.json"))["kind"] == "retention"
+
+
+def test_pack_oversight_subcommand(workspace: Path) -> None:
+    out = workspace / "oversight.zip"
+    result = _run(
+        [
+            "pack",
+            "oversight",
+            "--since",
+            "2026-01-01",
+            "--until",
+            "2026-06-30",
+            "--org",
+            "Acme",
+            "--output",
+            str(out),
+            "--workdir",
+            str(workspace),
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    with zipfile.ZipFile(out) as zf:
+        manifest = json.loads(zf.read("pack-manifest.json"))
+    assert manifest["kind"] == "oversight"
+    assert manifest["receipt_count"] == 1
+
+
+def test_pack_incident_subcommand_records_gap(workspace: Path) -> None:
+    out = workspace / "incident.zip"
+    result = _run(
+        ["pack", "incident", "--run", "run-42", "--org", "Acme", "--output", str(out), "--workdir", str(workspace)]
+    )
+    assert result.exit_code == 0, result.output
+    with zipfile.ZipFile(out) as zf:
+        manifest = json.loads(zf.read("pack-manifest.json"))
+        gaps = json.loads(zf.read("gaps.json"))
+    assert manifest["kind"] == "incident"
+    # task-present resolved, task-missing recorded as a gap.
+    assert manifest["gap_count"] == 1
+    assert gaps["gaps"][0]["ref"] == "task-missing"

--- a/verify_cli/bernstein_verify/verify.py
+++ b/verify_cli/bernstein_verify/verify.py
@@ -54,6 +54,16 @@ _PACK_FORMAT_BYTE_BINDING = 2
 #: so it is verified under the original re-canonicalise rule.
 _PACK_FORMAT_LEGACY = 1
 
+# Regulator-mapped pack kinds (issue #2517). An absent ``kind`` is the
+# Article 12 bundle (verified by the legacy path below); these three kinds are
+# projections of the chain that also carry a member-integrity + substrate-
+# recomputation contract enforced by ``_verify_regulator_pack``.
+_KIND_ARTICLE12 = "article-12"
+_KIND_RETENTION = "retention"
+_KIND_INCIDENT = "incident"
+_KIND_OVERSIGHT = "oversight"
+_REGULATOR_KINDS = frozenset({_KIND_RETENTION, _KIND_INCIDENT, _KIND_OVERSIGHT})
+
 
 # ---------- RFC 8785 JCS ----------
 
@@ -258,6 +268,26 @@ def _pack_format_version(zf: zipfile.ZipFile) -> int:
     return _PACK_FORMAT_LEGACY
 
 
+def _read_manifest(zf: zipfile.ZipFile) -> dict[str, Any] | None:
+    """Return the parsed ``pack-manifest.json`` dict, or None if absent/bad."""
+    raw = _read_text_member(zf, _MANIFEST_NAME)
+    if raw is None:
+        return None
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return manifest if isinstance(manifest, dict) else None
+
+
+def _pack_kind(manifest: dict[str, Any] | None) -> str:
+    """Return the pack ``kind``; an absent/invalid field is the Article 12 bundle."""
+    if manifest is None:
+        return _KIND_ARTICLE12
+    value = manifest.get("kind", _KIND_ARTICLE12)
+    return value if isinstance(value, str) else _KIND_ARTICLE12
+
+
 def _split_jsonl_bytes(raw_bytes: bytes) -> list[bytes]:
     """Strictly split the log's raw bytes on ``b"\\n"`` only.
 
@@ -368,77 +398,26 @@ def verify_pack(zip_path: Path | str) -> VerifyResult:
         return VerifyResult(ok=False, errors=[f"not a valid zip archive: {path}"])
 
     with zf:
+        manifest = _read_manifest(zf)
         pack_format = _pack_format_version(zf)
+        kind = _pack_kind(manifest)
 
-        if pack_format >= _PACK_FORMAT_BYTE_BINDING:
-            log_bytes = _read_bytes_member(zf, _LOG_NAME)
-            if log_bytes is None:
-                return VerifyResult(ok=False, errors=[f"missing {_LOG_NAME} in pack"])
-            entries, parse_errors = _parse_log_v2(log_bytes)
-        else:
-            log_raw = _read_text_member(zf, _LOG_NAME)
-            if log_raw is None:
-                return VerifyResult(ok=False, errors=[f"missing {_LOG_NAME} in pack"])
-            entries, parse_errors = _parse_log_v1(log_raw)
+        if kind in _REGULATOR_KINDS:
+            return _verify_regulator_pack(zf, manifest, kind=kind, pack_format=pack_format)
+
+        entries, parse_errors = _parse_lineage_log(zf, pack_format)
+        if entries is None:
+            return VerifyResult(ok=False, errors=parse_errors)
 
         result_errors: list[str] = list(parse_errors)
-
         chain_ok, chain_errors = walk_chain(entries)
         result_errors.extend(chain_errors)
 
-        # Pre-load agent cards (one per agent_id).
-        cards: dict[str, dict[str, Any]] = {}
-        for info in zf.infolist():
-            # Defence-in-depth: ignore zip-slip paths. We never write
-            # files anyway, but skip suspicious names so we don't try to
-            # parse `../../etc/passwd` as a card.
-            if ".." in Path(info.filename).parts:
-                continue
-            if not info.filename.startswith(_CARD_DIR) or info.filename.endswith("/"):
-                continue
-            card_raw = _read_text_member(zf, info.filename)
-            if card_raw is None:
-                continue
-            try:
-                card = json.loads(card_raw)
-            except json.JSONDecodeError:
-                result_errors.append(f"{info.filename}: invalid JSON")
-                continue
-            aid = card.get("agent_id")
-            if isinstance(aid, str):
-                cards[aid] = card
+        cards, card_errors = _load_agent_cards(zf)
+        result_errors.extend(card_errors)
 
-        # Per-entry signature verification.
-        sig_failures = 0
-        for e in entries:
-            entry_hash = _entry_hash(e)
-            agent_id = e.get("agent_id", "")
-            expected_kid = e.get("agent_card_kid", "")
-            card = cards.get(agent_id)
-            if card is None:
-                result_errors.append(f"entry {entry_hash}: no Agent Card for {agent_id}")
-                sig_failures += 1
-                continue
-            if card.get("kid") != expected_kid:
-                result_errors.append(
-                    f"entry {entry_hash}: kid mismatch (card={card.get('kid')!r}, "
-                    f"entry={expected_kid!r})"
-                )
-                sig_failures += 1
-                continue
-            sig_member = f"{_SIG_DIR}{entry_hash}.jws"
-            jws = _read_text_member(zf, sig_member)
-            if jws is None:
-                result_errors.append(f"entry {entry_hash}: missing signature {sig_member}")
-                sig_failures += 1
-                continue
-            payload = jcs_canonicalise(e)
-            pub_pem = card.get("public_key_pem", "")
-            if not isinstance(pub_pem, str) or not verify_jws_detached(
-                payload, jws, pub_pem, expected_kid=expected_kid
-            ):
-                result_errors.append(f"entry {entry_hash}: signature verification failed")
-                sig_failures += 1
+        sig_failures, sig_errors = _verify_entry_signatures(zf, entries, cards)
+        result_errors.extend(sig_errors)
 
         stats = {
             "entries": len(entries),
@@ -449,3 +428,364 @@ def verify_pack(zip_path: Path | str) -> VerifyResult:
         }
         ok = not parse_errors and chain_ok and sig_failures == 0
         return VerifyResult(ok=ok, errors=result_errors, stats=stats)
+
+
+# ---------- shared lineage-log verification helpers ----------
+
+
+def _parse_lineage_log(
+    zf: zipfile.ZipFile, pack_format: int
+) -> tuple[list[dict[str, Any]] | None, list[str]]:
+    """Parse ``lineage-log.jsonl`` under the format-appropriate rule.
+
+    Returns ``(None, [error])`` when the log member is absent so the caller
+    can short-circuit; otherwise ``(entries, parse_errors)``.
+    """
+    if pack_format >= _PACK_FORMAT_BYTE_BINDING:
+        log_bytes = _read_bytes_member(zf, _LOG_NAME)
+        if log_bytes is None:
+            return None, [f"missing {_LOG_NAME} in pack"]
+        return _parse_log_v2(log_bytes)
+    log_raw = _read_text_member(zf, _LOG_NAME)
+    if log_raw is None:
+        return None, [f"missing {_LOG_NAME} in pack"]
+    return _parse_log_v1(log_raw)
+
+
+def _load_agent_cards(zf: zipfile.ZipFile) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    """Pre-load Agent Cards keyed by agent_id, skipping zip-slip paths."""
+    cards: dict[str, dict[str, Any]] = {}
+    errors: list[str] = []
+    for info in zf.infolist():
+        if ".." in Path(info.filename).parts:
+            continue
+        if not info.filename.startswith(_CARD_DIR) or info.filename.endswith("/"):
+            continue
+        card_raw = _read_text_member(zf, info.filename)
+        if card_raw is None:
+            continue
+        try:
+            card = json.loads(card_raw)
+        except json.JSONDecodeError:
+            errors.append(f"{info.filename}: invalid JSON")
+            continue
+        aid = card.get("agent_id")
+        if isinstance(aid, str):
+            cards[aid] = card
+    return cards, errors
+
+
+def _verify_entry_signatures(
+    zf: zipfile.ZipFile,
+    entries: list[dict[str, Any]],
+    cards: dict[str, dict[str, Any]],
+) -> tuple[int, list[str]]:
+    """Verify the detached JWS of every entry against its Agent Card."""
+    errors: list[str] = []
+    sig_failures = 0
+    for e in entries:
+        entry_hash = _entry_hash(e)
+        agent_id = e.get("agent_id", "")
+        expected_kid = e.get("agent_card_kid", "")
+        card = cards.get(agent_id)
+        if card is None:
+            errors.append(f"entry {entry_hash}: no Agent Card for {agent_id}")
+            sig_failures += 1
+            continue
+        if card.get("kid") != expected_kid:
+            errors.append(
+                f"entry {entry_hash}: kid mismatch (card={card.get('kid')!r}, "
+                f"entry={expected_kid!r})"
+            )
+            sig_failures += 1
+            continue
+        sig_member = f"{_SIG_DIR}{entry_hash}.jws"
+        jws = _read_text_member(zf, sig_member)
+        if jws is None:
+            errors.append(f"entry {entry_hash}: missing signature {sig_member}")
+            sig_failures += 1
+            continue
+        payload = jcs_canonicalise(e)
+        pub_pem = card.get("public_key_pem", "")
+        if not isinstance(pub_pem, str) or not verify_jws_detached(
+            payload, jws, pub_pem, expected_kid=expected_kid
+        ):
+            errors.append(f"entry {entry_hash}: signature verification failed")
+            sig_failures += 1
+    return sig_failures, errors
+
+
+# ===========================================================================
+# Regulator-mapped pack verification (kind = retention / incident / oversight)
+#
+# Each kind is a projection of the chain, not a new log. Verification recomputes
+# the facts from the substrate the pack carries: the signed lineage log (with its
+# boundary head hashes) for retention, the prev_hmac-chained audit slice plus the
+# declared evidence-gap list for incident, and the content-addressed displayed-
+# versus-executed binding of every approval receipt for oversight. On top of that
+# every member is bound by sha256 to the signed manifest, so a one-byte tamper in
+# any member (including a rendered PDF) is rejected by hash mismatch naming the
+# member. Strip the substrate and there is nothing left to recompute.
+# ===========================================================================
+
+
+def _sha256_hex(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _canonical_any(obj: Any) -> bytes:
+    """Canonical JSON bytes for any JSON value (matches the pack builder)."""
+    return json.dumps(obj, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode(
+        "utf-8"
+    )
+
+
+def _verify_manifest_anchor(manifest: dict[str, Any]) -> list[str]:
+    """Confirm ``output_hash`` self-anchors the canonical manifest body."""
+    output_hash = manifest.get("output_hash")
+    if not isinstance(output_hash, str):
+        return [f"{_MANIFEST_NAME}: missing output_hash"]
+    body = {k: v for k, v in manifest.items() if k != "output_hash"}
+    recomputed = _sha256_hex(_canonical_any(body))
+    if recomputed != output_hash:
+        return [
+            f"{_MANIFEST_NAME}: output_hash mismatch (expected {output_hash}, got {recomputed})"
+        ]
+    return []
+
+
+def _verify_member_integrity(zf: zipfile.ZipFile, manifest: dict[str, Any]) -> list[str]:
+    """Recompute the sha256 of every member listed in ``input_hashes``.
+
+    Names the offending member on any mismatch or absence so an auditor can
+    point at the exact file - including a rendered PDF - that was altered.
+    """
+    input_hashes = manifest.get("input_hashes")
+    if not isinstance(input_hashes, dict):
+        return [f"{_MANIFEST_NAME}: input_hashes missing or malformed"]
+    present = set(zf.namelist())
+    errors: list[str] = []
+    for name, expected in sorted(input_hashes.items()):
+        if name not in present:
+            errors.append(f"{name}: member listed in input_hashes is missing from the pack")
+            continue
+        data = _read_bytes_member(zf, name)
+        if data is None:
+            errors.append(f"{name}: member unreadable")
+            continue
+        actual = _sha256_hex(data)
+        if actual != expected:
+            errors.append(f"{name}: content hash mismatch (expected {expected}, got {actual})")
+    return errors
+
+
+def _parse_canonical_jsonl(raw_bytes: bytes, name: str) -> tuple[list[dict[str, Any]], list[str]]:
+    """Split ``name`` on ``b"\\n"`` and require every record be byte-canonical."""
+    events: list[dict[str, Any]] = []
+    errors: list[str] = []
+    if raw_bytes and not raw_bytes.endswith(b"\n"):
+        errors.append(f"{name}: missing trailing newline")
+    for lineno, raw_line in enumerate(_split_jsonl_bytes(raw_bytes), start=1):
+        if raw_line == b"":
+            continue
+        try:
+            obj = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"{name}:{lineno}: invalid JSON ({exc.msg})")
+            continue
+        if not isinstance(obj, dict):
+            errors.append(f"{name}:{lineno}: not a JSON object")
+            continue
+        if _canonical_any(obj) != raw_line:
+            errors.append(f"{name}:{lineno}: non-canonical line bytes")
+            continue
+        events.append(obj)
+    return events, errors
+
+
+def _verify_prev_hmac_chain(events: list[dict[str, Any]], name: str) -> list[str]:
+    """Confirm the slice is contiguous: each ``prev_hmac`` chains to its predecessor."""
+    errors: list[str] = []
+    prev_hmac: str | None = None
+    for idx, event in enumerate(events):
+        cur_prev = str(event.get("prev_hmac", ""))
+        cur_hmac = str(event.get("hmac", ""))
+        if prev_hmac is not None and cur_prev != prev_hmac:
+            errors.append(f"{name}: prev_hmac chain break at index {idx}")
+        prev_hmac = cur_hmac
+    return errors
+
+
+def _verify_retention(
+    zf: zipfile.ZipFile,
+    manifest: dict[str, Any],
+    pack_format: int,
+    errors: list[str],
+    stats: dict[str, Any],
+) -> None:
+    """Re-verify the embedded signed log and recompute the boundary head hashes."""
+    entries, parse_errors = _parse_lineage_log(zf, pack_format)
+    errors.extend(parse_errors)
+    if entries is None:
+        return
+    chain_ok, chain_errors = walk_chain(entries)
+    errors.extend(chain_errors)
+    cards, card_errors = _load_agent_cards(zf)
+    errors.extend(card_errors)
+    sig_failures, sig_errors = _verify_entry_signatures(zf, entries, cards)
+    errors.extend(sig_errors)
+    stats.update(entries=len(entries), chain_ok=chain_ok, signature_failures=sig_failures)
+
+    evidence_raw = _read_bytes_member(zf, "retention-evidence.json")
+    if evidence_raw is None:
+        errors.append("retention-evidence.json: missing")
+        return
+    try:
+        evidence = json.loads(evidence_raw)
+    except json.JSONDecodeError:
+        errors.append("retention-evidence.json: invalid JSON")
+        return
+
+    ordered = sorted(entries, key=lambda e: (e.get("ts_ns", 0), _entry_hash(e)))
+    first = _entry_hash(ordered[0]) if ordered else None
+    last = _entry_hash(ordered[-1]) if ordered else None
+    boundary = evidence.get("boundary", {}) if isinstance(evidence, dict) else {}
+    if boundary.get("first_entry_hash") != first:
+        errors.append("retention-evidence.json: first_entry_hash does not match the embedded log")
+    if boundary.get("last_entry_hash") != last:
+        errors.append("retention-evidence.json: last_entry_hash does not match the embedded log")
+    if evidence.get("entry_count") != len(entries):
+        errors.append("retention-evidence.json: entry_count does not match the embedded log")
+
+    m_boundary = manifest.get("boundary", {})
+    if isinstance(m_boundary, dict) and (
+        m_boundary.get("first_entry_hash") != first or m_boundary.get("last_entry_hash") != last
+    ):
+        errors.append(f"{_MANIFEST_NAME}: boundary head hashes do not match the embedded log")
+    stats["coverage_gaps"] = len(
+        evidence.get("coverage_gaps", []) if isinstance(evidence, dict) else []
+    )
+
+
+def _verify_oversight(
+    zf: zipfile.ZipFile, manifest: dict[str, Any], errors: list[str], stats: dict[str, Any]
+) -> None:
+    """Recompute the displayed-versus-executed binding of every approval receipt."""
+    evidence_raw = _read_bytes_member(zf, "oversight-evidence.json")
+    ev_by_id: dict[str, dict[str, Any]] = {}
+    if evidence_raw is None:
+        errors.append("oversight-evidence.json: missing")
+    else:
+        try:
+            evidence = json.loads(evidence_raw)
+            if isinstance(evidence, dict):
+                for row in evidence.get("receipts", []):
+                    if isinstance(row, dict):
+                        ev_by_id[str(row.get("receipt_id"))] = row
+        except json.JSONDecodeError:
+            errors.append("oversight-evidence.json: invalid JSON")
+
+    receipt_count = 0
+    binding_failures = 0
+    for info in zf.infolist():
+        name = info.filename
+        if ".." in Path(name).parts or not name.startswith("receipts/") or name.endswith("/"):
+            continue
+        raw = _read_bytes_member(zf, name)
+        if raw is None:
+            continue
+        try:
+            receipt = json.loads(raw)
+        except json.JSONDecodeError:
+            errors.append(f"{name}: invalid JSON")
+            binding_failures += 1
+            continue
+        receipt_count += 1
+        displayed_hash = _sha256_hex(_canonical_any(receipt.get("displayed")))
+        executed_hash = _sha256_hex(_canonical_any(receipt.get("executed")))
+        if displayed_hash != receipt.get("displayed_hash"):
+            errors.append(f"{name}: displayed_hash does not match the displayed payload")
+            binding_failures += 1
+        if executed_hash != receipt.get("executed_hash"):
+            errors.append(f"{name}: executed_hash does not match the executed payload")
+            binding_failures += 1
+        row = ev_by_id.get(str(receipt.get("receipt_id")))
+        if row is None:
+            errors.append(f"{name}: receipt is not present in oversight-evidence.json")
+            binding_failures += 1
+        else:
+            expected_binding = receipt.get("displayed_hash") == receipt.get("executed_hash")
+            if (
+                row.get("displayed_hash") != receipt.get("displayed_hash")
+                or row.get("executed_hash") != receipt.get("executed_hash")
+                or row.get("binding_ok") != expected_binding
+            ):
+                errors.append(f"{name}: oversight-evidence row is inconsistent with the receipt")
+                binding_failures += 1
+    stats.update(receipts=receipt_count, binding_failures=binding_failures)
+
+
+def _verify_incident(
+    zf: zipfile.ZipFile, manifest: dict[str, Any], errors: list[str], stats: dict[str, Any]
+) -> None:
+    """Re-walk the audit slice and surface the declared evidence-gap list."""
+    slice_bytes = _read_bytes_member(zf, "audit-slice.jsonl")
+    if slice_bytes is None:
+        errors.append("audit-slice.jsonl: missing")
+    else:
+        events, slice_errors = _parse_canonical_jsonl(slice_bytes, "audit-slice.jsonl")
+        errors.extend(slice_errors)
+        errors.extend(_verify_prev_hmac_chain(events, "audit-slice.jsonl"))
+        stats["audit_events"] = len(events)
+
+    gaps_list: list[Any] = []
+    gaps_raw = _read_bytes_member(zf, "gaps.json")
+    if gaps_raw is None:
+        errors.append("gaps.json: missing")
+    else:
+        try:
+            gaps_doc = json.loads(gaps_raw)
+            if isinstance(gaps_doc, dict):
+                gaps_list = list(gaps_doc.get("gaps", []))
+        except json.JSONDecodeError:
+            errors.append("gaps.json: invalid JSON")
+
+    stats["gaps"] = gaps_list
+    stats["gap_count"] = len(gaps_list)
+    m_gap_count = manifest.get("gap_count")
+    if (
+        isinstance(m_gap_count, int)
+        and not isinstance(m_gap_count, bool)
+        and m_gap_count != len(gaps_list)
+    ):
+        errors.append(
+            f"gaps.json: gap_count {len(gaps_list)} disagrees with manifest gap_count {m_gap_count}"
+        )
+
+
+def _verify_regulator_pack(
+    zf: zipfile.ZipFile,
+    manifest: dict[str, Any] | None,
+    *,
+    kind: str,
+    pack_format: int,
+) -> VerifyResult:
+    """Verify a retention / incident / oversight pack as a chain projection."""
+    stats: dict[str, Any] = {"kind": kind, "pack_format_version": pack_format}
+    if manifest is None:
+        return VerifyResult(
+            ok=False, errors=[f"{_MANIFEST_NAME}: missing or unparseable"], stats=stats
+        )
+
+    errors: list[str] = []
+    errors.extend(_verify_manifest_anchor(manifest))
+    errors.extend(_verify_member_integrity(zf, manifest))
+
+    if kind == _KIND_RETENTION:
+        _verify_retention(zf, manifest, pack_format, errors, stats)
+    elif kind == _KIND_OVERSIGHT:
+        _verify_oversight(zf, manifest, errors, stats)
+    elif kind == _KIND_INCIDENT:
+        _verify_incident(zf, manifest, errors, stats)
+
+    return VerifyResult(ok=not errors, errors=errors, stats=stats)

--- a/verify_cli/tests/test_regulator_packs.py
+++ b/verify_cli/tests/test_regulator_packs.py
@@ -1,0 +1,320 @@
+"""Offline-verification tests for regulator-mapped compliance packs.
+
+Builds each pack kind with bernstein (test scope) then verifies it with the
+standalone `bernstein_verify` re-implementation - proving the packs re-verify
+offline against the chain and that a one-byte tamper in ANY member (including
+a rendered PDF) fails verification naming the member.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from dataclasses import asdict
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+# Test-scope imports of the production builder are allowed; the package under
+# test (bernstein_verify) never imports bernstein.
+from bernstein.core.compliance.pack import (
+    build_incident_pack,
+    build_oversight_pack,
+    build_retention_pack,
+)
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein_verify.verify import verify_pack
+
+
+def _date_to_ns(d: str) -> int:
+    dt = datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _operator_key(tmp_path: Path) -> Path:
+    priv = Ed25519PrivateKey.generate()
+    pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path = tmp_path / "operator.key"
+    key_path.write_bytes(pem)
+    return key_path
+
+
+def _lineage_layout(tmp_path: Path) -> dict[str, Path]:
+    import hashlib
+
+    lineage_dir = tmp_path / "lineage"
+    signatures_dir = lineage_dir / "signatures"
+    agent_cards_dir = tmp_path / "agents"
+    lineage_dir.mkdir()
+    signatures_dir.mkdir()
+    agent_cards_dir.mkdir()
+
+    priv_pem, pub_pem = generate_keypair()
+    agent_id = "agent:worker-1"
+    kid = f"{agent_id}-kid"
+    card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=pub_pem)
+    (agent_cards_dir / f"{agent_id.replace(':', '_')}.json").write_text(
+        json.dumps(asdict(card), sort_keys=True), encoding="utf-8"
+    )
+
+    entries = []
+    for i, day in enumerate(("2026-03-01", "2026-03-20")):
+        entries.append(
+            LineageEntry(
+                v=1,
+                artefact_path=f"src/f{i}.py",
+                artefact_kind="file",
+                content_hash="sha256:" + hashlib.sha256(str(i).encode()).hexdigest(),
+                parent_hashes=[],
+                agent_id=agent_id,
+                agent_card_kid=kid,
+                tool_call_id=f"tc-{i}",
+                span_id=f"{i:016x}"[:16],
+                ts_ns=_date_to_ns(day),
+                operator_hmac="deadbeef",
+            )
+        )
+    log_path = lineage_dir / "log.jsonl"
+    with log_path.open("w", encoding="utf-8") as f:
+        for entry in entries:
+            f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    for entry in entries:
+        h = entry_hash(entry)
+        jws = sign_detached(canonicalise(entry), priv_pem, kid=kid)
+        (signatures_dir / f"{h.split(':', 1)[1]}.jws").write_text(jws, encoding="utf-8")
+    return {"lineage_dir": lineage_dir, "agent_cards_dir": agent_cards_dir}
+
+
+def _approvals() -> list[dict]:
+    return [
+        {
+            "receipt_id": "ap-1111",
+            "principal": "alice@acme.example",
+            "decision": "allow",
+            "ts_ns": _date_to_ns("2026-03-05"),
+            "displayed": {"tool": "shell", "args": {"command": "ls -la"}},
+            "executed": {"tool": "shell", "args": {"command": "ls -la"}},
+        },
+        {
+            "receipt_id": "ap-2222",
+            "principal": "bob@acme.example",
+            "decision": "reject",
+            "ts_ns": _date_to_ns("2026-03-06"),
+            "displayed": {"tool": "http", "args": {"url": "https://x.example/y"}},
+            "executed": {"tool": "http", "args": {"url": "https://x.example/y"}},
+        },
+    ]
+
+
+def _build_retention(tmp_path: Path) -> Path:
+    layout = _lineage_layout(tmp_path)
+    out = tmp_path / "retention.zip"
+    build_retention_pack(
+        since=date(2026, 1, 1),
+        until=date(2026, 6, 30),
+        org="Acme",
+        lineage_dir=layout["lineage_dir"],
+        agent_cards_dir=layout["agent_cards_dir"],
+        output_path=out,
+        operator_key_path=_operator_key(tmp_path),
+    )
+    return out
+
+
+def _build_oversight(tmp_path: Path) -> Path:
+    out = tmp_path / "oversight.zip"
+    build_oversight_pack(
+        since=date(2026, 1, 1),
+        until=date(2026, 6, 30),
+        org="Acme",
+        approvals=_approvals(),
+        output_path=out,
+        operator_key_path=_operator_key(tmp_path),
+    )
+    return out
+
+
+def _build_incident(tmp_path: Path, *, gaps: list[dict] | None = None) -> Path:
+    out = tmp_path / "incident.zip"
+    build_incident_pack(
+        run_id="run-42",
+        org="Acme",
+        timeline={
+            "run_id": "run-42",
+            "opened_ts_ns": _date_to_ns("2026-03-10"),
+            "events": [{"ts_ns": _date_to_ns("2026-03-10"), "kind": "detected", "detail": "spike"}],
+            "involved_agents": ["agent:worker-1"],
+            "artifacts": ["src/f0.py"],
+        },
+        audit_events=[
+            {"seq": 0, "prev_hmac": "", "hmac": "aaaa", "event": "start"},
+            {"seq": 1, "prev_hmac": "aaaa", "hmac": "bbbb", "event": "end"},
+        ],
+        evidence_bundles={} if gaps else {"task-1.json": b'{"b":1}'},
+        receipts={} if gaps else {"ap-9.json": b'{"r":9}'},
+        gaps=gaps or [],
+        output_path=out,
+        operator_key_path=_operator_key(tmp_path),
+    )
+    return out
+
+
+def _rewrite_member(zip_path: Path, member: str, new_bytes: bytes) -> Path:
+    """Return a new zip with one member's bytes replaced (a one-byte tamper)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(zip_path) as src, zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as dst:
+        for info in src.infolist():
+            data = src.read(info.filename)
+            if info.filename == member:
+                data = new_bytes
+            dst.writestr(info.filename, data)
+    tampered = zip_path.with_suffix(".tampered.zip")
+    tampered.write_bytes(buf.getvalue())
+    return tampered
+
+
+# ---------------------------------------------------------------------------
+# Happy path: all three kinds verify offline.
+# ---------------------------------------------------------------------------
+
+
+def test_retention_pack_verifies(tmp_path):
+    result = verify_pack(_build_retention(tmp_path))
+    assert result.ok, result.errors
+    assert result.stats["kind"] == "retention"
+
+
+def test_oversight_pack_verifies(tmp_path):
+    result = verify_pack(_build_oversight(tmp_path))
+    assert result.ok, result.errors
+    assert result.stats["kind"] == "oversight"
+
+
+def test_incident_pack_verifies(tmp_path):
+    result = verify_pack(_build_incident(tmp_path))
+    assert result.ok, result.errors
+    assert result.stats["kind"] == "incident"
+
+
+# ---------------------------------------------------------------------------
+# Tamper: flip one byte in any member (including a PDF) -> FAIL naming member.
+# ---------------------------------------------------------------------------
+
+
+def _flip_one_byte(data: bytes) -> bytes:
+    mid = len(data) // 2
+    return data[:mid] + bytes([data[mid] ^ 0x01]) + data[mid + 1 :]
+
+
+def test_retention_pdf_tamper_fails_naming_member(tmp_path):
+    pack = _build_retention(tmp_path)
+    with zipfile.ZipFile(pack) as zf:
+        pdf = zf.read("retention-evidence.pdf")
+    tampered = _rewrite_member(pack, "retention-evidence.pdf", _flip_one_byte(pdf))
+    result = verify_pack(tampered)
+    assert not result.ok
+    assert any("retention-evidence.pdf" in e for e in result.errors), result.errors
+
+
+def test_oversight_receipt_tamper_fails(tmp_path):
+    pack = _build_oversight(tmp_path)
+    with zipfile.ZipFile(pack) as zf:
+        member = next(n for n in zf.namelist() if n.startswith("receipts/"))
+        raw = zf.read(member)
+    tampered = _rewrite_member(pack, member, _flip_one_byte(raw))
+    result = verify_pack(tampered)
+    assert not result.ok
+    assert any(member in e for e in result.errors), result.errors
+
+
+def test_oversight_binding_break_fails(tmp_path):
+    """Rewriting a receipt so displayed != executed but keeping a matching
+    stored hash is caught by binding recomputation."""
+    pack = _build_oversight(tmp_path)
+    with zipfile.ZipFile(pack) as zf:
+        member = next(n for n in zf.namelist() if n.startswith("receipts/"))
+        receipt = json.loads(zf.read(member))
+    # Change executed action but leave executed_hash stale -> recompute catches it.
+    receipt["executed"] = {"tool": "shell", "args": {"command": "rm -rf /"}}
+    forged = json.dumps(receipt, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    # Update input_hashes so the member-integrity layer passes and we exercise
+    # the binding-recomputation layer specifically.
+    tampered = _repack_with_manifest_hash(pack, member, forged)
+    result = verify_pack(tampered)
+    assert not result.ok
+    assert any(member in e for e in result.errors), result.errors
+
+
+def _repack_with_manifest_hash(zip_path: Path, member: str, new_bytes: bytes) -> Path:
+    import hashlib
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(zip_path) as src:
+        manifest = json.loads(src.read("pack-manifest.json"))
+        members = {i.filename: src.read(i.filename) for i in src.infolist()}
+    members[member] = new_bytes
+    manifest["input_hashes"][member] = "sha256:" + hashlib.sha256(new_bytes).hexdigest()
+    body = {k: v for k, v in manifest.items() if k != "output_hash"}
+    manifest["output_hash"] = (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+        ).hexdigest()
+    )
+    manifest_bytes = json.dumps(
+        manifest, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode()
+    members["pack-manifest.json"] = manifest_bytes
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as dst:
+        for name, data in members.items():
+            dst.writestr(name, data)
+    out = zip_path.with_suffix(".binding.zip")
+    out.write_bytes(buf.getvalue())
+    return out
+
+
+def test_incident_gap_list_is_reported(tmp_path):
+    """A pack with declared gaps verifies but surfaces the gap list (never a
+    silent PASS that hides an incomplete store)."""
+    gaps = [
+        {"kind": "evidence_bundle", "ref": "task-77", "reason": "missing_from_store"},
+        {"kind": "receipt", "ref": "ap-55", "reason": "missing_from_store"},
+    ]
+    result = verify_pack(_build_incident(tmp_path, gaps=gaps))
+    assert result.ok, result.errors
+    assert result.stats["gap_count"] == 2
+    assert len(result.stats["gaps"]) == 2
+
+
+def test_incident_audit_slice_tamper_fails(tmp_path):
+    pack = _build_incident(tmp_path)
+    with zipfile.ZipFile(pack) as zf:
+        slice_bytes = zf.read("audit-slice.jsonl")
+    tampered = _rewrite_member(pack, "audit-slice.jsonl", _flip_one_byte(slice_bytes))
+    result = verify_pack(tampered)
+    assert not result.ok
+    assert any("audit-slice.jsonl" in e for e in result.errors), result.errors
+
+
+def test_incident_broken_hmac_chain_fails(tmp_path):
+    """A recomputed member hash cannot hide a broken prev_hmac linkage."""
+    pack = _build_incident(tmp_path)
+    with zipfile.ZipFile(pack) as zf:
+        lines = [json.loads(ln) for ln in zf.read("audit-slice.jsonl").decode().split("\n") if ln]
+    lines[1]["prev_hmac"] = "wrong"
+    forged = b"".join(
+        json.dumps(o, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode() + b"\n"
+        for o in lines
+    )
+    tampered = _repack_with_manifest_hash(pack, "audit-slice.jsonl", forged)
+    result = verify_pack(tampered)
+    assert not result.ok
+    assert any("prev_hmac" in e or "chain" in e for e in result.errors), result.errors


### PR DESCRIPTION
## What

Extends the compliance pack builder into a family of regulator-mapped packs, each a deterministic projection of the audit chain and offline-verifiable with the standalone verifier. Adds three kinds on top of the Article 12 bundle:

| Pack | Command | Maps to | Proves |
|------|---------|---------|--------|
| Retention | `pack retention --since --until` | Article 12(3) | logs existed over the window and were not truncated or rewritten |
| Incident | `pack incident --run <id>` | Article 73 | the incident timeline joined with its audit slice, evidence bundles, and receipts |
| Oversight | `pack oversight --since --until` | Article 14 | who approved what, and that the displayed action equalled the executed action |

`bernstein compliance pack` becomes a group; with no subcommand (or a leading option) it defaults to `article-12`, so the existing `pack --since ...` invocation keeps working.

## Design

- Shared sealing in `core/compliance/pack.py`: a `kind`-tagged manifest, per-kind content assemblers, and canonical-bytes member writing reused across kinds.
- Retention embeds the signed lineage log; the boundary head hashes and entry count are recomputed from the actual signed entries at verify time.
- Incident joins the prev_hmac-chained audit slice with referenced evidence bundles and receipts; a reference missing from the store is recorded as an explicit `gaps.json` entry, and verification reports the gap list rather than passing silently.
- Oversight receipts carry the attested displayed-versus-executed binding (`displayed_hash`, `executed_hash`); the verifier recomputes the binding from the receipt payloads.
- `bernstein_verify` gains per-kind dispatch: member sha256 integrity against the signed manifest, manifest self-anchoring (`output_hash`), and per-kind substrate recomputation. The verifier remains dependency-minimal (no reportlab) and imports nothing from `bernstein`.

## Acceptance criteria

- Each kind builds with one command from a workspace, no manual file selection.
- Building the same kind twice over the same window yields byte-identical member content hashes; build timestamps are isolated in the manifest.
- `python -m bernstein_verify` verifies all three kinds with no Bernstein installed; flipping one byte in any member, including a rendered PDF, fails verification naming the member.
- The incident pack records missing references as explicit gap entries; verification surfaces the gap list.
- Existing Article 12 packs (format v1 and v2) verify unchanged.

## Tests

- `tests/unit/compliance/test_regulator_packs.py` (9): builders, sealing, boundary recomputation, determinism, receipt bindings, gap recording.
- `tests/unit/compliance/test_regulator_packs_cli.py` (4): CLI wiring and the default-subcommand fallback.
- `verify_cli/tests/test_regulator_packs.py` (9): offline verification of all three kinds plus tamper tests (PDF byte flip, receipt binding break, audit-slice byte flip, broken prev_hmac chain).

## e2e

Built all three packs via the CLI from a seeded workspace and verified each offline:

```
Retention pack written to: .../retention.zip
Oversight pack written to: .../oversight.zip (2 candidate approvals)
Incident pack written to: .../incident.zip (2 evidence gap(s))

PASS  pack: {'kind': 'retention', 'pack_format_version': 2, 'entries': 3, 'chain_ok': True, 'signature_failures': 0, 'coverage_gaps': 0}
PASS  pack: {'kind': 'oversight', 'pack_format_version': 2, 'receipts': 2, 'binding_failures': 0}
PASS  pack: {'kind': 'incident', 'pack_format_version': 2, 'audit_events': 3, 'gaps': [{'kind': 'evidence_bundle', 'reason': 'missing_from_store', 'ref': 'task-missing'}, {'kind': 'receipt', 'reason': 'missing_from_store', 'ref': 'ap-missing'}], 'gap_count': 2}
```

Determinism: two retention builds produced byte-identical member `input_hashes`. Tamper: a one-byte flip in `incident-report.pdf` fails verification naming the member.

Closes #2517