### PR TITLE
feat(chat): approval cards v2 with hash-committed decision context and Teams driver

### DIFF
--- a/docs/integrations/approval-cards.md
+++ b/docs/integrations/approval-cards.md
@@ -1,0 +1,83 @@
+# Approval cards v2
+
+An approval card is what an operator sees when a gated tool call needs a human
+decision. In v2 the card is a **hash-committed decision record**: the whole
+decision context is canonicalised, hashed, and appended to the HMAC audit
+chain, so a postmortem can prove not just *what* was approved but *what the
+approver was told* at decision time.
+
+## What the card carries
+
+Every field below lives inside one hashed envelope (`ApprovalCardV2`):
+
+| Field | Meaning |
+|---|---|
+| `action` | Tool name plus a canonical SHA-256 digest of its arguments |
+| `reasoning` | The agent's stated intent, bounded to a fixed length |
+| `impact` | Blast-radius score, `hard_one_way` flag, rationale, and the ids of every detector that fired |
+| `rollback` | A per-tool-class undo procedure, with an explicit `irreversible` marker when a one-way-door detector fired |
+| `not_after` | The expiry deadline, in unix epoch seconds |
+
+`card_hash` is the SHA-256 over the canonical JSON of the envelope (sorted
+keys, compact separators). Because it commits to every field the operator saw,
+a decision that echoes `card_hash` commits to exactly what was displayed. A
+card that merely displays extra text without hashing it cannot offer that
+guarantee.
+
+## The lifecycle
+
+1. **Issue.** The gate builds the envelope, computes `card_hash`, and appends a
+   `chat.approval_card.issued` event carrying the full envelope, the hash, and
+   the previous chain digest. Drivers render the envelope fields **verbatim**
+   (`render_card_text`), so the displayed card equals the hashed record.
+2. **Resolve.** A decision must echo the exact `card_hash`. The gate refuses
+   when:
+   - the echoed hash matches no issued envelope (any field the operator saw was
+     changed), recording a `chat.approval_card.refused` event with reason
+     `hash_mismatch`, or
+   - the decision arrives at or after `not_after`, recording a refusal with
+     reason `expired`.
+   A clean resolve records `chat.approval_card.resolved`.
+3. **Verify offline.** `bernstein audit verify` reconstructs every resolved
+   card from the issue event, confirms the stored envelope still hashes to its
+   recorded `card_hash`, confirms the decision echoed an issued envelope, and
+   confirms the decision landed before expiry.
+
+## Chain-enforced expiry
+
+Expiry is decided by the chain-side clock against the envelope's `not_after`,
+never by whatever buttons the chat client still renders. This holds across a
+chat-process restart: a fresh process reconstructs the issued envelope from the
+audit chain and still refuses a stale approve. The refusal is chain-recorded,
+so an operator can prove a late decision was contained and never executed.
+
+## Determinism
+
+Issuing the same pending approval against identical repository state produces
+byte-identical envelopes and an identical `card_hash`. The envelope is a pure
+projection of its inputs (the tool call, the stated intent, the blast-radius
+detectors, and the issue time), so two operators reconstruct the same card.
+
+## Irreversible actions
+
+When a change trips a `hard_one_way` blast-radius detector (schema migration,
+secrets write, `rm -rf`, `DROP`/`DELETE` SQL, ...), the card carries
+`rollback.irreversible = true` and renders an explicit irreversible marker.
+Because the flag is part of the hashed envelope, the marker is cryptographically
+committed and cannot be stripped without changing `card_hash`.
+
+## Server-initiated prompts
+
+MCP `elicitation/create` requests that match no auto-resolve policy, and A2A
+tasks entering `input-required`, are routed into the same pipeline. The
+server-initiated prompt becomes a v2 card on the bound chat thread and inherits
+the whole discipline: committed decision context, chain-side expiry, and the
+audit trail. For an MCP elicitation the response equals the operator decision,
+and the issue and resolve events share `card_hash`, so the answer and the
+approval record are chain-linked.
+
+## Related
+
+- Chat bridges (delivery surfaces): `operations/chat-bridges.md`
+- Microsoft Teams setup: `integrations/teams-setup.md`
+- Audit log and `bernstein audit verify`: `security/audit-log.md`

--- a/docs/integrations/teams-setup.md
+++ b/docs/integrations/teams-setup.md
@@ -1,0 +1,60 @@
+# Microsoft Teams setup
+
+The Teams driver gives operators whose org standardises on Microsoft Teams the
+same attested approval surface as Slack, Discord, and Telegram: interactive
+Adaptive Cards, HMAC-chained approval events, worktree pinning, and Ed25519
+outbound message signing.
+
+## Install the extra
+
+```bash
+pip install 'bernstein[teams]'
+```
+
+This pulls in the Bot Framework connector SDK. The import is deferred, so the
+other chat drivers keep working without it.
+
+## Register a bot
+
+1. In the Azure portal, create an **Azure Bot** resource.
+2. Note the **Microsoft App id** and create a **client secret** (app password).
+3. Add the **Microsoft Teams** channel to the bot.
+4. Point the bot's messaging endpoint at wherever you route inbound activities
+   into the bridge.
+
+## Configure credentials
+
+The app id and the client secret rotate independently, so they live in
+separate environment variables:
+
+```bash
+export BERNSTEIN_TEAMS_TOKEN='<Microsoft App id>'
+export BERNSTEIN_TEAMS_APP_PASSWORD='<client secret>'
+```
+
+## Run the bridge
+
+```bash
+bernstein chat serve --platform=teams
+```
+
+The app id may also be passed with `--token`; the app password is only read
+from `BERNSTEIN_TEAMS_APP_PASSWORD`.
+
+## What you get
+
+| Capability | Behaviour |
+|---|---|
+| Commands | A Teams message naming a registered subcommand routes to its handler |
+| Approval cards | `push_approval` renders an Adaptive Card with Approve / Reject submit actions; a v2 card body is the verbatim projection of the hashed envelope |
+| Attested approvals | Each resolution appends a `chat.teams.approval` audit event covering `(approver, activity_id, decision, tool_call_hash, worktree_id)` |
+| Worktree pinning | A resolve from `wt-a` cannot settle an approval bound to a different worktree; the attempt is logged as `chat.teams.approval_rejected` |
+| Signed messages | Every outbound message carries an Ed25519 signature over `(install_id, session_id, content_hash)`; the shared verifier confirms authenticity |
+
+The signature envelope is identical to the Slack driver's, so one verifier
+covers both surfaces.
+
+## Related
+
+- Approval card reference: `integrations/approval-cards.md`
+- Chat bridges overview: `operations/chat-bridges.md`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -299,7 +299,9 @@ nav:
       - Intent capsules: operations/intent-capsules.md
       - Checkpointed retries: operations/checkpointed-retries.md
       - Audited webhook node: operations/webhook-node.md
-      - Chat bridges (Slack/Discord/Telegram): operations/chat-bridges.md
+      - Chat bridges (Slack/Discord/Telegram/Teams): operations/chat-bridges.md
+      - Approval cards v2: integrations/approval-cards.md
+      - Microsoft Teams setup: integrations/teams-setup.md
       - Lineage v2: operations/lineage-v2.md
       - GitLab integration: operations/gitlab.md
       - Cost optimization: operations/cost-optimization.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,6 +215,12 @@ slack = ["slack-sdk>=3.27", "aiohttp>=3.9"]
 # bot token, and set ``BERNSTEIN_DISCORD_TOKEN`` before invoking
 # ``bernstein chat serve --platform=discord``.
 discord = ["discord.py>=2.4"]
+# Microsoft Teams bidirectional driver over the Bot Framework. Enable with:
+#   pip install 'bernstein[teams]'
+# Register a bot in the Azure Bot Service, copy the app id and password, and
+# set ``BERNSTEIN_TEAMS_TOKEN`` (app id) plus ``BERNSTEIN_TEAMS_APP_PASSWORD``
+# (client secret) before invoking ``bernstein chat serve --platform=teams``.
+teams = ["botbuilder-core>=4.15", "aiohttp>=3.9"]
 # Contamination-resistant eval harness (SWE-bench Pro / Terminal-Bench 2.0 /
 # SWE-rebench). Kept optional so production installs don't pull HuggingFace
 # datasets unless the operator opts into the nightly leaderboard path.

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -224,6 +224,12 @@ def verify_cmd(merkle_only: bool, hmac_only: bool) -> None:
     # HMAC chain and Merkle seal.
     all_passed = _verify_grant_chains() and all_passed
 
+    # Approval cards are a further integrity pillar: a resolved approval must be
+    # re-checkable offline (#2511). A mutated stored envelope, a decision that
+    # echoed an unknown card_hash, or a decision made after expiry must fail
+    # verify. Orthogonal to both HMAC chain and Merkle seal.
+    all_passed = _verify_approval_cards() and all_passed
+
     console.print()
     raise SystemExit(0 if all_passed else 1)
 
@@ -407,6 +413,40 @@ def _verify_tournament_receipts() -> bool:
     for result in failures:
         task = result.receipt.task_id if result.receipt is not None else "?"
         console.print(f"  [red]![/red] task {task}: {result.reason}")
+    return False
+
+
+def _verify_approval_cards() -> bool:
+    """Verify resolved approval cards offline. Returns True if all valid.
+
+    Reconstructs, from the ``chat.approval_card.issued`` / ``resolved`` chain
+    entries alone, that every resolved card's stored envelope still hashes to
+    its recorded ``card_hash`` (no post-hoc mutation), that the decision echoed
+    an issued envelope, and that it landed before expiry (#2511). When no cards
+    were recorded the check is a silent no-op.
+    """
+    from bernstein.core.approval.card_verify import verify_approval_cards
+
+    result = verify_approval_cards(AUDIT_DIR)
+    if result.issued_count == 0 and result.resolved_count == 0:
+        return True  # no approval cards recorded; nothing to verify
+
+    console.print()
+    if result.ok:
+        console.print(
+            Panel("[bold green]Approval Card Verification Passed[/bold green]", border_style="green", expand=False)
+        )
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+        table.add_column("Value")
+        table.add_row("Issued", str(result.issued_count))
+        table.add_row("Resolved", str(result.reconstructed_count))
+        console.print(table)
+        return True
+
+    console.print(Panel("[bold red]Approval Card Verification FAILED[/bold red]", border_style="red", expand=False))
+    for err in result.errors:
+        console.print(f"  [red]![/red] {err}")
     return False
 
 

--- a/src/bernstein/cli/commands/chat_cmd.py
+++ b/src/bernstein/cli/commands/chat_cmd.py
@@ -43,11 +43,12 @@ __all__ = ["chat_group"]
 logger = logging.getLogger(__name__)
 
 _DEFAULT_WORKDIR = Path.cwd
-_PLATFORM_CHOICES = ("telegram", "discord", "slack")
+_PLATFORM_CHOICES = ("telegram", "discord", "slack", "teams")
 _ENV_TOKEN_MAP = {
     "telegram": "BERNSTEIN_TELEGRAM_TOKEN",
     "discord": "BERNSTEIN_DISCORD_TOKEN",
     "slack": "BERNSTEIN_SLACK_TOKEN",
+    "teams": "BERNSTEIN_TEAMS_TOKEN",
 }
 
 #: Slack Socket Mode app-level token env var. Bot token (``xoxb-...``) goes
@@ -55,10 +56,15 @@ _ENV_TOKEN_MAP = {
 #: lives separately so operators can rotate the two independently.
 _SLACK_APP_TOKEN_ENV = "BERNSTEIN_SLACK_APP_TOKEN"
 
+#: Microsoft Teams app-password env var. The app id (``MicrosoftAppId``) goes
+#: in ``BERNSTEIN_TEAMS_TOKEN``; the client secret lives here so operators can
+#: rotate the two independently.
+_TEAMS_APP_PASSWORD_ENV = "BERNSTEIN_TEAMS_APP_PASSWORD"
+
 
 @click.group("chat")
 def chat_group() -> None:
-    """Drive Bernstein agents from Telegram, Discord, or Slack."""
+    """Drive Bernstein agents from Telegram, Discord, Slack, or Microsoft Teams."""
 
 
 @chat_group.command("serve")
@@ -89,6 +95,10 @@ def chat_serve(platform: str, token: str | None, allow: str | None) -> None:
     if platform == "discord" and not resolved_token:
         raise click.UsageError(
             "Discord requires `--token` or $BERNSTEIN_DISCORD_TOKEN.",
+        )
+    if platform == "teams" and not resolved_token:
+        raise click.UsageError(
+            "Teams requires `--token` (the app id) or $BERNSTEIN_TEAMS_TOKEN.",
         )
 
     overrides = _split_allow(allow)
@@ -630,6 +640,13 @@ def _instantiate_bridge(driver_cls: Any, platform: str, token: str) -> BridgePro
                 f"Slack requires the Socket Mode app token in ${_SLACK_APP_TOKEN_ENV} (in addition to the bot token).",
             )
         return driver_cls(token=token, app_token=app_token)
+    if platform == "teams":
+        app_password = os.environ.get(_TEAMS_APP_PASSWORD_ENV, "")
+        if not app_password:
+            raise click.UsageError(
+                f"Teams requires the app password in ${_TEAMS_APP_PASSWORD_ENV} (in addition to the app id).",
+            )
+        return driver_cls(token=token, app_password=app_password)
     return driver_cls(token)
 
 

--- a/src/bernstein/core/approval/card.py
+++ b/src/bernstein/core/approval/card.py
@@ -1,0 +1,439 @@
+"""Approval card v2: a hash-committed, chain-anchored decision record.
+
+Issue #2511. The v1 chat approval card carried only ``(title, body,
+thread_id)``: the attested event proved *who* approved *which* tool call but
+not *what decision context the operator was shown*. The v2 card closes that
+gap by turning the card into a canonical, hashable decision record.
+
+The envelope (:class:`ApprovalCardV2`) carries, all inside one hashed
+structure:
+
+* the action -- the tool name plus a canonical digest of its arguments,
+* a bounded reasoning digest -- the agent's stated intent,
+* an impact estimate -- the blast-radius score plus the fired-detector
+  rationale from :func:`bernstein.core.quality.blast_radius.score_change`,
+* a rollback procedure -- a per-tool-class template, carrying an explicit
+  ``irreversible`` marker whenever a ``hard_one_way`` detector fired,
+* a ``not_after`` expiry.
+
+:func:`card_hash` computes the SHA-256 over the canonical JSON of the
+envelope (sorted keys, compact separators). Two issuances of the same
+pending approval against identical repository state produce byte-identical
+envelopes and an identical ``card_hash`` -- the card is a deterministic
+projection of its inputs, not a re-summarisation. Drivers render the
+envelope fields verbatim (see :func:`render_card_text`) so what is displayed
+is exactly what was hashed.
+
+This module is intentionally free of any transport, chat, or audit-chain
+imports: it only depends on the blast-radius scorer and the stdlib, so the
+envelope can be built and hashed from anywhere -- CLI, gate, MCP router --
+before the orchestrator is bootstrapped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.quality.blast_radius import score_change
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.core.quality.blast_radius import BlastRadiusReport, Detector
+
+__all__ = [
+    "CARD_VERSION",
+    "REASONING_MAX_CHARS",
+    "ActionRef",
+    "ApprovalCardV2",
+    "ImpactEstimate",
+    "RollbackPlan",
+    "args_digest",
+    "build_card",
+    "canonical_card_bytes",
+    "card_hash",
+    "impact_from_tool_call",
+    "render_card_text",
+    "rollback_for",
+]
+
+#: Schema marker embedded in every envelope. Bumping it changes ``card_hash``
+#: for every card, so a verifier can tell v2 envelopes apart from any future
+#: revision without guessing from field presence.
+CARD_VERSION = "v2"
+
+#: The reasoning digest is bounded so a runaway intent string cannot bloat the
+#: envelope (and the audit chain). The bound is part of the contract: the same
+#: over-long intent always truncates to the same bytes, keeping the hash
+#: deterministic.
+REASONING_MAX_CHARS = 600
+
+
+def _canonical_dumps(payload: dict[str, Any]) -> str:
+    """Return the canonical JSON string for *payload* (sorted, compact)."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def args_digest(tool_args: dict[str, Any]) -> str:
+    """Return the SHA-256 hex digest of *tool_args* in canonical form.
+
+    The digest binds exactly the arguments the tool would run with, so a
+    decision echoing the card commits to the concrete invocation and not just
+    the tool name.
+    """
+    return hashlib.sha256(_canonical_dumps(dict(tool_args)).encode("utf-8")).hexdigest()
+
+
+def _bound_reasoning(reasoning: str) -> str:
+    """Return *reasoning* trimmed to :data:`REASONING_MAX_CHARS` characters.
+
+    The bound is applied deterministically so identical intent text always
+    yields identical envelope bytes.
+    """
+    text = (reasoning or "").strip()
+    if len(text) <= REASONING_MAX_CHARS:
+        return text
+    return text[: REASONING_MAX_CHARS - 1].rstrip() + "…"
+
+
+@dataclass(frozen=True, slots=True)
+class ActionRef:
+    """The concrete tool invocation the card gates."""
+
+    tool_name: str
+    args_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"tool_name": self.tool_name, "args_digest": self.args_digest}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ActionRef:
+        return cls(
+            tool_name=str(data.get("tool_name", "")),
+            args_digest=str(data.get("args_digest", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ImpactEstimate:
+    """Quantified blast-radius impact surfaced on the card.
+
+    Attributes:
+        score: Blast-radius score in ``[0, 1]``.
+        hard_one_way: ``True`` when a ``hard_one_way`` detector fired, i.e. the
+            change contains a one-way door (schema migration, secrets write,
+            ``rm -rf``, ``DROP``/``DELETE`` SQL, ...).
+        rationale: The scorer's structured rationale string.
+        fired_detectors: Ordered ids of every detector that fired.
+    """
+
+    score: float
+    hard_one_way: bool
+    rationale: str
+    fired_detectors: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": float(self.score),
+            "hard_one_way": bool(self.hard_one_way),
+            "rationale": self.rationale,
+            "fired_detectors": list(self.fired_detectors),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ImpactEstimate:
+        return cls(
+            score=float(data.get("score", 0.0)),
+            hard_one_way=bool(data.get("hard_one_way", False)),
+            rationale=str(data.get("rationale", "")),
+            fired_detectors=tuple(str(d) for d in data.get("fired_detectors", [])),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RollbackPlan:
+    """How to undo the action if the approval turns out wrong.
+
+    Attributes:
+        procedure: Operator-facing text describing the undo path.
+        irreversible: ``True`` when the change tripped a one-way door and no
+            clean automatic rollback exists. When ``True`` the card renders an
+            explicit irreversible marker, and because this flag lives inside
+            the hashed envelope the marker is cryptographically committed.
+    """
+
+    procedure: str
+    irreversible: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"procedure": self.procedure, "irreversible": bool(self.irreversible)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RollbackPlan:
+        return cls(
+            procedure=str(data.get("procedure", "")),
+            irreversible=bool(data.get("irreversible", False)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalCardV2:
+    """The canonical, hashable approval decision record.
+
+    Every field is operator-visible and lives inside the hashed envelope, so
+    :func:`card_hash` commits to the entire decision context: intent,
+    quantified impact, undo path, and a real deadline. A decision that echoes
+    the ``card_hash`` therefore commits to exactly what was displayed; a card
+    that merely displays extra text (without hashing it) cannot satisfy that.
+    """
+
+    approval_id: str
+    action: ActionRef
+    reasoning: str
+    impact: ImpactEstimate
+    rollback: RollbackPlan
+    created_at: float
+    not_after: float
+    card_version: str = CARD_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical envelope dict.
+
+        Floats are coerced explicitly so a JSON round-trip through the audit
+        chain rehydrates byte-identical values and the hash stays stable.
+        """
+        return {
+            "approval_id": self.approval_id,
+            "action": self.action.to_dict(),
+            "reasoning": self.reasoning,
+            "impact": self.impact.to_dict(),
+            "rollback": self.rollback.to_dict(),
+            "created_at": float(self.created_at),
+            "not_after": float(self.not_after),
+            "card_version": self.card_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ApprovalCardV2:
+        """Rebuild an envelope from its canonical dict (round-trips ``to_dict``)."""
+        return cls(
+            approval_id=str(data.get("approval_id", "")),
+            action=ActionRef.from_dict(dict(data.get("action", {}))),
+            reasoning=str(data.get("reasoning", "")),
+            impact=ImpactEstimate.from_dict(dict(data.get("impact", {}))),
+            rollback=RollbackPlan.from_dict(dict(data.get("rollback", {}))),
+            created_at=float(data.get("created_at", 0.0)),
+            not_after=float(data.get("not_after", 0.0)),
+            card_version=str(data.get("card_version", CARD_VERSION)),
+        )
+
+    def is_expired(self, *, now: float) -> bool:
+        """Return ``True`` when *now* is at or past the envelope's ``not_after``."""
+        return now >= self.not_after
+
+
+def canonical_card_bytes(card: ApprovalCardV2) -> bytes:
+    """Return the canonical bytes hashed into ``card_hash``."""
+    return _canonical_dumps(card.to_dict()).encode("utf-8")
+
+
+def card_hash(card: ApprovalCardV2) -> str:
+    """Return the SHA-256 hex digest committing to the whole envelope."""
+    return hashlib.sha256(canonical_card_bytes(card)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Impact estimation (blast radius)
+# ---------------------------------------------------------------------------
+
+# Argument fields that name a file the tool would touch.
+_PATH_FIELDS = ("file_path", "path", "notebook_path", "target")
+# Argument fields whose value is content / a command we can scan with the
+# content_regex detectors (rm -rf, DROP TABLE, secrets writes, ...).
+_CONTENT_FIELDS = (
+    "content",
+    "new_string",
+    "new_str",
+    "command",
+    "shell_cmd",
+    "code",
+    "body",
+    "diff",
+)
+
+
+def _derive_change(tool_name: str, tool_args: dict[str, Any]) -> tuple[list[str], str]:
+    """Derive ``(files, diff_text)`` for the blast-radius scorer from a call."""
+    del tool_name  # kept for future per-tool overrides
+    files: list[str] = []
+    for field_name in _PATH_FIELDS:
+        value = tool_args.get(field_name)
+        if isinstance(value, str) and value:
+            files.append(value)
+            break
+    diff_parts: list[str] = []
+    for field_name in _CONTENT_FIELDS:
+        value = tool_args.get(field_name)
+        if isinstance(value, str) and value:
+            diff_parts.append(value)
+    return files, "\n".join(diff_parts)
+
+
+def impact_from_tool_call(
+    tool_name: str,
+    tool_args: dict[str, Any],
+    *,
+    detectors: Sequence[Detector] | None = None,
+) -> BlastRadiusReport:
+    """Score the blast radius of a tool call.
+
+    The change set is derived from well-known argument fields: the first path
+    field names the touched file, and content / command fields feed the
+    content detectors so ``rm -rf``, ``DROP``/``DELETE`` SQL and secrets
+    writes surface as one-way doors.
+    """
+    files, diff_text = _derive_change(tool_name, tool_args)
+    return score_change(files=files, diff_text=diff_text, detectors=detectors)
+
+
+# ---------------------------------------------------------------------------
+# Rollback templates (per tool class)
+# ---------------------------------------------------------------------------
+
+_WRITE_TOOLS = frozenset(
+    {"write", "edit", "multiedit", "notebookedit", "str_replace", "str_replace_editor", "create_file", "apply_patch"}
+)
+_SHELL_TOOLS = frozenset({"bash", "shell", "run", "execute", "exec", "command"})
+_NET_TOOLS = frozenset({"webfetch", "websearch", "fetch", "http", "curl"})
+
+_IRREVERSIBLE_PREFIX = "IRREVERSIBLE: this change tripped a one-way-door detector; there is no clean automatic undo. "
+
+
+def rollback_for(tool_name: str, tool_args: dict[str, Any], *, irreversible: bool) -> RollbackPlan:
+    """Return a rollback plan for a tool call, keyed by tool class.
+
+    When *irreversible* is ``True`` (a ``hard_one_way`` detector fired) the
+    plan is prefixed with an explicit irreversible marker and carries the
+    ``irreversible`` flag, both of which land inside the hashed envelope.
+    """
+    name = tool_name.strip().lower()
+    path = ""
+    for field_name in _PATH_FIELDS:
+        value = tool_args.get(field_name)
+        if isinstance(value, str) and value:
+            path = value
+            break
+
+    if name in _WRITE_TOOLS:
+        target = f" `{path}`" if path else " the affected file"
+        body = (
+            f"Restore the prior contents of{target} from version control "
+            f"(for example `git checkout HEAD --{(' ' + path) if path else ' <path>'}`), "
+            "or discard the worktree change before it is committed."
+        )
+    elif name in _SHELL_TOOLS:
+        body = (
+            "Shell effects are not auto-reversible: review the command's side effects and "
+            "undo them manually (restore deleted paths from backup or version control, "
+            "revert created resources)."
+        )
+    elif name in _NET_TOOLS:
+        body = "Read-only network access has no state to roll back; no undo step is required."
+    else:
+        body = (
+            "No per-tool rollback template is registered for this tool class; inspect the "
+            "tool's effects and undo them from version control or backup before relying on them."
+        )
+
+    if irreversible:
+        return RollbackPlan(procedure=_IRREVERSIBLE_PREFIX + body, irreversible=True)
+    return RollbackPlan(procedure=body, irreversible=False)
+
+
+# ---------------------------------------------------------------------------
+# Envelope factory
+# ---------------------------------------------------------------------------
+
+
+def build_card(
+    *,
+    approval_id: str,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    reasoning: str,
+    created_at: float,
+    ttl_seconds: float,
+    report: BlastRadiusReport | None = None,
+    detectors: Sequence[Detector] | None = None,
+) -> ApprovalCardV2:
+    """Build a canonical :class:`ApprovalCardV2` from a pending tool call.
+
+    Args:
+        approval_id: The approval id the card is issued for.
+        tool_name: Tool being invoked.
+        tool_args: Arguments the tool would run with (digested into the card).
+        reasoning: The agent's stated intent (bounded into the envelope).
+        created_at: Issue time in unix epoch seconds. Passed explicitly so the
+            envelope is a pure function of its inputs (determinism).
+        ttl_seconds: Lifetime; ``not_after = created_at + ttl_seconds``.
+        report: Optional precomputed blast-radius report. When ``None`` the
+            scorer is run over the derived change set.
+        detectors: Optional detector override forwarded to the scorer.
+
+    Returns:
+        The canonical envelope. Two calls with identical inputs (and identical
+        detector set / repository state) return byte-identical envelopes.
+    """
+    effective = report if report is not None else impact_from_tool_call(tool_name, tool_args, detectors=detectors)
+    impact = ImpactEstimate(
+        score=effective.score,
+        hard_one_way=effective.hard_one_way,
+        rationale=effective.rationale,
+        fired_detectors=tuple(hit.detector_id for hit in effective.hits),
+    )
+    rollback = rollback_for(tool_name, tool_args, irreversible=effective.hard_one_way)
+    return ApprovalCardV2(
+        approval_id=approval_id,
+        action=ActionRef(tool_name=tool_name, args_digest=args_digest(tool_args)),
+        reasoning=_bound_reasoning(reasoning),
+        impact=impact,
+        rollback=rollback,
+        created_at=float(created_at),
+        not_after=float(created_at) + float(ttl_seconds),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verbatim rendering (shared by every driver)
+# ---------------------------------------------------------------------------
+
+
+def render_card_text(card: ApprovalCardV2) -> str:
+    """Render the envelope as operator-facing text, verbatim from hashed fields.
+
+    Every driver calls this instead of re-summarising, so the displayed text
+    is a pure projection of the hashed envelope: if any field the operator saw
+    differed from what was hashed, the echoed ``card_hash`` would not match.
+    The final line prints the ``card_hash`` itself so the operator (and any
+    verifier) can confirm the message equals the committed record.
+    """
+    impact = card.impact
+    if impact.fired_detectors:
+        detector_note = f"; fired detectors: {', '.join(impact.fired_detectors)}"
+    else:
+        detector_note = "; no detectors fired"
+    lines = [
+        f"Action: {card.action.tool_name}",
+        f"Args digest: {card.action.args_digest}",
+        f"Intent: {card.reasoning or '(none provided)'}",
+        f"Impact: score {impact.score:.2f}{detector_note}",
+    ]
+    if impact.hard_one_way or card.rollback.irreversible:
+        lines.append("IRREVERSIBLE ACTION: change tripped a one-way-door blast-radius detector.")
+    lines.append(f"Rollback: {card.rollback.procedure}")
+    lines.append(f"Expires at: {card.not_after:.0f} (enforced by the audit chain, not this chat client)")
+    lines.append(f"Card hash: {card_hash(card)}")
+    return "\n".join(lines)

--- a/src/bernstein/core/approval/card_gate.py
+++ b/src/bernstein/core/approval/card_gate.py
@@ -1,0 +1,292 @@
+"""Chain-anchored gate for approval card v2 issue / resolve.
+
+Issue #2511. The gate is where the card stops being a message and becomes a
+proof. It does three things, all against the HMAC audit chain rather than the
+chat client:
+
+* **Issue.** :meth:`ApprovalCardGate.issue` appends a
+  ``chat.approval_card.issued`` event carrying the full canonical envelope,
+  its ``card_hash``, and the previous chain digest. The issued envelope is now
+  a signed, tamper-evident record.
+
+* **Resolve with hash echo.** :meth:`ApprovalCardGate.resolve` refuses to
+  settle unless the caller echoes the exact ``card_hash`` of an issued
+  envelope. An echo that differs in any field the operator saw (impact,
+  rollback text, expiry, args digest, reasoning) matches no issued card and is
+  refused, with a ``chat.approval_card.refused`` event recorded and the tool
+  call left un-executed.
+
+* **Chain-side expiry.** Expiry is decided by the chain-side clock against the
+  envelope's ``not_after`` -- never by what the chat client still renders. A
+  resolve at or after ``not_after`` is refused and chain-recorded, including
+  after a chat-process restart: the gate reconstructs issued cards from the
+  audit chain, so a fresh process still refuses a stale approve whose buttons
+  a client kept live.
+
+Strip the audit chain and every guarantee above collapses: the "gate" becomes
+an in-memory dict that a restart forgets. The chain is the substrate that
+makes the card a decision record instead of a message with a log.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.approval.card import ApprovalCardV2, card_hash
+from bernstein.core.security.audit_chain import (
+    EVENT_APPROVAL_CARD_ISSUED,
+    EVENT_APPROVAL_CARD_REFUSED,
+    EVENT_APPROVAL_CARD_RESOLVED,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+__all__ = [
+    "REFUSAL_REASON_EXPIRED",
+    "REFUSAL_REASON_HASH_MISMATCH",
+    "ApprovalCardExpired",
+    "ApprovalCardGate",
+    "ApprovalCardHashMismatch",
+    "IssuedCard",
+]
+
+#: Refusal reason recorded when the echoed ``card_hash`` matches no issued card.
+REFUSAL_REASON_HASH_MISMATCH = "hash_mismatch"
+
+#: Refusal reason recorded when a decision arrives at or after ``not_after``.
+REFUSAL_REASON_EXPIRED = "expired"
+
+
+class ApprovalCardHashMismatch(RuntimeError):
+    """Raised when a resolve echoes a ``card_hash`` that no issued card matches.
+
+    The gate records a ``chat.approval_card.refused`` event before raising so
+    the tampered or unknown echo is visible in the chain, and the tool call is
+    not allowed to proceed.
+    """
+
+
+class ApprovalCardExpired(RuntimeError):
+    """Raised when a resolve arrives at or after the envelope's ``not_after``.
+
+    Expiry is enforced by the chain-side clock regardless of what the chat
+    client renders. The gate records a ``chat.approval_card.refused`` event
+    before raising.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class IssuedCard:
+    """Bookkeeping for one issued approval card.
+
+    Attributes:
+        card: The canonical envelope.
+        card_hash: Its committed hash (equals ``card_hash(card)``).
+        worktree_id: Worktree the card is pinned to, when known.
+        thread_id: Chat thread the card was delivered on, when known.
+    """
+
+    card: ApprovalCardV2
+    card_hash: str
+    worktree_id: str = ""
+    thread_id: str = ""
+
+
+class ApprovalCardGate:
+    """Issues and resolves hash-committed approval cards against the audit chain.
+
+    Args:
+        chain: The audit chain store the gate appends events to and, on
+            resolve after a restart, reconstructs issued cards from.
+        install_id: Install identifier recorded on issued / resolved events.
+        session_id: Session identifier recorded on issued / resolved events.
+    """
+
+    def __init__(self, chain: AuditChainStore, *, install_id: str = "", session_id: str = "") -> None:
+        self._chain = chain
+        self._install_id = install_id
+        self._session_id = session_id
+        self._issued: dict[str, IssuedCard] = {}
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------
+    # Issue
+    # ------------------------------------------------------------------
+
+    def issue(
+        self,
+        card: ApprovalCardV2,
+        *,
+        worktree_id: str = "",
+        thread_id: str = "",
+        actor: str = "approval_card",
+    ) -> IssuedCard:
+        """Append a ``chat.approval_card.issued`` event and return the record.
+
+        The event stores the full canonical envelope and its ``card_hash`` so
+        a verifier can later reconstruct exactly the fields shown to the
+        operator and detect any post-hoc mutation.
+        """
+        digest = card_hash(card)
+        issued = IssuedCard(card=card, card_hash=digest, worktree_id=worktree_id, thread_id=thread_id)
+        with self._lock:
+            self._issued[digest] = issued
+        self._chain.log_with_prev_digest(
+            event_type=EVENT_APPROVAL_CARD_ISSUED,
+            actor=actor,
+            resource_type="approval_card",
+            resource_id=digest,
+            details={
+                "card_hash": digest,
+                "envelope": card.to_dict(),
+                "worktree_id": worktree_id,
+                "thread_id": thread_id,
+                "install_id": self._install_id,
+                "session_id": self._session_id,
+            },
+        )
+        return issued
+
+    # ------------------------------------------------------------------
+    # Resolve
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        *,
+        card_hash: str,
+        decision: str,
+        approver: str = "",
+        worktree_id: str = "",
+        now: float | None = None,
+    ) -> IssuedCard:
+        """Resolve an issued card, enforcing hash echo and chain-side expiry.
+
+        Args:
+            card_hash: The ``card_hash`` echoed by the decision. Must match an
+                issued envelope exactly.
+            decision: ``approve`` or ``reject``.
+            approver: Identifier of the operator who decided.
+            worktree_id: Worktree the decision was made from (recorded).
+            now: Injected clock for deterministic tests; defaults to
+                ``time.time()``.
+
+        Returns:
+            The :class:`IssuedCard` that was resolved.
+
+        Raises:
+            ApprovalCardHashMismatch: When *card_hash* matches no issued card.
+            ApprovalCardExpired: When the decision arrives at or after the
+                envelope's ``not_after``.
+        """
+        current = time.time() if now is None else now
+        echoed = card_hash
+        issued = self._lookup(echoed)
+        if issued is None:
+            self._refuse(
+                card_hash=echoed,
+                reason=REFUSAL_REASON_HASH_MISMATCH,
+                approver=approver,
+                worktree_id=worktree_id,
+                expected_card_hash="",
+            )
+            raise ApprovalCardHashMismatch(
+                f"echoed card_hash {echoed!r} matches no issued approval card; refusing to resolve",
+            )
+        if issued.card.is_expired(now=current):
+            self._refuse(
+                card_hash=echoed,
+                reason=REFUSAL_REASON_EXPIRED,
+                approver=approver,
+                worktree_id=worktree_id or issued.worktree_id,
+                expected_card_hash=issued.card_hash,
+            )
+            raise ApprovalCardExpired(
+                f"approval card {echoed!r} expired at not_after={issued.card.not_after:.0f}; "
+                f"refusing to resolve at {current:.0f} regardless of the chat client's rendered buttons",
+            )
+        self._chain.log_with_prev_digest(
+            event_type=EVENT_APPROVAL_CARD_RESOLVED,
+            actor=approver or "operator",
+            resource_type="approval_card",
+            resource_id=echoed,
+            details={
+                "card_hash": echoed,
+                "decision": decision,
+                "approver": approver,
+                "worktree_id": issued.worktree_id,
+                "resolved_at": current,
+                "install_id": self._install_id,
+                "session_id": self._session_id,
+            },
+        )
+        return issued
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _lookup(self, digest: str) -> IssuedCard | None:
+        """Return the issued card for *digest*, reconstructing from the chain.
+
+        In-memory issued cards are consulted first; on a miss (for example
+        after a chat-process restart) the audit chain is walked for the
+        matching ``chat.approval_card.issued`` event and the envelope is
+        rehydrated so expiry can still be enforced.
+        """
+        with self._lock:
+            hit = self._issued.get(digest)
+        if hit is not None:
+            return hit
+        for event in self._chain.query(event_type=EVENT_APPROVAL_CARD_ISSUED):
+            details: dict[str, Any] = event.details
+            if str(details.get("card_hash", "")) != digest:
+                continue
+            envelope_any: Any = details.get("envelope")
+            if not isinstance(envelope_any, dict):
+                continue
+            card = ApprovalCardV2.from_dict(cast("dict[str, Any]", envelope_any))
+            # Only trust a reconstructed envelope whose stored hash still
+            # matches its bytes; a mutated envelope is rejected as unknown.
+            if card_hash(card) != digest:
+                continue
+            issued = IssuedCard(
+                card=card,
+                card_hash=digest,
+                worktree_id=str(details.get("worktree_id", "")),
+                thread_id=str(details.get("thread_id", "")),
+            )
+            with self._lock:
+                self._issued.setdefault(digest, issued)
+            return issued
+        return None
+
+    def _refuse(
+        self,
+        *,
+        card_hash: str,
+        reason: str,
+        approver: str,
+        worktree_id: str,
+        expected_card_hash: str,
+    ) -> None:
+        """Append a ``chat.approval_card.refused`` event."""
+        self._chain.log_with_prev_digest(
+            event_type=EVENT_APPROVAL_CARD_REFUSED,
+            actor=approver or "operator",
+            resource_type="approval_card",
+            resource_id=card_hash,
+            details={
+                "card_hash": card_hash,
+                "reason": reason,
+                "expected_card_hash": expected_card_hash,
+                "approver": approver,
+                "worktree_id": worktree_id,
+                "install_id": self._install_id,
+                "session_id": self._session_id,
+            },
+        )

--- a/src/bernstein/core/approval/card_inbound.py
+++ b/src/bernstein/core/approval/card_inbound.py
@@ -1,0 +1,269 @@
+"""Route server-initiated prompts into the approval card v2 pipeline.
+
+Issue #2511. Two server-initiated prompt surfaces previously bypassed the
+attested approval path:
+
+* **MCP elicitations.** ``elicitation/create`` requests were auto-resolved by
+  policy or queued in a separate pending list, and never rendered as chat
+  cards.
+* **A2A ``input-required``.** A cross-agent task entering ``input-required``
+  mapped to a blocked task state with no operator-facing prompt.
+
+This module maps both onto :class:`ApprovalCardV2`: a server-initiated prompt
+that no auto-resolve policy matches becomes a hash-committed card that
+inherits the whole discipline -- committed decision context, chain-side
+expiry, and the audit trail -- without any extra integration work on the MCP
+server or peer agent side.
+
+The elicitation response equals the operator's decision, and the issue and
+resolve events share the ``card_hash``, so the elicitation answer and the
+approval record are chain-linked.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.approval.card import ApprovalCardV2, build_card
+
+if TYPE_CHECKING:
+    from bernstein.core.approval.card_gate import ApprovalCardGate, IssuedCard
+    from bernstein.core.chat.bridge import BridgeProtocol, PendingApproval
+    from bernstein.core.protocols.mcp.mcp_elicitation import (
+        ElicitationHandler,
+        ElicitationRequest,
+    )
+
+__all__ = [
+    "DEFAULT_CARD_TTL_SECONDS",
+    "A2AInputRequiredRouter",
+    "ElicitationApprovalRouter",
+    "card_for_a2a_input_required",
+    "card_for_elicitation",
+]
+
+#: Default lifetime for a card issued from a server-initiated prompt.
+DEFAULT_CARD_TTL_SECONDS = 600.0
+
+
+def card_for_elicitation(
+    request: ElicitationRequest,
+    *,
+    created_at: float,
+    ttl_seconds: float = DEFAULT_CARD_TTL_SECONDS,
+) -> ApprovalCardV2:
+    """Build a v2 card from an MCP elicitation request.
+
+    The tool name is namespaced by the originating server, the arguments
+    digest binds the exact prompt (message, request type, schema), and the
+    stated intent is the server's message.
+    """
+    tool_args: dict[str, Any] = {
+        "message": request.message,
+        "request_type": request.request_type,
+        "schema": request.schema,
+    }
+    return build_card(
+        approval_id=f"elicit-{request.id}",
+        tool_name=f"mcp.elicitation/{request.server_name}",
+        tool_args=tool_args,
+        reasoning=request.message,
+        created_at=created_at,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def card_for_a2a_input_required(
+    *,
+    task_uuid: str,
+    message: str,
+    created_at: float,
+    ttl_seconds: float = DEFAULT_CARD_TTL_SECONDS,
+    peer: str = "",
+) -> ApprovalCardV2:
+    """Build a v2 card from an A2A task that entered ``input-required``."""
+    tool_args: dict[str, Any] = {
+        "task_uuid": task_uuid,
+        "message": message,
+        "state": "input-required",
+        "peer": peer,
+    }
+    return build_card(
+        approval_id=f"a2a-{task_uuid}",
+        tool_name=f"a2a.input_required/{peer}" if peer else "a2a.input_required",
+        tool_args=tool_args,
+        reasoning=message,
+        created_at=created_at,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+class ElicitationApprovalRouter:
+    """Route unresolved MCP elicitations into the approval card pipeline.
+
+    Args:
+        handler: The elicitation handler; its auto-resolve policies run first.
+        gate: The chain-anchored approval card gate.
+        bridge: Optional chat bridge to deliver the card on. When set the card
+            is pushed to ``thread_id`` as a :class:`PendingApproval` carrying
+            the hashed envelope.
+        thread_id: Chat thread the card is delivered on.
+        worktree_id: Worktree the card is pinned to.
+    """
+
+    def __init__(
+        self,
+        *,
+        handler: ElicitationHandler,
+        gate: ApprovalCardGate,
+        bridge: BridgeProtocol | None = None,
+        thread_id: str = "",
+        worktree_id: str = "",
+    ) -> None:
+        self._handler = handler
+        self._gate = gate
+        self._bridge = bridge
+        self._thread_id = thread_id
+        self._worktree_id = worktree_id
+
+    async def route(
+        self,
+        request: ElicitationRequest,
+        *,
+        now: float,
+        ttl_seconds: float = DEFAULT_CARD_TTL_SECONDS,
+    ) -> IssuedCard | None:
+        """Handle an elicitation; issue and deliver a card if unresolved.
+
+        Returns:
+            The :class:`IssuedCard` when the elicitation matched no auto-policy
+            (a card was issued and, if a bridge is configured, delivered), or
+            ``None`` when an auto-policy resolved it (no card needed).
+        """
+        from bernstein.core.protocols.mcp.mcp_elicitation import ElicitationStatus
+
+        processed = self._handler.handle(request)
+        if processed.status is not ElicitationStatus.PENDING:
+            return None
+
+        card = card_for_elicitation(request, created_at=now, ttl_seconds=ttl_seconds)
+        issued = self._gate.issue(card, worktree_id=self._worktree_id, thread_id=self._thread_id)
+        if self._bridge is not None:
+            await self._bridge.push_approval(self._pending_payload(request, issued))
+        return issued
+
+    def _pending_payload(self, request: ElicitationRequest, issued: IssuedCard) -> PendingApproval:
+        from bernstein.core.chat.bridge import PendingApproval
+
+        return PendingApproval(
+            approval_id=card_approval_id(issued),
+            title=f"MCP elicitation from {request.server_name}",
+            body=request.message,
+            thread_id=self._thread_id,
+            card=issued.card,
+            card_hash=issued.card_hash,
+        )
+
+    def resolve(
+        self,
+        *,
+        request_id: str,
+        card_hash: str,
+        decision: str,
+        approver: str = "",
+        now: float | None = None,
+    ) -> tuple[IssuedCard, ElicitationRequest | None]:
+        """Resolve a routed elicitation via the gate, then the handler.
+
+        The gate enforces the hash echo and chain-side expiry and records the
+        ``chat.approval_card.resolved`` event; the handler records the
+        elicitation response, which equals the operator decision. Both are
+        chain-linked through the shared ``card_hash``.
+        """
+        issued = self._gate.resolve(
+            card_hash=card_hash,
+            decision=decision,
+            approver=approver,
+            worktree_id=self._worktree_id,
+            now=now,
+        )
+        resolved = self._handler.resolve(request_id, decision)
+        return issued, resolved
+
+
+class A2AInputRequiredRouter:
+    """Issue an approval card when an A2A task enters ``input-required``.
+
+    Mirrors :class:`ElicitationApprovalRouter` for the A2A surface: a bound
+    chat thread receives the hash-committed card, and the operator's decision
+    resolves it through the same gate.
+    """
+
+    def __init__(
+        self,
+        *,
+        gate: ApprovalCardGate,
+        bridge: BridgeProtocol | None = None,
+        thread_id: str = "",
+        worktree_id: str = "",
+        peer: str = "",
+    ) -> None:
+        self._gate = gate
+        self._bridge = bridge
+        self._thread_id = thread_id
+        self._worktree_id = worktree_id
+        self._peer = peer
+
+    async def route(
+        self,
+        *,
+        task_uuid: str,
+        message: str,
+        now: float,
+        ttl_seconds: float = DEFAULT_CARD_TTL_SECONDS,
+    ) -> IssuedCard:
+        """Issue and deliver a card for an A2A ``input-required`` task."""
+        card = card_for_a2a_input_required(
+            task_uuid=task_uuid,
+            message=message,
+            created_at=now,
+            ttl_seconds=ttl_seconds,
+            peer=self._peer,
+        )
+        issued = self._gate.issue(card, worktree_id=self._worktree_id, thread_id=self._thread_id)
+        if self._bridge is not None:
+            from bernstein.core.chat.bridge import PendingApproval
+
+            await self._bridge.push_approval(
+                PendingApproval(
+                    approval_id=card.approval_id,
+                    title=f"A2A input required ({self._peer or 'peer'})",
+                    body=message,
+                    thread_id=self._thread_id,
+                    card=issued.card,
+                    card_hash=issued.card_hash,
+                ),
+            )
+        return issued
+
+    def resolve(
+        self,
+        *,
+        card_hash: str,
+        decision: str,
+        approver: str = "",
+        now: float | None = None,
+    ) -> IssuedCard:
+        """Resolve the A2A card via the gate (hash echo + chain-side expiry)."""
+        return self._gate.resolve(
+            card_hash=card_hash,
+            decision=decision,
+            approver=approver,
+            worktree_id=self._worktree_id,
+            now=now,
+        )
+
+
+def card_approval_id(issued: IssuedCard) -> str:
+    """Return the approval id carried by an issued card's envelope."""
+    return issued.card.approval_id

--- a/src/bernstein/core/approval/card_verify.py
+++ b/src/bernstein/core/approval/card_verify.py
@@ -1,0 +1,119 @@
+"""Offline verification of resolved approval cards (issue #2511).
+
+A resolved approval must be re-checkable offline from the audit chain alone.
+:func:`verify_approval_cards` walks the ``chat.approval_card.issued`` and
+``chat.approval_card.resolved`` events and proves, for every resolved card:
+
+* the stored envelope still hashes to the recorded ``card_hash`` -- any
+  post-hoc mutation of the stored envelope is detected, because a mutated
+  envelope no longer hashes to the committed value,
+* the decision echoed the issued envelope's ``card_hash`` (the operator
+  decided against the fields that were hashed, not a divergent view),
+* the decision landed before the envelope's ``not_after`` (expiry is
+  reconstructable, not merely enforced live).
+
+This is orthogonal to the HMAC chain check: the HMAC chain proves the event
+bytes were not altered; this check proves the *card semantics* hold across the
+issue/resolve pair. Together they make the card a decision record whose whole
+context is verifiable after the fact.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.approval.card import ApprovalCardV2, card_hash
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_chain import (
+    EVENT_APPROVAL_CARD_ISSUED,
+    EVENT_APPROVAL_CARD_RESOLVED,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.security.audit import AuditEvent
+
+__all__ = ["ApprovalCardVerifyResult", "verify_approval_cards"]
+
+
+@dataclass(frozen=True)
+class ApprovalCardVerifyResult:
+    """Outcome of :func:`verify_approval_cards`."""
+
+    ok: bool
+    errors: list[str]
+    issued_count: int = 0
+    resolved_count: int = 0
+    reconstructed_count: int = 0
+
+
+def _reconstruct_issued(events: list[AuditEvent], errors: list[str]) -> dict[str, ApprovalCardV2]:
+    """Return ``card_hash -> envelope`` for every issue event, flagging mutation."""
+    issued: dict[str, ApprovalCardV2] = {}
+    for event in events:
+        details: dict[str, Any] = event.details
+        stored_hash = str(details.get("card_hash", ""))
+        envelope_any: Any = details.get("envelope")
+        if not stored_hash or not isinstance(envelope_any, dict):
+            errors.append(f"approval card issue event {event.resource_id!r} is missing card_hash or envelope")
+            continue
+        card = ApprovalCardV2.from_dict(cast("dict[str, Any]", envelope_any))
+        recomputed = card_hash(card)
+        if recomputed != stored_hash:
+            errors.append(
+                f"approval card {stored_hash!r} envelope was mutated after issue "
+                f"(stored hash {stored_hash[:16]}…, envelope hashes to {recomputed[:16]}…)",
+            )
+            continue
+        issued[stored_hash] = card
+    return issued
+
+
+def verify_approval_cards(audit_dir: Path, *, key: bytes | None = None) -> ApprovalCardVerifyResult:
+    """Verify every resolved approval card in *audit_dir* offline.
+
+    Args:
+        audit_dir: Directory holding the HMAC-chained audit JSONL files.
+        key: Optional HMAC key. Only used to read the events; the semantic
+            checks here do not depend on the key (the HMAC chain check does).
+
+    Returns:
+        An :class:`ApprovalCardVerifyResult`. ``ok`` is ``True`` when no
+        resolved card references a mutated envelope, an unknown ``card_hash``,
+        or a decision made after expiry (and when there are no cards at all).
+    """
+    log = AuditLog(audit_dir=audit_dir, key=key) if key is not None else AuditLog(audit_dir=audit_dir)
+    issued_events = log.query(event_type=EVENT_APPROVAL_CARD_ISSUED)
+    resolved_events = log.query(event_type=EVENT_APPROVAL_CARD_RESOLVED)
+
+    errors: list[str] = []
+    issued = _reconstruct_issued(issued_events, errors)
+
+    reconstructed = 0
+    for event in resolved_events:
+        details: dict[str, Any] = event.details
+        echoed = str(details.get("card_hash", ""))
+        card = issued.get(echoed)
+        if card is None:
+            errors.append(
+                f"resolved approval card {echoed!r} has no matching issued envelope with an intact hash",
+            )
+            continue
+        resolved_at = float(details.get("resolved_at", 0.0))
+        if resolved_at and resolved_at >= card.not_after:
+            errors.append(
+                f"resolved approval card {echoed!r} was decided at {resolved_at:.0f} "
+                f"at or after its not_after {card.not_after:.0f}",
+            )
+            continue
+        reconstructed += 1
+
+    return ApprovalCardVerifyResult(
+        ok=not errors,
+        errors=errors,
+        issued_count=len(issued_events),
+        resolved_count=len(resolved_events),
+        reconstructed_count=reconstructed,
+    )

--- a/src/bernstein/core/chat/__init__.py
+++ b/src/bernstein/core/chat/__init__.py
@@ -45,7 +45,8 @@ def load_driver(platform: str) -> type[BridgeProtocol]:
     installed) only surfaces when that driver is actually selected.
 
     Args:
-        platform: One of ``"telegram"``, ``"discord"``, ``"slack"``.
+        platform: One of ``"telegram"``, ``"discord"``, ``"slack"``,
+            ``"teams"``.
 
     Returns:
         The driver class. Instantiation is the caller's responsibility.
@@ -66,6 +67,10 @@ def load_driver(platform: str) -> type[BridgeProtocol]:
         from bernstein.core.chat.drivers.slack import SlackBridge
 
         return SlackBridge
+    if normalised == "teams":
+        from bernstein.core.chat.drivers.teams import TeamsBridge
+
+        return TeamsBridge
     raise ValueError(
-        f"Unknown chat platform {platform!r}. Supported: telegram, discord, slack.",
+        f"Unknown chat platform {platform!r}. Supported: telegram, discord, slack, teams.",
     )

--- a/src/bernstein/core/chat/bridge.py
+++ b/src/bernstein/core/chat/bridge.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.approval.card import ApprovalCardV2
 
 
 @dataclass(slots=True)
@@ -54,12 +57,36 @@ class PendingApproval:
         title: Short human-friendly headline.
         body: Multi-line description (diff preview, tool args, etc.).
         thread_id: Where to deliver the approval card.
+        card: Optional hash-committed v2 decision envelope (issue #2511).
+            When set, drivers render the envelope fields verbatim via
+            :func:`bernstein.core.approval.card.render_card_text` instead of
+            re-summarising ``body``, so what is displayed is exactly what was
+            hashed into ``card_hash``.
+        card_hash: The ``card_hash`` the decision must echo on resolve. Empty
+            for legacy v1 cards.
     """
 
     approval_id: str
     title: str
     body: str
     thread_id: str
+    card: ApprovalCardV2 | None = None
+    card_hash: str = ""
+
+
+def approval_body(approval: PendingApproval) -> str:
+    """Return the operator-facing body a driver should render for *approval*.
+
+    For a v2 card the body is the verbatim projection of the hashed envelope;
+    for a legacy v1 card it is the free-text ``body``. Centralising this keeps
+    every driver rendering exactly what was hashed (no driver-local
+    re-summarisation).
+    """
+    if approval.card is not None:
+        from bernstein.core.approval.card import render_card_text
+
+        return render_card_text(approval.card)
+    return approval.body
 
 
 CommandHandler = Callable[[ChatMessage], Awaitable[None]]

--- a/src/bernstein/core/chat/drivers/discord.py
+++ b/src/bernstein/core/chat/drivers/discord.py
@@ -81,6 +81,7 @@ from bernstein.core.chat.bridge import (
     ChatMessage,
     CommandHandler,
     PendingApproval,
+    approval_body,
 )
 from bernstein.core.orchestration.scheduler_partitions import (
     PartitionViolationError,
@@ -442,7 +443,7 @@ class DiscordBridge(BridgeProtocol):
             )
 
         channel = await self._resolve_channel(approval.thread_id)
-        text = f"{approval.title}\n\n{approval.body}"
+        text = f"{approval.title}\n\n{approval_body(approval)}"
         view_cls: Any = self._ui_mod.View
         button_cls: Any = self._ui_mod.Button
         style_cls: Any = getattr(self._discord_mod, "ButtonStyle", None)

--- a/src/bernstein/core/chat/drivers/slack.py
+++ b/src/bernstein/core/chat/drivers/slack.py
@@ -74,6 +74,7 @@ from bernstein.core.chat.bridge import (
     ChatMessage,
     CommandHandler,
     PendingApproval,
+    approval_body,
 )
 
 if TYPE_CHECKING:
@@ -384,7 +385,8 @@ class SlackBridge(BridgeProtocol):
         carries the approval id.
         """
         client = self._require_web()
-        text = f"{approval.title}\n\n{approval.body}"
+        body = approval_body(approval)
+        text = f"{approval.title}\n\n{body}"
         blocks = [
             {
                 "type": "section",
@@ -392,7 +394,7 @@ class SlackBridge(BridgeProtocol):
             },
             {
                 "type": "section",
-                "text": {"type": "mrkdwn", "text": approval.body},
+                "text": {"type": "mrkdwn", "text": body},
             },
             {
                 "type": "actions",

--- a/src/bernstein/core/chat/drivers/teams.py
+++ b/src/bernstein/core/chat/drivers/teams.py
@@ -1,0 +1,680 @@
+"""Microsoft Teams driver -- attested approvals over the Bot Framework.
+
+Issue #2511. Operators whose org standardises on Microsoft Teams get the same
+attested approval surface as Slack, Discord, and Telegram: interactive
+Adaptive Cards, HMAC-chained approval events, worktree pinning, and Ed25519
+outbound message signing.
+
+Standard Teams bot integration: register a bot in the Azure Bot Service,
+configure the Microsoft App id and password, and set ``BERNSTEIN_TEAMS_TOKEN``
+(the app id) plus ``BERNSTEIN_TEAMS_APP_PASSWORD`` (the client secret).
+``pip install 'bernstein[teams]'`` pulls in the Bot Framework SDK.
+
+The SDK import is guarded so the module can always be imported --
+``botbuilder-core`` is only required when :meth:`TeamsBridge.start` actually
+runs. This keeps ``bernstein chat serve --platform=slack`` working for users
+who only installed the Slack extra.
+
+Key behaviours mirror the Slack driver:
+
+  * **Commands.** A Teams message activity whose text names a registered
+    subcommand routes to the matching :meth:`on_command` handler.
+  * **Approval cards.** :meth:`push_approval` renders a Teams-native Adaptive
+    Card with two ``Action.Submit`` buttons. When the approval carries a v2
+    envelope the card body is the verbatim projection of the hashed envelope
+    (no driver-local re-summarisation), so what is displayed is exactly what
+    was hashed.
+  * **Card actions.** An ``invoke`` / submit activity carries
+    ``value = {"action": "approve"|"reject", "approval_id": ...}``; decoding
+    is symmetric.
+  * **Edit throttle.** :meth:`edit_message` is debounced per conversation to
+    stay inside the Bot Framework's per-conversation update budget.
+  * **Attested approvals.** Every card action that resolves a pending approval
+    is appended to the HMAC-chained audit log as a ``chat.teams.approval``
+    event covering ``(approver, activity_id, decision, tool_call_hash,
+    worktree_id)``.
+  * **Worktree pinning.** Approvals carry a ``worktree_id`` so a resolve for a
+    worker bound to ``wt-a`` cannot settle a pending approval registered
+    against a different worktree; cross-worktree attempts log a
+    ``chat.teams.approval_rejected`` entry.
+  * **Outbound message signing.** Every outbound message carries an Ed25519
+    detached signature over ``(install_id, session_id, content_hash)`` so a
+    recipient with the install's public key can confirm authenticity. The
+    signature format is identical to the Slack driver's, so the shared
+    :func:`verify_chat_signature` verifies both.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import importlib
+import json
+import logging
+import shlex
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.chat.bridge import (
+    BridgeProtocol,
+    ButtonHandler,
+    ChatMessage,
+    CommandHandler,
+    PendingApproval,
+    approval_body,
+)
+
+# The signature verifier is shared with the Slack driver: both drivers sign
+# the identical canonical envelope, so one verifier covers both surfaces.
+from bernstein.core.chat.drivers.slack import verify_chat_signature
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit import AuditLog
+
+__all__ = [
+    "APPROVAL_EVENT_TYPE",
+    "APPROVAL_REJECTED_EVENT_TYPE",
+    "EDIT_THROTTLE_S",
+    "CrossWorktreeApprovalError",
+    "PendingApprovalRecord",
+    "TeamsBridge",
+    "TeamsDependencyError",
+    "verify_chat_signature",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Minimum seconds between consecutive edits to the same conversation.
+EDIT_THROTTLE_S: float = 1.0
+
+#: Audit-chain event type for a Teams approval that resolved cleanly.
+APPROVAL_EVENT_TYPE: str = "chat.teams.approval"
+
+#: Audit-chain event type for a Teams approval refused by the worktree guard.
+APPROVAL_REJECTED_EVENT_TYPE: str = "chat.teams.approval_rejected"
+
+#: Adaptive Card schema version rendered by :meth:`TeamsBridge.push_approval`.
+ADAPTIVE_CARD_VERSION: str = "1.4"
+
+#: Adaptive Card content type used for the message attachment.
+ADAPTIVE_CARD_CONTENT_TYPE: str = "application/vnd.microsoft.card.adaptive"
+
+
+class TeamsDependencyError(RuntimeError):
+    """Raised when the Bot Framework SDK is not installed."""
+
+
+class CrossWorktreeApprovalError(RuntimeError):
+    """Raised when a resolve settles a pending approval on a different worktree.
+
+    The bridge logs the rejection into the audit chain before raising so
+    operators can audit attempted bypasses.
+    """
+
+
+@dataclass(slots=True)
+class _EditState:
+    """Per-conversation debouncing bookkeeping."""
+
+    last_edit_ts: float = 0.0
+    pending_text: str = ""
+    task: asyncio.Task[None] | None = field(default=None, repr=False)
+
+
+@dataclass(slots=True, frozen=True)
+class PendingApprovalRecord:
+    """Server-side bookkeeping for a pending Teams approval."""
+
+    approval_id: str
+    tool_call_hash: str
+    worktree_id: str
+    thread_id: str
+
+
+class TeamsBridge(BridgeProtocol):
+    """Microsoft Teams implementation of :class:`BridgeProtocol`.
+
+    Args:
+        token: Microsoft App id of the registered bot. Used to authenticate
+            outbound Bot Framework calls. Must be non-empty.
+        app_password: Microsoft App password / client secret. Must be
+            non-empty for :meth:`start` to succeed.
+        install_id: Stable identifier for this Bernstein install; bound into
+            the signed envelope on every outbound message.
+        session_id: Stable identifier for the active chat session.
+        worktree_id: Worktree this driver instance is bound to; the
+            approval-resolution path refuses to settle a pending approval whose
+            ``worktree_id`` differs.
+        audit_log: Optional :class:`AuditLog`. When set, every resolution lands
+            as a chained ``chat.teams.approval`` entry and every cross-worktree
+            attempt as a ``chat.teams.approval_rejected`` entry.
+        key_dir: Filesystem directory backing the install's Ed25519 keypair.
+            Defaults to ``<workdir>/.bernstein/keys/teams`` when unset.
+        service_url: Optional Bot Framework service url override forwarded to
+            the transport when replies target a specific tenant endpoint.
+    """
+
+    platform: str = "teams"
+
+    def __init__(
+        self,
+        token: str,
+        app_password: str,
+        *,
+        install_id: str = "",
+        session_id: str = "",
+        worktree_id: str = "",
+        audit_log: AuditLog | None = None,
+        key_dir: Path | None = None,
+        service_url: str = "",
+    ) -> None:
+        if not token:
+            raise ValueError("Teams app id (token) must be non-empty.")
+        if not app_password:
+            raise ValueError("Teams app password must be non-empty.")
+
+        self._token = token
+        self._app_password = app_password
+        self._install_id = install_id
+        self._session_id = session_id
+        self._worktree_id = worktree_id
+        self._audit_log = audit_log
+        self._service_url = service_url
+
+        self._command_handlers: dict[str, CommandHandler] = {}
+        self._button_handler: ButtonHandler | None = None
+
+        self._client: Any = None
+
+        self._edit_state: dict[str, _EditState] = {}
+        self._edit_lock = asyncio.Lock()
+
+        self._pending_approvals: dict[str, PendingApprovalRecord] = {}
+        self._approved_tool_call_hashes: set[str] = set()
+
+        self._key_dir = key_dir
+        self._private_key_pem: bytes | None = None
+        self._public_key_pem: bytes | None = None
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def on_command(self, name: str, handler: CommandHandler) -> None:
+        """Register ``handler`` for the subcommand ``<name>``."""
+        self._command_handlers[name.lstrip("/")] = handler
+
+    def on_button(self, handler: ButtonHandler) -> None:
+        """Register the single approve/reject callback."""
+        self._button_handler = handler
+
+    def register_pending_approval(
+        self,
+        *,
+        approval_id: str,
+        tool_call_hash: str,
+        worktree_id: str,
+        thread_id: str,
+    ) -> None:
+        """Tell the bridge a tool call is waiting for a Teams approval."""
+        self._pending_approvals[approval_id] = PendingApprovalRecord(
+            approval_id=approval_id,
+            tool_call_hash=tool_call_hash,
+            worktree_id=worktree_id,
+            thread_id=thread_id,
+        )
+
+    def approved_tool_call_hashes(self) -> set[str]:
+        """Return a snapshot of every tool-call hash that has been approved."""
+        return self._approved_tool_call_hashes.copy()
+
+    def public_key_pem(self) -> bytes:
+        """Return the install's Ed25519 public key (PEM, SubjectPublicKeyInfo)."""
+        self._ensure_keypair()
+        assert self._public_key_pem is not None
+        return self._public_key_pem
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Construct the Bot Framework connector client and begin serving."""
+        connector_mod = _import_teams_connector()
+        credentials_mod = _import_teams_credentials()
+        credentials = credentials_mod.MicrosoftAppCredentials(self._token, self._app_password)
+        # ``ConnectorClient`` targets a tenant service url; when the operator
+        # did not pin one we defer to the SDK default so replies still route.
+        self._client = connector_mod.ConnectorClient(credentials, base_url=self._service_url or None)
+
+    async def stop(self) -> None:
+        """Flush pending edits and release the connector client."""
+        async with self._edit_lock:
+            for state in self._edit_state.values():
+                task = state.task
+                if task is not None and not task.done():
+                    task.cancel()
+            self._edit_state.clear()
+        self._client = None
+
+    # ------------------------------------------------------------------
+    # Outbound primitives
+    # ------------------------------------------------------------------
+
+    async def send_message(self, thread_id: str, text: str) -> str:
+        """Post ``text`` to ``thread_id`` and return the new activity id.
+
+        Outbound messages carry a signed envelope so a recipient with the
+        install's public key can confirm the message originated here.
+        """
+        client = self._require_client()
+        activity = {
+            "type": "message",
+            "text": text,
+            "channelData": {"bernstein": self._build_signed_metadata(text)},
+        }
+        result: Any = await _maybe_await(client.send_activity(thread_id, activity))
+        return _activity_id(result)
+
+    async def edit_message(self, thread_id: str, message_id: str, text: str) -> None:
+        """Edit ``message_id`` in ``thread_id``, debounced per conversation."""
+        key = f"{thread_id}:{message_id}"
+        now = time.monotonic()
+        async with self._edit_lock:
+            state = self._edit_state.setdefault(key, _EditState())
+            state.pending_text = text
+            elapsed = now - state.last_edit_ts
+            if elapsed >= EDIT_THROTTLE_S and (state.task is None or state.task.done()):
+                state.last_edit_ts = now
+                body = state.pending_text
+                state.pending_text = ""
+                await self._flush_edit(thread_id, message_id, body)
+                return
+            if state.task is None or state.task.done():
+                delay = max(0.0, EDIT_THROTTLE_S - elapsed)
+                state.task = asyncio.create_task(
+                    self._deferred_flush(thread_id, message_id, delay, key),
+                )
+
+    async def push_approval(self, approval: PendingApproval) -> str:
+        """Render a Teams-native Adaptive Card for ``approval``.
+
+        The card body is the verbatim projection of the hashed v2 envelope
+        (falling back to the legacy free-text body), and the two
+        ``Action.Submit`` buttons carry ``{"action", "approval_id"}`` so the
+        decode path can recover the decision.
+        """
+        client = self._require_client()
+        body_text = approval_body(approval)
+        text = f"{approval.title}\n\n{body_text}"
+        card = self._adaptive_card(approval.title, body_text, approval.approval_id)
+        activity = {
+            "type": "message",
+            "text": text,
+            "attachments": [
+                {
+                    "contentType": ADAPTIVE_CARD_CONTENT_TYPE,
+                    "content": card,
+                },
+            ],
+            "channelData": {"bernstein": self._build_signed_metadata(text)},
+        }
+        result: Any = await _maybe_await(client.send_activity(approval.thread_id, activity))
+        return _activity_id(result)
+
+    def _adaptive_card(self, title: str, body_text: str, approval_id: str) -> dict[str, Any]:
+        """Build the Adaptive Card payload for an approval."""
+        return {
+            "type": "AdaptiveCard",
+            "version": ADAPTIVE_CARD_VERSION,
+            "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+            "body": [
+                {"type": "TextBlock", "text": title, "weight": "Bolder", "wrap": True},
+                {"type": "TextBlock", "text": body_text, "wrap": True},
+            ],
+            "actions": [
+                {
+                    "type": "Action.Submit",
+                    "title": "Approve",
+                    "data": {"action": "approve", "approval_id": approval_id},
+                },
+                {
+                    "type": "Action.Submit",
+                    "title": "Reject",
+                    "data": {"action": "reject", "approval_id": approval_id},
+                },
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Inbound dispatch -- activity handler
+    # ------------------------------------------------------------------
+
+    async def handle_activity(self, activity: dict[str, Any]) -> None:
+        """Public entry point for an inbound Teams activity.
+
+        Message activities route to slash-style command handlers; card submit
+        actions (message activities carrying a ``value`` with an ``action``, or
+        ``invoke`` activities) route to the approval-button path.
+        """
+        await self._handle_activity(activity)
+
+    async def _handle_activity(self, activity: dict[str, Any]) -> None:
+        value_any: Any = activity.get("value")
+        value: dict[str, Any] = cast("dict[str, Any]", value_any) if isinstance(value_any, dict) else {}
+        if value.get("action") in {"approve", "reject"}:
+            await self._dispatch_card_action(activity, value)
+            return
+        if activity.get("type") == "message":
+            await self._dispatch_message(activity)
+
+    async def _dispatch_message(self, activity: dict[str, Any]) -> None:
+        """Route a message activity to the matching registered handler."""
+        text = str(activity.get("text") or "").strip()
+        if not text:
+            return
+        try:
+            tokens = shlex.split(text, posix=True)
+        except ValueError:
+            tokens = text.split()
+        if not tokens:
+            return
+        subcommand = tokens[0].lstrip("/")
+        handler = self._command_handlers.get(subcommand)
+        if handler is None:
+            return
+        thread_id = _conversation_id(activity)
+        user_id = _from_id(activity)
+        await handler(
+            ChatMessage(
+                thread_id=thread_id,
+                user_id=user_id,
+                text=text,
+                args=text.split()[1:],
+                raw=activity,
+            ),
+        )
+
+    async def _dispatch_card_action(self, activity: dict[str, Any], value: dict[str, Any]) -> None:
+        """Route a card submit action to the registered button handler.
+
+        Enforces worktree pinning and writes a chained audit entry before
+        invoking the handler; the audit record lands even if no button handler
+        is registered so cross-worktree rejection and the approval-chain entry
+        do not depend on the orchestrator wiring an inbound callback.
+        """
+        decision = str(value.get("action") or "")
+        if decision not in {"approve", "reject"}:
+            return
+        approval_id = str(value.get("approval_id") or "")
+        if not approval_id:
+            return
+        thread_id = _conversation_id(activity)
+        user_id = _from_id(activity)
+        activity_id = str(activity.get("id") or activity.get("replyToId") or "")
+
+        pending = self._pending_approvals.get(approval_id)
+        if pending is not None and self._worktree_id and pending.worktree_id != self._worktree_id:
+            self._record_rejected_approval(
+                approver=user_id,
+                approval_id=approval_id,
+                pending=pending,
+                activity_id=activity_id,
+                reason="cross_worktree",
+            )
+            raise CrossWorktreeApprovalError(
+                f"approval {approval_id!r} bound to worktree {pending.worktree_id!r} "
+                f"cannot be resolved from worktree {self._worktree_id!r}",
+            )
+
+        if pending is not None:
+            self._record_resolved_approval(
+                approver=user_id,
+                approval_id=approval_id,
+                pending=pending,
+                decision=decision,
+                activity_id=activity_id,
+            )
+            del self._pending_approvals[approval_id]
+
+        if self._button_handler is not None:
+            await self._button_handler(thread_id, approval_id, decision)
+
+    # ------------------------------------------------------------------
+    # Audit-chain helpers
+    # ------------------------------------------------------------------
+
+    def _record_resolved_approval(
+        self,
+        *,
+        approver: str,
+        approval_id: str,
+        pending: PendingApprovalRecord,
+        decision: str,
+        activity_id: str,
+    ) -> None:
+        """Track scheduler state and emit a chained approval audit entry."""
+        if decision == "approve":
+            self._approved_tool_call_hashes.add(pending.tool_call_hash)
+        elif decision == "reject":
+            self._approved_tool_call_hashes.discard(pending.tool_call_hash)
+        if self._audit_log is None:
+            return
+        self._audit_log.log(
+            event_type=APPROVAL_EVENT_TYPE,
+            actor=approver or "unknown",
+            resource_type="approval",
+            resource_id=approval_id,
+            details={
+                "approver": approver,
+                "decision": decision,
+                "tool_call_hash": pending.tool_call_hash,
+                "activity_id": activity_id,
+                "worktree_id": pending.worktree_id,
+                "install_id": self._install_id,
+                "session_id": self._session_id,
+            },
+        )
+
+    def _record_rejected_approval(
+        self,
+        *,
+        approver: str,
+        approval_id: str,
+        pending: PendingApprovalRecord,
+        activity_id: str,
+        reason: str,
+    ) -> None:
+        """Log a rejected cross-worktree approval into the audit chain."""
+        if self._audit_log is None:
+            return
+        self._audit_log.log(
+            event_type=APPROVAL_REJECTED_EVENT_TYPE,
+            actor=approver or "unknown",
+            resource_type="approval",
+            resource_id=approval_id,
+            details={
+                "approver": approver,
+                "reason": reason,
+                "tool_call_hash": pending.tool_call_hash,
+                "activity_id": activity_id,
+                "pending_worktree_id": pending.worktree_id,
+                "request_worktree_id": self._worktree_id,
+                "install_id": self._install_id,
+                "session_id": self._session_id,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Throttle internals
+    # ------------------------------------------------------------------
+
+    async def _deferred_flush(self, thread_id: str, message_id: str, delay: float, key: str) -> None:
+        """Sleep ``delay`` then flush the pending body for ``key``."""
+        await asyncio.sleep(delay)
+        async with self._edit_lock:
+            state = self._edit_state.get(key)
+            if state is None or not state.pending_text:
+                return
+            body = state.pending_text
+            state.pending_text = ""
+            state.last_edit_ts = time.monotonic()
+        await self._flush_edit(thread_id, message_id, body)
+
+    async def _flush_edit(self, thread_id: str, message_id: str, text: str) -> None:
+        """Issue the actual update-activity API call."""
+        client = self._require_client()
+        activity = {
+            "type": "message",
+            "id": message_id,
+            "text": text,
+            "channelData": {"bernstein": self._build_signed_metadata(text)},
+        }
+        try:
+            await _maybe_await(client.update_activity(thread_id, message_id, activity))
+        except Exception as exc:  # pragma: no cover - network-only path.
+            logger.warning("teams edit failed for %s:%s: %s", thread_id, message_id, exc)
+
+    def _require_client(self) -> Any:
+        if self._client is None:
+            raise RuntimeError("TeamsBridge is not started; call await bridge.start() first.")
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Signing helpers (envelope identical to the Slack driver)
+    # ------------------------------------------------------------------
+
+    def _ensure_keypair(self) -> None:
+        """Load or generate the install's Ed25519 keypair on demand."""
+        if self._private_key_pem is not None and self._public_key_pem is not None:
+            return
+        key_dir = self._key_dir or Path.cwd() / ".bernstein" / "keys" / "teams"
+        key_dir.mkdir(parents=True, exist_ok=True)
+        priv_path = key_dir / "teams-bridge.ed25519"
+        pub_path = key_dir / "teams-bridge.ed25519.pub"
+
+        if priv_path.exists() and pub_path.exists():
+            self._private_key_pem = priv_path.read_bytes()
+            self._public_key_pem = pub_path.read_bytes()
+            return
+
+        priv = Ed25519PrivateKey.generate()
+        self._private_key_pem = priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        self._public_key_pem = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        try:
+            priv_path.write_bytes(self._private_key_pem)
+            priv_path.chmod(0o600)
+            pub_path.write_bytes(self._public_key_pem)
+        except OSError as exc:  # pragma: no cover - filesystem flake
+            logger.warning("could not persist teams bridge keypair under %s: %s", key_dir, exc)
+
+    def _build_signed_metadata(self, content: str) -> dict[str, Any]:
+        """Return the signed envelope embedded in ``channelData``.
+
+        The signed payload covers ``(install_id, session_id, content_hash)``
+        using the same canonical bytes the Slack driver signs, so the shared
+        :func:`verify_chat_signature` verifies both surfaces.
+        """
+        self._ensure_keypair()
+        assert self._private_key_pem is not None
+        content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        priv = serialization.load_pem_private_key(self._private_key_pem, password=None)
+        if not isinstance(priv, Ed25519PrivateKey):  # pragma: no cover - we just generated it
+            raise TypeError("expected Ed25519 private key")
+        message = _canonical_attestation_bytes(self._install_id, self._session_id, content_hash)
+        signature = priv.sign(message)
+        return {
+            "install_id": self._install_id,
+            "session_id": self._session_id,
+            "content_hash": content_hash,
+            "signature": base64.b64encode(signature).decode("ascii"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_attestation_bytes(install_id: str, session_id: str, content_hash: str) -> bytes:
+    """Canonical signing bytes -- identical to the Slack driver's envelope."""
+    return json.dumps(
+        {
+            "install_id": install_id,
+            "session_id": session_id,
+            "content_hash": content_hash,
+            "v": 1,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+async def _maybe_await(result: Any) -> Any:
+    """Return ``result``, awaiting it first when it is awaitable."""
+    if hasattr(result, "__await__"):
+        return await result
+    return result
+
+
+def _activity_id(result: Any) -> str:
+    """Extract the activity/resource id from a send/update result."""
+    if isinstance(result, dict):
+        mapping: dict[str, Any] = cast("dict[str, Any]", result)
+        return str(mapping.get("id") or mapping.get("activityId") or "")
+    return str(getattr(result, "id", "") or getattr(result, "activity_id", "") or "")
+
+
+def _nested_id(activity: dict[str, Any], nested_key: str, flat_key: str) -> str:
+    """Return ``activity[nested_key]['id']`` or the flat fallback ``activity[flat_key]``."""
+    nested_any: Any = activity.get(nested_key)
+    if isinstance(nested_any, dict):
+        nested: dict[str, Any] = cast("dict[str, Any]", nested_any)
+        return str(nested.get("id") or "")
+    return str(activity.get(flat_key) or "")
+
+
+def _conversation_id(activity: dict[str, Any]) -> str:
+    """Return the conversation id from an inbound activity."""
+    return _nested_id(activity, "conversation", "conversation_id")
+
+
+def _from_id(activity: dict[str, Any]) -> str:
+    """Return the sender id from an inbound activity."""
+    return _nested_id(activity, "from", "from_id")
+
+
+# ---------------------------------------------------------------------------
+# Import helpers -- keep the SDK optional.
+# ---------------------------------------------------------------------------
+
+
+def _import_teams_connector() -> Any:
+    try:
+        return importlib.import_module("botframework.connector")
+    except ImportError as exc:
+        raise TeamsDependencyError(
+            "botbuilder-core is not installed. Install with: pip install 'bernstein[teams]'",
+        ) from exc
+
+
+def _import_teams_credentials() -> Any:
+    try:
+        return importlib.import_module("botframework.connector.auth")
+    except ImportError as exc:
+        raise TeamsDependencyError(
+            "botbuilder-core is not installed. Install with: pip install 'bernstein[teams]'",
+        ) from exc

--- a/src/bernstein/core/chat/drivers/telegram.py
+++ b/src/bernstein/core/chat/drivers/telegram.py
@@ -42,6 +42,7 @@ from bernstein.core.chat.bridge import (
     ChatMessage,
     CommandHandler,
     PendingApproval,
+    approval_body,
 )
 
 __all__ = ["EDIT_THROTTLE_S", "TelegramBridge", "TelegramDependencyError"]
@@ -200,7 +201,7 @@ class TelegramBridge(BridgeProtocol):
         app = self._require_app()
         sent = await app.bot.send_message(
             chat_id=_to_chat_id(approval.thread_id),
-            text=f"{approval.title}\n\n{approval.body}",
+            text=f"{approval.title}\n\n{approval_body(approval)}",
             reply_markup=keyboard,
         )
         return str(sent.message_id)

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -609,6 +609,37 @@ EVENT_PROVENANCE_TAINT_DECISION = "provenance.taint_decision"
 #: text withheld) is itself anchored into the chain.
 EVENT_PROVENANCE_QUARANTINE = "provenance.quarantine"
 
+#: Issue #2511 -- emitted once per approval card v2 issuance. An approval card
+#: is a hash-committed decision record: the operator-visible envelope (action
+#: and canonical args digest, bounded reasoning digest, blast-radius impact
+#: estimate, rollback procedure with an explicit irreversible marker, and a
+#: ``not_after`` expiry) is canonicalised and hashed into ``card_hash``, and
+#: this event stores the full envelope plus ``card_hash`` and
+#: ``prev_chain_digest``. Because the whole envelope is inside the signed HMAC
+#: chain, a verifier can reconstruct exactly the fields shown to the operator
+#: and detect any post-hoc mutation: a mutated envelope no longer hashes to the
+#: recorded ``card_hash`` and no longer matches the chain HMAC. Strip the chain
+#: and the card degrades from a verifiable decision record to a message with a
+#: log.
+EVENT_APPROVAL_CARD_ISSUED = "chat.approval_card.issued"
+
+#: Issue #2511 -- emitted when an issued approval card is resolved (approve /
+#: reject) after the gate has confirmed the echoed ``card_hash`` matches the
+#: issued envelope and the decision arrived before ``not_after``. The event
+#: binds ``{card_hash, decision, approver, worktree_id, resolved_at}`` so a
+#: verifier can join the decision to the exact issued envelope and prove the
+#: operator decided against the fields that were hashed, not a divergent view.
+EVENT_APPROVAL_CARD_RESOLVED = "chat.approval_card.resolved"
+
+#: Issue #2511 -- emitted when the gate refuses to resolve an approval card:
+#: either the echoed ``card_hash`` does not match any issued envelope (a field
+#: the operator saw was mutated) or the decision arrived at or after
+#: ``not_after`` (expiry is enforced by the chain-side clock regardless of what
+#: the chat client still renders). The refusal records ``{card_hash, reason,
+#: expected_card_hash, worktree_id}`` so an operator can prove, from the chain
+#: alone, that a stale or tampered decision was contained and never executed.
+EVENT_APPROVAL_CARD_REFUSED = "chat.approval_card.refused"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -4008,6 +4039,9 @@ __all__ = [
     "EVENT_ADAPTER_FLOOR_UPDATE",
     "EVENT_ADAPTER_SPAWN_PREFLIGHT",
     "EVENT_ADAPTER_VERSION_POSTURE",
+    "EVENT_APPROVAL_CARD_ISSUED",
+    "EVENT_APPROVAL_CARD_REFUSED",
+    "EVENT_APPROVAL_CARD_RESOLVED",
     "EVENT_CHECKPOINT_RETRY",
     "EVENT_COMPACTION_RECEIPT",
     "EVENT_COMPACTION_SENSITIVE_GATE",

--- a/tests/unit/approval/test_card_inbound.py
+++ b/tests/unit/approval/test_card_inbound.py
@@ -1,0 +1,143 @@
+"""MCP elicitation + A2A input-required routing into approval cards (#2511)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from bernstein.core.approval.card_gate import ApprovalCardGate
+from bernstein.core.approval.card_inbound import (
+    A2AInputRequiredRouter,
+    ElicitationApprovalRouter,
+)
+from bernstein.core.protocols.mcp.mcp_elicitation import (
+    ElicitationHandler,
+    ElicitationRequest,
+    ElicitationStatus,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_APPROVAL_CARD_ISSUED,
+    EVENT_APPROVAL_CARD_RESOLVED,
+    AuditChainStore,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.chat.bridge import PendingApproval
+
+_KEY = b"deterministic-test-key-2511"
+
+
+class _RecordingBridge:
+    """Minimal bridge capturing push_approval payloads."""
+
+    platform = "fake"
+
+    def __init__(self) -> None:
+        self.pushed: list[PendingApproval] = []
+
+    async def push_approval(self, approval: PendingApproval) -> str:
+        self.pushed.append(approval)
+        return f"msg-{len(self.pushed)}"
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_KEY)
+
+
+# ---------------------------------------------------------------------------
+# MCP elicitation -> card (AC: elicitation with no auto-policy -> v2 card)
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_elicitation_produces_card_on_thread(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    handler = ElicitationHandler()
+    bridge = _RecordingBridge()
+    router = ElicitationApprovalRouter(handler=handler, gate=gate, bridge=bridge, thread_id="C42", worktree_id="wt-a")
+
+    request = ElicitationRequest(
+        id="e1",
+        server_name="github",
+        message="Confirm delete branch main?",
+        request_type="confirmation",
+    )
+
+    issued = asyncio.run(router.route(request, now=1_000.0))
+    assert issued is not None
+    # A card was delivered to the bound thread carrying the hashed envelope.
+    assert len(bridge.pushed) == 1
+    payload = bridge.pushed[0]
+    assert payload.thread_id == "C42"
+    assert payload.card is not None
+    assert payload.card_hash == issued.card_hash
+    # The issue event is chain-recorded.
+    events = chain.query(event_type=EVENT_APPROVAL_CARD_ISSUED)
+    assert len(events) == 1
+    assert events[0].details["card_hash"] == issued.card_hash
+
+
+def test_auto_resolved_elicitation_produces_no_card(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    handler = ElicitationHandler()
+    handler.add_auto_policy("auto-confirm", pattern="confirm", response="yes")
+    bridge = _RecordingBridge()
+    router = ElicitationApprovalRouter(handler=handler, gate=gate, bridge=bridge, thread_id="C42")
+
+    request = ElicitationRequest(
+        id="e2", server_name="github", message="Confirm safe read?", request_type="confirmation"
+    )
+    issued = asyncio.run(router.route(request, now=1_000.0))
+    assert issued is None
+    assert bridge.pushed == []
+    assert chain.query(event_type=EVENT_APPROVAL_CARD_ISSUED) == []
+
+
+def test_elicitation_response_equals_decision_and_is_chain_linked(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    handler = ElicitationHandler()
+    router = ElicitationApprovalRouter(handler=handler, gate=gate, thread_id="C42")
+
+    request = ElicitationRequest(id="e3", server_name="github", message="Provide a branch name", request_type="input")
+    issued = asyncio.run(router.route(request, now=1_000.0))
+    assert issued is not None
+
+    _, resolved = router.resolve(
+        request_id="e3", card_hash=issued.card_hash, decision="approve", approver="U7", now=1_100.0
+    )
+    assert resolved is not None
+    # The elicitation response equals the operator decision.
+    assert resolved.response == "approve"
+    assert resolved.status is ElicitationStatus.USER_RESOLVED
+    # The issue and resolved events share the card_hash: chain-linked.
+    resolved_events = chain.query(event_type=EVENT_APPROVAL_CARD_RESOLVED)
+    assert len(resolved_events) == 1
+    assert resolved_events[0].details["card_hash"] == issued.card_hash
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# A2A input-required -> card
+# ---------------------------------------------------------------------------
+
+
+def test_a2a_input_required_produces_card_and_resolves(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    bridge = _RecordingBridge()
+    router = A2AInputRequiredRouter(gate=gate, bridge=bridge, thread_id="C42", worktree_id="wt-a", peer="planner")
+
+    issued = asyncio.run(
+        router.route(task_uuid="task-123", message="Need the deploy target region", now=1_000.0),
+    )
+    assert len(bridge.pushed) == 1
+    assert bridge.pushed[0].card_hash == issued.card_hash
+
+    resolved = router.resolve(card_hash=issued.card_hash, decision="reject", approver="U7", now=1_050.0)
+    assert resolved.card_hash == issued.card_hash
+    assert chain.query(event_type=EVENT_APPROVAL_CARD_RESOLVED)

--- a/tests/unit/approval/test_card_v2.py
+++ b/tests/unit/approval/test_card_v2.py
@@ -1,0 +1,252 @@
+"""Approval card v2 envelope + chain-anchored gate (issue #2511).
+
+Covers the acceptance criteria that make the card a hash-committed decision
+record rather than a message with a log:
+
+* determinism -- identical inputs / repo state -> byte-identical envelope,
+* the envelope carries reasoning, impact estimate, rollback, and expiry,
+* a decision echoing a mutated ``card_hash`` is refused and chain-recorded,
+* expiry is enforced by the chain-side clock, including across a restart,
+* offline reconstruction rebuilds the shown fields and detects mutation,
+* a ``hard_one_way`` change carries an explicit, hashed irreversible marker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.approval.card import (
+    ApprovalCardV2,
+    build_card,
+    canonical_card_bytes,
+    card_hash,
+    render_card_text,
+)
+from bernstein.core.approval.card_gate import (
+    ApprovalCardExpired,
+    ApprovalCardGate,
+    ApprovalCardHashMismatch,
+)
+from bernstein.core.security.audit_chain import (
+    EVENT_APPROVAL_CARD_ISSUED,
+    EVENT_APPROVAL_CARD_REFUSED,
+    EVENT_APPROVAL_CARD_RESOLVED,
+    AuditChainStore,
+)
+
+_KEY = b"deterministic-test-key-2511"
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_KEY)
+
+
+def _safe_card(*, created_at: float = 1_000.0, ttl: float = 600.0) -> ApprovalCardV2:
+    return build_card(
+        approval_id="ap-safe",
+        tool_name="Edit",
+        tool_args={"file_path": "src/app.py", "new_string": "x = 1"},
+        reasoning="Add a constant used by the new endpoint.",
+        created_at=created_at,
+        ttl_seconds=ttl,
+    )
+
+
+def _destructive_card(*, created_at: float = 1_000.0, ttl: float = 600.0) -> ApprovalCardV2:
+    return build_card(
+        approval_id="ap-danger",
+        tool_name="Bash",
+        tool_args={"command": "rm -rf /var/data"},
+        reasoning="Clear the stale data directory.",
+        created_at=created_at,
+        ttl_seconds=ttl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Determinism (AC1)
+# ---------------------------------------------------------------------------
+
+
+def test_same_inputs_produce_byte_identical_envelope_and_hash() -> None:
+    a = _safe_card()
+    b = _safe_card()
+    assert canonical_card_bytes(a) == canonical_card_bytes(b)
+    assert card_hash(a) == card_hash(b)
+
+
+def test_envelope_round_trips_through_dict_preserving_hash() -> None:
+    card = _safe_card()
+    restored = ApprovalCardV2.from_dict(card.to_dict())
+    assert card_hash(restored) == card_hash(card)
+    assert canonical_card_bytes(restored) == canonical_card_bytes(card)
+
+
+def test_any_shown_field_change_changes_the_hash() -> None:
+    base = _safe_card()
+    # Mutating any operator-visible field must change the committed hash.
+    mutated_reasoning = ApprovalCardV2.from_dict({**base.to_dict(), "reasoning": "totally different intent"})
+    assert card_hash(mutated_reasoning) != card_hash(base)
+
+    envelope = base.to_dict()
+    envelope["impact"] = {**envelope["impact"], "score": envelope["impact"]["score"] + 0.5}
+    mutated_impact = ApprovalCardV2.from_dict(envelope)
+    assert card_hash(mutated_impact) != card_hash(base)
+
+
+# ---------------------------------------------------------------------------
+# Envelope content: reasoning + impact + rollback + expiry (AC content)
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_carries_reasoning_impact_rollback_expiry() -> None:
+    card = _safe_card(created_at=1_000.0, ttl=600.0)
+    assert card.reasoning
+    assert 0.0 <= card.impact.score <= 1.0
+    assert card.rollback.procedure
+    assert card.not_after == 1_600.0
+
+
+def test_render_shows_impact_rollback_and_expiry() -> None:
+    text = render_card_text(_safe_card())
+    assert "Impact:" in text
+    assert "Rollback:" in text
+    assert "Expires at:" in text
+    assert "Card hash:" in text
+
+
+# ---------------------------------------------------------------------------
+# hard_one_way -> irreversible marker inside the hashed envelope (AC7)
+# ---------------------------------------------------------------------------
+
+
+def test_hard_one_way_change_marks_irreversible_in_envelope_and_render() -> None:
+    card = _destructive_card()
+    assert card.impact.hard_one_way is True
+    assert card.rollback.irreversible is True
+    # The marker is part of the hashed envelope: flipping it changes the hash.
+    flipped = ApprovalCardV2.from_dict(
+        {**card.to_dict(), "rollback": {**card.to_dict()["rollback"], "irreversible": False}}
+    )
+    assert card_hash(flipped) != card_hash(card)
+    assert "IRREVERSIBLE" in render_card_text(card)
+
+
+# ---------------------------------------------------------------------------
+# Gate: issue emits a chain event carrying the envelope + hash
+# ---------------------------------------------------------------------------
+
+
+def test_issue_appends_chain_event_with_envelope(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain, install_id="install-A", session_id="sess-1")
+    card = _safe_card()
+    issued = gate.issue(card, worktree_id="wt-a", thread_id="C42")
+
+    events = chain.query(event_type=EVENT_APPROVAL_CARD_ISSUED)
+    assert len(events) == 1
+    details = events[0].details
+    assert details["card_hash"] == issued.card_hash == card_hash(card)
+    assert details["envelope"] == card.to_dict()
+    assert details["worktree_id"] == "wt-a"
+    assert "prev_chain_digest" in details
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# Gate: hash-echo enforcement (AC2, verifiability)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_with_matching_hash_records_resolved_event(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    card = _safe_card()
+    issued = gate.issue(card)
+    gate.resolve(card_hash=issued.card_hash, decision="approve", approver="U7", now=1_100.0)
+
+    resolved = chain.query(event_type=EVENT_APPROVAL_CARD_RESOLVED)
+    assert len(resolved) == 1
+    assert resolved[0].details["card_hash"] == issued.card_hash
+    assert resolved[0].details["decision"] == "approve"
+
+
+def test_resolve_with_mutated_hash_is_refused_and_recorded(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    card = _safe_card()
+    gate.issue(card)
+
+    # The operator "saw" a card whose impact score was tampered: its hash
+    # differs from the issued envelope's hash.
+    tampered = ApprovalCardV2.from_dict({**card.to_dict(), "impact": {**card.to_dict()["impact"], "score": 0.99}})
+    tampered_hash = card_hash(tampered)
+    assert tampered_hash != card_hash(card)
+
+    with pytest.raises(ApprovalCardHashMismatch):
+        gate.resolve(card_hash=tampered_hash, decision="approve", approver="U7", now=1_100.0)
+
+    # No resolution happened; a refusal is chain-recorded so the tool call
+    # provably did not proceed.
+    assert chain.query(event_type=EVENT_APPROVAL_CARD_RESOLVED) == []
+    refused = chain.query(event_type=EVENT_APPROVAL_CARD_REFUSED)
+    assert len(refused) == 1
+    assert refused[0].details["reason"] == "hash_mismatch"
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# Gate: chain-side expiry enforcement, including across a restart (AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_after_not_after_is_refused(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    gate = ApprovalCardGate(chain)
+    card = _safe_card(created_at=1_000.0, ttl=600.0)  # not_after == 1600
+    issued = gate.issue(card)
+
+    with pytest.raises(ApprovalCardExpired):
+        gate.resolve(card_hash=issued.card_hash, decision="approve", now=1_600.0)
+
+    assert chain.query(event_type=EVENT_APPROVAL_CARD_RESOLVED) == []
+    refused = chain.query(event_type=EVENT_APPROVAL_CARD_REFUSED)
+    assert len(refused) == 1
+    assert refused[0].details["reason"] == "expired"
+
+
+def test_expiry_enforced_after_chat_process_restart(tmp_path: Path) -> None:
+    # Issue on one gate/process.
+    chain1 = _chain(tmp_path)
+    gate1 = ApprovalCardGate(chain1)
+    card = _safe_card(created_at=1_000.0, ttl=600.0)
+    issued = gate1.issue(card)
+
+    # A fresh gate over a fresh chain store on the same audit dir models a
+    # chat-process restart: it holds no in-memory issued cards. It must still
+    # refuse the expired approve by reconstructing the envelope from the chain.
+    chain2 = _chain(tmp_path)
+    gate2 = ApprovalCardGate(chain2)
+    with pytest.raises(ApprovalCardExpired):
+        gate2.resolve(card_hash=issued.card_hash, decision="approve", now=1_700.0)
+
+    refused = chain2.query(event_type=EVENT_APPROVAL_CARD_REFUSED)
+    assert len(refused) == 1
+    assert refused[0].details["reason"] == "expired"
+
+
+def test_resolve_still_works_after_restart_before_expiry(tmp_path: Path) -> None:
+    chain1 = _chain(tmp_path)
+    gate1 = ApprovalCardGate(chain1)
+    issued = gate1.issue(_safe_card(created_at=1_000.0, ttl=600.0))
+
+    chain2 = _chain(tmp_path)
+    gate2 = ApprovalCardGate(chain2)
+    # Before not_after, a reconstructed card resolves cleanly.
+    resolved = gate2.resolve(card_hash=issued.card_hash, decision="approve", now=1_200.0)
+    assert resolved.card_hash == issued.card_hash
+    assert chain2.query(event_type=EVENT_APPROVAL_CARD_RESOLVED)

--- a/tests/unit/approval/test_card_verify.py
+++ b/tests/unit/approval/test_card_verify.py
@@ -1,0 +1,94 @@
+"""Offline verification of resolved approval cards (issue #2511, AC4)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.approval.card import build_card
+from bernstein.core.approval.card_gate import ApprovalCardGate
+from bernstein.core.approval.card_verify import verify_approval_cards
+from bernstein.core.security.audit_chain import (
+    EVENT_APPROVAL_CARD_ISSUED,
+    AuditChainStore,
+)
+
+_KEY = b"deterministic-test-key-2511"
+
+
+def _card(approval_id: str = "ap-1", *, created_at: float = 1_000.0, ttl: float = 600.0):
+    return build_card(
+        approval_id=approval_id,
+        tool_name="Edit",
+        tool_args={"file_path": "src/app.py", "new_string": "x = 1"},
+        reasoning="Add a constant.",
+        created_at=created_at,
+        ttl_seconds=ttl,
+    )
+
+
+def _issue_and_resolve(tmp_path: Path) -> str:
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    gate = ApprovalCardGate(chain)
+    issued = gate.issue(_card())
+    gate.resolve(card_hash=issued.card_hash, decision="approve", approver="U7", now=1_100.0)
+    return issued.card_hash
+
+
+def test_verify_passes_for_clean_resolved_card(tmp_path: Path) -> None:
+    _issue_and_resolve(tmp_path)
+    result = verify_approval_cards(tmp_path / "audit", key=_KEY)
+    assert result.ok, result.errors
+    assert result.issued_count == 1
+    assert result.reconstructed_count == 1
+
+
+def test_verify_noop_when_no_cards(tmp_path: Path) -> None:
+    # A chain with unrelated activity but no approval cards must pass silently.
+    chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    chain.log(event_type="unrelated.event", actor="x", resource_type="thing", resource_id="1", details={})
+    result = verify_approval_cards(tmp_path / "audit", key=_KEY)
+    assert result.ok
+    assert result.issued_count == 0
+    assert result.resolved_count == 0
+
+
+def test_verify_detects_post_hoc_envelope_mutation(tmp_path: Path) -> None:
+    _issue_and_resolve(tmp_path)
+    audit_dir = tmp_path / "audit"
+    log_files = sorted(audit_dir.glob("*.jsonl"))
+    assert log_files, "expected an audit jsonl file"
+    path = log_files[0]
+
+    # Tamper the stored envelope's impact score, leaving card_hash unchanged.
+    lines = path.read_text(encoding="utf-8").splitlines()
+    tampered = False
+    out: list[str] = []
+    for line in lines:
+        entry = json.loads(line)
+        if entry.get("event_type") == EVENT_APPROVAL_CARD_ISSUED:
+            entry["details"]["envelope"]["impact"]["score"] = 0.999
+            tampered = True
+        out.append(json.dumps(entry, sort_keys=True))
+    assert tampered
+    path.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+    result = verify_approval_cards(audit_dir, key=_KEY)
+    assert not result.ok
+    assert any("mutated" in err for err in result.errors)
+
+
+def test_verify_detects_resolved_without_issued(tmp_path: Path) -> None:
+    audit_dir = tmp_path / "audit"
+    chain = AuditChainStore(audit_dir, key=_KEY)
+    # A resolved event that references a card_hash never issued must fail.
+    chain.log_with_prev_digest(
+        event_type="chat.approval_card.resolved",
+        actor="U7",
+        resource_type="approval_card",
+        resource_id="deadbeef",
+        details={"card_hash": "deadbeef", "decision": "approve", "resolved_at": 1_100.0},
+    )
+    result = verify_approval_cards(audit_dir, key=_KEY)
+    assert not result.ok
+    assert any("no matching issued" in err for err in result.errors)

--- a/tests/unit/cli/test_audit_verify_cards.py
+++ b/tests/unit/cli/test_audit_verify_cards.py
@@ -1,0 +1,64 @@
+"""``bernstein audit verify`` includes resolved approval cards (issue #2511).
+
+A resolved approval must be re-checkable offline: a mutated stored envelope, a
+decision echoing an unknown ``card_hash``, or a decision after expiry must make
+``bernstein audit verify`` fail. When no cards exist the check is a silent
+no-op that does not affect the exit code.
+"""
+
+from __future__ import annotations
+
+import json
+
+from bernstein.cli.commands import audit_cmd
+from bernstein.core.approval.card import build_card
+from bernstein.core.approval.card_gate import ApprovalCardGate
+from bernstein.core.security.audit_chain import (
+    EVENT_APPROVAL_CARD_ISSUED,
+    AuditChainStore,
+)
+
+_KEY = b"k" * 32
+
+
+def _seed(audit_dir) -> str:
+    chain = AuditChainStore(audit_dir, key=_KEY)
+    gate = ApprovalCardGate(chain)
+    card = build_card(
+        approval_id="ap-1",
+        tool_name="Edit",
+        tool_args={"file_path": "src/app.py", "new_string": "x = 1"},
+        reasoning="Add a constant.",
+        created_at=1_000.0,
+        ttl_seconds=600.0,
+    )
+    issued = gate.issue(card)
+    gate.resolve(card_hash=issued.card_hash, decision="approve", approver="U7", now=1_100.0)
+    return issued.card_hash
+
+
+def test_verify_approval_cards_passes_for_intact(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    _seed(tmp_path)
+    assert audit_cmd._verify_approval_cards() is True
+
+
+def test_verify_approval_cards_noop_when_absent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    assert audit_cmd._verify_approval_cards() is True
+
+
+def test_verify_approval_cards_fails_for_tampered_envelope(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(audit_cmd, "AUDIT_DIR", tmp_path)
+    _seed(tmp_path)
+
+    log_file = next(iter(sorted(tmp_path.glob("*.jsonl"))))
+    out: list[str] = []
+    for line in log_file.read_text(encoding="utf-8").splitlines():
+        entry = json.loads(line)
+        if entry.get("event_type") == EVENT_APPROVAL_CARD_ISSUED:
+            entry["details"]["envelope"]["rollback"]["procedure"] = "rewritten after the fact"
+        out.append(json.dumps(entry, sort_keys=True))
+    log_file.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+    assert audit_cmd._verify_approval_cards() is False

--- a/tests/unit/core/chat/test_teams_driver.py
+++ b/tests/unit/core/chat/test_teams_driver.py
@@ -1,0 +1,497 @@
+"""Unit tests for the Microsoft Teams driver (issue #2511).
+
+The Teams driver must pass the same driver contract as Slack, Discord, and
+Telegram:
+
+* token / app-password validation
+* missing-SDK error path
+* command dispatch
+* card-action decode (approve / reject)
+* push_approval renders a Teams-native Adaptive Card with two submit actions
+* edit debounce (rate-limit guard)
+* outbound message signature verification
+* cross-worktree approval rejection
+* audit-chain entry shape for approvals
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.chat.bridge import ChatMessage, PendingApproval
+
+# ---------------------------------------------------------------------------
+# Fake botframework connector SDK
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _FakeConnectorClient:
+    """Records every outbound Bot Framework call."""
+
+    credentials: Any = None
+    base_url: str | None = None
+    sent: list[dict[str, Any]] = field(default_factory=list)
+    updated: list[dict[str, Any]] = field(default_factory=list)
+    counter: int = 0
+
+    async def send_activity(self, conversation_id: str, activity: dict[str, Any]) -> dict[str, Any]:
+        self.counter += 1
+        activity_id = f"act-{self.counter}"
+        self.sent.append({"conversation_id": conversation_id, "activity": activity, "id": activity_id})
+        return {"id": activity_id}
+
+    async def update_activity(self, conversation_id: str, activity_id: str, activity: dict[str, Any]) -> dict[str, Any]:
+        self.updated.append({"conversation_id": conversation_id, "activity_id": activity_id, "activity": activity})
+        return {"id": activity_id}
+
+
+@dataclass(slots=True)
+class _FakeCredentials:
+    app_id: str = ""
+    app_password: str = ""
+
+
+@pytest.fixture
+def fake_teams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a synthetic ``botframework`` tree in ``sys.modules``."""
+    connector = types.ModuleType("botframework.connector")
+    connector.ConnectorClient = _FakeConnectorClient  # type: ignore[attr-defined]
+
+    auth = types.ModuleType("botframework.connector.auth")
+    auth.MicrosoftAppCredentials = _FakeCredentials  # type: ignore[attr-defined]
+
+    connector.auth = auth  # type: ignore[attr-defined]
+
+    pkg = types.ModuleType("botframework")
+    pkg.connector = connector  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "botframework", pkg)
+    monkeypatch.setitem(sys.modules, "botframework.connector", connector)
+    monkeypatch.setitem(sys.modules, "botframework.connector.auth", auth)
+
+
+# ---------------------------------------------------------------------------
+# Constructor / token validation
+# ---------------------------------------------------------------------------
+
+
+def test_teams_empty_app_id_rejected() -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    with pytest.raises(ValueError):
+        TeamsBridge(token="", app_password="secret")
+
+
+def test_teams_empty_app_password_rejected() -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    with pytest.raises(ValueError):
+        TeamsBridge(token="app-id", app_password="")
+
+
+# ---------------------------------------------------------------------------
+# Missing-SDK error path
+# ---------------------------------------------------------------------------
+
+
+def test_teams_start_without_sdk_raises_structured_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge, TeamsDependencyError
+
+    for modname in list(sys.modules):
+        if modname == "botframework" or modname.startswith("botframework."):
+            monkeypatch.delitem(sys.modules, modname, raising=False)
+    monkeypatch.setitem(sys.modules, "botframework", None)  # type: ignore[arg-type]
+
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+    with pytest.raises(TeamsDependencyError) as excinfo:
+        asyncio.run(bridge.start())
+    assert "bernstein[teams]" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Command dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_teams_message_routes_to_registered_handler(fake_teams: None) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    received: list[ChatMessage] = []
+
+    async def handler(msg: ChatMessage) -> None:  # NOSONAR
+        received.append(msg)
+
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+    bridge.on_command("run", handler)
+
+    async def scenario() -> None:
+        await bridge.start()
+        await bridge.handle_activity(_message_activity(text='run "Add JWT auth"', conversation="C42", user="U7"))
+        await bridge.stop()
+
+    asyncio.run(scenario())
+    assert len(received) == 1
+    assert received[0].thread_id == "C42"
+    assert received[0].user_id == "U7"
+
+
+def test_teams_message_ignores_unknown_subcommand(fake_teams: None) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+
+    async def scenario() -> None:
+        await bridge.start()
+        await bridge.handle_activity(_message_activity(text="nope", conversation="C42", user="U7"))
+        await bridge.stop()
+
+    asyncio.run(scenario())
+
+
+# ---------------------------------------------------------------------------
+# Card-action decode (approve / reject)
+# ---------------------------------------------------------------------------
+
+
+def test_teams_card_action_decode_round_trip(fake_teams: None) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    decisions: list[tuple[str, str, str]] = []
+
+    async def button(thread_id: str, approval_id: str, decision: str) -> None:  # NOSONAR
+        decisions.append((thread_id, approval_id, decision))
+
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+    bridge.on_button(button)
+
+    async def scenario() -> None:
+        await bridge.start()
+        await bridge.handle_activity(_card_action(action="approve", approval_id="t-42", conversation="C99"))
+        await bridge.handle_activity(_card_action(action="reject", approval_id="t-43", conversation="C99"))
+        await bridge.stop()
+
+    asyncio.run(scenario())
+    assert decisions == [("C99", "t-42", "approve"), ("C99", "t-43", "reject")]
+
+
+def test_teams_card_action_ignores_unknown_action(fake_teams: None) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    decisions: list[tuple[str, str, str]] = []
+
+    async def button(thread_id: str, approval_id: str, decision: str) -> None:  # NOSONAR
+        decisions.append((thread_id, approval_id, decision))
+
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+    bridge.on_button(button)
+
+    async def scenario() -> None:
+        await bridge.start()
+        await bridge.handle_activity(_card_action(action="snooze", approval_id="t-42", conversation="C99"))
+        await bridge.stop()
+
+    asyncio.run(scenario())
+    assert decisions == []
+
+
+# ---------------------------------------------------------------------------
+# push_approval renders an Adaptive Card
+# ---------------------------------------------------------------------------
+
+
+def test_teams_push_approval_renders_adaptive_card(fake_teams: None) -> None:
+    from bernstein.core.chat.drivers.teams import ADAPTIVE_CARD_CONTENT_TYPE, TeamsBridge
+
+    bridge = TeamsBridge(token="app-id", app_password="secret", install_id="install-test", session_id="sess-1")
+
+    async def scenario() -> list[dict[str, Any]]:
+        await bridge.start()
+        await bridge.push_approval(
+            PendingApproval(
+                approval_id="t-7",
+                title="Approve shell command?",
+                body="rm -rf /tmp/scratch",
+                thread_id="C42",
+            ),
+        )
+        sent = list(bridge._client.sent)  # type: ignore[attr-defined]
+        await bridge.stop()
+        return sent
+
+    sent = asyncio.run(scenario())
+    assert len(sent) == 1
+    attachments = sent[0]["activity"]["attachments"]
+    assert attachments[0]["contentType"] == ADAPTIVE_CARD_CONTENT_TYPE
+    actions = attachments[0]["content"]["actions"]
+    assert [a["data"]["action"] for a in actions] == ["approve", "reject"]
+    assert [a["data"]["approval_id"] for a in actions] == ["t-7", "t-7"]
+
+
+def test_teams_push_approval_renders_v2_card_verbatim(fake_teams: None) -> None:
+    from bernstein.core.approval.card import build_card, card_hash, render_card_text
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    card = build_card(
+        approval_id="t-9",
+        tool_name="Bash",
+        tool_args={"command": "rm -rf /var/data"},
+        reasoning="Clear stale data.",
+        created_at=1_000.0,
+        ttl_seconds=600.0,
+    )
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+
+    async def scenario() -> dict[str, Any]:
+        await bridge.start()
+        await bridge.push_approval(
+            PendingApproval(
+                approval_id="t-9",
+                title="Approve?",
+                body="ignored-when-card-present",
+                thread_id="C42",
+                card=card,
+                card_hash=card_hash(card),
+            ),
+        )
+        sent = bridge._client.sent[0]  # type: ignore[attr-defined]
+        await bridge.stop()
+        return sent
+
+    sent = asyncio.run(scenario())
+    body_blocks = sent["activity"]["attachments"][0]["content"]["body"]
+    rendered = body_blocks[1]["text"]
+    # The card body is the verbatim projection of the hashed envelope.
+    assert rendered == render_card_text(card)
+    assert "IRREVERSIBLE" in rendered
+    assert card_hash(card) in rendered
+
+
+# ---------------------------------------------------------------------------
+# Edit debounce
+# ---------------------------------------------------------------------------
+
+
+def test_teams_edit_debounce_collapses_rapid_updates(fake_teams: None) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+
+    bridge = TeamsBridge(token="app-id", app_password="secret")
+
+    async def scenario() -> list[dict[str, Any]]:
+        await bridge.start()
+        for i in range(5):
+            await bridge.edit_message("C42", "act-1", f"tick {i}")
+        edits = list(bridge._client.updated)  # type: ignore[attr-defined]
+        await bridge.stop()
+        return edits
+
+    edits = asyncio.run(scenario())
+    assert len(edits) == 1, f"expected a single throttled edit, got {edits}"
+    assert edits[0]["activity"]["text"] == "tick 0"
+
+
+# ---------------------------------------------------------------------------
+# Outbound message signing
+# ---------------------------------------------------------------------------
+
+
+def test_teams_send_message_includes_signed_envelope(fake_teams: None, tmp_path: Path) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge, verify_chat_signature
+
+    bridge = TeamsBridge(
+        token="app-id",
+        app_password="secret",
+        install_id="install-A",
+        session_id="sess-1",
+        key_dir=tmp_path / "keys-A",
+    )
+
+    async def scenario() -> dict[str, Any]:
+        await bridge.start()
+        await bridge.send_message("C42", "hello operator")
+        sent = bridge._client.sent[0]  # type: ignore[attr-defined]
+        await bridge.stop()
+        return sent
+
+    sent = asyncio.run(scenario())
+    assert "hello operator" in sent["activity"]["text"]
+    payload = sent["activity"]["channelData"]["bernstein"]
+    assert payload["install_id"] == "install-A"
+    assert payload["session_id"] == "sess-1"
+    assert verify_chat_signature(
+        install_id="install-A",
+        session_id="sess-1",
+        content="hello operator",
+        signature=payload["signature"],
+        public_key_pem=bridge.public_key_pem(),
+    )
+
+
+def test_teams_signature_rejects_foreign_install(fake_teams: None, tmp_path: Path) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge, verify_chat_signature
+
+    bridge_a = TeamsBridge(
+        token="app-a",
+        app_password="secret",
+        install_id="install-A",
+        session_id="sess-1",
+        key_dir=tmp_path / "keys-A",
+    )
+    bridge_b = TeamsBridge(
+        token="app-b",
+        app_password="secret",
+        install_id="install-B",
+        session_id="sess-2",
+        key_dir=tmp_path / "keys-B",
+    )
+
+    async def scenario() -> tuple[str, bytes]:
+        await bridge_a.start()
+        await bridge_b.start()
+        await bridge_b.send_message("C42", "spoofed")
+        sig = bridge_b._client.sent[0]["activity"]["channelData"]["bernstein"]["signature"]  # type: ignore[attr-defined]
+        pub_a = bridge_a.public_key_pem()
+        await bridge_a.stop()
+        await bridge_b.stop()
+        return sig, pub_a
+
+    foreign_signature, public_key_a = asyncio.run(scenario())
+    assert not verify_chat_signature(
+        install_id="install-B",
+        session_id="sess-2",
+        content="spoofed",
+        signature=foreign_signature,
+        public_key_pem=public_key_a,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit-chain entry shape for approvals
+# ---------------------------------------------------------------------------
+
+
+def test_teams_approval_audit_chain_entry_shape(fake_teams: None, tmp_path: Path) -> None:
+    from bernstein.core.chat.drivers.teams import TeamsBridge
+    from bernstein.core.security.audit import AuditLog
+
+    audit = AuditLog(audit_dir=tmp_path / "audit", key=b"deterministic-test-key")
+    bridge = TeamsBridge(
+        token="app-id",
+        app_password="secret",
+        install_id="install-A",
+        session_id="sess-1",
+        worktree_id="wt-a",
+        audit_log=audit,
+        key_dir=tmp_path / "keys-A",
+    )
+
+    async def scenario() -> None:
+        await bridge.start()
+        bridge.register_pending_approval(
+            approval_id="t-7",
+            tool_call_hash="hash-of-tool-call",
+            worktree_id="wt-a",
+            thread_id="C42",
+        )
+        await bridge.handle_activity(
+            _card_action(action="approve", approval_id="t-7", conversation="C42", user="U7", activity_id="act-x"),
+        )
+        await bridge.stop()
+
+    asyncio.run(scenario())
+
+    entries = audit.query(event_type="chat.teams.approval")
+    assert len(entries) == 1
+    details = entries[0].details
+    assert details["approver"] == "U7"
+    assert details["decision"] == "approve"
+    assert details["tool_call_hash"] == "hash-of-tool-call"
+    assert details["activity_id"] == "act-x"
+    assert details["worktree_id"] == "wt-a"
+    valid, errors = audit.verify()
+    assert valid, errors
+
+
+# ---------------------------------------------------------------------------
+# Worktree pinning -- cross-worktree rejection
+# ---------------------------------------------------------------------------
+
+
+def test_teams_cross_worktree_approval_rejected(fake_teams: None, tmp_path: Path) -> None:
+    from bernstein.core.chat.drivers.teams import CrossWorktreeApprovalError, TeamsBridge
+    from bernstein.core.security.audit import AuditLog
+
+    audit = AuditLog(audit_dir=tmp_path / "audit", key=b"deterministic-test-key")
+    bridge = TeamsBridge(
+        token="app-id",
+        app_password="secret",
+        install_id="install-A",
+        session_id="sess-1",
+        worktree_id="wt-a",
+        audit_log=audit,
+        key_dir=tmp_path / "keys-A",
+    )
+
+    async def scenario() -> bool:
+        await bridge.start()
+        bridge.register_pending_approval(
+            approval_id="t-7",
+            tool_call_hash="hash-of-tool-call",
+            worktree_id="wt-b",
+            thread_id="C42",
+        )
+        try:
+            await bridge.handle_activity(
+                _card_action(action="approve", approval_id="t-7", conversation="C42", user="U7"),
+            )
+        except CrossWorktreeApprovalError:
+            raised = True
+        else:
+            raised = False
+        await bridge.stop()
+        return raised
+
+    raised = asyncio.run(scenario())
+    assert raised, "approve from a different worktree must be rejected"
+    assert audit.query(event_type="chat.teams.approval") == []
+    rejected = audit.query(event_type="chat.teams.approval_rejected")
+    assert len(rejected) == 1
+    assert rejected[0].details["reason"] == "cross_worktree"
+
+
+# ---------------------------------------------------------------------------
+# Activity helpers
+# ---------------------------------------------------------------------------
+
+
+def _message_activity(*, text: str, conversation: str, user: str) -> dict[str, Any]:
+    return {
+        "type": "message",
+        "text": text,
+        "conversation": {"id": conversation},
+        "from": {"id": user},
+    }
+
+
+def _card_action(
+    *,
+    action: str,
+    approval_id: str,
+    conversation: str,
+    user: str = "U7",
+    activity_id: str = "act-1",
+) -> dict[str, Any]:
+    return {
+        "type": "message",
+        "id": activity_id,
+        "conversation": {"id": conversation},
+        "from": {"id": user},
+        "value": {"action": action, "approval_id": approval_id},
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -416,6 +416,10 @@ slack = [
 spiffe = [
     { name = "spiffe" },
 ]
+teams = [
+    { name = "aiohttp" },
+    { name = "botbuilder-core" },
+]
 telegram = [
     { name = "python-telegram-bot" },
 ]
@@ -451,10 +455,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9" },
+    { name = "aiohttp", marker = "extra == 'teams'", specifier = ">=3.9" },
     { name = "asn1crypto", specifier = ">=1.5" },
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.20" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "beartype", marker = "extra == 'dev'", specifier = ">=0.21" },
+    { name = "botbuilder-core", marker = "extra == 'teams'", specifier = ">=4.15" },
     { name = "boto3", marker = "extra == 'r2'", specifier = ">=1.43.6" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.43.6" },
     { name = "click", specifier = ">=8.3.3" },
@@ -530,7 +536,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "grpc", "k8s", "spiffe", "ml", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2", "telegram", "slack", "discord", "eval", "gui", "otel", "observability"]
+provides-extras = ["dev", "grpc", "k8s", "spiffe", "ml", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2", "telegram", "slack", "discord", "teams", "eval", "gui", "otel", "observability"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -567,6 +573,58 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "botbuilder-core"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+    { name = "botframework-streaming" },
+    { name = "jsonpickle" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/11/cd231b48525e6b34a11cf211db110a95e901204f141c1633bdcbfe1866f1/botbuilder_core-4.17.1-py3-none-any.whl", hash = "sha256:b0a5eea6ce9759dba0847adeed0587fec83ce069f3b4938eb348bb44becde8d7", size = 116145, upload-time = "2026-01-05T19:49:41.946Z" },
+]
+
+[[package]]
+name = "botbuilder-schema"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msrest" },
+    { name = "urllib3" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/44/abac81a80ed8aea977afbf8c40c22dec11610bbc1e4bd5bff4a7d7386b94/botbuilder_schema-4.17.1-py2.py3-none-any.whl", hash = "sha256:34da28d721b0635fc41bbe3b368225b9883f527d6f17337f858efe80f74656eb", size = 38196, upload-time = "2026-01-05T19:49:45.501Z" },
+]
+
+[[package]]
+name = "botframework-connector"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "msal" },
+    { name = "msrest" },
+    { name = "pyjwt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/37/6c325f4e6441cba2b3184e6c9a15c3ddc00b5e5aa47966398c3d9836b598/botframework_connector-4.17.1-py2.py3-none-any.whl", hash = "sha256:929d242a242f16c7c637eec7c239a84fd7f5f5bb7f95968407d3a9aa9d7bdf8d", size = 100883, upload-time = "2026-01-05T19:49:48.285Z" },
+]
+
+[[package]]
+name = "botframework-streaming"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/67/16b1a40b9bdc6288d90f17a464fca457e1e50cc36f1c25bc6265bcdffefe/botframework_streaming-4.17.1-py3-none-any.whl", hash = "sha256:66ad1cfe24c8c6b1fde8f95131e39e01197158e7e0bab797dfa709b4f905deb3", size = 41951, upload-time = "2026-01-05T19:49:50.245Z" },
 ]
 
 [[package]]
@@ -1994,6 +2052,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpickle"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/d9/05365407d3312653498001adcebe64a14024f7189691b728610209991c46/jsonpickle-3.4.2.tar.gz", hash = "sha256:2efa2778859b6397d5804b0a98d52cd2a7d9a70fcb873bc5a3ca5acca8f499ba", size = 314339, upload-time = "2024-11-06T07:48:25.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/a3/e610ae0feba3e7374da08ab6cc9bb76c8bfa84b4e502aa357bda0ef6dcae/jsonpickle-3.4.2-py3-none-any.whl", hash = "sha256:fd6c273278a02b3b66e3405db3dd2f4dbc8f4a4a3123bfcab3045177c6feb9c3", size = 46256, upload-time = "2024-11-06T07:48:22.923Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2430,6 +2497,20 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2479,6 +2560,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
     { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
     { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
+name = "msrest"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "certifi" },
+    { name = "isodate" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384, upload-time = "2022-06-13T22:41:22.42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The chat approval card becomes a hash-committed decision record. The whole
decision context the operator sees is canonicalised, hashed, and appended to
the HMAC audit chain, so a postmortem can prove not just what was approved but
what the approver was told at decision time.

## What landed

### Envelope and gate
- `ApprovalCardV2` canonical envelope in `src/bernstein/core/approval/card.py`:
  action plus a canonical args digest, a bounded reasoning digest, a
  blast-radius impact estimate (score, fired detectors, rationale from
  `score_change`), a rollback plan with an explicit `irreversible` marker when
  a `hard_one_way` detector fires, and a `not_after` expiry. `card_hash` is the
  SHA-256 over the canonical JSON of the envelope.
- `ApprovalCardGate` in `src/bernstein/core/approval/card_gate.py`: issuing
  appends `chat.approval_card.issued` (constant in `audit_chain.py`) carrying
  the full envelope, `card_hash`, and `prev_chain_digest`. Resolving requires a
  matching `card_hash` echo and enforces `not_after` by the chain-side clock;
  a hash mismatch or an expired decision records `chat.approval_card.refused`
  and leaves the tool call un-executed. Expiry survives a chat-process restart
  because the gate reconstructs issued cards from the chain.

### Drivers
- Slack, Discord, and Telegram render the envelope verbatim (no driver-local
  re-summarisation), so what is displayed is exactly what was hashed.
- New Microsoft Teams driver in `src/bernstein/core/chat/drivers/teams.py` over
  the Bot Framework: Adaptive Cards, the same attested approval events,
  worktree pinning, and Ed25519 outbound signing (envelope shared with Slack).
  Wired into `load_driver` and `chat serve --platform=teams`; ships as optional
  extra `bernstein[teams]`.

### MCP and A2A inbound
- MCP elicitations with no matching auto-policy and A2A `input-required` route
  into the same pipeline via `src/bernstein/core/approval/card_inbound.py`. The
  elicitation response equals the operator decision, and the issue and resolve
  events are chain-linked by `card_hash`.

### Offline verification
- `bernstein audit verify` reconstructs every resolved card from the issue
  event, confirms the stored envelope still hashes to its recorded `card_hash`
  (detecting post-hoc mutation), confirms the decision echoed an issued
  envelope, and confirms it landed before expiry.

### Docs
- Approval card reference and Teams setup guide under `docs/integrations/`.

## Tests
- New: `tests/unit/approval/test_card_v2.py`,
  `tests/unit/approval/test_card_inbound.py`,
  `tests/unit/approval/test_card_verify.py`,
  `tests/unit/core/chat/test_teams_driver.py`,
  `tests/unit/cli/test_audit_verify_cards.py`.
- Determinism, hash-echo refusal, chain-enforced expiry across a restart,
  offline reconstruction plus mutation detection, the Teams driver contract
  (cross-worktree rejection, signature verification), and the MCP/A2A mapping
  are all covered. Relevant existing chat, approval, MCP, A2A, and audit suites
  stay green. ruff check and ruff format --check are clean; new modules are
  pyright-clean.

Closes #2511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft Teams chat integration with interactive Adaptive Card approvals, signed messages, audit logging, and worktree safeguards.
  * Introduced hash-committed Approval Cards v2 with impact, rollback, irreversible-action indicators, and expiry enforcement.
  * Routed MCP elicitation and A2A input-required prompts through the approval-card workflow.
  * Added offline approval-card integrity checks to `bernstein audit verify`.

* **Documentation**
  * Added Approval Cards v2 and Microsoft Teams setup guides, with updated documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->