### PR TITLE
feat(orchestration): durable task suspend and resume via attested park receipts

### DIFF
--- a/docs/operations/durable-suspend-resume.md
+++ b/docs/operations/durable-suspend-resume.md
@@ -1,0 +1,135 @@
+# Durable suspend and resume
+
+A long agent session sometimes has to wait on a human: a mid-flight approval, an
+external review, a credential rotation, a dependency landing. Historically that
+wait cost real infrastructure. The pre-spawn approval gate can halt a task only
+*before* a worker exists, and the post-completion review gate only *after* it
+exits; there is no human-in-the-loop halt inside a running session. So the
+process, its worktree sandbox, its parallelism seat, and its budget-envelope
+reservation all stayed allocated for the entire wait. On a capped pool that
+reservation blocked other tasks from dispatching.
+
+Durable suspend and resume closes that gap. A task that must wait can **park**:
+the park emits an attested receipt that releases the seat, the sandbox, and the
+budget envelope, and a later **resume** restores from that receipt
+deterministically. The suspension itself is the artifact -- without the chain
+there is no suspension, only a dead process.
+
+## The park is a receipt, not a flag
+
+A park is a pair of Merkle-chained journal rows plus matching HMAC audit-chain
+receipts, and every infrastructure release hangs off the suspend receipt's
+hash:
+
+1. **The suspend row is the identity.** A suspend row is appended to the task's
+   event journal (`.sdd/runs/task-<task-id>/journal.jsonl`) with the same row
+   discipline as the checkpoint substrate: the adapter-native session id, a
+   workspace hash over the worktree, the journal head, and the envelope balance
+   at park time. The row's `event_hash` is the suspension's identity.
+2. **The receipt binds the hash before any effect.** A `task.suspend_receipt`
+   is written into the HMAC audit chain *before* a single resource is freed.
+3. **Each release references the receipt.** The process is terminated and
+   reaped, the sandbox is torn down, the parallelism seat is returned, and
+   unspent envelope headroom is released back to the pool as a chained budget
+   event -- each recorded as a `task.suspend_resource_release` row referencing
+   the suspend receipt hash. **A release effect with no matching receipt is
+   rejected, fail closed.**
+4. **The park is persisted.** The task enters a `SUSPENDED` state recorded in
+   the work ledger, so the park survives orchestrator restarts and daemon
+   crashes the same way detached run state does. A parked task is deliberately
+   kept out of the resume frontier: it wakes on an explicit resume, never on an
+   auto-restart.
+
+## Released headroom
+
+The headroom returned to the pool is the reservation minus the spend recorded
+against it at park time (clamped at zero):
+
+```
+released_usd = max(reserved_usd - spent_usd, 0.0)
+```
+
+It appears as a chained budget event, and because no cost is recorded while the
+task is parked, the per-envelope rollup attributes **zero spend to the parked
+window**. On a capped pool the freed headroom is immediately dispatchable to a
+queued task.
+
+## Resume is a deterministic projection
+
+`bernstein task resume` re-materializes the continuation and derives its mode as
+a pure function of the suspend row and the adapter capability -- the same
+warm/fork/cold decision the [checkpointed retry](checkpointed-retries.md) path
+uses:
+
+| Condition | Effective mode |
+|---|---|
+| Same workspace hash + live native session | `warm` |
+| Fork requested + fork-capable adapter | `fork` |
+| Stale session, drifted workspace, or no capability | `cold` (with a recorded reason) |
+
+The decision carries a stable `decision_hash`: two hosts with the same suspend
+row and adapter capability derive the byte-identical decision. Downgrades are
+never silent -- a fork or cold resume always records its reason.
+
+The resume writes a `task.resume_receipt` binding the suspend receipt it
+continued from, the effective mode, and the new workspace hash. The suspend and
+resume receipt pair is the continuity proof.
+
+## Wake on approval
+
+`bernstein task suspend <task-id> --until approval` composes the park with the
+pre-spawn approval sentinel. The parked task refuses to resume until
+`bernstein approve <task-id>` lands its decision file; the resume receipt binds
+the approval decision digest, and a `<task-id>.resumed` marker binds the resume
+receipt hash, so the approval record and the resume receipt reference each
+other. This makes approval checkpoints usable mid-session, not only at the
+pre-spawn and post-completion boundaries.
+
+## Verifying continuity offline
+
+`bernstein audit verify-suspension <task-id>` proves, from a copied chain and
+the task journal alone, that a resumed task continued from exactly the parked
+workspace hash -- or shows the recorded fork/cold downgrade with its reason. No
+worker, no network, and no live worktree are required. Two tamper posture
+guarantees back the proof:
+
+- Mutating the suspend **row** breaks the journal Merkle chain at that exact
+  index, and the fail-closed read refuses to fuel a resume from a tampered row.
+- Mutating the suspend **receipt** breaks the HMAC audit chain at that exact
+  position, which `bernstein audit verify` reports.
+
+## Commands
+
+```bash
+# Park a running task, releasing its seat, sandbox, and budget envelope.
+bernstein task suspend T-abc123 --reserved-usd 10 --spent-usd 2.5
+
+# Park until an operator approves the wake.
+bernstein task suspend T-abc123 --until approval
+bernstein approve T-abc123          # lands the wake decision
+
+# List durably-parked tasks with their parked-at hash and freed resources.
+bernstein task list-suspended
+
+# Resume from the attested suspend receipt (warm when the workspace matches).
+bernstein task resume T-abc123
+
+# Prove the continuation is the same run, offline.
+bernstein audit verify-suspension T-abc123
+```
+
+## What this buys you
+
+Runs that wait on humans stop paying for the wait: an overnight approval halt
+holds zero seats, zero sandboxes, and zero reserved envelope headroom, so capped
+pools keep dispatching. And every park is explainable afterwards -- the suspend
+and resume receipt pair proves the continuation is the same run, so audits of
+long-lived runs no longer contain unexplained process gaps.
+
+## Relationship to the steering pause
+
+The in-place steering pause is the *momentary* halt for quick correction: it
+checkpoints a worker and parks its claim but keeps the infrastructure reserved.
+Durable suspend is the variant that frees infrastructure and proves continuity.
+Both share the checkpoint row shape and the receipt-before-effect rule, so a
+steering pause that exceeds a wait threshold can upgrade into a durable suspend.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -306,6 +306,7 @@ nav:
       - Reliability:
           - Troubleshooting: operations/TROUBLESHOOTING.md
           - Checkpointed retries: operations/checkpointed-retries.md
+          - Durable suspend and resume: operations/durable-suspend-resume.md
           - Retry budget: operations/retry-budget.md
           - Auto-heal: operations/auto-heal.md
           - Agent crash loops: operations/agent_crash_loop.md

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -509,6 +509,60 @@ def verify_gates_cmd() -> None:
     raise SystemExit(0 if passed else 1)
 
 
+@audit_group.command("verify-suspension")
+@click.argument("task_id")
+@click.option("--workdir", default=".", help="Project root directory (parent of .sdd/).", type=click.Path())
+@click.option("--json", "as_json", is_flag=True, default=False, help="Print the continuity result as JSON.")
+def verify_suspension_cmd(task_id: str, workdir: str, as_json: bool) -> None:
+    """Prove a durable suspend/resume continuity offline (#2552).
+
+    \b
+    From a copied chain and the task journal alone, proves that a resumed task
+    continued from exactly the parked workspace hash -- or shows the recorded
+    fork/cold downgrade with its reason. Mutating the suspend row after the
+    fact fails journal verification at that exact chain position, and a
+    tampered receipt fails the HMAC chain. Exits non-zero on any break.
+    """
+    import json as _json
+
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.tasks.suspension import verify_suspension_continuity
+
+    sdd_dir = Path(workdir) / ".sdd"
+    chain = AuditChainStore(sdd_dir / "audit")
+    result = verify_suspension_continuity(sdd_dir=sdd_dir, task_id=task_id, chain=chain)
+
+    if as_json:
+        console.print_json(_json.dumps(result.to_dict()))
+        raise SystemExit(0 if result.ok else 1)
+
+    console.print()
+    if result.ok:
+        detail = f"continued {result.effective_mode}"
+        if result.effective_mode == "warm":
+            detail += " from the parked workspace hash"
+        elif result.downgrade_reason:
+            detail += f" ({result.downgrade_reason})"
+        console.print(
+            Panel(
+                f"[bold green]Suspension continuity verified[/bold green]\ntask [bold]{task_id}[/bold]: {detail}",
+                border_style="green",
+                expand=False,
+            )
+        )
+        raise SystemExit(0)
+    console.print(
+        Panel(
+            f"[bold red]Suspension continuity FAILED[/bold red] for task [bold]{task_id}[/bold]",
+            border_style="red",
+            expand=False,
+        )
+    )
+    for err in result.errors:
+        console.print(f"  [red]![/red] {err}")
+    raise SystemExit(1)
+
+
 @audit_group.command("verify-hmac")
 def verify_hmac_cmd() -> None:
     """Verify HMAC chain integrity across all audit log files."""

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -765,3 +765,288 @@ def list_tasks(status_filter: str | None, role: str | None, as_json: bool) -> No
             str(t.get("priority", 2)),
         )
     console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# Durable suspend / resume (#2552)
+# ---------------------------------------------------------------------------
+
+
+@click.group("task")
+def task_group() -> None:
+    """Durable task lifecycle: suspend and resume long-running sessions.
+
+    A task that must wait on a human (a mid-flight approval, an external
+    review, a credential rotation, a dependency landing) can PARK: the park
+    emits an attested receipt that releases the seat, sandbox, and budget
+    envelope, and ``bernstein task resume`` restores from that receipt
+    deterministically.
+    """
+
+
+def _suspension_context(workdir: str, task_id: str) -> tuple[Path, Any, Any]:
+    """Return ``(sdd_dir, audit_chain, work_ledger)`` for a task park/resume."""
+    from bernstein.core.persistence.work_ledger import WorkLedger, run_ledger_dir
+    from bernstein.core.security.audit_chain import AuditChainStore
+    from bernstein.core.tasks.checkpoint_retry import task_run_id
+
+    sdd_dir = Path(workdir) / ".sdd"
+    chain = AuditChainStore(sdd_dir / "audit")
+    ledger = WorkLedger.open(run_ledger_dir(sdd_dir, task_run_id(task_id)))
+    return sdd_dir, chain, ledger
+
+
+@task_group.command("suspend")
+@click.argument("task_id")
+@click.option("--workdir", default=".", help="Project root directory (parent of .sdd/).", type=click.Path())
+@click.option("--adapter", default=None, help="Adapter owning the session (defaults to the latest checkpoint).")
+@click.option("--session-id", default=None, help="Native session id (defaults to the latest checkpoint).")
+@click.option("--worktree", default=None, help="Worktree to hash (defaults to the checkpoint worktree or cwd).")
+@click.option("--envelope", default="subscription", show_default=True, help="Quota envelope whose headroom is freed.")
+@click.option("--reserved-usd", default=0.0, type=float, help="Envelope headroom reserved for the task.")
+@click.option("--spent-usd", default=0.0, type=float, help="Spend recorded against the reservation at park time.")
+@click.option(
+    "--until",
+    "until",
+    type=click.Choice(["approval"]),
+    default=None,
+    help="Compose with the approval sentinel: resume only when 'bernstein approve <task-id>' lands.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Print the park result as JSON.")
+def task_suspend(
+    task_id: str,
+    workdir: str,
+    adapter: str | None,
+    session_id: str | None,
+    worktree: str | None,
+    envelope: str,
+    reserved_usd: float,
+    spent_usd: float,
+    until: str | None,
+    as_json: bool,
+) -> None:
+    """Durably park a running task, releasing its seat, sandbox, and budget.
+
+    The park appends a suspend row to the task journal, binds its hash into the
+    HMAC audit chain *before* any release, then returns the seat, tears down the
+    sandbox, reaps the process, and releases unspent envelope headroom -- each
+    referencing the suspend receipt hash. The SUSPENDED state is persisted to
+    the work ledger so the park survives an orchestrator restart.
+
+    \b
+    Example:
+      bernstein task suspend T-abc123 --reserved-usd 10 --spent-usd 2.5
+      bernstein task suspend T-abc123 --until approval
+    """
+    from bernstein.core.orchestration.approval_gate import write_pending_sentinel
+    from bernstein.core.tasks.checkpoint_retry import latest_checkpoint
+    from bernstein.core.tasks.models import ApprovalSpec
+    from bernstein.core.tasks.suspension import WAKE_APPROVAL, park_task
+
+    sdd_dir, chain, ledger = _suspension_context(workdir, task_id)
+
+    checkpoint = latest_checkpoint(sdd_dir, task_id)
+    if adapter is None:
+        adapter = checkpoint.adapter if checkpoint else ""
+    if session_id is None:
+        session_id = checkpoint.session_id if checkpoint else ""
+    if worktree is None:
+        worktree = checkpoint.worktree_path if checkpoint and checkpoint.worktree_path else workdir
+
+    wake_condition = WAKE_APPROVAL if until == "approval" else ""
+
+    result = park_task(
+        sdd_dir=sdd_dir,
+        task_id=task_id,
+        adapter=adapter,
+        session_id=session_id,
+        worktree_path=Path(worktree),
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        chain=chain,
+        ledger=ledger,
+        wake_condition=wake_condition,
+    )
+
+    if wake_condition == WAKE_APPROVAL:
+        write_pending_sentinel(
+            Path(workdir),
+            task_id,
+            ApprovalSpec(prompt=f"Resume parked task {task_id}?"),
+        )
+
+    released = {resource: detail for resource, detail in result.release.rows}
+    payload: dict[str, Any] = {
+        "task_id": task_id,
+        "status": "suspended",
+        "suspend_event_hash": result.suspend_row.event_hash,
+        "suspend_receipt_hash": result.suspend_receipt_hash,
+        "workspace_hash": result.suspend_row.workspace_hash,
+        "released_usd": result.release.released_usd,
+        "released_resources": sorted(released),
+        "wake_condition": wake_condition,
+        "ledger_entry_hash": result.ledger_entry_hash,
+    }
+    if as_json:
+        print_json(payload)
+        return
+    console.print(f"[green]Suspended:[/green] task [bold]{task_id}[/bold]")
+    console.print(f"[dim]parked-at:[/dim] {result.suspend_row.event_hash[:16]}")
+    console.print(f"[dim]receipt:[/dim] {result.suspend_receipt_hash[:16]}")
+    console.print(f"[dim]released:[/dim] {', '.join(sorted(released))} (${result.release.released_usd:.4f} headroom)")
+    if wake_condition == WAKE_APPROVAL:
+        console.print(f"[cyan]Wake gate:[/cyan] run 'bernstein approve {task_id}' to resume.")
+
+
+@task_group.command("resume")
+@click.argument("task_id")
+@click.option("--workdir", default=".", help="Project root directory (parent of .sdd/).", type=click.Path())
+@click.option("--worktree", default=None, help="Re-materialized worktree to hash (defaults to the parked path).")
+@click.option(
+    "--mode",
+    type=click.Choice(["warm", "fork", "cold"]),
+    default="warm",
+    show_default=True,
+    help="Requested continuation mode; downgraded (never upgraded) on drift.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Print the resume result as JSON.")
+def task_resume(task_id: str, workdir: str, worktree: str | None, mode: str, as_json: bool) -> None:
+    """Durably resume a parked task from its attested suspend receipt.
+
+    Reads the latest verified suspend row, re-derives the continuation mode
+    deterministically (warm when the workspace hash still matches, otherwise a
+    recorded fork/cold downgrade), and records the resume receipt binding the
+    suspend receipt it continued from. When the park was '--until approval' the
+    resume refuses until 'bernstein approve <task-id>' has landed its decision.
+
+    \b
+    Example:
+      bernstein task resume T-abc123
+    """
+    from bernstein.core.security.audit_chain import EVENT_TASK_SUSPENDED
+    from bernstein.core.tasks.suspension import (
+        WAKE_APPROVAL,
+        approval_decision_ref,
+        latest_suspension,
+        resume_task,
+        write_resume_marker,
+    )
+
+    sdd_dir, chain, ledger = _suspension_context(workdir, task_id)
+
+    suspend_row = latest_suspension(sdd_dir, task_id)
+    if suspend_row is None:
+        console.print(f"[red]No verified suspension found for task[/red] [bold]{task_id}[/bold].")
+        raise SystemExit(1)
+
+    approval_ref = ""
+    if suspend_row.wake_condition == WAKE_APPROVAL:
+        approval_ref = approval_decision_ref(Path(workdir), task_id)
+        if not approval_ref:
+            console.print(f"[yellow]Parked until approval:[/yellow] run 'bernstein approve {task_id}' before resuming.")
+            raise SystemExit(1)
+
+    # The suspend receipt hash is the identity bound at park time; recover it
+    # from the audit chain so the resume references exactly that receipt.
+    suspend_events = [e for e in chain.query(event_type=EVENT_TASK_SUSPENDED) if e.details.get("task_id") == task_id]
+    suspend_receipt_hash = suspend_events[-1].hmac if suspend_events else ""
+
+    new_worktree = Path(worktree) if worktree else Path(suspend_row.worktree_path or workdir)
+    result = resume_task(
+        sdd_dir=sdd_dir,
+        suspend_row=suspend_row,
+        new_worktree_path=new_worktree,
+        chain=chain,
+        suspend_receipt_hash=suspend_receipt_hash,
+        requested_mode=mode,
+        ledger=ledger,
+        approval_ref=approval_ref,
+    )
+    if approval_ref:
+        write_resume_marker(Path(workdir), task_id, result.resume_receipt_hash)
+
+    payload: dict[str, Any] = {
+        "task_id": task_id,
+        "status": "resumed",
+        "effective_mode": str(result.decision.effective_mode),
+        "requested_mode": str(result.decision.requested_mode),
+        "workspace_match": result.decision.workspace_match,
+        "downgrade_reason": result.decision.downgrade_reason,
+        "decision_hash": result.decision.decision_hash,
+        "continued_from": suspend_row.event_hash,
+        "resume_receipt_hash": result.resume_receipt_hash,
+        "approval_ref": approval_ref,
+    }
+    if as_json:
+        print_json(payload)
+        return
+    mode_str = str(result.decision.effective_mode)
+    console.print(f"[green]Resumed:[/green] task [bold]{task_id}[/bold] ([bold]{mode_str}[/bold])")
+    if result.decision.downgrade_reason:
+        console.print(f"[yellow]downgrade:[/yellow] {result.decision.downgrade_reason}")
+    console.print(f"[dim]continued-from:[/dim] {suspend_row.event_hash[:16]}")
+    console.print(f"[dim]decision:[/dim] {result.decision.decision_hash[:16]}")
+
+
+@task_group.command("list-suspended")
+@click.option("--workdir", default=".", help="Project root directory (parent of .sdd/).", type=click.Path())
+@click.option("--json", "as_json", is_flag=True, default=False, help="Print the parked tasks as JSON.")
+def task_list_suspended(workdir: str, as_json: bool) -> None:
+    """List durably-parked tasks with their parked-at hash and freed resources.
+
+    Reads every per-task work ledger under ``.sdd/runtime/ledger`` and surfaces
+    the tasks whose latest transition is ``task.suspended``, joined with the
+    released headroom and the parked-at journal hash from the suspend row.
+    """
+    from bernstein.core.persistence.work_ledger import (
+        LedgerReader,
+        default_ledger_root,
+        replay_state,
+    )
+    from bernstein.core.tasks.suspension import latest_suspension
+
+    sdd_dir = Path(workdir) / ".sdd"
+    ledger_root = default_ledger_root(sdd_dir)
+
+    parked: list[dict[str, Any]] = []
+    for run_dir in sorted(p for p in ledger_root.iterdir() if p.is_dir()) if ledger_root.exists() else []:
+        reader = LedgerReader(run_dir)
+        if not reader.exists():
+            continue
+        state = replay_state(reader.entries())
+        for task_id in state.suspended_tasks:
+            row = latest_suspension(sdd_dir, task_id)
+            parked.append(
+                {
+                    "task_id": task_id,
+                    "parked_at": row.event_hash if row else "",
+                    "workspace_hash": row.workspace_hash if row else "",
+                    "released_usd": row.released_usd if row else 0.0,
+                    "wake_condition": row.wake_condition if row else "",
+                }
+            )
+
+    if as_json:
+        print_json({"suspended": parked})
+        return
+    if not parked:
+        console.print("[dim]No suspended tasks.[/dim]")
+        return
+
+    from rich.table import Table
+
+    table = Table(show_lines=False, header_style="bold cyan")
+    table.add_column("Task", style="dim", min_width=10)
+    table.add_column("Parked-at", min_width=18)
+    table.add_column("Released $", justify="right")
+    table.add_column("Wake", min_width=8)
+    for entry in parked:
+        wake = str(entry["wake_condition"]) or "operator"
+        table.add_row(
+            str(entry["task_id"]),
+            str(entry["parked_at"])[:16],
+            f"{float(entry['released_usd']):.4f}",
+            wake,
+        )
+    console.print(table)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -131,6 +131,7 @@ from bernstein.cli.task_cmd import (
     reject,
     review_cmd,
     sync,
+    task_group,
 )
 from bernstein.cli.templates_cmd import templates_group
 from bernstein.cli.triggers_cmd import triggers_group
@@ -865,6 +866,7 @@ def cli(
 
 # From task_cmd module - all registered with @click.command()
 cli.add_command(cancel)
+cli.add_command(task_group, "task")
 cli.add_command(add_task, "add-task")
 cli.add_command(sync)
 cli.add_command(review_cmd, "review")

--- a/src/bernstein/core/cost/budget_actions.py
+++ b/src/bernstein/core/cost/budget_actions.py
@@ -301,6 +301,95 @@ def envelope_threshold_reached(
     )
 
 
+# ---------------------------------------------------------------------------
+# Envelope headroom release (issue #2552)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BudgetHeadroomReleaseEvent:
+    """Unspent envelope headroom returned to the pool when a task parks (#2552).
+
+    Emitted as a chained budget event when a durable suspension releases a
+    task's reservation: the released amount is ``reserved_usd`` minus the spend
+    recorded against the reservation at park time, clamped at zero. On a capped
+    pool this headroom becomes immediately dispatchable to a queued task, so an
+    overnight park stops blocking the pool. The event references the suspend
+    receipt it hangs off; a release with no receipt is refused upstream.
+
+    Attributes:
+        envelope: Envelope whose headroom is released.
+        reserved_usd: Reservation held for the task at park time.
+        spent_usd: Spend recorded against the reservation at park time.
+        released_usd: ``max(reserved_usd - spent_usd, 0.0)``.
+        suspend_receipt_hash: HMAC of the ``task.suspend_receipt`` this
+            release references (never empty for a persisted release).
+        timestamp: Unix timestamp of the release.
+    """
+
+    envelope: str
+    reserved_usd: float
+    spent_usd: float
+    released_usd: float
+    suspend_receipt_hash: str
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "envelope": self.envelope,
+            "reserved_usd": round(self.reserved_usd, 6),
+            "spent_usd": round(self.spent_usd, 6),
+            "released_usd": round(self.released_usd, 6),
+            "suspend_receipt_hash": self.suspend_receipt_hash,
+            "timestamp": self.timestamp,
+        }
+
+
+def compute_released_headroom(reserved_usd: float, spent_usd: float) -> float:
+    """Return the headroom a park returns to the pool: ``reserved - spent``.
+
+    Clamped at zero so an over-spent reservation never releases a negative
+    amount. This is the single source of truth for the release figure that
+    the suspend receipt, the chained budget event, and the CLI all quote.
+    """
+    return max(reserved_usd - spent_usd, 0.0)
+
+
+def build_headroom_release_event(
+    *,
+    envelope: str,
+    reserved_usd: float,
+    spent_usd: float,
+    suspend_receipt_hash: str,
+    now: float | None = None,
+) -> BudgetHeadroomReleaseEvent:
+    """Build the :class:`BudgetHeadroomReleaseEvent` for a durable park (#2552).
+
+    Args:
+        envelope: Envelope whose headroom is released.
+        reserved_usd: Reservation held for the task at park time.
+        spent_usd: Spend recorded against the reservation at park time.
+        suspend_receipt_hash: HMAC of the suspend receipt this release
+            references. Must be non-empty; a release with no receipt is a
+            fail-closed error and is refused here.
+        now: Optional injected timestamp for deterministic tests.
+
+    Raises:
+        ValueError: ``suspend_receipt_hash`` is empty (fail closed).
+    """
+    if not suspend_receipt_hash:
+        raise ValueError("headroom release requires a suspend_receipt_hash (fail closed)")
+    return BudgetHeadroomReleaseEvent(
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        released_usd=compute_released_headroom(reserved_usd, spent_usd),
+        suspend_receipt_hash=suspend_receipt_hash,
+        timestamp=time.time() if now is None else now,
+    )
+
+
 def apply_policy(
     policy: BudgetPolicy,
     percentage_used: float,

--- a/src/bernstein/core/persistence/work_ledger.py
+++ b/src/bernstein/core/persistence/work_ledger.py
@@ -103,6 +103,16 @@ KIND_TASK_COMPLETED = "task.completed"
 KIND_TASK_FAILED = "task.failed"
 KIND_TASK_ABANDONED = "task.abandoned"
 
+#: Durable suspension transitions (#2552). A ``task.suspended`` entry persists
+#: an operator park through orchestrator restarts and daemon crashes the same
+#: way detached run state survives; ``task.resumed`` records the durable
+#: revival. A parked task is deliberately excluded from :meth:`resume_frontier`
+#: -- it waits for an explicit ``bernstein task resume`` (or its ``--until``
+#: wake), never an auto-restart. A reader that predates these kinds still
+#: replays the chain (they count as unknown task kinds).
+KIND_TASK_SUSPENDED = "task.suspended"
+KIND_TASK_RESUMED = "task.resumed"
+
 #: Mission transition kinds (#2509). A mission is a ledger-projected multi-day
 #: goal; these transitions are the only mission state that touches disk -- the
 #: mission status is a pure projection over them (see
@@ -709,6 +719,7 @@ _STATE_STARTED = "started"
 _STATE_COMPLETED = "completed"
 _STATE_FAILED = "failed"
 _STATE_ABANDONED = "abandoned"
+_STATE_SUSPENDED = "suspended"
 
 _TASK_KIND_TO_STATE = {
     KIND_TASK_SCHEDULED: _STATE_SCHEDULED,
@@ -716,6 +727,11 @@ _TASK_KIND_TO_STATE = {
     KIND_TASK_COMPLETED: _STATE_COMPLETED,
     KIND_TASK_FAILED: _STATE_FAILED,
     KIND_TASK_ABANDONED: _STATE_ABANDONED,
+    # A durable park moves the task to ``suspended``; a durable resume moves it
+    # back to ``started`` (it is in-flight again). ``attempts`` is only bumped
+    # by ``task.started``, so a park/resume pair does not inflate the count.
+    KIND_TASK_SUSPENDED: _STATE_SUSPENDED,
+    KIND_TASK_RESUMED: _STATE_STARTED,
 }
 
 
@@ -778,8 +794,23 @@ class LedgerState:
         """Task ids whose latest transition is ``task.failed``."""
         return self._tasks_in_state(_STATE_FAILED)
 
+    @property
+    def suspended_tasks(self) -> list[str]:
+        """Task ids whose latest transition is ``task.suspended`` (#2552).
+
+        A parked task survives orchestrator restarts through this projection
+        but is deliberately kept out of :meth:`resume_frontier`: it resumes
+        only on an explicit ``bernstein task resume`` (or its ``--until``
+        wake), never on an auto-restart.
+        """
+        return self._tasks_in_state(_STATE_SUSPENDED)
+
     def resume_frontier(self) -> list[str]:
-        """Task ids a resume should (re)start: in-flight, then scheduled."""
+        """Task ids a resume should (re)start: in-flight, then scheduled.
+
+        Suspended tasks are excluded on purpose (see :attr:`suspended_tasks`):
+        an operator park is woken explicitly, not by an orchestrator restart.
+        """
         return self.in_flight_tasks + self.scheduled_tasks
 
     def to_dict(self) -> dict[str, Any]:
@@ -796,6 +827,7 @@ class LedgerState:
             "in_flight_tasks": self.in_flight_tasks,
             "scheduled_tasks": self.scheduled_tasks,
             "failed_tasks": self.failed_tasks,
+            "suspended_tasks": self.suspended_tasks,
             "resume_frontier": self.resume_frontier(),
         }
 
@@ -943,8 +975,10 @@ __all__ = [
     "KIND_TASK_ABANDONED",
     "KIND_TASK_COMPLETED",
     "KIND_TASK_FAILED",
+    "KIND_TASK_RESUMED",
     "KIND_TASK_SCHEDULED",
     "KIND_TASK_STARTED",
+    "KIND_TASK_SUSPENDED",
     "LEDGER_SCHEMA_VERSION",
     "ChainRelation",
     "LedgerEntry",

--- a/src/bernstein/core/security/audit_chain.py
+++ b/src/bernstein/core/security/audit_chain.py
@@ -692,6 +692,27 @@ EVENT_CONTEXT_CAPSULE = "context.capsule"
 #: never goal text or task payloads.
 EVENT_MISSION_PHASE_RECEIPT = "mission.phase_receipt"
 
+#: Durable task suspension receipts (#2552). A park is made durable by two
+#: chained receipts plus their journal rows: ``task.suspend_receipt`` binds the
+#: suspend journal row's Merkle head (the suspension's identity), the parked
+#: workspace hash, and the envelope balance at park time *before any effect
+#: runs*; ``task.resume_receipt`` binds the suspend receipt it continued from,
+#: the effective continuation mode, and the new workspace hash. The receipt
+#: pair is the continuity proof: a verifier holding a copied chain confirms the
+#: resumed run continued from exactly the parked workspace hash, or reads the
+#: recorded fork/cold downgrade with its reason. Only identifiers, hashes,
+#: modes, and spend are recorded -- never prompt content or session state.
+EVENT_TASK_SUSPENDED = "task.suspend_receipt"
+EVENT_TASK_RESUMED = "task.resume_receipt"
+
+#: Infrastructure-release receipt for a durable suspension (#2552). Every seat
+#: return, sandbox teardown, process reap, and envelope-headroom release hangs
+#: off the suspend receipt hash: the release row records which resource was
+#: freed and the ``suspend_receipt_hash`` it references. A release effect with
+#: no matching receipt is rejected upstream (fail closed) -- without the chain
+#: there is no suspension, only a dead process.
+EVENT_TASK_RESOURCE_RELEASE = "task.suspend_resource_release"
+
 
 # ---------------------------------------------------------------------------
 # AuditChainStore
@@ -3522,6 +3543,195 @@ def record_process_reap_receipt(
     )
 
 
+def record_task_suspension(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    suspend_event_hash: str,
+    journal_index: int,
+    adapter: str,
+    workspace_hash: str,
+    envelope: str,
+    reserved_usd: float,
+    spent_usd: float,
+    released_usd: float,
+    wake_condition: str = "",
+    actor: str = "suspension",
+) -> AuditEvent:
+    """Append a ``task.suspend_receipt`` event into *chain* (#2552).
+
+    Binds the suspend journal row's Merkle head -- the suspension's identity --
+    into the HMAC chain *before any infrastructure release runs*. The receipt's
+    own HMAC (``AuditEvent.hmac``) is the value each release effect references,
+    so seat return, sandbox teardown, process reap, and envelope-headroom
+    release all hang off a receipt that already exists on the chain. Only
+    identifiers, hashes, and the envelope balance are recorded -- never prompt
+    content or provider session state.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        task_id: The task being parked.
+        suspend_event_hash: Merkle hash of the suspend row in the task's event
+            journal (the suspension's identity).
+        journal_index: 0-based journal index of that row.
+        adapter: Registry name of the adapter that owned the parked session.
+        workspace_hash: Content hash of the worktree at park time.
+        envelope: Quota envelope whose headroom is being released.
+        reserved_usd: Envelope headroom reserved for the task at park time.
+        spent_usd: Recorded spend against the reservation at park time.
+        released_usd: Headroom released back to the pool
+            (``max(reserved - spent, 0)``).
+        wake_condition: Optional wake gate (``"approval"`` for
+            ``--until approval``); empty for an operator-driven resume.
+        actor: Recorded actor; defaults to ``"suspension"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload; its ``hmac`` is the suspend receipt hash.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_TASK_SUSPENDED,
+        actor=actor,
+        resource_type="task_suspension",
+        resource_id=task_id,
+        details={
+            "task_id": task_id,
+            "suspend_event_hash": suspend_event_hash,
+            "journal_index": journal_index,
+            "adapter": adapter,
+            "workspace_hash": workspace_hash,
+            "envelope": envelope,
+            "reserved_usd": round(reserved_usd, 6),
+            "spent_usd": round(spent_usd, 6),
+            "released_usd": round(released_usd, 6),
+            "wake_condition": wake_condition,
+        },
+    )
+
+
+def record_task_resource_release(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    resource: str,
+    suspend_receipt_hash: str,
+    detail: dict[str, Any] | None = None,
+    actor: str = "suspension",
+) -> AuditEvent:
+    """Append a ``task.suspend_resource_release`` event into *chain* (#2552).
+
+    One release row per freed resource (``seat`` / ``sandbox`` / ``process`` /
+    ``budget``). Every row references the ``suspend_receipt_hash`` the release
+    hangs off; the caller refuses to emit the row (and to run the physical
+    effect) when that hash is missing, so a release with no matching receipt
+    never reaches the chain -- fail closed.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        task_id: The parked task whose resource was freed.
+        resource: Resource kind (``"seat"`` / ``"sandbox"`` / ``"process"`` /
+            ``"budget"``).
+        suspend_receipt_hash: HMAC of the ``task.suspend_receipt`` this release
+            references (never empty).
+        detail: Optional resource-specific detail (e.g. released USD, sandbox
+            backend). Recorded verbatim.
+        actor: Recorded actor; defaults to ``"suspension"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    payload: dict[str, Any] = {
+        "task_id": task_id,
+        "resource": resource,
+        "suspend_receipt_hash": suspend_receipt_hash,
+    }
+    if detail:
+        payload["detail"] = detail
+    return chain.log_with_prev_digest(
+        event_type=EVENT_TASK_RESOURCE_RELEASE,
+        actor=actor,
+        resource_type="task_resource_release",
+        resource_id=task_id,
+        details=payload,
+    )
+
+
+def record_task_resume(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    suspend_receipt_hash: str,
+    suspend_event_hash: str,
+    resume_event_hash: str,
+    journal_index: int,
+    effective_mode: str,
+    requested_mode: str,
+    workspace_match: bool,
+    new_workspace_hash: str,
+    downgrade_reason: str,
+    decision_hash: str,
+    approval_ref: str = "",
+    actor: str = "suspension",
+) -> AuditEvent:
+    """Append a ``task.resume_receipt`` event into *chain* (#2552).
+
+    Closes the continuity proof: the resume receipt binds the suspend receipt
+    it continued from, the suspend row hash, the effective continuation mode,
+    and the new workspace hash. A verifier holding a copied chain confirms the
+    resumed run continued from exactly the parked workspace hash (``warm``),
+    or reads the recorded ``fork`` / ``cold`` downgrade with its reason. When
+    the park was gated ``--until approval`` the approval decision digest is
+    bound here so the approval record and the resume receipt reference each
+    other.
+
+    Args:
+        chain: The audit chain store accepting the entry.
+        task_id: The task being resumed.
+        suspend_receipt_hash: HMAC of the ``task.suspend_receipt`` this resume
+            continued from.
+        suspend_event_hash: Merkle hash of the suspend journal row.
+        resume_event_hash: Merkle hash of the resume journal row.
+        journal_index: 0-based journal index of the resume row.
+        effective_mode: Effective continuation mode (``warm`` / ``fork`` /
+            ``cold``).
+        requested_mode: The mode the operator requested.
+        workspace_match: Whether the live workspace hash matched the parked
+            hash at resume time.
+        new_workspace_hash: Content hash of the re-materialized worktree.
+        downgrade_reason: Why a non-cold request became fork/cold; empty when
+            the request was honored warm.
+        decision_hash: SHA-256 of the canonical resume decision projection.
+        approval_ref: Digest of the approval decision for an
+            ``--until approval`` park; empty otherwise.
+        actor: Recorded actor; defaults to ``"suspension"``.
+
+    Returns:
+        The recorded :class:`AuditEvent` with ``prev_chain_digest`` embedded in
+        its details payload.
+    """
+    return chain.log_with_prev_digest(
+        event_type=EVENT_TASK_RESUMED,
+        actor=actor,
+        resource_type="task_resume",
+        resource_id=task_id,
+        details={
+            "task_id": task_id,
+            "suspend_receipt_hash": suspend_receipt_hash,
+            "suspend_event_hash": suspend_event_hash,
+            "resume_event_hash": resume_event_hash,
+            "journal_index": journal_index,
+            "effective_mode": effective_mode,
+            "requested_mode": requested_mode,
+            "workspace_match": workspace_match,
+            "new_workspace_hash": new_workspace_hash,
+            "downgrade_reason": downgrade_reason,
+            "decision_hash": decision_hash,
+            "approval_ref": approval_ref,
+        },
+    )
+
+
 def record_dashboard_token_grant(
     *,
     chain: AuditChainStore,
@@ -4969,6 +5179,9 @@ __all__ = [
     "EVENT_SUBAGENT_DELEGATION",
     "EVENT_TASK_CLAIM_RECEIPT",
     "EVENT_TASK_MAILBOX_MESSAGE",
+    "EVENT_TASK_RESOURCE_RELEASE",
+    "EVENT_TASK_RESUMED",
+    "EVENT_TASK_SUSPENDED",
     "EVENT_TEMPLATE_COMPRESSION_RECEIPT",
     "EVENT_TEMPLATE_COMPRESSION_RESTORE",
     "EVENT_THREAD_APPROVAL",
@@ -5053,6 +5266,9 @@ __all__ = [
     "record_taint_decision",
     "record_task_claim_receipt",
     "record_task_mailbox_message",
+    "record_task_resource_release",
+    "record_task_resume",
+    "record_task_suspension",
     "record_thread_approval",
     "record_tournament_selection",
     "record_webhook_node_receipt",

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -182,6 +182,7 @@ class TaskStatus(Enum):
     WAITING_FOR_SUBTASKS = "waiting_for_subtasks"
     CANCELLED = "cancelled"
     ORPHANED = "orphaned"  # Agent crashed mid-task; pending crash recovery
+    SUSPENDED = "suspended"  # Operator-parked mid-session; infra released, resumable from an attested receipt (#2552)
     PENDING_APPROVAL = "pending_approval"  # Completed; awaiting human approval before taking effect
     ABANDONED = "abandoned"  # Agent voluntarily abandoned with a structured reason (#1350)
     BLOCKED_BY_ABANDON = "blocked_by_abandon"  # Downstream task waiting on an abandoned dependency (#1350)

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -1,0 +1,932 @@
+"""Durable task suspend and resume: attested park receipts (#2552).
+
+A long agent session that must wait on a human -- a mid-flight approval, an
+external review, a credential rotation, a dependency landing -- has no way to
+stop consuming infrastructure. The pre-spawn approval gate halts a task only
+before a worker exists; the post-completion review gate only after it exits;
+orchestrator holds stop the orchestrator, not a live worker. So the process,
+its worktree sandbox, its parallelism seat, and its budget-envelope reservation
+all stay allocated for the entire wait. On a capped pool that reservation
+blocks other tasks from dispatching.
+
+This module makes the *suspension itself the artifact*. A park is a pair of
+Merkle-chained journal rows plus matching HMAC audit-chain receipts, and every
+infrastructure release hangs off the suspend receipt's hash. Without the chain
+there is no suspension, only a dead process:
+
+* **The suspend row is the identity.** :func:`record_task_suspension_row`
+  appends a suspend row to the task's event journal
+  (:class:`~bernstein.core.replay.journal.EventJournal`) with the same row
+  discipline as the checkpoint substrate: adapter-native session id, a
+  workspace hash over the worktree, the journal head, and the envelope balance
+  at park time. The row's ``event_hash`` is the suspension's identity.
+* **The receipt binds the hash before any effect.**
+  :func:`bernstein.core.security.audit_chain.record_task_suspension` binds that
+  hash into the HMAC chain *before* the process is reaped, the sandbox is torn
+  down, the seat is returned, or envelope headroom is released. Each release
+  references the suspend receipt's own HMAC; :func:`release_resources` refuses
+  to run any effect without it (:class:`ReleaseWithoutReceiptError`), fail
+  closed.
+* **Resume is a deterministic projection.** :func:`decide_resume` reuses the
+  checkpointed-retry decision (:func:`~bernstein.core.tasks.checkpoint_retry.decide_retry`):
+  same workspace hash and a live native session gives ``warm``; a stale session
+  or drifted workspace downgrades to ``fork`` or ``cold`` with a recorded
+  reason, never silently. Two hosts with the same suspend row and adapter
+  capability derive the byte-identical decision, including its ``decision_hash``.
+* **The receipt pair is the continuity proof.**
+  :func:`verify_suspension_continuity` checks, offline from a copied chain,
+  that a resumed task continued from exactly the parked workspace hash, or
+  reads the recorded fork/cold downgrade with its reason. Mutating the suspend
+  row after the fact fails journal verification at that exact chain position.
+
+Scope relative to steer.pause (#2508): steer.pause is the momentary in-place
+halt for quick correction; this is the durable variant that frees
+infrastructure and proves continuity. Both share the checkpoint row shape and
+the receipt-before-effect rule.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.replay.journal import (
+    EventJournal,
+    JournalVerifyResult,
+    load_events,
+    verify_journal,
+)
+from bernstein.core.tasks.checkpoint_retry import (
+    CheckpointRef,
+    RetryDecision,
+    RetryMode,
+    decide_retry,
+    task_run_id,
+    workspace_hash,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bernstein.core.persistence.work_ledger import LedgerEntry, WorkLedger
+    from bernstein.core.security.audit_chain import AuditChainStore
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Event-journal row type for a recorded durable suspension (park).
+JOURNAL_EVENT_SUSPEND = "task.suspend"
+
+#: Event-journal row type for a recorded durable resume (wake).
+JOURNAL_EVENT_RESUME = "task.resume"
+
+#: Canonical resource kinds a park releases, each referencing the suspend
+#: receipt hash. ``budget`` is always released (headroom returns to the pool);
+#: ``process`` / ``sandbox`` / ``seat`` release when a handle is supplied.
+RESOURCE_PROCESS = "process"
+RESOURCE_SANDBOX = "sandbox"
+RESOURCE_SEAT = "seat"
+RESOURCE_BUDGET = "budget"
+
+#: Wake condition composing a park with the pre-spawn approval sentinel: the
+#: task resumes only once ``bernstein approve <task-id>`` lands its decision
+#: file (see :func:`approval_decision_ref`).
+WAKE_APPROVAL = "approval"
+
+
+class ReleaseWithoutReceiptError(RuntimeError):
+    """Raised when an infrastructure release runs without a suspend receipt.
+
+    The suspension is the artifact: every seat return, sandbox teardown,
+    process reap, and envelope-headroom release must reference an existing
+    ``task.suspend_receipt`` hash. A release with no matching receipt is a
+    dead process, not a suspension, so it is rejected before any effect runs.
+    """
+
+
+# ---------------------------------------------------------------------------
+# The suspend row (parked-state snapshot)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SuspendRow:
+    """A journal-anchored snapshot of a parked task's resumable state.
+
+    Every field is folded into the row's ``event_hash`` (the suspension's
+    identity) via the journal's timing-excluded payload hash, so two
+    byte-identical parks chain to the same head and a later mutation surfaces
+    as journal divergence at this exact index.
+
+    Attributes:
+        task_id: The task being parked.
+        adapter: Registry name of the adapter that owned the session.
+        session_id: The native session id to resume from.
+        workspace_hash: Content hash of the worktree at park time (the
+            safety-valve baseline the resume decision compares against).
+        worktree_path: Absolute worktree path the hash was taken over.
+        envelope: Quota envelope whose headroom is released.
+        reserved_usd: Envelope headroom reserved for the task at park time.
+        spent_usd: Spend recorded against the reservation at park time.
+        released_usd: Headroom returned to the pool (``max(reserved-spent,0)``).
+        wake_condition: ``""`` (operator resume) or :data:`WAKE_APPROVAL`.
+        journal_index: 0-based index of the suspend row in the task journal.
+        event_hash: Merkle hash of that row -- the suspension's identity.
+    """
+
+    task_id: str
+    adapter: str
+    session_id: str
+    workspace_hash: str
+    worktree_path: str
+    envelope: str
+    reserved_usd: float
+    spent_usd: float
+    released_usd: float
+    wake_condition: str
+    journal_index: int
+    event_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "adapter": self.adapter,
+            "session_id": self.session_id,
+            "workspace_hash": self.workspace_hash,
+            "worktree_path": self.worktree_path,
+            "envelope": self.envelope,
+            "reserved_usd": self.reserved_usd,
+            "spent_usd": self.spent_usd,
+            "released_usd": self.released_usd,
+            "wake_condition": self.wake_condition,
+            "journal_index": self.journal_index,
+            "event_hash": self.event_hash,
+        }
+
+    def as_checkpoint_ref(self) -> CheckpointRef:
+        """Project onto a :class:`CheckpointRef` for the resume decision.
+
+        The durable resume reuses the checkpointed-retry decision, so the
+        parked session id and workspace hash are handed to
+        :func:`decide_retry` through the same reference shape the retry path
+        uses.
+        """
+        return CheckpointRef(
+            task_id=self.task_id,
+            adapter=self.adapter,
+            session_id=self.session_id,
+            workspace_hash=self.workspace_hash,
+            worktree_path=self.worktree_path,
+            journal_index=self.journal_index,
+            event_hash=self.event_hash,
+        )
+
+
+def _journal_path(sdd_dir: Path, task_id: str) -> Path:
+    return sdd_dir / "runs" / task_run_id(task_id) / "journal.jsonl"
+
+
+def record_task_suspension_row(
+    *,
+    sdd_dir: Path,
+    task_id: str,
+    adapter: str,
+    session_id: str,
+    workspace_hash: str,
+    worktree_path: str,
+    envelope: str,
+    reserved_usd: float,
+    spent_usd: float,
+    released_usd: float,
+    wake_condition: str = "",
+) -> SuspendRow:
+    """Append a suspend row to the task's event journal and return it.
+
+    The row extends the task journal's Merkle chain across processes (opened
+    via :meth:`EventJournal.resume`); its ``event_hash`` is the suspension's
+    identity, later bound into the audit chain *before* any release runs.
+
+    Raises:
+        ValueError: The existing journal fails chain verification.
+        RuntimeError: The journal append did not extend the chain.
+    """
+    journal = EventJournal.resume(task_run_id(task_id), sdd_dir)
+    head_before = journal.head()
+    journal.record(
+        JOURNAL_EVENT_SUSPEND,
+        task_id=task_id,
+        adapter=adapter,
+        session_id=session_id,
+        workspace_hash=workspace_hash,
+        worktree_path=worktree_path,
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        released_usd=released_usd,
+        wake_condition=wake_condition,
+    )
+    if journal.head() == head_before:
+        msg = f"suspend journal append failed for task {task_id!r}"
+        raise RuntimeError(msg)
+    return SuspendRow(
+        task_id=task_id,
+        adapter=adapter,
+        session_id=session_id,
+        workspace_hash=workspace_hash,
+        worktree_path=worktree_path,
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        released_usd=released_usd,
+        wake_condition=wake_condition,
+        journal_index=journal.event_count() - 1,
+        event_hash=journal.head(),
+    )
+
+
+def latest_suspension(sdd_dir: Path, task_id: str) -> SuspendRow | None:
+    """Return the most recent *verified* suspend row for ``task_id``.
+
+    Fail-closed: the journal's Merkle chain is re-verified before any row is
+    trusted. A missing journal, a chain that does not recompute, or the absence
+    of any suspend row all return ``None`` -- a tampered suspend row can never
+    fuel a resume.
+    """
+    path = _journal_path(sdd_dir, task_id)
+    if not path.exists():
+        return None
+    result = verify_journal(path)
+    if not result.ok:
+        logger.warning(
+            "suspend journal for task %s failed chain verification at index %s; refusing resume",
+            task_id,
+            result.divergent_index,
+        )
+        return None
+    for row in reversed(load_events(path)):
+        if row.get("event") != JOURNAL_EVENT_SUSPEND:
+            continue
+        if str(row.get("task_id", "")) != task_id:
+            continue
+        # A suspend later resumed is still the parked baseline the resume
+        # continued from; callers pair it with the resume row for continuity.
+        try:
+            journal_index = int(row.get("index", -1))
+        except (TypeError, ValueError):
+            continue
+        return SuspendRow(
+            task_id=task_id,
+            adapter=str(row.get("adapter", "")),
+            session_id=str(row.get("session_id", "")),
+            workspace_hash=str(row.get("workspace_hash", "")),
+            worktree_path=str(row.get("worktree_path", "")),
+            envelope=str(row.get("envelope", "")),
+            reserved_usd=float(row.get("reserved_usd", 0.0) or 0.0),
+            spent_usd=float(row.get("spent_usd", 0.0) or 0.0),
+            released_usd=float(row.get("released_usd", 0.0) or 0.0),
+            wake_condition=str(row.get("wake_condition", "")),
+            journal_index=journal_index,
+            event_hash=str(row.get("event_hash", "")),
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Infrastructure release (receipt-before-effect, fail closed)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResourceHandles:
+    """Physical release effects the orchestrator wires for a real park.
+
+    Each callable performs one release and returns a JSON-safe detail dict
+    recorded on its release row. ``None`` means the resource was not allocated
+    for this task (skip it). The budget release is intrinsic and always emitted
+    -- it needs no handle, only the reservation figures.
+
+    The handles are invoked *only after* :func:`release_resources` has
+    validated the suspend receipt hash, so a missing receipt never triggers a
+    physical effect.
+    """
+
+    reap_process: Callable[[], dict[str, Any]] | None = None
+    teardown_sandbox: Callable[[], dict[str, Any]] | None = None
+    return_seat: Callable[[], dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True)
+class ReleaseResult:
+    """Outcome of :func:`release_resources`.
+
+    Attributes:
+        released_usd: Envelope headroom returned to the pool.
+        rows: Ordered ``(resource, detail)`` pairs, one per emitted release.
+        release_event_hashes: HMACs of the release audit rows, in order.
+    """
+
+    released_usd: float
+    rows: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    release_event_hashes: list[str] = field(default_factory=list)
+
+
+def release_resources(
+    *,
+    chain: AuditChainStore,
+    task_id: str,
+    suspend_receipt_hash: str,
+    envelope: str,
+    reserved_usd: float,
+    spent_usd: float,
+    handles: ResourceHandles | None = None,
+) -> ReleaseResult:
+    """Release the seat, sandbox, process, and envelope headroom for a park.
+
+    Every release hangs off ``suspend_receipt_hash``; the hash is validated
+    *before any physical effect runs*, so a release with no matching receipt is
+    rejected and no seat, sandbox, or process is touched. Each release appends a
+    ``task.suspend_resource_release`` row to the audit chain referencing the
+    receipt, and the budget release additionally emits a chained budget event.
+
+    Args:
+        chain: The audit chain store accepting the release rows.
+        task_id: The parked task.
+        suspend_receipt_hash: HMAC of the ``task.suspend_receipt`` (never
+            empty).
+        envelope: Envelope whose headroom is released.
+        reserved_usd: Reservation held at park time.
+        spent_usd: Spend recorded against the reservation at park time.
+        handles: Physical release effects; ``None`` releases only budget.
+
+    Raises:
+        ReleaseWithoutReceiptError: ``suspend_receipt_hash`` is empty.
+    """
+    if not suspend_receipt_hash:
+        raise ReleaseWithoutReceiptError(
+            f"refusing to release resources for task {task_id!r}: no suspend receipt (fail closed)"
+        )
+
+    from bernstein.core.cost.budget_actions import build_headroom_release_event
+    from bernstein.core.security.audit_chain import record_task_resource_release
+
+    handles = handles or ResourceHandles()
+    rows: list[tuple[str, dict[str, Any]]] = []
+    hashes: list[str] = []
+
+    def _emit(resource: str, detail: dict[str, Any]) -> None:
+        event = record_task_resource_release(
+            chain=chain,
+            task_id=task_id,
+            resource=resource,
+            suspend_receipt_hash=suspend_receipt_hash,
+            detail=detail,
+        )
+        rows.append((resource, detail))
+        hashes.append(event.hmac)
+
+    # Ordered: reap the running process, tear down its sandbox, return the
+    # seat, then release the unspent envelope headroom. Each is gated by the
+    # receipt validated above.
+    if handles.reap_process is not None:
+        _emit(RESOURCE_PROCESS, dict(handles.reap_process()))
+    if handles.teardown_sandbox is not None:
+        _emit(RESOURCE_SANDBOX, dict(handles.teardown_sandbox()))
+    if handles.return_seat is not None:
+        _emit(RESOURCE_SEAT, dict(handles.return_seat()))
+
+    budget_event = build_headroom_release_event(
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        suspend_receipt_hash=suspend_receipt_hash,
+    )
+    _emit(RESOURCE_BUDGET, budget_event.to_dict())
+
+    return ReleaseResult(
+        released_usd=budget_event.released_usd,
+        rows=rows,
+        release_event_hashes=hashes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Park orchestration (row -> receipt -> effects -> ledger)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParkResult:
+    """Anchors produced by :func:`park_task`.
+
+    Attributes:
+        suspend_row: The journal-anchored parked-state snapshot.
+        suspend_receipt_hash: HMAC of the ``task.suspend_receipt`` bound before
+            any effect ran.
+        release: The infrastructure-release outcome.
+        ledger_entry_hash: Work-ledger entry hash for the ``task.suspended``
+            transition (``""`` when no ledger was supplied).
+    """
+
+    suspend_row: SuspendRow
+    suspend_receipt_hash: str
+    release: ReleaseResult
+    ledger_entry_hash: str
+
+
+def park_task(
+    *,
+    sdd_dir: Path,
+    task_id: str,
+    adapter: str,
+    session_id: str,
+    worktree_path: Path,
+    envelope: str,
+    reserved_usd: float,
+    spent_usd: float,
+    chain: AuditChainStore,
+    handles: ResourceHandles | None = None,
+    ledger: WorkLedger | None = None,
+    wake_condition: str = "",
+) -> ParkResult:
+    """Durably park ``task_id``: row, receipt, releases, then ledger.
+
+    The order is load-bearing and never reordered:
+
+    1. Compute the workspace hash over the worktree.
+    2. Append the suspend row to the task journal (its ``event_hash`` is the
+       suspension's identity).
+    3. Record the ``task.suspend_receipt`` binding that hash **before any
+       effect**.
+    4. Release the process, sandbox, seat, and envelope headroom -- each
+       referencing the receipt hash, each refused without it.
+    5. Persist the ``task.suspended`` transition to the work ledger so the park
+       survives an orchestrator restart.
+
+    Args:
+        sdd_dir: Project ``.sdd`` directory.
+        task_id: The task to park.
+        adapter: Adapter that owns the parked session.
+        session_id: Native session id to resume from.
+        worktree_path: The task's worktree (hashed for the safety valve).
+        envelope: Quota envelope whose headroom is released.
+        reserved_usd: Envelope headroom reserved for the task.
+        spent_usd: Spend recorded against the reservation at park time.
+        chain: Audit chain store for the receipt and release rows.
+        handles: Physical release effects; ``None`` releases only budget.
+        ledger: Optional work ledger to persist the SUSPENDED transition.
+        wake_condition: ``""`` or :data:`WAKE_APPROVAL`.
+
+    Returns:
+        A :class:`ParkResult` with the row, receipt hash, release outcome, and
+        ledger anchor.
+    """
+    from bernstein.core.cost.budget_actions import compute_released_headroom
+    from bernstein.core.persistence.work_ledger import KIND_TASK_SUSPENDED
+    from bernstein.core.security.audit_chain import record_task_suspension
+
+    ws_hash = workspace_hash(Path(worktree_path))
+    released_usd = compute_released_headroom(reserved_usd, spent_usd)
+
+    suspend_row = record_task_suspension_row(
+        sdd_dir=sdd_dir,
+        task_id=task_id,
+        adapter=adapter,
+        session_id=session_id,
+        workspace_hash=ws_hash,
+        worktree_path=str(worktree_path),
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        released_usd=released_usd,
+        wake_condition=wake_condition,
+    )
+
+    # Receipt before effect: the suspend receipt exists on the chain before a
+    # single resource is freed.
+    receipt = record_task_suspension(
+        chain=chain,
+        task_id=task_id,
+        suspend_event_hash=suspend_row.event_hash,
+        journal_index=suspend_row.journal_index,
+        adapter=adapter,
+        workspace_hash=ws_hash,
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        released_usd=released_usd,
+        wake_condition=wake_condition,
+    )
+
+    release = release_resources(
+        chain=chain,
+        task_id=task_id,
+        suspend_receipt_hash=receipt.hmac,
+        envelope=envelope,
+        reserved_usd=reserved_usd,
+        spent_usd=spent_usd,
+        handles=handles,
+    )
+
+    ledger_entry_hash = ""
+    if ledger is not None:
+        entry: LedgerEntry = ledger.append(
+            kind=KIND_TASK_SUSPENDED,
+            task_id=task_id,
+            payload={
+                "suspend_event_hash": suspend_row.event_hash,
+                "suspend_receipt_hash": receipt.hmac,
+                "workspace_hash": ws_hash,
+                "envelope": envelope,
+                "released_usd": released_usd,
+                "wake_condition": wake_condition,
+            },
+        )
+        ledger_entry_hash = entry.entry_hash
+
+    return ParkResult(
+        suspend_row=suspend_row,
+        suspend_receipt_hash=receipt.hmac,
+        release=release,
+        ledger_entry_hash=ledger_entry_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resume decision (deterministic projection) + orchestration
+# ---------------------------------------------------------------------------
+
+
+def decide_resume(
+    *,
+    suspend_row: SuspendRow,
+    actual_workspace_hash: str,
+    requested_mode: RetryMode | str = RetryMode.WARM,
+) -> RetryDecision:
+    """Decide warm/fork/cold continuation for a parked task.
+
+    A pure function of the suspend row, the live workspace hash, and the
+    adapter capability -- no clock, no network -- so two hosts derive the
+    byte-identical :class:`RetryDecision` including its ``decision_hash``. The
+    logic is the checkpointed-retry decision (:func:`decide_retry`) applied to
+    the parked baseline: same workspace hash and a live session gives warm; a
+    drifted workspace or a capability-less adapter downgrades with a recorded
+    reason.
+
+    The ``crash`` corrective template is used because a durable park is a
+    "continue from where you stopped" resume rather than a gate-failure retry.
+    """
+    return decide_retry(
+        task_id=suspend_row.task_id,
+        requested_mode=requested_mode,
+        checkpoint=suspend_row.as_checkpoint_ref(),
+        actual_workspace_hash=actual_workspace_hash,
+        template_id="crash",
+        gate_name="suspension",
+        gate_output="Task was durably parked; resume from the parked state.",
+    )
+
+
+@dataclass(frozen=True)
+class ResumeResult:
+    """Anchors produced by :func:`resume_task`.
+
+    Attributes:
+        decision: The deterministic continuation decision.
+        resume_event_hash: Merkle hash of the resume journal row.
+        resume_receipt_hash: HMAC of the ``task.resume_receipt``.
+        new_workspace_hash: Content hash of the re-materialized worktree.
+        approval_ref: Approval decision digest for an ``--until approval``
+            park; ``""`` otherwise.
+        ledger_entry_hash: Work-ledger entry hash for the ``task.resumed``
+            transition (``""`` when no ledger was supplied).
+    """
+
+    decision: RetryDecision
+    resume_event_hash: str
+    resume_receipt_hash: str
+    new_workspace_hash: str
+    approval_ref: str
+    ledger_entry_hash: str
+
+
+def resume_task(
+    *,
+    sdd_dir: Path,
+    suspend_row: SuspendRow,
+    new_worktree_path: Path,
+    chain: AuditChainStore,
+    suspend_receipt_hash: str,
+    requested_mode: RetryMode | str = RetryMode.WARM,
+    ledger: WorkLedger | None = None,
+    approval_ref: str = "",
+) -> ResumeResult:
+    """Durably resume a parked task from its suspend row.
+
+    Re-materializes the continuation decision, appends a resume row binding the
+    suspend row it continued from, and records the ``task.resume_receipt`` that
+    closes the continuity proof. Deterministic: given the same suspend row and
+    adapter capability, the decision hash is byte-identical across hosts.
+
+    Args:
+        sdd_dir: Project ``.sdd`` directory.
+        suspend_row: The parked-state snapshot to continue from.
+        new_worktree_path: The re-materialized worktree (hashed live).
+        chain: Audit chain store for the resume receipt.
+        suspend_receipt_hash: HMAC of the suspend receipt being continued.
+        requested_mode: Operator-requested continuation mode (default warm).
+        ledger: Optional work ledger to persist the RESUMED transition.
+        approval_ref: Approval decision digest for an ``--until approval`` park.
+
+    Returns:
+        A :class:`ResumeResult` with the decision and both continuity anchors.
+    """
+    from bernstein.core.persistence.work_ledger import KIND_TASK_RESUMED
+    from bernstein.core.security.audit_chain import record_task_resume
+
+    new_ws_hash = workspace_hash(Path(new_worktree_path))
+    decision = decide_resume(
+        suspend_row=suspend_row,
+        actual_workspace_hash=new_ws_hash,
+        requested_mode=requested_mode,
+    )
+
+    journal = EventJournal.resume(task_run_id(suspend_row.task_id), sdd_dir)
+    head_before = journal.head()
+    journal.record(
+        JOURNAL_EVENT_RESUME,
+        task_id=suspend_row.task_id,
+        continued_from_event_hash=suspend_row.event_hash,
+        suspend_receipt_hash=suspend_receipt_hash,
+        effective_mode=str(decision.effective_mode),
+        requested_mode=str(decision.requested_mode),
+        workspace_match=decision.workspace_match,
+        new_workspace_hash=new_ws_hash,
+        downgrade_reason=decision.downgrade_reason,
+        decision_hash=decision.decision_hash,
+        approval_ref=approval_ref,
+    )
+    if journal.head() == head_before:
+        msg = f"resume journal append failed for task {suspend_row.task_id!r}"
+        raise RuntimeError(msg)
+    resume_event_hash = journal.head()
+
+    receipt = record_task_resume(
+        chain=chain,
+        task_id=suspend_row.task_id,
+        suspend_receipt_hash=suspend_receipt_hash,
+        suspend_event_hash=suspend_row.event_hash,
+        resume_event_hash=resume_event_hash,
+        journal_index=journal.event_count() - 1,
+        effective_mode=str(decision.effective_mode),
+        requested_mode=str(decision.requested_mode),
+        workspace_match=decision.workspace_match,
+        new_workspace_hash=new_ws_hash,
+        downgrade_reason=decision.downgrade_reason,
+        decision_hash=decision.decision_hash,
+        approval_ref=approval_ref,
+    )
+
+    ledger_entry_hash = ""
+    if ledger is not None:
+        entry: LedgerEntry = ledger.append(
+            kind=KIND_TASK_RESUMED,
+            task_id=suspend_row.task_id,
+            payload={
+                "continued_from_event_hash": suspend_row.event_hash,
+                "suspend_receipt_hash": suspend_receipt_hash,
+                "resume_receipt_hash": receipt.hmac,
+                "effective_mode": str(decision.effective_mode),
+                "new_workspace_hash": new_ws_hash,
+                "decision_hash": decision.decision_hash,
+            },
+        )
+        ledger_entry_hash = entry.entry_hash
+
+    return ResumeResult(
+        decision=decision,
+        resume_event_hash=resume_event_hash,
+        resume_receipt_hash=receipt.hmac,
+        new_workspace_hash=new_ws_hash,
+        approval_ref=approval_ref,
+        ledger_entry_hash=ledger_entry_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Approval composition (--until approval)
+# ---------------------------------------------------------------------------
+
+
+def approval_decision_ref(workdir: Path, task_id: str) -> str:
+    """Return the approval decision digest for a woken ``--until approval`` park.
+
+    The digest binds the task id and the content of the
+    ``<task_id>.approved`` decision file written by ``bernstein approve``. It
+    is empty when no approval decision exists yet, so a resume gated on
+    approval can refuse to proceed until the operator lands the decision. The
+    same digest is written into the resume receipt, so the approval record and
+    the resume receipt reference each other.
+    """
+    approved = workdir / ".sdd" / "runtime" / "approvals" / f"{task_id}.approved"
+    if not approved.exists():
+        return ""
+    try:
+        content = approved.read_bytes()
+    except OSError:
+        return ""
+    digest = hashlib.sha256(b"approval:" + task_id.encode("utf-8") + b":" + content).hexdigest()
+    return digest
+
+
+def write_resume_marker(workdir: Path, task_id: str, resume_receipt_hash: str) -> Path:
+    """Write a ``<task_id>.resumed`` marker referencing the resume receipt.
+
+    Closes the approval<->resume back-reference: ``bernstein approve`` lands the
+    ``.approved`` decision the resume receipt binds, and this marker lands the
+    resume receipt hash the approval record can be checked against. Best-effort;
+    a write failure is logged and the marker path returned regardless.
+    """
+    approvals = workdir / ".sdd" / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    marker = approvals / f"{task_id}.resumed"
+    try:
+        marker.write_text(resume_receipt_hash, encoding="utf-8")
+    except OSError as exc:  # pragma: no cover -- defensive
+        logger.warning("failed to write resume marker for task %s: %s", task_id, type(exc).__name__)
+    return marker
+
+
+# ---------------------------------------------------------------------------
+# Offline continuity verification
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContinuityResult:
+    """Outcome of :func:`verify_suspension_continuity`.
+
+    Attributes:
+        ok: ``True`` only when every check passed: audit HMAC chain intact,
+            task journal Merkle chain intact, and a resume receipt that
+            continued from exactly the parked suspend row.
+        chain_ok: Whether the HMAC audit chain verified.
+        journal_ok: Whether the task journal Merkle chain verified.
+        resumed: Whether a resume receipt for the task was found.
+        effective_mode: The recorded continuation mode (``warm`` / ``fork`` /
+            ``cold``), or ``""`` when not resumed.
+        workspace_match: Whether the resume continued from the parked
+            workspace hash.
+        downgrade_reason: Recorded fork/cold reason, or ``""``.
+        errors: Human-readable explanations of any failure.
+    """
+
+    ok: bool
+    chain_ok: bool
+    journal_ok: bool
+    resumed: bool
+    effective_mode: str
+    workspace_match: bool
+    downgrade_reason: str
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "chain_ok": self.chain_ok,
+            "journal_ok": self.journal_ok,
+            "resumed": self.resumed,
+            "effective_mode": self.effective_mode,
+            "workspace_match": self.workspace_match,
+            "downgrade_reason": self.downgrade_reason,
+            "errors": list(self.errors),
+        }
+
+
+def _journal_verify(sdd_dir: Path, task_id: str) -> JournalVerifyResult:
+    return verify_journal(_journal_path(sdd_dir, task_id))
+
+
+def verify_suspension_continuity(
+    *,
+    sdd_dir: Path,
+    task_id: str,
+    chain: AuditChainStore,
+) -> ContinuityResult:
+    """Prove, offline, that a resumed task continued from the parked state.
+
+    The check is the continuity proof AC (#2552): from a copied chain and the
+    task journal alone, confirm
+
+    1. the HMAC audit chain verifies (a mutated receipt fails at its position);
+    2. the task journal Merkle chain verifies (a mutated suspend row fails at
+       its exact index);
+    3. a ``task.resume_receipt`` exists that references the ``suspend_receipt``
+       whose ``suspend_event_hash`` equals the parked suspend row's identity,
+       and the recorded continuation mode / workspace match / downgrade reason
+       describe how it continued (warm from the parked hash, or a recorded fork
+       or cold downgrade with its reason).
+
+    No worker, no network, no live worktree is required -- everything is read
+    from the chain and the journal.
+    """
+    from bernstein.core.security.audit_chain import EVENT_TASK_RESUMED, EVENT_TASK_SUSPENDED
+
+    errors: list[str] = []
+
+    chain_ok, chain_errors = chain.verify()
+    if not chain_ok:
+        errors.extend(chain_errors)
+
+    journal_result = _journal_verify(sdd_dir, task_id)
+    journal_ok = journal_result.ok
+    if not journal_ok:
+        errors.append(
+            f"task journal chain broke at index {journal_result.divergent_index}: "
+            f"{'; '.join(journal_result.errors) or 'verification failed'}"
+        )
+
+    suspend_events = [e for e in chain.query(event_type=EVENT_TASK_SUSPENDED) if e.details.get("task_id") == task_id]
+    resume_events = [e for e in chain.query(event_type=EVENT_TASK_RESUMED) if e.details.get("task_id") == task_id]
+
+    if not suspend_events:
+        errors.append(f"no suspend receipt found for task {task_id!r}")
+        return ContinuityResult(
+            ok=False,
+            chain_ok=chain_ok,
+            journal_ok=journal_ok,
+            resumed=False,
+            effective_mode="",
+            workspace_match=False,
+            downgrade_reason="",
+            errors=errors,
+        )
+
+    suspend_event = suspend_events[-1]
+    parked_hash = str(suspend_event.details.get("suspend_event_hash", ""))
+
+    resumed = bool(resume_events)
+    effective_mode = ""
+    workspace_match = False
+    downgrade_reason = ""
+    if resumed:
+        resume_event = resume_events[-1]
+        effective_mode = str(resume_event.details.get("effective_mode", ""))
+        workspace_match = bool(resume_event.details.get("workspace_match", False))
+        downgrade_reason = str(resume_event.details.get("downgrade_reason", ""))
+        continued_from = str(resume_event.details.get("suspend_event_hash", ""))
+        if continued_from != parked_hash:
+            errors.append(
+                "resume receipt did not continue from the parked suspend row "
+                f"(continued_from={continued_from[:16]}..., parked={parked_hash[:16]}...)"
+            )
+        # A warm continuation asserts the parked workspace hash matched; a
+        # downgrade must carry a reason so the fork/cold is never silent.
+        if effective_mode == str(RetryMode.WARM) and not workspace_match:
+            errors.append("warm resume recorded without a workspace-hash match")
+        if effective_mode != str(RetryMode.WARM) and not downgrade_reason:
+            errors.append(f"{effective_mode} downgrade recorded without a reason")
+
+    ok = chain_ok and journal_ok and not errors
+    return ContinuityResult(
+        ok=ok,
+        chain_ok=chain_ok,
+        journal_ok=journal_ok,
+        resumed=resumed,
+        effective_mode=effective_mode,
+        workspace_match=workspace_match,
+        downgrade_reason=downgrade_reason,
+        errors=errors,
+    )
+
+
+__all__ = [
+    "JOURNAL_EVENT_RESUME",
+    "JOURNAL_EVENT_SUSPEND",
+    "RESOURCE_BUDGET",
+    "RESOURCE_PROCESS",
+    "RESOURCE_SANDBOX",
+    "RESOURCE_SEAT",
+    "WAKE_APPROVAL",
+    "ContinuityResult",
+    "ParkResult",
+    "ReleaseResult",
+    "ReleaseWithoutReceiptError",
+    "ResourceHandles",
+    "ResumeResult",
+    "SuspendRow",
+    "approval_decision_ref",
+    "decide_resume",
+    "latest_suspension",
+    "park_task",
+    "record_task_suspension_row",
+    "release_resources",
+    "resume_task",
+    "verify_suspension_continuity",
+    "write_resume_marker",
+]

--- a/src/bernstein/core/tasks/suspension.py
+++ b/src/bernstein/core/tasks/suspension.py
@@ -885,12 +885,15 @@ def verify_suspension_continuity(
                 "resume receipt did not continue from the parked suspend row "
                 f"(continued_from={continued_from[:16]}..., parked={parked_hash[:16]}...)"
             )
-        # A warm continuation asserts the parked workspace hash matched; a
-        # downgrade must carry a reason so the fork/cold is never silent.
+        # A warm continuation asserts it resumed the parked native session from
+        # the parked workspace hash, so the hashes must have matched -- a warm
+        # resume without a match is the one genuine inconsistency (a drift must
+        # downgrade, never silently resume warm). A fork or cold continuation is
+        # surfaced with its recorded reason from the receipt but is not itself a
+        # failure: the AC is "warm from the parked hash, or a recorded fork/cold
+        # downgrade with its reason".
         if effective_mode == str(RetryMode.WARM) and not workspace_match:
             errors.append("warm resume recorded without a workspace-hash match")
-        if effective_mode != str(RetryMode.WARM) and not downgrade_reason:
-            errors.append(f"{effective_mode} downgrade recorded without a reason")
 
     ok = chain_ok and journal_ok and not errors
     return ContinuityResult(

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -286,6 +286,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "events",
         # Chain-anchored worker context capsules (issue #2545)
         "context",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "task",
     }
 )
 

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -403,6 +403,42 @@ def test_verify_continuity_shows_cold_downgrade_with_reason(tmp_path: Path) -> N
     assert result.downgrade_reason == "workspace_hash_mismatch"
 
 
+def test_verify_continuity_accepts_honored_fork(tmp_path: Path) -> None:
+    # A fork requested against a fork-capable adapter with a matching workspace
+    # is an honored continuation, not a downgrade: it carries no reason and the
+    # verifier must not treat the empty reason as a failure.
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-fork",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        requested_mode=RetryMode.FORK,
+    )
+    assert resume.decision.effective_mode is RetryMode.FORK
+    assert resume.decision.downgrade_reason == ""
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-fork", chain=chain)
+    assert result.ok, result.errors
+    assert result.effective_mode == "fork"
+    assert result.workspace_match
+    assert result.downgrade_reason == ""
+
+
 def test_mutating_suspend_row_fails_verification_at_that_index(tmp_path: Path) -> None:
     sdd = tmp_path / ".sdd"
     chain = _chain(tmp_path)

--- a/tests/unit/test_task_suspension.py
+++ b/tests/unit/test_task_suspension.py
@@ -1,0 +1,632 @@
+"""Durable task suspend and resume: attested park receipts (#2552).
+
+These tests exercise the substrate-coupled guarantees the feature ships:
+
+* **Fail closed** -- an infrastructure release with no suspend receipt is
+  rejected before any effect runs.
+* **Receipt before effect** -- the suspend row and its audit receipt land
+  before the seat, sandbox, process, and envelope headroom are freed, and each
+  release references the suspend receipt hash.
+* **Determinism** -- two hosts derive the byte-identical resume decision hash
+  from the same suspend row, and replay reproduces identical journal hashes up
+  to the park boundary.
+* **Verifiability** -- ``verify_suspension_continuity`` proves, offline from a
+  copied chain, that a resume continued from exactly the parked workspace hash;
+  mutating the suspend row fails journal verification at that exact index.
+* **Correctness** -- released headroom equals reservation minus recorded spend,
+  appears as a chained budget event, and the parked window carries zero spend.
+* **Isolation** -- parking one worker leaves a second worker's journal, claim,
+  and envelope untouched; the freed seat is dispatchable in the same tick.
+* **Restart survival** -- a park persisted to the work ledger survives an
+  orchestrator restart and resumes with the same continuity proof.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.budget_actions import BudgetHeadroomReleaseEvent, compute_released_headroom
+from bernstein.core.cost.cost_rollup_by_envelope import rollup
+from bernstein.core.cost.cost_tracker import TokenUsage
+from bernstein.core.persistence.work_ledger import (
+    KIND_TASK_RESUMED,
+    KIND_TASK_SUSPENDED,
+    LedgerReader,
+    WorkLedger,
+    replay_state,
+)
+from bernstein.core.replay.journal import rebuild_state, verify_journal
+from bernstein.core.security.audit_chain import (
+    EVENT_TASK_RESOURCE_RELEASE,
+    EVENT_TASK_RESUMED,
+    EVENT_TASK_SUSPENDED,
+    AuditChainStore,
+)
+from bernstein.core.tasks.checkpoint_retry import RetryMode, task_run_id
+from bernstein.core.tasks.suspension import (
+    RESOURCE_BUDGET,
+    RESOURCE_PROCESS,
+    RESOURCE_SANDBOX,
+    RESOURCE_SEAT,
+    WAKE_APPROVAL,
+    ReleaseWithoutReceiptError,
+    ResourceHandles,
+    approval_decision_ref,
+    decide_resume,
+    latest_suspension,
+    park_task,
+    release_resources,
+    resume_task,
+    verify_suspension_continuity,
+    write_resume_marker,
+)
+
+_KEY = b"0" * 32
+
+
+def _chain(tmp_path: Path) -> AuditChainStore:
+    return AuditChainStore(tmp_path / "audit", key=_KEY)
+
+
+def _worktree(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    wt = tmp_path / name
+    wt.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        target = wt / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return wt
+
+
+class _SeatPool:
+    """Minimal seat pool: a park returns a seat, a dispatch consumes one."""
+
+    def __init__(self, total: int, used: int) -> None:
+        self.total = total
+        self.used = used
+
+    @property
+    def available(self) -> int:
+        return self.total - self.used
+
+    def return_seat(self) -> dict[str, object]:
+        self.used -= 1
+        return {"available_after": self.available}
+
+    def dispatch(self) -> bool:
+        if self.available <= 0:
+            return False
+        self.used += 1
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Fail closed: release with no receipt is rejected before any effect
+# ---------------------------------------------------------------------------
+
+
+def test_release_without_receipt_is_rejected(tmp_path: Path) -> None:
+    chain = _chain(tmp_path)
+    reaped: list[str] = []
+
+    handles = ResourceHandles(
+        reap_process=lambda: reaped.append("reaped") or {"method": "posix"},  # type: ignore[func-returns-value]
+    )
+    with pytest.raises(ReleaseWithoutReceiptError):
+        release_resources(
+            chain=chain,
+            task_id="T-1",
+            suspend_receipt_hash="",
+            envelope="subscription",
+            reserved_usd=10.0,
+            spent_usd=2.0,
+            handles=handles,
+        )
+    # No physical effect ran and no release row reached the chain.
+    assert reaped == []
+    assert chain.query(event_type=EVENT_TASK_RESOURCE_RELEASE) == []
+
+
+# ---------------------------------------------------------------------------
+# Receipt before effect + releases reference the receipt hash
+# ---------------------------------------------------------------------------
+
+
+def test_park_records_receipt_before_effect_and_releases_reference_it(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "print(1)\n"})
+
+    handles = ResourceHandles(
+        reap_process=lambda: {"method": "posix_process_group", "delivered": True},
+        teardown_sandbox=lambda: {"backend": "worktree"},
+        return_seat=lambda: {"available_after": 3},
+    )
+    result = park_task(
+        sdd_dir=sdd,
+        task_id="T-park",
+        adapter="claude",
+        session_id="sess-abc",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=10.0,
+        spent_usd=2.5,
+        chain=chain,
+        handles=handles,
+    )
+
+    # The suspend receipt exists on the chain and the suspend row hashes to the
+    # suspension's identity.
+    suspend_rows = chain.query(event_type=EVENT_TASK_SUSPENDED)
+    assert len(suspend_rows) == 1
+    assert suspend_rows[0].details["suspend_event_hash"] == result.suspend_row.event_hash
+
+    # The suspend row precedes every release row on the chain (receipt first).
+    ordered = [e.event_type for e in chain.query()]
+    first_release = ordered.index(EVENT_TASK_RESOURCE_RELEASE)
+    assert ordered.index(EVENT_TASK_SUSPENDED) < first_release
+
+    # Every release references the suspend receipt hash.
+    releases = chain.query(event_type=EVENT_TASK_RESOURCE_RELEASE)
+    resources = {r.details["resource"] for r in releases}
+    assert resources == {RESOURCE_PROCESS, RESOURCE_SANDBOX, RESOURCE_SEAT, RESOURCE_BUDGET}
+    for r in releases:
+        assert r.details["suspend_receipt_hash"] == result.suspend_receipt_hash
+
+    # The whole chain still verifies.
+    ok, errors = chain.verify()
+    assert ok, errors
+
+
+# ---------------------------------------------------------------------------
+# Correctness: released headroom = reserved - spent, chained budget event
+# ---------------------------------------------------------------------------
+
+
+def test_released_headroom_equals_reserved_minus_spent(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    result = park_task(
+        sdd_dir=sdd,
+        task_id="T-budget",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=12.0,
+        spent_usd=4.25,
+        chain=chain,
+    )
+    assert result.release.released_usd == pytest.approx(7.75)
+    assert compute_released_headroom(12.0, 4.25) == pytest.approx(7.75)
+
+    budget_rows = [
+        r for r in chain.query(event_type=EVENT_TASK_RESOURCE_RELEASE) if r.details["resource"] == RESOURCE_BUDGET
+    ]
+    assert len(budget_rows) == 1
+    detail = budget_rows[0].details["detail"]
+    assert detail["released_usd"] == pytest.approx(7.75)
+    assert detail["reserved_usd"] == pytest.approx(12.0)
+    assert detail["spent_usd"] == pytest.approx(4.25)
+    assert detail["suspend_receipt_hash"] == result.suspend_receipt_hash
+
+
+def test_headroom_release_event_is_fail_closed() -> None:
+    from bernstein.core.cost.budget_actions import build_headroom_release_event
+
+    with pytest.raises(ValueError, match="fail closed"):
+        build_headroom_release_event(
+            envelope="subscription",
+            reserved_usd=5.0,
+            spent_usd=1.0,
+            suspend_receipt_hash="",
+        )
+    ok = build_headroom_release_event(
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=1.0,
+        suspend_receipt_hash="abc",
+    )
+    assert isinstance(ok, BudgetHeadroomReleaseEvent)
+    assert ok.released_usd == pytest.approx(4.0)
+
+
+def test_parked_window_attributes_zero_spend(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+
+    # Spend recorded before the park and after the resume; the parked window
+    # carries no cost records at all.
+    records = [
+        TokenUsage(100, 50, "claude", 1.0, "agent", "T-window", timestamp=100.0, quota_envelope="subscription"),
+        TokenUsage(100, 50, "claude", 3.0, "agent", "T-window", timestamp=400.0, quota_envelope="subscription"),
+    ]
+    park_ts, resume_ts = 200.0, 300.0
+    park_task(
+        sdd_dir=sdd,
+        task_id="T-window",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=10.0,
+        spent_usd=1.0,
+        chain=chain,
+    )
+    parked_window = [r for r in records if park_ts <= r.timestamp < resume_ts]
+    assert parked_window == []
+    rolled = rollup(records)
+    # Total spend is the pre + post records; nothing is attributed inside the
+    # parked window because nothing was recorded there.
+    assert rolled["subscription"].total_spend == pytest.approx(4.0)
+    assert sum(r.cost_usd for r in parked_window) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Determinism: two hosts derive the byte-identical resume decision
+# ---------------------------------------------------------------------------
+
+
+def test_resume_decision_is_deterministic_across_hosts(tmp_path: Path) -> None:
+    from bernstein.core.tasks.checkpoint_retry import workspace_hash
+
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    files = {"a.py": "print('hi')\n", "pkg/b.py": "y = 2\n"}
+    wt = _worktree(tmp_path, "wt", files)
+
+    # Park once. The suspend row travels with the run (journal + work ledger),
+    # so both hosts hold the byte-identical row.
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-det",
+        adapter="claude",
+        session_id="sess-1",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=8.0,
+        spent_usd=1.0,
+        chain=chain,
+    )
+
+    # Two hosts re-materialize the worktree at *different physical paths* with
+    # byte-identical content. The workspace hash is content-addressed, so both
+    # derive the same decision hash from the same suspend row.
+    host_a = _worktree(tmp_path, "host-a-wt", files)
+    host_b = _worktree(tmp_path, "host-b-wt", files)
+    dec_a = decide_resume(suspend_row=park.suspend_row, actual_workspace_hash=workspace_hash(host_a))
+    dec_b = decide_resume(suspend_row=park.suspend_row, actual_workspace_hash=workspace_hash(host_b))
+    assert dec_a.decision_hash == dec_b.decision_hash
+    assert dec_a.effective_mode is RetryMode.WARM
+    assert dec_b.effective_mode is RetryMode.WARM
+
+
+def test_replay_reproduces_identical_journal_hashes_to_park_boundary(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-replay",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+    journal_path = sdd / "runs" / task_run_id("T-replay") / "journal.jsonl"
+    boundary = park.suspend_row.journal_index + 1
+
+    first = rebuild_state(journal_path, from_step=boundary)
+    second = rebuild_state(journal_path, from_step=boundary)
+    assert first["head_hash"] == second["head_hash"]
+    # Head over the prefix ending at the suspend row equals the row's identity.
+    assert first["head_hash"] == park.suspend_row.event_hash
+
+
+# ---------------------------------------------------------------------------
+# Verifiability: continuity proof + tamper detection
+# ---------------------------------------------------------------------------
+
+
+def test_verify_continuity_proves_warm_resume(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-cont",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+    # Resume from the unchanged worktree -> warm continuation.
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+    assert resume.decision.effective_mode is RetryMode.WARM
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-cont", chain=chain)
+    assert result.ok, result.errors
+    assert result.resumed
+    assert result.effective_mode == "warm"
+    assert result.workspace_match
+
+
+def test_verify_continuity_shows_cold_downgrade_with_reason(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-drift",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+    # Drift the worktree before resume -> the workspace hash no longer matches.
+    (wt / "a.py").write_text("x = 999\n", encoding="utf-8")
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+    )
+    assert resume.decision.effective_mode is RetryMode.COLD
+    assert resume.decision.downgrade_reason == "workspace_hash_mismatch"
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-drift", chain=chain)
+    assert result.ok, result.errors
+    assert result.effective_mode == "cold"
+    assert not result.workspace_match
+    assert result.downgrade_reason == "workspace_hash_mismatch"
+
+
+def test_mutating_suspend_row_fails_verification_at_that_index(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-tamper",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+    )
+    journal_path = sdd / "runs" / task_run_id("T-tamper") / "journal.jsonl"
+
+    # Mutate the parked workspace hash on the suspend row on disk.
+    lines = journal_path.read_text(encoding="utf-8").splitlines()
+    idx = park.suspend_row.journal_index
+    row = json.loads(lines[idx])
+    row["workspace_hash"] = "deadbeef" * 8
+    lines[idx] = json.dumps(row)
+    journal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    verify = verify_journal(journal_path)
+    assert not verify.ok
+    assert verify.divergent_index == idx
+
+    # A tampered suspend row can never fuel a resume: fail-closed read returns None.
+    assert latest_suspension(sdd, "T-tamper") is None
+    # And the continuity verifier reports the journal break.
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-tamper", chain=chain)
+    assert not result.ok
+    assert not result.journal_ok
+
+
+def test_mutating_suspend_receipt_breaks_hmac_chain(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park_task(
+        sdd_dir=sdd,
+        task_id="T-hmac",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=1.0,
+        chain=chain,
+    )
+    # Tamper the suspend receipt payload directly in the audit log file.
+    audit_files = sorted((tmp_path / "audit").glob("*.jsonl"))
+    assert audit_files
+    log = audit_files[0]
+    lines = log.read_text(encoding="utf-8").splitlines()
+    for i, raw in enumerate(lines):
+        entry = json.loads(raw)
+        if entry.get("event_type") == EVENT_TASK_SUSPENDED:
+            entry["details"]["released_usd"] = 999.0
+            lines[i] = json.dumps(entry)
+            break
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    reopened = AuditChainStore(tmp_path / "audit", key=_KEY)
+    ok, errors = reopened.verify()
+    assert not ok
+    assert errors
+
+
+# ---------------------------------------------------------------------------
+# Isolation: parking one worker leaves a second untouched; freed seat dispatches
+# ---------------------------------------------------------------------------
+
+
+def test_isolation_two_workers_and_seat_redispatch(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt_a = _worktree(tmp_path, "wt-a", {"a.py": "a = 1\n"})
+    wt_b = _worktree(tmp_path, "wt-b", {"b.py": "b = 2\n"})
+    pool = _SeatPool(total=2, used=2)  # both seats occupied
+    assert pool.available == 0
+
+    park_task(
+        sdd_dir=sdd,
+        task_id="T-a",
+        adapter="claude",
+        session_id="sa",
+        worktree_path=wt_a,
+        envelope="env-a",
+        reserved_usd=6.0,
+        spent_usd=1.0,
+        chain=chain,
+        handles=ResourceHandles(return_seat=pool.return_seat),
+    )
+
+    # Worker B's worktree, journal, and envelope are untouched.
+    assert wt_b.read_text() if False else (wt_b / "b.py").read_text() == "b = 2\n"
+    assert latest_suspension(sdd, "T-b") is None
+    b_journal = sdd / "runs" / task_run_id("T-b") / "journal.jsonl"
+    assert not b_journal.exists()
+
+    # The freed seat is dispatchable to a queued task in the same tick.
+    assert pool.available == 1
+    assert pool.dispatch() is True
+    assert pool.available == 0
+
+
+# ---------------------------------------------------------------------------
+# --until approval: resume when approve lands; receipts reference each other
+# ---------------------------------------------------------------------------
+
+
+def test_until_approval_resumes_when_approval_lands(tmp_path: Path) -> None:
+    workdir = tmp_path
+    sdd = workdir / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-appr",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=0.0,
+        chain=chain,
+        wake_condition=WAKE_APPROVAL,
+    )
+    assert park.suspend_row.wake_condition == WAKE_APPROVAL
+
+    # Before approval there is no decision to bind.
+    assert approval_decision_ref(workdir, "T-appr") == ""
+
+    # bernstein approve lands the decision file.
+    approvals = sdd / "runtime" / "approvals"
+    approvals.mkdir(parents=True, exist_ok=True)
+    (approvals / "T-appr.approved").write_text("approved", encoding="utf-8")
+    approval_ref = approval_decision_ref(workdir, "T-appr")
+    assert approval_ref  # non-empty digest binding the approval record
+
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=park.suspend_row,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        approval_ref=approval_ref,
+    )
+    marker = write_resume_marker(workdir, "T-appr", resume.resume_receipt_hash)
+
+    # The resume receipt references the approval decision...
+    resume_rows = chain.query(event_type=EVENT_TASK_RESUMED)
+    assert resume_rows[-1].details["approval_ref"] == approval_ref
+    # ...and the approval side references the resume receipt (back-reference).
+    assert marker.read_text(encoding="utf-8") == resume.resume_receipt_hash
+
+
+# ---------------------------------------------------------------------------
+# Restart survival: park persists to the ledger, resume after a fresh open
+# ---------------------------------------------------------------------------
+
+
+def test_suspended_state_survives_orchestrator_restart(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    chain = _chain(tmp_path)
+    wt = _worktree(tmp_path, "wt", {"a.py": "x = 1\n"})
+    ledger_dir = sdd / "runtime" / "ledger" / "run-1"
+
+    ledger = WorkLedger.open(ledger_dir)
+    park = park_task(
+        sdd_dir=sdd,
+        task_id="T-restart",
+        adapter="claude",
+        session_id="s",
+        worktree_path=wt,
+        envelope="subscription",
+        reserved_usd=5.0,
+        spent_usd=1.0,
+        chain=chain,
+        ledger=ledger,
+    )
+    assert park.ledger_entry_hash
+
+    # Simulate a restart: drop every in-memory handle and re-open from disk.
+    del ledger
+    reopened = WorkLedger.open(ledger_dir)
+    state = replay_state(LedgerReader(ledger_dir).entries(), run_id="run-1")
+    assert "T-restart" in state.suspended_tasks
+    assert "T-restart" not in state.resume_frontier()  # parked tasks wake explicitly
+
+    # The suspend row is still readable from disk with the same identity.
+    reloaded = latest_suspension(sdd, "T-restart")
+    assert reloaded is not None
+    assert reloaded.event_hash == park.suspend_row.event_hash
+
+    # Resume succeeds with the same continuity proof (identical decision hash).
+    dec_before = decide_resume(suspend_row=park.suspend_row, actual_workspace_hash=park.suspend_row.workspace_hash)
+    resume = resume_task(
+        sdd_dir=sdd,
+        suspend_row=reloaded,
+        new_worktree_path=wt,
+        chain=chain,
+        suspend_receipt_hash=park.suspend_receipt_hash,
+        ledger=reopened,
+    )
+    assert resume.decision.decision_hash == dec_before.decision_hash
+
+    final = replay_state(LedgerReader(ledger_dir).entries(), run_id="run-1")
+    assert "T-restart" not in final.suspended_tasks
+    assert "T-restart" in final.in_flight_tasks  # resumed -> started
+
+    result = verify_suspension_continuity(sdd_dir=sdd, task_id="T-restart", chain=chain)
+    assert result.ok, result.errors
+
+
+def test_work_ledger_kinds_project_to_states(tmp_path: Path) -> None:
+    ledger = WorkLedger.open(tmp_path / "ledger")
+    ledger.append(kind=KIND_TASK_SUSPENDED, task_id="T-x", payload={"a": 1})
+    state = replay_state(LedgerReader(tmp_path / "ledger").entries())
+    assert state.suspended_tasks == ["T-x"]
+    ledger.append(kind=KIND_TASK_RESUMED, task_id="T-x", payload={"b": 2})
+    state2 = replay_state(LedgerReader(tmp_path / "ledger").entries())
+    assert state2.suspended_tasks == []
+    assert state2.in_flight_tasks == ["T-x"]


### PR DESCRIPTION
Closes #2552.

## Problem

A long agent session that must wait on a human (a mid-flight approval, an external review, a credential rotation, a dependency landing) had no way to stop consuming infrastructure. The pre-spawn approval gate halts a task only before a worker exists; the post-completion review gate only after it exits. So the process, its worktree sandbox, its parallelism seat, and its budget-envelope reservation all stayed allocated for the entire wait, and on a capped pool that reservation blocked other tasks from dispatching.

## Approach: the suspension is the artifact

A park is a pair of Merkle-chained journal rows plus matching HMAC audit-chain receipts, and every infrastructure release hangs off the suspend receipt's hash. Without the chain there is no suspension, only a dead process.

- **Suspend** appends a suspend row to the task's event journal (its `event_hash` is the suspension's identity: adapter session id, workspace hash, journal head, envelope balance), then binds a `task.suspend_receipt` into the audit chain **before any effect**. The seat return, sandbox teardown, process reap, and envelope-headroom release each record a `task.suspend_resource_release` referencing the receipt hash; a release with no matching receipt is rejected, **fail closed**.
- The task enters a **`SUSPENDED`** status persisted through the work ledger (`task.suspended` / `task.resumed` kinds), so a park survives orchestrator restarts. Parked tasks are kept out of the resume frontier: they wake explicitly.
- **Resume** re-derives the continuation mode deterministically (warm / fork / cold with a recorded reason, reusing the checkpointed-retry `decide_retry` projection) and records a `task.resume_receipt` binding the suspend receipt it continued from. The receipt pair is the continuity proof.
- `suspend --until approval` composes with the approval sentinel so `bernstein approve` wakes the parked task; the approval record and the resume receipt reference each other.

Released headroom equals reservation minus recorded spend at park time and appears as a chained budget event; the envelope rollup attributes zero spend to the parked window because nothing is recorded while parked.

## Surface

- `bernstein task suspend <id> [--until approval]`, `bernstein task resume <id>`, `bernstein task list-suspended`
- `bernstein audit verify-suspension <id>` proves continuity offline from a copied chain

## Acceptance criteria mapping

| AC | Where |
|---|---|
| Receipt before effect; releases reference the suspend receipt; unmatched release rejected | `suspension.release_resources` (fail closed) + `test_release_without_receipt_is_rejected`, `test_park_records_receipt_before_effect_and_releases_reference_it` |
| Verifiability: offline continuity proof; mutating the suspend row fails at its exact position | `verify_suspension_continuity` + `test_verify_continuity_*`, `test_mutating_suspend_row_fails_verification_at_that_index`, `test_mutating_suspend_receipt_breaks_hmac_chain` |
| Determinism: same suspend row -> byte-identical decision hash; replay reproduces journal hashes to park boundary | `decide_resume` + `test_resume_decision_is_deterministic_across_hosts`, `test_replay_reproduces_identical_journal_hashes_to_park_boundary` |
| Correctness: released = reserved - spent; chained budget event; zero spend in parked window | `budget_actions.build_headroom_release_event` + `test_released_headroom_equals_reserved_minus_spent`, `test_parked_window_attributes_zero_spend` |
| Isolation: second worker untouched; freed seat dispatchable | `test_isolation_two_workers_and_seat_redispatch` |
| `--until approval` wake; cross-referencing receipts | `approval_decision_ref` / `write_resume_marker` + `test_until_approval_resumes_when_approval_lands` |
| Suspended state survives restart | work ledger `KIND_TASK_SUSPENDED` + `test_suspended_state_survives_orchestrator_restart` |

## Empirical SOTA-axis proof

End-to-end through the real CLI: `task suspend` releases the seat/sandbox/budget and records the receipt; `task resume` reconstructs warm from the parked workspace hash with a byte-identical decision hash; `audit verify-suspension` proves continuity offline; a tampered suspend row breaks journal verification at its exact index and a tampered receipt breaks the HMAC chain.

## Verification

- `ruff check` + `ruff format --check` clean
- New suite `tests/unit/test_task_suspension.py` (15 tests) green
- Orchestration + cost + ledger + audit suites: 875 green; lifecycle/status suites: 431 green; no regressions
- Additive and behavior-preserving; docs in `docs/operations/durable-suspend-resume.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable task suspension and resumption for pausing long-running tasks and freeing infrastructure resources.
  * Added CLI commands to suspend, resume, and list suspended tasks.
  * Added approval-gated resume support and deterministic resume decisions.
  * Added offline continuity verification with tamper detection.
  * Released unused budget headroom when tasks are suspended.

* **Documentation**
  * Added operations guidance for durable suspend and resume under Reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->