### PR TITLE
chore(typos): allowlist strat abbreviation

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -25,6 +25,7 @@ mis = "mis"          # false positive on partial words
 hel = "hel"          # truncated stream-chunk fixture "hel"+"lo" (test_client_hardened.py)
 fo = "fo"            # fo = fan_out (test_complexity_correlation.py)
 thr = "thr"          # thr = threshold (scripts/mutmut_critical.py)
+strat = "strat"      # strat = strategy (adapter STRATEGY_MATRIX, test_adapter_wave_2521.py)
 Aktive = "Aktive"    # correct German word for "Active" (i18n.py)
 
 # Technical terms used consistently in the codebase


### PR DESCRIPTION
The adapter wave (#2521) uses strat as a consistent shorthand for strategy (STRATEGY_MATRIX and tests). The spelling gate flags it repo-wide, reddening the typos check on every PR. Adds it to the typos extend-words allowlist.