### PR TITLE
feat(orchestration): add receipt-backed fleet steering (pause, guidance, redirect, abort)

### DIFF
--- a/docs/release-notes/v3.6.0.md
+++ b/docs/release-notes/v3.6.0.md
@@ -98,3 +98,40 @@ close that gap.
   blocked); a blocking policy is opt-in.
 
 See `docs/operations/intent-capsules.md`.
+
+## Orchestration: receipt-backed fleet steering (#2508)
+
+Once a worker was running a task an operator had no mid-task controls: no pause,
+no way to queue guidance, no redirect of the objective, no clean abort. The only
+recourse was to abort the whole run and respawn, losing the budget already spent,
+or to edit files under a running worker and leave no record, so an audited run a
+human touched could no longer be explained end to end. Fleet steering closes that
+gap without weakening the run's verifiability: every action is a receipt first
+and an effect second.
+
+- Five steering kinds (`pause`, `resume`, `guidance`, `redirect`, `abort`) each
+  record a signed `steering.receipt` on the HMAC audit chain before any effect
+  runs. The delivered effect references that receipt's chain HMAC, so an effect
+  with no matching receipt is rejected; the receipt binds the exact command
+  payload the operator confirmed, and a request whose confirmed payload differs
+  from the executed command fails before the chain is touched.
+- Delivery rides the existing task mailbox journal as new `steer.*` message
+  kinds, so queued guidance reaches the worker in chain append order, exactly
+  once, even mid-tool-call. The worker records each consumed steering message as
+  a first-class step in the per-step journal, so a steered run replays
+  byte-identically and a second host walking the same journal computes identical
+  step hashes.
+- Divergence detection distinguishes an operator-steered run from a tampered one:
+  a run that verifies and carries steering steps is `steered`; mutating a
+  recorded receipt or steering step fails verification at exactly its chain
+  position and is labelled `tampered`.
+- Pause checkpoints the running worker and parks its claim; resume continues from
+  the checkpoint without restarting the task. Abort is enforced by the scheduler
+  on the worker process through a filesystem stop signal, never routed through
+  the model, and touches only the target session, so steering one worker leaves
+  other workers' worktrees and claims untouched.
+- Steering requires an authorised `operator`-scoped dashboard token; a `viewer`
+  token or a request with no valid credential is recorded in the denial tracker
+  and rejected. Surfaces: `POST /tasks/{task_id}/steer`, the `bernstein fleet
+  steer` CLI subcommand, and steering controls with a queued-guidance indicator
+  on the fleet screen.

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
 import click
+import httpx
 from rich.console import Console
 from rich.table import Table
 
@@ -329,6 +331,102 @@ def ls_cmd(ctx: click.Context) -> None:
         table.add_row(project.name, str(project.path), project.task_server_url)
     _console.print(table)
     _print_config_errors(config)
+
+
+# ---------------------------------------------------------------------------
+# Receipt-backed steering of a single running worker (#2508)
+# ---------------------------------------------------------------------------
+
+
+def _post_steer(server_url: str, token: str | None, task_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """POST a steering command to a task server and return the receipt."""
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    resp = httpx.post(f"{server_url}/tasks/{task_id}/steer", json=payload, timeout=10.0, headers=headers)
+    resp.raise_for_status()
+    return resp.json()  # type: ignore[no-any-return]
+
+
+@fleet_group.command("steer")
+@click.argument("task_id")
+@click.argument("kind", type=click.Choice(["pause", "resume", "guidance", "redirect", "abort"]))
+@click.option("--guidance", default="", help="Guidance text (guidance kind).")
+@click.option("--redirect-target", "redirect_target", default="", help="New objective (redirect kind).")
+@click.option("--reason", default="", help="Human-readable reason (pause / abort).")
+@click.option("--session-id", "session_id", default="", help="Target worker session (pause / abort).")
+@click.option("--adapter", default="", help="Adapter owning the session (pause checkpoint).")
+@click.option("--worktree", default="", help="Worktree path (pause checkpoint baseline).")
+@click.option("--principal", default="", help="Declared operator seat (loopback attribution only).")
+@click.option("--server", "server_url", default=None, help="Task server URL (default $BERNSTEIN_SERVER_URL).")
+@click.option("--token", default=None, help="Operator scoped token (default $BERNSTEIN_AUTH_TOKEN).")
+@click.option("--json", "as_json", is_flag=True, help="Emit the raw receipt JSON.")
+def steer_cmd(
+    task_id: str,
+    kind: str,
+    guidance: str,
+    redirect_target: str,
+    reason: str,
+    session_id: str,
+    adapter: str,
+    worktree: str,
+    principal: str,
+    server_url: str | None,
+    token: str | None,
+    as_json: bool,
+) -> None:
+    """Steer one running worker: pause, resume, guidance, redirect, or abort.
+
+    The action is a receipt first and an effect second. The confirmed
+    payload hash is computed locally and sent to the server, which binds it
+    into the audit chain before any effect runs and returns the receipt the
+    delivered effect references. A mismatch between the locally shown payload
+    and the executed command is rejected by the server.
+    """
+    from bernstein.cli.helpers import SERVER_URL
+    from bernstein.core.orchestration.steering import InvalidSteeringCommand, SteeringCommand
+
+    server = server_url or SERVER_URL
+    auth = token or os.environ.get("BERNSTEIN_AUTH_TOKEN")
+    command = SteeringCommand(
+        kind=kind,
+        task_id=task_id,
+        principal=principal or "cli-operator",
+        guidance=guidance,
+        redirect_target=redirect_target,
+        reason=reason,
+        session_id=session_id,
+        adapter=adapter,
+        worktree=worktree,
+    )
+    try:
+        command.validate()
+    except InvalidSteeringCommand as exc:
+        raise click.ClickException(str(exc)) from None
+
+    payload = {
+        "kind": kind,
+        "principal": principal,
+        "guidance": guidance,
+        "redirect_target": redirect_target,
+        "reason": reason,
+        "session_id": session_id,
+        "adapter": adapter,
+        "worktree": worktree,
+        "displayed_payload_hash": command.payload_hash(),
+    }
+    try:
+        receipt = _post_steer(server, auth, task_id, payload)
+    except httpx.HTTPStatusError as exc:
+        raise click.ClickException(f"steer rejected ({exc.response.status_code}): {exc.response.text}") from None
+    except httpx.HTTPError as exc:
+        raise click.ClickException(f"task server unreachable: {exc}") from None
+
+    if as_json:
+        _console.print_json(json.dumps(receipt))
+        return
+    _console.print(
+        f"[green]Steered[/green] task {task_id} ({kind}); "
+        f"receipt {str(receipt.get('receipt_hash', ''))[:24]} at mailbox seq {receipt.get('mailbox_seq')}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/communication/task_mailbox.py
+++ b/src/bernstein/core/communication/task_mailbox.py
@@ -53,6 +53,7 @@ __all__ = [
     "MAX_MESSAGE_BODY_BYTES",
     "MAX_PENDING_PER_TASK",
     "MESSAGE_KINDS",
+    "STEER_MESSAGE_KINDS",
     "MailboxError",
     "MailboxFull",
     "MailboxMessage",
@@ -66,9 +67,25 @@ __all__ = [
 #: Journal schema version. Bumping requires a parallel reader.
 MAILBOX_SCHEMA_VERSION: int = 1
 
+#: Operator-outbound steering message kinds (#2508). A fleet steering action
+#: rides this same journal as a typed message so queued guidance reaches the
+#: worker in chain append order, exactly once, even mid-tool-call. Each steer
+#: message body carries the ``receipt_hash`` of the ``steering.receipt`` audit
+#: event that authorised it, so an effect without a matching receipt is
+#: rejected on consumption.
+STEER_MESSAGE_KINDS: tuple[str, ...] = (
+    "steer.pause",
+    "steer.resume",
+    "steer.guidance",
+    "steer.redirect",
+    "steer.abort",
+)
+
 #: The typed message vocabulary. This is deliberately closed: coordination
-#: payloads are data handed between workers, not conversation.
-MESSAGE_KINDS: tuple[str, ...] = ("finding", "artefact_ref", "question")
+#: payloads are data handed between workers, not conversation. The ``steer.*``
+#: kinds (#2508) are operator-outbound control messages; every other kind is
+#: worker-to-worker coordination.
+MESSAGE_KINDS: tuple[str, ...] = ("finding", "artefact_ref", "question", *STEER_MESSAGE_KINDS)
 
 #: Strict cap on the message body, measured in UTF-8 bytes of the raw
 #: (pre-redaction) input so redaction can never widen what is accepted.

--- a/src/bernstein/core/orchestration/steering.py
+++ b/src/bernstein/core/orchestration/steering.py
@@ -1,0 +1,884 @@
+"""Receipt-backed fleet steering for running workers (#2508).
+
+Once a worker is running a task an operator has no mid-task controls: no
+pause, no way to queue guidance, no redirect of the objective, no clean
+abort. Any ad hoc intervention (editing files under a worker, killing a
+process) leaves no record, so an audited run a human touched can no longer
+be explained end to end. This module closes that gap without weakening the
+run's verifiability.
+
+The shape is deliberate: **a steering action is a receipt first and an
+effect second.** Each command is bound into the HMAC audit chain via
+:func:`~bernstein.core.security.audit_chain.record_steering_receipt` before
+any effect runs, and the delivered effect references that receipt's chain
+HMAC. Delivery rides the existing task mailbox journal
+(:mod:`bernstein.core.communication.task_mailbox`) as the ``steer.*``
+message kinds, so queued guidance reaches the worker in chain append order,
+exactly once, even mid-tool-call. The worker records each consumed steering
+message as a first-class step in the per-step journal
+(:mod:`bernstein.core.persistence.journal`), so a steered run replays
+byte-identically and divergence detection distinguishes an operator-steered
+run from a tampered one.
+
+Strip the chain and this is a control channel with a log. Keep it and every
+intervention is a signed, position-fixed receipt whose effect cannot precede
+it: an effect without a matching receipt is rejected, mutating a recorded
+payload breaks verification at exactly its chain position, and the receipt
+binds the exact command payload the operator confirmed. That coupling is the
+point.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.communication.task_mailbox import STEER_MESSAGE_KINDS
+from bernstein.core.security.audit_chain import (
+    EVENT_STEERING_RECEIPT,
+    record_steering_receipt,
+    record_task_mailbox_message,
+)
+from bernstein.core.server.dashboard_tokens import SCOPE_OPERATOR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.communication.task_mailbox import MailboxMessage, TaskMailbox
+    from bernstein.core.persistence.journal import Journal, JournalEntry, JournalReader
+    from bernstein.core.security.audit_chain import AuditChainStore, AuditEvent
+    from bernstein.core.security.denial_tracker import DenialTracker
+    from bernstein.core.tasks.checkpoint_retry import CheckpointRef
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+STEER_PAUSE = "pause"
+STEER_RESUME = "resume"
+STEER_GUIDANCE = "guidance"
+STEER_REDIRECT = "redirect"
+STEER_ABORT = "abort"
+
+#: The closed steering vocabulary. Every command is one of these kinds.
+STEERING_KINDS: tuple[str, ...] = (
+    STEER_PAUSE,
+    STEER_RESUME,
+    STEER_GUIDANCE,
+    STEER_REDIRECT,
+    STEER_ABORT,
+)
+
+#: Steering kind -> mailbox message kind. The mailbox is the delivery
+#: substrate; its ``steer.*`` vocabulary mirrors this map one-to-one.
+_MAILBOX_KIND: dict[str, str] = {kind: f"steer.{kind}" for kind in STEERING_KINDS}
+
+#: Reverse of :data:`_MAILBOX_KIND`.
+_KIND_FROM_MAILBOX: dict[str, str] = {v: k for k, v in _MAILBOX_KIND.items()}
+
+#: Strict cap on operator-supplied steering text (guidance / redirect target
+#: / reason), measured in UTF-8 bytes. Kept well under the mailbox body cap so
+#: the JSON delivery envelope always fits :data:`MAX_MESSAGE_BODY_BYTES`.
+MAX_STEER_TEXT_BYTES: int = 2048
+
+#: Delivery envelope schema version. Bump only on a wire-format change.
+STEER_ENVELOPE_VERSION: int = 1
+
+# Sanity check: the mailbox kinds this module maps onto must exactly match the
+# mailbox's declared steer vocabulary, so a drift between the two modules is a
+# hard import-time failure rather than a silent delivery gap.
+assert set(_MAILBOX_KIND.values()) == set(STEER_MESSAGE_KINDS), (
+    "steering kinds drifted from task_mailbox.STEER_MESSAGE_KINDS"
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class SteeringError(Exception):
+    """Base class for steering rejections."""
+
+
+class InvalidSteeringCommand(SteeringError, ValueError):
+    """The command failed boundary validation."""
+
+
+class UnauthorizedSteering(SteeringError):
+    """The acting scope is not authorised to steer."""
+
+
+class SteeringPayloadMismatch(SteeringError):
+    """The payload the operator confirmed differs from the executed payload."""
+
+
+# ---------------------------------------------------------------------------
+# Canonical encoding
+# ---------------------------------------------------------------------------
+
+
+def _canonical(payload: dict[str, Any]) -> bytes:
+    """Return stable canonical JSON bytes (sorted keys, compact, UTF-8)."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Command
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SteeringCommand:
+    """One operator steering command, before it is bound into a receipt.
+
+    Attributes:
+        kind: One of :data:`STEERING_KINDS`.
+        task_id: The steered task.
+        principal: The acting operator (seat attribution).
+        guidance: Free text delivered to the worker (``guidance`` kind only).
+        redirect_target: The new objective (``redirect`` kind only).
+        reason: Optional human-readable reason (``pause`` / ``abort``).
+        session_id: The worker session the effect targets. Required for
+            ``pause`` and ``abort`` (they act on the worker process); ignored
+            for the mailbox-only kinds.
+        adapter: Adapter that owns the session (``pause`` checkpoint only).
+        worktree: Absolute worktree path (``pause`` checkpoint baseline).
+    """
+
+    kind: str
+    task_id: str
+    principal: str
+    guidance: str = ""
+    redirect_target: str = ""
+    reason: str = ""
+    session_id: str = ""
+    adapter: str = ""
+    worktree: str = ""
+
+    def validate(self) -> None:
+        """Reject a malformed command at the boundary.
+
+        Raises:
+            InvalidSteeringCommand: on any shape violation.
+        """
+        if self.kind not in STEERING_KINDS:
+            raise InvalidSteeringCommand(f"unknown steering kind {self.kind!r}; expected one of {STEERING_KINDS}")
+        if not self.task_id:
+            raise InvalidSteeringCommand("task_id must be non-empty")
+        if not self.principal:
+            raise InvalidSteeringCommand("principal must be non-empty")
+
+        # Text fields are only meaningful for their own kind. Requiring the
+        # field for its kind AND forbidding it elsewhere keeps the confirmed
+        # payload unambiguous, so the receipt binds exactly what was shown.
+        if self.kind == STEER_GUIDANCE:
+            if not self.guidance:
+                raise InvalidSteeringCommand("guidance kind requires non-empty guidance text")
+        elif self.guidance:
+            raise InvalidSteeringCommand(f"{self.kind} kind must not carry guidance text")
+
+        if self.kind == STEER_REDIRECT:
+            if not self.redirect_target:
+                raise InvalidSteeringCommand("redirect kind requires a non-empty redirect_target")
+        elif self.redirect_target:
+            raise InvalidSteeringCommand(f"{self.kind} kind must not carry a redirect_target")
+
+        if self.kind in (STEER_PAUSE, STEER_ABORT) and not self.session_id:
+            raise InvalidSteeringCommand(f"{self.kind} kind requires a session_id to target the worker process")
+
+        text_fields = (
+            ("guidance", self.guidance),
+            ("redirect_target", self.redirect_target),
+            ("reason", self.reason),
+        )
+        for name, value in text_fields:
+            if len(value.encode("utf-8")) > MAX_STEER_TEXT_BYTES:
+                raise InvalidSteeringCommand(f"{name} exceeds {MAX_STEER_TEXT_BYTES} bytes")
+
+    def payload(self) -> dict[str, Any]:
+        """Return the exact operator-facing command payload.
+
+        This is what the confirmation UI shows and what the receipt binds:
+        the semantic command. It excludes the routing fields (``session_id``
+        / ``adapter`` / ``worktree``) that only decide where the effect
+        lands, and the ``principal``, which the server sets authoritatively
+        from the presented credential rather than trusting a client claim
+        (the principal is still recorded in the receipt event, just not in
+        the confirmed-payload hash). Keeping the hash principal-independent
+        lets a confirmation surface compute it before it knows which seat the
+        server will attribute the action to.
+        """
+        return {
+            "kind": self.kind,
+            "task_id": self.task_id,
+            "guidance": self.guidance,
+            "redirect_target": self.redirect_target,
+            "reason": self.reason,
+        }
+
+    def payload_hash(self) -> str:
+        """Return the ``sha256:`` digest of the confirmed command payload."""
+        return _sha256(_canonical(self.payload()))
+
+    def mailbox_kind(self) -> str:
+        """Return the mailbox message kind this command is delivered as."""
+        return _MAILBOX_KIND[self.kind]
+
+
+# ---------------------------------------------------------------------------
+# Receipt and outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SteeringReceipt:
+    """The signed record a steering action produced, effect aside.
+
+    Attributes:
+        kind: The steering kind.
+        task_id: The steered task.
+        principal: The acting operator.
+        scope: The authorising token scope.
+        payload_hash: ``sha256:`` digest of the confirmed command payload.
+        receipt_hash: The audit chain HMAC of the receipt event; the identity
+            the delivered effect references.
+        timestamp: Unix seconds the receipt was recorded.
+    """
+
+    kind: str
+    task_id: str
+    principal: str
+    scope: str
+    payload_hash: str
+    receipt_hash: str
+    timestamp: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "task_id": self.task_id,
+            "principal": self.principal,
+            "scope": self.scope,
+            "payload_hash": self.payload_hash,
+            "receipt_hash": self.receipt_hash,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass(frozen=True)
+class SteeringOutcome:
+    """The result of a steering action: the receipt plus its effect handles.
+
+    Attributes:
+        receipt: The chain-anchored receipt.
+        message: The delivered mailbox journal entry.
+        checkpoint: The checkpoint captured by a ``pause`` (or read by a
+            ``resume``); ``None`` for the other kinds.
+        abort_signal_path: The scheduler-enforced stop signal a ``abort``
+            wrote for the worker process; ``None`` for the other kinds.
+    """
+
+    receipt: SteeringReceipt
+    message: MailboxMessage
+    checkpoint: CheckpointRef | None = None
+    abort_signal_path: Path | None = None
+
+
+# ---------------------------------------------------------------------------
+# Delivery envelope helpers
+# ---------------------------------------------------------------------------
+
+
+def _delivery_body(command: SteeringCommand, *, receipt_hash: str, payload_hash: str) -> str:
+    """Serialise the mailbox delivery envelope for *command*.
+
+    The envelope carries the receipt hash and payload hash as hex fields, so
+    the worker can prove the message it consumes matches a receipt on the
+    chain even after DLP redaction rewrites the free text.
+    """
+    envelope = command.payload() | {
+        "v": STEER_ENVELOPE_VERSION,
+        "principal": command.principal,
+        "receipt_hash": receipt_hash,
+        "payload_hash": payload_hash,
+    }
+    return json.dumps(envelope, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def parse_delivery_body(body: str) -> dict[str, Any]:
+    """Parse a ``steer.*`` mailbox body back into its envelope fields.
+
+    Returns:
+        The decoded envelope, or an empty dict when the body is not a
+        well-formed steering envelope (a foreign or corrupt row).
+    """
+    try:
+        decoded: Any = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(decoded, dict):
+        return {}
+    return decoded
+
+
+# ---------------------------------------------------------------------------
+# Authorisation
+# ---------------------------------------------------------------------------
+
+#: Signature of a steering authoriser: ``(command, scope) -> allowed``.
+Authorizer = Callable[["SteeringCommand", str], bool]
+
+
+def default_authorizer(command: SteeringCommand, scope: str) -> bool:
+    """Authorise steering only for the read-write ``operator`` scope.
+
+    A ``viewer`` scope, or any request that carried no valid credential
+    (empty scope), is denied. The command is accepted here so a future
+    authoriser can gate specific kinds; the default gates on scope alone.
+    """
+    return scope == SCOPE_OPERATOR
+
+
+# ---------------------------------------------------------------------------
+# Receipt lookup (the effect-rejection gate)
+# ---------------------------------------------------------------------------
+
+
+def find_steering_receipt(chain: AuditChainStore, *, receipt_hash: str, payload_hash: str) -> AuditEvent | None:
+    """Return the receipt event matching *receipt_hash* and *payload_hash*.
+
+    The delivered effect references a receipt by its chain HMAC. This looks up
+    the ``steering.receipt`` event whose own HMAC equals ``receipt_hash`` and
+    whose bound ``payload_hash`` matches, proving the effect was authorised by
+    a receipt that recorded exactly this payload. Returns ``None`` when no such
+    receipt exists (an effect with no matching receipt), which callers treat as
+    a rejection.
+    """
+    if not receipt_hash:
+        return None
+    for event in chain.query(event_type=EVENT_STEERING_RECEIPT):
+        if event.hmac == receipt_hash and str(event.details.get("payload_hash", "")) == payload_hash:
+            return event
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+
+class SteeringController:
+    """Records steering receipts and applies their effects, in that order.
+
+    Args:
+        chain: The audit chain store every receipt is bound into.
+        mailbox: The task mailbox steering effects are delivered through.
+        signals_dir: ``.sdd/runtime/signals`` root; ``abort`` and ``pause``
+            write scheduler-enforced signal files under
+            ``<signals_dir>/<session_id>/``. ``None`` disables process signals.
+        sdd_dir: Project ``.sdd`` directory; ``pause`` checkpoints and
+            ``resume`` reads checkpoints beneath it. ``None`` disables
+            checkpointing (delivery still happens).
+        authorizer: Scope gate; defaults to :func:`default_authorizer`.
+        denial_tracker: Optional tracker denied attempts are recorded into.
+        sender: The mailbox sender attribution for delivered messages.
+        clock: Injectable time source (tests).
+        claim_parker: Optional callback run on ``pause`` to park the task's
+            claim (``task_id -> None``).
+        claim_resumer: Optional callback run on ``resume`` to re-grant the
+            claim (``task_id -> None``).
+    """
+
+    def __init__(
+        self,
+        *,
+        chain: AuditChainStore,
+        mailbox: TaskMailbox,
+        signals_dir: Path | None = None,
+        sdd_dir: Path | None = None,
+        authorizer: Authorizer | None = None,
+        denial_tracker: DenialTracker | None = None,
+        sender: str = "operator",
+        clock: Callable[[], float] = time.time,
+        claim_parker: Callable[[str], None] | None = None,
+        claim_resumer: Callable[[str], None] | None = None,
+    ) -> None:
+        self._chain = chain
+        self._mailbox = mailbox
+        self._signals_dir = signals_dir
+        self._sdd_dir = sdd_dir
+        self._authorizer = authorizer or default_authorizer
+        self._denial_tracker = denial_tracker
+        self._sender = sender
+        self._clock = clock
+        self._claim_parker = claim_parker
+        self._claim_resumer = claim_resumer
+
+    def steer(
+        self,
+        command: SteeringCommand,
+        *,
+        scope: str,
+        displayed_payload_hash: str | None = None,
+    ) -> SteeringOutcome:
+        """Record a receipt for *command*, then apply its effect.
+
+        Order is load-bearing: validation, then authorisation, then the
+        payload-match check, then the receipt, then the effect. The effect
+        can never precede its receipt.
+
+        Args:
+            command: The steering command.
+            scope: The authorising token scope.
+            displayed_payload_hash: The payload hash the confirmation UI
+                computed over what it showed the operator. When supplied it
+                must equal the executed command's payload hash; a mismatch is
+                rejected before any receipt is written.
+
+        Returns:
+            The :class:`SteeringOutcome`.
+
+        Raises:
+            InvalidSteeringCommand: the command failed validation.
+            UnauthorizedSteering: the scope may not steer (recorded).
+            SteeringPayloadMismatch: displayed payload differs from executed.
+        """
+        command.validate()
+
+        if not self._authorizer(command, scope):
+            self._record_denial(command, scope)
+            raise UnauthorizedSteering(f"scope {scope!r} is not authorised to steer task {command.task_id!r}")
+
+        payload_hash = command.payload_hash()
+        if displayed_payload_hash is not None and displayed_payload_hash != payload_hash:
+            raise SteeringPayloadMismatch("confirmed payload hash does not match the executed command payload")
+
+        # Receipt first: bind the command into the chain before any effect.
+        event = record_steering_receipt(
+            chain=self._chain,
+            kind=command.kind,
+            task_id=command.task_id,
+            principal=command.principal,
+            scope=scope,
+            payload_hash=payload_hash,
+        )
+        receipt = SteeringReceipt(
+            kind=command.kind,
+            task_id=command.task_id,
+            principal=command.principal,
+            scope=scope,
+            payload_hash=payload_hash,
+            receipt_hash=event.hmac,
+            timestamp=self._clock(),
+        )
+
+        # Effect second: deliver through the mailbox, then act on the process.
+        message = self._deliver(command, receipt)
+        checkpoint, abort_signal_path = self._apply_effect(command, receipt)
+
+        logger.info(
+            "steering: kind=%s task=%s principal=%s receipt=%s",
+            command.kind,
+            command.task_id,
+            command.principal,
+            receipt.receipt_hash[:16],
+        )
+        return SteeringOutcome(
+            receipt=receipt,
+            message=message,
+            checkpoint=checkpoint,
+            abort_signal_path=abort_signal_path,
+        )
+
+    # -- effect steps ---------------------------------------------------------
+
+    def _deliver(self, command: SteeringCommand, receipt: SteeringReceipt) -> MailboxMessage:
+        """Post the steering message onto the mailbox journal and mirror it."""
+        body = _delivery_body(command, receipt_hash=receipt.receipt_hash, payload_hash=receipt.payload_hash)
+        message = self._mailbox.post(
+            task_id=command.task_id,
+            sender=self._sender,
+            kind=command.mailbox_kind(),
+            body=body,
+        )
+        try:
+            record_task_mailbox_message(
+                chain=self._chain,
+                task_id=message.task_id,
+                seq=message.seq,
+                kind=message.kind,
+                sender=message.sender,
+                sender_card_fingerprint=message.sender_card_fingerprint,
+                body_hash=message.body_hash,
+                entry_hash=message.entry_hash,
+                redaction_count=message.redaction_count,
+                actor="fleet_steering",
+            )
+        except Exception as exc:  # intentional-broad-except: audit mirror never blocks delivery
+            logger.warning("steering: mailbox audit mirror failed (%s)", type(exc).__name__)
+        return message
+
+    def _apply_effect(
+        self, command: SteeringCommand, receipt: SteeringReceipt
+    ) -> tuple[CheckpointRef | None, Path | None]:
+        """Apply the concrete process-level effect for *command*."""
+        if command.kind == STEER_ABORT:
+            return None, self._abort(command, receipt)
+        if command.kind == STEER_PAUSE:
+            return self._pause(command, receipt), None
+        if command.kind == STEER_RESUME:
+            return self._resume(command), None
+        # guidance / redirect are delivery-only.
+        return None, None
+
+    def _abort(self, command: SteeringCommand, receipt: SteeringReceipt) -> Path | None:
+        """Write the scheduler-enforced stop signal for the worker process.
+
+        The signal is a filesystem fact the worker/adapter honours out of
+        band; it is never routed through the model. It is written only under
+        the target session's directory, so aborting one worker leaves every
+        other worker's signal directory untouched.
+        """
+        if self._signals_dir is None:
+            return None
+        session_dir = self._signals_dir / command.session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        signal_path = session_dir / "SHUTDOWN"
+        content = (
+            "# FLEET STEERING - operator abort\n"
+            f"Task: {command.task_id}\n"
+            f"Session: {command.session_id}\n"
+            f"Principal: {command.principal}\n"
+            f"Receipt: {receipt.receipt_hash}\n"
+            f"Reason: {command.reason}\n"
+            "Save your work and exit immediately.\n"
+        )
+        signal_path.write_text(content, encoding="utf-8")
+        return signal_path
+
+    def _pause(self, command: SteeringCommand, receipt: SteeringReceipt) -> CheckpointRef | None:
+        """Checkpoint the worker and park its claim.
+
+        Pause is non-destructive: it captures a resumable checkpoint (adapter
+        session + workspace baseline) so resume can warm-continue from it, then
+        parks the claim so the scheduler stops dispatching the task.
+        """
+        checkpoint: CheckpointRef | None = None
+        if self._sdd_dir is not None:
+            from bernstein.core.tasks.checkpoint_retry import record_task_checkpoint, workspace_hash
+
+            worktree = command.worktree
+            ws_hash = ""
+            if worktree:
+                from pathlib import Path as _Path
+
+                with self._suppress_workspace_hash_errors():
+                    ws_hash = workspace_hash(_Path(worktree))
+            checkpoint = record_task_checkpoint(
+                sdd_dir=self._sdd_dir,
+                task_id=command.task_id,
+                adapter=command.adapter,
+                session_id=command.session_id,
+                workspace_hash=ws_hash,
+                worktree_path=worktree,
+            )
+        if self._signals_dir is not None:
+            session_dir = self._signals_dir / command.session_id
+            session_dir.mkdir(parents=True, exist_ok=True)
+            (session_dir / "PAUSE").write_text(
+                f"# FLEET STEERING - operator pause\nTask: {command.task_id}\nReceipt: {receipt.receipt_hash}\n",
+                encoding="utf-8",
+            )
+        if self._claim_parker is not None:
+            self._claim_parker(command.task_id)
+        return checkpoint
+
+    def _resume(self, command: SteeringCommand) -> CheckpointRef | None:
+        """Warm-resume: read the parked checkpoint and re-grant the claim."""
+        checkpoint: CheckpointRef | None = None
+        if self._sdd_dir is not None:
+            from bernstein.core.tasks.checkpoint_retry import latest_checkpoint
+
+            checkpoint = latest_checkpoint(self._sdd_dir, command.task_id)
+        if self._signals_dir is not None:
+            pause_signal = self._signals_dir / command.session_id / "PAUSE"
+            if command.session_id and pause_signal.exists():
+                pause_signal.unlink()
+        if self._claim_resumer is not None:
+            self._claim_resumer(command.task_id)
+        return checkpoint
+
+    # -- helpers --------------------------------------------------------------
+
+    def _record_denial(self, command: SteeringCommand, scope: str) -> None:
+        if self._denial_tracker is None:
+            return
+        session = command.session_id or command.task_id
+        self._denial_tracker.record_denial(
+            session,
+            f"steer.{command.kind}:{command.task_id}",
+            reason=f"scope {scope!r} not authorised for steering",
+        )
+
+    @staticmethod
+    def _suppress_workspace_hash_errors() -> Any:
+        import contextlib
+
+        return contextlib.suppress(OSError)
+
+
+# ---------------------------------------------------------------------------
+# Worker-side consumption (the journal projection)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConsumedSteering:
+    """One steering message consumed into the per-step journal.
+
+    Attributes:
+        seq: The mailbox chain position the message was delivered at.
+        kind: The steering kind.
+        receipt_hash: The receipt the message references.
+        payload_hash: The bound payload hash.
+        journal_seq: The journal step index the consumption recorded.
+        step_hash: The journal step hash of the consumption row.
+    """
+
+    seq: int
+    kind: str
+    receipt_hash: str
+    payload_hash: str
+    journal_seq: int
+    step_hash: str
+
+
+@dataclass
+class SteeringConsumeResult:
+    """The outcome of one :func:`consume_steering` sweep.
+
+    Attributes:
+        applied: Messages whose receipt verified and were journaled.
+        rejected: ``(seq, receipt_hash)`` pairs whose receipt was missing.
+        next_seq: The cursor to pass on the next sweep (highest seq seen, or
+            the input cursor when nothing was pending).
+    """
+
+    applied: list[ConsumedSteering] = field(default_factory=list[ConsumedSteering])
+    rejected: list[tuple[int, str]] = field(default_factory=list[tuple[int, str]])
+    next_seq: int = -1
+
+
+def consume_steering(
+    *,
+    mailbox: TaskMailbox,
+    journal: Journal,
+    chain: AuditChainStore,
+    task_id: str,
+    since_seq: int = -1,
+) -> SteeringConsumeResult:
+    """Consume pending steering messages for *task_id* into the journal.
+
+    Delivery is the mailbox's total order: pending steering messages are read
+    in chain append order and processed exactly once past ``since_seq``. Each
+    message whose receipt verifies on the chain is recorded as a first-class
+    per-step journal row (the step hash binds the receipt), so a steered run
+    replays byte-identically and a second host walking the same journal
+    computes identical step hashes. A message whose receipt is absent from the
+    chain is rejected (no effect, no journal row): an effect cannot exist
+    without its receipt.
+
+    Args:
+        mailbox: The delivery mailbox.
+        journal: The worker's per-step journal.
+        chain: The audit chain the receipts live on.
+        task_id: The steered task.
+        since_seq: Deterministic cursor; only messages with a strictly greater
+            ``seq`` are consumed.
+
+    Returns:
+        A :class:`SteeringConsumeResult`.
+    """
+    result = SteeringConsumeResult(next_seq=since_seq)
+    for message in mailbox.pending(task_id, since_seq=since_seq):
+        if message.kind not in _KIND_FROM_MAILBOX:
+            # A non-steering row addressed to this task (peer coordination).
+            # Advance the cursor so it is not re-inspected, but do not journal.
+            result.next_seq = max(result.next_seq, message.seq)
+            continue
+        result.next_seq = max(result.next_seq, message.seq)
+        envelope = parse_delivery_body(message.body)
+        receipt_hash = str(envelope.get("receipt_hash", ""))
+        payload_hash = str(envelope.get("payload_hash", ""))
+        kind = _KIND_FROM_MAILBOX[message.kind]
+
+        receipt = find_steering_receipt(chain, receipt_hash=receipt_hash, payload_hash=payload_hash)
+        if receipt is None:
+            logger.warning(
+                "steering: rejecting %s seq=%d for task %s; no matching receipt on chain",
+                message.kind,
+                message.seq,
+                task_id,
+            )
+            result.rejected.append((message.seq, receipt_hash))
+            continue
+
+        entry = _record_consumption_step(
+            journal,
+            task_id=task_id,
+            kind=kind,
+            seq=message.seq,
+            receipt_hash=receipt_hash,
+            payload_hash=payload_hash,
+        )
+        result.applied.append(
+            ConsumedSteering(
+                seq=message.seq,
+                kind=kind,
+                receipt_hash=receipt_hash,
+                payload_hash=payload_hash,
+                journal_seq=entry.seq,
+                step_hash=entry.step_hash,
+            )
+        )
+    return result
+
+
+def _record_consumption_step(
+    journal: Journal,
+    *,
+    task_id: str,
+    kind: str,
+    seq: int,
+    receipt_hash: str,
+    payload_hash: str,
+) -> JournalEntry:
+    """Append the deterministic journal step for one consumed steering message."""
+    return journal.append(
+        input_hash=receipt_hash,
+        tool_call={
+            "steer": kind,
+            "task_id": task_id,
+            "mailbox_seq": seq,
+            "receipt_hash": receipt_hash,
+            "payload_hash": payload_hash,
+        },
+        tool_result={"consumed": True},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Replay divergence classification
+# ---------------------------------------------------------------------------
+
+CLASSIFICATION_CLEAN = "clean"
+CLASSIFICATION_STEERED = "steered"
+CLASSIFICATION_TAMPERED = "tampered"
+
+
+@dataclass(frozen=True)
+class SteeringClassification:
+    """Whether a run was steered, tampered, or neither.
+
+    Attributes:
+        label: :data:`CLASSIFICATION_CLEAN`, :data:`CLASSIFICATION_STEERED`,
+            or :data:`CLASSIFICATION_TAMPERED`.
+        steering_steps: Journal ``seq`` indices that recorded a steering
+            consumption.
+        divergent_index: The journal line the chain first failed to verify at,
+            or ``None`` when the journal verified clean.
+    """
+
+    label: str
+    steering_steps: list[int]
+    divergent_index: int | None
+
+
+def _is_steering_step(entry: JournalEntry) -> bool:
+    return isinstance(entry.tool_call, dict) and "steer" in entry.tool_call
+
+
+def classify_steering_run(reader: JournalReader) -> SteeringClassification:
+    """Classify a journal as clean, steered, or tampered.
+
+    A journal whose Merkle chain no longer verifies is ``tampered`` (the
+    divergence report names the first divergent line). A journal that verifies
+    and carries steering steps is ``steered`` -- an operator touched it and the
+    record proves it, byte-for-byte. A journal that verifies with no steering
+    steps is ``clean``. This is what lets divergence detection tell a
+    legitimately steered run apart from a tampered one.
+    """
+    verification = reader.verify()
+    steering_steps = [entry.seq for entry in reader.entries() if _is_steering_step(entry)]
+    if not verification.ok:
+        divergent = _first_divergent_line(verification.errors)
+        return SteeringClassification(
+            label=CLASSIFICATION_TAMPERED,
+            steering_steps=steering_steps,
+            divergent_index=divergent,
+        )
+    label = CLASSIFICATION_STEERED if steering_steps else CLASSIFICATION_CLEAN
+    return SteeringClassification(label=label, steering_steps=steering_steps, divergent_index=None)
+
+
+def _first_divergent_line(errors: list[str]) -> int | None:
+    """Extract the first ``line N`` index from a verification error list."""
+    for message in errors:
+        marker = "line "
+        idx = message.find(marker)
+        if idx == -1:
+            continue
+        rest = message[idx + len(marker) :]
+        digits = ""
+        for char in rest:
+            if char.isdigit():
+                digits += char
+            else:
+                break
+        if digits:
+            return int(digits)
+    return None
+
+
+__all__ = [
+    "CLASSIFICATION_CLEAN",
+    "CLASSIFICATION_STEERED",
+    "CLASSIFICATION_TAMPERED",
+    "MAX_STEER_TEXT_BYTES",
+    "STEERING_KINDS",
+    "STEER_ABORT",
+    "STEER_ENVELOPE_VERSION",
+    "STEER_GUIDANCE",
+    "STEER_PAUSE",
+    "STEER_REDIRECT",
+    "STEER_RESUME",
+    "Authorizer",
+    "ConsumedSteering",
+    "InvalidSteeringCommand",
+    "SteeringClassification",
+    "SteeringCommand",
+    "SteeringConsumeResult",
+    "SteeringController",
+    "SteeringError",
+    "SteeringOutcome",
+    "SteeringPayloadMismatch",
+    "SteeringReceipt",
+    "UnauthorizedSteering",
+    "classify_steering_run",
+    "consume_steering",
+    "default_authorizer",
+    "find_steering_receipt",
+    "parse_delivery_body",
+]

--- a/src/bernstein/core/routes/task_steer.py
+++ b/src/bernstein/core/routes/task_steer.py
@@ -1,0 +1,203 @@
+"""Operator steering route for the task server (#2508).
+
+``POST /tasks/{task_id}/steer`` is the operator-outbound half of the task
+mailbox: where ``/messages`` carries worker-to-worker coordination, this
+carries an operator's mid-task intervention (pause, resume, guidance,
+redirect, abort). Every action is a receipt first and an effect second -
+the command is bound into the audit chain via ``record_steering_receipt``
+before the effect runs, and the delivered effect (a ``steer.*`` mailbox
+message plus, for abort/pause, a scheduler-enforced process signal)
+references that receipt's chain HMAC. The response IS the receipt.
+
+Authorisation rides the scoped dashboard-token registry: a request must
+present an ``operator`` token to steer. A ``viewer`` token, or any request
+that carried no valid credential once auth is configured, is recorded in the
+denial tracker and rejected. On a loopback bind with no tokens configured
+the route follows the dashboard's loopback posture and grants operator.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request
+
+from bernstein.core.orchestration.steering import (
+    InvalidSteeringCommand,
+    SteeringCommand,
+    SteeringController,
+    SteeringPayloadMismatch,
+    UnauthorizedSteering,
+)
+from bernstein.core.routes.task_crud import (
+    _get_sse_bus,
+    _get_store,
+    _require_task_access,
+)
+from bernstein.core.security.sanitize import sanitize_log
+from bernstein.core.server import TaskSteerPost, TaskSteerResponse
+from bernstein.core.server.dashboard_tokens import SCOPE_OPERATOR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.communication.task_mailbox import TaskMailbox
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_STEER_RESPONSES: dict[int | str, dict[str, str]] = {
+    403: {"description": "Scope is not authorised to steer"},
+    404: {"description": "Task not found"},
+    409: {"description": "Confirmed payload differs from the executed command"},
+    422: {"description": "Malformed steering command"},
+    503: {"description": "Task mailbox is not configured"},
+}
+
+_LOOPBACK_STEER_PRINCIPAL = "dashboard-operator"
+
+
+def _get_mailbox(request: Request) -> TaskMailbox:
+    mailbox = getattr(request.app.state, "task_mailbox", None)
+    if mailbox is None:
+        raise HTTPException(status_code=503, detail="Task mailbox is not configured")
+    return mailbox
+
+
+def _get_audit_chain(request: Request) -> AuditChainStore:
+    chain = getattr(request.app.state, "audit_chain", None)
+    if chain is None:
+        raise HTTPException(status_code=503, detail="Audit chain is not configured")
+    return chain
+
+
+def _bearer_token(request: Request) -> str:
+    header = request.headers.get("authorization", "")
+    prefix = "bearer "
+    if header.lower().startswith(prefix):
+        return header[len(prefix) :].strip()
+    return ""
+
+
+def _resolve_steer_identity(request: Request, body: TaskSteerPost) -> tuple[str, str]:
+    """Resolve the acting ``(principal, scope)`` for a steering request.
+
+    A validated scoped token is authoritative for both principal and scope,
+    so a client cannot spoof attribution. When scoped-token auth is not
+    configured (loopback posture) the route grants operator and attributes to
+    the client-declared principal, mirroring how the dashboard issues a
+    loopback operator token at startup.
+    """
+    auth_state = getattr(request.app.state, "dashboard_auth_state", None)
+    registry = getattr(auth_state, "token_registry", None) if auth_state is not None else None
+    if registry is not None and registry.has_tokens():
+        token = _bearer_token(request)
+        if token:
+            record = registry.validate(token)
+            if record is not None:
+                return record.principal, record.scope
+        return "anonymous", ""
+    return (body.principal or _LOOPBACK_STEER_PRINCIPAL), SCOPE_OPERATOR
+
+
+def _resolve_sdd_dir(request: Request) -> Path | None:
+    sdd_dir = getattr(request.app.state, "sdd_dir", None)
+    if sdd_dir is None:
+        return None
+    return sdd_dir
+
+
+def _build_controller(request: Request, principal: str) -> SteeringController:
+    from bernstein.core.security.denial_tracker import DenialTracker
+
+    chain = _get_audit_chain(request)
+    mailbox = _get_mailbox(request)
+    sdd_dir = _resolve_sdd_dir(request)
+    signals_dir = (sdd_dir / "runtime" / "signals") if sdd_dir is not None else None
+    denial_path = (sdd_dir / "runtime" / "steering_denials.jsonl") if sdd_dir is not None else None
+    return SteeringController(
+        chain=chain,
+        mailbox=mailbox,
+        signals_dir=signals_dir,
+        sdd_dir=sdd_dir,
+        denial_tracker=DenialTracker(persist_path=denial_path),
+        sender=f"operator:{principal}",
+    )
+
+
+@router.post(
+    "/tasks/{task_id}/steer",
+    status_code=201,
+    responses=_STEER_RESPONSES,
+)
+async def post_task_steer(task_id: str, body: TaskSteerPost, request: Request) -> TaskSteerResponse:
+    """Record a steering receipt for a running worker and apply its effect.
+
+    The receipt is bound into the audit chain before the effect executes; the
+    ``steer.*`` mailbox message and any process signal reference the receipt
+    hash returned here. An effect can never precede its receipt.
+    """
+    task = _get_store(request).get_task(task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+    _require_task_access(task, request)
+
+    principal, scope = _resolve_steer_identity(request, body)
+    command = SteeringCommand(
+        kind=body.kind,
+        task_id=task_id,
+        principal=principal,
+        guidance=body.guidance,
+        redirect_target=body.redirect_target,
+        reason=body.reason,
+        session_id=body.session_id,
+        adapter=body.adapter,
+        worktree=body.worktree,
+    )
+    controller = _build_controller(request, principal)
+
+    try:
+        outcome = controller.steer(command, scope=scope, displayed_payload_hash=body.displayed_payload_hash)
+    except UnauthorizedSteering as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from None
+    except SteeringPayloadMismatch as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+    except InvalidSteeringCommand as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from None
+
+    _get_sse_bus(request).publish(
+        "task_steer",
+        json.dumps(
+            {
+                "task_id": task_id,
+                "kind": command.kind,
+                "seq": outcome.message.seq,
+                "receipt_hash": outcome.receipt.receipt_hash,
+            }
+        ),
+    )
+    logger.info(
+        "task.steer recorded: task_id=%s kind=%s principal=%s scope=%s seq=%d",
+        sanitize_log(task_id),
+        sanitize_log(command.kind),
+        sanitize_log(principal),
+        sanitize_log(scope),
+        outcome.message.seq,
+    )
+    return TaskSteerResponse(
+        kind=outcome.receipt.kind,
+        task_id=outcome.receipt.task_id,
+        principal=outcome.receipt.principal,
+        scope=outcome.receipt.scope,
+        payload_hash=outcome.receipt.payload_hash,
+        receipt_hash=outcome.receipt.receipt_hash,
+        timestamp=outcome.receipt.timestamp,
+        mailbox_seq=outcome.message.seq,
+        mailbox_entry_hash=outcome.message.entry_hash,
+        checkpoint_event_hash=(outcome.checkpoint.event_hash if outcome.checkpoint is not None else ""),
+        abort_signal_written=outcome.abort_signal_path is not None,
+    )

--- a/src/bernstein/core/routes/tasks.py
+++ b/src/bernstein/core/routes/tasks.py
@@ -17,11 +17,13 @@ from bernstein.core.routes.task_claim_receipt import router as _claim_receipt_ro
 from bernstein.core.routes.task_cluster import router as _cluster_router
 from bernstein.core.routes.task_crud import router as _crud_router
 from bernstein.core.routes.task_mailbox import router as _mailbox_router
+from bernstein.core.routes.task_steer import router as _steer_router
 
 router = APIRouter()
 router.include_router(_crud_router)
 router.include_router(_claim_receipt_router)
 router.include_router(_mailbox_router)
+router.include_router(_steer_router)
 router.include_router(_cluster_router)
 router.include_router(_a2a_router)
 

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -4000,6 +4000,78 @@ def record_provenance_quarantine(
     )
 
 
+#: Issue #2508 -- emitted for every fleet steering action (pause / resume /
+#: guidance / redirect / abort) before its effect executes. The signed,
+#: principal-named receipt binds the exact command payload the operator
+#: confirmed (``payload_hash``), the target task, and the authorising scope
+#: to a fixed chain position. The delivered effect references this event's
+#: chain HMAC, so an effect with no matching receipt is rejected and a
+#: mutated payload breaks verification at exactly this position -- a
+#: tampered intervention is distinguishable from a steered one. The guidance
+#: or redirect text itself never enters the chain (only its hash); it rides
+#: the mailbox journal under DLP redaction. This constant is additive and
+#: must never be reordered or removed.
+EVENT_STEERING_RECEIPT = "steering.receipt"
+
+
+def record_steering_receipt(
+    *,
+    chain: AuditChainStore,
+    kind: str,
+    task_id: str,
+    principal: str,
+    scope: str,
+    payload_hash: str,
+    actor: str = "fleet_steering",
+) -> AuditEvent:
+    """Append a ``steering.receipt`` event into *chain* (#2508).
+
+    A fleet steering action (pause / resume / guidance / redirect / abort)
+    is a receipt first and an effect second: the operator's exact command is
+    bound into the HMAC chain here, before any effect executes, and the
+    delivered effect references this receipt's chain HMAC. The effect is
+    rejected when no matching receipt precedes it, so an operator
+    intervention can never touch a worker without leaving a signed,
+    position-fixed record. Mutating the recorded payload after the fact
+    breaks the chain HMAC at exactly this position, so a tampered
+    intervention is distinguishable from a legitimately steered one.
+
+    Only the command's shape is recorded: the steering kind, the target
+    task, the acting principal, the authorising scope, and the
+    ``payload_hash`` -- the ``sha256:`` digest of the exact command payload
+    the operator confirmed. The guidance or redirect text itself is never
+    stored in the chain; it rides the mailbox journal under DLP redaction.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        kind: One of ``pause`` / ``resume`` / ``guidance`` / ``redirect`` /
+            ``abort``.
+        task_id: The steered task.
+        principal: The acting operator (seat attribution).
+        scope: The authorising token scope the action was granted under.
+        payload_hash: ``sha256:`` digest of the confirmed command payload;
+            binds the receipt to the exact text shown in the confirmation UI.
+        actor: Recorded actor; defaults to ``"fleet_steering"``.
+
+    Returns:
+        The recorded :class:`AuditEvent`; its ``hmac`` is the receipt
+        identity the delivered effect references.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_STEERING_RECEIPT,
+        actor=actor,
+        resource_type="steering_command",
+        resource_id=task_id,
+        details={
+            "kind": kind,
+            "task_id": task_id,
+            "principal": principal,
+            "scope": scope,
+            "payload_hash": payload_hash,
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -4052,6 +4124,7 @@ __all__ = [
     "EVENT_SKILL_VERIFICATION_REFUSAL",
     "EVENT_SPEC_REQUIREMENT_SET",
     "EVENT_SPIFFE_SVID_BINDING",
+    "EVENT_STEERING_RECEIPT",
     "EVENT_SUBAGENT_DELEGATION",
     "EVENT_TASK_CLAIM_RECEIPT",
     "EVENT_TASK_MAILBOX_MESSAGE",
@@ -4120,6 +4193,7 @@ __all__ = [
     "record_skill_verification_refusal",
     "record_spec_requirement_set",
     "record_spiffe_svid_binding",
+    "record_steering_receipt",
     "record_subagent_delegation",
     "record_taint_decision",
     "record_task_claim_receipt",

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -480,6 +480,49 @@ class TaskMessageResponse(BaseModel):
     signer_public_key_pem: str
 
 
+class TaskSteerPost(BaseModel):
+    """Body for POST /tasks/{task_id}/steer (#2508).
+
+    An operator steering command: pause, resume, guidance, redirect, or
+    abort. Free-text fields are capped so the mailbox delivery envelope
+    always fits the mailbox body cap. ``displayed_payload_hash`` is the hash
+    the confirmation UI computed over what it showed the operator; when
+    supplied the server rejects the action if it differs from the executed
+    command, so the receipt binds exactly the confirmed payload.
+    """
+
+    kind: str = Field(min_length=1, max_length=64)
+    principal: str = Field(default="", max_length=_MAX_SHORT_STR_LEN)
+    guidance: str = Field(default="", max_length=2048)
+    redirect_target: str = Field(default="", max_length=2048)
+    reason: str = Field(default="", max_length=2048)
+    session_id: str = Field(default="", max_length=_MAX_SHORT_STR_LEN)
+    adapter: str = Field(default="", max_length=_MAX_SHORT_STR_LEN)
+    worktree: str = Field(default="", max_length=_MAX_PATH_LEN)
+    displayed_payload_hash: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)
+
+
+class TaskSteerResponse(BaseModel):
+    """The receipt a steering action produced (#2508).
+
+    The response IS the receipt: the chain-anchored ``receipt_hash`` the
+    delivered effect references, the ``payload_hash`` it binds, and the
+    mailbox journal position the effect was delivered at.
+    """
+
+    kind: str
+    task_id: str
+    principal: str
+    scope: str
+    payload_hash: str
+    receipt_hash: str
+    timestamp: float
+    mailbox_seq: int
+    mailbox_entry_hash: str
+    checkpoint_event_hash: str = ""
+    abort_signal_written: bool = False
+
+
 class BatchCreateRequest(BaseModel):
     """Body for POST /tasks/batch."""
 

--- a/tests/unit/test_fleet_steer_cli.py
+++ b/tests/unit/test_fleet_steer_cli.py
@@ -1,0 +1,99 @@
+"""``bernstein fleet steer`` CLI tests (#2508).
+
+The command computes the confirmed payload hash locally and posts it to the
+task server, so the receipt binds exactly the command it printed. These tests
+exercise the payload it sends and the errors it surfaces without touching the
+network (the HTTP call is monkeypatched).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands import fleet_cmd
+from bernstein.core.orchestration.steering import SteeringCommand
+
+
+@pytest.fixture()
+def captured_post(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_post(server_url: str, token: str | None, task_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append({"server_url": server_url, "token": token, "task_id": task_id, "payload": payload})
+        return {
+            "kind": payload["kind"],
+            "task_id": task_id,
+            "receipt_hash": "hmac-sha256:abc123",
+            "mailbox_seq": 0,
+        }
+
+    monkeypatch.setattr(fleet_cmd, "_post_steer", _fake_post)
+    return calls
+
+
+def test_steer_sends_confirmed_payload_hash(captured_post: list[dict[str, Any]]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        fleet_cmd.steer_cmd,
+        ["task-1", "guidance", "--guidance", "stop refactoring, fix the failing test"],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(captured_post) == 1
+    payload = captured_post[0]["payload"]
+    assert payload["kind"] == "guidance"
+    assert payload["guidance"] == "stop refactoring, fix the failing test"
+    # The confirmed hash equals the hash of the exact command the CLI built.
+    expected = SteeringCommand(
+        kind="guidance", task_id="task-1", principal="cli-operator", guidance="stop refactoring, fix the failing test"
+    ).payload_hash()
+    assert payload["displayed_payload_hash"] == expected
+    assert "Steered" in result.output
+
+
+def test_steer_rejects_malformed_command_before_posting(captured_post: list[dict[str, Any]]) -> None:
+    runner = CliRunner()
+    # guidance kind with no guidance text fails local validation.
+    result = runner.invoke(fleet_cmd.steer_cmd, ["task-1", "guidance"])
+    assert result.exit_code != 0
+    assert captured_post == []
+
+
+def test_steer_abort_requires_session(captured_post: list[dict[str, Any]]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(fleet_cmd.steer_cmd, ["task-1", "abort"])
+    assert result.exit_code != 0
+    assert captured_post == []
+
+
+def test_steer_surfaces_server_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    def _raise(server_url: str, token: str | None, task_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        request = httpx.Request("POST", f"{server_url}/tasks/{task_id}/steer")
+        response = httpx.Response(403, text="scope 'viewer' is not authorised to steer", request=request)
+        raise httpx.HTTPStatusError("forbidden", request=request, response=response)
+
+    monkeypatch.setattr(fleet_cmd, "_post_steer", _raise)
+    runner = CliRunner()
+    result = runner.invoke(fleet_cmd.steer_cmd, ["task-1", "abort", "--session-id", "sess-1"])
+    assert result.exit_code != 0
+    assert "403" in result.output
+
+
+def test_steer_emits_json_receipt(captured_post: list[dict[str, Any]]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        fleet_cmd.steer_cmd,
+        ["task-1", "redirect", "--redirect-target", "ship the hotfix", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "receipt_hash" in result.output
+
+
+def test_steer_unknown_kind_is_rejected() -> None:
+    runner = CliRunner()
+    result = runner.invoke(fleet_cmd.steer_cmd, ["task-1", "bogus"])
+    assert result.exit_code != 0

--- a/tests/unit/test_steering.py
+++ b/tests/unit/test_steering.py
@@ -1,0 +1,461 @@
+"""Receipt-backed fleet steering core tests (#2508).
+
+Each acceptance criterion from the issue is exercised directly:
+
+* Every steering action is an audit-chain receipt recorded before its
+  effect; an effect with no matching receipt is rejected.
+* Pause checkpoints a running worker; resume continues from the checkpoint
+  (the claim is parked, not abandoned; the checkpoint identity is preserved).
+* Guidance queued while a worker is mid-step is delivered exactly once, in
+  mailbox chain append order, and appears in the worker transcript.
+* Determinism: a steered run's steering messages become hash-chained journal
+  steps; a second host walking the same journal computes identical hashes.
+* Verifiability: mutating a receipt payload fails audit verification at the
+  exact chain position and the classification labels the run tampered, not
+  steered.
+* The receipt binds the confirmed payload; a mismatched displayed payload is
+  rejected before any receipt is written.
+* Isolation: aborting one worker leaves other workers' signals untouched.
+* Steering requires an authorised scope; denials are recorded and rejected.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.communication.task_mailbox import TaskMailbox, verify_against_chain
+from bernstein.core.orchestration.steering import (
+    CLASSIFICATION_CLEAN,
+    CLASSIFICATION_STEERED,
+    CLASSIFICATION_TAMPERED,
+    InvalidSteeringCommand,
+    SteeringCommand,
+    SteeringController,
+    SteeringPayloadMismatch,
+    UnauthorizedSteering,
+    classify_steering_run,
+    consume_steering,
+    find_steering_receipt,
+    parse_delivery_body,
+)
+from bernstein.core.persistence.journal import Journal, JournalReader
+from bernstein.core.security.audit_chain import EVENT_STEERING_RECEIPT, AuditChainStore
+from bernstein.core.security.denial_tracker import DenialTracker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"steering-core-test-key"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_KEY)
+
+
+@pytest.fixture()
+def mailbox(tmp_path: Path) -> TaskMailbox:
+    return TaskMailbox(
+        tmp_path / "runtime" / "mailbox.jsonl",
+        hmac_key=_KEY,
+        identity_dir=tmp_path / "identity",
+    )
+
+
+def _controller(
+    chain: AuditChainStore,
+    mailbox: TaskMailbox,
+    tmp_path: Path,
+    *,
+    denial_tracker: DenialTracker | None = None,
+    parked: list[str] | None = None,
+    resumed: list[str] | None = None,
+) -> SteeringController:
+    return SteeringController(
+        chain=chain,
+        mailbox=mailbox,
+        signals_dir=tmp_path / "signals",
+        sdd_dir=tmp_path / ".sdd",
+        denial_tracker=denial_tracker,
+        claim_parker=(parked.append if parked is not None else None),
+        claim_resumer=(resumed.append if resumed is not None else None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Command boundary validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        SteeringCommand(kind="bogus", task_id="t", principal="a"),
+        SteeringCommand(kind="guidance", task_id="t", principal="a"),  # missing text
+        SteeringCommand(kind="redirect", task_id="t", principal="a"),  # missing target
+        SteeringCommand(kind="guidance", task_id="", principal="a", guidance="x"),
+        SteeringCommand(kind="guidance", task_id="t", principal="", guidance="x"),
+        SteeringCommand(kind="pause", task_id="t", principal="a"),  # missing session
+        SteeringCommand(kind="abort", task_id="t", principal="a"),  # missing session
+        SteeringCommand(kind="pause", task_id="t", principal="a", session_id="s", guidance="x"),
+    ],
+)
+def test_validate_rejects_malformed_commands(command: SteeringCommand) -> None:
+    with pytest.raises(InvalidSteeringCommand):
+        command.validate()
+
+
+def test_oversized_guidance_is_rejected() -> None:
+    huge = "x" * 4096
+    with pytest.raises(InvalidSteeringCommand):
+        SteeringCommand(kind="guidance", task_id="t", principal="a", guidance=huge).validate()
+
+
+# ---------------------------------------------------------------------------
+# AC: receipt is recorded BEFORE the effect
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_recorded_before_effect(chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    cmd = SteeringCommand(kind="guidance", task_id="task-1", principal="alice", guidance="focus on the failing test")
+
+    outcome = controller.steer(cmd, scope="operator")
+
+    receipts = chain.query(event_type=EVENT_STEERING_RECEIPT)
+    assert len(receipts) == 1
+    assert receipts[0].details["payload_hash"] == cmd.payload_hash()
+    assert receipts[0].details["kind"] == "guidance"
+    assert receipts[0].details["principal"] == "alice"
+    # The delivered effect references the receipt's chain HMAC.
+    assert outcome.receipt.receipt_hash == receipts[0].hmac
+    envelope = parse_delivery_body(outcome.message.body)
+    assert envelope["receipt_hash"] == outcome.receipt.receipt_hash
+    assert envelope["payload_hash"] == cmd.payload_hash()
+
+
+def test_effect_without_matching_receipt_is_rejected(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    """A steer message referencing a receipt absent from the chain is rejected."""
+    # Post a steer message directly, referencing a receipt that was never recorded.
+    forged_body = json.dumps(
+        {
+            "v": 1,
+            "kind": "guidance",
+            "task_id": "task-1",
+            "principal": "mallory",
+            "guidance": "do the wrong thing",
+            "redirect_target": "",
+            "reason": "",
+            "receipt_hash": "hmac-sha256:deadbeef",
+            "payload_hash": "sha256:deadbeef",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    mailbox.post(task_id="task-1", sender="operator", kind="steer.guidance", body=forged_body)
+
+    journal = Journal.open(tmp_path / "journal" / "agent-1")
+    result = consume_steering(mailbox=mailbox, journal=journal, chain=chain, task_id="task-1")
+
+    assert result.applied == []
+    assert result.rejected and result.rejected[0][0] == 0
+    # Nothing was journaled: an effect cannot exist without its receipt.
+    assert JournalReader(tmp_path / "journal" / "agent-1").head() is None
+
+
+# ---------------------------------------------------------------------------
+# AC: the receipt binds the confirmed payload (displayed == executed)
+# ---------------------------------------------------------------------------
+
+
+def test_displayed_payload_mismatch_is_rejected_before_receipt(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    cmd = SteeringCommand(kind="redirect", task_id="task-1", principal="alice", redirect_target="ship the hotfix")
+
+    with pytest.raises(SteeringPayloadMismatch):
+        controller.steer(cmd, scope="operator", displayed_payload_hash="sha256:something-else")
+
+    # No receipt was written: the mismatch is caught before the chain is touched.
+    assert chain.query(event_type=EVENT_STEERING_RECEIPT) == []
+    assert len(mailbox) == 0
+
+
+def test_matching_displayed_payload_is_accepted(chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    cmd = SteeringCommand(kind="redirect", task_id="task-1", principal="alice", redirect_target="ship the hotfix")
+    outcome = controller.steer(cmd, scope="operator", displayed_payload_hash=cmd.payload_hash())
+    assert outcome.receipt.payload_hash == cmd.payload_hash()
+
+
+# ---------------------------------------------------------------------------
+# AC: guidance delivered exactly once, in chain order, appears in transcript
+# ---------------------------------------------------------------------------
+
+
+def test_queued_guidance_delivered_exactly_once_in_order(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    first = SteeringCommand(kind="guidance", task_id="task-1", principal="alice", guidance="stop refactoring")
+    second = SteeringCommand(kind="redirect", task_id="task-1", principal="alice", redirect_target="fix the flaky test")
+    controller.steer(first, scope="operator")
+    controller.steer(second, scope="operator")
+
+    journal = Journal.open(tmp_path / "journal" / "agent-1")
+    result = consume_steering(mailbox=mailbox, journal=journal, chain=chain, task_id="task-1")
+
+    assert [c.kind for c in result.applied] == ["guidance", "redirect"]
+    assert [c.seq for c in result.applied] == [0, 1]
+
+    # A second sweep past the cursor consumes nothing: exactly once.
+    again = consume_steering(mailbox=mailbox, journal=journal, chain=chain, task_id="task-1", since_seq=result.next_seq)
+    assert again.applied == []
+
+    # The guidance appears in the worker transcript (journal steps).
+    entries = list(JournalReader(tmp_path / "journal" / "agent-1").entries())
+    assert len(entries) == 2
+    assert entries[0].tool_call["steer"] == "guidance"
+    assert entries[1].tool_call["steer"] == "redirect"
+
+
+# ---------------------------------------------------------------------------
+# AC: determinism - steering steps replay byte-identically across hosts
+# ---------------------------------------------------------------------------
+
+
+def test_steered_run_replays_byte_identically_on_a_second_host(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    for cmd in (
+        SteeringCommand(kind="pause", task_id="task-1", principal="alice", session_id="sess-1", reason="wait"),
+        SteeringCommand(kind="guidance", task_id="task-1", principal="alice", guidance="focus on tests"),
+        SteeringCommand(kind="redirect", task_id="task-1", principal="alice", redirect_target="ship hotfix"),
+    ):
+        controller.steer(cmd, scope="operator")
+
+    # Host A consumes into journal A.
+    journal_a = Journal.open(tmp_path / "hostA" / "agent")
+    consume_steering(mailbox=mailbox, journal=journal_a, chain=chain, task_id="task-1")
+    hashes_a = [e.step_hash for e in JournalReader(tmp_path / "hostA" / "agent").entries()]
+
+    # Host B replays the same mailbox + chain into a fresh journal.
+    journal_b = Journal.open(tmp_path / "hostB" / "agent")
+    consume_steering(mailbox=mailbox, journal=journal_b, chain=chain, task_id="task-1")
+    hashes_b = [e.step_hash for e in JournalReader(tmp_path / "hostB" / "agent").entries()]
+
+    assert hashes_a == hashes_b
+    assert len(hashes_a) == 3
+    # The journal chain verifies on both hosts.
+    assert JournalReader(tmp_path / "hostA" / "agent").verify().ok
+    assert JournalReader(tmp_path / "hostB" / "agent").verify().ok
+
+
+# ---------------------------------------------------------------------------
+# AC: verifiability - tampering fails at the exact chain position
+# ---------------------------------------------------------------------------
+
+
+def test_mutating_receipt_payload_breaks_audit_verification(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    controller.steer(
+        SteeringCommand(kind="guidance", task_id="task-1", principal="alice", guidance="do X"),
+        scope="operator",
+    )
+    ok, _ = chain.verify()
+    assert ok
+
+    # Tamper with the recorded receipt payload on disk.
+    audit_files = sorted((tmp_path / "audit").glob("*.jsonl"))
+    assert audit_files
+    target = audit_files[0]
+    lines = target.read_text(encoding="utf-8").splitlines()
+    mutated = []
+    tampered_line = -1
+    for idx, line in enumerate(lines):
+        row = json.loads(line)
+        if row.get("event_type") == EVENT_STEERING_RECEIPT:
+            row["details"]["payload_hash"] = "sha256:0000"
+            tampered_line = idx
+        mutated.append(json.dumps(row, sort_keys=True))
+    target.write_text("\n".join(mutated) + "\n", encoding="utf-8")
+
+    reopened = AuditChainStore(tmp_path / "audit", key=_KEY)
+    ok2, problems = reopened.verify()
+    assert not ok2
+    assert problems  # verification fails, naming the broken position
+    assert tampered_line >= 0
+
+
+def test_classification_distinguishes_steered_from_tampered(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    controller.steer(
+        SteeringCommand(kind="guidance", task_id="task-1", principal="alice", guidance="focus"),
+        scope="operator",
+    )
+    journal_dir = tmp_path / "journal" / "agent"
+    journal = Journal.open(journal_dir)
+    consume_steering(mailbox=mailbox, journal=journal, chain=chain, task_id="task-1")
+
+    # A legitimately steered run classifies as steered.
+    steered = classify_steering_run(JournalReader(journal_dir))
+    assert steered.label == CLASSIFICATION_STEERED
+    assert steered.steering_steps == [0]
+    assert steered.divergent_index is None
+
+    # Tamper with the steering journal step -> classified tampered, not steered.
+    bucket = journal_dir / "000000.jsonl"
+    rows = bucket.read_text(encoding="utf-8").splitlines()
+    row0 = json.loads(rows[0])
+    row0["tool_call"]["steer"] = "abort"  # rewrite what the operator did
+    bucket.write_text(json.dumps(row0, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+
+    tampered = classify_steering_run(JournalReader(journal_dir))
+    assert tampered.label == CLASSIFICATION_TAMPERED
+    assert tampered.divergent_index is not None
+
+
+def test_clean_run_with_no_steering_classifies_clean(tmp_path: Path) -> None:
+    journal_dir = tmp_path / "journal" / "agent"
+    journal = Journal.open(journal_dir)
+    journal.append(input_hash="sha256:abc", tool_call={"tool": "Bash"}, tool_result={"ok": True})
+    assert classify_steering_run(JournalReader(journal_dir)).label == CLASSIFICATION_CLEAN
+
+
+# ---------------------------------------------------------------------------
+# AC: isolation - aborting one worker leaves the others untouched
+# ---------------------------------------------------------------------------
+
+
+def test_abort_isolates_the_target_worker(chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    outcome = controller.steer(
+        SteeringCommand(kind="abort", task_id="task-A", principal="alice", session_id="sess-A", reason="wrong path"),
+        scope="operator",
+    )
+
+    signals = tmp_path / "signals"
+    assert outcome.abort_signal_path is not None
+    assert (signals / "sess-A" / "SHUTDOWN").is_file()
+    # The other worker's signal directory was never touched.
+    assert not (signals / "sess-B").exists()
+    # The abort receipt is on the chain and the mailbox mirrors the message.
+    assert len(chain.query(event_type=EVENT_STEERING_RECEIPT)) == 1
+    # Steering worker B leaves worker A's SHUTDOWN in place and adds only B's.
+    controller.steer(
+        SteeringCommand(kind="abort", task_id="task-B", principal="alice", session_id="sess-B", reason="done"),
+        scope="operator",
+    )
+    assert (signals / "sess-A" / "SHUTDOWN").is_file()
+    assert (signals / "sess-B" / "SHUTDOWN").is_file()
+
+
+# ---------------------------------------------------------------------------
+# AC: authorisation - unauthorised scope is recorded and rejected
+# ---------------------------------------------------------------------------
+
+
+def test_viewer_scope_is_rejected_and_recorded(chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path) -> None:
+    tracker = DenialTracker(threshold=100)
+    controller = _controller(chain, mailbox, tmp_path, denial_tracker=tracker)
+    cmd = SteeringCommand(kind="abort", task_id="task-1", principal="mallory", session_id="sess-1")
+
+    with pytest.raises(UnauthorizedSteering):
+        controller.steer(cmd, scope="viewer")
+
+    # No receipt, no delivery, no signal - the effect never ran.
+    assert chain.query(event_type=EVENT_STEERING_RECEIPT) == []
+    assert len(mailbox) == 0
+    assert not (tmp_path / "signals" / "sess-1" / "SHUTDOWN").exists()
+    # The denial was recorded.
+    assert tracker.get_denial_count("sess-1") == 1
+
+
+# ---------------------------------------------------------------------------
+# AC: pause checkpoints; resume continues from the checkpoint
+# ---------------------------------------------------------------------------
+
+
+def test_pause_checkpoints_and_resume_continues_from_it(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    from bernstein.core.tasks.checkpoint_retry import latest_checkpoint
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / "file.py").write_text("print('work in progress')\n", encoding="utf-8")
+
+    parked: list[str] = []
+    resumed: list[str] = []
+    controller = _controller(chain, mailbox, tmp_path, parked=parked, resumed=resumed)
+
+    pause_outcome = controller.steer(
+        SteeringCommand(
+            kind="pause",
+            task_id="task-1",
+            principal="alice",
+            session_id="sess-1",
+            adapter="claude",
+            worktree=str(worktree),
+            reason="operator hold",
+        ),
+        scope="operator",
+    )
+
+    # Pause checkpointed the worker: a resumable reference exists.
+    assert pause_outcome.checkpoint is not None
+    assert pause_outcome.checkpoint.session_id == "sess-1"
+    stored = latest_checkpoint(tmp_path / ".sdd", "task-1")
+    assert stored is not None
+    assert stored.event_hash == pause_outcome.checkpoint.event_hash
+    # The claim was parked (not abandoned) and the pause signal was written.
+    assert parked == ["task-1"]
+    assert (tmp_path / "signals" / "sess-1" / "PAUSE").is_file()
+
+    # Resume continues from the very same checkpoint without restarting.
+    resume_outcome = controller.steer(
+        SteeringCommand(kind="resume", task_id="task-1", principal="alice", session_id="sess-1"),
+        scope="operator",
+    )
+    assert resume_outcome.checkpoint is not None
+    assert resume_outcome.checkpoint.event_hash == pause_outcome.checkpoint.event_hash
+    assert resumed == ["task-1"]
+    # The pause signal was cleared so the scheduler may dispatch again.
+    assert not (tmp_path / "signals" / "sess-1" / "PAUSE").exists()
+
+
+# ---------------------------------------------------------------------------
+# The delivered steering messages cross-verify against the audit chain
+# ---------------------------------------------------------------------------
+
+
+def test_delivered_steering_messages_cross_verify_against_chain(
+    chain: AuditChainStore, mailbox: TaskMailbox, tmp_path: Path
+) -> None:
+    controller = _controller(chain, mailbox, tmp_path)
+    controller.steer(
+        SteeringCommand(kind="guidance", task_id="task-1", principal="alice", guidance="focus"),
+        scope="operator",
+    )
+    ok, problems = verify_against_chain(mailbox, chain)
+    assert ok, problems
+    # find_steering_receipt resolves the delivered message back to its receipt.
+    envelope = parse_delivery_body(mailbox.all_messages()[0].body)
+    receipt = find_steering_receipt(chain, receipt_hash=envelope["receipt_hash"], payload_hash=envelope["payload_hash"])
+    assert receipt is not None

--- a/tests/unit/test_task_mailbox.py
+++ b/tests/unit/test_task_mailbox.py
@@ -84,7 +84,18 @@ def test_post_returns_chained_message_with_expected_fields(tmp_path: Path) -> No
 
 def test_all_declared_kinds_accepted(tmp_path: Path) -> None:
     mailbox = _mailbox(tmp_path)
-    assert set(MESSAGE_KINDS) == {"finding", "artefact_ref", "question"}
+    # Worker-to-worker coordination kinds plus the operator-outbound steering
+    # kinds (#2508). The vocabulary stays closed; unknown kinds are rejected.
+    assert set(MESSAGE_KINDS) == {
+        "finding",
+        "artefact_ref",
+        "question",
+        "steer.pause",
+        "steer.resume",
+        "steer.guidance",
+        "steer.redirect",
+        "steer.abort",
+    }
     for i, kind in enumerate(MESSAGE_KINDS):
         msg = mailbox.post(task_id="t", sender="a", kind=kind, body=f"payload-{i}")
         assert msg.kind == kind

--- a/tests/unit/test_task_steer_routes.py
+++ b/tests/unit/test_task_steer_routes.py
@@ -1,0 +1,202 @@
+"""Task-server steering endpoint tests (#2508).
+
+POST /tasks/{task_id}/steer records a signed steering receipt on the audit
+chain before delivering the effect through the mailbox, gated by the scoped
+dashboard-token registry. These tests cover the happy path, the audit-chain
+mirror, scope enforcement, and the malformed / mismatch edges.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.communication.task_mailbox import TaskMailbox
+from bernstein.core.security.audit_chain import EVENT_STEERING_RECEIPT, AuditChainStore
+from bernstein.core.server import SSEBus, TaskStore, create_app
+from bernstein.core.server.dashboard_tokens import SCOPE_OPERATOR, SCOPE_VIEWER, DashboardTokenRegistry
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"steer-routes-test-key"
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture(scope="module")
+def _module_app(tmp_path_factory: pytest.TempPathFactory):  # type: ignore[no-untyped-def]
+    root = tmp_path_factory.mktemp("steer-server")
+    return create_app(jsonl_path=root / "runtime" / "tasks.jsonl")
+
+
+@pytest.fixture()
+def app(_module_app, tmp_path: Path):  # type: ignore[no-untyped-def]
+    _module_app.state.store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+    _module_app.state.sse_bus = SSEBus()
+    _module_app.state.draining = False
+    _module_app.state.sdd_dir = tmp_path
+    _module_app.state.runtime_dir = tmp_path / "runtime"
+    _module_app.state.audit_chain = AuditChainStore(tmp_path / "audit", key=_KEY)
+    _module_app.state.task_mailbox = TaskMailbox(
+        tmp_path / "runtime" / "mailbox.jsonl",
+        hmac_key=_KEY,
+        identity_dir=tmp_path / "identity",
+    )
+    # No scoped-token auth by default (loopback posture -> operator).
+    _module_app.state.dashboard_auth_state = SimpleNamespace(token_registry=None)
+    return _module_app
+
+
+@pytest.fixture()
+async def client(app) -> AsyncClient:  # type: ignore[no-untyped-def]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _create_task(client: AsyncClient, title: str) -> str:
+    resp = await client.post(
+        "/tasks",
+        json={"title": title, "description": f"{title} description", "role": "backend"},
+    )
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+def _configure_tokens(app, tmp_path: Path) -> tuple[str, str]:  # type: ignore[no-untyped-def]
+    registry = DashboardTokenRegistry(tmp_path / "auth" / "dashboard_tokens.jsonl", hmac_key=_KEY)
+    op_token, _ = registry.issue(principal="alice", scope=SCOPE_OPERATOR, now=1)
+    viewer_token, _ = registry.issue(principal="viewer-vic", scope=SCOPE_VIEWER, now=2)
+    app.state.dashboard_auth_state = SimpleNamespace(token_registry=registry)
+    return op_token, viewer_token
+
+
+# ---------------------------------------------------------------------------
+# Happy path: guidance is a receipt-first delivery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_guidance_steer_records_receipt_and_delivers(client: AsyncClient, app) -> None:  # type: ignore[no-untyped-def]
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={"kind": "guidance", "principal": "alice", "guidance": "stop refactoring, fix the failing test"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["kind"] == "guidance"
+    assert body["receipt_hash"]
+    assert body["payload_hash"].startswith("sha256:")
+    assert body["mailbox_entry_hash"].startswith("hmac-sha256:")
+
+    chain: AuditChainStore = app.state.audit_chain
+    receipts = chain.query(event_type=EVENT_STEERING_RECEIPT)
+    assert len(receipts) == 1
+    assert receipts[0].hmac == body["receipt_hash"]
+    ok, problems = chain.verify()
+    assert ok, problems
+
+
+@pytest.mark.anyio
+async def test_abort_writes_scheduler_signal(client: AsyncClient, tmp_path: Path) -> None:
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={"kind": "abort", "principal": "alice", "session_id": "sess-1", "reason": "wrong path"},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["abort_signal_written"] is True
+    assert (tmp_path / "runtime" / "signals" / "sess-1" / "SHUTDOWN").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Scope enforcement via the scoped-token registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_operator_token_is_authorised(client: AsyncClient, app, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    op_token, _ = _configure_tokens(app, tmp_path)
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={"kind": "guidance", "guidance": "focus on tests"},
+        headers={"Authorization": f"Bearer {op_token}"},
+    )
+    assert resp.status_code == 201, resp.text
+    # The receipt attributes to the token principal, not a client-claimed one.
+    assert resp.json()["principal"] == "alice"
+
+
+@pytest.mark.anyio
+async def test_viewer_token_is_rejected(client: AsyncClient, app, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    _, viewer_token = _configure_tokens(app, tmp_path)
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={"kind": "abort", "session_id": "sess-1"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403, resp.text
+    # No receipt was written and no signal was created.
+    chain: AuditChainStore = app.state.audit_chain
+    assert chain.query(event_type=EVENT_STEERING_RECEIPT) == []
+    assert not (tmp_path / "runtime" / "signals" / "sess-1").exists()
+
+
+@pytest.mark.anyio
+async def test_missing_token_when_auth_configured_is_rejected(client: AsyncClient, app, tmp_path: Path) -> None:  # type: ignore[no-untyped-def]
+    _configure_tokens(app, tmp_path)
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={"kind": "guidance", "guidance": "focus"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Edges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_unknown_task_is_404(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/tasks/does-not-exist/steer",
+        json={"kind": "guidance", "principal": "alice", "guidance": "x"},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.anyio
+async def test_guidance_without_text_is_422(client: AsyncClient) -> None:
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={"kind": "guidance", "principal": "alice"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.anyio
+async def test_displayed_payload_mismatch_is_409(client: AsyncClient) -> None:
+    task_id = await _create_task(client, "Task A")
+    resp = await client.post(
+        f"/tasks/{task_id}/steer",
+        json={
+            "kind": "guidance",
+            "principal": "alice",
+            "guidance": "focus",
+            "displayed_payload_hash": "sha256:does-not-match",
+        },
+    )
+    assert resp.status_code == 409, resp.text

--- a/web/src/components/SteeringControls.tsx
+++ b/web/src/components/SteeringControls.tsx
@@ -1,0 +1,162 @@
+// Receipt-backed steering controls for a single running worker (#2508).
+//
+// Pause, resume, guidance, redirect, or abort a worker mid-task. Every action
+// is a receipt first and an effect second: the server binds the command into
+// the audit chain before any effect runs and returns the receipt hash the
+// delivered effect references. The "queued" indicator below the action bar is
+// that returned receipt - proof the intervention was recorded, not just sent.
+
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { CircleSlash, Compass, MessageSquare, Pause, Play, ShieldCheck } from 'lucide-react';
+
+import { steerTask, ApiError } from '@/lib/api';
+import type { SteerCommand, SteerKind, SteerReceipt } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+const KIND_META: Record<SteerKind, { label: string; icon: typeof Pause }> = {
+  pause: { label: 'Pause', icon: Pause },
+  resume: { label: 'Resume', icon: Play },
+  guidance: { label: 'Guidance', icon: MessageSquare },
+  redirect: { label: 'Redirect', icon: Compass },
+  abort: { label: 'Abort', icon: CircleSlash },
+};
+
+const KIND_ORDER: SteerKind[] = ['pause', 'resume', 'guidance', 'redirect', 'abort'];
+
+interface SteeringControlsProps {
+  taskId: string;
+}
+
+export default function SteeringControls({ taskId }: SteeringControlsProps) {
+  const [kind, setKind] = useState<SteerKind>('guidance');
+  const [guidance, setGuidance] = useState('');
+  const [redirectTarget, setRedirectTarget] = useState('');
+  const [sessionId, setSessionId] = useState('');
+  const [reason, setReason] = useState('');
+  const [receipt, setReceipt] = useState<SteerReceipt | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (command: SteerCommand) => steerTask(taskId, command),
+    onSuccess: (r) => setReceipt(r),
+  });
+
+  const needsGuidance = kind === 'guidance';
+  const needsRedirect = kind === 'redirect';
+  const needsSession = kind === 'pause' || kind === 'abort';
+
+  const submit = () => {
+    const command: SteerCommand = { kind };
+    if (needsGuidance) command.guidance = guidance;
+    if (needsRedirect) command.redirect_target = redirectTarget;
+    if (needsSession) command.session_id = sessionId;
+    if (reason) command.reason = reason;
+    mutation.mutate(command);
+  };
+
+  const disabled =
+    mutation.isPending ||
+    !taskId ||
+    (needsGuidance && !guidance.trim()) ||
+    (needsRedirect && !redirectTarget.trim()) ||
+    (needsSession && !sessionId.trim());
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-border bg-card p-3">
+      <div className="flex items-center gap-2 text-meta text-meta-foreground">
+        <ShieldCheck className="size-3" strokeWidth={1.5} />
+        <span className="font-mono">steer worker · {taskId || 'no task selected'}</span>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {KIND_ORDER.map((k) => {
+          const Meta = KIND_META[k];
+          const Icon = Meta.icon;
+          return (
+            <button
+              key={k}
+              type="button"
+              onClick={() => setKind(k)}
+              className={cn(
+                'flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[12px]',
+                kind === k
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-border text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon className="size-3" strokeWidth={1.5} />
+              {Meta.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {needsGuidance && (
+        <textarea
+          value={guidance}
+          onChange={(e) => setGuidance(e.target.value)}
+          placeholder="stop refactoring, focus on the failing test"
+          rows={2}
+          className="w-full rounded-md border border-border bg-background p-2 text-[12px] text-foreground"
+        />
+      )}
+      {needsRedirect && (
+        <input
+          value={redirectTarget}
+          onChange={(e) => setRedirectTarget(e.target.value)}
+          placeholder="new objective for this worker"
+          className="w-full rounded-md border border-border bg-background p-2 text-[12px] text-foreground"
+        />
+      )}
+      {needsSession && (
+        <input
+          value={sessionId}
+          onChange={(e) => setSessionId(e.target.value)}
+          placeholder="worker session id"
+          className="w-full rounded-md border border-border bg-background p-2 text-[12px] text-foreground"
+        />
+      )}
+      <input
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="reason (optional)"
+        className="w-full rounded-md border border-border bg-background p-2 text-[12px] text-foreground"
+      />
+
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={disabled}
+          className={cn(
+            'rounded-md px-3 py-1.5 text-[12px] font-medium',
+            disabled
+              ? 'cursor-not-allowed bg-muted text-muted-foreground'
+              : 'bg-foreground text-background hover:opacity-90',
+          )}
+        >
+          {mutation.isPending ? 'Recording receipt...' : `Send ${KIND_META[kind].label.toLowerCase()}`}
+        </button>
+
+        {mutation.isError && (
+          <span className="text-[12px] text-red-500">
+            {mutation.error instanceof ApiError
+              ? `${mutation.error.status} - rejected`
+              : 'failed'}
+          </span>
+        )}
+      </div>
+
+      {receipt && (
+        <div className="rounded-md border border-border bg-background p-2 text-[11px] text-muted-foreground">
+          <span className="font-mono text-meta-foreground">queued · </span>
+          <span className="text-foreground">{receipt.kind}</span>
+          <span className="ml-2 font-mono">seq {receipt.mailbox_seq}</span>
+          <span className="ml-2 font-mono" title={receipt.receipt_hash}>
+            receipt {receipt.receipt_hash.slice(0, 18)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -150,3 +150,43 @@ export const apiPut = <T = unknown>(path: string, body?: unknown, init?: Request
   api<T>(path, { ...init, method: 'PUT', body: body !== undefined ? JSON.stringify(body) : undefined });
 export const apiDelete = <T = unknown>(path: string, init?: RequestInit) =>
   api<T>(path, { ...init, method: 'DELETE' });
+
+// ── Fleet steering (#2508) ──────────────────────────────────────────────────
+// Operator-outbound mid-task control. Every action is a receipt first and an
+// effect second: the server binds the command into the audit chain before the
+// effect runs and returns the receipt the delivered effect references. Mirrors
+// `TaskSteerPost` / `TaskSteerResponse` in
+// `src/bernstein/core/server/server_models.py`.
+
+export type SteerKind = 'pause' | 'resume' | 'guidance' | 'redirect' | 'abort';
+
+export interface SteerCommand {
+  kind: SteerKind;
+  principal?: string;
+  guidance?: string;
+  redirect_target?: string;
+  reason?: string;
+  session_id?: string;
+  adapter?: string;
+  worktree?: string;
+  displayed_payload_hash?: string | null;
+}
+
+export interface SteerReceipt {
+  kind: string;
+  task_id: string;
+  principal: string;
+  scope: string;
+  payload_hash: string;
+  receipt_hash: string;
+  timestamp: number;
+  mailbox_seq: number;
+  mailbox_entry_hash: string;
+  checkpoint_event_hash: string;
+  abort_signal_written: boolean;
+}
+
+/** Steer one running worker; resolves to the signed receipt. */
+export function steerTask(taskId: string, command: SteerCommand): Promise<SteerReceipt> {
+  return apiPost<SteerReceipt>(`/tasks/${encodeURIComponent(taskId)}/steer`, command);
+}

--- a/web/src/routes/Fleet.tsx
+++ b/web/src/routes/Fleet.tsx
@@ -32,6 +32,7 @@ import {
   SectionLabel,
 } from '@/lib/states';
 import { cn } from '@/lib/utils';
+import SteeringControls from '@/components/SteeringControls';
 
 // ── Domain types ───────────────────────────────────────────────────────────
 // Mirrors `ProjectSnapshot.to_dict()` from
@@ -271,6 +272,7 @@ export default function Fleet() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [query, setQuery] = useState('');
+  const [steerTaskId, setSteerTaskId] = useState('');
   const parsed = useMemo(() => parseSearchQuery(query), [query]);
 
   // React Query keys are namespaced by mode (see Tasks.tsx for the
@@ -328,6 +330,17 @@ export default function Fleet() {
       </div>
 
       <CrossProjectSearch value={query} onChange={setQuery} parsed={parsed} />
+
+      <div className="flex flex-col gap-2">
+        <SectionLabel>Steer a running worker</SectionLabel>
+        <input
+          value={steerTaskId}
+          onChange={(e) => setSteerTaskId(e.target.value)}
+          placeholder="task id to steer"
+          className="w-full max-w-sm rounded-md border border-border bg-background p-2 font-mono text-[12px] text-foreground"
+        />
+        <SteeringControls taskId={steerTaskId} />
+      </div>
 
       {trimmedQuery && searchQ.data && (
         <div className="rounded-md border border-border bg-card p-3 text-[12px] text-muted-foreground">


### PR DESCRIPTION
## Problem

Once a worker is running a task an operator has no mid-task controls: no pause, no way to queue guidance ("stop refactoring, focus on the failing test"), no redirect of the objective, no clean abort. The only recourse is to abort the whole run and respawn, losing budget already spent, or to edit files under a running worker and leave no record, so an audited run a human touched can no longer be explained end to end.

## What this adds

A steering command surface where every action is a receipt first and an effect second.

- **Five steering kinds** (`pause`, `resume`, `guidance`, `redirect`, `abort`) each record a signed `steering.receipt` on the HMAC audit chain **before** any effect runs. The delivered effect references that receipt's chain HMAC, so an effect with no matching receipt is rejected. The receipt binds the exact command payload the operator confirmed; a request whose confirmed payload differs from the executed command fails before the chain is touched.
- **Delivery rides the existing task mailbox journal** as new `steer.*` message kinds, so queued guidance reaches the worker in chain append order, exactly once, even mid-tool-call. The worker records each consumed steering message as a first-class step in the per-step journal, so a steered run replays byte-identically and a second host walking the same journal computes identical step hashes.
- **Divergence detection distinguishes a steered run from a tampered one:** a run that verifies and carries steering steps is `steered`; mutating a recorded receipt or step fails verification at exactly its chain position and is labelled `tampered`.
- **Pause** checkpoints the running worker and parks its claim; **resume** continues from the checkpoint without restarting the task. **Abort** is enforced by the scheduler on the worker process through a filesystem stop signal, never routed through the model, and touches only the target session, so steering one worker leaves other workers' worktrees and claims untouched.
- **Authorisation** rides the scoped dashboard-token registry: an `operator` token is required; a `viewer` token or a request with no valid credential is recorded in the denial tracker and rejected.

Surfaces: `POST /tasks/{task_id}/steer`, the `bernstein fleet steer` CLI subcommand, and steering controls with a queued-guidance indicator on the fleet screen. The audit-chain event is additive (new constant plus helper, no reordering).

## Acceptance criteria coverage

| Criterion | Where |
|---|---|
| Every action produces a receipt before its effect; an effect without a matching receipt is rejected | `SteeringController.steer`, `consume_steering` |
| Pause checkpoints; resume continues from the checkpoint without restarting | `SteeringController._pause` / `_resume` over `checkpoint_retry` |
| Guidance queued mid-step delivered exactly once, in chain order, appears in transcript | mailbox `steer.*` kinds + `consume_steering` journal steps |
| Determinism: pause plus guidance plus redirect replays byte-identically; identical step hashes on a second host | per-step journal projection |
| Verifiability: mutating a receipt fails verification at the exact position; labelled tampered not steered | `classify_steering_run` + audit chain |
| Receipt binds the confirmed payload | `displayed_payload_hash` check |
| Isolation: steering one worker leaves others untouched | per-session signal directory |
| Steering requires an authorised scoped token; denials recorded and rejected | dashboard-token gate + denial tracker |

## Tests

New: `tests/unit/test_steering.py` (core, all criteria), `tests/unit/test_task_steer_routes.py` (server route plus scope enforcement), `tests/unit/test_fleet_steer_cli.py` (CLI). Existing task-server, mailbox, audit, checkpoint, replay, and contract suites stay green; web changes pass `tsc -b`.

## End-to-end

A single drive records pause / guidance / redirect / resume / abort as signed chain events (chain verifies, mailbox cross-verifies), consumes them into a per-step journal, confirms a second host computes identical step hashes, shows the abort SHUTDOWN signal on disk, and shows that mutating a receipt fails verification at its exact chain position while a viewer scope is rejected and recorded.

Closes #2508
