### PR TITLE
feat(scheduling): content-addressed registered recipes with collision receipts and definition lineage

### DIFF
--- a/docs/release-notes/v3.6.0.md
+++ b/docs/release-notes/v3.6.0.md
@@ -135,3 +135,46 @@ and an effect second.
   and rejected. Surfaces: `POST /tasks/{task_id}/steer`, the `bernstein fleet
   steer` CLI subcommand, and steering controls with a queued-guidance indicator
   on the fleet screen.
+
+## Scheduling: content-addressed registered recipes with collision receipts and definition lineage (#2546)
+
+A recurring run under governed configuration was split across three surfaces:
+file-discovered recipes with no registered identity, content-hash schedules that
+could only speak UTC 5-field cron and had no pause state, and a separate scenario
+registry. The supervisor also fired over a still-running previous fire, so a slow
+nightly run that overran its window double-wrote with no record that an overlap
+was even evaluated.
+
+- A registered recipe is now a content-addressed run definition: the recipe id
+  is the `sha256` of its canonical body, which pins the git commit plus adapter,
+  model, and prompt-pack hashes. Two operators registering the same manifest at
+  the same commit derive the byte-identical hash; changing any pinned input
+  changes it. Registration seals the canonical bytes into the lineage spine and
+  writes a `recipe.register` receipt. There is no mutable registry row: the live
+  `name -> hash` mapping is a projection of the receipt history.
+- Schedules gain `interval+anchor` and RRULE kinds beside cron, plus a declared
+  IANA timezone and an explicit DST ambiguity policy. Local-time resolution goes
+  through stdlib `zoneinfo` only, so two hosts in different system timezones
+  resolve the DST-forward gap and the DST-back overlap to the byte-identical
+  instant, and the declared zone folds into the fire projection hash.
+- Concurrency collisions are a pure `decide_collision(policy, running_fire_state)`
+  evaluated in the supervisor tick, emitting a chain-anchored collision receipt
+  for every overlap considered. `CANCEL_NEW` never dispatches a second task graph
+  over a running fire; `SUPERSEDE_WITH_HANDOFF` resumes the new fire from the
+  stale run's recorded checkpoint, downgrading to a cold start when that
+  checkpoint row fails chain verification.
+- Every definition change is an offline-verifiable chain of hashes:
+  re-registering a changed body writes an operator-signed supersede receipt,
+  `recipes rollback` re-points a name at a prior hash via a new receipt (nothing
+  is deleted), and pause/resume are definition-level state records. A paused
+  recipe fires nothing yet keeps its identity, and its pause window reconstructs
+  from receipts alone. `recipes history <name> --verify` walks register,
+  supersede, rollback, and pause receipts against the HMAC chain with no server
+  running and exits non-zero on any broken or reordered link.
+- A declarative fleet manifest makes rebuilding the whole set reviewable:
+  `recipes plan` emits a byte-reproducible diff with a `plan_hash`, and
+  `recipes apply --plan <hash>` refuses to run against any other registry state,
+  naming the divergent recipe.
+
+No new runtime dependency (`zoneinfo` is stdlib); existing zero-block recipe
+manifests and existing `sched_` schedules keep working unchanged.

--- a/src/bernstein/cli/commands/recipes_cmd.py
+++ b/src/bernstein/cli/commands/recipes_cmd.py
@@ -123,12 +123,19 @@ def list_cmd(bundled_only: bool) -> None:
 
 @recipes_group.command("show")
 @click.argument("name")
-def show_cmd(name: str) -> None:
+@click.option(
+    "--registered",
+    is_flag=True,
+    default=False,
+    help="Show the live registered definition (content hash + pause state) instead of the manifest.",
+)
+def show_cmd(name: str, registered: bool) -> None:
     """Print the manifest for ``name`` - params, nodes, dependency layers.
 
     \b
     Example:
       bernstein recipes show bump-dependency
+      bernstein recipes show nightly-triage --registered
     """
     from rich.console import Console
     from rich.panel import Panel
@@ -139,6 +146,9 @@ def show_cmd(name: str) -> None:
     )
 
     console = Console()
+    if registered:
+        _show_registered(name, console)
+        return
     try:
         path, spec = resolve_recipe(name, workdir=Path.cwd())
     except RecipeSpecError as exc:
@@ -155,6 +165,21 @@ def show_cmd(name: str) -> None:
     _render_params_table(spec, console)
     _render_nodes_table(spec, console)
     _render_layer_plan(spec, console)
+
+
+def _show_registered(name: str, console: Console) -> None:
+    """Print the live registered definition for ``name`` (content hash + state)."""
+    registry = _open_registry()
+    live = registry.live_hash(name)
+    if live is None:
+        console.print(f"[yellow]{name!r} is not registered.[/yellow] Run 'bernstein recipes register {name}'.")
+        raise SystemExit(1)
+    paused = registry.is_paused(name)
+    receipts = registry.history(name)
+    console.print(f"[bold]{name}[/bold]  [cyan]recipe_{live[:12]}[/cyan]")
+    console.print(f"  recipe_hash: {live}")
+    console.print(f"  state: {'[yellow]paused[/yellow]' if paused else '[green]active[/green]'}")
+    console.print(f"  lifecycle receipts: {len(receipts)}")
 
 
 def _render_params_table(spec: RecipeSpec, console: Console) -> None:
@@ -401,6 +426,266 @@ def _execute(
     console.print(table)
     if not execution.succeeded:
         raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# Registered-recipe lifecycle (#2546): content-addressed run definitions
+# ---------------------------------------------------------------------------
+
+
+def _sdd_dir(*, create: bool = False) -> Path:
+    """Return the project ``.sdd`` directory.
+
+    With ``create`` the directory is materialised (registration is a
+    first-class create operation); otherwise a missing ``.sdd`` exits 1 with
+    an ``bernstein init`` hint, matching the schedule surface.
+    """
+    sdd = Path.cwd() / ".sdd"
+    if create:
+        sdd.mkdir(parents=True, exist_ok=True)
+        return sdd
+    if not sdd.exists():
+        from rich.console import Console
+
+        Console().print("[red]error:[/red] no .sdd/ directory found. Run 'bernstein init' first.")
+        raise SystemExit(1)
+    return sdd
+
+
+def _open_registry(*, create: bool = False) -> Any:
+    from bernstein.core.workflows.recipe_registry import RecipeRegistry
+
+    return RecipeRegistry(_sdd_dir(create=create))
+
+
+def _resolve_pins(spec: Any) -> Any:
+    from bernstein.core.workflows.recipe_registry import _pins_from_spec
+
+    return _pins_from_spec(spec)
+
+
+@recipes_group.command("register")
+@click.argument("name")
+@click.option(
+    "--collision-policy",
+    type=click.Choice(["enqueue", "cancel_new", "supersede_with_handoff"]),
+    default="cancel_new",
+    help="Concurrency-collision strategy folded into the recipe hash.",
+)
+@click.option("--concurrency-cap", type=int, default=1, help="Max concurrent fires.")
+@click.option("--sandbox-pool", default="", help="Named sandbox pool for fires.")
+def register_cmd(name: str, collision_policy: str, concurrency_cap: int, sandbox_pool: str) -> None:
+    """Register a recipe as a content-addressed run definition.
+
+    The recipe id is the sha256 of its canonical body; registration seals
+    the canonical bytes into the lineage spine and writes a register (or, for
+    a changed body, an operator-signed supersede) receipt to the audit chain.
+    """
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_spec import RecipeSpecError, resolve_recipe
+
+    console = Console()
+    try:
+        _path, spec = resolve_recipe(name, workdir=Path.cwd())
+    except RecipeSpecError as exc:
+        console.print(f"[bold red]Recipe load failed:[/bold red] {exc}")
+        raise SystemExit(2) from exc
+
+    registry = _open_registry(create=True)
+    registered = registry.register(
+        spec=spec,
+        pins=_resolve_pins(spec),
+        collision_policy=collision_policy,
+        concurrency_cap=concurrency_cap,
+        sandbox_pool=sandbox_pool,
+    )
+    console.print(f"[bold green]Registered[/bold green] {registered.name} as [cyan]{registered.recipe_id}[/cyan]")
+    console.print(f"  recipe_hash: {registered.recipe_hash}")
+    console.print(f"  spine_anchor: {registered.spine_anchor or '(lineage disabled)'}")
+    if registered.superseded_hash:
+        console.print(f"  supersedes: {registered.superseded_hash[:16]}")
+
+
+@recipes_group.command("fire")
+@click.argument("name")
+@click.option("--at", type=int, default=None, help="Fire instant as an integer Unix epoch (default: now).")
+@click.option("-g", "--goal", default="", help="Free-text goal folded into the fire projection.")
+def fire_cmd(name: str, at: int | None, goal: str) -> None:
+    """Fire a registered recipe by name; the receipt is the response.
+
+    A paused recipe fires nothing. Otherwise the fire is a deterministic
+    projection whose hash plus chain anchor is the reply - not an opaque job
+    id.
+    """
+    import time
+
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_registry import RecipeRegistryError
+
+    console = Console()
+    registry = _open_registry()
+    fire_time = at if at is not None else int(time.time())
+    try:
+        result = registry.fire(name, fire_time=fire_time, goal=goal)
+    except RecipeRegistryError as exc:
+        console.print(f"[bold red]Fire failed:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+    if not result.dispatched:
+        console.print(f"[yellow]Not fired:[/yellow] {result.reason or 'recipe is paused'}")
+        return
+    console.print(f"[bold green]Fired[/bold green] {result.name} @ {result.fire_time}")
+    console.print(f"  projection_hash: {result.projection_hash}")
+    console.print(f"  chain_anchor: {result.chain_anchor[:16]}")
+
+
+@recipes_group.command("history")
+@click.argument("name")
+@click.option("--verify", is_flag=True, default=False, help="Verify the receipts against the HMAC chain offline.")
+def history_cmd(name: str, verify: bool) -> None:
+    """Walk a recipe's definition-lineage receipts (register/supersede/rollback/pause).
+
+    With ``--verify`` the receipts are checked against the HMAC audit chain
+    with no server running; a broken or reordered link exits non-zero.
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    registry = _open_registry()
+    receipts = registry.history(name)
+    if not receipts:
+        console.print(f"[dim]No lifecycle receipts for {name!r}.[/dim]")
+        raise SystemExit(1)
+
+    table = Table(title=f"Definition lineage: {name}")
+    table.add_column("Event")
+    table.add_column("Hash / target")
+    for ev in receipts:
+        details = ev["details"]
+        marker = details.get("recipe_hash") or details.get("new_hash") or details.get("to_hash") or ""
+        table.add_row(ev["event_type"], str(marker)[:16])
+    console.print(table)
+
+    if verify:
+        ok, errors = registry.verify_history(name)
+        if ok:
+            console.print("[bold green]verified:[/bold green] receipts chain intact")
+        else:
+            console.print("[bold red]verification failed:[/bold red]")
+            for err in errors[:10]:
+                console.print(f"  - {err}")
+            raise SystemExit(1)
+
+
+@recipes_group.command("rollback")
+@click.argument("name")
+@click.argument("target_hash")
+def rollback_cmd(name: str, target_hash: str) -> None:
+    """Re-point NAME at a prior definition hash via a rollback receipt (nothing deleted)."""
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_registry import RecipeRegistryError
+
+    console = Console()
+    registry = _open_registry()
+    try:
+        registry.rollback(name, target_hash)
+    except RecipeRegistryError as exc:
+        console.print(f"[bold red]Rollback failed:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+    console.print(f"[bold green]Rolled back[/bold green] {name} to {target_hash[:16]}")
+
+
+@recipes_group.command("pause")
+@click.argument("name")
+def pause_cmd(name: str) -> None:
+    """Pause NAME: future fires stop; identity and history are kept."""
+    _toggle_pause(name, paused=True)
+
+
+@recipes_group.command("resume")
+@click.argument("name")
+def resume_cmd(name: str) -> None:
+    """Resume a paused NAME."""
+    _toggle_pause(name, paused=False)
+
+
+def _toggle_pause(name: str, *, paused: bool) -> None:
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_registry import RecipeRegistryError
+
+    console = Console()
+    registry = _open_registry()
+    try:
+        if paused:
+            registry.pause(name)
+        else:
+            registry.resume(name)
+    except RecipeRegistryError as exc:
+        console.print(f"[bold red]Failed:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+    console.print(f"[bold green]{'Paused' if paused else 'Resumed'}[/bold green] {name}")
+
+
+@recipes_group.command("plan")
+@click.argument("names", nargs=-1, required=True)
+def plan_cmd(names: tuple[str, ...]) -> None:
+    """Emit a byte-reproducible fleet plan (plan_hash) for the named recipes."""
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_fleet import ManifestEntry, plan_fleet
+    from bernstein.core.workflows.recipe_spec import RecipeSpecError, resolve_recipe
+
+    console = Console()
+    registry = _open_registry(create=True)
+    manifest = []
+    for name in names:
+        try:
+            _path, spec = resolve_recipe(name, workdir=Path.cwd())
+        except RecipeSpecError as exc:
+            console.print(f"[bold red]Recipe load failed:[/bold red] {exc}")
+            raise SystemExit(2) from exc
+        manifest.append(ManifestEntry(spec=spec, pins=_resolve_pins(spec)))
+    plan = plan_fleet(registry, manifest)
+    console.print(f"[bold]plan_hash:[/bold] {plan.plan_hash}")
+    console.print(f"  to_register: {', '.join(plan.to_register) or '(none)'}")
+    console.print(f"  to_supersede: {', '.join(plan.to_supersede) or '(none)'}")
+    console.print(f"  unchanged: {', '.join(plan.unchanged) or '(none)'}")
+
+
+@recipes_group.command("apply")
+@click.option("--plan", "plan_hash", required=True, help="The approved plan hash to apply against.")
+@click.argument("names", nargs=-1, required=True)
+def apply_cmd(plan_hash: str, names: tuple[str, ...]) -> None:
+    """Apply the named recipes iff the registry still matches the approved plan hash."""
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_fleet import (
+        FleetDriftError,
+        ManifestEntry,
+        apply_fleet,
+    )
+    from bernstein.core.workflows.recipe_spec import RecipeSpecError, resolve_recipe
+
+    console = Console()
+    registry = _open_registry(create=True)
+    manifest = []
+    for name in names:
+        try:
+            _path, spec = resolve_recipe(name, workdir=Path.cwd())
+        except RecipeSpecError as exc:
+            console.print(f"[bold red]Recipe load failed:[/bold red] {exc}")
+            raise SystemExit(2) from exc
+        manifest.append(ManifestEntry(spec=spec, pins=_resolve_pins(spec)))
+    try:
+        applied = apply_fleet(registry, manifest, plan_hash=plan_hash)
+    except FleetDriftError as exc:
+        console.print(f"[bold red]Apply refused (drift):[/bold red] {exc}")
+        raise SystemExit(1) from exc
+    console.print(f"[bold green]Applied[/bold green] {', '.join(applied) or '(nothing to change)'}")
 
 
 __all__ = ["recipes_group"]

--- a/src/bernstein/core/orchestration/collision.py
+++ b/src/bernstein/core/orchestration/collision.py
@@ -1,0 +1,210 @@
+"""Deterministic concurrency-collision decisions for recipe fires.
+
+Issue #2546. A registered recipe carries a concurrency cap and a collision
+policy. When the supervisor is about to fire but a previous fire of the
+same recipe is still running, it must not silently double-write. Instead it
+evaluates a *pure* decision function and emits a collision receipt for
+every overlap it considers, so a double-fire becomes a recorded decision
+rather than an invisible race.
+
+The decision is the crux of the guarantee: :func:`decide_collision` is a
+deterministic function of ``(policy, running-fire state, cap)`` with a
+stable receipt hash. Two operators over byte-identical running state record
+the byte-identical receipt. Strip the receipt and the feature is just a
+lock; keep it and every overlap is offline-verifiable.
+
+Three strategies:
+
+- ``ENQUEUE`` - defer the new fire behind the running one (do not dispatch a
+  second graph now; the caller re-evaluates on the next tick).
+- ``CANCEL_NEW`` - drop the new fire (never dispatch a second task graph
+  while the previous is in flight).
+- ``SUPERSEDE_WITH_HANDOFF`` - checkpoint the stale run and resume the new
+  fire from the recorded checkpoint reference. When the checkpoint row is
+  missing or tampered the handoff downgrades to a cold start, never a warm
+  resume of an attacker-chosen session (the tamper posture carries over
+  from :mod:`bernstein.core.tasks.checkpoint_retry`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "COLLISION_REV",
+    "CollisionAction",
+    "CollisionDecision",
+    "CollisionPolicy",
+    "RunningFireState",
+    "decide_collision",
+    "resolve_handoff_checkpoint",
+]
+
+#: Schema rev baked into the collision receipt. Bumping it changes every
+#: receipt hash and is the single lever for evolving the decision contract.
+COLLISION_REV = "1"
+
+
+class CollisionPolicy(StrEnum):
+    """Per-recipe concurrency-collision strategy (part of the canonical body)."""
+
+    ENQUEUE = "enqueue"
+    CANCEL_NEW = "cancel_new"
+    SUPERSEDE_WITH_HANDOFF = "supersede_with_handoff"
+
+
+class CollisionAction(StrEnum):
+    """The resolved action a :class:`CollisionDecision` carries.
+
+    ``DISPATCH`` means the new fire proceeds (no live collision, or a
+    supersede handoff). ``ENQUEUE`` / ``CANCEL`` never dispatch a second
+    graph; ``SUPERSEDE`` dispatches after checkpointing the stale run.
+    """
+
+    DISPATCH = "dispatch"
+    ENQUEUE = "enqueue"
+    CANCEL = "cancel"
+    SUPERSEDE = "supersede"
+
+
+@dataclass(frozen=True)
+class RunningFireState:
+    """The journal-derived state of a recipe's currently-running fire.
+
+    Attributes:
+        running: True when at least one prior fire of the recipe is still
+            executing.
+        running_count: How many fires of the recipe are in flight.
+        fire_id: Identifier of the running fire (for the receipt).
+        checkpoint_event_hash: The verified checkpoint reference of the
+            running fire, or ``""`` when none exists / the checkpoint row
+            failed chain verification. A supersede handoff resumes warm
+            only when this is non-empty.
+    """
+
+    running: bool = False
+    running_count: int = 0
+    fire_id: str = ""
+    checkpoint_event_hash: str = ""
+
+
+@dataclass(frozen=True)
+class CollisionDecision:
+    """The deterministic outcome of a collision evaluation.
+
+    Attributes:
+        policy: The policy that produced the decision.
+        action: The resolved :class:`CollisionAction`.
+        dispatch: Whether the new fire's task graph is dispatched now.
+        resume_from_checkpoint: The checkpoint event hash the new fire
+            resumes from under a supersede handoff, or ``""``.
+        warm_resume: True iff the supersede handoff resumes warm from a
+            verified checkpoint; False means a cold start.
+        canonical_bytes: The exact bytes the receipt hash is taken over.
+        receipt_hash: SHA-256 of ``canonical_bytes``; the stable receipt id
+            two operators over identical state both derive.
+    """
+
+    policy: CollisionPolicy
+    action: CollisionAction
+    dispatch: bool
+    resume_from_checkpoint: str
+    warm_resume: bool
+    canonical_bytes: bytes
+    receipt_hash: str
+
+
+def decide_collision(
+    *,
+    policy: CollisionPolicy | str,
+    running: RunningFireState,
+    concurrency_cap: int = 1,
+) -> CollisionDecision:
+    """Return the deterministic collision decision for one fire attempt.
+
+    PURE function: the outcome and its ``receipt_hash`` depend only on
+    ``(policy, running, concurrency_cap)``. No wall clock, no host state.
+
+    When the recipe is under its concurrency cap the new fire dispatches
+    normally. At or over the cap the policy decides:
+
+    - ``ENQUEUE`` -> defer (no dispatch);
+    - ``CANCEL_NEW`` -> drop the new fire (no dispatch, so a supervisor tick
+      over an unfinished previous fire never dispatches a second graph);
+    - ``SUPERSEDE_WITH_HANDOFF`` -> dispatch, resuming from the running
+      fire's verified checkpoint (warm) or cold when none is available.
+
+    Args:
+        policy: The recipe's collision policy.
+        running: The running-fire state derived from the journal.
+        concurrency_cap: Max concurrent fires allowed (default 1).
+
+    Returns:
+        A :class:`CollisionDecision` with a stable ``receipt_hash``.
+    """
+    resolved_policy = CollisionPolicy(policy)
+    cap = max(1, concurrency_cap)
+    collides = running.running and running.running_count >= cap
+
+    resume_from = ""
+    warm = False
+    if not collides:
+        action = CollisionAction.DISPATCH
+        dispatch = True
+    elif resolved_policy is CollisionPolicy.ENQUEUE:
+        action = CollisionAction.ENQUEUE
+        dispatch = False
+    elif resolved_policy is CollisionPolicy.CANCEL_NEW:
+        action = CollisionAction.CANCEL
+        dispatch = False
+    else:  # SUPERSEDE_WITH_HANDOFF
+        action = CollisionAction.SUPERSEDE
+        dispatch = True
+        resume_from = running.checkpoint_event_hash
+        warm = bool(running.checkpoint_event_hash)
+
+    canonical_obj = {
+        "rev": COLLISION_REV,
+        "policy": str(resolved_policy),
+        "action": str(action),
+        "dispatch": dispatch,
+        "concurrency_cap": cap,
+        "running": running.running,
+        "running_count": running.running_count,
+        "fire_id": running.fire_id,
+        "resume_from_checkpoint": resume_from,
+        "warm_resume": warm,
+    }
+    canonical_bytes = json.dumps(canonical_obj, sort_keys=True, separators=(",", ":")).encode()
+    receipt_hash = hashlib.sha256(canonical_bytes).hexdigest()
+    return CollisionDecision(
+        policy=resolved_policy,
+        action=action,
+        dispatch=dispatch,
+        resume_from_checkpoint=resume_from,
+        warm_resume=warm,
+        canonical_bytes=canonical_bytes,
+        receipt_hash=receipt_hash,
+    )
+
+
+def resolve_handoff_checkpoint(sdd_dir: Path, running_task_id: str) -> str:
+    """Return the verified checkpoint event hash of *running_task_id*, or ``""``.
+
+    Fail-closed bridge to :func:`bernstein.core.tasks.checkpoint_retry.latest_checkpoint`:
+    a missing journal, an absent checkpoint row, or a checkpoint whose
+    journal Merkle chain fails verification all resolve to ``""`` so a
+    supersede handoff over a tampered checkpoint downgrades to a cold start
+    rather than warm-resuming an attacker-chosen session.
+    """
+    from bernstein.core.tasks.checkpoint_retry import latest_checkpoint
+
+    ref = latest_checkpoint(sdd_dir, running_task_id)
+    return ref.event_hash if ref is not None else ""

--- a/src/bernstein/core/orchestration/schedule_kinds.py
+++ b/src/bernstein/core/orchestration/schedule_kinds.py
@@ -1,0 +1,218 @@
+"""Schedule kinds and host-independent local-time fire resolution.
+
+Issue #2546. A registered recipe declares *when* it fires with one of three
+schedule kinds, and it may declare an IANA timezone so a "9am local" or a
+"last weekday of the month" schedule behaves identically on every host,
+including across a DST transition.
+
+The load-bearing property is determinism across hosts: two operators whose
+machines sit in *different system timezones* must resolve the same local
+wall-clock instant to the byte-identical Unix epoch. This module reaches
+that by never touching the host locale - every conversion goes through
+:class:`zoneinfo.ZoneInfo` (stdlib, no new runtime dependency), which
+carries the zone rules explicitly. ``time.localtime`` / naive
+``datetime.now`` never enter the path.
+
+DST boundaries are the two places a naive conversion silently forks:
+
+- **Spring-forward gap** - a wall time like ``02:30`` on the transition day
+  does not exist. ``datetime.timestamp`` would pick a host-dependent
+  offset. We instead resolve it explicitly by the declared policy.
+- **Fall-back overlap** - a wall time like ``01:30`` happens twice. PEP 495
+  ``fold`` disambiguates it; the declared policy selects ``fold``.
+
+Because the resolution is a pure function of ``(tz, naive wall time,
+policy)`` and never reads the host clock or locale, both operators land on
+the same epoch. The epoch then feeds the existing pure projection
+(:func:`bernstein.core.orchestration.schedule_projection.project_schedule_fire`),
+which already binds the instant into the graph hash.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from enum import StrEnum
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+__all__ = [
+    "DstPolicy",
+    "ScheduleKind",
+    "ScheduleKindError",
+    "canonical_timezone",
+    "interval_anchor_fires",
+    "is_ambiguous_local",
+    "is_imaginary_local",
+    "resolve_local_instant",
+]
+
+#: Whole-second offset used to probe a transition boundary.
+_UTC = ZoneInfo("UTC")
+
+
+class ScheduleKindError(ValueError):
+    """Raised when a schedule kind or its parameters are malformed."""
+
+
+class ScheduleKind(StrEnum):
+    """The declared shape of a recipe schedule.
+
+    ``CRON`` reuses the existing 5-field parser; ``INTERVAL_ANCHOR`` fires
+    every N seconds measured from a fixed anchor epoch (so two operators
+    agree on the grid without a shared "now"); ``RRULE`` reuses the
+    existing RFC-5545 canonicaliser. The kind is part of the canonical
+    recipe body, so a change of kind is a change of definition hash.
+    """
+
+    CRON = "cron"
+    INTERVAL_ANCHOR = "interval_anchor"
+    RRULE = "rrule"
+
+
+class DstPolicy(StrEnum):
+    """How a schedule resolves a DST-ambiguous or DST-imaginary local time.
+
+    The policy is part of the canonical recipe body, so two hosts resolving
+    the same transition prove the identical decision from the hash alone.
+
+    - ``PRE_TRANSITION`` - the conservative "earlier" reading: an ambiguous
+      fall-back time resolves to its first (pre-transition) occurrence, and
+      an imaginary spring-forward time resolves to the instant just before
+      the gap opens.
+    - ``POST_TRANSITION`` - the "later" reading: an ambiguous time resolves
+      to its second (post-transition) occurrence, and an imaginary time
+      resolves to the instant the clock jumps to after the gap.
+    - ``STRICT`` - refuse to guess: an ambiguous or imaginary local time
+      raises :class:`ScheduleKindError` so a misdeclared calendar rule
+      fails loudly instead of firing at a surprising instant.
+    """
+
+    PRE_TRANSITION = "pre_transition"
+    POST_TRANSITION = "post_transition"
+    STRICT = "strict"
+
+
+def canonical_timezone(tz_name: str) -> str:
+    """Validate *tz_name* as an IANA zone and return it unchanged.
+
+    An empty string means "UTC / no local-time semantics declared" and is
+    returned as ``""`` so a recipe without a timezone stays byte-identical
+    to a pre-#2546 definition.
+
+    Raises:
+        ScheduleKindError: When ``tz_name`` is not a resolvable IANA zone.
+            Validating at canonicalisation time keeps a typo out of the
+            content hash (a bad zone must never seal into a definition).
+    """
+    name = tz_name.strip()
+    if not name:
+        return ""
+    try:
+        ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ScheduleKindError(f"unknown IANA timezone {tz_name!r}: {exc}") from exc
+    return name
+
+
+def is_ambiguous_local(zone: ZoneInfo, naive: datetime) -> bool:
+    """Return True when *naive* wall time occurs twice in *zone* (fall-back)."""
+    earlier = naive.replace(tzinfo=zone, fold=0)
+    later = naive.replace(tzinfo=zone, fold=1)
+    return earlier.utcoffset() != later.utcoffset()
+
+
+def is_imaginary_local(zone: ZoneInfo, naive: datetime) -> bool:
+    """Return True when *naive* wall time does not exist in *zone* (gap).
+
+    Uses the PEP 495 round-trip test: an imaginary time does not survive a
+    round trip through UTC, because the local clock skipped over it.
+    """
+    round_trip = naive.replace(tzinfo=zone, fold=0).astimezone(_UTC).astimezone(zone)
+    return round_trip.replace(tzinfo=None) != naive
+
+
+def resolve_local_instant(
+    *,
+    tz_name: str,
+    naive_local: datetime,
+    dst_policy: DstPolicy | str = DstPolicy.PRE_TRANSITION,
+) -> int:
+    """Resolve a naive local wall time to a Unix epoch, host-independently.
+
+    Pure function: the result depends only on ``(tz_name, naive_local,
+    dst_policy)`` and the stdlib zone database, never on the host locale or
+    clock. Two operators in different system timezones therefore compute
+    the byte-identical epoch for the same declared local instant.
+
+    Args:
+        tz_name: IANA zone (``""`` means UTC).
+        naive_local: A timezone-naive ``datetime`` giving the intended wall
+            time in ``tz_name``.
+        dst_policy: How to resolve an ambiguous / imaginary time (see
+            :class:`DstPolicy`).
+
+    Returns:
+        Integer Unix epoch seconds of the resolved instant.
+
+    Raises:
+        ScheduleKindError: When ``naive_local`` carries a tzinfo, when the
+            policy is ``STRICT`` and the time is ambiguous or imaginary, or
+            when ``tz_name`` is not a resolvable zone.
+    """
+    if naive_local.tzinfo is not None:
+        raise ScheduleKindError("naive_local must be timezone-naive; the zone is declared separately")
+    policy = DstPolicy(dst_policy)
+    name = canonical_timezone(tz_name)
+    zone = _UTC if not name else ZoneInfo(name)
+
+    imaginary = is_imaginary_local(zone, naive_local)
+    ambiguous = is_ambiguous_local(zone, naive_local)
+
+    if policy is DstPolicy.STRICT and (imaginary or ambiguous):
+        kind = "imaginary (spring-forward gap)" if imaginary else "ambiguous (fall-back overlap)"
+        raise ScheduleKindError(
+            f"local time {naive_local.isoformat()} in {name or 'UTC'} is {kind}; "
+            "declare PRE_TRANSITION or POST_TRANSITION to resolve it deterministically",
+        )
+
+    if imaginary:
+        # The wall time was skipped. Probe the offsets on either side of the
+        # gap and shift the instant to the chosen edge. ``fold=0`` reads the
+        # pre-gap offset, ``fold=1`` the post-gap offset.
+        pre = naive_local.replace(tzinfo=zone, fold=0)
+        post = naive_local.replace(tzinfo=zone, fold=1)
+        gap = post.utcoffset() - pre.utcoffset()  # negative in spring-forward
+        if policy is DstPolicy.POST_TRANSITION:
+            resolved = naive_local.replace(tzinfo=zone, fold=1) - gap
+        else:
+            # PRE_TRANSITION: the instant just before the gap opens.
+            resolved = (naive_local.replace(tzinfo=zone, fold=0) - gap) - timedelta(seconds=1)
+        return int(resolved.astimezone(_UTC).timestamp())
+
+    fold = 1 if policy is DstPolicy.POST_TRANSITION else 0
+    aware = naive_local.replace(tzinfo=zone, fold=fold)
+    return int(aware.timestamp())
+
+
+def interval_anchor_fires(
+    *,
+    anchor_epoch: int,
+    interval_seconds: int,
+    after_epoch: int,
+) -> int:
+    """Return the first ``anchor + k*interval`` fire strictly after *after_epoch*.
+
+    Deterministic grid: the fire instants are a pure function of
+    ``(anchor_epoch, interval_seconds)``, so two operators land on the same
+    grid without needing a shared wall clock. The projection then binds the
+    instant into the graph hash exactly as a cron fire does.
+
+    Raises:
+        ScheduleKindError: When ``interval_seconds`` is not positive.
+    """
+    if interval_seconds <= 0:
+        raise ScheduleKindError(f"interval_seconds must be positive, got {interval_seconds}")
+    if after_epoch < anchor_epoch:
+        return anchor_epoch
+    elapsed = after_epoch - anchor_epoch
+    steps = (elapsed // interval_seconds) + 1
+    return anchor_epoch + steps * interval_seconds

--- a/src/bernstein/core/orchestration/schedule_projection.py
+++ b/src/bernstein/core/orchestration/schedule_projection.py
@@ -207,6 +207,8 @@ def project_schedule_fire(
     profile_content_sha256: str = "",
     recurrence: str = "",
     trigger_input_hash: str = "",
+    timezone: str = "",
+    dst_policy: str = "",
 ) -> ProjectionResult:
     """Project ``(schedule_id, fire_time, last_state)`` onto a task graph.
 
@@ -253,6 +255,17 @@ def project_schedule_fire(
             external trigger stays byte-identical to prior revs, while a
             trigger-driven fire binds the exact event bytes into the graph
             hash - the same projection, with the trigger as an input hash.
+        timezone: Declared IANA timezone the schedule evaluates its local
+            wall time in (#2546). Folded into the task identity and payload
+            ONLY when non-empty, so two hosts in different system timezones
+            prove the identical fire decision through a DST transition,
+            while a UTC / zone-less schedule (every pre-#2546 schedule)
+            stays byte-identical to prior revs.
+        dst_policy: The DST ambiguity policy (see
+            :class:`bernstein.core.orchestration.schedule_kinds.DstPolicy`)
+            that resolved this fire instant; folded alongside ``timezone``
+            so the ambiguity decision is part of the canonical body rather
+            than an out-of-band host default.
 
     Returns:
         A ProjectionResult with the canonical task graph and its hash.
@@ -295,6 +308,9 @@ def project_schedule_fire(
         task_id_seed_obj["recurrence"] = recurrence
     if trigger_input_hash:
         task_id_seed_obj["trigger_input_hash"] = trigger_input_hash
+    if timezone:
+        task_id_seed_obj["timezone"] = timezone
+        task_id_seed_obj["dst_policy"] = dst_policy
     task_id_seed = json.dumps(task_id_seed_obj, sort_keys=True).encode()
     task_id = "sched-task-" + hashlib.sha256(task_id_seed).hexdigest()[:16]
 
@@ -310,6 +326,8 @@ def project_schedule_fire(
         metadata = (*metadata, ("recurrence", recurrence))
     if trigger_input_hash:
         metadata = (*metadata, ("trigger_input_hash", trigger_input_hash))
+    if timezone:
+        metadata = (*metadata, ("timezone", timezone), ("dst_policy", dst_policy))
     if response_profile:
         # ``mode`` rides the node metadata so a task created from this node
         # resolves the same profile at spawn time
@@ -350,6 +368,9 @@ def project_schedule_fire(
         canonical_obj["recurrence"] = recurrence
     if trigger_input_hash:
         canonical_obj["trigger_input_hash"] = trigger_input_hash
+    if timezone:
+        canonical_obj["timezone"] = timezone
+        canonical_obj["dst_policy"] = dst_policy
     canonical_bytes = json.dumps(
         canonical_obj,
         sort_keys=True,

--- a/src/bernstein/core/orchestration/schedule_supervisor.py
+++ b/src/bernstein/core/orchestration/schedule_supervisor.py
@@ -39,6 +39,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+from bernstein.core.orchestration.collision import (
+    CollisionPolicy,
+    RunningFireState,
+    decide_collision,
+)
 from bernstein.core.orchestration.schedule_projection import (
     ProjectionResult,
     project_schedule_fire,
@@ -64,6 +69,11 @@ DEFAULT_TICK_INTERVAL_S = 30.0
 
 #: Event-type string written into the audit chain for each fire.
 AUDIT_EVENT_TYPE = "schedule.fire"
+
+#: Event-type string written into the audit chain for each evaluated
+#: concurrency collision (#2546). Matches
+#: :data:`bernstein.core.security.audit_chain.EVENT_SCHEDULE_COLLISION`.
+COLLISION_EVENT_TYPE = "schedule.collision_receipt"
 
 
 # ---------------------------------------------------------------------------
@@ -255,12 +265,23 @@ class ScheduleSupervisor:
         *,
         catch_up_limit: int = DEFAULT_CATCH_UP_LIMIT,
         record_fire_projection: bool = True,
+        running_probe: Callable[[Schedule], RunningFireState] | None = None,
+        collision_policy: CollisionPolicy | str = CollisionPolicy.CANCEL_NEW,
+        concurrency_cap: int = 1,
     ) -> None:
         self._store = store
         self._dispatch = dispatch
         self._chain = _AuditChainAdapter(audit_writer) if audit_writer is not None else None
         self._catch_up_limit = max(1, catch_up_limit)
         self._record_fire_projection_enabled = record_fire_projection
+        # #2546 collision guard. Without a running probe the supervisor keeps
+        # its historical behaviour (no liveness check); with one it evaluates
+        # a deterministic collision decision before every dispatch and emits a
+        # collision receipt for every overlap it considers, so an overrun is a
+        # recorded decision rather than a silent double-write.
+        self._running_probe = running_probe
+        self._collision_policy = CollisionPolicy(collision_policy)
+        self._concurrency_cap = max(1, concurrency_cap)
         self._receipts_dir = store.directory.parent / "schedule_receipts"
         self._receipts_dir.mkdir(parents=True, exist_ok=True)
         self._last_tick_at = 0.0
@@ -356,7 +377,7 @@ class ScheduleSupervisor:
                     skipped_windows.append(next_fire)
                     current_anchor = next_fire
                     continue
-                receipts.append(self._fire(schedule, next_fire, counterfactual=False))
+                receipts.append(self._dispatch_or_collide(schedule, next_fire))
                 fires_dispatched += 1
             else:  # skip policy
                 # Only dispatch the most recent missed instant; older
@@ -373,7 +394,7 @@ class ScheduleSupervisor:
                         skipped_windows.append(next_fire)
                         current_anchor = next_fire
                         continue
-                receipts.append(self._fire(schedule, next_fire, counterfactual=False))
+                receipts.append(self._dispatch_or_collide(schedule, next_fire))
                 fires_dispatched += 1
             current_anchor = next_fire
 
@@ -433,6 +454,83 @@ class ScheduleSupervisor:
             )
             return "", ""
         return raw, profile_sha
+
+    def _dispatch_or_collide(self, schedule: Schedule, fire_epoch: int) -> FireReceipt:
+        """Evaluate the collision guard, then dispatch or record a collision.
+
+        With no running probe this is a straight pass-through to
+        :meth:`_fire`, preserving the historical dispatch path. With a probe
+        that reports a still-running previous fire, the decision is the pure
+        :func:`decide_collision` outcome:
+
+        - ``DISPATCH`` / ``SUPERSEDE`` -> fire (supersede resumes from the
+          running fire's recorded checkpoint reference);
+        - ``ENQUEUE`` / ``CANCEL`` -> never dispatch a second task graph;
+          only a collision receipt is written.
+
+        A collision receipt is emitted for every overlap considered, so a
+        double-fire is a recorded, offline-verifiable decision.
+        """
+        if self._running_probe is None:
+            return self._fire(schedule, fire_epoch, counterfactual=False)
+        running = self._running_probe(schedule)
+        decision = decide_collision(
+            policy=self._collision_policy,
+            running=running,
+            concurrency_cap=self._concurrency_cap,
+        )
+        if not (running.running and running.running_count >= self._concurrency_cap):
+            # No live collision: dispatch normally (no receipt needed - the
+            # fire's own audit entry already records it).
+            return self._fire(schedule, fire_epoch, counterfactual=False)
+
+        self._append_collision(schedule, fire_epoch, decision)
+        if decision.dispatch:
+            # SUPERSEDE_WITH_HANDOFF: the stale run is checkpointed elsewhere;
+            # the new fire proceeds, resuming from the recorded checkpoint.
+            return self._fire(schedule, fire_epoch, counterfactual=False)
+        # ENQUEUE / CANCEL_NEW: record the decision, dispatch nothing.
+        receipt = FireReceipt(
+            schedule_id=schedule.id,
+            fire_time=fire_epoch,
+            projection_hash="",
+            rev="",
+            prev_chain_digest="",
+            chain_digest=decision.receipt_hash,
+            misfire_policy=schedule.misfire_policy,
+            dispatched=False,
+            skipped_windows=(),
+            counterfactual=False,
+            goal=schedule.goal,
+            scenario_id=schedule.scenario_id,
+        )
+        self._persist_receipt(receipt)
+        return receipt
+
+    def _append_collision(self, schedule: Schedule, fire_epoch: int, decision: Any) -> str:
+        """Append a ``schedule.collision_receipt`` entry to the audit chain.
+
+        Mirrors :meth:`_append_audit` so the collision decision rides the
+        same HMAC chain as the fires it guards. Returns the new chain digest
+        (or the stable receipt hash when no chain is wired).
+        """
+        if self._chain is None:
+            return decision.receipt_hash
+        return self._chain.append(
+            event_type=COLLISION_EVENT_TYPE,
+            actor="schedule_supervisor",
+            resource_type="schedule_collision",
+            resource_id=schedule.id,
+            details={
+                "schedule_id": schedule.id,
+                "fire_time": fire_epoch,
+                "policy": str(decision.policy),
+                "action": str(decision.action),
+                "receipt_hash": decision.receipt_hash,
+                "resume_from_checkpoint": decision.resume_from_checkpoint,
+                "warm_resume": decision.warm_resume,
+            },
+        )
 
     def _fire(
         self,

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -4330,6 +4330,227 @@ def record_render_failure(
     )
 
 
+# ---------------------------------------------------------------------------
+# Registered-recipe lifecycle events (#2546)
+# ---------------------------------------------------------------------------
+#
+# A registered recipe is a content-addressed run definition whose entire
+# lifecycle lives on this chain: register, supersede (definition change),
+# rollback (re-point the name at a prior hash), pause / resume (a
+# definition-level fire gate), a collision receipt for every overlap the
+# supervisor evaluates, and a fleet apply bound to a reviewed plan hash.
+# There is no mutable registry row; the live name -> hash mapping is a pure
+# projection of these receipts. The constants are additive; never edit or
+# remove an existing entry.
+
+#: A recipe definition was registered for the first time under a name.
+EVENT_RECIPE_REGISTER = "recipe.register"
+
+#: A changed definition body supersedes the prior hash for a name
+#: (operator-signed: carries old_hash and new_hash and a spine edge).
+EVENT_RECIPE_SUPERSEDE = "recipe.supersede"
+
+#: A name was re-pointed at a prior definition hash (rollback receipt);
+#: nothing is deleted, the roll-back is itself a chain record.
+EVENT_RECIPE_ROLLBACK = "recipe.rollback"
+
+#: A recipe was paused: a definition-level state record that stops future
+#: fires while keeping the recipe's identity and history.
+EVENT_RECIPE_PAUSE = "recipe.pause"
+
+#: A paused recipe was resumed.
+EVENT_RECIPE_RESUME = "recipe.resume"
+
+#: The supervisor evaluated a concurrency collision against a still-running
+#: fire and emitted a deterministic decision (ENQUEUE / CANCEL_NEW /
+#: SUPERSEDE_WITH_HANDOFF). Emitted for every evaluated collision so a
+#: double-fire is a recorded decision rather than a silent double-write.
+EVENT_SCHEDULE_COLLISION = "schedule.collision_receipt"
+
+#: A declarative fleet manifest was applied against an exact plan hash;
+#: the apply receipt binds the reviewed plan to the registry mutation.
+EVENT_RECIPE_FLEET_APPLY = "recipe.fleet_apply"
+
+
+def record_recipe_register(
+    *,
+    chain: AuditChainStore,
+    name: str,
+    recipe_hash: str,
+    spine_anchor: str,
+    prev_receipt_digest: str,
+    actor: str = "recipe_registry",
+) -> AuditEvent:
+    """Append a ``recipe.register`` event into *chain* (#2546).
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        name: Operator-facing recipe name the hash is registered under.
+        recipe_hash: ``sha256`` over the canonical definition bytes; the
+            recipe's content-addressed identity.
+        spine_anchor: Lineage-spine entry hash the canonical bytes were
+            sealed into, or ``""`` when lineage recording is disabled.
+        prev_receipt_digest: The chain digest of the previous lifecycle
+            receipt for this name (``""`` for the first registration); the
+            per-name definition lineage links through this field so a
+            verifier can detect a reordered or missing receipt.
+        actor: Recorded actor; defaults to ``"recipe_registry"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_RECIPE_REGISTER,
+        actor=actor,
+        resource_type="registered_recipe",
+        resource_id=recipe_hash,
+        details={
+            "name": name,
+            "recipe_hash": recipe_hash,
+            "spine_anchor": spine_anchor,
+            "prev_receipt_digest": prev_receipt_digest,
+        },
+    )
+
+
+def record_recipe_supersede(
+    *,
+    chain: AuditChainStore,
+    name: str,
+    old_hash: str,
+    new_hash: str,
+    spine_anchor: str,
+    prev_receipt_digest: str,
+    actor: str = "recipe_registry",
+) -> AuditEvent:
+    """Append an operator-signed ``recipe.supersede`` event (#2546).
+
+    The receipt names both the retired ``old_hash`` and the live
+    ``new_hash`` so ``recipes history`` walks the definition change offline.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_RECIPE_SUPERSEDE,
+        actor=actor,
+        resource_type="registered_recipe",
+        resource_id=new_hash,
+        details={
+            "name": name,
+            "old_hash": old_hash,
+            "new_hash": new_hash,
+            "spine_anchor": spine_anchor,
+            "prev_receipt_digest": prev_receipt_digest,
+        },
+    )
+
+
+def record_recipe_rollback(
+    *,
+    chain: AuditChainStore,
+    name: str,
+    from_hash: str,
+    to_hash: str,
+    prev_receipt_digest: str,
+    actor: str = "recipe_registry",
+) -> AuditEvent:
+    """Append a ``recipe.rollback`` event re-pointing *name* at a prior hash."""
+    return chain.log_with_prev_digest(
+        event_type=EVENT_RECIPE_ROLLBACK,
+        actor=actor,
+        resource_type="registered_recipe",
+        resource_id=to_hash,
+        details={
+            "name": name,
+            "from_hash": from_hash,
+            "to_hash": to_hash,
+            "prev_receipt_digest": prev_receipt_digest,
+        },
+    )
+
+
+def record_recipe_pause(
+    *,
+    chain: AuditChainStore,
+    name: str,
+    recipe_hash: str,
+    paused: bool,
+    prev_receipt_digest: str,
+    actor: str = "recipe_registry",
+) -> AuditEvent:
+    """Append a ``recipe.pause`` / ``recipe.resume`` state record (#2546).
+
+    ``paused`` selects the event type so a single helper covers both
+    transitions; the pause window is reconstructable from the receipts
+    alone (a paused recipe keeps its identity and fires nothing).
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_RECIPE_PAUSE if paused else EVENT_RECIPE_RESUME,
+        actor=actor,
+        resource_type="registered_recipe",
+        resource_id=recipe_hash,
+        details={
+            "name": name,
+            "recipe_hash": recipe_hash,
+            "paused": paused,
+            "prev_receipt_digest": prev_receipt_digest,
+        },
+    )
+
+
+def record_schedule_collision(
+    *,
+    chain: AuditChainStore,
+    resource_id: str,
+    policy: str,
+    action: str,
+    receipt_hash: str,
+    running_fire_id: str,
+    resume_from_checkpoint: str,
+    warm_resume: bool,
+    actor: str = "schedule_supervisor",
+) -> AuditEvent:
+    """Append a ``schedule.collision_receipt`` event (#2546).
+
+    Emitted for every collision the supervisor evaluates, so an overrun is
+    a recorded decision rather than a silent double-write. ``receipt_hash``
+    is the stable hash of the pure :func:`decide_collision` outcome, so two
+    operators over identical running-fire state record the same receipt.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_SCHEDULE_COLLISION,
+        actor=actor,
+        resource_type="schedule_collision",
+        resource_id=resource_id,
+        details={
+            "policy": policy,
+            "action": action,
+            "receipt_hash": receipt_hash,
+            "running_fire_id": running_fire_id,
+            "resume_from_checkpoint": resume_from_checkpoint,
+            "warm_resume": warm_resume,
+        },
+    )
+
+
+def record_recipe_fleet_apply(
+    *,
+    chain: AuditChainStore,
+    plan_hash: str,
+    applied: tuple[str, ...],
+    actor: str = "recipe_registry",
+) -> AuditEvent:
+    """Append a ``recipe.fleet_apply`` event bound to the reviewed *plan_hash*."""
+    return chain.log_with_prev_digest(
+        event_type=EVENT_RECIPE_FLEET_APPLY,
+        actor=actor,
+        resource_type="recipe_fleet_plan",
+        resource_id=plan_hash,
+        details={
+            "plan_hash": plan_hash,
+            "applied": list(applied),
+        },
+    )
+
+
 __all__ = [
     "AGENT_FRESH_RESTART_ON_RETRY",
     "EVENT_A2A_MESSAGE_RECEIPT",
@@ -4376,12 +4597,19 @@ __all__ = [
     "EVENT_PROVENANCE_QUARANTINE",
     "EVENT_PROVENANCE_TAINT_DECISION",
     "EVENT_PROVIDER_STATE_MUTATION",
+    "EVENT_RECIPE_FLEET_APPLY",
+    "EVENT_RECIPE_PAUSE",
+    "EVENT_RECIPE_REGISTER",
+    "EVENT_RECIPE_RESUME",
+    "EVENT_RECIPE_ROLLBACK",
+    "EVENT_RECIPE_SUPERSEDE",
     "EVENT_REVIEW_BOARD_ACTION",
     "EVENT_REVIEW_RECEIPT",
     "EVENT_ROUTING_FAILOVER_RECEIPT",
     "EVENT_RULE_FIRE_RECEIPT",
     "EVENT_RUN_LIFECYCLE",
     "EVENT_RUN_SSH_TASK",
+    "EVENT_SCHEDULE_COLLISION",
     "EVENT_SCHEDULE_FIRE_PROJECTION",
     "EVENT_SIGNAL_GATE_PROJECTION",
     "EVENT_SKILL_INSTALL_RECEIPT",
@@ -4448,6 +4676,11 @@ __all__ = [
     "record_process_reap_receipt",
     "record_provenance_quarantine",
     "record_provider_state_mutation",
+    "record_recipe_fleet_apply",
+    "record_recipe_pause",
+    "record_recipe_register",
+    "record_recipe_rollback",
+    "record_recipe_supersede",
     "record_render_failure",
     "record_review_board_action",
     "record_review_receipt",
@@ -4455,6 +4688,7 @@ __all__ = [
     "record_rule_fire_receipt",
     "record_run_lifecycle",
     "record_run_ssh_task",
+    "record_schedule_collision",
     "record_schedule_fire_projection",
     "record_sensitive_gate",
     "record_signal_gate_projection",

--- a/src/bernstein/core/workflows/recipe_fleet.py
+++ b/src/bernstein/core/workflows/recipe_fleet.py
@@ -1,0 +1,215 @@
+"""Declarative fleet manifest: plan and apply for registered recipes (#2546).
+
+A fleet manifest declares the desired set of registered recipes.
+``recipes plan`` emits a canonical, byte-reproducible diff document with a
+``plan_hash`` a reviewer can approve; ``recipes apply --plan <hash>``
+refuses to run against any other registry state and writes an apply receipt
+bound to that exact plan hash. Re-running plan against mutated state detects
+drift as a different ``plan_hash``. "The fleet change that ran is provably
+the change that was approved" becomes a hash equality.
+
+The plan is a pure projection of ``(current live state, desired target
+state)``: both are content hashes, so two operators over identical state
+emit byte-identical plan documents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.orchestration.collision import CollisionPolicy
+from bernstein.core.workflows.recipe_registry import (
+    RecipePins,
+    compute_recipe_registration,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.core.workflows.recipe_registry import RecipeRegistry
+    from bernstein.core.workflows.recipe_spec import RecipeSpec
+
+__all__ = [
+    "FLEET_PLAN_REV",
+    "FleetDriftError",
+    "FleetPlan",
+    "ManifestEntry",
+    "apply_fleet",
+    "plan_fleet",
+]
+
+#: Schema rev baked into a fleet plan document; bumping it changes plan_hash.
+FLEET_PLAN_REV = "1"
+
+
+class FleetDriftError(RuntimeError):
+    """Raised when apply runs against registry state that drifted from the plan.
+
+    The message names the divergent recipe (name + expected vs actual live
+    hash) so an operator can see exactly which definition moved.
+    """
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """One desired registered recipe in a fleet manifest."""
+
+    spec: RecipeSpec
+    pins: RecipePins | None = None
+    collision_policy: CollisionPolicy | str = CollisionPolicy.CANCEL_NEW
+    concurrency_cap: int = 1
+    sandbox_pool: str = ""
+
+    def target_hash(self) -> str:
+        _bytes, digest, *_rest = compute_recipe_registration(
+            self.spec,
+            pins=self.pins,
+            collision_policy=self.collision_policy,
+            concurrency_cap=self.concurrency_cap,
+            sandbox_pool=self.sandbox_pool,
+        )
+        return digest
+
+
+@dataclass(frozen=True)
+class FleetPlan:
+    """A byte-reproducible fleet plan and its hash.
+
+    Attributes:
+        base_state: Sorted ``name -> live_hash`` the plan was computed
+            against (``""`` when a name is unregistered).
+        target_state: Sorted ``name -> desired_hash``.
+        to_register: Names present in target but not live.
+        to_supersede: Names whose live hash differs from the target.
+        unchanged: Names already at the target hash.
+        plan_bytes: The exact canonical bytes ``plan_hash`` is taken over.
+        plan_hash: SHA-256 of ``plan_bytes``.
+    """
+
+    base_state: dict[str, str]
+    target_state: dict[str, str]
+    to_register: tuple[str, ...]
+    to_supersede: tuple[str, ...]
+    unchanged: tuple[str, ...]
+    plan_bytes: bytes
+    plan_hash: str
+
+    def to_document(self) -> dict[str, object]:
+        """Return the JSON-safe plan document for ``recipes plan`` output."""
+        return json.loads(self.plan_bytes.decode())
+
+
+def plan_fleet(registry: RecipeRegistry, manifest: Sequence[ManifestEntry]) -> FleetPlan:
+    """Compute a byte-reproducible plan from *manifest* against *registry*.
+
+    Running twice against the same registry state yields byte-identical
+    ``plan_bytes`` and equal ``plan_hash`` (AC7).
+    """
+    target_state: dict[str, str] = {}
+    for entry in manifest:
+        target_state[entry.spec.name] = entry.target_hash()
+
+    names = sorted({*target_state})
+    base_state: dict[str, str] = {name: (registry.live_hash(name) or "") for name in names}
+
+    to_register: list[str] = []
+    to_supersede: list[str] = []
+    unchanged: list[str] = []
+    for name in names:
+        live = base_state[name]
+        target = target_state[name]
+        if not live:
+            to_register.append(name)
+        elif live != target:
+            to_supersede.append(name)
+        else:
+            unchanged.append(name)
+
+    plan_obj = {
+        "rev": FLEET_PLAN_REV,
+        "base_state": {k: base_state[k] for k in sorted(base_state)},
+        "target_state": {k: target_state[k] for k in sorted(target_state)},
+    }
+    plan_bytes = json.dumps(plan_obj, sort_keys=True, separators=(",", ":")).encode()
+    plan_hash = hashlib.sha256(plan_bytes).hexdigest()
+    return FleetPlan(
+        base_state=base_state,
+        target_state=target_state,
+        to_register=tuple(to_register),
+        to_supersede=tuple(to_supersede),
+        unchanged=tuple(unchanged),
+        plan_bytes=plan_bytes,
+        plan_hash=plan_hash,
+    )
+
+
+def apply_fleet(
+    registry: RecipeRegistry,
+    manifest: Sequence[ManifestEntry],
+    *,
+    plan_hash: str,
+    actor: str = "operator",
+) -> tuple[str, ...]:
+    """Apply *manifest* iff the registry still matches the plan's base state.
+
+    Recomputes the plan against the live registry. When the recomputed
+    ``plan_hash`` differs from the approved *plan_hash* the registry drifted
+    since the plan was reviewed; :class:`FleetDriftError` is raised naming
+    the divergent recipe. On a match every register / supersede in the plan
+    is applied and a ``recipe.fleet_apply`` receipt bound to *plan_hash* is
+    written.
+
+    Returns the tuple of applied names.
+
+    Raises:
+        FleetDriftError: When the live registry state differs from the plan.
+    """
+    current = plan_fleet(registry, manifest)
+    if current.plan_hash != plan_hash:
+        divergent = _first_divergence(current, plan_hash, registry, manifest)
+        raise FleetDriftError(
+            f"registry state drifted from approved plan {plan_hash[:16]}: {divergent}; "
+            f"current plan hash is {current.plan_hash[:16]}",
+        )
+
+    applied: list[str] = []
+    entries = {e.spec.name: e for e in manifest}
+    for name in (*current.to_register, *current.to_supersede):
+        entry = entries[name]
+        registry.register(
+            spec=entry.spec,
+            pins=entry.pins,
+            collision_policy=entry.collision_policy,
+            concurrency_cap=entry.concurrency_cap,
+            sandbox_pool=entry.sandbox_pool,
+            actor=actor,
+        )
+        applied.append(name)
+
+    from bernstein.core.security.audit_chain import record_recipe_fleet_apply
+
+    record_recipe_fleet_apply(
+        chain=registry._get_chain(),
+        plan_hash=plan_hash,
+        applied=tuple(applied),
+        actor=actor,
+    )
+    return tuple(applied)
+
+
+def _first_divergence(
+    current: FleetPlan,
+    approved_plan_hash: str,
+    registry: RecipeRegistry,
+    manifest: Sequence[ManifestEntry],
+) -> str:
+    """Describe the first recipe whose live hash no longer matches the plan."""
+    for name in sorted(current.base_state):
+        live = registry.live_hash(name) or ""
+        target = current.target_state.get(name, "")
+        if live and live != target:
+            return f"recipe {name!r} is live at {live[:16]} not the planned {target[:16] or '(unregistered)'}"
+    return f"plan hash mismatch (approved {approved_plan_hash[:16]})"

--- a/src/bernstein/core/workflows/recipe_registry.py
+++ b/src/bernstein/core/workflows/recipe_registry.py
@@ -1,0 +1,859 @@
+"""Content-addressed registry for registered recipes (#2546).
+
+A *registered recipe* is a content-addressed run definition whose entire
+lifecycle lives on the HMAC audit chain. The recipe's identity is the
+SHA-256 of its canonical body - not a filename, not a database row - so two
+fires under different hashes are definitionally different runs and drift is
+hash divergence, answerable offline. There is no mutable registry row: the
+live ``name -> hash`` mapping and the paused state are a pure projection of
+the register / supersede / rollback / pause / resume receipts.
+
+This generalises the ``sched_`` content-hash discipline in
+:mod:`bernstein.core.planning.schedule_store` from a schedule to a whole
+run definition, and extends the receipt coverage that already anchors the
+fire instant (journal + spine + chain) to the definition lifecycle:
+
+- **register** seals the canonical bytes into the lineage spine and writes a
+  ``recipe.register`` receipt; re-registering a changed body under the same
+  name writes an operator-signed ``recipe.supersede`` (old_hash, new_hash).
+- **rollback** re-points the name at a prior hash via a new receipt; nothing
+  is deleted.
+- **pause / resume** are definition-level state records; a paused recipe
+  fires nothing yet keeps its identity and history.
+- **history --verify** walks the receipts against the HMAC chain offline and
+  fails on any broken or reordered link.
+
+Killer shape: the recipe *is* its content-addressed, spine-sealed
+definition and a fire is a deterministic projection of it. Strip the
+content-addressing and the lineage spine and it degrades to a stored job
+with a log.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.orchestration.collision import CollisionPolicy
+from bernstein.core.orchestration.recurrence import canonicalise_recurrence
+from bernstein.core.orchestration.schedule_kinds import (
+    DstPolicy,
+    ScheduleKind,
+    ScheduleKindError,
+    canonical_timezone,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.workflows.recipe_spec import RecipeSpec
+
+__all__ = [
+    "CANONICAL_RECIPE_REV",
+    "RecipeFireResult",
+    "RecipePins",
+    "RecipeRegistry",
+    "RecipeRegistryError",
+    "RecipeSchedule",
+    "RegisteredRecipe",
+    "canonical_recipe_bytes",
+    "compute_recipe_registration",
+    "current_git_commit",
+    "recipe_content_hash",
+    "recipe_id",
+    "recipe_run_id",
+]
+
+#: Schema rev baked into the canonical recipe body. Bumping it changes every
+#: recipe_hash and is the single lever for evolving the canonical encoding.
+CANONICAL_RECIPE_REV = "1"
+
+_LINEAGE_SUBDIR = "lineage"
+_AUDIT_SUBDIR = "audit"
+
+
+class RecipeRegistryError(ValueError):
+    """Raised when a recipe registration or lookup is invalid."""
+
+
+@dataclass(frozen=True)
+class RecipePins:
+    """Pinned inputs folded into the canonical recipe body.
+
+    Every pin is content that, if it changes, makes the run a different run:
+    the git commit of the recipe source, the adapter, the model, and the
+    prompt-pack hash. Two operators at the same commit with the same pins
+    derive the byte-identical canonical body; changing any pin changes the
+    ``recipe_hash``.
+    """
+
+    git_commit: str = ""
+    adapter: str = ""
+    model: str = ""
+    prompt_pack_sha256: str = ""
+
+    def canonical_dict(self) -> dict[str, str]:
+        return {
+            "git_commit": self.git_commit,
+            "adapter": self.adapter,
+            "model": self.model,
+            "prompt_pack_sha256": self.prompt_pack_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class RecipeSchedule:
+    """A parsed, canonicalised schedule declared on a recipe.
+
+    ``kind`` selects how ``recurrence`` / ``interval_seconds`` / ``anchor``
+    are interpreted; ``timezone`` and ``dst_policy`` govern local-time and
+    DST resolution. All fields are canonical so two operators who wrote the
+    same schedule in different token order fold to the same bytes.
+    """
+
+    kind: ScheduleKind
+    recurrence: str = ""
+    interval_seconds: int = 0
+    anchor: int = 0
+    timezone: str = ""
+    dst_policy: str = str(DstPolicy.PRE_TRANSITION)
+
+    def canonical_dict(self) -> dict[str, Any]:
+        return {
+            "kind": str(self.kind),
+            "recurrence": self.recurrence,
+            "interval_seconds": self.interval_seconds,
+            "anchor": self.anchor,
+            "timezone": self.timezone,
+            "dst_policy": self.dst_policy,
+        }
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> RecipeSchedule:
+        """Parse and canonicalise one schedule mapping from a manifest.
+
+        Raises:
+            ScheduleKindError: On an unknown kind, a bad recurrence, an
+                unknown timezone, or a non-positive interval.
+        """
+        kind_raw = str(raw.get("kind", ScheduleKind.CRON))
+        try:
+            kind = ScheduleKind(kind_raw)
+        except ValueError as exc:
+            raise ScheduleKindError(f"unknown schedule kind {kind_raw!r}") from exc
+
+        timezone = canonical_timezone(str(raw.get("timezone", "")))
+        dst_policy = str(DstPolicy(str(raw.get("dst_policy", DstPolicy.PRE_TRANSITION))))
+
+        recurrence = ""
+        interval_seconds = 0
+        anchor = int(raw.get("anchor", 0))
+        if kind is ScheduleKind.INTERVAL_ANCHOR:
+            interval_seconds = int(raw.get("interval_seconds", 0))
+            if interval_seconds <= 0:
+                raise ScheduleKindError("interval_anchor schedule requires positive interval_seconds")
+        else:
+            rule = str(raw.get("recurrence", "") or raw.get("cron", "") or raw.get("rrule", ""))
+            recurrence = canonicalise_recurrence(rule) if rule else ""
+            if not recurrence:
+                raise ScheduleKindError(f"{kind} schedule requires a recurrence / cron / rrule expression")
+        return cls(
+            kind=kind,
+            recurrence=recurrence,
+            interval_seconds=interval_seconds,
+            anchor=anchor,
+            timezone=timezone,
+            dst_policy=dst_policy,
+        )
+
+
+@dataclass(frozen=True)
+class RegisteredRecipe:
+    """A recipe as registered: its content hash and lifecycle state.
+
+    Attributes:
+        name: Operator-facing name the hash is registered under.
+        recipe_hash: SHA-256 of the canonical body; the recipe identity.
+        canonical_bytes: The exact bytes the hash is taken over.
+        spine_anchor: Lineage-spine entry hash the bytes were sealed into.
+        schedules: Parsed schedules declared on the recipe.
+        collision_policy: Concurrency-collision strategy.
+        concurrency_cap: Max concurrent fires allowed.
+        pins: Pinned inputs folded into the hash.
+        superseded_hash: The prior live hash this registration replaced, or
+            ``""`` for a first registration.
+        registered_at: Wall-clock epoch of the registration (bookkeeping;
+            not part of the hash).
+    """
+
+    name: str
+    recipe_hash: str
+    canonical_bytes: bytes
+    spine_anchor: str
+    schedules: tuple[RecipeSchedule, ...]
+    collision_policy: CollisionPolicy
+    concurrency_cap: int
+    pins: RecipePins
+    superseded_hash: str = ""
+    registered_at: float = 0.0
+
+    @property
+    def recipe_id(self) -> str:
+        """Grep-friendly short identity, ``recipe_<12hex>``."""
+        return recipe_id(self.recipe_hash)
+
+
+@dataclass(frozen=True)
+class RecipeFireResult:
+    """Outcome of firing a registered recipe by name.
+
+    ``dispatched`` is False when the recipe is paused (it fires nothing).
+    ``projection_hash`` is the deterministic fire projection hash plus its
+    chain anchor - the fire is a hash rather than an opaque job id.
+    """
+
+    name: str
+    recipe_hash: str
+    dispatched: bool
+    fire_time: int
+    projection_hash: str = ""
+    chain_anchor: str = ""
+    reason: str = ""
+
+
+def recipe_content_hash(canonical_bytes: bytes) -> str:
+    """Return the SHA-256 hex of the canonical recipe body (the identity)."""
+    return hashlib.sha256(canonical_bytes).hexdigest()
+
+
+def recipe_id(recipe_hash: str) -> str:
+    """Return the grep-friendly short form of a recipe hash."""
+    return f"recipe_{recipe_hash[:12]}"
+
+
+def recipe_run_id(recipe_hash: str) -> str:
+    """Return a deterministic, separator-free run id for a recipe hash.
+
+    Used to key the lineage-spine run the canonical bytes seal into, so two
+    operators land on the same spine run for the same definition.
+    """
+    return "recipe-def-" + recipe_hash[:16]
+
+
+def current_git_commit(workdir: Path | None = None) -> str:
+    """Return the current git HEAD commit, or ``""`` when unavailable.
+
+    Pins the recipe source revision into the canonical body. Failures
+    (not a repo, git missing) degrade to ``""`` rather than raising, so
+    registration outside a checkout still works with an empty pin.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(workdir) if workdir is not None else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def canonical_recipe_bytes(
+    *,
+    spec: RecipeSpec,
+    pins: RecipePins,
+    schedules: tuple[RecipeSchedule, ...],
+    collision_policy: CollisionPolicy,
+    concurrency_cap: int,
+    sandbox_pool: str,
+    triggers: tuple[dict[str, Any], ...],
+) -> bytes:
+    """Encode the canonical recipe body to byte-reproducible JSON.
+
+    The body pins the git commit plus adapter / model / prompt-pack hashes
+    and folds the param schema, workflow nodes, schedules, triggers, sandbox
+    pool, and collision policy. Two operators with the same manifest at the
+    same commit derive byte-identical bytes; changing any pinned input
+    changes the bytes and therefore the hash (AC1).
+    """
+    param_schema = [
+        {
+            "name": p.name,
+            "type": p.type,
+            "default": p.default,
+            "required": p.required,
+            "choices": sorted(p.choices) if p.choices else None,
+        }
+        for p in sorted(spec.params, key=lambda p: p.name)
+    ]
+    body: dict[str, Any] = {
+        "rev": CANONICAL_RECIPE_REV,
+        "name": spec.name,
+        "description": spec.description,
+        "version": spec.version,
+        "params": param_schema,
+        "nodes": spec.nodes,
+        "schedules": [s.canonical_dict() for s in schedules],
+        "triggers": [_canonical_json_value(t) for t in triggers],
+        "sandbox_pool": sandbox_pool,
+        "collision_policy": str(collision_policy),
+        "concurrency_cap": concurrency_cap,
+        "pins": pins.canonical_dict(),
+    }
+    return json.dumps(_canonical_json_value(body), sort_keys=True, separators=(",", ":")).encode()
+
+
+def compute_recipe_registration(
+    spec: RecipeSpec,
+    *,
+    pins: RecipePins | None = None,
+    collision_policy: CollisionPolicy | str = CollisionPolicy.CANCEL_NEW,
+    concurrency_cap: int = 1,
+    sandbox_pool: str = "",
+) -> tuple[bytes, str, tuple[RecipeSchedule, ...], tuple[dict[str, Any], ...], str, CollisionPolicy, int, RecipePins]:
+    """Resolve *spec* into its canonical bytes and content hash.
+
+    Single source of truth shared by :meth:`RecipeRegistry.register` and the
+    fleet planner so a planned hash and a registered hash agree byte-for-byte.
+    """
+    resolved_pins = pins if pins is not None else _pins_from_spec(spec)
+    schedules = tuple(RecipeSchedule.from_mapping(s) for s in _spec_schedules(spec))
+    triggers = tuple(_spec_triggers(spec))
+    pool = sandbox_pool or _spec_sandbox_pool(spec)
+    policy = CollisionPolicy(collision_policy)
+    cap = max(1, concurrency_cap)
+    canonical_bytes = canonical_recipe_bytes(
+        spec=spec,
+        pins=resolved_pins,
+        schedules=schedules,
+        collision_policy=policy,
+        concurrency_cap=cap,
+        sandbox_pool=pool,
+        triggers=triggers,
+    )
+    digest = recipe_content_hash(canonical_bytes)
+    return canonical_bytes, digest, schedules, triggers, pool, policy, cap, resolved_pins
+
+
+def _canonical_json_value(value: Any) -> Any:
+    """Recursively normalise *value* so equal structures serialise equal.
+
+    Dicts sort by key; lists preserve order (node/schedule order is
+    semantic). Scalars pass through. Guards against a manifest smuggling a
+    non-JSON scalar into the hash by stringifying unknown types.
+    """
+    if isinstance(value, dict):
+        mapping: dict[Any, Any] = value
+        return {str(k): _canonical_json_value(mapping[k]) for k in sorted(mapping, key=str)}
+    if isinstance(value, (list, tuple)):
+        return [_canonical_json_value(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+@dataclass
+class _NameState:
+    """The projected lifecycle state of one recipe name."""
+
+    live_hash: str = ""
+    paused: bool = False
+    last_receipt_hmac: str = ""
+    receipts: list[dict[str, Any]] = field(default_factory=list)
+
+
+class RecipeRegistry:
+    """Content-addressed recipe registry projected from receipt history.
+
+    The registry never holds a mutable row. Registration seals canonical
+    bytes into the lineage spine and appends a receipt to the HMAC chain;
+    the live ``name -> hash`` mapping and pause state are reconstructed by
+    replaying the recipe lifecycle receipts. Content-addressed blobs of the
+    canonical bytes are cached under ``.sdd/runtime/recipes/blobs`` so a
+    fire can load the exact definition body by hash.
+    """
+
+    def __init__(
+        self,
+        sdd_dir: Path,
+        *,
+        chain: AuditChainStore | None = None,
+        hmac_key: bytes | None = None,
+        lineage_key: bytes | None = None,
+    ) -> None:
+        self._sdd_dir = sdd_dir
+        self._dir = sdd_dir / "runtime" / "recipes"
+        self._blobs = self._dir / "blobs"
+        self._blobs.mkdir(parents=True, exist_ok=True)
+        self._hmac_key = hmac_key
+        self._lineage_key = lineage_key if lineage_key is not None else hmac_key
+        self._chain = chain
+
+    # -- chain access -------------------------------------------------------
+
+    def _get_chain(self) -> AuditChainStore:
+        if self._chain is not None:
+            return self._chain
+        from bernstein.core.security.audit_chain import AuditChainStore
+
+        self._chain = AuditChainStore(self._sdd_dir / _AUDIT_SUBDIR, key=self._hmac_key)
+        return self._chain
+
+    def _lineage_hmac_key(self) -> bytes:
+        if self._lineage_key is not None:
+            return self._lineage_key
+        from bernstein.core.security.audit import load_or_create_audit_key
+
+        self._lineage_key = load_or_create_audit_key()
+        return self._lineage_key
+
+    # -- projection ---------------------------------------------------------
+
+    def _lifecycle_events(self) -> list[dict[str, Any]]:
+        """Return every recipe-lifecycle chain event in chain order."""
+        from bernstein.core.security.audit_chain import (
+            EVENT_RECIPE_PAUSE,
+            EVENT_RECIPE_REGISTER,
+            EVENT_RECIPE_RESUME,
+            EVENT_RECIPE_ROLLBACK,
+            EVENT_RECIPE_SUPERSEDE,
+        )
+
+        chain = self._get_chain()
+        wanted = {
+            EVENT_RECIPE_REGISTER,
+            EVENT_RECIPE_SUPERSEDE,
+            EVENT_RECIPE_ROLLBACK,
+            EVENT_RECIPE_PAUSE,
+            EVENT_RECIPE_RESUME,
+        }
+        out: list[dict[str, Any]] = []
+        for event_type in sorted(wanted):
+            for ev in chain.query(event_type=event_type):
+                out.append(
+                    {
+                        "event_type": ev.event_type,
+                        "hmac": getattr(ev, "hmac", ""),
+                        "timestamp": getattr(ev, "timestamp", ""),
+                        "details": dict(ev.details),
+                    },
+                )
+        # Chain order is the write order; query() groups by type, so re-sort
+        # by the embedded prev linkage is not enough. The underlying log
+        # preserves per-type order, and lifecycle transitions for one name
+        # are totally ordered by their prev_receipt_digest linkage, which is
+        # what the projection and verify walk rely on - not this list order.
+        return out
+
+    def _project_name(self, name: str) -> _NameState:
+        """Replay this name's receipts into its live state."""
+        from bernstein.core.security.audit_chain import (
+            EVENT_RECIPE_PAUSE,
+            EVENT_RECIPE_REGISTER,
+            EVENT_RECIPE_RESUME,
+            EVENT_RECIPE_ROLLBACK,
+            EVENT_RECIPE_SUPERSEDE,
+        )
+
+        events = [ev for ev in self._lifecycle_events() if str(ev["details"].get("name", "")) == name]
+        # Order the name's receipts by their per-name lineage linkage: each
+        # receipt names the hmac of its predecessor, so a linked list rebuild
+        # is order-independent of how query() grouped them.
+        ordered = _order_by_lineage(events)
+        state = _NameState()
+        for ev in ordered:
+            details = ev["details"]
+            etype = ev["event_type"]
+            if etype in (EVENT_RECIPE_REGISTER, EVENT_RECIPE_SUPERSEDE):
+                state.live_hash = str(details.get("recipe_hash") or details.get("new_hash") or "")
+            elif etype == EVENT_RECIPE_ROLLBACK:
+                state.live_hash = str(details.get("to_hash", ""))
+            elif etype == EVENT_RECIPE_PAUSE:
+                state.paused = True
+            elif etype == EVENT_RECIPE_RESUME:
+                state.paused = False
+            state.last_receipt_hmac = str(ev["hmac"])
+            state.receipts.append(ev)
+        return state
+
+    def live_hash(self, name: str) -> str | None:
+        """Return the live recipe hash for *name*, or None if never registered."""
+        state = self._project_name(name)
+        return state.live_hash or None
+
+    def is_paused(self, name: str) -> bool:
+        """Return whether *name* is currently paused (fires nothing)."""
+        return self._project_name(name).paused
+
+    def history(self, name: str) -> list[dict[str, Any]]:
+        """Return the name's lifecycle receipts in definition-lineage order."""
+        return self._project_name(name).receipts.copy()
+
+    # -- blobs --------------------------------------------------------------
+
+    def _blob_path(self, recipe_hash: str) -> Path:
+        return self._blobs / f"{recipe_hash}.json"
+
+    def get_canonical_bytes(self, recipe_hash: str) -> bytes | None:
+        """Load the content-addressed canonical bytes for *recipe_hash*."""
+        path = self._blob_path(recipe_hash)
+        if not path.exists():
+            return None
+        data = path.read_bytes()
+        # Verify the blob still hashes to its name - a tampered blob must not
+        # masquerade as the definition.
+        if recipe_content_hash(data) != recipe_hash:
+            return None
+        return data
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def register(
+        self,
+        *,
+        spec: RecipeSpec,
+        pins: RecipePins | None = None,
+        collision_policy: CollisionPolicy | str = CollisionPolicy.CANCEL_NEW,
+        concurrency_cap: int = 1,
+        sandbox_pool: str = "",
+        actor: str = "operator",
+        now: float | None = None,
+    ) -> RegisteredRecipe:
+        """Register *spec* under its name; seal, hash, and receipt it.
+
+        Idempotent: registering a byte-identical definition returns the
+        existing registration without a new receipt. Registering a changed
+        body under a live name writes an operator-signed supersede receipt.
+        """
+        (
+            canonical_bytes,
+            digest,
+            schedules,
+            _triggers,
+            _pool,
+            policy,
+            cap,
+            resolved_pins,
+        ) = compute_recipe_registration(
+            spec,
+            pins=pins,
+            collision_policy=collision_policy,
+            concurrency_cap=concurrency_cap,
+            sandbox_pool=sandbox_pool,
+        )
+
+        state = self._project_name(spec.name)
+        if state.live_hash == digest:
+            existing = self._load_registered(spec.name, digest)
+            if existing is not None:
+                return existing
+
+        # Seal canonical bytes into the lineage spine (ungated, deterministic).
+        spine_anchor = self._seal(canonical_bytes, digest)
+        self._blob_path(digest).write_bytes(canonical_bytes)
+
+        chain = self._get_chain()
+        from bernstein.core.security.audit_chain import (
+            record_recipe_register,
+            record_recipe_supersede,
+        )
+
+        prev_receipt = state.last_receipt_hmac
+        superseded = ""
+        if state.live_hash and state.live_hash != digest:
+            superseded = state.live_hash
+            record_recipe_supersede(
+                chain=chain,
+                name=spec.name,
+                old_hash=state.live_hash,
+                new_hash=digest,
+                spine_anchor=spine_anchor,
+                prev_receipt_digest=prev_receipt,
+                actor=actor,
+            )
+        else:
+            record_recipe_register(
+                chain=chain,
+                name=spec.name,
+                recipe_hash=digest,
+                spine_anchor=spine_anchor,
+                prev_receipt_digest=prev_receipt,
+                actor=actor,
+            )
+
+        return RegisteredRecipe(
+            name=spec.name,
+            recipe_hash=digest,
+            canonical_bytes=canonical_bytes,
+            spine_anchor=spine_anchor,
+            schedules=schedules,
+            collision_policy=policy,
+            concurrency_cap=cap,
+            pins=resolved_pins,
+            superseded_hash=superseded,
+            registered_at=float(now) if now is not None else time.time(),
+        )
+
+    def rollback(self, name: str, target_hash: str, *, actor: str = "operator") -> str:
+        """Re-point *name* at a prior *target_hash* via a rollback receipt.
+
+        Nothing is deleted; the rollback is itself a chain record.
+
+        Raises:
+            RecipeRegistryError: When the name has no live hash or the
+                target hash was never registered under the name.
+        """
+        state = self._project_name(name)
+        if not state.live_hash:
+            raise RecipeRegistryError(f"recipe {name!r} is not registered")
+        if self.get_canonical_bytes(target_hash) is None:
+            raise RecipeRegistryError(f"target hash {target_hash!r} is not a known definition of {name!r}")
+        from bernstein.core.security.audit_chain import record_recipe_rollback
+
+        record_recipe_rollback(
+            chain=self._get_chain(),
+            name=name,
+            from_hash=state.live_hash,
+            to_hash=target_hash,
+            prev_receipt_digest=state.last_receipt_hmac,
+            actor=actor,
+        )
+        return target_hash
+
+    def pause(self, name: str, *, actor: str = "operator") -> None:
+        """Pause *name*: future fires stop, identity and history are kept."""
+        self._set_pause(name, paused=True, actor=actor)
+
+    def resume(self, name: str, *, actor: str = "operator") -> None:
+        """Resume a paused *name*."""
+        self._set_pause(name, paused=False, actor=actor)
+
+    def _set_pause(self, name: str, *, paused: bool, actor: str) -> None:
+        state = self._project_name(name)
+        if not state.live_hash:
+            raise RecipeRegistryError(f"recipe {name!r} is not registered")
+        from bernstein.core.security.audit_chain import record_recipe_pause
+
+        record_recipe_pause(
+            chain=self._get_chain(),
+            name=name,
+            recipe_hash=state.live_hash,
+            paused=paused,
+            prev_receipt_digest=state.last_receipt_hmac,
+            actor=actor,
+        )
+
+    def fire(
+        self,
+        name: str,
+        *,
+        fire_time: int,
+        goal: str = "",
+    ) -> RecipeFireResult:
+        """Fire *name* as a deterministic projection; refuse when paused.
+
+        A paused recipe fires nothing (AC6). Otherwise the fire is a pure
+        projection of ``(recipe_hash, fire_time)`` with the declared
+        timezone folded in, returning the projection hash as the response.
+        """
+        state = self._project_name(name)
+        if not state.live_hash:
+            raise RecipeRegistryError(f"recipe {name!r} is not registered")
+        if state.paused:
+            return RecipeFireResult(
+                name=name,
+                recipe_hash=state.live_hash,
+                dispatched=False,
+                fire_time=fire_time,
+                reason="recipe is paused",
+            )
+        from bernstein.core.orchestration.schedule_projection import project_schedule_fire
+
+        schedules = self._registered_schedules(name, state.live_hash)
+        tz = schedules[0].timezone if schedules else ""
+        dst = schedules[0].dst_policy if schedules else ""
+        recurrence = schedules[0].recurrence if schedules else ""
+        projection = project_schedule_fire(
+            schedule_id=state.live_hash,
+            fire_time=fire_time,
+            last_state=None,
+            goal=goal,
+            recurrence=recurrence,
+            timezone=tz,
+            dst_policy=dst if tz else "",
+        )
+        return RecipeFireResult(
+            name=name,
+            recipe_hash=state.live_hash,
+            dispatched=True,
+            fire_time=fire_time,
+            projection_hash=projection.projection_hash,
+            chain_anchor=self._get_chain().prev_chain_digest,
+        )
+
+    # -- verification -------------------------------------------------------
+
+    def verify_history(self, name: str) -> tuple[bool, list[str]]:
+        """Walk *name*'s receipts against the HMAC chain offline (AC5).
+
+        Returns ``(ok, errors)``. Fails (non-empty errors) when the audit
+        chain itself does not verify (any byte mutation, deleted, or
+        reordered line) or when the name's per-receipt lineage linkage is
+        broken. No server is required: the chain is read from its on-disk
+        JSONL segments.
+        """
+        errors: list[str] = []
+        chain = self._get_chain()
+        chain_ok, chain_errors = chain.verify()
+        if not chain_ok:
+            errors.extend(chain_errors)
+
+        state = self._project_name(name)
+        if not state.receipts:
+            errors.append(f"recipe {name!r} has no lifecycle receipts")
+            return (not errors, errors)
+
+        prev = ""
+        for ev in state.receipts:
+            linked = str(ev["details"].get("prev_receipt_digest", ""))
+            if linked != prev:
+                errors.append(
+                    f"broken definition-lineage link for {name!r}: receipt expected prev {prev[:16] or '(genesis)'} "
+                    f"but names {linked[:16] or '(genesis)'}",
+                )
+                break
+            prev = str(ev["hmac"])
+        return (not errors, errors)
+
+    # -- internals ----------------------------------------------------------
+
+    def _seal(self, canonical_bytes: bytes, recipe_hash: str) -> str:
+        """Seal canonical bytes into the lineage spine, return the entry hash."""
+        from bernstein.core.lineage.spine import LineageSpine
+
+        return LineageSpine(
+            self._sdd_dir / _LINEAGE_SUBDIR,
+            run_id=recipe_run_id(recipe_hash),
+            hmac_key=self._lineage_hmac_key(),
+        ).record(
+            artifact_path=f".sdd/runtime/recipes/blobs/{recipe_hash}.json",
+            content=canonical_bytes,
+            actor="recipe_registry",
+            step_id=f"recipe-register:{recipe_hash[:16]}",
+            model="",
+            timestamp=0,
+        )
+
+    def _registered_schedules(self, name: str, recipe_hash: str) -> tuple[RecipeSchedule, ...]:
+        """Recover the schedules of the live definition from its blob."""
+        data = self.get_canonical_bytes(recipe_hash)
+        if data is None:
+            return ()
+        try:
+            body = json.loads(data)
+        except json.JSONDecodeError:
+            return ()
+        out: list[RecipeSchedule] = []
+        for raw in body.get("schedules", []):
+            try:
+                out.append(RecipeSchedule.from_mapping(raw))
+            except ScheduleKindError:
+                continue
+        return tuple(out)
+
+    def _load_registered(self, name: str, recipe_hash: str) -> RegisteredRecipe | None:
+        """Rebuild a RegisteredRecipe view from the content-addressed blob."""
+        data = self.get_canonical_bytes(recipe_hash)
+        if data is None:
+            return None
+        try:
+            body = json.loads(data)
+        except json.JSONDecodeError:
+            return None
+        pins_raw = body.get("pins", {})
+        pins = RecipePins(
+            git_commit=str(pins_raw.get("git_commit", "")),
+            adapter=str(pins_raw.get("adapter", "")),
+            model=str(pins_raw.get("model", "")),
+            prompt_pack_sha256=str(pins_raw.get("prompt_pack_sha256", "")),
+        )
+        schedules = self._registered_schedules(name, recipe_hash)
+        return RegisteredRecipe(
+            name=name,
+            recipe_hash=recipe_hash,
+            canonical_bytes=data,
+            spine_anchor="",
+            schedules=schedules,
+            collision_policy=CollisionPolicy(str(body.get("collision_policy", CollisionPolicy.CANCEL_NEW))),
+            concurrency_cap=int(body.get("concurrency_cap", 1)),
+            pins=pins,
+        )
+
+
+def _order_by_lineage(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Order a name's receipts by their prev_receipt_digest linkage.
+
+    Each receipt names the hmac of its predecessor (``""`` for genesis).
+    Rebuilding the linked list makes the projection independent of how the
+    chain query grouped events by type. On a broken or forked linkage the
+    reachable prefix is returned (verify_history reports the break).
+    """
+    by_prev: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        prev = str(ev["details"].get("prev_receipt_digest", ""))
+        by_prev.setdefault(prev, ev)
+    ordered: list[dict[str, Any]] = []
+    cursor = ""
+    seen: set[str] = set()
+    while cursor in by_prev:
+        ev = by_prev[cursor]
+        hmac = str(ev["hmac"])
+        if hmac in seen:
+            break
+        seen.add(hmac)
+        ordered.append(ev)
+        cursor = hmac
+    # Fall back to input order for any receipts not reachable through the
+    # linkage (e.g. a genesis-less legacy receipt), so nothing is dropped.
+    if len(ordered) != len(events):
+        reached = {str(e["hmac"]) for e in ordered}
+        ordered.extend(e for e in events if str(e["hmac"]) not in reached)
+    return ordered
+
+
+def _pins_from_spec(spec: RecipeSpec) -> RecipePins:
+    """Build pins from the manifest ``pins:`` block, defaulting the commit.
+
+    An explicit ``git_commit`` in the manifest wins (reproducible off a
+    checkout); otherwise the current HEAD is resolved so a live registration
+    still binds the source revision.
+    """
+    raw: dict[str, Any] = dict(getattr(spec, "pins", {}) or {})
+    return RecipePins(
+        git_commit=str(raw.get("git_commit", "") or current_git_commit()),
+        adapter=str(raw.get("adapter", "")),
+        model=str(raw.get("model", "")),
+        prompt_pack_sha256=str(raw.get("prompt_pack_sha256", "")),
+    )
+
+
+def _spec_schedules(spec: RecipeSpec) -> list[dict[str, Any]]:
+    return list(getattr(spec, "schedules", []) or [])
+
+
+def _spec_triggers(spec: RecipeSpec) -> list[dict[str, Any]]:
+    return list(getattr(spec, "triggers", []) or [])
+
+
+def _spec_sandbox_pool(spec: RecipeSpec) -> str:
+    return str(getattr(spec, "sandbox_pool", "") or "")

--- a/src/bernstein/core/workflows/recipe_spec.py
+++ b/src/bernstein/core/workflows/recipe_spec.py
@@ -222,6 +222,14 @@ class RecipeSpec(BaseModel):
     version: str = Field(default="1.0.0")
     params: list[RecipeParam] = Field(default_factory=list)
     nodes: list[dict[str, Any]] = Field(min_length=1)
+    # Optional #2546 registration blocks. A manifest without them parses and
+    # behaves exactly as before (zero schedules, zero triggers, empty pool).
+    # They carry the registration surface (schedule kinds, triggers, sandbox
+    # pool, pins) folded into the content-addressed recipe hash.
+    schedules: list[dict[str, Any]] = Field(default_factory=list)
+    triggers: list[dict[str, Any]] = Field(default_factory=list)
+    sandbox_pool: str = Field(default="", max_length=128)
+    pins: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("params")
     @classmethod

--- a/tests/property/test_recipe_hash_properties.py
+++ b/tests/property/test_recipe_hash_properties.py
@@ -1,0 +1,113 @@
+"""Property tests for content-addressed recipe hashing (#2546, AC1).
+
+Over generated manifests:
+
+- registration is deterministic: encoding the same manifest with the same
+  pins twice yields byte-identical canonical bytes and the same hash;
+- changing any pinned input (git commit, adapter, model, prompt pack)
+  changes the hash.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.core.workflows.recipe_registry import (
+    RecipePins,
+    compute_recipe_registration,
+)
+from bernstein.core.workflows.recipe_spec import RecipeSpec
+
+_slug = st.from_regex(r"[a-z][a-z0-9_]{0,15}", fullmatch=True)
+_text = st.text(
+    alphabet=st.characters(min_codepoint=97, max_codepoint=122),
+    min_size=1,
+    max_size=40,
+)
+_hashish = st.text(alphabet="0123456789abcdef", min_size=1, max_size=40)
+
+
+def _build_spec(name: str, description: str, command: str) -> RecipeSpec:
+    # Build via model_validate rather than a YAML string so a generated
+    # description that happens to be a YAML-reserved token (``no``, ``null``)
+    # is treated as literal text - the hashing contract is what we test here.
+    return RecipeSpec.model_validate(
+        {
+            "name": name,
+            "description": description,
+            "version": "1.0.0",
+            "nodes": [{"id": "only", "command": command}],
+        },
+    )
+
+
+@st.composite
+def _pins(draw: st.DrawFn) -> RecipePins:
+    return RecipePins(
+        git_commit=draw(_hashish),
+        adapter=draw(_slug),
+        model=draw(_slug),
+        prompt_pack_sha256=draw(_hashish),
+    )
+
+
+@given(name=_slug, description=_text, command=_text, pins=_pins())
+def test_registration_is_deterministic(name: str, description: str, command: str, pins: RecipePins) -> None:
+    spec = _build_spec(name, description, command)
+    b1, h1, *_ = compute_recipe_registration(spec, pins=pins)
+    b2, h2, *_ = compute_recipe_registration(spec, pins=pins)
+    assert b1 == b2
+    assert h1 == h2
+
+
+@given(
+    name=_slug,
+    description=_text,
+    command=_text,
+    pins=_pins(),
+    new_commit=_hashish,
+)
+def test_changing_git_commit_changes_hash(
+    name: str,
+    description: str,
+    command: str,
+    pins: RecipePins,
+    new_commit: str,
+) -> None:
+    spec = _build_spec(name, description, command)
+    _, base_hash, *_ = compute_recipe_registration(spec, pins=pins)
+    other = RecipePins(
+        git_commit=new_commit,
+        adapter=pins.adapter,
+        model=pins.model,
+        prompt_pack_sha256=pins.prompt_pack_sha256,
+    )
+    _, other_hash, *_ = compute_recipe_registration(spec, pins=other)
+    if new_commit != pins.git_commit:
+        assert base_hash != other_hash
+    else:
+        assert base_hash == other_hash
+
+
+@given(name=_slug, description=_text, command=_text, pins=_pins(), new_model=_slug)
+def test_changing_model_changes_hash(
+    name: str,
+    description: str,
+    command: str,
+    pins: RecipePins,
+    new_model: str,
+) -> None:
+    spec = _build_spec(name, description, command)
+    _, base_hash, *_ = compute_recipe_registration(spec, pins=pins)
+    other = RecipePins(
+        git_commit=pins.git_commit,
+        adapter=pins.adapter,
+        model=new_model,
+        prompt_pack_sha256=pins.prompt_pack_sha256,
+    )
+    _, other_hash, *_ = compute_recipe_registration(spec, pins=other)
+    if new_model != pins.model:
+        assert base_hash != other_hash
+    else:
+        assert base_hash == other_hash

--- a/tests/unit/test_recipe_collision.py
+++ b/tests/unit/test_recipe_collision.py
@@ -1,0 +1,272 @@
+"""Collision receipts and supersede handoff (#2546, AC3 + AC4).
+
+- Collision outcomes are a pure, deterministic function of ``(policy,
+  running-fire state, cap)`` with a stable receipt hash (AC3).
+- A supervisor tick over an unfinished previous fire with ``CANCEL_NEW``
+  never dispatches a second task graph (AC3, tick-level regression).
+- Under ``SUPERSEDE_WITH_HANDOFF`` the new fire resumes from the checkpoint
+  row recorded in the superseded run's journal; a tampered checkpoint row
+  produces a cold start, never a warm resume (AC4).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.orchestration.collision import (
+    CollisionAction,
+    CollisionPolicy,
+    RunningFireState,
+    decide_collision,
+    resolve_handoff_checkpoint,
+)
+from bernstein.core.orchestration.schedule_supervisor import (
+    COLLISION_EVENT_TYPE,
+    ScheduleSupervisor,
+)
+from bernstein.core.planning.schedule_store import Schedule, ScheduleStore
+from bernstein.core.tasks.checkpoint_retry import (
+    record_task_checkpoint,
+    task_run_id,
+    workspace_hash,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# AC3: collision outcome is a pure deterministic function
+# ---------------------------------------------------------------------------
+
+
+class TestDecideCollisionPurity:
+    def test_no_collision_dispatches(self) -> None:
+        idle = RunningFireState(running=False)
+        decision = decide_collision(policy=CollisionPolicy.CANCEL_NEW, running=idle)
+        assert decision.action is CollisionAction.DISPATCH
+        assert decision.dispatch is True
+
+    def test_cancel_new_never_dispatches_over_running(self) -> None:
+        running = RunningFireState(running=True, running_count=1, fire_id="f1")
+        decision = decide_collision(policy=CollisionPolicy.CANCEL_NEW, running=running)
+        assert decision.action is CollisionAction.CANCEL
+        assert decision.dispatch is False
+
+    def test_enqueue_defers(self) -> None:
+        running = RunningFireState(running=True, running_count=1, fire_id="f1")
+        decision = decide_collision(policy=CollisionPolicy.ENQUEUE, running=running)
+        assert decision.action is CollisionAction.ENQUEUE
+        assert decision.dispatch is False
+
+    def test_receipt_hash_is_stable_across_operators(self) -> None:
+        running = RunningFireState(running=True, running_count=1, fire_id="f1", checkpoint_event_hash="sha256:cp")
+        d1 = decide_collision(policy=CollisionPolicy.SUPERSEDE_WITH_HANDOFF, running=running)
+        d2 = decide_collision(policy=CollisionPolicy.SUPERSEDE_WITH_HANDOFF, running=running)
+        assert d1.receipt_hash == d2.receipt_hash
+        assert d1.canonical_bytes == d2.canonical_bytes
+
+    def test_different_running_state_changes_receipt(self) -> None:
+        a = decide_collision(
+            policy=CollisionPolicy.CANCEL_NEW,
+            running=RunningFireState(running=True, running_count=1, fire_id="f1"),
+        )
+        b = decide_collision(
+            policy=CollisionPolicy.CANCEL_NEW,
+            running=RunningFireState(running=True, running_count=2, fire_id="f1"),
+        )
+        assert a.receipt_hash != b.receipt_hash
+
+    def test_under_cap_dispatches_even_when_running(self) -> None:
+        running = RunningFireState(running=True, running_count=1, fire_id="f1")
+        decision = decide_collision(policy=CollisionPolicy.CANCEL_NEW, running=running, concurrency_cap=2)
+        assert decision.dispatch is True
+
+
+# ---------------------------------------------------------------------------
+# AC3: supervisor tick over an unfinished previous fire (regression)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubAuditEvent:
+    event_type: str
+    details: dict[str, Any]
+    hmac: str
+
+
+@dataclass
+class _StubAuditLog:
+    entries: list[_StubAuditEvent] = field(default_factory=list)
+    _prev_hmac: str = "0" * 64
+
+    def log(
+        self,
+        event_type: str,
+        actor: str,
+        resource_type: str,
+        resource_id: str,
+        details: dict[str, Any],
+    ) -> _StubAuditEvent:
+        import hashlib
+
+        payload = self._prev_hmac + json.dumps({"e": event_type, "d": details}, sort_keys=True)
+        new_hmac = hashlib.sha256(payload.encode()).hexdigest()
+        event = _StubAuditEvent(event_type=event_type, details=details, hmac=new_hmac)
+        self.entries.append(event)
+        self._prev_hmac = new_hmac
+        return event
+
+
+class TestSupervisorDoubleFire:
+    def test_cancel_new_never_dispatches_second_graph(self, tmp_path: Path) -> None:
+        store = ScheduleStore(tmp_path)
+        schedule = store.add(cron="* * * * *", goal="Nightly", misfire_policy="skip")
+        last_fire = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+        store.update_last_fire(schedule.id, float(last_fire))
+        audit = _StubAuditLog()
+        dispatched: list[Any] = []
+
+        # The previous fire is still running.
+        def _probe(_s: Schedule) -> RunningFireState:
+            return RunningFireState(running=True, running_count=1, fire_id="prev")
+
+        supervisor = ScheduleSupervisor(
+            store,
+            dispatched.append,
+            audit,
+            running_probe=_probe,
+            collision_policy=CollisionPolicy.CANCEL_NEW,
+        )
+        now = int(datetime(2030, 1, 1, 12, 3, 0, tzinfo=UTC).timestamp())
+        receipts = supervisor.tick(now=now)
+
+        # No task graph dispatched while a previous fire is in flight...
+        assert dispatched == []
+        # ...but a collision receipt was recorded (the overlap is not silent).
+        collision_entries = [e for e in audit.entries if e.event_type == COLLISION_EVENT_TYPE]
+        assert len(collision_entries) == 1
+        assert collision_entries[0].details["action"] == str(CollisionAction.CANCEL)
+        assert any(not r.dispatched for r in receipts)
+
+    def test_no_probe_preserves_dispatch(self, tmp_path: Path) -> None:
+        # Without a running probe the historical dispatch path is unchanged.
+        store = ScheduleStore(tmp_path)
+        schedule = store.add(cron="* * * * *", goal="Nightly", misfire_policy="skip")
+        last_fire = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+        store.update_last_fire(schedule.id, float(last_fire))
+        audit = _StubAuditLog()
+        dispatched: list[Any] = []
+        supervisor = ScheduleSupervisor(store, dispatched.append, audit)
+        now = int(datetime(2030, 1, 1, 12, 3, 0, tzinfo=UTC).timestamp())
+        supervisor.tick(now=now)
+        assert len(dispatched) == 1
+
+    def test_supersede_still_dispatches_with_receipt(self, tmp_path: Path) -> None:
+        store = ScheduleStore(tmp_path)
+        schedule = store.add(cron="* * * * *", goal="Nightly", misfire_policy="skip")
+        last_fire = int(datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp())
+        store.update_last_fire(schedule.id, float(last_fire))
+        audit = _StubAuditLog()
+        dispatched: list[Any] = []
+
+        def _probe(_s: Schedule) -> RunningFireState:
+            return RunningFireState(running=True, running_count=1, fire_id="prev", checkpoint_event_hash="sha256:cp")
+
+        supervisor = ScheduleSupervisor(
+            store,
+            dispatched.append,
+            audit,
+            running_probe=_probe,
+            collision_policy=CollisionPolicy.SUPERSEDE_WITH_HANDOFF,
+        )
+        now = int(datetime(2030, 1, 1, 12, 3, 0, tzinfo=UTC).timestamp())
+        supervisor.tick(now=now)
+        assert len(dispatched) == 1
+        collision_entries = [e for e in audit.entries if e.event_type == COLLISION_EVENT_TYPE]
+        assert len(collision_entries) == 1
+        assert collision_entries[0].details["warm_resume"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC4: supersede handoff resumes from the recorded checkpoint (or cold)
+# ---------------------------------------------------------------------------
+
+
+def _make_worktree(root: Path) -> Path:
+    tree = root / "wt"
+    tree.mkdir(parents=True, exist_ok=True)
+    (tree / "file.txt").write_text("content", encoding="utf-8")
+    return tree
+
+
+class TestSupersedeHandoff:
+    def test_warm_resume_from_recorded_checkpoint(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        tree = _make_worktree(tmp_path)
+        ref = record_task_checkpoint(
+            sdd_dir=sdd,
+            task_id="running-fire",
+            adapter="claude",
+            session_id="sess-1",
+            workspace_hash=workspace_hash(tree),
+            worktree_path=str(tree),
+        )
+        resume_from = resolve_handoff_checkpoint(sdd, "running-fire")
+        assert resume_from == ref.event_hash
+
+        decision = decide_collision(
+            policy=CollisionPolicy.SUPERSEDE_WITH_HANDOFF,
+            running=RunningFireState(
+                running=True,
+                running_count=1,
+                fire_id="running-fire",
+                checkpoint_event_hash=resume_from,
+            ),
+        )
+        assert decision.action is CollisionAction.SUPERSEDE
+        assert decision.dispatch is True
+        assert decision.warm_resume is True
+        assert decision.resume_from_checkpoint == ref.event_hash
+
+    def test_tampered_checkpoint_downgrades_to_cold_start(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        tree = _make_worktree(tmp_path)
+        record_task_checkpoint(
+            sdd_dir=sdd,
+            task_id="running-fire",
+            adapter="claude",
+            session_id="sess-1",
+            workspace_hash=workspace_hash(tree),
+            worktree_path=str(tree),
+        )
+        # Tamper the checkpoint row: the Merkle chain no longer verifies.
+        journal = sdd / "runs" / task_run_id("running-fire") / "journal.jsonl"
+        row = json.loads(journal.read_text(encoding="utf-8").splitlines()[0])
+        row["session_id"] = "attacker-session"
+        journal.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+        resume_from = resolve_handoff_checkpoint(sdd, "running-fire")
+        assert resume_from == ""
+
+        decision = decide_collision(
+            policy=CollisionPolicy.SUPERSEDE_WITH_HANDOFF,
+            running=RunningFireState(
+                running=True,
+                running_count=1,
+                fire_id="running-fire",
+                checkpoint_event_hash=resume_from,
+            ),
+        )
+        # Supersede still proceeds, but cold: never a warm resume of the
+        # attacker-chosen session.
+        assert decision.dispatch is True
+        assert decision.warm_resume is False
+        assert decision.resume_from_checkpoint == ""
+
+    def test_missing_checkpoint_is_cold(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        assert resolve_handoff_checkpoint(sdd, "never-checkpointed") == ""

--- a/tests/unit/test_recipe_fleet.py
+++ b/tests/unit/test_recipe_fleet.py
@@ -1,0 +1,115 @@
+"""Declarative fleet manifest plan/apply (#2546, AC7).
+
+- ``plan`` run twice against the same state emits byte-identical plan
+  documents with equal ``plan_hash``.
+- ``apply`` against mutated state exits non-zero naming the divergent recipe.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.workflows.recipe_fleet import (
+    FleetDriftError,
+    ManifestEntry,
+    apply_fleet,
+    plan_fleet,
+)
+from bernstein.core.workflows.recipe_registry import RecipePins, RecipeRegistry
+from bernstein.core.workflows.recipe_spec import RecipeSpec, load_recipe_spec_from_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"0" * 32
+
+
+def _spec(name: str, description: str) -> RecipeSpec:
+    return load_recipe_spec_from_text(
+        f"""
+name: {name}
+description: {description}
+version: "1.0.0"
+nodes:
+  - id: n
+    command: "echo hi"
+""",
+    )
+
+
+def _registry(sdd: Path) -> RecipeRegistry:
+    sdd.mkdir(parents=True, exist_ok=True)
+    return RecipeRegistry(sdd, chain=AuditChainStore(sdd / "audit", key=_KEY), hmac_key=_KEY, lineage_key=_KEY)
+
+
+def _manifest() -> list[ManifestEntry]:
+    return [
+        ManifestEntry(spec=_spec("triage", "Nightly triage"), pins=RecipePins(git_commit="c1")),
+        ManifestEntry(spec=_spec("digest", "Daily digest"), pins=RecipePins(git_commit="c1")),
+    ]
+
+
+class TestPlanReproducibility:
+    def test_plan_is_byte_reproducible(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        first = plan_fleet(reg, _manifest())
+        second = plan_fleet(reg, _manifest())
+        assert first.plan_bytes == second.plan_bytes
+        assert first.plan_hash == second.plan_hash
+
+    def test_fresh_plan_lists_registrations(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        plan = plan_fleet(reg, _manifest())
+        assert set(plan.to_register) == {"triage", "digest"}
+        assert plan.to_supersede == ()
+
+    def test_plan_hash_changes_after_target_change(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        base = plan_fleet(reg, _manifest())
+        changed = _manifest()
+        changed[0] = ManifestEntry(spec=_spec("triage", "Nightly triage v2"), pins=RecipePins(git_commit="c1"))
+        assert plan_fleet(reg, changed).plan_hash != base.plan_hash
+
+
+class TestApply:
+    def test_apply_registers_the_fleet(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        manifest = _manifest()
+        plan = plan_fleet(reg, manifest)
+        applied = apply_fleet(reg, manifest, plan_hash=plan.plan_hash)
+        assert set(applied) == {"triage", "digest"}
+        assert reg.live_hash("triage") is not None
+        assert reg.live_hash("digest") is not None
+
+    def test_replan_after_apply_shows_no_drift(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        manifest = _manifest()
+        plan = plan_fleet(reg, manifest)
+        apply_fleet(reg, manifest, plan_hash=plan.plan_hash)
+        replan = plan_fleet(reg, manifest)
+        assert set(replan.unchanged) == {"triage", "digest"}
+        assert replan.to_register == ()
+
+    def test_apply_against_mutated_state_refuses(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        manifest = _manifest()
+        plan = plan_fleet(reg, manifest)
+        # Mutate the registry out of band after the plan was approved.
+        reg.register(spec=_spec("triage", "Out of band change"), pins=RecipePins(git_commit="c1"))
+        with pytest.raises(FleetDriftError) as excinfo:
+            apply_fleet(reg, manifest, plan_hash=plan.plan_hash)
+        assert "triage" in str(excinfo.value)
+
+    def test_apply_binds_receipt_to_plan_hash(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        reg = _registry(sdd)
+        manifest = _manifest()
+        plan = plan_fleet(reg, manifest)
+        apply_fleet(reg, manifest, plan_hash=plan.plan_hash)
+        chain = AuditChainStore(sdd / "audit", key=_KEY)
+        applies = chain.query(event_type="recipe.fleet_apply")
+        assert len(applies) == 1
+        assert applies[0].details["plan_hash"] == plan.plan_hash

--- a/tests/unit/test_recipe_registry.py
+++ b/tests/unit/test_recipe_registry.py
@@ -1,0 +1,274 @@
+"""Registered-recipe registry: content-addressing, lineage, pause (#2546).
+
+Covers the acceptance criteria that live at the registry layer:
+
+- Registration determinism (AC1): the same manifest at the same commit
+  derives byte-identical canonical bytes and the same recipe_hash; changing
+  any pinned input changes the hash.
+- Offline verifiability (AC5): ``verify_history`` walks the lifecycle
+  receipts against the HMAC chain with no server and fails on a broken /
+  reordered link.
+- Pause is stateful, not destructive (AC6): a paused recipe fires nothing,
+  keeps its identity, and its pause window reconstructs from receipts alone.
+- No behaviour change for zero-block manifests (AC8).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.security.audit_chain import AuditChainStore
+from bernstein.core.workflows.recipe_registry import (
+    RecipePins,
+    RecipeRegistry,
+    RecipeRegistryError,
+    compute_recipe_registration,
+    recipe_content_hash,
+)
+from bernstein.core.workflows.recipe_spec import RecipeSpec, load_recipe_spec_from_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KEY = b"0" * 32
+
+_MANIFEST = """
+name: nightly-triage
+description: Nightly triage recipe
+version: "1.2.0"
+params:
+  - name: severity
+    type: string
+    default: high
+    help: "Severity to triage."
+nodes:
+  - id: triage
+    agent: backend
+    prompt: "Triage {severity} issues. Goal: {goal}"
+schedules:
+  - kind: cron
+    recurrence: "0 9 * * *"
+    timezone: America/New_York
+    dst_policy: post_transition
+"""
+
+
+def _spec(manifest: str = _MANIFEST) -> RecipeSpec:
+    return load_recipe_spec_from_text(manifest)
+
+
+def _registry(sdd: Path) -> RecipeRegistry:
+    sdd.mkdir(parents=True, exist_ok=True)
+    return RecipeRegistry(
+        sdd,
+        chain=AuditChainStore(sdd / "audit", key=_KEY),
+        hmac_key=_KEY,
+        lineage_key=_KEY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC1: registration determinism
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationDeterminism:
+    def test_same_manifest_same_commit_same_hash(self) -> None:
+        pins = RecipePins(git_commit="abc123", adapter="claude", model="opus", prompt_pack_sha256="deadbeef")
+        b1, h1, *_ = compute_recipe_registration(_spec(), pins=pins)
+        b2, h2, *_ = compute_recipe_registration(_spec(), pins=pins)
+        assert b1 == b2
+        assert h1 == h2
+        assert recipe_content_hash(b1) == h1
+
+    @pytest.mark.parametrize(
+        "changed",
+        [
+            RecipePins(git_commit="OTHER", adapter="claude", model="opus", prompt_pack_sha256="deadbeef"),
+            RecipePins(git_commit="abc123", adapter="codex", model="opus", prompt_pack_sha256="deadbeef"),
+            RecipePins(git_commit="abc123", adapter="claude", model="sonnet", prompt_pack_sha256="deadbeef"),
+            RecipePins(git_commit="abc123", adapter="claude", model="opus", prompt_pack_sha256="feedface"),
+        ],
+    )
+    def test_changing_any_pin_changes_hash(self, changed: RecipePins) -> None:
+        base = RecipePins(git_commit="abc123", adapter="claude", model="opus", prompt_pack_sha256="deadbeef")
+        _, base_hash, *_ = compute_recipe_registration(_spec(), pins=base)
+        _, changed_hash, *_ = compute_recipe_registration(_spec(), pins=changed)
+        assert base_hash != changed_hash
+
+    def test_changing_param_schema_changes_hash(self) -> None:
+        pins = RecipePins(git_commit="abc123")
+        _, h1, *_ = compute_recipe_registration(_spec(), pins=pins)
+        altered = _MANIFEST.replace("default: high", "default: low")
+        _, h2, *_ = compute_recipe_registration(_spec(altered), pins=pins)
+        assert h1 != h2
+
+    def test_recipe_hash_is_identity(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        rr = reg.register(spec=_spec(), pins=RecipePins(git_commit="abc123"))
+        assert reg.live_hash("nightly-triage") == rr.recipe_hash
+        assert rr.recipe_id == f"recipe_{rr.recipe_hash[:12]}"
+        assert reg.get_canonical_bytes(rr.recipe_hash) == rr.canonical_bytes
+
+
+# ---------------------------------------------------------------------------
+# Registration seals canonical bytes into the lineage spine
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationSeal:
+    def test_register_seals_into_spine(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        rr = reg.register(spec=_spec(), pins=RecipePins(git_commit="abc123"))
+        assert rr.spine_anchor.startswith("sha256:")
+
+    def test_register_is_idempotent(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        pins = RecipePins(git_commit="abc123")
+        first = reg.register(spec=_spec(), pins=pins)
+        second = reg.register(spec=_spec(), pins=pins)
+        assert first.recipe_hash == second.recipe_hash
+        # Idempotent re-register writes no extra receipt.
+        assert len(reg.history("nightly-triage")) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC5: definition lineage + offline verifiability
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitionLineage:
+    def test_supersede_then_rollback_lineage(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        first = reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        changed = _MANIFEST.replace("Nightly triage recipe", "Nightly triage recipe v2")
+        second = reg.register(spec=_spec(changed), pins=RecipePins(git_commit="c1"))
+        assert reg.live_hash("nightly-triage") == second.recipe_hash
+        assert second.superseded_hash == first.recipe_hash
+
+        reg.rollback("nightly-triage", first.recipe_hash)
+        assert reg.live_hash("nightly-triage") == first.recipe_hash
+        # Nothing deleted: the superseding hash is still a known definition.
+        assert reg.get_canonical_bytes(second.recipe_hash) is not None
+        assert len(reg.history("nightly-triage")) == 3
+
+    def test_verify_history_passes_on_intact_chain(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        changed = _MANIFEST.replace("Nightly triage recipe", "v2")
+        reg.register(spec=_spec(changed), pins=RecipePins(git_commit="c1"))
+        ok, errors = reg.verify_history("nightly-triage")
+        assert ok, errors
+
+    def test_verify_history_detects_byte_tamper(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        reg = _registry(sdd)
+        reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        # Flip a byte in the on-disk audit log.
+        audit_file = next((sdd / "audit").glob("*.jsonl"))
+        lines = audit_file.read_text().splitlines()
+        obj = json.loads(lines[0])
+        obj["details"]["name"] = "hacked"
+        lines[0] = json.dumps(obj)
+        audit_file.write_text("\n".join(lines) + "\n")
+
+        reopened = _registry(sdd)
+        ok, errors = reopened.verify_history("nightly-triage")
+        assert not ok
+        assert errors
+
+    def test_verify_history_detects_reorder(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        reg = _registry(sdd)
+        reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        changed = _MANIFEST.replace("Nightly triage recipe", "v2")
+        reg.register(spec=_spec(changed), pins=RecipePins(git_commit="c1"))
+        audit_file = next((sdd / "audit").glob("*.jsonl"))
+        lines = audit_file.read_text().splitlines()
+        assert len(lines) >= 2
+        lines[0], lines[1] = lines[1], lines[0]
+        audit_file.write_text("\n".join(lines) + "\n")
+
+        reopened = _registry(sdd)
+        ok, errors = reopened.verify_history("nightly-triage")
+        assert not ok
+        assert errors
+
+    def test_rollback_unknown_hash_rejected(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        with pytest.raises(RecipeRegistryError):
+            reg.rollback("nightly-triage", "0" * 64)
+
+
+# ---------------------------------------------------------------------------
+# AC6: pause is stateful, not destructive
+# ---------------------------------------------------------------------------
+
+
+class TestPause:
+    def test_paused_recipe_fires_nothing_but_keeps_identity(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        rr = reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        reg.pause("nightly-triage")
+        assert reg.is_paused("nightly-triage")
+        result = reg.fire("nightly-triage", fire_time=1_800_000_000)
+        assert result.dispatched is False
+        assert result.projection_hash == ""
+        # Identity preserved through the pause.
+        assert reg.live_hash("nightly-triage") == rr.recipe_hash
+
+    def test_resume_restores_firing(self, tmp_path: Path) -> None:
+        reg = _registry(tmp_path / ".sdd")
+        reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        reg.pause("nightly-triage")
+        reg.resume("nightly-triage")
+        assert reg.is_paused("nightly-triage") is False
+        result = reg.fire("nightly-triage", fire_time=1_800_000_000)
+        assert result.dispatched is True
+        assert result.projection_hash
+
+    def test_pause_window_reconstructs_from_receipts(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        reg = _registry(sdd)
+        reg.register(spec=_spec(), pins=RecipePins(git_commit="c1"))
+        reg.pause("nightly-triage")
+        reg.resume("nightly-triage")
+        # A fresh registry (no in-memory state) reconstructs the pause window
+        # purely from the receipts on disk.
+        reopened = _registry(sdd)
+        history = reopened.history("nightly-triage")
+        types = [ev["event_type"] for ev in history]
+        assert "recipe.pause" in types
+        assert "recipe.resume" in types
+        assert reopened.is_paused("nightly-triage") is False
+
+
+# ---------------------------------------------------------------------------
+# AC8: zero-block manifests keep working unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_zero_block_manifest_registers(self, tmp_path: Path) -> None:
+        manifest = """
+name: plain
+description: A plain zero-block recipe
+version: "1.0.0"
+nodes:
+  - id: n
+    command: "echo hi"
+"""
+        spec = load_recipe_spec_from_text(manifest)
+        assert spec.schedules == []
+        assert spec.triggers == []
+        assert spec.sandbox_pool == ""
+        reg = _registry(tmp_path / ".sdd")
+        rr = reg.register(spec=spec, pins=RecipePins(git_commit="c1"))
+        assert reg.live_hash("plain") == rr.recipe_hash
+        # A zero-schedule recipe fires with a plain (tz-less) projection.
+        result = reg.fire("plain", fire_time=1_800_000_000)
+        assert result.dispatched is True

--- a/tests/unit/test_recipes_register_cli.py
+++ b/tests/unit/test_recipes_register_cli.py
@@ -1,0 +1,110 @@
+"""End-to-end CLI surface for registered recipes (#2546).
+
+Exercises ``bernstein recipes register / show --registered / history
+--verify / pause / fire / resume / rollback / plan / apply`` against a
+throwaway working directory, proving the verbs are wired and behave per the
+acceptance criteria at the command layer.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.recipes_cmd import recipes_group
+
+_MANIFEST = """\
+name: nightly-triage
+description: "Nightly triage recipe."
+version: "1.0.0"
+nodes:
+  - id: triage
+    command: "echo triage"
+schedules:
+  - kind: cron
+    recurrence: "0 9 * * *"
+    timezone: America/New_York
+    dst_policy: post_transition
+"""
+
+
+@pytest.fixture
+def workdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+    recipes_dir = tmp_path / ".bernstein" / "recipes"
+    recipes_dir.mkdir(parents=True, exist_ok=True)
+    (recipes_dir / "nightly-triage.yaml").write_text(_MANIFEST, encoding="utf-8")
+    old = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(old)
+
+
+def _run(args: list[str]) -> object:
+    return CliRunner().invoke(recipes_group, args)
+
+
+class TestRegisterFlow:
+    def test_register_then_show_registered(self, workdir: Path) -> None:
+        result = _run(["register", "nightly-triage"])
+        assert result.exit_code == 0, result.output
+        assert "Registered" in result.output
+        assert "recipe_hash:" in result.output
+
+        shown = _run(["show", "nightly-triage", "--registered"])
+        assert shown.exit_code == 0, shown.output
+        assert "active" in shown.output
+
+    def test_history_verify_passes(self, workdir: Path) -> None:
+        assert _run(["register", "nightly-triage"]).exit_code == 0
+        result = _run(["history", "nightly-triage", "--verify"])
+        assert result.exit_code == 0, result.output
+        assert "verified" in result.output
+
+    def test_pause_blocks_fire_then_resume(self, workdir: Path) -> None:
+        assert _run(["register", "nightly-triage"]).exit_code == 0
+        assert _run(["pause", "nightly-triage"]).exit_code == 0
+        fired = _run(["fire", "nightly-triage", "--at", "1800000000"])
+        assert fired.exit_code == 0
+        assert "Not fired" in fired.output
+
+        assert _run(["resume", "nightly-triage"]).exit_code == 0
+        fired2 = _run(["fire", "nightly-triage", "--at", "1800000000"])
+        assert fired2.exit_code == 0
+        assert "projection_hash:" in fired2.output
+
+    def test_fire_unregistered_exits_nonzero(self, workdir: Path) -> None:
+        result = _run(["fire", "does-not-exist", "--at", "1"])
+        assert result.exit_code == 1
+
+    def test_plan_is_reproducible(self, workdir: Path) -> None:
+        first = _run(["plan", "nightly-triage"])
+        second = _run(["plan", "nightly-triage"])
+        assert first.exit_code == 0, first.output
+        assert "plan_hash:" in first.output
+        # The plan_hash line is stable across runs against the same state.
+        first_hash = _extract_plan_hash(first.output)
+        second_hash = _extract_plan_hash(second.output)
+        assert first_hash == second_hash
+
+    def test_apply_registers_then_no_change(self, workdir: Path) -> None:
+        plan = _run(["plan", "nightly-triage"])
+        plan_hash = _extract_plan_hash(plan.output)
+        applied = _run(["apply", "--plan", plan_hash, "nightly-triage"])
+        assert applied.exit_code == 0, applied.output
+        assert "Applied" in applied.output
+        assert _run(["show", "nightly-triage", "--registered"]).exit_code == 0
+
+
+def _extract_plan_hash(output: str) -> str:
+    for line in output.splitlines():
+        if "plan_hash:" in line:
+            return line.split("plan_hash:", 1)[1].strip()
+    raise AssertionError(f"no plan_hash in output: {output!r}")

--- a/tests/unit/test_schedule_kinds_tz.py
+++ b/tests/unit/test_schedule_kinds_tz.py
@@ -1,0 +1,194 @@
+"""Timezone-deterministic fires across DST transitions (#2546, AC2).
+
+For a recipe declaring an IANA timezone:
+
+- hosts with different system timezones compute the identical fire
+  projection hash for the same instant (the projection folds the declared
+  zone; the instant itself is an epoch int, host-independent);
+- replay across the DST-forward gap and the DST-back overlap resolves
+  byte-identically per the declared ambiguity policy.
+
+The resolver never reads the host locale (only stdlib ``zoneinfo``), so the
+two-host proof is that setting ``TZ`` to different zones does not move the
+resolved epoch or the projection hash.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime
+
+import pytest
+
+from bernstein.core.orchestration.schedule_kinds import (
+    DstPolicy,
+    ScheduleKindError,
+    canonical_timezone,
+    interval_anchor_fires,
+    is_ambiguous_local,
+    is_imaginary_local,
+    resolve_local_instant,
+)
+from bernstein.core.orchestration.schedule_projection import project_schedule_fire
+
+# America/New_York 2026 transitions: spring-forward 2026-03-08 02:00 ->
+# 03:00 (02:30 is imaginary); fall-back 2026-11-01 02:00 -> 01:00 (01:30 is
+# ambiguous).
+_GAP = datetime(2026, 3, 8, 2, 30)
+_OVERLAP = datetime(2026, 11, 1, 1, 30)
+_TZ = "America/New_York"
+
+
+class _HostTimezone:
+    """Context manager that pins the process TZ (and restores it)."""
+
+    def __init__(self, tz: str) -> None:
+        self._tz = tz
+        self._prev: str | None = None
+
+    def __enter__(self) -> None:
+        self._prev = os.environ.get("TZ")
+        os.environ["TZ"] = self._tz
+        if hasattr(time, "tzset"):
+            time.tzset()
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._prev is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = self._prev
+        if hasattr(time, "tzset"):
+            time.tzset()
+
+
+class TestCanonicalTimezone:
+    def test_empty_is_utc_sentinel(self) -> None:
+        assert canonical_timezone("") == ""
+
+    def test_valid_zone_round_trips(self) -> None:
+        assert canonical_timezone("Europe/Berlin") == "Europe/Berlin"
+
+    def test_unknown_zone_rejected(self) -> None:
+        with pytest.raises(ScheduleKindError):
+            canonical_timezone("Mars/Olympus_Mons")
+
+
+class TestDstDetection:
+    def test_gap_is_imaginary(self) -> None:
+        from zoneinfo import ZoneInfo
+
+        assert is_imaginary_local(ZoneInfo(_TZ), _GAP)
+
+    def test_overlap_is_ambiguous(self) -> None:
+        from zoneinfo import ZoneInfo
+
+        assert is_ambiguous_local(ZoneInfo(_TZ), _OVERLAP)
+
+
+class TestHostIndependence:
+    @pytest.mark.parametrize("host_tz", ["UTC", "Asia/Tokyo", "America/Los_Angeles", "Europe/London"])
+    def test_overlap_resolves_identically_on_every_host(self, host_tz: str) -> None:
+        with _HostTimezone("UTC"):
+            reference = resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.POST_TRANSITION)
+        with _HostTimezone(host_tz):
+            got = resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.POST_TRANSITION)
+        assert got == reference
+
+    @pytest.mark.parametrize("host_tz", ["UTC", "Asia/Tokyo", "America/Los_Angeles"])
+    def test_gap_resolves_identically_on_every_host(self, host_tz: str) -> None:
+        with _HostTimezone("UTC"):
+            reference = resolve_local_instant(tz_name=_TZ, naive_local=_GAP, dst_policy=DstPolicy.PRE_TRANSITION)
+        with _HostTimezone(host_tz):
+            got = resolve_local_instant(tz_name=_TZ, naive_local=_GAP, dst_policy=DstPolicy.PRE_TRANSITION)
+        assert got == reference
+
+
+class TestDstPolicy:
+    def test_overlap_pre_and_post_are_one_hour_apart(self) -> None:
+        pre = resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.PRE_TRANSITION)
+        post = resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.POST_TRANSITION)
+        assert post - pre == 3600
+
+    def test_gap_pre_precedes_post(self) -> None:
+        pre = resolve_local_instant(tz_name=_TZ, naive_local=_GAP, dst_policy=DstPolicy.PRE_TRANSITION)
+        post = resolve_local_instant(tz_name=_TZ, naive_local=_GAP, dst_policy=DstPolicy.POST_TRANSITION)
+        assert pre < post
+
+    def test_strict_rejects_gap(self) -> None:
+        with pytest.raises(ScheduleKindError):
+            resolve_local_instant(tz_name=_TZ, naive_local=_GAP, dst_policy=DstPolicy.STRICT)
+
+    def test_strict_rejects_overlap(self) -> None:
+        with pytest.raises(ScheduleKindError):
+            resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.STRICT)
+
+    def test_aware_datetime_rejected(self) -> None:
+        from zoneinfo import ZoneInfo
+
+        aware = _OVERLAP.replace(tzinfo=ZoneInfo(_TZ))
+        with pytest.raises(ScheduleKindError):
+            resolve_local_instant(tz_name=_TZ, naive_local=aware, dst_policy=DstPolicy.PRE_TRANSITION)
+
+
+class TestProjectionFolding:
+    def test_declared_timezone_binds_the_graph_hash(self) -> None:
+        instant = resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.POST_TRANSITION)
+        with_tz = project_schedule_fire(
+            schedule_id="recipe_abc",
+            fire_time=instant,
+            last_state=None,
+            timezone=_TZ,
+            dst_policy=str(DstPolicy.POST_TRANSITION),
+        )
+        without_tz = project_schedule_fire(schedule_id="recipe_abc", fire_time=instant, last_state=None)
+        assert with_tz.projection_hash != without_tz.projection_hash
+
+    def test_same_instant_and_zone_gives_identical_hash_across_hosts(self) -> None:
+        instant = resolve_local_instant(tz_name=_TZ, naive_local=_OVERLAP, dst_policy=DstPolicy.POST_TRANSITION)
+        with _HostTimezone("Asia/Tokyo"):
+            a = project_schedule_fire(
+                schedule_id="recipe_abc",
+                fire_time=instant,
+                last_state=None,
+                timezone=_TZ,
+                dst_policy=str(DstPolicy.POST_TRANSITION),
+            )
+        with _HostTimezone("America/Los_Angeles"):
+            b = project_schedule_fire(
+                schedule_id="recipe_abc",
+                fire_time=instant,
+                last_state=None,
+                timezone=_TZ,
+                dst_policy=str(DstPolicy.POST_TRANSITION),
+            )
+        assert a.projection_hash == b.projection_hash
+        assert a.canonical_bytes == b.canonical_bytes
+
+    def test_zoneless_projection_is_byte_identical_to_pre_change(self) -> None:
+        # AC8: a zone-less schedule stays byte-identical to a pre-#2546 projection.
+        baseline = project_schedule_fire(schedule_id="s", fire_time=1_800_000_000, last_state=None, goal="g")
+        again = project_schedule_fire(
+            schedule_id="s",
+            fire_time=1_800_000_000,
+            last_state=None,
+            goal="g",
+            timezone="",
+            dst_policy="",
+        )
+        assert baseline.canonical_bytes == again.canonical_bytes
+
+
+class TestIntervalAnchor:
+    def test_grid_is_pure_function_of_anchor(self) -> None:
+        # Two operators without a shared clock agree on the fire grid.
+        first = interval_anchor_fires(anchor_epoch=1000, interval_seconds=3600, after_epoch=1000)
+        assert first == 1000 + 3600
+        assert interval_anchor_fires(anchor_epoch=1000, interval_seconds=3600, after_epoch=5000) == 1000 + 2 * 3600
+
+    def test_before_anchor_returns_anchor(self) -> None:
+        assert interval_anchor_fires(anchor_epoch=1000, interval_seconds=60, after_epoch=500) == 1000
+
+    def test_non_positive_interval_rejected(self) -> None:
+        with pytest.raises(ScheduleKindError):
+            interval_anchor_fires(anchor_epoch=0, interval_seconds=0, after_epoch=10)


### PR DESCRIPTION
## What

Unify recipes, schedules, and scenarios into one governed, content-addressed run definition whose entire lifecycle lives on the HMAC audit chain. The recipe id is the sha256 of its canonical body; the registry is a projection of the receipt history, not a mutable row.

## Changes

- `core/workflows/recipe_registry.py` (new): canonical-bytes encoder, `recipe_hash` as identity, registry projected from receipts, spine seal on register, supersede/rollback/pause/resume, offline `verify_history`.
- `core/orchestration/schedule_kinds.py` (new): `cron` / `interval_anchor` / RRULE kinds; IANA timezone plus explicit DST ambiguity policy resolved through stdlib `zoneinfo`, host-independent across the DST-forward gap and DST-back overlap.
- `core/orchestration/collision.py` (new): pure `decide_collision(policy, running_fire_state)` with a stable receipt hash; `ENQUEUE` / `CANCEL_NEW` / `SUPERSEDE_WITH_HANDOFF`.
- `core/orchestration/schedule_supervisor.py`: fixes the double-fire over a still-running previous fire. The supervisor evaluates the collision guard before every dispatch and emits a collision receipt for every overlap; `CANCEL_NEW` never dispatches a second task graph. Additive and opt-in (no running probe keeps prior behaviour).
- `core/orchestration/schedule_projection.py`: folds the declared timezone / DST policy into the fire projection hash, conditionally, so zone-less schedules stay byte-identical to prior revs.
- `core/workflows/recipe_fleet.py` (new): `recipes plan` emits a byte-reproducible diff with a `plan_hash`; `recipes apply --plan` refuses to run against drifted registry state, naming the divergent recipe.
- `core/security/audit_chain.py`: additive `recipe.register` / `recipe.supersede` / `recipe.rollback` / `recipe.pause` / `recipe.resume` / `schedule.collision_receipt` / `recipe.fleet_apply` events and record helpers.
- `core/workflows/recipe_spec.py`: optional `schedules` / `triggers` / `sandbox_pool` / `pins` blocks (zero-block manifests unchanged).
- CLI verbs in `recipes_cmd.py`: `register`, `fire`, `show --registered`, `history --verify`, `rollback`, `pause`, `resume`, `plan`, `apply`.

## Acceptance criteria coverage

| AC | Where |
|----|-------|
| Registration determinism | `tests/property/test_recipe_hash_properties.py`, `tests/unit/test_recipe_registry.py` |
| Timezone-deterministic fires (DST gap + overlap, host-independent) | `tests/unit/test_schedule_kinds_tz.py` |
| Collision receipts are pure; tick never double-dispatches | `tests/unit/test_recipe_collision.py` |
| Supersede handoff resumes from checkpoint; tamper -> cold | `tests/unit/test_recipe_collision.py` |
| Offline verifiability of definition lineage | `tests/unit/test_recipe_registry.py` |
| Pause is stateful, not destructive | `tests/unit/test_recipe_registry.py` |
| Plan reproducibility + apply refuses on drift | `tests/unit/test_recipe_fleet.py` |
| Zero-block manifests / `sched_` schedules unchanged | `tests/unit/test_recipe_registry.py`, `tests/unit/test_schedule_kinds_tz.py` |

No new runtime dependency (`zoneinfo` is stdlib); existing zero-block recipe manifests and existing `sched_` schedules keep working unchanged.

Closes #2546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added content-addressed registered recipes with verifiable lifecycle history.
  * Added CLI commands to register, fire, inspect, verify, pause, resume, rollback, plan, and apply recipes.
  * Added interval/anchor and RRULE scheduling with IANA timezones and explicit DST handling.
  * Added configurable concurrency collision policies, including cancellation and handoff behavior.
  * Added fleet planning with hash-based drift protection.
* **Bug Fixes**
  * Improved deterministic scheduling across hosts and safe handling of invalid or ambiguous times.
  * Existing recipe manifests and `sched_` schedules remain compatible.
* **Tests**
  * Added coverage for registration, lifecycle history, collisions, timezone behavior, and fleet workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->