### PR TITLE
chore(release): v3.6.0

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bernstein",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Multi-agent orchestration for CLI coding agents. Spawn parallel agents, verify their work, and merge results.",
   "author": {
     "name": "chernistry",

--- a/docs/release-notes/v3.6.0.md
+++ b/docs/release-notes/v3.6.0.md
@@ -1,6 +1,6 @@
 # v3.6.0
 
-Unreleased.
+Released 2026-07-17.
 
 ## Security: provenance trust classes with lineage-propagated egress confinement (#2513)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "3.5.0"
+version = "3.6.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/sipyourdrink-ltd/bernstein",
     "source": "github"
   },
-  "version": "3.5.0",
+  "version": "3.6.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "bernstein",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "transport": {
         "type": "stdio"
       }
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.5.0",
+      "identifier": "ghcr.io/sipyourdrink-ltd/bernstein:3.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
Release v3.6.0 - closes the 20-issue v3.6.0 milestone.

- Bump version 3.5.0 -> 3.6.0 in pyproject.toml
- Relock uv.lock
- Regenerate distribution manifests (server.json, .plugin/plugin.json) to 3.6.0
- Date the v3.6.0 release notes

On merge, auto-release tags v3.6.0; publish workflows are dispatched after the tag lands.